### PR TITLE
feat: propagate request context through mcp client connection

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3641,12 +3641,12 @@ func (bifrost *Bifrost) GetAvailableMCPTools(ctx *schemas.BifrostContext) []sche
 //
 // Example:
 //
-//	err := bifrost.AddMCPClient(schemas.MCPClientConfig{
+//	err := bifrost.AddMCPClient(ctx, &schemas.MCPClientConfig{
 //	    Name: "my-mcp-client",
 //	    ConnectionType: schemas.MCPConnectionTypeHTTP,
 //	    ConnectionString: &url,
 //	})
-func (bifrost *Bifrost) AddMCPClient(config *schemas.MCPClientConfig) error {
+func (bifrost *Bifrost) AddMCPClient(ctx context.Context, config *schemas.MCPClientConfig) error {
 	if bifrost.MCPManager == nil {
 		// Use sync.Once to ensure thread-safe initialization
 		bifrost.mcpInitOnce.Do(func() {
@@ -3674,7 +3674,7 @@ func (bifrost *Bifrost) AddMCPClient(config *schemas.MCPClientConfig) error {
 		return fmt.Errorf("MCP manager is not initialized")
 	}
 
-	return bifrost.MCPManager.AddClient(config)
+	return bifrost.MCPManager.AddClient(ctx, config)
 }
 
 // RemoveMCPClient removes an MCP client from the Bifrost instance.

--- a/core/internal/mcptests/agent_filtering_test.go
+++ b/core/internal/mcptests/agent_filtering_test.go
@@ -1,6 +1,7 @@
 package mcptests
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -507,7 +508,7 @@ func TestAgent_FilteringWithMultipleClients(t *testing.T) {
 	tempConfig := GetTemperatureMCPClientConfig("")
 	tempConfig.ToolsToAutoExecute = []string{} // Not auto-executed
 
-	err = manager.AddClient(&tempConfig)
+	err = manager.AddClient(context.Background(), &tempConfig)
 	if err != nil {
 		t.Skipf("Skipping test - temperature server not available: %v", err)
 		return
@@ -528,7 +529,7 @@ func TestAgent_FilteringWithMultipleClients(t *testing.T) {
 					ID:   schemas.Ptr("call-2"),
 					Type: schemas.Ptr("function"),
 					Function: schemas.ChatAssistantMessageToolCallFunction{
-						Name: schemas.Ptr("bifrostInternal-get_temperature"),
+						Name:      schemas.Ptr("bifrostInternal-get_temperature"),
 						Arguments: `{"location": "New York"}`,
 					},
 				},
@@ -593,7 +594,7 @@ func TestAgent_ToolConflictInAgentMode(t *testing.T) {
 	tempConfig := GetTemperatureMCPClientConfig("")
 	tempConfig.ToolsToAutoExecute = []string{} // Not auto
 
-	err = manager.AddClient(&tempConfig)
+	err = manager.AddClient(context.Background(), &tempConfig)
 	if err != nil {
 		t.Skipf("Skipping test - temperature server not available: %v", err)
 		return
@@ -611,7 +612,7 @@ func TestAgent_ToolConflictInAgentMode(t *testing.T) {
 					ID:   schemas.Ptr("call-1"),
 					Type: schemas.Ptr("function"),
 					Function: schemas.ChatAssistantMessageToolCallFunction{
-						Name: schemas.Ptr("bifrostInternal-get_temperature"),
+						Name:      schemas.Ptr("bifrostInternal-get_temperature"),
 						Arguments: `{"location": "New York"}`,
 					},
 				},
@@ -823,7 +824,7 @@ func TestAgent_Filtering_ResponsesFormat(t *testing.T) {
 			CreateResponsesResponseWithToolCalls([]schemas.ResponsesToolMessage{
 				{
 					CallID:    schemas.Ptr("call-1"),
-					Name: schemas.Ptr("bifrostInternal-echo"),
+					Name:      schemas.Ptr("bifrostInternal-echo"),
 					Arguments: schemas.Ptr(`{"message": "responses format"}`),
 				},
 			}),

--- a/core/internal/mcptests/client_management_test.go
+++ b/core/internal/mcptests/client_management_test.go
@@ -1,6 +1,7 @@
 package mcptests
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -25,11 +26,11 @@ func TestAddClientDuplicate(t *testing.T) {
 
 	// Add client
 	clientConfig := GetSampleHTTPClientConfig(config.HTTPServerURL)
-	err := manager.AddClient(&clientConfig)
+	err := manager.AddClient(context.Background(), &clientConfig)
 	require.NoError(t, err, "should add client first time")
 
 	// Try to add same client again
-	err = manager.AddClient(&clientConfig)
+	err = manager.AddClient(context.Background(), &clientConfig)
 	// Should either return error or be idempotent
 	if err == nil {
 		clients := manager.GetClients()
@@ -431,7 +432,7 @@ func TestConcurrentClientOperations(t *testing.T) {
 			clientConfig.ID = string(rune('a'+id)) + "-concurrent-client"
 			clientConfig.Name = "TestHTTPServer" + string(rune('a'+id))
 
-			err := manager.AddClient(&clientConfig)
+			err := manager.AddClient(context.Background(), &clientConfig)
 			if err != nil {
 				errors <- err
 			}

--- a/core/internal/mcptests/concurrency_advanced_test.go
+++ b/core/internal/mcptests/concurrency_advanced_test.go
@@ -162,7 +162,7 @@ func TestConcurrent_AddRemoveClients(t *testing.T) {
 				ToolsToAutoExecute: []string{},
 			}
 
-			err := manager.AddClient(&clientConfig)
+			err := manager.AddClient(context.Background(), &clientConfig)
 			if err != nil {
 				// InProcess connections without a server instance will fail
 				// This is expected - we're just testing that the operations are concurrent and don't deadlock

--- a/core/internal/mcptests/connect_ping_listtools_test.go
+++ b/core/internal/mcptests/connect_ping_listtools_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	core "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/mcp"
 	"github.com/maximhq/bifrost/core/schemas"
-	mcpgo "github.com/mark3labs/mcp-go/mcp"
-	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -91,7 +91,7 @@ func TestConnectHook_FiresOnAddClient(t *testing.T) {
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
 
 	cfg := inProcessClientConfig("connect_fires", buildInProcessServer(t))
-	require.NoError(t, manager.AddClient(cfg))
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
 
 	pre := plugin.GetPreHookCalls()
 	post := plugin.GetPostHookCalls()
@@ -111,7 +111,7 @@ func TestConnectHook_PostHookPopulatesServerInfo(t *testing.T) {
 	plugin := NewTestConnectPlugin()
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
 
-	require.NoError(t, manager.AddClient(inProcessClientConfig("server_info", buildInProcessServer(t))))
+	require.NoError(t, manager.AddClient(context.Background(), inProcessClientConfig("server_info", buildInProcessServer(t))))
 
 	post := plugin.GetPostHookCalls()
 	require.Len(t, post, 1)
@@ -147,7 +147,7 @@ func TestConnectHook_PreHookShortCircuitError_FailsAddClient(t *testing.T) {
 	})
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
 
-	err := manager.AddClient(inProcessClientConfig("blocked_client", buildInProcessServer(t)))
+	err := manager.AddClient(context.Background(), inProcessClientConfig("blocked_client", buildInProcessServer(t)))
 	require.Error(t, err, "Plugin error short-circuit should fail AddClient")
 	assert.Contains(t, err.Error(), "blocked by governance")
 
@@ -176,7 +176,7 @@ func TestConnectHook_PreHookShortCircuitResponse_RegistersWithEmptyTools(t *test
 
 	// AddClient should succeed (no wire dial happens) — documented Connect-success
 	// short-circuit gotcha: client registered as connected with no live transport.
-	require.NoError(t, manager.AddClient(inProcessClientConfig("synthetic_client", buildInProcessServer(t))))
+	require.NoError(t, manager.AddClient(context.Background(), inProcessClientConfig("synthetic_client", buildInProcessServer(t))))
 
 	clients := manager.GetClients()
 	var found *schemas.MCPClientState
@@ -223,7 +223,7 @@ func TestConnectHook_AuthorizationHidden_HeadersAuth(t *testing.T) {
 		ToolsToExecute: []string{"*"},
 	}
 	// Short-circuit returns an error → AddClient fails. That's expected.
-	_ = manager.AddClient(cfg)
+	_ = manager.AddClient(context.Background(), cfg)
 
 	calls := plugin.GetPreHookCalls()
 	require.NotEmpty(t, calls, "PreHook should have fired before short-circuit")
@@ -276,7 +276,7 @@ func TestListToolsHook_FiresOnAddClient(t *testing.T) {
 	plugin := NewTestListToolsPlugin()
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
 
-	require.NoError(t, manager.AddClient(inProcessClientConfig("list_fires", buildInProcessServer(t))))
+	require.NoError(t, manager.AddClient(context.Background(), inProcessClientConfig("list_fires", buildInProcessServer(t))))
 
 	pre := plugin.GetPreHookCalls()
 	post := plugin.GetPostHookCalls()
@@ -306,7 +306,7 @@ func TestListToolsHook_PostHookFilterAppliedToClientState(t *testing.T) {
 	})
 
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
-	require.NoError(t, manager.AddClient(inProcessClientConfig("list_filter", buildInProcessServer(t))))
+	require.NoError(t, manager.AddClient(context.Background(), inProcessClientConfig("list_filter", buildInProcessServer(t))))
 
 	// Verify the filtered set landed in the manager's stored ToolMap (not just the
 	// gate response). The connect path applies the gate result to clientState.ToolMap.
@@ -345,7 +345,7 @@ func TestListToolsHook_PreHookShortCircuitWithSyntheticTools(t *testing.T) {
 	plugin.SetShortCircuitResponse(synthetic)
 
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
-	require.NoError(t, manager.AddClient(inProcessClientConfig("list_synth", buildInProcessServer(t))))
+	require.NoError(t, manager.AddClient(context.Background(), inProcessClientConfig("list_synth", buildInProcessServer(t))))
 
 	clients := manager.GetClients()
 	var target *schemas.MCPClientState
@@ -375,7 +375,7 @@ func TestListToolsHook_PreHookShortCircuitError_LeavesEmptyToolMap(t *testing.T)
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
 	// AddClient should still succeed — the connect path tolerates list_tools failure
 	// and falls back to empty tools (matching pre-plugin behavior).
-	require.NoError(t, manager.AddClient(inProcessClientConfig("list_err", buildInProcessServer(t))))
+	require.NoError(t, manager.AddClient(context.Background(), inProcessClientConfig("list_err", buildInProcessServer(t))))
 
 	clients := manager.GetClients()
 	var target *schemas.MCPClientState
@@ -397,7 +397,7 @@ func TestListToolsHook_FiresOnConnectAndAgain(t *testing.T) {
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
 
 	cfg := inProcessClientConfig("list_reconnect", buildInProcessServer(t))
-	require.NoError(t, manager.AddClient(cfg))
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
 	require.Len(t, plugin.GetPreHookCalls(), 1, "first AddClient should fire list_tools once")
 
 	// Reconnect: this tears down and re-establishes the client, firing list_tools again.
@@ -416,7 +416,7 @@ func TestPingHook_FiresViaHealthMonitor(t *testing.T) {
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
 
 	cfg := inProcessClientConfig("ping_fires", buildInProcessServer(t))
-	require.NoError(t, manager.AddClient(cfg))
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
 
 	// AddClient starts its own health monitor at 10s interval — far too slow for
 	// tests. Spin up a dedicated monitor at 10ms instead.
@@ -454,7 +454,7 @@ func TestPingHook_PreHookShortCircuitHealthy(t *testing.T) {
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
 
 	cfg := inProcessClientConfig("ping_healthy", buildInProcessServer(t))
-	require.NoError(t, manager.AddClient(cfg))
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
 
 	monitor := mcp.NewClientHealthMonitor(manager, cfg.ID, 10*time.Millisecond, true, core.NewDefaultLogger(schemas.LogLevelError))
 	monitor.Start()
@@ -488,7 +488,7 @@ func TestPingHook_PreHookShortCircuitError_DoesNotPanic(t *testing.T) {
 
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
 	cfg := inProcessClientConfig("ping_err", buildInProcessServer(t))
-	require.NoError(t, manager.AddClient(cfg))
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
 
 	monitor := mcp.NewClientHealthMonitor(manager, cfg.ID, 10*time.Millisecond, true, core.NewDefaultLogger(schemas.LogLevelError))
 	monitor.Start()
@@ -517,7 +517,7 @@ func TestPingHook_DoesNotFireWhenPingUnavailable(t *testing.T) {
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{pingPlugin, listPlugin})
 
 	cfg := inProcessClientConfig("ping_unavailable", buildInProcessServer(t))
-	require.NoError(t, manager.AddClient(cfg))
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
 
 	// Reset the list-tools plugin so we ignore the AddClient-time invocation.
 	listPlugin.Reset()
@@ -550,7 +550,7 @@ func TestMCPGate_AllRequestTypesCarryClientName(t *testing.T) {
 	logPlugin := NewTestLoggingPlugin()
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{logPlugin})
 
-	require.NoError(t, manager.AddClient(inProcessClientConfig("client_name_test", buildInProcessServer(t))))
+	require.NoError(t, manager.AddClient(context.Background(), inProcessClientConfig("client_name_test", buildInProcessServer(t))))
 
 	// Force a list_tools via reconnect to make sure we see at least one of each kind.
 	require.NoError(t, manager.ReconnectClient("client_name_test-id"))
@@ -584,7 +584,7 @@ func TestMCPGate_NoPluginsConfigured_OpStillRuns(t *testing.T) {
 	// Even with no MCP plugins, the gate must transparently pass through.
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{})
 
-	require.NoError(t, manager.AddClient(inProcessClientConfig("no_plugins", buildInProcessServer(t))))
+	require.NoError(t, manager.AddClient(context.Background(), inProcessClientConfig("no_plugins", buildInProcessServer(t))))
 
 	clients := manager.GetClients()
 	var found bool

--- a/core/internal/mcptests/error_handling_protocol_test.go
+++ b/core/internal/mcptests/error_handling_protocol_test.go
@@ -1,6 +1,7 @@
 package mcptests
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -289,7 +290,7 @@ func TestErrorHandling_STDIO_MCPErrorResponse(t *testing.T) {
 	errorServerConfig := GetErrorTestServerConfig(bifrostRoot)
 
 	manager := setupMCPManager(t)
-	err := manager.AddClient(&errorServerConfig)
+	err := manager.AddClient(context.Background(), &errorServerConfig)
 	if err != nil {
 		t.Skipf("error-test-server not available: %v (build with: cd examples/mcps/error-test-server && go build -o bin/error-test-server)", err)
 	}
@@ -367,7 +368,7 @@ func TestErrorHandling_STDIO_TimeoutScenario(t *testing.T) {
 		ToolExecutionTimeout: schemas.Duration(2 * time.Second), // 2 second timeout
 	})
 
-	err := manager.AddClient(&errorServerConfig)
+	err := manager.AddClient(context.Background(), &errorServerConfig)
 	if err != nil {
 		t.Skipf("error-test-server not available: %v", err)
 	}
@@ -420,7 +421,7 @@ func TestErrorHandling_STDIO_MalformedJSON(t *testing.T) {
 	errorServerConfig := GetErrorTestServerConfig(bifrostRoot)
 
 	manager := setupMCPManager(t)
-	err := manager.AddClient(&errorServerConfig)
+	err := manager.AddClient(context.Background(), &errorServerConfig)
 	if err != nil {
 		t.Skipf("error-test-server not available: %v", err)
 	}
@@ -469,7 +470,7 @@ func TestErrorHandling_STDIO_IntermittentFailures(t *testing.T) {
 	errorServerConfig := GetErrorTestServerConfig(bifrostRoot)
 
 	manager := setupMCPManager(t)
-	err := manager.AddClient(&errorServerConfig)
+	err := manager.AddClient(context.Background(), &errorServerConfig)
 	if err != nil {
 		t.Skipf("error-test-server not available: %v", err)
 	}

--- a/core/internal/mcptests/health_monitoring_test.go
+++ b/core/internal/mcptests/health_monitoring_test.go
@@ -1,6 +1,7 @@
 package mcptests
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func TestHealthCheckSTDIOServerDropAndRecoverIn20Seconds(t *testing.T) {
 	t.Logf("✅ Health monitor detected server drop")
 
 	// 5. Restart STDIO process (re-add client)
-	err = manager.AddClient(&clientConfig)
+	err = manager.AddClient(context.Background(), &clientConfig)
 	require.NoError(t, err, "should re-add client to simulate server recovery")
 	t.Logf("🔄 Simulated STDIO server recovery by re-adding client")
 
@@ -181,7 +182,7 @@ func TestHealthCheckStateTransitions(t *testing.T) {
 	assert.Len(t, clients, 0, "client should be removed")
 
 	// Re-add client (simulates reconnection)
-	err = manager.AddClient(&clientConfig)
+	err = manager.AddClient(context.Background(), &clientConfig)
 	require.NoError(t, err, "should re-add client")
 
 	// Verify client is connected again
@@ -394,7 +395,7 @@ func TestHealthCheckReconnectAfterFailure(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Re-add client (manual reconnection)
-	err = manager.AddClient(&clientConfig)
+	err = manager.AddClient(context.Background(), &clientConfig)
 	require.NoError(t, err, "should re-add client")
 
 	// Wait for health monitoring to stabilize

--- a/core/internal/mcptests/integration_test.go
+++ b/core/internal/mcptests/integration_test.go
@@ -1,6 +1,7 @@
 package mcptests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -34,7 +35,7 @@ func TestIntegration_FullChatWorkflow(t *testing.T) {
 		httpConfig := GetSampleHTTPClientConfig(config.HTTPServerURL)
 		httpConfig.ID = "http-integration-test"
 		applyTestConfigHeaders(t, &httpConfig)
-		err := manager.AddClient(&httpConfig)
+		err := manager.AddClient(context.Background(), &httpConfig)
 		if err != nil {
 			t.Logf("Could not add HTTP client: %v", err)
 		}
@@ -341,7 +342,7 @@ func TestIntegration_ReconnectDuringExecution(t *testing.T) {
 	httpConfig := GetSampleHTTPClientConfig(config.HTTPServerURL)
 	httpConfig.ID = "reconnect-test-client"
 	applyTestConfigHeaders(t, &httpConfig)
-	err := manager.AddClient(&httpConfig)
+	err := manager.AddClient(context.Background(), &httpConfig)
 	require.NoError(t, err, "should add HTTP client")
 
 	// Wait for client to connect

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -239,7 +239,7 @@ func (m *MCPManager) ReconnectClient(id string) error {
 
 	// Reconnect using the client's configuration
 	// Retry logic is handled internally by connectToMCPClient
-	if err := m.connectToMCPClient(config); err != nil {
+	if err := m.connectToMCPClient(m.ctx, config); err != nil {
 		return fmt.Errorf("failed to reconnect MCP client %s: %w", id, err)
 	}
 
@@ -256,7 +256,14 @@ func (m *MCPManager) ReconnectClient(id string) error {
 //
 // Returns:
 //   - error: Any error that occurred during client addition or connection
-func (m *MCPManager) AddClient(config *schemas.MCPClientConfig) error {
+//
+// AddClient adds a new MCP client using the provided context for
+// request-scoped connect hooks. Existing transport lifetimes still use the
+// manager context so persistent MCP connections are not tied to the caller.
+func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPClientConfig) error {
+	if requestCtx == nil {
+		requestCtx = m.ctx
+	}
 	if err := validateMCPClientConfig(config); err != nil {
 		return fmt.Errorf("invalid MCP client configuration: %w", err)
 	}
@@ -349,7 +356,7 @@ func (m *MCPManager) AddClient(config *schemas.MCPClientConfig) error {
 	}
 
 	// Connect using the copied config
-	if err := m.connectToMCPClient(configCopy); err != nil {
+	if err := m.connectToMCPClient(requestCtx, configCopy); err != nil {
 		// Clean up the failed entry — this is a user-initiated action (UI/API),
 		// so surface the error cleanly rather than retaining a ghost entry.
 		m.mu.Lock()
@@ -826,7 +833,7 @@ func (m *MCPManager) EnableClient(id string) error {
 	}
 	defer m.reconnectingClients.Delete(id)
 
-	if err := m.connectToMCPClient(configCopy); err != nil {
+	if err := m.connectToMCPClient(m.ctx, configCopy); err != nil {
 		// Connection failed — leave the entry as Disconnected so the health monitor can
 		// recover it, but only if the client has not been disabled in the meantime.
 		m.mu.Lock()
@@ -1028,7 +1035,7 @@ func (m *MCPManager) UpdateClientConnection(id string, newConfig *schemas.MCPCli
 	m.mu.RUnlock()
 
 	// connectToMCPClient will close the current connection and create a new clientMap entry.
-	if err := m.connectToMCPClient(&mergedConfig); err != nil {
+	if err := m.connectToMCPClient(m.ctx, &mergedConfig); err != nil {
 		m.mu.Lock()
 		if cs, exists := m.clientMap[id]; exists {
 			cs.ExecutionConfig = oldConfig
@@ -1162,7 +1169,10 @@ func (m *MCPManager) RegisterTool(name, description string, toolFunction MCPTool
 // connectToMCPClient establishes a connection to an external MCP server and
 // registers its available tools with the manager. Uses exponential backoff
 // retry logic (5 retries, 1-30 seconds) for connection establishment.
-func (m *MCPManager) connectToMCPClient(config *schemas.MCPClientConfig) error {
+func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *schemas.MCPClientConfig) error {
+	if requestCtx == nil {
+		requestCtx = m.ctx
+	}
 	// First lock: Initialize or validate client entry
 	m.mu.Lock()
 
@@ -1261,10 +1271,9 @@ func (m *MCPManager) connectToMCPClient(config *schemas.MCPClientConfig) error {
 		connectReq.StdioArgs = append([]string(nil), config.StdioConfig.Args...)
 	}
 
-	// Fresh BifrostContext for the gate so it doesn't inherit any SkipPluginPipeline flag
-	// from the caller's request context. Connect runs as infrastructure, not as part of an
-	// in-flight LLM request.
-	gateCtx := schemas.NewBifrostContext(m.ctx, schemas.NoDeadline)
+	// Wrap the caller context so connection hooks can read request-scoped
+	// values, such as headers extracted by the HTTP transport.
+	gateCtx := schemas.NewBifrostContext(requestCtx, schemas.NoDeadline)
 
 	// To capture InitializeResult for the response, the op closure populates these.
 	var initResult *mcp.InitializeResult

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -55,7 +55,7 @@ type MCPManagerInterface interface {
 	GetClients() []schemas.MCPClientState
 
 	// AddClient adds a new MCP client with the given configuration
-	AddClient(config *schemas.MCPClientConfig) error
+	AddClient(ctx context.Context, config *schemas.MCPClientConfig) error
 
 	// RemoveClient removes an MCP client by ID
 	RemoveClient(id string) error

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -139,7 +139,7 @@ func NewMCPManager(ctx context.Context, config schemas.MCPConfig, credStore sche
 		for _, clientConfig := range config.ClientConfigs {
 			go func(clientConfig *schemas.MCPClientConfig) {
 				defer wg.Done()
-				if err := manager.AddClient(clientConfig); err != nil {
+				if err := manager.AddClient(manager.ctx, clientConfig); err != nil {
 					manager.logger.Warn("%s Failed to register MCP client %s: %v", MCPLogPrefix, clientConfig.Name, err)
 					// Retain the entry in Disconnected state and start a health monitor to
 					// recover it automatically. On startup, a connection failure is likely

--- a/examples/mcps/temperature/package-lock.json
+++ b/examples/mcps/temperature/package-lock.json
@@ -73,7 +73,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -399,7 +398,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -604,7 +602,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }

--- a/examples/mcps/test-tools-server/package-lock.json
+++ b/examples/mcps/test-tools-server/package-lock.json
@@ -76,7 +76,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -405,7 +404,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -610,7 +608,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }

--- a/examples/plugins/mcp-only/go.sum
+++ b/examples/plugins/mcp-only/go.sum
@@ -36,7 +36,6 @@ github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8
 github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy/I=
 github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
-github.com/maximhq/bifrost v0.0.0-20260525064143-d2e60fa069b4/go.mod h1:Y/pTTQFN/CBxF2+0L+zLlnQaA/cvIvTlEjv7G6aGY8E=
 github.com/maximhq/bifrost/core v1.5.12 h1:tm4FVr9Vyy4Srr4Gg91kLrXFuZrMytGV6Rkrdpw3kXI=
 github.com/maximhq/bifrost/core v1.5.12/go.mod h1:bzcFxKjI2NCRtOeQOwA0KxKJkjsY/UgnXd/cmg7Q+4U=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/examples/plugins/mcp-only/main.go
+++ b/examples/plugins/mcp-only/main.go
@@ -228,6 +228,10 @@ func PreMCPConnectionHook(ctx *schemas.BifrostContext, req *schemas.BifrostMCPCo
 	if pluginConfig.EnableLogging {
 		fmt.Printf("[MCP-Only Plugin] PreMCPConnectionHook called: client=%s type=%s auth=%s\n",
 			req.ClientName, req.ConnectionType, req.AuthType)
+
+		allHeaders := ctx.Value(schemas.BifrostContextKeyRequestHeaders)
+		fmt.Printf("[MCP-Only Plugin] Request headers: %+v\n", allHeaders)
+
 	}
 
 	// Example: refuse connections to blocklisted clients.

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -363,6 +363,9 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
 		return
 	}
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.store)
+	defer cancel()
+
 	var req MCPClientRequest
 	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err))
@@ -478,7 +481,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		// persist so the DB row includes them from the start — same
 		// convention as the per-user OAuth branch below. Pass the canon
 		// form so the verify path sees the same keys the schema declares.
-		tools, toolNameMapping, verifyErr := h.mcpManager.VerifyHeadersConnection(ctx, schemasConfig, canonUserHeaders)
+		tools, toolNameMapping, verifyErr := h.mcpManager.VerifyHeadersConnection(bifrostCtx, schemasConfig, canonUserHeaders)
 		if verifyErr != nil {
 			SendError(ctx, fasthttp.StatusUnprocessableEntity, fmt.Sprintf("Verification failed: %v", verifyErr))
 			return
@@ -490,7 +493,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
 			return
 		}
-		if err := h.mcpManager.AddMCPClient(ctx, schemasConfig); err != nil {
+		if err := h.mcpManager.AddMCPClient(bifrostCtx, schemasConfig); err != nil {
 			if delErr := h.store.ConfigStore.DeleteMCPClientConfig(ctx, schemasConfig.ID); delErr != nil {
 				logger.Error(fmt.Sprintf("Failed to roll back MCP client config after AddMCPClient failure: %v", delErr))
 			}
@@ -732,7 +735,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			return
 		}
 	}
-	if err := h.mcpManager.AddMCPClient(ctx, schemasConfig); err != nil {
+	if err := h.mcpManager.AddMCPClient(bifrostCtx, schemasConfig); err != nil {
 		// Delete the created config from config store
 		if h.store.ConfigStore != nil {
 			if err := h.store.ConfigStore.DeleteMCPClientConfig(ctx, schemasConfig.ID); err != nil {
@@ -1450,6 +1453,9 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
 		return
 	}
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.store)
+	defer cancel()
+
 	oauthConfigID, err := getIDFromCtx(ctx)
 	if err != nil {
 		logger.Error(fmt.Sprintf("[OAuth Complete] Invalid oauth_config_id: %v", err))
@@ -1513,7 +1519,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		defer h.oauthHandler.RemovePendingMCPClient(oauthConfigID)
 
 		// Verify connection and discover tools using admin's temp token
-		tools, toolNameMapping, err := h.mcpManager.VerifyPerUserOAuthConnection(ctx, mcpClientConfig, accessToken)
+		tools, toolNameMapping, err := h.mcpManager.VerifyPerUserOAuthConnection(bifrostCtx, mcpClientConfig, accessToken)
 		if err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth configuration test failed: %v", err))
 			return
@@ -1550,7 +1556,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update MCP config: %v", err))
 				return
 			}
-			if err := h.updateMCPClientWithRetry(ctx, mcpClientConfig.ID, mcpClientConfig); err != nil {
+			if err := h.updateMCPClientWithRetry(bifrostCtx, mcpClientConfig.ID, mcpClientConfig); err != nil {
 				if rollbackErr := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, &oldDBConfig); rollbackErr != nil {
 					logger.Error(fmt.Sprintf("Failed to rollback MCP client DB update: %v. please restart bifrost to keep core and database in sync", rollbackErr))
 				}
@@ -1567,7 +1573,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			}
 
 			// Add MCP client to manager (skips connection for per_user_oauth)
-			if err := h.mcpManager.AddMCPClient(ctx, mcpClientConfig); err != nil {
+			if err := h.mcpManager.AddMCPClient(bifrostCtx, mcpClientConfig); err != nil {
 				// Clean up DB entry on failure
 				if h.store.ConfigStore != nil {
 					if delErr := h.store.ConfigStore.DeleteMCPClientConfig(ctx, mcpClientConfig.ID); delErr != nil {
@@ -1621,7 +1627,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update MCP config: %v", err))
 			return
 		}
-		if err := h.updateMCPClientConnectionWithRetry(ctx, mcpClientConfig.ID, mcpClientConfig); err != nil {
+		if err := h.updateMCPClientConnectionWithRetry(bifrostCtx, mcpClientConfig.ID, mcpClientConfig); err != nil {
 			if rollbackErr := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, &oldDBConfig); rollbackErr != nil {
 				logger.Error(fmt.Sprintf("Failed to rollback MCP client DB update: %v. please restart bifrost to keep core and database in sync", rollbackErr))
 			}
@@ -1638,7 +1644,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		}
 
 		// Add MCP client to Bifrost and connect
-		if err := h.mcpManager.AddMCPClient(ctx, mcpClientConfig); err != nil {
+		if err := h.mcpManager.AddMCPClient(bifrostCtx, mcpClientConfig); err != nil {
 			if h.store.ConfigStore != nil {
 				if delErr := h.store.ConfigStore.DeleteMCPClientConfig(ctx, mcpClientConfig.ID); delErr != nil {
 					logger.Warn(fmt.Sprintf("Failed to rollback MCP client config after add failure: %v", delErr))

--- a/transports/bifrost-http/handlers/mcp_per_user_headers.go
+++ b/transports/bifrost-http/handlers/mcp_per_user_headers.go
@@ -178,6 +178,9 @@ func (h *MCPPerUserHeadersHandler) flowSubmit(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusServiceUnavailable, "per-user headers credential provider is not configured")
 		return
 	}
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.store)
+	defer cancel()
+
 	flowID, ok := ctx.UserValue("id").(string)
 	if !ok || strings.TrimSpace(flowID) == "" {
 		SendError(ctx, fasthttp.StatusBadRequest, "Invalid flow id")
@@ -236,7 +239,7 @@ func (h *MCPPerUserHeadersHandler) flowSubmit(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	if _, _, verifyErr := h.mcpManager.VerifyHeadersConnection(ctx, config, filtered); verifyErr != nil {
+	if _, _, verifyErr := h.mcpManager.VerifyHeadersConnection(bifrostCtx, config, filtered); verifyErr != nil {
 		SendError(ctx, fasthttp.StatusUnprocessableEntity, fmt.Sprintf("Verification failed: %v", verifyErr))
 		return
 	}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -4760,7 +4760,7 @@ func (c *Config) AddMCPClient(ctx context.Context, clientConfig *schemas.MCPClie
 	// Track new environment variables
 	c.MCPConfig.ClientConfigs = append(c.MCPConfig.ClientConfigs, clientConfig)
 	// Config with processed env vars
-	if err := c.client.AddMCPClient(clientConfig); err != nil {
+	if err := c.client.AddMCPClient(ctx, clientConfig); err != nil {
 		c.MCPConfig.ClientConfigs = c.MCPConfig.ClientConfigs[:len(c.MCPConfig.ClientConfigs)-1]
 		return fmt.Errorf("failed to connect MCP client: %w", err)
 	}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -215,7 +215,7 @@ func (s *BifrostHTTPServer) ReconnectMCPClient(ctx context.Context, id string) e
 	if err != nil {
 		return err
 	}
-	if err := s.Client.AddMCPClient(clientConfig); err != nil {
+	if err := s.Client.AddMCPClient(ctx, clientConfig); err != nil {
 		return err
 	}
 	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {


### PR DESCRIPTION
## Summary

`AddMCPClient` and `connectToMCPClient` previously used the manager's background context when running connection hooks, which meant request-scoped values (such as HTTP headers extracted by the transport layer) were invisible to MCP plugins during the connect phase. This PR threads the caller's `context.Context` through `AddMCPClient` so that connect-time hooks can read request-scoped values while keeping persistent transport lifetimes bound to the manager context.

## Changes

- `MCPManager.AddClient`, `Bifrost.AddMCPClient`, and the internal `connectToMCPClient` now accept a `context.Context` parameter. The `BifrostContext` passed to connect/list-tools hooks is derived from the caller's context rather than the manager's background context.
- `ReconnectClient`, `EnableClient`, and `UpdateClientConnection` continue to use the manager context (`m.ctx`) since they are infrastructure-initiated and have no caller request context.
- `NewMCPManager` passes `manager.ctx` when calling `AddClient` during startup initialization, preserving existing behavior.
- The HTTP transport's `addMCPClient`, `completeMCPClientOAuth`, and `flowSubmit` handlers now convert the incoming `fasthttp.RequestCtx` to a `BifrostContext` before calling `AddMCPClient` and related verification methods, so HTTP request headers are available to MCP plugins.
- `MCPManagerInterface` updated to reflect the new `AddClient` signature.
- The `mcp-only` plugin example logs request headers received in `PreMCPConnectionHook` to demonstrate the new capability.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/...
go test ./transports/...
```

To verify that request headers are visible in a connect hook, configure the `mcp-only` plugin example with `EnableLogging: true` and call the `POST /mcp/clients` endpoint with custom headers. The plugin's `PreMCPConnectionHook` log line will print the headers extracted from the incoming request.

## Breaking changes

- [x] Yes
- [ ] No

`MCPManagerInterface.AddClient` and `Bifrost.AddMCPClient` now require a `context.Context` as the first argument. Any callers implementing or calling these interfaces directly must add a context argument (e.g. `context.Background()` as a minimal migration).

## Related issues

## Security considerations

Request headers passed through the context may contain credentials or tokens. MCP plugin authors should treat values read from `BifrostContextKeyRequestHeaders` as sensitive and avoid logging them in production.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable