### PR TITLE
fix: skip empty text block in bedrock

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -4157,6 +4157,9 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 			bedrockBlock := BedrockContentBlock{}
 			switch block.Type {
 			case schemas.ResponsesInputMessageContentBlockTypeText, schemas.ResponsesOutputMessageContentTypeText:
+				if block.Text == nil || *block.Text == "" {
+					continue
+				}
 				bedrockBlock.Text = block.Text
 			case schemas.ResponsesInputMessageContentBlockTypeImage:
 				if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil {


### PR DESCRIPTION
## Summary

Fixes a bug where empty or nil text content blocks were being passed through to Bedrock during response conversion, which could cause unexpected behavior or errors when Bedrock receives blank text blocks.

## Changes

- Added a nil and empty string check for `block.Text` in `convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks`. When a text block is nil or empty, it is now skipped via `continue` rather than being forwarded to Bedrock.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request to the Bedrock provider that includes a message with an empty or nil text content block and verify it is handled gracefully without errors.

```sh
go test ./...
```

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable