### PR TITLE
fix: use `user_name` instead of `user_id` for user filter display name

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -219,14 +219,12 @@ var filterMatViews = []filterMatViewDef{
 		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},
 	{
-		name: "mv_filter_users",
-		// user_id is exposed as both "id" and "name" for the dropdown and
-		// also as the scope column.
-		selectExpr: "user_id AS id, user_id AS name, " +
+		name:       "mv_filter_users",
+		selectExpr: "user_id AS id, user_name AS name, " +
 			"COALESCE(user_id, '') AS user_id, COALESCE(team_id, '') AS team_id, " +
 			"COALESCE(virtual_key_id, '') AS virtual_key_id",
 		whereExpr:       "user_id IS NOT NULL AND user_id != ''",
-		uniqueIdx:       "id, " + scopeIdxColumns,
+		uniqueIdx:       "id, name, " + scopeIdxColumns,
 		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},
 	{
@@ -246,7 +244,7 @@ var filterMatViewKeyPairColumns = map[[2]string]string{
 	{"routing_rule_id", "routing_rule_name"}:   "mv_filter_routing_rules",
 	{"team_id", "team_name"}:                   "mv_filter_teams",
 	{"customer_id", "customer_name"}:           "mv_filter_customers",
-	{"user_id", "user_id"}:                     "mv_filter_users",
+	{"user_id", "user_name"}:                    "mv_filter_users",
 	{"business_unit_id", "business_unit_name"}: "mv_filter_business_units",
 }
 

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1093,10 +1093,9 @@ func (p *LoggerPlugin) GetAvailableCustomers(ctx context.Context, limit int, que
 	return keyPairResultsToKeyPairs(results)
 }
 
-// GetAvailableUsers returns all unique user IDs from logs.
-// Both ID and Name are set to user_id since users don't have a separate name column.
+// GetAvailableUsers returns all unique user ID-Name pairs from logs.
 func (p *LoggerPlugin) GetAvailableUsers(ctx context.Context, limit int, query string) []KeyPair {
-	results, err := p.store.GetDistinctKeyPairs(ctx, "user_id", "user_id", limit, query)
+	results, err := p.store.GetDistinctKeyPairs(ctx, "user_id", "user_name", limit, query)
 	if err != nil {
 		p.logger.Error("failed to get available users: %v", err)
 		return []KeyPair{}


### PR DESCRIPTION
## Summary

Users in the logging system previously had their `user_id` used as both the ID and display name in filter dropdowns. This PR fixes that by using `user_name` as the display name, so users are now shown by their actual name rather than their ID.

## Changes

- The `mv_filter_users` materialized view now selects `user_name AS name` instead of `user_id AS name`, so the display name in filter dropdowns reflects the actual user name.
- The unique index for `mv_filter_users` now includes `name` to account for the distinct `user_name` values.
- The `filterMatViewKeyPairColumns` mapping updated the key from `{"user_id", "user_id"}` to `{"user_id", "user_name"}` to correctly pair the ID and name columns.
- `GetAvailableUsers` now queries `user_name` as the name column instead of `user_id`, returning proper ID-Name pairs.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that the user filter dropdown in the logging UI displays user names instead of user IDs after the materialized view is refreshed.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only affects display names in filter dropdowns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable