### PR TITLE
go 1.26.3 upgrade

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Run chart-testing (lint)
         run: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Run CLI tests
         working-directory: cli
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Configure Git
         run: |

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Detect what needs release
         id: detect
@@ -192,7 +192,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -311,7 +311,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Docker Compose
         run: |
@@ -416,7 +416,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Docker Compose
         run: |
@@ -521,7 +521,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -595,7 +595,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -685,7 +685,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -815,7 +815,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -935,7 +935,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1031,7 +1031,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1130,7 +1130,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Configure Git
         run: |
@@ -1250,7 +1250,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1368,7 +1368,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1432,7 +1432,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1501,7 +1501,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/scripts/schemasync/go.mod
+++ b/.github/workflows/scripts/schemasync/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/tools/schema-sync
 
-go 1.26.2
+go 1.26.3
 
 require golang.org/x/tools v0.30.0
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Setup Go workspace
         run: make setup-workspace
@@ -132,7 +132,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Setup Go workspace
         run: make setup-workspace

--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 				-e GOOS=$(TARGET_OS) \
 				-e GOARCH=$(TARGET_ARCH) \
 				 $(if $(LOCAL),,-e GOWORK=off) \
-				golang:1.26.1-alpine3.23 \
+				golang:1.26.3-alpine3.23 \
 				sh -c "apk add --no-cache gcc musl-dev && \
 				go build \
 					-ldflags='-w -s -X main.Version=v$(VERSION)' \
@@ -403,7 +403,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 				-e GOOS=$(TARGET_OS) \
 				-e GOARCH=$(TARGET_ARCH) \
 				 $(if $(LOCAL),,-e GOWORK=off) \
-				golang:1.26.1-alpine3.23 \
+				golang:1.26.3-alpine3.23 \
 				sh -c "apk add --no-cache gcc musl-dev && \
 				go build \
 					-ldflags='-w -s -extldflags "-static" -X main.Version=v$(VERSION)' \

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/cli
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/core
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go v0.123.0

--- a/examples/mcps/auth-demo-server/go.mod
+++ b/examples/mcps/auth-demo-server/go.mod
@@ -1,6 +1,6 @@
 module auth-demo-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/edge-case-server/go.mod
+++ b/examples/mcps/edge-case-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/edge-case-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/error-test-server/go.mod
+++ b/examples/mcps/error-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/error-test-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/go-test-server/go.mod
+++ b/examples/mcps/go-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/go-test-server
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0

--- a/examples/mcps/http-no-ping-server/go.mod
+++ b/examples/mcps/http-no-ping-server/go.mod
@@ -1,6 +1,6 @@
 module http-no-ping-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/oauth-demo-server/go.mod
+++ b/examples/mcps/oauth-demo-server/go.mod
@@ -1,6 +1,6 @@
 module oauth-demo-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/parallel-test-server/go.mod
+++ b/examples/mcps/parallel-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/parallel-test-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/plugins/hello-world-wasm-go/go.mod
+++ b/examples/plugins/hello-world-wasm-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/hello-world-wasm
 
-go 1.26.2
+go 1.26.3
 
 require github.com/maximhq/bifrost/core v1.4.17
 

--- a/examples/plugins/hello-world/Makefile
+++ b/examples/plugins/hello-world/Makefile
@@ -127,7 +127,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 			-e CGO_ENABLED=1 \
 			-e GOOS=$(TARGET_OS) \
 			-e GOARCH=$(TARGET_ARCH) \
-			golang:1.26.1-alpine3.23 \
+			golang:1.26.3-alpine3.23 \
 			sh -c "apk add --no-cache gcc musl-dev && \
 				go build -buildmode=plugin -ldflags='-w -s' -trimpath -o $(OUTPUT) main.go"; \
 		echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT) ($(TARGET_OS)/$(TARGET_ARCH))$(COLOR_RESET)"; \

--- a/examples/plugins/hello-world/go.mod
+++ b/examples/plugins/hello-world/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/hello-world
 
-go 1.26.2
+go 1.26.3
 
 require github.com/maximhq/bifrost/core v1.5.12
 

--- a/examples/plugins/http-transport-only/go.mod
+++ b/examples/plugins/http-transport-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/http-transport-only
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/examples/plugins/llm-only/go.mod
+++ b/examples/plugins/llm-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/llm-only
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/examples/plugins/mcp-only/go.mod
+++ b/examples/plugins/mcp-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/mcp-only
 
-go 1.26.2
+go 1.26.3
 
 require github.com/maximhq/bifrost/core v1.5.12
 

--- a/examples/plugins/multi-interface/go.mod
+++ b/examples/plugins/multi-interface/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/multi-interface
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/framework
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go/storage v1.61.3

--- a/plugins/compat/go.mod
+++ b/plugins/compat/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/compat
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/plugins/governance/go.mod
+++ b/plugins/governance/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/governance
 
-go 1.26.2
+go 1.26.3
 
 require gorm.io/gorm v1.31.1
 

--- a/plugins/jsonparser/go.mod
+++ b/plugins/jsonparser/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/jsonparser
 
-go 1.26.2
+go 1.26.3
 
 require github.com/maximhq/bifrost/core v1.5.12
 

--- a/plugins/logging/go.mod
+++ b/plugins/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/logging
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/plugins/maxim/go.mod
+++ b/plugins/maxim/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/maxim
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/maximhq/bifrost/core v1.5.12

--- a/plugins/mocker/go.mod
+++ b/plugins/mocker/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/mocker
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/jaswdr/faker/v2 v2.8.0

--- a/plugins/otel/go.mod
+++ b/plugins/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/otel
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/maximhq/bifrost/core v1.5.12

--- a/plugins/prompts/go.mod
+++ b/plugins/prompts/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/prompts
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/maximhq/bifrost/core v1.5.12

--- a/plugins/semanticcache/go.mod
+++ b/plugins/semanticcache/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/semanticcache
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/plugins/telemetry/go.mod
+++ b/plugins/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/telemetry
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/tests/async/go.mod
+++ b/tests/async/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/async
 
-go 1.26.2
+go 1.26.3

--- a/tests/governance/go.mod
+++ b/tests/governance/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/governance
 
-go 1.26.2
+go 1.26.3

--- a/tests/scripts/1millogs/go.mod
+++ b/tests/scripts/1millogs/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/tests/scripts/1millogs
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/maximhq/bifrost/core v1.4.18

--- a/tests/scripts/migration-checker/go.mod
+++ b/tests/scripts/migration-checker/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/scripts/migration-checker
 
-go 1.26.2
+go 1.26.3

--- a/tests/semanticcache/go.mod
+++ b/tests/semanticcache/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/semanticcache
 
-go 1.26.2
+go 1.26.3

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -17,7 +17,7 @@
   # Skip the copy-build step since we'll copy the files in the Go build stage
   
   # --- Go Build Stage: Compile the Go binary ---
-  FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+  FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
   WORKDIR /app
   
   # Install dependencies including gcc for CGO and sqlite (with latest security patches)
@@ -51,7 +51,7 @@
   RUN test -f /app/main || (echo "Build failed" && exit 1)
   
   # --- Runtime Stage: Minimal runtime image ---
-  FROM alpine:3.21.7@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+  FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
   WORKDIR /app
   
   # Install runtime dependencies for CGO-enabled binary

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -17,7 +17,7 @@
   # Skip the copy-build step since we'll copy the files in the Go build stage
 
   # --- Go Build Stage: Compile the Go binary using local modules ---
-  FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+  FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
   WORKDIR /build
 
   # Install dependencies including gcc for CGO and sqlite
@@ -65,7 +65,7 @@
   RUN test -f /app/main || (echo "Build failed" && exit 1)
 
   # --- Runtime Stage: Minimal runtime image ---
-  FROM alpine:3.21.7@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+  FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
   WORKDIR /app
 
   # Install runtime dependencies for CGO-enabled binary

--- a/transports/Dockerfile.redhat
+++ b/transports/Dockerfile.redhat
@@ -17,7 +17,7 @@ RUN npm run build-enterprise
 # Skip the copy-build step since we'll copy the files in the Go build stage
 
 # --- Go Build Stage: Compile the Go binary ---
-FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 WORKDIR /app
 
 # Install dependencies including gcc for CGO and sqlite (with latest security patches)

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/transports
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain version from `1.26.2` to `1.26.3` across all modules and Docker build images, and upgrades the Alpine runtime base image from `3.21.7` to `3.23.4` in the transport Dockerfiles.

## Changes

- Updated all `go.mod` files across core, CLI, transports, plugins, examples, framework, and test modules to require Go `1.26.3`
- Updated Docker build stages in `Dockerfile`, `Dockerfile.local`, and `Dockerfile.redhat` to use `golang:1.26.3-alpine3.23` with the corresponding new digest
- Updated the runtime stage in `Dockerfile` and `Dockerfile.local` from `alpine:3.21.7` to `alpine:3.23.4` with the corresponding new digest
- Updated `Makefile` targets (root and `examples/plugins/hello-world`) to use `golang:1.26.3-alpine3.23` for Docker-based cross-compilation

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Verify Docker builds succeed:

```sh
docker build -f transports/Dockerfile .
docker build -f transports/Dockerfile.local .
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The Alpine runtime base image upgrade from `3.21.7` to `3.23.4` incorporates upstream security patches available in the newer Alpine release.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable