### PR TITLE
fix anthropic tool call

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -1109,12 +1109,20 @@ func ToAnthropicChatResponse(bifrostResp *schemas.BifrostChatResponse) *Anthropi
 type AnthropicStreamState struct {
 	nextToolCallIndex         int
 	contentBlockToToolCallIdx map[int]int
+	// sawArgsDelta records, per content_block index, whether any non-empty
+	// input_json_delta has been forwarded for that tool_use block. Anthropic
+	// emits a spurious empty partial_json marker right after content_block_start;
+	// suppressing it would leave tools with no input fields (struct{} schema)
+	// with an empty accumulated arguments string. We track this so content_block_stop
+	// can flush a synthetic "{}" delta when no real arguments arrived.
+	sawArgsDelta map[int]bool
 }
 
 // NewAnthropicStreamState returns an initialised stream state for one streaming response.
 func NewAnthropicStreamState() *AnthropicStreamState {
 	return &AnthropicStreamState{
 		contentBlockToToolCallIdx: make(map[int]int),
+		sawArgsDelta:              make(map[int]bool),
 	}
 }
 
@@ -1122,8 +1130,12 @@ func NewAnthropicStreamState() *AnthropicStreamState {
 func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.BifrostContext, structuredOutputToolName string, state *AnthropicStreamState) (*schemas.BifrostChatResponse, *schemas.BifrostError, bool) {
 	if state == nil {
 		state = NewAnthropicStreamState()
-	} else if state.contentBlockToToolCallIdx == nil {
+	}
+	if state.contentBlockToToolCallIdx == nil {
 		state.contentBlockToToolCallIdx = make(map[int]int)
+	}
+	if state.sawArgsDelta == nil {
+		state.sawArgsDelta = make(map[int]bool)
 	}
 
 	switch chunk.Type {
@@ -1221,10 +1233,23 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 			case AnthropicStreamDeltaTypeInputJSON:
 				// Handle tool use streaming - accumulate partial JSON.
 				if chunk.Delta.PartialJSON != nil {
+					// Anthropic emits a spurious empty partial_json marker right
+					// after a tool_use content_block_start. Suppress it: the
+					// initial setup chunk already carries arguments:"" and
+					// downstream OpenAI clients concatenate the deltas, so an
+					// extra empty re-declaration trips strict parsers. Tools
+					// with no input fields (struct{} schemas) get a single "{}"
+					// flushed on content_block_stop (see below).
+					if *chunk.Delta.PartialJSON == "" {
+						return nil, nil, false
+					}
+
 					// Resolve which tool-call this delta belongs to via the content-block index.
 					toolCallIdx := state.contentBlockToToolCallIdx[*chunk.Index]
+					state.sawArgsDelta[*chunk.Index] = true
 
-					// Create streaming response for tool input delta
+					// Continuation chunks must omit function.type; only the initial
+					// setup chunk declares it (strict OpenAI parsers reject re-declaration).
 					streamResponse := &schemas.BifrostChatResponse{
 						Object: "chat.completion.chunk",
 						Choices: []schemas.BifrostResponseChoice{
@@ -1235,7 +1260,6 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 										ToolCalls: []schemas.ChatAssistantMessageToolCall{
 											{
 												Index: uint16(toolCallIdx),
-												Type:  schemas.Ptr(string(schemas.ChatToolTypeFunction)),
 												Function: schemas.ChatAssistantMessageToolCallFunction{
 													Arguments: *chunk.Delta.PartialJSON,
 												},
@@ -1307,7 +1331,41 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 		}
 
 	case AnthropicStreamEventTypeContentBlockStop:
-		// Content block is complete, no specific action needed for streaming
+		// If this closes a tool_use block whose arguments were never streamed
+		// (i.e. the tool has no input fields — its JSON schema is `{}`), flush
+		// a single synthetic arguments:"{}" delta so downstream OpenAI clients
+		// can unmarshal the accumulated arguments as valid JSON. Without this,
+		// the only chunk emitted for the block was the initial setup chunk
+		// with arguments:"" — concatenation yields "" and json.Unmarshal fails
+		// with "unexpected end of JSON input" on strict clients (genkit-go).
+		if chunk.Index != nil {
+			toolCallIdx, isToolBlock := state.contentBlockToToolCallIdx[*chunk.Index]
+			needsFlush := isToolBlock && !state.sawArgsDelta[*chunk.Index]
+			delete(state.contentBlockToToolCallIdx, *chunk.Index)
+			delete(state.sawArgsDelta, *chunk.Index)
+			if needsFlush {
+				return &schemas.BifrostChatResponse{
+					Object: "chat.completion.chunk",
+					Choices: []schemas.BifrostResponseChoice{
+						{
+							Index: 0,
+							ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+								Delta: &schemas.ChatStreamResponseChoiceDelta{
+									ToolCalls: []schemas.ChatAssistantMessageToolCall{
+										{
+											Index: uint16(toolCallIdx),
+											Function: schemas.ChatAssistantMessageToolCallFunction{
+												Arguments: "{}",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil, false
+			}
+		}
 		return nil, nil, false
 
 	case AnthropicStreamEventTypeMessageDelta:

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -1304,3 +1304,327 @@ func TestToAnthropicChatRequest_MidConversationSystem_NotOnOpus47(t *testing.T) 
 		}
 	}
 }
+
+// TestToBifrostChatCompletionStream_NoArgToolFlushesEmptyObject covers the
+// "no-arg tool" case (e.g. tools whose Go input type is `struct{}` and whose
+// JSON schema is `{}`). Anthropic emits content_block_start followed
+// immediately by content_block_stop with no input_json_delta in between. The
+// converter must flush a synthetic `arguments: "{}"` on stop so OpenAI clients
+// can unmarshal the accumulated arguments as valid JSON.
+func TestToBifrostChatCompletionStream_NoArgToolFlushesEmptyObject(t *testing.T) {
+	state := NewAnthropicStreamState()
+
+	idx := 0
+	toolID := "toolu_no_args"
+	toolName := "response_start"
+
+	start := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStart,
+		Index: &idx,
+		ContentBlock: &AnthropicContentBlock{
+			Type: AnthropicContentBlockTypeToolUse,
+			ID:   &toolID,
+			Name: &toolName,
+		},
+	}
+	startResp, bErr, isLast := start.ToBifrostChatCompletionStream(nil, "", state)
+	if bErr != nil {
+		t.Fatalf("unexpected error on start: %v", bErr)
+	}
+	if isLast {
+		t.Fatal("expected non-terminal chunk on start")
+	}
+	if startResp == nil || len(startResp.Choices) != 1 {
+		t.Fatalf("expected one choice on start, got %#v", startResp)
+	}
+	startDelta := startResp.Choices[0].ChatStreamResponseChoice.Delta
+	if startDelta == nil || len(startDelta.ToolCalls) != 1 {
+		t.Fatalf("expected one tool call on start, got %#v", startDelta)
+	}
+	startTC := startDelta.ToolCalls[0]
+	if startTC.Type == nil || *startTC.Type != string(schemas.ChatToolTypeFunction) {
+		t.Fatalf("expected type=function on start, got %#v", startTC.Type)
+	}
+	if startTC.ID == nil || *startTC.ID != toolID {
+		t.Fatalf("expected id %q on start, got %#v", toolID, startTC.ID)
+	}
+	if startTC.Function.Name == nil || *startTC.Function.Name != toolName {
+		t.Fatalf("expected name %q on start, got %#v", toolName, startTC.Function.Name)
+	}
+	if startTC.Function.Arguments != "" {
+		t.Fatalf("expected empty initial arguments, got %q", startTC.Function.Arguments)
+	}
+
+	stop := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStop,
+		Index: &idx,
+	}
+	stopResp, bErr, isLast := stop.ToBifrostChatCompletionStream(nil, "", state)
+	if bErr != nil {
+		t.Fatalf("unexpected error on stop: %v", bErr)
+	}
+	if isLast {
+		t.Fatal("expected non-terminal chunk on stop")
+	}
+	if stopResp == nil || len(stopResp.Choices) != 1 {
+		t.Fatalf("expected one choice on stop flush, got %#v", stopResp)
+	}
+	stopDelta := stopResp.Choices[0].ChatStreamResponseChoice.Delta
+	if stopDelta == nil || len(stopDelta.ToolCalls) != 1 {
+		t.Fatalf("expected one tool call on stop flush, got %#v", stopDelta)
+	}
+	stopTC := stopDelta.ToolCalls[0]
+	if stopTC.Type != nil {
+		t.Errorf("expected type to be nil on stop-flush continuation, got %q", *stopTC.Type)
+	}
+	if stopTC.Function.Arguments != "{}" {
+		t.Fatalf("expected flushed arguments \"{}\", got %q", stopTC.Function.Arguments)
+	}
+
+	accumulated := startTC.Function.Arguments + stopTC.Function.Arguments
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(accumulated), &parsed); err != nil {
+		t.Fatalf("accumulated arguments %q did not parse as JSON: %v", accumulated, err)
+	}
+	if len(parsed) != 0 {
+		t.Errorf("expected empty JSON object, got %#v", parsed)
+	}
+
+	// A defensive duplicate stop event must not re-emit a flush chunk.
+	dupResp, _, _ := stop.ToBifrostChatCompletionStream(nil, "", state)
+	if dupResp != nil {
+		t.Errorf("duplicate stop should not re-flush, got %#v", dupResp)
+	}
+}
+
+// TestToBifrostChatCompletionStream_EmptyPartialJSONSuppressedBeforeArgs
+// guards two things at once: (1) the spurious empty partial_json marker that
+// Anthropic emits right after content_block_start is suppressed (returns
+// nil response); (2) once real non-empty input_json_delta chunks arrive, the
+// subsequent content_block_stop must NOT emit a synthetic "{}" flush —
+// otherwise concatenation would yield malformed JSON like `{"x":1}{}`.
+func TestToBifrostChatCompletionStream_EmptyPartialJSONSuppressedBeforeArgs(t *testing.T) {
+	state := NewAnthropicStreamState()
+
+	idx := 0
+	toolID := "toolu_real_args"
+	toolName := "get_thing"
+	empty := ""
+	frag1 := `{"x":`
+	frag2 := `1}`
+
+	start := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStart,
+		Index: &idx,
+		ContentBlock: &AnthropicContentBlock{
+			Type: AnthropicContentBlockTypeToolUse,
+			ID:   &toolID,
+			Name: &toolName,
+		},
+	}
+	startResp, _, _ := start.ToBifrostChatCompletionStream(nil, "", state)
+	if startResp == nil {
+		t.Fatal("expected a response on start")
+	}
+	accumulated := startResp.Choices[0].ChatStreamResponseChoice.Delta.ToolCalls[0].Function.Arguments
+
+	emptyDelta := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockDelta,
+		Index: &idx,
+		Delta: &AnthropicStreamDelta{
+			Type:        AnthropicStreamDeltaTypeInputJSON,
+			PartialJSON: &empty,
+		},
+	}
+	resp, bErr, isLast := emptyDelta.ToBifrostChatCompletionStream(nil, "", state)
+	if bErr != nil {
+		t.Fatalf("unexpected error on empty delta: %v", bErr)
+	}
+	if isLast {
+		t.Fatal("expected non-terminal chunk on empty delta")
+	}
+	if resp != nil {
+		t.Fatalf("expected empty partial_json to be suppressed, got %#v", resp)
+	}
+
+	for _, frag := range []*string{&frag1, &frag2} {
+		ev := &AnthropicStreamEvent{
+			Type:  AnthropicStreamEventTypeContentBlockDelta,
+			Index: &idx,
+			Delta: &AnthropicStreamDelta{
+				Type:        AnthropicStreamDeltaTypeInputJSON,
+				PartialJSON: frag,
+			},
+		}
+		r, _, _ := ev.ToBifrostChatCompletionStream(nil, "", state)
+		if r == nil {
+			t.Fatalf("expected response for fragment %q", *frag)
+		}
+		tc := r.Choices[0].ChatStreamResponseChoice.Delta.ToolCalls[0]
+		if tc.Type != nil {
+			t.Errorf("expected type to be nil on continuation chunk for fragment %q, got %q", *frag, *tc.Type)
+		}
+		accumulated += tc.Function.Arguments
+	}
+
+	stop := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStop,
+		Index: &idx,
+	}
+	stopResp, _, _ := stop.ToBifrostChatCompletionStream(nil, "", state)
+	if stopResp != nil {
+		t.Fatalf("expected no flush on stop when args were streamed, got %#v", stopResp)
+	}
+
+	var parsed struct {
+		X int `json:"x"`
+	}
+	if err := json.Unmarshal([]byte(accumulated), &parsed); err != nil {
+		t.Fatalf("accumulated arguments %q did not parse as JSON: %v", accumulated, err)
+	}
+	if parsed.X != 1 {
+		t.Errorf("expected {\"x\":1}, got %#v", parsed)
+	}
+}
+
+// TestToBifrostChatCompletionStream_ContinuationOmitsTypeField is the
+// regression guard for issue #3443: only the initial tool_call setup chunk
+// should carry `function.type`; continuation chunks must not re-declare it,
+// because strict OpenAI Chat Completions stream parsers treat a repeated
+// `type` field on a continuation as a fresh tool-call declaration.
+func TestToBifrostChatCompletionStream_ContinuationOmitsTypeField(t *testing.T) {
+	state := NewAnthropicStreamState()
+
+	idx := 0
+	toolID := "toolu_type_check"
+	toolName := "noop"
+	frag := `{"a":1}`
+
+	start := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStart,
+		Index: &idx,
+		ContentBlock: &AnthropicContentBlock{
+			Type: AnthropicContentBlockTypeToolUse,
+			ID:   &toolID,
+			Name: &toolName,
+		},
+	}
+	startResp, _, _ := start.ToBifrostChatCompletionStream(nil, "", state)
+	if startResp == nil {
+		t.Fatal("expected response on start")
+	}
+	startTC := startResp.Choices[0].ChatStreamResponseChoice.Delta.ToolCalls[0]
+	if startTC.Type == nil || *startTC.Type != string(schemas.ChatToolTypeFunction) {
+		t.Fatalf("expected start chunk to carry type=function, got %#v", startTC.Type)
+	}
+
+	delta := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockDelta,
+		Index: &idx,
+		Delta: &AnthropicStreamDelta{
+			Type:        AnthropicStreamDeltaTypeInputJSON,
+			PartialJSON: &frag,
+		},
+	}
+	deltaResp, _, _ := delta.ToBifrostChatCompletionStream(nil, "", state)
+	if deltaResp == nil {
+		t.Fatal("expected response on continuation delta")
+	}
+	contTC := deltaResp.Choices[0].ChatStreamResponseChoice.Delta.ToolCalls[0]
+	if contTC.Type != nil {
+		t.Errorf("expected continuation chunk to omit type, got %q", *contTC.Type)
+	}
+}
+
+// TestToBifrostChatCompletionStream_MixedToolBlocks interleaves a no-arg tool
+// and a real-args tool across two content_block indices. Ensures the
+// per-content-block sawArgsDelta tracking flushes "{}" for the no-arg block
+// and not for the real-args block.
+func TestToBifrostChatCompletionStream_MixedToolBlocks(t *testing.T) {
+	state := NewAnthropicStreamState()
+
+	noArgIdx := 0
+	argIdx := 1
+	noArgID := "toolu_no_args"
+	argID := "toolu_args"
+	noArgName := "response_start"
+	argName := "get_thing"
+	frag := `{"y":2}`
+
+	events := []*AnthropicStreamEvent{
+		{
+			Type:  AnthropicStreamEventTypeContentBlockStart,
+			Index: &noArgIdx,
+			ContentBlock: &AnthropicContentBlock{
+				Type: AnthropicContentBlockTypeToolUse,
+				ID:   &noArgID,
+				Name: &noArgName,
+			},
+		},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockStart,
+			Index: &argIdx,
+			ContentBlock: &AnthropicContentBlock{
+				Type: AnthropicContentBlockTypeToolUse,
+				ID:   &argID,
+				Name: &argName,
+			},
+		},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockDelta,
+			Index: &argIdx,
+			Delta: &AnthropicStreamDelta{
+				Type:        AnthropicStreamDeltaTypeInputJSON,
+				PartialJSON: &frag,
+			},
+		},
+	}
+
+	args := map[int]string{noArgIdx: "", argIdx: ""}
+	for _, ev := range events {
+		r, _, _ := ev.ToBifrostChatCompletionStream(nil, "", state)
+		if r == nil {
+			continue
+		}
+		tcs := r.Choices[0].ChatStreamResponseChoice.Delta.ToolCalls
+		if len(tcs) != 1 {
+			continue
+		}
+		// Each tool call carries its own assistant-message index; map back via
+		// the state we already populated by content-block index.
+		for cbIdx, callIdx := range state.contentBlockToToolCallIdx {
+			if uint16(callIdx) == tcs[0].Index {
+				args[cbIdx] += tcs[0].Function.Arguments
+				break
+			}
+		}
+	}
+
+	// Stop the no-arg block first; expect a "{}" flush.
+	stopNoArg := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStop,
+		Index: &noArgIdx,
+	}
+	r, _, _ := stopNoArg.ToBifrostChatCompletionStream(nil, "", state)
+	if r == nil {
+		t.Fatal("expected flush on stop for no-arg block")
+	}
+	args[noArgIdx] += r.Choices[0].ChatStreamResponseChoice.Delta.ToolCalls[0].Function.Arguments
+
+	// Stop the args block; expect no flush.
+	stopArg := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStop,
+		Index: &argIdx,
+	}
+	r, _, _ = stopArg.ToBifrostChatCompletionStream(nil, "", state)
+	if r != nil {
+		t.Fatalf("expected no flush on stop for args block, got %#v", r)
+	}
+
+	if args[noArgIdx] != "{}" {
+		t.Errorf("no-arg accumulated arguments = %q, want \"{}\"", args[noArgIdx])
+	}
+	if args[argIdx] != `{"y":2}` {
+		t.Errorf("args accumulated arguments = %q, want %q", args[argIdx], `{"y":2}`)
+	}
+}


### PR DESCRIPTION
## Summary

Fix Anthropic → OpenAI streaming conversion for tool calls. Two bugs were corrupting tool-call deltas seen by strict OpenAI-compatible clients (e.g. genkit-go): continuation chunks re-declared `function.type`, and tools with no input fields (`struct{}` schema → JSON schema `{}`) ended up with empty accumulated `arguments`, which fails `json.Unmarshal` with "unexpected end of JSON input".

## Changes

- `core/providers/anthropic/chat.go`
  - Removed `Type: schemas.Ptr(string(schemas.ChatToolTypeFunction))` from continuation `input_json_delta` chunks. Only the initial `content_block_start` setup chunk now declares `function.type`; strict OpenAI Chat Completions stream parsers treat a repeated `type` on a continuation as a fresh tool-call declaration.
  - Suppressed the spurious empty `partial_json` marker Anthropic emits immediately after `content_block_start`. The setup chunk already carries `arguments: ""`, so re-emitting it as a continuation tripped strict parsers.
  - Added a synthetic `arguments: "{}"` flush on `content_block_stop` for tool blocks where no `input_json_delta` was ever forwarded. Without it, no-arg tools (e.g. `response_start` with `struct{}` input) accumulate `""`, which is not valid JSON.
  - Added `sawArgsDelta map[int]bool` to `AnthropicStreamState` to track, per content-block index, whether any non-empty delta was forwarded. Needed because no existing per-block accumulator on the state struct could be repurposed.
  - On `content_block_stop`, both `contentBlockToToolCallIdx` and `sawArgsDelta` entries are deleted to bound state size on long streams with many tool_use blocks. Deletion also acts as the duplicate-stop guard (second stop hits "not a tool block" and returns nil).
- `core/providers/anthropic/chat_test.go`
  - `TestToBifrostChatCompletionStream_NoArgToolFlushesEmptyObject`: start → stop yields a flushed `"{}"`; accumulated arguments parse as an empty JSON object; duplicate stop does not re-flush.
  - `TestToBifrostChatCompletionStream_EmptyPartialJSONSuppressedBeforeArgs`: empty `partial_json` returns nil; subsequent real fragments stream through; stop does NOT add a synthetic `"{}"` (would yield `{"x":1}{}`).
  - `TestToBifrostChatCompletionStream_ContinuationOmitsTypeField`: regression guard — start chunk carries `type=function`, continuation chunk omits it.
  - `TestToBifrostChatCompletionStream_MixedToolBlocks`: interleaved no-arg and real-args tool blocks across two content-block indices; flush fires only for the no-arg block.

### Design notes / trade-offs

- The fix is in the converter rather than the upstream Anthropic SDK because the empty-`partial_json` marker is a documented quirk of Anthropic's SSE stream and the OpenAI-side strict-parser expectation is what we own.
- `sawArgsDelta` is a separate map rather than reusing an accumulator because no per-content-block argument accumulator exists on `AnthropicStreamState` today; adding one purely for this check would be heavier than a `map[int]bool`.
- The synthetic flush emits a continuation chunk (no `type` field), matching the rule above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go version
go test ./providers/anthropic/ -run TestToBifrostChatCompletionStream -v
go test ./...
```

Expected: all four new `TestToBifrostChatCompletionStream_*` subtests pass; full `core/providers/anthropic` package suite passes.

End-to-end validation can be done with this [main.go](https://gist.github.com/rmarku/8ec5a47b08c66a41d528326e054916e9) against a strict client (genkit-go) calling a no-arg tool through the Anthropic → OpenAI path: previously failed with `json: unexpected end of JSON input` when unmarshalling the accumulated `arguments`; now succeeds with `{}`.

No new configs or environment variables.

## Screenshots/Recordings

N/A — backend-only change.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes https://github.com/maximhq/bifrost/issues/3443

## Security considerations

None. No changes to auth, secrets handling, PII, or sandboxing; the converter operates on already-authenticated streamed responses and the new code paths only adjust delta framing.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (no docs surface for this internal converter behavior)
- [x] I verified builds succeed (Go and UI) — `go build ./core/providers/anthropic/` succeeds; UI unaffected
- [x] I verified the CI pipeline passes locally if applicable — `go test ./providers/anthropic/` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-function streaming in chat completions to properly handle argument deltas and eliminate spurious empty markers.
  * Fixed edge case where tool calls with no arguments now correctly emit an empty arguments object instead of remaining incomplete.

* **Tests**
  * Added comprehensive unit tests validating tool-use streaming behavior across multiple scenarios, including no-argument tools and interleaved cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->