### PR TITLE
plugins/telemetry: add disabled_labels config to drop high-cardinality defaults

### DIFF
--- a/.github/workflows/scripts/validate-helm-schema.sh
+++ b/.github/workflows/scripts/validate-helm-schema.sh
@@ -643,6 +643,7 @@ check_property_exists "cluster.region" ".properties.bifrost.properties.cluster.p
 echo ""
 echo "  Checking miscellaneous properties (Gap 8)..."
 check_property_exists "telemetry.custom_labels" ".properties.bifrost.properties.plugins.properties.telemetry.properties.config.properties.custom_labels" "$HELM_SCHEMA"
+check_property_exists "telemetry.disabled_labels" ".properties.bifrost.properties.plugins.properties.telemetry.properties.config.properties.disabled_labels" "$HELM_SCHEMA"
 check_property_exists "semanticCache.default_cache_key" ".properties.bifrost.properties.plugins.properties.semanticCache.properties.config.properties.default_cache_key" "$HELM_SCHEMA"
 
 # Also verify these exist in config.schema.json

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -226,6 +226,35 @@ All Bifrost metrics include these labels:
   **v1.5.0-prerelease4+**: `selected_key_id` / `selected_key_name` are only populated when the request succeeds. On final errors both are empty - use `bifrost_key_rotation_events_total` or the `attempt_trail` log field to see which keys were tried.
 </Note>
 
+### Disabling Default Labels
+
+Some default labels carry unbounded cardinality in certain deployment patterns. The most common one is operators who mint a separate Bifrost virtual key per upstream request — `virtual_key_id` and `virtual_key_name` then grow proportional to total request count, multiplied by every histogram's `le` bucket count, and the scrape body grows fast enough to OOM the agent doing the scrape.
+
+`disabled_labels` lets you omit any default Bifrost or HTTP label from every metric. Per-request drilldown should live in logs / traces, not in metric labels — Prometheus is for aggregates.
+
+```json
+{
+  "plugins": [
+    {
+      "name": "telemetry",
+      "enabled": true,
+      "config": {
+        "disabled_labels": [
+          "virtual_key_id",
+          "virtual_key_name"
+        ]
+      }
+    }
+  ]
+}
+```
+
+The match is the same hyphen/underscore-insensitive match used by `custom_labels`, so `"virtual-key-id"` and `"virtual_key_id"` both work. Names not present in the default label set are silently ignored. A `custom_labels` entry that names the same label is also dropped (with a log message), so the disable wins.
+
+<Warning>
+  Disabling a label is a breaking change for any dashboard / alert that groups by it. Check downstream queries before rolling out.
+</Warning>
+
 ### Key Rotation Events <sup>v1.5.0-prerelease4+</sup>
 
 `bifrost_key_rotation_events_total` is incremented once per **failed attempt** (not per request), giving you time-series visibility into retry pressure:

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -591,6 +591,13 @@
                       },
                       "description": "Custom labels to add to all metrics"
                     },
+                    "disabled_labels": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Default labels to omit from every metric. Use to drop high-cardinality defaults (e.g. virtual_key_id / virtual_key_name) when a deployment pattern would otherwise blow up histogram series counts. Same hyphen/underscore-insensitive match as custom_labels."
+                    },
                     "push_gateway": {
                       "type": "object",
                       "description": "Configuration for pushing metrics to a Prometheus Push Gateway for multi-node cluster deployments",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -390,6 +390,16 @@ bifrost:
       version: 1
       config:
         custom_labels: []
+        # Default labels to omit from every metric. Use this when a default
+        # label carries unbounded cardinality for your deployment — e.g. you
+        # mint a Bifrost virtual key per upstream request, in which case
+        # `virtual_key_id` / `virtual_key_name` will blow up histogram series
+        # counts proportional to request volume × bucket count and the scrape
+        # body will grow fast enough to OOM the Prometheus agent. Per-request
+        # drilldown should live in logs / traces, not metric labels.
+        # Names use the same hyphen/underscore-insensitive match as
+        # `custom_labels`. See docs/features/observability/prometheus.mdx.
+        disabled_labels: []
         # push_gateway:
         #   enabled: false
         #   push_gateway_url: ""

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -390,15 +390,7 @@ bifrost:
       version: 1
       config:
         custom_labels: []
-        # Default labels to omit from every metric. Use this when a default
-        # label carries unbounded cardinality for your deployment — e.g. you
-        # mint a Bifrost virtual key per upstream request, in which case
-        # `virtual_key_id` / `virtual_key_name` will blow up histogram series
-        # counts proportional to request volume × bucket count and the scrape
-        # body will grow fast enough to OOM the Prometheus agent. Per-request
-        # drilldown should live in logs / traces, not metric labels.
-        # Names use the same hyphen/underscore-insensitive match as
-        # `custom_labels`. See docs/features/observability/prometheus.mdx.
+        # docs/features/observability/prometheus.mdx#disabling-default-labels
         disabled_labels: []
         # push_gateway:
         #   enabled: false

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -188,22 +188,8 @@ type PrometheusPlugin struct {
 }
 
 type Config struct {
-	CustomLabels []string `json:"custom_labels"`
-	// DisabledLabels lists default labels to omit from every Bifrost and HTTP
-	// metric. Use this when a default label carries unbounded cardinality for
-	// your deployment — e.g. operators who mint a Bifrost virtual key per
-	// upstream request will see `virtual_key_id` / `virtual_key_name` blow up
-	// histogram series counts proportional to request volume × bucket count,
-	// at which point the scrape body grows fast enough to OOM the Prometheus
-	// agent doing the scrape. Disabling those labels is the supported escape
-	// hatch — per-request drilldown should live in logs / traces, not metric
-	// labels. Names are matched against `defaultBifrostLabels` and
-	// `defaultHTTPLabels` using the same hyphen/underscore-insensitive rule
-	// as `CustomLabels`.
-	//
-	// Disabling a label is a breaking change for any dashboard / alert that
-	// groups by it; verify before rolling out.
-	DisabledLabels []string `json:"disabled_labels"`
+	CustomLabels   []string `json:"custom_labels"`
+	DisabledLabels []string `json:"disabled_labels"` // see docs/features/observability/prometheus.mdx
 	Registry       *prometheus.Registry
 	PushGateway    *PushGatewayConfig `json:"push_gateway"`
 	// MetricsEnabled controls whether the /metrics scrape endpoint is served.
@@ -286,9 +272,8 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		"customer_name",
 	}
 
-	// Strip operator-disabled defaults BEFORE registering metrics. Once a
-	// MetricVec is created with a label set, prom-client rejects any later
-	// attempt to omit a registered label, so this has to happen up front.
+	// Filter disabled defaults before any MetricVec is registered: prom-client
+	// rejects later attempts to omit a registered label.
 	if len(config.DisabledLabels) > 0 {
 		defaultBifrostLabels = filterDisabledLabels(defaultBifrostLabels, config.DisabledLabels, "default Bifrost", logger)
 		defaultHTTPLabels = filterDisabledLabels(defaultHTTPLabels, config.DisabledLabels, "default HTTP", logger)
@@ -301,8 +286,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 			case containsLabel(defaultBifrostLabels, label) || containsLabel(defaultHTTPLabels, label):
 				logger.Info("custom label %s is already a default label, it will be ignored", label)
 			case containsLabel(config.DisabledLabels, label):
-				// Don't let a custom label silently re-add a label the operator
-				// just disabled — the disable wins.
+				// disabled_labels wins; otherwise a stale custom_labels entry could re-add what an operator just disabled.
 				logger.Info("custom label %s is disabled via disabled_labels, it will be ignored", label)
 			default:
 				filteredCustomLabels = append(filteredCustomLabels, label)

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -189,8 +189,23 @@ type PrometheusPlugin struct {
 
 type Config struct {
 	CustomLabels []string `json:"custom_labels"`
-	Registry     *prometheus.Registry
-	PushGateway  *PushGatewayConfig `json:"push_gateway"`
+	// DisabledLabels lists default labels to omit from every Bifrost and HTTP
+	// metric. Use this when a default label carries unbounded cardinality for
+	// your deployment — e.g. operators who mint a Bifrost virtual key per
+	// upstream request will see `virtual_key_id` / `virtual_key_name` blow up
+	// histogram series counts proportional to request volume × bucket count,
+	// at which point the scrape body grows fast enough to OOM the Prometheus
+	// agent doing the scrape. Disabling those labels is the supported escape
+	// hatch — per-request drilldown should live in logs / traces, not metric
+	// labels. Names are matched against `defaultBifrostLabels` and
+	// `defaultHTTPLabels` using the same hyphen/underscore-insensitive rule
+	// as `CustomLabels`.
+	//
+	// Disabling a label is a breaking change for any dashboard / alert that
+	// groups by it; verify before rolling out.
+	DisabledLabels []string `json:"disabled_labels"`
+	Registry       *prometheus.Registry
+	PushGateway    *PushGatewayConfig `json:"push_gateway"`
 	// MetricsEnabled controls whether the /metrics scrape endpoint is served.
 	MetricsEnabled *bool `json:"metrics_enabled,omitempty"`
 }
@@ -271,13 +286,26 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		"customer_name",
 	}
 
+	// Strip operator-disabled defaults BEFORE registering metrics. Once a
+	// MetricVec is created with a label set, prom-client rejects any later
+	// attempt to omit a registered label, so this has to happen up front.
+	if len(config.DisabledLabels) > 0 {
+		defaultBifrostLabels = filterDisabledLabels(defaultBifrostLabels, config.DisabledLabels, "default Bifrost", logger)
+		defaultHTTPLabels = filterDisabledLabels(defaultHTTPLabels, config.DisabledLabels, "default HTTP", logger)
+	}
+
 	var filteredCustomLabels []string
 	if len(config.CustomLabels) > 0 {
 		for _, label := range config.CustomLabels {
-			if !containsLabel(defaultBifrostLabels, label) && !containsLabel(defaultHTTPLabels, label) {
-				filteredCustomLabels = append(filteredCustomLabels, label)
-			} else {
+			switch {
+			case containsLabel(defaultBifrostLabels, label) || containsLabel(defaultHTTPLabels, label):
 				logger.Info("custom label %s is already a default label, it will be ignored", label)
+			case containsLabel(config.DisabledLabels, label):
+				// Don't let a custom label silently re-add a label the operator
+				// just disabled — the disable wins.
+				logger.Info("custom label %s is disabled via disabled_labels, it will be ignored", label)
+			default:
+				filteredCustomLabels = append(filteredCustomLabels, label)
 			}
 		}
 	}

--- a/plugins/telemetry/utils.go
+++ b/plugins/telemetry/utils.go
@@ -80,16 +80,14 @@ func safeObserve(histogram *prometheus.HistogramVec, value float64, labels ...st
 }
 
 // filterDisabledLabels returns labels with any entry present in disabled
-// removed (using the same hyphen/underscore-insensitive match as
-// containsLabel). It logs each disabled default at info level so operators
-// can see the effective label set on plugin startup. setName is the
-// human-readable label set name used in the log message
-// (e.g. "default Bifrost", "default HTTP").
+// removed, using containsLabel's hyphen/underscore-insensitive match.
 func filterDisabledLabels(labels, disabled []string, setName string, logger schemas.Logger) []string {
 	if len(disabled) == 0 {
 		return labels
 	}
-	out := labels[:0:0] // new backing array; never alias the caller's slice
+	// Cap-clip ([:0:0]) so a downstream `append(defaultBifrostLabels, ...)`
+	// can't write through the caller's backing array.
+	out := labels[:0:0]
 	for _, label := range labels {
 		if containsLabel(disabled, label) {
 			logger.Info("%s label %s is disabled via disabled_labels, it will be omitted from all metrics", setName, label)

--- a/plugins/telemetry/utils.go
+++ b/plugins/telemetry/utils.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"strings"
 
+	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/valyala/fasthttp"
 )
@@ -76,6 +77,27 @@ func safeObserve(histogram *prometheus.HistogramVec, value float64, labels ...st
 			metric.Observe(value)
 		}
 	}
+}
+
+// filterDisabledLabels returns labels with any entry present in disabled
+// removed (using the same hyphen/underscore-insensitive match as
+// containsLabel). It logs each disabled default at info level so operators
+// can see the effective label set on plugin startup. setName is the
+// human-readable label set name used in the log message
+// (e.g. "default Bifrost", "default HTTP").
+func filterDisabledLabels(labels, disabled []string, setName string, logger schemas.Logger) []string {
+	if len(disabled) == 0 {
+		return labels
+	}
+	out := labels[:0:0] // new backing array; never alias the caller's slice
+	for _, label := range labels {
+		if containsLabel(disabled, label) {
+			logger.Info("%s label %s is disabled via disabled_labels, it will be omitted from all metrics", setName, label)
+			continue
+		}
+		out = append(out, label)
+	}
+	return out
 }
 
 // containsLabel checks if a string slice contains a specific label, ignoring differences

--- a/plugins/telemetry/utils_test.go
+++ b/plugins/telemetry/utils_test.go
@@ -1,0 +1,112 @@
+package telemetry
+
+import (
+	"reflect"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// recordingLogger captures Info messages for assertions; all other levels noop.
+type recordingLogger struct {
+	infoMsgs []string
+}
+
+func (l *recordingLogger) Debug(string, ...any)            {}
+func (l *recordingLogger) Info(format string, args ...any) { l.infoMsgs = append(l.infoMsgs, format) }
+func (l *recordingLogger) Warn(string, ...any)             {}
+func (l *recordingLogger) Error(string, ...any)            {}
+func (l *recordingLogger) Fatal(string, ...any)            {}
+func (l *recordingLogger) SetLevel(schemas.LogLevel)       {}
+func (l *recordingLogger) SetOutputType(schemas.LoggerOutputType) {
+}
+
+func (l *recordingLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func TestFilterDisabledLabels(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		labels   []string
+		disabled []string
+		want     []string
+		wantLogs int
+	}{
+		{
+			name:     "empty disabled list is a no-op",
+			labels:   []string{"provider", "model", "virtual_key_id"},
+			disabled: nil,
+			want:     []string{"provider", "model", "virtual_key_id"},
+			wantLogs: 0,
+		},
+		{
+			name:     "drops exact matches",
+			labels:   []string{"provider", "model", "virtual_key_id", "virtual_key_name"},
+			disabled: []string{"virtual_key_id", "virtual_key_name"},
+			want:     []string{"provider", "model"},
+			wantLogs: 2,
+		},
+		{
+			name: "matches across hyphen/underscore variants",
+			// Operators write hyphenated names ("virtual-key-id") in helm
+			// values; the registered labels use underscores. containsLabel
+			// already normalises both directions; this asserts the filter
+			// inherits that.
+			labels:   []string{"virtual_key_id", "team_id"},
+			disabled: []string{"virtual-key-id"},
+			want:     []string{"team_id"},
+			wantLogs: 1,
+		},
+		{
+			name:     "preserves order of remaining labels",
+			labels:   []string{"a", "b", "c", "d", "e"},
+			disabled: []string{"b", "d"},
+			want:     []string{"a", "c", "e"},
+			wantLogs: 2,
+		},
+		{
+			name:     "unknown disabled label is silently ignored",
+			labels:   []string{"provider", "model"},
+			disabled: []string{"not_a_real_label"},
+			want:     []string{"provider", "model"},
+			wantLogs: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			logger := &recordingLogger{}
+			got := filterDisabledLabels(tc.labels, tc.disabled, "test", logger)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			if len(logger.infoMsgs) != tc.wantLogs {
+				t.Fatalf("got %d info logs, want %d (%v)", len(logger.infoMsgs), tc.wantLogs, logger.infoMsgs)
+			}
+		})
+	}
+}
+
+// Asserts the filter never aliases the caller's slice — important because the
+// returned slice is later passed to promauto.NewHistogramVec etc. via
+// `append(defaultBifrostLabels, filteredCustomLabels...)` and we do not want a
+// later `append` to corrupt the original `defaultBifrostLabels` backing array.
+func TestFilterDisabledLabels_DoesNotAliasInput(t *testing.T) {
+	t.Parallel()
+	input := []string{"provider", "model", "virtual_key_id"}
+	logger := &recordingLogger{}
+
+	got := filterDisabledLabels(input, []string{"virtual_key_id"}, "test", logger)
+
+	// Mutating the result's backing array must not bleed into input.
+	if cap(got) > 0 {
+		got = append(got, "mutated")
+	}
+	if input[0] != "provider" || input[1] != "model" || input[2] != "virtual_key_id" {
+		t.Fatalf("input was mutated: %v", input)
+	}
+}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1237,6 +1237,13 @@
                       },
                       "description": "Custom labels to add to Prometheus metrics"
                     },
+                    "disabled_labels": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Default labels to omit from every Prometheus metric. Use to drop high-cardinality defaults (e.g. virtual_key_id / virtual_key_name) when a deployment pattern would otherwise blow up histogram series counts. Same hyphen/underscore-insensitive match as custom_labels."
+                    },
                     "push_gateway": {
                       "type": "object",
                       "description": "Configuration for pushing metrics to a Prometheus Push Gateway for multi-node cluster deployments",


### PR DESCRIPTION
## Summary

Adds `Config.DisabledLabels []string` (`disabled_labels` in JSON / helm) to the Prometheus telemetry plugin so operators can omit specific default labels from every metric. Today the default label set is hardcoded and unconditional, which is painful for deployments where one of the defaults carries unbounded cardinality.

## Why this exists

Some default labels carry per-request cardinality in particular deployment patterns. The motivating case in our deployment: we mint a fresh Bifrost virtual key per upstream LLM request, named `exec-<execution-uuid>`, so we can use governance budget tracking per execution and clean up the key when the execution finishes. The side effect is that `virtual_key_id` and `virtual_key_name` carry per-execution cardinality. Because they're stamped onto every histogram, the bucket multiplier (~12 `le` buckets) makes `bifrost_upstream_latency_seconds_bucket` alone hit **82,016 series per pod after 5 hours of uptime**, growing linearly with traffic. The whole `/metrics` payload reaches **182 MB per pod** (and 438 MB at 28 hours), and the Grafana Alloy agent that scrapes it OOMs every ~15 minutes trying to parse it (1083 lifetime restarts, 95+/day on our cluster).

The Alloy-side `metric_relabel_configs` `labeldrop` workaround fires after the agent has already deserialised the entire exposition into Go heap, so it doesn't help with the OOM. The clean fix is for Bifrost to never register the labels in the MetricVec in the first place — that's what this PR does.

`disabled_labels` is the supported escape hatch for these patterns. Per-request drilldown should live in logs / traces — Prometheus is for aggregates. **Disabling a label is a breaking change for any dashboard / alert that groups by it**; the docs warn about it explicitly.

## Changes

- `plugins/telemetry/main.go`: new `Config.DisabledLabels` field. After `defaultBifrostLabels` and `defaultHTTPLabels` are constructed, both are filtered through `DisabledLabels` *before* any MetricVec is registered. This ordering is required: prom-client rejects subsequent attempts to omit a registered label, so the filter has to happen up front (called out by the inline comment).
- `plugins/telemetry/utils.go`: new `filterDisabledLabels` helper using the same hyphen/underscore-insensitive match as `containsLabel`, so `\"virtual-key-id\"` and `\"virtual_key_id\"` both work. Uses a `[:0:0]` cap-clip on the input so a downstream `append(defaultBifrostLabels, filteredCustomLabels...)` cannot bleed back into the caller's backing array.
- `CustomLabels` filter is extended: a custom label that names a disabled label is silently dropped (with a log message) rather than letting it re-add the label. The disable wins; this is intentional so a stale `custom_labels` entry can't silently negate a deliberate `disabled_labels` change.
- `plugins/telemetry/utils_test.go`: 7 unit tests — empty disabled list, exact match, hyphen/underscore variants, order preservation, unknown names, and a regression test that the returned slice's backing array is independent of the input.
- `plugins/otel/metrics.go` builds attributes positionally via `BuildBifrostAttributes` and would need every callsite changed to plumb a filtered set. Left as follow-up — OTEL attributes don't get bucketized so the cardinality cost is multiplicatively smaller than Prometheus histograms. Happy to take it in a follow-up PR if maintainers want it.
- Docs: `docs/features/observability/prometheus.mdx` gains a `Disabling Default Labels` section with a config example and the breaking-change warning.
- Schemas: `helm-charts/bifrost/{values.yaml,values.schema.json}` and `transports/config.schema.json` both gain the new field. `.github/workflows/scripts/validate-helm-schema.sh` gets a guard for it next to the existing `custom_labels` check.

The label values are still computed and passed into `WithLabelValues` via the existing `getPrometheusLabelValues` helper, which walks the registered label set — disabled labels are simply absent from that walk, so their values are dropped on the floor without any caller changes. No metric callsites were touched.

## Type of change

- [x] Feature

## Affected areas

- [x] Plugins
- [x] Docs

## How to test

```sh
cd plugins/telemetry
GOWORK=off go vet ./...
GOWORK=off go test -v -run TestFilterDisabledLabels ./...
```

End-to-end: drop a config with `disabled_labels: [\"virtual_key_id\", \"virtual_key_name\"]` and curl `/metrics` — those labels are absent from every series. Bifrost's startup log includes one `default Bifrost label virtual_key_id is disabled via disabled_labels, it will be omitted from all metrics` line per disabled default. Adding the same name to `custom_labels` is a no-op (logs `... is disabled via disabled_labels, it will be ignored`).

## Breaking changes

- [x] No

The default behaviour is unchanged when `disabled_labels` is not set or is empty. Operators who opt in are explicitly choosing to break any downstream queries that group by the disabled labels — both the helm comment and the docs warning call this out.

## Related issues

Reproduction of the cardinality bomb in our deployment is documented in our internal investigation; happy to share more details / cardinality measurements / scrape-body samples in this PR thread if useful.

## Security considerations

None. The change is config plumbing for the metric label set; no auth, secrets, or PII surfaces are touched.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (`GOWORK=off go vet ./...` + tests pass)