### PR TITLE
fixes docker manifest script for hardenend runner

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1725,6 +1725,7 @@ jobs:
             auth.docker.io:443
             github.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
 
       - name: Checkout repository
@@ -1946,6 +1947,7 @@ jobs:
             auth.docker.io:443
             github.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
 
       - name: Checkout repository

--- a/.github/workflows/scripts/create-docker-manifest-ubi9.sh
+++ b/.github/workflows/scripts/create-docker-manifest-ubi9.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 if [ "${1:-}" = "" ]; then
   echo "Usage: $0 <version>" >&2
   exit 1
@@ -9,24 +12,24 @@ ACCOUNT="maximhq"
 IMAGE_NAME="bifrost"
 IMAGE="${REGISTRY}/${ACCOUNT}/${IMAGE_NAME}"
 
-AMD64_DIGEST=$(docker manifest inspect ${IMAGE}:v${VERSION}-ubi9-amd64 | jq -r '.manifests[0].digest')
-ARM64_DIGEST=$(docker manifest inspect ${IMAGE}:v${VERSION}-ubi9-arm64 | jq -r '.manifests[0].digest')
+AMD64_DIGEST=$(docker manifest inspect "${IMAGE}:v${VERSION}-ubi9-amd64" | jq -er '.manifests[0].digest')
+ARM64_DIGEST=$(docker manifest inspect "${IMAGE}:v${VERSION}-ubi9-arm64" | jq -er '.manifests[0].digest')
 
 echo "UBI9 AMD64 digest: ${AMD64_DIGEST}"
 echo "UBI9 ARM64 digest: ${ARM64_DIGEST}"
 
 docker manifest create \
-    ${IMAGE}:v${VERSION}-ubi9 \
-    ${IMAGE}@${AMD64_DIGEST} \
-    ${IMAGE}@${ARM64_DIGEST}
+    "${IMAGE}:v${VERSION}-ubi9" \
+    "${IMAGE}@${AMD64_DIGEST}" \
+    "${IMAGE}@${ARM64_DIGEST}"
 
-docker manifest push ${IMAGE}:v${VERSION}-ubi9
+docker manifest push "${IMAGE}:v${VERSION}-ubi9"
 
 if [[ "$VERSION" != *-* ]]; then
     docker manifest create \
-        ${IMAGE}:latest-ubi9 \
-        ${IMAGE}@${AMD64_DIGEST} \
-        ${IMAGE}@${ARM64_DIGEST}
+        "${IMAGE}:latest-ubi9" \
+        "${IMAGE}@${AMD64_DIGEST}" \
+        "${IMAGE}@${ARM64_DIGEST}"
 
-    docker manifest push ${IMAGE}:latest-ubi9
+    docker manifest push "${IMAGE}:latest-ubi9"
 fi

--- a/.github/workflows/scripts/create-docker-manifest.sh
+++ b/.github/workflows/scripts/create-docker-manifest.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 # Validate input argument
 if [ "${1:-}" = "" ]; then
   echo "Usage: $0 <version>" >&2
@@ -11,26 +14,26 @@ IMAGE_NAME="bifrost"
 IMAGE="${REGISTRY}/${ACCOUNT}/${IMAGE_NAME}"
 
 # Get the actual image digests from the platform-specific builds
-AMD64_DIGEST=$(docker manifest inspect ${IMAGE}:v${VERSION}-amd64 | jq -r '.manifests[0].digest')
-ARM64_DIGEST=$(docker manifest inspect ${IMAGE}:v${VERSION}-arm64 | jq -r '.manifests[0].digest')
+AMD64_DIGEST=$(docker manifest inspect "${IMAGE}:v${VERSION}-amd64" | jq -er '.manifests[0].digest')
+ARM64_DIGEST=$(docker manifest inspect "${IMAGE}:v${VERSION}-arm64" | jq -er '.manifests[0].digest')
 
 echo "AMD64 digest: ${AMD64_DIGEST}"
 echo "ARM64 digest: ${ARM64_DIGEST}"
 
 # Create manifest for versioned tag using digests
 docker manifest create \
-    ${IMAGE}:v${VERSION} \
-    ${IMAGE}@${AMD64_DIGEST} \
-    ${IMAGE}@${ARM64_DIGEST}
+    "${IMAGE}:v${VERSION}" \
+    "${IMAGE}@${AMD64_DIGEST}" \
+    "${IMAGE}@${ARM64_DIGEST}"
 
-docker manifest push ${IMAGE}:v${VERSION}
+docker manifest push "${IMAGE}:v${VERSION}"
 
 # Create latest manifest only for stable versions
 if [[ "$VERSION" != *-* ]]; then
     docker manifest create \
-        ${IMAGE}:latest \
-        ${IMAGE}@${AMD64_DIGEST} \
-        ${IMAGE}@${ARM64_DIGEST}
+        "${IMAGE}:latest" \
+        "${IMAGE}@${AMD64_DIGEST}" \
+        "${IMAGE}@${ARM64_DIGEST}"
     
-    docker manifest push ${IMAGE}:latest
+    docker manifest push "${IMAGE}:latest"
 fi


### PR DESCRIPTION
## Summary

Fixes intermittent Docker registry connectivity issues in the release pipeline and hardens the Docker manifest shell scripts.

## Changes

- Added `production.cloudfront.docker.com:443` to the allowed egress hosts in the release pipeline workflow, alongside the existing `production.cloudflare.docker.com:443` entry, to ensure Docker registry pulls succeed regardless of which CDN endpoint is used.
- Added `#!/usr/bin/env bash` shebang and `set -euo pipefail` to both `create-docker-manifest.sh` and `create-docker-manifest-ubi9.sh` so the scripts fail fast on errors, unset variables, or pipeline failures.
- Quoted all variable expansions in both manifest scripts to prevent word splitting and globbing issues.
- Switched `jq -r` to `jq -er` so that `jq` exits with a non-zero status if the extracted digest value is null or empty, preventing silent failures when building manifests.
- Added a trailing newline to `create-docker-manifest.sh`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger a release pipeline run and verify that Docker manifest creation completes successfully for both standard and UBI9 images across amd64 and arm64 platforms.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Changes are limited to CI workflow egress rules and shell script robustness.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable