### PR TITLE
feat: filter `ListAllModels` provider fan-out by virtual key's allowed providers to suppress noisy governance errors

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -609,9 +609,14 @@ func filterProvidersByContext(ctx *schemas.BifrostContext, providerKeys []schema
 		return providerKeys
 	}
 
-	availableProviders, ok := ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
-	if !ok {
+	rawAvailableProviders := ctx.Value(schemas.BifrostContextKeyAvailableProviders)
+	if rawAvailableProviders == nil {
 		return providerKeys
+	}
+
+	availableProviders, ok := rawAvailableProviders.([]schemas.ModelProvider)
+	if !ok {
+		return []schemas.ModelProvider{}
 	}
 
 	if len(availableProviders) == 0 || len(providerKeys) == 0 {

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -458,6 +458,7 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 			},
 		}
 	}
+	providerKeys = filterProvidersByContext(ctx, providerKeys)
 
 	startTime := time.Now()
 
@@ -601,6 +602,30 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 	response = response.ApplyPagination(req.PageSize, req.PageToken)
 
 	return response, nil
+}
+
+func filterProvidersByContext(ctx *schemas.BifrostContext, providerKeys []schemas.ModelProvider) []schemas.ModelProvider {
+	if ctx == nil {
+		return providerKeys
+	}
+
+	availableProviders, ok := ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	if !ok {
+		return providerKeys
+	}
+
+	if len(availableProviders) == 0 || len(providerKeys) == 0 {
+		return []schemas.ModelProvider{}
+	}
+
+	filteredProviders := make([]schemas.ModelProvider, 0, len(providerKeys))
+	for _, providerKey := range providerKeys {
+		if slices.Contains(availableProviders, providerKey) {
+			filteredProviders = append(filteredProviders, providerKey)
+		}
+	}
+
+	return filteredProviders
 }
 
 // TextCompletionRequest sends a text completion request to the specified provider.

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -789,6 +789,41 @@ func (t *countingTracer) CompleteAndFlushTrace(_ string) {
 	t.flushed.Add(1)
 }
 
+func TestFilterProvidersByContext(t *testing.T) {
+	providers := []schemas.ModelProvider{
+		schemas.OpenAI,
+		schemas.Anthropic,
+		schemas.Mistral,
+	}
+
+	t.Run("no context filter keeps all providers", func(t *testing.T) {
+		filtered := filterProvidersByContext(nil, providers)
+		if len(filtered) != len(providers) {
+			t.Fatalf("expected all providers, got %v", filtered)
+		}
+	})
+
+	t.Run("available providers restrict list models fanout", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{schemas.Anthropic})
+
+		filtered := filterProvidersByContext(ctx, providers)
+		if len(filtered) != 1 || filtered[0] != schemas.Anthropic {
+			t.Fatalf("expected only anthropic, got %v", filtered)
+		}
+	})
+
+	t.Run("empty available providers denies all providers", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{})
+
+		filtered := filterProvidersByContext(ctx, providers)
+		if len(filtered) != 0 {
+			t.Fatalf("expected no providers, got %v", filtered)
+		}
+	})
+}
+
 func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	account := NewMockAccount()

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -822,6 +822,16 @@ func TestFilterProvidersByContext(t *testing.T) {
 			t.Fatalf("expected no providers, got %v", filtered)
 		}
 	})
+
+	t.Run("malformed available providers fails closed", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, "openai")
+
+		filtered := filterProvidersByContext(ctx, providers)
+		if len(filtered) != 0 {
+			t.Fatalf("expected no providers for malformed context value, got %v", filtered)
+		}
+	})
 }
 
 func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -799,6 +799,9 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
 	}
+	if provider == "" && !h.applyListModelsVirtualKeyProviderFilter(ctx, bifrostCtx) {
+		return
+	}
 
 	var resp *schemas.BifrostListModelsResponse
 	var bifrostErr *schemas.BifrostError

--- a/transports/bifrost-http/handlers/list_models_vk.go
+++ b/transports/bifrost-http/handlers/list_models_vk.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	governanceplugin "github.com/maximhq/bifrost/plugins/governance"
+	"github.com/valyala/fasthttp"
+)
+
+// applyListModelsVirtualKeyProviderFilter narrows provider fan-out for GET /v1/models
+// when the request is made with a virtual key. Without this, ListAllModels asks every
+// configured provider to list models and governance rejects providers outside the VK,
+// creating noisy, expected errors in request logs.
+func (h *CompletionHandler) applyListModelsVirtualKeyProviderFilter(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext) bool {
+	vkValue := governanceplugin.ParseVirtualKeyFromFastHTTPRequest(ctx)
+	if vkValue == nil {
+		return true
+	}
+
+	trimmedVKValue := strings.TrimSpace(*vkValue)
+	if trimmedVKValue == "" {
+		return true
+	}
+
+	if h.config == nil || h.config.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "database store unavailable")
+		return false
+	}
+
+	vk, err := h.config.ConfigStore.GetVirtualKeyByValue(ctx, trimmedVKValue)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			return true
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to resolve virtual key: %v", err))
+		return false
+	}
+	if vk == nil {
+		return true
+	}
+
+	availableProviders := make([]schemas.ModelProvider, 0, len(vk.ProviderConfigs))
+	for _, providerConfig := range vk.ProviderConfigs {
+		provider := strings.TrimSpace(providerConfig.Provider)
+		if provider == "" {
+			continue
+		}
+		availableProviders = append(availableProviders, schemas.ModelProvider(provider))
+	}
+
+	bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, availableProviders)
+	return true
+}

--- a/transports/bifrost-http/handlers/list_models_vk.go
+++ b/transports/bifrost-http/handlers/list_models_vk.go
@@ -39,7 +39,7 @@ func (h *CompletionHandler) applyListModelsVirtualKeyProviderFilter(ctx *fasthtt
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to resolve virtual key: %v", err))
 		return false
 	}
-	if vk == nil {
+	if vk == nil || !vk.IsActive {
 		return true
 	}
 

--- a/transports/bifrost-http/handlers/list_models_vk.go
+++ b/transports/bifrost-http/handlers/list_models_vk.go
@@ -39,7 +39,7 @@ func (h *CompletionHandler) applyListModelsVirtualKeyProviderFilter(ctx *fasthtt
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to resolve virtual key: %v", err))
 		return false
 	}
-	if vk == nil || !vk.IsActive {
+	if vk == nil || !vk.IsActiveValue() {
 		return true
 	}
 

--- a/transports/bifrost-http/handlers/list_models_vk_test.go
+++ b/transports/bifrost-http/handlers/list_models_vk_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +22,83 @@ type mockListModelsVKConfigStore struct {
 
 func (m *mockListModelsVKConfigStore) GetVirtualKeyByValue(_ context.Context, _ string) (*configstoreTables.TableVirtualKey, error) {
 	return m.vk, m.err
+}
+
+func TestApplyListModelsVirtualKeyProviderFilterSetsActiveVKProviders(t *testing.T) {
+	h := &CompletionHandler{
+		config: &lib.Config{
+			ConfigStore: &mockListModelsVKConfigStore{vk: &configstoreTables.TableVirtualKey{
+				Value:    "sk-bf-active",
+				IsActive: true,
+				ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
+					{Provider: "openai"},
+					{Provider: " anthropic "},
+					{Provider: ""},
+				},
+			}},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer sk-bf-active")
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
+
+	if ok := h.applyListModelsVirtualKeyProviderFilter(ctx, bifrostCtx); !ok {
+		t.Fatalf("expected active VK to apply provider filter")
+	}
+	got, ok := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	if !ok {
+		t.Fatalf("expected available providers to be set")
+	}
+	want := []schemas.ModelProvider{schemas.OpenAI, schemas.Anthropic}
+	if len(got) != len(want) {
+		t.Fatalf("expected providers %#v, got %#v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected providers %#v, got %#v", want, got)
+		}
+	}
+}
+
+func TestApplyListModelsVirtualKeyProviderFilterReturnsErrorOnLookupFailure(t *testing.T) {
+	h := &CompletionHandler{
+		config: &lib.Config{
+			ConfigStore: &mockListModelsVKConfigStore{err: errors.New("database unavailable")},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer sk-bf-active")
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
+
+	if ok := h.applyListModelsVirtualKeyProviderFilter(ctx, bifrostCtx); ok {
+		t.Fatalf("expected lookup error to fail request")
+	}
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", fasthttp.StatusInternalServerError, got)
+	}
+	if body := string(ctx.Response.Body()); !strings.Contains(body, "Failed to resolve virtual key") {
+		t.Fatalf("expected virtual key lookup error response, got %q", body)
+	}
+}
+
+func TestApplyListModelsVirtualKeyProviderFilterReturnsUnavailableWithoutConfigStore(t *testing.T) {
+	h := &CompletionHandler{config: &lib.Config{}}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer sk-bf-active")
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
+
+	if ok := h.applyListModelsVirtualKeyProviderFilter(ctx, bifrostCtx); ok {
+		t.Fatalf("expected missing config store to fail request")
+	}
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d", fasthttp.StatusServiceUnavailable, got)
+	}
+	if body := string(ctx.Response.Body()); !strings.Contains(body, "database store unavailable") {
+		t.Fatalf("expected unavailable response, got %q", body)
+	}
 }
 
 func TestApplyListModelsVirtualKeyProviderFilterSkipsInactiveVK(t *testing.T) {

--- a/transports/bifrost-http/handlers/list_models_vk_test.go
+++ b/transports/bifrost-http/handlers/list_models_vk_test.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+type mockListModelsVKConfigStore struct {
+	configstore.ConfigStore
+	vk  *configstoreTables.TableVirtualKey
+	err error
+}
+
+func (m *mockListModelsVKConfigStore) GetVirtualKeyByValue(_ context.Context, _ string) (*configstoreTables.TableVirtualKey, error) {
+	return m.vk, m.err
+}
+
+func TestApplyListModelsVirtualKeyProviderFilterSkipsInactiveVK(t *testing.T) {
+	h := &CompletionHandler{
+		config: &lib.Config{
+			ConfigStore: &mockListModelsVKConfigStore{vk: &configstoreTables.TableVirtualKey{
+				Value:    "sk-bf-inactive",
+				IsActive: false,
+				ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
+					{Provider: "openai"},
+				},
+			}},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer sk-bf-inactive")
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
+
+	if ok := h.applyListModelsVirtualKeyProviderFilter(ctx, bifrostCtx); !ok {
+		t.Fatalf("expected inactive VK to be ignored without failing request")
+	}
+	if got := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+		t.Fatalf("expected inactive VK not to set available providers, got %#v", got)
+	}
+}

--- a/transports/bifrost-http/handlers/list_models_vk_test.go
+++ b/transports/bifrost-http/handlers/list_models_vk_test.go
@@ -101,6 +101,25 @@ func TestApplyListModelsVirtualKeyProviderFilterReturnsUnavailableWithoutConfigS
 	}
 }
 
+func TestApplyListModelsVirtualKeyProviderFilterSkipsWhenVKNotFound(t *testing.T) {
+	h := &CompletionHandler{
+		config: &lib.Config{
+			ConfigStore: &mockListModelsVKConfigStore{},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer sk-bf-missing")
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
+
+	if ok := h.applyListModelsVirtualKeyProviderFilter(ctx, bifrostCtx); !ok {
+		t.Fatalf("expected missing VK to be ignored without failing request")
+	}
+	if got := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+		t.Fatalf("expected missing VK not to set available providers, got %#v", got)
+	}
+}
+
 func TestApplyListModelsVirtualKeyProviderFilterSkipsInactiveVK(t *testing.T) {
 	h := &CompletionHandler{
 		config: &lib.Config{

--- a/transports/bifrost-http/handlers/list_models_vk_test.go
+++ b/transports/bifrost-http/handlers/list_models_vk_test.go
@@ -29,7 +29,7 @@ func TestApplyListModelsVirtualKeyProviderFilterSetsActiveVKProviders(t *testing
 		config: &lib.Config{
 			ConfigStore: &mockListModelsVKConfigStore{vk: &configstoreTables.TableVirtualKey{
 				Value:    "sk-bf-active",
-				IsActive: true,
+				IsActive: schemas.Ptr(true),
 				ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
 					{Provider: "openai"},
 					{Provider: " anthropic "},
@@ -102,22 +102,43 @@ func TestApplyListModelsVirtualKeyProviderFilterReturnsUnavailableWithoutConfigS
 }
 
 func TestApplyListModelsVirtualKeyProviderFilterSkipsWhenVKNotFound(t *testing.T) {
-	h := &CompletionHandler{
-		config: &lib.Config{
-			ConfigStore: &mockListModelsVKConfigStore{},
-		},
-	}
+	t.Run("nil return from store", func(t *testing.T) {
+		h := &CompletionHandler{
+			config: &lib.Config{
+				ConfigStore: &mockListModelsVKConfigStore{},
+			},
+		}
 
-	ctx := &fasthttp.RequestCtx{}
-	ctx.Request.Header.Set("Authorization", "Bearer sk-bf-missing")
-	bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.Header.Set("Authorization", "Bearer sk-bf-missing")
+		bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
 
-	if ok := h.applyListModelsVirtualKeyProviderFilter(ctx, bifrostCtx); !ok {
-		t.Fatalf("expected missing VK to be ignored without failing request")
-	}
-	if got := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
-		t.Fatalf("expected missing VK not to set available providers, got %#v", got)
-	}
+		if ok := h.applyListModelsVirtualKeyProviderFilter(ctx, bifrostCtx); !ok {
+			t.Fatalf("expected missing VK to be ignored without failing request")
+		}
+		if got := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+			t.Fatalf("expected missing VK not to set available providers, got %#v", got)
+		}
+	})
+
+	t.Run("ErrNotFound from store", func(t *testing.T) {
+		h := &CompletionHandler{
+			config: &lib.Config{
+				ConfigStore: &mockListModelsVKConfigStore{err: configstore.ErrNotFound},
+			},
+		}
+
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.Header.Set("Authorization", "Bearer sk-bf-missing")
+		bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
+
+		if ok := h.applyListModelsVirtualKeyProviderFilter(ctx, bifrostCtx); !ok {
+			t.Fatalf("expected ErrNotFound to be ignored without failing request")
+		}
+		if got := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+			t.Fatalf("expected ErrNotFound not to set available providers, got %#v", got)
+		}
+	})
 }
 
 func TestApplyListModelsVirtualKeyProviderFilterSkipsInactiveVK(t *testing.T) {
@@ -125,7 +146,7 @@ func TestApplyListModelsVirtualKeyProviderFilterSkipsInactiveVK(t *testing.T) {
 		config: &lib.Config{
 			ConfigStore: &mockListModelsVKConfigStore{vk: &configstoreTables.TableVirtualKey{
 				Value:    "sk-bf-inactive",
-				IsActive: false,
+				IsActive: schemas.Ptr(false),
 				ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
 					{Provider: "openai"},
 				},


### PR DESCRIPTION
## Summary

When `GET /v1/models` is called with a virtual key, `ListAllModels` previously fanned out to every configured provider. Governance would then reject providers outside the virtual key's allowed set, producing noisy, expected errors in request logs. This PR scopes the provider fan-out to only the providers permitted by the virtual key.

## Changes

- Added `filterProvidersByContext` in `core/bifrost.go` that reads `BifrostContextKeyAvailableProviders` from the request context and filters the provider list before fan-out. If the context value is malformed, it fails closed and returns an empty list.
- Added `applyListModelsVirtualKeyProviderFilter` in a new `list_models_vk.go` handler file. When a virtual key is present on a `GET /v1/models` request with no explicit provider, it resolves the virtual key, extracts its allowed providers, and sets `BifrostContextKeyAvailableProviders` on the Bifrost context before the fan-out occurs. Inactive or missing virtual keys are silently skipped; lookup failures return an error response.
- The `listModels` handler in `inference.go` now calls `applyListModelsVirtualKeyProviderFilter` before dispatching to `ListAllModels` when no specific provider is requested.
- Updated the `BifrostContextKeyAvailableProviders` comment to clarify it is set by internal bifrost components rather than bifrost alone.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/... ./transports/bifrost-http/handlers/...
```

- Make a `GET /v1/models` request with a virtual key scoped to a subset of providers and confirm only those providers' models are returned with no governance rejection errors in the logs.
- Make a `GET /v1/models` request without a virtual key and confirm all configured providers are still queried.
- Make a `GET /v1/models` request with an inactive or unknown virtual key and confirm all providers are still queried without errors.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The virtual key lookup fails closed on malformed context values and returns a 503 if the config store is unavailable, preventing unintended provider exposure. An unrecognized or inactive virtual key falls through without restricting providers, preserving existing behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model listing now supports provider filtering through virtual key configurations, enabling restricted access to specific providers based on authentication context.

* **Tests**
  * Added comprehensive test coverage for virtual key-based provider filtering and context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->