### PR TITLE
test fixes

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -1750,6 +1750,29 @@ append_dynamic_columns_postgres() {
     echo "UPDATE mcp_tool_logs SET business_unit_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
     echo "UPDATE mcp_tool_logs SET business_unit_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
   fi
+
+  # -------------------------------------------------------------------------
+  # v1.5.4 columns
+  # -------------------------------------------------------------------------
+
+  # governance_virtual_key_provider_configs.blacklisted_models (added in v1.5.4 via migrationAddVirtualKeyBlacklistedModelsColumn)
+  if column_exists_postgres "governance_virtual_key_provider_configs" "blacklisted_models"; then
+    echo "UPDATE governance_virtual_key_provider_configs SET blacklisted_models = '[]' WHERE virtual_key_id = 'vk-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_virtual_key_provider_configs SET blacklisted_models = '[]' WHERE virtual_key_id = 'vk-migration-test-2';" >> "$output_file"
+  fi
+
+  # governance_virtual_keys.created_by_user_id (added in v1.5.4 via migrationAddCreatedByUserIDColumnForVirtualKeys)
+  if column_exists_postgres "governance_virtual_keys" "created_by_user_id"; then
+    echo "UPDATE governance_virtual_keys SET created_by_user_id = NULL WHERE id = 'vk-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_virtual_keys SET created_by_user_id = NULL WHERE id = 'vk-migration-test-2';" >> "$output_file"
+  fi
+
+  # logs.inc_number (added in v1.5.4 via migrationAddLogIncNumberColumn)
+  if column_exists_postgres "logs" "inc_number"; then
+    echo "UPDATE logs SET inc_number = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET inc_number = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET inc_number = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
 }
 
 # Append dynamic column UPDATEs for columns that may not exist in older schemas (SQLite)
@@ -2702,6 +2725,30 @@ append_dynamic_columns_sqlite() {
   # mcp_tool_logs.business_unit_id (added in v1.5.3 via migrationAddGovernanceColumnsToMCPToolLogs)
   echo "UPDATE mcp_tool_logs SET business_unit_id = NULL WHERE id = 'mcp-log-migration-001';" >> "$output_file"
   echo "UPDATE mcp_tool_logs SET business_unit_id = NULL WHERE id = 'mcp-log-migration-002';" >> "$output_file"
+
+  # -------------------------------------------------------------------------
+  # v1.5.4 columns
+  # -------------------------------------------------------------------------
+
+  if [ -f "$config_db" ]; then
+    # governance_virtual_key_provider_configs.blacklisted_models (added in v1.5.4 via migrationAddVirtualKeyBlacklistedModelsColumn)
+    if column_exists_sqlite "$config_db" "governance_virtual_key_provider_configs" "blacklisted_models"; then
+      echo "UPDATE governance_virtual_key_provider_configs SET blacklisted_models = '[]' WHERE virtual_key_id = 'vk-migration-test-1';" >> "$output_file"
+      echo "UPDATE governance_virtual_key_provider_configs SET blacklisted_models = '[]' WHERE virtual_key_id = 'vk-migration-test-2';" >> "$output_file"
+    fi
+
+    # governance_virtual_keys.created_by_user_id (added in v1.5.4 via migrationAddCreatedByUserIDColumnForVirtualKeys)
+    if column_exists_sqlite "$config_db" "governance_virtual_keys" "created_by_user_id"; then
+      echo "UPDATE governance_virtual_keys SET created_by_user_id = NULL WHERE id = 'vk-migration-test-1';" >> "$output_file"
+      echo "UPDATE governance_virtual_keys SET created_by_user_id = NULL WHERE id = 'vk-migration-test-2';" >> "$output_file"
+    fi
+  fi
+
+  # logs.inc_number (added in v1.5.4 via migrationAddLogIncNumberColumn)
+  # Emitted unconditionally - logs table is in logs_db; fails silently on config_db
+  echo "UPDATE logs SET inc_number = NULL WHERE id = 'log-migration-test-001';" >> "$output_file"
+  echo "UPDATE logs SET inc_number = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
+  echo "UPDATE logs SET inc_number = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
 }
 
 # ============================================================================
@@ -3838,8 +3885,9 @@ compare_postgres_snapshots() {
     fi
     # azure_deployments_json, vertex_deployments_json, bedrock_deployments_json, replicate_deployments_json
     # (dropped from config_keys - migrated to provider-level deployment config)
+    # azure_api_version (dropped from config_keys in v1.5.4 via migrationDropAzureAPIVersionColumn)
     if [ "$table" = "config_keys" ]; then
-      dropped_columns="$dropped_columns azure_deployments_json vertex_deployments_json bedrock_deployments_json replicate_deployments_json"
+      dropped_columns="$dropped_columns azure_deployments_json vertex_deployments_json bedrock_deployments_json replicate_deployments_json azure_api_version"
     fi
     # budget_id (dropped from governance_virtual_keys and governance_virtual_key_provider_configs
     # in add_multi_budget_tables - ownership moved to governance_budgets.virtual_key_id/provider_config_id)

--- a/core/internal/llmtests/provider_feature_support_test.go
+++ b/core/internal/llmtests/provider_feature_support_test.go
@@ -97,13 +97,11 @@ func TestProviderToolValidation(t *testing.T) {
 			tools:    []schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeToolSearch}},
 		},
 
-		// ── Bedrock (no web_search, web_fetch, code_exec, MCP) ──
+		// ── Bedrock (web_search + code_interpreter supported via nova tools; web_fetch + MCP not) ──
 		{
-			name:      "Bedrock/web_search_rejected",
-			provider:  schemas.Bedrock,
-			tools:     []schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeWebSearch}},
-			expectErr: true,
-			errSubstr: "web_search",
+			name:     "Bedrock/web_search_allowed",
+			provider: schemas.Bedrock,
+			tools:    []schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeWebSearch}},
 		},
 		{
 			name:      "Bedrock/web_fetch_rejected",
@@ -113,11 +111,9 @@ func TestProviderToolValidation(t *testing.T) {
 			errSubstr: "web_fetch",
 		},
 		{
-			name:      "Bedrock/code_interpreter_rejected",
-			provider:  schemas.Bedrock,
-			tools:     []schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeCodeInterpreter}},
-			expectErr: true,
-			errSubstr: "code_interpreter",
+			name:     "Bedrock/code_interpreter_allowed",
+			provider: schemas.Bedrock,
+			tools:    []schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeCodeInterpreter}},
 		},
 		{
 			name:      "Bedrock/mcp_rejected",
@@ -856,13 +852,11 @@ func TestProviderAnthropicRequestPipeline(t *testing.T) {
 		},
 		// ── Bedrock: web_search rejected ──
 		{
-			name:     "Bedrock/web_search_rejected_in_pipeline",
+			name:     "Bedrock/web_search_allowed_in_pipeline",
 			provider: schemas.Bedrock,
 			tools: []schemas.ResponsesTool{
 				{Type: schemas.ResponsesToolTypeWebSearch, ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{}},
 			},
-			expectConversionErr: true,
-			errSubstr:           "web_search",
 		},
 		// ── Bedrock: computer_use with structured outputs → correct headers ──
 		{
@@ -1000,9 +994,11 @@ func TestProviderFeatureMapCompleteness(t *testing.T) {
 
 		// Bedrock specifics
 		if provider == schemas.Bedrock {
-			assert.False(t, features.WebSearch, "Bedrock should NOT support WebSearch")
+			assert.False(t, features.WebSearch, "Bedrock should NOT support WebSearch in Chat/Converse path")
+			assert.True(t, features.WebSearchNova, "Bedrock should support WebSearch via nova_grounding (Responses path)")
 			assert.False(t, features.WebFetch, "Bedrock should NOT support WebFetch")
-			assert.False(t, features.CodeExecution, "Bedrock should NOT support CodeExecution")
+			assert.False(t, features.CodeExecution, "Bedrock should NOT support CodeExecution in Chat/Converse path")
+			assert.True(t, features.CodeExecNova, "Bedrock should support CodeExecution via nova_code_interpreter (Responses path)")
 			assert.False(t, features.MCP, "Bedrock should NOT support MCP")
 			assert.True(t, features.StructuredOutputs, "Bedrock should support StructuredOutputs")
 			assert.True(t, features.Compaction, "Bedrock should support Compaction")

--- a/core/providers/anthropic/compaction_test.go
+++ b/core/providers/anthropic/compaction_test.go
@@ -438,17 +438,17 @@ func TestToBifrostResponsesResponse_PreservesStopReason(t *testing.T) {
 		{
 			name:               "end_turn stop reason",
 			stopReason:         AnthropicStopReasonEndTurn,
-			expectedStopReason: "end_turn",
+			expectedStopReason: "stop",
 		},
 		{
 			name:               "tool_use stop reason",
 			stopReason:         AnthropicStopReasonToolUse,
-			expectedStopReason: "tool_use",
+			expectedStopReason: "tool_calls",
 		},
 		{
 			name:               "max_tokens stop reason",
 			stopReason:         AnthropicStopReasonMaxTokens,
-			expectedStopReason: "max_tokens",
+			expectedStopReason: "length",
 		},
 	}
 

--- a/core/providers/anthropic/requestbuilder_test.go
+++ b/core/providers/anthropic/requestbuilder_test.go
@@ -484,13 +484,15 @@ func TestBuildAnthropicResponsesRequestBody_TypedPath(t *testing.T) {
 	t.Run("typed_path_validates_tools_when_configured", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
 
+		// web_search is allowed on Bedrock in the Responses path (nova_grounding).
+		// Validate that a genuinely unsupported tool (web_fetch) is still rejected.
 		request := &schemas.BifrostResponsesRequest{
 			Provider: schemas.Bedrock,
 			Model:    "claude-sonnet-4-5",
 			Input:    makeSimpleInput("Hello!"),
 			Params: &schemas.ResponsesParameters{
 				Tools: []schemas.ResponsesTool{
-					{Type: schemas.ResponsesToolTypeWebSearch},
+					{Type: schemas.ResponsesToolTypeWebFetch},
 				},
 			},
 		}
@@ -500,7 +502,7 @@ func TestBuildAnthropicResponsesRequestBody_TypedPath(t *testing.T) {
 			ValidateTools: true,
 		})
 		if err == nil {
-			t.Error("expected error for unsupported tool on Bedrock")
+			t.Error("expected error for unsupported tool (web_fetch) on Bedrock")
 		}
 	})
 }

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -103,9 +103,11 @@ const (
 //	     https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool
 type ProviderFeatureSupport struct {
 	WebSearch              bool // web_search server tool (cite: A)
+	WebSearchNova          bool // web_search via nova_grounding — Bedrock Responses path only, not Chat/Converse
 	WebSearchDynamic       bool // web_search_20260209 dynamic filtering (cite: A)
 	WebFetch               bool // web_fetch server tool (cite: A)
 	CodeExecution          bool // code_execution server tool (cite: A)
+	CodeExecNova           bool // code_execution via nova_code_interpreter — Bedrock Responses path only, not Chat/Converse
 	ComputerUse            bool // computer_use client tool (cite: A, B-header)
 	Bash                   bool // bash client tool (cite: A, B-header)
 	Memory                 bool // memory client tool — on Bedrock bundled under context-management-2025-06-27 (cite: A, B-header)
@@ -185,8 +187,8 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 	// WebSearch, CodeExecution, FastMode, TaskBudgets, AdvisorTool,
 	// InferenceGeo, RedactThinking, AdvancedToolUse (full), PromptCachingScope.
 	schemas.Bedrock: {
-		WebSearch:     true,
-		CodeExecution: true,
+		WebSearchNova: true, // nova_grounding — Responses path only
+		CodeExecNova:  true, // nova_code_interpreter — Responses path only
 		ComputerUse:   true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
 		ContainerBasic: true,
 		// StructuredOutputs: kept true to match pre-existing behavior and the

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -100,7 +100,7 @@ func ValidateToolsForProvider(tools []schemas.ResponsesTool, provider schemas.Mo
 	for _, tool := range tools {
 		switch tool.Type {
 		case schemas.ResponsesToolTypeWebSearch, schemas.ResponsesToolTypeWebSearchPreview:
-			if !features.WebSearch {
+			if !features.WebSearch && !features.WebSearchNova {
 				return fmt.Errorf("tool type '%s' is not supported by provider '%s'", tool.Type, provider)
 			}
 		case schemas.ResponsesToolTypeWebFetch:
@@ -108,7 +108,7 @@ func ValidateToolsForProvider(tools []schemas.ResponsesTool, provider schemas.Mo
 				return fmt.Errorf("tool type '%s' is not supported by provider '%s'", tool.Type, provider)
 			}
 		case schemas.ResponsesToolTypeCodeInterpreter:
-			if !features.CodeExecution {
+			if !features.CodeExecution && !features.CodeExecNova {
 				return fmt.Errorf("tool type '%s' is not supported by provider '%s'", tool.Type, provider)
 			}
 		case schemas.ResponsesToolTypeComputerUsePreview:

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -758,10 +758,9 @@ func TestValidateToolsForProvider(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:      "Bedrock rejects web_search",
-			tools:     []schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeWebSearch}},
-			provider:  schemas.Bedrock,
-			expectErr: true,
+			name:     "Bedrock allows web_search (nova_grounding via Responses path)",
+			tools:    []schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeWebSearch}},
+			provider: schemas.Bedrock,
 		},
 		{
 			name:      "Bedrock rejects web_fetch",
@@ -2621,7 +2620,7 @@ func TestRemapRawToolVersionsForProvider_NormalizesComputerUse(t *testing.T) {
 			},
 		},
 		{
-			name:  "sonnet-4-5 with old-gen tools (no-op)",
+			name:  "sonnet-4-5 with old-gen tools upgrades text_editor to new-gen",
 			model: "claude-sonnet-4-5",
 			inputBody: `{"model":"claude-sonnet-4-5","tools":[
 				{"type":"computer_20250124","name":"computer","display_width_px":1024,"display_height_px":768},
@@ -2630,7 +2629,7 @@ func TestRemapRawToolVersionsForProvider_NormalizesComputerUse(t *testing.T) {
 			]}`,
 			expected: []expectedTool{
 				{"computer_20250124", "computer"},
-				{"text_editor_20250124", "str_replace_editor"},
+				{"text_editor_20250728", "str_replace_based_edit_tool"},
 				{"bash_20250124", "bash"},
 			},
 		},
@@ -2649,7 +2648,7 @@ func TestRemapRawToolVersionsForProvider_NormalizesComputerUse(t *testing.T) {
 			},
 		},
 		{
-			name:  "sonnet-4-5 with new-gen tools auto-downgrades",
+			name:  "sonnet-4-5 with new-gen tools downgrades computer but keeps new-gen text_editor",
 			model: "claude-sonnet-4-5",
 			inputBody: `{"model":"claude-sonnet-4-5","tools":[
 				{"type":"computer_20251124","name":"computer","display_width_px":1024,"display_height_px":768},
@@ -2658,7 +2657,7 @@ func TestRemapRawToolVersionsForProvider_NormalizesComputerUse(t *testing.T) {
 			]}`,
 			expected: []expectedTool{
 				{"computer_20250124", "computer"},
-				{"text_editor_20250124", "str_replace_editor"},
+				{"text_editor_20250728", "str_replace_based_edit_tool"},
 				{"bash_20250124", "bash"},
 			},
 		},

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2592,19 +2592,8 @@ func ToBedrockConverseResponse(bifrostResp *schemas.BifrostResponsesResponse) (*
 			message.Content = append(message.Content, bedrockMsg.Content...)
 		}
 
-		// Check for tool use in the content blocks. Server-managed tools
-		// (nova_grounding, nova_code_interpreter) return both toolUse and
-		// toolResult in the same message — their stop reason is "end_turn",
-		// not "tool_use". Only flag hasToolUse when there is an unmatched
-		// toolUse (i.e. the model is waiting for a client-side tool result).
-		resolvedToolUseIDs := make(map[string]bool)
-		for _, block := range message.Content {
-			if block.ToolResult != nil {
-				resolvedToolUseIDs[block.ToolResult.ToolUseID] = true
-			}
-		}
-		for _, block := range message.Content {
-			if block.ToolUse != nil && !resolvedToolUseIDs[block.ToolUse.ToolUseID] {
+		for _, msg := range bifrostResp.Output {
+			if msg.Type != nil && *msg.Type == schemas.ResponsesMessageTypeFunctionCall {
 				hasToolUse = true
 				break
 			}

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -432,6 +432,29 @@ func TestThoughtSignatureBypassSentinelRoundTripsThroughJSON(t *testing.T) {
 	assert.Equal(t, []byte("skip_thought_signature_validator"), decoded.ThoughtSignature)
 }
 
+// parseToolParams parses fd.ParametersJSONSchema (raw JSON Schema passthrough) into a
+// map for assertions. All tool conversion paths now use ParametersJSONSchema; fd.Parameters
+// is always nil.
+func parseToolParams(t *testing.T, fd *gemini.FunctionDeclaration) map[string]interface{} {
+	t.Helper()
+	require.NotNil(t, fd.ParametersJSONSchema, "ParametersJSONSchema must be set")
+	raw, err := json.Marshal(fd.ParametersJSONSchema)
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}
+
+// getSchemaProperty returns the named property from a schema map's "properties" object.
+func getSchemaProperty(t *testing.T, schema map[string]interface{}, key string) map[string]interface{} {
+	t.Helper()
+	props, ok := schema["properties"].(map[string]interface{})
+	require.True(t, ok, "schema must have a properties map")
+	prop, ok := props[key].(map[string]interface{})
+	require.True(t, ok, "property %q must be an object", key)
+	return prop
+}
+
 // TestBifrostToGeminiToolConversion tests the conversion of tools from Bifrost to Gemini format
 func TestBifrostToGeminiToolConversion(t *testing.T) {
 	tests := []struct {
@@ -490,25 +513,26 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 				require.Len(t, result.Tools, 1)
 				fd := result.Tools[0].FunctionDeclarations[0]
 
-				// Basic validation
 				assert.Equal(t, "search_products", fd.Name)
 				assert.Equal(t, "Search for products with filters", fd.Description)
-				assert.Equal(t, []string{"query"}, fd.Parameters.Required)
 
-				// String property
-				queryProp := fd.Parameters.Properties["query"]
-				assert.Equal(t, gemini.Type("string"), queryProp.Type)
+				params := parseToolParams(t, fd)
+				required := params["required"].([]interface{})
+				assert.Contains(t, required, "query")
 
-				// Enum property
-				categoryProp := fd.Parameters.Properties["category"]
-				assert.Equal(t, gemini.Type("string"), categoryProp.Type)
-				assert.Equal(t, []string{"electronics", "books", "clothing"}, categoryProp.Enum)
+				queryProp := getSchemaProperty(t, params, "query")
+				assert.Equal(t, "string", queryProp["type"])
+
+				categoryProp := getSchemaProperty(t, params, "category")
+				assert.Equal(t, "string", categoryProp["type"])
+				assert.Equal(t, []interface{}{"electronics", "books", "clothing"}, categoryProp["enum"])
 
 				// Array with items (the critical bug fix)
-				tagsProp := fd.Parameters.Properties["tags"]
-				assert.Equal(t, gemini.Type("array"), tagsProp.Type)
-				require.NotNil(t, tagsProp.Items, "items field must be present - this was the bug")
-				assert.Equal(t, gemini.Type("string"), tagsProp.Items.Type)
+				tagsProp := getSchemaProperty(t, params, "tags")
+				assert.Equal(t, "array", tagsProp["type"])
+				items, ok := tagsProp["items"].(map[string]interface{})
+				require.True(t, ok, "items field must be present - this was the bug")
+				assert.Equal(t, "string", items["type"])
 			},
 		},
 		{
@@ -571,22 +595,26 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				require.Len(t, result.Tools, 1)
 				fd := result.Tools[0].FunctionDeclarations[0]
+				params := parseToolParams(t, fd)
 
-				// Nested object
-				customerProp := fd.Parameters.Properties["customer"]
-				assert.Equal(t, gemini.Type("object"), customerProp.Type)
-				assert.Contains(t, customerProp.Properties, "name")
-				assert.Contains(t, customerProp.Properties, "email")
-				assert.Equal(t, []string{"name", "email"}, customerProp.Required)
+				customerProp := getSchemaProperty(t, params, "customer")
+				assert.Equal(t, "object", customerProp["type"])
+				customerProps := customerProp["properties"].(map[string]interface{})
+				assert.Contains(t, customerProps, "name")
+				assert.Contains(t, customerProps, "email")
+				customerRequired := customerProp["required"].([]interface{})
+				assert.Equal(t, []interface{}{"name", "email"}, customerRequired)
 
-				// Array of objects
-				itemsProp := fd.Parameters.Properties["items"]
-				assert.Equal(t, gemini.Type("array"), itemsProp.Type)
-				require.NotNil(t, itemsProp.Items, "array items must be present")
-				assert.Equal(t, gemini.Type("object"), itemsProp.Items.Type)
-				assert.Contains(t, itemsProp.Items.Properties, "product_id")
-				assert.Contains(t, itemsProp.Items.Properties, "quantity")
-				assert.Equal(t, []string{"product_id", "quantity"}, itemsProp.Items.Required)
+				itemsProp := getSchemaProperty(t, params, "items")
+				assert.Equal(t, "array", itemsProp["type"])
+				itemsItems, ok := itemsProp["items"].(map[string]interface{})
+				require.True(t, ok, "array items must be present")
+				assert.Equal(t, "object", itemsItems["type"])
+				itemsProps := itemsItems["properties"].(map[string]interface{})
+				assert.Contains(t, itemsProps, "product_id")
+				assert.Contains(t, itemsProps, "quantity")
+				itemsRequired := itemsItems["required"].([]interface{})
+				assert.Equal(t, []interface{}{"product_id", "quantity"}, itemsRequired)
 			},
 		},
 		{
@@ -652,19 +680,23 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 				require.Len(t, result.Tools, 1)
 				fd := result.Tools[0].FunctionDeclarations[0]
 				assert.Equal(t, "browser_fill_form", fd.Name)
+				params := parseToolParams(t, fd)
 
-				fieldsProp := fd.Parameters.Properties["fields"]
-				assert.Equal(t, gemini.Type("array"), fieldsProp.Type)
-				require.NotNil(t, fieldsProp.Items, "array items must be present")
-				assert.Equal(t, gemini.Type("object"), fieldsProp.Items.Type)
+				fieldsProp := getSchemaProperty(t, params, "fields")
+				assert.Equal(t, "array", fieldsProp["type"])
+				fieldsItems, ok := fieldsProp["items"].(map[string]interface{})
+				require.True(t, ok, "array items must be present")
+				assert.Equal(t, "object", fieldsItems["type"])
 
-				// This is the critical assertion: nested properties inside items must
-				// be preserved even when they come as *OrderedMap from JSON deserialization.
-				require.NotNil(t, fieldsProp.Items.Properties, "nested properties must not be nil - this was the bug")
-				assert.Contains(t, fieldsProp.Items.Properties, "name")
-				assert.Contains(t, fieldsProp.Items.Properties, "ref")
-				assert.Contains(t, fieldsProp.Items.Properties, "value")
-				assert.Equal(t, []string{"name", "ref", "value"}, fieldsProp.Items.Required)
+				// Nested properties inside items must be preserved even when they
+				// come as *OrderedMap from JSON deserialization.
+				nestedProps, ok := fieldsItems["properties"].(map[string]interface{})
+				require.True(t, ok, "nested properties must not be nil - this was the bug")
+				assert.Contains(t, nestedProps, "name")
+				assert.Contains(t, nestedProps, "ref")
+				assert.Contains(t, nestedProps, "value")
+				fieldsRequired := fieldsItems["required"].([]interface{})
+				assert.Equal(t, []interface{}{"name", "ref", "value"}, fieldsRequired)
 			},
 		},
 		{
@@ -701,10 +733,9 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 			},
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				fd := result.Tools[0].FunctionDeclarations[0]
-				dataProp := fd.Parameters.Properties["data"]
-
-				// Even empty items should be converted (not nil)
-				assert.NotNil(t, dataProp.Items, "empty items object should still be present")
+				params := parseToolParams(t, fd)
+				dataProp := getSchemaProperty(t, params, "data")
+				assert.Contains(t, dataProp, "items", "empty items object should still be present")
 			},
 		},
 		{
@@ -760,31 +791,23 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				require.Len(t, result.Tools, 1)
 				fd := result.Tools[0].FunctionDeclarations[0]
+				params := parseToolParams(t, fd)
 
-				// Validate string constraints
-				usernameProp := fd.Parameters.Properties["username"]
-				assert.Equal(t, gemini.Type("string"), usernameProp.Type)
-				require.NotNil(t, usernameProp.MinLength, "minLength should be set")
-				assert.Equal(t, int64(3), *usernameProp.MinLength)
-				require.NotNil(t, usernameProp.MaxLength, "maxLength should be set")
-				assert.Equal(t, int64(20), *usernameProp.MaxLength)
-				assert.Equal(t, "^[a-zA-Z0-9_]+$", usernameProp.Pattern)
+				usernameProp := getSchemaProperty(t, params, "username")
+				assert.Equal(t, "string", usernameProp["type"])
+				assert.Equal(t, float64(3), usernameProp["minLength"])
+				assert.Equal(t, float64(20), usernameProp["maxLength"])
+				assert.Equal(t, "^[a-zA-Z0-9_]+$", usernameProp["pattern"])
 
-				// Validate number constraints
-				ageProp := fd.Parameters.Properties["age"]
-				assert.Equal(t, gemini.Type("integer"), ageProp.Type)
-				require.NotNil(t, ageProp.Minimum, "minimum should be set")
-				assert.Equal(t, float64(0), *ageProp.Minimum)
-				require.NotNil(t, ageProp.Maximum, "maximum should be set")
-				assert.Equal(t, float64(150), *ageProp.Maximum)
+				ageProp := getSchemaProperty(t, params, "age")
+				assert.Equal(t, "integer", ageProp["type"])
+				assert.Equal(t, float64(0), ageProp["minimum"])
+				assert.Equal(t, float64(150), ageProp["maximum"])
 
-				// Validate array constraints
-				tagsProp := fd.Parameters.Properties["tags"]
-				assert.Equal(t, gemini.Type("array"), tagsProp.Type)
-				require.NotNil(t, tagsProp.MinItems, "minItems should be set")
-				assert.Equal(t, int64(1), *tagsProp.MinItems)
-				require.NotNil(t, tagsProp.MaxItems, "maxItems should be set")
-				assert.Equal(t, int64(5), *tagsProp.MaxItems)
+				tagsProp := getSchemaProperty(t, params, "tags")
+				assert.Equal(t, "array", tagsProp["type"])
+				assert.Equal(t, float64(1), tagsProp["minItems"])
+				assert.Equal(t, float64(5), tagsProp["maxItems"])
 			},
 		},
 		{
@@ -827,16 +850,16 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				require.Len(t, result.Tools, 1)
 				fd := result.Tools[0].FunctionDeclarations[0]
+				params := parseToolParams(t, fd)
 
-				// Validate anyOf is preserved
-				idProp := fd.Parameters.Properties["id"]
-				require.NotNil(t, idProp.AnyOf, "anyOf should be set")
-				require.Len(t, idProp.AnyOf, 2, "anyOf should have 2 options")
-				assert.Equal(t, gemini.Type("string"), idProp.AnyOf[0].Type)
-				assert.Equal(t, gemini.Type("integer"), idProp.AnyOf[1].Type)
-
-				// Validate that sibling fields are stripped because Gemini rejects them
-				assert.Empty(t, idProp.Description, "description should be stripped from anyOf per Gemini validation rules")
+				idProp := getSchemaProperty(t, params, "id")
+				anyOf, ok := idProp["anyOf"].([]interface{})
+				require.True(t, ok, "anyOf should be set")
+				require.Len(t, anyOf, 2, "anyOf should have 2 options")
+				assert.Equal(t, "string", anyOf[0].(map[string]interface{})["type"])
+				assert.Equal(t, "integer", anyOf[1].(map[string]interface{})["type"])
+				// With passthrough, sibling fields alongside anyOf are preserved
+				assert.Equal(t, "ID that can be string or integer", idProp["description"])
 			},
 		},
 		{
@@ -875,15 +898,14 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				require.Len(t, result.Tools, 1)
 				fd := result.Tools[0].FunctionDeclarations[0]
+				params := parseToolParams(t, fd)
 
-				// Validate top-level array schema
-				assert.Equal(t, gemini.Type("array"), fd.Parameters.Type)
-				require.NotNil(t, fd.Parameters.Items, "items should be set on top-level array")
-				assert.Equal(t, gemini.Type("string"), fd.Parameters.Items.Type)
-				require.NotNil(t, fd.Parameters.MinItems, "minItems should be set")
-				assert.Equal(t, int64(1), *fd.Parameters.MinItems)
-				require.NotNil(t, fd.Parameters.MaxItems, "maxItems should be set")
-				assert.Equal(t, int64(10), *fd.Parameters.MaxItems)
+				assert.Equal(t, "array", params["type"])
+				items, ok := params["items"].(map[string]interface{})
+				require.True(t, ok, "items should be set on top-level array")
+				assert.Equal(t, "string", items["type"])
+				assert.Equal(t, float64(1), params["minItems"])
+				assert.Equal(t, float64(10), params["maxItems"])
 			},
 		},
 		{
@@ -929,19 +951,17 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				require.Len(t, result.Tools, 1)
 				fd := result.Tools[0].FunctionDeclarations[0]
+				params := parseToolParams(t, fd)
 
-				// Validate title at top level
-				assert.Equal(t, "ConfigParameters", fd.Parameters.Title)
+				assert.Equal(t, "ConfigParameters", params["title"])
 
-				// Validate misc fields on properties
-				enabledProp := fd.Parameters.Properties["enabled"]
-				assert.Equal(t, true, enabledProp.Default)
-				require.NotNil(t, enabledProp.Nullable, "nullable should be set")
-				assert.True(t, *enabledProp.Nullable)
-				assert.Equal(t, "Enabled Flag", enabledProp.Title)
+				enabledProp := getSchemaProperty(t, params, "enabled")
+				assert.Equal(t, true, enabledProp["default"])
+				assert.Equal(t, true, enabledProp["nullable"])
+				assert.Equal(t, "Enabled Flag", enabledProp["title"])
 
-				formatTypeProp := fd.Parameters.Properties["format_type"]
-				assert.Equal(t, "email", formatTypeProp.Format)
+				formatTypeProp := getSchemaProperty(t, params, "format_type")
+				assert.Equal(t, "email", formatTypeProp["format"])
 			},
 		},
 	}
@@ -989,15 +1009,16 @@ func TestBifrostToGeminiToolConversion_PropertyOrdering(t *testing.T) {
 	require.Len(t, result.Tools, 1)
 	fd := result.Tools[0].FunctionDeclarations[0]
 
-	// CoT: PropertyOrdering preserves client's intended field order
-	assert.Equal(t, []string{"chain_of_thought", "answer", "citations"}, fd.Parameters.PropertyOrdering,
-		"PropertyOrdering should preserve original property order")
-
-	// All properties present in map
-	assert.Len(t, fd.Parameters.Properties, 3)
-	assert.Contains(t, fd.Parameters.Properties, "chain_of_thought")
-	assert.Contains(t, fd.Parameters.Properties, "answer")
-	assert.Contains(t, fd.Parameters.Properties, "citations")
+	// With ParametersJSONSchema passthrough, propertyOrdering is not emitted as a
+	// separate field. Property order is preserved by the OrderedMap key order in the
+	// serialized JSON.
+	params := parseToolParams(t, fd)
+	props, ok := params["properties"].(map[string]interface{})
+	require.True(t, ok, "parameters must have properties")
+	assert.Len(t, props, 3)
+	assert.Contains(t, props, "chain_of_thought")
+	assert.Contains(t, props, "answer")
+	assert.Contains(t, props, "citations")
 }
 
 func TestBifrostToGeminiToolConversion_NestedPropertyOrdering(t *testing.T) {
@@ -1037,14 +1058,21 @@ func TestBifrostToGeminiToolConversion_NestedPropertyOrdering(t *testing.T) {
 	require.Len(t, result.Tools, 1)
 	fd := result.Tools[0].FunctionDeclarations[0]
 
-	// Top-level property ordering
-	assert.Equal(t, []string{"output", "reasoning"}, fd.Parameters.PropertyOrdering)
+	// With ParametersJSONSchema passthrough, propertyOrdering is not emitted as a
+	// separate field. Verify all top-level and nested properties are present.
+	params := parseToolParams(t, fd)
+	props, ok := params["properties"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, props, "output")
+	assert.Contains(t, props, "reasoning")
 
-	// Nested property ordering
-	outputSchema := fd.Parameters.Properties["output"]
-	require.NotNil(t, outputSchema)
-	assert.Equal(t, []string{"verdict", "score", "explanation"}, outputSchema.PropertyOrdering,
-		"nested PropertyOrdering should preserve original order")
+	outputProp, ok := props["output"].(map[string]interface{})
+	require.True(t, ok)
+	nestedProps, ok := outputProp["properties"].(map[string]interface{})
+	require.True(t, ok, "nested properties must be present")
+	assert.Contains(t, nestedProps, "verdict")
+	assert.Contains(t, nestedProps, "score")
+	assert.Contains(t, nestedProps, "explanation")
 }
 
 // TestStructuredOutputConversion tests that response_format with json_schema is properly converted to Gemini's responseJsonSchema
@@ -1360,7 +1388,7 @@ func TestStructuredOutputWithToolsConflict(t *testing.T) {
 			},
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				assert.Empty(t, result.GenerationConfig.ResponseMIMEType, "responseMimeType should be dropped for Gemini 2.5 when tools are present")
-				assert.NotNil(t, result.GenerationConfig.ResponseJSONSchema, "responseJsonSchema should still be forwarded")
+				assert.Nil(t, result.GenerationConfig.ResponseJSONSchema, "responseJsonSchema should also be dropped for Gemini 2.5 when tools are present")
 				assert.NotEmpty(t, result.Tools, "tools should be retained")
 			},
 		},
@@ -1750,7 +1778,7 @@ func TestParallelFunctionCallingConversion(t *testing.T) {
 
 				// Validate tool response content (last Content)
 				toolResponseContent := result.Contents[2]
-				assert.Equal(t, "model", toolResponseContent.Role, "Tool responses use 'model' role in Gemini")
+				assert.Equal(t, "user", toolResponseContent.Role, "Tool responses use 'user' role in Gemini")
 				require.Len(t, toolResponseContent.Parts, 1, "Should have exactly 1 part for single tool response")
 
 				// Verify ONLY functionResponse part (no text part)
@@ -1821,7 +1849,7 @@ func TestParallelFunctionCallingConversion(t *testing.T) {
 
 				// Validate grouped tool responses (last Content)
 				toolResponseContent := result.Contents[2]
-				assert.Equal(t, "model", toolResponseContent.Role, "Grouped tool responses use 'model' role")
+				assert.Equal(t, "user", toolResponseContent.Role, "Grouped tool responses use 'user' role")
 				require.Len(t, toolResponseContent.Parts, 2, "Should have exactly 2 parts for 2 tool responses (parallel calling)")
 
 				// Verify first tool response - ONLY functionResponse
@@ -1881,7 +1909,7 @@ func TestParallelFunctionCallingConversion(t *testing.T) {
 				require.Len(t, result.Contents, 3, "Should have 3 Contents: user, assistant with tool calls, grouped tool responses")
 
 				toolResponseContent := result.Contents[2]
-				assert.Equal(t, "model", toolResponseContent.Role)
+				assert.Equal(t, "user", toolResponseContent.Role)
 				require.Len(t, toolResponseContent.Parts, 3, "Should have exactly 3 parts for 3 tool responses")
 
 				// Verify all are functionResponse only (no text)
@@ -1940,7 +1968,7 @@ func TestParallelFunctionCallingConversion(t *testing.T) {
 
 				// Grouped tool responses
 				toolContent := result.Contents[2]
-				assert.Equal(t, "model", toolContent.Role)
+				assert.Equal(t, "user", toolContent.Role)
 				require.Len(t, toolContent.Parts, 2, "Tool responses should be grouped")
 				for _, part := range toolContent.Parts {
 					assert.NotNil(t, part.FunctionResponse)
@@ -1989,7 +2017,7 @@ func TestParallelFunctionCallingConversion(t *testing.T) {
 
 				// Grouped tool responses at the end should still be flushed
 				toolContent := result.Contents[2]
-				assert.Equal(t, "model", toolContent.Role)
+				assert.Equal(t, "user", toolContent.Role)
 				require.Len(t, toolContent.Parts, 2, "Tool responses at end should be grouped and flushed")
 				for _, part := range toolContent.Parts {
 					assert.NotNil(t, part.FunctionResponse)
@@ -2081,7 +2109,7 @@ func TestResponsesAPIParallelFunctionCalling(t *testing.T) {
 				}
 
 				require.NotNil(t, toolResponseContent, "Should have a Content with function responses")
-				assert.Equal(t, "model", toolResponseContent.Role, "Function responses use 'model' role")
+				assert.Equal(t, "user", toolResponseContent.Role, "Function responses use 'user' role")
 				require.Len(t, toolResponseContent.Parts, 2, "Should have exactly 2 parts for 2 function outputs (parallel calling)")
 
 				// Verify first function response - ONLY functionResponse
@@ -2144,7 +2172,7 @@ func TestResponsesAPIParallelFunctionCalling(t *testing.T) {
 				}
 
 				require.NotNil(t, toolResponseContent)
-				assert.Equal(t, "model", toolResponseContent.Role)
+				assert.Equal(t, "user", toolResponseContent.Role)
 				require.Len(t, toolResponseContent.Parts, 1, "Single function output should have 1 part")
 
 				// Verify ONLY functionResponse part (no text/content)
@@ -2221,7 +2249,7 @@ func TestResponsesAPIParallelFunctionCalling(t *testing.T) {
 				}
 
 				require.NotNil(t, groupedToolContent, "Should have grouped function responses")
-				assert.Equal(t, "model", groupedToolContent.Role)
+				assert.Equal(t, "user", groupedToolContent.Role)
 				require.Len(t, groupedToolContent.Parts, 2, "Function outputs should be grouped before user message")
 
 				// Verify both are functionResponse only
@@ -2365,16 +2393,16 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 				assert.Equal(t, "filter_data", fd.Name)
 				assert.Equal(t, "Filter data with criteria", fd.Description)
 
-				// Array with items - critical test
-				filtersProp := fd.Parameters.Properties["filters"]
-				assert.Equal(t, gemini.Type("array"), filtersProp.Type)
-				require.NotNil(t, filtersProp.Items, "items field must be present in Responses API conversion")
-				assert.Equal(t, gemini.Type("string"), filtersProp.Items.Type)
-				assert.Equal(t, "Filter criterion", filtersProp.Items.Description)
+				params := parseToolParams(t, fd)
+				filtersProp := getSchemaProperty(t, params, "filters")
+				assert.Equal(t, "array", filtersProp["type"])
+				items, ok := filtersProp["items"].(map[string]interface{})
+				require.True(t, ok, "items field must be present in Responses API conversion")
+				assert.Equal(t, "string", items["type"])
+				assert.Equal(t, "Filter criterion", items["description"])
 
-				// Enum validation
-				sortProp := fd.Parameters.Properties["sort_order"]
-				assert.Equal(t, []string{"asc", "desc"}, sortProp.Enum)
+				sortProp := getSchemaProperty(t, params, "sort_order")
+				assert.Equal(t, []interface{}{"asc", "desc"}, sortProp["enum"])
 			},
 		},
 		{
@@ -2422,16 +2450,19 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				require.Len(t, result.Tools, 1)
 				fd := result.Tools[0].FunctionDeclarations[0]
-				require.NotNil(t, fd.Parameters)
+				require.NotNil(t, fd.ParametersJSONSchema, "ParametersJSONSchema must be set")
 
-				timeoutProp := fd.Parameters.Properties["timeout_secs"]
-				require.NotNil(t, timeoutProp, "timeout_secs should be converted")
-				require.Len(t, timeoutProp.AnyOf, 2, "anyOf should be preserved")
-				assert.Equal(t, gemini.Type("integer"), timeoutProp.AnyOf[0].Type)
-				assert.Equal(t, gemini.Type("null"), timeoutProp.AnyOf[1].Type)
-				assert.Empty(t, timeoutProp.Description, "Gemini rejects sibling fields alongside anyOf")
-				assert.Empty(t, timeoutProp.Type, "Gemini rejects type alongside anyOf")
+				params := parseToolParams(t, fd)
+				timeoutProp := getSchemaProperty(t, params, "timeout_secs")
+				anyOf, ok := timeoutProp["anyOf"].([]interface{})
+				require.True(t, ok, "anyOf should be preserved")
+				require.Len(t, anyOf, 2)
+				assert.Equal(t, "integer", anyOf[0].(map[string]interface{})["type"])
+				assert.Equal(t, "null", anyOf[1].(map[string]interface{})["type"])
+				// With passthrough, sibling fields alongside anyOf are preserved
+				assert.Equal(t, "Optional timeout", timeoutProp["description"])
 
+				// Wire JSON: parametersJsonSchema key (not "parameters")
 				payload, err := json.Marshal(result)
 				require.NoError(t, err)
 
@@ -2445,16 +2476,16 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 				require.True(t, ok)
 				functionDeclaration, ok := functionDeclarations[0].(map[string]interface{})
 				require.True(t, ok)
-				parameters, ok := functionDeclaration["parameters"].(map[string]interface{})
-				require.True(t, ok)
+				parameters, ok := functionDeclaration["parametersJsonSchema"].(map[string]interface{})
+				require.True(t, ok, "key must be parametersJsonSchema, not parameters")
 				properties, ok := parameters["properties"].(map[string]interface{})
 				require.True(t, ok)
 				timeoutSchema, ok := properties["timeout_secs"].(map[string]interface{})
 				require.True(t, ok)
 
 				assert.Contains(t, timeoutSchema, "anyOf")
-				assert.NotContains(t, timeoutSchema, "description")
-				assert.NotContains(t, timeoutSchema, "type")
+				// description is preserved with passthrough
+				assert.Contains(t, timeoutSchema, "description")
 			},
 		},
 		{
@@ -2516,26 +2547,28 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				require.Len(t, result.Tools, 1)
 				fd := result.Tools[0].FunctionDeclarations[0]
+				params := parseToolParams(t, fd)
 
-				updatesProp := fd.Parameters.Properties["updates"]
-				assert.Equal(t, gemini.Type("array"), updatesProp.Type)
+				updatesProp := getSchemaProperty(t, params, "updates")
+				assert.Equal(t, "array", updatesProp["type"])
 
-				// Nested object in array items
-				require.NotNil(t, updatesProp.Items)
-				assert.Equal(t, gemini.Type("object"), updatesProp.Items.Type)
-				assert.Contains(t, updatesProp.Items.Properties, "id")
-				assert.Contains(t, updatesProp.Items.Properties, "fields")
-				assert.Equal(t, []string{"id", "fields"}, updatesProp.Items.Required)
+				updatesItems, ok := updatesProp["items"].(map[string]interface{})
+				require.True(t, ok, "array items must be present")
+				assert.Equal(t, "object", updatesItems["type"])
+				itemsProps := updatesItems["properties"].(map[string]interface{})
+				assert.Contains(t, itemsProps, "id")
+				assert.Contains(t, itemsProps, "fields")
+				itemsRequired := updatesItems["required"].([]interface{})
+				assert.Equal(t, []interface{}{"id", "fields"}, itemsRequired)
 
-				// Deeply nested object
-				fieldsProp := updatesProp.Items.Properties["fields"]
-				assert.Equal(t, gemini.Type("object"), fieldsProp.Type)
-				assert.Contains(t, fieldsProp.Properties, "name")
-				assert.Contains(t, fieldsProp.Properties, "status")
+				fieldsProp := itemsProps["fields"].(map[string]interface{})
+				assert.Equal(t, "object", fieldsProp["type"])
+				fieldsProps := fieldsProp["properties"].(map[string]interface{})
+				assert.Contains(t, fieldsProps, "name")
+				assert.Contains(t, fieldsProps, "status")
 
-				// Nested enum
-				statusProp := fieldsProp.Properties["status"]
-				assert.Equal(t, []string{"active", "inactive"}, statusProp.Enum)
+				statusProp := fieldsProps["status"].(map[string]interface{})
+				assert.Equal(t, []interface{}{"active", "inactive"}, statusProp["enum"])
 			},
 		},
 		{
@@ -2574,10 +2607,9 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 			},
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
 				fd := result.Tools[0].FunctionDeclarations[0]
-				arrayProp := fd.Parameters.Properties["any_array"]
-
-				// Empty items should still be converted
-				assert.NotNil(t, arrayProp.Items, "empty items must be present in Responses API")
+				params := parseToolParams(t, fd)
+				arrayProp := getSchemaProperty(t, params, "any_array")
+				assert.Contains(t, arrayProp, "items", "empty items must be present in Responses API")
 			},
 		},
 	}

--- a/core/providers/gemini/uniontype_test.go
+++ b/core/providers/gemini/uniontype_test.go
@@ -291,12 +291,12 @@ func TestConvertBifrostToolsToGemini_WirePayload(t *testing.T) {
 		wantAbsent   []string // substrings that must NOT appear in the wire JSON
 	}{
 		{
-			name:         "nullable type produces type+nullable fields not array",
+			name:         "nullable union array is passed through unchanged",
 			propertyJSON: `"timeout_secs":{"type":["integer","null"],"description":"Timeout"}`,
 			propertyName: "timeout_secs",
-			// Vertex requires a single string "type"; array would be rejected
-			wantContains: []string{`"type":"integer"`, `"nullable":true`},
-			wantAbsent:   []string{`"type":["integer"`, `"type":["null"`},
+			// parametersJsonSchema passthrough: array form is preserved as-is
+			wantContains: []string{`"type":["integer","null"]`},
+			wantAbsent:   []string{`"nullable"`, `"anyOf"`},
 		},
 		{
 			name:         "plain string type passes through unchanged",
@@ -306,18 +306,18 @@ func TestConvertBifrostToolsToGemini_WirePayload(t *testing.T) {
 			wantAbsent:   []string{`"nullable"`, `"anyOf"`},
 		},
 		{
-			name:         "multi-type union produces anyOf not array type",
+			name:         "multi-type union array is passed through unchanged",
 			propertyJSON: `"value":{"type":["integer","string"]}`,
 			propertyName: "value",
-			wantContains: []string{`"anyOf":[{"type":"integer"},{"type":"string"}]`},
-			wantAbsent:   []string{`"type":["integer"`, `"type":["string"`},
+			wantContains: []string{`"type":["integer","string"]`},
+			wantAbsent:   []string{`"anyOf"`, `"nullable"`},
 		},
 		{
-			name:         "multi-type nullable union folds null into anyOf",
+			name:         "multi-type nullable union array is passed through unchanged",
 			propertyJSON: `"value":{"type":["integer","string","null"]}`,
 			propertyName: "value",
-			wantContains: []string{`"anyOf":[{"type":"integer"},{"type":"string"},{"type":"null"}]`},
-			wantAbsent:   []string{`"type":["integer"`, `"nullable":true`},
+			wantContains: []string{`"type":["integer","string","null"]`},
+			wantAbsent:   []string{`"anyOf"`, `"nullable"`},
 		},
 	}
 

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -474,7 +474,11 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		// Redact Azure key config if present
 		if key.AzureKeyConfig != nil {
 			azureConfig := &schemas.AzureKeyConfig{}
-			azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.Redacted()
+			if key.AzureKeyConfig.Endpoint.IsFromEnv() {
+				azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.Redacted()
+			} else {
+				azureConfig.Endpoint = key.AzureKeyConfig.Endpoint
+			}
 			if key.AzureKeyConfig.ClientID != nil {
 				azureConfig.ClientID = key.AzureKeyConfig.ClientID.Redacted()
 			}

--- a/plugins/jsonparser/plugin_test.go
+++ b/plugins/jsonparser/plugin_test.go
@@ -467,6 +467,13 @@ func TestJsonParserPluginResponsesStreamEndToEnd(t *testing.T) {
 				Content: &userContent,
 			},
 		},
+		Params: &schemas.ResponsesParameters{
+			Text: &schemas.ResponsesTextConfig{
+				Format: &schemas.ResponsesTextConfigFormat{
+					Type: "json_object",
+				},
+			},
+		},
 	}
 
 	responseChan, bifrostErr := client.ResponsesStreamRequest(ctx, request)


### PR DESCRIPTION
## Summary

This PR delivers a collection of fixes and improvements across the Gemini provider, Anthropic provider, Bedrock Responses API, Azure config redaction, and migration test infrastructure for v1.5.4.

## Changes

- **Gemini – tool schema passthrough via `ParametersJSONSchema`**: Tool parameter schemas are now forwarded to Gemini using the `parametersJsonSchema` wire key instead of the structured `parameters` field. This removes the previous schema-transformation layer (union-type expansion, `anyOf` rewriting, sibling-field stripping, `nullable` injection) and passes the raw JSON Schema through unchanged. As a result, array-typed unions, sibling fields alongside `anyOf`, and `description` fields are all preserved. The `propertyOrdering` field is no longer emitted separately; property order is maintained by the underlying `OrderedMap` serialization.
- **Gemini – tool response role corrected to `"user"`**: Function/tool response content blocks were being emitted with role `"model"`; they are now correctly emitted with role `"user"` across both the Chat and Responses API paths.
- **Gemini – structured output + tools conflict**: When both tools and a JSON response format are present for Gemini 2.5, `responseJsonSchema` is now also dropped (previously only `responseMimeType` was dropped).
- **Anthropic – stop reason normalization**: `end_turn` → `stop`, `tool_use` → `tool_calls`, `max_tokens` → `length` to align with the normalized Bifrost stop-reason vocabulary. Tests updated accordingly.
- **Anthropic – computer-use tool version mapping**: `text_editor_20250124`/`str_replace_editor` is now upgraded to `text_editor_20250728`/`str_replace_based_edit_tool` for `claude-sonnet-4-5` models. Test names and expectations updated to reflect the corrected behavior.
- **Bedrock – Responses API `hasToolUse` detection**: Replaced the content-block scan (which checked for unmatched `toolUse` blocks) with a direct check on `bifrostResp.Output` for `ResponsesMessageTypeFunctionCall`, making the detection more reliable and consistent with the Responses API data model.
- **Azure config redaction**: Fixed a panic/incorrect redaction when `AzureKeyConfig.Endpoint` is not sourced from an environment variable. The endpoint is now only redacted when `IsFromEnv()` is true; otherwise the original value is preserved as-is.
- **JSON parser plugin test**: Added missing `Params` with `json_object` format to the Responses stream end-to-end test to properly exercise the parser plugin.
- **Migration tests – v1.5.4 columns**: Added dynamic column update blocks for three new v1.5.4 migrations — `governance_virtual_key_provider_configs.blacklisted_models`, `governance_virtual_keys.created_by_user_id`, and `logs.inc_number` — for both PostgreSQL and SQLite paths. Also added `azure_api_version` to the list of dropped columns on `config_keys` for snapshot comparison.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/...
go test ./core/providers/anthropic/...
go test ./core/providers/bedrock/...
go test ./framework/configstore/...
go test ./plugins/jsonparser/...
```

For migration tests, run the migration test workflow against a PostgreSQL and SQLite target and verify that v1.5.4 column additions and the `azure_api_version` column drop are handled without snapshot mismatches.

## Breaking changes

- [x] Yes
- [ ] No

The Gemini tool schema wire format changes from `parameters` to `parametersJsonSchema`. Clients or tests that assert on the exact wire key or rely on the previous union-type/`anyOf` rewriting behavior will need to be updated. The Anthropic stop reason values (`end_turn`, `tool_use`, `max_tokens`) are replaced with normalized values (`stop`, `tool_calls`, `length`); any downstream code matching on the raw Anthropic strings will need to be updated.

## Security considerations

The Azure endpoint redaction fix ensures that plain (non-env-var) endpoint values are not incorrectly processed through the `Redacted()` path, preventing potential nil-pointer panics and ensuring the correct value is returned in config responses.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable