### PR TITLE
refactor: propagate errors from `GetAvailable*` methods instead of silently returning empty slices

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -1567,6 +1567,7 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 	}
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
+	q = q.Where("model IS NOT NULL AND model != ''")
 	if err := q.Select(`
 		model, provider,
 		SUM(count) AS total,
@@ -1599,6 +1600,7 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 		prevFilters.EndTime = &prevEnd
 		pq := s.ScopedDB(ctx).Table("mv_logs_hourly")
 		pq = s.applyMatViewFilters(pq, prevFilters)
+		pq = pq.Where("model IS NOT NULL AND model != ''")
 		if err := pq.Select(`
 			model, provider,
 			SUM(count) AS total,

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1025,93 +1025,84 @@ func (p *LoggerPlugin) GetModelRankings(ctx context.Context, filters logstore.Se
 
 // GetAvailableModels returns all unique models from logs.
 // Uses DISTINCT to avoid loading all rows (28K+) when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableModels(ctx context.Context, limit int, query string) []string {
+func (p *LoggerPlugin) GetAvailableModels(ctx context.Context, limit int, query string) ([]string, error) {
 	models, err := p.store.GetDistinctModels(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available models: %v", err)
-		return []string{}
+		return nil, fmt.Errorf("failed to get available models: %w", err)
 	}
-	return models
+	return models, nil
 }
 
 // GetAvailableAliases returns all unique alias values from logs.
-func (p *LoggerPlugin) GetAvailableAliases(ctx context.Context, limit int, query string) []string {
+func (p *LoggerPlugin) GetAvailableAliases(ctx context.Context, limit int, query string) ([]string, error) {
 	aliases, err := p.store.GetDistinctAliases(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available aliases: %v", err)
-		return []string{}
+		return nil, fmt.Errorf("failed to get available aliases: %w", err)
 	}
-	return aliases
+	return aliases, nil
 }
 
-func (p *LoggerPlugin) GetAvailableSelectedKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableSelectedKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "selected_key_id", "selected_key_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available selected keys: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available selected keys: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
-func (p *LoggerPlugin) GetAvailableVirtualKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "virtual_key_id", "virtual_key_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available virtual keys: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available virtual keys: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
-func (p *LoggerPlugin) GetAvailableRoutingRules(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableRoutingRules(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "routing_rule_id", "routing_rule_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available routing rules: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available routing rules: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetAvailableTeams returns all unique team ID-Name pairs from logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableTeams(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableTeams(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "team_id", "team_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available teams: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available teams: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetAvailableCustomers returns all unique customer ID-Name pairs from logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableCustomers(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableCustomers(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "customer_id", "customer_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available customers: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available customers: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetAvailableUsers returns all unique user ID-Name pairs from logs.
-func (p *LoggerPlugin) GetAvailableUsers(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableUsers(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "user_id", "user_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available users: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available users: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetAvailableBusinessUnits returns all unique business unit ID-Name pairs from logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableBusinessUnits(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableBusinessUnits(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "business_unit_id", "business_unit_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available business units: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available business units: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetDimensionCostHistogram returns time-bucketed cost data grouped by the specified dimension.
@@ -1134,24 +1125,22 @@ func (p *LoggerPlugin) GetDimensionLatencyHistogram(ctx context.Context, filters
 
 // GetAvailableRoutingEngines returns all unique routing engine types used in logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableRoutingEngines(ctx context.Context, limit int, query string) []string {
+func (p *LoggerPlugin) GetAvailableRoutingEngines(ctx context.Context, limit int, query string) ([]string, error) {
 	engines, err := p.store.GetDistinctRoutingEngines(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available routing engines: %v", err)
-		return []string{}
+		return nil, fmt.Errorf("failed to get available routing engines: %w", err)
 	}
-	return engines
+	return engines, nil
 }
 
 // GetAvailableStopReasons returns all unique stop reason values from logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableStopReasons(ctx context.Context, limit int, query string) []string {
+func (p *LoggerPlugin) GetAvailableStopReasons(ctx context.Context, limit int, query string) ([]string, error) {
 	stopReasons, err := p.store.GetDistinctStopReasons(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available stop reasons: %v", err)
-		return []string{}
+		return nil, fmt.Errorf("failed to get available stop reasons: %w", err)
 	}
-	return stopReasons
+	return stopReasons, nil
 }
 
 // keyPairResultsToKeyPairs converts logstore.KeyPairResult slice to KeyPair slice
@@ -1164,11 +1153,10 @@ func keyPairResultsToKeyPairs(results []logstore.KeyPairResult) []KeyPair {
 }
 
 // GetAvailableMCPVirtualKeys returns all unique virtual key ID-Name pairs from MCP tool logs
-func (p *LoggerPlugin) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	result, err := p.store.GetAvailableMCPVirtualKeys(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available virtual keys from MCP logs: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available virtual keys from MCP logs: %w", err)
 	}
 	return p.extractUniqueMCPKeyPairs(result, func(log *logstore.MCPToolLog) KeyPair {
 		if log.VirtualKeyID != nil && log.VirtualKeyName != nil {
@@ -1178,7 +1166,7 @@ func (p *LoggerPlugin) GetAvailableMCPVirtualKeys(ctx context.Context, limit int
 			}
 		}
 		return KeyPair{}
-	})
+	}), nil
 }
 
 // extractUniqueMCPKeyPairs extracts unique non-empty key pairs from MCP logs using the provided extractor function

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -68,37 +68,37 @@ type LogManager interface {
 	GetDroppedRequests(ctx context.Context) int64
 
 	// GetAvailableModels returns all unique models from logs
-	GetAvailableModels(ctx context.Context, limit int, query string) []string
+	GetAvailableModels(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableAliases returns all unique alias values from logs
-	GetAvailableAliases(ctx context.Context, limit int, query string) []string
+	GetAvailableAliases(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableSelectedKeys returns all unique selected key ID-Name pairs from logs
-	GetAvailableSelectedKeys(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableSelectedKeys(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableVirtualKeys returns all unique virtual key ID-Name pairs from logs
-	GetAvailableVirtualKeys(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableRoutingRules returns all unique routing rule ID-Name pairs from logs
-	GetAvailableRoutingRules(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableRoutingRules(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableRoutingEngines returns all unique routing engine types from logs
-	GetAvailableRoutingEngines(ctx context.Context, limit int, query string) []string
+	GetAvailableRoutingEngines(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableStopReasons returns all unique stop reason values from logs
-	GetAvailableStopReasons(ctx context.Context, limit int, query string) []string
+	GetAvailableStopReasons(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableTeams returns all unique team ID-Name pairs from logs
-	GetAvailableTeams(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableTeams(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableCustomers returns all unique customer ID-Name pairs from logs
-	GetAvailableCustomers(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableCustomers(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableUsers returns all unique user IDs from logs
-	GetAvailableUsers(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableUsers(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableBusinessUnits returns all unique business unit ID-Name pairs from logs
-	GetAvailableBusinessUnits(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableBusinessUnits(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableMetadataKeys returns distinct metadata keys and their values from recent logs
 	GetAvailableMetadataKeys(ctx context.Context, limit int, query string) (map[string][]string, error)
@@ -138,7 +138,7 @@ type LogManager interface {
 	GetAvailableServerLabels(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableMCPVirtualKeys returns all unique virtual key ID-Name pairs from MCP tool logs
-	GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetMCPHistogram returns time-bucketed MCP tool call volume
 	GetMCPHistogram(ctx context.Context, filters logstore.MCPToolLogSearchFilters, bucketSizeSeconds int64) (*logstore.MCPHistogramResult, error)
@@ -261,47 +261,47 @@ func (p *PluginLogManager) GetDroppedRequests(ctx context.Context) int64 {
 }
 
 // GetAvailableModels returns all unique models from logs
-func (p *PluginLogManager) GetAvailableModels(ctx context.Context, limit int, query string) []string {
+func (p *PluginLogManager) GetAvailableModels(ctx context.Context, limit int, query string) ([]string, error) {
 	return p.plugin.GetAvailableModels(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableAliases(ctx context.Context, limit int, query string) []string {
+func (p *PluginLogManager) GetAvailableAliases(ctx context.Context, limit int, query string) ([]string, error) {
 	return p.plugin.GetAvailableAliases(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableSelectedKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableSelectedKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableSelectedKeys(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableVirtualKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableVirtualKeys(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableRoutingRules(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableRoutingRules(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableRoutingRules(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableRoutingEngines(ctx context.Context, limit int, query string) []string {
+func (p *PluginLogManager) GetAvailableRoutingEngines(ctx context.Context, limit int, query string) ([]string, error) {
 	return p.plugin.GetAvailableRoutingEngines(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableStopReasons(ctx context.Context, limit int, query string) []string {
+func (p *PluginLogManager) GetAvailableStopReasons(ctx context.Context, limit int, query string) ([]string, error) {
 	return p.plugin.GetAvailableStopReasons(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableTeams(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableTeams(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableTeams(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableCustomers(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableCustomers(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableCustomers(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableUsers(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableUsers(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableUsers(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableBusinessUnits(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableBusinessUnits(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableBusinessUnits(ctx, limit, query)
 }
 
@@ -401,9 +401,9 @@ func (p *PluginLogManager) GetAvailableServerLabels(ctx context.Context, limit i
 	return p.plugin.store.GetAvailableServerLabels(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	if p == nil || p.plugin == nil {
-		return []KeyPair{}
+		return []KeyPair{}, nil
 	}
 	return p.plugin.GetAvailableMCPVirtualKeys(ctx, limit, query)
 }

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -1130,7 +1130,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 
 	if _, ok := want[filterDimModels]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableModels(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableModels(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			models = result
 			mu.Unlock()
@@ -1139,7 +1142,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimAliases]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableAliases(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableAliases(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			aliases = result
 			mu.Unlock()
@@ -1148,7 +1154,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimSelectedKeys]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableSelectedKeys(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableSelectedKeys(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			selectedKeys = result
 			mu.Unlock()
@@ -1157,7 +1166,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimVirtualKeys]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableVirtualKeys(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableVirtualKeys(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			virtualKeys = result
 			mu.Unlock()
@@ -1166,7 +1178,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimRoutingRules]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableRoutingRules(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableRoutingRules(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			routingRules = result
 			mu.Unlock()
@@ -1175,7 +1190,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimRoutingEngines]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableRoutingEngines(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableRoutingEngines(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			routingEngines = result
 			mu.Unlock()
@@ -1184,7 +1202,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimStopReasons]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableStopReasons(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableStopReasons(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			stopReasons = result
 			mu.Unlock()
@@ -1193,7 +1214,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimTeams]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableTeams(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableTeams(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			teams = result
 			mu.Unlock()
@@ -1202,7 +1226,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimCustomers]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableCustomers(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableCustomers(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			customers = result
 			mu.Unlock()
@@ -1211,7 +1238,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimUsers]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableUsers(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableUsers(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			users = result
 			mu.Unlock()
@@ -1220,7 +1250,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimBusinessUnits]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableBusinessUnits(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableBusinessUnits(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			businessUnits = result
 			mu.Unlock()
@@ -1907,7 +1940,12 @@ func (h *LoggingHandler) getMCPLogsFilterData(ctx *fasthttp.RequestCtx) {
 
 	var virtualKeysArray []tables.TableVirtualKey
 	if _, ok := want[mcpFilterDimVirtualKeys]; ok {
-		virtualKeys := h.logManager.GetAvailableMCPVirtualKeys(ctx, defaultFilterDataLimit, query)
+		virtualKeys, err := h.logManager.GetAvailableMCPVirtualKeys(ctx, defaultFilterDataLimit, query)
+		if err != nil {
+			logger.Error("failed to get available MCP virtual keys: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get available MCP virtual keys: %v", err))
+			return
+		}
 
 		virtualKeyIDs := make([]string, len(virtualKeys))
 		for i, key := range virtualKeys {


### PR DESCRIPTION
## Summary

The `GetAvailable*` methods on `LoggerPlugin` and `LogManager` previously swallowed errors by logging them internally and returning empty slices. This change propagates errors to callers instead, allowing them to handle failures appropriately (e.g., returning HTTP 500 responses).

## Changes

- All `GetAvailable*` methods (`GetAvailableModels`, `GetAvailableAliases`, `GetAvailableSelectedKeys`, `GetAvailableVirtualKeys`, `GetAvailableRoutingRules`, `GetAvailableRoutingEngines`, `GetAvailableStopReasons`, `GetAvailableTeams`, `GetAvailableCustomers`, `GetAvailableUsers`, `GetAvailableBusinessUnits`, `GetAvailableMCPVirtualKeys`) now return `(T, error)` instead of `T`.
- Errors are wrapped with `fmt.Errorf(...%w...)` and returned rather than being logged and discarded with an empty-value fallback.
- The `LogManager` interface signatures are updated to match.
- HTTP handler goroutines in `getAvailableFilterData` now propagate errors through the `errgroup`, and `getMCPLogsFilterData` explicitly handles the error by returning an HTTP 500 response.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/logging/...
go test ./transports/bifrost-http/...
```

Trigger requests to the filter data endpoints (e.g., `getAvailableFilterData`, `getMCPLogsFilterData`) and verify that store-level errors result in appropriate HTTP error responses rather than silently returning empty data.

## Breaking changes

- [x] Yes
- [ ] No

Any code implementing the `LogManager` interface must update all `GetAvailable*` method signatures to return `(T, error)`. Callers that previously ignored errors by relying on empty-slice fallbacks must now handle the returned error explicitly.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable