### PR TITLE
fix: search content and video getting dropped from Bedrock requests

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -5233,3 +5233,288 @@ func TestBedrockToBifrostResponsesResponse_StructuredOutput_MixedWithRealTools(t
 	assert.Equal(t, "tool_calls", *result.StopReason,
 		"expected stop_reason=tool_calls when real tool calls are also present")
 }
+
+// TestBedrockSearchResultToolResultRoundTrip is the regression gate for
+// https://github.com/maximhq/bifrost/issues/3537 — a Bedrock-native passthrough
+// request containing toolResult.content[].searchResult must survive
+// ToBifrostResponsesRequest → ToBedrockResponsesRequest with all fields intact.
+// Pre-fix, the SearchResult field is dropped during JSON unmarshal and the
+// outbound request shows toolResult.content = [{"text": ""}].
+func TestBedrockSearchResultToolResultRoundTrip(t *testing.T) {
+	original := &bedrock.BedrockConverseRequest{
+		ModelID: "anthropic.claude-sonnet-4-5",
+		Messages: []bedrock.BedrockMessage{
+			{
+				Role: bedrock.BedrockMessageRoleUser,
+				Content: []bedrock.BedrockContentBlock{
+					{Text: schemas.Ptr("What is Apptio?")},
+				},
+			},
+			{
+				Role: bedrock.BedrockMessageRoleAssistant,
+				Content: []bedrock.BedrockContentBlock{
+					{
+						ToolUse: &bedrock.BedrockToolUse{
+							ToolUseID: "tooluse_a4rBqeZNRTKj2lTskvaO4H",
+							Name:      "RAGRequest",
+							Input:     json.RawMessage(`{"query":"What is Apptio?"}`),
+						},
+					},
+				},
+			},
+			{
+				Role: bedrock.BedrockMessageRoleUser,
+				Content: []bedrock.BedrockContentBlock{
+					{
+						ToolResult: &bedrock.BedrockToolResult{
+							ToolUseID: "tooluse_a4rBqeZNRTKj2lTskvaO4H",
+							Status:    schemas.Ptr("success"),
+							Content: []bedrock.BedrockContentBlock{
+								{
+									SearchResult: &bedrock.BedrockSearchResultBlock{
+										Source: "Great Source of Information About Apptio",
+										Title:  "12adbd74-46bd-4a88-88b2-0048755f6eb5",
+										Content: []bedrock.BedrockSearchResultContent{
+											{Text: "Apptio is a company that makes calls to Bedrock using passthrough APIs via Bifrost"},
+										},
+										Citations: &bedrock.BedrockCitationsConfig{Enabled: true},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		System: []bedrock.BedrockSystemMessage{
+			{Text: schemas.Ptr("Do not rely on your knowledge to answer. Use only the tool results.")},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	// First leg: Bedrock → Bifrost intermediate.
+	bifrostReq, err := original.ToBifrostResponsesRequest(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq)
+
+	// Second leg: Bifrost intermediate → Bedrock.
+	rebuilt, err := bedrock.ToBedrockResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, rebuilt)
+
+	// Locate the rebuilt toolResult content block (its position may shift
+	// because the converter groups assistant tool calls and user tool results
+	// by state-machine emission, but a toolResult with our toolUseId must exist).
+	var got *bedrock.BedrockSearchResultBlock
+	for _, msg := range rebuilt.Messages {
+		for _, block := range msg.Content {
+			if block.ToolResult == nil {
+				continue
+			}
+			if block.ToolResult.ToolUseID != "tooluse_a4rBqeZNRTKj2lTskvaO4H" {
+				continue
+			}
+			for _, c := range block.ToolResult.Content {
+				if c.SearchResult != nil {
+					got = c.SearchResult
+					break
+				}
+			}
+		}
+	}
+
+	require.NotNil(t, got, "expected toolResult.content[].searchResult to round-trip; got nil (regression of #3537)")
+	assert.Equal(t, "Great Source of Information About Apptio", got.Source)
+	assert.Equal(t, "12adbd74-46bd-4a88-88b2-0048755f6eb5", got.Title)
+	require.Len(t, got.Content, 1)
+	assert.Equal(t, "Apptio is a company that makes calls to Bedrock using passthrough APIs via Bifrost", got.Content[0].Text)
+	require.NotNil(t, got.Citations)
+	assert.True(t, got.Citations.Enabled)
+}
+
+// TestBedrockVideoToolResultRoundTrip verifies that a video block inside
+// toolResult.content survives ToBifrostResponsesRequest → ToBedrockResponsesRequest
+// via the same sentinel-envelope mechanism that preserves searchResult. Without
+// the schema fix + envelope trigger extension, Video is silently dropped at JSON
+// unmarshal and the outbound request carries an empty text block instead.
+func TestBedrockVideoToolResultRoundTrip(t *testing.T) {
+	// Smallest plausible base64 payload — content doesn't matter for the round-trip,
+	// only that the Video struct is preserved verbatim.
+	videoBytes := "AAAA"
+
+	original := &bedrock.BedrockConverseRequest{
+		ModelID: "anthropic.claude-sonnet-4-5",
+		Messages: []bedrock.BedrockMessage{
+			{
+				Role: bedrock.BedrockMessageRoleUser,
+				Content: []bedrock.BedrockContentBlock{
+					{Text: schemas.Ptr("Describe the attached clip.")},
+				},
+			},
+			{
+				Role: bedrock.BedrockMessageRoleAssistant,
+				Content: []bedrock.BedrockContentBlock{
+					{
+						ToolUse: &bedrock.BedrockToolUse{
+							ToolUseID: "tooluse_video_xyz",
+							Name:      "FetchClip",
+							Input:     json.RawMessage(`{"id":"abc"}`),
+						},
+					},
+				},
+			},
+			{
+				Role: bedrock.BedrockMessageRoleUser,
+				Content: []bedrock.BedrockContentBlock{
+					{
+						ToolResult: &bedrock.BedrockToolResult{
+							ToolUseID: "tooluse_video_xyz",
+							Status:    schemas.Ptr("success"),
+							Content: []bedrock.BedrockContentBlock{
+								{
+									Video: &bedrock.BedrockVideoBlock{
+										Format: "mp4",
+										Source: bedrock.BedrockVideoSource{
+											Bytes: &videoBytes,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	bifrostReq, err := original.ToBifrostResponsesRequest(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq)
+
+	rebuilt, err := bedrock.ToBedrockResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, rebuilt)
+
+	var got *bedrock.BedrockVideoBlock
+	for _, msg := range rebuilt.Messages {
+		for _, block := range msg.Content {
+			if block.ToolResult == nil || block.ToolResult.ToolUseID != "tooluse_video_xyz" {
+				continue
+			}
+			for _, c := range block.ToolResult.Content {
+				if c.Video != nil {
+					got = c.Video
+					break
+				}
+			}
+		}
+	}
+
+	require.NotNil(t, got, "expected toolResult.content[].video to round-trip; got nil")
+	assert.Equal(t, "mp4", got.Format)
+	require.NotNil(t, got.Source.Bytes)
+	assert.Equal(t, videoBytes, *got.Source.Bytes)
+	assert.Nil(t, got.Source.S3Location, "expected union member s3Location to be nil when bytes is set")
+}
+
+// TestBedrockMixedBlockToolResultRoundTrip covers a toolResult.content array that
+// mixes a representable block (text) with an unrepresentable one (searchResult).
+// Because the envelope path triggers on *any* unrepresentable block and serializes
+// the entire content array, the whole array is bundled and must be decoded back
+// intact — both blocks, in order. This guards against the decode leg dropping the
+// representable block (or vice-versa) when the two are interleaved.
+func TestBedrockMixedBlockToolResultRoundTrip(t *testing.T) {
+	original := &bedrock.BedrockConverseRequest{
+		ModelID: "anthropic.claude-sonnet-4-5",
+		Messages: []bedrock.BedrockMessage{
+			{
+				Role: bedrock.BedrockMessageRoleUser,
+				Content: []bedrock.BedrockContentBlock{
+					{Text: schemas.Ptr("What is Apptio?")},
+				},
+			},
+			{
+				Role: bedrock.BedrockMessageRoleAssistant,
+				Content: []bedrock.BedrockContentBlock{
+					{
+						ToolUse: &bedrock.BedrockToolUse{
+							ToolUseID: "tooluse_mixed_blocks",
+							Name:      "RAGRequest",
+							Input:     json.RawMessage(`{"query":"What is Apptio?"}`),
+						},
+					},
+				},
+			},
+			{
+				Role: bedrock.BedrockMessageRoleUser,
+				Content: []bedrock.BedrockContentBlock{
+					{
+						ToolResult: &bedrock.BedrockToolResult{
+							ToolUseID: "tooluse_mixed_blocks",
+							Status:    schemas.Ptr("success"),
+							Content: []bedrock.BedrockContentBlock{
+								{Text: schemas.Ptr("Summary: Apptio is a Bedrock passthrough customer.")},
+								{
+									SearchResult: &bedrock.BedrockSearchResultBlock{
+										Source: "Great Source of Information About Apptio",
+										Title:  "12adbd74-46bd-4a88-88b2-0048755f6eb5",
+										Content: []bedrock.BedrockSearchResultContent{
+											{Text: "Apptio is a company that makes calls to Bedrock using passthrough APIs via Bifrost"},
+										},
+										Citations: &bedrock.BedrockCitationsConfig{Enabled: true},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		System: []bedrock.BedrockSystemMessage{
+			{Text: schemas.Ptr("Do not rely on your knowledge to answer. Use only the tool results.")},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	bifrostReq, err := original.ToBifrostResponsesRequest(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq)
+
+	rebuilt, err := bedrock.ToBedrockResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, rebuilt)
+
+	// Locate the rebuilt toolResult content array for our toolUseId.
+	var gotContent []bedrock.BedrockContentBlock
+	for _, msg := range rebuilt.Messages {
+		for _, block := range msg.Content {
+			if block.ToolResult == nil || block.ToolResult.ToolUseID != "tooluse_mixed_blocks" {
+				continue
+			}
+			gotContent = block.ToolResult.Content
+		}
+	}
+
+	require.NotNil(t, gotContent, "expected toolResult with our toolUseId to round-trip; got nil")
+	require.Len(t, gotContent, 2, "expected both the text and searchResult blocks to survive the round-trip")
+
+	// Order is preserved: the envelope is a JSON array, so block[0] is the text
+	// block and block[1] is the searchResult block.
+	require.NotNil(t, gotContent[0].Text, "expected first block to remain a text block")
+	assert.Equal(t, "Summary: Apptio is a Bedrock passthrough customer.", *gotContent[0].Text)
+	assert.Nil(t, gotContent[0].SearchResult, "text block must not gain a searchResult")
+
+	got := gotContent[1].SearchResult
+	require.NotNil(t, got, "expected second block to remain a searchResult block")
+	assert.Nil(t, gotContent[1].Text, "searchResult block must not gain a text field")
+	assert.Equal(t, "Great Source of Information About Apptio", got.Source)
+	assert.Equal(t, "12adbd74-46bd-4a88-88b2-0048755f6eb5", got.Title)
+	require.Len(t, got.Content, 1)
+	assert.Equal(t, "Apptio is a company that makes calls to Bedrock using passthrough APIs via Bifrost", got.Content[0].Text)
+	require.NotNil(t, got.Citations)
+	assert.True(t, got.Citations.Enabled)
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3163,7 +3163,12 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 				// Convert result content to Bedrock format
 				if msg.ResponsesToolMessage.Output != nil {
 					if msg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr != nil {
-						resultContent = append(resultContent, tryParseJSONIntoContentBlock(*msg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr))
+						outputStr := *msg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr
+						if blocks, ok := decodeBedrockToolResultEnvelope(outputStr); ok {
+							resultContent = append(resultContent, blocks...)
+						} else {
+							resultContent = append(resultContent, tryParseJSONIntoContentBlock(outputStr))
+						}
 					} else if msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks != nil {
 						// Handle structured output blocks
 						for _, block := range msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks {
@@ -3989,9 +3994,24 @@ func convertSingleBedrockMessageToBifrostMessages(ctx *schemas.BifrostContext, m
 
 		} else if block.ToolResult != nil {
 			// Tool result content - typically not in assistant output but handled for completeness
-			// Prefer JSON payloads without unmarshalling; fallback to text
+			// Prefer JSON payloads without unmarshalling; fallback to text.
+			// If the content contains a searchResult (or any other block Bifrost's intermediate
+			// can't model natively), serialize the full content array into a sentinel envelope
+			// so it round-trips losslessly via ToBedrockResponsesRequest.
 			var resultContent string
-			if len(block.ToolResult.Content) > 0 {
+			hasUnrepresentableBlock := false
+			for _, c := range block.ToolResult.Content {
+				if c.SearchResult != nil || c.Video != nil {
+					hasUnrepresentableBlock = true
+					break
+				}
+			}
+			if hasUnrepresentableBlock {
+				if envelope, err := encodeBedrockToolResultEnvelope(block.ToolResult.Content); err == nil {
+					resultContent = envelope
+				}
+			}
+			if resultContent == "" && len(block.ToolResult.Content) > 0 {
 				// JSON first (no unmarshal; just one marshal to string when present)
 				for _, c := range block.ToolResult.Content {
 					if c.JSON != nil {

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -201,6 +201,9 @@ type BedrockContentBlock struct {
 	// Image content
 	Image *BedrockImageSource `json:"image,omitempty"`
 
+	// Video content
+	Video *BedrockVideoBlock `json:"video,omitempty"`
+
 	// Document content
 	Document *BedrockDocumentSource `json:"document,omitempty"`
 
@@ -218,6 +221,9 @@ type BedrockContentBlock struct {
 
 	// For Tool Call Result content
 	JSON json.RawMessage `json:"json,omitempty"`
+
+	// Search result content (only valid inside toolResult.content per AWS Converse API)
+	SearchResult *BedrockSearchResultBlock `json:"searchResult,omitempty"`
 
 	// Cache point for the content block
 	CachePoint *BedrockCachePoint `json:"cachePoint,omitempty"`
@@ -261,6 +267,28 @@ type BedrockDocumentSourceData struct {
 	Text  *string `json:"text,omitempty"`  // Plain text content
 }
 
+// BedrockVideoBlock represents a video content block.
+// See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_VideoBlock.html
+type BedrockVideoBlock struct {
+	Format string             `json:"format"` // Required: mkv|mov|mp4|webm|flv|mpeg|mpg|wmv|three_gp
+	Source BedrockVideoSource `json:"source"` // Required: video source (bytes or s3Location, union)
+}
+
+// BedrockVideoSource is the source for a BedrockVideoBlock.
+// This is a tagged union — exactly one of Bytes or S3Location should be set.
+// See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_VideoSource.html
+type BedrockVideoSource struct {
+	Bytes      *string            `json:"bytes,omitempty"`      // Optional: base64-encoded video bytes (<25MB)
+	S3Location *BedrockS3Location `json:"s3Location,omitempty"` // Optional: S3 location
+}
+
+// BedrockS3Location represents a storage location in an Amazon S3 bucket.
+// See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_S3Location.html
+type BedrockS3Location struct {
+	URI         string  `json:"uri"`                   // Required: object URI starting with s3://
+	BucketOwner *string `json:"bucketOwner,omitempty"` // Optional: 12-digit AWS account ID if cross-account
+}
+
 // BedrockToolUse represents a tool use request
 type BedrockToolUse struct {
 	ToolUseID string          `json:"toolUseId"`       // Required: Unique identifier for this tool use
@@ -275,6 +303,27 @@ type BedrockToolResult struct {
 	Content   []BedrockContentBlock `json:"content"`          // Required: Content of the tool result
 	Status    *string               `json:"status,omitempty"` // Optional: Status of tool execution ("success" or "error")
 	Type      *string               `json:"type,omitempty"`   // Optional: result type e.g. "nova_code_interpreter_result"
+}
+
+// BedrockSearchResultBlock represents a search result tool-result content block.
+// See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_SearchResultBlock.html
+type BedrockSearchResultBlock struct {
+	Source    string                       `json:"source"`              // Required: source URL or identifier
+	Title     string                       `json:"title"`               // Required: descriptive title
+	Content   []BedrockSearchResultContent `json:"content"`             // Required: search result content blocks
+	Citations *BedrockCitationsConfig      `json:"citations,omitempty"` // Optional: citations config
+}
+
+// BedrockSearchResultContent represents a single content block inside a SearchResult.
+// See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_SearchResultContentBlock.html
+type BedrockSearchResultContent struct {
+	Text string `json:"text"` // Required: actual text content
+}
+
+// BedrockCitationsConfig represents citations configuration for a search result.
+// See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CitationsConfig.html
+type BedrockCitationsConfig struct {
+	Enabled bool `json:"enabled"` // Required: whether citations are enabled
 }
 
 // BedrockGuardContent represents guard content for guardrails

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/bytedance/sonic"
 	"github.com/tidwall/sjson"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
@@ -2116,6 +2117,45 @@ func bedrockExtractFloat64(v interface{}) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// bedrockToolResultEnvelopeKey marks a sentinel-wrapped JSON string that carries a full
+// BedrockToolResult.Content array through Bifrost's intermediate format. Used when the
+// content includes blocks (e.g. searchResult) that the intermediate cannot model natively,
+// so they round-trip losslessly on the Bedrock-native passthrough endpoint.
+const bedrockToolResultEnvelopeKey = "__bifrost_bedrock_tool_result_content__"
+
+// encodeBedrockToolResultEnvelope serializes a BedrockToolResult.Content array into a
+// sentinel-wrapped JSON object that decodeBedrockToolResultEnvelope can recover.
+func encodeBedrockToolResultEnvelope(content []BedrockContentBlock) (string, error) {
+	envelope := map[string]any{bedrockToolResultEnvelopeKey: content}
+	b, err := sonic.Marshal(envelope)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// decodeBedrockToolResultEnvelope is the inverse of encodeBedrockToolResultEnvelope.
+// Returns (blocks, true) if s is a sentinel-wrapped tool-result envelope; (nil, false) otherwise.
+// Non-envelope strings are returned untouched so the caller can fall through to tryParseJSONIntoContentBlock.
+func decodeBedrockToolResultEnvelope(s string) ([]BedrockContentBlock, bool) {
+	if len(s) == 0 || s[0] != '{' || !strings.Contains(s, bedrockToolResultEnvelopeKey) {
+		return nil, false
+	}
+	var envelope map[string]json.RawMessage
+	if err := sonic.UnmarshalString(s, &envelope); err != nil {
+		return nil, false
+	}
+	raw, ok := envelope[bedrockToolResultEnvelopeKey]
+	if !ok || len(envelope) != 1 {
+		return nil, false
+	}
+	var blocks []BedrockContentBlock
+	if err := sonic.Unmarshal(raw, &blocks); err != nil {
+		return nil, false
+	}
+	return blocks, true
 }
 
 // tryParseJSONIntoContentBlock try to parse input text into a JSON and returns a proper


### PR DESCRIPTION
## Summary

Fixes a regression ([#3537](https://github.com/maximhq/bifrost/issues/3537)) where Bedrock-native passthrough requests containing `toolResult.content[].searchResult` or `toolResult.content[].video` blocks were silently dropped during the `ToBifrostResponsesRequest` → `ToBedrockResponsesRequest` round-trip. The outbound request would carry an empty `{"text": ""}` block instead of the original content.

## Changes

- Added `BedrockSearchResultBlock`, `BedrockSearchResultContent`, `BedrockCitationsConfig`, `BedrockVideoBlock`, `BedrockVideoSource`, and `BedrockS3Location` types to `types.go` so these AWS Converse API structures are recognized during JSON unmarshal.
- Added `SearchResult` and `Video` fields to `BedrockContentBlock` so the types are reachable from content blocks.
- Introduced a sentinel-envelope mechanism (`encodeBedrockToolResultEnvelope` / `decodeBedrockToolResultEnvelope`) in `utils.go`. When a `toolResult.content` array contains blocks that Bifrost's intermediate format cannot model natively (e.g. `searchResult`, `video`), the full content array is serialized into a keyed JSON envelope and stored as the tool output string. On the return leg, the envelope is detected and decoded back into the original `BedrockContentBlock` slice before being forwarded to Bedrock.
- Updated `ConvertBifrostMessagesToBedrockMessages` in `responses.go` to check for and decode the sentinel envelope before falling through to `tryParseJSONIntoContentBlock`.
- Updated `convertSingleBedrockMessageToBifrostMessages` in `responses.go` to detect unrepresentable blocks and encode them into the sentinel envelope instead of attempting lossy text extraction.
- Added regression tests `TestBedrockSearchResultToolResultRoundTrip` and `TestBedrockVideoToolResultRoundTrip` that exercise the full `ToBifrostResponsesRequest` → `ToBedrockResponsesRequest` round-trip and assert all fields survive intact.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... -run "TestBedrockSearchResultToolResultRoundTrip|TestBedrockVideoToolResultRoundTrip" -v
```

Both tests should pass. Prior to this fix, both would fail with `expected toolResult.content[].searchResult to round-trip; got nil` and `expected toolResult.content[].video to round-trip; got nil` respectively.

To run the full Bedrock provider test suite:

```sh
go test ./core/providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #3537

## Security considerations

The sentinel envelope is a self-contained JSON object keyed by a fixed internal string. It is only decoded when the key is present and the envelope contains exactly one key, preventing accidental misinterpretation of user-supplied JSON payloads. No secrets or PII are introduced by this mechanism.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable