### PR TITLE
fix(governance): enforce vk blocked models

### DIFF
--- a/plugins/governance/blocklist_test.go
+++ b/plugins/governance/blocklist_test.go
@@ -1,0 +1,67 @@
+package governance
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestIsModelBlockedByList(t *testing.T) {
+	tests := []struct {
+		name      string
+		blacklist schemas.BlackList
+		model     string
+		want      bool
+	}{
+		{
+			name:      "empty blacklist allows",
+			blacklist: schemas.BlackList{},
+			model:     "mistral:latest",
+			want:      false,
+		},
+		{
+			name:      "wildcard blocks all",
+			blacklist: schemas.BlackList{"*"},
+			model:     "llama3.2:latest",
+			want:      true,
+		},
+		{
+			name:      "bare blocks bare",
+			blacklist: schemas.BlackList{"mistral:latest"},
+			model:     "mistral:latest",
+			want:      true,
+		},
+		{
+			name:      "prefixed blacklist blocks bare request",
+			blacklist: schemas.BlackList{"ollama/mistral:latest"},
+			model:     "mistral:latest",
+			want:      true,
+		},
+		{
+			name:      "bare blacklist blocks prefixed request",
+			blacklist: schemas.BlackList{"mistral:latest"},
+			model:     "ollama/mistral:latest",
+			want:      true,
+		},
+		{
+			name:      "prefixed blocks prefixed",
+			blacklist: schemas.BlackList{"ollama/mistral:latest"},
+			model:     "ollama/mistral:latest",
+			want:      true,
+		},
+		{
+			name:      "different model not blocked",
+			blacklist: schemas.BlackList{"mistral:latest"},
+			model:     "llama3.2:latest",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isModelBlockedByList(tt.blacklist, tt.model); got != tt.want {
+				t.Fatalf("isModelBlockedByList(%v, %q) = %v, want %v", tt.blacklist, tt.model, got, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -770,7 +770,7 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	// Pre-pass: if any config for a provider blacklists the model, that provider is fully blocked.
 	blacklistedProviders := make(map[string]bool)
 	for _, config := range providerConfigs {
-		if config.BlacklistedModels.IsBlocked(modelStr) {
+		if isModelBlockedByList(config.BlacklistedModels, modelStr) {
 			blacklistedProviders[config.Provider] = true
 		}
 	}

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -332,8 +332,10 @@ func (r *BudgetResolver) isModelAllowed(vk *configstoreTables.TableVirtualKey, p
 	}
 
 	// Pass 1: if any matching provider config blacklists the model, block immediately.
+	// isModelBlockedByList handles entries stored with a provider prefix (e.g. "gemini/model")
+	// as well as bare names, matching how IsModelAllowedForProvider normalizes the allowlist.
 	for _, pc := range vk.ProviderConfigs {
-		if pc.Provider == string(provider) && pc.BlacklistedModels.IsBlocked(model) {
+		if pc.Provider == string(provider) && isModelBlockedByList(pc.BlacklistedModels, model) {
 			return false
 		}
 	}

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -87,6 +87,31 @@ func getWeight(w *float64) float64 {
 	return *w
 }
 
+// isModelBlockedByList checks if a model is blocked by a blacklist that may store entries
+// with or without a provider prefix (e.g., "ollama/mistral:latest" or "mistral:latest").
+// Both the blacklist entry and the incoming model are normalized before comparison so that
+// bare and provider-prefixed forms are treated as equivalent.
+func isModelBlockedByList(blacklist schemas.BlackList, model string) bool {
+	if blacklist.IsBlockAll() {
+		return true
+	}
+
+	_, normalizedModel := schemas.ParseModelString(model, "")
+
+	for _, blocked := range blacklist {
+		if strings.EqualFold(blocked, model) {
+			return true
+		}
+
+		_, normalizedBlocked := schemas.ParseModelString(blocked, "")
+		if strings.EqualFold(normalizedBlocked, normalizedModel) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // filterModelsForVirtualKey filters models based on virtual key's provider configs
 // Returns only models that are allowed by the virtual key's ProviderConfigs
 func (p *GovernancePlugin) filterModelsForVirtualKey(
@@ -114,7 +139,7 @@ func (p *GovernancePlugin) filterModelsForVirtualKey(
 		// Pre-pass: if any matching config blacklists the model, block it entirely.
 		isBlocked := false
 		for _, pc := range vk.ProviderConfigs {
-			if pc.Provider == string(provider) && pc.BlacklistedModels.IsBlocked(modelName) {
+			if pc.Provider == string(provider) && isModelBlockedByList(pc.BlacklistedModels, modelName) {
 				isBlocked = true
 				break
 			}

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -122,6 +122,7 @@ const providerConfigSchema = z.object({
     .max(1, "Weight must be at most 1")
     .optional(),
   allowed_models: z.array(z.string()).optional(),
+  blacklisted_models: z.array(z.string()).optional(),
   key_ids: z.array(z.string()).optional(), // Keys associated with this provider config
   // Provider-level budget
   budgets: z
@@ -286,6 +287,7 @@ export default function VirtualKeySheet({
           provider: config.provider,
           weight: config.weight ?? undefined,
           allowed_models: config.allowed_models,
+          blacklisted_models: config.blacklisted_models || [],
           key_ids: config.allow_all_keys
             ? ["*"]
             : config.keys?.map((key) => key.key_id) || [],
@@ -433,6 +435,7 @@ export default function VirtualKeySheet({
       provider: provider,
       weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
       allowed_models: ["*"],
+      blacklisted_models: [],
       key_ids: ["*"],
     };
 
@@ -1409,6 +1412,114 @@ export default function VirtualKeySheet({
                                       All Models” to allow all. Leave empty to
                                       deny all.
                                     </p>
+                                  </div>
+                                </div>
+
+                                {/* Blocked Models for this provider */}
+                                <div className="flex w-full items-start gap-2">
+                                  <div className="w-1/4" />
+                                  <div className="w-3/4 space-y-2">
+                                    <div className="flex items-center gap-2">
+                                      <Label className="text-sm font-medium">
+                                        Blocked Models
+                                      </Label>
+                                      <TooltipProvider>
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <span>
+                                              <Info className="text-muted-foreground h-3 w-3" />
+                                            </span>
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            <p>
+                                              Models this VK must never serve.
+                                              The denylist wins if a model
+                                              appears in both Allowed Models and
+                                              Blocked Models.
+                                            </p>
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      </TooltipProvider>
+                                    </div>
+                                    {(() => {
+                                      const hasWildcardBlocked = (
+                                        config.blacklisted_models || []
+                                      ).includes("*");
+                                      return (
+                                        <ModelMultiselect
+                                          data-testid={`vk-models-blocked-multiselect-${index}`}
+                                          provider={config.provider}
+                                          keys={(() => {
+                                            const providerKeys =
+                                              availableKeys.filter(
+                                                (key) =>
+                                                  key.provider ===
+                                                  config.provider,
+                                              );
+                                            const configKeyIds =
+                                              config.key_ids || [];
+                                            return configKeyIds.includes("*")
+                                              ? providerKeys.map(
+                                                  (key) => key.key_id,
+                                                )
+                                              : providerKeys
+                                                  .filter((key) =>
+                                                    configKeyIds.includes(
+                                                      key.key_id,
+                                                    ),
+                                                  )
+                                                  .map((key) => key.key_id);
+                                          })()}
+                                          allowAllOption={true}
+                                          value={
+                                            hasWildcardBlocked
+                                              ? ["*"]
+                                              : config.blacklisted_models || []
+                                          }
+                                          onChange={(models: string[]) => {
+                                            const hadStar = (
+                                              config.blacklisted_models || []
+                                            ).includes("*");
+                                            const hasStar =
+                                              models.includes("*");
+                                            if (!hadStar && hasStar) {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "blacklisted_models",
+                                                ["*"],
+                                              );
+                                            } else if (
+                                              hadStar &&
+                                              hasStar &&
+                                              models.length > 1
+                                            ) {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "blacklisted_models",
+                                                models.filter((m) => m !== "*"),
+                                              );
+                                            } else {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "blacklisted_models",
+                                                models,
+                                              );
+                                            }
+                                          }}
+                                          placeholder={
+                                            hasWildcardBlocked
+                                              ? "All models blocked"
+                                              : (
+                                                    config.blacklisted_models ||
+                                                    []
+                                                  ).length === 0
+                                                ? "No models blocked"
+                                                : "Search models..."
+                                          }
+                                          className="min-h-10 max-w-[500px] min-w-[200px]"
+                                        />
+                                      );
+                                    })()}
                                   </div>
                                 </div>
 


### PR DESCRIPTION

## Summary

Adds the missing create/edit UI for VK-level blocked models and fixes runtime enforcement for provider-prefixed model names.

The previous VK blocked-model support had backend storage, API handling, runtime hooks, and read-only display, but the create/edit sheet did not expose the `Blocked Models` editor. This PR adds that missing UI field and also fixes an enforcement issue found during E2E testing: the UI stores selected models as `provider/model`, while the governance resolver could compare against bare model names. Because of that mismatch, blocked models could bypass the VK blacklist in some request paths.

## Changes

* Added editable `Blocked Models` field in the VK create/edit provider config section.

  * Placed between `Allowed Models` and `Allowed Keys`.
  * Uses the same `ModelMultiselect` pattern as the allowed models field.
  * Adds `blacklisted_models` to the zod schema.
  * Initializes edit mode with `config.blacklisted_models || []`.
  * Defaults new provider configs to `blacklisted_models: []`.

* Added prefix-aware blocked-model matching in governance.

  * Added `isModelBlockedByList()` to handle both bare and provider-prefixed model names.
  * This prevents bypasses where the UI stores `ollama/mistral:latest`, but the runtime request is evaluated as `mistral:latest`, or the other way around.

* Updated VK runtime enforcement paths to use the prefix-aware matcher:

  * `plugins/governance/resolver.go`
  * `plugins/governance/main.go`
  * `plugins/governance/utils.go`

Design decision:

* The fix keeps the existing `schemas.BlackList` behavior intact and adds a small VK-specific helper for prefix-aware comparison.
* Provider-key behavior is unchanged.

## Type of change

* [x] Bug fix
* [x] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

## Affected areas

* [ ] Core (Go)
* [ ] Transports (HTTP)
* [ ] Providers/Integrations
* [x] Plugins
* [x] UI (React)
* [ ] Docs

## How to test

Build checks:

```sh
go build -o ./tmp/bifrost-http ./transports/bifrost-http

cd ui
npm run build
```

Local server:

```sh
./tmp/bifrost-http -port 9090
```

Open:

```sh
http://localhost:9090/workspace/governance/virtual-keys
```

UI validation:

1. Open Governance → Virtual Keys.
2. Create or edit a virtual key.
3. Expand a provider config.
4. Confirm the field order is:

   * Allowed Models
   * Blocked Models
   * Allowed Keys
5. Select a blocked model and save.
6. Reopen the virtual key and confirm the blocked model is still selected.
7. Open the details sheet and confirm the blocked model is displayed.

E2E validation with local Ollama:

* Blocked bare model: `403 model_blocked`
* Blocked provider-prefixed model: `403 model_blocked`
* Allowed bare model: `200 OK`
* Allowed provider-prefixed model: `200 OK`
* Same model in allowlist and blocklist: `403 model_blocked`
* Empty blocklist: `200 OK`
* Wildcard blocklist `["*"]`: all tested models return `403 model_blocked`
* UI-created VK also works end-to-end with the same blocked/allowed behavior

## Screenshots/Recordings

Added/available recording showing the `Blocked Models` field in the VK provider config create/edit flow.



Uploading Screen Recording 2026-05-25 003101.mp4…




## Breaking changes

* [ ] Yes
* [x] No

## Related issues

BF-896

## Security considerations

This improves VK-level governance by ensuring blocked models are actually enforced for both bare and provider-prefixed model strings.

No secrets, provider keys, auth tokens, or PII are exposed or stored by this change. Provider-key behavior is unchanged.

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [ ] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [ ] I verified the CI pipeline passes locally if applicable
