### PR TITLE
feat: add mcp per-user headers auth flow ui wiring

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/mcp-tool-groups/mcpToolGroups.tsx
+++ b/ui/app/_fallbacks/enterprise/components/mcp-tool-groups/mcpToolGroups.tsx
@@ -6,7 +6,7 @@ export default function MCPToolGroups() {
 		<>
 			<div className="mb-4 flex items-center justify-between gap-4">
 				<div>
-					<h2 className="text-lg font-semibold tracking-tight">MCP tool groups</h2>
+					<h2 className="text-lg font-semibold tracking-tight">MCP Tool Groups</h2>
 					<p className="text-muted-foreground text-sm">Configure tool groups for MCP servers to organize and govern tools.</p>
 				</div>
 			</div>

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -7,6 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useCreateMCPClientMutation } from "@/lib/store";
@@ -16,6 +17,7 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Info } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+import { MCPHeadersAuthorizer } from "./mcpHeadersAuthorizer";
 import { OAuth2Authorizer } from "./oauth2Authorizer";
 
 interface ClientFormProps {
@@ -58,6 +60,16 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		isPerUserOauth?: boolean;
 	} | null>(null);
 
+	// Per-user-headers admin flow: admin declares the required key names
+	// (perUserHeaderKeys), then on Create the MCPHeadersAuthorizer dialog
+	// runs a sample-values verify and returns discovered tools. The form
+	// then persists the MCP client with those tools attached — first-time
+	// end users skip re-discovery that way. Mirrors the OAuth2Authorizer
+	// flow exactly: nothing is persisted until the test succeeds.
+	const [perUserHeaderKeys, setPerUserHeaderKeys] = useState<string[]>([]);
+	const [newHeaderKeyInput, setNewHeaderKeyInput] = useState("");
+	const [headersFlow, setHeadersFlow] = useState<{ payload: CreateMCPClientRequest } | null>(null);
+
 	const methods = useForm<CreateMCPClientRequest>({ defaultValues: emptyForm });
 	const { control, handleSubmit, setValue, watch, reset, setError, clearErrors } = methods;
 
@@ -65,9 +77,19 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 	const authType = watch("auth_type");
 	const headers = watch("headers");
 
-	// Inline header validation (shown live as user edits headers)
+	// Inline header validation (shown live as user edits headers).
+	// Both "headers" and "per_user_headers" auth types persist the static
+	// headers map via the submit path (see "headers" property of payload
+	// below), so the validation gate must cover both — otherwise an empty
+	// static header in the per-user flow slips past client validation and
+	// opens MCPHeadersAuthorizer with an invalid config the server has to
+	// reject.
 	let headersValidationError: string | null = null;
-	if ((connectionType === "http" || connectionType === "sse") && authType === "headers" && headers) {
+	if (
+		(connectionType === "http" || connectionType === "sse") &&
+		(authType === "headers" || authType === "per_user_headers") &&
+		headers
+	) {
 		for (const [key, envVar] of Object.entries(headers)) {
 			if (!envVar.value && !envVar.env_var) {
 				headersValidationError = `Header "${key}" must have a value`;
@@ -84,6 +106,9 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			setEnvsText("");
 			setScopesText("");
 			setOauthFlow(null);
+			setHeadersFlow(null);
+			setPerUserHeaderKeys([]);
+			setNewHeaderKeyInput("");
 			setIsLoading(false);
 		}
 	}, [open, reset]);
@@ -130,6 +155,17 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			}
 		}
 
+		if (authType === "per_user_headers") {
+			if (perUserHeaderKeys.length === 0) {
+				toast({
+					title: "Header keys required",
+					description: "Declare at least one header name users must supply.",
+					variant: "destructive",
+				});
+				hasErrors = true;
+			}
+		}
+
 		if (headersValidationError || hasErrors) return;
 
 		setIsLoading(true);
@@ -139,29 +175,47 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			stdio_config:
 				connectionType === "stdio"
 					? {
-							command: data.stdio_config?.command || "",
-							args: parseArrayFromText(argsText),
-							envs: parseArrayFromText(envsText),
-						}
+						command: data.stdio_config?.command || "",
+						args: parseArrayFromText(argsText),
+						envs: parseArrayFromText(envsText),
+					}
 					: undefined,
 			oauth_config:
 				authType === "oauth" || authType === "per_user_oauth"
 					? {
-							client_id: data.oauth_config?.client_id ?? emptyEnvVar,
-							client_secret:
-								data.oauth_config?.client_secret?.value || data.oauth_config?.client_secret?.from_env
-									? data.oauth_config.client_secret
-									: undefined,
-							authorize_url: data.oauth_config?.authorize_url || undefined,
-							token_url: data.oauth_config?.token_url || undefined,
-							registration_url: data.oauth_config?.registration_url || undefined,
-							scopes: scopesText.trim() ? parseArrayFromText(scopesText) : undefined,
-							server_url: data.connection_string?.value || undefined,
-						}
+						client_id: data.oauth_config?.client_id ?? emptyEnvVar,
+						client_secret:
+							data.oauth_config?.client_secret?.value || data.oauth_config?.client_secret?.from_env
+								? data.oauth_config.client_secret
+								: undefined,
+						authorize_url: data.oauth_config?.authorize_url || undefined,
+						token_url: data.oauth_config?.token_url || undefined,
+						registration_url: data.oauth_config?.registration_url || undefined,
+						scopes: scopesText.trim() ? parseArrayFromText(scopesText) : undefined,
+						server_url: data.connection_string?.value || undefined,
+					}
 					: undefined,
-			headers: authType === "headers" && data.headers && Object.keys(data.headers).length > 0 ? data.headers : undefined,
+			// "headers" and "per_user_headers" both can carry static admin
+			// headers on data.headers (per-user values are submitted
+			// separately by end users). Persist when present.
+			headers:
+				(authType === "headers" || authType === "per_user_headers") && data.headers && Object.keys(data.headers).length > 0
+					? data.headers
+					: undefined,
+			per_user_header_keys: authType === "per_user_headers" ? perUserHeaderKeys : undefined,
 			tools_to_execute: ["*"],
 		};
+
+		// Per-user-headers: stash the payload and open the headers test
+		// dialog. The dialog collects sample values and POSTs once to
+		// /api/mcp/client where the server verifies, discovers tools,
+		// and persists in a single round-trip. Mirrors the per-user
+		// OAuth flow's single-call shape.
+		if (authType === "per_user_headers") {
+			setIsLoading(false);
+			setHeadersFlow({ payload });
+			return;
+		}
 
 		try {
 			const response = await createMCPClient(payload).unwrap();
@@ -196,7 +250,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 
 				<Form {...methods}>
 					<form onSubmit={handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
-						<div className="flex-1 space-y-4 overflow-y-auto px-8">
+						<div className="flex-1 space-y-4 overflow-y-auto px-8 pb-8">
 							{/* Name */}
 							<FormField
 								control={control}
@@ -387,6 +441,9 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 														<SelectItem value="headers" data-testid="auth-type-headers">
 															Headers
 														</SelectItem>
+														<SelectItem value="per_user_headers" data-testid="auth-type-per-user-headers">
+															Per-User Headers
+														</SelectItem>
 														<SelectItem value="oauth" data-testid="auth-type-oauth">
 															OAuth 2.0
 														</SelectItem>
@@ -419,6 +476,63 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 												</FormItem>
 											)}
 										/>
+									)}
+
+									{authType === "per_user_headers" && (
+										<div className="space-y-4">
+											{/* Required header keys (admin schema). Same Textarea +
+											    comma-separated pattern as workspace/config security
+											    Required Headers, so the two surfaces stay visually
+											    consistent. End users supply values per-user at first
+											    tool use via the inline auth landing page. */}
+											<div className="space-y-1">
+												<div className="space-y-0.5">
+													<div className="text-sm font-medium">
+														Required Headers
+													</div>
+													<p className="text-muted-foreground text-sm">
+														Comma-separated list of header names each caller must supply when they first use this server (e.g.{" "}
+														<code>X-API-Key, X-Tenant-ID</code>). Values are submitted per user — never stored on this server config.
+													</p>
+												</div>
+												<Textarea
+													id="per-user-header-keys"
+													data-testid="per-user-header-keys-textarea"
+													className="h-24"
+													placeholder="X-API-Key, X-Tenant-ID"
+													value={newHeaderKeyInput}
+													onChange={(e) => {
+														setNewHeaderKeyInput(e.target.value);
+														setPerUserHeaderKeys(parseArrayFromText(e.target.value));
+													}}
+												/>
+											</div>
+
+											{/* Optional static admin headers (e.g. a fixed tenant header) */}
+											<FormField
+												control={control}
+												name="headers"
+												render={({ field }) => (
+													<FormItem>
+														<HeadersTable
+															value={field.value || {}}
+															onChange={field.onChange}
+															keyPlaceholder="Header name"
+															valuePlaceholder="Header value"
+															label="Static Headers (optional, applied alongside user values)"
+															useEnvVarInput
+														/>
+														{headersValidationError && <p className="text-destructive text-xs">{headersValidationError}</p>}
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+
+											{/* Sample values are collected in the MCPHeadersAuthorizer
+											    dialog that opens on Create — mirrors the OAuth flow
+											    where the verification step is also a dialog, not an
+											    inline panel. */}
+										</div>
 									)}
 
 									{(authType === "oauth" || authType === "per_user_oauth") && (
@@ -688,6 +802,31 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					oauthConfigId={oauthFlow.oauthConfigId}
 					mcpClientId={oauthFlow.mcpClientId}
 					isPerUserOauth={oauthFlow.isPerUserOauth}
+				/>
+			)}
+
+			{/* Per-user-headers create dialog. Collects sample values inline,
+			    then calls POST /api/mcp/client once — the server verifies
+			    upstream + discovers tools + persists atomically. Mirrors
+			    the per-user OAuth flow's single-call shape. Nothing is
+			    committed if the user cancels or verification fails. */}
+			{headersFlow && (
+				<MCPHeadersAuthorizer
+					open={!!headersFlow}
+					onClose={() => {
+						setHeadersFlow(null);
+					}}
+					onSuccess={() => {
+						setHeadersFlow(null);
+						toast({ title: "Success", description: "MCP server connected with per-user headers" });
+						onSaved();
+						onClose();
+					}}
+					onError={() => {
+						/* error toast handled by the dialog itself */
+					}}
+					payload={headersFlow.payload}
+					perUserHeaderKeys={perUserHeaderKeys}
 				/>
 			)}
 		</Sheet>

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -12,6 +12,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { TriStateCheckbox } from "@/components/ui/tristateCheckbox";
 import { useToast } from "@/hooks/use-toast";
@@ -20,6 +21,7 @@ import { MCP_STATUS_COLORS } from "@/lib/constants/config";
 import { getErrorMessage, useGetCoreConfigQuery, useGetVirtualKeysQuery, useUpdateMCPClientMutation } from "@/lib/store";
 import { MCPClient, MCPVKConfig } from "@/lib/types/mcp";
 import { mcpClientUpdateSchema, type MCPClientUpdateSchema } from "@/lib/types/schemas";
+import { parseArrayFromText } from "@/lib/utils/array";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ChevronDown, ChevronRight, Info, Plus, Trash2 } from "lucide-react";
@@ -66,6 +68,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 	const [vkConfigs, setVKConfigs] = useState<MCPVKConfig[]>([]);
 	const [vkConfigsDirty, setVKConfigsDirty] = useState(false);
 	const [allowedExtraHeadersRaw, setAllowedExtraHeadersRaw] = useState<string>((mcpClient.config.allowed_extra_headers || []).join(", "));
+	const [perUserHeaderKeysRaw, setPerUserHeaderKeysRaw] = useState<string>((mcpClient.config.per_user_header_keys || []).join(", "));
 	const [oauthFlow, setOauthFlow] = useState<{
 		authorizeUrl: string;
 		oauthConfigId: string;
@@ -86,6 +89,10 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 	useEffect(() => {
 		setAllowedExtraHeadersRaw((mcpClient.config.allowed_extra_headers || []).join(", "));
 	}, [mcpClient.config.allowed_extra_headers]);
+
+	useEffect(() => {
+		setPerUserHeaderKeysRaw((mcpClient.config.per_user_header_keys || []).join(", "));
+	}, [mcpClient.config.per_user_header_keys]);
 
 	// Name lookup: server response names → search results → locally cached names (highest priority)
 	const vkNameByID = useMemo<Record<string, string>>(() => {
@@ -153,6 +160,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			allow_on_all_virtual_keys: mcpClient.config.allow_on_all_virtual_keys || false,
 			disabled: mcpClient.config.disabled || false,
 			headers: mcpClient.config.headers,
+			per_user_header_keys: mcpClient.config.auth_type === "per_user_headers" ? mcpClient.config.per_user_header_keys || [] : undefined,
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
@@ -174,6 +182,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			allow_on_all_virtual_keys: mcpClient.config.allow_on_all_virtual_keys || false,
 			disabled: mcpClient.config.disabled || false,
 			headers: mcpClient.config.headers,
+			per_user_header_keys: mcpClient.config.auth_type === "per_user_headers" ? mcpClient.config.per_user_header_keys || [] : undefined,
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
@@ -187,6 +196,14 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 
 	const onSubmit = async (data: MCPClientUpdateSchema) => {
 		try {
+			if (mcpClient.config.auth_type === "per_user_headers" && (!data.per_user_header_keys || data.per_user_header_keys.length === 0)) {
+				toast({
+					title: "Header keys required",
+					description: "Declare at least one header name users must supply.",
+					variant: "destructive",
+				});
+				return;
+			}
 			const oauthClientID = data.oauth_config?.client_id;
 			const oauthClientSecret = data.oauth_config?.client_secret;
 			// Only rotate when the user actually changed a credential field.
@@ -202,6 +219,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 					allow_on_all_virtual_keys: data.allow_on_all_virtual_keys,
 					disabled: data.disabled,
 					headers: data.headers ?? {},
+					per_user_header_keys: mcpClient.config.auth_type === "per_user_headers" ? data.per_user_header_keys : undefined,
 					tools_to_execute: data.tools_to_execute,
 					tools_to_auto_execute: data.tools_to_auto_execute,
 					tool_pricing: data.tool_pricing,
@@ -567,6 +585,59 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 										</FormItem>
 									)}
 								/>
+								{mcpClient.config.auth_type === "per_user_headers" && (
+									<FormField
+										control={form.control}
+										name="per_user_header_keys"
+										render={({ field }) => (
+											<FormItem className="space-y-1">
+												<div className="space-y-0.5">
+													<div className="flex items-center gap-2">
+														<FormLabel>Required Headers</FormLabel>
+														<TooltipProvider>
+															<Tooltip>
+																<TooltipTrigger asChild>
+																	<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																</TooltipTrigger>
+																<TooltipContent className="max-w-xs">
+																	<p>
+																		Changing this list marks existing per-user header submissions as needing an update, so callers resubmit
+																		values on next use.
+																	</p>
+																</TooltipContent>
+															</Tooltip>
+														</TooltipProvider>
+													</div>
+													<p className="text-muted-foreground text-sm">
+														Comma-separated list of header names each caller must supply when they first use this server (e.g.{" "}
+														<code>X-API-Key, X-Tenant-ID</code>). Values are submitted per user, not stored on this server config.
+													</p>
+												</div>
+												<FormControl>
+													<Textarea
+														id="mcpclient-per-user-header-keys"
+														data-testid="mcpclient-per-user-header-keys-textarea"
+														className="h-24"
+														placeholder="X-API-Key, X-Tenant-ID"
+														name={field.name}
+														ref={field.ref}
+														value={perUserHeaderKeysRaw}
+														onChange={(e) => {
+															const value = e.target.value;
+															setPerUserHeaderKeysRaw(value);
+															form.setValue("per_user_header_keys", parseArrayFromText(value), {
+																shouldDirty: true,
+																shouldValidate: true,
+															});
+														}}
+														onBlur={field.onBlur}
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								)}
 								<FormField
 									control={form.control}
 									name="allowed_extra_headers"

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -30,7 +30,7 @@ function MCPClientActionsMenu({
 	hasUpdateAccess,
 	hasDeleteAccess,
 	isReconnecting,
-	isPerUserOAuth,
+	isPerUserAuth,
 	onReconnect,
 	onDelete,
 }: {
@@ -38,7 +38,7 @@ function MCPClientActionsMenu({
 	hasUpdateAccess: boolean;
 	hasDeleteAccess: boolean;
 	isReconnecting: boolean;
-	isPerUserOAuth: boolean;
+	isPerUserAuth: boolean;
 	onReconnect: (client: MCPClient) => void;
 	onDelete: (client: MCPClient) => void;
 }) {
@@ -61,7 +61,7 @@ function MCPClientActionsMenu({
 				{hasUpdateAccess && (
 					<DropdownMenuItem
 						className="cursor-pointer"
-						disabled={isPerUserOAuth || client.config.disabled || isReconnecting}
+						disabled={isPerUserAuth || client.config.disabled || isReconnecting}
 						onSelect={(e) => {
 							e.preventDefault();
 							onReconnect(client);
@@ -204,6 +204,8 @@ export default function MCPClientsTable({
 				return "OAuth";
 			case "per_user_oauth":
 				return "Per-user OAuth";
+			case "per_user_headers":
+				return "Per-user Headers";
 			default:
 				return type;
 		}
@@ -324,7 +326,11 @@ export default function MCPClientsTable({
 							</TableRow>
 						) : (
 							mcpClients.map((c: MCPClient) => {
-								const isPerUserOAuth = c.config.auth_type === "per_user_oauth";
+								// Per-user auth types (OAuth + headers) don't hold a shared
+								// upstream connection, so reconnect is a no-op for them — the
+								// backend's ReconnectClient rejects with ErrMCPReconnectNotApplicable.
+								const isPerUserAuth =
+									c.config.auth_type === "per_user_oauth" || c.config.auth_type === "per_user_headers";
 								const enabledToolsCount =
 									c.state == "connected"
 										? c.config.tools_to_execute?.includes("*")
@@ -389,7 +395,7 @@ export default function MCPClientsTable({
 												hasUpdateAccess={hasUpdateMCPClientAccess}
 												hasDeleteAccess={hasDeleteMCPClientAccess}
 												isReconnecting={reconnectingClients.includes(c.config.client_id)}
-												isPerUserOAuth={isPerUserOAuth}
+												isPerUserAuth={isPerUserAuth}
 												onReconnect={(client) => void handleReconnect(client)}
 												onDelete={setClientToDelete}
 											/>

--- a/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
@@ -1,0 +1,196 @@
+// MCPHeadersAuthorizer mirrors OAuth2Authorizer's UI/UX for the per-user-
+// headers create flow: same Dialog shell, same wording structure, same
+// state machine (confirm → input → testing → success/failed), same Cancel /
+// Continue affordances. The divergence is that the verify step is a values
+// form filled inline (no upstream redirect/popup), and the create call is
+// a single POST /api/mcp/client where the server runs verify + discover +
+// persist atomically. Mirrors per-user OAuth where the admin's temp access
+// token plays the analogous role.
+
+import HeadersForm from "@/components/headersForm";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { getErrorMessage, useCreateMCPClientMutation } from "@/lib/store";
+import { CreateMCPClientRequest } from "@/lib/types/mcp";
+import { Loader2 } from "lucide-react";
+import React, { useEffect, useRef, useState } from "react";
+
+interface MCPHeadersAuthorizerProps {
+	open: boolean;
+	onClose: () => void;
+	onSuccess: () => void;
+	onError: (error: string) => void;
+	// Full payload the parent has already assembled. The dialog adds
+	// user_headers (collected inline) and POSTs once.
+	payload: CreateMCPClientRequest;
+	// Required key schema, rendered as the form's input fields.
+	perUserHeaderKeys: string[];
+}
+
+type Status = "confirm" | "input" | "testing" | "success" | "failed";
+
+export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
+	open,
+	onClose,
+	onSuccess,
+	onError,
+	payload,
+	perUserHeaderKeys,
+}) => {
+	const [status, setStatus] = useState<Status>("confirm");
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	// Set to true when the user cancels so in-flight async callbacks do not
+	// invoke onSuccess / onError / onClose after the dialog is dismissed.
+	const cancelledRef = useRef(false);
+
+	const [createMCPClient] = useCreateMCPClientMutation();
+
+	// Reset state every time the dialog opens so a retry from a previous
+	// session doesn't carry over.
+	useEffect(() => {
+		if (open) {
+			setStatus("confirm");
+			setErrorMessage(null);
+			cancelledRef.current = false;
+		}
+	}, [open]);
+
+	const handleConfirm = () => {
+		setStatus("input");
+	};
+
+	const handleRunTest = async (values: Record<string, string>) => {
+		if (cancelledRef.current) return;
+		setStatus("testing");
+		try {
+			await createMCPClient({ ...payload, user_headers: values }).unwrap();
+			if (cancelledRef.current) return;
+			setStatus("success");
+			onSuccess();
+		} catch (err) {
+			if (cancelledRef.current) return;
+			const errMsg = getErrorMessage(err);
+			setStatus("failed");
+			setErrorMessage(errMsg);
+			onError(errMsg);
+		}
+	};
+
+	const handleRetry = () => {
+		setErrorMessage(null);
+		setStatus("input");
+	};
+
+	const handleCancel = () => {
+		cancelledRef.current = true;
+		onClose();
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) {
+					handleCancel();
+				}
+			}}
+		>
+			<DialogContent
+				className="sm:max-w-md"
+				onPointerDownOutside={(e) => {
+					e.preventDefault();
+					handleCancel();
+				}}
+				onEscapeKeyDown={(e) => {
+					e.preventDefault();
+					handleCancel();
+				}}
+			>
+				<DialogHeader>
+					<DialogTitle>{status === "confirm" ? "Test Header Configuration" : "Header Authorization"}</DialogTitle>
+					<DialogDescription>
+						{status === "confirm" && "A one-time test is needed to verify your header setup."}
+						{status === "input" && "Enter sample values to verify the connection."}
+						{status === "testing" && "Verifying connection..."}
+						{status === "success" && "Verification successful!"}
+						{status === "failed" && "Verification failed"}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex flex-col space-y-4">
+					{status === "confirm" && (
+						<>
+							<div className="text-muted-foreground space-y-3 text-sm">
+								<p>
+									To set up this MCP server, we need to verify that your header configuration is correct and discover the available tools.
+								</p>
+								<p>
+									You will be asked to provide sample values for the required headers. This is a <strong>one-time test</strong> to confirm the
+									setup works. Your sample values will <strong>not</strong> be stored or used for any other purpose.
+								</p>
+								<p>Once verified, each user will submit their own header values when they use this MCP server.</p>
+							</div>
+							<div className="flex w-full justify-end space-x-2">
+								<Button onClick={handleCancel} variant="outline" data-testid="per-user-headers-cancel">
+									Cancel
+								</Button>
+								<Button onClick={handleConfirm} data-testid="per-user-headers-confirm">
+									Continue with Test
+								</Button>
+							</div>
+						</>
+					)}
+
+					{status === "input" && (
+						<>
+							<p className="text-muted-foreground text-sm">
+								These values are used only for this verification. They are <strong>not</strong> persisted.
+							</p>
+							<HeadersForm
+								requiredKeys={perUserHeaderKeys}
+								onSubmit={handleRunTest}
+								submitLabel="Run Test"
+								onCancel={handleCancel}
+								testIdPrefix="per-user-headers-admin-test"
+							/>
+						</>
+					)}
+
+					{status === "testing" && (
+						<>
+							<div className="flex flex-col items-center space-y-2">
+								<Loader2 className="text-secondary-foreground h-4 w-4 animate-spin" />
+								<p className="text-muted-foreground text-sm">Verifying connection and discovering tools...</p>
+							</div>
+						</>
+					)}
+
+					{status === "success" && (
+						<div className="flex flex-col items-center space-y-2">
+							<div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+								<svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+								</svg>
+							</div>
+							<p className="text-sm text-green-600">MCP server connected successfully!</p>
+						</div>
+					)}
+
+					{status === "failed" && (
+						<div className="flex flex-col items-center space-y-2">
+							<div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+								<svg className="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+								</svg>
+							</div>
+							<p className="text-sm text-red-600">{errorMessage || "An error occurred"}</p>
+							<Button onClick={handleRetry} variant="outline" data-testid="mcp-headers-authorizer-retry-btn">
+								Retry
+							</Button>
+						</div>
+					)}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/ui/app/workspace/mcp-sessions/auth/page.tsx
+++ b/ui/app/workspace/mcp-sessions/auth/page.tsx
@@ -1,13 +1,25 @@
 // Auth landing route for inline-401 URLs returned by the inference path.
 //
-// The inference response embeds a frontend URL of the form
-//   {base}/workspace/mcp-sessions/auth?flow={flowId}
-// pointing here. The page fetches the pending flow's metadata, shows the
-// user what they're about to authenticate, and on "Authenticate" click
-// asks the backend for the upstream provider authorize URL and redirects
-// the browser to it. The upstream provider redirects back to
-// /api/oauth/callback which completes the flow server-side.
+// Both per-user-OAuth and per-user-headers flows land here. The URL shape
+// is identical except for the kind discriminator:
+//   - OAuth:   {base}/workspace/mcp-sessions/auth?flow={flowId}#t={token}
+//   - Headers: {base}/workspace/mcp-sessions/auth?flow={flowId}&kind=headers#t={token}
+//
+// The temp token in the URL fragment binds the page request to the flow ID,
+// letting anonymous browser visitors complete the flow without a dashboard
+// session. The page picks the right backend (oauth/per-user/flows vs
+// mcp/per-user-headers/flows) based on the kind param.
+//
+// - OAuth flow:    fetches pending flow metadata, on "Authenticate" click
+//                  requests the upstream authorize URL and redirects the
+//                  browser. Upstream redirects back to /api/oauth/callback
+//                  which completes the flow server-side.
+// - Headers flow:  fetches the same flow row plus the schema and renders
+//                  the values form, submitting back to the flow row's
+//                  PUT endpoint. The backend verifies upstream, upserts
+//                  the credential, and consumes the flow row + temp token.
 
+import HeadersForm from "@/components/headersForm";
 import FullPageLoader from "@/components/fullPageLoader";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -15,37 +27,55 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { getActiveTempToken } from "@/lib/store/apis/tempToken";
 import {
-  getErrorMessage,
-  useGetMCPFlowDetailQuery,
-  useIsAuthEnabledQuery,
-  useStartMCPFlowMutation,
+	getErrorMessage,
+	useGetMCPFlowDetailQuery,
+	useGetMCPPerUserHeadersFlowQuery,
+	useIsAuthEnabledQuery,
+	useStartMCPFlowMutation,
+	useSubmitMCPPerUserHeadersFlowMutation,
 } from "@/lib/store";
 import { MCPFlowDetail } from "@/lib/types/mcpSessions";
+import { MCPHeadersFlowDetail } from "@/lib/types/mcpPerUserHeaders";
 import { Link } from "@tanstack/react-router";
 import {
-  ExternalLink,
-  Fingerprint,
-  KeyRound,
-  Loader2,
+	CheckCircle2,
+	ExternalLink,
+	Fingerprint,
+	KeyRound,
+	Loader2,
   LogIn,
-  ShieldCheck,
+	ShieldCheck,
   TriangleAlert,
-  UserRound,
+	UserRound,
 } from "lucide-react";
 import { useQueryState } from "nuqs";
+import React from "react";
 import { useMemo, useState } from "react";
 
 export default function MCPSessionsAuthPage() {
-  const { toast } = useToast();
-  const [flowId] = useQueryState("flow");
-  const skip = !flowId;
-  const {
-    data: flow,
-    isLoading,
-    isError,
-    error,
-  } = useGetMCPFlowDetailQuery(flowId ?? "", { skip });
-  const [startFlow, { isLoading: starting }] = useStartMCPFlowMutation();
+	const [flowId] = useQueryState("flow");
+	const [kind] = useQueryState("kind");
+
+	// Both surfaces ride on ?flow={id}; `kind=headers` selects the headers
+	// backend. Default (no kind / kind=oauth) is the OAuth branch — keeps the
+	// OAuth URL shape unchanged.
+	if (kind === "headers" && flowId) {
+		return <HeadersAuthView flowId={flowId} />;
+	}
+	return <OAuthAuthView />;
+}
+
+function OAuthAuthView() {
+	const { toast } = useToast();
+	const [flowId] = useQueryState("flow");
+	const skip = !flowId;
+	const {
+		data: flow,
+		isLoading,
+		isError,
+		error,
+	} = useGetMCPFlowDetailQuery(flowId ?? "", { skip });
+	const [startFlow, { isLoading: starting }] = useStartMCPFlowMutation();
   const { data: authState } = useIsAuthEnabledQuery();
   const [usingTempToken] = useState(() => getActiveTempToken() !== null);
   const loginGoto = useMemo(() => {
@@ -68,127 +98,127 @@ export default function MCPSessionsAuthPage() {
   const showTempTokenSSOWarning =
     showLoginOption && authState.auth_type === "sso";
 
-  if (!flowId) {
-    return (
-      <CenteredCard>
-        <h1 className="text-xl font-semibold">Missing flow identifier</h1>
-        <p className="text-muted-foreground mt-2 text-sm">
-          This URL is missing the{" "}
-          <code className="bg-muted rounded px-1 py-0.5">flow</code> query
-          parameter. Open the link from your inference response or the sessions
-          tab.
-        </p>
-        <div className="mt-6">
-          <SessionsTabLink />
-        </div>
-      </CenteredCard>
-    );
-  }
+	if (!flowId) {
+		return (
+			<CenteredCard>
+				<h1 className="text-xl font-semibold">Missing flow identifier</h1>
+				<p className="text-muted-foreground mt-2 text-sm">
+					This URL is missing the{" "}
+					<code className="bg-muted rounded px-1 py-0.5">flow</code> query
+					parameter. Open the link from your inference response or the sessions
+					tab.
+				</p>
+				<div className="mt-6">
+					<SessionsTabLink />
+				</div>
+			</CenteredCard>
+		);
+	}
 
-  if (isLoading) {
-    return <FullPageLoader />;
-  }
+	if (isLoading) {
+		return <FullPageLoader />;
+	}
 
-  if (isError || !flow) {
-    const status = (error as { status?: number } | undefined)?.status;
-    if (status === 401) {
-      return <InvalidLinkView />;
-    }
-    if (status === 403) {
-      return (
-        <CenteredCard>
-          <h1 className="text-xl font-semibold">
-            This authentication flow isn't yours
-          </h1>
-          <p className="text-muted-foreground mt-2 text-sm">
-            The pending flow belongs to a different identity. Ask the teammate
-            whose VK or user identity triggered the original request to complete
-            it, or trigger a new request yourself.
-          </p>
-          <div className="mt-6">
-            <SessionsTabLink />
-          </div>
-        </CenteredCard>
-      );
-    }
-    if (status === 404) {
-      return (
-        <CenteredCard>
-          <h1 className="text-xl font-semibold">
-            This authentication flow has expired or been completed
-          </h1>
-          <p className="text-muted-foreground mt-2 text-sm">
-            Pending flows expire after a short window. If you still need to
-            authenticate, trigger the original action again so a fresh flow is
-            created.
-          </p>
-          <div className="mt-6">
-            <SessionsTabLink />
-          </div>
-        </CenteredCard>
-      );
-    }
-    return (
-      <CenteredCard>
-        <h1 className="text-xl font-semibold">
-          Could not load this authentication flow
-        </h1>
-        <p className="text-muted-foreground mt-2 text-sm">
-          {getErrorMessage(error)}
-        </p>
-      </CenteredCard>
-    );
-  }
+	if (isError || !flow) {
+		const status = (error as { status?: number } | undefined)?.status;
+		if (status === 401) {
+			return <InvalidLinkView />;
+		}
+		if (status === 403) {
+			return (
+				<CenteredCard>
+					<h1 className="text-xl font-semibold">
+						This authentication flow isn't yours
+					</h1>
+					<p className="text-muted-foreground mt-2 text-sm">
+						The pending flow belongs to a different identity. Ask the teammate
+						whose VK or user identity triggered the original request to complete
+						it, or trigger a new request yourself.
+					</p>
+					<div className="mt-6">
+						<SessionsTabLink />
+					</div>
+				</CenteredCard>
+			);
+		}
+		if (status === 404) {
+			return (
+				<CenteredCard>
+					<h1 className="text-xl font-semibold">
+						This authentication flow has expired or been completed
+					</h1>
+					<p className="text-muted-foreground mt-2 text-sm">
+						Pending flows expire after a short window. If you still need to
+						authenticate, trigger the original action again so a fresh flow is
+						created.
+					</p>
+					<div className="mt-6">
+						<SessionsTabLink />
+					</div>
+				</CenteredCard>
+			);
+		}
+		return (
+			<CenteredCard>
+				<h1 className="text-xl font-semibold">
+					Could not load this authentication flow
+				</h1>
+				<p className="text-muted-foreground mt-2 text-sm">
+					{getErrorMessage(error)}
+				</p>
+			</CenteredCard>
+		);
+	}
 
-  // Flow row exists but isn't pending: it's already been completed, failed,
-  // or expired. Don't show the "Authenticate" button since startFlow would
-  // reject (BuildUpstreamAuthorizeURL rejects non-pending flows).
-  if (flow.status !== "pending") {
-    return <CompletedFlowView flow={flow} />;
-  }
+	// Flow row exists but isn't pending: it's already been completed, failed,
+	// or expired. Don't show the "Authenticate" button since startFlow would
+	// reject (BuildUpstreamAuthorizeURL rejects non-pending flows).
+	if (flow.status !== "pending") {
+		return <CompletedFlowView flow={flow} />;
+	}
 
-  const handleAuthenticate = async () => {
-    try {
-      const res = await startFlow(flowId).unwrap();
-      window.location.href = res.authorize_url;
-    } catch (err) {
-      toast({
-        title: "Failed to start authentication",
-        description: getErrorMessage(err),
-        variant: "destructive",
-      });
-    }
-  };
+	const handleAuthenticate = async () => {
+		try {
+			const res = await startFlow(flowId).unwrap();
+			window.location.href = res.authorize_url;
+		} catch (err) {
+			toast({
+				title: "Failed to start authentication",
+				description: getErrorMessage(err),
+				variant: "destructive",
+			});
+		}
+	};
 
-  const mcpClientName =
-    flow.mcp_client?.name || flow.mcp_client?.client_id || "MCP server";
-  const isReauth = flow.has_active_token === true;
+	const mcpClientName =
+		flow.mcp_client?.name || flow.mcp_client?.client_id || "MCP server";
+	const isReauth = flow.has_active_token === true;
 
-  return (
-    <CenteredCard>
-      <div className="mb-5 flex size-12 items-center justify-center rounded-full bg-primary/10">
-        <ShieldCheck className="text-primary size-6" />
-      </div>
-      <h1 className="text-xl font-semibold tracking-tight">
-        {isReauth ? "Re-authenticate with" : "Authenticate with"}{" "}
-        {mcpClientName}
-      </h1>
-      <p className="text-muted-foreground mt-2 text-sm">
-        {isReauth ? (
-          <>
-            An active credential already exists for the binding below.
-            Completing this flow will <strong>replace</strong> it with a fresh
-            credential. You can also close this tab to keep using the existing
-            one.
-          </>
-        ) : (
-          <>
-            You'll be redirected to the provider to sign in and grant access.
-            Bifrost stores the resulting credential against the binding below so
-            this request and future ones can proceed automatically.
-          </>
-        )}
-      </p>
+	return (
+		<CenteredCard>
+			<div className="bg-primary/10 mb-5 flex size-12 items-center justify-center rounded-full">
+				<ShieldCheck className="text-primary size-6" />
+			</div>
+			<h1 className="text-xl font-semibold tracking-tight">
+				{isReauth ? "Re-authenticate with" : "Authenticate with"}{" "}
+				{mcpClientName}
+			</h1>
+			<p className="text-muted-foreground mt-2 text-sm">
+				{isReauth ? (
+					<>
+						An active credential already exists for the binding below.
+						Completing this flow will <strong>replace</strong> it with a fresh
+						credential. You can also close this tab to keep using the existing
+						one.
+					</>
+				) : (
+					<>
+						You'll be redirected to the provider to sign in and grant access.
+						Bifrost stores the resulting credential against the binding below so
+						this request and future ones can proceed automatically.
+					</>
+				)}
+			</p>
 
       {showTempTokenSSOWarning ? (
         <Alert variant="warning" className="mt-6">
@@ -216,29 +246,29 @@ export default function MCPSessionsAuthPage() {
         </Alert>
       ) : null}
 
-      <dl className="bg-muted/40 mt-6 space-y-3 rounded-sm border p-4 text-sm">
-        <DetailRow
-          label="MCP client"
-          value={mcpClientName}
-          mono={!flow.mcp_client?.name}
-        />
-        <DetailRow label="Bound to" value={<BindingValue flow={flow} />} />
-        <DetailRow label="Flow expires" value={formatExpiry(flow.expires_at)} />
-      </dl>
+			<dl className="bg-muted/40 mt-6 space-y-3 rounded-sm border p-4 text-sm">
+				<DetailRow
+					label="MCP client"
+					value={mcpClientName}
+					mono={!flow.mcp_client?.name}
+				/>
+				<DetailRow label="Bound to" value={<BindingValue flow={flow} />} />
+				<DetailRow label="Flow expires" value={formatExpiry(flow.expires_at)} />
+			</dl>
 
-      <div className="mt-6 flex gap-3">
-        <Button
-          onClick={handleAuthenticate}
-          disabled={starting}
-          data-testid="mcp-auth-authenticate-button"
-        >
-          {starting ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : (
-            <ExternalLink className="size-4" />
-          )}
-          <span>{isReauth ? "Re-authenticate" : "Authenticate"}</span>
-        </Button>
+			<div className="mt-6 flex gap-3">
+				<Button
+					onClick={handleAuthenticate}
+					disabled={starting}
+					data-testid="mcp-auth-authenticate-button"
+				>
+					{starting ? (
+						<Loader2 className="size-4 animate-spin" />
+					) : (
+						<ExternalLink className="size-4" />
+					)}
+					<span>{isReauth ? "Re-authenticate" : "Authenticate"}</span>
+				</Button>
         {showLoginOption && !showTempTokenSSOWarning ? (
           <Button
             asChild
@@ -251,152 +281,363 @@ export default function MCPSessionsAuthPage() {
             </a>
           </Button>
         ) : null}
-        <SessionsTabLink variant="ghost" />
-      </div>
-    </CenteredCard>
-  );
+				<SessionsTabLink variant="ghost" />
+			</div>
+		</CenteredCard>
+	);
+}
+
+// HeadersAuthView renders the per-user-headers submission form. Fetches the
+// pending flow row + schema from /api/mcp/per-user-headers/flows/{id},
+// renders one input per required key, PUTs the values back to the same flow
+// endpoint. On success the backend verifies upstream, upserts the credential
+// row, deletes the flow row + temp token, and we show a success card.
+function HeadersAuthView({ flowId }: { flowId: string }) {
+	const { toast } = useToast();
+	const [submitted, setSubmitted] = useQueryState("submitted");
+	// Skip the GET once the submit has completed — the backend deletes the
+	// flow row on success, so any refetch returns 404 and we'd render the
+	// "expired" view on top of a freshly successful submission.
+	const {
+		data: detail,
+		isLoading,
+		isError,
+		error,
+	} = useGetMCPPerUserHeadersFlowQuery(flowId, { skip: submitted === "true" });
+	const [submit, { isLoading: submitting }] =
+		useSubmitMCPPerUserHeadersFlowMutation();
+
+	if (submitted === "true") {
+		return (
+			<CenteredCard>
+				<div className="mb-5 flex size-12 items-center justify-center rounded-full bg-emerald-500/10">
+					<CheckCircle2 className="size-6 text-emerald-600" />
+				</div>
+				<h1 className="text-xl font-semibold tracking-tight">Headers saved</h1>
+				<p className="text-muted-foreground mt-2 text-sm">
+					Bifrost verified the connection and stored your credentials. You can
+					close this tab and retry the original action.
+				</p>
+				<div className="mt-6 flex gap-3">
+					<SessionsTabLink />
+				</div>
+			</CenteredCard>
+		);
+	}
+
+	if (isLoading) {
+		return <FullPageLoader />;
+	}
+
+	if (isError || !detail) {
+		const status = (error as { status?: number } | undefined)?.status;
+		if (status === 401) {
+			return <InvalidLinkView />;
+		}
+		// Enterprise RBAC middleware short-circuits flow endpoints with 403
+		// when the caller doesn't own the flow. Mirrors the OAuth branch above
+		// so headers flows get the same dedicated card instead of falling
+		// through to the generic load-failure state.
+		if (status === 403) {
+			return (
+				<CenteredCard>
+					<h1 className="text-xl font-semibold">
+						This submission flow isn't yours
+					</h1>
+					<p className="text-muted-foreground mt-2 text-sm">
+						The pending flow belongs to a different identity. Ask the teammate
+						whose VK or user identity triggered the original request to complete
+						it, or trigger a new request yourself.
+					</p>
+					<div className="mt-6">
+						<SessionsTabLink />
+					</div>
+				</CenteredCard>
+			);
+		}
+		if (status === 404 || status === 410) {
+			return (
+				<CenteredCard>
+					<h1 className="text-xl font-semibold">
+						This submission link has expired or been used
+					</h1>
+					<p className="text-muted-foreground mt-2 text-sm">
+						Submission flows expire after a short window. Trigger the original
+						request again to get a fresh link.
+					</p>
+					<div className="mt-6">
+						<SessionsTabLink />
+					</div>
+				</CenteredCard>
+			);
+		}
+		return (
+			<CenteredCard>
+				<h1 className="text-xl font-semibold">
+					Could not load this submission link
+				</h1>
+				<p className="text-muted-foreground mt-2 text-sm">
+					{getErrorMessage(error)}
+				</p>
+			</CenteredCard>
+		);
+	}
+
+	const handleSubmit = async (values: Record<string, string>) => {
+		try {
+			await submit({ flowId, body: { headers: values } }).unwrap();
+			void setSubmitted("true");
+		} catch (err) {
+			toast({
+				title: "Submission failed",
+				description: getErrorMessage(err),
+				variant: "destructive",
+			});
+		}
+	};
+
+	const mcpClientName =
+		detail.mcp_client?.name || detail.mcp_client?.client_id || "MCP server";
+	const isEdit = detail.has_active_credential;
+	const title = isEdit
+		? `Update credentials for ${mcpClientName}`
+		: `Submit credentials for ${mcpClientName}`;
+
+	return (
+		<CenteredCard>
+			<div className="bg-primary/10 mb-5 flex size-12 items-center justify-center rounded-full">
+				<ShieldCheck className="text-primary size-6" />
+			</div>
+			<h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+			<p className="text-muted-foreground mt-2 text-sm">
+				{isEdit ? (
+					<>
+						This server already has stored credentials for you. Submitting new
+						values <strong>replaces</strong> the existing entry; the server will
+						be re-verified before saving.
+					</>
+				) : (
+					<>
+						This server requires you to supply your own API keys / tokens. The
+						values you submit are stored encrypted and only used to authenticate
+						your own requests.
+					</>
+				)}
+			</p>
+
+			<dl className="bg-muted/40 mt-6 space-y-3 rounded-sm border p-4 text-sm">
+				<DetailRow
+					label="MCP client"
+					value={mcpClientName}
+					mono={!detail.mcp_client?.name}
+				/>
+				<DetailRow
+					label="Bound to"
+					value={<HeadersBindingValue flow={detail} />}
+				/>
+				<DetailRow
+					label="Flow expires"
+					value={formatExpiry(detail.expires_at)}
+				/>
+			</dl>
+
+			<div className="mt-6">
+				<HeadersForm
+					requiredKeys={detail.required_header_keys}
+					adminHeaderKeys={detail.admin_header_keys}
+					previouslySubmittedKeys={detail.submitted_keys}
+					onSubmit={handleSubmit}
+					busy={submitting}
+					submitLabel={isEdit ? "Save" : "Submit"}
+					testIdPrefix="mcp-headers-submit"
+				/>
+			</div>
+		</CenteredCard>
+	);
+}
+
+function HeadersBindingValue({ flow }: { flow: MCPHeadersFlowDetail }) {
+	if (flow.flow_mode === "user") {
+		const userID = flow.user_id;
+		if (!userID) {
+			return (
+				<span className="inline-flex items-center gap-2">
+					<UserRound className="text-muted-foreground size-3.5" />
+					<Badge variant="secondary">First signed-in user</Badge>
+				</span>
+			);
+		}
+		const displayName = flow.user?.name || flow.user?.email;
+		return (
+			<span className="inline-flex items-center gap-2">
+				<UserRound className="text-muted-foreground size-3.5" />
+				{displayName ? (
+					<span>{displayName}</span>
+				) : (
+					<span className="font-mono">{userID}</span>
+				)}
+			</span>
+		);
+	}
+	if (flow.flow_mode === "vk" && flow.virtual_key) {
+		return (
+			<span className="inline-flex items-center gap-2">
+				<KeyRound className="text-muted-foreground size-3.5" />
+				<span>{flow.virtual_key.name || flow.virtual_key.id}</span>
+			</span>
+		);
+	}
+	if (flow.flow_mode === "session" && flow.session_id) {
+		return (
+			<span className="inline-flex items-center gap-2">
+				<Fingerprint className="text-muted-foreground size-3.5" />
+				<span className="font-mono">{flow.session_id}</span>
+			</span>
+		);
+	}
+	return <span className="text-muted-foreground italic">Unknown</span>;
 }
 
 function CompletedFlowView({ flow }: { flow: MCPFlowDetail }) {
-  const mcpClientName =
-    flow.mcp_client?.name || flow.mcp_client?.client_id || "this MCP server";
-  // has_active_token wins over the flow's row status: a pending flow with an
-  // existing active token means OAuth was re-initiated unnecessarily.
-  const effectivelyAuthorized =
-    flow.status === "authorized" || flow.has_active_token;
-  const title = effectivelyAuthorized
-    ? "Already authenticated"
-    : flow.status === "expired"
-      ? "This authentication flow has expired"
-      : "This authentication flow can no longer be completed";
-  const body = effectivelyAuthorized
-    ? `The OAuth credential for ${mcpClientName} is already stored. You can close this tab.`
-    : "Trigger the original action again so a fresh flow is created.";
-  return (
-    <CenteredCard>
-      <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
-      <p className="text-muted-foreground mt-2 text-sm">{body}</p>
-      <dl className="bg-muted/40 mt-6 space-y-3 rounded-sm border p-4 text-sm">
-        <DetailRow
-          label="MCP client"
-          value={mcpClientName}
-          mono={!flow.mcp_client?.name}
-        />
-        <DetailRow label="Bound to" value={<BindingValue flow={flow} />} />
-      </dl>
-      <div className="mt-6">
-        <SessionsTabLink />
-      </div>
-    </CenteredCard>
-  );
+	const mcpClientName =
+		flow.mcp_client?.name || flow.mcp_client?.client_id || "this MCP server";
+	// has_active_token wins over the flow's row status: a pending flow with an
+	// existing active token means OAuth was re-initiated unnecessarily.
+	const effectivelyAuthorized =
+		flow.status === "authorized" || flow.has_active_token;
+	const title = effectivelyAuthorized
+		? "Already authenticated"
+		: flow.status === "expired"
+			? "This authentication flow has expired"
+			: "This authentication flow can no longer be completed";
+	const body = effectivelyAuthorized
+		? `The OAuth credential for ${mcpClientName} is already stored. You can close this tab.`
+		: "Trigger the original action again so a fresh flow is created.";
+	return (
+		<CenteredCard>
+			<h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+			<p className="text-muted-foreground mt-2 text-sm">{body}</p>
+			<dl className="bg-muted/40 mt-6 space-y-3 rounded-sm border p-4 text-sm">
+				<DetailRow
+					label="MCP client"
+					value={mcpClientName}
+					mono={!flow.mcp_client?.name}
+				/>
+				<DetailRow label="Bound to" value={<BindingValue flow={flow} />} />
+			</dl>
+			<div className="mt-6">
+				<SessionsTabLink />
+			</div>
+		</CenteredCard>
+	);
 }
 
 function DetailRow({
-  label,
-  value,
-  mono = false,
+	label,
+	value,
+	mono = false,
 }: {
-  label: string;
-  value: React.ReactNode;
-  mono?: boolean;
+	label: string;
+	value: React.ReactNode;
+	mono?: boolean;
 }) {
-  return (
-    <div className="flex items-start justify-between gap-4">
-      <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-        {label}
-      </dt>
-      <dd className={`text-right text-sm ${mono ? "font-mono" : ""}`}>
-        {value}
-      </dd>
-    </div>
-  );
+	return (
+		<div className="flex items-start justify-between gap-4">
+			<dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+				{label}
+			</dt>
+			<dd className={`text-right text-sm ${mono ? "font-mono" : ""}`}>
+				{value}
+			</dd>
+		</div>
+	);
 }
 
 function BindingValue({ flow }: { flow: MCPFlowDetail }) {
-  if (flow.flow_mode === "user") {
-    const userID = flow.user_id;
-    if (!userID) {
-      return (
-        <span className="inline-flex items-center gap-2">
-          <UserRound className="text-muted-foreground size-3.5" />
-          <Badge variant="secondary">First signed-in user</Badge>
-        </span>
-      );
-    }
-    const displayName = flow.user?.name || flow.user?.email;
-    return (
-      <span className="inline-flex items-center gap-2">
-        <UserRound className="text-muted-foreground size-3.5" />
-        {displayName ? (
-          <span>{displayName}</span>
-        ) : (
-          <span className="font-mono">{userID}</span>
-        )}
-      </span>
-    );
-  }
-  if (flow.flow_mode === "vk" && flow.virtual_key) {
-    return (
-      <span className="inline-flex items-center gap-2">
-        <KeyRound className="text-muted-foreground size-3.5" />
-        <span>{flow.virtual_key.name || flow.virtual_key.id}</span>
-      </span>
-    );
-  }
-  if (flow.flow_mode === "session" && flow.session_id) {
-    return (
-      <span className="inline-flex items-center gap-2">
-        <Fingerprint className="text-muted-foreground size-3.5" />
-        <span className="font-mono">{flow.session_id}</span>
-      </span>
-    );
-  }
-  return <span className="text-muted-foreground italic">Unknown</span>;
+	if (flow.flow_mode === "user") {
+		const userID = flow.user_id;
+		if (!userID) {
+			return (
+				<span className="inline-flex items-center gap-2">
+					<UserRound className="text-muted-foreground size-3.5" />
+					<Badge variant="secondary">First signed-in user</Badge>
+				</span>
+			);
+		}
+		const displayName = flow.user?.name || flow.user?.email;
+		return (
+			<span className="inline-flex items-center gap-2">
+				<UserRound className="text-muted-foreground size-3.5" />
+				{displayName ? (
+					<span>{displayName}</span>
+				) : (
+					<span className="font-mono">{userID}</span>
+				)}
+			</span>
+		);
+	}
+	if (flow.flow_mode === "vk" && flow.virtual_key) {
+		return (
+			<span className="inline-flex items-center gap-2">
+				<KeyRound className="text-muted-foreground size-3.5" />
+				<span>{flow.virtual_key.name || flow.virtual_key.id}</span>
+			</span>
+		);
+	}
+	if (flow.flow_mode === "session" && flow.session_id) {
+		return (
+			<span className="inline-flex items-center gap-2">
+				<Fingerprint className="text-muted-foreground size-3.5" />
+				<span className="font-mono">{flow.session_id}</span>
+			</span>
+		);
+	}
+	return <span className="text-muted-foreground italic">Unknown</span>;
 }
 
 function formatExpiry(iso: string): string {
-  try {
-    const t = new Date(iso).getTime();
-    if (Number.isNaN(t)) return iso;
-    const diffMs = t - Date.now();
-    if (diffMs < 0) return "Expired";
-    const mins = Math.floor(diffMs / 60_000);
-    if (mins < 1) return "in less than a minute";
-    if (mins === 1) return "in 1 minute";
-    return `in ${mins} minutes`;
-  } catch {
-    return iso;
-  }
+	try {
+		const t = new Date(iso).getTime();
+		if (Number.isNaN(t)) return iso;
+		const diffMs = t - Date.now();
+		if (diffMs < 0) return "Expired";
+		const mins = Math.floor(diffMs / 60_000);
+		if (mins < 1) return "in less than a minute";
+		if (mins === 1) return "in 1 minute";
+		return `in ${mins} minutes`;
+	} catch {
+		return iso;
+	}
 }
 
 function CenteredCard({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mx-auto flex min-h-[60vh] w-full max-w-xl items-center justify-center p-6">
-      <div className="bg-card w-full rounded-sm border p-8 shadow-sm">
-        {children}
-      </div>
-    </div>
-  );
+	return (
+		<div className="mx-auto flex min-h-[calc(100dvh-6rem)] w-full max-w-xl items-center justify-center p-6">
+			<div className="bg-card w-full rounded-sm border p-8 shadow-sm">
+				{children}
+			</div>
+		</div>
+	);
 }
 
 function SessionsTabLink({
-  variant = "outline",
+	variant = "outline",
 }: {
-  variant?: "outline" | "ghost";
+	variant?: "outline" | "ghost";
 }) {
-  // Hide the link only when the visitor has no dashboard session — for them,
-  // /workspace/mcp-sessions would 401 and bounce to /login. Admins (cookie
-  // present) still see it. ClientLayout already cached this query for the
-  // route, so this is a free hook call.
-  const { data: authState } = useIsAuthEnabledQuery();
-  if (authState?.is_auth_enabled && !authState.has_valid_token) {
-    return null;
-  }
-  return (
-    <Button asChild variant={variant} data-testid="mcp-auth-sessions-tab-link">
-      <Link to="/workspace/mcp-sessions">Open sessions tab</Link>
-    </Button>
-  );
+	// Hide the link only when the visitor has no dashboard session — for them,
+	// /workspace/mcp-sessions would 401 and bounce to /login. Admins (cookie
+	// present) still see it. ClientLayout already cached this query for the
+	// route, so this is a free hook call.
+	const { data: authState } = useIsAuthEnabledQuery();
+	if (authState?.is_auth_enabled && !authState.has_valid_token) {
+		return null;
+	}
+	return (
+		<Button asChild variant={variant} data-testid="mcp-auth-sessions-tab-link">
+			<Link to="/workspace/mcp-sessions">Open sessions tab</Link>
+		</Button>
+	);
 }
 
 // InvalidLinkView renders when the per-user-flow API returns 401, which now
@@ -406,16 +647,16 @@ function SessionsTabLink({
 // fragment was dropped along the way. Trigger the original action again to
 // get a fresh URL.
 function InvalidLinkView() {
-  return (
-    <CenteredCard>
-      <h1 className="text-xl font-semibold tracking-tight">
-        This authentication link is no longer valid
-      </h1>
-      <p className="text-muted-foreground mt-2 text-sm">
-        The link may have expired, been used already, invalid, or had its
-        short-lived token stripped. Trigger the original action again so a fresh
-        authentication link is created.
-      </p>
-    </CenteredCard>
-  );
+	return (
+		<CenteredCard>
+			<h1 className="text-xl font-semibold tracking-tight">
+				This authentication link is no longer valid
+			</h1>
+			<p className="text-muted-foreground mt-2 text-sm">
+				The link may have expired, been used already, invalid, or had its
+				short-lived token stripped. Trigger the original action again so a fresh
+				authentication link is created.
+			</p>
+		</CenteredCard>
+	);
 }

--- a/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
@@ -1,18 +1,21 @@
-// Base sessions table: renders token rows + pending flow rows visible to
-// the caller's identity. VK-keyed rows render directly with their VK ID;
-// user-keyed rows show the preloaded user.name (falling back to email,
-// then raw user_id). The `user` field is populated server-side by the
-// enterprise configstore wrapper; OSS leaves it absent and the UI falls
-// back to the raw ID.
+// Base sessions table: renders token rows + pending flow rows + per-user
+// header credential rows visible to the caller's identity. VK-keyed rows
+// render directly with their VK ID; user-keyed rows show the preloaded
+// user.name (falling back to email, then raw user_id). The `user` field
+// is populated server-side by the enterprise configstore wrapper; OSS
+// leaves it absent and the UI falls back to the raw ID.
 //
 // Status badges:
-//   active:       token row, usable
-//   orphaned:     token row; user lost their last granting VK. Credential
-//                 still alive upstream — auto-reactivates when access is
-//                 restored. Re-auth wouldn't help so the action is hidden.
+//   active:       token / header row, usable
+//   orphaned:     credential row (token or header); caller lost their last
+//                 granting VK. Credential still intact — auto-reactivates
+//                 when access is restored. Re-auth / edit wouldn't help so
+//                 the corresponding action is hidden.
 //   needs_reauth: token row; upstream credential dead (refresh failed).
 //                 Re-auth required.
-//   pending:      flow row, user must complete authentication.
+//   needs_update: header row; admin changed the PerUserHeaderKeys schema.
+//                 Caller must resubmit values.
+//   pending:      flow row, user must complete OAuth authentication.
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -34,7 +37,7 @@ import { Info } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useReauthMCPSessionMutation, useRevokeMCPSessionMutation } from "@/lib/store";
 import { MCPSessionRow } from "@/lib/types/mcpSessions";
-import { ExternalLink, Fingerprint, KeyRound, Loader2, MoreHorizontal, RefreshCcw, Trash2, UserRound } from "lucide-react";
+import { ExternalLink, Fingerprint, KeyRound, Loader2, MoreHorizontal, Pencil, RefreshCcw, Trash2, UserRound } from "lucide-react";
 import { useState } from "react";
 
 interface SessionsTableProps {
@@ -46,14 +49,17 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 	const [reauth, { isLoading: reauthing }] = useReauthMCPSessionMutation();
 	const [revoke, { isLoading: revoking }] = useRevokeMCPSessionMutation();
 	const [pendingDelete, setPendingDelete] = useState<MCPSessionRow | null>(null);
+	const [pendingActionRowId, setPendingActionRowId] = useState<string | null>(null);
 
 	const handleReauth = async (row: MCPSessionRow) => {
+		setPendingActionRowId(row.id);
 		try {
 			const res = await reauth(row.id).unwrap();
 			// Open the upstream authorize URL. User completes there, then
 			// is redirected back to /api/oauth/callback by the provider.
 			window.location.href = res.authorize_url;
 		} catch (err) {
+			setPendingActionRowId(null);
 			toast({ title: "Re-authentication failed", description: getErrorMessage(err), variant: "destructive" });
 		}
 	};
@@ -62,11 +68,18 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 		if (!pendingDelete) return;
 		const row = pendingDelete;
 		setPendingDelete(null);
+		setPendingActionRowId(row.id);
 		try {
 			await revoke(row.id).unwrap();
-			toast({ title: "Session revoked" });
+			toast({ title: row.kind === "header" ? "Header values revoked" : "Session revoked" });
 		} catch (err) {
-			toast({ title: "Failed to revoke session", description: getErrorMessage(err), variant: "destructive" });
+			toast({
+				title: row.kind === "header" ? "Failed to revoke header values" : "Failed to revoke session",
+				description: getErrorMessage(err),
+				variant: "destructive",
+			});
+		} finally {
+			setPendingActionRowId(null);
 		}
 	};
 
@@ -75,11 +88,23 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 			<AlertDialog open={pendingDelete !== null} onOpenChange={(open) => !open && setPendingDelete(null)}>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Revoke this MCP session?</AlertDialogTitle>
-						<AlertDialogDescription>
-							Bifrost will attempt to revoke the upstream OAuth token and remove the stored credential. Anyone using this binding
-							will need to re-authenticate.
-						</AlertDialogDescription>
+						{pendingDelete?.kind === "header" ? (
+							<>
+								<AlertDialogTitle>Revoke these stored header values?</AlertDialogTitle>
+								<AlertDialogDescription>
+									Bifrost will remove the stored credential values for this binding. There is no upstream token to revoke; the user will
+									need to resubmit their header values to use this MCP again.
+								</AlertDialogDescription>
+							</>
+						) : (
+							<>
+								<AlertDialogTitle>Revoke this MCP session?</AlertDialogTitle>
+								<AlertDialogDescription>
+									Bifrost will remove the stored credential for this binding. The upstream OAuth token is not revoked at the provider — it
+									stays detached and expires naturally. Anyone using this binding will need to re-authenticate to obtain a fresh token.
+								</AlertDialogDescription>
+							</>
+						)}
 					</AlertDialogHeader>
 					<AlertDialogFooter>
 						<AlertDialogCancel data-testid="mcp-session-revoke-cancel">Cancel</AlertDialogCancel>
@@ -94,7 +119,7 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">MCP Auth Sessions</h2>
 					<p className="text-muted-foreground text-sm">
-						Per-user OAuth tokens stored for MCP servers, plus any pending authentication flows.
+						Per-user credentials stored for MCP servers (OAuth tokens and submitted headers), plus any pending authentication flows.
 					</p>
 				</div>
 			</div>
@@ -106,20 +131,26 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 							<TableHead>MCP Client</TableHead>
 							<TableHead>
 								<HeaderWithTooltip
+									label="Type"
+									tooltip="OAuth: per-user OAuth token stored after the user completed an upstream sign-in flow. Headers: per-user header values (API keys / signed tokens) submitted directly. Pending: an authentication flow that has not yet completed."
+								/>
+							</TableHead>
+							<TableHead>
+								<HeaderWithTooltip
 									label="Bound to"
-									tooltip="The identity this OAuth token is keyed to: an end user (via SSO), a virtual key (shared by anyone using that VK), or a client-issued session ID (asserted via the x-bf-mcp-session-id header)."
+									tooltip="The identity this credential is keyed to: an end user (via SSO), a virtual key (shared by anyone using that VK), or a client-issued session ID (asserted via the x-bf-mcp-session-id header)."
 								/>
 							</TableHead>
 							<TableHead>
 								<HeaderWithTooltip
 									label="Status"
-									tooltip="Active: credential valid and usable. Pending: OAuth flow in progress, user must complete sign-in. Needs re-auth: upstream credential expired or revoked at the provider; user must reconnect. Orphaned: the user lost access to this MCP (e.g. an access profile change); credential is preserved and will become Active automatically if access is restored. Re-auth doesn't help an orphaned row."
+									tooltip="Active: credential valid and usable. Pending: OAuth flow in progress, user must complete sign-in. Needs re-auth: upstream credential expired or revoked at the provider; user must reconnect. Needs update: the admin changed the required header keys; user must resubmit. Orphaned: the user lost access to this MCP (e.g. an access profile change); credential is preserved and will become Active automatically if access is restored."
 								/>
 							</TableHead>
 							<TableHead>
 								<HeaderWithTooltip
 									label="Access token expiry"
-									tooltip="When the current access token expires. Bifrost auto-refreshes using the refresh token on the next request, so an active row past its expiry will silently mint a new token at use time."
+									tooltip="When the current access token expires. Bifrost auto-refreshes using the refresh token on the next request, so an active row past its expiry will silently mint a new token at use time. Header rows do not have an upstream expiry; their values stay valid until revoked or the schema changes."
 								/>
 							</TableHead>
 							<TableHead>Created</TableHead>
@@ -129,9 +160,10 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 					<TableBody>
 						{sessions.length === 0 ? (
 							<TableRow>
-								<TableCell colSpan={6} className="h-24 text-center">
+								<TableCell colSpan={7} className="h-24 text-center">
 									<span className="text-muted-foreground text-sm">
-										No sessions yet. Sessions appear here when an inference request or MCP gateway call triggers per-user OAuth.
+										No sessions yet. Sessions appear here when an inference request or MCP gateway call triggers per-user authentication
+										(OAuth or header submission).
 									</span>
 								</TableCell>
 							</TableRow>
@@ -139,6 +171,9 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 							sessions.map((row) => (
 								<TableRow key={`${row.kind}-${row.id}`} className="group">
 									<TableCell className="font-medium">{row.mcp_client?.name || row.mcp_client?.client_id || "-"}</TableCell>
+									<TableCell>
+										<TypeBadge kind={row.kind} />
+									</TableCell>
 									<TableCell>
 										<BindingCell row={row} />
 									</TableCell>
@@ -148,9 +183,7 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 									<TableCell className="text-muted-foreground text-sm">
 										<div className="flex flex-col">
 											<span>{formatAccessExpiry(row)}</span>
-											{row.last_refreshed_at ? (
-												<span className="text-xs">refreshed {formatRelativePast(row.last_refreshed_at)}</span>
-											) : null}
+											{row.last_refreshed_at && <span className="text-xs">refreshed {formatRelativePast(row.last_refreshed_at)}</span>}
 										</div>
 									</TableCell>
 									<TableCell className="text-muted-foreground text-sm">{formatRelativePast(row.created_at)}</TableCell>
@@ -161,6 +194,7 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 											row={row}
 											reauthing={reauthing}
 											revoking={revoking}
+											isPendingRow={pendingActionRowId === row.id}
 											onReauth={() => handleReauth(row)}
 											onRevoke={() => setPendingDelete(row)}
 										/>
@@ -182,7 +216,7 @@ function HeaderWithTooltip({ label, tooltip }: { label: string; tooltip: string 
 				<TooltipTrigger asChild>
 					<span className="inline-flex cursor-help items-center gap-2">
 						{label}
-						<Info className="size-3 text-muted-foreground" />
+						<Info className="text-muted-foreground size-3" />
 					</span>
 				</TooltipTrigger>
 				<TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
@@ -196,7 +230,7 @@ function BindingCell({ row }: { row: MCPSessionRow }) {
 		const displayName = row.user?.name || row.user?.email;
 		return (
 			<div className="flex items-center gap-1.5 text-sm">
-				<UserRound className="size-3.5 text-muted-foreground" />
+				<UserRound className="text-muted-foreground size-3.5" />
 				{displayName ? <span>{displayName}</span> : <span className="font-mono">{row.user_id}</span>}
 			</div>
 		);
@@ -204,7 +238,7 @@ function BindingCell({ row }: { row: MCPSessionRow }) {
 	if (row.auth_mode === "vk" && row.virtual_key) {
 		return (
 			<div className="flex items-center gap-1.5 text-sm">
-				<KeyRound className="size-3.5 text-muted-foreground" />
+				<KeyRound className="text-muted-foreground size-3.5" />
 				<span>{row.virtual_key.name || row.virtual_key.id}</span>
 			</div>
 		);
@@ -212,12 +246,22 @@ function BindingCell({ row }: { row: MCPSessionRow }) {
 	if (row.auth_mode === "session" && row.session_id) {
 		return (
 			<div className="flex items-center gap-1.5 text-sm">
-				<Fingerprint className="size-3.5 text-muted-foreground" />
+				<Fingerprint className="text-muted-foreground size-3.5" />
 				<span className="font-mono">{row.session_id}</span>
 			</div>
 		);
 	}
-	return <span className="text-sm text-muted-foreground">Session-bound</span>;
+	return <span className="text-muted-foreground text-sm">Session-bound</span>;
+}
+
+function TypeBadge({ kind }: { kind: string }) {
+	if (kind === "flow") {
+		return <Badge variant="secondary">Pending</Badge>;
+	}
+	if (kind === "header") {
+		return <Badge variant="outline">Headers</Badge>;
+	}
+	return <Badge variant="outline">OAuth</Badge>;
 }
 
 function StatusBadge({ status, kind }: { status: string; kind: string }) {
@@ -237,6 +281,11 @@ function StatusBadge({ status, kind }: { status: string; kind: string }) {
 	if (status === "needs_reauth") {
 		return <Badge variant="destructive">Needs re-auth</Badge>;
 	}
+	if (status === "needs_update") {
+		// Same destructive treatment as needs_reauth — user action required.
+		// Distinct copy so the row affordance ("Edit") matches.
+		return <Badge variant="destructive">Needs update</Badge>;
+	}
 	return <Badge>Active</Badge>;
 }
 
@@ -244,11 +293,12 @@ interface RowActionsProps {
 	row: MCPSessionRow;
 	reauthing: boolean;
 	revoking: boolean;
+	isPendingRow: boolean;
 	onReauth: () => void;
 	onRevoke: () => void;
 }
 
-function RowActions({ row, reauthing, revoking, onReauth, onRevoke }: RowActionsProps) {
+function RowActions({ row, reauthing, revoking, isPendingRow, onReauth, onRevoke }: RowActionsProps) {
 	const busy = reauthing || revoking;
 	return (
 		<DropdownMenu>
@@ -259,8 +309,9 @@ function RowActions({ row, reauthing, revoking, onReauth, onRevoke }: RowActions
 					className="h-8 w-8"
 					aria-label="MCP session actions"
 					data-testid={`mcp-session-row-actions-${row.id}`}
+					disabled={busy}
 				>
-					{busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
+					{busy && isPendingRow ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end">
@@ -269,7 +320,7 @@ function RowActions({ row, reauthing, revoking, onReauth, onRevoke }: RowActions
 						// The PKCE state on this flow row is dead; a fresh request to the
 						// MCP client will start a new flow. No action we can offer wires
 						// up to the existing flow row, so surface guidance instead.
-						<DropdownMenuItem disabled className="cursor-default text-xs text-muted-foreground">
+						<DropdownMenuItem disabled className="text-muted-foreground cursor-default text-xs">
 							Trigger a request to re-authenticate
 						</DropdownMenuItem>
 					) : (
@@ -278,13 +329,54 @@ function RowActions({ row, reauthing, revoking, onReauth, onRevoke }: RowActions
 							data-testid="mcp-session-complete-auth-menu-item"
 							onSelect={(e) => {
 								e.preventDefault();
-								window.location.href = `/workspace/mcp-sessions/auth?flow=${row.id}`;
+								// Header flows need &kind=headers so the auth landing page
+								// routes to the per-user-headers backend; OAuth flows use
+								// the default branch.
+								const url =
+									row.auth_kind === "headers"
+										? `/workspace/mcp-sessions/auth?flow=${row.id}&kind=headers`
+										: `/workspace/mcp-sessions/auth?flow=${row.id}`;
+								window.location.href = url;
 							}}
 						>
 							<ExternalLink className="h-4 w-4" />
 							Complete authentication
 						</DropdownMenuItem>
 					)
+				) : row.kind === "header" ? (
+					<>
+						{row.status !== "orphaned" && (
+							// "Edit values" hits reauth server-side: the handler mints a
+							// fresh header submission flow + temp token and returns the
+							// auth-landing URL. Same single-click → redirect dance as the
+							// OAuth row's "Re-authenticate" action.
+							<DropdownMenuItem
+								className="cursor-pointer"
+								disabled={busy}
+								data-testid="mcp-session-edit-headers-menu-item"
+								onSelect={(e) => {
+									e.preventDefault();
+									onReauth();
+								}}
+							>
+								<Pencil className="h-4 w-4" />
+								{row.status === "needs_update" ? "Update values" : "Edit values"}
+							</DropdownMenuItem>
+						)}
+						<DropdownMenuItem
+							variant="destructive"
+							className="cursor-pointer"
+							disabled={busy}
+							data-testid="mcp-session-revoke-menu-item"
+							onSelect={(e) => {
+								e.preventDefault();
+								onRevoke();
+							}}
+						>
+							<Trash2 className="h-4 w-4" />
+							Revoke
+						</DropdownMenuItem>
+					</>
 				) : (
 					<>
 						{row.status !== "orphaned" && (
@@ -293,7 +385,7 @@ function RowActions({ row, reauthing, revoking, onReauth, onRevoke }: RowActions
 							// granting VK. Surface guidance instead of an action.
 							<DropdownMenuItem
 								className="cursor-pointer"
-								disabled={reauthing}
+								disabled={busy}
 								data-testid="mcp-session-reauth-menu-item"
 								onSelect={(e) => {
 									e.preventDefault();
@@ -307,6 +399,7 @@ function RowActions({ row, reauthing, revoking, onReauth, onRevoke }: RowActions
 						<DropdownMenuItem
 							variant="destructive"
 							className="cursor-pointer"
+							disabled={busy}
 							data-testid="mcp-session-revoke-menu-item"
 							onSelect={(e) => {
 								e.preventDefault();
@@ -341,6 +434,13 @@ function formatRelativePast(iso: string): string {
 }
 
 function formatAccessExpiry(row: MCPSessionRow): string {
+	// Header rows don't have an upstream-side expiry — the submitted values
+	// are durable until the user revokes or the schema changes. The status
+	// column already conveys lifecycle state (Active / Needs update /
+	// Orphaned), so this column collapses to a dash for headers.
+	if (row.kind === "header") {
+		return "—";
+	}
 	if (!row.expires_at) return "-";
 	try {
 		const t = new Date(row.expires_at).getTime();

--- a/ui/components/headersForm.tsx
+++ b/ui/components/headersForm.tsx
@@ -1,0 +1,254 @@
+// Reusable form for the MCP per-user-headers flow.
+//
+// Two callers exercise this:
+//   - Admin-test panel (MCP client form): admin enters sample values for the
+//     PerUserHeaderKeys schema they just declared, hits "Test", and the
+//     backend verifies + discovers tools. Values are NOT persisted from
+//     this path.
+//   - User submission page (auth landing): authenticated caller submits
+//     their own values for an existing MCP client; backend verifies +
+//     upserts the credential row.
+//
+// Both share the same input shape: one labelled secret input per
+// requiredKey, an optional read-only display of admin-static header names
+// (so the user knows what static context will accompany their request),
+// optional prefill of previously-submitted key NAMES (never values), and
+// Test/Submit handlers.
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Eye, EyeOff, Info, Loader2 } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+
+export interface HeadersFormProps {
+	// Required keys — admin-declared, immutable in this form. Labels and
+	// input order follow array order.
+	requiredKeys: string[];
+	// Optional read-only context: admin-static header *names* (no values)
+	// that always accompany the caller's request. Surfaced so the user
+	// knows what shape the upstream will see; not editable here.
+	adminHeaderKeys?: string[];
+	// Names (not values) of keys the user has already submitted before.
+	// Used to render a "previously submitted" badge so the user knows which
+	// fields they're editing vs filling in fresh.
+	previouslySubmittedKeys?: string[];
+	// Optional "Test" handler. When provided, a Test button is rendered
+	// alongside Submit. Used by the admin-test panel.
+	onTest?: (values: Record<string, string>) => Promise<void> | void;
+	// Submit handler. Required.
+	onSubmit: (values: Record<string, string>) => Promise<void> | void;
+	// Disable all inputs + buttons (e.g. during network calls).
+	busy?: boolean;
+	// Label override for the Submit button (e.g. "Save" vs "Submit").
+	submitLabel?: string;
+	// Label override for the Test button.
+	testLabel?: string;
+	// Optional starting values for each key. Used by neither caller right
+	// now (we never round-trip secrets to the client), but kept for future
+	// reveal flows.
+	initialValues?: Record<string, string>;
+	// Optional "data-testid" prefix so tests can target individual inputs.
+	testIdPrefix?: string;
+	// When true, the Submit button is not rendered. Used by the admin-test
+	// panel inside the MCP client form — commit happens via the parent
+	// form's main button, so a per-form submit here would be misleading.
+	hideSubmit?: boolean;
+	// Optional Cancel handler. When provided, a Cancel button is rendered
+	// in the same row as Test/Submit so the dialog's two buttons share one
+	// flex row instead of stacking.
+	onCancel?: () => void;
+	cancelLabel?: string;
+}
+
+export default function HeadersForm({
+	requiredKeys,
+	adminHeaderKeys,
+	previouslySubmittedKeys,
+	onTest,
+	onSubmit,
+	busy = false,
+	submitLabel = "Submit",
+	testLabel = "Test",
+	initialValues,
+	testIdPrefix = "headers-form",
+	hideSubmit = false,
+	onCancel,
+	cancelLabel = "Cancel",
+}: HeadersFormProps) {
+	const [values, setValues] = useState<Record<string, string>>(() => buildInitialValues(requiredKeys, initialValues));
+	const [reveal, setReveal] = useState<Record<string, boolean>>({});
+
+	// If the schema changes mid-form (e.g. admin adds a key), reset state
+	// so we don't leak stale entries for removed keys.
+	useEffect(() => {
+		setValues((prev) => syncValuesToSchema(prev, requiredKeys, initialValues));
+	}, [requiredKeys, initialValues]);
+
+	const previouslySubmittedSet = useMemo(() => new Set(previouslySubmittedKeys ?? []), [previouslySubmittedKeys]);
+
+	const canSubmit = useMemo(
+		() => requiredKeys.every((k) => previouslySubmittedSet.has(k) || (values[k] ?? "").trim() !== ""),
+		[previouslySubmittedSet, requiredKeys, values],
+	);
+
+	const handleChange = (key: string, value: string) => {
+		setValues((prev) => ({ ...prev, [key]: value }));
+	};
+
+	// canSubmit is computed via Array.every() which returns true for an
+	// empty array — so an empty schema (requiredKeys.length === 0) would
+	// satisfy the "all filled" check. Both handlers must explicitly guard
+	// against the empty-schema case; the Submit button already does via
+	// disabled state but Test does not, and an Enter-key submit would
+	// otherwise fire onSubmit with no values.
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		if (requiredKeys.length === 0 || !canSubmit || busy) return;
+		await onSubmit(buildSubmissionValues(requiredKeys, values, previouslySubmittedSet));
+	};
+
+	const handleTest = async () => {
+		if (!onTest || requiredKeys.length === 0 || !canSubmit || busy) return;
+		await onTest(buildSubmissionValues(requiredKeys, values, previouslySubmittedSet));
+	};
+
+	return (
+		<form onSubmit={handleSubmit} className="space-y-4">
+			{adminHeaderKeys && adminHeaderKeys.length > 0 && (
+				<div className="border-muted-foreground/20 bg-muted/40 rounded-md border p-3">
+					<div className="flex items-center gap-1.5">
+						<p className="text-muted-foreground text-xs font-medium">Static admin headers</p>
+						<TooltipProvider>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Info className="text-muted-foreground size-3" />
+								</TooltipTrigger>
+								<TooltipContent className="max-w-xs">
+									<p>
+										These headers are set by the admin on the MCP client and accompany every request alongside your submitted values. You
+										can&apos;t edit them here.
+									</p>
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+					</div>
+					<div className="mt-2 flex flex-wrap gap-1.5">
+						{adminHeaderKeys.map((name) => (
+							<code key={name} className="bg-background rounded px-1.5 py-0.5 font-mono text-xs">
+								{name}
+							</code>
+						))}
+					</div>
+				</div>
+			)}
+
+			<div className="space-y-3">
+				{requiredKeys.length === 0 ? (
+					<p className="text-muted-foreground text-sm">No header keys have been declared on this MCP client.</p>
+				) : (
+					requiredKeys.map((key) => {
+						const isRevealed = reveal[key] === true;
+						const wasSubmitted = previouslySubmittedSet.has(key);
+						return (
+							<div key={key} className="space-y-1.5">
+								<div className="flex items-center justify-between gap-2">
+									<Label htmlFor={`${testIdPrefix}-${key}`} className="font-mono text-xs">
+										{key}
+									</Label>
+									{wasSubmitted && <span className="text-muted-foreground text-xs">Previously submitted</span>}
+								</div>
+								<div className="relative">
+									<Input
+										id={`${testIdPrefix}-${key}`}
+										type={isRevealed ? "text" : "password"}
+										autoComplete="off"
+										value={values[key] ?? ""}
+										onChange={(e) => handleChange(key, e.target.value)}
+										placeholder={wasSubmitted ? "•••••• (enter new value to overwrite)" : `Value for ${key}`}
+										disabled={busy}
+										data-testid={`${testIdPrefix}-input-${key}`}
+									/>
+									<button
+										type="button"
+										onClick={() => setReveal((r) => ({ ...r, [key]: !r[key] }))}
+										className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+										aria-label={isRevealed ? "Hide value" : "Show value"}
+										data-testid={`${testIdPrefix}-reveal-${key}`}
+									>
+										{isRevealed ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+									</button>
+								</div>
+							</div>
+						);
+					})
+				)}
+			</div>
+
+			<div className="flex items-center justify-end gap-2 pt-2">
+				{onCancel && (
+					<Button type="button" variant="outline" onClick={onCancel} disabled={busy} data-testid={`${testIdPrefix}-cancel-btn`}>
+						{cancelLabel}
+					</Button>
+				)}
+				{onTest && (
+					<Button
+						type="button"
+						variant="outline"
+						onClick={handleTest}
+						disabled={!canSubmit || busy || requiredKeys.length === 0}
+						data-testid={`${testIdPrefix}-test-btn`}
+					>
+						{busy ? <Loader2 className="size-3.5 animate-spin" /> : null}
+						{testLabel}
+					</Button>
+				)}
+				{!hideSubmit && (
+					<Button type="submit" disabled={!canSubmit || busy || requiredKeys.length === 0} data-testid={`${testIdPrefix}-submit-btn`}>
+						{busy ? <Loader2 className="size-3.5 animate-spin" /> : null}
+						{submitLabel}
+					</Button>
+				)}
+			</div>
+		</form>
+	);
+}
+
+function buildSubmissionValues(
+	keys: string[],
+	values: Record<string, string>,
+	previouslySubmittedSet: Set<string>,
+): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const k of keys) {
+		const value = values[k] ?? "";
+		if (value.trim() !== "" || !previouslySubmittedSet.has(k)) {
+			out[k] = value;
+		}
+	}
+	return out;
+}
+
+function buildInitialValues(keys: string[], initial?: Record<string, string>): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const k of keys) {
+		out[k] = initial?.[k] ?? "";
+	}
+	return out;
+}
+
+// syncValuesToSchema preserves user-entered values for keys that still
+// exist in the new schema, drops values for removed keys, and seeds blank
+// entries for newly added keys.
+function syncValuesToSchema(prev: Record<string, string>, keys: string[], initial?: Record<string, string>): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const k of keys) {
+		if (k in prev) {
+			out[k] = prev[k];
+		} else {
+			out[k] = initial?.[k] ?? "";
+		}
+	}
+	return out;
+}

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -188,6 +188,7 @@ export const baseApi = createApi({
     "PromptDeployments",
     "AuthType",
     "MCPSessions",
+    "MCPPerUserHeaderCredentials",
     "FeatureFlags",
   ],
   endpoints: () => ({}),

--- a/ui/lib/store/apis/index.ts
+++ b/ui/lib/store/apis/index.ts
@@ -9,6 +9,7 @@ export * from "./governanceApi";
 export * from "./logsApi";
 export * from "./mcpApi";
 export * from "./mcpLogsApi";
+export * from "./mcpPerUserHeadersApi";
 export * from "./mcpSessionsApi";
 export * from "./pluginsApi";
 export * from "./providersApi";

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -2,7 +2,6 @@ import {
 	CreateMCPClientRequest,
 	GetMCPClientsParams,
 	GetMCPClientsResponse,
-	MCPClient,
 	OAuthFlowResponse,
 	OAuthStatusResponse,
 	UpdateMCPClientRequest,
@@ -75,6 +74,7 @@ export const mcpApi = baseApi.injectEndpoints({
 									if (data.name !== undefined) draft.clients[index].config.name = data.name;
 									if (data.is_code_mode_client !== undefined) draft.clients[index].config.is_code_mode_client = data.is_code_mode_client;
 									if (data.headers !== undefined) draft.clients[index].config.headers = data.headers;
+									if (data.per_user_header_keys !== undefined) draft.clients[index].config.per_user_header_keys = data.per_user_header_keys;
 									if (data.tools_to_execute !== undefined) draft.clients[index].config.tools_to_execute = data.tools_to_execute;
 									if (data.tools_to_auto_execute !== undefined)
 										draft.clients[index].config.tools_to_auto_execute = data.tools_to_auto_execute;

--- a/ui/lib/store/apis/mcpPerUserHeadersApi.ts
+++ b/ui/lib/store/apis/mcpPerUserHeadersApi.ts
@@ -1,0 +1,56 @@
+// RTK Query endpoints for the MCP per-user headers credential flow.
+// Mirrors the backend handler in transports/bifrost-http/handlers/mcp_per_user_headers.go.
+
+import {
+	MCPHeadersFlowDetail,
+	MCPPerUserHeadersSubmitRequest,
+	MCPPerUserHeadersSubmitResponse,
+} from "@/lib/types/mcpPerUserHeaders";
+import { baseApi } from "./baseApi";
+
+export const mcpPerUserHeadersApi = baseApi.injectEndpoints({
+	endpoints: (builder) => ({
+		// Flow detail: pending headers-submission flow row metadata + the
+		// schema the form needs. Authorization on the backend accepts either
+		// a dashboard session OR the mcp_headers_auth temp token bound to
+		// {flowId} (carried in the URL fragment by the auth page).
+		getMCPPerUserHeadersFlow: builder.query<MCPHeadersFlowDetail, string>({
+			query: (flowID) => ({ url: `/mcp/per-user-headers/flows/${flowID}` }),
+			providesTags: (_result, _err, id) => [{ type: "MCPPerUserHeaderCredentials", id }],
+		}),
+
+		// Submit caller-supplied header values for a pending flow row.
+		// Backend verifies upstream + upserts the credential + consumes
+		// (deletes) the flow row and its temp token. Invalidates the sessions
+		// list so UI surfaces the fresh credential row immediately.
+		submitMCPPerUserHeadersFlow: builder.mutation<
+			MCPPerUserHeadersSubmitResponse,
+			{ flowId: string; body: MCPPerUserHeadersSubmitRequest }
+		>({
+			query: ({ flowId, body }) => ({
+				url: `/mcp/per-user-headers/flows/${flowId}`,
+				method: "PUT",
+				body,
+			}),
+			invalidatesTags: (_result, _err, arg) => [
+				"MCPSessions",
+				{ type: "MCPPerUserHeaderCredentials", id: arg.flowId },
+			],
+		}),
+
+		// Revoke a single credential row by primary key. The sessions tab uses
+		// the unified /api/mcp/sessions/{id} DELETE which falls back to header
+		// credential lookup on OAuth miss — this typed endpoint exists for
+		// callers that already know they're acting on a header row.
+		revokeMCPPerUserHeaders: builder.mutation<void, string>({
+			query: (credentialID) => ({ url: `/mcp/per-user-headers/credential/${credentialID}`, method: "DELETE" }),
+			invalidatesTags: ["MCPSessions"],
+		}),
+	}),
+});
+
+export const {
+	useGetMCPPerUserHeadersFlowQuery,
+	useSubmitMCPPerUserHeadersFlowMutation,
+	useRevokeMCPPerUserHeadersMutation,
+} = mcpPerUserHeadersApi;

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -5,7 +5,16 @@ export type MCPConnectionType = "http" | "stdio" | "sse";
 
 export type MCPConnectionState = "connected" | "disconnected" | "error" | "pending_tools" | "disabled";
 
-export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth";
+export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth" | "per_user_headers";
+
+// Lifecycle states for a per-user MCP header credential row. Mirrors the
+// status column on mcp_per_user_header_credentials.
+//   - active:       caller-submitted, usable
+//   - orphaned:     caller lost access via VK reassignment; auto-reactivates
+//                   if access is regained
+//   - needs_update: admin changed the PerUserHeaderKeys schema; caller must
+//                   resubmit values
+export type MCPHeadersUserCredentialStatus = "active" | "orphaned" | "needs_update";
 
 export type { EnvVar };
 
@@ -45,6 +54,11 @@ export interface MCPClientConfig {
 	tools_to_execute?: string[];
 	tools_to_auto_execute?: string[];
 	headers?: Record<string, EnvVar>;
+	// per_user_header_keys: admin-declared header *names* that each caller
+	// must supply when auth_type === "per_user_headers". Values live per-user
+	// in the credential store, not on the client config. Required (non-empty)
+	// for per_user_headers auth; ignored for all other auth types.
+	per_user_header_keys?: string[];
 	is_ping_available?: boolean;
 	tool_pricing?: Record<string, number>;
 	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
@@ -77,6 +91,14 @@ export interface CreateMCPClientRequest {
 	tools_to_execute?: string[];
 	tools_to_auto_execute?: string[];
 	headers?: Record<string, EnvVar>;
+	// per_user_headers-only: admin-declared header schema (names only).
+	per_user_header_keys?: string[];
+	// per_user_headers-only: a sample set of header values supplied by the
+	// admin so the server can verify upstream + discover tools in the same
+	// create call. Discarded after verification (never persisted). Mirrors
+	// the per-user OAuth flow where the admin's temp access token plays
+	// the analogous role. Ignored for all other auth types.
+	user_headers?: Record<string, string>;
 	is_ping_available?: boolean;
 }
 
@@ -108,6 +130,11 @@ export interface UpdateMCPClientRequest {
 	name?: string;
 	is_code_mode_client?: boolean;
 	headers?: Record<string, EnvVar>;
+	// Set to a new list (including empty) to replace per-user-headers schema.
+	// Omitted = preserve existing. When this list changes against the stored
+	// value, the backend flips all existing user credential rows to
+	// 'needs_update' so callers re-submit on next tool use.
+	per_user_header_keys?: string[];
 	tools_to_execute?: string[];
 	tools_to_auto_execute?: string[];
 	is_ping_available?: boolean;

--- a/ui/lib/types/mcpPerUserHeaders.ts
+++ b/ui/lib/types/mcpPerUserHeaders.ts
@@ -1,0 +1,62 @@
+// Types for the MCP per-user headers credential flow.
+// Mirrors the wire shapes in transports/bifrost-http/handlers/mcp_per_user_headers.go.
+//
+// Admin verification + tool discovery happen inline on POST /api/mcp/client
+// (see CreateMCPClientRequest.user_headers); this module only carries the
+// end-user submission types.
+import { MCPHeadersUserCredentialStatus } from "./mcp";
+import {
+	AuthMode,
+	MCPClientSummary,
+	UserSummary,
+	VirtualKeySummary,
+} from "./mcpSessions";
+
+// MCPHeadersUserCredentialStatus is exported from mcp.ts so the sessions
+// table can switch on it. Re-exported here for clarity from the headers-
+// specific module.
+export type { MCPHeadersUserCredentialStatus };
+
+// Submit request body for PUT /api/mcp/per-user-headers/flows/{id}. The
+// flow row identifies the (mode, identity, mcp_client) triple, so the
+// caller doesn't carry any of those on the body — just the values.
+// Extra keys are dropped server-side against the live PerUserHeaderKeys
+// schema, so stale UI submissions can't persist deprecated keys.
+export interface MCPPerUserHeadersSubmitRequest {
+	headers: Record<string, string>;
+}
+
+export interface MCPPerUserHeadersSubmitResponse {
+	status: "success";
+	credential_id: string;
+	updated_at: string;
+}
+
+// Flow detail for GET /api/mcp/per-user-headers/flows/{id}. Mirrors
+// MCPFlowDetail on the OAuth side: identity binding for display + the
+// schema (required + admin key names) needed to render the submit form.
+// has_active_credential / submitted_keys are populated when the caller's
+// identity already has a stored credential — the page renders this as an
+// "edit existing" affordance.
+export interface MCPHeadersFlowDetail {
+	id: string;
+	flow_mode: AuthMode;
+	status: "pending" | "completed" | "expired";
+	mcp_client?: MCPClientSummary | null;
+	user_id?: string | null;
+	user?: UserSummary | null;
+	virtual_key?: VirtualKeySummary | null;
+	session_id?: string | null;
+	expires_at: string;
+	created_at: string;
+	required_header_keys: string[];
+	admin_header_keys?: string[];
+	submitted_keys?: string[];
+	has_active_credential: boolean;
+}
+
+// Local re-export so consumers don't need to import from mcp.ts directly.
+export type MCPHeadersFlowStatus = MCPHeadersFlowDetail["status"];
+
+// Retained alias for the credential status enum used by sessions table rows.
+export type { MCPHeadersUserCredentialStatus as _MCPHeadersUserCredentialStatus };

--- a/ui/lib/types/mcpSessions.ts
+++ b/ui/lib/types/mcpSessions.ts
@@ -3,7 +3,7 @@
 
 export type AuthMode = "user" | "vk" | "session";
 
-export type MCPSessionKind = "token" | "flow";
+export type MCPSessionKind = "token" | "flow" | "header";
 
 // Status values vary by Kind:
 //   token:  "active" | "orphaned" | "needs_reauth"
@@ -16,7 +16,13 @@ export type MCPSessionKind = "token" | "flow";
 //                       The list endpoint only returns pending flow rows;
 //                       "authorized" / "failed" / "expired" are filtered out
 //                       server-side and never reach the wire here.
-export type MCPSessionStatus = "active" | "orphaned" | "pending" | "needs_reauth";
+//   header: "active" | "orphaned" | "needs_update"
+//     - "active":       caller-submitted headers, usable
+//     - "orphaned":     parallel of OAuth orphaned (lost MCP access via VK
+//                       reassignment); reactivates if access is restored
+//     - "needs_update": admin changed the PerUserHeaderKeys schema; caller
+//                       must resubmit their values
+export type MCPSessionStatus = "active" | "orphaned" | "pending" | "needs_reauth" | "needs_update";
 
 export interface MCPClientSummary {
 	client_id: string;
@@ -40,6 +46,10 @@ export interface UserSummary {
 export interface MCPSessionRow {
 	id: string;
 	kind: MCPSessionKind;
+	// auth_kind disambiguates OAuth vs Headers within "flow" rows so the UI
+	// routes Complete-authentication to the correct landing-page kind. For
+	// "token" rows it's always "oauth"; for "header" rows always "headers".
+	auth_kind: "oauth" | "headers";
 	auth_mode: AuthMode;
 	user_id?: string | null;
 	user?: UserSummary | null;
@@ -50,6 +60,9 @@ export interface MCPSessionRow {
 	expires_at?: string | null;
 	created_at: string;
 	last_refreshed_at?: string | null;
+	// updated_at: header credential rows only — timestamp of the caller's
+	// last submission/edit. OAuth rows omit this field.
+	updated_at?: string | null;
 	oauth_config_id?: string;
 }
 
@@ -58,8 +71,15 @@ export interface MCPSessionsListResponse {
 }
 
 export interface MCPSessionReauthResponse {
+	// authorize_url is the URL the caller should redirect to. For OAuth rows
+	// it's the upstream authorize endpoint; for header credential rows it's
+	// the bifrost auth-landing page that serves the submission form.
 	authorize_url: string;
+	// submit_url is set on header re-auth and matches authorize_url; kept
+	// for callers that want to be explicit about the underlying surface.
+	submit_url?: string;
 	session_id: string;
+	kind?: "oauth" | "headers";
 }
 
 export interface MCPFlowDetail {

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -974,6 +974,17 @@ export const mcpClientUpdateSchema = z.object({
 			message: "Client name cannot start with a number",
 		}),
 	headers: z.record(z.string(), envVarSchema).optional().nullable(),
+	per_user_header_keys: z
+		.array(z.string().trim().min(1, "Header name cannot be empty"))
+		.optional()
+		.refine(
+			(headers) => {
+				if (!headers) return true;
+				const normalized = headers.map((h) => h.trim().toLowerCase());
+				return normalized.length === new Set(normalized).size;
+			},
+			{ message: "Duplicate header names are not allowed" },
+		),
 	tools_to_execute: z
 		.array(z.string())
 		.optional()


### PR DESCRIPTION
## Summary

Adds a **per-user headers** authentication type for MCP clients, mirroring the existing per-user OAuth flow. Admins declare a set of required header key names on the MCP client config; each end user then submits their own values (API keys, tokens, etc.) via a dedicated auth landing page. The backend verifies upstream connectivity and stores credentials encrypted per-user. This enables MCP servers that require caller-specific API keys without sharing a single set of credentials across all users.

## Changes

- **New `per_user_headers` auth type** added to `MCPAuthType`, `MCPClientConfig`, `CreateMCPClientRequest`, and `UpdateMCPClientRequest`. Admins declare required header key names via `per_user_header_keys`; user-submitted values are never stored on the client config.
- **`MCPHeadersAuthorizer` dialog** (`mcpHeadersAuthorizer.tsx`): mirrors `OAuth2Authorizer`'s state machine (confirm → input → testing → success/failed). On Create, the admin supplies sample values; the server verifies upstream, discovers tools, and persists atomically in a single POST. Nothing is committed if the user cancels or verification fails.
- **`HeadersForm` component** (`headersForm.tsx`): reusable secret-input form used by both the admin test panel and the end-user submission page. Renders one password input per required key, supports show/hide toggle, previously-submitted key badges, and optional read-only display of admin-static header names.
- **Auth landing page** (`mcp-sessions/auth/page.tsx`): split into `OAuthAuthView` and `HeadersAuthView`. The `kind=headers` query param routes to the headers branch. `HeadersAuthView` fetches the pending flow row and schema, renders `HeadersForm`, and PUTs values back to the flow endpoint. Handles 401/404/410 error states and a post-submit success card.
- **Sessions table** (`sessionsTable.tsx`): adds a `Type` column with `OAuth`, `Headers`, and `Pending` badges. Adds `needs_update` status badge for header rows whose schema has changed. Header rows show an "Edit values" / "Update values" action instead of "Re-authenticate". Reconnect is disabled for all per-user auth types (`isPerUserAuth` replaces `isPerUserOAuth`). Header rows display `—` in the access token expiry column.
- **RTK Query API** (`mcpPerUserHeadersApi.ts`): `getMCPPerUserHeadersFlow`, `submitMCPPerUserHeadersFlow`, and `revokeMCPPerUserHeaders` endpoints targeting `/api/mcp/per-user-headers/flows/{id}`.
- **Type definitions** (`mcpPerUserHeaders.ts`, `mcpSessions.ts`): `MCPHeadersFlowDetail`, `MCPPerUserHeadersSubmitRequest/Response`, `MCPHeadersUserCredentialStatus`, `MCPSessionKind` extended with `"header"`, `MCPSessionStatus` extended with `"needs_update"`, and `auth_kind` discriminator on `MCPSessionRow`.
- **MCP clients table**: `per_user_headers` auth type renders as "Per-user Headers" in the auth type display column.
- Minor copy fix: "MCP tool groups" heading capitalised to "MCP Tool Groups".

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
pnpm test
```

1. Navigate to **MCP Registry → Add Client**.
2. Select **Per-User Headers** as the auth type.
3. Enter comma-separated header key names (e.g. `X-API-Key, X-Tenant-ID`) in the Required Headers textarea.
4. Click **Create** — the `MCPHeadersAuthorizer` dialog opens.
5. Enter sample values and click **Run Test**. Verify the server connects, discovers tools, and the client appears in the registry.
6. As an end user, trigger a tool call that requires per-user headers. Confirm the auth landing page (`/workspace/mcp-sessions/auth?flow=...&kind=headers`) renders the submission form with the correct required keys.
7. Submit values and confirm the sessions table shows a `Headers` type row with `Active` status.
8. In the admin, change the `per_user_header_keys` schema. Confirm the existing credential row flips to `Needs update` and the "Update values" action appears.

## Screenshots/Recordings

_Add before/after screenshots of the MCP client form auth type selector, the `MCPHeadersAuthorizer` dialog, the auth landing page headers form, and the sessions table Type/Status columns._

## Breaking changes

- [x] No

`isPerUserOAuth` prop on `MCPClientActionsMenu` renamed to `isPerUserAuth` — internal component only, no external API surface affected.

## Related issues

## Security considerations

- Per-user header values (API keys, tokens) are submitted directly to the backend and stored encrypted in the credential store. Values are never round-tripped to the client after submission.
- Admin sample values supplied during the create-time verification step are discarded after the upstream connectivity check and are never persisted.
- The auth landing page accepts a temp token in the URL fragment (`#t=`) to bind anonymous browser visitors to a specific flow ID without requiring a dashboard session.
- Extra keys in user submissions are dropped server-side against the live `PerUserHeaderKeys` schema, preventing stale UI submissions from persisting deprecated keys.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable