### PR TITLE
chore: fix bedrock transport tests

### DIFF
--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -554,7 +554,7 @@ func TestBedrockTransportHTTP2Config(t *testing.T) {
 	}
 	config.CheckAndSetDefaults()
 
-	provider, err := NewBedrockProvider(config, nil)
+	provider, err := NewBedrockProvider(config, noopLogger{})
 	require.NoError(t, err)
 	require.NotNil(t, provider)
 
@@ -576,7 +576,7 @@ func TestBedrockTransportCustomMaxConns(t *testing.T) {
 	}
 	config.CheckAndSetDefaults()
 
-	provider, err := NewBedrockProvider(config, nil)
+	provider, err := NewBedrockProvider(config, noopLogger{})
 	require.NoError(t, err)
 
 	transport, ok := provider.client.Transport.(*http.Transport)
@@ -598,7 +598,7 @@ func TestBedrockTransportDefaultMaxConns(t *testing.T) {
 
 	assert.Equal(t, schemas.DefaultMaxConnsPerHost, config.NetworkConfig.MaxConnsPerHost)
 
-	provider, err := NewBedrockProvider(config, nil)
+	provider, err := NewBedrockProvider(config, noopLogger{})
 	require.NoError(t, err)
 
 	transport, ok := provider.client.Transport.(*http.Transport)
@@ -619,7 +619,7 @@ func TestBedrockTransportTLSInsecureSkipVerify(t *testing.T) {
 	}
 	config.CheckAndSetDefaults()
 
-	provider, err := NewBedrockProvider(config, nil)
+	provider, err := NewBedrockProvider(config, noopLogger{})
 	require.NoError(t, err)
 
 	transport, ok := provider.client.Transport.(*http.Transport)
@@ -643,7 +643,7 @@ func TestBedrockTransportTLSCACert(t *testing.T) {
 	}
 	config.CheckAndSetDefaults()
 
-	provider, err := NewBedrockProvider(config, nil)
+	provider, err := NewBedrockProvider(config, noopLogger{})
 	require.NoError(t, err)
 
 	transport, ok := provider.client.Transport.(*http.Transport)
@@ -663,7 +663,7 @@ func TestBedrockTransportDefaultTLS(t *testing.T) {
 	}
 	config.CheckAndSetDefaults()
 
-	provider, err := NewBedrockProvider(config, nil)
+	provider, err := NewBedrockProvider(config, noopLogger{})
 	require.NoError(t, err)
 
 	transport, ok := provider.client.Transport.(*http.Transport)
@@ -683,7 +683,7 @@ func TestBedrockTransportEnforceHTTP2(t *testing.T) {
 	}
 	config.CheckAndSetDefaults()
 
-	provider, err := NewBedrockProvider(config, nil)
+	provider, err := NewBedrockProvider(config, noopLogger{})
 	require.NoError(t, err)
 
 	transport, ok := provider.client.Transport.(*http.Transport)
@@ -702,7 +702,7 @@ func TestBedrockTransportEnforceHTTP2Disabled(t *testing.T) {
 	}
 	config.CheckAndSetDefaults()
 
-	provider, err := NewBedrockProvider(config, nil)
+	provider, err := NewBedrockProvider(config, noopLogger{})
 	require.NoError(t, err)
 
 	transport, ok := provider.client.Transport.(*http.Transport)


### PR DESCRIPTION
## Summary

Replaces `nil` logger arguments with a `noopLogger{}` instance in Bedrock transport tests to ensure tests use a valid logger implementation rather than a nil value.

## Changes

- Replaced `nil` with `noopLogger{}` when calling `NewBedrockProvider` across all Bedrock transport tests to provide a proper no-op logger, avoiding potential nil pointer dereferences during test execution.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/...
```

All Bedrock transport tests should pass without nil pointer panics or logger-related errors.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This is a test-only change that swaps a nil logger for a no-op implementation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable