### PR TITLE
test fixes for hardened runners

### DIFF
--- a/.github/workflows/configs/docker-compose.yml
+++ b/.github/workflows/configs/docker-compose.yml
@@ -43,11 +43,6 @@ services:
         - "9000:8080"
     volumes:
         - weaviate_data:/var/lib/weaviate
-    healthcheck:
-        test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/v1/.well-known/ready"]
-        interval: 10s
-        timeout: 5s
-        retries: 5
     networks:
         bifrost_network:
             ipv4_address: 172.38.0.12

--- a/.github/workflows/scripts/test-api-integrations.sh
+++ b/.github/workflows/scripts/test-api-integrations.sh
@@ -102,6 +102,24 @@ if [ $ELAPSED -ge $MAX_WAIT ]; then
   exit 1
 fi
 
+echo "⏳ Waiting for Weaviate readiness via host..."
+WEAVIATE_WAIT=60
+WEAVIATE_ELAPSED=0
+WEAVIATE_READY=false
+while [ $WEAVIATE_ELAPSED -lt $WEAVIATE_WAIT ]; do
+  if curl -fsS -o /dev/null "http://localhost:9000/v1/.well-known/ready"; then
+    WEAVIATE_READY=true
+    echo "✅ Weaviate ready (${WEAVIATE_ELAPSED}s)"
+    break
+  fi
+  sleep 2
+  WEAVIATE_ELAPSED=$((WEAVIATE_ELAPSED + 2))
+done
+if [ "$WEAVIATE_READY" = false ]; then
+  echo "❌ Weaviate failed readiness check within ${WEAVIATE_WAIT}s"
+  exit 1
+fi
+
 echo "🔄 Resetting PostgreSQL database..."
 POSTGRES_CONTAINER=$(docker compose -f "$COMPOSE_FILE" ps -q postgres)
 if [ -n "$POSTGRES_CONTAINER" ]; then

--- a/.github/workflows/scripts/test-bifrost-http.sh
+++ b/.github/workflows/scripts/test-bifrost-http.sh
@@ -139,6 +139,24 @@ if [ "$SERVICES_READY" = false ]; then
   exit 1
 fi
 
+echo "⏳ Waiting for Weaviate readiness via host..."
+WEAVIATE_WAIT=60
+WEAVIATE_ELAPSED=0
+WEAVIATE_READY=false
+while [ $WEAVIATE_ELAPSED -lt $WEAVIATE_WAIT ]; do
+  if curl -fsS -o /dev/null "http://localhost:9000/v1/.well-known/ready"; then
+    WEAVIATE_READY=true
+    echo "✅ Weaviate ready (${WEAVIATE_ELAPSED}s)"
+    break
+  fi
+  sleep 2
+  WEAVIATE_ELAPSED=$((WEAVIATE_ELAPSED + 2))
+done
+if [ "$WEAVIATE_READY" = false ]; then
+  echo "❌ Weaviate failed readiness check within ${WEAVIATE_WAIT}s"
+  exit 1
+fi
+
 for config in "${CONFIGS_TO_TEST[@]}"; do
   echo "  🔍 Testing with config: $config"
   config_path="$CONFIGS_DIR/$config"

--- a/.github/workflows/scripts/test-e2e-ui.sh
+++ b/.github/workflows/scripts/test-e2e-ui.sh
@@ -79,6 +79,24 @@ if [ "$SERVICES_READY" = false ]; then
   exit 1
 fi
 
+echo "⏳ Waiting for Weaviate readiness via host..."
+WEAVIATE_WAIT=60
+WEAVIATE_ELAPSED=0
+WEAVIATE_READY=false
+while [ $WEAVIATE_ELAPSED -lt $WEAVIATE_WAIT ]; do
+  if curl -fsS -o /dev/null "http://localhost:9000/v1/.well-known/ready"; then
+    WEAVIATE_READY=true
+    echo "✅ Weaviate ready (${WEAVIATE_ELAPSED}s)"
+    break
+  fi
+  sleep 2
+  WEAVIATE_ELAPSED=$((WEAVIATE_ELAPSED + 2))
+done
+if [ "$WEAVIATE_READY" = false ]; then
+  echo "❌ Weaviate failed readiness check within ${WEAVIATE_WAIT}s"
+  exit 1
+fi
+
 # Reset PostgreSQL database to clean state
 echo "🧹 Resetting PostgreSQL database..."
 docker exec -e PGPASSWORD=bifrost_password "$(docker compose -f "$CONFIGS_DIR/docker-compose.yml" ps -q postgres)" \


### PR DESCRIPTION
## Summary

Weaviate's Docker healthcheck was unreliable in CI environments because it runs inside the container, which doesn't reflect host-level reachability. This PR removes the Docker-native healthcheck for Weaviate and replaces it with explicit host-side readiness polling in each test script.

## Changes

- Removed the `healthcheck` block from the Weaviate service in `docker-compose.yml`
- Added a host-side readiness loop in `test-api-integrations.sh`, `test-bifrost-http.sh`, and `test-e2e-ui.sh` that polls `http://localhost:9000/v1/.well-known/ready` via `curl` with a 60-second timeout before proceeding with tests

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run any of the affected CI test scripts locally with Docker Compose and verify that the Weaviate readiness check passes before tests proceed:

```sh
bash .github/workflows/scripts/test-bifrost-http.sh
bash .github/workflows/scripts/test-api-integrations.sh
bash .github/workflows/scripts/test-e2e-ui.sh
```

Expected output should include `✅ Weaviate ready (Xs)` before test execution begins. If Weaviate does not become reachable within 60 seconds, the script exits with `❌ Weaviate failed readiness check within 60s`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects CI readiness polling logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable