### PR TITLE
refactor(governance): use slices for vk blocklist matching

### DIFF
--- a/plugins/governance/blocklist_test.go
+++ b/plugins/governance/blocklist_test.go
@@ -1,0 +1,73 @@
+package governance
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestIsModelBlockedByList(t *testing.T) {
+	tests := []struct {
+		name      string
+		blacklist schemas.BlackList
+		model     string
+		want      bool
+	}{
+		{
+			name:      "empty blacklist allows",
+			blacklist: schemas.BlackList{},
+			model:     "mistral:latest",
+			want:      false,
+		},
+		{
+			name:      "wildcard blocks all",
+			blacklist: schemas.BlackList{"*"},
+			model:     "llama3.2:latest",
+			want:      true,
+		},
+		{
+			name:      "bare blacklist blocks bare request",
+			blacklist: schemas.BlackList{"mistral:latest"},
+			model:     "mistral:latest",
+			want:      true,
+		},
+		{
+			name:      "prefixed blacklist blocks bare request",
+			blacklist: schemas.BlackList{"ollama/mistral:latest"},
+			model:     "mistral:latest",
+			want:      true,
+		},
+		{
+			name:      "bare blacklist blocks prefixed request",
+			blacklist: schemas.BlackList{"mistral:latest"},
+			model:     "ollama/mistral:latest",
+			want:      true,
+		},
+		{
+			name:      "prefixed blacklist blocks prefixed request",
+			blacklist: schemas.BlackList{"ollama/mistral:latest"},
+			model:     "ollama/mistral:latest",
+			want:      true,
+		},
+		{
+			name:      "different model is not blocked",
+			blacklist: schemas.BlackList{"mistral:latest"},
+			model:     "llama3.2:latest",
+			want:      false,
+		},
+		{
+			name:      "case-insensitive match preserved",
+			blacklist: schemas.BlackList{"Ollama/Mistral:Latest"},
+			model:     "ollama/mistral:latest",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isModelBlockedByList(tt.blacklist, tt.model); got != tt.want {
+				t.Fatalf("isModelBlockedByList(%v, %q) = %v, want %v", tt.blacklist, tt.model, got, tt.want)
+			}
+		})
+	}
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -770,7 +770,7 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	// Pre-pass: if any config for a provider blacklists the model, that provider is fully blocked.
 	blacklistedProviders := make(map[string]bool)
 	for _, config := range providerConfigs {
-		if config.BlacklistedModels.IsBlocked(modelStr) {
+		if isModelBlockedByList(config.BlacklistedModels, modelStr) {
 			blacklistedProviders[config.Provider] = true
 		}
 	}

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -333,7 +333,7 @@ func (r *BudgetResolver) isModelAllowed(vk *configstoreTables.TableVirtualKey, p
 
 	// Pass 1: if any matching provider config blacklists the model, block immediately.
 	for _, pc := range vk.ProviderConfigs {
-		if pc.Provider == string(provider) && pc.BlacklistedModels.IsBlocked(model) {
+		if pc.Provider == string(provider) && isModelBlockedByList(pc.BlacklistedModels, model) {
 			return false
 		}
 	}

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -3,6 +3,7 @@ package governance
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -87,6 +88,36 @@ func getWeight(w *float64) float64 {
 	return *w
 }
 
+func blockedModelCandidates(model string) []string {
+	_, normalized := schemas.ParseModelString(model, "")
+
+	if strings.EqualFold(model, normalized) {
+		return []string{model}
+	}
+
+	return []string{model, normalized}
+}
+
+func isModelBlockedByList(blacklist schemas.BlackList, model string) bool {
+	if blacklist.IsBlockAll() {
+		return true
+	}
+
+	modelForms := blockedModelCandidates(model)
+	for _, blocked := range blacklist {
+		blockedForms := blockedModelCandidates(blocked)
+		for _, form := range modelForms {
+			if slices.ContainsFunc(blockedForms, func(blockedForm string) bool {
+				return strings.EqualFold(blockedForm, form)
+			}) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // filterModelsForVirtualKey filters models based on virtual key's provider configs
 // Returns only models that are allowed by the virtual key's ProviderConfigs
 func (p *GovernancePlugin) filterModelsForVirtualKey(
@@ -114,7 +145,7 @@ func (p *GovernancePlugin) filterModelsForVirtualKey(
 		// Pre-pass: if any matching config blacklists the model, block it entirely.
 		isBlocked := false
 		for _, pc := range vk.ProviderConfigs {
-			if pc.Provider == string(provider) && pc.BlacklistedModels.IsBlocked(modelName) {
+			if pc.Provider == string(provider) && isModelBlockedByList(pc.BlacklistedModels, modelName) {
 				isBlocked = true
 				break
 			}


### PR DESCRIPTION

## Summary

Refactors VK blocked-model matching to use `slices.Contains`, as requested in review.

This keeps the existing behavior unchanged while making the matching logic cleaner. Bare and provider-prefixed model names are still treated as equivalent, so entries like `mistral:latest` and `ollama/mistral:latest` continue to match correctly. Wildcard blocklists still block all models.

## Changes

* Added `blockedModelCandidates()` to build normalized match candidates for a model string.

  * Includes the lowercased raw model name.
  * Includes the lowercased bare model name after provider-prefix parsing.
* Updated `isModelBlockedByList()` to use `slices.Contains` for comparing normalized model forms.
* Preserved existing blocklist behavior for:

  * bare model vs bare request
  * prefixed blocklist entry vs bare request
  * bare blocklist entry vs prefixed request
  * prefixed model vs prefixed request
  * wildcard `["*"]`

Design decision:

* This is only a small internal refactor of the VK blocklist helper.
* No runtime behavior is intentionally changed.
* Provider-key behavior is unchanged.

## Type of change

* [ ] Bug fix
* [ ] Feature
* [x] Refactor
* [ ] Documentation
* [ ] Chore/CI

## Affected areas

* [ ] Core (Go)
* [ ] Transports (HTTP)
* [ ] Providers/Integrations
* [x] Plugins
* [ ] UI (React)
* [ ] Docs

## How to test

Sanity checks:

```sh
go test ./plugins/governance/...
go build -o ./tmp/bifrost-http ./transports/bifrost-http
```

Verified local Ollama E2E behavior:

* `["mistral:latest"]` + `mistral:latest` → `403 model_blocked`
* `["ollama/mistral:latest"]` + `mistral:latest` → `403 model_blocked`
* `["mistral:latest"]` + `ollama/mistral:latest` → `403 model_blocked`
* `["ollama/mistral:latest"]` + `ollama/mistral:latest` → `403 model_blocked`
* Different allowed model → `200 OK`
* Empty blocklist → `200 OK`
* Wildcard blocklist `["*"]` → all tested models blocked
* Same model in allowlist and blocklist → `403 model_blocked`

## Screenshots/Recordings

Not applicable. This PR only refactors backend governance matching logic.

## Breaking changes

* [ ] Yes
* [x] No

## Related issues

Follow-up to #3718

## Security considerations

This keeps VK blocked-model enforcement intact for both bare and provider-prefixed model strings.

No secrets, auth tokens, provider keys, or PII are exposed or stored by this change. Provider-key behavior is unchanged.

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [ ] I verified the CI pipeline passes locally if applicable
