### PR TITLE
feat: include `ProviderConfigs` with budgets and rate limits in virtual key quota query and response

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -38481,7 +38481,7 @@
       "get": {
         "operationId": "getVirtualKeyQuota",
         "summary": "Get virtual key quota",
-        "description": "Returns the budget and rate limit quota for the authenticated virtual key.\nThis is a self-service endpoint - no admin authentication required.\nThe virtual key value itself (provided via header) is the credential.\n",
+        "description": "Returns the overall budget and rate limit quota for the authenticated virtual key,\nas well as per-provider budgets and rate limits.\nThis is a self-service endpoint - no admin authentication required.\nThe virtual key value itself (provided via header) is the credential.\n",
         "tags": [
           "Governance"
         ],
@@ -38515,13 +38515,20 @@
                     },
                     "budgets": {
                       "type": "array",
-                      "description": "Budget quotas assigned to this virtual key",
+                      "description": "Overall budget quotas assigned to this virtual key",
                       "items": {
                         "$ref": "#/components/schemas/Budget"
                       }
                     },
                     "rate_limit": {
                       "$ref": "#/components/schemas/RateLimit"
+                    },
+                    "provider_configs": {
+                      "type": "array",
+                      "description": "Per-provider budget quotas and rate limits (provider-level splits and limits)",
+                      "items": {
+                        "$ref": "#/components/schemas/VirtualKeyProviderConfig"
+                      }
                     }
                   }
                 }
@@ -61005,20 +61012,33 @@
               "type": "string"
             }
           },
-          "budget_id": {
-            "type": "string"
+          "blacklisted_models": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "allow_all_keys": {
+            "type": "boolean"
           },
           "rate_limit_id": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
-          "budget": {
-            "$ref": "#/components/schemas/Budget"
+          "budgets": {
+            "type": "array",
+            "description": "Budget quotas assigned to this provider config",
+            "items": {
+              "$ref": "#/components/schemas/Budget"
+            }
           },
           "rate_limit": {
             "$ref": "#/components/schemas/RateLimit"
           },
           "keys": {
             "type": "array",
+            "nullable": true,
+            "description": "Associated API keys for this provider config. **Always null in the quota endpoint** — keys are intentionally not loaded here to keep the response lean and avoid exposing sensitive credentials. Use the admin virtual-key API to inspect actual key assignments.\n",
             "items": {
               "$ref": "#/components/schemas/TableKey"
             }

--- a/docs/openapi/paths/management/governance.yaml
+++ b/docs/openapi/paths/management/governance.yaml
@@ -53,7 +53,8 @@ virtual-keys-quota:
     operationId: getVirtualKeyQuota
     summary: Get virtual key quota
     description: |
-      Returns the budget and rate limit quota for the authenticated virtual key.
+      Returns the overall budget and rate limit quota for the authenticated virtual key,
+      as well as per-provider budgets and rate limits.
       This is a self-service endpoint - no admin authentication required.
       The virtual key value itself (provided via header) is the credential.
     tags:

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -157,16 +157,29 @@ VirtualKeyProviderConfig:
       type: array
       items:
         type: string
-    budget_id:
-      type: string
+    blacklisted_models:
+      type: array
+      items:
+        type: string
+    allow_all_keys:
+      type: boolean
     rate_limit_id:
       type: string
-    budget:
-      $ref: '#/Budget'
+      nullable: true
+    budgets:
+      type: array
+      description: Budget quotas assigned to this provider config
+      items:
+        $ref: '#/Budget'
     rate_limit:
       $ref: '#/RateLimit'
     keys:
       type: array
+      nullable: true
+      description: >
+        Associated API keys for this provider config. **Always null in the quota endpoint** —
+        keys are intentionally not loaded here to keep the response lean and avoid
+        exposing sensitive credentials. Use the admin virtual-key API to inspect actual key assignments.
       items:
         $ref: '#/TableKey'
 
@@ -343,11 +356,16 @@ VirtualKeyQuotaResponse:
       description: Whether the virtual key is active
     budgets:
       type: array
-      description: Budget quotas assigned to this virtual key
+      description: Overall budget quotas assigned to this virtual key
       items:
         $ref: '#/Budget'
     rate_limit:
       $ref: '#/RateLimit'
+    provider_configs:
+      type: array
+      description: Per-provider budget quotas and rate limits (provider-level splits and limits)
+      items:
+        $ref: '#/VirtualKeyProviderConfig'
 
 VirtualKeyResponse:
   type: object

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2538,12 +2538,17 @@ func (s *RDBConfigStore) GetVirtualKeyByValue(ctx context.Context, value string)
 	return &virtualKey, nil
 }
 
-// GetVirtualKeyQuotaByValue retrieves only the budget and rate limit data for a virtual key.
-// This is a lean query that avoids loading Team, Customer, ProviderConfigs, MCPConfigs, and Keys.
+// GetVirtualKeyQuotaByValue retrieves budget, rate limit, and provider-level limit data for a virtual key.
+// This is a lean query that avoids loading Team, Customer, MCPConfigs, and provider Keys.
 func (s *RDBConfigStore) GetVirtualKeyQuotaByValue(ctx context.Context, value string) (*tables.TableVirtualKey, error) {
 	valueHash := encrypt.HashSHA256(value)
 	var virtualKey tables.TableVirtualKey
-	baseQuery := s.DB().WithContext(ctx).Preload("Budgets").Preload("RateLimit")
+	baseQuery := s.DB().WithContext(ctx).
+		Preload("Budgets").
+		Preload("RateLimit").
+		Preload("ProviderConfigs").
+		Preload("ProviderConfigs.Budgets").
+		Preload("ProviderConfigs.RateLimit")
 	if err := baseQuery.Session(&gorm.Session{}).Where("value_hash = ?", valueHash).First(&virtualKey).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// Fallback: try plaintext lookup for rows not yet migrated

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -4214,5 +4214,6 @@ func (h *GovernanceHandler) getVirtualKeyQuota(ctx *fasthttp.RequestCtx) {
 		"is_active":        vk.IsActiveValue(),
 		"budgets":          vk.Budgets,
 		"rate_limit":       vk.RateLimit,
+		"provider_configs": vk.ProviderConfigs,
 	})
 }


### PR DESCRIPTION
## Summary

Provider-level budget and rate limit configurations were not being included when fetching virtual key quota data, meaning the `getVirtualKeyQuota` endpoint returned incomplete governance information. This PR extends the lean quota query to also load `ProviderConfigs` along with their associated `Budgets` and `RateLimit`, and exposes them in the API response.

## Changes

- `GetVirtualKeyQuotaByValue` now preloads `ProviderConfigs`, `ProviderConfigs.Budgets`, and `ProviderConfigs.RateLimit` in addition to the existing top-level `Budgets` and `RateLimit` preloads.
- The `getVirtualKeyQuota` HTTP handler now includes `provider_configs` in the JSON response payload.
- Updated the comment on `GetVirtualKeyQuotaByValue` to accurately reflect what is and isn't loaded (provider `Keys` and `MCPConfigs` are still excluded; `ProviderConfigs` themselves are now included).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Call the virtual key quota endpoint with a virtual key that has provider configs attached and verify the response includes `provider_configs` with their respective `budgets` and `rate_limit` fields populated.

```sh
go test ./framework/configstore/...
go test ./transports/bifrost-http/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new secrets or PII are introduced. `ProviderConfigs` data returned is scoped to the authenticated virtual key, consistent with existing quota data access controls.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable