### PR TITLE
chore: bump Bifrost Helm chart to 2.1.19 with bug fixes and changelog reorganization

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.18
+version: 2.1.19
 appVersion: "1.5.3"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,21 +4,24 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.18
+**Latest Version:** 2.1.19
 
 ## Changelog
 
-### 2.1.18
+### 2.1.19
 
 - Added `existingSecret` support for hosted PostgreSQL (`postgresql.enabled: true`). Set `postgresql.auth.existingSecret` and `postgresql.auth.passwordKey` to reference a Kubernetes secret (e.g. from Vault Secrets Operator) instead of a plaintext password in values. Both the postgres pod and the bifrost pod will read the password from the secret; the chart-managed secret is not created when `existingSecret` is set.
 - Added `postgresql.primary.podSecurityContext` and `postgresql.primary.containerSecurityContext` to allow configuring pod- and container-level security contexts on the hosted PostgreSQL deployment. Defaults to `podSecurityContext: { fsGroup: 999 }` (preserving prior behaviour) and `containerSecurityContext: {}` (no container security context). Required for clusters enforcing strict Kyverno/OPA policies (e.g. `runAsNonRoot`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile`).
 - Added `bifrost.featureFlags` map to `values.yaml` and `_helpers.tpl`. Renders into `feature_flags.flags` in the generated config JSON. Each entry accepts a literal boolean or `"env.NAME"` string.
-- Added `bifrost.modelCatalog.modelParametersUrl` to `values.yaml`, `values.schema.json`, and `_helpers.tpl`, allowing operators to override the URL Bifrost uses to fetch model parameter definitions.
 - Fixed Deployment not exposing the cluster gRPC container port; fixed `service.yaml` missing the gRPC service port. Both now match StatefulSet/headless service behaviour.
 - Fixed Weaviate PVC rendering when `vectorStore.weaviate.persistence.enabled=false`; PVC is now gated on persistence being enabled.
 - Fixed Redis probes passing password via `-a` flag in process args; switched to `REDISCLI_AUTH` env var.
 - Fixed nondeterministic env var order for `providerSecrets` and `weaviate.env` map iterations; keys are now sorted with `sortAlpha`.
 - Corrected guardrail `timeout` examples in `values.yaml`: provider default is `30s`, rule default is `60s`.
+
+### 2.1.18
+- Added `bifrost.framework.pricing.modelParametersUrl` to `values.yaml`, `values.schema.json`, and `_helpers.tpl`, allowing operators to override the URL Bifrost uses to fetch model parameter definitions.
+
 
 ### 2.1.17
 

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -20,8 +20,8 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 - Corrected guardrail `timeout` examples in `values.yaml`: provider default is `30s`, rule default is `60s`.
 
 ### 2.1.18
-- Added `bifrost.framework.pricing.modelParametersUrl` to `values.yaml`, `values.schema.json`, and `_helpers.tpl`, allowing operators to override the URL Bifrost uses to fetch model parameter definitions.
 
+- Added `bifrost.framework.pricing.modelParametersUrl` to `values.yaml`, `values.schema.json`, and `_helpers.tpl`, allowing operators to override the URL Bifrost uses to fetch model parameter definitions.
 
 ### 2.1.17
 

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,30 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.5.3
+    created: "2026-05-26T14:33:57.417916+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 8e0d91b5fd3a095abfa2c5034149709cbd0c3ea62f3fcf3ca6ca46b223175c42
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.19.tgz
+    version: 2.1.19
+  - apiVersion: v2
+    appVersion: 1.5.3
     created: "2026-05-22T17:10:47.506843+05:30"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
@@ -940,4 +964,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-05-22T17:10:47.503755+05:30"
+generated: "2026-05-26T14:33:57.415309+05:30"


### PR DESCRIPTION
## Summary

Releases Bifrost Helm chart version 2.1.19, incorporating several bug fixes and new configuration options introduced since 2.1.18.

## Changes

- Bumped chart version from `2.1.18` to `2.1.19`
- Added `existingSecret` support for hosted PostgreSQL, allowing `postgresql.auth.existingSecret` and `postgresql.auth.passwordKey` to reference a Kubernetes secret instead of a plaintext password
- Added `postgresql.primary.podSecurityContext` and `postgresql.primary.containerSecurityContext` to support clusters enforcing strict Kyverno/OPA security policies
- Added `bifrost.featureFlags` map to `values.yaml` and `_helpers.tpl`, rendering into `feature_flags.flags` in the generated config JSON
- Fixed Deployment not exposing the cluster gRPC container port and `service.yaml` missing the gRPC service port
- Fixed Weaviate PVC rendering when `vectorStore.weaviate.persistence.enabled=false`
- Fixed Redis probes passing password via `-a` flag; switched to `REDISCLI_AUTH` env var
- Fixed nondeterministic env var ordering for `providerSecrets` and `weaviate.env` map iterations by sorting keys with `sortAlpha`
- Corrected guardrail `timeout` example values in `values.yaml`
- Moved `bifrost.framework.pricing.modelParametersUrl` (previously `bifrost.modelCatalog.modelParametersUrl`) into the 2.1.18 changelog entry where it was originally introduced

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
helm repo update
helm install bifrost bifrost/bifrost --version 2.1.19 --dry-run
```

To validate `existingSecret` support:

```sh
helm install bifrost bifrost/bifrost \
  --set postgresql.enabled=true \
  --set postgresql.auth.existingSecret=my-pg-secret \
  --set postgresql.auth.passwordKey=password \
  --dry-run
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `existingSecret` support for PostgreSQL allows operators to avoid storing plaintext passwords in Helm values, enabling integration with secret management tools such as the Vault Secrets Operator. The chart-managed secret is not created when `existingSecret` is set.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicablecs