### PR TITLE
fix: remove save/cancel icons and fix sheet layout growth in routing rule and virtual key sheets

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -390,6 +390,11 @@ div.content-container:has(.no-border-parent) #trial-notification-banner {
 	@apply rounded-sm!;
 }
 
+/* Ensure toasts remain clickable above modal overlays (radix react-remove-scroll) */
+[data-sonner-toaster] {
+	pointer-events: auto !important;
+}
+
 /* Move Sonner toast close button to top-right */
 [data-sonner-toaster][dir="ltr"],
 [data-sonner-toaster] {

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -3,7 +3,6 @@
  * Create/Edit form for routing rules
  */
 
-import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Button } from "@/components/ui/button";
 import { ComboboxSelect } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
@@ -30,7 +29,8 @@ import {
 } from "@/lib/types/routingRules";
 import { validateRateLimitAndBudgetRules, validateRoutingRules } from "@/lib/utils/celConverterRouting";
 import { normalizeRoutingRuleGroupQuery } from "@/lib/utils/routingRuleGroupQuery";
-import { Plus, Save, Trash2, X } from "lucide-react";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { Plus, Trash2, X } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { RuleGroupType } from "react-querybuilder";
@@ -273,8 +273,8 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 					</SheetDescription>
 				</SheetHeader>
 
-				<form onSubmit={handleSubmit(onSubmit)}>
-					<div className="flex flex-col gap-6 px-8 pb-6">
+				<form onSubmit={handleSubmit(onSubmit)} className="flex flex-col grow">
+					<div className="flex flex-col gap-6 px-8 pb-6 grow">
 						{/* Rule Name */}
 						<div className="space-y-3">
 							<Label htmlFor="name">
@@ -584,11 +584,9 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 					{/* Action Buttons */}
 					<div className="bg-card sticky bottom-0 flex justify-end gap-3 border-t px-8 py-4">
 						<Button type="button" variant="outline" onClick={handleCancel} disabled={isLoading}>
-							<X className="h-4 w-4" />
 							Cancel
 						</Button>
 						<Button type="submit" disabled={isLoading || !hasRequiredAccess}>
-							<Save className="h-4 w-4" />
 							{isEditing ? "Update Rule" : "Save Rule"}
 						</Button>
 					</div>

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -1013,7 +1013,7 @@ export default function VirtualKeySheet({
             onSubmit={form.handleSubmit(onSubmit)}
             className="flex h-full flex-col gap-6"
           >
-            <div className="space-y-4 px-8">
+            <div className="space-y-4 px-8 grow">
               {isManagedByProfile && (
                 <Alert variant="info">
                   <Lock className="h-4 w-4" />


### PR DESCRIPTION
## Summary

Cleans up the routing rule sheet UI by removing icon decorations from action buttons and fixing layout issues where the form content doesn't grow to fill available space in both the routing rule and virtual key sheets.

## Changes

- Removed the `X` and `Save` icons from the Cancel and Save/Update buttons in the routing rule sheet, leaving text-only labels
- Added `grow` and `flex flex-col` classes to the routing rule sheet form and its inner container so the form expands to fill the sheet height correctly
- Added `grow` to the virtual key sheet's inner content div for consistent layout behavior
- Moved the `RbacOperation`, `RbacResource`, and `useRbac` import to be grouped with other non-local imports

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the routing rules sheet (create or edit a rule) and verify the form content fills the full height of the sheet without collapsing.
2. Confirm the Cancel and Save/Update buttons display text only, without icons.
3. Open the virtual key sheet and verify the form content similarly fills the available height.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before/after screenshots showing the button label changes and corrected sheet layout are recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable