### PR TITLE
github actions tigthining fixes

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -289,6 +289,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
@@ -373,6 +374,7 @@ jobs:
             _https._tcp.esm.ubuntu.com:443
             _https._tcp.motd.ubuntu.com:443
             _https._tcp.packages.microsoft.com:443
+            production.cloudfront.docker.com:443
             api.github.com:443
             api.openai.com:443
             auth.docker.io:443
@@ -485,6 +487,7 @@ jobs:
             github.com:443
             nodejs.org:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443
@@ -555,6 +558,7 @@ jobs:
             github.com:443
             nodejs.org:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443
@@ -637,6 +641,7 @@ jobs:
             openrouter.ai:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443
@@ -730,7 +735,13 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: block
+          # 172.28.0.16:5432 is the pinned postgres IP from
+          # tests/docker-compose.yml (postgres.networks.bifrost_network.ipv4_address).
+          # Keep both files in sync - drift here will block egress to Postgres
+          # during the docker image test.
           allowed-endpoints: >
+            127.0.0.11:53
+            172.28.0.16:5432
             api.anthropic.com:443
             api.cerebras.ai:443
             api.cohere.ai:443
@@ -840,7 +851,13 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: block
+          # 172.28.0.16:5432 is the pinned postgres IP from
+          # tests/docker-compose.yml (postgres.networks.bifrost_network.ipv4_address).
+          # Keep both files in sync - drift here will block egress to Postgres
+          # during the docker image test.
           allowed-endpoints: >
+            127.0.0.11:53
+            172.28.0.16:5432
             api.anthropic.com:443
             api.cerebras.ai:443
             api.cohere.ai:443
@@ -1480,13 +1497,7 @@ jobs:
 
   # Finalize: changelog, tagging, GitHub release, R2 latest copy
   bifrost-http-release:
-    needs:
-      [
-        build-binaries-x86,
-        build-binaries-arm64,
-        detect-changes,
-        bifrost-http-prep,
-      ]
+    needs: [build-binaries-x86, build-binaries-arm64, detect-changes, bifrost-http-prep]
     if: "always() && needs.build-binaries-x86.result == 'success' && needs.build-binaries-arm64.result == 'success'"
     runs-on: ubuntu-latest
     permissions:
@@ -1924,13 +1935,7 @@ jobs:
 
   # Docker UBI9 manifest — merges amd64 + arm64 into a single multi-arch tag
   docker-manifest-ubi9:
-    needs:
-      [
-        check-skip,
-        detect-changes,
-        docker-build-ubi9-amd64,
-        docker-build-ubi9-arm64,
-      ]
+    needs: [check-skip, detect-changes, docker-build-ubi9-amd64, docker-build-ubi9-arm64]
     if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.docker-build-ubi9-amd64.result == 'success' && needs.docker-build-ubi9-arm64.result == 'success'"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/scripts/test-docker-image.sh
+++ b/.github/workflows/scripts/test-docker-image.sh
@@ -210,8 +210,7 @@ cat > "$CONFIG_FILE" << 'CONFIGEOF'
     "initial_pool_size": 300,
     "allowed_origins": ["http://localhost:3000", "https://localhost:3000"],
     "enable_logging": true,
-    "enforce_governance_header": false,
-    "allow_direct_keys": false,
+    "enforce_auth_on_inference": false,
     "max_request_body_size_mb": 100
   },
   "encryption_key": ""

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -203,6 +203,10 @@ services:
             - "5432:5432"
         networks:
             bifrost_network:
+                # PINNED IP - keep in sync with harden-runner allowed-endpoints
+                # in .github/workflows/release-pipeline.yml (test-docker-image-amd64
+                # and test-docker-image-arm64 jobs). Changing this breaks egress
+                # for container-to-container Postgres traffic on CI runners.
                 ipv4_address: 172.28.0.16
 
 networks:


### PR DESCRIPTION
## Summary

Adds `production.cloudfront.docker.com` to the allowed egress endpoints across multiple CI jobs, fixes missing DNS and PostgreSQL endpoints for integration test jobs, and updates the Docker image test script to reflect a renamed configuration field.

## Changes

- Added `production.cloudfront.docker.com:443` to the egress allowlist for several release pipeline jobs where Docker registry access is required, alongside the existing `production.cloudflare.docker.com` entry
- Added `127.0.0.11:53` (Docker internal DNS) and `172.28.0.16:5432` (PostgreSQL) to the allowed endpoints for two integration test jobs that require database connectivity
- Replaced the `enforce_governance_header` and `allow_direct_keys` config fields with the unified `enforce_auth_on_inference` field in the Docker image test configuration script
- Reformatted two `needs` arrays in the release pipeline from multi-line to single-line style for readability

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger the release pipeline and verify that Docker pulls succeed across all jobs without egress policy violations, and that integration test jobs requiring PostgreSQL complete successfully.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The egress allowlist additions are scoped to known Docker CDN infrastructure (`cloudfront.docker.com`) and internal Docker network addresses for DNS resolution and the PostgreSQL test database. No external secrets or PII are exposed by these changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable