### PR TITLE
feat: add responses stream in json parser plugin

### DIFF
--- a/plugins/jsonparser/main.go
+++ b/plugins/jsonparser/main.go
@@ -127,6 +127,10 @@ func (p *JsonParserPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		return result, err, nil
 	}
 
+	if result == nil {
+		return result, err, nil
+	}
+
 	extraFields := result.GetExtraFields()
 
 	// Check if plugin should run based on usage type
@@ -134,8 +138,8 @@ func (p *JsonParserPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		return result, err, nil
 	}
 
-	// If no chat response, return as is
-	if result == nil || result.ChatResponse == nil {
+	// If no supported response type, return as is
+	if result.ChatResponse == nil && result.ResponsesStreamResponse == nil {
 		return result, err, nil
 	}
 
@@ -148,44 +152,78 @@ func (p *JsonParserPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	// Create a deep copy of the result to avoid modifying the original pointer
 	// This ensures other plugins using the same pointer don't get corrupted data
 	resultCopy := p.deepCopyBifrostResponse(result)
-	if resultCopy == nil || resultCopy.ChatResponse == nil {
+	if resultCopy == nil {
 		return result, err, nil
 	}
 
-	// Process only streaming choices to accumulate and fix partial JSON
-	if len(resultCopy.ChatResponse.Choices) > 0 {
-		for i := range resultCopy.ChatResponse.Choices {
-			choice := &resultCopy.ChatResponse.Choices[i]
+	if extraFields.RequestType == schemas.ChatCompletionStreamRequest {
+		if resultCopy.ChatResponse == nil {
+			return result, err, nil
+		}
 
-			// Handle only streaming response
-			if choice.ChatStreamResponseChoice != nil {
-				if choice.ChatStreamResponseChoice.Delta.Content != nil {
-					content := *choice.ChatStreamResponseChoice.Delta.Content
-					if content != "" {
-						// Accumulate the content
-						accumulated := p.accumulateContent(requestID, content)
+		// Process only streaming choices to accumulate and fix partial JSON
+		if len(resultCopy.ChatResponse.Choices) > 0 {
+			for i := range resultCopy.ChatResponse.Choices {
+				choice := &resultCopy.ChatResponse.Choices[i]
 
-						// Process the accumulated content to make it valid JSON
-						fixedContent := p.parsePartialJSON(accumulated)
+				// Handle only streaming response
+				if choice.ChatStreamResponseChoice != nil {
+					if choice.ChatStreamResponseChoice.Delta != nil && choice.ChatStreamResponseChoice.Delta.Content != nil {
+						content := *choice.ChatStreamResponseChoice.Delta.Content
+						if content != "" {
+							// Accumulate the content
+							accumulated := p.accumulateContent(requestID, content)
 
-						if !p.isValidJSON(fixedContent) {
-							err = &schemas.BifrostError{
-								Error: &schemas.ErrorField{
-									Message: "Invalid JSON in streaming response",
-								},
-								StreamControl: &schemas.StreamControl{
-									SkipStream: bifrost.Ptr(true),
-								},
+							// Process the accumulated content to make it valid JSON
+							fixedContent := p.parsePartialJSON(accumulated)
+
+							if !p.isValidJSON(fixedContent) {
+								err = &schemas.BifrostError{
+									Error: &schemas.ErrorField{
+										Message: "Invalid JSON in streaming response",
+									},
+									StreamControl: &schemas.StreamControl{
+										SkipStream: bifrost.Ptr(true),
+									},
+								}
+
+								return nil, err, nil
 							}
 
-							return nil, err, nil
+							// Replace the delta content with the complete valid JSON
+							choice.ChatStreamResponseChoice.Delta.Content = &fixedContent
 						}
-
-						// Replace the delta content with the complete valid JSON
-						choice.ChatStreamResponseChoice.Delta.Content = &fixedContent
 					}
 				}
 			}
+		}
+	} else if extraFields.RequestType == schemas.ResponsesStreamRequest {
+		if resultCopy.ResponsesStreamResponse == nil {
+			return result, err, nil
+		}
+
+		resp := resultCopy.ResponsesStreamResponse
+
+		// Only process output text delta events
+		if resp.Type == schemas.ResponsesStreamResponseTypeOutputTextDelta && resp.Delta != nil && *resp.Delta != "" {
+			accumulated := p.accumulateContent(requestID, *resp.Delta)
+
+			fixedContent := p.parsePartialJSON(accumulated)
+
+			if !p.isValidJSON(fixedContent) {
+				err = &schemas.BifrostError{
+					Error: &schemas.ErrorField{
+						Message: "Invalid JSON in streaming response",
+					},
+					StreamControl: &schemas.StreamControl{
+						SkipStream: bifrost.Ptr(true),
+					},
+				}
+
+				return nil, err, nil
+			}
+
+			resp.Delta = &fixedContent
 		}
 	}
 

--- a/plugins/jsonparser/plugin_test.go
+++ b/plugins/jsonparser/plugin_test.go
@@ -245,6 +245,259 @@ func TestJsonParserPluginPerRequest(t *testing.T) {
 	t.Log("Per-request test completed - check logs for JSON parsing behavior")
 }
 
+// newResponsesStreamResponse builds a BifrostResponse for a responses stream delta event.
+func newResponsesStreamResponse(responseID, delta string) *schemas.BifrostResponse {
+	d := delta
+	id := responseID
+	return &schemas.BifrostResponse{
+		ResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Type:  schemas.ResponsesStreamResponseTypeOutputTextDelta,
+			Delta: &d,
+			Response: &schemas.BifrostResponsesResponse{
+				ID: &id,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ResponsesStreamRequest,
+			},
+		},
+	}
+}
+
+// newResponsesStreamNonDeltaResponse builds a BifrostResponse for a non-delta responses stream event.
+func newResponsesStreamNonDeltaResponse(responseID string, eventType schemas.ResponsesStreamResponseType) *schemas.BifrostResponse {
+	id := responseID
+	return &schemas.BifrostResponse{
+		ResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Type: eventType,
+			Response: &schemas.BifrostResponsesResponse{
+				ID: &id,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ResponsesStreamRequest,
+			},
+		},
+	}
+}
+
+// TestPostLLMHookResponsesStreamDelta verifies that output_text.delta events are accumulated
+// and the Delta field is replaced with the repaired partial JSON after each chunk.
+func TestPostLLMHookResponsesStreamDelta(t *testing.T) {
+	plugin, err := Init(PluginConfig{
+		Usage:           AllRequests,
+		CleanupInterval: 5 * time.Minute,
+		MaxAge:          30 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("failed to init plugin: %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	const reqID = "test-responses-stream-id"
+
+	chunks := []string{`{"name": "Jo`, `hn", "age": 3`, `0}`}
+
+	for i, chunk := range chunks {
+		resp := newResponsesStreamResponse(reqID, chunk)
+		result, bifrostErr, hookErr := plugin.PostLLMHook(ctx, resp, nil)
+		if hookErr != nil {
+			t.Fatalf("chunk %d: unexpected error: %v", i, hookErr)
+		}
+		if bifrostErr != nil {
+			t.Fatalf("chunk %d: unexpected bifrost error: %v", i, bifrostErr)
+		}
+		if result.ResponsesStreamResponse.Delta == nil {
+			t.Fatalf("chunk %d: Delta is nil", i)
+		}
+		if !plugin.isValidJSON(*result.ResponsesStreamResponse.Delta) {
+			t.Errorf("chunk %d: Delta is not valid JSON: %q", i, *result.ResponsesStreamResponse.Delta)
+		}
+		t.Logf("chunk %d: %q", i, *result.ResponsesStreamResponse.Delta)
+	}
+}
+
+// TestPostLLMHookResponsesStreamNonDeltaPassthrough verifies that non-delta events
+// (e.g. response.created) are passed through without modification.
+func TestPostLLMHookResponsesStreamNonDeltaPassthrough(t *testing.T) {
+	plugin, err := Init(PluginConfig{
+		Usage:           AllRequests,
+		CleanupInterval: 5 * time.Minute,
+		MaxAge:          30 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("failed to init plugin: %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	nonDeltaTypes := []schemas.ResponsesStreamResponseType{
+		schemas.ResponsesStreamResponseTypeCreated,
+		schemas.ResponsesStreamResponseTypeInProgress,
+		schemas.ResponsesStreamResponseTypeCompleted,
+		schemas.ResponsesStreamResponseTypeOutputItemAdded,
+	}
+
+	for _, eventType := range nonDeltaTypes {
+		resp := newResponsesStreamNonDeltaResponse("req-passthrough", eventType)
+		result, bifrostErr, hookErr := plugin.PostLLMHook(ctx, resp, nil)
+		if hookErr != nil {
+			t.Fatalf("event %q: unexpected error: %v", eventType, hookErr)
+		}
+		if bifrostErr != nil {
+			t.Fatalf("event %q: unexpected bifrost error: %v", eventType, bifrostErr)
+		}
+		if result.ResponsesStreamResponse.Delta != nil {
+			t.Errorf("event %q: expected nil Delta but got %q", eventType, *result.ResponsesStreamResponse.Delta)
+		}
+	}
+}
+
+// TestPostLLMHookResponsesStreamDoesNotMutateOriginal verifies that the original response
+// pointer is not modified when the plugin rewrites Delta.
+func TestPostLLMHookResponsesStreamDoesNotMutateOriginal(t *testing.T) {
+	plugin, err := Init(PluginConfig{
+		Usage:           AllRequests,
+		CleanupInterval: 5 * time.Minute,
+		MaxAge:          30 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("failed to init plugin: %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	original := newResponsesStreamResponse("req-mutate", `{"name": "Jo`)
+	originalDelta := *original.ResponsesStreamResponse.Delta
+
+	result, bifrostErr, hookErr := plugin.PostLLMHook(ctx, original, nil)
+	if hookErr != nil {
+		t.Fatalf("unexpected error: %v", hookErr)
+	}
+	if bifrostErr != nil {
+		t.Fatalf("unexpected bifrost error: %v", bifrostErr)
+	}
+
+	if *original.ResponsesStreamResponse.Delta != originalDelta {
+		t.Errorf("original Delta was mutated: got %q, want %q",
+			*original.ResponsesStreamResponse.Delta, originalDelta)
+	}
+	if result == original {
+		t.Error("PostLLMHook returned the original pointer, expected a copy")
+	}
+}
+
+// TestPostLLMHookResponsesStreamPerRequest verifies that with PerRequest usage the plugin
+// only runs when EnableStreamingJSONParser is set in the context.
+func TestPostLLMHookResponsesStreamPerRequest(t *testing.T) {
+	plugin, err := Init(PluginConfig{
+		Usage:           PerRequest,
+		CleanupInterval: 5 * time.Minute,
+		MaxAge:          30 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("failed to init plugin: %v", err)
+	}
+
+	resp := newResponsesStreamResponse("req-per", `{"name": "Jo`)
+	originalDelta := *resp.ResponsesStreamResponse.Delta
+
+	// Without the context key the plugin should be a no-op.
+	ctxOff := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	result, bifrostErr, hookErr := plugin.PostLLMHook(ctxOff, resp, nil)
+	if hookErr != nil {
+		t.Fatalf("unexpected error (no-op path): %v", hookErr)
+	}
+	if bifrostErr != nil {
+		t.Fatalf("unexpected bifrost error (no-op path): %v", bifrostErr)
+	}
+	if *result.ResponsesStreamResponse.Delta != originalDelta {
+		t.Errorf("expected no-op but Delta changed to %q", *result.ResponsesStreamResponse.Delta)
+	}
+
+	// With the context key the plugin should process the chunk.
+	ctxOn := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline).
+		WithValue(EnableStreamingJSONParser, true)
+	result, bifrostErr, hookErr = plugin.PostLLMHook(ctxOn, resp, nil)
+	if hookErr != nil {
+		t.Fatalf("unexpected error (enabled path): %v", hookErr)
+	}
+	if bifrostErr != nil {
+		t.Fatalf("unexpected bifrost error (enabled path): %v", bifrostErr)
+	}
+	if !plugin.isValidJSON(*result.ResponsesStreamResponse.Delta) {
+		t.Errorf("expected valid JSON but got %q", *result.ResponsesStreamResponse.Delta)
+	}
+}
+
+// TestJsonParserPluginResponsesStreamEndToEnd tests the full integration against OpenAI's
+// responses stream API. Skipped when OPENAI_API_KEY is not set.
+func TestJsonParserPluginResponsesStreamEndToEnd(t *testing.T) {
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("OPENAI_API_KEY is not set, skipping end-to-end test")
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	plugin, err := Init(PluginConfig{
+		Usage:           AllRequests,
+		CleanupInterval: 5 * time.Minute,
+		MaxAge:          30 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("failed to init plugin: %v", err)
+	}
+
+	client, err := bifrost.Init(ctx, schemas.BifrostConfig{
+		Account:    &BaseAccount{},
+		LLMPlugins: []schemas.LLMPlugin{plugin},
+		Logger:     bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+	})
+	if err != nil {
+		t.Fatalf("failed to init bifrost: %v", err)
+	}
+	defer client.Shutdown()
+
+	userContent := schemas.ResponsesMessageContent{
+		ContentStr: bifrost.Ptr(`Return a JSON object with name, age, and city fields. Example: {"name": "John", "age": 30, "city": "New York"}`),
+	}
+	request := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role:    bifrost.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &userContent,
+			},
+		},
+	}
+
+	responseChan, bifrostErr := client.ResponsesStreamRequest(ctx, request)
+	if bifrostErr != nil {
+		t.Fatalf("request error: %v", bifrostErr)
+	}
+
+	chunkCount := 0
+	for streamChunk := range responseChan {
+		if streamChunk.BifrostError != nil {
+			t.Logf("stream error: %v", streamChunk.BifrostError)
+			continue
+		}
+		if streamChunk.BifrostResponsesStreamResponse != nil {
+			resp := streamChunk.BifrostResponsesStreamResponse
+			if resp.Type == schemas.ResponsesStreamResponseTypeOutputTextDelta && resp.Delta != nil && *resp.Delta != "" {
+				chunkCount++
+				if !plugin.isValidJSON(*resp.Delta) {
+					t.Errorf("chunk %d not valid JSON: %q", chunkCount, *resp.Delta)
+				}
+				t.Logf("chunk %d: %s", chunkCount, *resp.Delta)
+			}
+		}
+	}
+
+	t.Logf("stream completed after %d delta chunks", chunkCount)
+	if chunkCount == 0 {
+		t.Error("no output_text.delta chunks received; JSON-repair behavior was not exercised")
+	}
+}
+
 func TestParsePartialJSON(t *testing.T) {
 	plugin, err := Init(PluginConfig{
 		Usage:           AllRequests,

--- a/plugins/jsonparser/utils.go
+++ b/plugins/jsonparser/utils.go
@@ -11,9 +11,16 @@ import (
 // getRequestID extracts a unique identifier for the request to maintain state
 func (p *JsonParserPlugin) getRequestID(ctx *schemas.BifrostContext, result *schemas.BifrostResponse) string {
 
-	// Try to get from result
+	// Try to get from chat result
 	if result != nil && result.ChatResponse != nil && result.ChatResponse.ID != "" {
 		return result.ChatResponse.ID
+	}
+
+	// Try to get from responses stream result
+	if result != nil && result.ResponsesStreamResponse != nil {
+		if result.ResponsesStreamResponse.Response != nil && result.ResponsesStreamResponse.Response.ID != nil && *result.ResponsesStreamResponse.Response.ID != "" {
+			return *result.ResponsesStreamResponse.Response.ID
+		}
 	}
 
 	// Try to get from context if not available in result
@@ -28,8 +35,8 @@ func (p *JsonParserPlugin) getRequestID(ctx *schemas.BifrostContext, result *sch
 
 // shouldRun determines if the plugin should process the request based on usage type
 func (p *JsonParserPlugin) shouldRun(ctx *schemas.BifrostContext, requestType schemas.RequestType) bool {
-	// Run only for chat completion stream requests
-	if requestType != schemas.ChatCompletionStreamRequest {
+	// Run only for streaming requests
+	if requestType != schemas.ChatCompletionStreamRequest && requestType != schemas.ResponsesStreamRequest {
 		return false
 	}
 
@@ -223,10 +230,14 @@ func (p *JsonParserPlugin) deepCopyBifrostResponse(original *schemas.BifrostResp
 		result.ChatResponse = p.deepCopyBifrostChatResponse(original.ChatResponse)
 	}
 
+	// Deep copy ResponsesStreamResponse since we modify its Delta field
+	if original.ResponsesStreamResponse != nil {
+		result.ResponsesStreamResponse = p.deepCopyResponsesStreamResponse(original.ResponsesStreamResponse)
+	}
+
 	// Copy other response types if they exist (shallow copy since we don't modify them)
 	result.TextCompletionResponse = original.TextCompletionResponse
 	result.ResponsesResponse = original.ResponsesResponse
-	result.ResponsesStreamResponse = original.ResponsesStreamResponse
 	result.EmbeddingResponse = original.EmbeddingResponse
 	result.SpeechResponse = original.SpeechResponse
 	result.SpeechStreamResponse = original.SpeechStreamResponse
@@ -234,6 +245,19 @@ func (p *JsonParserPlugin) deepCopyBifrostResponse(original *schemas.BifrostResp
 	result.TranscriptionStreamResponse = original.TranscriptionStreamResponse
 
 	return result
+}
+
+// deepCopyResponsesStreamResponse returns a shallow copy of BifrostResponsesStreamResponse.
+// Delta is the only field this plugin reassigns, and it is a top-level pointer slot, so a
+// struct value copy is sufficient — writing result.Delta = &x does not affect original.Delta.
+// Pointer fields such as Response, Item, and Part share the same underlying data as the
+// original; do not mutate them through this copy.
+func (p *JsonParserPlugin) deepCopyResponsesStreamResponse(original *schemas.BifrostResponsesStreamResponse) *schemas.BifrostResponsesStreamResponse {
+	if original == nil {
+		return nil
+	}
+	result := *original
+	return &result
 }
 
 // deepCopyBifrostChatResponse creates a deep copy of BifrostChatResponse


### PR DESCRIPTION
## Summary

Extends the `jsonparser` plugin to handle OpenAI Responses API streaming (`ResponsesStreamRequest`) in addition to the existing chat completion streaming support. Previously, the plugin only accumulated and repaired partial JSON for `ChatCompletionStreamRequest`; `output_text.delta` events from the Responses stream were silently passed through unprocessed.

## Changes

- `shouldRun` now permits both `ChatCompletionStreamRequest` and `ResponsesStreamRequest` instead of only chat completion streams.
- The early-return nil check in `PostLLMHook` now accepts responses with either `ChatResponse` or `ResponsesStreamResponse` set.
- `PostLLMHook` branches on `extraFields.RequestType` to apply the existing accumulate-and-repair logic to `ResponsesStreamResponse.Delta` for `output_text.delta` events, while leaving all other event types (e.g. `response.created`, `response.completed`) untouched.
- `getRequestID` now falls back to `ResponsesStreamResponse.Response.ID` when a chat response ID is unavailable.
- `deepCopyBifrostResponse` performs a proper deep copy of `ResponsesStreamResponse` (instead of a shallow reference copy) so that rewriting `Delta` does not mutate the original pointer.
- A new `deepCopyResponsesStreamResponse` helper is introduced to support the above.
- Tests cover: delta accumulation and repair across multiple chunks, passthrough of non-delta event types, immutability of the original pointer, `PerRequest` usage gating, and an optional end-to-end integration test against the OpenAI Responses stream API (skipped when `OPENAI_API_KEY` is unset).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run all plugin tests
go test ./plugins/jsonparser/...

# Run the new responses-stream-specific tests
go test ./plugins/jsonparser/... -run TestPostLLMHookResponsesStream

# Run the end-to-end integration test (requires a valid OpenAI key)
OPENAI_API_KEY=<your-key> go test ./plugins/jsonparser/... -run TestJsonParserPluginResponsesStreamEndToEnd -v
```

Expected outcomes:
- `TestPostLLMHookResponsesStreamDelta`: each accumulated delta chunk is valid JSON.
- `TestPostLLMHookResponsesStreamNonDeltaPassthrough`: non-delta events pass through with a nil `Delta`.
- `TestPostLLMHookResponsesStreamDoesNotMutateOriginal`: the original response pointer is not modified.
- `TestPostLLMHookResponsesStreamPerRequest`: plugin is a no-op without `EnableStreamingJSONParser` in context, and active with it.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth, secrets, or PII handling introduced. The plugin continues to operate only on in-flight response content already present in memory.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable