### PR TITLE
fix: fixes streaming latency for observability by deferring EndSpan

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -1120,6 +1120,17 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 				if len(transportLogs) > 0 {
 					tracer.AttachPluginLogs(traceID, transportLogs)
 				}
+				// End the root HTTP span now that the stream has fully drained, so its
+				// latency covers the entire streamed response. For deferred (streaming)
+				// requests the TracingMiddleware defer below intentionally leaves the root
+				// span open; ending it here keeps the parent from closing before its child
+				// llm.call span (which is ended by completeDeferredSpan on the final chunk).
+				// Status is always Ok: deferral is only set after the stream was set up with
+				// HTTP 200, and mid-stream failures surface as SSE error frames / on the
+				// llm.call span, not as an HTTP error on the root.
+				if rootHandle := tracer.GetSpanHandleByID(traceID, nil); rootHandle != nil {
+					tracer.EndSpan(rootHandle, schemas.SpanStatusOk, "")
+				}
 				tracer.CompleteAndFlushTrace(traceID)
 			})
 			// Create root span for the HTTP request
@@ -1137,18 +1148,27 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 				}
 			}
 			defer func() {
+				deferred, _ := ctx.UserValue(schemas.BifrostContextKeyDeferTraceCompletion).(bool)
 				// Record response status on the root span
 				if rootSpan != nil {
 					tracer.SetAttribute(rootSpan, "http.status_code", ctx.Response.StatusCode())
-					if ctx.Response.StatusCode() >= 400 {
-						tracer.EndSpan(rootSpan, schemas.SpanStatusError, fmt.Sprintf("HTTP %d", ctx.Response.StatusCode()))
-					} else {
-						tracer.EndSpan(rootSpan, schemas.SpanStatusOk, "")
+					// For deferred (streaming) requests, the trace completer ends the root
+					// span after the stream fully drains, so its latency reflects the whole
+					// streamed response. Ending it here (at handler return) would close the
+					// parent before the deferred llm.call span finishes, making the child
+					// span appear longer than its parent in trace viewers.
+					if !deferred {
+						if ctx.Response.StatusCode() >= 400 {
+							tracer.EndSpan(rootSpan, schemas.SpanStatusError, fmt.Sprintf("HTTP %d", ctx.Response.StatusCode()))
+						} else {
+							tracer.EndSpan(rootSpan, schemas.SpanStatusOk, "")
+						}
 					}
 				}
 				// Check if trace completion is deferred (for streaming requests)
-				// If deferred, the streaming handler will complete the trace after stream ends
-				if deferred, ok := ctx.UserValue(schemas.BifrostContextKeyDeferTraceCompletion).(bool); ok && deferred {
+				// If deferred, the streaming handler will complete the trace (and end the
+				// root span via the trace completer) after the stream ends.
+				if deferred {
 					return
 				}
 				// Attach transport plugin logs to trace before completion

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -4,16 +4,19 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"context"
 	cryptoRand "crypto/rand"
 	"encoding/json"
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/tracing"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -2019,4 +2022,104 @@ func zstdCompress(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+// captureTracePlugin is an ObservabilityPlugin that captures the root and llm.call
+// span timestamps from a flushed trace. Timestamps are copied synchronously inside
+// Inject because the tracer releases the pooled trace once Inject returns.
+type captureTracePlugin struct {
+	done      chan struct{}
+	rootStart time.Time
+	rootEnd   time.Time
+	llmEnd    time.Time
+	foundLLM  bool
+}
+
+func (p *captureTracePlugin) GetName() string { return "capture-trace" }
+func (p *captureTracePlugin) Cleanup() error  { return nil }
+func (p *captureTracePlugin) Inject(_ context.Context, trace *schemas.Trace) error {
+	defer close(p.done)
+	if trace == nil || trace.RootSpan == nil {
+		return nil
+	}
+	p.rootStart = trace.RootSpan.StartTime
+	p.rootEnd = trace.RootSpan.EndTime
+	for _, span := range trace.Spans {
+		if span != nil && span.Kind == schemas.SpanKindLLMCall {
+			p.llmEnd = span.EndTime
+			p.foundLLM = true
+		}
+	}
+	return nil
+}
+
+// TestTracingMiddleware_StreamingRootSpanEndsAfterLLMSpan asserts that for a deferred
+// (streaming) request the root HTTP span is ended by the trace completer — after the
+// stream drains — rather than at handler return. Before the fix the middleware ended
+// the root span in its defer, so the root closed before the deferred llm.call span,
+// making the child appear longer than its parent in trace viewers.
+func TestTracingMiddleware_StreamingRootSpanEndsAfterLLMSpan(t *testing.T) {
+	store := tracing.NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+	tracer := tracing.NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	plugin := &captureTracePlugin{done: make(chan struct{})}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{plugin})
+
+	tm := NewTracingMiddleware(tracer)
+
+	var traceID, rootSpanID string
+	var completer func([]schemas.PluginLogEntry)
+	next := func(ctx *fasthttp.RequestCtx) {
+		traceID, _ = ctx.UserValue(schemas.BifrostContextKeyTraceID).(string)
+		rootSpanID, _ = ctx.UserValue(schemas.BifrostContextKeySpanID).(string)
+		completer, _ = ctx.UserValue(schemas.BifrostContextKeyTraceCompleter).(func([]schemas.PluginLogEntry))
+		// Mark this as a deferred (streaming) request so the middleware leaves the
+		// root span open for the completer to end.
+		ctx.SetUserValue(schemas.BifrostContextKeyDeferTraceCompletion, true)
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/openai/v1/chat/completions")
+	ctx.Request.Header.SetMethod("POST")
+	// Runs setup, next, and the middleware defer (which must NOT end the root span
+	// because the request is deferred).
+	tm.Middleware()(next)(ctx)
+
+	if traceID == "" {
+		t.Fatal("middleware did not set a trace ID")
+	}
+	if completer == nil {
+		t.Fatal("middleware did not set a trace completer")
+	}
+
+	// Simulate the provider goroutine: the deferred llm.call span ends mid-stream...
+	goCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	goCtx = context.WithValue(goCtx, schemas.BifrostContextKeySpanID, rootSpanID)
+	_, llmHandle := tracer.StartSpan(goCtx, "chat test-model", schemas.SpanKindLLMCall)
+	time.Sleep(10 * time.Millisecond)
+	tracer.EndSpan(llmHandle, schemas.SpanStatusOk, "")
+
+	// ...and the trace completer fires after the stream fully drains.
+	completer(nil)
+
+	select {
+	case <-plugin.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for trace injection")
+	}
+
+	if !plugin.foundLLM {
+		t.Fatal("llm.call span not found in flushed trace")
+	}
+	if plugin.rootEnd.IsZero() {
+		t.Fatal("root span EndTime is zero — it was never ended")
+	}
+	if plugin.rootEnd.Before(plugin.llmEnd) {
+		t.Fatalf("root span ended before llm.call span: root.EndTime=%v, llm.EndTime=%v", plugin.rootEnd, plugin.llmEnd)
+	}
+	if !plugin.rootEnd.After(plugin.rootStart) {
+		t.Fatalf("root span has non-positive duration: start=%v, end=%v", plugin.rootStart, plugin.rootEnd)
+	}
 }


### PR DESCRIPTION
## Summary

For streaming (deferred) requests, the tracing middleware was ending the root HTTP span inside its `defer` block at handler return — before the deferred `llm.call` child span had finished. This caused the child span to appear longer than its parent in trace viewers, which is an invalid trace hierarchy.

The fix moves root span termination for deferred requests into the trace completer callback, which fires only after the stream has fully drained. This ensures the root span's latency covers the entire streamed response and that the `llm.call` child span always ends before its parent.

## Changes

- The middleware `defer` block now checks `BifrostContextKeyDeferTraceCompletion` before ending the root span — if the request is deferred, the root span is left open.
- The trace completer (registered via `OnStreamComplete`) now explicitly ends the root span via `GetSpanHandleByID` before calling `CompleteAndFlushTrace`, so the root span closes after the final SSE chunk is written.
- A new test `TestTracingMiddleware_StreamingRootSpanEndsAfterLLMSpan` verifies that the root span's `EndTime` is always greater than or equal to the `llm.call` span's `EndTime` for deferred requests, and that the root span has a positive duration.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/... -run TestTracingMiddleware_StreamingRootSpanEndsAfterLLMSpan -v
```

Expected: the test passes, confirming the root span ends after the `llm.call` span for streaming requests.

To validate no regressions in non-streaming tracing:

```sh
go test ./transports/bifrost-http/handlers/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects span lifecycle management within the tracing middleware.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable