### PR TITLE
fix(governance): restore vk blocked models create/edit UI

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -122,6 +122,7 @@ const providerConfigSchema = z.object({
     .max(1, "Weight must be at most 1")
     .optional(),
   allowed_models: z.array(z.string()).optional(),
+  blacklisted_models: z.array(z.string()).optional(),
   key_ids: z.array(z.string()).optional(), // Keys associated with this provider config
   // Provider-level budget
   budgets: z
@@ -285,7 +286,8 @@ export default function VirtualKeySheet({
           id: config.id,
           provider: config.provider,
           weight: config.weight ?? undefined,
-          allowed_models: config.allowed_models,
+          allowed_models: config.allowed_models || [],
+          blacklisted_models: config.blacklisted_models || [],
           key_ids: config.allow_all_keys
             ? ["*"]
             : config.keys?.map((key) => key.key_id) || [],
@@ -433,6 +435,7 @@ export default function VirtualKeySheet({
       provider: provider,
       weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
       allowed_models: ["*"],
+      blacklisted_models: [],
       key_ids: ["*"],
     };
 
@@ -1409,6 +1412,114 @@ export default function VirtualKeySheet({
                                       All Models” to allow all. Leave empty to
                                       deny all.
                                     </p>
+                                  </div>
+                                </div>
+
+                                {/* Blocked Models for this provider */}
+                                <div className="flex w-full items-start gap-2">
+                                  <div className="w-1/4" />
+                                  <div className="w-3/4 space-y-2">
+                                    <div className="flex items-center gap-2">
+                                      <Label className="text-sm font-medium">
+                                        Blocked Models
+                                      </Label>
+                                      <TooltipProvider>
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <span>
+                                              <Info className="text-muted-foreground h-3 w-3" />
+                                            </span>
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            <p>
+                                              Models this VK must never serve.
+                                              The denylist wins if a model
+                                              appears in both Allowed Models and
+                                              Blocked Models.
+                                            </p>
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      </TooltipProvider>
+                                    </div>
+                                    {(() => {
+                                      const hasWildcardBlocked = (
+                                        config.blacklisted_models || []
+                                      ).includes("*");
+                                      return (
+                                        <ModelMultiselect
+                                          data-testid={`vk-models-blocked-multiselect-${index}`}
+                                          provider={config.provider}
+                                          keys={(() => {
+                                            const providerKeys =
+                                              availableKeys.filter(
+                                                (key) =>
+                                                  key.provider ===
+                                                  config.provider,
+                                              );
+                                            const configKeyIds =
+                                              config.key_ids || [];
+                                            return configKeyIds.includes("*")
+                                              ? providerKeys.map(
+                                                  (key) => key.key_id,
+                                                )
+                                              : providerKeys
+                                                  .filter((key) =>
+                                                    configKeyIds.includes(
+                                                      key.key_id,
+                                                    ),
+                                                  )
+                                                  .map((key) => key.key_id);
+                                          })()}
+                                          allowAllOption={true}
+                                          value={
+                                            hasWildcardBlocked
+                                              ? ["*"]
+                                              : config.blacklisted_models || []
+                                          }
+                                          onChange={(models: string[]) => {
+                                            const hadStar = (
+                                              config.blacklisted_models || []
+                                            ).includes("*");
+                                            const hasStar =
+                                              models.includes("*");
+                                            if (!hadStar && hasStar) {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "blacklisted_models",
+                                                ["*"],
+                                              );
+                                            } else if (
+                                              hadStar &&
+                                              hasStar &&
+                                              models.length > 1
+                                            ) {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "blacklisted_models",
+                                                models.filter((m) => m !== "*"),
+                                              );
+                                            } else {
+                                              handleUpdateProviderConfig(
+                                                index,
+                                                "blacklisted_models",
+                                                models,
+                                              );
+                                            }
+                                          }}
+                                          placeholder={
+                                            hasWildcardBlocked
+                                              ? "All models blocked"
+                                              : (
+                                                    config.blacklisted_models ||
+                                                    []
+                                                  ).length === 0
+                                                ? "No models blocked"
+                                                : "Search models..."
+                                          }
+                                          className="min-h-10 max-w-[500px] min-w-[200px]"
+                                        />
+                                      );
+                                    })()}
                                   </div>
                                 </div>
 


### PR DESCRIPTION
## Summary

Restores the missing `Blocked Models` create/edit UI in the VK provider config sheet.

The backend enforcement (`isModelBlockedByList`, `blockedModelCandidates`, `blocklist_test.go`) was already present on `dev`. The only missing piece was the frontend editor, which became unreachable after dev was rebased/force-pushed following the original merge of #3718.

Changes in this PR:
- Added `blacklisted_models` to the zod provider config schema
- Initialized edit mode with `config.blacklisted_models || []`
- Added `blacklisted_models: []` default for new provider configs
- Added `Blocked Models` `ModelMultiselect` block, placed between `Allowed Models` and `Allowed Keys`
- Wildcard (`*`) toggle behavior consistent with allowed models

## How to test

Build:

```sh
go test ./plugins/governance/...
go build -o ./tmp/bifrost-http ./transports/bifrost-http
cd ui && npm run build
```

Manual UI check:

`http://localhost:9090/workspace/governance/virtual-keys`

Expected create/edit flow:

`Allowed Models → Blocked Models → Allowed Keys`

Runtime enforcement (prefix-aware, already on dev):
- blacklist `["ollama/mistral:latest"]`, request `"mistral:latest"` → 403
- blacklist `["mistral:latest"]`, request `"ollama/mistral:latest"` → 403
- wildcard `["*"]` → 403 for any model
- empty blacklist → passes through

## Related

Restores the UI lost from #3718. Backend enforcement already present on `dev`.