### PR TITLE
refactor: centralize mcp connection lifecycle into `AcquireClientConn` and decouple credentials from plugin gate

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3701,7 +3701,7 @@ func (bifrost *Bifrost) RemoveMCPClient(id string) error {
 }
 
 // SetMCPManager sets the MCP manager for this Bifrost instance.
-// This allows injecting a custom MCP manager implementation (e.g., for enterprise features).
+// This allows injecting a custom MCP manager implementation.
 // If the provided manager is a concrete *mcp.MCPManager, Bifrost's plugin pipeline is injected
 // into the manager's CodeMode so that nested tool calls run through the plugin hooks.
 //

--- a/core/internal/mcptests/tool_filtering_test.go
+++ b/core/internal/mcptests/tool_filtering_test.go
@@ -1,6 +1,7 @@
 package mcptests
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -44,25 +45,33 @@ func getActualToolsFromGoTestServer(t *testing.T) (tool1, tool2 string) {
 	return toolList[0], toolList[1]
 }
 
-// Helper to execute a tool via MCP manager and check if it's allowed
-func executeToolViaManager(t *testing.T, manager interface{ ExecuteToolCall(*schemas.BifrostContext, *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) }, toolName string) error {
+// Helper to execute a tool via MCP manager and check if it's allowed.
+// Runs through the canonical plugin-wrapped path (ExecuteChatTool); the
+// test setup wires a no-op plugin pipeline so this is functionally
+// equivalent to a direct execution for filtering assertions.
+func executeToolViaManager(t *testing.T, manager interface {
+	ExecuteChatTool(ctx *schemas.BifrostContext, toolCall *schemas.ChatAssistantMessageToolCall) (*schemas.ChatMessage, *schemas.BifrostError)
+}, toolName string) error {
 	t.Helper()
 
 	ctx := createTestContext()
-	request := &schemas.BifrostMCPRequest{
-		RequestType: schemas.MCPRequestTypeChatToolCall,
-		ChatAssistantMessageToolCall: &schemas.ChatAssistantMessageToolCall{
-			ID:   schemas.Ptr("call-1"),
-			Type: schemas.Ptr("function"),
-			Function: schemas.ChatAssistantMessageToolCallFunction{
-				Name:      schemas.Ptr(toolName),
-				Arguments: `{}`,
-			},
+	toolCall := &schemas.ChatAssistantMessageToolCall{
+		ID:   schemas.Ptr("call-1"),
+		Type: schemas.Ptr("function"),
+		Function: schemas.ChatAssistantMessageToolCallFunction{
+			Name:      schemas.Ptr(toolName),
+			Arguments: `{}`,
 		},
 	}
 
-	_, err := manager.ExecuteToolCall(ctx, request)
-	return err
+	_, bErr := manager.ExecuteChatTool(ctx, toolCall)
+	if bErr == nil {
+		return nil
+	}
+	if bErr.Error != nil {
+		return fmt.Errorf("%s", bErr.Error.Message)
+	}
+	return fmt.Errorf("tool execution failed")
 }
 
 // TestToolsToExecute_Nil - FULLY IMPLEMENTED EXAMPLE

--- a/core/mcp/agent.go
+++ b/core/mcp/agent.go
@@ -39,7 +39,7 @@ func (a *AgentModeExecutor) ExecuteAgentForChatRequest(
 	initialResponse *schemas.BifrostChatResponse,
 	makeReq func(ctx *schemas.BifrostContext, req *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError),
 	fetchNewRequestIDFunc func(ctx *schemas.BifrostContext) string,
-	executeToolFunc func(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error),
+	executeToolFunc MCPToolExecutor,
 	clientManager ClientManager,
 ) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	// Create adapter for Chat API
@@ -92,7 +92,7 @@ func (a *AgentModeExecutor) ExecuteAgentForResponsesRequest(
 	initialResponse *schemas.BifrostResponsesResponse,
 	makeReq func(ctx *schemas.BifrostContext, req *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError),
 	fetchNewRequestIDFunc func(ctx *schemas.BifrostContext) string,
-	executeToolFunc func(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error),
+	executeToolFunc MCPToolExecutor,
 	clientManager ClientManager,
 ) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	// Create adapter for Responses API
@@ -142,7 +142,7 @@ func (a *AgentModeExecutor) executeAgent(
 	maxAgentDepth int,
 	adapter agentAPIAdapter,
 	fetchNewRequestIDFunc func(ctx *schemas.BifrostContext) string,
-	executeToolFunc func(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error),
+	executeToolFunc MCPToolExecutor,
 	clientManager ClientManager,
 ) (interface{}, *schemas.BifrostError) {
 	// Get initial response from adapter

--- a/core/mcp/agent_test.go
+++ b/core/mcp/agent_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/mark3labs/mcp-go/client"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -77,8 +78,11 @@ func (m *MockClientManager) GetToolPerClient(ctx context.Context) map[string][]s
 	return make(map[string][]schemas.ChatTool)
 }
 
-func (m *MockClientManager) GetPluginPipeline() PluginPipeline                { return nil }
-func (m *MockClientManager) ReleasePluginPipeline(pipeline PluginPipeline)    {}
+func (m *MockClientManager) GetPluginPipeline() PluginPipeline             { return nil }
+func (m *MockClientManager) ReleasePluginPipeline(pipeline PluginPipeline)  {}
+func (m *MockClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
+	return nil, func() {}, nil
+}
 
 func TestHasToolCallsForChatResponse(t *testing.T) {
 	// Test nil response
@@ -561,6 +565,9 @@ func (m *MockAutoClientManager) GetToolPerClient(ctx context.Context) map[string
 
 func (m *MockAutoClientManager) GetPluginPipeline() PluginPipeline             { return nil }
 func (m *MockAutoClientManager) ReleasePluginPipeline(pipeline PluginPipeline) {}
+func (m *MockAutoClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
+	return nil, func() {}, nil
+}
 
 // TestParallelToolCallsHaveUniqueMCPLogIDs verifies that parallel tool calls within a
 // single LLM response each receive a unique BifrostContextKeyMCPLogID in their context.

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -16,6 +17,169 @@ import (
 	"github.com/maximhq/bifrost/core/mcp/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+// AcquireClientConn returns a live upstream MCP client connection for the
+// given client state, along with a release function the caller must invoke
+// (typically via defer).
+//
+// For shared-connection auth types (none, headers, server_oauth) the
+// connection is the persistent state.Conn and the release is a no-op — the
+// caller MUST NOT close it.
+//
+// For per-user auth types (per_user_oauth, …) a fresh ephemeral connection
+// is opened per call. The opening is wrapped in the connect-plugin gate
+// (runConnectWithPluginPipeline) just like AddClient/Reconnect does for
+// shared connections — PreConnectionHook plugins observe the admin-configured
+// static headers and may mutate them; credstore-resolved auth headers are
+// layered on top AFTER the plugin gate, so the bearer token is never
+// observable by plugins. Credential-resolution errors (including
+// *MCPUserOAuthRequiredError) surface from this method without opening any
+// connection.
+func (m *MCPManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
+	if state == nil || state.ExecutionConfig == nil {
+		return nil, nil, fmt.Errorf("client state is required")
+	}
+	config := state.ExecutionConfig
+
+	if !m.credStore.RequiresPerCallConnection(config) {
+		if state.Conn == nil {
+			return nil, nil, fmt.Errorf("MCP client %s has no active connection", config.Name)
+		}
+		return state.Conn, func() {}, nil
+	}
+
+	// Per-user: open an ephemeral transport per call, wrapped in the
+	// connect-plugin gate for parity with shared-connection setup.
+	if config.ConnectionString == nil || config.ConnectionString.GetValue() == "" {
+		return nil, nil, fmt.Errorf("connection URL is required for ephemeral MCP execution")
+	}
+	url := config.ConnectionString.GetValue()
+
+	connectReq := &schemas.BifrostMCPConnectRequest{
+		ClientName:       config.Name,
+		ConnectionType:   config.ConnectionType,
+		AuthType:         config.AuthType,
+		ConnectionString: &url,
+		Headers:          utils.FlattenHeaders(utils.StaticConfigHeaders(config)),
+	}
+
+	// Closure-captured outputs from the op so the caller can CallTool on the
+	// live client after the gate returns.
+	var tempClient *client.Client
+	// MCPUserOAuthRequiredError is wrapped into a generic BifrostError by the
+	// pipeline before PostConnectionHook runs, so capture it out-of-band to
+	// preserve the typed-error info for the envelope path.
+	var oauthErr *schemas.MCPUserOAuthRequiredError
+	start := time.Now()
+
+	_, gateErr := m.runConnectWithPluginPipeline(ctx, connectReq, func(preReq *schemas.BifrostMCPConnectRequest) (*schemas.BifrostMCPConnectResponse, error) {
+		// Resolve auth headers AFTER PreConnectionHook ran. Plugins never see
+		// the Authorization header — it lives only on the wire transport.
+		authHeaders, credErr := m.credStore.ConnectionHeaders(ctx, config)
+		if credErr != nil {
+			errors.As(credErr, &oauthErr)
+			return nil, credErr
+		}
+
+		// Compose final transport headers: plugin-mutated static base + auth on top.
+		finalHeaders := make(map[string]string, len(preReq.Headers)+len(authHeaders))
+		maps.Copy(finalHeaders, preReq.Headers)
+		for k, vals := range authHeaders {
+			if len(vals) > 0 {
+				finalHeaders[k] = vals[0]
+			}
+		}
+
+		targetURL := url
+		if preReq.ConnectionString != nil && *preReq.ConnectionString != "" {
+			targetURL = *preReq.ConnectionString
+		}
+
+		httpTransport, err := transport.NewStreamableHTTP(targetURL, transport.WithHTTPHeaders(finalHeaders))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP transport: %w", err)
+		}
+		tempClient = client.NewClient(httpTransport)
+		if err := tempClient.Start(ctx); err != nil {
+			return nil, fmt.Errorf("failed to start ephemeral MCP connection: %w", err)
+		}
+
+		initRequest := mcp.InitializeRequest{
+			Params: mcp.InitializeParams{
+				ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+				Capabilities:    mcp.ClientCapabilities{},
+				ClientInfo: mcp.Implementation{
+					Name:    fmt.Sprintf("Bifrost-%s-user", config.Name),
+					Version: "1.0.0",
+				},
+			},
+		}
+		// Bound the MCP `initialize` handshake — a stalled upstream (TCP open
+		// succeeds but JSON-RPC initialize never returns) would otherwise block
+		// the entire tool call until the parent request ctx fires. Mirrors the
+		// bound used for shared-connection Initialize in connectToMCPClient.
+		initCtx, initCancel := context.WithTimeout(ctx, MCPClientConnectionEstablishTimeout)
+		defer initCancel()
+		initResult, err := tempClient.Initialize(initCtx, initRequest)
+		if err != nil {
+			_ = tempClient.Close()
+			tempClient = nil
+			return nil, fmt.Errorf("failed to initialize ephemeral MCP connection: %w", err)
+		}
+
+		// Build the gate response from the captured initialize result so
+		// PostConnectionHook plugins observe what the upstream advertised.
+		resp := &schemas.BifrostMCPConnectResponse{
+			ConnectionInfo: &schemas.MCPClientConnectionInfo{
+				Type:          config.ConnectionType,
+				ConnectionURL: &targetURL,
+			},
+			ExtraFields: schemas.BifrostMCPResponseExtraFields{
+				Latency: time.Since(start).Milliseconds(),
+			},
+		}
+		if initResult != nil {
+			resp.ProtocolVersion = initResult.ProtocolVersion
+			resp.ServerInfo = &schemas.MCPServerInfo{
+				Name:    initResult.ServerInfo.Name,
+				Version: initResult.ServerInfo.Version,
+			}
+			resp.ServerCapabilities = &schemas.MCPServerCapabilities{
+				Tools:     initResult.Capabilities.Tools != nil,
+				Resources: initResult.Capabilities.Resources != nil,
+				Prompts:   initResult.Capabilities.Prompts != nil,
+				Logging:   initResult.Capabilities.Logging != nil,
+			}
+		}
+		return resp, nil
+	})
+
+	if gateErr != nil {
+		if tempClient != nil {
+			_ = tempClient.Close()
+		}
+		if oauthErr != nil {
+			return nil, nil, oauthErr
+		}
+		if gateErr.Error != nil {
+			return nil, nil, fmt.Errorf("%s", gateErr.Error.Message)
+		}
+		return nil, nil, fmt.Errorf("ephemeral connection setup failed for %s", config.Name)
+	}
+
+	if tempClient == nil {
+		// Plugin short-circuited connect with a synthetic success response and
+		// no live transport — we have nothing to execute against.
+		return nil, nil, fmt.Errorf("ephemeral MCP connection was short-circuited by plugin for %s", config.Name)
+	}
+
+	release := func() {
+		if err := tempClient.Close(); err != nil {
+			m.logger.Warn("%s Failed to close ephemeral client for %s: %v", MCPLogPrefix, config.Name, err)
+		}
+	}
+	return tempClient, release, nil
+}
 
 // GetClients returns all MCP clients managed by the manager.
 //
@@ -937,22 +1101,14 @@ func (m *MCPManager) connectToMCPClient(config *schemas.MCPClientConfig) error {
 		u := config.ConnectionString.GetValue()
 		connectReq.ConnectionString = &u
 	}
-	var authHeader string // captured for re-injection after PreHooks
+	// Plugin-visible headers are ONLY the admin-configured static headers
+	// (config.Headers). Credentials from the CredStore (Bearer tokens, signing
+	// headers) are layered AFTER the connect-plugin gate runs, inside the op
+	// closure — plugins can mutate static headers but never observe or
+	// interfere with auth. This is the structural guarantee that replaces
+	// the older strip-and-reinject Authorization dance.
 	if config.ConnectionType == schemas.MCPConnectionTypeHTTP || config.ConnectionType == schemas.MCPConnectionTypeSSE {
-		// Connection-time has no caller identity; wrap m.ctx into a synthetic
-		// BifrostContext so the CredentialStore can be invoked uniformly.
-		// Shared resolvers ignore identity; per-user resolvers won't be
-		// called here because the per-user code path skips persistent
-		// connections entirely (RequiresPerCallConnection).
-		bfCtx := schemas.NewBifrostContext(m.ctx, schemas.NoDeadline)
-		if h, hErr := m.credStore.ConnectionHeaders(bfCtx, config); hErr == nil {
-			flat := utils.FlattenHeaders(h)
-			if auth, ok := flat["Authorization"]; ok {
-				authHeader = auth
-				delete(flat, "Authorization")
-			}
-			connectReq.Headers = flat
-		}
+		connectReq.Headers = utils.FlattenHeaders(utils.StaticConfigHeaders(config))
 	}
 	if config.StdioConfig != nil {
 		cmd := config.StdioConfig.Command
@@ -970,14 +1126,24 @@ func (m *MCPManager) connectToMCPClient(config *schemas.MCPClientConfig) error {
 	start := time.Now()
 
 	_, gateErr := m.runConnectWithPluginPipeline(gateCtx, connectReq, func(preReq *schemas.BifrostMCPConnectRequest) (*schemas.BifrostMCPConnectResponse, error) {
-		// Re-inject Authorization after PreHooks. Use a shallow-cloned overrides
-		// struct so the merged headers don't leak back into the request object that
-		// plugins captured in PreHook (which they may still reference in PostHook).
+		// Layer credstore-resolved auth headers onto the plugin-mutated static
+		// headers. Build a shallow clone so the merged result doesn't leak back
+		// into the request object that plugins captured in PreHook (which they
+		// may still reference in PostHook).
 		mutForWire := preReq
-		if authHeader != "" {
-			merged := make(map[string]string, len(preReq.Headers)+1)
+		if config.ConnectionType == schemas.MCPConnectionTypeHTTP || config.ConnectionType == schemas.MCPConnectionTypeSSE {
+			bfCtx := schemas.NewBifrostContext(m.ctx, schemas.NoDeadline)
+			authHeaders, credErr := m.credStore.ConnectionHeaders(bfCtx, config)
+			if credErr != nil {
+				return nil, credErr
+			}
+			merged := make(map[string]string, len(preReq.Headers)+len(authHeaders))
 			maps.Copy(merged, preReq.Headers)
-			merged["Authorization"] = authHeader
+			for k, vals := range authHeaders {
+				if len(vals) > 0 {
+					merged[k] = vals[0]
+				}
+			}
 			clone := *preReq
 			clone.Headers = merged
 			mutForWire = &clone
@@ -1248,17 +1414,25 @@ func (m *MCPManager) createHTTPConnection(ctx context.Context, config *schemas.M
 		url = *overrides.ConnectionString
 	}
 
-	// Resolve headers (override wins)
+	// Resolve headers (override wins). The override path is used when the
+	// connect-plugin gate has already supplied final headers (static + plugin
+	// mutations + auth). The fallback path is for direct callers that bypass
+	// the gate; it composes static config headers with credstore auth here.
 	var headers map[string]string
 	if overrides != nil && overrides.Headers != nil {
 		headers = overrides.Headers
 	} else {
 		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		h, err := m.credStore.ConnectionHeaders(bfCtx, config)
+		authHeaders, err := m.credStore.ConnectionHeaders(bfCtx, config)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get HTTP headers: %w", err)
 		}
-		headers = utils.FlattenHeaders(h)
+		headers = utils.FlattenHeaders(utils.StaticConfigHeaders(config))
+		for k, vals := range authHeaders {
+			if len(vals) > 0 {
+				headers[k] = vals[0]
+			}
+		}
 	}
 
 	// Create StreamableHTTP transport
@@ -1326,16 +1500,23 @@ func (m *MCPManager) createSSEConnection(ctx context.Context, config *schemas.MC
 		url = *overrides.ConnectionString
 	}
 
+	// Same composition rule as createHTTPConnection: override wins (gate-supplied
+	// final headers); otherwise compose static + credstore auth.
 	var headers map[string]string
 	if overrides != nil && overrides.Headers != nil {
 		headers = overrides.Headers
 	} else {
 		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		h, err := m.credStore.ConnectionHeaders(bfCtx, config)
+		authHeaders, err := m.credStore.ConnectionHeaders(bfCtx, config)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get HTTP headers: %w", err)
 		}
-		headers = utils.FlattenHeaders(h)
+		headers = utils.FlattenHeaders(utils.StaticConfigHeaders(config))
+		for k, vals := range authHeaders {
+			if len(vals) > 0 {
+				headers[k] = vals[0]
+			}
+		}
 	}
 
 	sseTransport, err := transport.NewSSE(url, transport.WithHeaders(headers))

--- a/core/mcp/codemode/starlark/executecode.go
+++ b/core/mcp/codemode/starlark/executecode.go
@@ -525,38 +525,35 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 	toolCtx, cancel := context.WithTimeout(nestedCtx, toolExecutionTimeout)
 	defer cancel()
 
-	var toolResponse *mcp.CallToolResult
-	var callErr error
+	// Acquire a connection through the shared ClientManager abstraction:
+	// shared-mode clients return their persistent state.Conn (release is a
+	// no-op); per-user clients get a fresh ephemeral transport that the
+	// release function closes. Credential errors (e.g. MCPUserOAuthRequiredError)
+	// surface here.
+	conn, release, err := s.clientManager.AcquireClientConn(nestedCtx, client)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
-	if s.credStore.RequiresPerCallConnection(client.ExecutionConfig) {
-		// Per-user auth types: ephemeral upstream connection per call carries
-		// the full credential set (static + extras + per-user auth).
-		connHeaders, err := s.credStore.ConnectionHeaders(nestedCtx, client.ExecutionConfig)
-		if err != nil {
-			return nil, err
-		}
-		toolResponse, callErr = codemcp.OpenConnectionAndExecuteTool(toolCtx, client.ExecutionConfig, toolNameToCall, args, connHeaders)
-		if callErr != nil && toolCtx.Err() == context.DeadlineExceeded {
-			callErr = fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
-		}
-	} else {
-		// Shared persistent connection — admin credentials are on the
-		// transport; the per-call request only carries filtered extras.
-		reqHeaders, err := s.credStore.RequestHeaders(nestedCtx, client.ExecutionConfig)
-		if err != nil {
-			return nil, err
-		}
-		callRequest := mcp.CallToolRequest{
-			Request: mcp.Request{
-				Method: string(mcp.MethodToolsCall),
-			},
-			Params: mcp.CallToolParams{
-				Name:      toolNameToCall,
-				Arguments: args,
-			},
-			Header: reqHeaders,
-		}
-		toolResponse, callErr = client.Conn.CallTool(toolCtx, callRequest)
+	reqHeaders, err := s.credStore.RequestHeaders(nestedCtx, client.ExecutionConfig)
+	if err != nil {
+		return nil, err
+	}
+	callRequest := mcp.CallToolRequest{
+		Request: mcp.Request{
+			Method: string(mcp.MethodToolsCall),
+		},
+		Params: mcp.CallToolParams{
+			Name:      toolNameToCall,
+			Arguments: args,
+		},
+		Header: reqHeaders,
+	}
+
+	toolResponse, callErr := conn.CallTool(toolCtx, callRequest)
+	if callErr != nil && toolCtx.Err() == context.DeadlineExceeded {
+		callErr = fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
 	}
 
 	latency := time.Since(startTime).Milliseconds()

--- a/core/mcp/codemode/starlark/starlark_test.go
+++ b/core/mcp/codemode/starlark/starlark_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/mark3labs/mcp-go/client"
 	codemcp "github.com/maximhq/bifrost/core/mcp"
 	"github.com/maximhq/bifrost/core/schemas"
 	"go.starlark.net/starlark"
@@ -44,6 +45,9 @@ func (m *testClientManager) GetPluginPipeline() codemcp.PluginPipeline {
 }
 
 func (m *testClientManager) ReleasePluginPipeline(pipeline codemcp.PluginPipeline) {}
+func (m *testClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
+	return nil, func() {}, nil
+}
 
 func TestStarlarkToGo(t *testing.T) {
 	t.Run("Convert None", func(t *testing.T) {

--- a/core/mcp/credstore/credstore.go
+++ b/core/mcp/credstore/credstore.go
@@ -80,15 +80,20 @@ func (s *CredStore) RequiresPerCallConnection(config *schemas.MCPClientConfig) b
 }
 
 // resolverFor returns the resolver matching config.AuthType, or an error if
-// the type is unknown / config is nil. The DB layer defaults AuthType to
-// 'headers' (see TableMCPClient.AuthType default), so this should only fire
-// on programmatically-constructed configs that bypass persistence — a sign
-// of a real configuration bug worth surfacing.
+// the type is truly unknown / config is nil. Empty AuthType is normalized to
+// MCPAuthTypeHeaders — matching the DB column default
+// (TableMCPClient.AuthType default 'headers') and clientmanager.UpdateClient's
+// long-standing normalization. Programmatically-constructed configs that
+// leave AuthType blank therefore behave as plain "headers" auth.
 func (s *CredStore) resolverFor(config *schemas.MCPClientConfig) (resolver, error) {
 	if config == nil {
 		return nil, fmt.Errorf("MCP client config is nil")
 	}
-	if r, ok := s.resolvers[config.AuthType]; ok {
+	authType := config.AuthType
+	if authType == "" {
+		authType = schemas.MCPAuthTypeHeaders
+	}
+	if r, ok := s.resolvers[authType]; ok {
 		return r, nil
 	}
 	return nil, fmt.Errorf("unsupported MCP auth type %q for client %q", config.AuthType, config.Name)

--- a/core/mcp/credstore/none.go
+++ b/core/mcp/credstore/none.go
@@ -3,17 +3,17 @@ package credstore
 import (
 	"net/http"
 
-	"github.com/maximhq/bifrost/core/mcp/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// noneResolver handles MCPAuthTypeNone — no auth credentials, but the
-// transport still gets any static config headers + filtered context-extras
-// the caller passes in via BifrostContext.
+// noneResolver handles MCPAuthTypeNone — no credentials, no auth header.
+// Static config headers are layered separately by the caller via
+// utils.StaticConfigHeaders, and per-request extras flow through
+// CredStore.RequestHeaders. ConnectionHeaders here is empty by design.
 type noneResolver struct{}
 
-func (r *noneResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
-	return utils.GetHeadersForToolExecution(ctx, config), nil
+func (r *noneResolver) ConnectionHeaders(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) (http.Header, error) {
+	return http.Header{}, nil
 }
 
 func (r *noneResolver) RequiresPerCallConnection() bool { return false }

--- a/core/mcp/credstore/per_user_oauth.go
+++ b/core/mcp/credstore/per_user_oauth.go
@@ -14,10 +14,15 @@ import (
 // expiry, an OAuth flow is initiated and a *MCPUserOAuthRequiredError is
 // raised so the caller can complete authentication.
 //
+// ConnectionHeaders returns only the Authorization header — static config
+// headers are layered separately by AcquireClientConn / clientmanager via
+// utils.StaticConfigHeaders so the connect-plugin gate never observes the
+// bearer token.
+//
 // RequiresPerCallConnection is true: per-user OAuth clients never hold a
-// persistent upstream connection (clientmanager skips Connect for them); each
-// invocation builds an ephemeral HTTP transport with the resolved Bearer +
-// any static config + context-extras.
+// persistent upstream connection; AcquireClientConn opens a fresh ephemeral
+// HTTP transport per call using the resolved Bearer + plugin-mutated static
+// headers.
 type perUserOAuthResolver struct {
 	provider schemas.OAuth2Provider
 }
@@ -71,7 +76,7 @@ func (r *perUserOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, co
 		}
 	}
 
-	headers := utils.GetHeadersForToolExecution(ctx, config)
+	headers := http.Header{}
 	headers.Set("Authorization", "Bearer "+accessToken)
 	return headers, nil
 }

--- a/core/mcp/credstore/server_oauth.go
+++ b/core/mcp/credstore/server_oauth.go
@@ -1,33 +1,20 @@
 package credstore
 
 import (
-	"errors"
 	"net/http"
-	"strings"
 
-	"github.com/maximhq/bifrost/core/mcp/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
 // serverOAuthResolver handles MCPAuthTypeOauth — admin-once OAuth where the
-// upstream token is shared across all callers. The token is fetched from the
-// OAuth2Provider's cache (kept fresh by the background sync worker) and added
-// as a Bearer header on top of static config headers + any context-extras.
+// upstream token is shared across all callers. ConnectionHeaders returns
+// only the Authorization header; static config headers are layered
+// separately by the caller via utils.StaticConfigHeaders.
 type serverOAuthResolver struct {
 	provider schemas.OAuth2Provider
 }
 
 func (r *serverOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
-	headers := utils.GetHeadersForToolExecution(ctx, config)
-
-	if config == nil {
-		return headers, nil
-	}
-	// Reject nil OR empty IDs at the resolver boundary so the caller gets
-	// the explicit ErrOAuth2ConfigNotFound rather than a less clear
-	// lookup-miss error from GetAccessToken downstream. The ID itself is a
-	// server-generated UUID (oauth2/main.go), so whitespace-only values
-	// aren't reachable today; only the empty case is worth guarding.
 	if config.OauthConfigID == nil || *config.OauthConfigID == "" {
 		return nil, schemas.ErrOAuth2ConfigNotFound
 	}
@@ -38,15 +25,8 @@ func (r *serverOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, con
 	if err != nil {
 		return nil, err
 	}
-	// Validate token format — trim whitespace and reject control characters.
-	// Preserves the legacy MCPClientConfig.HttpHeaders behavior.
-	accessToken = strings.TrimSpace(accessToken)
-	if accessToken == "" {
-		return nil, errors.New("access token is empty")
-	}
-	if strings.ContainsAny(accessToken, "\n\r\t") {
-		return nil, errors.New("access token contains invalid characters")
-	}
+
+	headers := http.Header{}
 	headers.Set("Authorization", "Bearer "+accessToken)
 	return headers, nil
 }

--- a/core/mcp/credstore/static_headers.go
+++ b/core/mcp/credstore/static_headers.go
@@ -2,19 +2,36 @@ package credstore
 
 import (
 	"net/http"
+	"strings"
 
-	"github.com/maximhq/bifrost/core/mcp/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// staticHeadersResolver handles MCPAuthTypeHeaders — admin-configured static
-// headers, merged with any context-extras present in the BifrostContext. Also
-// serves as the fallback for empty/unrecognized AuthType (matches the
-// existing "empty AuthType means headers" normalization in UpdateClient).
+// staticHeadersResolver handles MCPAuthTypeHeaders — the admin-configured
+// static headers on the MCP client. ConnectionHeaders here returns ONLY the
+// Authorization header (if admin set one in config.Headers); other static
+// headers are layered by the caller via utils.StaticConfigHeaders so they
+// remain plugin-mutable.
+//
+// CredStore.resolverFor also normalizes empty AuthType to "headers" so this
+// resolver covers the legacy DB default.
 type staticHeadersResolver struct{}
 
-func (r *staticHeadersResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
-	return utils.GetHeadersForToolExecution(ctx, config), nil
+func (r *staticHeadersResolver) ConnectionHeaders(_ *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+	headers := http.Header{}
+	if config == nil {
+		return headers, nil
+	}
+	// Headers are case-insensitive on the wire but case-sensitive in Go maps;
+	// match case-insensitively (consistent with utils.StaticConfigHeaders'
+	// Authorization exclusion) to keep the security guarantee tight.
+	for key, value := range config.Headers {
+		if strings.EqualFold(key, "Authorization") {
+			headers.Set("Authorization", value.GetValue())
+			break
+		}
+	}
+	return headers, nil
 }
 
 func (r *staticHeadersResolver) RequiresPerCallConnection() bool { return false }

--- a/core/mcp/exec.go
+++ b/core/mcp/exec.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/mark3labs/mcp-go/client"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -63,9 +64,17 @@ func (m *MCPManager) executeToolWithHooks(
 	request *schemas.BifrostMCPRequest,
 	requestType schemas.RequestType,
 ) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
+	if request == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error:          &schemas.ErrorField{Message: "request cannot be nil"},
+			ExtraFields:    schemas.BifrostErrorExtraFields{RequestType: requestType},
+		}
+	}
+
 	// Populate top-level ClientName from the prefixed tool name so the gate can
 	// attribute short-circuit responses without depending on prefix parsing.
-	if request != nil && request.ClientName == "" {
+	if request.ClientName == "" {
 		if toolName := request.GetToolName(); toolName != "" {
 			if idx := strings.IndexByte(toolName, '-'); idx > 0 {
 				request.ClientName = toolName[:idx]
@@ -73,14 +82,38 @@ func (m *MCPManager) executeToolWithHooks(
 		}
 	}
 
-	// Capture MCPUserOAuthRequiredError out-of-band: runWithPluginPipeline wraps Go errors into
-	// a generic BifrostError before PostHooks, which strips typed-error info.
-	var oauthErr *schemas.MCPUserOAuthRequiredError
+	// Resolve the upstream client and acquire its connection BEFORE the plugin
+	// gate runs. Connection lifecycle is the orchestrator's concern, not the
+	// plugin op's — the plugin pipeline only wraps the actual CallTool. When
+	// AcquireClientConn fails (e.g. *MCPUserOAuthRequiredError for per-user
+	// clients that need re-auth), the plugin gate is never invoked.
+	state, conn, release, prepErr := m.prepareToolExecution(ctx, request)
+	if prepErr != nil {
+		bErr := &schemas.BifrostError{
+			IsBifrostError: false,
+			Error:          &schemas.ErrorField{Message: prepErr.Error()},
+			ExtraFields:    schemas.BifrostErrorExtraFields{RequestType: requestType, MCPRequestType: request.RequestType},
+		}
+		var oauthErr *schemas.MCPUserOAuthRequiredError
+		if errors.As(prepErr, &oauthErr) {
+			bErr.ExtraFields.MCPAuthRequired = oauthErr
+		}
+		return nil, bErr
+	}
+	defer release()
+
+	// state == nil signals a code-mode tool: pass nil conn/config/mapping and
+	// ToolsManager.ExecuteTool routes directly to CodeMode.
+	var executionConfig *schemas.MCPClientConfig
+	var toolNameMapping map[string]string
+	if state != nil {
+		executionConfig = state.ExecutionConfig
+		toolNameMapping = state.ToolNameMapping
+	}
 
 	resp, bErr := m.runWithPluginPipeline(ctx, request, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
-		result, opErr := m.ExecuteToolCall(ctx, preReq)
+		result, opErr := m.toolsManager.ExecuteTool(ctx, preReq, conn, executionConfig, toolNameMapping)
 		if opErr != nil {
-			errors.As(opErr, &oauthErr)
 			return nil, opErr
 		}
 		if result == nil {
@@ -91,12 +124,68 @@ func (m *MCPManager) executeToolWithHooks(
 
 	if bErr != nil {
 		bErr.ExtraFields.RequestType = requestType
-		if oauthErr != nil {
-			bErr.ExtraFields.MCPAuthRequired = oauthErr
-		}
 		return nil, bErr
 	}
 	return resp, nil
+}
+
+// prepareToolExecution resolves the tool to its owning MCP client and
+// acquires a connection. Returns (state, conn, release, err):
+//   - For regular MCP tools: state non-nil, conn is the live transport, release
+//     must be called by the caller (defer).
+//   - For code-mode tools: state nil, conn nil, release is a no-op. The caller
+//     forwards nil conn/config/mapping to ToolsManager.ExecuteTool which
+//     dispatches via the CodeMode implementation.
+//
+// Errors here mean the call should NOT run — neither the envelope plugin
+// gate nor the wire op. Typed errors (e.g. *MCPUserOAuthRequiredError)
+// propagate so the caller can stamp BifrostError.ExtraFields.
+func (m *MCPManager) prepareToolExecution(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.MCPClientState, *client.Client, func(), error) {
+	toolName := request.GetToolName()
+	if toolName == "" {
+		return nil, nil, nil, fmt.Errorf("tool call missing function name")
+	}
+
+	// Code-mode tools have no upstream client — skip client lookup.
+	codeMode := m.toolsManager.GetCodeMode()
+	if codeMode != nil && codeMode.IsCodeModeTool(toolName) {
+		return nil, nil, func() {}, nil
+	}
+
+	state := m.GetClientForTool(toolName)
+	if state == nil {
+		return nil, nil, nil, fmt.Errorf("tool '%s' is not available or not permitted", toolName)
+	}
+	clientName := state.ExecutionConfig.Name
+	// Enforce the same filters that GetToolPerClient applies for tool
+	// discovery, in the same order. Without these a caller could invoke a
+	// tool by name that was deliberately hidden from the tool list.
+	//
+	//  1. Client lifecycle — a disabled client is not usable.
+	//  2. Client allow-list — request-context MCPContextKeyIncludeClients.
+	//  3. Tool allow-list   — client-level ToolsToExecute (most restrictive).
+	//  4. Tool narrowing    — request-context MCPContextKeyIncludeTools.
+	if state.State == schemas.MCPConnectionStateDisabled {
+		return nil, nil, nil, fmt.Errorf("tool '%s' is not permitted (client %s is disabled)", toolName, clientName)
+	}
+	var includeClients []string
+	if v, ok := ctx.Value(schemas.MCPContextKeyIncludeClients).([]string); ok {
+		includeClients = v
+	}
+	if !shouldIncludeClient(clientName, includeClients, m.logger) {
+		return nil, nil, nil, fmt.Errorf("tool '%s' is not permitted (client %s is not in request-context include list)", toolName, clientName)
+	}
+	if shouldSkipToolForConfig(toolName, state.ExecutionConfig) {
+		return nil, nil, nil, fmt.Errorf("tool '%s' is not permitted (not in client's ToolsToExecute allow-list)", toolName)
+	}
+	if shouldSkipToolForRequest(ctx, clientName, toolName) {
+		return nil, nil, nil, fmt.Errorf("tool '%s' is not permitted (filtered by request context)", toolName)
+	}
+	conn, release, err := m.AcquireClientConn(ctx, state)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return state, conn, release, nil
 }
 
 // executeToolForAgent is the agent-mode-facing helper. The agent loop expects a

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -9,8 +9,8 @@ import (
 )
 
 // MCPManagerInterface defines the interface for MCP management functionality.
-// This interface allows different implementations (OSS and Enterprise) to be used
-// interchangeably in the Bifrost core.
+// This interface allows different implementations to be used interchangeably
+// in the Bifrost core.
 type MCPManagerInterface interface {
 	// Tool Operations
 	// AddToolsToRequest parses available MCP tools and adds them to the request
@@ -18,9 +18,6 @@ type MCPManagerInterface interface {
 
 	// GetAvailableTools returns all available MCP tools for the given context
 	GetAvailableTools(ctx *schemas.BifrostContext) []schemas.ChatTool
-
-	// ExecuteToolCall executes a single tool call and returns the result
-	ExecuteToolCall(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error)
 
 	// UpdateToolManagerConfig updates the configuration for the tool manager.
 	// DisableAutoToolInject in the config controls auto injection — pass the

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -216,23 +216,6 @@ func (m *MCPManager) GetAvailableTools(ctx *schemas.BifrostContext) []schemas.Ch
 	return m.toolsManager.GetAvailableTools(ctx)
 }
 
-// ExecuteToolCall executes a single tool call and returns the result.
-// This is the primary tool executor and is used by both Chat Completions and Responses APIs.
-//
-// The method accepts an MCP request containing either a ChatAssistantMessageToolCall or
-// ResponsesToolMessage, and returns the appropriate result format based on the request type.
-//
-// Parameters:
-//   - ctx: Context for the tool execution
-//   - request: The MCP request containing the tool call (ChatAssistantMessageToolCall or ResponsesToolMessage)
-//
-// Returns:
-//   - *schemas.BifrostMCPResponse: The result response containing tool execution output (ChatMessage or ResponsesMessage)
-//   - error: Any error that occurred during tool execution
-func (m *MCPManager) ExecuteToolCall(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
-	return m.toolsManager.ExecuteTool(ctx, request)
-}
-
 // UpdateToolManagerConfig updates the configuration for the tool manager.
 // This allows runtime updates to settings like execution timeout and max agent depth.
 //

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -6,16 +6,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
-	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/maximhq/bifrost/core/mcp/credstore"
-	"github.com/maximhq/bifrost/core/mcp/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -26,7 +23,20 @@ type ClientManager interface {
 	GetToolPerClient(ctx context.Context) map[string][]schemas.ChatTool
 	GetPluginPipeline() PluginPipeline
 	ReleasePluginPipeline(pipeline PluginPipeline)
+	// AcquireClientConn returns a live upstream MCP client connection for the
+	// given client state along with a release function the caller must invoke
+	// (typically via defer). For shared-connection auth types the connection is
+	// the persistent state.Conn and the release is a no-op; for per-user auth
+	// types a fresh ephemeral connection is opened (with the caller-resolved
+	// credentials) and closed on release. The credential-resolution error path
+	// (e.g. *MCPUserOAuthRequiredError) surfaces here.
+	AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error)
 }
+
+// MCPToolExecutor is the per-call executor signature used by the agent loop.
+// Callers (e.g. MCPManager.executeToolForAgent) handle client lifecycle
+// internally — the agent itself is decoupled from connection management.
+type MCPToolExecutor func(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error)
 
 // PluginPipeline represents the plugin execution pipeline interface
 // This allows ToolsManager to run plugin hooks without direct dependency on Bifrost.
@@ -530,11 +540,20 @@ func (m *ToolsManager) ParseAndAddToolsToRequest(ctx *schemas.BifrostContext, re
 // Parameters:
 //   - ctx: Execution context
 //   - request: The MCP request containing the tool call (Chat or Responses format)
+//   - clientConn: The client connection for executing the tool
+//   - executionConfig: The MCP client configuration for execution context
+//   - toolNameMapping: Mapping of sanitized tool names to original MCP tool names for accurate logging and response metadata
 //
 // Returns:
 //   - *schemas.BifrostMCPResponse: Tool execution result (Chat or Responses format)
 //   - error: Any execution error
-func (m *ToolsManager) ExecuteTool(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
+func (m *ToolsManager) ExecuteTool(
+	ctx *schemas.BifrostContext,
+	request *schemas.BifrostMCPRequest,
+	clientConn *client.Client,
+	executionConfig *schemas.MCPClientConfig,
+	toolNameMapping map[string]string,
+) (*schemas.BifrostMCPResponse, error) {
 	// Validate request is not nil
 	if request == nil {
 		return nil, fmt.Errorf("request cannot be nil")
@@ -571,7 +590,7 @@ func (m *ToolsManager) ExecuteTool(ctx *schemas.BifrostContext, request *schemas
 	now := time.Now()
 
 	// Execute the tool in Chat format (internal execution format)
-	chatResult, clientName, originalToolName, err := m.executeToolInternal(ctx, toolCall)
+	chatResult, clientName, originalToolName, err := m.executeToolInternal(ctx, toolCall, clientConn, executionConfig, toolNameMapping)
 	if err != nil {
 		return nil, err
 	}
@@ -612,7 +631,13 @@ func (m *ToolsManager) ExecuteTool(ctx *schemas.BifrostContext, request *schemas
 // executeToolInternal is the internal tool executor that works with Chat format.
 // This is used internally by ExecuteTool after format conversion.
 // Returns: (message, clientName, originalToolName, error)
-func (m *ToolsManager) executeToolInternal(ctx *schemas.BifrostContext, toolCall *schemas.ChatAssistantMessageToolCall) (*schemas.ChatMessage, string, string, error) {
+func (m *ToolsManager) executeToolInternal(
+	ctx *schemas.BifrostContext,
+	toolCall *schemas.ChatAssistantMessageToolCall,
+	clientConn *client.Client,
+	executionConfig *schemas.MCPClientConfig,
+	toolNameMapping map[string]string,
+) (*schemas.ChatMessage, string, string, error) {
 	toolName := *toolCall.Function.Name
 
 	// Check if this is a code mode tool and delegate to CodeMode implementation
@@ -621,30 +646,11 @@ func (m *ToolsManager) executeToolInternal(ctx *schemas.BifrostContext, toolCall
 		return msg, "", toolName, err
 	}
 
-	// Handle regular MCP tools
-	// Check if the user has permission to execute the tool call
-	availableTools := m.clientManager.GetToolPerClient(ctx)
-	toolFound := false
-	for _, tools := range availableTools {
-		for _, mcpTool := range tools {
-			if mcpTool.Function != nil && mcpTool.Function.Name == toolName {
-				toolFound = true
-				break
-			}
-		}
-		if toolFound {
-			break
-		}
-	}
-
-	if !toolFound {
-		return nil, "", "", fmt.Errorf("tool '%s' is not available or not permitted", toolName)
-	}
-
-	client := m.clientManager.GetClientForTool(toolName)
-	if client == nil {
-		return nil, "", "", fmt.Errorf("client not found for tool %s", toolName)
-	}
+	// The caller (MCPManager.prepareToolExecution → executeToolWithHooks /
+	// ExecuteChatTool) is responsible for resolving the tool to a client and
+	// supplying the corresponding connection + execution config. Tool
+	// availability and permission checks are enforced at that layer, so no
+	// redundant lookup is needed here.
 
 	// Parse tool arguments
 	var arguments map[string]interface{}
@@ -658,36 +664,18 @@ func (m *ToolsManager) executeToolInternal(ctx *schemas.BifrostContext, toolCall
 
 	// Strip the client name prefix from tool name before calling MCP server
 	// The MCP server expects the original tool name (with hyphens), not the sanitized version
-	sanitizedToolName := stripClientPrefix(toolName, client.ExecutionConfig.Name)
-	originalMCPToolName := getOriginalToolName(sanitizedToolName, client)
+	sanitizedToolName := stripClientPrefix(toolName, executionConfig.Name)
+	originalMCPToolName := getOriginalToolName(sanitizedToolName, toolNameMapping)
 
 	// Create timeout context for tool execution
 	toolExecutionTimeout := m.toolExecutionTimeout.Load().(time.Duration)
 	toolCtx, cancel := context.WithTimeout(ctx, toolExecutionTimeout)
 	defer cancel()
 
-	// Per-user auth types open an ephemeral transport per call with the
-	// caller's full set of credentials (static + extras + per-user auth).
-	if m.credStore.RequiresPerCallConnection(client.ExecutionConfig) {
-		connHeaders, err := m.credStore.ConnectionHeaders(ctx, client.ExecutionConfig)
-		if err != nil {
-			return nil, "", "", err
-		}
-		toolResponse, callErr := OpenConnectionAndExecuteTool(toolCtx, client.ExecutionConfig, originalMCPToolName, arguments, connHeaders)
-		if callErr != nil {
-			if toolCtx.Err() == context.DeadlineExceeded {
-				return nil, "", "", fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
-			}
-			m.logger.Error("%s Tool execution failed for %s via client %s: %v", MCPLogPrefix, toolName, client.ExecutionConfig.Name, callErr)
-			return nil, "", "", fmt.Errorf("MCP tool call failed: %v", callErr)
-		}
-		responseText := extractTextFromMCPResponse(toolResponse, toolName)
-		return createToolResponseMessage(*toolCall, responseText), client.ExecutionConfig.Name, sanitizedToolName, nil
-	}
-
-	// Shared persistent connection path — admin-level credentials are already
-	// on the transport; per-call only carries filtered context-extras.
-	reqHeaders, err := m.credStore.RequestHeaders(ctx, client.ExecutionConfig)
+	// The connection (shared persistent OR ephemeral per-call) is supplied by
+	// the caller via AcquireClientConn. Admin-level credentials live on the
+	// transport; per-call request carries filtered context-extras only.
+	reqHeaders, err := m.credStore.RequestHeaders(ctx, executionConfig)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -702,13 +690,13 @@ func (m *ToolsManager) executeToolInternal(ctx *schemas.BifrostContext, toolCall
 		Header: reqHeaders,
 	}
 
-	toolResponse, callErr := client.Conn.CallTool(toolCtx, callRequest)
+	toolResponse, callErr := clientConn.CallTool(toolCtx, callRequest)
 	if callErr != nil {
 		// Check if it was a timeout error
 		if toolCtx.Err() == context.DeadlineExceeded {
 			return nil, "", "", fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
 		}
-		m.logger.Error("%s Tool execution failed for %s via client %s: %v", MCPLogPrefix, toolName, client.ExecutionConfig.Name, callErr)
+		m.logger.Error("%s Tool execution failed for %s via client %s: %v", MCPLogPrefix, toolName, executionConfig.Name, callErr)
 		return nil, "", "", fmt.Errorf("MCP tool call failed: %v", callErr)
 	}
 
@@ -716,7 +704,7 @@ func (m *ToolsManager) executeToolInternal(ctx *schemas.BifrostContext, toolCall
 	responseText := extractTextFromMCPResponse(toolResponse, toolName)
 
 	// Create tool response message
-	return createToolResponseMessage(*toolCall, responseText), client.ExecutionConfig.Name, sanitizedToolName, nil
+	return createToolResponseMessage(*toolCall, responseText), executionConfig.Name, sanitizedToolName, nil
 }
 
 // ExecuteAgentForChatRequest executes agent mode for a chat request, handling
@@ -728,12 +716,13 @@ func (m *ToolsManager) ExecuteAgentForChatRequest(
 	req *schemas.BifrostChatRequest,
 	resp *schemas.BifrostChatResponse,
 	makeReq func(ctx *schemas.BifrostContext, req *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError),
-	executeTool func(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error),
+	executeTool MCPToolExecutor,
 ) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	// Defensive: if no executor was supplied, fall back to the un-hooked path. This
-	// path is only exercised by internal callers that have already gated above.
 	if executeTool == nil {
-		executeTool = m.ExecuteTool
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error:          &schemas.ErrorField{Message: "executeTool is required for agent mode"},
+		}
 	}
 	return m.agentModeExecutor.ExecuteAgentForChatRequest(
 		ctx,
@@ -753,10 +742,13 @@ func (m *ToolsManager) ExecuteAgentForResponsesRequest(
 	req *schemas.BifrostResponsesRequest,
 	resp *schemas.BifrostResponsesResponse,
 	makeReq func(ctx *schemas.BifrostContext, req *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError),
-	executeTool func(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error),
+	executeTool MCPToolExecutor,
 ) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	if executeTool == nil {
-		executeTool = m.ExecuteTool
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error:          &schemas.ErrorField{Message: "executeTool is required for agent mode"},
+		}
 	}
 	return m.agentModeExecutor.ExecuteAgentForResponsesRequest(
 		ctx,
@@ -794,78 +786,6 @@ func (m *ToolsManager) UpdateConfig(config *schemas.MCPToolManagerConfig) {
 	m.disableAutoToolInject.Store(config.DisableAutoToolInject)
 
 	m.logger.Info("%s tool manager configuration updated with tool execution timeout: %v, max agent depth: %d, and code mode binding level: %s", MCPLogPrefix, config.ToolExecutionTimeout.D(), config.MaxAgentDepth, config.CodeModeBindingLevel)
-}
-
-// OpenConnectionAndExecuteTool opens an ephemeral HTTP MCP connection to the
-// configured server using the provided headers, performs the Initialize
-// handshake, calls the named tool, and closes. Used for per-user auth types
-// where credentials vary by caller and no persistent upstream connection is
-// maintained.
-//
-// Parameters:
-//   - ctx: cancellable context (caller usually wraps with the tool execution timeout)
-//   - config: MCP client config (provides ConnectionString + Name)
-//   - toolName: original MCP tool name (with hyphens; not the sanitized form)
-//   - arguments: tool arguments
-//   - headers: complete header set for opening the transport (Authorization +
-//     static + extras). Typically obtained from CredentialStore.ConnectionHeaders.
-//   - logger: optional logger (reserved for future trace logs)
-//
-// Returns:
-//   - *mcp.CallToolResult: tool execution result
-//   - error: any error during connection or execution
-func OpenConnectionAndExecuteTool(
-	ctx context.Context,
-	config *schemas.MCPClientConfig,
-	toolName string,
-	arguments map[string]any,
-	headers http.Header,
-) (*mcp.CallToolResult, error) {
-	if config == nil {
-		return nil, fmt.Errorf("config is required for ephemeral MCP tool execution")
-	}
-	if config.ConnectionString == nil || config.ConnectionString.GetValue() == "" {
-		return nil, fmt.Errorf("connection URL is required for ephemeral MCP tool execution")
-	}
-
-	httpTransport, err := transport.NewStreamableHTTP(config.ConnectionString.GetValue(), transport.WithHTTPHeaders(utils.FlattenHeaders(headers)))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP transport: %w", err)
-	}
-
-	// Create temporary MCP client
-	tempClient := client.NewClient(httpTransport)
-	if err := tempClient.Start(ctx); err != nil {
-		return nil, fmt.Errorf("failed to start temporary MCP connection: %w", err)
-	}
-	defer tempClient.Close()
-
-	// Initialize MCP handshake
-	initRequest := mcp.InitializeRequest{
-		Params: mcp.InitializeParams{
-			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
-			Capabilities:    mcp.ClientCapabilities{},
-			ClientInfo: mcp.Implementation{
-				Name:    fmt.Sprintf("Bifrost-%s-user", config.Name),
-				Version: "1.0.0",
-			},
-		},
-	}
-	if _, err := tempClient.Initialize(ctx, initRequest); err != nil {
-		return nil, fmt.Errorf("failed to initialize temporary MCP connection: %w", err)
-	}
-
-	// Call the tool
-	callRequest := mcp.CallToolRequest{
-		Request: mcp.Request{
-			Method: string(mcp.MethodToolsCall),
-		},
-		Params: mcp.CallToolParams{
-			Name:      toolName,
-			Arguments: arguments,
-		},
-	}
-	return tempClient.CallTool(ctx, callRequest)
 }
 
 // GetCodeModeBindingLevel returns the current code mode binding level.

--- a/core/mcp/toolmanager_test.go
+++ b/core/mcp/toolmanager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/mark3labs/mcp-go/client"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -44,6 +45,9 @@ func (m *mockToolClientManager) GetToolPerClient(ctx context.Context) map[string
 
 func (m *mockToolClientManager) GetPluginPipeline() PluginPipeline             { return nil }
 func (m *mockToolClientManager) ReleasePluginPipeline(pipeline PluginPipeline) {}
+func (m *mockToolClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
+	return nil, func() {}, nil
+}
 
 // makeTool is a convenience constructor for test tool fixtures.
 func makeTool(name string) schemas.ChatTool {

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -872,17 +872,17 @@ func stripClientPrefix(prefixedToolName, clientName string) string {
 //
 // Parameters:
 //   - sanitizedToolName: Sanitized tool name (e.g., "notion_search")
-//   - client: The MCP client state containing the name mapping
+//   - toolNameMapping: Map of sanitized tool names to original MCP tool names
 //
 // Returns:
 //   - string: Original MCP tool name (e.g., "notion-search"), or sanitizedToolName if not found in mapping
-func getOriginalToolName(sanitizedToolName string, client *schemas.MCPClientState) string {
-	if client == nil || client.ToolNameMapping == nil {
+func getOriginalToolName(sanitizedToolName string, toolNameMapping map[string]string) string {
+	if toolNameMapping == nil {
 		return sanitizedToolName
 	}
 
 	// Look up the original MCP name in the mapping
-	if originalName, exists := client.ToolNameMapping[sanitizedToolName]; exists {
+	if originalName, exists := toolNameMapping[sanitizedToolName]; exists {
 		return originalName
 	}
 

--- a/core/mcp/utils/utils.go
+++ b/core/mcp/utils/utils.go
@@ -2,18 +2,15 @@ package utils
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
 // FlattenHeaders converts an http.Header into a map[string]string suitable
-// for mcp-go's transport.WithHTTPHeaders, which is the API used for both
-// the persistent shared upstream connection (in clientmanager) and the
-// ephemeral per-call connection (in OpenConnectionAndExecuteTool).
-// Multi-value headers collapse to their first value — matching the legacy
-// MCPClientConfig.HttpHeaders / ExecuteToolWithUserToken behavior, which
-// built map[string]string directly from config.Headers with a single value
-// per key.
+// for mcp-go's transport.WithHTTPHeaders, used for both shared persistent
+// connections (clientmanager) and ephemeral per-call connections
+// (AcquireClientConn). Multi-value headers collapse to their first value.
 func FlattenHeaders(h http.Header) map[string]string {
 	out := make(map[string]string, len(h))
 	for k, v := range h {
@@ -33,12 +30,36 @@ func BuildRedirectURIFromContext(ctx *schemas.BifrostContext) string {
 	return ""
 }
 
+// StaticConfigHeaders returns the admin-configured static headers from
+// config.Headers MINUS any Authorization header. These are the headers that
+// are safe to expose to MCP connect-plugins via the PreConnectionHook gate —
+// plugins may add, remove, or rewrite them.
+//
+// Authorization is excluded by design even when an admin sets it manually
+// in config.Headers (e.g. for MCPAuthTypeHeaders with a hard-coded bearer):
+// it is a credential, and credentials are layered AFTER the plugin gate
+// runs. The CredentialStore resolver for the relevant auth type emits the
+// final Authorization value (either from config or from a dynamic token).
+func StaticConfigHeaders(config *schemas.MCPClientConfig) http.Header {
+	headers := make(http.Header)
+	if config == nil {
+		return headers
+	}
+	for key, value := range config.Headers {
+		if strings.EqualFold(key, "Authorization") {
+			continue
+		}
+		headers.Add(key, value.GetValue())
+	}
+	return headers
+}
+
 // ExtractFilteredExtras returns just the per-request "extra" headers carried
 // in the BifrostContext (BifrostContextKeyMCPExtraHeaders), scoped by the
 // client's AllowedExtraHeaders. Static config headers are NOT included here —
-// those live on the upstream transport and apply automatically to every
-// message it carries. This function exists for the per-message
-// CredentialStore.RequestHeaders path on shared connections.
+// those live on the upstream transport via StaticConfigHeaders and apply
+// automatically to every message it carries. This function exists for the
+// per-message CredentialStore.RequestHeaders path on shared connections.
 func ExtractFilteredExtras(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) http.Header {
 	headers := make(http.Header)
 	if ctx == nil || config == nil {
@@ -57,33 +78,6 @@ func ExtractFilteredExtras(ctx *schemas.BifrostContext, config *schemas.MCPClien
 				headers.Set(key, value)
 			} else {
 				headers.Add(key, value)
-			}
-		}
-	}
-	return headers
-}
-
-// GetHeadersForToolExecution returns the union of the client's static config
-// headers and the filtered per-request extras carried in the BifrostContext.
-// Used by CredentialStore resolvers to assemble the "stable + per-call" base
-// before adding any auth-specific headers (e.g. a Bearer token).
-func GetHeadersForToolExecution(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) http.Header {
-	if ctx == nil || config == nil {
-		return make(http.Header)
-	}
-	headers := make(http.Header)
-	if config.Headers != nil {
-		for key, value := range config.Headers {
-			headers.Add(key, value.GetValue())
-		}
-	}
-	// Layer per-request extras on top.
-	for key, values := range ExtractFilteredExtras(ctx, config) {
-		for i, v := range values {
-			if i == 0 {
-				headers.Set(key, v)
-			} else {
-				headers.Add(key, v)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This PR refactors how MCP client connections are acquired and how credentials are composed for tool execution. The core problem was that the `Authorization` header (and other credentials) were being assembled too early — before the connect-plugin gate ran — meaning plugins could observe or interfere with auth tokens. Additionally, per-user OAuth clients used a separate `OpenConnectionAndExecuteTool` code path that bypassed the plugin pipeline entirely.

## Changes

- Introduced `AcquireClientConn` on `MCPManager` and the `ClientManager` interface. This method returns a live upstream connection plus a release function. For shared-connection auth types (none, headers, server OAuth), it returns the persistent `state.Conn` with a no-op release. For per-user OAuth, it opens a fresh ephemeral transport per call, running it through the connect-plugin gate (`runConnectWithPluginPipeline`) for parity with shared connections.

- Removed `OpenConnectionAndExecuteTool` (the standalone ephemeral connection helper). All connection lifecycle is now routed through `AcquireClientConn`, eliminating the divergent per-user code path in `ToolsManager` and `StarlarkCodeMode`.

- Restructured credential composition so that static config headers (minus `Authorization`) are exposed to plugins via `StaticConfigHeaders`, and auth credentials are layered on top *after* the plugin gate runs. This is a structural guarantee: plugins can mutate static headers but never observe bearer tokens or signing headers.

- Moved tool availability and permission checks (client lifecycle, allow-lists, `ToolsToExecute`, request-context filters) into a new `prepareToolExecution` method on `MCPManager`. `ToolsManager.executeToolInternal` no longer performs redundant tool lookups — the resolved connection, config, and tool name mapping are passed in directly.

- Removed `ExecuteToolCall` from `MCPManagerInterface` and `MCPManager`. The plugin-wrapped `ExecuteChatTool` path is now the canonical entry point for tool execution; tests updated accordingly.

- Introduced `MCPToolExecutor` as a named function type for the agent loop's tool executor, replacing the anonymous `func(...)` signature.

- `CredStore.resolverFor` now normalizes empty `AuthType` to `MCPAuthTypeHeaders`, matching the DB column default and `UpdateClient`'s existing normalization. Programmatically constructed configs with a blank auth type no longer return an error.

- `staticHeadersResolver`, `noneResolver`, `serverOAuthResolver`, and `perUserOAuthResolver` `ConnectionHeaders` implementations now return only the auth-specific header (e.g. `Authorization`). Static config headers are no longer bundled here — they are layered separately by the caller.

- Removed `GetHeadersForToolExecution` from `utils` (no longer needed). Added `StaticConfigHeaders` to `utils` which returns config headers excluding `Authorization`.

- `ToolsManager.ExecuteAgentForChatRequest` and `ExecuteAgentForResponsesRequest` now return an error if `executeTool` is nil, rather than silently falling back to the un-hooked path.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/...
go test ./core/internal/mcptests/...
go test ./core/mcp/...
go test ./core/mcp/codemode/starlark/...
```

Validate that:
- Tool filtering tests pass and exercise `ExecuteChatTool` rather than the removed `ExecuteToolCall`.
- Per-user OAuth tool calls open an ephemeral connection through the plugin gate and close it after execution.
- Shared-connection clients continue to use their persistent `state.Conn` with no additional connection overhead.
- Agent mode returns an explicit error when no `executeTool` function is provided.

## Breaking changes

- [x] Yes
- [ ] No

`ExecuteToolCall` has been removed from `MCPManagerInterface`. Any custom `MCPManagerInterface` implementation must remove this method. Callers that previously invoked `ExecuteToolCall` directly should use the plugin-wrapped `ExecuteChatTool` path instead. `ToolsManager.ExecuteTool` now requires `clientConn`, `executionConfig`, and `toolNameMapping` arguments; direct callers must be updated.

## Security considerations

The primary motivation for this refactor is a security boundary improvement: credentials (bearer tokens, signing headers) are now guaranteed to be invisible to MCP connect-plugins. Plugins operate only on admin-configured static headers (excluding `Authorization`). Auth headers are composed after the plugin gate returns, on the wire transport, and are never present in the `BifrostMCPConnectRequest` object that plugins receive in `PreConnectionHook` or `PostConnectionHook`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable