### PR TITLE
chore: remove api version references from code

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -62122,22 +62122,6 @@
             },
             "nullable": true
           },
-          "azure_api_version": {
-            "type": "object",
-            "description": "Environment variable configuration",
-            "properties": {
-              "value": {
-                "type": "string"
-              },
-              "env_var": {
-                "type": "string"
-              },
-              "from_env": {
-                "type": "boolean"
-              }
-            },
-            "nullable": true
-          },
           "azure_client_id": {
             "type": "object",
             "description": "Environment variable configuration",

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -599,9 +599,6 @@ TableKey:
     azure_endpoint:
       $ref: '../../schemas/management/common.yaml#/EnvVar'
       nullable: true
-    azure_api_version:
-      $ref: '../../schemas/management/common.yaml#/EnvVar'
-      nullable: true
     azure_client_id:
       $ref: '../../schemas/management/common.yaml#/EnvVar'
       nullable: true

--- a/examples/configs/withprompushgateway/config.json
+++ b/examples/configs/withprompushgateway/config.json
@@ -164,8 +164,7 @@
           "name": "Azure API Key",
           "value": "env.AZURE_API_KEY",
           "azure_key_config": {
-            "endpoint": "env.AZURE_ENDPOINT",
-            "api_version": "env.AZURE_API_VERSION"
+            "endpoint": "env.AZURE_ENDPOINT"
           },
           "weight": 1,
           "models": [

--- a/examples/configs/withvirtualkeys/config.json
+++ b/examples/configs/withvirtualkeys/config.json
@@ -134,7 +134,6 @@
         {
           "id": "key-azure-us-1-prod",
           "azure_key_config": {
-            "api_version": "2025-03-01-preview",
             "endpoint": "https://orca-prod-us-east-1.openai.azure.com/"
           },
           "models": [
@@ -153,7 +152,6 @@
         {
           "id": "key-azure-us-2-prod",
           "azure_key_config": {
-            "api_version": "2025-03-01-preview",
             "endpoint": "https://orca-prod-us-east-2.openai.azure.com/"
           },
           "models": [
@@ -172,7 +170,6 @@
         {
           "id": "key-azure-eu-1-prod",
           "azure_key_config": {
-            "api_version": "2025-03-01-preview",
             "endpoint": "https://orca-prod-eu-central-1.openai.azure.com/"
           },
           "models": [

--- a/tests/config.json
+++ b/tests/config.json
@@ -215,8 +215,7 @@
           "name": "Azure API Key",
           "value": "env.AZURE_API_KEY",
           "azure_key_config": {
-            "endpoint": "env.AZURE_ENDPOINT",
-            "api_version": "env.AZURE_API_VERSION"
+            "endpoint": "env.AZURE_ENDPOINT"
           },
           "aliases": {
             "gpt-5.4": "gpt-5.4",

--- a/tests/integrations/python/config.json
+++ b/tests/integrations/python/config.json
@@ -216,7 +216,6 @@
           "value": "env.AZURE_API_KEY",
           "azure_key_config": {
             "endpoint": "env.AZURE_ENDPOINT",
-            "api_version": "env.AZURE_API_VERSION",
             "deployments": {
               "gpt-4o": "gpt-4o",
               "gpt-4o-mini": "gpt-4o-mini",

--- a/tests/integrations/typescript/config.json
+++ b/tests/integrations/typescript/config.json
@@ -143,8 +143,7 @@
                     "name": "Azure OpenAI API Key",
                     "value": "env.AZURE_OPENAI_API_KEY",
                     "azure_key_config": {
-                        "endpoint": "env.AZURE_OPENAI_ENDPOINT",
-                        "api_version": "env.AZURE_OPENAI_API_VERSION"
+                        "endpoint": "env.AZURE_OPENAI_ENDPOINT"
                     },
                     "weight": 1,
                     "models": ["*"]

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2425,6 +2425,10 @@
                   "type": "array",
                   "items": { "type": "string" },
                   "description": "OAuth2 scopes for Entra authentication"
+                },
+                "api_version": {
+                  "type": "string",
+                  "description": "Deprecated: Bifrost now uses the Azure OpenAI v1 API which does not require an api-version parameter."
                 }
               },
               "required": ["endpoint"],

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -74,7 +74,6 @@ const AllowedRequestsSchema = z.object({
 // Key configuration schemas
 const AzureKeyConfigSchema = z.object({
 	endpoint: z.string().min(1, "Endpoint is required for Azure keys"),
-	api_version: z.string().optional(),
 	client_id: z.string().optional(),
 	client_secret: z.string().optional(),
 	tenant_id: z.string().optional(),

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -23,7 +23,6 @@ export const isKnownProvider = (provider: string): provider is KnownProvider => 
 // AzureKeyConfig matching Go's schemas.AzureKeyConfig
 export interface AzureKeyConfig {
 	endpoint: EnvVar;
-	api_version?: EnvVar;
 	client_id?: EnvVar;
 	client_secret?: EnvVar;
 	tenant_id?: EnvVar;
@@ -32,7 +31,6 @@ export interface AzureKeyConfig {
 
 export const DefaultAzureKeyConfig: AzureKeyConfig = {
 	endpoint: { value: "", env_var: "", from_env: false },
-	api_version: { value: "2024-02-01", env_var: "", from_env: false },
 	client_id: { value: "", env_var: "", from_env: false },
 	client_secret: { value: "", env_var: "", from_env: false },
 	tenant_id: { value: "", env_var: "", from_env: false },

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -79,7 +79,6 @@ export const azureKeyConfigSchema = z
 	.object({
 		_auth_type: z.enum(["api_key", "entra_id", "default_credential"]).optional(),
 		endpoint: envVarSchema.optional(),
-		api_version: envVarSchema.optional(),
 		client_id: envVarSchema.optional(),
 		client_secret: envVarSchema.optional(),
 		tenant_id: envVarSchema.optional(),


### PR DESCRIPTION
## Summary

Removes the `api_version` field from `AzureKeyConfig` across the codebase. Bifrost now uses the Azure OpenAI v1 API, which does not require an `api-version` query parameter, making this field obsolete.

## Changes

- Removed `api_version` from `AzureKeyConfig` in UI types, schemas, and form validation
- Removed `azure_api_version` from the OpenAPI spec and governance schema
- Removed `api_version` from all example and test config files
- Added a deprecated notice for `api_version` in `config.schema.json` to maintain backward compatibility for existing configs that may still include the field

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify that Azure provider keys configured without `api_version` continue to route requests correctly to Azure OpenAI endpoints.

## Breaking changes

- [x] Yes
- [ ] No

The `api_version` field is no longer accepted in `AzureKeyConfig`. Existing configurations that include `api_version` should remove it. The field has been marked as deprecated in the JSON schema to avoid hard failures, but it will have no effect if present.

## Related issues

## Security considerations

No security implications. This change removes an unused configuration field and does not affect authentication or secret handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable