### PR TITLE
feat: add `tlsConfig` (insecureSkipVerify, caCertPem) for HTTP/SSE MCP client connections in Bifrost Helm chart

### DIFF
--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -8,6 +8,13 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ## Changelog
 
+### Upcoming
+
+- **[Upcoming]** Added `tlsConfig` to `bifrost.mcp.clientConfigs[]` for HTTP and SSE MCP connection types:
+  - `insecureSkipVerify` — disable TLS certificate verification (development/testing only; takes priority over `caCertPem`).
+  - `caCertPem` — PEM-encoded CA certificate for MCP servers that use a self-signed or private CA. Accepts a literal PEM string or an `env.VAR_NAME` reference (e.g. `"env.MY_MCP_CA_CERT"`).
+  - Chart maps `tlsConfig.insecureSkipVerify` → `tls_config.insecure_skip_verify` and `tlsConfig.caCertPem` → `tls_config.ca_cert_pem` in the generated config JSON.
+
 ### 2.1.19
 
 - Added `bifrost.modelCatalog.modelParametersUrl` to `values.yaml`, `values.schema.json`, and `_helpers.tpl`, allowing operators to override the URL Bifrost uses to fetch model parameter definitions.
@@ -644,6 +651,8 @@ bifrost:
 | `bifrost.mcp.toolManagerConfig.codeModeBindingLevel`  | Code mode binding level (`server` or `tool`)                                                                                                                                                  | `server` |
 | `bifrost.mcp.toolManagerConfig.disableAutoToolInject` | Disable automatic MCP tool injection                                                                                                                                                          | `false`  |
 | `bifrost.mcp.toolSyncInterval`                        | Global MCP tool sync interval. Prefer a Go duration string (for example, `10m`); legacy numeric nanoseconds are still supported for backward compatibility, but string format is recommended. | `10m`    |
+| `bifrost.mcp.clientConfigs[].tlsConfig.insecureSkipVerify` | **[Upcoming]** Disable TLS certificate verification for HTTP/SSE MCP connections. Takes priority over `caCertPem`. For development/testing only — not recommended for production. | `false`  |
+| `bifrost.mcp.clientConfigs[].tlsConfig.caCertPem`    | **[Upcoming]** PEM-encoded CA certificate to trust for HTTP/SSE MCP server connections. Accepts a literal PEM string or an `env.VAR_NAME` reference. Use when the MCP server uses a self-signed or private CA. | `""`     |
 
 #### MCP Migration Guide (`client.mcp*` -> `mcp.*`)
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -953,6 +953,19 @@ false
 {{- if hasKey $client "allowOnAllVirtualKeys" }}
 {{- $_ := set $cc "allow_on_all_virtual_keys" $client.allowOnAllVirtualKeys }}
 {{- end }}
+{{- /* Map tlsConfig -> tls_config (only for http/sse/websocket connection types) */ -}}
+{{- if and $client.tlsConfig (or (eq $client.connectionType "http") (eq $client.connectionType "sse") (eq $client.connectionType "websocket")) }}
+{{- $tls := dict }}
+{{- if hasKey $client.tlsConfig "insecureSkipVerify" }}
+{{- $_ := set $tls "insecure_skip_verify" $client.tlsConfig.insecureSkipVerify }}
+{{- end }}
+{{- if $client.tlsConfig.caCertPem }}
+{{- $_ := set $tls "ca_cert_pem" $client.tlsConfig.caCertPem }}
+{{- end }}
+{{- if $tls }}
+{{- $_ := set $cc "tls_config" $tls }}
+{{- end }}
+{{- end }}
 {{- /* Override connection_string with env var placeholder when secretRef is set */ -}}
 {{- if and $client.secretRef $client.secretRef.name }}
 {{- $envName := printf "BIFROST_MCP_%s_CONNECTION_STRING" (regexReplaceAll "[^A-Z0-9]+" (upper $client.name) "_") }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3968,6 +3968,22 @@
           "type": "boolean",
           "description": "When true, this MCP server is accessible to all virtual keys without requiring explicit per-key assignment.",
           "default": false
+        },
+        "tlsConfig": {
+          "type": "object",
+          "description": "[Upcoming] TLS configuration for HTTP and SSE connection types. Not applicable to stdio or inprocess.",
+          "properties": {
+            "insecureSkipVerify": {
+              "type": "boolean",
+              "description": "Disable TLS certificate verification. Takes priority over caCertPem. Development/testing only.",
+              "default": false
+            },
+            "caCertPem": {
+              "type": "string",
+              "description": "PEM-encoded CA certificate for MCP server connections. Accepts a literal PEM string or an env.VAR_NAME reference."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": ["name", "connectionType"],

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -374,6 +374,15 @@ bifrost:
       #   secretRef:
       #     name: ""                               # k8s secret name
       #     connectionStringKey: "connection-string"  # key within the secret
+      #
+      # - name: "example-https-mcp"
+      #   connectionType: "http"
+      #   connectionString: "https://my-internal-mcp.corp/mcp"
+      #   # TLS configuration for HTTP and SSE connection types.
+      #   # Use when the MCP server presents a self-signed or private CA certificate.
+      #   tlsConfig:
+      #     insecureSkipVerify: false              # Disable TLS verification (dev/test only — takes priority over caCertPem)
+      #     caCertPem: "env.MY_MCP_CA_CERT"       # PEM string or env.VAR_NAME reference
     # toolSyncInterval: "10m"   # Global tool sync interval (Go duration string, e.g. "10m", "1h", "0s")
     # Tool manager configuration
     toolManagerConfig:

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2910,6 +2910,21 @@
           "type": "boolean",
           "description": "When true, this MCP client is disabled (connection and workers are stopped while preserving configuration).",
           "default": false
+        },
+        "tls_config": {
+          "type": "object",
+          "description": "TLS configuration for HTTP and SSE connections. Not applicable to stdio or inprocess connection types.",
+          "properties": {
+            "insecure_skip_verify": {
+              "type": "boolean",
+              "description": "Disable TLS certificate verification. Takes priority over ca_cert_pem when both are set. Use only in development or trusted isolated environments. Not recommended for production."
+            },
+            "ca_cert_pem": {
+              "type": "string",
+              "description": "PEM-encoded CA certificate to trust for MCP server connections. Use when the MCP server uses a self-signed or private CA certificate. Supports env.VAR_NAME syntax to read the certificate from an environment variable."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": ["name", "connection_type"],


### PR DESCRIPTION
## Summary

Adds TLS configuration support (`tlsConfig`) for HTTP and SSE MCP client connections in the Bifrost Helm chart, allowing operators to connect to MCP servers that use self-signed or private CA certificates, or to disable TLS verification in development/testing environments.

## Changes

- Added `tls_config` object to the MCP client config JSON schema (`config.schema.json`) with `insecure_skip_verify` and `ca_cert_pem` fields.
- Updated `_helpers.tpl` to map `tlsConfig.insecureSkipVerify` → `tls_config.insecure_skip_verify` and `tlsConfig.caCertPem` → `tls_config.ca_cert_pem` in the generated config JSON.
- Added a commented example `tlsConfig` block in `values.yaml` for the `clientConfigs[]` array.
- Documented the new fields in `README.md` under an "Upcoming" changelog entry and the values reference table.
- `caCertPem` supports both a literal PEM string and an `env.VAR_NAME` reference for reading the certificate from an environment variable.
- `insecureSkipVerify` takes priority over `caCertPem` when both are set; it is intended for development/testing only and is not recommended for production.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy the Helm chart with an MCP client config that uses a self-signed CA certificate:

```yaml
bifrost:
  mcp:
    clientConfigs:
      - name: "example-https-mcp"
        connectionType: "http"
        connectionString: "https://my-internal-mcp.corp/mcp"
        tlsConfig:
          insecureSkipVerify: false
          caCertPem: "env.MY_MCP_CA_CERT"
```

Verify the generated ConfigMap contains the expected `tls_config` JSON:

```sh
helm template . -f values.yaml | grep -A5 tls_config
```

Expected output should include:
```json
"tls_config": {
  "insecure_skip_verify": false,
  "ca_cert_pem": "env.MY_MCP_CA_CERT"
}
```

**New config fields:**

| Field | Description | Default |
|---|---|---|
| `bifrost.mcp.clientConfigs[].tlsConfig.insecureSkipVerify` | Disable TLS certificate verification (dev/test only) | `false` |
| `bifrost.mcp.clientConfigs[].tlsConfig.caCertPem` | PEM-encoded CA cert or `env.VAR_NAME` reference | `""` |

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

- `insecureSkipVerify: true` disables TLS certificate verification entirely and should never be used in production environments. This is documented explicitly in the schema, README, and values comments.
- `caCertPem` supports `env.VAR_NAME` references to avoid embedding sensitive certificate material directly in Helm values.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable