### PR TITLE
fix: fix the path check for temp token

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -863,7 +863,8 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 				next(ctx)
 				return
 			}
-			url := string(ctx.Request.URI().RequestURI())
+			// Match the whitelist against the path only
+			url := string(ctx.Path())
 			// We skip authorization for the login route
 			if shouldSkip(authConfig, url) {
 				next(ctx)


### PR DESCRIPTION
## Summary

The auth middleware whitelist was being matched against the full request URI (including query parameters), which could cause whitelist entries to fail to match when query strings were present. This fix ensures the whitelist is matched against the path only.

## Changes

- Replaced `ctx.Request.URI().RequestURI()` with `ctx.Path()` in the auth middleware so that URL whitelist checks are evaluated against the path component only, excluding any query parameters.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Add a whitelisted route to the auth config and make a request to that route with query parameters appended (e.g. `/login?redirect=/dashboard`). Verify that the request is correctly skipped for authorization rather than being blocked.

```sh
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change narrows the input used for whitelist matching to the path only. Ensure that no existing whitelist entries rely on query parameter values for access control decisions, as those will no longer be considered during the skip check.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable