### PR TITLE
test: add v1.5.3 migration test coverage for feature flags, temp tokens, OAuth schema refactor, and new columns

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -727,6 +727,8 @@ append_dynamic_mcp_clients_insert() {
     generate_async_jobs_insert_postgres "$now" "$future" "$faker_sql"
     generate_prompt_repo_tables_insert_postgres "$now" "$faker_sql"
     generate_per_user_oauth_tables_insert_postgres "$now" "$faker_sql"
+    generate_feature_flags_insert_postgres "$now" "$faker_sql"
+    generate_temp_tokens_insert_postgres "$now" "$faker_sql"
     generate_model_parameters_insert_postgres "$now" "$faker_sql"
     generate_routing_targets_insert_postgres "$now" "$faker_sql"
     generate_pricing_overrides_insert_postgres "$now" "$faker_sql"
@@ -739,6 +741,8 @@ append_dynamic_mcp_clients_insert() {
     generate_async_jobs_insert_sqlite "$now" "$future" "$faker_sql"
     generate_prompt_repo_tables_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_per_user_oauth_tables_insert_sqlite "$now" "$faker_sql" "$config_db"
+    generate_feature_flags_insert_sqlite "$now" "$faker_sql" "$config_db"
+    generate_temp_tokens_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_model_parameters_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_routing_targets_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_pricing_overrides_insert_sqlite "$now" "$faker_sql" "$config_db"
@@ -1660,6 +1664,92 @@ append_dynamic_columns_postgres() {
     echo "UPDATE prompt_sessions SET variables_json = '{}' WHERE prompt_id = 'prompt-migration-test-001';" >> "$output_file"
     echo "UPDATE prompt_sessions SET variables_json = '{}' WHERE prompt_id = 'prompt-migration-test-002';" >> "$output_file"
   fi
+
+  # -------------------------------------------------------------------------
+  # v1.5.3 columns - config store tables
+  # -------------------------------------------------------------------------
+
+  # config_client.metadata_json (added in v1.5.3 via migrationAddClientConfigMetadataColumn)
+  if column_exists_postgres "config_client" "metadata_json"; then
+    echo "UPDATE config_client SET metadata_json = '{}' WHERE id = 1;" >> "$output_file"
+  fi
+
+  # framework_configs.model_parameters_url (added in v1.5.3 via add_model_parameters_url_column)
+  if column_exists_postgres "framework_configs" "model_parameters_url"; then
+    echo "UPDATE framework_configs SET model_parameters_url = NULL WHERE id = 1;" >> "$output_file"
+  fi
+
+  # framework_configs.config_hash (added in v1.5.3 via migrationAddFrameworkConfigHashColumn)
+  if column_exists_postgres "framework_configs" "config_hash"; then
+    echo "UPDATE framework_configs SET config_hash = 'framework-config-hash-001' WHERE id = 1;" >> "$output_file"
+  fi
+
+  # governance_teams.source_id (added in v1.5.3 via add_team_source_id_column)
+  if column_exists_postgres "governance_teams" "source_id"; then
+    echo "UPDATE governance_teams SET source_id = NULL WHERE id = 'team-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_teams SET source_id = NULL WHERE id = 'team-migration-test-2';" >> "$output_file"
+  fi
+
+  # governance_teams.calendar_aligned (added in v1.5.3 via migrationAddTeamCalendarAlignedColumn)
+  if column_exists_postgres "governance_teams" "calendar_aligned"; then
+    echo "UPDATE governance_teams SET calendar_aligned = false WHERE id = 'team-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_teams SET calendar_aligned = false WHERE id = 'team-migration-test-2';" >> "$output_file"
+  fi
+
+  # governance_virtual_keys.access_profile_id (added in v1.5.3 via add_vk_access_profile_id_column)
+  if column_exists_postgres "governance_virtual_keys" "access_profile_id"; then
+    echo "UPDATE governance_virtual_keys SET access_profile_id = NULL WHERE id = 'vk-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_virtual_keys SET access_profile_id = NULL WHERE id = 'vk-migration-test-2';" >> "$output_file"
+  fi
+
+  # -------------------------------------------------------------------------
+  # v1.5.3 columns - log store tables
+  # -------------------------------------------------------------------------
+
+  # logs.cluster_node_id (added in v1.5.3 via migrationAddClusterGovernanceColumns)
+  if column_exists_postgres "logs" "cluster_node_id"; then
+    echo "UPDATE logs SET cluster_node_id = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET cluster_node_id = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET cluster_node_id = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+
+  # logs.budget_ids (added in v1.5.3 via migrationAddClusterGovernanceColumns)
+  if column_exists_postgres "logs" "budget_ids"; then
+    echo "UPDATE logs SET budget_ids = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET budget_ids = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET budget_ids = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+
+  # logs.rate_limit_ids (added in v1.5.3 via migrationAddClusterGovernanceColumns)
+  if column_exists_postgres "logs" "rate_limit_ids"; then
+    echo "UPDATE logs SET rate_limit_ids = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET rate_limit_ids = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET rate_limit_ids = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+
+  # mcp_tool_logs.user_id (added in v1.5.3 via migrationAddGovernanceColumnsToMCPToolLogs)
+  if column_exists_postgres "mcp_tool_logs" "user_id"; then
+    echo "UPDATE mcp_tool_logs SET user_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
+    echo "UPDATE mcp_tool_logs SET user_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
+  fi
+
+  # mcp_tool_logs.team_id (added in v1.5.3 via migrationAddGovernanceColumnsToMCPToolLogs)
+  if column_exists_postgres "mcp_tool_logs" "team_id"; then
+    echo "UPDATE mcp_tool_logs SET team_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
+    echo "UPDATE mcp_tool_logs SET team_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
+  fi
+
+  # mcp_tool_logs.customer_id (added in v1.5.3 via migrationAddGovernanceColumnsToMCPToolLogs)
+  if column_exists_postgres "mcp_tool_logs" "customer_id"; then
+    echo "UPDATE mcp_tool_logs SET customer_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
+    echo "UPDATE mcp_tool_logs SET customer_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
+  fi
+
+  # mcp_tool_logs.business_unit_id (added in v1.5.3 via migrationAddGovernanceColumnsToMCPToolLogs)
+  if column_exists_postgres "mcp_tool_logs" "business_unit_id"; then
+    echo "UPDATE mcp_tool_logs SET business_unit_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
+    echo "UPDATE mcp_tool_logs SET business_unit_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
+  fi
 }
 
 # Append dynamic column UPDATEs for columns that may not exist in older schemas (SQLite)
@@ -2539,7 +2629,79 @@ append_dynamic_columns_sqlite() {
       echo "UPDATE prompt_sessions SET variables_json = '{}' WHERE prompt_id = 'prompt-migration-test-001';" >> "$output_file"
       echo "UPDATE prompt_sessions SET variables_json = '{}' WHERE prompt_id = 'prompt-migration-test-002';" >> "$output_file"
     fi
+
+    # -------------------------------------------------------------------------
+    # v1.5.3 columns - config store tables
+    # -------------------------------------------------------------------------
+
+    # config_client.metadata_json (added in v1.5.3 via migrationAddClientConfigMetadataColumn)
+    if column_exists_sqlite "$config_db" "config_client" "metadata_json"; then
+      echo "UPDATE config_client SET metadata_json = '{}' WHERE id = 1;" >> "$output_file"
+    fi
+
+    # framework_configs.model_parameters_url (added in v1.5.3 via add_model_parameters_url_column)
+    if column_exists_sqlite "$config_db" "framework_configs" "model_parameters_url"; then
+      echo "UPDATE framework_configs SET model_parameters_url = NULL WHERE id = 1;" >> "$output_file"
+    fi
+
+    # framework_configs.config_hash (added in v1.5.3 via migrationAddFrameworkConfigHashColumn)
+    if column_exists_sqlite "$config_db" "framework_configs" "config_hash"; then
+      echo "UPDATE framework_configs SET config_hash = 'framework-config-hash-001' WHERE id = 1;" >> "$output_file"
+    fi
+
+    # governance_teams.source_id (added in v1.5.3 via add_team_source_id_column)
+    if column_exists_sqlite "$config_db" "governance_teams" "source_id"; then
+      echo "UPDATE governance_teams SET source_id = NULL WHERE id = 'team-migration-test-1';" >> "$output_file"
+      echo "UPDATE governance_teams SET source_id = NULL WHERE id = 'team-migration-test-2';" >> "$output_file"
+    fi
+
+    # governance_teams.calendar_aligned (added in v1.5.3 via migrationAddTeamCalendarAlignedColumn)
+    if column_exists_sqlite "$config_db" "governance_teams" "calendar_aligned"; then
+      echo "UPDATE governance_teams SET calendar_aligned = 0 WHERE id = 'team-migration-test-1';" >> "$output_file"
+      echo "UPDATE governance_teams SET calendar_aligned = 0 WHERE id = 'team-migration-test-2';" >> "$output_file"
+    fi
+
+    # governance_virtual_keys.access_profile_id (added in v1.5.3 via add_vk_access_profile_id_column)
+    if column_exists_sqlite "$config_db" "governance_virtual_keys" "access_profile_id"; then
+      echo "UPDATE governance_virtual_keys SET access_profile_id = NULL WHERE id = 'vk-migration-test-1';" >> "$output_file"
+      echo "UPDATE governance_virtual_keys SET access_profile_id = NULL WHERE id = 'vk-migration-test-2';" >> "$output_file"
+    fi
   fi
+
+  # -------------------------------------------------------------------------
+  # v1.5.3 columns - log store tables (emitted unconditionally; fail silently on config_db)
+  # -------------------------------------------------------------------------
+
+  # logs.cluster_node_id (added in v1.5.3 via migrationAddClusterGovernanceColumns)
+  echo "UPDATE logs SET cluster_node_id = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
+  echo "UPDATE logs SET cluster_node_id = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
+  echo "UPDATE logs SET cluster_node_id = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
+
+  # logs.budget_ids (added in v1.5.3 via migrationAddClusterGovernanceColumns)
+  echo "UPDATE logs SET budget_ids = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
+  echo "UPDATE logs SET budget_ids = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
+  echo "UPDATE logs SET budget_ids = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
+
+  # logs.rate_limit_ids (added in v1.5.3 via migrationAddClusterGovernanceColumns)
+  echo "UPDATE logs SET rate_limit_ids = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
+  echo "UPDATE logs SET rate_limit_ids = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
+  echo "UPDATE logs SET rate_limit_ids = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
+
+  # mcp_tool_logs.user_id (added in v1.5.3 via migrationAddGovernanceColumnsToMCPToolLogs)
+  echo "UPDATE mcp_tool_logs SET user_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
+  echo "UPDATE mcp_tool_logs SET user_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
+
+  # mcp_tool_logs.team_id (added in v1.5.3 via migrationAddGovernanceColumnsToMCPToolLogs)
+  echo "UPDATE mcp_tool_logs SET team_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
+  echo "UPDATE mcp_tool_logs SET team_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
+
+  # mcp_tool_logs.customer_id (added in v1.5.3 via migrationAddGovernanceColumnsToMCPToolLogs)
+  echo "UPDATE mcp_tool_logs SET customer_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
+  echo "UPDATE mcp_tool_logs SET customer_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
+
+  # mcp_tool_logs.business_unit_id (added in v1.5.3 via migrationAddGovernanceColumnsToMCPToolLogs)
+  echo "UPDATE mcp_tool_logs SET business_unit_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
+  echo "UPDATE mcp_tool_logs SET business_unit_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
 }
 
 # ============================================================================
@@ -3069,45 +3231,61 @@ generate_per_user_oauth_tables_insert_postgres() {
   local now="$1"
   local output_file="$2"
 
-  # Check if the tables exist (added in v1.5.0-prerelease4)
-  if ! column_exists_postgres "oauth_per_user_clients" "id"; then
-    return
+  # Generate based on schema version:
+  # - If oauth_per_user_clients exists  -> v1.5.0-prerelease4 schema with all per-user tables
+  # - If oauth_per_user_clients dropped but oauth_user_sessions has session_id -> v1.5.3+ refactored schema
+  if column_exists_postgres "oauth_per_user_clients" "id"; then
+    echo "" >> "$output_file"
+    echo "-- ============================================================================" >> "$output_file"
+    echo "-- Per-User OAuth Tables (added in v1.5.0-prerelease4, dynamically generated)" >> "$output_file"
+    echo "-- ============================================================================" >> "$output_file"
+
+    # oauth_per_user_clients (no FK dependencies)
+    echo "" >> "$output_file"
+    echo "-- oauth_per_user_clients (registered OAuth clients for per-user flows)" >> "$output_file"
+    echo "INSERT INTO oauth_per_user_clients (id, client_id, client_name, redirect_uris, grant_types, created_at, updated_at) VALUES ('per-user-oauth-client-001', 'client-id-migration-test-001', 'Migration Test Client', '[\"http://localhost:3000/callback\"]', '[\"authorization_code\"]', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_per_user_sessions (client_id is a string field, no FK constraint enforced by DB)
+    echo "" >> "$output_file"
+    echo "-- oauth_per_user_sessions (Bifrost-issued sessions for authenticated MCP connections)" >> "$output_file"
+    echo "INSERT INTO oauth_per_user_sessions (id, access_token, access_token_hash, refresh_token, refresh_token_hash, client_id, virtual_key_id, user_id, expires_at, encryption_status, created_at, updated_at) VALUES ('per-user-oauth-session-001', 'migration-test-access-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3', '', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae4', 'client-id-migration-test-001', 'vk-migration-test-1', NULL, $now + INTERVAL '1 hour', 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_per_user_codes (references per_user_sessions.id as session_id, no enforced FK)
+    echo "" >> "$output_file"
+    echo "-- oauth_per_user_codes (short-lived authorization codes)" >> "$output_file"
+    echo "INSERT INTO oauth_per_user_codes (id, code, code_hash, client_id, redirect_uri, code_challenge, scopes, session_id, expires_at, used, created_at) VALUES ('per-user-oauth-code-001', 'migration-test-code-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae5', 'client-id-migration-test-001', 'http://localhost:3000/callback', 'migration-test-challenge-001', '[\"openid\"]', 'per-user-oauth-session-001', $now + INTERVAL '5 minutes', false, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_per_user_pending_flows (no enforced FK)
+    echo "" >> "$output_file"
+    echo "-- oauth_per_user_pending_flows (pending OAuth flows awaiting consent)" >> "$output_file"
+    echo "INSERT INTO oauth_per_user_pending_flows (id, client_id, redirect_uri, code_challenge, state, virtual_key_id, user_id, browser_secret_hash, expires_at, created_at, updated_at) VALUES ('per-user-oauth-flow-001', 'client-id-migration-test-001', 'http://localhost:3000/callback', 'migration-test-challenge-002', 'migration-test-state-001', NULL, NULL, 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae6', $now + INTERVAL '15 minutes', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_user_sessions (old prerelease4 schema: session_token, session_token_hash, gateway_session_id)
+    echo "" >> "$output_file"
+    echo "-- oauth_user_sessions (pending per-user OAuth flows)" >> "$output_file"
+    echo "INSERT INTO oauth_user_sessions (id, mcp_client_id, oauth_config_id, state, redirect_uri, code_verifier, session_token, session_token_hash, gateway_session_id, virtual_key_id, user_id, status, encryption_status, expires_at, created_at, updated_at) VALUES ('oauth-user-session-001', 'mcp-migration-test-001', 'oauth-config-migration-test-001', 'migration-test-state-002', 'http://localhost:3000/callback', 'migration-test-verifier-001', 'migration-test-session-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae7', 'gateway-session-001', 'vk-migration-test-1', NULL, 'authorized', 'plain_text', $now + INTERVAL '15 minutes', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_user_tokens (old prerelease4 schema: session_token, session_token_hash)
+    echo "" >> "$output_file"
+    echo "-- oauth_user_tokens (per-user OAuth credentials)" >> "$output_file"
+    echo "INSERT INTO oauth_user_tokens (id, session_token, session_token_hash, virtual_key_id, user_id, mcp_client_id, oauth_config_id, access_token, refresh_token, token_type, expires_at, scopes, last_refreshed_at, encryption_status, created_at, updated_at) VALUES ('oauth-user-token-001', 'migration-test-session-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae7', 'vk-migration-test-1', NULL, 'mcp-migration-test-001', 'oauth-config-migration-test-001', 'migration-test-user-access-token-001', '', 'Bearer', $now + INTERVAL '1 hour', '[\"openid\"]', NULL, 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+  elif column_exists_postgres "oauth_user_sessions" "session_id"; then
+    # v1.5.3+: oauth_per_user_* tables dropped; oauth_user_sessions/tokens refactored.
+    # New schema uses session_id + flow_mode instead of session_token/session_token_hash/gateway_session_id.
+    echo "" >> "$output_file"
+    echo "-- ============================================================================" >> "$output_file"
+    echo "-- OAuth User Tables (v1.5.3+ refactored schema, dynamically generated)" >> "$output_file"
+    echo "-- ============================================================================" >> "$output_file"
+
+    echo "" >> "$output_file"
+    echo "-- oauth_user_sessions (v1.5.3+ schema: session_id + flow_mode, no session_token/gateway_session_id)" >> "$output_file"
+    echo "INSERT INTO oauth_user_sessions (id, mcp_client_id, oauth_config_id, state, redirect_uri, code_verifier, session_id, virtual_key_id, user_id, flow_mode, status, encryption_status, expires_at, created_at, updated_at) VALUES ('oauth-user-session-001', 'mcp-migration-test-001', 'oauth-config-migration-test-001', 'migration-test-state-002', 'http://localhost:3000/callback', 'migration-test-verifier-001', '', 'vk-migration-test-1', NULL, 'vk', 'authorized', 'plain_text', $now + INTERVAL '15 minutes', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    echo "" >> "$output_file"
+    echo "-- oauth_user_tokens (v1.5.3+ schema: session_id + auth_mode + status, no session_token)" >> "$output_file"
+    echo "INSERT INTO oauth_user_tokens (id, session_id, virtual_key_id, user_id, mcp_client_id, auth_mode, status, oauth_config_id, access_token, refresh_token, token_type, expires_at, scopes, last_refreshed_at, encryption_status, created_at, updated_at) VALUES ('oauth-user-token-001', '', 'vk-migration-test-1', NULL, 'mcp-migration-test-001', 'vk', 'active', 'oauth-config-migration-test-001', 'migration-test-user-access-token-001', '', 'Bearer', $now + INTERVAL '1 hour', '[\"openid\"]', NULL, 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
   fi
-
-  echo "" >> "$output_file"
-  echo "-- ============================================================================" >> "$output_file"
-  echo "-- Per-User OAuth Tables (added in v1.5.0-prerelease4, dynamically generated)" >> "$output_file"
-  echo "-- ============================================================================" >> "$output_file"
-
-  # oauth_per_user_clients (no FK dependencies)
-  echo "" >> "$output_file"
-  echo "-- oauth_per_user_clients (registered OAuth clients for per-user flows)" >> "$output_file"
-  echo "INSERT INTO oauth_per_user_clients (id, client_id, client_name, redirect_uris, grant_types, created_at, updated_at) VALUES ('per-user-oauth-client-001', 'client-id-migration-test-001', 'Migration Test Client', '[\"http://localhost:3000/callback\"]', '[\"authorization_code\"]', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
-
-  # oauth_per_user_sessions (client_id is a string field, no FK constraint enforced by DB)
-  echo "" >> "$output_file"
-  echo "-- oauth_per_user_sessions (Bifrost-issued sessions for authenticated MCP connections)" >> "$output_file"
-  echo "INSERT INTO oauth_per_user_sessions (id, access_token, access_token_hash, refresh_token, refresh_token_hash, client_id, virtual_key_id, user_id, expires_at, encryption_status, created_at, updated_at) VALUES ('per-user-oauth-session-001', 'migration-test-access-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3', '', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae4', 'client-id-migration-test-001', 'vk-migration-test-1', NULL, $now + INTERVAL '1 hour', 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
-
-  # oauth_per_user_codes (references per_user_sessions.id as session_id, no enforced FK)
-  echo "" >> "$output_file"
-  echo "-- oauth_per_user_codes (short-lived authorization codes)" >> "$output_file"
-  echo "INSERT INTO oauth_per_user_codes (id, code, code_hash, client_id, redirect_uri, code_challenge, scopes, session_id, expires_at, used, created_at) VALUES ('per-user-oauth-code-001', 'migration-test-code-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae5', 'client-id-migration-test-001', 'http://localhost:3000/callback', 'migration-test-challenge-001', '[\"openid\"]', 'per-user-oauth-session-001', $now + INTERVAL '5 minutes', false, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
-
-  # oauth_per_user_pending_flows (no enforced FK)
-  echo "" >> "$output_file"
-  echo "-- oauth_per_user_pending_flows (pending OAuth flows awaiting consent)" >> "$output_file"
-  echo "INSERT INTO oauth_per_user_pending_flows (id, client_id, redirect_uri, code_challenge, state, virtual_key_id, user_id, browser_secret_hash, expires_at, created_at, updated_at) VALUES ('per-user-oauth-flow-001', 'client-id-migration-test-001', 'http://localhost:3000/callback', 'migration-test-challenge-002', 'migration-test-state-001', NULL, NULL, 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae6', $now + INTERVAL '15 minutes', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
-
-  # oauth_user_sessions (per-user OAuth flow tracking - no enforced FK)
-  echo "" >> "$output_file"
-  echo "-- oauth_user_sessions (pending per-user OAuth flows)" >> "$output_file"
-  echo "INSERT INTO oauth_user_sessions (id, mcp_client_id, oauth_config_id, state, redirect_uri, code_verifier, session_token, session_token_hash, gateway_session_id, virtual_key_id, user_id, status, encryption_status, expires_at, created_at, updated_at) VALUES ('oauth-user-session-001', 'mcp-migration-test-001', 'oauth-config-migration-001', 'migration-test-state-002', 'http://localhost:3000/callback', 'migration-test-verifier-001', 'migration-test-session-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae7', 'gateway-session-001', 'vk-migration-test-1', NULL, 'authorized', 'plain_text', $now + INTERVAL '15 minutes', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
-
-  # oauth_user_tokens (stores per-user access/refresh tokens - no enforced FK)
-  echo "" >> "$output_file"
-  echo "-- oauth_user_tokens (per-user OAuth credentials)" >> "$output_file"
-  echo "INSERT INTO oauth_user_tokens (id, session_token, session_token_hash, virtual_key_id, user_id, mcp_client_id, oauth_config_id, access_token, refresh_token, token_type, expires_at, scopes, last_refreshed_at, encryption_status, created_at, updated_at) VALUES ('oauth-user-token-001', 'migration-test-session-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae7', 'vk-migration-test-1', NULL, 'mcp-migration-test-001', 'oauth-config-migration-001', 'migration-test-user-access-token-001', '', 'Bearer', $now + INTERVAL '1 hour', '[\"openid\"]', NULL, 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
 }
 
 # Generate per-user OAuth tables INSERTs for SQLite
@@ -3121,46 +3299,127 @@ generate_per_user_oauth_tables_insert_sqlite() {
     return
   fi
 
-  local table_exists
-  table_exists=$(sqlite3 "$config_db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='oauth_per_user_clients';" 2>/dev/null || echo "0")
-  if [ "$table_exists" != "1" ]; then
+  local oauth_per_user_clients_exists
+  oauth_per_user_clients_exists=$(sqlite3 "$config_db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='oauth_per_user_clients';" 2>/dev/null || echo "0")
+
+  if [ "$oauth_per_user_clients_exists" = "1" ]; then
+    echo "" >> "$output_file"
+    echo "-- ============================================================================" >> "$output_file"
+    echo "-- Per-User OAuth Tables (added in v1.5.0-prerelease4, dynamically generated)" >> "$output_file"
+    echo "-- ============================================================================" >> "$output_file"
+
+    # oauth_per_user_clients
+    echo "" >> "$output_file"
+    echo "-- oauth_per_user_clients" >> "$output_file"
+    echo "INSERT INTO oauth_per_user_clients (id, client_id, client_name, redirect_uris, grant_types, created_at, updated_at) VALUES ('per-user-oauth-client-001', 'client-id-migration-test-001', 'Migration Test Client', '[\"http://localhost:3000/callback\"]', '[\"authorization_code\"]', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_per_user_sessions
+    echo "" >> "$output_file"
+    echo "-- oauth_per_user_sessions" >> "$output_file"
+    echo "INSERT INTO oauth_per_user_sessions (id, access_token, access_token_hash, refresh_token, refresh_token_hash, client_id, virtual_key_id, user_id, expires_at, encryption_status, created_at, updated_at) VALUES ('per-user-oauth-session-001', 'migration-test-access-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3', '', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae4', 'client-id-migration-test-001', 'vk-migration-test-1', NULL, datetime('now', '+1 hour'), 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_per_user_codes
+    echo "" >> "$output_file"
+    echo "-- oauth_per_user_codes" >> "$output_file"
+    echo "INSERT INTO oauth_per_user_codes (id, code, code_hash, client_id, redirect_uri, code_challenge, scopes, session_id, expires_at, used, created_at) VALUES ('per-user-oauth-code-001', 'migration-test-code-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae5', 'client-id-migration-test-001', 'http://localhost:3000/callback', 'migration-test-challenge-001', '[\"openid\"]', 'per-user-oauth-session-001', datetime('now', '+5 minutes'), 0, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_per_user_pending_flows
+    echo "" >> "$output_file"
+    echo "-- oauth_per_user_pending_flows" >> "$output_file"
+    echo "INSERT INTO oauth_per_user_pending_flows (id, client_id, redirect_uri, code_challenge, state, virtual_key_id, user_id, browser_secret_hash, expires_at, created_at, updated_at) VALUES ('per-user-oauth-flow-001', 'client-id-migration-test-001', 'http://localhost:3000/callback', 'migration-test-challenge-002', 'migration-test-state-001', NULL, NULL, 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae6', datetime('now', '+15 minutes'), $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_user_sessions (old prerelease4 schema: session_token, session_token_hash, gateway_session_id)
+    echo "" >> "$output_file"
+    echo "-- oauth_user_sessions" >> "$output_file"
+    echo "INSERT INTO oauth_user_sessions (id, mcp_client_id, oauth_config_id, state, redirect_uri, code_verifier, session_token, session_token_hash, gateway_session_id, virtual_key_id, user_id, status, encryption_status, expires_at, created_at, updated_at) VALUES ('oauth-user-session-001', 'mcp-migration-test-001', 'oauth-config-migration-test-001', 'migration-test-state-002', 'http://localhost:3000/callback', 'migration-test-verifier-001', 'migration-test-session-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae7', 'gateway-session-001', 'vk-migration-test-1', NULL, 'authorized', 'plain_text', datetime('now', '+15 minutes'), $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    # oauth_user_tokens (old prerelease4 schema: session_token, session_token_hash)
+    echo "" >> "$output_file"
+    echo "-- oauth_user_tokens" >> "$output_file"
+    echo "INSERT INTO oauth_user_tokens (id, session_token, session_token_hash, virtual_key_id, user_id, mcp_client_id, oauth_config_id, access_token, refresh_token, token_type, expires_at, scopes, last_refreshed_at, encryption_status, created_at, updated_at) VALUES ('oauth-user-token-001', 'migration-test-session-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae7', 'vk-migration-test-1', NULL, 'mcp-migration-test-001', 'oauth-config-migration-test-001', 'migration-test-user-access-token-001', '', 'Bearer', datetime('now', '+1 hour'), '[\"openid\"]', NULL, 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+  elif column_exists_sqlite "$config_db" "oauth_user_sessions" "session_id"; then
+    # v1.5.3+: oauth_per_user_* tables dropped; oauth_user_sessions/tokens refactored.
+    # New schema uses session_id + flow_mode instead of session_token/session_token_hash/gateway_session_id.
+    echo "" >> "$output_file"
+    echo "-- ============================================================================" >> "$output_file"
+    echo "-- OAuth User Tables (v1.5.3+ refactored schema, dynamically generated)" >> "$output_file"
+    echo "-- ============================================================================" >> "$output_file"
+
+    echo "" >> "$output_file"
+    echo "-- oauth_user_sessions (v1.5.3+ schema: session_id + flow_mode, no session_token/gateway_session_id)" >> "$output_file"
+    echo "INSERT INTO oauth_user_sessions (id, mcp_client_id, oauth_config_id, state, redirect_uri, code_verifier, session_id, virtual_key_id, user_id, flow_mode, status, encryption_status, expires_at, created_at, updated_at) VALUES ('oauth-user-session-001', 'mcp-migration-test-001', 'oauth-config-migration-test-001', 'migration-test-state-002', 'http://localhost:3000/callback', 'migration-test-verifier-001', '', 'vk-migration-test-1', NULL, 'vk', 'authorized', 'plain_text', datetime('now', '+15 minutes'), $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+    echo "" >> "$output_file"
+    echo "-- oauth_user_tokens (v1.5.3+ schema: session_id + auth_mode + status, no session_token)" >> "$output_file"
+    echo "INSERT INTO oauth_user_tokens (id, session_id, virtual_key_id, user_id, mcp_client_id, auth_mode, status, oauth_config_id, access_token, refresh_token, token_type, expires_at, scopes, last_refreshed_at, encryption_status, created_at, updated_at) VALUES ('oauth-user-token-001', '', 'vk-migration-test-1', NULL, 'mcp-migration-test-001', 'vk', 'active', 'oauth-config-migration-test-001', 'migration-test-user-access-token-001', '', 'Bearer', datetime('now', '+1 hour'), '[\"openid\"]', NULL, 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  fi
+}
+
+# Generate feature_flags INSERT for PostgreSQL (added in v1.5.3 via migrationAddFeatureFlagsTable)
+generate_feature_flags_insert_postgres() {
+  local now="$1"
+  local output_file="$2"
+
+  if ! column_exists_postgres "feature_flags" "id"; then
     return
   fi
 
   echo "" >> "$output_file"
-  echo "-- ============================================================================" >> "$output_file"
-  echo "-- Per-User OAuth Tables (added in v1.5.0-prerelease4, dynamically generated)" >> "$output_file"
-  echo "-- ============================================================================" >> "$output_file"
+  echo "-- feature_flags (user-toggled feature flag overrides - added in v1.5.3, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO feature_flags (id, enabled, updated_at) VALUES ('migration-test-flag-001', false, extract(epoch from NOW())::bigint * 1000) ON CONFLICT DO NOTHING;" >> "$output_file"
+}
 
-  # oauth_per_user_clients
-  echo "" >> "$output_file"
-  echo "-- oauth_per_user_clients" >> "$output_file"
-  echo "INSERT INTO oauth_per_user_clients (id, client_id, client_name, redirect_uris, grant_types, created_at, updated_at) VALUES ('per-user-oauth-client-001', 'client-id-migration-test-001', 'Migration Test Client', '[\"http://localhost:3000/callback\"]', '[\"authorization_code\"]', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+# Generate feature_flags INSERT for SQLite (added in v1.5.3 via migrationAddFeatureFlagsTable)
+generate_feature_flags_insert_sqlite() {
+  local now="$1"
+  local output_file="$2"
+  local config_db="$3"
 
-  # oauth_per_user_sessions
-  echo "" >> "$output_file"
-  echo "-- oauth_per_user_sessions" >> "$output_file"
-  echo "INSERT INTO oauth_per_user_sessions (id, access_token, access_token_hash, refresh_token, refresh_token_hash, client_id, virtual_key_id, user_id, expires_at, encryption_status, created_at, updated_at) VALUES ('per-user-oauth-session-001', 'migration-test-access-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3', '', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae4', 'client-id-migration-test-001', 'vk-migration-test-1', NULL, datetime('now', '+1 hour'), 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  if [ ! -f "$config_db" ]; then
+    return
+  fi
 
-  # oauth_per_user_codes
-  echo "" >> "$output_file"
-  echo "-- oauth_per_user_codes" >> "$output_file"
-  echo "INSERT INTO oauth_per_user_codes (id, code, code_hash, client_id, redirect_uri, code_challenge, scopes, session_id, expires_at, used, created_at) VALUES ('per-user-oauth-code-001', 'migration-test-code-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae5', 'client-id-migration-test-001', 'http://localhost:3000/callback', 'migration-test-challenge-001', '[\"openid\"]', 'per-user-oauth-session-001', datetime('now', '+5 minutes'), 0, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  if ! column_exists_sqlite "$config_db" "feature_flags" "id"; then
+    return
+  fi
 
-  # oauth_per_user_pending_flows
   echo "" >> "$output_file"
-  echo "-- oauth_per_user_pending_flows" >> "$output_file"
-  echo "INSERT INTO oauth_per_user_pending_flows (id, client_id, redirect_uri, code_challenge, state, virtual_key_id, user_id, browser_secret_hash, expires_at, created_at, updated_at) VALUES ('per-user-oauth-flow-001', 'client-id-migration-test-001', 'http://localhost:3000/callback', 'migration-test-challenge-002', 'migration-test-state-001', NULL, NULL, 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae6', datetime('now', '+15 minutes'), $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "-- feature_flags (user-toggled feature flag overrides - added in v1.5.3, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO feature_flags (id, enabled, updated_at) VALUES ('migration-test-flag-001', 0, cast(strftime('%s', 'now') as integer) * 1000) ON CONFLICT DO NOTHING;" >> "$output_file"
+}
 
-  # oauth_user_sessions
-  echo "" >> "$output_file"
-  echo "-- oauth_user_sessions" >> "$output_file"
-  echo "INSERT INTO oauth_user_sessions (id, mcp_client_id, oauth_config_id, state, redirect_uri, code_verifier, session_token, session_token_hash, gateway_session_id, virtual_key_id, user_id, status, encryption_status, expires_at, created_at, updated_at) VALUES ('oauth-user-session-001', 'mcp-migration-test-001', 'oauth-config-migration-001', 'migration-test-state-002', 'http://localhost:3000/callback', 'migration-test-verifier-001', 'migration-test-session-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae7', 'gateway-session-001', 'vk-migration-test-1', NULL, 'authorized', 'plain_text', datetime('now', '+15 minutes'), $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+# Generate temp_tokens INSERT for PostgreSQL (added in v1.5.3 via migrationAddTempTokensTable)
+generate_temp_tokens_insert_postgres() {
+  local now="$1"
+  local output_file="$2"
 
-  # oauth_user_tokens
+  if ! column_exists_postgres "temp_tokens" "id"; then
+    return
+  fi
+
   echo "" >> "$output_file"
-  echo "-- oauth_user_tokens" >> "$output_file"
-  echo "INSERT INTO oauth_user_tokens (id, session_token, session_token_hash, virtual_key_id, user_id, mcp_client_id, oauth_config_id, access_token, refresh_token, token_type, expires_at, scopes, last_refreshed_at, encryption_status, created_at, updated_at) VALUES ('oauth-user-token-001', 'migration-test-session-token-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae7', 'vk-migration-test-1', NULL, 'mcp-migration-test-001', 'oauth-config-migration-001', 'migration-test-user-access-token-001', '', 'Bearer', datetime('now', '+1 hour'), '[\"openid\"]', NULL, 'plain_text', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "-- temp_tokens (short-lived narrow-scope credentials - added in v1.5.3, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO temp_tokens (id, token, token_hash, scope, resource_id, expires_at, created_at, updated_at, encryption_status) VALUES ('temp-token-migration-test-001', 'migration-test-temp-token-value-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3', 'mcp_auth', 'oauth-config-migration-test-001', $now + INTERVAL '15 minutes', $now, $now, 'plain_text') ON CONFLICT DO NOTHING;" >> "$output_file"
+}
+
+# Generate temp_tokens INSERT for SQLite (added in v1.5.3 via migrationAddTempTokensTable)
+generate_temp_tokens_insert_sqlite() {
+  local now="$1"
+  local output_file="$2"
+  local config_db="$3"
+
+  if [ ! -f "$config_db" ]; then
+    return
+  fi
+
+  if ! column_exists_sqlite "$config_db" "temp_tokens" "id"; then
+    return
+  fi
+
+  echo "" >> "$output_file"
+  echo "-- temp_tokens (short-lived narrow-scope credentials - added in v1.5.3, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO temp_tokens (id, token, token_hash, scope, resource_id, expires_at, created_at, updated_at, encryption_status) VALUES ('temp-token-migration-test-001', 'migration-test-temp-token-value-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3', 'mcp_auth', 'oauth-config-migration-test-001', datetime('now', '+15 minutes'), $now, $now, 'plain_text') ON CONFLICT DO NOTHING;" >> "$output_file"
 }
 
 # Generate governance_model_parameters INSERT for PostgreSQL
@@ -3584,8 +3843,13 @@ compare_postgres_snapshots() {
     fi
     # budget_id (dropped from governance_virtual_keys and governance_virtual_key_provider_configs
     # in add_multi_budget_tables - ownership moved to governance_budgets.virtual_key_id/provider_config_id)
+    # access_profile_id (dropped from governance_virtual_keys in v1.5.3 via migrationDropVKAccessProfileIDColumn -
+    # the add migration ran transiently in v1.5.2 but the feature was reverted before stable release)
     if [ "$table" = "governance_virtual_keys" ] || [ "$table" = "governance_virtual_key_provider_configs" ]; then
       dropped_columns="$dropped_columns budget_id"
+    fi
+    if [ "$table" = "governance_virtual_keys" ]; then
+      dropped_columns="$dropped_columns access_profile_id"
     fi
     # budget_id (dropped from governance_teams in migrationAddTeamBudgetsToBudgetsTable v1.5.0-prerelease4 -
     # ownership moved to governance_budgets.team_id)
@@ -3693,6 +3957,12 @@ compare_postgres_snapshots() {
       # legacy minute values to seconds (e.g. 5 → 300), so this column intentionally changes.
       if [ "$table" = "config_mcp_clients" ]; then
         table_ignore_columns="$table_ignore_columns tool_sync_interval"
+      fi
+      # model_parameters_url: set to DefaultModelParametersURL by initFrameworkConfig on every
+      # startup (via ResolveFrameworkPricingConfig), so it changes from NULL to the URL when
+      # bifrost first starts after the add_model_parameters_url_column migration.
+      if [ "$table" = "framework_configs" ]; then
+        table_ignore_columns="$table_ignore_columns model_parameters_url"
       fi
       if [[ " $table_ignore_columns " == *" $col "* ]]; then
         col_idx=$((col_idx + 1))

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -771,6 +771,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddVKAccessProfileIDColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationDropVKAccessProfileIDColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddFeatureFlagsTable(ctx, db); err != nil {
 		return err
 	}
@@ -8418,41 +8421,7 @@ func migrationAddTeamCalendarAlignedColumn(ctx context.Context, db *gorm.DB) err
 	return nil
 }
 
-// migrationAddVKAccessProfileIDColumn adds access_profile_id to governance_virtual_keys
-// so that existing VKs can be attached directly to an access profile template (enterprise feature).
-func migrationAddVKAccessProfileIDColumn(ctx context.Context, db *gorm.DB) error {
-	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
-		ID: "add_vk_access_profile_id_column",
-		Migrate: func(tx *gorm.DB) error {
-			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if !mig.HasColumn(&tables.TableVirtualKey{}, "access_profile_id") {
-				if err := mig.AddColumn(&tables.TableVirtualKey{}, "AccessProfileID"); err != nil {
-					return fmt.Errorf("failed to add access_profile_id column to governance_virtual_keys: %w", err)
-				}
-			}
-			if !mig.HasIndex(&tables.TableVirtualKey{}, "idx_governance_virtual_keys_access_profile_id") {
-				if err := mig.CreateIndex(&tables.TableVirtualKey{}, "AccessProfileID"); err != nil {
-					return fmt.Errorf("failed to create index on governance_virtual_keys.access_profile_id: %w", err)
-				}
-			}
-			return nil
-		},
-		Rollback: func(tx *gorm.DB) error {
-			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&tables.TableVirtualKey{}, "access_profile_id") {
-				return mig.DropColumn(&tables.TableVirtualKey{}, "access_profile_id")
-			}
-			return nil
-		},
-	}})
-	if err := m.Migrate(); err != nil {
-		return fmt.Errorf("error running add_vk_access_profile_id_column migration: %s", err.Error())
-	}
-	return nil
-}
-
+// migrationAddModelParametersURLColumn adds the model_parameters_url column to framework_configs.
 func migrationAddModelParametersURLColumn(ctx context.Context, db *gorm.DB) error {
 	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
 		ID: "add_model_parameters_url_column",
@@ -8579,6 +8548,56 @@ func migrationAddVirtualKeyBlacklistedModelsColumn(ctx context.Context, db *gorm
 						Update("config_hash", newHash).Error; err != nil {
 						return fmt.Errorf("failed to update config_hash for VK %s: %w", vk.ID, err)
 					}
+
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_vk_provider_config_blacklisted_models_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddVKAccessProfileIDColumn adds the access_profile_id column to governance_virtual_keys.
+func migrationAddVKAccessProfileIDColumn(_ context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_vk_access_profile_id_column",
+		Migrate: func(tx *gorm.DB) error {
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_vk_access_profile_id_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationDropVKAccessProfileIDColumn drops the access_profile_id column and its
+// index from governance_virtual_keys, reverting migrationAddVKAccessProfileIDColumn.
+func migrationDropVKAccessProfileIDColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "drop_vk_access_profile_id_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			// DROP INDEX IF EXISTS avoids aborting the Postgres transaction when
+			// the index was never created (e.g. fresh installs where the add
+			// migration ran as a no-op).
+			if err := tx.Exec("DROP INDEX IF EXISTS idx_governance_virtual_keys_access_profile_id").Error; err != nil {
+				return fmt.Errorf("failed to drop index idx_governance_virtual_keys_access_profile_id: %w", err)
+			}
+			// Use raw ALTER TABLE instead of GORM's DropColumn: GORM's SQLite
+			// DropColumn does a full table rebuild inside a transaction where
+			// PRAGMA foreign_keys cannot be disabled, causing FK checks on
+			// unrelated columns to fail against test data.
+			// ALTER TABLE DROP COLUMN (SQLite 3.35+) modifies the schema in place.
+			if tx.Migrator().HasColumn("governance_virtual_keys", "access_profile_id") {
+				if err := tx.Exec("ALTER TABLE governance_virtual_keys DROP COLUMN access_profile_id").Error; err != nil {
+					return fmt.Errorf("failed to drop access_profile_id column from governance_virtual_keys: %w", err)
 				}
 			}
 			return nil
@@ -8595,7 +8614,7 @@ func migrationAddVirtualKeyBlacklistedModelsColumn(ctx context.Context, db *gorm
 		},
 	}})
 	if err := m.Migrate(); err != nil {
-		return fmt.Errorf("error running add_vk_provider_config_blacklisted_models_column migration: %s", err.Error())
+		return fmt.Errorf("error running drop_vk_access_profile_id_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2417,8 +2417,6 @@ func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params Vir
 		baseQuery = baseQuery.Where("customer_id = ?", params.CustomerID)
 	} else if params.TeamID != "" {
 		baseQuery = baseQuery.Where("team_id = ?", params.TeamID)
-	} else if params.AccessProfileID > 0 {
-		baseQuery = baseQuery.Where("access_profile_id = ?", params.AccessProfileID)
 	}
 	if params.Search != "" {
 		search := "%" + strings.ToLower(params.Search) + "%"

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -20,7 +20,6 @@ type VirtualKeyQueryParams struct {
 	Search                             string
 	CustomerID                         string
 	TeamID                             string
-	AccessProfileID                    uint // When set, return VKs attached to this access profile template
 	SortBy                             string // name, budget_spent, created_at, status (default: created_at)
 	Order                              string // asc, desc (default: asc)
 	Export                             bool   // When true, skip default pagination limits (caller controls limit)

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -215,11 +215,10 @@ type TableVirtualKey struct {
 	ProviderConfigs []TableVirtualKeyProviderConfig `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"provider_configs"` // Empty means no providers allowed (deny-by-default)
 	MCPConfigs      []TableVirtualKeyMCPConfig      `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"mcp_configs"`
 
-	// Foreign key relationships (mutually exclusive: TeamID, CustomerID, or AccessProfileID)
-	TeamID          *string `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
-	CustomerID      *string `gorm:"type:varchar(255);index" json:"customer_id,omitempty"`
-	AccessProfileID *uint   `gorm:"index" json:"access_profile_id,omitempty"`
-	RateLimitID     *string `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
+	// Foreign key relationships (mutually exclusive: either TeamID or CustomerID, not both)
+	TeamID      *string `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
+	CustomerID  *string `gorm:"type:varchar(255);index" json:"customer_id,omitempty"`
+	RateLimitID *string `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
 
 	CalendarAligned bool `gorm:"default:false" json:"calendar_aligned"`
 
@@ -254,22 +253,13 @@ func (vk *TableVirtualKey) IsActiveValue() bool {
 	return *vk.IsActive
 }
 
-// BeforeSave is a GORM hook that enforces mutual exclusion among team, customer, and
-// access profile attachments, computes a SHA-256 hash of the plaintext value for indexed
-// lookups, and encrypts the virtual key value before writing to the database.
+// BeforeSave is a GORM hook that enforces mutual exclusion (team vs customer), computes
+// a SHA-256 hash of the plaintext value for indexed lookups, and encrypts the virtual key
+// value before writing to the database.
 func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
-	entityCount := 0
-	if vk.TeamID != nil {
-		entityCount++
-	}
-	if vk.CustomerID != nil {
-		entityCount++
-	}
-	if vk.AccessProfileID != nil && *vk.AccessProfileID > 0 {
-		entityCount++
-	}
-	if entityCount > 1 {
-		return fmt.Errorf("virtual key can only be attached to one of: team, customer, or access profile")
+	// Enforce mutual exclusion: VK can belong to either Team OR Customer, not both
+	if vk.TeamID != nil && vk.CustomerID != nil {
+		return fmt.Errorf("virtual key cannot belong to both team and customer")
 	}
 
 	// Hash must be computed before encryption (from plaintext value)

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -92,10 +92,9 @@ type CreateVirtualKeyRequest struct {
 		MCPClientName  string            `json:"mcp_client_name" validate:"required"`
 		ToolsToExecute schemas.WhiteList `json:"tools_to_execute,omitempty"`
 	} `json:"mcp_configs,omitempty"` // Empty means no MCP clients allowed (deny-by-default)
-	TeamID          *string                 `json:"team_id,omitempty"`           // Mutually exclusive with CustomerID and AccessProfileID
-	CustomerID      *string                 `json:"customer_id,omitempty"`       // Mutually exclusive with TeamID and AccessProfileID
-	AccessProfileID *uint                   `json:"access_profile_id,omitempty"` // Mutually exclusive with TeamID and CustomerID
-	Budgets         []CreateBudgetRequest   `json:"budgets,omitempty"`           // Multi-budget: each must have a unique reset_duration
+	TeamID          *string                 `json:"team_id,omitempty"`     // Mutually exclusive with CustomerID
+	CustomerID      *string                 `json:"customer_id,omitempty"` // Mutually exclusive with TeamID
+	Budgets         []CreateBudgetRequest   `json:"budgets,omitempty"`     // Multi-budget: each must have a unique reset_duration
 	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`
 	IsActive        *bool                   `json:"is_active,omitempty"`
 	CalendarAligned bool                    `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
@@ -122,7 +121,6 @@ type UpdateVirtualKeyRequest struct {
 	} `json:"mcp_configs,omitempty"`
 	TeamID           *string                 `json:"team_id,omitempty"`
 	CustomerID       *string                 `json:"customer_id,omitempty"`
-	AccessProfileID  *uint                   `json:"access_profile_id,omitempty"`
 	Budgets          []CreateBudgetRequest   `json:"budgets,omitempty"` // Multi-budget: replaces all VK-level budgets
 	RateLimit        *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
 	IsActive         *bool                   `json:"is_active,omitempty"`
@@ -477,13 +475,12 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 	search := string(ctx.QueryArgs().Peek("search"))
 	customerID := string(ctx.QueryArgs().Peek("customer_id"))
 	teamID := string(ctx.QueryArgs().Peek("team_id"))
-	accessProfileIDStr := string(ctx.QueryArgs().Peek("access_profile_id"))
 	sortBy := string(ctx.QueryArgs().Peek("sort_by"))
 	order := string(ctx.QueryArgs().Peek("order"))
 	isExport := string(ctx.QueryArgs().Peek("export")) == "true"
 	excludeAccessProfileManagedVirtual := string(ctx.QueryArgs().Peek("exclude_access_profile_managed_virtual")) == "true"
 
-	if limitStr != "" || offsetStr != "" || search != "" || customerID != "" || teamID != "" || accessProfileIDStr != "" || sortBy != "" || isExport || excludeAccessProfileManagedVirtual {
+	if limitStr != "" || offsetStr != "" || search != "" || customerID != "" || teamID != "" || sortBy != "" || isExport || excludeAccessProfileManagedVirtual {
 		// Paginated/filtered path
 		params := configstore.VirtualKeyQueryParams{
 			Search:                             search,
@@ -493,18 +490,6 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 			Order:                              order,
 			Export:                             isExport,
 			ExcludeAccessProfileManagedVirtual: excludeAccessProfileManagedVirtual,
-		}
-		if accessProfileIDStr != "" {
-			apID, err := strconv.ParseUint(accessProfileIDStr, 10, 0)
-			if err != nil {
-				SendError(ctx, 400, "Invalid access_profile_id parameter: must be a number")
-				return
-			}
-			if (customerID != "" || teamID != "") && apID > 0 {
-				SendError(ctx, 400, "access_profile_id cannot be combined with team_id or customer_id filters")
-				return
-			}
-			params.AccessProfileID = uint(apID)
 		}
 		if limitStr != "" {
 			n, err := strconv.Atoi(limitStr)
@@ -580,19 +565,9 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, "Virtual key name is required")
 		return
 	}
-	// Validate mutually exclusive TeamID, CustomerID, and AccessProfileID
-	entityCount := 0
-	if req.TeamID != nil {
-		entityCount++
-	}
-	if req.CustomerID != nil {
-		entityCount++
-	}
-	if req.AccessProfileID != nil && *req.AccessProfileID > 0 {
-		entityCount++
-	}
-	if entityCount > 1 {
-		SendError(ctx, 400, "VirtualKey can only be attached to one of: Team, Customer, or AccessProfile")
+	// Validate mutually exclusive TeamID and CustomerID
+	if req.TeamID != nil && req.CustomerID != nil {
+		SendError(ctx, 400, "VirtualKey cannot be attached to both Team and Customer")
 		return
 	}
 	// Validate budgets if provided
@@ -638,7 +613,6 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 			Description:     req.Description,
 			TeamID:          req.TeamID,
 			CustomerID:      req.CustomerID,
-			AccessProfileID: req.AccessProfileID,
 			IsActive:        isActive,
 			CalendarAligned: req.CalendarAligned,
 		}
@@ -870,19 +844,9 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, "Invalid JSON")
 		return
 	}
-	// Validate mutually exclusive TeamID, CustomerID, and AccessProfileID
-	entityCount := 0
-	if req.TeamID != nil {
-		entityCount++
-	}
-	if req.CustomerID != nil {
-		entityCount++
-	}
-	if req.AccessProfileID != nil && *req.AccessProfileID > 0 {
-		entityCount++
-	}
-	if entityCount > 1 {
-		SendError(ctx, 400, "VirtualKey can only be attached to one of: Team, Customer, or AccessProfile")
+	// Validate mutually exclusive TeamID and CustomerID
+	if req.TeamID != nil && req.CustomerID != nil {
+		SendError(ctx, 400, "VirtualKey cannot be attached to both Team and Customer")
 		return
 	}
 	vk, err := h.configStore.GetVirtualKey(ctx, vkID)
@@ -934,21 +898,16 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		}
 		if req.TeamID != nil {
 			vk.TeamID = req.TeamID
-			vk.CustomerID = nil
-			vk.AccessProfileID = nil
-		} else if req.CustomerID != nil {
+			vk.CustomerID = nil // Clear CustomerID if setting TeamID
+		}
+		if req.CustomerID != nil {
 			vk.CustomerID = req.CustomerID
-			vk.TeamID = nil
-			vk.AccessProfileID = nil
-		} else if req.AccessProfileID != nil {
-			vk.AccessProfileID = req.AccessProfileID
-			vk.TeamID = nil
-			vk.CustomerID = nil
-		} else {
-			// All nil — clear entity assignment
+			vk.TeamID = nil // Clear TeamID if setting CustomerID
+		}
+		// When both TeamID and CustomerID are nil
+		if req.TeamID == nil && req.CustomerID == nil {
 			vk.TeamID = nil
 			vk.CustomerID = nil
-			vk.AccessProfileID = nil
 		}
 		if req.IsActive != nil {
 			vk.IsActive = req.IsActive
@@ -1083,13 +1042,6 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 
 		if err := h.configStore.UpdateVirtualKey(ctx, vk, tx); err != nil {
 			return err
-		}
-		// UpdateVirtualKey's Select list excludes access_profile_id to protect config-sync paths.
-		// Persist it separately so API-driven entity assignment is always saved.
-		if err := tx.Model(&configstoreTables.TableVirtualKey{}).
-			Where("id = ?", vk.ID).
-			Updates(map[string]interface{}{"access_profile_id": vk.AccessProfileID}).Error; err != nil {
-			return fmt.Errorf("failed to update virtual key access_profile_id: %w", err)
 		}
 		if req.ProviderConfigs != nil {
 			// Get existing provider configs for comparison

--- a/ui/app/_fallbacks/enterprise/lib/store/apis/accessProfileApi.ts
+++ b/ui/app/_fallbacks/enterprise/lib/store/apis/accessProfileApi.ts
@@ -1,22 +1,7 @@
-import { GetAccessProfilesParams, GetAccessProfilesResponse, GetUserAccessProfilesResponse } from "@enterprise/lib/types/accessProfile";
+import { GetUserAccessProfilesResponse } from "@enterprise/lib/types/accessProfile";
 
 // OSS build has no access-profile backend — return undefined data so consumers
-// fall back gracefully (empty lists, no AP-specific UI rendered).
-export const useGetAccessProfilesQuery = (
-	_params?: GetAccessProfilesParams | void,
-	_opts?: { skip?: boolean },
-): {
-	data: GetAccessProfilesResponse | undefined;
-	isLoading: boolean;
-	isError: boolean;
-	error: null;
-} => ({
-	data: undefined,
-	isLoading: false,
-	isError: false,
-	error: null,
-});
-
+// (e.g. useVirtualKeyUsage) fall back to VK-owned budget/rate-limit values.
 export const useGetUserAccessProfilesQuery = (
 	_userId: string,
 	_opts?: { skip?: boolean; pollingInterval?: number },

--- a/ui/app/_fallbacks/enterprise/lib/types/accessProfile.ts
+++ b/ui/app/_fallbacks/enterprise/lib/types/accessProfile.ts
@@ -39,19 +39,3 @@ export interface UserAccessProfile {
 export interface GetUserAccessProfilesResponse {
 	access_profiles: UserAccessProfile[];
 }
-
-export interface GetAccessProfilesParams {
-	limit?: number;
-	offset?: number;
-	search?: string;
-	tags?: string;
-	is_active?: boolean;
-}
-
-export interface GetAccessProfilesResponse {
-	access_profiles: { id: number; name: string; [key: string]: unknown }[];
-	count: number;
-	total_count: number;
-	limit: number;
-	offset: number;
-}

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -148,7 +148,7 @@ export default function GovernanceVirtualKeysPage() {
   };
 
   return (
-    <div className="mx-auto w-full max-w-7xl">
+    <div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full max-w-7xl flex-col overflow-hidden p-4">
       <VirtualKeysTable
         virtualKeys={virtualKeysData?.virtual_keys || []}
         totalCount={virtualKeysData?.total_count || 0}

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -50,8 +50,8 @@ interface VirtualKeyDetailSheetProps {
 }
 
 export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKeyDetailSheetProps) {
-	const { assignedUsers, isManagedByProfile, managingProfile, hasApRateLimit, displayBudgets, displayRateLimit } =
-		useVirtualKeyUsage(virtualKey);
+	const { assignedUsers, managingProfile, hasApRateLimit, displayBudgets, displayRateLimit } = useVirtualKeyUsage(virtualKey);
+	const isManagedByProfile = !!virtualKey.access_profile_id;
 
 	const getEntityInfo = () => {
 		if (virtualKey.team) {

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -50,8 +50,7 @@ interface VirtualKeyDetailSheetProps {
 }
 
 export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKeyDetailSheetProps) {
-	const { assignedUsers, managingProfile, hasApRateLimit, displayBudgets, displayRateLimit } = useVirtualKeyUsage(virtualKey);
-	const isManagedByProfile = !!virtualKey.access_profile_id;
+	const { assignedUsers, managingProfile, isManagedByProfile, hasApRateLimit, displayBudgets, displayRateLimit } = useVirtualKeyUsage(virtualKey);
 
 	const getEntityInfo = () => {
 		if (virtualKey.team) {

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -1,51 +1,96 @@
 import { useVirtualKeyUsage } from "@/app/workspace/virtual-keys/hooks/useVirtualKeyUsage";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
 } from "@/components/ui/alertDialog";
 import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
 import { Button } from "@/components/ui/button";
 import { ComboboxSelect } from "@/components/ui/combobox";
 import { ConfigSyncAlert } from "@/components/ui/configSyncAlert";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
 import MultiBudgetLines from "@/components/ui/multibudgets";
 import { MultiSelect } from "@/components/ui/multiSelect";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import Toggle from "@/components/ui/toggle";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/components/ui/utils";
 import { ModelPlaceholders } from "@/lib/constants/config";
-import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
+import {
+  resetDurationOptions,
+  supportsCalendarAlignment,
+} from "@/lib/constants/governance";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import {
-	getErrorMessage,
-	useCreateVirtualKeyMutation,
-	useGetAllKeysQuery,
-	useGetMCPClientsQuery,
-	useGetProvidersQuery,
-	useRotateVirtualKeyMutation,
-	useUpdateVirtualKeyMutation,
+  getErrorMessage,
+  useCreateVirtualKeyMutation,
+  useGetAllKeysQuery,
+  useGetMCPClientsQuery,
+  useGetProvidersQuery,
+  useRotateVirtualKeyMutation,
+  useUpdateVirtualKeyMutation,
 } from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
-import { CreateVirtualKeyRequest, Customer, Team, UpdateVirtualKeyRequest, VirtualKey } from "@/lib/types/governance";
+import {
+  CreateVirtualKeyRequest,
+  Customer,
+  Team,
+  UpdateVirtualKeyRequest,
+  VirtualKey,
+} from "@/lib/types/governance";
 import { useGetAccessProfilesQuery } from "@enterprise/lib/store/apis/accessProfileApi";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -58,2058 +103,2774 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 interface VirtualKeySheetProps {
-	virtualKey?: VirtualKey | null;
-	teams: Team[];
-	customers: Customer[];
-	// When set, the new VK is created under this team. The entity assignment is pre-set
-	// and cannot be changed (but all other fields remain editable).
-	defaultTeamId?: string;
-	// When set, the new VK is created under this access profile. The entity assignment is
-	// pre-set and cannot be changed.
-	defaultAccessProfileId?: number;
-	onSave: () => void;
-	onCancel: () => void;
+  virtualKey?: VirtualKey | null;
+  teams: Team[];
+  customers: Customer[];
+  // When set, the new VK is created under this team. The entity assignment is pre-set
+  // and cannot be changed (but all other fields remain editable).
+  defaultTeamId?: string;
+  // When set, the new VK is created under this access profile. The entity assignment is
+  // pre-set and cannot be changed.
+  defaultAccessProfileId?: number;
+  onSave: () => void;
+  onCancel: () => void;
 }
 
 // Provider configuration schema
 const providerConfigSchema = z.object({
-	id: z.number().optional(),
-	provider: z.string().min(1, "Provider is required"),
-	weight: z.number().min(0, "Weight must be at least 0").max(1, "Weight must be at most 1").optional(),
-	allowed_models: z.array(z.string()).optional(),
-	blacklisted_models: z.array(z.string()).optional(),
-	key_ids: z.array(z.string()).optional(), // Keys associated with this provider config
-	// Provider-level budget
-	budgets: z
-		.array(
-			z.object({
-				id: z.string().optional(),
-				max_limit: z.number().nonnegative().optional(),
-				reset_duration: z.string().optional(),
-			}),
-		)
-		.optional(),
-	// Provider-level rate limits
-	rate_limit: z
-		.object({
-			token_max_limit: z.number().int().nonnegative().optional(),
-			token_reset_duration: z.string().optional(),
-			request_max_limit: z.number().int().nonnegative().optional(),
-			request_reset_duration: z.string().optional(),
-		})
-		.optional(),
+  id: z.number().optional(),
+  provider: z.string().min(1, "Provider is required"),
+  weight: z
+    .number()
+    .min(0, "Weight must be at least 0")
+    .max(1, "Weight must be at most 1")
+    .optional(),
+  allowed_models: z.array(z.string()).optional(),
+  key_ids: z.array(z.string()).optional(), // Keys associated with this provider config
+  // Provider-level budget
+  budgets: z
+    .array(
+      z.object({
+        id: z.string().optional(),
+        max_limit: z.number().nonnegative().optional(),
+        reset_duration: z.string().optional(),
+      }),
+    )
+    .optional(),
+  // Provider-level rate limits
+  rate_limit: z
+    .object({
+      token_max_limit: z.number().int().nonnegative().optional(),
+      token_reset_duration: z.string().optional(),
+      request_max_limit: z.number().int().nonnegative().optional(),
+      request_reset_duration: z.string().optional(),
+    })
+    .optional(),
 });
 
 const mcpConfigSchema = z.object({
-	id: z.number().optional(),
-	mcp_client_name: z.string().min(1, "MCP client name is required"),
-	tools_to_execute: z.array(z.string()).optional(),
+  id: z.number().optional(),
+  mcp_client_name: z.string().min(1, "MCP client name is required"),
+  tools_to_execute: z.array(z.string()).optional(),
 });
 
 // Main form schema
 const formSchema = z
-	.object({
-		name: z.string().min(1, "Virtual key name is required"),
-		description: z.string().optional(),
-		providerConfigs: z.array(providerConfigSchema).optional(),
-		mcpConfigs: z.array(mcpConfigSchema).optional(),
-		entityType: z.enum(["team", "customer", "access_profile", "none"]),
-		teamId: z.string().optional(),
-		customerId: z.string().optional(),
-		accessProfileId: z.string().optional(),
-		isActive: z.boolean(),
-		// Budget
-		budgetCalendarAligned: z.boolean(),
-		budgets: z
-			.array(
-				z.object({
-					id: z.string().optional(),
-					max_limit: z.number().nonnegative().optional(),
-					reset_duration: z.string(),
-				}),
-			)
-			.optional(),
-		// Token limits
-		tokenMaxLimit: z.number().int().nonnegative().optional(),
-		tokenResetDuration: z.string().optional(),
-		// Request limits
-		requestMaxLimit: z.number().int().nonnegative().optional(),
-		requestResetDuration: z.string().optional(),
-	})
-	.refine(
-		(data) => {
-			// If entityType is "team", teamId must be provided and not empty
-			if (data.entityType === "team") {
-				return data.teamId && data.teamId.trim() !== "";
-			}
-			// If entityType is "customer", customerId must be provided and not empty
-			if (data.entityType === "customer") {
-				return data.customerId && data.customerId.trim() !== "";
-			}
-			// If entityType is "access_profile", accessProfileId must be provided and not empty
-			if (data.entityType === "access_profile") {
-				return data.accessProfileId && data.accessProfileId.trim() !== "";
-			}
-			return true;
-		},
-		{
-			message: "Please select a valid team, customer, or access profile when assignment type is chosen",
-			path: ["entityType"],
-		},
-	);
+  .object({
+    name: z.string().min(1, "Virtual key name is required"),
+    description: z.string().optional(),
+    providerConfigs: z.array(providerConfigSchema).optional(),
+    mcpConfigs: z.array(mcpConfigSchema).optional(),
+    entityType: z.enum(["team", "customer", "access_profile", "none"]),
+    teamId: z.string().optional(),
+    customerId: z.string().optional(),
+    accessProfileId: z.string().optional(),
+    isActive: z.boolean(),
+    // Budget
+    budgetCalendarAligned: z.boolean(),
+    budgets: z
+      .array(
+        z.object({
+          id: z.string().optional(),
+          max_limit: z.number().nonnegative().optional(),
+          reset_duration: z.string(),
+        }),
+      )
+      .optional(),
+    // Token limits
+    tokenMaxLimit: z.number().int().nonnegative().optional(),
+    tokenResetDuration: z.string().optional(),
+    // Request limits
+    requestMaxLimit: z.number().int().nonnegative().optional(),
+    requestResetDuration: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      // If entityType is "team", teamId must be provided and not empty
+      if (data.entityType === "team") {
+        return data.teamId && data.teamId.trim() !== "";
+      }
+      // If entityType is "customer", customerId must be provided and not empty
+      if (data.entityType === "customer") {
+        return data.customerId && data.customerId.trim() !== "";
+      }
+      // If entityType is "access_profile", accessProfileId must be provided and not empty
+      if (data.entityType === "access_profile") {
+        return data.accessProfileId && data.accessProfileId.trim() !== "";
+      }
+      return true;
+    },
+    {
+      message:
+        "Please select a valid team, customer, or access profile when assignment type is chosen",
+      path: ["entityType"],
+    },
+  );
 
 type FormData = z.infer<typeof formSchema>;
 type BudgetComparisonEntry = {
-	id?: string;
-	max_limit?: number;
-	reset_duration?: string;
-	current_usage?: number;
+  id?: string;
+  max_limit?: number;
+  reset_duration?: string;
+  current_usage?: number;
 };
 
 type VirtualKeyType = {
-	label: string;
-	value: string;
-	description: string;
-	provider: string;
+  label: string;
+  value: string;
+  description: string;
+  provider: string;
 };
 
 export default function VirtualKeySheet({
-	virtualKey,
-	teams,
-	customers,
-	defaultTeamId,
-	defaultAccessProfileId,
-	onSave,
-	onCancel,
+  virtualKey,
+  teams,
+  customers,
+  defaultTeamId,
+  defaultAccessProfileId,
+  onSave,
+  onCancel,
 }: VirtualKeySheetProps) {
-	const [isOpen, setIsOpen] = useState(true);
-	const navigate = useNavigate();
-	const isEditing = !!virtualKey;
-
-	const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create);
-	const hasUpdateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Update);
-	const canSubmit = isEditing ? hasUpdateAccess : hasCreateAccess;
-
-	// Detect AP-managed status via the managing profile's virtual_key_ids, not just by the presence
-	// of assignees — directly-attached users don't imply an access-profile relation.
-	const { assignedUsers, isManagedByProfile: isManagedByProfileHook } = useVirtualKeyUsage(virtualKey);
-	const isManagedByProfile = isEditing && isManagedByProfileHook;
-	// Team attachment: when creating from a team context (defaultTeamId provided), the entity
-	// assignment is pre-set and locked. When editing an existing VK the assignment can be changed.
-	const attachedTeamId = isEditing ? virtualKey?.team_id || "" : defaultTeamId || "";
-	const attachedTeam = attachedTeamId ? teams.find((t) => t.id === attachedTeamId) : undefined;
-	const isTeamLocked = !isEditing && !!defaultTeamId;
-	const isAPLocked = !isEditing && !!defaultAccessProfileId;
-
-	const handleClose = () => {
-		setIsOpen(false);
-		setTimeout(() => {
-			onCancel();
-		}, 150); // Slightly longer than the 100ms animation duration
-	};
-
-	// RTK Query hooks
-	const { data: providersData, error: providersError } = useGetProvidersQuery();
-	const { data: keysData, error: keysError } = useGetAllKeysQuery();
-	const [createVirtualKey, { isLoading: isCreating }] = useCreateVirtualKeyMutation();
-	const [updateVirtualKey, { isLoading: isUpdating }] = useUpdateVirtualKeyMutation();
-	const [rotateVirtualKey, { isLoading: isRotating }] = useRotateVirtualKeyMutation();
-	const { data: mcpClientsResponse, error: mcpClientsError } = useGetMCPClientsQuery();
-	const { data: accessProfilesData } = useGetAccessProfilesQuery({ limit: 100 });
-	const accessProfiles = accessProfilesData?.access_profiles ?? [];
-	const mcpClientsData = mcpClientsResponse?.clients || [];
-	const isLoading = isCreating || isUpdating || isRotating;
-
-	const availableKeys = keysData || [];
-	const availableProviders = providersData || [];
-
-	// Form setup
-	const form = useForm<z.input<typeof formSchema>, unknown, FormData>({
-		resolver: zodResolver(formSchema),
-		defaultValues: {
-			name: virtualKey?.name || "",
-			description: virtualKey?.description || "",
-			providerConfigs:
-				virtualKey?.provider_configs?.map((config) => ({
-					id: config.id,
-					provider: config.provider,
-					weight: config.weight ?? undefined,
-					allowed_models: config.allowed_models,
-					blacklisted_models: config.blacklisted_models,
-					key_ids: config.allow_all_keys ? ["*"] : config.keys?.map((key) => key.key_id) || [],
-					budgets: config.budgets?.map((b) => ({
-						id: b.id,
-						max_limit: b.max_limit,
-						reset_duration: b.reset_duration,
-					})),
-					rate_limit: config.rate_limit
-						? {
-								token_max_limit: config.rate_limit.token_max_limit ?? undefined,
-								token_reset_duration: config.rate_limit.token_reset_duration,
-								request_max_limit: config.rate_limit.request_max_limit ?? undefined,
-								request_reset_duration: config.rate_limit.request_reset_duration,
-							}
-						: undefined,
-				})) || [],
-			mcpConfigs:
-				virtualKey?.mcp_configs?.map((config) => ({
-					id: config.id,
-					mcp_client_name: config.mcp_client?.name || "",
-					tools_to_execute: config.tools_to_execute || [],
-				})) || [],
-			entityType: virtualKey?.team_id
-				? "team"
-				: virtualKey?.customer_id
-					? "customer"
-					: virtualKey?.access_profile_id
-						? "access_profile"
-						: !isEditing && defaultTeamId
-							? "team"
-							: !isEditing && defaultAccessProfileId
-								? "access_profile"
-								: "none",
-			teamId: virtualKey?.team_id || (!isEditing ? defaultTeamId || "" : ""),
-			customerId: virtualKey?.customer_id || "",
-			accessProfileId: virtualKey?.access_profile_id
-				? String(virtualKey.access_profile_id)
-				: !isEditing && defaultAccessProfileId
-					? String(defaultAccessProfileId)
-					: "",
-			isActive: virtualKey?.is_active ?? true,
-			budgets:
-				virtualKey?.budgets && virtualKey.budgets.length > 0
-					? virtualKey.budgets.map((b) => ({ id: b.id, max_limit: b.max_limit, reset_duration: b.reset_duration ?? "1M" }))
-					: [],
-			budgetCalendarAligned: virtualKey?.calendar_aligned ?? false,
-			tokenMaxLimit: virtualKey?.rate_limit?.token_max_limit ?? undefined,
-			tokenResetDuration: virtualKey?.rate_limit?.token_reset_duration || "1h",
-			requestMaxLimit: virtualKey?.rate_limit?.request_max_limit ?? undefined,
-			requestResetDuration: virtualKey?.rate_limit?.request_reset_duration || "1h",
-		},
-	});
-
-	// Handle keys loading error
-	useEffect(() => {
-		if (keysError) {
-			toast.error(`Failed to load available keys: ${getErrorMessage(keysError)}`);
-		}
-	}, [keysError]);
-
-	// Handle providers loading error
-	useEffect(() => {
-		if (providersError) {
-			toast.error(`Failed to load available providers: ${getErrorMessage(providersError)}`);
-		}
-	}, [providersError]);
-
-	// Handle mcp clients loading error
-	useEffect(() => {
-		if (mcpClientsError) {
-			toast.error(`Failed to load available MCP clients: ${getErrorMessage(mcpClientsError)}`);
-		}
-	}, [mcpClientsError]);
-
-	// Clear entity ID fields when entityType changes
-	useEffect(() => {
-		const entityType = form.watch("entityType");
-		if (entityType === "none") {
-			form.setValue("teamId", "", { shouldDirty: true });
-			form.setValue("customerId", "", { shouldDirty: true });
-			form.setValue("accessProfileId", "", { shouldDirty: true });
-		} else if (entityType === "team") {
-			form.setValue("customerId", "", { shouldDirty: true });
-			form.setValue("accessProfileId", "", { shouldDirty: true });
-		} else if (entityType === "customer") {
-			form.setValue("teamId", "", { shouldDirty: true });
-			form.setValue("accessProfileId", "", { shouldDirty: true });
-		} else if (entityType === "access_profile") {
-			form.setValue("teamId", "", { shouldDirty: true });
-			form.setValue("customerId", "", { shouldDirty: true });
-		}
-	}, [form.watch("entityType"), form]);
-
-	// Provider configuration state
-	const [selectedProvider, setSelectedProvider] = useState<string>("");
-
-	// MCP client configuration state
-	const [selectedMCPClient, setSelectedMCPClient] = useState<string>("");
-
-	// Get current provider configs from form
-	const providerConfigs = form.watch("providerConfigs") || [];
-
-	// Get current MCP configs from form
-	const mcpConfigs = form.watch("mcpConfigs") || [];
-
-	// Watch budget/rate-limit fields for conditional rendering of reset buttons
-	const watchedBudgets = form.watch("budgets");
-	const watchedTokenMaxLimit = form.watch("tokenMaxLimit");
-	const watchedRequestMaxLimit = form.watch("requestMaxLimit");
-	const watchedTokenResetDuration = form.watch("tokenResetDuration");
-	const watchedRequestResetDuration = form.watch("requestResetDuration");
-	const watchedBudgetCalendarAligned = form.watch("budgetCalendarAligned");
-
-	// Calendar alignment is VK-wide and applies to both budgets and rate limits: show the
-	// toggle when any configured budget or rate-limit uses a calendar-alignable duration.
-	const hasAnyAlignableBudget =
-		watchedBudgets &&
-		watchedBudgets.length > 0 &&
-		watchedBudgets.some((b) => b.max_limit !== undefined && b.max_limit !== null && supportsCalendarAlignment(b.reset_duration || "1M"));
-	const hasAnyAlignableRateLimit =
-		(watchedTokenMaxLimit !== undefined && watchedTokenMaxLimit !== null && supportsCalendarAlignment(watchedTokenResetDuration || "1h")) ||
-		(watchedRequestMaxLimit !== undefined &&
-			watchedRequestMaxLimit !== null &&
-			supportsCalendarAlignment(watchedRequestResetDuration || "1h"));
-	const showCalendarAlignToggle = hasAnyAlignableBudget || hasAnyAlignableRateLimit;
-
-	// Handle adding a new provider configuration
-	const handleAddProvider = (provider: string) => {
-		const existingConfig = providerConfigs.find((config) => config.provider === provider);
-		if (existingConfig) {
-			toast.error("This provider is already configured");
-			return;
-		}
-
-		const newConfig = {
-			provider: provider,
-			weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
-			allowed_models: ["*"],
-			blacklisted_models: [],
-			key_ids: ["*"],
-		};
-
-		form.setValue("providerConfigs", [...providerConfigs, newConfig], { shouldDirty: true });
-	};
-
-	// Handle removing a provider configuration
-	const handleRemoveProvider = (index: number) => {
-		const updatedConfigs = providerConfigs.filter((_, i) => i !== index);
-		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
-	};
-
-	// Handle updating provider configuration
-	const handleUpdateProviderConfig = (index: number, field: string, value: any) => {
-		const updatedConfigs = [...providerConfigs];
-		updatedConfigs[index] = { ...updatedConfigs[index], [field]: value };
-		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
-	};
-
-	// Handle adding a new MCP client configuration
-	const handleAddMCPClient = (mcpClientName: string) => {
-		const existingConfig = mcpConfigs.find((config) => config.mcp_client_name === mcpClientName);
-		if (existingConfig) {
-			toast.error("This MCP client is already configured");
-			return;
-		}
-
-		const newConfig = {
-			mcp_client_name: mcpClientName,
-			tools_to_execute: ["*"],
-		};
-
-		form.setValue("mcpConfigs", [...mcpConfigs, newConfig], { shouldDirty: true });
-	};
-
-	// Handle removing an MCP client configuration
-	const handleRemoveMCPClient = (index: number) => {
-		const updatedConfigs = mcpConfigs.filter((_, i) => i !== index);
-		form.setValue("mcpConfigs", updatedConfigs, { shouldDirty: true });
-	};
-
-	// Handle updating MCP client configuration
-	const handleUpdateMCPConfig = (index: number, field: keyof (typeof mcpConfigs)[0], value: any) => {
-		const updatedConfigs = [...mcpConfigs];
-		updatedConfigs[index] = { ...updatedConfigs[index], [field]: value };
-		form.setValue("mcpConfigs", updatedConfigs, { shouldDirty: true });
-	};
-
-	const [showCalendarAlignWarning, setShowCalendarAlignWarning] = useState(false);
-	const [showReassignTeamWarning, setShowReassignTeamWarning] = useState(false);
-	const [pendingTeamId, setPendingTeamId] = useState<string | null>(null);
-	const [showReassignAPWarning, setShowReassignAPWarning] = useState(false);
-	const [pendingAccessProfileId, setPendingAccessProfileId] = useState<string | null>(null);
-	const [showReassignTypeWarning, setShowReassignTypeWarning] = useState(false);
-	const [pendingEntityType, setPendingEntityType] = useState<"team" | "customer" | "access_profile" | "none" | null>(null);
-	const [showRotateWarning, setShowRotateWarning] = useState(false);
-	const [showBudgetResetPrompt, setShowBudgetResetPrompt] = useState(false);
-	const [pendingBudgetResetData, setPendingBudgetResetData] = useState<FormData | null>(null);
-	const [pendingBudgetUsageWarning, setPendingBudgetUsageWarning] = useState<string | null>(null);
-
-	const currentAssignmentLabel = useMemo(() => {
-		if (!isEditing) return null;
-		if (virtualKey?.team_id) {
-			const team = teams?.find((t) => t.id === virtualKey.team_id);
-			return team ? `Team: ${team.name}` : "a team";
-		}
-		if (virtualKey?.customer_id) {
-			const customer = customers?.find((c) => c.id === virtualKey.customer_id);
-			return customer ? `Customer: ${customer.name}` : "a customer";
-		}
-		if (virtualKey?.access_profile_id) {
-			const ap = accessProfiles?.find((p) => p.id === virtualKey.access_profile_id);
-			return ap ? `Access Profile: ${ap.name}` : "an access profile";
-		}
-		return null;
-	}, [isEditing, virtualKey, teams, customers, accessProfiles]);
-
-	const handleCalendarAlignedChange = (checked: boolean) => {
-		if (checked && isEditing) {
-			// Show warning when enabling on an existing VK
-			setShowCalendarAlignWarning(true);
-		} else {
-			form.setValue("budgetCalendarAligned", checked, { shouldDirty: true });
-		}
-	};
-
-	const clearVirtualKeyBudget = () => {
-		form.setValue("budgets", [], { shouldDirty: true });
-		form.setValue("budgetCalendarAligned", false, { shouldDirty: true });
-	};
-
-	const clearVirtualKeyRateLimits = () => {
-		form.setValue("tokenMaxLimit", undefined, { shouldDirty: true });
-		form.setValue("tokenResetDuration", "1h", { shouldDirty: true });
-		form.setValue("requestMaxLimit", undefined, { shouldDirty: true });
-		form.setValue("requestResetDuration", "1h", { shouldDirty: true });
-	};
-
-	const normalizeProviderConfigs = (configs: typeof providerConfigs, existingConfigs?: VirtualKey["provider_configs"]): any[] => {
-		return configs.map((config) => ({
-			...config,
-			budgets: config.budgets?.filter((b): b is { id?: string; max_limit: number; reset_duration: string } => b.max_limit !== undefined),
-			weight: config.weight ?? null,
-			rate_limit: (() => {
-				const hasTokenMaxLimit = config.rate_limit?.token_max_limit !== undefined;
-				const hasRequestMaxLimit = config.rate_limit?.request_max_limit !== undefined;
-				if (hasTokenMaxLimit || hasRequestMaxLimit) {
-					return {
-						token_max_limit: config.rate_limit?.token_max_limit ?? null,
-						token_reset_duration: hasTokenMaxLimit ? config.rate_limit?.token_reset_duration || "1h" : null,
-						request_max_limit: config.rate_limit?.request_max_limit ?? null,
-						request_reset_duration: hasRequestMaxLimit ? config.rate_limit?.request_reset_duration || "1h" : null,
-					};
-				}
-
-				const existingConfig = existingConfigs?.find((item) => (config.id ? item.id === config.id : item.provider === config.provider));
-				if (existingConfig?.rate_limit) {
-					return {};
-				}
-
-				return undefined;
-			})(),
-		}));
-	};
-
-	const budgetSignature = (budgets?: BudgetComparisonEntry[]) =>
-		(budgets || [])
-			.filter((budget) => budget.max_limit !== undefined)
-			.map((budget) => `${budget.id ?? ""}:${budget.max_limit}:${budget.reset_duration ?? ""}`)
-			.sort()
-			.join("|");
-
-	const parseResetDurationMs = (duration?: string) => {
-		if (!duration) return null;
-		const match = duration.match(/^(\d+(?:\.\d+)?)(ms|s|m|h|d|w|M|Y)$/);
-		if (!match) return null;
-		const amount = Number(match[1]);
-		const unit = match[2];
-		const multipliers: Record<string, number> = {
-			ms: 1,
-			s: 1000,
-			m: 60 * 1000,
-			h: 60 * 60 * 1000,
-			d: 24 * 60 * 60 * 1000,
-			w: 7 * 24 * 60 * 60 * 1000,
-			M: 30 * 24 * 60 * 60 * 1000,
-			Y: 365 * 24 * 60 * 60 * 1000,
-		};
-		return amount * multipliers[unit];
-	};
-
-	const formatBudgetAmount = (value: number) =>
-		new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(value);
-
-	const findBudgetUsageWarning = (
-		currentBudgets: BudgetComparisonEntry[] | undefined,
-		existingBudgets: BudgetComparisonEntry[] | undefined,
-		scopeLabel: string,
-	) => {
-		const current = (currentBudgets || [])
-			.filter((budget): budget is BudgetComparisonEntry & { max_limit: number; reset_duration: string } => {
-				return budget.max_limit !== undefined && !!budget.reset_duration;
-			})
-			.sort((left, right) => (parseResetDurationMs(left.reset_duration) ?? 0) - (parseResetDurationMs(right.reset_duration) ?? 0));
-		const existingByID = new Map((existingBudgets || []).filter((budget) => budget.id).map((budget) => [budget.id, budget]));
-		const existingByDuration = new Map((existingBudgets || []).map((budget) => [budget.reset_duration, budget]));
-		const reconciled: BudgetComparisonEntry[] = [];
-
-		for (const budget of current) {
-			const existing = budget.id ? existingByID.get(budget.id) : existingByDuration.get(budget.reset_duration);
-			if (existing) {
-				const configChanged = existing.max_limit !== budget.max_limit || existing.reset_duration !== budget.reset_duration;
-				const usage = existing.current_usage ?? 0;
-				if (configChanged && usage >= budget.max_limit) {
-					return `${scopeLabel} ${budget.reset_duration} budget has ${formatBudgetAmount(usage)} usage, which meets or exceeds the new ${formatBudgetAmount(budget.max_limit)} limit.`;
-				}
-				reconciled.push({ ...budget, current_usage: usage });
-				continue;
-			}
-
-			const targetDuration = parseResetDurationMs(budget.reset_duration);
-			const closestShorter = reconciled.reduce<BudgetComparisonEntry | null>((closest, candidate) => {
-				const candidateDuration = parseResetDurationMs(candidate.reset_duration);
-				const closestDuration = parseResetDurationMs(closest?.reset_duration);
-				if (targetDuration === null || candidateDuration === null || candidateDuration >= targetDuration) {
-					return closest;
-				}
-				if (closest === null || closestDuration === null || candidateDuration > closestDuration) {
-					return candidate;
-				}
-				return closest;
-			}, null);
-			const inheritedUsage = closestShorter?.current_usage ?? 0;
-			if (inheritedUsage >= budget.max_limit) {
-				return `${scopeLabel} ${budget.reset_duration} budget will inherit ${formatBudgetAmount(inheritedUsage)} from the ${closestShorter?.reset_duration} budget, which meets or exceeds the new ${formatBudgetAmount(budget.max_limit)} limit.`;
-			}
-			reconciled.push({ ...budget, current_usage: inheritedUsage });
-		}
-
-		return null;
-	};
-
-	const getBudgetUsageWarning = (data: FormData) => {
-		if (!isEditing || !virtualKey || isManagedByProfile) {
-			return null;
-		}
-
-		const vkWarning = findBudgetUsageWarning(data.budgets, virtualKey.budgets, "Virtual key");
-		if (vkWarning) {
-			return vkWarning;
-		}
-
-		const existingProviderConfigs = new Map<string, NonNullable<VirtualKey["provider_configs"]>[number]>();
-		(virtualKey.provider_configs || []).forEach((config) => {
-			existingProviderConfigs.set(String(config.id ?? config.provider), config);
-		});
-		for (const config of data.providerConfigs || []) {
-			const existingConfig = existingProviderConfigs.get(String(config.id ?? config.provider));
-			const providerLabel = ProviderLabels[config.provider as ProviderName] ?? config.provider;
-			const warning = findBudgetUsageWarning(config.budgets, existingConfig?.budgets, `${providerLabel} provider`);
-			if (warning) {
-				return warning;
-			}
-		}
-
-		return null;
-	};
-
-	const hasBudgetResetRelevantChanges = (data: FormData) => {
-		if (!isEditing || !virtualKey || isManagedByProfile) {
-			return false;
-		}
-
-		const currentBudgets = (data.budgets || []).filter(
-			(budget): budget is { id?: string; max_limit: number; reset_duration: string } => budget.max_limit !== undefined,
-		);
-		const existingBudgets = virtualKey.budgets || [];
-		const hasBudgetFields =
-			currentBudgets.length > 0 ||
-			existingBudgets.length > 0 ||
-			(data.providerConfigs || []).some((config) => (config.budgets || []).some((budget) => budget.max_limit !== undefined)) ||
-			(virtualKey.provider_configs || []).some((config) => (config.budgets || []).length > 0);
-
-		if (budgetSignature(currentBudgets) !== budgetSignature(existingBudgets)) {
-			return true;
-		}
-
-		if (hasBudgetFields && data.budgetCalendarAligned !== (virtualKey.calendar_aligned ?? false)) {
-			return true;
-		}
-
-		const existingProviderConfigs = new Map<string, NonNullable<VirtualKey["provider_configs"]>[number]>();
-		(virtualKey.provider_configs || []).forEach((config) => {
-			existingProviderConfigs.set(String(config.id ?? config.provider), config);
-		});
-
-		const currentProviderConfigs = new Map<string, NonNullable<FormData["providerConfigs"]>[number]>();
-		(data.providerConfigs || []).forEach((config) => {
-			currentProviderConfigs.set(String(config.id ?? config.provider), config);
-		});
-
-		const providerConfigKeys = new Set([...existingProviderConfigs.keys(), ...currentProviderConfigs.keys()]);
-		for (const key of providerConfigKeys) {
-			const currentSignature = budgetSignature(currentProviderConfigs.get(key)?.budgets);
-			const existingSignature = budgetSignature(existingProviderConfigs.get(key)?.budgets);
-			if (currentSignature !== existingSignature) {
-				return true;
-			}
-		}
-
-		return false;
-	};
-
-	const handleRotateVirtualKey = async () => {
-		if (!virtualKey) return;
-		if (!hasUpdateAccess) {
-			toast.error("You don't have permission to perform this action");
-			return;
-		}
-		try {
-			await rotateVirtualKey(virtualKey.id).unwrap();
-			toast.success("Virtual key rotated successfully");
-			setShowRotateWarning(false);
-			onSave();
-		} catch (error) {
-			toast.error(getErrorMessage(error));
-		}
-	};
-
-	const submitVirtualKeyForm = async (data: FormData, resetBudgetUsage = false) => {
-		if (!canSubmit) {
-			toast.error("You don't have permission to perform this action");
-			return;
-		}
-		try {
-			// Managed VKs only allow name + description updates; all other fields are owned by the access profile.
-			if (isManagedByProfile && virtualKey) {
-				await updateVirtualKey({
-					vkId: virtualKey.id,
-					data: {
-						name: data.name,
-						description: data.description,
-					},
-				}).unwrap();
-				toast.success("Virtual key updated");
-				onSave();
-				return;
-			}
-
-			// Normalize provider configs to ensure weights are numbers and handle budget/rate limits
-			const normalizedProviderConfigs = data.providerConfigs
-				? normalizeProviderConfigs(data.providerConfigs, virtualKey?.provider_configs)
-				: [];
-			if (isEditing && virtualKey) {
-				// Update existing virtual key
-				const updateData: UpdateVirtualKeyRequest = {
-					name: data.name,
-					description: data.description,
-					provider_configs: normalizedProviderConfigs,
-					mcp_configs: data.mcpConfigs,
-					team_id: data.entityType === "team" && data.teamId && data.teamId.trim() !== "" ? data.teamId : undefined,
-					customer_id: data.entityType === "customer" && data.customerId && data.customerId.trim() !== "" ? data.customerId : undefined,
-					access_profile_id:
-						data.entityType === "access_profile" && data.accessProfileId && data.accessProfileId.trim() !== ""
-							? Number(data.accessProfileId)
-							: undefined,
-					is_active: data.isActive,
-					calendar_aligned: data.budgetCalendarAligned,
-					reset_budget_usage: resetBudgetUsage,
-				};
-
-				// Add budgets if enabled
-				const validBudgets = (data.budgets || []).filter(
-					(b): b is { id?: string; max_limit: number; reset_duration: string } => b.max_limit !== undefined,
-				);
-				const hadBudget = virtualKey.budgets && virtualKey.budgets.length > 0;
-				if (validBudgets.length > 0) {
-					updateData.budgets = validBudgets;
-				} else if (hadBudget) {
-					updateData.budgets = [];
-				}
-
-				// Add rate limit if enabled
-				const hadRateLimit = !!virtualKey.rate_limit;
-				const hasTokenMaxLimit = data.tokenMaxLimit !== undefined;
-				const hasRequestMaxLimit = data.requestMaxLimit !== undefined;
-				const hasRateLimit = hasTokenMaxLimit || hasRequestMaxLimit;
-				if (hasRateLimit) {
-					updateData.rate_limit = {
-						token_max_limit: data.tokenMaxLimit ?? null,
-						token_reset_duration: hasTokenMaxLimit ? data.tokenResetDuration || "1h" : null,
-						request_max_limit: data.requestMaxLimit ?? null,
-						request_reset_duration: hasRequestMaxLimit ? data.requestResetDuration || "1h" : null,
-					};
-				} else if (hadRateLimit) {
-					updateData.rate_limit = {};
-				}
-
-				await updateVirtualKey({ vkId: virtualKey.id, data: updateData }).unwrap();
-				toast.success("Virtual key updated successfully");
-			} else {
-				// Create new virtual key
-				const createData: CreateVirtualKeyRequest = {
-					name: data.name,
-					description: data.description || undefined,
-					provider_configs: normalizedProviderConfigs,
-					mcp_configs: data.mcpConfigs,
-					team_id: data.entityType === "team" && data.teamId && data.teamId.trim() !== "" ? data.teamId : undefined,
-					customer_id: data.entityType === "customer" && data.customerId && data.customerId.trim() !== "" ? data.customerId : undefined,
-					access_profile_id:
-						data.entityType === "access_profile" && data.accessProfileId && data.accessProfileId.trim() !== ""
-							? Number(data.accessProfileId)
-							: undefined,
-					is_active: data.isActive,
-					// VK-level setting that governs both budget and rate-limit calendar alignment.
-					calendar_aligned: data.budgetCalendarAligned,
-				};
-
-				// Add budgets if enabled
-				const validBudgets = (data.budgets || []).filter(
-					(b): b is { id?: string; max_limit: number; reset_duration: string } => b.max_limit !== undefined,
-				);
-				if (validBudgets.length > 0) {
-					createData.budgets = validBudgets;
-				}
-
-				// Add rate limit if enabled
-				const hasTokenMaxLimit = data.tokenMaxLimit !== undefined;
-				const hasRequestMaxLimit = data.requestMaxLimit !== undefined;
-				if (hasTokenMaxLimit || hasRequestMaxLimit) {
-					createData.rate_limit = {
-						token_max_limit: data.tokenMaxLimit,
-						token_reset_duration: hasTokenMaxLimit ? data.tokenResetDuration || "1h" : undefined,
-						request_max_limit: data.requestMaxLimit,
-						request_reset_duration: hasRequestMaxLimit ? data.requestResetDuration || "1h" : undefined,
-					};
-				}
-
-				await createVirtualKey(createData).unwrap();
-				toast.success("Virtual key created successfully");
-			}
-
-			onSave();
-		} catch (error) {
-			toast.error(getErrorMessage(error));
-		}
-	};
-
-	// Handle form submission
-	const onSubmit = async (data: FormData) => {
-		if (hasBudgetResetRelevantChanges(data)) {
-			setPendingBudgetResetData(data);
-			setPendingBudgetUsageWarning(getBudgetUsageWarning(data));
-			setShowBudgetResetPrompt(true);
-			return;
-		}
-
-		await submitVirtualKeyForm(data, false);
-	};
-
-	const handleBudgetResetChoice = async (resetBudgetUsage: boolean) => {
-		if (!pendingBudgetResetData) return;
-		const data = pendingBudgetResetData;
-		setPendingBudgetResetData(null);
-		setPendingBudgetUsageWarning(null);
-		setShowBudgetResetPrompt(false);
-		await submitVirtualKeyForm(data, resetBudgetUsage);
-	};
-
-	return (
-		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-			<SheetContent
-				className="flex w-full flex-col gap-4 overflow-x-hidden p-0 pt-4"
-				data-testid="vk-sheet-content"
-				onInteractOutside={(e) => e.preventDefault()}
-				onEscapeKeyDown={() => handleClose()}
-			>
-				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
-					<SheetTitle className="flex items-center gap-2">{isEditing ? virtualKey?.name : "Create Virtual Key"}</SheetTitle>
-					<SheetDescription>
-						{isEditing
-							? "Update the virtual key configuration and permissions."
-							: "Create a new virtual key with specific permissions, budgets, and rate limits."}
-					</SheetDescription>
-				</SheetHeader>
-
-				<Form {...form}>
-					<form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col gap-6">
-						<div className="space-y-4 px-8">
-							{isManagedByProfile && (
-								<Alert variant="info">
-									<Lock className="h-4 w-4" />
-									<AlertDescription>
-										This virtual key is managed by an access profile. Only the name and description can be modified — providers, budgets,
-										rate limits, and MCP access are controlled by the profile.
-									</AlertDescription>
-								</Alert>
-							)}
-
-							{isTeamLocked && !isManagedByProfile && (
-								<Alert variant="info">
-									<Users className="h-4 w-4" />
-									<AlertDescription>
-										Creating this virtual key under team <span className="font-medium">{attachedTeam?.name ?? attachedTeamId}</span>. Team
-										assignment is pre-set — all other fields are editable.
-									</AlertDescription>
-								</Alert>
-							)}
-
-							{/* Assigned User */}
-							{assignedUsers.length > 0 && (
-								<div className="space-y-1">
-									<Label className="text-sm font-medium">Assigned To</Label>
-									<div className="flex items-center gap-2">
-										<Users className="text-muted-foreground h-4 w-4" />
-										<span className="text-sm">{assignedUsers.map((u) => u.name || u.email).join(", ")}</span>
-									</div>
-								</div>
-							)}
-
-							{/* Basic Information */}
-							<div className="space-y-4">
-								<FormField
-									control={form.control}
-									name="name"
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>Name *</FormLabel>
-											<FormControl>
-												<Input placeholder="e.g., Production API Key" data-testid="vk-name-input" {...field} />
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-
-								<FormField
-									control={form.control}
-									name="description"
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>Description</FormLabel>
-											<FormControl>
-												<Textarea placeholder="This key is used for..." data-testid="vk-description-input" {...field} rows={3} />
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							</div>
-							<fieldset
-								disabled={isManagedByProfile}
-								aria-disabled={isManagedByProfile}
-								inert={isManagedByProfile ? true : undefined}
-								className={isManagedByProfile ? "pointer-events-none space-y-4 opacity-50" : "space-y-4"}
-							>
-								<div className="space-y-4">
-									<FormField
-										control={form.control}
-										name="isActive"
-										render={({ field }) => (
-											<FormItem>
-												<Toggle label="Is this key active?" val={field.value} setVal={field.onChange} data-testid="vk-is-active-toggle" />
-											</FormItem>
-										)}
-									/>
-								</div>
-								{/* Provider Configurations */}
-								<div className="space-y-2">
-									<div className="flex items-center gap-2">
-										<Label className="text-sm font-medium">Provider Configurations</Label>
-										<TooltipProvider>
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<span>
-														<Info className="text-muted-foreground h-3 w-3" />
-													</span>
-												</TooltipTrigger>
-												<TooltipContent>
-													<p>
-														Configure which providers this virtual key can use and their specific settings. Leave empty to block all
-														providers. Add providers to allow them.
-													</p>
-												</TooltipContent>
-											</Tooltip>
-										</TooltipProvider>
-									</div>
-
-									{/* Add Provider Dropdown */}
-									<div className="flex gap-2">
-										<Select
-											value={selectedProvider}
-											onValueChange={(provider) => {
-												if (provider === "__manage_providers__") {
-													navigate({ to: "/workspace/providers" });
-													setSelectedProvider("");
-													return;
-												}
-												handleAddProvider(provider);
-												setSelectedProvider(""); // Reset to placeholder state
-											}}
-										>
-											<SelectTrigger className="flex-1" data-testid="vk-provider-select">
-												<SelectValue placeholder="Select a provider to add" />
-											</SelectTrigger>
-											<SelectContent>
-												{(() => {
-													// Filter out already configured providers
-													const unconfiguredProviders = availableProviders.filter(
-														(provider) => !providerConfigs.some((config) => config.provider === provider.name),
-													);
-
-													if (unconfiguredProviders.length === 0) {
-														return (
-															<SelectItem
-																value="__manage_providers__"
-																className="text-muted-foreground hover:text-foreground"
-																data-testid="vk-provider-config-link"
-															>
-																<span>
-																	No providers left to configure. <span className="text-primary font-medium underline">Click to add</span>
-																</span>
-															</SelectItem>
-														);
-													}
-
-													// Separate base providers and custom providers
-													const baseProviders = unconfiguredProviders.filter((provider) => !provider.custom_provider_config);
-													const customProviders = unconfiguredProviders.filter((provider) => provider.custom_provider_config);
-
-													return (
-														<>
-															{/* Base providers first */}
-															{baseProviders
-																.filter((p) => p.name)
-																.map((provider, index) => (
-																	<SelectItem key={`base-${index}`} value={provider.name}>
-																		<RenderProviderIcon provider={provider.name as KnownProvider} size="sm" className="h-4 w-4" />
-																		{ProviderLabels[provider.name as ProviderName]}
-																	</SelectItem>
-																))}
-
-															{/* Custom providers second */}
-															{customProviders
-																.filter((p) => p.name)
-																.map((provider, index) => (
-																	<SelectItem key={`custom-${index}`} value={provider.name}>
-																		<RenderProviderIcon
-																			provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
-																			size="sm"
-																			className="h-4 w-4"
-																		/>
-																		{provider.name}
-																	</SelectItem>
-																))}
-														</>
-													);
-												})()}
-											</SelectContent>
-										</Select>
-									</div>
-
-									{/* Provider Configurations Table */}
-									{providerConfigs.length > 0 && (
-										<div className="rounded-md border px-2">
-											<Accordion type="multiple" className="w-full">
-												{providerConfigs.map((config, index) => {
-													const providerConfig = availableProviders.find((provider) => provider.name === config.provider);
-													return (
-														<AccordionItem key={index} className="w-full" value={`${config.provider}-${index}`}>
-															<AccordionTrigger className="flex h-12 items-center gap-0 px-1">
-																<div className="flex w-full items-center justify-between">
-																	<div className="flex w-fit items-center gap-2">
-																		<RenderProviderIcon
-																			provider={
-																				providerConfig?.custom_provider_config?.base_provider_type || (config.provider as ProviderIconType)
-																			}
-																			size="sm"
-																			className="h-4 w-4"
-																		/>
-																		{providerConfig?.custom_provider_config
-																			? providerConfig.name
-																			: ProviderLabels[config.provider as ProviderName]}
-																	</div>
-																	<Button
-																		type="button"
-																		variant="ghost"
-																		size="icon"
-																		aria-label={`Remove ${config.provider} provider`}
-																		className="hover:bg-accent/50 h-8 w-8 rounded-sm p-2"
-																		data-testid={`vk-delete-provider-${index}`}
-																		onClick={(e) => {
-																			e.stopPropagation();
-																			handleRemoveProvider(index);
-																		}}
-																	>
-																		<Trash2 className="h-4 w-4 opacity-75" />
-																	</Button>
-																</div>
-															</AccordionTrigger>
-															<AccordionContent className="flex flex-col gap-4 px-1 text-balance">
-																<div className="flex w-full items-start gap-2">
-																	<div className="w-1/4">
-																		<NumberAndSelect
-																			id={`vk-weight-${index}`}
-																			label="Weight"
-																			labelClassName="text-sm font-medium"
-																			placeholder="Exclude from routing"
-																			inputClassName="h-[38px] w-full"
-																			dataTestId={`vk-weight-input-${index}`}
-																			value={config.weight}
-																			onChangeNumber={(value) => handleUpdateProviderConfig(index, "weight", value)}
-																		/>
-																	</div>
-																	<div className="w-3/4 space-y-2">
-																		<Label className="text-sm font-medium">
-																			Allowed Models <span className="text-muted-foreground ml-auto text-xs italic">type to search</span>
-																		</Label>
-																		{(() => {
-																			const hasWildcardModels = (config.allowed_models || []).includes("*");
-																			return (
-																				<ModelMultiselect
-																					data-testid={`vk-models-multiselect-${index}`}
-																					provider={config.provider}
-																					keys={(() => {
-																						const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-																						const configKeyIds = config.key_ids || [];
-																						return configKeyIds.includes("*")
-																							? providerKeys.map((key) => key.key_id)
-																							: providerKeys.filter((key) => configKeyIds.includes(key.key_id)).map((key) => key.key_id);
-																					})()}
-																					allowAllOption={true}
-																					value={hasWildcardModels ? ["*"] : config.allowed_models || []}
-																					onChange={(models: string[]) => {
-																						const hadStar = (config.allowed_models || []).includes("*");
-																						const hasStar = models.includes("*");
-																						if (!hadStar && hasStar) {
-																							handleUpdateProviderConfig(index, "allowed_models", ["*"]);
-																						} else if (hadStar && hasStar && models.length > 1) {
-																							handleUpdateProviderConfig(
-																								index,
-																								"allowed_models",
-																								models.filter((m) => m !== "*"),
-																							);
-																						} else {
-																							handleUpdateProviderConfig(index, "allowed_models", models);
-																						}
-																					}}
-																					placeholder={
-																						hasWildcardModels
-																							? "All models allowed"
-																							: (config.allowed_models || []).length === 0
-																								? "No models (deny all)"
-																								: config.provider
-																									? ModelPlaceholders[config.provider as keyof typeof ModelPlaceholders] ||
-																										ModelPlaceholders.default
-																									: ModelPlaceholders.default
-																					}
-																					className="min-h-10 max-w-[500px] min-w-[200px]"
-																				/>
-																			);
-																		})()}
-																		<p className="text-muted-foreground text-xs">
-																			Select specific models or choose "Allow All Models" to allow all. Leave empty to deny all.
-																		</p>
-																	</div>
-																</div>
-
-																<div className="flex w-full items-start gap-2">
-																	<div className="w-1/4" />
-																	<div className="w-3/4 space-y-2">
-																		<div className="flex items-center gap-2">
-																			<Label className="text-sm font-medium">Blocked Models</Label>
-																			<TooltipProvider>
-																				<Tooltip>
-																					<TooltipTrigger asChild>
-																						<span>
-																							<Info className="text-muted-foreground h-3 w-3" />
-																						</span>
-																					</TooltipTrigger>
-																					<TooltipContent className="max-w-sm">
-																						<p>
-																							Models this VK must never serve. The denylist always wins - if a model appears in both Allowed
-																							Models and here, it is blocked. Select "All Models" to block every model on this VK.
-																						</p>
-																					</TooltipContent>
-																				</Tooltip>
-																			</TooltipProvider>
-																		</div>
-																		{(() => {
-																			const hasWildcardBlocked = (config.blacklisted_models || []).includes("*");
-																			return (
-																				<ModelMultiselect
-																					data-testid={`vk-models-blocked-multiselect-${index}`}
-																					provider={config.provider}
-																					keys={(() => {
-																						const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-																						const configKeyIds = config.key_ids || [];
-																						return configKeyIds.includes("*")
-																							? providerKeys.map((key) => key.key_id)
-																							: providerKeys.filter((key) => configKeyIds.includes(key.key_id)).map((key) => key.key_id);
-																					})()}
-																					allowAllOption={true}
-																					value={hasWildcardBlocked ? ["*"] : config.blacklisted_models || []}
-																					onChange={(models: string[]) => {
-																						const hadStar = (config.blacklisted_models || []).includes("*");
-																						const hasStar = models.includes("*");
-																						if (!hadStar && hasStar) {
-																							handleUpdateProviderConfig(index, "blacklisted_models", ["*"]);
-																						} else if (hadStar && hasStar && models.length > 1) {
-																							handleUpdateProviderConfig(
-																								index,
-																								"blacklisted_models",
-																								models.filter((m) => m !== "*"),
-																							);
-																						} else {
-																							handleUpdateProviderConfig(index, "blacklisted_models", models);
-																						}
-																					}}
-																					placeholder={
-																						hasWildcardBlocked
-																							? "All models blocked"
-																							: (config.blacklisted_models || []).length === 0
-																								? "No models blocked"
-																								: "Search models..."
-																					}
-																					className="min-h-10 max-w-[500px] min-w-[200px]"
-																				/>
-																			);
-																		})()}
-																	</div>
-																</div>
-
-																{/* Allowed Keys for this provider */}
-																{(() => {
-																	const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-																	const configKeyIds = config.key_ids || [];
-																	const hasWildcard = configKeyIds.includes("*");
-																	const allKeyOptions = [
-																		{
-																			label: "Allow All Keys",
-																			value: "*",
-																			description: "Allow all current and future keys for this provider",
-																			provider: "",
-																		},
-																		...providerKeys.map((key) => ({
-																			label: key.name,
-																			value: key.key_id,
-																			description:
-																				key.models == null || key.models.includes("*")
-																					? "All models"
-																					: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
-																			provider: key.provider,
-																		})),
-																	];
-																	const selectedProviderKeys = hasWildcard
-																		? [allKeyOptions[0]]
-																		: providerKeys
-																				.filter((key) => configKeyIds.includes(key.key_id))
-																				.map((key) => ({
-																					label: key.name,
-																					value: key.key_id,
-																					description:
-																						key.models == null || key.models.includes("*")
-																							? "All models"
-																							: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
-																					provider: key.provider,
-																				}));
-
-																	return (
-																		<div className="mx-0.5 space-y-2">
-																			<Label className="text-sm font-medium">Allowed Keys</Label>
-																			<p className="text-muted-foreground text-xs">
-																				Select specific keys or allow all. Leave empty to block all keys for this provider.
-																			</p>
-																			<AsyncMultiSelect
-																				hideSelectedOptions
-																				isNonAsync
-																				closeMenuOnSelect={false}
-																				menuPlacement="auto"
-																				defaultOptions={allKeyOptions}
-																				views={{
-																					multiValue: (multiValueProps: MultiValueProps<VirtualKeyType>) => {
-																						return (
-																							<div
-																								{...multiValueProps.innerProps}
-																								className="bg-accent dark:!bg-card flex cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 text-sm"
-																							>
-																								{multiValueProps.data.label}{" "}
-																								<X
-																									className="hover:text-foreground text-muted-foreground h-4 w-4 cursor-pointer"
-																									onClick={(e) => {
-																										e.stopPropagation();
-																										multiValueProps.removeProps.onClick?.(e as any);
-																									}}
-																								/>
-																							</div>
-																						);
-																					},
-																					option: (optionProps: OptionProps<VirtualKeyType>) => {
-																						const { Option } = components;
-																						return (
-																							<Option
-																								{...optionProps}
-																								className={cn(
-																									"flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
-																									optionProps.isFocused && "bg-accent dark:!bg-card",
-																									"hover:bg-accent",
-																									optionProps.isSelected && "bg-accent dark:!bg-card",
-																								)}
-																							>
-																								<span className="text-content-primary grow truncate text-sm">{optionProps.data.label}</span>
-																								{optionProps.data.description && (
-																									<span className="text-content-tertiary max-w-[70%] text-sm">
-																										{optionProps.data.description}
-																									</span>
-																								)}
-																							</Option>
-																						);
-																					},
-																				}}
-																				value={selectedProviderKeys}
-																				onChange={(keys) => {
-																					const hadStar = hasWildcard;
-																					const hasStar = keys.some((k) => k.value === "*");
-																					if (!hadStar && hasStar) {
-																						// Just selected "Allow All Keys" — set to ["*"] only
-																						handleUpdateProviderConfig(index, "key_ids", ["*"]);
-																					} else if (hadStar && hasStar && keys.length > 1) {
-																						// Had "*", still has "*", but user also selected a specific key — drop "*"
-																						handleUpdateProviderConfig(
-																							index,
-																							"key_ids",
-																							keys.filter((k) => k.value !== "*").map((k) => k.value as string),
-																						);
-																					} else {
-																						handleUpdateProviderConfig(
-																							index,
-																							"key_ids",
-																							keys.map((k) => k.value as string),
-																						);
-																					}
-																				}}
-																				placeholder={
-																					hasWildcard
-																						? "All keys allowed"
-																						: configKeyIds.length === 0
-																							? "No keys selected"
-																							: "Select keys..."
-																				}
-																				className="hover:bg-accent w-full"
-																				menuClassName="z-[60] max-h-[300px] overflow-y-auto w-full cursor-pointer custom-scrollbar"
-																			/>
-																		</div>
-																	);
-																})()}
-
-																<DottedSeparator />
-
-																{/* Provider Budget Configuration */}
-																<MultiBudgetLines
-																	data-testid={`vk-provider-budget-${index}`}
-																	label="Provider Budget"
-																	lines={
-																		config.budgets && config.budgets.length > 0
-																			? config.budgets.map((b) => ({
-																					id: b.id,
-																					max_limit: b.max_limit,
-																					reset_duration: b.reset_duration || "1M",
-																				}))
-																			: []
-																	}
-																	onChange={(lines) => {
-																		const updatedConfigs = [...providerConfigs];
-																		updatedConfigs[index] = {
-																			...updatedConfigs[index],
-																			budgets: lines.map((l) => ({
-																				id: l.id,
-																				max_limit: l.max_limit,
-																				reset_duration: l.reset_duration,
-																			})),
-																		};
-																		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
-																	}}
-																/>
-
-																<DottedSeparator />
-
-																{/* Provider Rate Limit Configuration */}
-																<div className="space-y-4">
-																	<Label className="text-sm font-medium">Provider Rate Limits</Label>
-
-																	<NumberAndSelect
-																		id={`providerTokenLimit-${index}`}
-																		labelClassName="font-normal"
-																		label="Maximum Tokens"
-																		value={config.rate_limit?.token_max_limit}
-																		selectValue={config.rate_limit?.token_reset_duration || "1h"}
-																		onChangeNumber={(value) => {
-																			const currentRateLimit = config.rate_limit || {};
-																			handleUpdateProviderConfig(index, "rate_limit", {
-																				...currentRateLimit,
-																				token_max_limit: value,
-																			});
-																		}}
-																		onChangeSelect={(value) => {
-																			const currentRateLimit = config.rate_limit || {};
-																			handleUpdateProviderConfig(index, "rate_limit", {
-																				...currentRateLimit,
-																				token_reset_duration: value,
-																			});
-																		}}
-																		options={resetDurationOptions}
-																	/>
-
-																	<NumberAndSelect
-																		id={`providerRequestLimit-${index}`}
-																		labelClassName="font-normal"
-																		label="Maximum Requests"
-																		value={config.rate_limit?.request_max_limit}
-																		selectValue={config.rate_limit?.request_reset_duration || "1h"}
-																		onChangeNumber={(value) => {
-																			const currentRateLimit = config.rate_limit || {};
-																			handleUpdateProviderConfig(index, "rate_limit", {
-																				...currentRateLimit,
-																				request_max_limit: value,
-																			});
-																		}}
-																		onChangeSelect={(value) => {
-																			const currentRateLimit = config.rate_limit || {};
-																			handleUpdateProviderConfig(index, "rate_limit", {
-																				...currentRateLimit,
-																				request_reset_duration: value,
-																			});
-																		}}
-																		options={resetDurationOptions}
-																	/>
-																</div>
-															</AccordionContent>
-														</AccordionItem>
-													);
-												})}
-											</Accordion>
-										</div>
-									)}
-									{/* Display validation errors for provider configurations */}
-									{form.formState.errors.providerConfigs && (
-										<div className="text-destructive text-sm">{form.formState.errors.providerConfigs.message}</div>
-									)}
-								</div>
-								{/* MCP Client Configurations */}
-								{((mcpClientsData && mcpClientsData.length > 0) || (mcpConfigs && mcpConfigs.length > 0)) && (
-									<div className="mt-6 space-y-2">
-										<div className="flex items-center gap-2">
-											<Label className="text-sm font-medium">MCP Client Configurations</Label>
-											<TooltipProvider>
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<span>
-															<Info className="text-muted-foreground h-3 w-3" />
-														</span>
-													</TooltipTrigger>
-													<TooltipContent>
-														<p>
-															Configure which MCP clients this virtual key can use and their allowed tools. Leaving this section empty
-															blocks all MCP tools. After adding an MCP client, you must select specific tools or choose{" "}
-															<span className="font-medium">Allow All Tools</span> to grant tool access.
-														</p>
-													</TooltipContent>
-												</Tooltip>
-											</TooltipProvider>
-										</div>
-
-										{/* MCP servers available on all virtual keys by default, excluding explicitly overridden ones */}
-										{(() => {
-											const defaultMCPClients = mcpClientsData.filter(
-												(client) =>
-													client.config.allow_on_all_virtual_keys &&
-													!mcpConfigs.some((config) => config.mcp_client_name === client.config.name),
-											);
-											return defaultMCPClients.length > 0 ? (
-												<div className="text-muted-foreground rounded-md border p-3 text-xs">
-													<div className="flex items-start gap-1.5">
-														<Info className="mt-0.5 h-3 w-3 shrink-0" />
-														<span>
-															The following MCP servers are available to this key by default with all tools enabled on that client:{" "}
-															<span className="text-foreground font-medium">{defaultMCPClients.map((c) => c.config.name).join(", ")}</span>.
-															Adding an explicit config for any of them below will override the all-tools default for this key.
-														</span>
-													</div>
-												</div>
-											) : null;
-										})()}
-
-										{/* Add MCP Client Dropdown */}
-										{mcpClientsData && mcpClientsData.length > 0 && (
-											<div className="flex gap-2">
-												<Select
-													value={selectedMCPClient}
-													onValueChange={(mcpClientId) => {
-														handleAddMCPClient(mcpClientId);
-														setSelectedMCPClient(""); // Reset to placeholder state
-													}}
-												>
-													<SelectTrigger className="flex-1">
-														<SelectValue placeholder="Select an MCP client to add" />
-													</SelectTrigger>
-													<SelectContent>
-														{mcpClientsData.filter((client) => !mcpConfigs.some((config) => config.mcp_client_name === client.config.name))
-															.length > 0 ? (
-															mcpClientsData
-																.filter(
-																	(client) =>
-																		client.config.name && !mcpConfigs.some((config) => config.mcp_client_name === client.config.name),
-																)
-																.map((client, index) => {
-																	const client_tools = client.tools || [];
-																	const totalTools = client.config.tools_to_execute?.includes("*")
-																		? client_tools.length
-																		: client_tools.filter((tool) => client.config.tools_to_execute?.includes(tool.name)).length;
-																	return (
-																		<SelectItem key={index} value={client.config.name}>
-																			<div className="flex items-center gap-2">
-																				{client.config.name}
-																				<span className="text-muted-foreground text-xs">
-																					({totalTools} {totalTools === 1 ? "enabled tool" : "enabled tools"})
-																				</span>
-																			</div>
-																		</SelectItem>
-																	);
-																})
-														) : (
-															<div className="text-muted-foreground px-2 py-1.5 text-sm">All MCP clients configured</div>
-														)}
-													</SelectContent>
-												</Select>
-											</div>
-										)}
-
-										{/* MCP Configurations Table */}
-										{mcpConfigs.length > 0 && (
-											<div className="rounded-md border">
-												<Table>
-													<TableHeader>
-														<TableRow>
-															<TableHead>MCP Client</TableHead>
-															<TableHead>Allowed Tools</TableHead>
-															<TableHead className="w-[50px]"></TableHead>
-														</TableRow>
-													</TableHeader>
-													<TableBody>
-														{mcpConfigs.map((config, index) => {
-															const mcpClient = mcpClientsData?.find((client) => client.config.name === config.mcp_client_name);
-
-															// Handle new wildcard semantics for client-level filtering
-															const clientToolsToExecute = mcpClient?.config?.tools_to_execute;
-															let availableTools: any[] = [];
-
-															if (!clientToolsToExecute || clientToolsToExecute.length === 0) {
-																// nil/undefined or empty array - no tools available from client config
-																availableTools = [];
-															} else if (clientToolsToExecute.includes("*")) {
-																// Wildcard - all tools available
-																availableTools = mcpClient?.tools || [];
-															} else {
-																// Specific tools listed
-																availableTools = (mcpClient?.tools || []).filter((tool) => clientToolsToExecute.includes(tool.name)) || [];
-															}
-
-															const enabledToolsByConfig =
-																(mcpClient?.tools || []).filter((tool) => config.tools_to_execute?.includes(tool.name)) || [];
-															const selectedTools = config.tools_to_execute || [];
-
-															return (
-																<TableRow key={`${config.mcp_client_name}-${index}`}>
-																	<TableCell className="w-[150px]">{config.mcp_client_name}</TableCell>
-																	<TableCell>
-																		<MultiSelect
-																			options={[
-																				{
-																					label: "Allow All Tools",
-																					value: "*",
-																					description: "Allow all current and future tools",
-																				},
-																				...[...availableTools, ...enabledToolsByConfig]
-																					.filter((tool, index, arr) => arr.findIndex((t) => t.name === tool.name) === index)
-																					.map((tool) => ({
-																						label: tool.name,
-																						value: tool.name,
-																						description: tool.description,
-																					})),
-																			]}
-																			defaultValue={selectedTools}
-																			onValueChange={(tools: string[]) => {
-																				const hadStar = selectedTools.includes("*");
-																				const hasStar = tools.includes("*");
-																				if (!hadStar && hasStar) {
-																					// Just selected "Allow All Tools" — set to ["*"] only
-																					handleUpdateMCPConfig(index, "tools_to_execute", ["*"]);
-																				} else if (hadStar && hasStar && tools.length > 1) {
-																					// Had "*", still has "*", but user also selected a specific tool — drop "*"
-																					handleUpdateMCPConfig(
-																						index,
-																						"tools_to_execute",
-																						tools.filter((t) => t !== "*"),
-																					);
-																				} else {
-																					handleUpdateMCPConfig(index, "tools_to_execute", tools);
-																				}
-																			}}
-																			placeholder={
-																				selectedTools.length === 0
-																					? "No tools selected"
-																					: selectedTools.includes("*")
-																						? "All tools allowed"
-																						: "Select tools..."
-																			}
-																			variant="inverted"
-																			className="hover:bg-accent w-full bg-white dark:bg-zinc-800"
-																			commandClassName="w-full max-w-96"
-																			modalPopover={true}
-																			animation={0}
-																		/>
-																	</TableCell>
-																	<TableCell>
-																		<Button
-																			type="button"
-																			variant="ghost"
-																			size="sm"
-																			onClick={() => handleRemoveMCPClient(index)}
-																			data-testid={`vk-delete-mcp-${index}`}
-																		>
-																			<Trash2 className="h-4 w-4" />
-																		</Button>
-																	</TableCell>
-																</TableRow>
-															);
-														})}
-													</TableBody>
-												</Table>
-											</div>
-										)}
-									</div>
-								)}
-								<DottedSeparator className="mt-6 mb-5" />
-								{/* Budget Configuration */}
-								<div className="space-y-4">
-									<MultiBudgetLines
-										data-testid="vk-budget-lines"
-										label="Budget Configuration"
-										lines={form.watch("budgets") ?? []}
-										onChange={(lines) => {
-											form.setValue("budgets", lines, { shouldDirty: true });
-										}}
-										onReset={clearVirtualKeyBudget}
-										showReset={isEditing && !!(virtualKey?.budgets?.length || (watchedBudgets && watchedBudgets.length > 0))}
-									/>
-
-									{/* Reassign team confirmation dialog */}
-									<AlertDialog
-										open={showReassignTeamWarning}
-										onOpenChange={(open) => {
-											setShowReassignTeamWarning(open);
-											if (!open) {
-												setPendingTeamId(null);
-											}
-										}}
-									>
-										<AlertDialogContent>
-											<AlertDialogHeader>
-												<AlertDialogTitle>Reassign to a different team?</AlertDialogTitle>
-												<AlertDialogDescription>
-													This key is currently assigned to another team. Reassigning it will move budget tracking to this team — future
-													requests through this key will count against this team’s budget, not the previous one.
-												</AlertDialogDescription>
-											</AlertDialogHeader>
-											<AlertDialogFooter>
-												<AlertDialogCancel data-testid="virtual-key-reassign-cancel" onClick={() => setPendingTeamId(null)}>
-													Cancel
-												</AlertDialogCancel>
-												<AlertDialogAction
-													data-testid="virtual-key-reassign-confirm"
-													onClick={() => {
-														if (pendingTeamId !== null) {
-															form.setValue("teamId", pendingTeamId, { shouldDirty: true });
-														}
-														setPendingTeamId(null);
-														setShowReassignTeamWarning(false);
-													}}
-												>
-													Reassign
-												</AlertDialogAction>
-											</AlertDialogFooter>
-										</AlertDialogContent>
-									</AlertDialog>
-
-									<AlertDialog
-										open={showReassignAPWarning}
-										onOpenChange={(open) => {
-											setShowReassignAPWarning(open);
-											if (!open) {
-												setPendingAccessProfileId(null);
-											}
-										}}
-									>
-										<AlertDialogContent>
-											<AlertDialogHeader>
-												<AlertDialogTitle>Reassign to a different access profile?</AlertDialogTitle>
-												<AlertDialogDescription>
-													This key is currently assigned to another access profile. Reassigning it will move budget tracking to this access
-													profile — future requests through this key will count against this profile's budget, not the previous one.
-												</AlertDialogDescription>
-											</AlertDialogHeader>
-											<AlertDialogFooter>
-												<AlertDialogCancel data-testid="reassign-ap-cancel" onClick={() => setPendingAccessProfileId(null)}>
-													Cancel
-												</AlertDialogCancel>
-												<AlertDialogAction
-													data-testid="reassign-ap-confirm"
-													onClick={() => {
-														if (pendingAccessProfileId !== null) {
-															form.setValue("accessProfileId", pendingAccessProfileId, { shouldDirty: true });
-														}
-														setPendingAccessProfileId(null);
-														setShowReassignAPWarning(false);
-													}}
-												>
-													Reassign
-												</AlertDialogAction>
-											</AlertDialogFooter>
-										</AlertDialogContent>
-									</AlertDialog>
-
-									{/* Cross-type assignment warning */}
-									<AlertDialog
-										open={showReassignTypeWarning}
-										onOpenChange={(open) => {
-											if (!open) setPendingEntityType(null);
-											setShowReassignTypeWarning(open);
-										}}
-									>
-										<AlertDialogContent>
-											<AlertDialogHeader>
-												<AlertDialogTitle>Change assignment?</AlertDialogTitle>
-												<AlertDialogDescription>
-													This key is currently assigned to {currentAssignmentLabel}. Changing the assignment type will move budget tracking
-													— future requests will count against the new entity, not the previous one.
-												</AlertDialogDescription>
-											</AlertDialogHeader>
-											<AlertDialogFooter>
-												<AlertDialogCancel data-testid="reassign-type-cancel" onClick={() => setPendingEntityType(null)}>
-													Cancel
-												</AlertDialogCancel>
-												<AlertDialogAction
-													data-testid="reassign-type-confirm"
-													onClick={async () => {
-														if (pendingEntityType) {
-															form.setValue("entityType", pendingEntityType, { shouldDirty: true });
-															if (pendingEntityType === "team" && teams?.length > 0) {
-																form.setValue("teamId", teams[0].id, { shouldDirty: true, shouldValidate: true });
-																form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-																form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
-															} else if (pendingEntityType === "customer" && customers?.length > 0) {
-																form.setValue("customerId", customers[0].id, { shouldDirty: true, shouldValidate: true });
-																form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-																form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
-															} else if (pendingEntityType === "access_profile") {
-																const apId =
-																	accessProfiles?.length > 0
-																		? String(accessProfiles[0].id)
-																		: virtualKey?.access_profile_id
-																			? String(virtualKey.access_profile_id)
-																			: "";
-																form.setValue("accessProfileId", apId, { shouldDirty: true, shouldValidate: true });
-																form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-																form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-															} else {
-																form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-																form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-																form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
-															}
-															await form.trigger(["teamId", "customerId", "accessProfileId", "entityType"]);
-														}
-														setPendingEntityType(null);
-														setShowReassignTypeWarning(false);
-													}}
-												>
-													Change Assignment
-												</AlertDialogAction>
-											</AlertDialogFooter>
-										</AlertDialogContent>
-									</AlertDialog>
-								</div>
-								{/* Rate Limiting Configuration */}
-								<div className="space-y-4">
-									<div className="flex items-center justify-between gap-2">
-										<Label className="text-sm font-medium">Rate Limiting Configuration</Label>
-										{isEditing && (virtualKey?.rate_limit || watchedTokenMaxLimit || watchedRequestMaxLimit) && (
-											<Button
-												type="button"
-												variant="ghost"
-												size="sm"
-												onClick={clearVirtualKeyRateLimits}
-												data-testid="vk-rate-limit-reset-button"
-											>
-												<RotateCcw className="h-4 w-4" />
-												Reset
-											</Button>
-										)}
-									</div>
-
-									<FormField
-										control={form.control}
-										name="tokenMaxLimit"
-										render={({ field }) => (
-											<FormItem>
-												<NumberAndSelect
-													id="tokenMaxLimit"
-													labelClassName="font-normal"
-													label="Maximum Tokens"
-													value={field.value}
-													selectValue={form.watch("tokenResetDuration") || "1h"}
-													onChangeNumber={(value) => {
-														field.onChange(value);
-													}}
-													onChangeSelect={(value) => form.setValue("tokenResetDuration", value, { shouldDirty: true })}
-													options={resetDurationOptions}
-												/>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-
-									<FormField
-										control={form.control}
-										name="requestMaxLimit"
-										render={({ field }) => (
-											<FormItem>
-												<NumberAndSelect
-													id="requestMaxLimit"
-													labelClassName="font-normal"
-													label="Maximum Requests"
-													value={field.value}
-													selectValue={form.watch("requestResetDuration") || "1h"}
-													onChangeNumber={(value) => {
-														field.onChange(value);
-													}}
-													onChangeSelect={(value) => form.setValue("requestResetDuration", value, { shouldDirty: true })}
-													options={resetDurationOptions}
-												/>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-								</div>
-								{/* Calendar alignment — VK-wide setting that applies to both budgets and rate limits */}
-								{showCalendarAlignToggle && (
-									<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
-										<div className="space-y-0.5">
-											<Label htmlFor="vk-budget-calendar-aligned-toggle" className="text-sm font-normal">
-												Align to calendar cycle
-											</Label>
-											<p id="vk-budget-calendar-aligned-description" className="text-muted-foreground text-xs">
-												Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from creation date.
-												Applies to durations of a day or longer.
-											</p>
-										</div>
-										<Switch
-											id="vk-budget-calendar-aligned-toggle"
-											aria-describedby="vk-budget-calendar-aligned-description"
-											checked={watchedBudgetCalendarAligned}
-											onCheckedChange={handleCalendarAlignedChange}
-											data-testid="vk-budget-calendar-aligned-toggle"
-										/>
-									</div>
-								)}
-
-								{/* Warning dialog shown when enabling calendar alignment on an existing VK */}
-								<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
-									<AlertDialogContent>
-										<AlertDialogHeader>
-											<AlertDialogTitle>Reset budget and rate-limit usage?</AlertDialogTitle>
-											<AlertDialogDescription>
-												Enabling calendar alignment will reset budget usage to <span className="font-semibold">$0.00</span> and
-												token/request rate-limit counters to <span className="font-semibold">0</span> for this virtual key, then snap each
-												reset date to the start of its current period (e.g. start of day, week, month, or year). The usage reset cannot be
-												undone, but calendar alignment can be turned off later. This will take effect when you save.
-											</AlertDialogDescription>
-										</AlertDialogHeader>
-										<AlertDialogFooter>
-											<AlertDialogCancel data-testid="vk-calendar-align-cancel-btn">Cancel</AlertDialogCancel>
-											<AlertDialogAction
-												data-testid="vk-calendar-align-enable-btn"
-												onClick={() => {
-													form.setValue("budgetCalendarAligned", true, { shouldDirty: true });
-													setShowCalendarAlignWarning(false);
-												}}
-											>
-												Enable Calendar Alignment
-											</AlertDialogAction>
-										</AlertDialogFooter>
-									</AlertDialogContent>
-								</AlertDialog>
-								{(teams?.length > 0 ||
-									customers?.length > 0 ||
-									accessProfiles?.length > 0 ||
-									!!virtualKey?.access_profile_id ||
-									!!defaultAccessProfileId) && (
-									<>
-										<DottedSeparator className="my-6" />
-
-										{/* Entity Assignment */}
-										<div className="space-y-4">
-											<Label className="text-sm font-medium">Entity Assignment</Label>
-
-											<div className="grid grid-cols-1 items-center gap-2 md:grid-cols-2">
-												<FormField
-													control={form.control}
-													name="entityType"
-													render={({ field }) => (
-														<FormItem>
-															<FormLabel className="font-normal">Assignment Type</FormLabel>
-															<ComboboxSelect
-																options={[
-																	{ value: "none", label: "No Assignment" },
-																	...(teams?.length > 0 ? [{ value: "team", label: "Assign to Team" }] : []),
-																	...(customers?.length > 0 ? [{ value: "customer", label: "Assign to Customer" }] : []),
-																	...(accessProfiles?.length > 0 || virtualKey?.access_profile_id || defaultAccessProfileId
-																		? [{ value: "access_profile", label: "Assign to Access Profile" }]
-																		: []),
-																]}
-																value={field.value}
-																onValueChange={async (value) => {
-																	const val = value ?? "none";
-																	const originalType = virtualKey?.team_id
-																		? "team"
-																		: virtualKey?.customer_id
-																			? "customer"
-																			: virtualKey?.access_profile_id
-																				? "access_profile"
-																				: "none";
-																	if (isEditing && currentAssignmentLabel && val !== "none" && val !== originalType) {
-																		setPendingEntityType(val as "team" | "customer" | "access_profile");
-																		setShowReassignTypeWarning(true);
-																		return;
-																	}
-																	field.onChange(val);
-																	if (val === "team" && teams?.length > 0) {
-																		form.setValue("teamId", teams[0].id, { shouldDirty: true, shouldValidate: true });
-																		form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-																		form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
-																		await form.trigger(["teamId", "customerId", "accessProfileId", "entityType"]);
-																	} else if (val === "customer" && customers?.length > 0) {
-																		form.setValue("customerId", customers[0].id, { shouldDirty: true, shouldValidate: true });
-																		form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-																		form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
-																		await form.trigger(["teamId", "customerId", "accessProfileId", "entityType"]);
-																	} else if (val === "access_profile") {
-																		const apId =
-																			accessProfiles?.length > 0
-																				? String(accessProfiles[0].id)
-																				: virtualKey?.access_profile_id
-																					? String(virtualKey.access_profile_id)
-																					: "";
-																		form.setValue("accessProfileId", apId, { shouldDirty: true, shouldValidate: true });
-																		form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-																		form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-																		await form.trigger(["teamId", "customerId", "accessProfileId", "entityType"]);
-																	} else {
-																		form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-																		form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-																		form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
-																		await form.trigger(["teamId", "customerId", "accessProfileId", "entityType"]);
-																	}
-																}}
-																disabled={isTeamLocked || isAPLocked}
-																disableSearch
-																hideClear
-																className="h-9"
-															/>
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-												{form.watch("entityType") === "team" && teams?.length > 0 && (
-													<FormField
-														control={form.control}
-														name="teamId"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel className="font-normal">Select Team</FormLabel>
-																<ComboboxSelect
-																	options={teams.map((team) => ({
-																		value: team.id,
-																		label: team.customer ? `${team.name} — ${team.customer.name}` : team.name,
-																	}))}
-																	value={field.value || null}
-																	onValueChange={(val) => {
-																		const newVal = val ?? "";
-																		if (isEditing && virtualKey?.team_id && newVal && newVal !== virtualKey.team_id) {
-																			setPendingTeamId(newVal);
-																			setShowReassignTeamWarning(true);
-																		} else {
-																			field.onChange(newVal);
-																		}
-																	}}
-																	placeholder="Select a team"
-																	disabled={isTeamLocked}
-																	emptyMessage="No teams found."
-																	className="h-9"
-																/>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-												)}
-
-												{form.watch("entityType") === "customer" && customers?.length > 0 && (
-													<FormField
-														control={form.control}
-														name="customerId"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel className="font-normal">Select Customer</FormLabel>
-																<ComboboxSelect
-																	options={customers.map((customer) => ({
-																		value: customer.id,
-																		label: customer.name,
-																	}))}
-																	value={field.value || null}
-																	onValueChange={(val) => field.onChange(val ?? "")}
-																	placeholder="Select a customer"
-																	emptyMessage="No customers found."
-																	className="h-9"
-																/>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-												)}
-
-												{form.watch("entityType") === "access_profile" &&
-													(accessProfiles?.length > 0 || virtualKey?.access_profile_id || defaultAccessProfileId) && (
-														<FormField
-															control={form.control}
-															name="accessProfileId"
-															render={({ field }) => (
-																<FormItem>
-																	<FormLabel className="font-normal">Select Access Profile</FormLabel>
-																	<ComboboxSelect
-																		data-testid="access-profile-selector"
-																		options={accessProfiles.map((ap) => ({ value: String(ap.id), label: ap.name }))}
-																		value={field.value || null}
-																		onValueChange={(val) => {
-																			const newVal = val ?? "";
-																			if (
-																				isEditing &&
-																				virtualKey?.access_profile_id &&
-																				newVal &&
-																				newVal !== String(virtualKey.access_profile_id)
-																			) {
-																				setPendingAccessProfileId(newVal);
-																				setShowReassignAPWarning(true);
-																			} else {
-																				field.onChange(newVal);
-																			}
-																		}}
-																		placeholder="Select an access profile"
-																		disabled={isAPLocked}
-																		emptyMessage="No access profiles found."
-																		className="h-9"
-																	/>
-																	<FormMessage />
-																</FormItem>
-															)}
-														/>
-													)}
-											</div>
-										</div>
-									</>
-								)}
-							</fieldset>
-						</div>
-						<AlertDialog open={showRotateWarning} onOpenChange={setShowRotateWarning}>
-							<AlertDialogContent>
-								<AlertDialogHeader>
-									<AlertDialogTitle>Rotate virtual key?</AlertDialogTitle>
-									<AlertDialogDescription>
-										This will replace the secret value for &quot;{virtualKey?.name}&quot;. The key ID, budgets, rate limits, provider
-										permissions, MCP access, and assignments stay the same. The previous key value will stop working immediately.
-									</AlertDialogDescription>
-								</AlertDialogHeader>
-								<AlertDialogFooter>
-									<AlertDialogCancel data-testid="vk-rotate-cancel-btn">Cancel</AlertDialogCancel>
-									<AlertDialogAction onClick={handleRotateVirtualKey} disabled={isRotating} data-testid="vk-rotate-confirm-btn">
-										{isRotating ? "Rotating..." : "Rotate Key"}
-									</AlertDialogAction>
-								</AlertDialogFooter>
-							</AlertDialogContent>
-						</AlertDialog>
-						<AlertDialog open={showBudgetResetPrompt} onOpenChange={setShowBudgetResetPrompt}>
-							<AlertDialogContent data-testid="vk-budget-reset-dialog">
-								<AlertDialogHeader>
-									<AlertDialogTitle>{pendingBudgetUsageWarning ? "Preserve over-limit usage?" : "Reset budget usage?"}</AlertDialogTitle>
-									<AlertDialogDescription>
-										{pendingBudgetUsageWarning
-											? `${pendingBudgetUsageWarning} You can preserve usage anyway, or reset usage to 0.`
-											: "You changed a budget amount, reset frequency, or calendar alignment. Reset current budget usage to 0, or preserve the existing usage counters."}
-									</AlertDialogDescription>
-								</AlertDialogHeader>
-								<AlertDialogFooter>
-									<AlertDialogCancel onClick={() => handleBudgetResetChoice(false)} data-testid="vk-budget-reset-preserve-btn">
-										{pendingBudgetUsageWarning ? "Preserve Anyway" : "Preserve Usage"}
-									</AlertDialogCancel>
-									<AlertDialogAction onClick={() => handleBudgetResetChoice(true)} data-testid="vk-budget-reset-confirm-btn">
-										Reset Usage
-									</AlertDialogAction>
-								</AlertDialogFooter>
-							</AlertDialogContent>
-						</AlertDialog>
-						{isEditing && virtualKey?.config_hash && (
-							<div className="px-8">
-								<ConfigSyncAlert className="mt-2" />
-							</div>
-						)}
-						{/* Form Footer */}
-						<div className="border-border bg-card sticky bottom-0 z-10 border-t px-8 py-4">
-							<div className="flex items-center justify-between gap-2">
-								{isEditing ? (
-									<Button
-										type="button"
-										variant="outline"
-										onClick={() => setShowRotateWarning(true)}
-										disabled={!hasUpdateAccess || isRotating}
-										data-testid="vk-rotate-btn"
-									>
-										<RotateCcw className="h-4 w-4" />
-										{isRotating ? "Rotating..." : "Rotate Key"}
-									</Button>
-								) : (
-									<span />
-								)}
-								<div className="flex justify-end gap-2">
-									<Button type="button" variant="outline" onClick={handleClose} data-testid="vk-cancel-btn">
-										Cancel
-									</Button>
-									<TooltipProvider>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<span className="inline-block">
-													<Button type="submit" disabled={isLoading || !form.formState.isDirty || !canSubmit} data-testid="vk-save-btn">
-														{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
-													</Button>
-												</span>
-											</TooltipTrigger>
-											{(isLoading || !form.formState.isDirty || !canSubmit) && (
-												<TooltipContent>
-													<p>
-														{!canSubmit
-															? "You don't have permission to perform this action"
-															: isLoading
-																? "Saving..."
-																: !form.formState.isDirty
-																	? "No changes made"
-																	: ""}
-													</p>
-												</TooltipContent>
-											)}
-										</Tooltip>
-									</TooltipProvider>
-								</div>
-							</div>
-						</div>
-					</form>
-				</Form>
-			</SheetContent>
-		</Sheet>
-	);
+  const [isOpen, setIsOpen] = useState(true);
+  const navigate = useNavigate();
+  const isEditing = !!virtualKey;
+
+  const hasCreateAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.Create,
+  );
+  const hasUpdateAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.Update,
+  );
+  const canSubmit = isEditing ? hasUpdateAccess : hasCreateAccess;
+
+  const { assignedUsers } = useVirtualKeyUsage(virtualKey);
+  const isManagedByProfile = isEditing && !!virtualKey?.access_profile_id;
+  // Team attachment: when creating from a team context (defaultTeamId provided), the entity
+  // assignment is pre-set and locked. When editing an existing VK the assignment can be changed.
+  const attachedTeamId = isEditing
+    ? virtualKey?.team_id || ""
+    : defaultTeamId || "";
+  const attachedTeam = attachedTeamId
+    ? teams.find((t) => t.id === attachedTeamId)
+    : undefined;
+  const isTeamLocked = !isEditing && !!defaultTeamId;
+  const isAPLocked = !isEditing && !!defaultAccessProfileId;
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setTimeout(() => {
+      onCancel();
+    }, 150); // Slightly longer than the 100ms animation duration
+  };
+
+  // RTK Query hooks
+  const { data: providersData, error: providersError } = useGetProvidersQuery();
+  const { data: keysData, error: keysError } = useGetAllKeysQuery();
+  const [createVirtualKey, { isLoading: isCreating }] =
+    useCreateVirtualKeyMutation();
+  const [updateVirtualKey, { isLoading: isUpdating }] =
+    useUpdateVirtualKeyMutation();
+  const [rotateVirtualKey, { isLoading: isRotating }] =
+    useRotateVirtualKeyMutation();
+  const { data: mcpClientsResponse, error: mcpClientsError } =
+    useGetMCPClientsQuery();
+  const { data: accessProfilesData } = useGetAccessProfilesQuery({
+    limit: 100,
+  });
+  const accessProfiles = accessProfilesData?.access_profiles ?? [];
+  const mcpClientsData = mcpClientsResponse?.clients || [];
+  const isLoading = isCreating || isUpdating || isRotating;
+
+  const availableKeys = keysData || [];
+  const availableProviders = providersData || [];
+
+  // Form setup
+  const form = useForm<z.input<typeof formSchema>, unknown, FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: virtualKey?.name || "",
+      description: virtualKey?.description || "",
+      providerConfigs:
+        virtualKey?.provider_configs?.map((config) => ({
+          id: config.id,
+          provider: config.provider,
+          weight: config.weight ?? undefined,
+          allowed_models: config.allowed_models,
+          key_ids: config.allow_all_keys
+            ? ["*"]
+            : config.keys?.map((key) => key.key_id) || [],
+          budgets: config.budgets?.map((b) => ({
+            id: b.id,
+            max_limit: b.max_limit,
+            reset_duration: b.reset_duration,
+          })),
+          rate_limit: config.rate_limit
+            ? {
+                token_max_limit: config.rate_limit.token_max_limit ?? undefined,
+                token_reset_duration: config.rate_limit.token_reset_duration,
+                request_max_limit:
+                  config.rate_limit.request_max_limit ?? undefined,
+                request_reset_duration:
+                  config.rate_limit.request_reset_duration,
+              }
+            : undefined,
+        })) || [],
+      mcpConfigs:
+        virtualKey?.mcp_configs?.map((config) => ({
+          id: config.id,
+          mcp_client_name: config.mcp_client?.name || "",
+          tools_to_execute: config.tools_to_execute || [],
+        })) || [],
+      entityType: virtualKey?.team_id
+        ? "team"
+        : virtualKey?.customer_id
+          ? "customer"
+          : virtualKey?.access_profile_id
+            ? "access_profile"
+            : !isEditing && defaultTeamId
+              ? "team"
+              : !isEditing && defaultAccessProfileId
+                ? "access_profile"
+                : "none",
+      teamId: virtualKey?.team_id || (!isEditing ? defaultTeamId || "" : ""),
+      customerId: virtualKey?.customer_id || "",
+      accessProfileId: virtualKey?.access_profile_id
+        ? String(virtualKey.access_profile_id)
+        : !isEditing && defaultAccessProfileId
+          ? String(defaultAccessProfileId)
+          : "",
+      isActive: virtualKey?.is_active ?? true,
+      budgets:
+        virtualKey?.budgets && virtualKey.budgets.length > 0
+          ? virtualKey.budgets.map((b) => ({
+              id: b.id,
+              max_limit: b.max_limit,
+              reset_duration: b.reset_duration ?? "1M",
+            }))
+          : [],
+      budgetCalendarAligned: virtualKey?.calendar_aligned ?? false,
+      tokenMaxLimit: virtualKey?.rate_limit?.token_max_limit ?? undefined,
+      tokenResetDuration: virtualKey?.rate_limit?.token_reset_duration || "1h",
+      requestMaxLimit: virtualKey?.rate_limit?.request_max_limit ?? undefined,
+      requestResetDuration:
+        virtualKey?.rate_limit?.request_reset_duration || "1h",
+    },
+  });
+
+  // Handle keys loading error
+  useEffect(() => {
+    if (keysError) {
+      toast.error(
+        `Failed to load available keys: ${getErrorMessage(keysError)}`,
+      );
+    }
+  }, [keysError]);
+
+  // Handle providers loading error
+  useEffect(() => {
+    if (providersError) {
+      toast.error(
+        `Failed to load available providers: ${getErrorMessage(providersError)}`,
+      );
+    }
+  }, [providersError]);
+
+  // Handle mcp clients loading error
+  useEffect(() => {
+    if (mcpClientsError) {
+      toast.error(
+        `Failed to load available MCP clients: ${getErrorMessage(mcpClientsError)}`,
+      );
+    }
+  }, [mcpClientsError]);
+
+  // Clear entity ID fields when entityType changes
+  useEffect(() => {
+    const entityType = form.watch("entityType");
+    if (entityType === "none") {
+      form.setValue("teamId", "", { shouldDirty: true });
+      form.setValue("customerId", "", { shouldDirty: true });
+      form.setValue("accessProfileId", "", { shouldDirty: true });
+    } else if (entityType === "team") {
+      form.setValue("customerId", "", { shouldDirty: true });
+      form.setValue("accessProfileId", "", { shouldDirty: true });
+    } else if (entityType === "customer") {
+      form.setValue("teamId", "", { shouldDirty: true });
+      form.setValue("accessProfileId", "", { shouldDirty: true });
+    } else if (entityType === "access_profile") {
+      form.setValue("teamId", "", { shouldDirty: true });
+      form.setValue("customerId", "", { shouldDirty: true });
+    }
+  }, [form.watch("entityType"), form]);
+
+  // Provider configuration state
+  const [selectedProvider, setSelectedProvider] = useState<string>("");
+
+  // MCP client configuration state
+  const [selectedMCPClient, setSelectedMCPClient] = useState<string>("");
+
+  // Get current provider configs from form
+  const providerConfigs = form.watch("providerConfigs") || [];
+
+  // Get current MCP configs from form
+  const mcpConfigs = form.watch("mcpConfigs") || [];
+
+  // Watch budget/rate-limit fields for conditional rendering of reset buttons
+  const watchedBudgets = form.watch("budgets");
+  const watchedTokenMaxLimit = form.watch("tokenMaxLimit");
+  const watchedRequestMaxLimit = form.watch("requestMaxLimit");
+  const watchedTokenResetDuration = form.watch("tokenResetDuration");
+  const watchedRequestResetDuration = form.watch("requestResetDuration");
+  const watchedBudgetCalendarAligned = form.watch("budgetCalendarAligned");
+
+  // Calendar alignment is VK-wide and applies to both budgets and rate limits: show the
+  // toggle when any configured budget or rate-limit uses a calendar-alignable duration.
+  const hasAnyAlignableBudget =
+    watchedBudgets &&
+    watchedBudgets.length > 0 &&
+    watchedBudgets.some(
+      (b) =>
+        b.max_limit !== undefined &&
+        b.max_limit !== null &&
+        supportsCalendarAlignment(b.reset_duration || "1M"),
+    );
+  const hasAnyAlignableRateLimit =
+    (watchedTokenMaxLimit !== undefined &&
+      watchedTokenMaxLimit !== null &&
+      supportsCalendarAlignment(watchedTokenResetDuration || "1h")) ||
+    (watchedRequestMaxLimit !== undefined &&
+      watchedRequestMaxLimit !== null &&
+      supportsCalendarAlignment(watchedRequestResetDuration || "1h"));
+  const showCalendarAlignToggle =
+    hasAnyAlignableBudget || hasAnyAlignableRateLimit;
+
+  // Handle adding a new provider configuration
+  const handleAddProvider = (provider: string) => {
+    const existingConfig = providerConfigs.find(
+      (config) => config.provider === provider,
+    );
+    if (existingConfig) {
+      toast.error("This provider is already configured");
+      return;
+    }
+
+    const newConfig = {
+      provider: provider,
+      weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
+      allowed_models: ["*"],
+      key_ids: ["*"],
+    };
+
+    form.setValue("providerConfigs", [...providerConfigs, newConfig], {
+      shouldDirty: true,
+    });
+  };
+
+  // Handle removing a provider configuration
+  const handleRemoveProvider = (index: number) => {
+    const updatedConfigs = providerConfigs.filter((_, i) => i !== index);
+    form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
+  };
+
+  // Handle updating provider configuration
+  const handleUpdateProviderConfig = (
+    index: number,
+    field: string,
+    value: any,
+  ) => {
+    const updatedConfigs = [...providerConfigs];
+    updatedConfigs[index] = { ...updatedConfigs[index], [field]: value };
+    form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
+  };
+
+  // Handle adding a new MCP client configuration
+  const handleAddMCPClient = (mcpClientName: string) => {
+    const existingConfig = mcpConfigs.find(
+      (config) => config.mcp_client_name === mcpClientName,
+    );
+    if (existingConfig) {
+      toast.error("This MCP client is already configured");
+      return;
+    }
+
+    const newConfig = {
+      mcp_client_name: mcpClientName,
+      tools_to_execute: ["*"],
+    };
+
+    form.setValue("mcpConfigs", [...mcpConfigs, newConfig], {
+      shouldDirty: true,
+    });
+  };
+
+  // Handle removing an MCP client configuration
+  const handleRemoveMCPClient = (index: number) => {
+    const updatedConfigs = mcpConfigs.filter((_, i) => i !== index);
+    form.setValue("mcpConfigs", updatedConfigs, { shouldDirty: true });
+  };
+
+  // Handle updating MCP client configuration
+  const handleUpdateMCPConfig = (
+    index: number,
+    field: keyof (typeof mcpConfigs)[0],
+    value: any,
+  ) => {
+    const updatedConfigs = [...mcpConfigs];
+    updatedConfigs[index] = { ...updatedConfigs[index], [field]: value };
+    form.setValue("mcpConfigs", updatedConfigs, { shouldDirty: true });
+  };
+
+  const [showCalendarAlignWarning, setShowCalendarAlignWarning] =
+    useState(false);
+  const [showReassignTeamWarning, setShowReassignTeamWarning] = useState(false);
+  const [pendingTeamId, setPendingTeamId] = useState<string | null>(null);
+  const [showReassignAPWarning, setShowReassignAPWarning] = useState(false);
+  const [pendingAccessProfileId, setPendingAccessProfileId] = useState<
+    string | null
+  >(null);
+  const [showReassignTypeWarning, setShowReassignTypeWarning] = useState(false);
+  const [pendingEntityType, setPendingEntityType] = useState<
+    "team" | "customer" | "access_profile" | "none" | null
+  >(null);
+  const [showRotateWarning, setShowRotateWarning] = useState(false);
+  const [showBudgetResetPrompt, setShowBudgetResetPrompt] = useState(false);
+  const [pendingBudgetResetData, setPendingBudgetResetData] =
+    useState<FormData | null>(null);
+  const [pendingBudgetUsageWarning, setPendingBudgetUsageWarning] = useState<
+    string | null
+  >(null);
+
+  const currentAssignmentLabel = useMemo(() => {
+    if (!isEditing) return null;
+    if (virtualKey?.team_id) {
+      const team = teams?.find((t) => t.id === virtualKey.team_id);
+      return team ? `Team: ${team.name}` : "a team";
+    }
+    if (virtualKey?.customer_id) {
+      const customer = customers?.find((c) => c.id === virtualKey.customer_id);
+      return customer ? `Customer: ${customer.name}` : "a customer";
+    }
+    if (virtualKey?.access_profile_id) {
+      const ap = accessProfiles?.find(
+        (p) => p.id === virtualKey.access_profile_id,
+      );
+      return ap ? `Access Profile: ${ap.name}` : "an access profile";
+    }
+    return null;
+  }, [isEditing, virtualKey, teams, customers, accessProfiles]);
+
+  const handleCalendarAlignedChange = (checked: boolean) => {
+    if (checked && isEditing) {
+      // Show warning when enabling on an existing VK
+      setShowCalendarAlignWarning(true);
+    } else {
+      form.setValue("budgetCalendarAligned", checked, { shouldDirty: true });
+    }
+  };
+
+  const clearVirtualKeyBudget = () => {
+    form.setValue("budgets", [], { shouldDirty: true });
+    form.setValue("budgetCalendarAligned", false, { shouldDirty: true });
+  };
+
+  const clearVirtualKeyRateLimits = () => {
+    form.setValue("tokenMaxLimit", undefined, { shouldDirty: true });
+    form.setValue("tokenResetDuration", "1h", { shouldDirty: true });
+    form.setValue("requestMaxLimit", undefined, { shouldDirty: true });
+    form.setValue("requestResetDuration", "1h", { shouldDirty: true });
+  };
+
+  const normalizeProviderConfigs = (
+    configs: typeof providerConfigs,
+    existingConfigs?: VirtualKey["provider_configs"],
+  ): any[] => {
+    return configs.map((config) => ({
+      ...config,
+      budgets: config.budgets?.filter(
+        (b): b is { id?: string; max_limit: number; reset_duration: string } =>
+          b.max_limit !== undefined,
+      ),
+      weight: config.weight ?? null,
+      rate_limit: (() => {
+        const hasTokenMaxLimit =
+          config.rate_limit?.token_max_limit !== undefined;
+        const hasRequestMaxLimit =
+          config.rate_limit?.request_max_limit !== undefined;
+        if (hasTokenMaxLimit || hasRequestMaxLimit) {
+          return {
+            token_max_limit: config.rate_limit?.token_max_limit ?? null,
+            token_reset_duration: hasTokenMaxLimit
+              ? config.rate_limit?.token_reset_duration || "1h"
+              : null,
+            request_max_limit: config.rate_limit?.request_max_limit ?? null,
+            request_reset_duration: hasRequestMaxLimit
+              ? config.rate_limit?.request_reset_duration || "1h"
+              : null,
+          };
+        }
+
+        const existingConfig = existingConfigs?.find((item) =>
+          config.id ? item.id === config.id : item.provider === config.provider,
+        );
+        if (existingConfig?.rate_limit) {
+          return {};
+        }
+
+        return undefined;
+      })(),
+    }));
+  };
+
+  const budgetSignature = (budgets?: BudgetComparisonEntry[]) =>
+    (budgets || [])
+      .filter((budget) => budget.max_limit !== undefined)
+      .map(
+        (budget) =>
+          `${budget.id ?? ""}:${budget.max_limit}:${budget.reset_duration ?? ""}`,
+      )
+      .sort()
+      .join("|");
+
+  const parseResetDurationMs = (duration?: string) => {
+    if (!duration) return null;
+    const match = duration.match(/^(\d+(?:\.\d+)?)(ms|s|m|h|d|w|M|Y)$/);
+    if (!match) return null;
+    const amount = Number(match[1]);
+    const unit = match[2];
+    const multipliers: Record<string, number> = {
+      ms: 1,
+      s: 1000,
+      m: 60 * 1000,
+      h: 60 * 60 * 1000,
+      d: 24 * 60 * 60 * 1000,
+      w: 7 * 24 * 60 * 60 * 1000,
+      M: 30 * 24 * 60 * 60 * 1000,
+      Y: 365 * 24 * 60 * 60 * 1000,
+    };
+    return amount * multipliers[unit];
+  };
+
+  const formatBudgetAmount = (value: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 2,
+    }).format(value);
+
+  const findBudgetUsageWarning = (
+    currentBudgets: BudgetComparisonEntry[] | undefined,
+    existingBudgets: BudgetComparisonEntry[] | undefined,
+    scopeLabel: string,
+  ) => {
+    const current = (currentBudgets || [])
+      .filter(
+        (
+          budget,
+        ): budget is BudgetComparisonEntry & {
+          max_limit: number;
+          reset_duration: string;
+        } => {
+          return budget.max_limit !== undefined && !!budget.reset_duration;
+        },
+      )
+      .sort(
+        (left, right) =>
+          (parseResetDurationMs(left.reset_duration) ?? 0) -
+          (parseResetDurationMs(right.reset_duration) ?? 0),
+      );
+    const existingByID = new Map(
+      (existingBudgets || [])
+        .filter((budget) => budget.id)
+        .map((budget) => [budget.id, budget]),
+    );
+    const existingByDuration = new Map(
+      (existingBudgets || []).map((budget) => [budget.reset_duration, budget]),
+    );
+    const reconciled: BudgetComparisonEntry[] = [];
+
+    for (const budget of current) {
+      const existing = budget.id
+        ? existingByID.get(budget.id)
+        : existingByDuration.get(budget.reset_duration);
+      if (existing) {
+        const configChanged =
+          existing.max_limit !== budget.max_limit ||
+          existing.reset_duration !== budget.reset_duration;
+        const usage = existing.current_usage ?? 0;
+        if (configChanged && usage >= budget.max_limit) {
+          return `${scopeLabel} ${budget.reset_duration} budget has ${formatBudgetAmount(usage)} usage, which meets or exceeds the new ${formatBudgetAmount(budget.max_limit)} limit.`;
+        }
+        reconciled.push({ ...budget, current_usage: usage });
+        continue;
+      }
+
+      const targetDuration = parseResetDurationMs(budget.reset_duration);
+      const closestShorter = reconciled.reduce<BudgetComparisonEntry | null>(
+        (closest, candidate) => {
+          const candidateDuration = parseResetDurationMs(
+            candidate.reset_duration,
+          );
+          const closestDuration = parseResetDurationMs(closest?.reset_duration);
+          if (
+            targetDuration === null ||
+            candidateDuration === null ||
+            candidateDuration >= targetDuration
+          ) {
+            return closest;
+          }
+          if (
+            closest === null ||
+            closestDuration === null ||
+            candidateDuration > closestDuration
+          ) {
+            return candidate;
+          }
+          return closest;
+        },
+        null,
+      );
+      const inheritedUsage = closestShorter?.current_usage ?? 0;
+      if (inheritedUsage >= budget.max_limit) {
+        return `${scopeLabel} ${budget.reset_duration} budget will inherit ${formatBudgetAmount(inheritedUsage)} from the ${closestShorter?.reset_duration} budget, which meets or exceeds the new ${formatBudgetAmount(budget.max_limit)} limit.`;
+      }
+      reconciled.push({ ...budget, current_usage: inheritedUsage });
+    }
+
+    return null;
+  };
+
+  const getBudgetUsageWarning = (data: FormData) => {
+    if (!isEditing || !virtualKey || isManagedByProfile) {
+      return null;
+    }
+
+    const vkWarning = findBudgetUsageWarning(
+      data.budgets,
+      virtualKey.budgets,
+      "Virtual key",
+    );
+    if (vkWarning) {
+      return vkWarning;
+    }
+
+    const existingProviderConfigs = new Map<
+      string,
+      NonNullable<VirtualKey["provider_configs"]>[number]
+    >();
+    (virtualKey.provider_configs || []).forEach((config) => {
+      existingProviderConfigs.set(String(config.id ?? config.provider), config);
+    });
+    for (const config of data.providerConfigs || []) {
+      const existingConfig = existingProviderConfigs.get(
+        String(config.id ?? config.provider),
+      );
+      const providerLabel =
+        ProviderLabels[config.provider as ProviderName] ?? config.provider;
+      const warning = findBudgetUsageWarning(
+        config.budgets,
+        existingConfig?.budgets,
+        `${providerLabel} provider`,
+      );
+      if (warning) {
+        return warning;
+      }
+    }
+
+    return null;
+  };
+
+  const hasBudgetResetRelevantChanges = (data: FormData) => {
+    if (!isEditing || !virtualKey || isManagedByProfile) {
+      return false;
+    }
+
+    const currentBudgets = (data.budgets || []).filter(
+      (
+        budget,
+      ): budget is { id?: string; max_limit: number; reset_duration: string } =>
+        budget.max_limit !== undefined,
+    );
+    const existingBudgets = virtualKey.budgets || [];
+    const hasBudgetFields =
+      currentBudgets.length > 0 ||
+      existingBudgets.length > 0 ||
+      (data.providerConfigs || []).some((config) =>
+        (config.budgets || []).some((budget) => budget.max_limit !== undefined),
+      ) ||
+      (virtualKey.provider_configs || []).some(
+        (config) => (config.budgets || []).length > 0,
+      );
+
+    if (budgetSignature(currentBudgets) !== budgetSignature(existingBudgets)) {
+      return true;
+    }
+
+    if (
+      hasBudgetFields &&
+      data.budgetCalendarAligned !== (virtualKey.calendar_aligned ?? false)
+    ) {
+      return true;
+    }
+
+    const existingProviderConfigs = new Map<
+      string,
+      NonNullable<VirtualKey["provider_configs"]>[number]
+    >();
+    (virtualKey.provider_configs || []).forEach((config) => {
+      existingProviderConfigs.set(String(config.id ?? config.provider), config);
+    });
+
+    const currentProviderConfigs = new Map<
+      string,
+      NonNullable<FormData["providerConfigs"]>[number]
+    >();
+    (data.providerConfigs || []).forEach((config) => {
+      currentProviderConfigs.set(String(config.id ?? config.provider), config);
+    });
+
+    const providerConfigKeys = new Set([
+      ...existingProviderConfigs.keys(),
+      ...currentProviderConfigs.keys(),
+    ]);
+    for (const key of providerConfigKeys) {
+      const currentSignature = budgetSignature(
+        currentProviderConfigs.get(key)?.budgets,
+      );
+      const existingSignature = budgetSignature(
+        existingProviderConfigs.get(key)?.budgets,
+      );
+      if (currentSignature !== existingSignature) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  const handleRotateVirtualKey = async () => {
+    if (!virtualKey) return;
+    if (!hasUpdateAccess) {
+      toast.error("You don't have permission to perform this action");
+      return;
+    }
+    try {
+      await rotateVirtualKey(virtualKey.id).unwrap();
+      toast.success("Virtual key rotated successfully");
+      setShowRotateWarning(false);
+      onSave();
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    }
+  };
+
+  const submitVirtualKeyForm = async (
+    data: FormData,
+    resetBudgetUsage = false,
+  ) => {
+    if (!canSubmit) {
+      toast.error("You don't have permission to perform this action");
+      return;
+    }
+    try {
+      // Managed VKs only allow name + description updates; all other fields are owned by the access profile.
+      if (isManagedByProfile && virtualKey) {
+        await updateVirtualKey({
+          vkId: virtualKey.id,
+          data: {
+            name: data.name,
+            description: data.description,
+          },
+        }).unwrap();
+        toast.success("Virtual key updated");
+        onSave();
+        return;
+      }
+
+      // Normalize provider configs to ensure weights are numbers and handle budget/rate limits
+      const normalizedProviderConfigs = data.providerConfigs
+        ? normalizeProviderConfigs(
+            data.providerConfigs,
+            virtualKey?.provider_configs,
+          )
+        : [];
+      if (isEditing && virtualKey) {
+        // Update existing virtual key
+        const updateData: UpdateVirtualKeyRequest = {
+          name: data.name,
+          description: data.description,
+          provider_configs: normalizedProviderConfigs,
+          mcp_configs: data.mcpConfigs,
+          team_id:
+            data.entityType === "team" &&
+            data.teamId &&
+            data.teamId.trim() !== ""
+              ? data.teamId
+              : undefined,
+          customer_id:
+            data.entityType === "customer" &&
+            data.customerId &&
+            data.customerId.trim() !== ""
+              ? data.customerId
+              : undefined,
+          access_profile_id:
+            data.entityType === "access_profile" &&
+            data.accessProfileId &&
+            data.accessProfileId.trim() !== ""
+              ? Number(data.accessProfileId)
+              : undefined,
+          is_active: data.isActive,
+          calendar_aligned: data.budgetCalendarAligned,
+          reset_budget_usage: resetBudgetUsage,
+        };
+
+        // Add budgets if enabled
+        const validBudgets = (data.budgets || []).filter(
+          (
+            b,
+          ): b is { id?: string; max_limit: number; reset_duration: string } =>
+            b.max_limit !== undefined,
+        );
+        const hadBudget = virtualKey.budgets && virtualKey.budgets.length > 0;
+        if (validBudgets.length > 0) {
+          updateData.budgets = validBudgets;
+        } else if (hadBudget) {
+          updateData.budgets = [];
+        }
+
+        // Add rate limit if enabled
+        const hadRateLimit = !!virtualKey.rate_limit;
+        const hasTokenMaxLimit = data.tokenMaxLimit !== undefined;
+        const hasRequestMaxLimit = data.requestMaxLimit !== undefined;
+        const hasRateLimit = hasTokenMaxLimit || hasRequestMaxLimit;
+        if (hasRateLimit) {
+          updateData.rate_limit = {
+            token_max_limit: data.tokenMaxLimit ?? null,
+            token_reset_duration: hasTokenMaxLimit
+              ? data.tokenResetDuration || "1h"
+              : null,
+            request_max_limit: data.requestMaxLimit ?? null,
+            request_reset_duration: hasRequestMaxLimit
+              ? data.requestResetDuration || "1h"
+              : null,
+          };
+        } else if (hadRateLimit) {
+          updateData.rate_limit = {};
+        }
+
+        await updateVirtualKey({
+          vkId: virtualKey.id,
+          data: updateData,
+        }).unwrap();
+        toast.success("Virtual key updated successfully");
+      } else {
+        // Create new virtual key
+        const createData: CreateVirtualKeyRequest = {
+          name: data.name,
+          description: data.description || undefined,
+          provider_configs: normalizedProviderConfigs,
+          mcp_configs: data.mcpConfigs,
+          team_id:
+            data.entityType === "team" &&
+            data.teamId &&
+            data.teamId.trim() !== ""
+              ? data.teamId
+              : undefined,
+          customer_id:
+            data.entityType === "customer" &&
+            data.customerId &&
+            data.customerId.trim() !== ""
+              ? data.customerId
+              : undefined,
+          access_profile_id:
+            data.entityType === "access_profile" &&
+            data.accessProfileId &&
+            data.accessProfileId.trim() !== ""
+              ? Number(data.accessProfileId)
+              : undefined,
+          is_active: data.isActive,
+          // VK-level setting that governs both budget and rate-limit calendar alignment.
+          calendar_aligned: data.budgetCalendarAligned,
+        };
+
+        // Add budgets if enabled
+        const validBudgets = (data.budgets || []).filter(
+          (
+            b,
+          ): b is { id?: string; max_limit: number; reset_duration: string } =>
+            b.max_limit !== undefined,
+        );
+        if (validBudgets.length > 0) {
+          createData.budgets = validBudgets;
+        }
+
+        // Add rate limit if enabled
+        const hasTokenMaxLimit = data.tokenMaxLimit !== undefined;
+        const hasRequestMaxLimit = data.requestMaxLimit !== undefined;
+        if (hasTokenMaxLimit || hasRequestMaxLimit) {
+          createData.rate_limit = {
+            token_max_limit: data.tokenMaxLimit,
+            token_reset_duration: hasTokenMaxLimit
+              ? data.tokenResetDuration || "1h"
+              : undefined,
+            request_max_limit: data.requestMaxLimit,
+            request_reset_duration: hasRequestMaxLimit
+              ? data.requestResetDuration || "1h"
+              : undefined,
+          };
+        }
+
+        await createVirtualKey(createData).unwrap();
+        toast.success("Virtual key created successfully");
+      }
+
+      onSave();
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    }
+  };
+
+  // Handle form submission
+  const onSubmit = async (data: FormData) => {
+    if (hasBudgetResetRelevantChanges(data)) {
+      setPendingBudgetResetData(data);
+      setPendingBudgetUsageWarning(getBudgetUsageWarning(data));
+      setShowBudgetResetPrompt(true);
+      return;
+    }
+
+    await submitVirtualKeyForm(data, false);
+  };
+
+  const handleBudgetResetChoice = async (resetBudgetUsage: boolean) => {
+    if (!pendingBudgetResetData) return;
+    const data = pendingBudgetResetData;
+    setPendingBudgetResetData(null);
+    setPendingBudgetUsageWarning(null);
+    setShowBudgetResetPrompt(false);
+    await submitVirtualKeyForm(data, resetBudgetUsage);
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <SheetContent
+        className="flex w-full flex-col gap-4 overflow-x-hidden p-0 pt-4"
+        data-testid="vk-sheet-content"
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={() => handleClose()}
+      >
+        <SheetHeader
+          className="flex flex-col items-start px-8 py-4"
+          headerClassName="mb-0 sticky -top-4 bg-card z-10"
+        >
+          <SheetTitle className="flex items-center gap-2">
+            {isEditing ? virtualKey?.name : "Create Virtual Key"}
+          </SheetTitle>
+          <SheetDescription>
+            {isEditing
+              ? "Update the virtual key configuration and permissions."
+              : "Create a new virtual key with specific permissions, budgets, and rate limits."}
+          </SheetDescription>
+        </SheetHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="flex h-full flex-col gap-6"
+          >
+            <div className="space-y-4 px-8">
+              {isManagedByProfile && (
+                <Alert variant="info">
+                  <Lock className="h-4 w-4" />
+                  <AlertDescription>
+                    This virtual key is managed by an access profile. Only the
+                    name and description can be modified — providers, budgets,
+                    rate limits, and MCP access are controlled by the profile.
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {isTeamLocked && !isManagedByProfile && (
+                <Alert variant="info">
+                  <Users className="h-4 w-4" />
+                  <AlertDescription>
+                    <p>
+                      Creating this virtual key under team{" "}
+                      <span className="font-medium">
+                        {attachedTeam?.name ?? attachedTeamId}
+                      </span>
+                      . Team assignment is pre-set — all other fields are
+                      editable.
+                    </p>
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {/* Assigned User */}
+              {assignedUsers.length > 0 && (
+                <div className="space-y-1">
+                  <Label className="text-sm font-medium">Assigned To</Label>
+                  <div className="flex items-center gap-2">
+                    <Users className="text-muted-foreground h-4 w-4" />
+                    <span className="text-sm">
+                      {assignedUsers.map((u) => u.name || u.email).join(", ")}
+                    </span>
+                  </div>
+                </div>
+              )}
+
+              {/* Basic Information */}
+              <div className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Name *</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="e.g., Production API Key"
+                          data-testid="vk-name-input"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="This key is used for..."
+                          data-testid="vk-description-input"
+                          {...field}
+                          rows={3}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <fieldset
+                disabled={isManagedByProfile}
+                aria-disabled={isManagedByProfile}
+                inert={isManagedByProfile ? true : undefined}
+                className={
+                  isManagedByProfile
+                    ? "pointer-events-none space-y-4 opacity-50"
+                    : "space-y-4"
+                }
+              >
+                <div className="space-y-4">
+                  <FormField
+                    control={form.control}
+                    name="isActive"
+                    render={({ field }) => (
+                      <FormItem>
+                        <Toggle
+                          label="Is this key active?"
+                          val={field.value}
+                          setVal={field.onChange}
+                          data-testid="vk-is-active-toggle"
+                        />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                {/* Provider Configurations */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Label className="text-sm font-medium">
+                      Provider Configurations
+                    </Label>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span>
+                            <Info className="text-muted-foreground h-3 w-3" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>
+                            Configure which providers this virtual key can use
+                            and their specific settings. Leave empty to block
+                            all providers. Add providers to allow them.
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+
+                  {/* Add Provider Dropdown */}
+                  <div className="flex gap-2">
+                    <Select
+                      value={selectedProvider}
+                      onValueChange={(provider) => {
+                        if (provider === "__manage_providers__") {
+                          navigate({ to: "/workspace/providers" });
+                          setSelectedProvider("");
+                          return;
+                        }
+                        handleAddProvider(provider);
+                        setSelectedProvider(""); // Reset to placeholder state
+                      }}
+                    >
+                      <SelectTrigger
+                        className="flex-1"
+                        data-testid="vk-provider-select"
+                      >
+                        <SelectValue placeholder="Select a provider to add" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {(() => {
+                          // Filter out already configured providers
+                          const unconfiguredProviders =
+                            availableProviders.filter(
+                              (provider) =>
+                                !providerConfigs.some(
+                                  (config) => config.provider === provider.name,
+                                ),
+                            );
+
+                          if (unconfiguredProviders.length === 0) {
+                            return (
+                              <SelectItem
+                                value="__manage_providers__"
+                                className="text-muted-foreground hover:text-foreground"
+                                data-testid="vk-provider-config-link"
+                              >
+                                <span>
+                                  No providers left to configure.{" "}
+                                  <span className="text-primary font-medium underline">
+                                    Click to add
+                                  </span>
+                                </span>
+                              </SelectItem>
+                            );
+                          }
+
+                          // Separate base providers and custom providers
+                          const baseProviders = unconfiguredProviders.filter(
+                            (provider) => !provider.custom_provider_config,
+                          );
+                          const customProviders = unconfiguredProviders.filter(
+                            (provider) => provider.custom_provider_config,
+                          );
+
+                          return (
+                            <>
+                              {/* Base providers first */}
+                              {baseProviders
+                                .filter((p) => p.name)
+                                .map((provider, index) => (
+                                  <SelectItem
+                                    key={`base-${index}`}
+                                    value={provider.name}
+                                  >
+                                    <RenderProviderIcon
+                                      provider={provider.name as KnownProvider}
+                                      size="sm"
+                                      className="h-4 w-4"
+                                    />
+                                    {
+                                      ProviderLabels[
+                                        provider.name as ProviderName
+                                      ]
+                                    }
+                                  </SelectItem>
+                                ))}
+
+                              {/* Custom providers second */}
+                              {customProviders
+                                .filter((p) => p.name)
+                                .map((provider, index) => (
+                                  <SelectItem
+                                    key={`custom-${index}`}
+                                    value={provider.name}
+                                  >
+                                    <RenderProviderIcon
+                                      provider={
+                                        provider.custom_provider_config
+                                          ?.base_provider_type ||
+                                        (provider.name as KnownProvider)
+                                      }
+                                      size="sm"
+                                      className="h-4 w-4"
+                                    />
+                                    {provider.name}
+                                  </SelectItem>
+                                ))}
+                            </>
+                          );
+                        })()}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  {/* Provider Configurations Table */}
+                  {providerConfigs.length > 0 && (
+                    <div className="rounded-md border px-2">
+                      <Accordion type="multiple" className="w-full">
+                        {providerConfigs.map((config, index) => {
+                          const providerConfig = availableProviders.find(
+                            (provider) => provider.name === config.provider,
+                          );
+                          return (
+                            <AccordionItem
+                              key={index}
+                              className="w-full"
+                              value={`${config.provider}-${index}`}
+                            >
+                              <AccordionTrigger className="flex h-12 items-center gap-0 px-1">
+                                <div className="flex w-full items-center justify-between">
+                                  <div className="flex w-fit items-center gap-2">
+                                    <RenderProviderIcon
+                                      provider={
+                                        providerConfig?.custom_provider_config
+                                          ?.base_provider_type ||
+                                        (config.provider as ProviderIconType)
+                                      }
+                                      size="sm"
+                                      className="h-4 w-4"
+                                    />
+                                    {providerConfig?.custom_provider_config
+                                      ? providerConfig.name
+                                      : ProviderLabels[
+                                          config.provider as ProviderName
+                                        ]}
+                                  </div>
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    aria-label={`Remove ${config.provider} provider`}
+                                    className="hover:bg-accent/50 h-8 w-8 rounded-sm p-2"
+                                    data-testid={`vk-delete-provider-${index}`}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleRemoveProvider(index);
+                                    }}
+                                  >
+                                    <Trash2 className="h-4 w-4 opacity-75" />
+                                  </Button>
+                                </div>
+                              </AccordionTrigger>
+                              <AccordionContent className="flex flex-col gap-4 px-1 text-balance">
+                                <div className="flex w-full items-start gap-2">
+                                  <div className="w-1/4">
+                                    <NumberAndSelect
+                                      id={`vk-weight-${index}`}
+                                      label="Weight"
+                                      labelClassName="text-sm font-medium"
+                                      placeholder="Exclude from routing"
+                                      inputClassName="h-[38px] w-full"
+                                      dataTestId={`vk-weight-input-${index}`}
+                                      value={config.weight}
+                                      onChangeNumber={(value) =>
+                                        handleUpdateProviderConfig(
+                                          index,
+                                          "weight",
+                                          value,
+                                        )
+                                      }
+                                    />
+                                  </div>
+                                  <div className="w-3/4 space-y-2">
+                                    <Label className="text-sm font-medium">
+                                      Allowed Models{" "}
+                                      <span className="text-muted-foreground ml-auto text-xs italic">
+                                        type to search
+                                      </span>
+                                    </Label>
+                                    {(() => {
+                                      const hasWildcardModels = (
+                                        config.allowed_models || []
+                                      ).includes("*");
+                                      return (
+                                        <ModelMultiselect
+                                          data-testid={`vk-models-multiselect-${index}`}
+                                          provider={config.provider}
+                                          keys={(() => {
+                                            const providerKeys =
+                                              availableKeys.filter(
+                                                (key) =>
+                                                  key.provider ===
+                                                  config.provider,
+                                              );
+                                            const configKeyIds =
+                                              config.key_ids || [];
+                                            return configKeyIds.includes("*")
+                                              ? providerKeys.map(
+                                                  (key) => key.key_id,
+                                                )
+                                              : providerKeys
+                                                  .filter((key) =>
+                                                    configKeyIds.includes(
+                                                      key.key_id,
+                                                    ),
+                                                  )
+                                                  .map((key) => key.key_id);
+                                          })()}
+                                          allowAllOption={true}
+                                          value={
+                                            hasWildcardModels
+                                              ? ["*"]
+                                              : config.allowed_models || []
+                                          }
+                                          onChange={(models: string[]) => {
+                                            const hadStar = (
+                                              config.allowed_models || []
+                                            ).includes("*");
+                                            const hasStar =
+                                              models.includes("*");
+                                            if (!hadStar && hasStar) {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "allowed_models",
+                                                ["*"],
+                                              );
+                                            } else if (
+                                              hadStar &&
+                                              hasStar &&
+                                              models.length > 1
+                                            ) {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "allowed_models",
+                                                models.filter((m) => m !== "*"),
+                                              );
+                                            } else {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "allowed_models",
+                                                models,
+                                              );
+                                            }
+                                          }}
+                                          placeholder={
+                                            hasWildcardModels
+                                              ? "All models allowed"
+                                              : (config.allowed_models || [])
+                                                    .length === 0
+                                                ? "No models (deny all)"
+                                                : config.provider
+                                                  ? ModelPlaceholders[
+                                                      config.provider as keyof typeof ModelPlaceholders
+                                                    ] ||
+                                                    ModelPlaceholders.default
+                                                  : ModelPlaceholders.default
+                                          }
+                                          className="min-h-10 max-w-[500px] min-w-[200px]"
+                                        />
+                                      );
+                                    })()}
+                                    <p className="text-muted-foreground text-xs">
+                                      Select specific models or choose “Allow
+                                      All Models” to allow all. Leave empty to
+                                      deny all.
+                                    </p>
+                                  </div>
+                                </div>
+
+                                {/* Allowed Keys for this provider */}
+                                {(() => {
+                                  const providerKeys = availableKeys.filter(
+                                    (key) => key.provider === config.provider,
+                                  );
+                                  const configKeyIds = config.key_ids || [];
+                                  const hasWildcard =
+                                    configKeyIds.includes("*");
+                                  const allKeyOptions = [
+                                    {
+                                      label: "Allow All Keys",
+                                      value: "*",
+                                      description:
+                                        "Allow all current and future keys for this provider",
+                                      provider: "",
+                                    },
+                                    ...providerKeys.map((key) => ({
+                                      label: key.name,
+                                      value: key.key_id,
+                                      description:
+                                        key.models == null ||
+                                        key.models.includes("*")
+                                          ? "All models"
+                                          : key.models
+                                              .filter((m) => m !== "*")
+                                              .join(", ") ||
+                                            "No models (deny all)",
+                                      provider: key.provider,
+                                    })),
+                                  ];
+                                  const selectedProviderKeys = hasWildcard
+                                    ? [allKeyOptions[0]]
+                                    : providerKeys
+                                        .filter((key) =>
+                                          configKeyIds.includes(key.key_id),
+                                        )
+                                        .map((key) => ({
+                                          label: key.name,
+                                          value: key.key_id,
+                                          description:
+                                            key.models == null ||
+                                            key.models.includes("*")
+                                              ? "All models"
+                                              : key.models
+                                                  .filter((m) => m !== "*")
+                                                  .join(", ") ||
+                                                "No models (deny all)",
+                                          provider: key.provider,
+                                        }));
+
+                                  return (
+                                    <div className="mx-0.5 space-y-2">
+                                      <Label className="text-sm font-medium">
+                                        Allowed Keys
+                                      </Label>
+                                      <p className="text-muted-foreground text-xs">
+                                        Select specific keys or allow all. Leave
+                                        empty to block all keys for this
+                                        provider.
+                                      </p>
+                                      <AsyncMultiSelect
+                                        hideSelectedOptions
+                                        isNonAsync
+                                        closeMenuOnSelect={false}
+                                        menuPlacement="auto"
+                                        defaultOptions={allKeyOptions}
+                                        views={{
+                                          multiValue: (
+                                            multiValueProps: MultiValueProps<VirtualKeyType>,
+                                          ) => {
+                                            return (
+                                              <div
+                                                {...multiValueProps.innerProps}
+                                                className="bg-accent dark:!bg-card flex cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 text-sm"
+                                              >
+                                                {multiValueProps.data.label}{" "}
+                                                <X
+                                                  className="hover:text-foreground text-muted-foreground h-4 w-4 cursor-pointer"
+                                                  onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    multiValueProps.removeProps.onClick?.(
+                                                      e as any,
+                                                    );
+                                                  }}
+                                                />
+                                              </div>
+                                            );
+                                          },
+                                          option: (
+                                            optionProps: OptionProps<VirtualKeyType>,
+                                          ) => {
+                                            const { Option } = components;
+                                            return (
+                                              <Option
+                                                {...optionProps}
+                                                className={cn(
+                                                  "flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
+                                                  optionProps.isFocused &&
+                                                    "bg-accent dark:!bg-card",
+                                                  "hover:bg-accent",
+                                                  optionProps.isSelected &&
+                                                    "bg-accent dark:!bg-card",
+                                                )}
+                                              >
+                                                <span className="text-content-primary grow truncate text-sm">
+                                                  {optionProps.data.label}
+                                                </span>
+                                                {optionProps.data
+                                                  .description && (
+                                                  <span className="text-content-tertiary max-w-[70%] text-sm">
+                                                    {
+                                                      optionProps.data
+                                                        .description
+                                                    }
+                                                  </span>
+                                                )}
+                                              </Option>
+                                            );
+                                          },
+                                        }}
+                                        value={selectedProviderKeys}
+                                        onChange={(keys) => {
+                                          const hadStar = hasWildcard;
+                                          const hasStar = keys.some(
+                                            (k) => k.value === "*",
+                                          );
+                                          if (!hadStar && hasStar) {
+                                            // Just selected "Allow All Keys" — set to ["*"] only
+                                            handleUpdateProviderConfig(
+                                              index,
+                                              "key_ids",
+                                              ["*"],
+                                            );
+                                          } else if (
+                                            hadStar &&
+                                            hasStar &&
+                                            keys.length > 1
+                                          ) {
+                                            // Had "*", still has "*", but user also selected a specific key — drop "*"
+                                            handleUpdateProviderConfig(
+                                              index,
+                                              "key_ids",
+                                              keys
+                                                .filter((k) => k.value !== "*")
+                                                .map((k) => k.value as string),
+                                            );
+                                          } else {
+                                            handleUpdateProviderConfig(
+                                              index,
+                                              "key_ids",
+                                              keys.map(
+                                                (k) => k.value as string,
+                                              ),
+                                            );
+                                          }
+                                        }}
+                                        placeholder={
+                                          hasWildcard
+                                            ? "All keys allowed"
+                                            : configKeyIds.length === 0
+                                              ? "No keys selected"
+                                              : "Select keys..."
+                                        }
+                                        className="hover:bg-accent w-full"
+                                        menuClassName="z-[60] max-h-[300px] overflow-y-auto w-full cursor-pointer custom-scrollbar"
+                                      />
+                                    </div>
+                                  );
+                                })()}
+
+                                <DottedSeparator />
+
+                                {/* Provider Budget Configuration */}
+                                <MultiBudgetLines
+                                  data-testid={`vk-provider-budget-${index}`}
+                                  label="Provider Budget"
+                                  lines={
+                                    config.budgets && config.budgets.length > 0
+                                      ? config.budgets.map((b) => ({
+                                          id: b.id,
+                                          max_limit: b.max_limit,
+                                          reset_duration:
+                                            b.reset_duration || "1M",
+                                        }))
+                                      : []
+                                  }
+                                  onChange={(lines) => {
+                                    const updatedConfigs = [...providerConfigs];
+                                    updatedConfigs[index] = {
+                                      ...updatedConfigs[index],
+                                      budgets: lines.map((l) => ({
+                                        id: l.id,
+                                        max_limit: l.max_limit,
+                                        reset_duration: l.reset_duration,
+                                      })),
+                                    };
+                                    form.setValue(
+                                      "providerConfigs",
+                                      updatedConfigs,
+                                      { shouldDirty: true },
+                                    );
+                                  }}
+                                />
+
+                                <DottedSeparator />
+
+                                {/* Provider Rate Limit Configuration */}
+                                <div className="space-y-4">
+                                  <Label className="text-sm font-medium">
+                                    Provider Rate Limits
+                                  </Label>
+
+                                  <NumberAndSelect
+                                    id={`providerTokenLimit-${index}`}
+                                    labelClassName="font-normal"
+                                    label="Maximum Tokens"
+                                    value={config.rate_limit?.token_max_limit}
+                                    selectValue={
+                                      config.rate_limit?.token_reset_duration ||
+                                      "1h"
+                                    }
+                                    onChangeNumber={(value) => {
+                                      const currentRateLimit =
+                                        config.rate_limit || {};
+                                      handleUpdateProviderConfig(
+                                        index,
+                                        "rate_limit",
+                                        {
+                                          ...currentRateLimit,
+                                          token_max_limit: value,
+                                        },
+                                      );
+                                    }}
+                                    onChangeSelect={(value) => {
+                                      const currentRateLimit =
+                                        config.rate_limit || {};
+                                      handleUpdateProviderConfig(
+                                        index,
+                                        "rate_limit",
+                                        {
+                                          ...currentRateLimit,
+                                          token_reset_duration: value,
+                                        },
+                                      );
+                                    }}
+                                    options={resetDurationOptions}
+                                  />
+
+                                  <NumberAndSelect
+                                    id={`providerRequestLimit-${index}`}
+                                    labelClassName="font-normal"
+                                    label="Maximum Requests"
+                                    value={config.rate_limit?.request_max_limit}
+                                    selectValue={
+                                      config.rate_limit
+                                        ?.request_reset_duration || "1h"
+                                    }
+                                    onChangeNumber={(value) => {
+                                      const currentRateLimit =
+                                        config.rate_limit || {};
+                                      handleUpdateProviderConfig(
+                                        index,
+                                        "rate_limit",
+                                        {
+                                          ...currentRateLimit,
+                                          request_max_limit: value,
+                                        },
+                                      );
+                                    }}
+                                    onChangeSelect={(value) => {
+                                      const currentRateLimit =
+                                        config.rate_limit || {};
+                                      handleUpdateProviderConfig(
+                                        index,
+                                        "rate_limit",
+                                        {
+                                          ...currentRateLimit,
+                                          request_reset_duration: value,
+                                        },
+                                      );
+                                    }}
+                                    options={resetDurationOptions}
+                                  />
+                                </div>
+                              </AccordionContent>
+                            </AccordionItem>
+                          );
+                        })}
+                      </Accordion>
+                    </div>
+                  )}
+                  {/* Display validation errors for provider configurations */}
+                  {form.formState.errors.providerConfigs && (
+                    <div className="text-destructive text-sm">
+                      {form.formState.errors.providerConfigs.message}
+                    </div>
+                  )}
+                </div>
+                {/* MCP Client Configurations */}
+                {((mcpClientsData && mcpClientsData.length > 0) ||
+                  (mcpConfigs && mcpConfigs.length > 0)) && (
+                  <div className="mt-6 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Label className="text-sm font-medium">
+                        MCP Client Configurations
+                      </Label>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span>
+                              <Info className="text-muted-foreground h-3 w-3" />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>
+                              Configure which MCP clients this virtual key can
+                              use and their allowed tools. Leaving this section
+                              empty blocks all MCP tools. After adding an MCP
+                              client, you must select specific tools or choose{" "}
+                              <span className="font-medium">
+                                Allow All Tools
+                              </span>{" "}
+                              to grant tool access.
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+
+                    {/* MCP servers available on all virtual keys by default, excluding explicitly overridden ones */}
+                    {(() => {
+                      const defaultMCPClients = mcpClientsData.filter(
+                        (client) =>
+                          client.config.allow_on_all_virtual_keys &&
+                          !mcpConfigs.some(
+                            (config) =>
+                              config.mcp_client_name === client.config.name,
+                          ),
+                      );
+                      return defaultMCPClients.length > 0 ? (
+                        <div className="text-muted-foreground rounded-md border p-3 text-xs">
+                          <div className="flex items-start gap-1.5">
+                            <Info className="mt-0.5 h-3 w-3 shrink-0" />
+                            <span>
+                              The following MCP servers are available to this
+                              key by default with all tools enabled on that
+                              client:{" "}
+                              <span className="text-foreground font-medium">
+                                {defaultMCPClients
+                                  .map((c) => c.config.name)
+                                  .join(", ")}
+                              </span>
+                              . Adding an explicit config for any of them below
+                              will override the all-tools default for this key.
+                            </span>
+                          </div>
+                        </div>
+                      ) : null;
+                    })()}
+
+                    {/* Add MCP Client Dropdown */}
+                    {mcpClientsData && mcpClientsData.length > 0 && (
+                      <div className="flex gap-2">
+                        <Select
+                          value={selectedMCPClient}
+                          onValueChange={(mcpClientId) => {
+                            handleAddMCPClient(mcpClientId);
+                            setSelectedMCPClient(""); // Reset to placeholder state
+                          }}
+                        >
+                          <SelectTrigger className="flex-1">
+                            <SelectValue placeholder="Select an MCP client to add" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {mcpClientsData.filter(
+                              (client) =>
+                                !mcpConfigs.some(
+                                  (config) =>
+                                    config.mcp_client_name ===
+                                    client.config.name,
+                                ),
+                            ).length > 0 ? (
+                              mcpClientsData
+                                .filter(
+                                  (client) =>
+                                    client.config.name &&
+                                    !mcpConfigs.some(
+                                      (config) =>
+                                        config.mcp_client_name ===
+                                        client.config.name,
+                                    ),
+                                )
+                                .map((client, index) => {
+                                  const client_tools = client.tools || [];
+                                  const totalTools =
+                                    client.config.tools_to_execute?.includes(
+                                      "*",
+                                    )
+                                      ? client_tools.length
+                                      : client_tools.filter((tool) =>
+                                          client.config.tools_to_execute?.includes(
+                                            tool.name,
+                                          ),
+                                        ).length;
+                                  return (
+                                    <SelectItem
+                                      key={index}
+                                      value={client.config.name}
+                                    >
+                                      <div className="flex items-center gap-2">
+                                        {client.config.name}
+                                        <span className="text-muted-foreground text-xs">
+                                          ({totalTools}{" "}
+                                          {totalTools === 1
+                                            ? "enabled tool"
+                                            : "enabled tools"}
+                                          )
+                                        </span>
+                                      </div>
+                                    </SelectItem>
+                                  );
+                                })
+                            ) : (
+                              <div className="text-muted-foreground px-2 py-1.5 text-sm">
+                                All MCP clients configured
+                              </div>
+                            )}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+
+                    {/* MCP Configurations Table */}
+                    {mcpConfigs.length > 0 && (
+                      <div className="rounded-md border">
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>MCP Client</TableHead>
+                              <TableHead>Allowed Tools</TableHead>
+                              <TableHead className="w-[50px]"></TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {mcpConfigs.map((config, index) => {
+                              const mcpClient = mcpClientsData?.find(
+                                (client) =>
+                                  client.config.name === config.mcp_client_name,
+                              );
+
+                              // Handle new wildcard semantics for client-level filtering
+                              const clientToolsToExecute =
+                                mcpClient?.config?.tools_to_execute;
+                              let availableTools: any[] = [];
+
+                              if (
+                                !clientToolsToExecute ||
+                                clientToolsToExecute.length === 0
+                              ) {
+                                // nil/undefined or empty array - no tools available from client config
+                                availableTools = [];
+                              } else if (clientToolsToExecute.includes("*")) {
+                                // Wildcard - all tools available
+                                availableTools = mcpClient?.tools || [];
+                              } else {
+                                // Specific tools listed
+                                availableTools =
+                                  (mcpClient?.tools || []).filter((tool) =>
+                                    clientToolsToExecute.includes(tool.name),
+                                  ) || [];
+                              }
+
+                              const enabledToolsByConfig =
+                                (mcpClient?.tools || []).filter((tool) =>
+                                  config.tools_to_execute?.includes(tool.name),
+                                ) || [];
+                              const selectedTools =
+                                config.tools_to_execute || [];
+
+                              return (
+                                <TableRow
+                                  key={`${config.mcp_client_name}-${index}`}
+                                >
+                                  <TableCell className="w-[150px]">
+                                    {config.mcp_client_name}
+                                  </TableCell>
+                                  <TableCell>
+                                    <MultiSelect
+                                      options={[
+                                        {
+                                          label: "Allow All Tools",
+                                          value: "*",
+                                          description:
+                                            "Allow all current and future tools",
+                                        },
+                                        ...[
+                                          ...availableTools,
+                                          ...enabledToolsByConfig,
+                                        ]
+                                          .filter(
+                                            (tool, index, arr) =>
+                                              arr.findIndex(
+                                                (t) => t.name === tool.name,
+                                              ) === index,
+                                          )
+                                          .map((tool) => ({
+                                            label: tool.name,
+                                            value: tool.name,
+                                            description: tool.description,
+                                          })),
+                                      ]}
+                                      defaultValue={selectedTools}
+                                      onValueChange={(tools: string[]) => {
+                                        const hadStar =
+                                          selectedTools.includes("*");
+                                        const hasStar = tools.includes("*");
+                                        if (!hadStar && hasStar) {
+                                          // Just selected "Allow All Tools" — set to ["*"] only
+                                          handleUpdateMCPConfig(
+                                            index,
+                                            "tools_to_execute",
+                                            ["*"],
+                                          );
+                                        } else if (
+                                          hadStar &&
+                                          hasStar &&
+                                          tools.length > 1
+                                        ) {
+                                          // Had "*", still has "*", but user also selected a specific tool — drop "*"
+                                          handleUpdateMCPConfig(
+                                            index,
+                                            "tools_to_execute",
+                                            tools.filter((t) => t !== "*"),
+                                          );
+                                        } else {
+                                          handleUpdateMCPConfig(
+                                            index,
+                                            "tools_to_execute",
+                                            tools,
+                                          );
+                                        }
+                                      }}
+                                      placeholder={
+                                        selectedTools.length === 0
+                                          ? "No tools selected"
+                                          : selectedTools.includes("*")
+                                            ? "All tools allowed"
+                                            : "Select tools..."
+                                      }
+                                      variant="inverted"
+                                      className="hover:bg-accent w-full bg-white dark:bg-zinc-800"
+                                      commandClassName="w-full max-w-96"
+                                      modalPopover={true}
+                                      animation={0}
+                                    />
+                                  </TableCell>
+                                  <TableCell>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() =>
+                                        handleRemoveMCPClient(index)
+                                      }
+                                      data-testid={`vk-delete-mcp-${index}`}
+                                    >
+                                      <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                  </TableCell>
+                                </TableRow>
+                              );
+                            })}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    )}
+                  </div>
+                )}
+                <DottedSeparator className="mt-6 mb-5" />
+                {/* Budget Configuration */}
+                <div className="space-y-4">
+                  <MultiBudgetLines
+                    data-testid="vk-budget-lines"
+                    label="Budget Configuration"
+                    lines={form.watch("budgets") ?? []}
+                    onChange={(lines) => {
+                      form.setValue("budgets", lines, { shouldDirty: true });
+                    }}
+                    onReset={clearVirtualKeyBudget}
+                    showReset={
+                      isEditing &&
+                      !!(
+                        virtualKey?.budgets?.length ||
+                        (watchedBudgets && watchedBudgets.length > 0)
+                      )
+                    }
+                  />
+
+                  {/* Reassign team confirmation dialog */}
+                  <AlertDialog
+                    open={showReassignTeamWarning}
+                    onOpenChange={(open) => {
+                      setShowReassignTeamWarning(open);
+                      if (!open) {
+                        setPendingTeamId(null);
+                      }
+                    }}
+                  >
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>
+                          Reassign to a different team?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This key is currently assigned to another team.
+                          Reassigning it will move budget tracking to this team
+                          — future requests through this key will count against
+                          this team’s budget, not the previous one.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel
+                          data-testid="virtual-key-reassign-cancel"
+                          onClick={() => setPendingTeamId(null)}
+                        >
+                          Cancel
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                          data-testid="virtual-key-reassign-confirm"
+                          onClick={() => {
+                            if (pendingTeamId !== null) {
+                              form.setValue("teamId", pendingTeamId, {
+                                shouldDirty: true,
+                              });
+                            }
+                            setPendingTeamId(null);
+                            setShowReassignTeamWarning(false);
+                          }}
+                        >
+                          Reassign
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+
+                  <AlertDialog
+                    open={showReassignAPWarning}
+                    onOpenChange={(open) => {
+                      setShowReassignAPWarning(open);
+                      if (!open) {
+                        setPendingAccessProfileId(null);
+                      }
+                    }}
+                  >
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>
+                          Reassign to a different access profile?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This key is currently assigned to another access
+                          profile. Reassigning it will move budget tracking to
+                          this access profile — future requests through this key
+                          will count against this profile's budget, not the
+                          previous one.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel
+                          data-testid="reassign-ap-cancel"
+                          onClick={() => setPendingAccessProfileId(null)}
+                        >
+                          Cancel
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                          data-testid="reassign-ap-confirm"
+                          onClick={() => {
+                            if (pendingAccessProfileId !== null) {
+                              form.setValue(
+                                "accessProfileId",
+                                pendingAccessProfileId,
+                                { shouldDirty: true },
+                              );
+                            }
+                            setPendingAccessProfileId(null);
+                            setShowReassignAPWarning(false);
+                          }}
+                        >
+                          Reassign
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+
+                  {/* Cross-type assignment warning */}
+                  <AlertDialog
+                    open={showReassignTypeWarning}
+                    onOpenChange={(open) => {
+                      if (!open) setPendingEntityType(null);
+                      setShowReassignTypeWarning(open);
+                    }}
+                  >
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Change assignment?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This key is currently assigned to{" "}
+                          {currentAssignmentLabel}. Changing the assignment type
+                          will move budget tracking — future requests will count
+                          against the new entity, not the previous one.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel
+                          data-testid="reassign-type-cancel"
+                          onClick={() => setPendingEntityType(null)}
+                        >
+                          Cancel
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                          data-testid="reassign-type-confirm"
+                          onClick={async () => {
+                            if (pendingEntityType) {
+                              form.setValue("entityType", pendingEntityType, {
+                                shouldDirty: true,
+                              });
+                              if (
+                                pendingEntityType === "team" &&
+                                teams?.length > 0
+                              ) {
+                                form.setValue("teamId", teams[0].id, {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                                form.setValue("customerId", "", {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                                form.setValue("accessProfileId", "", {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                              } else if (
+                                pendingEntityType === "customer" &&
+                                customers?.length > 0
+                              ) {
+                                form.setValue("customerId", customers[0].id, {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                                form.setValue("teamId", "", {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                                form.setValue("accessProfileId", "", {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                              } else if (
+                                pendingEntityType === "access_profile"
+                              ) {
+                                const apId =
+                                  accessProfiles?.length > 0
+                                    ? String(accessProfiles[0].id)
+                                    : virtualKey?.access_profile_id
+                                      ? String(virtualKey.access_profile_id)
+                                      : "";
+                                form.setValue("accessProfileId", apId, {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                                form.setValue("teamId", "", {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                                form.setValue("customerId", "", {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                              } else {
+                                form.setValue("teamId", "", {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                                form.setValue("customerId", "", {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                                form.setValue("accessProfileId", "", {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                              }
+                              await form.trigger([
+                                "teamId",
+                                "customerId",
+                                "accessProfileId",
+                                "entityType",
+                              ]);
+                            }
+                            setPendingEntityType(null);
+                            setShowReassignTypeWarning(false);
+                          }}
+                        >
+                          Change Assignment
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+                {/* Rate Limiting Configuration */}
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <Label className="text-sm font-medium">
+                      Rate Limiting Configuration
+                    </Label>
+                    {isEditing &&
+                      (virtualKey?.rate_limit ||
+                        watchedTokenMaxLimit ||
+                        watchedRequestMaxLimit) && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={clearVirtualKeyRateLimits}
+                          data-testid="vk-rate-limit-reset-button"
+                        >
+                          <RotateCcw className="h-4 w-4" />
+                          Reset
+                        </Button>
+                      )}
+                  </div>
+
+                  <FormField
+                    control={form.control}
+                    name="tokenMaxLimit"
+                    render={({ field }) => (
+                      <FormItem>
+                        <NumberAndSelect
+                          id="tokenMaxLimit"
+                          labelClassName="font-normal"
+                          label="Maximum Tokens"
+                          value={field.value}
+                          selectValue={form.watch("tokenResetDuration") || "1h"}
+                          onChangeNumber={(value) => {
+                            field.onChange(value);
+                          }}
+                          onChangeSelect={(value) =>
+                            form.setValue("tokenResetDuration", value, {
+                              shouldDirty: true,
+                            })
+                          }
+                          options={resetDurationOptions}
+                        />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="requestMaxLimit"
+                    render={({ field }) => (
+                      <FormItem>
+                        <NumberAndSelect
+                          id="requestMaxLimit"
+                          labelClassName="font-normal"
+                          label="Maximum Requests"
+                          value={field.value}
+                          selectValue={
+                            form.watch("requestResetDuration") || "1h"
+                          }
+                          onChangeNumber={(value) => {
+                            field.onChange(value);
+                          }}
+                          onChangeSelect={(value) =>
+                            form.setValue("requestResetDuration", value, {
+                              shouldDirty: true,
+                            })
+                          }
+                          options={resetDurationOptions}
+                        />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                {/* Calendar alignment — VK-wide setting that applies to both budgets and rate limits */}
+                {showCalendarAlignToggle && (
+                  <div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+                    <div className="space-y-0.5">
+                      <Label
+                        htmlFor="vk-budget-calendar-aligned-toggle"
+                        className="text-sm font-normal"
+                      >
+                        Align to calendar cycle
+                      </Label>
+                      <p
+                        id="vk-budget-calendar-aligned-description"
+                        className="text-muted-foreground text-xs"
+                      >
+                        Reset budgets and rate limits at the start of each
+                        period (e.g. 1st of month) instead of rolling from
+                        creation date. Applies to durations of a day or longer.
+                      </p>
+                    </div>
+                    <Switch
+                      id="vk-budget-calendar-aligned-toggle"
+                      aria-describedby="vk-budget-calendar-aligned-description"
+                      checked={watchedBudgetCalendarAligned}
+                      onCheckedChange={handleCalendarAlignedChange}
+                      data-testid="vk-budget-calendar-aligned-toggle"
+                    />
+                  </div>
+                )}
+
+                {/* Warning dialog shown when enabling calendar alignment on an existing VK */}
+                <AlertDialog
+                  open={showCalendarAlignWarning}
+                  onOpenChange={setShowCalendarAlignWarning}
+                >
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        Reset budget and rate-limit usage?
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Enabling calendar alignment will reset budget usage to{" "}
+                        <span className="font-semibold">$0.00</span> and
+                        token/request rate-limit counters to{" "}
+                        <span className="font-semibold">0</span> for this
+                        virtual key, then snap each reset date to the start of
+                        its current period (e.g. start of day, week, month, or
+                        year). The usage reset cannot be undone, but calendar
+                        alignment can be turned off later. This will take effect
+                        when you save.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel data-testid="vk-calendar-align-cancel-btn">
+                        Cancel
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        data-testid="vk-calendar-align-enable-btn"
+                        onClick={() => {
+                          form.setValue("budgetCalendarAligned", true, {
+                            shouldDirty: true,
+                          });
+                          setShowCalendarAlignWarning(false);
+                        }}
+                      >
+                        Enable Calendar Alignment
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                {(teams?.length > 0 ||
+                  customers?.length > 0 ||
+                  accessProfiles?.length > 0 ||
+                  !!virtualKey?.access_profile_id ||
+                  !!defaultAccessProfileId) && (
+                  <>
+                    <DottedSeparator className="my-6" />
+
+                    {/* Entity Assignment */}
+                    <div className="space-y-4">
+                      <Label className="text-sm font-medium">
+                        Entity Assignment
+                      </Label>
+
+                      <div className="grid grid-cols-1 items-center gap-2 md:grid-cols-2">
+                        <FormField
+                          control={form.control}
+                          name="entityType"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel className="font-normal">
+                                Assignment Type
+                              </FormLabel>
+                              <ComboboxSelect
+                                options={[
+                                  { value: "none", label: "No Assignment" },
+                                  ...(teams?.length > 0
+                                    ? [
+                                        {
+                                          value: "team",
+                                          label: "Assign to Team",
+                                        },
+                                      ]
+                                    : []),
+                                  ...(customers?.length > 0
+                                    ? [
+                                        {
+                                          value: "customer",
+                                          label: "Assign to Customer",
+                                        },
+                                      ]
+                                    : []),
+                                  ...(accessProfiles?.length > 0 ||
+                                  virtualKey?.access_profile_id ||
+                                  defaultAccessProfileId
+                                    ? [
+                                        {
+                                          value: "access_profile",
+                                          label: "Assign to Access Profile",
+                                        },
+                                      ]
+                                    : []),
+                                ]}
+                                value={field.value}
+                                onValueChange={async (value) => {
+                                  const val = value ?? "none";
+                                  const originalType = virtualKey?.team_id
+                                    ? "team"
+                                    : virtualKey?.customer_id
+                                      ? "customer"
+                                      : virtualKey?.access_profile_id
+                                        ? "access_profile"
+                                        : "none";
+                                  if (
+                                    isEditing &&
+                                    currentAssignmentLabel &&
+                                    val !== "none" &&
+                                    val !== originalType
+                                  ) {
+                                    setPendingEntityType(
+                                      val as
+                                        | "team"
+                                        | "customer"
+                                        | "access_profile",
+                                    );
+                                    setShowReassignTypeWarning(true);
+                                    return;
+                                  }
+                                  field.onChange(val);
+                                  if (val === "team" && teams?.length > 0) {
+                                    form.setValue("teamId", teams[0].id, {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    form.setValue("customerId", "", {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    form.setValue("accessProfileId", "", {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    await form.trigger([
+                                      "teamId",
+                                      "customerId",
+                                      "accessProfileId",
+                                      "entityType",
+                                    ]);
+                                  } else if (
+                                    val === "customer" &&
+                                    customers?.length > 0
+                                  ) {
+                                    form.setValue(
+                                      "customerId",
+                                      customers[0].id,
+                                      {
+                                        shouldDirty: true,
+                                        shouldValidate: true,
+                                      },
+                                    );
+                                    form.setValue("teamId", "", {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    form.setValue("accessProfileId", "", {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    await form.trigger([
+                                      "teamId",
+                                      "customerId",
+                                      "accessProfileId",
+                                      "entityType",
+                                    ]);
+                                  } else if (val === "access_profile") {
+                                    const apId =
+                                      accessProfiles?.length > 0
+                                        ? String(accessProfiles[0].id)
+                                        : virtualKey?.access_profile_id
+                                          ? String(virtualKey.access_profile_id)
+                                          : "";
+                                    form.setValue("accessProfileId", apId, {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    form.setValue("teamId", "", {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    form.setValue("customerId", "", {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    await form.trigger([
+                                      "teamId",
+                                      "customerId",
+                                      "accessProfileId",
+                                      "entityType",
+                                    ]);
+                                  } else {
+                                    form.setValue("teamId", "", {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    form.setValue("customerId", "", {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    form.setValue("accessProfileId", "", {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                    await form.trigger([
+                                      "teamId",
+                                      "customerId",
+                                      "accessProfileId",
+                                      "entityType",
+                                    ]);
+                                  }
+                                }}
+                                disabled={isTeamLocked || isAPLocked}
+                                disableSearch
+                                hideClear
+                                className="h-9"
+                              />
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                        {form.watch("entityType") === "team" &&
+                          teams?.length > 0 && (
+                            <FormField
+                              control={form.control}
+                              name="teamId"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel className="font-normal">
+                                    Select Team
+                                  </FormLabel>
+                                  <ComboboxSelect
+                                    options={teams.map((team) => ({
+                                      value: team.id,
+                                      label: team.customer
+                                        ? `${team.name} — ${team.customer.name}`
+                                        : team.name,
+                                    }))}
+                                    value={field.value || null}
+                                    onValueChange={(val) => {
+                                      const newVal = val ?? "";
+                                      if (
+                                        isEditing &&
+                                        virtualKey?.team_id &&
+                                        newVal &&
+                                        newVal !== virtualKey.team_id
+                                      ) {
+                                        setPendingTeamId(newVal);
+                                        setShowReassignTeamWarning(true);
+                                      } else {
+                                        field.onChange(newVal);
+                                      }
+                                    }}
+                                    placeholder="Select a team"
+                                    disabled={isTeamLocked}
+                                    emptyMessage="No teams found."
+                                    className="h-9"
+                                  />
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          )}
+
+                        {form.watch("entityType") === "customer" &&
+                          customers?.length > 0 && (
+                            <FormField
+                              control={form.control}
+                              name="customerId"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel className="font-normal">
+                                    Select Customer
+                                  </FormLabel>
+                                  <ComboboxSelect
+                                    options={customers.map((customer) => ({
+                                      value: customer.id,
+                                      label: customer.name,
+                                    }))}
+                                    value={field.value || null}
+                                    onValueChange={(val) =>
+                                      field.onChange(val ?? "")
+                                    }
+                                    placeholder="Select a customer"
+                                    emptyMessage="No customers found."
+                                    className="h-9"
+                                  />
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          )}
+
+                        {form.watch("entityType") === "access_profile" &&
+                          (accessProfiles?.length > 0 ||
+                            virtualKey?.access_profile_id ||
+                            defaultAccessProfileId) && (
+                            <FormField
+                              control={form.control}
+                              name="accessProfileId"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel className="font-normal">
+                                    Select Access Profile
+                                  </FormLabel>
+                                  <ComboboxSelect
+                                    data-testid="access-profile-selector"
+                                    options={accessProfiles.map((ap) => ({
+                                      value: String(ap.id),
+                                      label: ap.name,
+                                    }))}
+                                    value={field.value || null}
+                                    onValueChange={(val) => {
+                                      const newVal = val ?? "";
+                                      if (
+                                        isEditing &&
+                                        virtualKey?.access_profile_id &&
+                                        newVal &&
+                                        newVal !==
+                                          String(virtualKey.access_profile_id)
+                                      ) {
+                                        setPendingAccessProfileId(newVal);
+                                        setShowReassignAPWarning(true);
+                                      } else {
+                                        field.onChange(newVal);
+                                      }
+                                    }}
+                                    placeholder="Select an access profile"
+                                    disabled={isAPLocked}
+                                    emptyMessage="No access profiles found."
+                                    className="h-9"
+                                  />
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          )}
+                      </div>
+                    </div>
+                  </>
+                )}
+              </fieldset>
+            </div>
+            <AlertDialog
+              open={showRotateWarning}
+              onOpenChange={setShowRotateWarning}
+            >
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Rotate virtual key?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will replace the secret value for &quot;
+                    {virtualKey?.name}&quot;. The key ID, budgets, rate limits,
+                    provider permissions, MCP access, and assignments stay the
+                    same. The previous key value will stop working immediately.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel data-testid="vk-rotate-cancel-btn">
+                    Cancel
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleRotateVirtualKey}
+                    disabled={isRotating}
+                    data-testid="vk-rotate-confirm-btn"
+                  >
+                    {isRotating ? "Rotating..." : "Rotate Key"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+            <AlertDialog
+              open={showBudgetResetPrompt}
+              onOpenChange={setShowBudgetResetPrompt}
+            >
+              <AlertDialogContent data-testid="vk-budget-reset-dialog">
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    {pendingBudgetUsageWarning
+                      ? "Preserve over-limit usage?"
+                      : "Reset budget usage?"}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {pendingBudgetUsageWarning
+                      ? `${pendingBudgetUsageWarning} You can preserve usage anyway, or reset usage to 0.`
+                      : "You changed a budget amount, reset frequency, or calendar alignment. Reset current budget usage to 0, or preserve the existing usage counters."}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel
+                    onClick={() => handleBudgetResetChoice(false)}
+                    data-testid="vk-budget-reset-preserve-btn"
+                  >
+                    {pendingBudgetUsageWarning
+                      ? "Preserve Anyway"
+                      : "Preserve Usage"}
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => handleBudgetResetChoice(true)}
+                    data-testid="vk-budget-reset-confirm-btn"
+                  >
+                    Reset Usage
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+            {isEditing && virtualKey?.config_hash && (
+              <div className="px-8">
+                <ConfigSyncAlert className="mt-2" />
+              </div>
+            )}
+            {/* Form Footer */}
+            <div className="border-border bg-card sticky bottom-0 z-10 border-t px-8 py-4">
+              <div className="flex items-center justify-between gap-2">
+                {isEditing ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setShowRotateWarning(true)}
+                    disabled={!hasUpdateAccess || isRotating}
+                    data-testid="vk-rotate-btn"
+                  >
+                    <RotateCcw className="h-4 w-4" />
+                    {isRotating ? "Rotating..." : "Rotate Key"}
+                  </Button>
+                ) : (
+                  <span />
+                )}
+                <div className="flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleClose}
+                    data-testid="vk-cancel-btn"
+                  >
+                    Cancel
+                  </Button>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-block">
+                          <Button
+                            type="submit"
+                            disabled={
+                              isLoading || !form.formState.isDirty || !canSubmit
+                            }
+                            data-testid="vk-save-btn"
+                          >
+                            {isLoading
+                              ? "Saving..."
+                              : isEditing
+                                ? "Update"
+                                : "Create"}
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      {(isLoading || !form.formState.isDirty || !canSubmit) && (
+                        <TooltipContent>
+                          <p>
+                            {!canSubmit
+                              ? "You don't have permission to perform this action"
+                              : isLoading
+                                ? "Saving..."
+                                : !form.formState.isDirty
+                                  ? "No changes made"
+                                  : ""}
+                          </p>
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                  </TooltipProvider>
+                </div>
+              </div>
+            </div>
+          </form>
+        </Form>
+      </SheetContent>
+    </Sheet>
+  );
 }

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -91,12 +91,11 @@ import {
   UpdateVirtualKeyRequest,
   VirtualKey,
 } from "@/lib/types/governance";
-import { useGetAccessProfilesQuery } from "@enterprise/lib/store/apis/accessProfileApi";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
 import { Info, Lock, RotateCcw, Trash2, Users, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { components, MultiValueProps, OptionProps } from "react-select";
 import { toast } from "sonner";
@@ -109,9 +108,6 @@ interface VirtualKeySheetProps {
   // When set, the new VK is created under this team. The entity assignment is pre-set
   // and cannot be changed (but all other fields remain editable).
   defaultTeamId?: string;
-  // When set, the new VK is created under this access profile. The entity assignment is
-  // pre-set and cannot be changed.
-  defaultAccessProfileId?: number;
   onSave: () => void;
   onCancel: () => void;
 }
@@ -126,7 +122,6 @@ const providerConfigSchema = z.object({
     .max(1, "Weight must be at most 1")
     .optional(),
   allowed_models: z.array(z.string()).optional(),
-  blacklisted_models: z.array(z.string()).optional(),
   key_ids: z.array(z.string()).optional(), // Keys associated with this provider config
   // Provider-level budget
   budgets: z
@@ -162,10 +157,9 @@ const formSchema = z
     description: z.string().optional(),
     providerConfigs: z.array(providerConfigSchema).optional(),
     mcpConfigs: z.array(mcpConfigSchema).optional(),
-    entityType: z.enum(["team", "customer", "access_profile", "none"]),
+    entityType: z.enum(["team", "customer", "none"]),
     teamId: z.string().optional(),
     customerId: z.string().optional(),
-    accessProfileId: z.string().optional(),
     isActive: z.boolean(),
     // Budget
     budgetCalendarAligned: z.boolean(),
@@ -195,16 +189,12 @@ const formSchema = z
       if (data.entityType === "customer") {
         return data.customerId && data.customerId.trim() !== "";
       }
-      // If entityType is "access_profile", accessProfileId must be provided and not empty
-      if (data.entityType === "access_profile") {
-        return data.accessProfileId && data.accessProfileId.trim() !== "";
-      }
       return true;
     },
     {
       message:
-        "Please select a valid team, customer, or access profile when assignment type is chosen",
-      path: ["entityType"],
+        "Please select a valid team or customer when assignment type is chosen",
+      path: ["entityType"], // This will show the error on the entityType field
     },
   );
 
@@ -228,7 +218,6 @@ export default function VirtualKeySheet({
   teams,
   customers,
   defaultTeamId,
-  defaultAccessProfileId,
   onSave,
   onCancel,
 }: VirtualKeySheetProps) {
@@ -260,7 +249,6 @@ export default function VirtualKeySheet({
     ? teams.find((t) => t.id === attachedTeamId)
     : undefined;
   const isTeamLocked = !isEditing && !!defaultTeamId;
-  const isAPLocked = !isEditing && !!defaultAccessProfileId;
 
   const handleClose = () => {
     setIsOpen(false);
@@ -280,10 +268,6 @@ export default function VirtualKeySheet({
     useRotateVirtualKeyMutation();
   const { data: mcpClientsResponse, error: mcpClientsError } =
     useGetMCPClientsQuery();
-  const { data: accessProfilesData } = useGetAccessProfilesQuery({
-    limit: 100,
-  });
-  const accessProfiles = accessProfilesData?.access_profiles ?? [];
   const mcpClientsData = mcpClientsResponse?.clients || [];
   const isLoading = isCreating || isUpdating || isRotating;
 
@@ -302,7 +286,6 @@ export default function VirtualKeySheet({
           provider: config.provider,
           weight: config.weight ?? undefined,
           allowed_models: config.allowed_models,
-          blacklisted_models: config.blacklisted_models,
           key_ids: config.allow_all_keys
             ? ["*"]
             : config.keys?.map((key) => key.key_id) || [],
@@ -332,20 +315,11 @@ export default function VirtualKeySheet({
         ? "team"
         : virtualKey?.customer_id
           ? "customer"
-          : virtualKey?.access_profile_id
-            ? "access_profile"
-            : !isEditing && defaultTeamId
-              ? "team"
-              : !isEditing && defaultAccessProfileId
-                ? "access_profile"
-                : "none",
+          : !isEditing && defaultTeamId
+            ? "team"
+            : "none",
       teamId: virtualKey?.team_id || (!isEditing ? defaultTeamId || "" : ""),
       customerId: virtualKey?.customer_id || "",
-      accessProfileId: virtualKey?.access_profile_id
-        ? String(virtualKey.access_profile_id)
-        : !isEditing && defaultAccessProfileId
-          ? String(defaultAccessProfileId)
-          : "",
       isActive: virtualKey?.is_active ?? true,
       budgets:
         virtualKey?.budgets && virtualKey.budgets.length > 0
@@ -391,22 +365,16 @@ export default function VirtualKeySheet({
     }
   }, [mcpClientsError]);
 
-  // Clear entity ID fields when entityType changes
+  // Clear team/customer IDs when entityType changes to "none"
   useEffect(() => {
     const entityType = form.watch("entityType");
     if (entityType === "none") {
       form.setValue("teamId", "", { shouldDirty: true });
       form.setValue("customerId", "", { shouldDirty: true });
-      form.setValue("accessProfileId", "", { shouldDirty: true });
     } else if (entityType === "team") {
       form.setValue("customerId", "", { shouldDirty: true });
-      form.setValue("accessProfileId", "", { shouldDirty: true });
     } else if (entityType === "customer") {
       form.setValue("teamId", "", { shouldDirty: true });
-      form.setValue("accessProfileId", "", { shouldDirty: true });
-    } else if (entityType === "access_profile") {
-      form.setValue("teamId", "", { shouldDirty: true });
-      form.setValue("customerId", "", { shouldDirty: true });
     }
   }, [form.watch("entityType"), form]);
 
@@ -465,7 +433,6 @@ export default function VirtualKeySheet({
       provider: provider,
       weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
       allowed_models: ["*"],
-      blacklisted_models: [],
       key_ids: ["*"],
     };
 
@@ -532,14 +499,6 @@ export default function VirtualKeySheet({
     useState(false);
   const [showReassignTeamWarning, setShowReassignTeamWarning] = useState(false);
   const [pendingTeamId, setPendingTeamId] = useState<string | null>(null);
-  const [showReassignAPWarning, setShowReassignAPWarning] = useState(false);
-  const [pendingAccessProfileId, setPendingAccessProfileId] = useState<
-    string | null
-  >(null);
-  const [showReassignTypeWarning, setShowReassignTypeWarning] = useState(false);
-  const [pendingEntityType, setPendingEntityType] = useState<
-    "team" | "customer" | "access_profile" | "none" | null
-  >(null);
   const [showRotateWarning, setShowRotateWarning] = useState(false);
   const [showBudgetResetPrompt, setShowBudgetResetPrompt] = useState(false);
   const [pendingBudgetResetData, setPendingBudgetResetData] =
@@ -547,25 +506,6 @@ export default function VirtualKeySheet({
   const [pendingBudgetUsageWarning, setPendingBudgetUsageWarning] = useState<
     string | null
   >(null);
-
-  const currentAssignmentLabel = useMemo(() => {
-    if (!isEditing) return null;
-    if (virtualKey?.team_id) {
-      const team = teams?.find((t) => t.id === virtualKey.team_id);
-      return team ? `Team: ${team.name}` : "a team";
-    }
-    if (virtualKey?.customer_id) {
-      const customer = customers?.find((c) => c.id === virtualKey.customer_id);
-      return customer ? `Customer: ${customer.name}` : "a customer";
-    }
-    if (virtualKey?.access_profile_id) {
-      const ap = accessProfiles?.find(
-        (p) => p.id === virtualKey.access_profile_id,
-      );
-      return ap ? `Access Profile: ${ap.name}` : "an access profile";
-    }
-    return null;
-  }, [isEditing, virtualKey, teams, customers, accessProfiles]);
 
   const handleCalendarAlignedChange = (checked: boolean) => {
     if (checked && isEditing) {
@@ -920,12 +860,6 @@ export default function VirtualKeySheet({
             data.customerId.trim() !== ""
               ? data.customerId
               : undefined,
-          access_profile_id:
-            data.entityType === "access_profile" &&
-            data.accessProfileId &&
-            data.accessProfileId.trim() !== ""
-              ? Number(data.accessProfileId)
-              : undefined,
           is_active: data.isActive,
           calendar_aligned: data.budgetCalendarAligned,
           reset_budget_usage: resetBudgetUsage,
@@ -988,12 +922,6 @@ export default function VirtualKeySheet({
             data.customerId &&
             data.customerId.trim() !== ""
               ? data.customerId
-              : undefined,
-          access_profile_id:
-            data.entityType === "access_profile" &&
-            data.accessProfileId &&
-            data.accessProfileId.trim() !== ""
-              ? Number(data.accessProfileId)
               : undefined,
           is_active: data.isActive,
           // VK-level setting that governs both budget and rate-limit calendar alignment.
@@ -1477,119 +1405,10 @@ export default function VirtualKeySheet({
                                       );
                                     })()}
                                     <p className="text-muted-foreground text-xs">
-                                      Select specific models or choose "Allow
-                                      All Models" to allow all. Leave empty to
+                                      Select specific models or choose “Allow
+                                      All Models” to allow all. Leave empty to
                                       deny all.
                                     </p>
-                                  </div>
-                                </div>
-
-                                <div className="flex w-full items-start gap-2">
-                                  <div className="w-1/4" />
-                                  <div className="w-3/4 space-y-2">
-                                    <div className="flex items-center gap-2">
-                                      <Label className="text-sm font-medium">
-                                        Blocked Models
-                                      </Label>
-                                      <TooltipProvider>
-                                        <Tooltip>
-                                          <TooltipTrigger asChild>
-                                            <span>
-                                              <Info className="text-muted-foreground h-3 w-3" />
-                                            </span>
-                                          </TooltipTrigger>
-                                          <TooltipContent className="max-w-sm">
-                                            <p>
-                                              Models this VK must never serve.
-                                              The denylist always wins - if a
-                                              model appears in both Allowed
-                                              Models and here, it is blocked.
-                                              Select "All Models" to block every
-                                              model on this VK.
-                                            </p>
-                                          </TooltipContent>
-                                        </Tooltip>
-                                      </TooltipProvider>
-                                    </div>
-                                    {(() => {
-                                      const hasWildcardBlocked = (
-                                        config.blacklisted_models || []
-                                      ).includes("*");
-                                      return (
-                                        <ModelMultiselect
-                                          data-testid={`vk-models-blocked-multiselect-${index}`}
-                                          provider={config.provider}
-                                          keys={(() => {
-                                            const providerKeys =
-                                              availableKeys.filter(
-                                                (key) =>
-                                                  key.provider ===
-                                                  config.provider,
-                                              );
-                                            const configKeyIds =
-                                              config.key_ids || [];
-                                            return configKeyIds.includes("*")
-                                              ? providerKeys.map(
-                                                  (key) => key.key_id,
-                                                )
-                                              : providerKeys
-                                                  .filter((key) =>
-                                                    configKeyIds.includes(
-                                                      key.key_id,
-                                                    ),
-                                                  )
-                                                  .map((key) => key.key_id);
-                                          })()}
-                                          allowAllOption={true}
-                                          value={
-                                            hasWildcardBlocked
-                                              ? ["*"]
-                                              : config.blacklisted_models || []
-                                          }
-                                          onChange={(models: string[]) => {
-                                            const hadStar = (
-                                              config.blacklisted_models || []
-                                            ).includes("*");
-                                            const hasStar =
-                                              models.includes("*");
-                                            if (!hadStar && hasStar) {
-                                              handleUpdateProviderConfig(
-                                                index,
-                                                "blacklisted_models",
-                                                ["*"],
-                                              );
-                                            } else if (
-                                              hadStar &&
-                                              hasStar &&
-                                              models.length > 1
-                                            ) {
-                                              handleUpdateProviderConfig(
-                                                index,
-                                                "blacklisted_models",
-                                                models.filter((m) => m !== "*"),
-                                              );
-                                            } else {
-                                              handleUpdateProviderConfig(
-                                                index,
-                                                "blacklisted_models",
-                                                models,
-                                              );
-                                            }
-                                          }}
-                                          placeholder={
-                                            hasWildcardBlocked
-                                              ? "All models blocked"
-                                              : (
-                                                    config.blacklisted_models ||
-                                                    []
-                                                  ).length === 0
-                                                ? "No models blocked"
-                                                : "Search models..."
-                                          }
-                                          className="min-h-10 max-w-[500px] min-w-[200px]"
-                                        />
-                                      );
-                                    })()}
                                   </div>
                                 </div>
 
@@ -2237,171 +2056,6 @@ export default function VirtualKeySheet({
                       </AlertDialogFooter>
                     </AlertDialogContent>
                   </AlertDialog>
-
-                  <AlertDialog
-                    open={showReassignAPWarning}
-                    onOpenChange={(open) => {
-                      setShowReassignAPWarning(open);
-                      if (!open) {
-                        setPendingAccessProfileId(null);
-                      }
-                    }}
-                  >
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>
-                          Reassign to a different access profile?
-                        </AlertDialogTitle>
-                        <AlertDialogDescription>
-                          This key is currently assigned to another access
-                          profile. Reassigning it will move budget tracking to
-                          this access profile — future requests through this key
-                          will count against this profile's budget, not the
-                          previous one.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel
-                          data-testid="reassign-ap-cancel"
-                          onClick={() => setPendingAccessProfileId(null)}
-                        >
-                          Cancel
-                        </AlertDialogCancel>
-                        <AlertDialogAction
-                          data-testid="reassign-ap-confirm"
-                          onClick={() => {
-                            if (pendingAccessProfileId !== null) {
-                              form.setValue(
-                                "accessProfileId",
-                                pendingAccessProfileId,
-                                { shouldDirty: true },
-                              );
-                            }
-                            setPendingAccessProfileId(null);
-                            setShowReassignAPWarning(false);
-                          }}
-                        >
-                          Reassign
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-
-                  {/* Cross-type assignment warning */}
-                  <AlertDialog
-                    open={showReassignTypeWarning}
-                    onOpenChange={(open) => {
-                      if (!open) setPendingEntityType(null);
-                      setShowReassignTypeWarning(open);
-                    }}
-                  >
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Change assignment?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          This key is currently assigned to{" "}
-                          {currentAssignmentLabel}. Changing the assignment type
-                          will move budget tracking — future requests will count
-                          against the new entity, not the previous one.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel
-                          data-testid="reassign-type-cancel"
-                          onClick={() => setPendingEntityType(null)}
-                        >
-                          Cancel
-                        </AlertDialogCancel>
-                        <AlertDialogAction
-                          data-testid="reassign-type-confirm"
-                          onClick={async () => {
-                            if (pendingEntityType) {
-                              form.setValue("entityType", pendingEntityType, {
-                                shouldDirty: true,
-                              });
-                              if (
-                                pendingEntityType === "team" &&
-                                teams?.length > 0
-                              ) {
-                                form.setValue("teamId", teams[0].id, {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                                form.setValue("customerId", "", {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                                form.setValue("accessProfileId", "", {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                              } else if (
-                                pendingEntityType === "customer" &&
-                                customers?.length > 0
-                              ) {
-                                form.setValue("customerId", customers[0].id, {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                                form.setValue("teamId", "", {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                                form.setValue("accessProfileId", "", {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                              } else if (
-                                pendingEntityType === "access_profile"
-                              ) {
-                                const apId =
-                                  accessProfiles?.length > 0
-                                    ? String(accessProfiles[0].id)
-                                    : virtualKey?.access_profile_id
-                                      ? String(virtualKey.access_profile_id)
-                                      : "";
-                                form.setValue("accessProfileId", apId, {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                                form.setValue("teamId", "", {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                                form.setValue("customerId", "", {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                              } else {
-                                form.setValue("teamId", "", {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                                form.setValue("customerId", "", {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                                form.setValue("accessProfileId", "", {
-                                  shouldDirty: true,
-                                  shouldValidate: true,
-                                });
-                              }
-                              await form.trigger([
-                                "teamId",
-                                "customerId",
-                                "accessProfileId",
-                                "entityType",
-                              ]);
-                            }
-                            setPendingEntityType(null);
-                            setShowReassignTypeWarning(false);
-                          }}
-                        >
-                          Change Assignment
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
                 </div>
                 {/* Rate Limiting Configuration */}
                 <div className="space-y-4">
@@ -2549,11 +2203,7 @@ export default function VirtualKeySheet({
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
-                {(teams?.length > 0 ||
-                  customers?.length > 0 ||
-                  accessProfiles?.length > 0 ||
-                  !!virtualKey?.access_profile_id ||
-                  !!defaultAccessProfileId) && (
+                {(teams?.length > 0 || customers?.length > 0) && (
                   <>
                     <DottedSeparator className="my-6" />
 
@@ -2591,42 +2241,10 @@ export default function VirtualKeySheet({
                                         },
                                       ]
                                     : []),
-                                  ...(accessProfiles?.length > 0 ||
-                                  virtualKey?.access_profile_id ||
-                                  defaultAccessProfileId
-                                    ? [
-                                        {
-                                          value: "access_profile",
-                                          label: "Assign to Access Profile",
-                                        },
-                                      ]
-                                    : []),
                                 ]}
                                 value={field.value}
                                 onValueChange={async (value) => {
                                   const val = value ?? "none";
-                                  const originalType = virtualKey?.team_id
-                                    ? "team"
-                                    : virtualKey?.customer_id
-                                      ? "customer"
-                                      : virtualKey?.access_profile_id
-                                        ? "access_profile"
-                                        : "none";
-                                  if (
-                                    isEditing &&
-                                    currentAssignmentLabel &&
-                                    val !== "none" &&
-                                    val !== originalType
-                                  ) {
-                                    setPendingEntityType(
-                                      val as
-                                        | "team"
-                                        | "customer"
-                                        | "access_profile",
-                                    );
-                                    setShowReassignTypeWarning(true);
-                                    return;
-                                  }
                                   field.onChange(val);
                                   if (val === "team" && teams?.length > 0) {
                                     form.setValue("teamId", teams[0].id, {
@@ -2637,14 +2255,9 @@ export default function VirtualKeySheet({
                                       shouldDirty: true,
                                       shouldValidate: true,
                                     });
-                                    form.setValue("accessProfileId", "", {
-                                      shouldDirty: true,
-                                      shouldValidate: true,
-                                    });
                                     await form.trigger([
                                       "teamId",
                                       "customerId",
-                                      "accessProfileId",
                                       "entityType",
                                     ]);
                                   } else if (
@@ -2663,39 +2276,9 @@ export default function VirtualKeySheet({
                                       shouldDirty: true,
                                       shouldValidate: true,
                                     });
-                                    form.setValue("accessProfileId", "", {
-                                      shouldDirty: true,
-                                      shouldValidate: true,
-                                    });
                                     await form.trigger([
                                       "teamId",
                                       "customerId",
-                                      "accessProfileId",
-                                      "entityType",
-                                    ]);
-                                  } else if (val === "access_profile") {
-                                    const apId =
-                                      accessProfiles?.length > 0
-                                        ? String(accessProfiles[0].id)
-                                        : virtualKey?.access_profile_id
-                                          ? String(virtualKey.access_profile_id)
-                                          : "";
-                                    form.setValue("accessProfileId", apId, {
-                                      shouldDirty: true,
-                                      shouldValidate: true,
-                                    });
-                                    form.setValue("teamId", "", {
-                                      shouldDirty: true,
-                                      shouldValidate: true,
-                                    });
-                                    form.setValue("customerId", "", {
-                                      shouldDirty: true,
-                                      shouldValidate: true,
-                                    });
-                                    await form.trigger([
-                                      "teamId",
-                                      "customerId",
-                                      "accessProfileId",
                                       "entityType",
                                     ]);
                                   } else {
@@ -2707,19 +2290,14 @@ export default function VirtualKeySheet({
                                       shouldDirty: true,
                                       shouldValidate: true,
                                     });
-                                    form.setValue("accessProfileId", "", {
-                                      shouldDirty: true,
-                                      shouldValidate: true,
-                                    });
                                     await form.trigger([
                                       "teamId",
                                       "customerId",
-                                      "accessProfileId",
                                       "entityType",
                                     ]);
                                   }
                                 }}
-                                disabled={isTeamLocked || isAPLocked}
+                                disabled={isTeamLocked}
                                 disableSearch
                                 hideClear
                                 className="h-9"
@@ -2792,51 +2370,6 @@ export default function VirtualKeySheet({
                                     }
                                     placeholder="Select a customer"
                                     emptyMessage="No customers found."
-                                    className="h-9"
-                                  />
-                                  <FormMessage />
-                                </FormItem>
-                              )}
-                            />
-                          )}
-
-                        {form.watch("entityType") === "access_profile" &&
-                          (accessProfiles?.length > 0 ||
-                            virtualKey?.access_profile_id ||
-                            defaultAccessProfileId) && (
-                            <FormField
-                              control={form.control}
-                              name="accessProfileId"
-                              render={({ field }) => (
-                                <FormItem>
-                                  <FormLabel className="font-normal">
-                                    Select Access Profile
-                                  </FormLabel>
-                                  <ComboboxSelect
-                                    data-testid="access-profile-selector"
-                                    options={accessProfiles.map((ap) => ({
-                                      value: String(ap.id),
-                                      label: ap.name,
-                                    }))}
-                                    value={field.value || null}
-                                    onValueChange={(val) => {
-                                      const newVal = val ?? "";
-                                      if (
-                                        isEditing &&
-                                        virtualKey?.access_profile_id &&
-                                        newVal &&
-                                        newVal !==
-                                          String(virtualKey.access_profile_id)
-                                      ) {
-                                        setPendingAccessProfileId(newVal);
-                                        setShowReassignAPWarning(true);
-                                      } else {
-                                        field.onChange(newVal);
-                                      }
-                                    }}
-                                    placeholder="Select an access profile"
-                                    disabled={isAPLocked}
-                                    emptyMessage="No access profiles found."
                                     className="h-9"
                                   />
                                   <FormMessage />

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -126,6 +126,7 @@ const providerConfigSchema = z.object({
     .max(1, "Weight must be at most 1")
     .optional(),
   allowed_models: z.array(z.string()).optional(),
+  blacklisted_models: z.array(z.string()).optional(),
   key_ids: z.array(z.string()).optional(), // Keys associated with this provider config
   // Provider-level budget
   budgets: z
@@ -245,8 +246,11 @@ export default function VirtualKeySheet({
   );
   const canSubmit = isEditing ? hasUpdateAccess : hasCreateAccess;
 
-  const { assignedUsers } = useVirtualKeyUsage(virtualKey);
-  const isManagedByProfile = isEditing && !!virtualKey?.access_profile_id;
+  // Detect AP-managed status via the managing profile's virtual_key_ids, not just by the presence
+  // of assignees — directly-attached users don't imply an access-profile relation.
+  const { assignedUsers, isManagedByProfile: isManagedByProfileHook } =
+    useVirtualKeyUsage(virtualKey);
+  const isManagedByProfile = isEditing && isManagedByProfileHook;
   // Team attachment: when creating from a team context (defaultTeamId provided), the entity
   // assignment is pre-set and locked. When editing an existing VK the assignment can be changed.
   const attachedTeamId = isEditing
@@ -298,6 +302,7 @@ export default function VirtualKeySheet({
           provider: config.provider,
           weight: config.weight ?? undefined,
           allowed_models: config.allowed_models,
+          blacklisted_models: config.blacklisted_models,
           key_ids: config.allow_all_keys
             ? ["*"]
             : config.keys?.map((key) => key.key_id) || [],
@@ -460,6 +465,7 @@ export default function VirtualKeySheet({
       provider: provider,
       weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
       allowed_models: ["*"],
+      blacklisted_models: [],
       key_ids: ["*"],
     };
 
@@ -1095,14 +1101,12 @@ export default function VirtualKeySheet({
                 <Alert variant="info">
                   <Users className="h-4 w-4" />
                   <AlertDescription>
-                    <p>
-                      Creating this virtual key under team{" "}
-                      <span className="font-medium">
-                        {attachedTeam?.name ?? attachedTeamId}
-                      </span>
-                      . Team assignment is pre-set — all other fields are
-                      editable.
-                    </p>
+                    Creating this virtual key under team{" "}
+                    <span className="font-medium">
+                      {attachedTeam?.name ?? attachedTeamId}
+                    </span>
+                    . Team assignment is pre-set — all other fields are
+                    editable.
                   </AlertDescription>
                 </Alert>
               )}
@@ -1473,10 +1477,119 @@ export default function VirtualKeySheet({
                                       );
                                     })()}
                                     <p className="text-muted-foreground text-xs">
-                                      Select specific models or choose “Allow
-                                      All Models” to allow all. Leave empty to
+                                      Select specific models or choose "Allow
+                                      All Models" to allow all. Leave empty to
                                       deny all.
                                     </p>
+                                  </div>
+                                </div>
+
+                                <div className="flex w-full items-start gap-2">
+                                  <div className="w-1/4" />
+                                  <div className="w-3/4 space-y-2">
+                                    <div className="flex items-center gap-2">
+                                      <Label className="text-sm font-medium">
+                                        Blocked Models
+                                      </Label>
+                                      <TooltipProvider>
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <span>
+                                              <Info className="text-muted-foreground h-3 w-3" />
+                                            </span>
+                                          </TooltipTrigger>
+                                          <TooltipContent className="max-w-sm">
+                                            <p>
+                                              Models this VK must never serve.
+                                              The denylist always wins - if a
+                                              model appears in both Allowed
+                                              Models and here, it is blocked.
+                                              Select "All Models" to block every
+                                              model on this VK.
+                                            </p>
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      </TooltipProvider>
+                                    </div>
+                                    {(() => {
+                                      const hasWildcardBlocked = (
+                                        config.blacklisted_models || []
+                                      ).includes("*");
+                                      return (
+                                        <ModelMultiselect
+                                          data-testid={`vk-models-blocked-multiselect-${index}`}
+                                          provider={config.provider}
+                                          keys={(() => {
+                                            const providerKeys =
+                                              availableKeys.filter(
+                                                (key) =>
+                                                  key.provider ===
+                                                  config.provider,
+                                              );
+                                            const configKeyIds =
+                                              config.key_ids || [];
+                                            return configKeyIds.includes("*")
+                                              ? providerKeys.map(
+                                                  (key) => key.key_id,
+                                                )
+                                              : providerKeys
+                                                  .filter((key) =>
+                                                    configKeyIds.includes(
+                                                      key.key_id,
+                                                    ),
+                                                  )
+                                                  .map((key) => key.key_id);
+                                          })()}
+                                          allowAllOption={true}
+                                          value={
+                                            hasWildcardBlocked
+                                              ? ["*"]
+                                              : config.blacklisted_models || []
+                                          }
+                                          onChange={(models: string[]) => {
+                                            const hadStar = (
+                                              config.blacklisted_models || []
+                                            ).includes("*");
+                                            const hasStar =
+                                              models.includes("*");
+                                            if (!hadStar && hasStar) {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "blacklisted_models",
+                                                ["*"],
+                                              );
+                                            } else if (
+                                              hadStar &&
+                                              hasStar &&
+                                              models.length > 1
+                                            ) {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "blacklisted_models",
+                                                models.filter((m) => m !== "*"),
+                                              );
+                                            } else {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "blacklisted_models",
+                                                models,
+                                              );
+                                            }
+                                          }}
+                                          placeholder={
+                                            hasWildcardBlocked
+                                              ? "All models blocked"
+                                              : (
+                                                    config.blacklisted_models ||
+                                                    []
+                                                  ).length === 0
+                                                ? "No models blocked"
+                                                : "Search models..."
+                                          }
+                                          className="min-h-10 max-w-[500px] min-w-[200px]"
+                                        />
+                                      );
+                                    })()}
                                   </div>
                                 </div>
 

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -33,7 +33,6 @@ import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useGetAccessProfilesQuery } from "@enterprise/lib/store/apis/accessProfileApi";
 import {
 	ArrowDown,
 	ArrowUp,
@@ -80,8 +79,6 @@ function virtualKeysToCSV(vks: VirtualKey[], accessProfileNames: Record<number, 
 			? `Team: ${vk.team.name}`
 			: vk.customer
 				? `Customer: ${vk.customer.name}`
-				: vk.access_profile_id
-					? `Access Profile: ${accessProfileNames[vk.access_profile_id] ?? vk.access_profile_id}`
 					: "";
 		const budgetLimit = vk.budgets?.length ? vk.budgets.map((b) => formatCurrency(b.max_limit)).join("; ") : "";
 		const budgetSpent = vk.budgets?.length ? vk.budgets.map((b) => formatCurrency(b.current_usage)).join("; ") : "";
@@ -295,15 +292,6 @@ export default function VirtualKeysTable({
 	const [showBulkRotateDialog, setShowBulkRotateDialog] = useState(false);
 	const [fetchVirtualKeys, { isFetching: isExporting }] = useLazyGetVirtualKeysQuery();
 
-	const { data: accessProfilesData } = useGetAccessProfilesQuery({ limit: 100 });
-	const accessProfileNames = useMemo(() => {
-		const map: Record<number, string> = {};
-		for (const ap of accessProfilesData?.access_profiles ?? []) {
-			map[ap.id] = ap.name;
-		}
-		return map;
-	}, [accessProfilesData]);
-
 	// Derive objects from props so they stay in sync with RTK cache updates
 	const editingVirtualKey = useMemo(
 		() => (editingVirtualKeyId ? (virtualKeys.find((vk) => vk.id === editingVirtualKeyId) ?? null) : null),
@@ -477,7 +465,7 @@ export default function VirtualKeysTable({
 
 	const handleExportCSV = async () => {
 		if (exportScope === "current_page") {
-			downloadCSV(virtualKeysToCSV(virtualKeys, accessProfileNames));
+			downloadCSV(virtualKeysToCSV(virtualKeys));
 			toast.success(`Exported ${virtualKeys.length} virtual keys`);
 			setShowExportDialog(false);
 			return;
@@ -499,7 +487,7 @@ export default function VirtualKeysTable({
 				export: true,
 			}).unwrap();
 
-			downloadCSV(virtualKeysToCSV(result.virtual_keys, accessProfileNames));
+			downloadCSV(virtualKeysToCSV(result.virtual_keys));
 			toast.success(`Exported ${result.virtual_keys.length} virtual keys`);
 			setShowExportDialog(false);
 		} catch (error) {
@@ -796,10 +784,6 @@ export default function VirtualKeysTable({
 												) : vk.customer ? (
 													<Badge variant="outline" className="block max-w-full truncate text-left">
 														Customer: {vk.customer.name}
-													</Badge>
-												) : vk.access_profile_id ? (
-													<Badge variant="outline" className="block max-w-full truncate text-left">
-														AP: {accessProfileNames[vk.access_profile_id] ?? vk.access_profile_id}
 													</Badge>
 												) : (
 													<span className="text-muted-foreground max-w-full truncate text-left text-sm">-</span>

--- a/ui/components/ui/combobox.tsx
+++ b/ui/components/ui/combobox.tsx
@@ -295,7 +295,6 @@ interface ComboboxSelectBaseProps {
 	hideClear?: boolean;
 	className?: string;
 	emptyMessage?: string;
-	"data-testid"?: string;
 }
 
 interface ComboboxSelectSingleProps extends ComboboxSelectBaseProps {
@@ -321,7 +320,6 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 		className,
 		emptyMessage = "No results found.",
 		noPortal,
-		"data-testid": dataTestId,
 	} = props;
 
 	const [open, setOpen] = React.useState(false);
@@ -444,7 +442,6 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 					role="combobox"
 					aria-expanded={open}
 					disabled={disabled}
-					data-testid={dataTestId}
 					className={cn(
 						"h-8 w-full justify-between !bg-transparent font-normal active:scale-none",
 						!selectedLabel && "text-muted-foreground",

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -184,7 +184,6 @@ export const baseApi = createApi({
     "Versions",
     "Sessions",
     "AccessProfiles",
-    "AccessProfileVirtualKeys",
     "BusinessUnits",
     "PromptDeployments",
     "AuthType",

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -63,7 +63,6 @@ export const governanceApi = baseApi.injectEndpoints({
 					...(params?.search && { search: params.search }),
 					...(params?.customer_id && { customer_id: params.customer_id }),
 					...(params?.team_id && { team_id: params.team_id }),
-					...(params?.access_profile_id !== undefined && { access_profile_id: params.access_profile_id }),
 					...(params?.exclude_access_profile_managed_virtual === true && {
 						exclude_access_profile_managed_virtual: "true",
 					}),

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -72,7 +72,6 @@ export interface VirtualKey {
 	mcp_configs?: VirtualKeyMCPConfig[];
 	team_id?: string;
 	customer_id?: string;
-	access_profile_id?: number;
 	rate_limit_id?: string;
 	is_active: boolean;
 	calendar_aligned?: boolean;
@@ -161,7 +160,6 @@ export interface CreateVirtualKeyRequest {
 	mcp_configs?: VirtualKeyMCPConfigRequest[];
 	team_id?: string;
 	customer_id?: string;
-	access_profile_id?: number;
 	budgets?: CreateBudgetRequest[];
 	rate_limit?: CreateRateLimitRequest;
 	is_active?: boolean;
@@ -175,7 +173,6 @@ export interface UpdateVirtualKeyRequest {
 	mcp_configs?: VirtualKeyMCPConfigRequest[];
 	team_id?: string;
 	customer_id?: string;
-	access_profile_id?: number;
 	budgets?: CreateBudgetRequest[];
 	rate_limit?: UpdateRateLimitRequest;
 	is_active?: boolean;
@@ -259,7 +256,6 @@ export interface GetVirtualKeysParams {
 	search?: string;
 	customer_id?: string;
 	team_id?: string;
-	access_profile_id?: number;
 	exclude_access_profile_managed_virtual?: boolean;
 	sort_by?: "name" | "budget_spent" | "created_at" | "status";
 	order?: "asc" | "desc";


### PR DESCRIPTION
## Summary

Extends the migration test script to cover v1.5.3 schema changes, including new tables (`feature_flags`, `temp_tokens`) and new columns added across config store and log store tables. Also refactors the per-user OAuth insert generation to handle both the legacy v1.5.0-prerelease4 schema and the v1.5.3 refactored schema, where `oauth_per_user_*` tables were dropped and `oauth_user_sessions`/`oauth_user_tokens` were restructured.

## Changes

- Added `generate_feature_flags_insert_postgres` and `generate_feature_flags_insert_sqlite` functions to seed the `feature_flags` table introduced in v1.5.3 via `migrationAddFeatureFlagsTable`.
- Added `generate_temp_tokens_insert_postgres` and `generate_temp_tokens_insert_sqlite` functions to seed the `temp_tokens` table introduced in v1.5.3 via `migrationAddTempTokensTable`.
- Both new insert generators are wired into `append_dynamic_mcp_clients_insert` for both PostgreSQL and SQLite paths.
- Added v1.5.3 dynamic column UPDATE blocks for both PostgreSQL and SQLite covering:
  - `config_client.metadata_json`
  - `framework_configs.model_parameters_url` and `config_hash`
  - `governance_teams.source_id` and `calendar_aligned`
  - `governance_virtual_keys.access_profile_id`
  - `logs.cluster_node_id`, `budget_ids`, and `rate_limit_ids`
  - `mcp_tool_logs.user_id`, `team_id`, `customer_id`, and `business_unit_id`
- Refactored `generate_per_user_oauth_tables_insert_postgres` and extracted a new `generate_per_user_oauth_tables_insert_sqlite` function. Both now branch on schema version: if `oauth_per_user_clients` exists, the prerelease4 schema is used; if `oauth_user_sessions.session_id` exists, the v1.5.3 refactored schema (using `session_id` + `flow_mode` instead of `session_token`/`gateway_session_id`) is used instead.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the migration test workflow against a deployment that includes v1.5.3 migrations and verify that the test script seeds all new tables and columns without errors. Also run against a pre-v1.5.3 schema to confirm the conditional guards correctly skip missing tables and columns.

```sh
bash .github/workflows/scripts/run-migration-tests.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Covers migration test coverage for v1.5.3 schema additions.

## Security considerations

No new secrets or auth flows are introduced. Test data uses placeholder tokens and hashes that are not used in production.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable