### PR TITLE
fix: preserve large numeric IDs in search params by skipping JSON parse for plain strings

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -220,7 +220,7 @@ var filterMatViews = []filterMatViewDef{
 	},
 	{
 		name:       "mv_filter_users",
-		selectExpr: "user_id AS id, user_name AS name, " +
+		selectExpr: "user_id AS id, COALESCE(NULLIF(user_name, ''), user_id) AS name, " +
 			"COALESCE(user_id, '') AS user_id, COALESCE(team_id, '') AS team_id, " +
 			"COALESCE(virtual_key_id, '') AS virtual_key_id",
 		whereExpr:       "user_id IS NOT NULL AND user_id != ''",

--- a/ui/app/main.tsx
+++ b/ui/app/main.tsx
@@ -1,13 +1,27 @@
-import { RouterProvider, createRouter } from "@tanstack/react-router";
+import { RouterProvider, createRouter, parseSearchWith } from "@tanstack/react-router";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 // Tailwind + global styles (also declares @font-face for local Geist fonts).
 import "@/app/globals.css";
 
-import { routeTree } from "./routeTree.gen";
 import { ErrorComponent } from "./__error";
 import { NotFoundComponent } from "./__notFound";
+import { routeTree } from "./routeTree.gen";
+
+// Only JSON.parse structured values (objects/arrays). Plain strings and numbers
+// stay as-is so large numeric IDs don't lose precision through Number coercion.
+function safeJsonParse(value: string): unknown {
+	const c = value[0];
+	if (c === "{" || c === "[") {
+		try {
+			return JSON.parse(value);
+		} catch {
+			return value;
+		}
+	}
+	return value;
+}
 
 const router = createRouter({
 	routeTree,
@@ -16,6 +30,7 @@ const router = createRouter({
 	notFoundMode: "root",
 	defaultNotFoundComponent: NotFoundComponent,
 	defaultErrorComponent: ErrorComponent,
+	parseSearch: parseSearchWith(safeJsonParse),
 });
 
 declare module "@tanstack/react-router" {


### PR DESCRIPTION
## Summary

Prevents large numeric IDs (e.g., 64-bit integers) from losing precision when parsed from URL search parameters. Previously, all search values were passed through `JSON.parse`, which coerces large numbers to JavaScript's `Number` type and silently truncates them. This fix ensures only structured JSON values (objects and arrays) are parsed, while plain strings and numbers are left as-is.

## Changes

- Introduced a `safeJsonParse` function that only calls `JSON.parse` on values beginning with `{` or `[`, leaving all other values as raw strings to avoid numeric precision loss.
- Configured the router to use `parseSearchWith(safeJsonParse)` instead of the default search parser.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to a route that includes a large numeric ID (greater than `Number.MAX_SAFE_INTEGER`) in the URL search parameters and verify the ID is preserved exactly without truncation.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects client-side URL search parameter parsing.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable