### PR TITLE
chore: bump Bifrost Helm chart to 2.1.18 with `modelParametersUrl` support

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.17
+version: 2.1.18
 appVersion: "1.5.0"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,12 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.17
+**Latest Version:** 2.1.18
 
 ## Changelog
+
+### 2.1.18
+- Added `bifrost.modelCatalog.modelParametersUrl` to `values.yaml`, `values.schema.json`, and `_helpers.tpl`, allowing operators to override the URL Bifrost uses to fetch model parameter definitions.
 
 ### 2.1.17
 

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,7 +3,31 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.5.0
-    created: "2026-05-17T14:30:00.000000+05:30"
+    created: "2026-05-26T02:16:32.155592+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 45375cb9bee998e2f62b27346f867c453d0e36f5c55a09683ac8443d188e4e5e
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.18.tgz
+    version: 2.1.18
+  - apiVersion: v2
+    appVersion: 1.5.0
+    created: "2026-05-17T14:30:00+05:30"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
     digest: 8e887afbbc89f079595200570b40267c18dcc50f0ac188cff2116358555a8c15
@@ -916,4 +940,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-05-17T14:30:00.000000+05:30"
+generated: "2026-05-26T02:16:32.148215+05:30"


### PR DESCRIPTION
## Summary

Adds support for overriding the URL Bifrost uses to fetch model parameter definitions, giving operators more control over model catalog configuration.

## Changes

- Added `bifrost.modelCatalog.modelParametersUrl` to `values.yaml`, `values.schema.json`, and `_helpers.tpl`, enabling operators to supply a custom URL for model parameter definitions.
- Bumped Helm chart version from `2.1.17` to `2.1.18`.
- Updated `helm-charts/index.yaml` with the new chart release entry.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Helm chart with a custom `modelParametersUrl` set and verify Bifrost uses the specified URL to fetch model parameter definitions.

```sh
helm upgrade --install bifrost ./helm-charts/bifrost \
  --set bifrost.modelCatalog.modelParametersUrl="https://your-custom-url/model-params.json"
```

Confirm the rendered config includes the overridden URL and that Bifrost fetches model parameters from the specified endpoint.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Operators should ensure the URL provided for `modelParametersUrl` points to a trusted source, as it will be used to load model parameter definitions into the gateway.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable