### PR TITLE
feat: log database type when connecting in `NewConfigStore`

### DIFF
--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -538,6 +538,7 @@ func NewConfigStore(ctx context.Context, config *Config, logger schemas.Logger) 
 	if !config.Enabled {
 		return nil, nil
 	}
+	logger.Info("connecting to %s database", config.Type)
 	switch config.Type {
 	case ConfigStoreTypeSQLite:
 		if sqliteConfig, ok := config.Config.(*SQLiteConfig); ok {


### PR DESCRIPTION
## Summary

Adds a log message when the config store initializes a database connection, making it easier to observe which database backend is being used at startup.

## Changes

- A log line is emitted at the `Info` level before the database type switch, reporting the configured store type (e.g., SQLite) when a connection is being established.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Start the application with a configured config store and verify that a log line similar to the following appears on startup:

```
connecting to sqlite database
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The log message only exposes the database type (e.g., `sqlite`), not any connection credentials or sensitive configuration values.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable