### PR TITLE
test case fixes

### DIFF
--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -98,6 +98,9 @@ var ignoreGoFields = map[string]string{
 	// integrating system (PR #3395). It is assigned through the API by that
 	// system, never authored in config.json.
 	"/properties/governance/properties/teams/items|source_id": "external identifier set via API by integrating systems; not authored in config.json",
+	// created_by_user_id is DB ownership metadata set by the API/session layer,
+	// never authored in config.json.
+	"/properties/governance/properties/virtual_keys/items|created_by_user_id": "DB ownership metadata; set by API/session layer, not authored in config.json",
 }
 
 // ignoreGoFieldNames are field names (regardless of parent path) that are
@@ -281,13 +284,13 @@ func printReport(w interface{ Write([]byte) (int, error) }, findings []Finding) 
 		groups[f.Category] = append(groups[f.Category], f)
 	}
 	titles := map[string]string{
-		"missing-in-schema":      "Missing in config.schema.json (Go has field, schema doesn't) — ERRORS",
-		"missing-in-go":          "Missing in Go (schema has property, ConfigData doesn't) — WARNINGS",
-		"enum-drift":             "Enum drift (Go constants vs schema enum array)",
-		"enum-no-schema":         "Go enum types with no schema `enum` constraint — WARNINGS",
-		"envvar-no-secret":       "EnvVar fields lacking chart-native Secret support — WARNINGS",
-		"schema-path-not-found":  "Schema path not found for a walked Go type — ERRORS",
-		"entrypoint":             "Entrypoint problems — ERRORS",
+		"missing-in-schema":     "Missing in config.schema.json (Go has field, schema doesn't) — ERRORS",
+		"missing-in-go":         "Missing in Go (schema has property, ConfigData doesn't) — WARNINGS",
+		"enum-drift":            "Enum drift (Go constants vs schema enum array)",
+		"enum-no-schema":        "Go enum types with no schema `enum` constraint — WARNINGS",
+		"envvar-no-secret":      "EnvVar fields lacking chart-native Secret support — WARNINGS",
+		"schema-path-not-found": "Schema path not found for a walked Go type — ERRORS",
+		"entrypoint":            "Entrypoint problems — ERRORS",
 	}
 	for _, cat := range order {
 		items := groups[cat]

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -792,6 +792,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddVirtualKeyBlacklistedModelsColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationBackfillVirtualKeyBlacklistedModels(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddCreatedByUserIDColumnForVirtualKeys(ctx, db); err != nil {
 		return err
 	}
@@ -5214,7 +5217,11 @@ func migrationAddBedrockAssumeRoleColumns(ctx context.Context, db *gorm.DB) erro
 // and backfills existing rows: any provider config with no keys in the join table previously meant
 // "allow all keys" (old semantic), so they get allow_all_keys = true to preserve behaviour.
 func migrationAddAllowAllKeysToProviderConfig(ctx context.Context, db *gorm.DB) error {
-	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+	// opts is a value copy: migrator.DefaultOptions is a shared global pointer,
+	// so mutating it in place would disable transactions for other migrations.
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = false
+	m := migrator.New(db, &opts, []*migrator.Migration{{
 		ID: "add_allow_all_keys_to_provider_config",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -8510,6 +8517,9 @@ func migrationAddTempTokensTable(ctx context.Context, db *gorm.DB) error {
 
 // migrationAddVirtualKeyBlacklistedModelsColumn adds the blacklisted_models JSON column
 // to governance_virtual_key_provider_configs, matching the provider-key blacklist pattern.
+// This migration performs the DDL only. The data backfill and config_hash recompute are
+// done by migrationBackfillVirtualKeyBlacklistedModels so the ALTER's ACCESS EXCLUSIVE
+// lock is not held across the backfill SELECT + UPDATE, which can deadlock Postgres.
 func migrationAddVirtualKeyBlacklistedModelsColumn(ctx context.Context, db *gorm.DB) error {
 	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
 		ID: "add_vk_provider_config_blacklisted_models_column",
@@ -8520,32 +8530,6 @@ func migrationAddVirtualKeyBlacklistedModelsColumn(ctx context.Context, db *gorm
 				if err := mg.AddColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models"); err != nil {
 					return fmt.Errorf("failed to add blacklisted_models column: %w", err)
 				}
-				// Backfill empty arrays for existing rows (only when column is newly added)
-				if err := tx.Exec("UPDATE governance_virtual_key_provider_configs SET blacklisted_models = '[]' WHERE blacklisted_models IS NULL OR blacklisted_models = ''").Error; err != nil {
-					return fmt.Errorf("failed to backfill blacklisted_models: %w", err)
-				}
-				// Recompute config_hash for all VKs affected by the backfill so they
-				// do not appear stale after upgrade (same pattern as allow_all_keys migration).
-				var virtualKeys []tables.TableVirtualKey
-				if err := tx.
-					Preload("ProviderConfigs").
-					Preload("ProviderConfigs.Keys").
-					Preload("MCPConfigs").
-					Find(&virtualKeys).Error; err != nil {
-					return fmt.Errorf("failed to fetch virtual keys for hash recomputation: %w", err)
-				}
-				for _, vk := range virtualKeys {
-					newHash, err := GenerateVirtualKeyHash(vk)
-					if err != nil {
-						return fmt.Errorf("failed to generate hash for VK %s: %w", vk.ID, err)
-					}
-					if err := tx.Model(&tables.TableVirtualKey{}).
-						Where("id = ?", vk.ID).
-						Update("config_hash", newHash).Error; err != nil {
-						return fmt.Errorf("failed to update config_hash for VK %s: %w", vk.ID, err)
-					}
-
-				}
 			}
 			return nil
 		},
@@ -8555,6 +8539,56 @@ func migrationAddVirtualKeyBlacklistedModelsColumn(ctx context.Context, db *gorm
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_vk_provider_config_blacklisted_models_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationBackfillVirtualKeyBlacklistedModels backfills empty JSON arrays into the
+// blacklisted_models column added by migrationAddVirtualKeyBlacklistedModelsColumn and
+// recomputes config_hash for every virtual key so they do not appear stale after upgrade.
+// It is a separate migration from the column-add so the DDL's ACCESS EXCLUSIVE lock is
+// never held across this SELECT + UPDATE backfill.
+func migrationBackfillVirtualKeyBlacklistedModels(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "backfill_vk_provider_config_blacklisted_models",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			// Backfill empty arrays for existing rows. Idempotent via the WHERE clause.
+			if err := tx.Exec("UPDATE governance_virtual_key_provider_configs SET blacklisted_models = '[]' WHERE blacklisted_models IS NULL OR blacklisted_models = ''").Error; err != nil {
+				return fmt.Errorf("failed to backfill blacklisted_models: %w", err)
+			}
+
+			// Recompute config_hash for all VKs affected by the backfill so they do
+			// not appear stale after upgrade. The hash is deterministic, so this is
+			// safe to re-run.
+			var virtualKeys []tables.TableVirtualKey
+			if err := tx.
+				Preload("ProviderConfigs").
+				Preload("ProviderConfigs.Keys").
+				Preload("MCPConfigs").
+				Find(&virtualKeys).Error; err != nil {
+				return fmt.Errorf("failed to fetch virtual keys for hash recomputation: %w", err)
+			}
+			for _, vk := range virtualKeys {
+				newHash, err := GenerateVirtualKeyHash(vk)
+				if err != nil {
+					return fmt.Errorf("failed to generate hash for VK %s: %w", vk.ID, err)
+				}
+				if err := tx.Model(&tables.TableVirtualKey{}).
+					Where("id = ?", vk.ID).
+					Update("config_hash", newHash).Error; err != nil {
+					return fmt.Errorf("failed to update config_hash for VK %s: %w", vk.ID, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running backfill_vk_provider_config_blacklisted_models migration: %s", err.Error())
 	}
 	return nil
 }

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -15757,13 +15757,14 @@ var excludedGoFields = map[string]map[string]bool{
 		"virtual_keys": true, // GORM relation
 	},
 	"tables.TableVirtualKey": {
-		"config_hash": true,
-		"created_at":  true,
-		"updated_at":  true,
-		"budgets":     true, // GORM relation (budgets have virtual_key_id FK)
-		"rate_limit":  true, // GORM relation
-		"team":        true, // GORM relation
-		"customer":    true, // GORM relation
+		"config_hash":        true,
+		"created_at":         true,
+		"updated_at":         true,
+		"created_by_user_id": true, // DB ownership metadata; set by API/session layer
+		"budgets":            true, // GORM relation (budgets have virtual_key_id FK)
+		"rate_limit":         true, // GORM relation
+		"team":               true, // GORM relation
+		"customer":           true, // GORM relation
 	},
 	"tables.TableVirtualKeyProviderConfig": {
 		"rate_limit":     true, // GORM relation

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -3,480 +3,757 @@ import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { DottedSeparator } from "@/components/ui/separator";
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { supportsCalendarAlignment } from "@/lib/constants/governance";
-import { calculateUsagePercentage, formatCurrency, parseResetPeriod } from "@/lib/utils/governance";
+import {
+  calculateUsagePercentage,
+  formatCurrency,
+  parseResetPeriod,
+} from "@/lib/utils/governance";
+import { AccessProfileSheet } from "@enterprise/components/access-profiles/dialogs/accessProfileSheet";
+import { useGetAccessProfileQuery } from "@enterprise/lib/store/apis/accessProfileApi";
 import { formatDistanceToNow } from "date-fns";
 import { Lock, Users } from "lucide-react";
+import { useState } from "react";
 import { useVirtualKeyUsage } from "../hooks/useVirtualKeyUsage";
 
 function usageBarClass(pct: number, exhausted: boolean) {
-	if (exhausted) return "[&>div]:bg-red-500/70";
-	if (pct > 80) return "[&>div]:bg-amber-500/70";
-	return "[&>div]:bg-emerald-500/70";
+  if (exhausted) return "[&>div]:bg-red-500/70";
+  if (pct > 80) return "[&>div]:bg-amber-500/70";
+  return "[&>div]:bg-emerald-500/70";
 }
 
-function UsageLine({ current, max, format }: { current: number; max: number; format: (n: number) => string }) {
-	const pct = calculateUsagePercentage(current, max);
-	const exhausted = max > 0 && current >= max;
-	return (
-		<div className="space-y-2">
-			<div className="flex items-center justify-between gap-3">
-				<span className="font-mono text-sm">
-					{format(current)} <span className="text-muted-foreground">/</span> {format(max)}
-				</span>
-				<span
-					className={cn(
-						"text-xs font-medium tabular-nums",
-						exhausted ? "text-red-500" : pct > 80 ? "text-amber-500" : "text-muted-foreground",
-					)}
-				>
-					{pct}%
-				</span>
-			</div>
-			<Progress value={Math.min(pct, 100)} className={cn("bg-muted/70 dark:bg-muted/30 h-1.5", usageBarClass(pct, exhausted))} />
-		</div>
-	);
+function UsageLine({
+  current,
+  max,
+  format,
+}: {
+  current: number;
+  max: number;
+  format: (n: number) => string;
+}) {
+  const pct = calculateUsagePercentage(current, max);
+  const exhausted = max > 0 && current >= max;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-mono text-sm">
+          {format(current)} <span className="text-muted-foreground">/</span>{" "}
+          {format(max)}
+        </span>
+        <span
+          className={cn(
+            "text-xs font-medium tabular-nums",
+            exhausted
+              ? "text-red-500"
+              : pct > 80
+                ? "text-amber-500"
+                : "text-muted-foreground",
+          )}
+        >
+          {pct}%
+        </span>
+      </div>
+      <Progress
+        value={Math.min(pct, 100)}
+        className={cn(
+          "bg-muted/70 dark:bg-muted/30 h-1.5",
+          usageBarClass(pct, exhausted),
+        )}
+      />
+    </div>
+  );
 }
 
 interface VirtualKeyDetailSheetProps {
-	virtualKey: VirtualKey;
-	onClose: () => void;
+  virtualKey: VirtualKey;
+  onClose: () => void;
 }
 
-export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKeyDetailSheetProps) {
-	const { assignedUsers, managingProfile, isManagedByProfile, hasApRateLimit, displayBudgets, displayRateLimit } = useVirtualKeyUsage(virtualKey);
+export default function VirtualKeyDetailSheet({
+  virtualKey,
+  onClose,
+}: VirtualKeyDetailSheetProps) {
+  const {
+    assignedUsers,
+    isManagedByProfile,
+    managingProfile,
+    hasApRateLimit,
+    displayBudgets,
+    displayRateLimit,
+  } = useVirtualKeyUsage(virtualKey);
+  const [showManagingProfile, setShowManagingProfile] = useState(false);
+  const managingParentProfileID = managingProfile?.parent_profile_id;
+  const { data: managingParentProfileData } = useGetAccessProfileQuery(
+    managingParentProfileID ?? 0,
+    {
+      skip: !showManagingProfile || !managingParentProfileID,
+    },
+  );
+  const managingParentProfile = managingParentProfileData
+    ? {
+        ...managingParentProfileData.access_profile,
+        roles: managingParentProfileData.roles,
+      }
+    : undefined;
 
-	const getEntityInfo = () => {
-		if (virtualKey.team) {
-			return { type: "Team", name: virtualKey.team.name };
-		}
-		if (virtualKey.customer) {
-			return { type: "Customer", name: virtualKey.customer.name };
-		}
-		return { type: "None", name: "" };
-	};
+  const getEntityInfo = () => {
+    if (virtualKey.team) {
+      return { type: "Team", name: virtualKey.team.name };
+    }
+    if (virtualKey.customer) {
+      return { type: "Customer", name: virtualKey.customer.name };
+    }
+    return { type: "None", name: "" };
+  };
 
-	const entityInfo = getEntityInfo();
+  const entityInfo = getEntityInfo();
 
-	const isExhausted =
-		// Budget exhausted (AP-mirrored when managed, VK-own otherwise)
-		displayBudgets?.some((b) => b.current_usage >= b.max_limit) ||
-		// Rate limits exhausted
-		(displayRateLimit?.token_current_usage &&
-			displayRateLimit?.token_max_limit &&
-			displayRateLimit.token_current_usage >= displayRateLimit.token_max_limit) ||
-		(displayRateLimit?.request_current_usage &&
-			displayRateLimit?.request_max_limit &&
-			displayRateLimit.request_current_usage >= displayRateLimit.request_max_limit);
+  const isExhausted =
+    // Budget exhausted (AP-mirrored when managed, VK-own otherwise)
+    displayBudgets?.some((b) => b.current_usage >= b.max_limit) ||
+    // Rate limits exhausted
+    (displayRateLimit?.token_current_usage &&
+      displayRateLimit?.token_max_limit &&
+      displayRateLimit.token_current_usage >=
+        displayRateLimit.token_max_limit) ||
+    (displayRateLimit?.request_current_usage &&
+      displayRateLimit?.request_max_limit &&
+      displayRateLimit.request_current_usage >=
+        displayRateLimit.request_max_limit);
 
-	return (
-		<Sheet open onOpenChange={onClose}>
-			<SheetContent className="flex w-full flex-col overflow-x-hidden p-8 sm:max-w-2xl">
-				<SheetHeader className="flex flex-col items-start p-0">
-					<SheetTitle>{virtualKey.name}</SheetTitle>
-					<SheetDescription>{virtualKey.description || "Virtual key details and usage information"}</SheetDescription>
-				</SheetHeader>
+  return (
+    <Sheet open onOpenChange={onClose}>
+      <SheetContent className="flex w-full flex-col overflow-x-hidden p-8 sm:max-w-2xl">
+        <SheetHeader className="flex flex-col items-start p-0">
+          <SheetTitle>{virtualKey.name}</SheetTitle>
+          <SheetDescription>
+            {virtualKey.description ||
+              "Virtual key details and usage information"}
+          </SheetDescription>
+        </SheetHeader>
 
-				<div className="space-y-6">
-					{isManagedByProfile ? (
-						<Alert variant="info">
-							<Lock className="h-4 w-4" />
-							<AlertDescription>
-								This virtual key is managed by an access profile. You can rename it or update its description from the edit button, but
-								providers, budgets, rate limits, and MCP access are controlled by the profile and must be changed there.
-							</AlertDescription>
-						</Alert>
-					) : null}
+        <div className="space-y-6">
+          {isManagedByProfile ? (
+            <Alert variant="info">
+              <Lock className="h-4 w-4" />
+              <AlertDescription>
+                <p>
+                  This virtual key is managed by access profile{" "}
+                  {managingParentProfileID ? (
+                    <button
+                      type="button"
+                      className="text-primary font-medium underline-offset-2 hover:underline"
+                      onClick={() => setShowManagingProfile(true)}
+                    >
+                      {managingProfile?.name ?? "Unknown"}
+                    </button>
+                  ) : (
+                    <span className="font-medium">
+                      {managingProfile?.name ?? "Unknown"}
+                    </span>
+                  )}
+                  . You can rename it or update its description from the edit
+                  button, but providers, budgets, rate limits, and MCP access
+                  are controlled by the profile and must be changed there.
+                </p>
+              </AlertDescription>
+            </Alert>
+          ) : null}
 
-					{assignedUsers.length > 0 ? (
-						<div className="space-y-1">
-							<Label className="text-sm font-medium">Assigned Users</Label>
-							<div className="flex items-center gap-2">
-								<Users className="text-muted-foreground h-4 w-4" />
-								<span className="text-sm">{assignedUsers.map((u) => u.name || u.email).join(", ")}</span>
-							</div>
-						</div>
-					) : null}
+          {assignedUsers.length > 0 ? (
+            <div className="space-y-1">
+              <Label className="text-sm font-medium">Assigned Users</Label>
+              <div className="flex items-center gap-2">
+                <Users className="text-muted-foreground h-4 w-4" />
+                <span className="text-sm">
+                  {assignedUsers.map((u) => u.name || u.email).join(", ")}
+                </span>
+              </div>
+            </div>
+          ) : null}
 
-					{/* Basic Information */}
-					<div className="space-y-4">
-						<h3 className="font-semibold">Basic Information</h3>
+          {/* Basic Information */}
+          <div className="space-y-4">
+            <h3 className="font-semibold">Basic Information</h3>
 
-						<div className="grid gap-4">
-							<div className="grid grid-cols-3 items-center gap-4">
-								<span className="text-muted-foreground text-sm">Status</span>
-								<div className="col-span-2">
-									<Badge variant={virtualKey.is_active ? (isExhausted ? "destructive" : "default") : "secondary"}>
-										{virtualKey.is_active ? (isExhausted ? "Exhausted" : "Active") : "Inactive"}
-									</Badge>
-								</div>
-							</div>
+            <div className="grid gap-4">
+              <div className="grid grid-cols-3 items-center gap-4">
+                <span className="text-muted-foreground text-sm">Status</span>
+                <div className="col-span-2">
+                  <Badge
+                    variant={
+                      virtualKey.is_active
+                        ? isExhausted
+                          ? "destructive"
+                          : "default"
+                        : "secondary"
+                    }
+                  >
+                    {virtualKey.is_active
+                      ? isExhausted
+                        ? "Exhausted"
+                        : "Active"
+                      : "Inactive"}
+                  </Badge>
+                </div>
+              </div>
 
-							<div className="grid grid-cols-3 items-center gap-4">
-								<span className="text-muted-foreground text-sm">Created</span>
-								<div className="col-span-2 text-sm">{formatDistanceToNow(new Date(virtualKey.created_at), { addSuffix: true })}</div>
-							</div>
+              <div className="grid grid-cols-3 items-center gap-4">
+                <span className="text-muted-foreground text-sm">Created</span>
+                <div className="col-span-2 text-sm">
+                  {formatDistanceToNow(new Date(virtualKey.created_at), {
+                    addSuffix: true,
+                  })}
+                </div>
+              </div>
 
-							<div className="grid grid-cols-3 items-center gap-4">
-								<span className="text-muted-foreground text-sm">Last Updated</span>
-								<div className="col-span-2 text-sm">{formatDistanceToNow(new Date(virtualKey.updated_at), { addSuffix: true })}</div>
-							</div>
+              <div className="grid grid-cols-3 items-center gap-4">
+                <span className="text-muted-foreground text-sm">
+                  Last Updated
+                </span>
+                <div className="col-span-2 text-sm">
+                  {formatDistanceToNow(new Date(virtualKey.updated_at), {
+                    addSuffix: true,
+                  })}
+                </div>
+              </div>
 
-							{entityInfo.type !== "None" && (
-								<div className="grid grid-cols-3 items-center gap-4">
-									<span className="text-muted-foreground text-sm">Assigned To</span>
-									<div className="col-span-2 flex items-center gap-2">
-										<Badge variant={entityInfo.type === "None" ? "outline" : "secondary"}>{entityInfo.type}</Badge>
-										<span className="text-sm">{entityInfo.name}</span>
-									</div>
-								</div>
-							)}
-						</div>
-					</div>
+              {entityInfo.type !== "None" && (
+                <div className="grid grid-cols-3 items-center gap-4">
+                  <span className="text-muted-foreground text-sm">
+                    Assigned To
+                  </span>
+                  <div className="col-span-2 flex items-center gap-2">
+                    <Badge
+                      variant={
+                        entityInfo.type === "None" ? "outline" : "secondary"
+                      }
+                    >
+                      {entityInfo.type}
+                    </Badge>
+                    <span className="text-sm">{entityInfo.name}</span>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
 
-					<DottedSeparator />
+          <DottedSeparator />
 
-					{/* Provider Configurations */}
-					<div className="space-y-4">
-						<h3 className="font-semibold">Provider Configurations</h3>
+          {/* Provider Configurations */}
+          <div className="space-y-4">
+            <h3 className="font-semibold">Provider Configurations</h3>
 
-						<div className="space-y-3">
-							{!virtualKey.provider_configs || virtualKey.provider_configs.length === 0 ? (
-								<span className="text-muted-foreground text-sm">No providers configured (deny-by-default)</span>
-							) : (
-								<div className="space-y-4">
-									{virtualKey.provider_configs.map((config, index) => (
-										<div key={`${config.provider}-${index}`} className="rounded-lg border p-4">
-											{/* Provider Header */}
-											<div className="mb-4 flex items-center justify-between">
-												<div className="flex items-center gap-2">
-													<RenderProviderIcon provider={config.provider as ProviderIconType} size="sm" className="h-5 w-5" />
-													<span className="font-medium">{ProviderLabels[config.provider as ProviderName] || config.provider}</span>
-												</div>
-												<Badge variant="outline" className="font-mono text-xs">
-													Weight: {config.weight}
-												</Badge>
-											</div>
+            <div className="space-y-3">
+              {!virtualKey.provider_configs ||
+              virtualKey.provider_configs.length === 0 ? (
+                <span className="text-muted-foreground text-sm">
+                  No providers configured (deny-by-default)
+                </span>
+              ) : (
+                <div className="space-y-4">
+                  {virtualKey.provider_configs.map((config, index) => (
+                    <div
+                      key={`${config.provider}-${index}`}
+                      className="rounded-lg border p-4"
+                    >
+                      {/* Provider Header */}
+                      <div className="mb-4 flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <RenderProviderIcon
+                            provider={config.provider as ProviderIconType}
+                            size="sm"
+                            className="h-5 w-5"
+                          />
+                          <span className="font-medium">
+                            {ProviderLabels[config.provider as ProviderName] ||
+                              config.provider}
+                          </span>
+                        </div>
+                        <Badge variant="outline" className="font-mono text-xs">
+                          Weight: {config.weight}
+                        </Badge>
+                      </div>
 
-											{/* Basic Config */}
-											<div className="space-y-3">
-												<div className="grid grid-cols-3 items-start gap-4">
-													<span className="text-muted-foreground pt-0.5 text-sm font-medium">Allowed Models</span>
-													<div className="col-span-2">
-														{config.allowed_models?.includes("*") ? (
-															<Badge variant="success" className="text-xs">
-																All Models
-															</Badge>
-														) : config.allowed_models && config.allowed_models.length > 0 ? (
-															<div className="flex flex-wrap gap-1">
-																{config.allowed_models.map((model) => (
-																	<Badge key={model} variant="secondary" className="text-xs">
-																		{model}
-																	</Badge>
-																))}
-															</div>
-														) : (
-															<Badge variant="destructive" className="text-xs">
-																No models (deny all)
-															</Badge>
-														)}
-													</div>
-												</div>
+                      {/* Basic Config */}
+                      <div className="space-y-3">
+                        <div className="grid grid-cols-3 items-start gap-4">
+                          <span className="text-muted-foreground pt-0.5 text-sm font-medium">
+                            Allowed Models
+                          </span>
+                          <div className="col-span-2">
+                            {config.allowed_models?.includes("*") ? (
+                              <Badge variant="success" className="text-xs">
+                                All Models
+                              </Badge>
+                            ) : config.allowed_models &&
+                              config.allowed_models.length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {config.allowed_models.map((model) => (
+                                  <Badge
+                                    key={model}
+                                    variant="secondary"
+                                    className="text-xs"
+                                  >
+                                    {model}
+                                  </Badge>
+                                ))}
+                              </div>
+                            ) : (
+                              <Badge variant="destructive" className="text-xs">
+                                No models (deny all)
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
 
-												<div className="grid grid-cols-3 items-start gap-4">
-													<span className="text-muted-foreground pt-0.5 text-sm font-medium">Blocked Models</span>
-													<div className="col-span-2">
-														{config.blacklisted_models?.includes("*") ? (
-															<Badge variant="destructive" className="text-xs">
-																All Models Blocked
-															</Badge>
-														) : config.blacklisted_models && config.blacklisted_models.length > 0 ? (
-															<div className="flex flex-wrap gap-1">
-																{config.blacklisted_models.map((model) => (
-																	<Badge key={model} variant="destructive" className="text-xs">
-																		{model}
-																	</Badge>
-																))}
-															</div>
-														) : (
-															<Badge variant="secondary" className="text-xs">
-																No models blocked
-															</Badge>
-														)}
-													</div>
-												</div>
+                        <div className="grid grid-cols-3 items-start gap-4">
+                          <span className="text-muted-foreground pt-0.5 text-sm font-medium">
+                            Blocked Models
+                          </span>
+                          <div className="col-span-2">
+                            {config.blacklisted_models?.includes("*") ? (
+                              <Badge variant="destructive" className="text-xs">
+                                All Models Blocked
+                              </Badge>
+                            ) : config.blacklisted_models &&
+                              config.blacklisted_models.length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {config.blacklisted_models.map((model) => (
+                                  <Badge
+                                    key={model}
+                                    variant="destructive"
+                                    className="text-xs"
+                                  >
+                                    {model}
+                                  </Badge>
+                                ))}
+                              </div>
+                            ) : (
+                              <Badge variant="secondary" className="text-xs">
+                                No models blocked
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
 
-												<div className="grid grid-cols-3 items-start gap-4">
-													<span className="text-muted-foreground pt-0.5 text-sm font-medium">Allowed Keys</span>
-													<div className="col-span-2">
-														{config.allow_all_keys ? (
-															<Badge variant="success" className="text-xs">
-																All Keys
-															</Badge>
-														) : config.keys && config.keys.length > 0 ? (
-															<div className="flex flex-wrap gap-1">
-																{config.keys.map((key) => (
-																	<Badge key={key.key_id} variant="outline" className="text-xs">
-																		{key.name}
-																	</Badge>
-																))}
-															</div>
-														) : (
-															<Badge variant="destructive" className="text-xs">
-																No keys (deny all)
-															</Badge>
-														)}
-													</div>
-												</div>
+                        <div className="grid grid-cols-3 items-start gap-4">
+                          <span className="text-muted-foreground pt-0.5 text-sm font-medium">
+                            Allowed Keys
+                          </span>
+                          <div className="col-span-2">
+                            {config.allow_all_keys ? (
+                              <Badge variant="success" className="text-xs">
+                                All Keys
+                              </Badge>
+                            ) : config.keys && config.keys.length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {config.keys.map((key) => (
+                                  <Badge
+                                    key={key.key_id}
+                                    variant="outline"
+                                    className="text-xs"
+                                  >
+                                    {key.name}
+                                  </Badge>
+                                ))}
+                              </div>
+                            ) : (
+                              <Badge variant="destructive" className="text-xs">
+                                No keys (deny all)
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
 
-												{/* Provider Budgets */}
-												{config.budgets && config.budgets.length > 0 && (
-													<>
-														<DottedSeparator />
-														<div className="space-y-2">
-															<h4 className="text-sm font-medium">Provider Budgets</h4>
-															{config.budgets.map((b, bIdx) => (
-																<div key={bIdx} className="space-y-2">
-																	<UsageLine current={b.current_usage} max={b.max_limit} format={formatCurrency} />
-																	<div className="text-muted-foreground flex items-center justify-between text-xs">
-																		<span>
-																			Resets {parseResetPeriod(b.reset_duration)}
-																			{virtualKey.calendar_aligned && supportsCalendarAlignment(b.reset_duration) && " (calendar)"}
-																		</span>
-																		{b.last_reset ? (
-																			<span>Last reset {formatDistanceToNow(new Date(b.last_reset), { addSuffix: true })}</span>
-																		) : null}
-																	</div>
-																</div>
-															))}
-														</div>
-													</>
-												)}
+                        {/* Provider Budgets */}
+                        {config.budgets && config.budgets.length > 0 && (
+                          <>
+                            <DottedSeparator />
+                            <div className="space-y-2">
+                              <h4 className="text-sm font-medium">
+                                Provider Budgets
+                              </h4>
+                              {config.budgets.map((b, bIdx) => (
+                                <div key={bIdx} className="space-y-2">
+                                  <UsageLine
+                                    current={b.current_usage}
+                                    max={b.max_limit}
+                                    format={formatCurrency}
+                                  />
+                                  <div className="text-muted-foreground flex items-center justify-between text-xs">
+                                    <span>
+                                      Resets{" "}
+                                      {parseResetPeriod(b.reset_duration)}
+                                      {virtualKey.calendar_aligned &&
+                                        supportsCalendarAlignment(
+                                          b.reset_duration,
+                                        ) &&
+                                        " (calendar)"}
+                                    </span>
+                                    {b.last_reset ? (
+                                      <span>
+                                        Last reset{" "}
+                                        {formatDistanceToNow(
+                                          new Date(b.last_reset),
+                                          {
+                                            addSuffix: true,
+                                          },
+                                        )}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </>
+                        )}
 
-												{/* Provider Rate Limits */}
-												{config.rate_limit && (
-													<>
-														<DottedSeparator />
-														<div className="space-y-3">
-															<h4 className="text-sm font-medium">Provider Rate Limits</h4>
+                        {/* Provider Rate Limits */}
+                        {config.rate_limit && (
+                          <>
+                            <DottedSeparator />
+                            <div className="space-y-3">
+                              <h4 className="text-sm font-medium">
+                                Provider Rate Limits
+                              </h4>
 
-															{/* Token Limits */}
-															{config.rate_limit.token_max_limit != null ? (
-																<div className="space-y-2">
-																	<span className="text-muted-foreground text-xs font-medium">TOKEN LIMITS</span>
-																	<UsageLine
-																		current={config.rate_limit.token_current_usage}
-																		max={config.rate_limit.token_max_limit}
-																		format={(n) => n.toLocaleString()}
-																	/>
-																	<div className="text-muted-foreground flex items-center justify-between text-xs">
-																		<span>
-																			Resets {parseResetPeriod(config.rate_limit.token_reset_duration || "")}
-																			{virtualKey.calendar_aligned &&
-																				supportsCalendarAlignment(config.rate_limit.token_reset_duration || "") &&
-																				" (calendar)"}
-																		</span>
-																		{config.rate_limit.token_last_reset ? (
-																			<span>
-																				Last reset {formatDistanceToNow(new Date(config.rate_limit.token_last_reset), { addSuffix: true })}
-																			</span>
-																		) : null}
-																	</div>
-																</div>
-															) : null}
+                              {/* Token Limits */}
+                              {config.rate_limit.token_max_limit != null ? (
+                                <div className="space-y-2">
+                                  <span className="text-muted-foreground text-xs font-medium">
+                                    TOKEN LIMITS
+                                  </span>
+                                  <UsageLine
+                                    current={
+                                      config.rate_limit.token_current_usage
+                                    }
+                                    max={config.rate_limit.token_max_limit}
+                                    format={(n) => n.toLocaleString()}
+                                  />
+                                  <div className="text-muted-foreground flex items-center justify-between text-xs">
+                                    <span>
+                                      Resets{" "}
+                                      {parseResetPeriod(
+                                        config.rate_limit
+                                          .token_reset_duration || "",
+                                      )}
+                                      {virtualKey.calendar_aligned &&
+                                        supportsCalendarAlignment(
+                                          config.rate_limit
+                                            .token_reset_duration || "",
+                                        ) &&
+                                        " (calendar)"}
+                                    </span>
+                                    {config.rate_limit.token_last_reset ? (
+                                      <span>
+                                        Last reset{" "}
+                                        {formatDistanceToNow(
+                                          new Date(
+                                            config.rate_limit.token_last_reset,
+                                          ),
+                                          { addSuffix: true },
+                                        )}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                </div>
+                              ) : null}
 
-															{/* Request Limits */}
-															{config.rate_limit.request_max_limit != null ? (
-																<div className="space-y-2">
-																	<span className="text-muted-foreground text-xs font-medium">REQUEST LIMITS</span>
-																	<UsageLine
-																		current={config.rate_limit.request_current_usage}
-																		max={config.rate_limit.request_max_limit}
-																		format={(n) => n.toLocaleString()}
-																	/>
-																	<div className="text-muted-foreground flex items-center justify-between text-xs">
-																		<span>
-																			Resets {parseResetPeriod(config.rate_limit.request_reset_duration || "")}
-																			{virtualKey.calendar_aligned &&
-																				supportsCalendarAlignment(config.rate_limit.request_reset_duration || "") &&
-																				" (calendar)"}
-																		</span>
-																		{config.rate_limit.request_last_reset ? (
-																			<span>
-																				Last reset{" "}
-																				{formatDistanceToNow(new Date(config.rate_limit.request_last_reset), { addSuffix: true })}
-																			</span>
-																		) : null}
-																	</div>
-																</div>
-															) : null}
+                              {/* Request Limits */}
+                              {config.rate_limit.request_max_limit != null ? (
+                                <div className="space-y-2">
+                                  <span className="text-muted-foreground text-xs font-medium">
+                                    REQUEST LIMITS
+                                  </span>
+                                  <UsageLine
+                                    current={
+                                      config.rate_limit.request_current_usage
+                                    }
+                                    max={config.rate_limit.request_max_limit}
+                                    format={(n) => n.toLocaleString()}
+                                  />
+                                  <div className="text-muted-foreground flex items-center justify-between text-xs">
+                                    <span>
+                                      Resets{" "}
+                                      {parseResetPeriod(
+                                        config.rate_limit
+                                          .request_reset_duration || "",
+                                      )}
+                                      {virtualKey.calendar_aligned &&
+                                        supportsCalendarAlignment(
+                                          config.rate_limit
+                                            .request_reset_duration || "",
+                                        ) &&
+                                        " (calendar)"}
+                                    </span>
+                                    {config.rate_limit.request_last_reset ? (
+                                      <span>
+                                        Last reset{" "}
+                                        {formatDistanceToNow(
+                                          new Date(
+                                            config.rate_limit
+                                              .request_last_reset,
+                                          ),
+                                          { addSuffix: true },
+                                        )}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                </div>
+                              ) : null}
 
-															{config.rate_limit.token_max_limit == null && config.rate_limit.request_max_limit == null && (
-																<p className="text-muted-foreground text-sm">No rate limits configured for this provider</p>
-															)}
-														</div>
-													</>
-												)}
-											</div>
-										</div>
-									))}
-								</div>
-							)}
-						</div>
-					</div>
+                              {config.rate_limit.token_max_limit == null &&
+                                config.rate_limit.request_max_limit == null && (
+                                  <p className="text-muted-foreground text-sm">
+                                    No rate limits configured for this provider
+                                  </p>
+                                )}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
 
-					{/* MCP Client Configurations */}
-					<div className="space-y-4">
-						<h3 className="font-semibold">MCP Client Configurations</h3>
+          {/* MCP Client Configurations */}
+          <div className="space-y-4">
+            <h3 className="font-semibold">MCP Client Configurations</h3>
 
-						<div className="space-y-3">
-							{!virtualKey.mcp_configs || virtualKey.mcp_configs.length === 0 ? (
-								<span className="text-muted-foreground text-sm">No MCP clients configured (deny-by-default)</span>
-							) : (
-								<div className="rounded-md border">
-									<Table>
-										<TableHeader>
-											<TableRow>
-												<TableHead>MCP Client</TableHead>
-												<TableHead>Allowed Tools</TableHead>
-											</TableRow>
-										</TableHeader>
-										<TableBody>
-											{virtualKey.mcp_configs.map((config, index) => (
-												<TableRow key={`${config.mcp_client?.name || config.id}-${index}`}>
-													<TableCell>{config.mcp_client?.name || "Unknown Client"}</TableCell>
-													<TableCell>
-														{config.tools_to_execute?.includes("*") ? (
-															<Badge variant="success" className="text-xs">
-																All Tools
-															</Badge>
-														) : config.tools_to_execute && config.tools_to_execute.length > 0 ? (
-															<div className="flex flex-wrap gap-1">
-																{config.tools_to_execute.map((tool) => (
-																	<Badge key={tool} variant="secondary" className="text-xs">
-																		{tool}
-																	</Badge>
-																))}
-															</div>
-														) : (
-															<Badge variant="destructive" className="text-xs">
-																No tools (deny all)
-															</Badge>
-														)}
-													</TableCell>
-												</TableRow>
-											))}
-										</TableBody>
-									</Table>
-								</div>
-							)}
-						</div>
-					</div>
+            <div className="space-y-3">
+              {!virtualKey.mcp_configs ||
+              virtualKey.mcp_configs.length === 0 ? (
+                <span className="text-muted-foreground text-sm">
+                  No MCP clients configured (deny-by-default)
+                </span>
+              ) : (
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>MCP Client</TableHead>
+                        <TableHead>Allowed Tools</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {virtualKey.mcp_configs.map((config, index) => (
+                        <TableRow
+                          key={`${config.mcp_client?.name || config.id}-${index}`}
+                        >
+                          <TableCell>
+                            {config.mcp_client?.name || "Unknown Client"}
+                          </TableCell>
+                          <TableCell>
+                            {config.tools_to_execute?.includes("*") ? (
+                              <Badge variant="success" className="text-xs">
+                                All Tools
+                              </Badge>
+                            ) : config.tools_to_execute &&
+                              config.tools_to_execute.length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {config.tools_to_execute.map((tool) => (
+                                  <Badge
+                                    key={tool}
+                                    variant="secondary"
+                                    className="text-xs"
+                                  >
+                                    {tool}
+                                  </Badge>
+                                ))}
+                              </div>
+                            ) : (
+                              <Badge variant="destructive" className="text-xs">
+                                No tools (deny all)
+                              </Badge>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </div>
+          </div>
 
-					<DottedSeparator />
+          <DottedSeparator />
 
-					{/* Budget Information */}
-					<div className="space-y-4">
-						<h3 className="font-semibold">
-							Budget Information
-							{isManagedByProfile && managingProfile?.budgets?.length ? (
-								<span className="text-muted-foreground ml-2 text-xs font-normal">(from {managingProfile.name})</span>
-							) : null}
-						</h3>
+          {/* Budget Information */}
+          <div className="space-y-4">
+            <h3 className="font-semibold">
+              Budget Information
+              {isManagedByProfile && managingProfile?.budgets?.length ? (
+                <span className="text-muted-foreground ml-2 text-xs font-normal">
+                  (from {managingProfile.name})
+                </span>
+              ) : null}
+            </h3>
 
-						{displayBudgets && displayBudgets.length > 0 ? (
-							<div className="space-y-4">
-								{displayBudgets.map((b, bIdx) => (
-									<div key={bIdx} className="space-y-2 rounded-lg border p-4">
-										<UsageLine current={b.current_usage} max={b.max_limit} format={formatCurrency} />
-										<div className="text-muted-foreground flex items-center justify-between text-xs">
-											<span>
-												Resets {parseResetPeriod(b.reset_duration)}
-												{virtualKey.calendar_aligned && supportsCalendarAlignment(b.reset_duration) && " (calendar)"}
-											</span>
-											{b.last_reset ? <span>Last reset {formatDistanceToNow(new Date(b.last_reset), { addSuffix: true })}</span> : null}
-										</div>
-									</div>
-								))}
-							</div>
-						) : (
-							<p className="text-muted-foreground text-sm">No budget limits configured</p>
-						)}
-					</div>
+            {displayBudgets && displayBudgets.length > 0 ? (
+              <div className="space-y-4">
+                {displayBudgets.map((b, bIdx) => (
+                  <div key={bIdx} className="space-y-2 rounded-lg border p-4">
+                    <UsageLine
+                      current={b.current_usage}
+                      max={b.max_limit}
+                      format={formatCurrency}
+                    />
+                    <div className="text-muted-foreground flex items-center justify-between text-xs">
+                      <span>
+                        Resets {parseResetPeriod(b.reset_duration)}
+                        {virtualKey.calendar_aligned &&
+                          supportsCalendarAlignment(b.reset_duration) &&
+                          " (calendar)"}
+                      </span>
+                      {b.last_reset ? (
+                        <span>
+                          Last reset{" "}
+                          {formatDistanceToNow(new Date(b.last_reset), {
+                            addSuffix: true,
+                          })}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                No budget limits configured
+              </p>
+            )}
+          </div>
 
-					{/* Rate Limits */}
-					<div className="space-y-4">
-						<h3 className="font-semibold">
-							Rate Limits
-							{isManagedByProfile && hasApRateLimit ? (
-								<span className="text-muted-foreground ml-2 text-xs font-normal">(from {managingProfile?.name})</span>
-							) : null}
-						</h3>
+          {/* Rate Limits */}
+          <div className="space-y-4">
+            <h3 className="font-semibold">
+              Rate Limits
+              {isManagedByProfile && hasApRateLimit ? (
+                <span className="text-muted-foreground ml-2 text-xs font-normal">
+                  (from {managingProfile?.name})
+                </span>
+              ) : null}
+            </h3>
 
-						{displayRateLimit ? (
-							<div className="space-y-4">
-								{/* Token Limits */}
-								{displayRateLimit.token_max_limit != null ? (
-									<div className="space-y-3 rounded-lg border p-4">
-										<span className="font-medium">Token Limits</span>
-										<UsageLine
-											current={displayRateLimit.token_current_usage}
-											max={displayRateLimit.token_max_limit}
-											format={(n) => n.toLocaleString()}
-										/>
-										<div className="text-muted-foreground flex items-center justify-between text-xs">
-											<span>
-												Resets {parseResetPeriod(displayRateLimit.token_reset_duration || "")}
-												{virtualKey.calendar_aligned &&
-													supportsCalendarAlignment(displayRateLimit.token_reset_duration || "") &&
-													" (calendar)"}
-											</span>
-											{displayRateLimit.token_last_reset ? (
-												<span>Last reset {formatDistanceToNow(new Date(displayRateLimit.token_last_reset), { addSuffix: true })}</span>
-											) : null}
-										</div>
-									</div>
-								) : null}
+            {displayRateLimit ? (
+              <div className="space-y-4">
+                {/* Token Limits */}
+                {displayRateLimit.token_max_limit != null ? (
+                  <div className="space-y-3 rounded-lg border p-4">
+                    <span className="font-medium">Token Limits</span>
+                    <UsageLine
+                      current={displayRateLimit.token_current_usage}
+                      max={displayRateLimit.token_max_limit}
+                      format={(n) => n.toLocaleString()}
+                    />
+                    <div className="text-muted-foreground flex items-center justify-between text-xs">
+                      <span>
+                        Resets{" "}
+                        {parseResetPeriod(
+                          displayRateLimit.token_reset_duration || "",
+                        )}
+                        {virtualKey.calendar_aligned &&
+                          supportsCalendarAlignment(
+                            displayRateLimit.token_reset_duration || "",
+                          ) &&
+                          " (calendar)"}
+                      </span>
+                      {displayRateLimit.token_last_reset ? (
+                        <span>
+                          Last reset{" "}
+                          {formatDistanceToNow(
+                            new Date(displayRateLimit.token_last_reset),
+                            {
+                              addSuffix: true,
+                            },
+                          )}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                ) : null}
 
-								{/* Request Limits */}
-								{displayRateLimit.request_max_limit != null ? (
-									<div className="space-y-3 rounded-lg border p-4">
-										<span className="font-medium">Request Limits</span>
-										<UsageLine
-											current={displayRateLimit.request_current_usage}
-											max={displayRateLimit.request_max_limit}
-											format={(n) => n.toLocaleString()}
-										/>
-										<div className="text-muted-foreground flex items-center justify-between text-xs">
-											<span>
-												Resets {parseResetPeriod(displayRateLimit.request_reset_duration || "")}
-												{virtualKey.calendar_aligned &&
-													supportsCalendarAlignment(displayRateLimit.request_reset_duration || "") &&
-													" (calendar)"}
-											</span>
-											{displayRateLimit.request_last_reset ? (
-												<span>Last reset {formatDistanceToNow(new Date(displayRateLimit.request_last_reset), { addSuffix: true })}</span>
-											) : null}
-										</div>
-									</div>
-								) : null}
+                {/* Request Limits */}
+                {displayRateLimit.request_max_limit != null ? (
+                  <div className="space-y-3 rounded-lg border p-4">
+                    <span className="font-medium">Request Limits</span>
+                    <UsageLine
+                      current={displayRateLimit.request_current_usage}
+                      max={displayRateLimit.request_max_limit}
+                      format={(n) => n.toLocaleString()}
+                    />
+                    <div className="text-muted-foreground flex items-center justify-between text-xs">
+                      <span>
+                        Resets{" "}
+                        {parseResetPeriod(
+                          displayRateLimit.request_reset_duration || "",
+                        )}
+                        {virtualKey.calendar_aligned &&
+                          supportsCalendarAlignment(
+                            displayRateLimit.request_reset_duration || "",
+                          ) &&
+                          " (calendar)"}
+                      </span>
+                      {displayRateLimit.request_last_reset ? (
+                        <span>
+                          Last reset{" "}
+                          {formatDistanceToNow(
+                            new Date(displayRateLimit.request_last_reset),
+                            {
+                              addSuffix: true,
+                            },
+                          )}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                ) : null}
 
-								{displayRateLimit.token_max_limit == null && displayRateLimit.request_max_limit == null && (
-									<p className="text-muted-foreground text-sm">No rate limits configured</p>
-								)}
-							</div>
-						) : (
-							<p className="text-muted-foreground text-sm">No rate limits configured</p>
-						)}
-					</div>
-				</div>
-			</SheetContent>
-		</Sheet>
-	);
+                {displayRateLimit.token_max_limit == null &&
+                  displayRateLimit.request_max_limit == null && (
+                    <p className="text-muted-foreground text-sm">
+                      No rate limits configured
+                    </p>
+                  )}
+              </div>
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                No rate limits configured
+              </p>
+            )}
+          </div>
+        </div>
+      </SheetContent>
+      <AccessProfileSheet
+        open={showManagingProfile && !!managingParentProfile}
+        onOpenChange={(open) => {
+          if (!open) setShowManagingProfile(false);
+        }}
+        profile={managingParentProfile}
+      />
+    </Sheet>
+  );
 }


### PR DESCRIPTION
## Summary

This PR adds a clickable link to the managing access profile in the virtual key details sheet, allowing users to navigate directly to the parent access profile. It also excludes `created_by_user_id` from schema sync and config test checks, and disables transaction wrapping for the `add_allow_all_keys_to_provider_config` migration.

## Changes

- The "managed by access profile" alert in `VirtualKeyDetailSheet` now renders the profile name as a clickable button when a parent profile ID is available. Clicking it fetches the parent profile via `useGetAccessProfileQuery` and opens it in an `AccessProfileSheet` overlay.
- `created_by_user_id` on `TableVirtualKey` is added to the `ignoreGoFields` map in the schema sync tool and to the `excludedGoFields` map in the config test, since it is DB ownership metadata set by the API/session layer and is never authored in `config.json`.
- The `migrationAddAllowAllKeysToProviderConfig` migration is changed to run with `UseTransaction = false`, avoiding issues with DDL statements that cannot run inside a transaction on certain databases.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open a virtual key that is managed by an access profile.
2. Verify the alert banner displays the profile name as a clickable link when a parent profile ID exists, and as plain text when it does not.
3. Click the link and confirm the `AccessProfileSheet` opens with the correct parent profile data.
4. Run the schema sync tool and confirm no false-positive findings for `created_by_user_id` on virtual keys.
5. Run the `add_allow_all_keys_to_provider_config` migration against a fresh database and confirm it completes without transaction-related errors.

```sh
go test ./framework/configstore/...
go test ./.github/workflows/scripts/schemasync/...

cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

Before: The managing profile name was displayed as static text with no way to navigate to it.

After: The managing profile name is a clickable link that opens the access profile detail sheet inline.

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

The parent access profile is fetched only when the user explicitly clicks the link and only when a valid `parent_profile_id` is present. No additional permissions bypass is introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable