### PR TITLE
fix: persist customers pagination/search in URL state and improve table layout

### DIFF
--- a/ui/app/workspace/governance/access-profiles/page.tsx
+++ b/ui/app/workspace/governance/access-profiles/page.tsx
@@ -10,7 +10,7 @@ export default function AccessProfilesPage() {
 	}
 
 	return (
-		<div className="mx-auto w-full max-w-7xl">
+		<div className="mx-auto w-full max-w-7xl h-[calc(100vh_-_50px)] flex flex-col">
 			<AccessProfilesIndexView />
 		</div>
 	);

--- a/ui/app/workspace/governance/customers/page.tsx
+++ b/ui/app/workspace/governance/customers/page.tsx
@@ -1,10 +1,11 @@
+import CustomersTable from "@/app/workspace/governance/views/customerTable";
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useEffect, useRef, useState } from "react";
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { useEffect, useRef } from "react";
 import { toast } from "sonner";
-import CustomersTable from "@/app/workspace/governance/views/customerTable";
 
 const POLLING_INTERVAL = 5000;
 const PAGE_SIZE = 25;
@@ -15,13 +16,15 @@ export default function GovernanceCustomersPage() {
 	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
 	const shownErrorsRef = useRef(new Set<string>());
 
-	const [search, setSearch] = useState("");
-	const [offset, setOffset] = useState(0);
-	const debouncedSearch = useDebouncedValue(search, 300);
+	const [urlState, setUrlState] = useQueryStates(
+		{
+			search: parseAsString.withDefault(""),
+			offset: parseAsInteger.withDefault(0),
+		},
+		{ history: "push" },
+	);
 
-	useEffect(() => {
-		setOffset(0);
-	}, [debouncedSearch]);
+	const debouncedSearch = useDebouncedValue(urlState.search, 300);
 
 	const {
 		data: virtualKeysData,
@@ -40,10 +43,11 @@ export default function GovernanceCustomersPage() {
 		data: customersData,
 		error: customersError,
 		isLoading: customersLoading,
+		isFetching,
 	} = useGetCustomersQuery(
 		{
 			limit: PAGE_SIZE,
-			offset,
+			offset: urlState.offset,
 			search: debouncedSearch || undefined,
 		},
 		{
@@ -56,9 +60,9 @@ export default function GovernanceCustomersPage() {
 
 	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
 	useEffect(() => {
-		if (!customersData || offset < customersTotal) return;
-		setOffset(customersTotal === 0 ? 0 : Math.floor((customersTotal - 1) / PAGE_SIZE) * PAGE_SIZE);
-	}, [customersTotal, offset]);
+		if (!customersData || urlState.offset < customersTotal) return;
+		setUrlState({ offset: customersTotal === 0 ? 0 : Math.floor((customersTotal - 1) / PAGE_SIZE) * PAGE_SIZE });
+	}, [customersTotal, urlState.offset]);
 
 	const isLoading = vkLoading || teamsLoading || customersLoading;
 
@@ -84,18 +88,19 @@ export default function GovernanceCustomersPage() {
 	}
 
 	return (
-		<div className="mx-auto w-full max-w-7xl">
+		<div className="mx-auto w-full max-w-7xl h-[calc(100vh_-_50px)] flex flex-col">
 			<CustomersTable
 				customers={customersData?.customers || []}
 				totalCount={customersData?.total_count || 0}
 				teams={teamsData?.teams || []}
 				virtualKeys={virtualKeysData?.virtual_keys || []}
-				search={search}
+				search={urlState.search}
 				debouncedSearch={debouncedSearch}
-				onSearchChange={setSearch}
-				offset={offset}
+				onSearchChange={(val) => setUrlState({ search: val || null, offset: 0 })}
+				offset={urlState.offset}
 				limit={PAGE_SIZE}
-				onOffsetChange={setOffset}
+				onOffsetChange={(newOffset) => setUrlState({ offset: newOffset })}
+				isFetching={isFetching}
 			/>
 		</div>
 	);

--- a/ui/app/workspace/governance/rbac/page.tsx
+++ b/ui/app/workspace/governance/rbac/page.tsx
@@ -2,7 +2,7 @@ import RBACView from "@enterprise/components/rbac/rbacView";
 
 export default function GovernanceRbacPage() {
 	return (
-		<div className="mx-auto w-full max-w-7xl">
+		<div className="mx-auto w-full max-w-7xl h-[calc(100vh_-_50px)] flex flex-col overflow-y-auto">
 			<RBACView />
 		</div>
 	);

--- a/ui/app/workspace/governance/views/customerSheet.tsx
+++ b/ui/app/workspace/governance/views/customerSheet.tsx
@@ -1,8 +1,8 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationOptions } from "@/lib/constants/governance";
@@ -13,7 +13,6 @@ import { Validator } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { formatDistanceToNow } from "date-fns";
 import isEqual from "lodash.isequal";
-import { Save } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -107,21 +106,21 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 				Validator.custom(formData.isDirty, "No changes to save"),
 				...(formData.budgetMaxLimit !== undefined && formData.budgetMaxLimit !== null
 					? [
-							Validator.minValue(budgetMaxLimitNum ?? 0, 0.01, "Budget max limit must be greater than $0.01"),
-							Validator.required(formData.budgetResetDuration, "Budget reset duration is required"),
-						]
+						Validator.minValue(budgetMaxLimitNum ?? 0, 0.01, "Budget max limit must be greater than $0.01"),
+						Validator.required(formData.budgetResetDuration, "Budget reset duration is required"),
+					]
 					: []),
 				...(formData.tokenMaxLimit !== undefined && formData.tokenMaxLimit !== null
 					? [
-							Validator.minValue(tokenMaxLimitNum ?? 0, 1, "Token max limit must be at least 1"),
-							Validator.required(formData.tokenResetDuration, "Token reset duration is required"),
-						]
+						Validator.minValue(tokenMaxLimitNum ?? 0, 1, "Token max limit must be at least 1"),
+						Validator.required(formData.tokenResetDuration, "Token reset duration is required"),
+					]
 					: []),
 				...(formData.requestMaxLimit !== undefined && formData.requestMaxLimit !== null
 					? [
-							Validator.minValue(requestMaxLimitNum ?? 0, 1, "Request max limit must be at least 1"),
-							Validator.required(formData.requestResetDuration, "Request reset duration is required"),
-						]
+						Validator.minValue(requestMaxLimitNum ?? 0, 1, "Request max limit must be at least 1"),
+						Validator.required(formData.requestResetDuration, "Request reset duration is required"),
+					]
 					: []),
 			]),
 		[formData, budgetMaxLimitNum, tokenMaxLimitNum, requestMaxLimitNum],
@@ -361,7 +360,6 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 								<TooltipTrigger asChild>
 									<span>
 										<Button type="submit" disabled={isSubmitDisabled}>
-											<Save className="h-4 w-4" />
 											{loading ? "Saving..." : isEditing ? "Update Customer" : "Create Customer"}
 										</Button>
 									</span>

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -12,6 +12,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -21,7 +22,6 @@ import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { Input } from "@/components/ui/input";
 import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -103,6 +103,7 @@ interface CustomersTableProps {
 	offset: number;
 	limit: number;
 	onOffsetChange: (offset: number) => void;
+	isFetching?: boolean
 }
 
 export default function CustomersTable({
@@ -116,6 +117,7 @@ export default function CustomersTable({
 	offset,
 	limit,
 	onOffsetChange,
+	isFetching
 }: CustomersTableProps) {
 	const [showCustomerSheet, setShowCustomerSheet] = useState(false);
 	const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null);
@@ -164,7 +166,7 @@ export default function CustomersTable({
 	const hasActiveFilters = debouncedSearch;
 
 	// True empty state: no customers at all (not just filtered to zero)
-	if (totalCount === 0 && !hasActiveFilters) {
+	if (totalCount === 0 && !hasActiveFilters && !isFetching) {
 		return (
 			<>
 				<TooltipProvider>
@@ -196,8 +198,8 @@ export default function CustomersTable({
 					onSuccess={handleCustomerSaved}
 				/>
 
-				<div className="space-y-4">
-					<div className="flex items-center justify-between">
+				<div className="flex flex-col grow">
+					<div className="flex items-center justify-between mb-4">
 						<div>
 							<h2 className="text-lg font-semibold">Customers</h2>
 							<p className="text-muted-foreground text-sm">Manage customer accounts with their own teams, budgets, and access controls.</p>
@@ -208,7 +210,7 @@ export default function CustomersTable({
 						</Button>
 					</div>
 
-					<div className="flex items-center gap-3">
+					<div className="flex items-center gap-3 mb-4">
 						<div className="relative max-w-sm flex-1">
 							<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 							<Input
@@ -222,7 +224,7 @@ export default function CustomersTable({
 						</div>
 					</div>
 
-					<div className="overflow-auto rounded-sm border" data-testid="customer-table-container">
+					<div className="overflow-auto rounded-sm border grow mb-2" data-testid="customer-table-container">
 						<Table className="min-w-[1100px]">
 							<TableHeader>
 								<TableRow>
@@ -463,28 +465,38 @@ export default function CustomersTable({
 
 					{/* Pagination */}
 					{totalCount > 0 && (
-						<div className="flex items-center justify-between px-2">
-							<p className="text-muted-foreground text-sm">
-								Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
-							</p>
-							<div className="flex gap-2">
+						<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+							<div className="text-muted-foreground flex items-center gap-2">
+								{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()} entries
+							</div>
+
+							<div className="flex items-center gap-2">
 								<Button
-									variant="outline"
+									variant="ghost"
 									size="sm"
-									disabled={offset === 0}
 									onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+									disabled={offset === 0}
 									data-testid="customers-pagination-prev-btn"
+									aria-label="Previous page"
 								>
-									<ChevronLeft className="mr-1 h-4 w-4" /> Previous
+									<ChevronLeft className="size-3" />
 								</Button>
+
+								<div className="flex items-center gap-1">
+									<span>Page</span>
+									<span>{Math.floor(offset / limit) + 1}</span>
+									<span>of {Math.ceil(totalCount / limit)}</span>
+								</div>
+
 								<Button
-									variant="outline"
+									variant="ghost"
 									size="sm"
-									disabled={offset + limit >= totalCount}
 									onClick={() => onOffsetChange(offset + limit)}
+									disabled={offset + limit >= totalCount}
 									data-testid="customers-pagination-next-btn"
+									aria-label="Next page"
 								>
-									Next <ChevronRight className="ml-1 h-4 w-4" />
+									<ChevronRight className="size-3" />
 								</Button>
 							</div>
 						</div>

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -46,6 +46,7 @@ export default function GovernanceVirtualKeysPage() {
     data: virtualKeysData,
     error: vkError,
     isLoading: vkLoading,
+    isFetching,
   } = useGetVirtualKeysQuery(
     {
       limit: PAGE_SIZE,
@@ -183,6 +184,7 @@ export default function GovernanceVirtualKeysPage() {
         onSortChange={handleSortChange}
         selectedVkId={urlState.selected_vk}
         onSelectedVkChange={handleSelectedVkChange}
+        isFetching={isFetching}
       />
     </div>
   );

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -261,6 +261,7 @@ interface VirtualKeysTableProps {
 	onSortChange: (sortBy: string, order: string) => void;
 	selectedVkId: string;
 	onSelectedVkChange: (id: string, options?: { offset?: number }) => void;
+	isFetching?: boolean
 }
 
 export default function VirtualKeysTable({
@@ -283,6 +284,7 @@ export default function VirtualKeysTable({
 	onSortChange,
 	selectedVkId,
 	onSelectedVkChange,
+	isFetching
 }: VirtualKeysTableProps) {
 	const [showVirtualKeySheet, setShowVirtualKeySheet] = useState(false);
 	const [editingVirtualKeyId, setEditingVirtualKeyId] = useState<string | null>(null);
@@ -569,7 +571,7 @@ export default function VirtualKeysTable({
 	};
 
 	// True empty state: no VKs at all (not just filtered to zero)
-	if (totalCount === 0 && !hasActiveFilters) {
+	if (totalCount === 0 && !hasActiveFilters && !isFetching) {
 		return (
 			<>
 				{showVirtualKeySheet && (


### PR DESCRIPTION
## Summary

Improves the layout of governance pages (Customers, Virtual Keys, Access Profiles, RBAC) so that tables fill the available viewport height without causing the full page to scroll. Also migrates the Customers page search and pagination state into URL query parameters so that filters and page position are preserved in browser history.

## Changes

- Applied `h-[calc(100vh_-_50px)] flex flex-col` to governance page wrappers so content fills the viewport and inner tables can grow to fill remaining space.
- Replaced `useState` for `search` and `offset` on the Customers page with `nuqs` `useQueryStates`, syncing both values to the URL with `history: "push"`. Resetting search now also resets offset to 0 in a single state update.
- Added `isFetching` prop to `CustomersTable` and `VirtualKeysTable` to prevent the empty state from flashing while a fetch is in progress.
- Refactored `CustomersTable` layout to use `flex flex-col grow` so the table container expands to fill available space and the pagination bar stays anchored at the bottom.
- Redesigned the customers pagination controls to use ghost icon-only prev/next buttons with a "Page X of Y" label, and formatted entry counts with `toLocaleString`.
- Removed the `Save` icon from the customer sheet submit button.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Customers governance page and verify the table fills the viewport without a full-page scrollbar.
2. Enter a search term and paginate — confirm the search and page offset are reflected in the URL and survive a browser back/forward navigation.
3. Clear the search and confirm the offset resets to 0.
4. Delete the last item on the last page and confirm the offset snaps back correctly.
5. Verify no empty-state flash occurs while data is loading on the Customers and Virtual Keys pages.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots of the governance table pages showing the full-height layout and updated pagination controls._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. URL state contains only non-sensitive pagination and search values.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable