### PR TITLE
session api

### DIFF
--- a/ui/lib/store/apis/sessionApi.ts
+++ b/ui/lib/store/apis/sessionApi.ts
@@ -41,17 +41,31 @@ export const sessionApi = baseApi.injectEndpoints({
 
 		// Logout endpoint
 		logout: builder.mutation<LogoutResponse, void>({
-			query: () => ({
-				url: "/session/logout",
-				method: "POST",
-			}),
+			async queryFn(_arg, _api, _extraOptions, baseQuery) {
+				const passwordLogout = await baseQuery({
+					url: "/session/logout",
+					method: "POST",
+				});
+
+				const oauthLogout = await baseQuery({
+					url: "/scim/oauth/logout",
+					method: "POST",
+				});
+
+				if (passwordLogout.error && oauthLogout.error) {
+					return { error: oauthLogout.error };
+				}
+
+				return { data: { message: "Logout successful" } };
+			},
 			// After logout, clear token and all cached data
-			async onQueryStarted(arg, { queryFulfilled }) {
+			async onQueryStarted(arg, { dispatch, queryFulfilled }) {
 				try {
 					await queryFulfilled;
 				} catch {
 				} finally {
 					clearAuthStorage();
+					dispatch(baseApi.util.resetApiState());
 				}
 			},
 			invalidatesTags: ["Sessions", "Config", "Providers", "Logs", "VirtualKeys", "Teams", "Customers", "Budgets", "RateLimits"],


### PR DESCRIPTION
## Summary

The logout flow now calls both the password-based session logout endpoint and the OAuth logout endpoint, ensuring users are fully signed out regardless of which authentication method they used. Previously, only the password session was terminated on logout.

## Changes

- Replaced the single `/session/logout` POST call with a `queryFn` that sequentially calls both `/session/logout` and `/scim/oauth/logout`, returning an error only if both fail
- Added `dispatch(baseApi.util.resetApiState())` in the `onQueryStarted` finalizer to clear all cached RTK Query state after logout, preventing stale data from persisting across sessions

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Log in using OAuth (SCIM/OAuth provider)
2. Click logout
3. Verify the user is redirected to the login page and the OAuth session is also invalidated (no silent re-authentication)
4. Repeat with a password-based login and confirm logout still works as expected

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Ensures OAuth sessions are explicitly terminated on logout, reducing the risk of session persistence after a user signs out. The API state reset also prevents cached sensitive data (keys, budgets, teams, etc.) from being accessible after logout.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable