### PR TITLE
Update allowed endpoints

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -471,10 +471,17 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: block
+          # bifrost-http binary runs on the host and connects to Postgres via
+          # the published port mapping (5432:5432) at 127.0.0.1. The integration
+          # test configs in .github/workflows/configs/*/config.json use
+          # "host": "localhost". The 172.38.0.12 entries below are weaviate's
+          # pinned bridge IP from .github/workflows/configs/docker-compose.yml;
+          # they are kept for any container-to-container traffic but the binary
+          # itself reaches weaviate via 127.0.0.1:9000 (published port).
           allowed-endpoints: >
+            127.0.0.1:5432
             172.38.0.12:8080
             172.38.0.12:8301
-            172.38.0.2:5432
             api.github.com:443
             auth.docker.io:443
             codecov.io:443
@@ -547,8 +554,12 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: block
+          # Migration test binary runs on the host (not in a container) and
+          # connects to Postgres via the published port mapping (5432:5432) at
+          # 127.0.0.1. See run-migration-tests.sh:46 (POSTGRES_HOST defaults to
+          # localhost).
           allowed-endpoints: >
-            172.38.0.2:5432
+            127.0.0.1:5432
             api.anthropic.com:443
             api.github.com:443
             api.openai.com:443
@@ -613,8 +624,12 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: block
+          # API integrations test compiles bifrost-http and runs it on the host
+          # (not in a container), connecting to Postgres via the published port
+          # mapping (5432:5432) at 127.0.0.1. See test-api-integrations.sh which
+          # defaults POSTGRES_HOST to localhost.
           allowed-endpoints: >
-            172.38.0.2:5432
+            127.0.0.1:5432
             api.anthropic.com:443
             api.cerebras.ai:443
             api.cohere.ai:443


### PR DESCRIPTION
## Summary

Fixes the egress allowlist in the release pipeline so that test binaries running on the host can reach Postgres. The binaries connect via the published port mapping (`5432:5432`) at `127.0.0.1`, not through the Docker bridge network address that was previously listed.

## Changes

- Replaced `172.38.0.2:5432` with `127.0.0.1:5432` in the `harden-runner` egress allowlists for the integration tests, migration tests, and API integrations test jobs.
- Added inline comments explaining why each job uses `127.0.0.1` — the test binaries (`bifrost-http` and the migration runner) execute on the host and reach Postgres through the published port, while container-to-container traffic (e.g., Weaviate at `172.38.0.12`) remains unchanged.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The CI pipeline itself validates this change. After merging, the integration, migration, and API integration test jobs should pass without being blocked by the `harden-runner` egress policy when connecting to Postgres.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `harden-runner` egress policy is kept in `block` mode. Only the Postgres endpoint address was corrected to reflect where the process actually connects from (`127.0.0.1` via published port rather than the internal Docker bridge IP). No new external endpoints are being permitted.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable