### PR TITLE
refactor: expose `RunWithPluginPipeline` on `ClientManager` and route Starlark nested tool calls through canonical plugin gate

### DIFF
--- a/core/mcp/agent_test.go
+++ b/core/mcp/agent_test.go
@@ -83,6 +83,13 @@ func (m *MockClientManager) ReleasePluginPipeline(pipeline PluginPipeline)  {}
 func (m *MockClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
 	return nil, func() {}, nil
 }
+func (m *MockClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
+	resp, err := op(req)
+	if err != nil {
+		return nil, &schemas.BifrostError{IsBifrostError: false, Error: &schemas.ErrorField{Message: err.Error()}}
+	}
+	return resp, nil
+}
 
 func TestHasToolCallsForChatResponse(t *testing.T) {
 	// Test nil response
@@ -567,6 +574,13 @@ func (m *MockAutoClientManager) GetPluginPipeline() PluginPipeline             {
 func (m *MockAutoClientManager) ReleasePluginPipeline(pipeline PluginPipeline) {}
 func (m *MockAutoClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
 	return nil, func() {}, nil
+}
+func (m *MockAutoClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
+	resp, err := op(req)
+	if err != nil {
+		return nil, &schemas.BifrostError{IsBifrostError: false, Error: &schemas.ErrorField{Message: err.Error()}}
+	}
+	return resp, nil
 }
 
 // TestParallelToolCallsHaveUniqueMCPLogIDs verifies that parallel tool calls within a

--- a/core/mcp/codemode/starlark/executecode.go
+++ b/core/mcp/codemode/starlark/executecode.go
@@ -460,76 +460,18 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 		},
 	}
 
-	// Create BifrostMCPRequest
+	// Create BifrostMCPRequest. ClientName is set explicitly so the plugin gate
+	// can attribute short-circuit responses without re-parsing the prefixed name.
 	mcpRequest := &schemas.BifrostMCPRequest{
 		RequestType:                  schemas.MCPRequestTypeChatToolCall,
+		ClientName:                   clientName,
 		ChatAssistantMessageToolCall: &toolCallReq,
 	}
 
-	// Get plugin pipeline and run hooks
-	pipeline := s.clientManager.GetPluginPipeline()
-	if pipeline == nil {
-		// Should never happen, but just in case
-		s.logger.Warn("%s Plugin pipeline is nil", codemcp.CodeModeLogPrefix)
-		return nil, fmt.Errorf("plugin pipeline is nil")
-	}
-	defer s.clientManager.ReleasePluginPipeline(pipeline)
-
-	// Run PreMCPHooks
-	preReq, shortCircuit, preCount := pipeline.RunMCPPreHooks(nestedCtx, mcpRequest)
-
-	// Handle short-circuit cases
-	if shortCircuit != nil {
-		if shortCircuit.Response != nil {
-			finalResp, _ := pipeline.RunMCPPostHooks(nestedCtx, shortCircuit.Response, nil, preCount)
-			if finalResp != nil {
-				if finalResp.ChatMessage != nil {
-					return extractResultFromChatMessage(finalResp.ChatMessage), nil
-				}
-				if finalResp.ResponsesMessage != nil {
-					result, err := extractResultFromResponsesMessage(finalResp.ResponsesMessage)
-					if err != nil {
-						return nil, err
-					}
-					if result != nil {
-						return result, nil
-					}
-				}
-			}
-			return nil, fmt.Errorf("plugin short-circuit returned invalid response")
-		}
-		if shortCircuit.Error != nil {
-			pipeline.RunMCPPostHooks(nestedCtx, nil, shortCircuit.Error, preCount)
-			if shortCircuit.Error.Error != nil {
-				return nil, fmt.Errorf("%s", shortCircuit.Error.Error.Message)
-			}
-			return nil, fmt.Errorf("plugin short-circuit error")
-		}
-	}
-
-	// If pre-hooks modified the request, extract updated args
-	if preReq != nil && preReq.ChatAssistantMessageToolCall != nil {
-		toolCallReq = *preReq.ChatAssistantMessageToolCall
-		if toolCallReq.Function.Arguments != "" {
-			if err := sonic.Unmarshal([]byte(toolCallReq.Function.Arguments), &args); err != nil {
-				s.logger.Warn("%s Failed to parse modified tool arguments, using original: %v", codemcp.CodeModeLogPrefix, err)
-			}
-		}
-	}
-
-	// Execute tool
-	startTime := time.Now()
-	toolNameToCall := originalToolName
-
-	toolExecutionTimeout := s.getToolExecutionTimeout()
-	toolCtx, cancel := context.WithTimeout(nestedCtx, toolExecutionTimeout)
-	defer cancel()
-
-	// Acquire a connection through the shared ClientManager abstraction:
-	// shared-mode clients return their persistent state.Conn (release is a
-	// no-op); per-user clients get a fresh ephemeral transport that the
-	// release function closes. Credential errors (e.g. MCPAuthRequiredError)
-	// surface here.
+	// Acquire a connection through the shared ClientManager abstraction outside
+	// the gate, mirroring the gateway's exec.go:prepareToolExecution → gate
+	// ordering. Connection lifecycle is the caller's concern; the gate's op
+	// closure only performs the wire CallTool.
 	conn, release, err := s.clientManager.AcquireClientConn(nestedCtx, client)
 	if err != nil {
 		return nil, err
@@ -540,68 +482,86 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 	if err != nil {
 		return nil, err
 	}
-	callRequest := mcp.CallToolRequest{
-		Request: mcp.Request{
-			Method: string(mcp.MethodToolsCall),
-		},
-		Params: mcp.CallToolParams{
-			Name:      toolNameToCall,
-			Arguments: args,
-		},
-		Header: reqHeaders,
-	}
 
-	toolResponse, callErr := conn.CallTool(toolCtx, callRequest)
-	if callErr != nil && toolCtx.Err() == context.DeadlineExceeded {
-		callErr = fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
-	}
+	toolExecutionTimeout := s.getToolExecutionTimeout()
 
-	latency := time.Since(startTime).Milliseconds()
+	// Delegate to the canonical plugin gate. RunWithPluginPipeline owns the
+	// tracing span, MCPRequestType/ClientName/ToolName stamping (via
+	// PopulateExtraFields), plugin log draining, and short-circuit semantics —
+	// the op closure below only handles the wire CallTool. Keeps Starlark
+	// nested calls observationally identical to gateway-routed calls.
+	finalResp, finalErr := s.clientManager.RunWithPluginPipeline(nestedCtx, mcpRequest, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
+		// Honor any pre-hook mutation of tool name + arguments before the wire
+		// call. Mirrors ToolsManager.executeToolInternal (toolmanager.go:648–670):
+		// mutated name has its client prefix stripped using the ORIGINAL client
+		// (we already hold a connection to it; redirecting is out of scope),
+		// empty mutated args become an empty map, and a parse failure is a hard
+		// error rather than a silent fallback.
+		effectiveToolName := originalToolName
+		effectiveArgs := args
+		if preReq != nil && preReq.ChatAssistantMessageToolCall != nil {
+			toolCallReq = *preReq.ChatAssistantMessageToolCall
+			if toolCallReq.Function.Name != nil && *toolCallReq.Function.Name != "" {
+				effectiveToolName = stripClientPrefix(*toolCallReq.Function.Name, clientName)
+			}
+			if strings.TrimSpace(toolCallReq.Function.Arguments) == "" {
+				effectiveArgs = map[string]interface{}{}
+			} else {
+				var mutatedArgs map[string]interface{}
+				if err := sonic.Unmarshal([]byte(toolCallReq.Function.Arguments), &mutatedArgs); err != nil {
+					return nil, fmt.Errorf("failed to parse modified tool arguments for '%s': %v", effectiveToolName, err)
+				}
+				effectiveArgs = mutatedArgs
+			}
+		}
 
-	var mcpResp *schemas.BifrostMCPResponse
-	var bifrostErr *schemas.BifrostError
+		startTime := time.Now()
+		toolCtx, cancel := context.WithTimeout(nestedCtx, toolExecutionTimeout)
+		defer cancel()
 
-	if callErr != nil {
-		s.logger.Debug("%s Tool call failed: %s.%s - %v", codemcp.CodeModeLogPrefix, clientName, toolName, callErr)
-		appendLog(fmt.Sprintf("[TOOL] %s.%s error: %v", clientName, toolName, callErr))
-		bifrostErr = &schemas.BifrostError{
-			IsBifrostError: false,
-			Error: &schemas.ErrorField{
-				Message: fmt.Sprintf("tool call failed for %s.%s: %v", clientName, toolName, callErr),
+		callRequest := mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
 			},
+			Params: mcp.CallToolParams{
+				Name:      effectiveToolName,
+				Arguments: effectiveArgs,
+			},
+			Header: reqHeaders,
 		}
-	} else {
-		rawResult := extractTextFromMCPResponse(toolResponse, toolName)
 
+		toolResponse, callErr := conn.CallTool(toolCtx, callRequest)
+		if callErr != nil && toolCtx.Err() == context.DeadlineExceeded {
+			callErr = fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, effectiveToolName)
+		}
+		latency := time.Since(startTime).Milliseconds()
+
+		if callErr != nil {
+			s.logger.Debug("%s Tool call failed: %s.%s - %v", codemcp.CodeModeLogPrefix, clientName, effectiveToolName, callErr)
+			appendLog(fmt.Sprintf("[TOOL] %s.%s error: %v", clientName, effectiveToolName, callErr))
+			return nil, fmt.Errorf("tool call failed for %s.%s: %v", clientName, effectiveToolName, callErr)
+		}
+
+		rawResult := extractTextFromMCPResponse(toolResponse, effectiveToolName)
 		if after, ok := strings.CutPrefix(rawResult, "Error: "); ok {
-			errorMsg := after
-			s.logger.Debug("%s Tool returned error result: %s.%s - %s", codemcp.CodeModeLogPrefix, clientName, toolName, errorMsg)
-			appendLog(fmt.Sprintf("[TOOL] %s.%s error result: %s", clientName, toolName, errorMsg))
-			bifrostErr = &schemas.BifrostError{
-				IsBifrostError: false,
-				Error: &schemas.ErrorField{
-					Message: errorMsg,
-				},
-			}
-		} else {
-			mcpResp = &schemas.BifrostMCPResponse{
-				ChatMessage: createToolResponseMessage(toolCallReq, rawResult),
-				ExtraFields: schemas.BifrostMCPResponseExtraFields{
-					ClientName: clientName,
-					ToolName:   originalToolName,
-					Latency:    latency,
-				},
-			}
-
-			resultStr := formatResultForLog(rawResult)
-			logToolName := stripClientPrefix(toolName, clientName)
-			logToolName = strings.ReplaceAll(logToolName, "-", "_")
-			appendLog(fmt.Sprintf("[TOOL] %s.%s raw response: %s", clientName, logToolName, resultStr))
+			s.logger.Debug("%s Tool returned error result: %s.%s - %s", codemcp.CodeModeLogPrefix, clientName, effectiveToolName, after)
+			appendLog(fmt.Sprintf("[TOOL] %s.%s error result: %s", clientName, effectiveToolName, after))
+			return nil, fmt.Errorf("%s", after)
 		}
-	}
 
-	// Run post-hooks
-	finalResp, finalErr := pipeline.RunMCPPostHooks(nestedCtx, mcpResp, bifrostErr, preCount)
+		resultStr := formatResultForLog(rawResult)
+		logToolName := strings.ReplaceAll(effectiveToolName, "-", "_")
+		appendLog(fmt.Sprintf("[TOOL] %s.%s raw response: %s", clientName, logToolName, resultStr))
+
+		return &schemas.BifrostMCPResponse{
+			ChatMessage: createToolResponseMessage(toolCallReq, rawResult),
+			ExtraFields: schemas.BifrostMCPResponseExtraFields{
+				ClientName: clientName,
+				ToolName:   effectiveToolName,
+				Latency:    latency,
+			},
+		}, nil
+	})
 
 	if finalErr != nil {
 		if finalErr.Error != nil {

--- a/core/mcp/codemode/starlark/starlark_test.go
+++ b/core/mcp/codemode/starlark/starlark_test.go
@@ -48,6 +48,13 @@ func (m *testClientManager) ReleasePluginPipeline(pipeline codemcp.PluginPipelin
 func (m *testClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
 	return nil, func() {}, nil
 }
+func (m *testClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op codemcp.MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
+	resp, err := op(req)
+	if err != nil {
+		return nil, &schemas.BifrostError{IsBifrostError: false, Error: &schemas.ErrorField{Message: err.Error()}}
+	}
+	return resp, nil
+}
 
 func TestStarlarkToGo(t *testing.T) {
 	t.Run("Convert None", func(t *testing.T) {

--- a/core/mcp/exec.go
+++ b/core/mcp/exec.go
@@ -112,7 +112,7 @@ func (m *MCPManager) executeToolWithHooks(
 		toolNameMapping = state.ToolNameMapping
 	}
 
-	resp, bErr := m.runWithPluginPipeline(ctx, request, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
+	resp, bErr := m.RunWithPluginPipeline(ctx, request, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
 		result, opErr := m.toolsManager.ExecuteTool(ctx, preReq, conn, executionConfig, toolNameMapping)
 		if opErr != nil {
 			return nil, opErr

--- a/core/mcp/pluginpipeline.go
+++ b/core/mcp/pluginpipeline.go
@@ -10,16 +10,18 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// MCPOpFunc is the closure each call site provides to runWithPluginPipeline. It receives the
+// MCPOpFunc is the closure each call site provides to RunWithPluginPipeline. It receives the
 // (possibly mutated) request that flowed through PreHooks and is responsible for
 // performing the wire call (including any internal retries) and building a
 // BifrostMCPResponse from the outcome. The plain Go error returned here is wrapped
 // into a BifrostError by the gate before being handed to PostMCPHooks.
 type MCPOpFunc func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error)
 
-// runWithPluginPipeline wraps an MCP wire operation (connect / ping / list_tools / execute_tool)
+// RunWithPluginPipeline wraps an MCP wire operation (connect / ping / list_tools / execute_tool)
 // with the plugin pipeline. It is the single source of truth for the MCP plugin gate
-// pattern — handleMCPToolExecution in core/bifrost.go calls into this same function.
+// pattern — handleMCPToolExecution in core/bifrost.go calls into this same function,
+// and the Starlark codemode sandbox calls into it via the ClientManager interface for
+// nested tool calls.
 //
 //  1. Acquire pipeline (no-op pass-through if none configured)
 //  2. Run PreMCPHooks — plugins may mutate the request or short-circuit
@@ -34,7 +36,7 @@ type MCPOpFunc func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPRespo
 //
 // Returns *BifrostError so callers can preserve rich error fields (AllowFallbacks,
 // MCPAuthRequired).
-func (m *MCPManager) runWithPluginPipeline(
+func (m *MCPManager) RunWithPluginPipeline(
 	ctx *schemas.BifrostContext,
 	req *schemas.BifrostMCPRequest,
 	op MCPOpFunc,
@@ -361,7 +363,7 @@ func (m *MCPManager) runListToolsWithHooks(ctx context.Context, conn *client.Cli
 	gateCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 	start := time.Now()
 
-	resp, bErr := m.runWithPluginPipeline(gateCtx, req, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
+	resp, bErr := m.RunWithPluginPipeline(gateCtx, req, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
 		detailed, opErr := retrieveExternalToolsDetailed(ctx, conn, clientName, m.logger)
 		if opErr != nil {
 			return nil, opErr
@@ -402,7 +404,7 @@ func (chm *ClientHealthMonitor) runPingWithHooks(ctx context.Context, conn *clie
 	}
 	gateCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 	start := time.Now()
-	_, bErr := chm.manager.runWithPluginPipeline(gateCtx, req, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
+	_, bErr := chm.manager.RunWithPluginPipeline(gateCtx, req, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
 		if pingErr := conn.Ping(ctx); pingErr != nil {
 			return nil, pingErr
 		}

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -31,6 +31,13 @@ type ClientManager interface {
 	// credentials) and closed on release. The credential-resolution error path
 	// (e.g. *MCPUserOAuthRequiredError) surfaces here.
 	AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error)
+	// RunWithPluginPipeline wraps an MCP wire operation in the canonical plugin
+	// gate (PreMCPHooks → op → PostMCPHooks). It owns the tracing span,
+	// MCPRequestType/ClientName/ToolName stamping, plugin log draining, and
+	// short-circuit semantics. Use this from any call site that needs to invoke
+	// an MCP tool/list/ping outside the gateway path — e.g. nested tool calls
+	// from the Starlark codemode sandbox — to stay in sync with the gateway.
+	RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError)
 }
 
 // MCPToolExecutor is the per-call executor signature used by the agent loop.

--- a/core/mcp/toolmanager_test.go
+++ b/core/mcp/toolmanager_test.go
@@ -48,6 +48,13 @@ func (m *mockToolClientManager) ReleasePluginPipeline(pipeline PluginPipeline) {
 func (m *mockToolClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
 	return nil, func() {}, nil
 }
+func (m *mockToolClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
+	resp, err := op(req)
+	if err != nil {
+		return nil, &schemas.BifrostError{IsBifrostError: false, Error: &schemas.ErrorField{Message: err.Error()}}
+	}
+	return resp, nil
+}
 
 // makeTool is a convenience constructor for test tool fixtures.
 func makeTool(name string) schemas.ChatTool {

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1294,10 +1294,6 @@ func (p *LoggerPlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 
 	fullToolName := req.GetToolName()
 	arguments := req.GetToolArguments()
-	// Skip execution for codemode tools
-	if bifrost.IsCodemodeTool(fullToolName) {
-		return req, nil, nil
-	}
 
 	// Extract server label from tool name (format: {client}-{tool_name})
 	// The first part before hyphen is the client/server label
@@ -1314,6 +1310,13 @@ func (p *LoggerPlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 				serverLabel = "codemode"
 			}
 		}
+	}
+	// Skip logging for codemode meta-tools. Check both the full name (bare,
+	// e.g. "executeToolCode") and the suffix after the client prefix (e.g.
+	// "myclient-executeToolCode") so PreMCP and PostMCP agree on what to skip
+	// and we never leave an orphan pending row to expire via the TTL path.
+	if bifrost.IsCodemodeTool(fullToolName) || bifrost.IsCodemodeTool(toolName) {
+		return req, nil, nil
 	}
 
 	// Get virtual key information from context - using same method as normal LLM logging

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -218,6 +218,45 @@ func TestCleanupStalePendingMCPLogsPersistsErrorFallback(t *testing.T) {
 	}
 }
 
+// TestPreMCPHookSkipsPrefixedCodemodeTool verifies that PreMCP skips codemode
+// meta-tools invoked with a client prefix (e.g. "myclient-executeToolCode"),
+// not just bare names. Otherwise PostMCP — which sees the stripped bare name —
+// would silently skip and leave the pending row to expire as a fake TTL error.
+func TestPreMCPHookSkipsPrefixedCodemodeTool(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if cleanupErr := plugin.Cleanup(); cleanupErr != nil {
+			t.Errorf("Cleanup() error = %v", cleanupErr)
+		}
+	})
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, "req-prefixed-codemode")
+	ctx.SetValue(schemas.BifrostContextKeyMCPLogID, "mcp-prefixed-codemode")
+
+	toolName := "myclient-executeToolCode"
+	_, _, err = plugin.PreMCPHook(ctx, &schemas.BifrostMCPRequest{
+		RequestType: schemas.MCPRequestTypeChatToolCall,
+		ChatAssistantMessageToolCall: &schemas.ChatAssistantMessageToolCall{
+			Function: schemas.ChatAssistantMessageToolCallFunction{
+				Name:      &toolName,
+				Arguments: `{}`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PreMCPHook() error = %v", err)
+	}
+
+	if _, ok := plugin.pendingMCPLogsToInject.Load("mcp-prefixed-codemode"); ok {
+		t.Fatal("expected PreMCPHook to skip prefixed codemode tool, but a pending row was created")
+	}
+}
+
 func assertMCPLogGovernanceFields(t *testing.T, logEntry *logstore.MCPToolLog, userID, teamID, customerID, businessUnitID string) {
 	t.Helper()
 	if logEntry.UserID == nil || *logEntry.UserID != userID {


### PR DESCRIPTION
## Summary

Starlark codemode nested tool calls previously duplicated the plugin gate logic inline, diverging from the canonical `RunWithPluginPipeline` path used by the gateway. This PR promotes `runWithPluginPipeline` to an exported method on `MCPManager`, adds it to the `ClientManager` interface, and routes Starlark nested tool calls through it — making codemode tool execution observationally identical to gateway-routed calls (tracing, pre/post hooks, short-circuit semantics, plugin log draining).

A secondary fix corrects the logging plugin's `PreMCPHook` to also skip codemode meta-tools when they arrive with a client prefix (e.g. `myclient-executeToolCode`), not just bare names. Previously, `PreMCPHook` would insert a pending log row for the prefixed name while `PostMCPHook` would skip on the stripped bare name, leaving an orphaned row to expire as a fake TTL error.

## Changes

- `runWithPluginPipeline` renamed to `RunWithPluginPipeline` and added to the `ClientManager` interface so any call site outside the gateway (e.g. Starlark codemode) can use the canonical plugin gate.
- `callMCPTool` in the Starlark codemode executor replaced its inline pre/post hook orchestration with a single `RunWithPluginPipeline` call. Connection acquisition still happens outside the gate, mirroring the gateway's `exec.go` ordering.
- `BifrostMCPRequest.ClientName` is now set explicitly before the gate so plugins can attribute short-circuit responses without re-parsing the prefixed tool name.
- Logging plugin's `PreMCPHook` now checks both the full tool name and the suffix after the client prefix for codemode meta-tools, preventing orphaned pending rows.
- All mock `ClientManager` implementations in tests implement the new `RunWithPluginPipeline` method with a pass-through that wraps plain errors into `BifrostError`.
- New test `TestPreMCPHookSkipsPrefixedCodemodeTool` verifies that `PreMCPHook` does not create a pending row for a client-prefixed codemode tool name.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/mcp/...
go test ./core/mcp/codemode/starlark/...
go test ./plugins/logging/...
```

Verify that:
- Starlark nested tool calls flow through pre/post hooks identically to gateway-routed calls.
- A codemode meta-tool invoked with a client prefix (e.g. `myclient-executeToolCode`) does not produce a pending log row in the logging plugin.

## Breaking changes

- [x] Yes
- [ ] No

`ClientManager` interface gains a new `RunWithPluginPipeline` method. Any external implementation of `ClientManager` must add this method. All in-repo mocks have been updated.

## Related issues

## Security considerations

No new auth, secrets, or PII surface area introduced. The gate's short-circuit and credential-error paths are preserved unchanged.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable