### PR TITLE
fix: recreate `mv_filter_users` matview to exclude rows with empty `user_name`

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -1567,6 +1567,7 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 	}
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
+	q = q.Where("model IS NOT NULL AND model != ''")
 	if err := q.Select(`
 		model, provider,
 		SUM(count) AS total,
@@ -1599,6 +1600,7 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 		prevFilters.EndTime = &prevEnd
 		pq := s.ScopedDB(ctx).Table("mv_logs_hourly")
 		pq = s.applyMatViewFilters(pq, prevFilters)
+		pq = pq.Where("model IS NOT NULL AND model != ''")
 		if err := pq.Select(`
 			model, provider,
 			SUM(count) AS total,

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -220,10 +220,8 @@ var filterMatViews = []filterMatViewDef{
 	},
 	{
 		name:       "mv_filter_users",
-		selectExpr: "user_id AS id, COALESCE(NULLIF(user_name, ''), user_id) AS name, " +
-			"COALESCE(user_id, '') AS user_id, COALESCE(team_id, '') AS team_id, " +
-			"COALESCE(virtual_key_id, '') AS virtual_key_id",
-		whereExpr:       "user_id IS NOT NULL AND user_id != ''",
+		selectExpr: "user_id AS id, user_name AS name, " + scopeProjection,
+		whereExpr:  "user_id IS NOT NULL AND user_id != '' AND user_name IS NOT NULL AND user_name != ''",
 		uniqueIdx:       "id, name, " + scopeIdxColumns,
 		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -336,6 +336,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddLogIncNumberColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationRecreateFilterUsersMatView(ctx, db); err != nil {
+		return err
+	}
 	// migrationSplitFilterDataMatView is intentionally NOT invoked in this
 	// release. Dropping mv_logs_filterdata while old replicas are still
 	// serving /api/logs/filterdata from it would surface "relation does not
@@ -3302,6 +3305,34 @@ func migrationAddLogIncNumberColumn(ctx context.Context, db *gorm.DB) error {
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while adding log inc_number column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationRecreateFilterUsersMatView drops mv_filter_users so ensureMatViews
+// recreates it with the corrected WHERE clause that excludes rows without a
+// user_name, preventing duplicate entries where name falls back to user_id.
+func migrationRecreateFilterUsersMatView(ctx context.Context, db *gorm.DB) error {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_recreate_filter_users_matview",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := tx.Exec("DROP MATERIALIZED VIEW IF EXISTS mv_filter_users CASCADE").Error; err != nil {
+				return fmt.Errorf("failed to drop mv_filter_users: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while recreating filter users matview: %s", err.Error())
 	}
 	return nil
 }

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1025,93 +1025,84 @@ func (p *LoggerPlugin) GetModelRankings(ctx context.Context, filters logstore.Se
 
 // GetAvailableModels returns all unique models from logs.
 // Uses DISTINCT to avoid loading all rows (28K+) when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableModels(ctx context.Context, limit int, query string) []string {
+func (p *LoggerPlugin) GetAvailableModels(ctx context.Context, limit int, query string) ([]string, error) {
 	models, err := p.store.GetDistinctModels(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available models: %v", err)
-		return []string{}
+		return nil, fmt.Errorf("failed to get available models: %w", err)
 	}
-	return models
+	return models, nil
 }
 
 // GetAvailableAliases returns all unique alias values from logs.
-func (p *LoggerPlugin) GetAvailableAliases(ctx context.Context, limit int, query string) []string {
+func (p *LoggerPlugin) GetAvailableAliases(ctx context.Context, limit int, query string) ([]string, error) {
 	aliases, err := p.store.GetDistinctAliases(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available aliases: %v", err)
-		return []string{}
+		return nil, fmt.Errorf("failed to get available aliases: %w", err)
 	}
-	return aliases
+	return aliases, nil
 }
 
-func (p *LoggerPlugin) GetAvailableSelectedKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableSelectedKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "selected_key_id", "selected_key_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available selected keys: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available selected keys: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
-func (p *LoggerPlugin) GetAvailableVirtualKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "virtual_key_id", "virtual_key_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available virtual keys: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available virtual keys: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
-func (p *LoggerPlugin) GetAvailableRoutingRules(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableRoutingRules(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "routing_rule_id", "routing_rule_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available routing rules: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available routing rules: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetAvailableTeams returns all unique team ID-Name pairs from logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableTeams(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableTeams(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "team_id", "team_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available teams: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available teams: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetAvailableCustomers returns all unique customer ID-Name pairs from logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableCustomers(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableCustomers(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "customer_id", "customer_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available customers: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available customers: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetAvailableUsers returns all unique user ID-Name pairs from logs.
-func (p *LoggerPlugin) GetAvailableUsers(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableUsers(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "user_id", "user_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available users: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available users: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetAvailableBusinessUnits returns all unique business unit ID-Name pairs from logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableBusinessUnits(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableBusinessUnits(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	results, err := p.store.GetDistinctKeyPairs(ctx, "business_unit_id", "business_unit_name", limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available business units: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available business units: %w", err)
 	}
-	return keyPairResultsToKeyPairs(results)
+	return keyPairResultsToKeyPairs(results), nil
 }
 
 // GetDimensionCostHistogram returns time-bucketed cost data grouped by the specified dimension.
@@ -1134,24 +1125,22 @@ func (p *LoggerPlugin) GetDimensionLatencyHistogram(ctx context.Context, filters
 
 // GetAvailableRoutingEngines returns all unique routing engine types used in logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableRoutingEngines(ctx context.Context, limit int, query string) []string {
+func (p *LoggerPlugin) GetAvailableRoutingEngines(ctx context.Context, limit int, query string) ([]string, error) {
 	engines, err := p.store.GetDistinctRoutingEngines(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available routing engines: %v", err)
-		return []string{}
+		return nil, fmt.Errorf("failed to get available routing engines: %w", err)
 	}
-	return engines
+	return engines, nil
 }
 
 // GetAvailableStopReasons returns all unique stop reason values from logs.
 // Uses DISTINCT to avoid loading all rows when only unique values are needed.
-func (p *LoggerPlugin) GetAvailableStopReasons(ctx context.Context, limit int, query string) []string {
+func (p *LoggerPlugin) GetAvailableStopReasons(ctx context.Context, limit int, query string) ([]string, error) {
 	stopReasons, err := p.store.GetDistinctStopReasons(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available stop reasons: %v", err)
-		return []string{}
+		return nil, fmt.Errorf("failed to get available stop reasons: %w", err)
 	}
-	return stopReasons
+	return stopReasons, nil
 }
 
 // keyPairResultsToKeyPairs converts logstore.KeyPairResult slice to KeyPair slice
@@ -1164,11 +1153,10 @@ func keyPairResultsToKeyPairs(results []logstore.KeyPairResult) []KeyPair {
 }
 
 // GetAvailableMCPVirtualKeys returns all unique virtual key ID-Name pairs from MCP tool logs
-func (p *LoggerPlugin) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *LoggerPlugin) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	result, err := p.store.GetAvailableMCPVirtualKeys(ctx, limit, query)
 	if err != nil {
-		p.logger.Error("failed to get available virtual keys from MCP logs: %v", err)
-		return []KeyPair{}
+		return nil, fmt.Errorf("failed to get available virtual keys from MCP logs: %w", err)
 	}
 	return p.extractUniqueMCPKeyPairs(result, func(log *logstore.MCPToolLog) KeyPair {
 		if log.VirtualKeyID != nil && log.VirtualKeyName != nil {
@@ -1178,7 +1166,7 @@ func (p *LoggerPlugin) GetAvailableMCPVirtualKeys(ctx context.Context, limit int
 			}
 		}
 		return KeyPair{}
-	})
+	}), nil
 }
 
 // extractUniqueMCPKeyPairs extracts unique non-empty key pairs from MCP logs using the provided extractor function

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -68,37 +68,37 @@ type LogManager interface {
 	GetDroppedRequests(ctx context.Context) int64
 
 	// GetAvailableModels returns all unique models from logs
-	GetAvailableModels(ctx context.Context, limit int, query string) []string
+	GetAvailableModels(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableAliases returns all unique alias values from logs
-	GetAvailableAliases(ctx context.Context, limit int, query string) []string
+	GetAvailableAliases(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableSelectedKeys returns all unique selected key ID-Name pairs from logs
-	GetAvailableSelectedKeys(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableSelectedKeys(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableVirtualKeys returns all unique virtual key ID-Name pairs from logs
-	GetAvailableVirtualKeys(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableRoutingRules returns all unique routing rule ID-Name pairs from logs
-	GetAvailableRoutingRules(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableRoutingRules(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableRoutingEngines returns all unique routing engine types from logs
-	GetAvailableRoutingEngines(ctx context.Context, limit int, query string) []string
+	GetAvailableRoutingEngines(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableStopReasons returns all unique stop reason values from logs
-	GetAvailableStopReasons(ctx context.Context, limit int, query string) []string
+	GetAvailableStopReasons(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableTeams returns all unique team ID-Name pairs from logs
-	GetAvailableTeams(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableTeams(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableCustomers returns all unique customer ID-Name pairs from logs
-	GetAvailableCustomers(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableCustomers(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableUsers returns all unique user IDs from logs
-	GetAvailableUsers(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableUsers(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableBusinessUnits returns all unique business unit ID-Name pairs from logs
-	GetAvailableBusinessUnits(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableBusinessUnits(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetAvailableMetadataKeys returns distinct metadata keys and their values from recent logs
 	GetAvailableMetadataKeys(ctx context.Context, limit int, query string) (map[string][]string, error)
@@ -138,7 +138,7 @@ type LogManager interface {
 	GetAvailableServerLabels(ctx context.Context, limit int, query string) ([]string, error)
 
 	// GetAvailableMCPVirtualKeys returns all unique virtual key ID-Name pairs from MCP tool logs
-	GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) []KeyPair
+	GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error)
 
 	// GetMCPHistogram returns time-bucketed MCP tool call volume
 	GetMCPHistogram(ctx context.Context, filters logstore.MCPToolLogSearchFilters, bucketSizeSeconds int64) (*logstore.MCPHistogramResult, error)
@@ -261,47 +261,47 @@ func (p *PluginLogManager) GetDroppedRequests(ctx context.Context) int64 {
 }
 
 // GetAvailableModels returns all unique models from logs
-func (p *PluginLogManager) GetAvailableModels(ctx context.Context, limit int, query string) []string {
+func (p *PluginLogManager) GetAvailableModels(ctx context.Context, limit int, query string) ([]string, error) {
 	return p.plugin.GetAvailableModels(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableAliases(ctx context.Context, limit int, query string) []string {
+func (p *PluginLogManager) GetAvailableAliases(ctx context.Context, limit int, query string) ([]string, error) {
 	return p.plugin.GetAvailableAliases(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableSelectedKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableSelectedKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableSelectedKeys(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableVirtualKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableVirtualKeys(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableRoutingRules(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableRoutingRules(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableRoutingRules(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableRoutingEngines(ctx context.Context, limit int, query string) []string {
+func (p *PluginLogManager) GetAvailableRoutingEngines(ctx context.Context, limit int, query string) ([]string, error) {
 	return p.plugin.GetAvailableRoutingEngines(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableStopReasons(ctx context.Context, limit int, query string) []string {
+func (p *PluginLogManager) GetAvailableStopReasons(ctx context.Context, limit int, query string) ([]string, error) {
 	return p.plugin.GetAvailableStopReasons(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableTeams(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableTeams(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableTeams(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableCustomers(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableCustomers(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableCustomers(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableUsers(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableUsers(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableUsers(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableBusinessUnits(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableBusinessUnits(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	return p.plugin.GetAvailableBusinessUnits(ctx, limit, query)
 }
 
@@ -401,9 +401,9 @@ func (p *PluginLogManager) GetAvailableServerLabels(ctx context.Context, limit i
 	return p.plugin.store.GetAvailableServerLabels(ctx, limit, query)
 }
 
-func (p *PluginLogManager) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) []KeyPair {
+func (p *PluginLogManager) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) ([]KeyPair, error) {
 	if p == nil || p.plugin == nil {
-		return []KeyPair{}
+		return []KeyPair{}, nil
 	}
 	return p.plugin.GetAvailableMCPVirtualKeys(ctx, limit, query)
 }

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -1130,7 +1130,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 
 	if _, ok := want[filterDimModels]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableModels(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableModels(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			models = result
 			mu.Unlock()
@@ -1139,7 +1142,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimAliases]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableAliases(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableAliases(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			aliases = result
 			mu.Unlock()
@@ -1148,7 +1154,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimSelectedKeys]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableSelectedKeys(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableSelectedKeys(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			selectedKeys = result
 			mu.Unlock()
@@ -1157,7 +1166,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimVirtualKeys]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableVirtualKeys(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableVirtualKeys(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			virtualKeys = result
 			mu.Unlock()
@@ -1166,7 +1178,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimRoutingRules]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableRoutingRules(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableRoutingRules(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			routingRules = result
 			mu.Unlock()
@@ -1175,7 +1190,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimRoutingEngines]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableRoutingEngines(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableRoutingEngines(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			routingEngines = result
 			mu.Unlock()
@@ -1184,7 +1202,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimStopReasons]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableStopReasons(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableStopReasons(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			stopReasons = result
 			mu.Unlock()
@@ -1193,7 +1214,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimTeams]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableTeams(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableTeams(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			teams = result
 			mu.Unlock()
@@ -1202,7 +1226,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimCustomers]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableCustomers(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableCustomers(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			customers = result
 			mu.Unlock()
@@ -1211,7 +1238,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimUsers]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableUsers(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableUsers(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			users = result
 			mu.Unlock()
@@ -1220,7 +1250,10 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	}
 	if _, ok := want[filterDimBusinessUnits]; ok {
 		g.Go(func() error {
-			result := h.logManager.GetAvailableBusinessUnits(gCtx, defaultFilterDataLimit, query)
+			result, err := h.logManager.GetAvailableBusinessUnits(gCtx, defaultFilterDataLimit, query)
+			if err != nil {
+				return err
+			}
 			mu.Lock()
 			businessUnits = result
 			mu.Unlock()
@@ -1907,7 +1940,12 @@ func (h *LoggingHandler) getMCPLogsFilterData(ctx *fasthttp.RequestCtx) {
 
 	var virtualKeysArray []tables.TableVirtualKey
 	if _, ok := want[mcpFilterDimVirtualKeys]; ok {
-		virtualKeys := h.logManager.GetAvailableMCPVirtualKeys(ctx, defaultFilterDataLimit, query)
+		virtualKeys, err := h.logManager.GetAvailableMCPVirtualKeys(ctx, defaultFilterDataLimit, query)
+		if err != nil {
+			logger.Error("failed to get available MCP virtual keys: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get available MCP virtual keys: %v", err))
+			return
+		}
 
 		virtualKeyIDs := make([]string, len(virtualKeys))
 		for i, key := range virtualKeys {

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -432,7 +432,7 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 		}
 	}
 	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
-		if start, end := resolvePeriod(period); start != nil {
+		if start, end := ResolvePeriod(period); start != nil {
 			filters.StartTime = start
 			filters.EndTime = end
 		}
@@ -673,7 +673,7 @@ func (h *LoggingHandler) getLogsStats(ctx *fasthttp.RequestCtx) {
 		}
 	}
 	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
-		if start, end := resolvePeriod(period); start != nil {
+		if start, end := ResolvePeriod(period); start != nil {
 			filters.StartTime = start
 			filters.EndTime = end
 		}
@@ -832,7 +832,7 @@ func parseHistogramFilters(ctx *fasthttp.RequestCtx) *logstore.SearchFilters {
 		}
 	}
 	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
-		if start, end := resolvePeriod(period); start != nil {
+		if start, end := ResolvePeriod(period); start != nil {
 			filters.StartTime = start
 			filters.EndTime = end
 		}
@@ -1645,7 +1645,7 @@ func parseMCPFiltersAndPagination(ctx *fasthttp.RequestCtx) (*logstore.MCPToolLo
 		}
 	}
 	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
-		if start, end := resolvePeriod(period); start != nil {
+		if start, end := ResolvePeriod(period); start != nil {
 			filters.StartTime = start
 			filters.EndTime = end
 			startTimeErr = nil
@@ -1767,7 +1767,7 @@ func parseMCPFilters(ctx *fasthttp.RequestCtx) (*logstore.MCPToolLogSearchFilter
 		}
 	}
 	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
-		if start, end := resolvePeriod(period); start != nil {
+		if start, end := ResolvePeriod(period); start != nil {
 			filters.StartTime = start
 			filters.EndTime = end
 			timeParseErr = nil

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -14,11 +14,11 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// resolvePeriod converts a relative period string ("1h","6h","24h","7d","30d") to concrete
+// ResolvePeriod converts a relative period string ("1h","6h","24h","7d","30d") to concrete
 // start/end time pointers computed from the current server time. Returns nil, nil for
 // unrecognised values. When used in filter parsing, period takes precedence over any explicit
 // start_time/end_time query parameters so every poll always covers the intended window.
-func resolvePeriod(period string) (start, end *time.Time) {
+func ResolvePeriod(period string) (start, end *time.Time) {
 	now := time.Now().UTC()
 	var from time.Time
 	switch period {


### PR DESCRIPTION
## Summary

Fixes duplicate entries in the `mv_filter_users` materialized view caused by rows where `user_name` is null or empty falling back to `user_id` as the display name. This resulted in users appearing twice in filter dropdowns — once with their actual name and once with their ID as the name.

## Changes

- Updated the `mv_filter_users` materialized view definition to use `user_name` directly (without the `COALESCE` fallback to `user_id`) and added `user_name IS NOT NULL AND user_name != ''` to the `WHERE` clause to exclude rows that would have previously triggered the fallback.
- Added a migration (`migrationRecreateFilterUsersMatView`) that drops the existing `mv_filter_users` view so `ensureMatViews` recreates it with the corrected definition on next startup.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Ensure there are log entries where some rows have a `user_name` and some do not.
2. Deploy this change and allow the migration to run.
3. Verify that `mv_filter_users` is recreated and contains only rows where `user_name` is non-empty.
4. Confirm that the user filter dropdown no longer shows duplicate entries (one with the user's name and one with the user's ID).

```sh
go test ./framework/logstore/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable