### PR TITLE
fix: strip cache point from bedrock requests for models which do not support it

### DIFF
--- a/core/providers/bedrock/cache_points_test.go
+++ b/core/providers/bedrock/cache_points_test.go
@@ -1,0 +1,160 @@
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func cachePoint() *BedrockCachePoint {
+	return &BedrockCachePoint{Type: BedrockCachePointTypeDefault}
+}
+
+// TestStripCachePoints_MessageBlocks — standalone CachePoint content blocks are
+// removed; non-CachePoint blocks survive untouched.
+func TestStripCachePoints_MessageBlocks(t *testing.T) {
+	req := &BedrockConverseRequest{
+		Messages: []BedrockMessage{
+			{
+				Role: BedrockMessageRoleUser,
+				Content: []BedrockContentBlock{
+					{Text: schemas.Ptr("hello")},
+					{CachePoint: cachePoint()},
+					{Text: schemas.Ptr("world")},
+				},
+			},
+		},
+	}
+
+	stripCachePointsFromBedrockRequest(req)
+
+	blocks := req.Messages[0].Content
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks after stripping, got %d", len(blocks))
+	}
+	if blocks[0].Text == nil || *blocks[0].Text != "hello" {
+		t.Errorf("expected first block text='hello', got %+v", blocks[0])
+	}
+	if blocks[1].Text == nil || *blocks[1].Text != "world" {
+		t.Errorf("expected second block text='world', got %+v", blocks[1])
+	}
+}
+
+// TestStripCachePoints_NestedToolResultContent — CachePoint blocks inside a
+// ToolResult's Content slice are filtered out; the tool result itself survives.
+func TestStripCachePoints_NestedToolResultContent(t *testing.T) {
+	req := &BedrockConverseRequest{
+		Messages: []BedrockMessage{
+			{
+				Role: BedrockMessageRoleUser,
+				Content: []BedrockContentBlock{
+					{
+						ToolResult: &BedrockToolResult{
+							ToolUseID: "call_1",
+							Content: []BedrockContentBlock{
+								{Text: schemas.Ptr("result text")},
+								{CachePoint: cachePoint()},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	stripCachePointsFromBedrockRequest(req)
+
+	inner := req.Messages[0].Content[0].ToolResult.Content
+	if len(inner) != 1 {
+		t.Fatalf("expected 1 inner block after stripping, got %d", len(inner))
+	}
+	if inner[0].Text == nil || *inner[0].Text != "result text" {
+		t.Errorf("expected inner text block to survive, got %+v", inner[0])
+	}
+}
+
+// TestStripCachePoints_SystemMessagesDropCachePointOnly — a system message
+// that contained only a CachePoint (text==nil) is removed entirely; a real
+// text system message is kept.
+func TestStripCachePoints_SystemMessagesDropCachePointOnly(t *testing.T) {
+	req := &BedrockConverseRequest{
+		System: []BedrockSystemMessage{
+			{Text: schemas.Ptr("You are helpful.")},
+			{CachePoint: cachePoint()}, // cache-point-only → must be removed
+			{Text: schemas.Ptr("Be concise.")},
+		},
+	}
+
+	stripCachePointsFromBedrockRequest(req)
+
+	if len(req.System) != 2 {
+		t.Fatalf("expected 2 system messages after stripping, got %d", len(req.System))
+	}
+	if req.System[0].Text == nil || *req.System[0].Text != "You are helpful." {
+		t.Errorf("first system message wrong: %+v", req.System[0])
+	}
+	if req.System[1].Text == nil || *req.System[1].Text != "Be concise." {
+		t.Errorf("second system message wrong: %+v", req.System[1])
+	}
+}
+
+// TestStripCachePoints_SystemMessageClearsCachePoint — a system message that
+// has both Text and CachePoint keeps its Text and loses only the CachePoint.
+func TestStripCachePoints_SystemMessageClearsCachePoint(t *testing.T) {
+	req := &BedrockConverseRequest{
+		System: []BedrockSystemMessage{
+			{Text: schemas.Ptr("sys prompt"), CachePoint: cachePoint()},
+		},
+	}
+
+	stripCachePointsFromBedrockRequest(req)
+
+	if len(req.System) != 1 {
+		t.Fatalf("expected system message to survive (has text), got %d entries", len(req.System))
+	}
+	if req.System[0].CachePoint != nil {
+		t.Errorf("expected CachePoint to be cleared, still set: %+v", req.System[0].CachePoint)
+	}
+	if req.System[0].Text == nil || *req.System[0].Text != "sys prompt" {
+		t.Errorf("expected text to be preserved, got %+v", req.System[0])
+	}
+}
+
+// TestStripCachePoints_ToolConfigCachePoints — cache-point-only tool entries
+// are removed entirely (same as system messages); real tool specs survive.
+func TestStripCachePoints_ToolConfigCachePoints(t *testing.T) {
+	req := &BedrockConverseRequest{
+		ToolConfig: &BedrockToolConfig{
+			Tools: []BedrockTool{
+				{ToolSpec: &BedrockToolSpec{Name: "get_weather"}},
+				{CachePoint: cachePoint()}, // cache-point-only → must be removed
+			},
+		},
+	}
+
+	stripCachePointsFromBedrockRequest(req)
+
+	tools := req.ToolConfig.Tools
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool after stripping cache-point-only entry, got %d", len(tools))
+	}
+	if tools[0].ToolSpec == nil || tools[0].ToolSpec.Name != "get_weather" {
+		t.Errorf("expected real tool to survive, got %+v", tools[0])
+	}
+}
+
+// TestStripCachePoints_NilToolConfig — no panic when ToolConfig is nil.
+func TestStripCachePoints_NilToolConfig(t *testing.T) {
+	req := &BedrockConverseRequest{}
+	// Should not panic.
+	stripCachePointsFromBedrockRequest(req)
+}
+
+// TestStripCachePoints_EmptyRequest — no panic and no mutation on an empty request.
+func TestStripCachePoints_EmptyRequest(t *testing.T) {
+	req := &BedrockConverseRequest{}
+	stripCachePointsFromBedrockRequest(req)
+	if len(req.Messages) != 0 || len(req.System) != 0 {
+		t.Errorf("expected empty request to remain empty, got %+v", req)
+	}
+}

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -64,6 +64,10 @@ func ToBedrockChatCompletionRequest(ctx *schemas.BifrostContext, bifrostReq *sch
 	// Ensure tool config is present when needed
 	ensureChatToolConfigForConversation(bifrostReq, bedrockReq)
 
+	if !schemas.BedrockModelSupportsCachePoints(bifrostReq.Model) {
+		stripCachePointsFromBedrockRequest(bedrockReq)
+	}
+
 	return bedrockReq, nil
 }
 

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2464,6 +2464,10 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 	// Ensure tool config is present when tool content exists (similar to Chat Completions)
 	ensureResponsesToolConfigForConversation(bifrostReq, bedrockReq)
 
+	if !schemas.BedrockModelSupportsCachePoints(bifrostReq.Model) {
+		stripCachePointsFromBedrockRequest(bedrockReq)
+	}
+
 	return bedrockReq, nil
 }
 

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -4157,6 +4157,9 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 			bedrockBlock := BedrockContentBlock{}
 			switch block.Type {
 			case schemas.ResponsesInputMessageContentBlockTypeText, schemas.ResponsesOutputMessageContentTypeText:
+				if block.Text == nil || *block.Text == "" {
+					continue
+				}
 				bedrockBlock.Text = block.Text
 			case schemas.ResponsesInputMessageContentBlockTypeImage:
 				if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil {

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -2188,3 +2188,56 @@ func tryParseJSONIntoContentBlock(text string) BedrockContentBlock {
 		return BedrockContentBlock{JSON: json.RawMessage(wrapped)}
 	}
 }
+
+// stripCachePointsFromBedrockRequest removes all CachePoint blocks from a
+// BedrockConverseRequest. Called for models that don't support prompt caching
+// (e.g. GLM, Llama) so their requests don't get a 400 from the Converse API.
+func stripCachePointsFromBedrockRequest(req *BedrockConverseRequest) {
+	// Strip cache points from message content blocks (including nested tool results).
+	for i := range req.Messages {
+		content := req.Messages[i].Content
+		n := 0
+		for j := range content {
+			if content[j].CachePoint != nil {
+				continue
+			}
+			if content[j].ToolResult != nil {
+				inner := content[j].ToolResult.Content
+				m := 0
+				for k := range inner {
+					if inner[k].CachePoint == nil {
+						inner[m] = inner[k]
+						m++
+					}
+				}
+				content[j].ToolResult.Content = inner[:m]
+			}
+			content[n] = content[j]
+			n++
+		}
+		req.Messages[i].Content = content[:n]
+	}
+	// Strip cache points from system messages.
+	// Filter out entries that were cache-point-only (would become empty objects).
+	ns := 0
+	for i := range req.System {
+		req.System[i].CachePoint = nil
+		if req.System[i].Text != nil || req.System[i].GuardContent != nil {
+			req.System[ns] = req.System[i]
+			ns++
+		}
+	}
+	req.System = req.System[:ns]
+	// Strip cache points from tools.
+	if req.ToolConfig != nil {
+		nt := 0
+		for i := range req.ToolConfig.Tools {
+			req.ToolConfig.Tools[i].CachePoint = nil
+			if req.ToolConfig.Tools[i].ToolSpec != nil || req.ToolConfig.Tools[i].SystemTool != nil {
+				req.ToolConfig.Tools[nt] = req.ToolConfig.Tools[i]
+				nt++
+			}
+		}
+		req.ToolConfig.Tools = req.ToolConfig.Tools[:nt]
+	}
+}

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1283,6 +1283,12 @@ func IsAnthropicModel(model string) bool {
 	return strings.Contains(model, "anthropic.") || strings.Contains(model, "claude")
 }
 
+// BedrockModelSupportsCachePoints reports whether the Bedrock model supports
+// explicit prompt-caching cache points in the Converse API request.
+func BedrockModelSupportsCachePoints(model string) bool {
+	return IsAnthropicModel(model) || IsNovaModel(model)
+}
+
 // IsMistralModel checks if the model is a Mistral or Codestral model.
 func IsMistralModel(model string) bool {
 	return strings.Contains(model, "mistral") || strings.Contains(model, "codestral")


### PR DESCRIPTION
## Summary

Some Bedrock models (e.g. GLM, Llama) do not support prompt-caching cache points in the Converse API and will return a 400 error if cache point blocks are present in the request. This PR adds a guard that strips cache points from Bedrock requests before they are sent, for any model that does not support them.

## Changes

- Added `BedrockModelSupportsCachePoints` in `core/schemas/utils.go` that returns `true` only for Anthropic and Nova models, which are the models known to support explicit cache points in the Converse API.
- Added `stripCachePointsFromBedrockRequest` in `core/providers/bedrock/utils.go` that removes cache point blocks from message content, nested tool result content, system messages, and tool config entries.
- Called `stripCachePointsFromBedrockRequest` in both `ToBedrockChatCompletionRequest` and `ToBedrockResponsesRequest` when the target model does not support cache points, preventing 400 errors from unsupported models receiving cache point blocks.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a Bedrock Converse request to a non-Anthropic, non-Nova model (e.g. a GLM or Llama model) with cache point blocks included in the request body. Verify the request succeeds without a 400 error and that cache point blocks are absent from the forwarded request.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications. Cache point blocks are stripped only from the outbound request payload for unsupported models and do not affect authentication, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable