### PR TITLE
fix: ensure toasts remain clickable above modal overlays

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -390,6 +390,11 @@ div.content-container:has(.no-border-parent) #trial-notification-banner {
 	@apply rounded-sm!;
 }
 
+/* Ensure toasts remain clickable above modal overlays (radix react-remove-scroll) */
+[data-sonner-toaster] {
+	pointer-events: auto !important;
+}
+
 /* Move Sonner toast close button to top-right */
 [data-sonner-toaster][dir="ltr"],
 [data-sonner-toaster] {


### PR DESCRIPTION
## Summary

Fixes an issue where toast notifications were unclickable when a modal was open. Radix UI's `react-remove-scroll` sets `pointer-events: none` on elements outside the modal, which inadvertently blocked interaction with Sonner toasts.

## Changes

- Added a CSS rule to force `pointer-events: auto` on `[data-sonner-toaster]`, ensuring toasts remain interactive even when a modal overlay is active.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open any modal dialog in the UI.
2. Trigger a toast notification while the modal is open.
3. Verify the toast is visible and can be clicked/dismissed without closing the modal first.

## Screenshots/Recordings

Before: Toasts displayed behind/blocked by modal overlay and could not be clicked.
After: Toasts remain fully interactive while a modal is open.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable