### PR TITLE
feat: add TLS configuration support for MCP HTTP/SSE client connections

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -2,9 +2,12 @@ package mcp
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"maps"
+	"net/http"
 	"os"
 	"slices"
 	"strings"
@@ -97,7 +100,15 @@ func (m *MCPManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schem
 			targetURL = *preReq.ConnectionString
 		}
 
-		httpTransport, err := transport.NewStreamableHTTP(targetURL, transport.WithHTTPHeaders(finalHeaders))
+		perUserOpts := []transport.StreamableHTTPCOption{transport.WithHTTPHeaders(finalHeaders)}
+		perUserTLSClient, tlsErr := m.buildTLSHTTPClient(config.TLSConfig)
+		if tlsErr != nil {
+			return nil, fmt.Errorf("failed to build TLS HTTP client: %w", tlsErr)
+		}
+		if perUserTLSClient != nil {
+			perUserOpts = append(perUserOpts, transport.WithHTTPBasicClient(perUserTLSClient))
+		}
+		httpTransport, err := transport.NewStreamableHTTP(targetURL, perUserOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create HTTP transport: %w", err)
 		}
@@ -434,7 +445,15 @@ func (m *MCPManager) VerifyPerUserOAuthConnection(ctx context.Context, config *s
 		maps.Copy(finalHeaders, preReq.Headers)
 		finalHeaders["Authorization"] = fmt.Sprintf("Bearer %s", accessToken)
 
-		httpTransport, hErr := transport.NewStreamableHTTP(finalURL, transport.WithHTTPHeaders(finalHeaders))
+		verifyOpts := []transport.StreamableHTTPCOption{transport.WithHTTPHeaders(finalHeaders)}
+		verifyHTTPClient, tlsErr := m.buildTLSHTTPClient(config.TLSConfig)
+		if tlsErr != nil {
+			return nil, fmt.Errorf("failed to build TLS HTTP client for verification: %w", tlsErr)
+		}
+		if verifyHTTPClient != nil {
+			verifyOpts = append(verifyOpts, transport.WithHTTPBasicClient(verifyHTTPClient))
+		}
+		httpTransport, hErr := transport.NewStreamableHTTP(finalURL, verifyOpts...)
 		if hErr != nil {
 			return nil, fmt.Errorf("failed to create HTTP transport for verification: %w", hErr)
 		}
@@ -578,7 +597,15 @@ func (m *MCPManager) VerifyHeadersConnection(ctx context.Context, config *schema
 			finalHeaders[k] = v
 		}
 
-		httpTransport, hErr := transport.NewStreamableHTTP(finalURL, transport.WithHTTPHeaders(finalHeaders))
+		headersVerifyOpts := []transport.StreamableHTTPCOption{transport.WithHTTPHeaders(finalHeaders)}
+		headersVerifyTLSClient, tlsErr := m.buildTLSHTTPClient(config.TLSConfig)
+		if tlsErr != nil {
+			return nil, fmt.Errorf("failed to build TLS HTTP client for verification: %w", tlsErr)
+		}
+		if headersVerifyTLSClient != nil {
+			headersVerifyOpts = append(headersVerifyOpts, transport.WithHTTPBasicClient(headersVerifyTLSClient))
+		}
+		httpTransport, hErr := transport.NewStreamableHTTP(finalURL, headersVerifyOpts...)
 		if hErr != nil {
 			return nil, fmt.Errorf("failed to create HTTP transport for verification: %w", hErr)
 		}
@@ -949,6 +976,7 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 		ToolSyncInterval:      updatedConfig.ToolSyncInterval,
 		AllowOnAllVirtualKeys: updatedConfig.AllowOnAllVirtualKeys,
 		Disabled:              updatedConfig.Disabled,
+		TLSConfig:             updatedConfig.TLSConfig,
 		PerUserHeaderKeys:     slices.Clone(updatedConfig.PerUserHeaderKeys),
 	}
 
@@ -1553,6 +1581,39 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 	return nil
 }
 
+// buildTLSHTTPClient constructs an *http.Client with a custom TLS configuration derived
+// from MCPTLSConfig. Returns nil when tlsCfg is nil so callers can use the library default.
+// InsecureSkipVerify takes priority over CACertPEM when both are set.
+func (m *MCPManager) buildTLSHTTPClient(tlsCfg *schemas.MCPTLSConfig) (*http.Client, error) {
+	if tlsCfg == nil {
+		return nil, nil
+	}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	if tlsCfg.InsecureSkipVerify {
+		m.logger.Warn("MCP client: skipping TLS verification — do not use in production")
+		tlsConfig.InsecureSkipVerify = true
+	} else if tlsCfg.CACertPEM != nil {
+		caPEM := tlsCfg.CACertPEM.GetValue()
+		if caPEM != "" {
+			rootCAs, err := x509.SystemCertPool()
+			if err != nil {
+				rootCAs = x509.NewCertPool()
+			}
+			if !rootCAs.AppendCertsFromPEM([]byte(caPEM)) {
+				return nil, fmt.Errorf("failed to parse MCP CA certificate PEM")
+			}
+			tlsConfig.RootCAs = rootCAs
+		}
+	}
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		transport = &http.Transport{}
+	}
+	cloned := transport.Clone()
+	cloned.TLSClientConfig = tlsConfig
+	return &http.Client{Transport: cloned}, nil
+}
+
 // createHTTPConnection creates an HTTP-based MCP client connection without holding locks.
 // If overrides is non-nil and carries a populated ConnectionString or Headers, those values
 // are used instead of resolving them from config. This is how plugin PreHook mutations flow
@@ -1590,7 +1651,15 @@ func (m *MCPManager) createHTTPConnection(ctx context.Context, config *schemas.M
 	}
 
 	// Create StreamableHTTP transport
-	httpTransport, err := transport.NewStreamableHTTP(url, transport.WithHTTPHeaders(headers))
+	opts := []transport.StreamableHTTPCOption{transport.WithHTTPHeaders(headers)}
+	httpClient, err := m.buildTLSHTTPClient(config.TLSConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build TLS HTTP client: %w", err)
+	}
+	if httpClient != nil {
+		opts = append(opts, transport.WithHTTPBasicClient(httpClient))
+	}
+	httpTransport, err := transport.NewStreamableHTTP(url, opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create HTTP transport: %w", err)
 	}
@@ -1673,7 +1742,15 @@ func (m *MCPManager) createSSEConnection(ctx context.Context, config *schemas.MC
 		}
 	}
 
-	sseTransport, err := transport.NewSSE(url, transport.WithHeaders(headers))
+	sseOpts := []transport.ClientOption{transport.WithHeaders(headers)}
+	sseHTTPClient, err := m.buildTLSHTTPClient(config.TLSConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build TLS HTTP client: %w", err)
+	}
+	if sseHTTPClient != nil {
+		sseOpts = append(sseOpts, transport.WithHTTPClient(sseHTTPClient))
+	}
+	sseTransport, err := transport.NewSSE(url, sseOpts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create SSE transport: %w", err)
 	}

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -277,18 +277,19 @@ const (
 
 // MCPClientConfig defines tool filtering for an MCP client.
 type MCPClientConfig struct {
-	ID                string            `json:"client_id"`                     // Client ID
-	Name              string            `json:"name"`                          // Client name
-	IsCodeModeClient  bool              `json:"is_code_mode_client"`           // Whether the client is a code mode client
-	ConnectionType    MCPConnectionType `json:"connection_type"`               // How to connect (HTTP, STDIO, SSE, or InProcess)
-	ConnectionString  *EnvVar           `json:"connection_string,omitempty"`   // HTTP or SSE URL (required for HTTP or SSE connections)
-	StdioConfig       *MCPStdioConfig   `json:"stdio_config,omitempty"`        // STDIO configuration (required for STDIO connections)
-	AuthType          MCPAuthType       `json:"auth_type"`                     // Authentication type (none, headers, or oauth)
-	OauthConfigID     *string           `json:"oauth_config_id,omitempty"`     // OAuth config ID (references oauth_configs table)
-	OauthClientID     *EnvVar           `json:"oauth_client_id,omitempty"`     // Redacted OAuth client ID (populated on GET, not stored here)
-	OauthClientSecret *EnvVar           `json:"oauth_client_secret,omitempty"` // Redacted OAuth client secret (populated on GET, not stored here)
-	State             string            `json:"state,omitempty"`               // Connection state (connected, disconnected, error)
-	Headers           map[string]EnvVar `json:"headers,omitempty"`             // Headers to send with the request (for headers auth type)
+	ID                  string            `json:"client_id"`                       // Client ID
+	Name                string            `json:"name"`                            // Client name
+	IsCodeModeClient    bool              `json:"is_code_mode_client"`             // Whether the client is a code mode client
+	ConnectionType      MCPConnectionType `json:"connection_type"`                 // How to connect (HTTP, STDIO, SSE, or InProcess)
+	ConnectionString    *EnvVar           `json:"connection_string,omitempty"`     // HTTP or SSE URL (required for HTTP or SSE connections)
+	StdioConfig         *MCPStdioConfig   `json:"stdio_config,omitempty"`          // STDIO configuration (required for STDIO connections)
+	TLSConfig           *MCPTLSConfig     `json:"tls_config,omitempty"`            // TLS configuration for HTTP/SSE connections
+	AuthType            MCPAuthType       `json:"auth_type"`                       // Authentication type (none, headers, or oauth)
+	OauthConfigID       *string           `json:"oauth_config_id,omitempty"`       // OAuth config ID (references oauth_configs table)
+	OauthClientID       *EnvVar           `json:"oauth_client_id,omitempty"`       // Redacted OAuth client ID (populated on GET, not stored here)
+	OauthClientSecret   *EnvVar           `json:"oauth_client_secret,omitempty"`   // Redacted OAuth client secret (populated on GET, not stored here)
+	State               string            `json:"state,omitempty"`                 // Connection state (connected, disconnected, error)
+	Headers             map[string]EnvVar `json:"headers,omitempty"`               // Headers to send with the request (for headers auth type)
 	// PerUserHeaderKeys lists the header *names* each caller must supply for
 	// MCPAuthTypePerUserHeaders clients. Admin-declared schema only — the
 	// values live per-user in the mcp_per_user_header_credentials table and
@@ -448,6 +449,31 @@ type MCPStdioConfig struct {
 	Command string   `json:"command"` // Executable command to run
 	Args    []string `json:"args"`    // Command line arguments
 	Envs    []string `json:"envs"`    // Environment variables required
+}
+
+// MCPTLSConfig holds TLS options for HTTP and SSE MCP connections.
+// InsecureSkipVerify takes priority over CACertPEM when both are set.
+type MCPTLSConfig struct {
+	InsecureSkipVerify bool    `json:"insecure_skip_verify,omitempty"` // Disable TLS certificate verification (development only)
+	CACertPEM          *EnvVar `json:"ca_cert_pem,omitempty"`          // PEM-encoded CA certificate to trust (supports env.*)
+}
+
+// MarshalForStorage serializes MCPTLSConfig for DB persistence.
+// ca_cert_pem is stored as a plain string ("env.VAR_NAME" or literal PEM).
+// For HTTP API responses use json.Marshal so clients receive the full EnvVar object.
+func (t *MCPTLSConfig) MarshalForStorage() ([]byte, error) {
+	if t == nil {
+		return []byte("null"), nil
+	}
+	type tlsConfigStorage struct {
+		InsecureSkipVerify bool   `json:"insecure_skip_verify,omitempty"`
+		CACertPEM          string `json:"ca_cert_pem,omitempty"`
+	}
+	a := tlsConfigStorage{InsecureSkipVerify: t.InsecureSkipVerify}
+	if t.CACertPEM != nil {
+		a.CACertPEM = EnvVarAsString(t.CACertPEM)
+	}
+	return json.Marshal(a)
 }
 
 type MCPConnectionState string

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -154,6 +154,23 @@ MCPClientCreateRequestBase:
         When true, this MCP client's tools are available to all virtual keys by default,
         without requiring an explicit virtual key assignment.
         An explicit virtual key config always overrides this setting for that key.
+    tls_config:
+      type: object
+      description: |
+        TLS configuration for HTTP and SSE connections.
+        Not applicable to stdio or inprocess connection types.
+      properties:
+        insecure_skip_verify:
+          type: boolean
+          description: |
+            Disable TLS certificate verification. Takes priority over ca_cert_pem when both are set.
+            Use only in development or trusted isolated environments. Not recommended for production.
+        ca_cert_pem:
+          type: string
+          description: |
+            PEM-encoded CA certificate to trust for MCP server connections.
+            Use when the MCP server uses a self-signed or private CA certificate.
+            Supports env.VAR_NAME syntax to read the certificate from an environment variable.
     per_user_header_keys:
       type: array
       items:
@@ -318,6 +335,23 @@ MCPClientUpdateRequest:
         When true, the client's connection, health monitor, and tool syncer are shut down.
         The client entry is preserved so it can be re-enabled later by sending disabled: false.
         Disabled clients do not expose tools to inference requests.
+    tls_config:
+      type: object
+      description: |
+        TLS configuration for HTTP and SSE connections.
+        Not applicable to stdio or inprocess connection types.
+      properties:
+        insecure_skip_verify:
+          type: boolean
+          description: |
+            Disable TLS certificate verification. Takes priority over ca_cert_pem when both are set.
+            Use only in development or trusted isolated environments. Not recommended for production.
+        ca_cert_pem:
+          type: string
+          description: |
+            PEM-encoded CA certificate to trust for MCP server connections.
+            Use when the MCP server uses a self-signed or private CA certificate.
+            Supports env.VAR_NAME syntax to read the certificate from an environment variable.
     vk_configs:
       type: array
       items:
@@ -367,6 +401,18 @@ MCPClientConfig:
       description: HTTP or SSE URL (required for HTTP or SSE connections)
     stdio_config:
       $ref: '#/MCPStdioConfig'
+    tls_config:
+      type: object
+      description: TLS configuration for HTTP and SSE connections.
+      properties:
+        insecure_skip_verify:
+          type: boolean
+          description: Disable TLS certificate verification. Development/testing only.
+        ca_cert_pem:
+          type: string
+          description: |
+            PEM-encoded CA certificate. Supports env.VAR_NAME syntax for input.
+            Responses return a redacted placeholder rather than the raw PEM value.
     auth_type:
       $ref: '#/MCPAuthType'
       description: Authentication type for the MCP connection

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1256,6 +1256,15 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 		hash.Write(data)
 	}
 
+	// Hash TLSConfig
+	if m.TLSConfig != nil {
+		data, err := sonic.Marshal(m.TLSConfig)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+
 	// Hash ToolsToExecute (sorted for deterministic hashing)
 	if len(m.ToolsToExecute) > 0 {
 		sortedTools := make([]string, len(m.ToolsToExecute))

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -813,6 +813,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPerUserHeadersFlowsTable(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddMCPClientTLSConfigColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -8866,7 +8869,7 @@ func migrationAddCreatedByUserIDColumnForVirtualKeys(ctx context.Context, db *go
 	return nil
 }
 
-// migrationAddCreatedByUserIDColumnForVirtualKeys adds the created_by_user_id column to the governance_virtual_keys table.
+// migrationDropAzureAPIVersionColumn adds the created_by_user_id column to the governance_virtual_keys table
 func migrationDropAzureAPIVersionColumn(ctx context.Context, db *gorm.DB) error {
 	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
 		ID: "drop_azure_api_version_column",
@@ -8891,6 +8894,35 @@ func migrationDropAzureAPIVersionColumn(ctx context.Context, db *gorm.DB) error 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running drop_azure_api_version_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPClientTLSConfigColumn adds the tls_config_json column to the config_mcp_clients table.
+func migrationAddMCPClientTLSConfigColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_mcp_client_tls_config_json_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if !tx.Migrator().HasColumn(&tables.TableMCPClient{}, "tls_config_json") {
+				if err := tx.Exec("ALTER TABLE config_mcp_clients ADD COLUMN tls_config_json TEXT").Error; err != nil {
+					return fmt.Errorf("failed to add tls_config_json column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if tx.Migrator().HasColumn(&tables.TableMCPClient{}, "tls_config_json") {
+				if err := tx.Exec("ALTER TABLE config_mcp_clients DROP COLUMN tls_config_json").Error; err != nil {
+					return fmt.Errorf("failed to drop tls_config_json column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_client_tls_config_json_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1491,6 +1491,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 					ConnectionType:            schemas.MCPConnectionType(dbClient.ConnectionType),
 					ConnectionString:          dbClient.ConnectionString,
 					StdioConfig:               dbClient.StdioConfig,
+					TLSConfig:                 dbClient.TLSConfig,
 					AuthType:                  schemas.MCPAuthType(dbClient.AuthType),
 					OauthConfigID:             dbClient.OauthConfigID,
 					ToolsToExecute:            dbClient.ToolsToExecute,
@@ -1532,6 +1533,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			ConnectionType:            schemas.MCPConnectionType(dbClient.ConnectionType),
 			ConnectionString:          dbClient.ConnectionString,
 			StdioConfig:               dbClient.StdioConfig,
+			TLSConfig:                 dbClient.TLSConfig,
 			AuthType:                  schemas.MCPAuthType(dbClient.AuthType),
 			OauthConfigID:             dbClient.OauthConfigID,
 			ToolsToExecute:            dbClient.ToolsToExecute,
@@ -1618,6 +1620,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 		ConnectionType:            schemas.MCPConnectionType(dbClient.ConnectionType),
 		ConnectionString:          dbClient.ConnectionString,
 		StdioConfig:               dbClient.StdioConfig,
+		TLSConfig:                 dbClient.TLSConfig,
 		AuthType:                  schemas.MCPAuthType(dbClient.AuthType),
 		OauthConfigID:             dbClient.OauthConfigID,
 		ToolsToExecute:            dbClient.ToolsToExecute,
@@ -1671,6 +1674,7 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 			ConnectionType:        string(clientConfigCopy.ConnectionType),
 			ConnectionString:      clientConfigCopy.ConnectionString,
 			StdioConfig:           clientConfigCopy.StdioConfig,
+			TLSConfig:             clientConfigCopy.TLSConfig,
 			AuthType:              string(clientConfigCopy.AuthType),
 			OauthConfigID:         clientConfigCopy.OauthConfigID,
 			ToolsToExecute:        clientConfigCopy.ToolsToExecute,
@@ -1764,6 +1768,15 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			stdioStr := string(stdioData)
 			stdioConfigJSON = &stdioStr
 		}
+		var tlsConfigJSON *string
+		if clientConfigCopy.TLSConfig != nil {
+			tlsData, marshalErr := clientConfigCopy.TLSConfig.MarshalForStorage()
+			if marshalErr != nil {
+				return fmt.Errorf("failed to marshal tls_config: %w", marshalErr)
+			}
+			tlsStr := string(tlsData)
+			tlsConfigJSON = &tlsStr
+		}
 
 		if clientConfigCopy.ToolPricing == nil {
 			clientConfigCopy.ToolPricing = map[string]float64{}
@@ -1829,6 +1842,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if clientConfigCopy.OauthConfigID != nil {
 			updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
 		}
+		updates["tls_config_json"] = tlsConfigJSON
 		if discoveredToolsJSON != "" {
 			updates["discovered_tools_json"] = discoveredToolsJSON
 		}
@@ -1862,6 +1876,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			updates["connection_type"] = clientConfigCopy.ConnectionType
 			updates["connection_string"] = connectionStringToPersist
 			updates["stdio_config_json"] = stdioConfigJSON
+			updates["tls_config_json"] = tlsConfigJSON
 			updates["auth_type"] = clientConfigCopy.AuthType
 			updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
 			updates["per_user_header_keys_json"] = perUserHeaderKeysJSON

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -20,6 +20,7 @@ type TableMCPClient struct {
 	ConnectionType          string          `gorm:"type:varchar(20);not null" json:"connection_type"` // schemas.MCPConnectionType
 	ConnectionString        *schemas.EnvVar `gorm:"type:text" json:"connection_string,omitempty"`
 	StdioConfigJSON         *string         `gorm:"type:text" json:"-"`                              // JSON serialized schemas.MCPStdioConfig
+	TLSConfigJSON           *string         `gorm:"type:text" json:"-"`                              // JSON serialized schemas.MCPTLSConfig
 	ToolsToExecuteJSON      string          `gorm:"type:text" json:"-"`                              // JSON serialized []string
 	ToolsToAutoExecuteJSON  string          `gorm:"type:text" json:"-"`                              // JSON serialized []string
 	HeadersJSON             string          `gorm:"type:text" json:"-"`                              // JSON serialized map[string]string
@@ -57,6 +58,7 @@ type TableMCPClient struct {
 
 	// Virtual fields for runtime use (not stored in DB)
 	StdioConfig               *schemas.MCPStdioConfig    `gorm:"-" json:"stdio_config,omitempty"`
+	TLSConfig                 *schemas.MCPTLSConfig      `gorm:"-" json:"tls_config,omitempty"`
 	ToolsToExecute            schemas.WhiteList          `gorm:"-" json:"tools_to_execute"`
 	ToolsToAutoExecute        schemas.WhiteList          `gorm:"-" json:"tools_to_auto_execute"`
 	Headers                   map[string]schemas.EnvVar  `gorm:"-" json:"headers"`
@@ -83,6 +85,17 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		c.StdioConfigJSON = &config
 	} else {
 		c.StdioConfigJSON = nil
+	}
+
+	if c.TLSConfig != nil {
+		data, err := c.TLSConfig.MarshalForStorage()
+		if err != nil {
+			return err
+		}
+		config := string(data)
+		c.TLSConfigJSON = &config
+	} else {
+		c.TLSConfigJSON = nil
 	}
 
 	if c.ToolsToExecute != nil {
@@ -230,6 +243,13 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 			return err
 		}
 		c.StdioConfig = &config
+	}
+	if c.TLSConfigJSON != nil {
+		var config schemas.MCPTLSConfig
+		if err := sonic.Unmarshal([]byte(*c.TLSConfigJSON), &config); err != nil {
+			return err
+		}
+		c.TLSConfig = &config
 	}
 	if c.ToolsToExecuteJSON != "" {
 		if err := sonic.Unmarshal([]byte(c.ToolsToExecuteJSON), &c.ToolsToExecute); err != nil {

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -218,6 +218,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 			ConnectionType:        schemas.MCPConnectionType(dbClient.ConnectionType),
 			ConnectionString:      dbClient.ConnectionString,
 			StdioConfig:           dbClient.StdioConfig,
+			TLSConfig:             dbClient.TLSConfig,
 			AuthType:              schemas.MCPAuthType(dbClient.AuthType),
 			OauthConfigID:         dbClient.OauthConfigID,
 			ToolsToExecute:        dbClient.ToolsToExecute,
@@ -563,6 +564,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
 			ConnectionString:      req.ConnectionString,
 			StdioConfig:           req.StdioConfig,
+			TLSConfig:             req.TLSConfig,
 			AuthType:              schemas.MCPAuthTypePerUserOauth,
 			OauthConfigID:         &flowInitiation.OauthConfigID,
 			ToolsToExecute:        req.ToolsToExecute,
@@ -655,6 +657,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
 			ConnectionString:      req.ConnectionString,
 			StdioConfig:           req.StdioConfig,
+			TLSConfig:             req.TLSConfig,
 			AuthType:              schemas.MCPAuthType(req.AuthType),
 			OauthConfigID:         &flowInitiation.OauthConfigID,
 			ToolsToExecute:        req.ToolsToExecute,
@@ -716,6 +719,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
 		ConnectionString:      req.ConnectionString,
 		StdioConfig:           req.StdioConfig,
+		TLSConfig:             req.TLSConfig,
 		ToolsToExecute:        req.ToolsToExecute,
 		ToolsToAutoExecute:    req.ToolsToAutoExecute,
 		Headers:               req.Headers,
@@ -1025,6 +1029,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		ConnectionType:        existingConfig.ConnectionType,
 		ConnectionString:      existingConfig.ConnectionString,
 		StdioConfig:           existingConfig.StdioConfig,
+		TLSConfig:             req.TLSConfig,
 		ToolsToExecute:        resolvedToolsToExecute,
 		ToolsToAutoExecute:    resolvedToolsToAutoExecute,
 		Headers:               req.Headers,
@@ -1399,6 +1404,22 @@ func mergeMCPRedactedValues(incoming *configstoreTables.TableMCPClient, oldRaw, 
 	// Preserve AllowedExtraHeaders if not explicitly set in incoming request
 	if incoming.AllowedExtraHeaders == nil {
 		merged.AllowedExtraHeaders = oldRaw.AllowedExtraHeaders
+	}
+
+	// Handle TLSConfig - preserve existing when not sent, restore raw CA cert when redacted
+	if incoming.TLSConfig == nil {
+		merged.TLSConfig = oldRaw.TLSConfig
+	} else {
+		tlsCopy := *incoming.TLSConfig
+		// If CACertPEM is a redacted placeholder that matches the old redacted value,
+		// restore the raw value to avoid writing ***** to the DB.
+		if tlsCopy.CACertPEM != nil &&
+			oldRaw.TLSConfig != nil && oldRaw.TLSConfig.CACertPEM != nil &&
+			oldRedacted.TLSConfig != nil && oldRedacted.TLSConfig.CACertPEM != nil &&
+			tlsCopy.CACertPEM.IsRedacted() && tlsCopy.CACertPEM.Equals(oldRedacted.TLSConfig.CACertPEM) {
+			tlsCopy.CACertPEM = oldRaw.TLSConfig.CACertPEM
+		}
+		merged.TLSConfig = &tlsCopy
 	}
 
 	return merged

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -5084,6 +5084,15 @@ func (c *Config) RedactMCPClientConfig(config *schemas.MCPClientConfig) *schemas
 		configCopy.OauthClientSecret = config.OauthClientSecret.Redacted()
 	}
 
+	// Redact TLS CA cert PEM if present
+	if config.TLSConfig != nil {
+		tlsCopy := *config.TLSConfig
+		if config.TLSConfig.CACertPEM != nil {
+			tlsCopy.CACertPEM = config.TLSConfig.CACertPEM.Redacted()
+		}
+		configCopy.TLSConfig = &tlsCopy
+	}
+
 	return &configCopy
 }
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -12,7 +12,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useCreateMCPClientMutation } from "@/lib/store";
-import { CreateMCPClientRequest, EnvVar, MCPConnectionType, MCPStdioConfig } from "@/lib/types/mcp";
+import { CreateMCPClientRequest, EnvVar, MCPAuthType, MCPConnectionType, MCPStdioConfig, MCPTLSConfig } from "@/lib/types/mcp";
 import { parseArrayFromText } from "@/lib/utils/array";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Info } from "lucide-react";
@@ -34,6 +34,15 @@ const emptyStdioConfig: MCPStdioConfig = {
 };
 
 const emptyEnvVar: EnvVar = { value: "", env_var: "", from_env: false };
+
+/** Strips empty TLS config so we don't send `{}` to the server. */
+function buildTLSConfigPayload(tls: MCPTLSConfig | undefined): MCPTLSConfig | undefined {
+	if (!tls) return undefined;
+	const hasSkipVerify = tls.insecure_skip_verify === true;
+	const hasCACert = tls.ca_cert_pem?.value || tls.ca_cert_pem?.from_env;
+	if (!hasSkipVerify && !hasCACert) return undefined;
+	return { insecure_skip_verify: tls.insecure_skip_verify, ca_cert_pem: hasCACert ? tls.ca_cert_pem : undefined };
+}
 
 const emptyForm: CreateMCPClientRequest = {
 	name: "",
@@ -217,6 +226,10 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 						args: parseArrayFromText(argsText),
 						envs: parseArrayFromText(envsText),
 					}
+					: undefined,
+			tls_config:
+				connectionType === "http" || connectionType === "sse"
+					? buildTLSConfigPayload(data.tls_config)
 					: undefined,
 			oauth_config:
 				authType === "oauth" || authType === "per_user_oauth"
@@ -715,6 +728,58 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 											</AccordionItem>
 										</Accordion>
 									)}
+
+									{/* TLS / Certificate */}
+									<div className="space-y-4 rounded-lg border p-4">
+										<h4 className="text-sm font-medium">TLS / Certificate</h4>
+										<FormField
+											control={control}
+											name="tls_config.insecure_skip_verify"
+											render={({ field }) => (
+												<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+													<div className="space-y-0.5">
+														<FormLabel>Skip TLS verification</FormLabel>
+														<p className="text-muted-foreground text-sm">
+															Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA certificate.
+														</p>
+													</div>
+													<FormControl>
+														<Switch
+															checked={field.value ?? false}
+															onCheckedChange={field.onChange}
+															data-testid="mcp-tls-insecure-skip-verify"
+														/>
+													</FormControl>
+												</FormItem>
+											)}
+										/>
+										<FormField
+											control={control}
+											name="tls_config.ca_cert_pem"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+													<FormControl>
+														<EnvVarInput
+															variant="textarea"
+															placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
+															className="font-mono text-xs"
+															rows={6}
+															hideValueWhenEnv
+															redactNonEnvValue
+															{...field}
+															value={field.value}
+															data-testid="mcp-tls-ca-cert-pem"
+														/>
+													</FormControl>
+													<p className="text-muted-foreground text-sm">
+														PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
+													</p>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+									</div>
 								</>
 							)}
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -187,6 +187,12 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess, on
 			oauth_config: supportsOAuthCredentialUpdate
 				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
 				: undefined,
+			tls_config: mcpClient.config.tls_config
+				? {
+						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+					}
+				: undefined,
 		},
 	});
 	const isDisabled = form.watch("disabled");
@@ -208,6 +214,12 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess, on
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
+				: undefined,
+			tls_config: mcpClient.config.tls_config
+				? {
+						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+					}
 				: undefined,
 		});
 	}, [form, mcpClient]);
@@ -268,6 +280,12 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess, on
 							client_id: oauthClientID,
 							client_secret: oauthClientSecret,
 						}
+						: undefined,
+					tls_config: data.tls_config !== undefined
+						? {
+								insecure_skip_verify: data.tls_config.insecure_skip_verify ?? false,
+								ca_cert_pem: data.tls_config.ca_cert_pem,
+							}
 						: undefined,
 					vk_configs: vkConfigsDirty ? vkConfigs : undefined,
 				},
@@ -614,6 +632,61 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess, on
 										</FormItem>
 									)}
 								/>
+								{(mcpClient.config.connection_type === "http" || mcpClient.config.connection_type === "sse") && (
+									<div className="space-y-4 rounded-lg border p-4">
+										<h4 className="text-sm font-medium">TLS / Certificate</h4>
+										<FormField
+											control={form.control}
+											name="tls_config.insecure_skip_verify"
+											render={({ field }) => (
+												<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+													<div className="space-y-0.5">
+														<FormLabel>Skip TLS verification</FormLabel>
+														<p className="text-muted-foreground text-sm">
+															Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA
+															certificate.
+														</p>
+													</div>
+													<FormControl>
+														<Switch
+															checked={field.value ?? false}
+															onCheckedChange={field.onChange}
+															disabled={!hasUpdateMCPClientAccess}
+															data-testid="mcp-tls-insecure-skip-verify"
+														/>
+													</FormControl>
+												</FormItem>
+											)}
+										/>
+										<FormField
+											control={form.control}
+											name="tls_config.ca_cert_pem"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+													<FormControl>
+														<EnvVarInput
+															variant="textarea"
+															placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
+															className="font-mono text-xs"
+															rows={6}
+															hideValueWhenEnv
+															redactNonEnvValue
+															{...field}
+															value={field.value}
+															disabled={!hasUpdateMCPClientAccess}
+															data-testid="mcp-tls-ca-cert-pem"
+														/>
+													</FormControl>
+													<p className="text-muted-foreground text-sm">
+														PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
+													</p>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+									</div>
+								)}
 								<FormField
 									control={form.control}
 									name="tool_sync_interval"

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -24,6 +24,11 @@ export interface MCPStdioConfig {
 	envs: string[];
 }
 
+export interface MCPTLSConfig {
+	insecure_skip_verify?: boolean;
+	ca_cert_pem?: EnvVar;
+}
+
 export interface OAuthConfig {
 	client_id: EnvVar;
 	client_secret?: EnvVar; // Optional for public clients using PKCE
@@ -47,6 +52,7 @@ export interface MCPClientConfig {
 	connection_type: MCPConnectionType;
 	connection_string?: EnvVar;
 	stdio_config?: MCPStdioConfig;
+	tls_config?: MCPTLSConfig;
 	auth_type?: MCPAuthType;
 	oauth_config_id?: string;
 	oauth_client_id?: EnvVar; // Redacted existing client ID (populated on GET for oauth clients)
@@ -86,6 +92,7 @@ export interface CreateMCPClientRequest {
 	connection_type: MCPConnectionType;
 	connection_string?: EnvVar;
 	stdio_config?: MCPStdioConfig;
+	tls_config?: MCPTLSConfig;
 	auth_type?: MCPAuthType;
 	oauth_config?: OAuthConfig;
 	tools_to_execute?: string[];
@@ -143,6 +150,7 @@ export interface UpdateMCPClientRequest {
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
 	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this
 	disabled?: boolean; // Set to true to shut down connection/workers; false to reconnect
+	tls_config?: MCPTLSConfig; // TLS configuration for HTTP/SSE connections
 	oauth_config?: OAuthConfigUpdate; // Only supported for existing oauth/per_user_oauth clients (credential rotation)
 	vk_configs?: MCPVKConfig[]; // When provided, replaces all VK assignments for this MCP client
 }

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1040,6 +1040,12 @@ export const mcpClientUpdateSchema = z.object({
 			client_secret: envVarSchema.optional(),
 		})
 		.optional(),
+	tls_config: z
+		.object({
+			insecure_skip_verify: z.boolean().optional(),
+			ca_cert_pem: envVarSchema.optional(),
+		})
+		.optional(),
 });
 
 // Global proxy type schema


### PR DESCRIPTION
## Summary

Adds TLS configuration support for HTTP and SSE MCP client connections, allowing users to connect to MCP servers that use self-signed or private CA certificates, or to disable TLS verification in development/testing environments.

## Changes

- Introduced `MCPTLSConfig` schema with `InsecureSkipVerify` and `CACertPEM` fields. `CACertPEM` supports `env.VAR_NAME` syntax for reading certificates from environment variables. `InsecureSkipVerify` takes priority over `CACertPEM` when both are set.
- Added `buildTLSHTTPClient` helper on `MCPManager` that constructs a custom `*http.Client` with the appropriate TLS configuration. Returns `nil` when no TLS config is provided so the library default is used.
- Applied the custom HTTP client to all three connection paths: StreamableHTTP, SSE, and the OAuth verification flow.
- `CACertPEM` is treated as a sensitive value and is redacted in API responses, with redaction-aware merge logic to preserve the raw value on update when the incoming value matches the previously redacted one.
- `TLSConfig` is persisted as a JSON column (`tls_config_json`) in the database via a new migration and included in the MCP client config hash for change detection.
- Added TLS configuration UI section to both the create form and the edit sheet, visible only for HTTP and SSE connection types. Includes a toggle for skipping TLS verification and an `EnvVarInput` textarea for the CA certificate PEM.
- Updated OpenAPI schema documentation for `MCPClientCreateRequestBase`, `MCPClientUpdateRequest`, and `MCPClientConfig`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./core/mcp/... ./framework/configstore/...

# UI
cd ui
pnpm i
pnpm build
```

**HTTP connection with a self-signed CA:**
1. Create an MCP client with `connection_type: http` and set `tls_config.ca_cert_pem` to a PEM-encoded CA certificate (or `env.MY_CA_CERT`).
2. Verify the client connects successfully to an MCP server using a certificate signed by that CA.

**Insecure skip verify (development only):**
1. Create an MCP client with `connection_type: http` or `sse` and set `tls_config.insecure_skip_verify: true`.
2. Verify the client connects to an MCP server with an untrusted certificate and that a warning is logged.

**Redaction:**
1. Create a client with a `ca_cert_pem` value.
2. Fetch the client via GET and confirm the PEM value is redacted.
3. Submit an update without changing the CA cert and confirm the original value is preserved.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- `InsecureSkipVerify` disables TLS certificate verification entirely. A warning is logged when this option is used. It is documented as development/testing only and not recommended for production.
- `CACertPEM` is treated as a sensitive credential: it is redacted in API responses and handled through the existing `EnvVar` redaction pipeline.
- A minimum TLS version of TLS 1.2 is enforced on all custom TLS clients constructed by `buildTLSHTTPClient`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable