### PR TITLE
1.4.3 enterprise release notes

### DIFF
--- a/docs/changelogs/ent-v1.4.3.mdx
+++ b/docs/changelogs/ent-v1.4.3.mdx
@@ -1,0 +1,215 @@
+---
+title: "v1.4.3"
+description: "Enterprise v1.4.3 changelog - 2026-05-22"
+---
+
+<Update label="Bifrost Enterprise" description="v1.4.3">
+
+<Warning>
+  **Breaking changes in v1.4.0.** See the [v1.4.0 Migration Guide](/enterprise/migration-guides/v1.4.0) for full before/after examples, automatic migration details, and a step-by-step checklist before upgrading.
+</Warning>
+
+## Changelog
+
+An expanded v1.4.3 on a clean OSS base of `transports/v1.5.4` (v1.4.2 had pinned an untagged commit). Headline items: **Data Access Control (DAC) goes fleet-wide** so `own-data` / `team-data` / `all-data` scoping now governs API keys, access profiles, roles, guardrails, MCP clients and tool groups, customers, teams, business units, and OAuth tokens, with targeted per-entity cache hydration replacing broad reloads. **Broker-mode clustering** routes all inter-node traffic through a central gRPC relay, enabling deployment on platforms without inbound peer connectivity such as Cloud Run, and a new **heartbeat-based ghost node detection and cluster health system** classifies partitioned and dead nodes and recovers their budget usage. **Temporary access tokens** and **MCP per-user OAuth** add scoped, time-limited credentials and per-user MCP authorization. The release also brings three new guardrail providers (CrowdStrike AIDR, Patronus AI, and Google Model Armor), team and access-profile calendar alignment, cluster-gossiped feature flags, a dedicated Dashboard RBAC resource, role and access-profile duplication, and OTEL-parity attributes across the Datadog and BigQuery exporters.
+
+## ✨ Features
+
+### Data Access Control (DAC)
+
+- **Row-level DAC across governed entities** : DAC scoping (`own-data` / `team-data` / `all-data`, set per role) now governs visibility of API keys, access profiles and AP templates, roles, guardrails and their configs/rules, MCP clients and tool groups, customers, teams, and business units. Each resource tracks a `created_by_user_id` owner, with backfill migrations attributing legacy rows to the oldest active admin. Unauthenticated and local-admin deployments bypass DAC filtering and are unaffected.
+- **Hierarchical entity ownership** : customers, teams, business units, MCP clients, and MCP tool groups carry creator ownership so DAC-scoped paginated listings filter them correctly under `own-data` and `team-data` roles.
+- **OAuth token DAC scoping and lifecycle reconciliation** : `oauth_user_tokens` and `oauth_user_sessions` are DAC-scoped; deleting a user or virtual key cascades token/session cleanup in a transaction, and virtual-key MCP allowlist changes reconcile both user-keyed and VK-keyed tokens.
+- **Targeted DAC cache hydration** : broad RBAC snapshot rebuilds are replaced with per-entity hydration for teams, virtual keys, and customers, narrowing the blast radius of each cluster gossip event and cutting database load.
+- **Role DAC level surfaced to the UI** : `/api/users/me/permissions` now returns the caller's `role_dac`, letting the UI gate features such as manual user creation.
+
+### Clustering & Broker Mode
+
+- **Broker-mode clustering** : a new `broker` cluster type routes all inter-node traffic through a central gRPC relay instead of a peer-to-peer memberlist mesh, enabling deployment on platforms without inbound peer connectivity such as Cloud Run. Start the lightweight relay with `-mode=broker` (or `BIFROST_MODE=broker`); leader election, roster sync, diagnostics, optional TLS, and auth tokens are all supported.
+- **Cluster controller interface** : a `cluster.Controller` interface and transport-neutral `Node` type decouple the codebase from the concrete mesh implementation, letting mesh and broker controllers be swapped behind one boundary.
+- **Cluster-aware logging** : log metadata and per-node usage aggregation are now cluster-aware.
+- **Ghost node detection and cluster health monitoring** : a heartbeat-based liveness system. Each node periodically upserts a row to the new `enterprise_cluster_node_heartbeats` table; the leader reads it to classify unknown or disconnected nodes as ghosts (alive but partitioned) or dead, and recovers their budget and rate-limit usage from the shared logs table using a monotonic cursor that never skips async-written log rows. Graceful shutdown writes a `shutting_down` heartbeat and broadcasts a notification so peers drop the node immediately instead of waiting for TTL expiry, and ghost usage snapshots plus cursor state are gossiped so followers stay consistent across leader failover.
+- **Cluster health and governance introspection APIs** : `GET /api/cluster/health` returns node classifications, partition count, and timing configuration; `GET /api/cluster/governance-introspection` returns local and remote budget and rate-limit state plus ghost and dead node IDs. The existing `/api/cluster/nodes` endpoint is augmented with ghost, dead, and detecting status.
+- **Cluster health visualization** : the enterprise cluster UI renders ghost, dead, detecting, and orphan nodes with distinct visual styles and status badges, auto-polling the new health endpoints.
+
+### Access & Identity
+
+- **Temporary access tokens** : short-lived, scoped access tokens for time-limited API access; the temp-token service is wired into Enterprise server bootstrap and accepted by the MCP per-user auth flow.
+- **MCP per-user OAuth** : MCP OAuth refactored into a per-user flow, with new `PreMCPHook` / `PostMCPHook` overrides promoting the virtual-key owner onto request context so the MCP path resolves `UserID` identically to the LLM path.
+- **Tenant-wide Okta provisioning** : Okta user and group sync drops app-assignment scoping in favor of tenant-wide endpoints, removing the per-user lookup loop and the requirement that every synced user or group be explicitly app-assigned.
+- **Stable team identity across renames** : team attribute mappings track the raw IdP claim as a `source_id`, and team lookup prefers `GetTeamBySourceID` so renamed teams are matched instead of duplicated on resync.
+- **User virtual-key lookup by email** : new `GET /api/users/email/{email}/virtual-keys` endpoint returns a user's virtual keys by email, for MDM and credential-helper integrations.
+- **Virtual key ownership** : virtual keys now capture and display the `created_by` user. A `created_by_user_id` column on `governance_virtual_keys` replaces the `enterprise_virtual_key_users` junction table as the single source of truth for VK ownership, and DAC membership and scope queries read from it directly.
+- **Role duplication** : duplicate an existing role from the roles table; the new role copies the source role's description, DAC level, and permissions, with its name suffixed `_copy`. Available to users with role-create permission.
+- **Duplicate access profile** : a Duplicate action on each access profile opens the sheet pre-filled with the source profile's provider configs, budgets, rate limits, and MCP settings, named `<original name> (copy)` with the name field auto-focused for quick renaming.
+
+### Governance
+
+- **Calendar-aligned budgets at team and access-profile level** : a `calendar_aligned` toggle resets budgets and rate limits at calendar boundaries (for example the 1st of the month) rather than rolling from the creation date. It is surfaced in the Create Team dialog, the Team Detail Sheet, and the access profile form, and is propagated through profile copy and virtual-key sync.
+- **Feature flags with cluster gossip** : feature flags toggled via UI or API are broadcast to all cluster nodes via gossip and persisted so late-joining nodes hydrate correctly; file-locked flags remain per-node. A new `FeatureFlags` RBAC resource gates view and update.
+- **Virtual key rotation** : rotate virtual keys from the UI and backend.
+- **Semantic cache wired as a direct dependency** : the `semanticcache` plugin is promoted to a direct dependency and the client's embedding executor is injected at bootstrap, so cache-key embeddings actually run.
+
+### Guardrails
+
+- **CrowdStrike AIDR guardrail provider** : new guardrail provider support.
+- **Patronus AI guardrail provider** : new guardrail provider support.
+- **Google Model Armor guardrail provider** : new guardrail provider support.
+- **Responses API support in guardrails** : guardrail content extraction and mapping handle the Responses API request and response shape, so Responses-format conversations are evaluated with full fidelity.
+- **Gray Swan tool-call support** : the Gray Swan provider now forwards `tool_calls`, `tool_call_id`, and the `tools` schema so function-calling conversations are evaluated with full fidelity; request header metadata is also forwarded.
+- **Per-rule conversation-turn cap** : a `maxTurnsToSend` field on guardrail rules limits how many historical turns are forwarded to a provider, with content extraction reworked to emit one block per message for role-aware payloads.
+- **Rule-level guardrail timeouts** : rule timeouts are passed to providers (Azure, Bedrock, Gray Swan) via context so each provider applies and reports the correct timeout.
+
+### Observability & Telemetry
+
+- **OTEL-parity Datadog metrics** : the Datadog exporter now emits per-attempt request, latency, error, and success counters (tagged with `provider`, `model`, and `fallback_index`), granular input and output token-detail breakdowns, retry counts, TTFT, and cache-hit metrics, matching the OTEL plugin's dimension set. A request ID is stamped on root spans, and stream latency conversions were corrected.
+- **OTEL-parity BigQuery schema** : the BigQuery exporter schema gains granular input and output token-detail columns, response metadata fields (`response_id`, `response_object`, `service_tier`, `system_fingerprint`, and more), and a `request_id` column. A startup schema sync detects and adds missing columns to existing tables automatically, with no manual migration or data rewrite.
+
+### Dashboard & UI
+
+- **Dedicated Dashboard RBAC resource** : a `Dashboard` resource with a `View` operation gates the analytics dashboard and its aggregate endpoints (`/api/logs/stats`, `/api/logs/histogram`, `/api/logs/rankings`) independently of raw log access. An upgrade migration grants it to roles already holding `Observability:View` or `Logs:View`.
+- **Granular dashboard RBAC** : finer RBAC for API keys, inference, metrics, and MCP logs, with inaccessible sidebar items filtered out.
+- **User rankings tab synced with extended log filters** : the user rankings tab syncs its URL state with extended log filters and supports user filtering.
+- **Onboarding checklist widget** : an onboarding setup checklist widget with backend support.
+- **Server-side filter search** : filter sidebar checkbox lists perform server-side search and pagination via a debounced `q` query param.
+- **UI action menus and chart polish** : inline action buttons are replaced with pinned dropdown menus across teams, virtual keys, MCP clients, pricing overrides, routing rules, model limits, and logs; chart card headers gain animated totals and full-precision tooltips.
+
+### OSS Base (`transports/v1.5.4`)
+
+- **Bedrock Mantle inference engine** : support for `gpt-oss` models on Bedrock Mantle via an OpenAI-compatible SSE endpoint.
+- **Azure realtime provider** : Azure realtime provider with nested model normalization, plus enriched realtime routing, logging, cost, and session tracking.
+- **Bedrock system tools** : system tool support for Bedrock models.
+- **Service tier mappings** : service tier mappings for Gemini and Anthropic.
+- **Config file override of DB values** : file values in `config.json` override DB values when the file changes between restarts; `model_parameters_url` is configurable via config JSON and the Helm chart.
+- **OTEL plugin selection** : custom selection of which plugins export OTEL trace spans.
+- **Semantic cache plugin rewrite** : the semantic cache plugin was rewritten, and the `cleanup_on_shutdown` config option was removed.
+- **Virtual key blocked models** : block specific models at the virtual-key provider-config level; blocked models take priority over allowed models and are enforced by governance.
+- **MCP log attribution** : MCP tool logs are stamped with user, team, customer, and business unit IDs so MCP usage is traceable like LLM usage.
+- **Team and business unit filters** : team and business unit filters across the dashboard and logs views.
+- **Sticky time filters** : time-filter selections persist when navigating between sidebar items.
+
+## 🐞 Fixed
+
+### DAC & Cluster
+
+- **Targeted access-profile broadcasts** : access profile cluster broadcasts are split into template-level and user-level message types, each carrying the IDs peer nodes need to take the correct targeted action.
+- **DAC resolver cache burst on entity creation** : a shared `reloadDACMembership` helper refreshes RBAC and DAC membership caches after team, customer, and virtual-key reloads so in-memory permission state never goes stale.
+- **Cluster node ID correlation** : cluster node IDs are correlated with WebSocket node IDs to prevent an empty cluster state in the UI.
+- **MCP tool group scope** : corrected subquery column references in the MCP tool group DAC scope.
+- **Streaming chunk context** : `ProcessStreamingChunk` now receives the request `BifrostContext`.
+
+### Access & Identity
+
+- **SCIM and OIDC session lifecycle** : OIDC session cleanup no longer deletes sessions when the access token expires; only orphaned sessions and sessions older than 30 days are removed, preventing forced re-login every hour. Cookie token selection is unified in a shared `ChooseAuthCookieToken`, and Keycloak now uses the access token so its `realm_access` and `resource_access` role claims resolve correctly.
+
+### Guardrails
+
+- **Sampling double-count fix** : guardrail sampling merges the decide and record steps into a single atomic `ShouldExecuteAndRecord` call so `both`-phase rules are sampled exactly once per request, and stale peer gossip is pruned.
+
+### Billing & UI
+
+- **Sheet layout** : sticky footer buttons stay anchored at the bottom of the CEL rule and MCP tool group sheets, alongside assorted UI polish.
+
+### OSS Base (`transports/v1.5.4`)
+
+- **fasthttp panic** : fixed a fasthttp panic on malformed requests.
+- **Streaming stability** : fixed a remote-stream-close race on context cancel, a nil-pointer dereference in stream cancellations, idle stream timeouts, and context-cancel ordering before read errors.
+- **Bedrock fixes** : Bedrock Mantle fixes, chat tool arguments, stop reason, missing lifecycle events, and Responses prefill handling.
+- **OpenAI Responses** : preserve OpenAI responses stream metadata and add usage to the completed event in the Responses-to-Chat-Completions fallback.
+- **Anthropic fixes** : set Anthropic beta headers on Vertex, emit a role chunk from message start, trim trailing whitespace, fix reasoning-content forwarding on Responses-to-Chat conversion, and preserve output schema refs.
+- **Streaming pricing overrides** : virtual-key and provider-key level pricing overrides now apply to streaming requests.
+- **Secret redaction** : `FullyRedacted()` for proxy passwords and `MarshalForStorage()` for `ProxyConfig` prevent partial value leakage in API responses.
+- **Calendar-aligned migrations** : multiple migration fixes for calendar-aligned budget tables.
+- **Semantic cache** : dimension check on namespace creation, a double-close panic guard, request-time plugin resolution, and telemetry decoupling.
+- **Filter queries** : removed the `defaultFilterDataLimit` cap and skipped the pagination clamp on virtual-key export requests.
+- **MCP logs** : stale stats removed from the logs list response.
+- **configstore** : clearer error message when an API key name conflicts across providers.
+- **DB safety** : the unsafe inline jsonb cast was replaced with a `bifrost_safe_jsonb` PL/pgSQL helper.
+- **Azure batch** : Azure blob fields are now included in batch responses.
+- **Idle timeout panic** : fixed a panic in the streaming idle-timeout reader, with a guard to skip reads once the connection is closed.
+- **TTFT metric accuracy** : corrected the request start-time so the time-to-first-token metric is accurate.
+- **Vertex service tier** : the Vertex traffic type now maps to the correct Bifrost service tier.
+- **Keyless providers** : `ListModels` works for providers configured without an API key.
+- **Anthropic tools** : stopped forcing `type: custom` on Anthropic tool definitions, and preserved the tool-call stop reason in the Anthropic streaming fallback.
+- **Node usage reconciliation** : a monotonic log cursor stops reconciliation from skipping late async log writes.
+- **Fallback budget tracking** : the stale governance rejection flag is cleared on a decision allow, so successful fallback retries count toward budgets and rate limits.
+- **UI fixes** : OAuth popup message validation, constrained table column widths, provider API form padding, and image parameter passthrough; the virtual keys table fills available height with a sticky header and scrollable body; routing-rule and virtual-key sheet layout growth is fixed; toasts remain clickable above modal overlays.
+
+## 📀 Base OSS version
+
+`transports/v1.5.4`
+
+This release pins clean tagged OSS modules (v1.4.2 had pinned an untagged commit, `bef816abe9c2`):
+
+```
+github.com/maximhq/bifrost/core                  v1.5.11
+github.com/maximhq/bifrost/framework             v1.3.12
+github.com/maximhq/bifrost/transports            v1.5.4
+github.com/maximhq/bifrost/plugins/governance    v1.5.12
+github.com/maximhq/bifrost/plugins/logging       v1.5.12
+github.com/maximhq/bifrost/plugins/prompts       v1.0.12
+github.com/maximhq/bifrost/plugins/semanticcache v1.5.12
+github.com/maximhq/bifrost/plugins/compat        v0.1.10
+github.com/maximhq/bifrost/plugins/maxim         v1.6.11
+github.com/maximhq/bifrost/plugins/mocker        v1.5.11
+github.com/maximhq/bifrost/plugins/otel          v1.2.11
+github.com/maximhq/bifrost/plugins/telemetry     v1.5.11
+```
+
+## 🔌 If you are compiling plugin against this release - use following deps
+
+```
+module github.com/maximhq/bifrost-enterprise
+
+go 1.26.2
+
+require (
+	cloud.google.com/go/bigquery v1.74.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/DataDog/datadog-go/v5 v5.6.0
+	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/aws/aws-sdk-go-v2 v1.41.7
+	github.com/aws/aws-sdk-go-v2/config v1.32.11
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.6
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
+	github.com/bytedance/sonic v1.15.0
+	github.com/coreos/go-oidc/v3 v3.12.0
+	github.com/fasthttp/router v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/cel-go v0.26.1
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/consul/api v1.28.2
+	github.com/hashicorp/memberlist v0.5.4
+	github.com/maximhq/bifrost/core v1.5.11
+	github.com/maximhq/bifrost/framework v1.3.12
+	github.com/maximhq/bifrost/plugins/governance v1.5.12
+	github.com/maximhq/bifrost/plugins/logging v1.5.12
+	github.com/maximhq/bifrost/plugins/prompts v1.0.12
+	github.com/maximhq/bifrost/plugins/semanticcache v1.5.12
+	github.com/maximhq/bifrost/transports v1.5.4
+	github.com/nakabonne/tstorage v0.3.6
+	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.40.0
+	github.com/tetratelabs/wazero v1.11.0
+	github.com/valyala/fasthttp v1.68.0
+	github.com/zricethezav/gitleaks/v8 v8.30.1
+	go.etcd.io/etcd/client/v3 v3.6.6
+	golang.org/x/crypto v0.49.0
+	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
+	google.golang.org/api v0.274.0
+	google.golang.org/grpc v1.80.0
+	google.golang.org/protobuf v1.36.11
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+	k8s.io/api v0.34.1
+	k8s.io/apimachinery v0.34.1
+	k8s.io/client-go v0.34.1
+)
+```
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -725,6 +725,7 @@
             "item": "Enterprise",
             "icon": "building",
             "pages": [
+              "changelogs/ent-v1.4.3",
               "changelogs/ent-v1.4.2",
               "changelogs/ent-v1.4.1",
               "changelogs/ent-v1.4.0",


### PR DESCRIPTION
## Summary

Adds the Enterprise v1.4.3 changelog page and registers it in the docs navigation. This release is built on a clean OSS base of `transports/v1.5.4` (fixing v1.4.2's pinned untagged commit) and delivers a large set of new capabilities and fixes across DAC, clustering, access/identity, guardrails, observability, and the dashboard.

## Changes

- Added `docs/changelogs/ent-v1.4.3.mdx` documenting all features, fixes, and dependency versions for the Enterprise v1.4.3 release
- Registered `changelogs/ent-v1.4.3` as the first entry in the Enterprise changelogs section of `docs/docs.json`

Key headline items covered in the changelog:
- **Data Access Control (DAC)** extended fleet-wide across API keys, access profiles, roles, guardrails, MCP clients/tool groups, customers, teams, business units, and OAuth tokens, with targeted per-entity cache hydration
- **Broker-mode clustering** routing inter-node traffic through a central gRPC relay for platforms without inbound peer connectivity (e.g. Cloud Run), plus heartbeat-based ghost node detection and cluster health APIs
- **Temporary access tokens** and **MCP per-user OAuth** for scoped, time-limited credentials
- Three new guardrail providers: CrowdStrike AIDR, Patronus AI, and Google Model Armor
- OTEL-parity attributes for Datadog and BigQuery exporters
- Dedicated Dashboard RBAC resource, role and access-profile duplication, calendar-aligned budgets at team/access-profile level, and cluster-gossiped feature flags

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the Enterprise changelogs section of the docs site and confirm the `v1.4.3` entry appears at the top of the list and renders correctly, including the breaking-change warning banner, all feature/fix sections, and the dependency code blocks.

## Screenshots/Recordings

N/A — documentation-only change.

## Breaking changes

- [ ] Yes
- [x] No

The changelog itself notes breaking changes introduced in v1.4.0; this PR only adds documentation.

## Related issues

N/A

## Security considerations

None — this is a documentation addition only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable