### PR TITLE
release pipeline changes

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -2070,6 +2070,8 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             _http._tcp.azure.archive.ubuntu.com:443
+            _https._tcp.dl.google.com:443
+            motd.ubuntu.com:443
             _https._tcp.esm.ubuntu.com:443
             _https._tcp.motd.ubuntu.com:443
             _https._tcp.packages.microsoft.com:443


### PR DESCRIPTION
## Summary

Adds missing allowed endpoints to the release pipeline's network egress policy to unblock CI steps that require access to Google's download servers and Ubuntu's MOTD service.

## Changes

- Added `_https._tcp.dl.google.com:443` to the allowed egress endpoints to permit downloads from Google (e.g., toolchain or dependency fetches)
- Added `motd.ubuntu.com:443` (non-prefixed form) alongside the existing `_https._tcp.motd.ubuntu.com:443` entry to ensure the Ubuntu MOTD endpoint is reachable regardless of how it is resolved

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger the release pipeline and verify that no network egress policy violations occur for `dl.google.com` or `motd.ubuntu.com`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The egress allowlist is being expanded minimally and only to well-known, trusted endpoints (`dl.google.com` and `motd.ubuntu.com`). No secrets or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable