### PR TITLE
adds cleanup flow for logging plugin

### DIFF
--- a/framework/logstore/asyncjob.go
+++ b/framework/logstore/asyncjob.go
@@ -161,7 +161,7 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 	}()
 
 	// Mark as processing
-	if err := e.logstore.UpdateAsyncJob(ctx, jobID, map[string]interface{}{
+	if err := e.logstore.UpdateAsyncJob(ctx, jobID, map[string]any{
 		"status": schemas.AsyncJobStatusProcessing,
 	}); err != nil {
 		e.logger.Warn("failed to update async job: %v", err)

--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -185,6 +185,11 @@ func (h *HybridLogStore) enqueueUpload(logID string, timestamp time.Time, payloa
 	h.enqueueRawUpload(logID, timestamp, ObjectKey(h.prefix, timestamp, logID), false, "", data, tags)
 }
 
+// enqueueRawUpload submits a pre-serialized payload to the upload queue.
+// Drops the upload (and increments droppedUploads) when the store is closed,
+// the data is empty, the in-flight byte budget would be exceeded, or the queue
+// is full. Used by both regular log uploads (via enqueueUpload) and MCP tool
+// log uploads, which already hold raw JSON bytes.
 func (h *HybridLogStore) enqueueRawUpload(logID string, timestamp time.Time, key string, mcp bool, status string, data []byte, tags map[string]string) {
 	if h.closed.Load() || len(data) == 0 {
 		return
@@ -250,6 +255,11 @@ func prepareDBEntry(dbEntry *Log, excluded map[string]struct{}) {
 	}
 }
 
+// Create writes a lightweight DB row (with payload fields stripped per
+// excludedPayloadFields) and asynchronously offloads the full payload to
+// object storage. The caller's entry is preserved on DB failure by writing to
+// a shallow copy; on success, only ContentSummary is propagated back so the
+// caller can observe what was persisted.
 func (h *HybridLogStore) Create(ctx context.Context, entry *Log) error {
 	if err := entry.SerializeFields(); err != nil {
 		return fmt.Errorf("logstore: serialize before extract: %w", err)
@@ -267,6 +277,9 @@ func (h *HybridLogStore) Create(ctx context.Context, entry *Log) error {
 	return nil
 }
 
+// CreateIfNotExists writes the lightweight DB row only when no row with the
+// same ID exists, then offloads the full payload to object storage on insert.
+// Same payload-stripping and shallow-copy semantics as Create.
 func (h *HybridLogStore) CreateIfNotExists(ctx context.Context, entry *Log) error {
 	if err := entry.SerializeFields(); err != nil {
 		return fmt.Errorf("logstore: serialize before extract: %w", err)
@@ -284,6 +297,9 @@ func (h *HybridLogStore) CreateIfNotExists(ctx context.Context, entry *Log) erro
 	return nil
 }
 
+// BatchCreateIfNotExists inserts many lightweight DB rows in a single inner
+// call, then enqueues one object-storage upload per inserted entry. Nil
+// entries are skipped. On DB failure no uploads are enqueued.
 func (h *HybridLogStore) BatchCreateIfNotExists(ctx context.Context, entries []*Log) error {
 	if len(entries) == 0 {
 		return nil
@@ -337,6 +353,9 @@ func (h *HybridLogStore) BatchCreateIfNotExists(ctx context.Context, entries []*
 	return nil
 }
 
+// FindByID loads a log row from the DB and hydrates its payload fields from
+// object storage when HasObject is true. Object-store fetch failures are
+// logged but not returned, so the caller still receives the DB row.
 func (h *HybridLogStore) FindByID(ctx context.Context, id string) (*Log, error) {
 	log, err := h.inner.FindByID(ctx, id)
 	if err != nil {
@@ -369,6 +388,10 @@ func (h *HybridLogStore) hydrateLog(ctx context.Context, log *Log, requestedFiel
 	pruneUnrequestedPayloadFields(log, requestedFields)
 }
 
+// hydrateMCPToolLog fetches the offloaded payload from object storage and
+// merges it into the MCPToolLog. It is a no-op when log is nil or HasObject
+// is false. Errors from the underlying object-store fetch are returned to the
+// caller (unlike hydrateLog, MCP tool log payloads are not optional).
 func (h *HybridLogStore) hydrateMCPToolLog(ctx context.Context, log *MCPToolLog) error {
 	if log == nil || !log.HasObject {
 		return nil
@@ -376,6 +399,10 @@ func (h *HybridLogStore) hydrateMCPToolLog(ctx context.Context, log *MCPToolLog)
 	return h.hydrateMCPToolLogFromObject(ctx, log)
 }
 
+// hydrateMCPToolLogFromObject unconditionally fetches the payload from object
+// storage (skipping the HasObject check) and merges it into the log. Used on
+// the update path where the payload must be loaded even when has_object has
+// not yet been set on the DB row.
 func (h *HybridLogStore) hydrateMCPToolLogFromObject(ctx context.Context, log *MCPToolLog) error {
 	if log == nil {
 		return nil
@@ -391,12 +418,19 @@ func (h *HybridLogStore) hydrateMCPToolLogFromObject(ctx context.Context, log *M
 	return nil
 }
 
+// Update passes the update through to the inner store for index/scalar field
+// updates. Payload-field changes are not re-offloaded here; the logging
+// plugin owns that path and calls processUpload directly when it needs to.
 func (h *HybridLogStore) Update(ctx context.Context, id string, entry any) error {
 	// Pass through to inner store for index field updates.
 	// Payload fields in the update map are handled separately by the logging plugin.
 	return h.inner.Update(ctx, id, entry)
 }
 
+// DeleteLog removes a single log row from the DB and, when HasObject is true,
+// also deletes the corresponding payload from object storage. Object-store
+// delete failures are logged but do not fail the operation, since the DB row
+// (the source of truth for visibility) is already gone.
 func (h *HybridLogStore) DeleteLog(ctx context.Context, id string) error {
 	log, findErr := h.inner.FindByID(ctx, id)
 	if findErr != nil && !errors.Is(findErr, ErrNotFound) {
@@ -414,6 +448,10 @@ func (h *HybridLogStore) DeleteLog(ctx context.Context, id string) error {
 	return nil
 }
 
+// DeleteLogs removes many log rows from the DB and batches a single
+// DeleteBatch call against object storage for any rows that had HasObject
+// set. Keys are collected before the DB delete so we can still identify
+// object-store entries to clean up.
 func (h *HybridLogStore) DeleteLogs(ctx context.Context, ids []string) error {
 	// Collect keys for S3 deletion before removing from DB.
 	var keys []string
@@ -437,11 +475,21 @@ func (h *HybridLogStore) DeleteLogs(ctx context.Context, ids []string) error {
 	return nil
 }
 
+// DeleteLogsBatch deletes old DB rows older than cutoff in batches of
+// batchSize. Object-store entries are intentionally NOT deleted here: the
+// expectation is that the bucket has a lifecycle policy configured to expire
+// objects on the same schedule, which is far cheaper than per-row DELETEs.
 func (h *HybridLogStore) DeleteLogsBatch(ctx context.Context, cutoff time.Time, batchSize int) (int64, error) {
 	// Delegate to inner — S3 objects will be cleaned up by lifecycle policies.
 	return h.inner.DeleteLogsBatch(ctx, cutoff, batchSize)
 }
 
+// Close shuts the store down cleanly: marks the store closed (so further
+// enqueues are dropped), closes the upload queue, waits for workers to drain
+// any in-flight uploads, then closes the object store and the inner store.
+// If ctx is cancelled before workers drain, the cancellation is logged but
+// Close still waits for workers to exit to avoid closing dependencies
+// mid-flight.
 func (h *HybridLogStore) Close(ctx context.Context) error {
 	h.closed.Store(true)
 	close(h.uploadQueue)
@@ -470,10 +518,15 @@ func (h *HybridLogStore) DroppedUploads() int64 {
 
 // --- Delegated methods (pass through to inner store unchanged) ---
 
+// Ping delegates to the inner store's health check.
 func (h *HybridLogStore) Ping(ctx context.Context) error {
 	return h.inner.Ping(ctx)
 }
 
+// FindFirst returns the first log matching query. When the projection asks
+// for payload-bearing fields (or the projection is empty, implying full
+// hydration), the result is hydrated from object storage; otherwise the DB
+// row is returned as-is.
 func (h *HybridLogStore) FindFirst(ctx context.Context, query any, fields ...string) (*Log, error) {
 	needsHydration := len(fields) == 0 || fieldsNeedHydration(fields)
 	if needsHydration && len(fields) > 0 {
@@ -489,6 +542,9 @@ func (h *HybridLogStore) FindFirst(ctx context.Context, query any, fields ...str
 	return log, nil
 }
 
+// FindAll returns all logs matching query. Each result is hydrated from
+// object storage when the projection requires payload fields. Per-row
+// hydration failures are logged inside hydrateLog and do not fail the call.
 func (h *HybridLogStore) FindAll(ctx context.Context, query any, fields ...string) ([]*Log, error) {
 	needsHydration := len(fields) == 0 || fieldsNeedHydration(fields)
 	if needsHydration && len(fields) > 0 {
@@ -506,118 +562,181 @@ func (h *HybridLogStore) FindAll(ctx context.Context, query any, fields ...strin
 	return logs, nil
 }
 
+// FindAllDistinct delegates to the inner store. No hydration is performed:
+// distinct queries operate purely on DB-resident columns and never need the
+// offloaded payload.
 func (h *HybridLogStore) FindAllDistinct(ctx context.Context, query any, fields ...string) ([]*Log, error) {
 	return h.inner.FindAllDistinct(ctx, query, fields...)
 }
 
+// HasLogs delegates to the inner store and reports whether any log rows
+// exist. The object store is not consulted.
 func (h *HybridLogStore) HasLogs(ctx context.Context) (bool, error) {
 	return h.inner.HasLogs(ctx)
 }
 
+// SearchLogs delegates to the inner store. Search operates on indexed DB
+// columns (including ContentSummary); payloads are not hydrated here.
 func (h *HybridLogStore) SearchLogs(ctx context.Context, filters SearchFilters, pagination PaginationOptions) (*SearchResult, error) {
 	return h.inner.SearchLogs(ctx, filters, pagination)
 }
 
+// GetSessionLogs delegates to the inner store and returns the paginated logs
+// belonging to the given session.
 func (h *HybridLogStore) GetSessionLogs(ctx context.Context, sessionID string, pagination PaginationOptions) (*SessionDetailResult, error) {
 	return h.inner.GetSessionLogs(ctx, sessionID, pagination)
 }
 
+// GetSessionSummary delegates to the inner store and returns an aggregated
+// summary for the given session.
 func (h *HybridLogStore) GetSessionSummary(ctx context.Context, sessionID string) (*SessionSummaryResult, error) {
 	return h.inner.GetSessionSummary(ctx, sessionID)
 }
 
+// GetStats delegates to the inner store and returns aggregate statistics for
+// the matching log rows.
 func (h *HybridLogStore) GetStats(ctx context.Context, filters SearchFilters) (*SearchStats, error) {
 	return h.inner.GetStats(ctx, filters)
 }
 
+// GetHistogram delegates to the inner store and returns a request-count
+// histogram bucketed by bucketSizeSeconds.
 func (h *HybridLogStore) GetHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*HistogramResult, error) {
 	return h.inner.GetHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetTokenHistogram delegates to the inner store and returns a token-usage
+// histogram bucketed by bucketSizeSeconds.
 func (h *HybridLogStore) GetTokenHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*TokenHistogramResult, error) {
 	return h.inner.GetTokenHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetCostHistogram delegates to the inner store and returns a cost histogram
+// bucketed by bucketSizeSeconds.
 func (h *HybridLogStore) GetCostHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*CostHistogramResult, error) {
 	return h.inner.GetCostHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetModelHistogram delegates to the inner store and returns a per-model
+// request histogram bucketed by bucketSizeSeconds.
 func (h *HybridLogStore) GetModelHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ModelHistogramResult, error) {
 	return h.inner.GetModelHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetLatencyHistogram delegates to the inner store and returns a latency
+// histogram bucketed by bucketSizeSeconds.
 func (h *HybridLogStore) GetLatencyHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*LatencyHistogramResult, error) {
 	return h.inner.GetLatencyHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetProviderCostHistogram delegates to the inner store and returns a
+// per-provider cost histogram bucketed by bucketSizeSeconds.
 func (h *HybridLogStore) GetProviderCostHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderCostHistogramResult, error) {
 	return h.inner.GetProviderCostHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetProviderTokenHistogram delegates to the inner store and returns a
+// per-provider token histogram bucketed by bucketSizeSeconds.
 func (h *HybridLogStore) GetProviderTokenHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderTokenHistogramResult, error) {
 	return h.inner.GetProviderTokenHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetProviderLatencyHistogram delegates to the inner store and returns a
+// per-provider latency histogram bucketed by bucketSizeSeconds.
 func (h *HybridLogStore) GetProviderLatencyHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderLatencyHistogramResult, error) {
 	return h.inner.GetProviderLatencyHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetModelRankings delegates to the inner store and returns ranked usage
+// aggregates per model for the matching log rows.
 func (h *HybridLogStore) GetModelRankings(ctx context.Context, filters SearchFilters) (*ModelRankingResult, error) {
 	return h.inner.GetModelRankings(ctx, filters)
 }
 
+// GetUserRankings delegates to the inner store and returns ranked usage
+// aggregates per user for the matching log rows.
 func (h *HybridLogStore) GetUserRankings(ctx context.Context, filters SearchFilters) (*UserRankingResult, error) {
 	return h.inner.GetUserRankings(ctx, filters)
 }
 
+// GetDimensionCostHistogram delegates to the inner store and returns a cost
+// histogram bucketed by bucketSizeSeconds and grouped by the given dimension.
 func (h *HybridLogStore) GetDimensionCostHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionCostHistogramResult, error) {
 	return h.inner.GetDimensionCostHistogram(ctx, filters, bucketSizeSeconds, dimension)
 }
 
+// GetDimensionTokenHistogram delegates to the inner store and returns a token
+// histogram bucketed by bucketSizeSeconds and grouped by the given dimension.
 func (h *HybridLogStore) GetDimensionTokenHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionTokenHistogramResult, error) {
 	return h.inner.GetDimensionTokenHistogram(ctx, filters, bucketSizeSeconds, dimension)
 }
 
+// GetDimensionLatencyHistogram delegates to the inner store and returns a
+// latency histogram bucketed by bucketSizeSeconds and grouped by the given
+// dimension.
 func (h *HybridLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionLatencyHistogramResult, error) {
 	return h.inner.GetDimensionLatencyHistogram(ctx, filters, bucketSizeSeconds, dimension)
 }
 
+// BulkUpdateCost delegates to the inner store and updates the cost column
+// for each (logID -> cost) pair in a single round trip.
 func (h *HybridLogStore) BulkUpdateCost(ctx context.Context, updates map[string]float64) error {
 	return h.inner.BulkUpdateCost(ctx, updates)
 }
 
+// GetNodeUsageAfter delegates to the inner store and returns usage
+// aggregates for the given node since cursor, used by the cluster gossip
+// path to ship incremental usage to peers.
 func (h *HybridLogStore) GetNodeUsageAfter(ctx context.Context, nodeID string, cursor NodeUsageCursor) (*NodeUsageAggregate, error) {
 	return h.inner.GetNodeUsageAfter(ctx, nodeID, cursor)
 }
 
+// Flush delegates to the inner store and forces any buffered DB writes since
+// the given timestamp to be persisted. Object-store uploads are independently
+// queued and not affected.
 func (h *HybridLogStore) Flush(ctx context.Context, since time.Time) error {
 	return h.inner.Flush(ctx, since)
 }
 
+// IsLogEntryPresent delegates to the inner store and reports whether a log
+// row with the given ID exists.
 func (h *HybridLogStore) IsLogEntryPresent(ctx context.Context, id string) (bool, error) {
 	return h.inner.IsLogEntryPresent(ctx, id)
 }
 
+// GetDistinctAliases delegates to the inner store and returns distinct alias
+// values matching query, capped at limit.
 func (h *HybridLogStore) GetDistinctAliases(ctx context.Context, limit int, query string) ([]string, error) {
 	return h.inner.GetDistinctAliases(ctx, limit, query)
 }
 
+// GetDistinctModels delegates to the inner store and returns distinct model
+// values matching query, capped at limit.
 func (h *HybridLogStore) GetDistinctModels(ctx context.Context, limit int, query string) ([]string, error) {
 	return h.inner.GetDistinctModels(ctx, limit, query)
 }
 
+// GetDistinctKeyPairs delegates to the inner store and returns distinct
+// (idCol, nameCol) pairs matching query, capped at limit. Used to populate
+// id/name filters in the UI for virtual keys, providers, etc.
 func (h *HybridLogStore) GetDistinctKeyPairs(ctx context.Context, idCol, nameCol string, limit int, query string) ([]KeyPairResult, error) {
 	return h.inner.GetDistinctKeyPairs(ctx, idCol, nameCol, limit, query)
 }
 
+// GetDistinctRoutingEngines delegates to the inner store and returns
+// distinct routing-engine values matching query, capped at limit.
 func (h *HybridLogStore) GetDistinctRoutingEngines(ctx context.Context, limit int, query string) ([]string, error) {
 	return h.inner.GetDistinctRoutingEngines(ctx, limit, query)
 }
 
+// GetDistinctStopReasons delegates to the inner store and returns distinct
+// stop-reason values matching query, capped at limit.
 func (h *HybridLogStore) GetDistinctStopReasons(ctx context.Context, limit int, query string) ([]string, error) {
 	return h.inner.GetDistinctStopReasons(ctx, limit, query)
 }
 
+// GetDistinctMetadataKeys delegates to the inner store and returns distinct
+// metadata keys (and their distinct values) matching query, capped at limit.
 func (h *HybridLogStore) GetDistinctMetadataKeys(ctx context.Context, limit int, query string) (map[string][]string, error) {
 	return h.inner.GetDistinctMetadataKeys(ctx, limit, query)
 }
@@ -625,18 +744,23 @@ func (h *HybridLogStore) GetDistinctMetadataKeys(ctx context.Context, limit int,
 // MCP Tool Log analytics methods are delegated directly. Detail/write paths
 // below offload full MCP log objects while keeping DB rows lightweight.
 
+// GetMCPHistogram delegates to the inner store and returns an MCP tool-call
+// count histogram bucketed by bucketSizeSeconds.
 func (h *HybridLogStore) GetMCPHistogram(ctx context.Context, filters MCPToolLogSearchFilters, bucketSizeSeconds int64) (*MCPHistogramResult, error) {
 	return h.inner.GetMCPHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetMCPCostHistogram returns the cost histogram for MCP tool logs.
 func (h *HybridLogStore) GetMCPCostHistogram(ctx context.Context, filters MCPToolLogSearchFilters, bucketSizeSeconds int64) (*MCPCostHistogramResult, error) {
 	return h.inner.GetMCPCostHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetMCPTopTools returns the top tools used in MCP tool logs.
 func (h *HybridLogStore) GetMCPTopTools(ctx context.Context, filters MCPToolLogSearchFilters, limit int) (*MCPTopToolsResult, error) {
 	return h.inner.GetMCPTopTools(ctx, filters, limit)
 }
 
+// applyMCPToolLogUpdate applies the updates from an entry to the target MCPToolLog entry.
 func applyMCPToolLogUpdate(target *MCPToolLog, entry any) error {
 	switch v := entry.(type) {
 	case map[string]interface{}:
@@ -661,6 +785,7 @@ func applyMCPToolLogUpdate(target *MCPToolLog, entry any) error {
 	}
 }
 
+// applyMCPToolLogUpdateMap applies the updates from a map to the target MCPToolLog entry.
 func applyMCPToolLogUpdateMap(target *MCPToolLog, updates map[string]interface{}) error {
 	for key, value := range updates {
 		switch key {
@@ -725,6 +850,7 @@ func applyMCPToolLogUpdateMap(target *MCPToolLog, updates map[string]interface{}
 	return target.DeserializeFields()
 }
 
+// applyMCPToolLogUpdateStruct applies the updates from a MCPToolLog struct to the target MCPToolLog entry.
 func applyMCPToolLogUpdateStruct(target *MCPToolLog, update *MCPToolLog) error {
 	if update.RequestID != "" {
 		target.RequestID = update.RequestID
@@ -778,7 +904,8 @@ func applyMCPToolLogUpdateStruct(target *MCPToolLog, update *MCPToolLog) error {
 	return target.DeserializeFields()
 }
 
-func prepareMCPToolLogDBUpdates(entry any) (map[string]interface{}, error) {
+// prepareMCPToolLogDBUpdates prepares a map of DB updates from a MCPToolLog entry.
+func prepareMCPToolLogDBUpdates(entry any) (map[string]any, error) {
 	switch v := entry.(type) {
 	case map[string]interface{}:
 		out := make(map[string]interface{}, len(v))
@@ -809,12 +936,13 @@ func prepareMCPToolLogDBUpdates(entry any) (map[string]interface{}, error) {
 	}
 }
 
-func prepareMCPToolLogDBUpdatesFromStruct(update MCPToolLog) (map[string]interface{}, error) {
+// prepareMCPToolLogDBUpdatesFromStruct prepares a map of DB updates from a MCPToolLog struct.
+func prepareMCPToolLogDBUpdatesFromStruct(update MCPToolLog) (map[string]any, error) {
 	if err := update.SerializeFields(); err != nil {
 		return nil, err
 	}
 	PrepareMCPToolDBEntry(&update)
-	out := make(map[string]interface{})
+	out := make(map[string]any)
 	if update.RequestID != "" {
 		out["request_id"] = update.RequestID
 	}
@@ -857,7 +985,8 @@ func prepareMCPToolLogDBUpdatesFromStruct(update MCPToolLog) (map[string]interfa
 	return out, nil
 }
 
-func numericToFloat64(value interface{}) (float64, bool) {
+// numericToFloat64 converts a numeric value to a float64, returning the value and a success flag.
+func numericToFloat64(value any) (float64, bool) {
 	switch v := value.(type) {
 	case float64:
 		return v, true
@@ -874,6 +1003,7 @@ func numericToFloat64(value interface{}) (float64, bool) {
 	}
 }
 
+// marshalMCPPreviewString marshals a string into a JSON string for use as an MCP preview field.
 func marshalMCPPreviewString(s string) string {
 	data, err := sonic.Marshal(s)
 	if err != nil {
@@ -882,6 +1012,7 @@ func marshalMCPPreviewString(s string) string {
 	return string(data)
 }
 
+// CreateMCPToolLog creates a new MCP tool log in the DB and enqueues it for offload to object storage.
 func (h *HybridLogStore) CreateMCPToolLog(ctx context.Context, entry *MCPToolLog) error {
 	payload, err := MarshalMCPToolLogPayload(entry)
 	if err != nil {
@@ -898,6 +1029,7 @@ func (h *HybridLogStore) CreateMCPToolLog(ctx context.Context, entry *MCPToolLog
 	return nil
 }
 
+// BatchCreateMCPToolLogsIfNotExists creates MCP tool logs in the DB and enqueues them for offload to object storage, if they do not already exist.
 func (h *HybridLogStore) BatchCreateMCPToolLogsIfNotExists(ctx context.Context, entries []*MCPToolLog) error {
 	if len(entries) == 0 {
 		return nil
@@ -945,6 +1077,7 @@ func (h *HybridLogStore) BatchCreateMCPToolLogsIfNotExists(ctx context.Context, 
 	return nil
 }
 
+// FindMCPToolLog finds an MCP tool log by its ID and hydrates it with any associated object storage data.
 func (h *HybridLogStore) FindMCPToolLog(ctx context.Context, id string) (*MCPToolLog, error) {
 	log, err := h.inner.FindMCPToolLog(ctx, id)
 	if err != nil {
@@ -956,6 +1089,7 @@ func (h *HybridLogStore) FindMCPToolLog(ctx context.Context, id string) (*MCPToo
 	return log, nil
 }
 
+// UpdateMCPToolLog updates an existing MCP tool log with the given ID using the provided entry data.
 func (h *HybridLogStore) UpdateMCPToolLog(ctx context.Context, id string, entry any) error {
 	current, err := h.inner.FindMCPToolLog(ctx, id)
 	if err != nil {
@@ -986,18 +1120,22 @@ func (h *HybridLogStore) UpdateMCPToolLog(ctx context.Context, id string, entry 
 	return nil
 }
 
+// SearchMCPToolLogs searches for MCP tool logs that match the given filters and returns the results.
 func (h *HybridLogStore) SearchMCPToolLogs(ctx context.Context, filters MCPToolLogSearchFilters, pagination PaginationOptions) (*MCPToolLogSearchResult, error) {
 	return h.inner.SearchMCPToolLogs(ctx, filters, pagination)
 }
 
+// GetMCPToolLogStats returns statistics about MCP tool logs that match the given filters.
 func (h *HybridLogStore) GetMCPToolLogStats(ctx context.Context, filters MCPToolLogSearchFilters) (*MCPToolLogStats, error) {
 	return h.inner.GetMCPToolLogStats(ctx, filters)
 }
 
+// HasMCPToolLogs returns whether there are any MCP tool logs in the store.
 func (h *HybridLogStore) HasMCPToolLogs(ctx context.Context) (bool, error) {
 	return h.inner.HasMCPToolLogs(ctx)
 }
 
+// DeleteMCPToolLogs deletes MCP tool logs with the given IDs, including any associated object storage objects.
 func (h *HybridLogStore) DeleteMCPToolLogs(ctx context.Context, ids []string) error {
 	var keys []string
 	for _, id := range ids {
@@ -1020,40 +1158,49 @@ func (h *HybridLogStore) DeleteMCPToolLogs(ctx context.Context, ids []string) er
 	return nil
 }
 
+// FlushMCPToolLogs flushes MCP tool logs that are older than the given time.
 func (h *HybridLogStore) FlushMCPToolLogs(ctx context.Context, since time.Time) error {
 	return h.inner.FlushMCPToolLogs(ctx, since)
 }
 
+// GetAvailableToolNames returns a list of tool names that match the given query.
 func (h *HybridLogStore) GetAvailableToolNames(ctx context.Context, limit int, query string) ([]string, error) {
 	return h.inner.GetAvailableToolNames(ctx, limit, query)
 }
 
+// GetAvailableServerLabels returns a list of server labels that match the given query.
 func (h *HybridLogStore) GetAvailableServerLabels(ctx context.Context, limit int, query string) ([]string, error) {
 	return h.inner.GetAvailableServerLabels(ctx, limit, query)
 }
 
+// GetAvailableMCPVirtualKeys returns a list of MCP tool log virtual keys that match the given query.
 func (h *HybridLogStore) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) ([]MCPToolLog, error) {
 	return h.inner.GetAvailableMCPVirtualKeys(ctx, limit, query)
 }
 
 // Async Job methods — delegated directly.
 
+// CreateAsyncJob creates a new async job.
 func (h *HybridLogStore) CreateAsyncJob(ctx context.Context, job *AsyncJob) error {
 	return h.inner.CreateAsyncJob(ctx, job)
 }
 
+// FindAsyncJobByID finds an async job by its ID.
 func (h *HybridLogStore) FindAsyncJobByID(ctx context.Context, id string) (*AsyncJob, error) {
 	return h.inner.FindAsyncJobByID(ctx, id)
 }
 
+// UpdateAsyncJob updates an async job with the given ID using the provided updates.
 func (h *HybridLogStore) UpdateAsyncJob(ctx context.Context, id string, updates map[string]interface{}) error {
 	return h.inner.UpdateAsyncJob(ctx, id, updates)
 }
 
+// DeleteExpiredAsyncJobs deletes async jobs that have not been updated since the given time.
 func (h *HybridLogStore) DeleteExpiredAsyncJobs(ctx context.Context) (int64, error) {
 	return h.inner.DeleteExpiredAsyncJobs(ctx)
 }
 
+// DeleteStaleAsyncJobs deletes async jobs that have not been updated since the given time.
 func (h *HybridLogStore) DeleteStaleAsyncJobs(ctx context.Context, staleSince time.Time) (int64, error) {
 	return h.inner.DeleteStaleAsyncJobs(ctx, staleSince)
 }

--- a/plugins/logging/cleanup_test.go
+++ b/plugins/logging/cleanup_test.go
@@ -1,0 +1,191 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/logstore"
+)
+
+// recordingStore wraps a LogStore and records every log ID that reaches
+// BatchCreateIfNotExists. Optional delay simulates a slow underlying store
+// so we can force entries to back up between the writeQueue channel buffer
+// and batchWriter's local batch slice at Cleanup time.
+type recordingStore struct {
+	logstore.LogStore
+	mu       sync.Mutex
+	received []string
+	delay    time.Duration
+}
+
+func (s *recordingStore) BatchCreateIfNotExists(ctx context.Context, entries []*logstore.Log) error {
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	if err := s.LogStore.BatchCreateIfNotExists(ctx, entries); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	for _, e := range entries {
+		s.received = append(s.received, e.ID)
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *recordingStore) uniqueIDs() map[string]struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]struct{}, len(s.received))
+	for _, id := range s.received {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+func makeTestLog(id string) *logstore.Log {
+	now := time.Now()
+	return &logstore.Log{
+		ID:        id,
+		Timestamp: now,
+		CreatedAt: now,
+		Provider:  "test-provider",
+		Model:     "test-model",
+		Status:    "success",
+	}
+}
+
+// TestCleanupDrainsRecoveredBatchNoDrops covers the recovered-batch handoff:
+// entries sit in batchWriter's in-memory batch (well under maxBatchSize, so
+// no automatic flush has happened) when Cleanup runs. drainPending must
+// recover and persist all of them.
+func TestCleanupDrainsRecoveredBatchNoDrops(t *testing.T) {
+	rec := &recordingStore{LogStore: newTestStore(t)}
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, rec, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	const N = 500 // well under maxBatchSize (1000); batchWriter will not auto-flush
+	for i := 0; i < N; i++ {
+		plugin.enqueueLogEntry(makeTestLog(fmt.Sprintf("recovered-%d", i)), nil)
+	}
+
+	// Let batchWriter dequeue everything into its local batch. 100ms is far
+	// less than batchInterval (2s), so no automatic flush should have run.
+	time.Sleep(100 * time.Millisecond)
+
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	got := rec.uniqueIDs()
+	if len(got) != N {
+		t.Fatalf("expected %d unique entries persisted via recovered batch, got %d", N, len(got))
+	}
+	for i := 0; i < N; i++ {
+		id := fmt.Sprintf("recovered-%d", i)
+		if _, ok := got[id]; !ok {
+			t.Fatalf("entry %s was dropped during Cleanup", id)
+		}
+	}
+	if dropped := plugin.droppedRequests.Load(); dropped != 0 {
+		t.Fatalf("expected 0 dropped requests, got %d", dropped)
+	}
+}
+
+// TestCleanupDrainsCombinedQueueAndBatchNoDrops covers the mixed path: a
+// large burst combined with a slow underlying store guarantees that some
+// entries land in writeQueue's channel buffer while others sit in
+// batchWriter's local batch when Cleanup arrives. Both paths must be drained.
+func TestCleanupDrainsCombinedQueueAndBatchNoDrops(t *testing.T) {
+	rec := &recordingStore{
+		LogStore: newTestStore(t),
+		delay:    25 * time.Millisecond, // slow store keeps batchWriter busy so the channel buffer fills
+	}
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, rec, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	const N = 2500 // > maxBatchSize so batchWriter triggers at least two intermediate flushes
+	for i := 0; i < N; i++ {
+		plugin.enqueueLogEntry(makeTestLog(fmt.Sprintf("combined-%d", i)), nil)
+	}
+
+	// Call Cleanup while batchWriter is likely mid-processBatch (the 25ms
+	// per-batch delay means the queue is still partially full). drainPending
+	// must wait for the ownership handoff, then drain the remainder.
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	got := rec.uniqueIDs()
+	if len(got) != N {
+		t.Fatalf("expected %d unique entries persisted (mix of batchWriter + drainPending), got %d; dropped=%d",
+			N, len(got), plugin.droppedRequests.Load())
+	}
+	for i := 0; i < N; i++ {
+		id := fmt.Sprintf("combined-%d", i)
+		if _, ok := got[id]; !ok {
+			t.Fatalf("entry %s was dropped during Cleanup", id)
+		}
+	}
+}
+
+// TestCleanupRejectsNewSendsAfterClosed verifies the producer-side guard
+// (p.closed.Load() in enqueueLogEntry) takes effect once Cleanup has run:
+// subsequent enqueues are dropped at the source and do not panic.
+func TestCleanupRejectsNewSendsAfterClosed(t *testing.T) {
+	rec := &recordingStore{LogStore: newTestStore(t)}
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, rec, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	plugin.enqueueLogEntry(makeTestLog("pre-cleanup"), nil)
+
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	// After Cleanup, the channel is closed and p.closed is true. Producers
+	// must short-circuit via the closed check (no panic, no enqueue).
+	dropsBefore := plugin.droppedRequests.Load()
+	plugin.enqueueLogEntry(makeTestLog("post-cleanup"), nil)
+	dropsAfter := plugin.droppedRequests.Load()
+
+	// The closed-check path returns silently without incrementing
+	// droppedRequests (matches existing semantics at writer.go:251-253).
+	if dropsBefore != dropsAfter {
+		t.Fatalf("post-cleanup enqueue should be a silent no-op; droppedRequests went from %d to %d",
+			dropsBefore, dropsAfter)
+	}
+
+	got := rec.uniqueIDs()
+	if _, ok := got["pre-cleanup"]; !ok {
+		t.Fatalf("pre-cleanup entry was dropped during Cleanup")
+	}
+	if _, ok := got["post-cleanup"]; ok {
+		t.Fatalf("post-cleanup entry should never have reached the store")
+	}
+}
+
+// TestCleanupIsIdempotent verifies the cleanupOnce guard: a second Cleanup
+// call must be a no-op rather than re-cancelling, re-closing channels, or
+// panicking.
+func TestCleanupIsIdempotent(t *testing.T) {
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, newTestStore(t), nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("first Cleanup() error = %v", err)
+	}
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("second Cleanup() error = %v", err)
+	}
+}

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -56,8 +56,8 @@ type UpdateLogData struct {
 	VideoDownloadOutput    *schemas.BifrostVideoDownloadResponse   // For non-streaming video download responses
 	VideoListOutput        *schemas.BifrostVideoListResponse       // For non-streaming video list responses
 	VideoDeleteOutput      *schemas.BifrostVideoDeleteResponse     // For non-streaming video delete responses
-	RawRequest             interface{}
-	RawResponse            interface{}
+	RawRequest             any
+	RawResponse            any
 	IsLargePayloadRequest  bool // When true, RawRequest is a truncated preview string (skip sonic.Marshal)
 	IsLargePayloadResponse bool // When true, RawResponse is a truncated preview string (skip sonic.Marshal)
 }
@@ -79,6 +79,8 @@ func applyLargePayloadPreviews(ctx *schemas.BifrostContext, updateData *UpdateLo
 	}
 }
 
+// applyLargePayloadPreviewsToEntry applies the large payload preview values from
+// the context to the log entry, if they are available and content logging is enabled.
 func applyLargePayloadPreviewsToEntry(ctx *schemas.BifrostContext, entry *logstore.Log, contentLoggingEnabled bool) {
 	if ctx == nil || entry == nil {
 		return
@@ -316,6 +318,10 @@ type LoggerPlugin struct {
 	closed                 atomic.Bool           // Set during cleanup to prevent sends on closed writeQueue
 	deferredUsageSem       chan struct{}         // Limits concurrent deferred usage DB updates
 	clusterNodeID          atomic.Value          // Cluster node ID (string) for log attribution in clustered deployments
+	batchCtx               context.Context       // Cancelled by Cleanup to stop the batchWriter goroutine before any further DB work
+	batchCancel            context.CancelFunc    // Cancels batchCtx
+	batchWriterDone        chan struct{}         // Closed by batchWriter on exit; receiving from it transfers writeQueue ownership to Cleanup
+	recoveredBatch         []*writeQueueEntry    // batchWriter parks its in-memory batch here before exiting; safe to read after batchWriterDone closes (happens-before)
 }
 
 // Init creates new logger plugin with given log store
@@ -333,6 +339,7 @@ func Init(ctx context.Context, config *Config, logger schemas.Logger, logsStore 
 		logger.Warn("logging plugin requires MCP catalog to calculate cost, all MCP cost calculations will be skipped.")
 	}
 
+	batchCtx, batchCancel := context.WithCancel(ctx)
 	plugin := &LoggerPlugin{
 		ctx:                   ctx,
 		store:                 logsStore,
@@ -344,6 +351,9 @@ func Init(ctx context.Context, config *Config, logger schemas.Logger, logsStore 
 		logger:                logger,
 		writeQueue:            make(chan *writeQueueEntry, writeQueueCapacity),
 		deferredUsageSem:      make(chan struct{}, maxDeferredUsageConcurrency),
+		batchCtx:              batchCtx,
+		batchCancel:           batchCancel,
+		batchWriterDone:       make(chan struct{}),
 		logMsgPool: sync.Pool{
 			New: func() any {
 				return &LogMessage{}
@@ -451,7 +461,7 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 		return nil
 	}
 
-	var metadata map[string]interface{}
+	var metadata map[string]any
 
 	// Check configured logging headers
 	if p.loggingHeaders != nil {
@@ -459,7 +469,7 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 			key := strings.ToLower(h)
 			if val, ok := allHeaders[key]; ok {
 				if metadata == nil {
-					metadata = make(map[string]interface{})
+					metadata = make(map[string]any)
 				}
 				metadata[key] = val
 			}
@@ -470,7 +480,7 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 	for key, val := range allHeaders {
 		if labelName, ok := strings.CutPrefix(key, "x-bf-lh-"); ok && labelName != "" {
 			if metadata == nil {
-				metadata = make(map[string]interface{})
+				metadata = make(map[string]any)
 			}
 			metadata[labelName] = val
 		}
@@ -480,7 +490,7 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 	if dims, ok := ctx.Value(schemas.BifrostContextKeyDimensions).(map[string]string); ok {
 		for k, v := range dims {
 			if metadata == nil {
-				metadata = make(map[string]interface{})
+				metadata = make(map[string]any)
 			}
 			if _, exists := metadata[k]; !exists {
 				metadata[k] = v
@@ -1031,11 +1041,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			}
 		}
 		applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
-
 		if tracer != nil && traceID != "" {
 			tracer.CleanupStreamAccumulator(traceID)
 		}
-
 		p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))
 		p.scheduleDeferredUsageUpdate(ctx, requestID, entry.TokenUsageParsed != nil)
 		return result, bifrostErr, nil
@@ -1110,26 +1118,80 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	return result, bifrostErr, nil
 }
 
-// Cleanup is called when the plugin is being shut down
+// Cleanup is called when the plugin is being shut down. It stops the
+// batchWriter goroutine before it issues any further DB writes, takes over
+// ownership of the write queue, and drains whatever is pending under a
+// bounded wall-clock deadline (cleanupDrainTimeout). Any entries that do not
+// finish within the deadline are dropped so that a slow or wedged log store
+// cannot wedge the server's overall 30s shutdown budget.
 func (p *LoggerPlugin) Cleanup() error {
 	p.cleanupOnce.Do(func() {
-		// Stop the cleanup ticker
 		if p.cleanupTicker != nil {
 			p.cleanupTicker.Stop()
 		}
-		// Signal the cleanup worker to stop
+		// Signal the cleanup worker to stop.
 		close(p.done)
-		// Close write queue FIRST — batchWriter drains remaining entries and exits.
-		// THEN set closed flag — this prevents panics from sends-on-closed-channel
-		// in enqueueLogEntry (the defer/recover there catches the race window).
-		close(p.writeQueue)
+		// Block new producers BEFORE killing batchWriter so the channel does
+		// not grow further while we drain it ourselves.
 		p.closed.Store(true)
-		// Wait for the cleanup worker and batch writer to finish
+		// Kill batchWriter. Its current in-memory batch is handed back via
+		// p.recoveredBatch; it does not issue any further DB writes.
+		p.batchCancel()
+		// Receiving from batchWriterDone is the ownership handoff: after this
+		// point, no other goroutine reads from p.writeQueue, so we can drain
+		// it ourselves. This wait is microseconds (no DB work involved).
+		<-p.batchWriterDone
+		// Drain p.recoveredBatch and whatever is still buffered in
+		// p.writeQueue under a bounded deadline.
+		p.drainPending()
+		// Close the channel as hygiene. The defer/recover in enqueueLogEntry
+		// (writer.go:254-259) absorbs any racing producer send.
+		close(p.writeQueue)
+		// wg.Wait covers the cleanupWorker (exited via close(p.done)) and
+		// any in-flight deferred usage updater goroutines. batchWriter has
+		// already called wg.Done before closing batchWriterDone above.
 		p.wg.Wait()
-		// Note: Accumulator cleanup is handled by the tracer, not the logging plugin
-		// GORM handles connection cleanup automatically
 	})
 	return nil
+}
+
+// drainPending processes p.recoveredBatch followed by any entries still
+// buffered in p.writeQueue. Runs synchronously under a wall-clock deadline;
+// remaining entries past the deadline are counted as dropped.
+func (p *LoggerPlugin) drainPending() {
+	deadline := time.Now().Add(cleanupDrainTimeout)
+	batch := p.recoveredBatch
+	p.recoveredBatch = nil
+
+	// Pull everything currently buffered in the channel. Non-blocking — we
+	// only want what is there right now; new sends are already blocked by
+	// p.closed.
+drainQueue:
+	for {
+		select {
+		case entry := <-p.writeQueue:
+			batch = append(batch, entry)
+		default:
+			break drainQueue
+		}
+	}
+
+	// Process in chunks of maxBatchSize, checking the wall-clock deadline
+	// between chunks so a single slow processBatch cannot consume the whole
+	// budget and starve later chunks.
+	for len(batch) > 0 {
+		if time.Now().After(deadline) {
+			p.droppedRequests.Add(int64(len(batch)))
+			p.logger.Warn("logging plugin cleanup deadline reached; dropping %d entries", len(batch))
+			return
+		}
+		chunkSize := maxBatchSize
+		if chunkSize > len(batch) {
+			chunkSize = len(batch)
+		}
+		p.safeProcessBatch(batch[:chunkSize])
+		batch = batch[chunkSize:]
+	}
 }
 
 // storeOrEnqueueEntry stores a log entry in pendingLogs keyed by traceID for later

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -23,6 +23,11 @@ const (
 	maxDeferredUsageConcurrency = 5
 	// pendingLogTTL is how long a pending log entry can stay in memory before cleanup
 	pendingLogTTL = 5 * time.Minute
+	// cleanupDrainTimeout caps how long Cleanup spends draining the write queue
+	// itself. Matches the outer server shutdown budget at server.go:1596 so the
+	// logging plugin can fully drain in the worst case; remaining entries beyond
+	// the deadline are dropped so the process is never wedged on a slow store.
+	cleanupDrainTimeout = 30 * time.Second
 )
 
 // PendingLogData holds PreLLMHook input data until PostLLMHook fires.
@@ -103,6 +108,14 @@ func (p *LoggerPlugin) batchWriter() {
 			if len(batch) > 0 {
 				flush()
 			}
+
+		case <-p.batchCtx.Done():
+			// Cleanup is taking over: hand the local batch back via
+			// recoveredBatch, signal exit, and return without touching the
+			// store. Cleanup owns the drain budget from this point on.
+			p.recoveredBatch = batch
+			close(p.batchWriterDone)
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The `Cleanup()` path in the logging plugin had a race condition where the `batchWriter` goroutine could still be mid-flush when the write queue was closed, causing in-memory log entries to be silently dropped on shutdown. This PR fixes the shutdown sequence so that `batchWriter` hands its in-progress batch back to `Cleanup`, which then drains both the recovered batch and any remaining channel-buffered entries under a bounded 30-second deadline before closing the queue.

## Changes

- **Shutdown sequencing fix**: `Cleanup` now cancels `batchCtx` to stop `batchWriter` before any further DB writes, waits on `batchWriterDone` for the ownership handoff, then calls `drainPending` to flush the recovered batch and remaining queue entries in `maxBatchSize` chunks.
- **`batchWriter` exit path**: Added a `batchCtx.Done()` case that parks the current in-memory batch into `p.recoveredBatch`, closes `batchWriterDone`, and returns without touching the store — leaving all drain responsibility to `Cleanup`.
- **`drainPending`**: New method that non-blockingly empties the write queue into a combined slice with the recovered batch, then processes it in chunks while checking a wall-clock deadline between chunks. Entries remaining past the deadline are counted as dropped and logged.
- **`cleanupDrainTimeout` constant**: Set to 30 seconds to match the outer server shutdown budget, ensuring the logging plugin can fully drain in the worst case without wedging the process.
- **`closed` flag ordering**: The closed flag is now set before cancelling `batchWriter` so no new producers can grow the queue while `drainPending` is running.
- **Doc comments**: Added Go doc comments to all exported and unexported methods in `hybrid.go` that were previously undocumented, covering hydration semantics, object-store error handling, and delegation behavior.
- **`interface{}` → `any`**: Replaced `interface{}` with the `any` alias in several map type literals and function signatures across `asyncjob.go`, `hybrid.go`, and `main.go`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Four new tests in `plugins/logging/cleanup_test.go` cover the fixed shutdown paths:

```sh
go test ./plugins/logging/... -run TestCleanup -v
```

- `TestCleanupDrainsRecoveredBatchNoDrops` — verifies that entries sitting in `batchWriter`'s in-memory batch (below `maxBatchSize`, no auto-flush) are fully recovered and persisted by `drainPending`.
- `TestCleanupDrainsCombinedQueueAndBatchNoDrops` — uses a slow store and a burst larger than `maxBatchSize` to force entries into both the channel buffer and the in-memory batch simultaneously; asserts zero drops.
- `TestCleanupRejectsNewSendsAfterClosed` — confirms that `enqueueLogEntry` calls after `Cleanup` are silent no-ops and do not reach the store.
- `TestCleanupIsIdempotent` — confirms that calling `Cleanup` twice does not panic or re-close channels.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Changes are limited to internal shutdown sequencing and logging infrastructure; no auth, secrets, or PII handling is affected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable