### PR TITLE
refactor: extract dashboard tab data-fetching into dedicated `TabView` components

### DIFF
--- a/ui/app/workspace/dashboard/components/tabViews/dimensionRankingsTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/dimensionRankingsTabView.tsx
@@ -1,0 +1,45 @@
+import { useGetDimensionRankingsQuery, useLazyGetDimensionRankingsQuery } from "@/lib/store";
+import type { LogFilters, RankingDimension } from "@/lib/types/logs";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
+import type { DashboardData } from "../../utils/exportUtils";
+import { DimensionRankingsTab } from "../dimensionRankingsTab";
+
+export interface DimensionRankingsTabViewHandle {
+	getData: () => Partial<DashboardData>;
+	loadData: () => Promise<void>;
+}
+
+interface DimensionRankingsTabViewProps {
+	filters: LogFilters;
+	active: boolean;
+	dimension: RankingDimension;
+	dimensionLabel: string;
+	testIdPrefix: string;
+	dataKey: keyof DashboardData;
+}
+
+export const DimensionRankingsTabView = forwardRef<DimensionRankingsTabViewHandle, DimensionRankingsTabViewProps>(
+	function DimensionRankingsTabView({ filters, active, dimension, dimensionLabel, testIdPrefix, dataKey }, ref) {
+		const fetchArg = useMemo(() => ({ filters, dimension }), [filters, dimension]);
+		const skipOpts = useMemo(() => ({ skip: !active }), [active]);
+
+		const { data, isLoading: loading } = useGetDimensionRankingsQuery(fetchArg, skipOpts);
+
+		const [triggerDimensionRankings] = useLazyGetDimensionRankingsQuery();
+
+		const loadData = useCallback(async () => {
+			await triggerDimensionRankings(fetchArg, true);
+		}, [fetchArg, triggerDimensionRankings]);
+
+		useImperativeHandle(
+			ref,
+			() => ({
+				getData: () => ({ [dataKey]: data ?? null }),
+				loadData,
+			}),
+			[data, dataKey, loadData],
+		);
+
+		return <DimensionRankingsTab data={data ?? null} loading={loading} dimensionLabel={dimensionLabel} testIdPrefix={testIdPrefix} />;
+	},
+);

--- a/ui/app/workspace/dashboard/components/tabViews/mcpTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/mcpTabView.tsx
@@ -1,0 +1,79 @@
+import {
+	useGetMCPCostHistogramQuery,
+	useGetMCPHistogramQuery,
+	useGetMCPTopToolsQuery,
+	useLazyGetMCPCostHistogramQuery,
+	useLazyGetMCPHistogramQuery,
+	useLazyGetMCPTopToolsQuery,
+} from "@/lib/store";
+import type { MCPToolLogFilters } from "@/lib/types/logs";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
+import type { DashboardData } from "../../utils/exportUtils";
+import type { ChartType } from "../charts/chartTypeToggle";
+import { MCPTab } from "../mcpTab";
+
+export interface MCPTabViewHandle {
+	getData: () => Partial<DashboardData>;
+	loadData: () => Promise<void>;
+}
+
+interface MCPTabViewProps {
+	filters: MCPToolLogFilters;
+	active: boolean;
+	startTime: number;
+	endTime: number;
+	mcpVolumeChartType: ChartType;
+	mcpCostChartType: ChartType;
+	onMcpVolumeChartToggle: (type: ChartType) => void;
+	onMcpCostChartToggle: (type: ChartType) => void;
+}
+
+export const MCPTabView = forwardRef<MCPTabViewHandle, MCPTabViewProps>(function MCPTabView(
+	{ filters, active, startTime, endTime, mcpVolumeChartType, mcpCostChartType, onMcpVolumeChartToggle, onMcpCostChartToggle },
+	ref,
+) {
+	const fetchArg = useMemo(() => ({ filters }), [filters]);
+	const skipOpts = useMemo(() => ({ skip: !active }), [active]);
+
+	const { data: mcpHistogramData, isLoading: loadingMcpHistogram } = useGetMCPHistogramQuery(fetchArg, skipOpts);
+	const { data: mcpCostData, isLoading: loadingMcpCost } = useGetMCPCostHistogramQuery(fetchArg, skipOpts);
+	const { data: mcpTopToolsData, isLoading: loadingMcpTopTools } = useGetMCPTopToolsQuery(fetchArg, skipOpts);
+
+	const [triggerMcpHistogram] = useLazyGetMCPHistogramQuery();
+	const [triggerMcpCost] = useLazyGetMCPCostHistogramQuery();
+	const [triggerMcpTopTools] = useLazyGetMCPTopToolsQuery();
+
+	const loadData = useCallback(async () => {
+		await Promise.all([triggerMcpHistogram(fetchArg, true), triggerMcpCost(fetchArg, true), triggerMcpTopTools(fetchArg, true)]);
+	}, [fetchArg, triggerMcpHistogram, triggerMcpCost, triggerMcpTopTools]);
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			getData: () => ({
+				mcpHistogramData: mcpHistogramData ?? null,
+				mcpCostData: mcpCostData ?? null,
+				mcpTopToolsData: mcpTopToolsData ?? null,
+			}),
+			loadData,
+		}),
+		[mcpHistogramData, mcpCostData, mcpTopToolsData, loadData],
+	);
+
+	return (
+		<MCPTab
+			mcpHistogramData={mcpHistogramData ?? null}
+			mcpCostData={mcpCostData ?? null}
+			mcpTopToolsData={mcpTopToolsData ?? null}
+			loadingMcpHistogram={loadingMcpHistogram}
+			loadingMcpCost={loadingMcpCost}
+			loadingMcpTopTools={loadingMcpTopTools}
+			startTime={startTime}
+			endTime={endTime}
+			mcpVolumeChartType={mcpVolumeChartType}
+			mcpCostChartType={mcpCostChartType}
+			onMcpVolumeChartToggle={onMcpVolumeChartToggle}
+			onMcpCostChartToggle={onMcpCostChartToggle}
+		/>
+	);
+});

--- a/ui/app/workspace/dashboard/components/tabViews/modelRankingsTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/modelRankingsTabView.tsx
@@ -1,0 +1,62 @@
+import {
+	useGetLogsModelHistogramQuery,
+	useGetModelRankingsQuery,
+	useLazyGetLogsModelHistogramQuery,
+	useLazyGetModelRankingsQuery,
+} from "@/lib/store";
+import type { LogFilters } from "@/lib/types/logs";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
+import type { DashboardData } from "../../utils/exportUtils";
+import { ModelRankingsTab } from "../modelRankingsTab";
+
+export interface ModelRankingsTabViewHandle {
+	getData: () => Partial<DashboardData>;
+	loadData: () => Promise<void>;
+}
+
+interface ModelRankingsTabViewProps {
+	filters: LogFilters;
+	active: boolean;
+	startTime: number;
+	endTime: number;
+}
+
+export const ModelRankingsTabView = forwardRef<ModelRankingsTabViewHandle, ModelRankingsTabViewProps>(
+	function ModelRankingsTabView({ filters, active, startTime, endTime }, ref) {
+		const fetchArg = useMemo(() => ({ filters }), [filters]);
+		const skipOpts = useMemo(() => ({ skip: !active }), [active]);
+
+		const { data: rankingsData, isLoading: loadingRankings } = useGetModelRankingsQuery(fetchArg, skipOpts);
+		const { data: modelData, isLoading: loadingModels } = useGetLogsModelHistogramQuery(fetchArg, skipOpts);
+
+		const [triggerRankings] = useLazyGetModelRankingsQuery();
+		const [triggerModels] = useLazyGetLogsModelHistogramQuery();
+
+		const loadData = useCallback(async () => {
+			await Promise.all([triggerRankings(fetchArg, true), triggerModels(fetchArg, true)]);
+		}, [fetchArg, triggerRankings, triggerModels]);
+
+		useImperativeHandle(
+			ref,
+			() => ({
+				getData: () => ({
+					rankingsData: rankingsData ?? null,
+					modelData: modelData ?? null,
+				}),
+				loadData,
+			}),
+			[rankingsData, modelData, loadData],
+		);
+
+		return (
+			<ModelRankingsTab
+				rankingsData={rankingsData ?? null}
+				loading={loadingRankings}
+				modelData={modelData ?? null}
+				loadingModels={loadingModels}
+				startTime={startTime}
+				endTime={endTime}
+			/>
+		);
+	},
+);

--- a/ui/app/workspace/dashboard/components/tabViews/overviewTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/overviewTabView.tsx
@@ -1,0 +1,161 @@
+import {
+	useGetLogsCostHistogramQuery,
+	useGetLogsHistogramQuery,
+	useGetLogsLatencyHistogramQuery,
+	useGetLogsModelHistogramQuery,
+	useGetLogsStatsQuery,
+	useGetLogsTokenHistogramQuery,
+	useLazyGetLogsCostHistogramQuery,
+	useLazyGetLogsHistogramQuery,
+	useLazyGetLogsLatencyHistogramQuery,
+	useLazyGetLogsModelHistogramQuery,
+	useLazyGetLogsStatsQuery,
+	useLazyGetLogsTokenHistogramQuery,
+} from "@/lib/store";
+import type { LogFilters } from "@/lib/types/logs";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
+import type { DashboardData } from "../../utils/exportUtils";
+import type { ChartType } from "../charts/chartTypeToggle";
+import { OverviewTab } from "../overviewTab";
+
+export interface OverviewTabViewHandle {
+	getData: () => Partial<DashboardData>;
+	loadData: () => Promise<void>;
+}
+
+const sanitizeSeriesLabels = (values?: string[]): string[] => {
+	if (!values) return [];
+	const trimmed = values.map((v) => v.trim()).filter((v) => v.length > 0);
+	return [...new Set(trimmed)];
+};
+
+interface OverviewTabViewProps {
+	filters: LogFilters;
+	active: boolean;
+	startTime: number;
+	endTime: number;
+	volumeChartType: ChartType;
+	tokenChartType: ChartType;
+	costChartType: ChartType;
+	modelChartType: ChartType;
+	latencyChartType: ChartType;
+	costModel: string;
+	usageModel: string;
+	onVolumeChartToggle: (type: ChartType) => void;
+	onTokenChartToggle: (type: ChartType) => void;
+	onCostChartToggle: (type: ChartType) => void;
+	onModelChartToggle: (type: ChartType) => void;
+	onLatencyChartToggle: (type: ChartType) => void;
+	onCostModelChange: (model: string) => void;
+	onUsageModelChange: (model: string) => void;
+}
+
+export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabViewProps>(function OverviewTabView(
+	{
+		filters,
+		active,
+		startTime,
+		endTime,
+		volumeChartType,
+		tokenChartType,
+		costChartType,
+		modelChartType,
+		latencyChartType,
+		costModel,
+		usageModel,
+		onVolumeChartToggle,
+		onTokenChartToggle,
+		onCostChartToggle,
+		onModelChartToggle,
+		onLatencyChartToggle,
+		onCostModelChange,
+		onUsageModelChange,
+	},
+	ref,
+) {
+	const fetchArg = useMemo(() => ({ filters }), [filters]);
+	const skipOpts = useMemo(() => ({ skip: !active }), [active]);
+
+	const { data: histogramData, isLoading: loadingHistogram } = useGetLogsHistogramQuery(fetchArg, skipOpts);
+	const { data: tokenData, isLoading: loadingTokens } = useGetLogsTokenHistogramQuery(fetchArg, skipOpts);
+	const { data: costData, isLoading: loadingCost } = useGetLogsCostHistogramQuery(fetchArg, skipOpts);
+	const { data: modelData, isLoading: loadingModels } = useGetLogsModelHistogramQuery(fetchArg, skipOpts);
+	const { data: latencyData, isLoading: loadingLatency } = useGetLogsLatencyHistogramQuery(fetchArg, skipOpts);
+	const { data: logsStats, isLoading: loadingStats } = useGetLogsStatsQuery(fetchArg, skipOpts);
+
+	const [triggerHistogram] = useLazyGetLogsHistogramQuery();
+	const [triggerTokens] = useLazyGetLogsTokenHistogramQuery();
+	const [triggerCost] = useLazyGetLogsCostHistogramQuery();
+	const [triggerModels] = useLazyGetLogsModelHistogramQuery();
+	const [triggerLatency] = useLazyGetLogsLatencyHistogramQuery();
+	const [triggerStats] = useLazyGetLogsStatsQuery();
+
+	const loadData = useCallback(async () => {
+		await Promise.all([
+			triggerHistogram(fetchArg, true),
+			triggerTokens(fetchArg, true),
+			triggerCost(fetchArg, true),
+			triggerModels(fetchArg, true),
+			triggerLatency(fetchArg, true),
+			triggerStats(fetchArg, true),
+		]);
+	}, [fetchArg, triggerHistogram, triggerTokens, triggerCost, triggerModels, triggerLatency, triggerStats]);
+
+	useImperativeHandle(
+		ref,
+		() => ({
+			getData: () => ({
+				histogramData: histogramData ?? null,
+				tokenData: tokenData ?? null,
+				costData: costData ?? null,
+				modelData: modelData ?? null,
+				latencyData: latencyData ?? null,
+			}),
+			loadData,
+		}),
+		[histogramData, tokenData, costData, modelData, latencyData, loadData],
+	);
+
+	const costModels = useMemo(() => sanitizeSeriesLabels(costData?.models), [costData?.models]);
+	const usageModels = useMemo(() => sanitizeSeriesLabels(modelData?.models), [modelData?.models]);
+	const availableModels = useMemo(
+		() => sanitizeSeriesLabels([...(costData?.models ?? []), ...(modelData?.models ?? [])]),
+		[costData?.models, modelData?.models],
+	);
+
+	return (
+		<OverviewTab
+			histogramData={histogramData ?? null}
+			tokenData={tokenData ?? null}
+			costData={costData ?? null}
+			modelData={modelData ?? null}
+			latencyData={latencyData ?? null}
+			logsStats={logsStats ?? null}
+			loadingHistogram={loadingHistogram}
+			loadingTokens={loadingTokens}
+			loadingCost={loadingCost}
+			loadingModels={loadingModels}
+			loadingLatency={loadingLatency}
+			loadingStats={loadingStats}
+			startTime={startTime}
+			endTime={endTime}
+			volumeChartType={volumeChartType}
+			tokenChartType={tokenChartType}
+			costChartType={costChartType}
+			modelChartType={modelChartType}
+			latencyChartType={latencyChartType}
+			costModel={costModel}
+			usageModel={usageModel}
+			costModels={costModels}
+			usageModels={usageModels}
+			availableModels={availableModels}
+			onVolumeChartToggle={onVolumeChartToggle}
+			onTokenChartToggle={onTokenChartToggle}
+			onCostChartToggle={onCostChartToggle}
+			onModelChartToggle={onModelChartToggle}
+			onLatencyChartToggle={onLatencyChartToggle}
+			onCostModelChange={onCostModelChange}
+			onUsageModelChange={onUsageModelChange}
+		/>
+	);
+});

--- a/ui/app/workspace/dashboard/components/tabViews/providerUsageTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/providerUsageTabView.tsx
@@ -1,0 +1,137 @@
+import {
+	useGetLogsProviderCostHistogramQuery,
+	useGetLogsProviderLatencyHistogramQuery,
+	useGetLogsProviderTokenHistogramQuery,
+	useLazyGetLogsProviderCostHistogramQuery,
+	useLazyGetLogsProviderLatencyHistogramQuery,
+	useLazyGetLogsProviderTokenHistogramQuery,
+} from "@/lib/store";
+import type { LogFilters } from "@/lib/types/logs";
+import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
+import type { DashboardData } from "../../utils/exportUtils";
+import type { ChartType } from "../charts/chartTypeToggle";
+import { ProviderUsageTab } from "../providerUsageTab";
+
+export interface ProviderUsageTabViewHandle {
+	getData: () => Partial<DashboardData>;
+	loadData: () => Promise<void>;
+}
+
+const sanitizeSeriesLabels = (values?: string[]): string[] => {
+	if (!values) return [];
+	const trimmed = values.map((v) => v.trim()).filter((v) => v.length > 0);
+	return [...new Set(trimmed)];
+};
+
+interface ProviderUsageTabViewProps {
+	filters: LogFilters;
+	active: boolean;
+	startTime: number;
+	endTime: number;
+	providerCostChartType: ChartType;
+	providerTokenChartType: ChartType;
+	providerLatencyChartType: ChartType;
+	providerCostProvider: string;
+	providerTokenProvider: string;
+	providerLatencyProvider: string;
+	onProviderCostChartToggle: (type: ChartType) => void;
+	onProviderTokenChartToggle: (type: ChartType) => void;
+	onProviderLatencyChartToggle: (type: ChartType) => void;
+	onProviderCostProviderChange: (provider: string) => void;
+	onProviderTokenProviderChange: (provider: string) => void;
+	onProviderLatencyProviderChange: (provider: string) => void;
+}
+
+export const ProviderUsageTabView = forwardRef<ProviderUsageTabViewHandle, ProviderUsageTabViewProps>(
+	function ProviderUsageTabView(
+		{
+			filters,
+			active,
+			startTime,
+			endTime,
+			providerCostChartType,
+			providerTokenChartType,
+			providerLatencyChartType,
+			providerCostProvider,
+			providerTokenProvider,
+			providerLatencyProvider,
+			onProviderCostChartToggle,
+			onProviderTokenChartToggle,
+			onProviderLatencyChartToggle,
+			onProviderCostProviderChange,
+			onProviderTokenProviderChange,
+			onProviderLatencyProviderChange,
+		},
+		ref,
+	) {
+		const fetchArg = useMemo(() => ({ filters }), [filters]);
+		const skipOpts = useMemo(() => ({ skip: !active }), [active]);
+
+		const { data: providerCostData, isLoading: loadingProviderCost } = useGetLogsProviderCostHistogramQuery(fetchArg, skipOpts);
+		const { data: providerTokenData, isLoading: loadingProviderTokens } = useGetLogsProviderTokenHistogramQuery(fetchArg, skipOpts);
+		const { data: providerLatencyData, isLoading: loadingProviderLatency } = useGetLogsProviderLatencyHistogramQuery(fetchArg, skipOpts);
+
+		const [triggerProviderCost] = useLazyGetLogsProviderCostHistogramQuery();
+		const [triggerProviderTokens] = useLazyGetLogsProviderTokenHistogramQuery();
+		const [triggerProviderLatency] = useLazyGetLogsProviderLatencyHistogramQuery();
+
+		const loadData = useCallback(async () => {
+			await Promise.all([triggerProviderCost(fetchArg, true), triggerProviderTokens(fetchArg, true), triggerProviderLatency(fetchArg, true)]);
+		}, [fetchArg, triggerProviderCost, triggerProviderTokens, triggerProviderLatency]);
+
+		useImperativeHandle(
+			ref,
+			() => ({
+				getData: () => ({
+					providerCostData: providerCostData ?? null,
+					providerTokenData: providerTokenData ?? null,
+					providerLatencyData: providerLatencyData ?? null,
+				}),
+				loadData,
+			}),
+			[providerCostData, providerTokenData, providerLatencyData, loadData],
+		);
+
+		const availableProviders = useMemo(
+			() =>
+				sanitizeSeriesLabels([
+					...(providerCostData?.providers ?? []),
+					...(providerTokenData?.providers ?? []),
+					...(providerLatencyData?.providers ?? []),
+				]),
+			[providerCostData?.providers, providerTokenData?.providers, providerLatencyData?.providers],
+		);
+		const providerCostProviders = useMemo(() => sanitizeSeriesLabels(providerCostData?.providers), [providerCostData?.providers]);
+		const providerTokenProviders = useMemo(() => sanitizeSeriesLabels(providerTokenData?.providers), [providerTokenData?.providers]);
+		const providerLatencyProviders = useMemo(() => sanitizeSeriesLabels(providerLatencyData?.providers), [providerLatencyData?.providers]);
+
+		return (
+			<ProviderUsageTab
+				providerCostData={providerCostData ?? null}
+				providerTokenData={providerTokenData ?? null}
+				providerLatencyData={providerLatencyData ?? null}
+				loadingProviderCost={loadingProviderCost}
+				loadingProviderTokens={loadingProviderTokens}
+				loadingProviderLatency={loadingProviderLatency}
+				startTime={startTime}
+				endTime={endTime}
+				providerCostChartType={providerCostChartType}
+				providerTokenChartType={providerTokenChartType}
+				providerLatencyChartType={providerLatencyChartType}
+				providerCostProvider={providerCostProvider}
+				providerTokenProvider={providerTokenProvider}
+				providerLatencyProvider={providerLatencyProvider}
+				availableProviders={availableProviders}
+				providerCostProviders={providerCostProviders}
+				providerTokenProviders={providerTokenProviders}
+				providerLatencyProviders={providerLatencyProviders}
+				onProviderCostChartToggle={onProviderCostChartToggle}
+				onProviderTokenChartToggle={onProviderTokenChartToggle}
+				onProviderLatencyChartToggle={onProviderLatencyChartToggle}
+				onProviderCostProviderChange={onProviderCostProviderChange}
+				onProviderTokenProviderChange={onProviderTokenProviderChange}
+				onProviderLatencyProviderChange={onProviderLatencyProviderChange}
+			/>
+		);
+	},
+);

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -2,144 +2,36 @@ import { LogsFilterSidebar } from "@/components/filters/logsFilterSidebar";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { ScrollArea } from "@/components/ui/scrollArea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-	useGetMCPAvailableFilterDataQuery,
-	useLazyGetDimensionRankingsQuery,
-	useLazyGetLogsCostHistogramQuery,
-	useLazyGetLogsHistogramQuery,
-	useLazyGetLogsLatencyHistogramQuery,
-	useLazyGetLogsModelHistogramQuery,
-	useLazyGetLogsProviderCostHistogramQuery,
-	useLazyGetLogsProviderLatencyHistogramQuery,
-	useLazyGetLogsProviderTokenHistogramQuery,
-	useLazyGetLogsStatsQuery,
-	useLazyGetLogsTokenHistogramQuery,
-	useLazyGetMCPCostHistogramQuery,
-	useLazyGetMCPHistogramQuery,
-	useLazyGetMCPTopToolsQuery,
-	useLazyGetModelRankingsQuery,
-} from "@/lib/store";
-import type {
-	CostHistogramResponse,
-	DimensionRankingsResponse,
-	LatencyHistogramResponse,
-	LogFilters,
-	LogStats,
-	LogsHistogramResponse,
-	MCPCostHistogramResponse,
-	MCPHistogramResponse,
-	MCPToolLogFilters,
-	MCPTopToolsResponse,
-	ModelHistogramResponse,
-	ModelRankingsResponse,
-	ProviderCostHistogramResponse,
-	ProviderLatencyHistogramResponse,
-	ProviderTokenHistogramResponse,
-	RankingDimension,
-	TokenHistogramResponse,
-} from "@/lib/types/logs";
+import { useGetMCPAvailableFilterDataQuery } from "@/lib/store";
+import type { LogFilters, MCPToolLogFilters } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
 import { useLocation } from "@tanstack/react-router";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { type ChartType } from "./components/charts/chartTypeToggle";
 import { ModelFilterSelect } from "./components/charts/modelFilterSelect";
-import { DimensionRankingsTab } from "./components/dimensionRankingsTab";
 import { ExportPopover } from "./components/exportPopover";
-import { MCPTab } from "./components/mcpTab";
-import { ModelRankingsTab } from "./components/modelRankingsTab";
-import { OverviewTab } from "./components/overviewTab";
-import { ProviderUsageTab } from "./components/providerUsageTab";
+import { type DimensionRankingsTabViewHandle, DimensionRankingsTabView } from "./components/tabViews/dimensionRankingsTabView";
+import { type MCPTabViewHandle, MCPTabView } from "./components/tabViews/mcpTabView";
+import { type ModelRankingsTabViewHandle, ModelRankingsTabView } from "./components/tabViews/modelRankingsTabView";
+import { type OverviewTabViewHandle, OverviewTabView } from "./components/tabViews/overviewTabView";
+import { type ProviderUsageTabViewHandle, ProviderUsageTabView } from "./components/tabViews/providerUsageTabView";
+import type { DashboardData } from "./utils/exportUtils";
 
-// Type-safe parser for chart type URL state
 const toChartType = (value: string): ChartType => (value === "line" ? "line" : "bar");
 
 const parseCsvParam = (value: string): string[] => (value ? value.split(",").filter(Boolean) : []);
-const sanitizeSeriesLabels = (values?: string[]): string[] => {
-	if (!values) return [];
-	const trimmedValues = values.map((value) => value.trim()).filter((value) => value.length > 0);
-
-	return [...new Set(trimmedValues)];
-};
 
 export default function DashboardPage() {
-	// Data states - Overview
-	const [histogramData, setHistogramData] = useState<LogsHistogramResponse | null>(null);
-	const [tokenData, setTokenData] = useState<TokenHistogramResponse | null>(null);
-	const [costData, setCostData] = useState<CostHistogramResponse | null>(null);
-	const [modelData, setModelData] = useState<ModelHistogramResponse | null>(null);
-	const [latencyData, setLatencyData] = useState<LatencyHistogramResponse | null>(null);
-	const [logsStats, setLogsStats] = useState<LogStats | null>(null);
-	const [loadingStats, setLoadingStats] = useState(true);
-	const [providerCostData, setProviderCostData] = useState<ProviderCostHistogramResponse | null>(null);
-	const [providerTokenData, setProviderTokenData] = useState<ProviderTokenHistogramResponse | null>(null);
-	const [providerLatencyData, setProviderLatencyData] = useState<ProviderLatencyHistogramResponse | null>(null);
-
-	// Data states - MCP
-	const [mcpHistogramData, setMcpHistogramData] = useState<MCPHistogramResponse | null>(null);
-	const [mcpCostData, setMcpCostData] = useState<MCPCostHistogramResponse | null>(null);
-	const [mcpTopToolsData, setMcpTopToolsData] = useState<MCPTopToolsResponse | null>(null);
-
-	// Data states - Rankings
-	const [rankingsData, setRankingsData] = useState<ModelRankingsResponse | null>(null);
-	const [teamRankingsData, setTeamRankingsData] = useState<DimensionRankingsResponse | null>(null);
-	const [customerRankingsData, setCustomerRankingsData] = useState<DimensionRankingsResponse | null>(null);
-	const [buRankingsData, setBuRankingsData] = useState<DimensionRankingsResponse | null>(null);
-	const [userRankingsData, setUserRankingsData] = useState<DimensionRankingsResponse | null>(null);
-
-	// Loading states - Overview
-	const [loadingHistogram, setLoadingHistogram] = useState(true);
-	const [loadingTokens, setLoadingTokens] = useState(true);
-	const [loadingCost, setLoadingCost] = useState(true);
-	const [loadingModels, setLoadingModels] = useState(true);
-	const [loadingLatency, setLoadingLatency] = useState(true);
-	const [loadingProviderCost, setLoadingProviderCost] = useState(true);
-	const [loadingProviderTokens, setLoadingProviderTokens] = useState(true);
-	const [loadingProviderLatency, setLoadingProviderLatency] = useState(true);
-
-	// Loading states - MCP
-	const [loadingMcpHistogram, setLoadingMcpHistogram] = useState(true);
-	const [loadingMcpCost, setLoadingMcpCost] = useState(true);
-	const [loadingMcpTopTools, setLoadingMcpTopTools] = useState(true);
-
-	// Loading states - Rankings
-	const [loadingRankings, setLoadingRankings] = useState(true);
-	const [loadingTeamRankings, setLoadingTeamRankings] = useState(true);
-	const [loadingCustomerRankings, setLoadingCustomerRankings] = useState(true);
-	const [loadingBuRankings, setLoadingBuRankings] = useState(true);
-	const [loadingUserRankings, setLoadingUserRankings] = useState(true);
-
-	// RTK Query lazy hooks - Overview
-	const [triggerHistogram] = useLazyGetLogsHistogramQuery({});
-	const [triggerTokens] = useLazyGetLogsTokenHistogramQuery();
-	const [triggerCost] = useLazyGetLogsCostHistogramQuery();
-	const [triggerModels] = useLazyGetLogsModelHistogramQuery();
-	const [triggerLatency] = useLazyGetLogsLatencyHistogramQuery();
-	const [triggerStats] = useLazyGetLogsStatsQuery();
-	const [triggerProviderCost] = useLazyGetLogsProviderCostHistogramQuery();
-	const [triggerProviderTokens] = useLazyGetLogsProviderTokenHistogramQuery();
-	const [triggerProviderLatency] = useLazyGetLogsProviderLatencyHistogramQuery();
-
-	// RTK Query lazy hooks - MCP
-	const [triggerMcpHistogram] = useLazyGetMCPHistogramQuery();
-	const [triggerMcpCost] = useLazyGetMCPCostHistogramQuery();
-	const [triggerMcpTopTools] = useLazyGetMCPTopToolsQuery();
-
-	// RTK Query lazy hooks - Rankings
-	const [triggerRankings] = useLazyGetModelRankingsQuery();
-	const [triggerDimensionRankings] = useLazyGetDimensionRankingsQuery();
-
 	// MCP filter data
 	const { data: mcpFilterData } = useGetMCPAvailableFilterDataQuery();
 
-	// Memoize default time range to prevent recalculation on every render
-	// This is crucial to avoid triggering refetches when the sheet opens/closes
 	const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
 
 	const { search } = useLocation();
 	const hasExplicitTimeRange = (search as Record<string, unknown>)?.start_time && (search as Record<string, unknown>)?.end_time;
-	// URL state management
+
 	const [urlState, setUrlState] = useQueryStates(
 		{
 			period: parseAsString.withDefault(hasExplicitTimeRange ? "" : "1h").withOptions({ clearOnDefault: false }),
@@ -207,28 +99,23 @@ export default function DashboardPage() {
 		}
 	}, [urlState.metadata_filters]);
 
-	// MCP filter arrays
 	const selectedMcpToolNames = useMemo(() => parseCsvParam(urlState.mcp_tool_names), [urlState.mcp_tool_names]);
 	const selectedMcpServerLabels = useMemo(() => parseCsvParam(urlState.mcp_server_labels), [urlState.mcp_server_labels]);
 
-	// Free-form / multi-value sidebar inputs
 	const selectedUserIds = useMemo(() => parseCsvParam(urlState.user_ids), [urlState.user_ids]);
 	const selectedTeamIds = useMemo(() => parseCsvParam(urlState.team_ids), [urlState.team_ids]);
 	const selectedCustomerIds = useMemo(() => parseCsvParam(urlState.customer_ids), [urlState.customer_ids]);
 	const selectedBusinessUnitIds = useMemo(() => parseCsvParam(urlState.business_unit_ids), [urlState.business_unit_ids]);
 	const selectedAliases = useMemo(() => parseCsvParam(urlState.aliases), [urlState.aliases]);
 
-	// Derived filter for API calls.
-	// When period is set, send it so the backend computes the window fresh on every request.
-	// For custom absolute ranges (period === "") use the stored URL timestamps.
 	const filters: LogFilters = useMemo(
 		() => ({
 			...(urlState.period
 				? { period: urlState.period }
 				: {
-						start_time: dateUtils.toISOString(urlState.start_time),
-						end_time: dateUtils.toISOString(urlState.end_time),
-					}),
+					start_time: dateUtils.toISOString(urlState.start_time),
+					end_time: dateUtils.toISOString(urlState.end_time),
+				}),
 			...(selectedProviders.length > 0 && { providers: selectedProviders }),
 			...(selectedModels.length > 0 && { models: selectedModels }),
 			...(selectedKeyIds.length > 0 && { selected_key_ids: selectedKeyIds }),
@@ -247,8 +134,8 @@ export default function DashboardPage() {
 			...(missingCostOnly && { missing_cost_only: true }),
 			...(metadataFilters &&
 				Object.keys(metadataFilters).length > 0 && {
-					metadata_filters: metadataFilters,
-				}),
+				metadata_filters: metadataFilters,
+			}),
 			...(urlState.parent_request_id && { parent_request_id: urlState.parent_request_id }),
 			...(selectedUserIds.length > 0 && { user_ids: selectedUserIds }),
 			...(selectedTeamIds.length > 0 && { team_ids: selectedTeamIds }),
@@ -280,15 +167,14 @@ export default function DashboardPage() {
 		],
 	);
 
-	// MCP filters — same period-first logic as filters above.
 	const mcpFilters: MCPToolLogFilters = useMemo(
 		() => ({
 			...(urlState.period
 				? { period: urlState.period }
 				: {
-						start_time: dateUtils.toISOString(urlState.start_time),
-						end_time: dateUtils.toISOString(urlState.end_time),
-					}),
+					start_time: dateUtils.toISOString(urlState.start_time),
+					end_time: dateUtils.toISOString(urlState.end_time),
+				}),
 			...(selectedMcpToolNames.length > 0 && {
 				tool_names: selectedMcpToolNames,
 			}),
@@ -311,358 +197,47 @@ export default function DashboardPage() {
 		],
 	);
 
-	// Model lists for each chart's legend (must match what the chart component actually renders)
-	const costModels = useMemo(() => sanitizeSeriesLabels(costData?.models), [costData?.models]);
-	const usageModels = useMemo(() => sanitizeSeriesLabels(modelData?.models), [modelData?.models]);
+	// Tab view refs for export data aggregation
+	const overviewRef = useRef<OverviewTabViewHandle>(null);
+	const providerRef = useRef<ProviderUsageTabViewHandle>(null);
+	const mcpRef = useRef<MCPTabViewHandle>(null);
+	const modelRankingsRef = useRef<ModelRankingsTabViewHandle>(null);
+	const teamRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
+	const customerRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
+	const buRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
+	const userRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
 
-	// Available models for filter dropdowns (union of both sources)
-	const availableModels = useMemo(() => {
-		return sanitizeSeriesLabels([...(costData?.models ?? []), ...(modelData?.models ?? [])]);
-	}, [costData?.models, modelData?.models]);
+	const allRefs = [overviewRef, providerRef, mcpRef, modelRankingsRef, teamRankingsRef, customerRankingsRef, buRankingsRef, userRankingsRef];
 
-	// Available providers for provider chart filter dropdowns
-	const availableProviders = useMemo(() => {
-		return sanitizeSeriesLabels([
-			...(providerCostData?.providers ?? []),
-			...(providerTokenData?.providers ?? []),
-			...(providerLatencyData?.providers ?? []),
-		]);
-	}, [providerCostData?.providers, providerTokenData?.providers, providerLatencyData?.providers]);
+	const getDashboardData = useCallback((): DashboardData => {
+		const merged: Partial<DashboardData> = {};
+		for (const r of allRefs) {
+			if (r.current) Object.assign(merged, r.current.getData());
+		}
+		return {
+			histogramData: null,
+			tokenData: null,
+			costData: null,
+			modelData: null,
+			latencyData: null,
+			providerCostData: null,
+			providerTokenData: null,
+			providerLatencyData: null,
+			rankingsData: null,
+			teamRankingsData: null,
+			customerRankingsData: null,
+			buRankingsData: null,
+			userRankingsData: null,
+			mcpHistogramData: null,
+			mcpCostData: null,
+			mcpTopToolsData: null,
+			...merged,
+		};
+	}, []);
 
-	// Provider lists for each chart's legend
-	const providerCostProviders = useMemo(() => sanitizeSeriesLabels(providerCostData?.providers), [providerCostData?.providers]);
-	const providerTokenProviders = useMemo(() => sanitizeSeriesLabels(providerTokenData?.providers), [providerTokenData?.providers]);
-	const providerLatencyProviders = useMemo(() => sanitizeSeriesLabels(providerLatencyData?.providers), [providerLatencyData?.providers]);
-
-	// Fetch Overview tab data (5 calls)
-	const fetchOverviewData = useCallback(async () => {
-		setLoadingHistogram(true);
-		setLoadingTokens(true);
-		setLoadingCost(true);
-		setLoadingModels(true);
-		setLoadingLatency(true);
-		setLoadingStats(true);
-
-		const fetchFilters = { filters };
-
-		const overviewPromise = Promise.all([
-			triggerHistogram(fetchFilters, false),
-			triggerTokens(fetchFilters, false),
-			triggerCost(fetchFilters, false),
-			triggerModels(fetchFilters, false),
-			triggerLatency(fetchFilters, false),
-		]).then(([histogramResult, tokenResult, costResult, modelResult, latencyResult]) => {
-			setHistogramData(histogramResult.data ?? null);
-			setLoadingHistogram(false);
-			setTokenData(tokenResult.data ?? null);
-			setLoadingTokens(false);
-			setCostData(costResult.data ?? null);
-			setLoadingCost(false);
-			setModelData(modelResult.data ?? null);
-			setLoadingModels(false);
-			setLatencyData(latencyResult.data ?? null);
-			setLoadingLatency(false);
-		});
-		const statsPromise = triggerStats(fetchFilters, false).then((statsResult) => {
-			setLogsStats(statsResult.data ?? null);
-			setLoadingStats(false);
-		});
-
-		await Promise.all([overviewPromise, statsPromise]);
-	}, [filters, triggerHistogram, triggerTokens, triggerCost, triggerModels, triggerLatency, triggerStats]);
-
-	// Fetch Provider Usage tab data (3 calls)
-	const fetchProviderData = useCallback(async () => {
-		setLoadingProviderCost(true);
-		setLoadingProviderTokens(true);
-		setLoadingProviderLatency(true);
-
-		const fetchFilters = { filters };
-
-		const [providerCostResult, providerTokenResult, providerLatencyResult] = await Promise.all([
-			triggerProviderCost(fetchFilters, false),
-			triggerProviderTokens(fetchFilters, false),
-			triggerProviderLatency(fetchFilters, false),
-		]);
-
-		setProviderCostData(providerCostResult.data ?? null);
-		setLoadingProviderCost(false);
-		setProviderTokenData(providerTokenResult.data ?? null);
-		setLoadingProviderTokens(false);
-		setProviderLatencyData(providerLatencyResult.data ?? null);
-		setLoadingProviderLatency(false);
-	}, [filters, triggerProviderCost, triggerProviderTokens, triggerProviderLatency]);
-
-	// Fetch MCP data
-	const fetchMcpData = useCallback(async () => {
-		setLoadingMcpHistogram(true);
-		setLoadingMcpCost(true);
-		setLoadingMcpTopTools(true);
-
-		const fetchFilters = { filters: mcpFilters };
-
-		const [mcpHistResult, mcpCostResult, mcpTopToolsResult] = await Promise.all([
-			triggerMcpHistogram(fetchFilters, false),
-			triggerMcpCost(fetchFilters, false),
-			triggerMcpTopTools(fetchFilters, false),
-		]);
-
-		setMcpHistogramData(mcpHistResult.data ?? null);
-		setLoadingMcpHistogram(false);
-		setMcpCostData(mcpCostResult.data ?? null);
-		setLoadingMcpCost(false);
-		setMcpTopToolsData(mcpTopToolsResult.data ?? null);
-		setLoadingMcpTopTools(false);
-	}, [mcpFilters, triggerMcpHistogram, triggerMcpCost, triggerMcpTopTools]);
-
-	// Fetch Rankings data
-	const fetchRankingsData = useCallback(async () => {
-		setLoadingRankings(true);
-		const result = await triggerRankings({ filters }, false);
-		setRankingsData(result.data ?? null);
-		setLoadingRankings(false);
-	}, [filters, triggerRankings]);
-
-	const fetchDimensionRankings = useCallback(
-		async (dimension: RankingDimension, setData: (d: DimensionRankingsResponse | null) => void, setLoading: (l: boolean) => void) => {
-			setLoading(true);
-			const result = await triggerDimensionRankings({ filters, dimension }, false);
-			setData(result.data ?? null);
-			setLoading(false);
-		},
-		[filters, triggerDimensionRankings],
-	);
-
-	const fetchTeamRankings = useCallback(() => fetchDimensionRankings("team", setTeamRankingsData, setLoadingTeamRankings), [fetchDimensionRankings]);
-	const fetchCustomerRankings = useCallback(() => fetchDimensionRankings("customer", setCustomerRankingsData, setLoadingCustomerRankings), [fetchDimensionRankings]);
-	const fetchBuRankings = useCallback(() => fetchDimensionRankings("business_unit", setBuRankingsData, setLoadingBuRankings), [fetchDimensionRankings]);
-	const fetchUserRankings = useCallback(() => fetchDimensionRankings("user", setUserRankingsData, setLoadingUserRankings), [fetchDimensionRankings]);
-
-	// --- Lazy-load refs: each tab fetches only once per filter change ---
-	const overviewFetchedRef = useRef(false);
-	const overviewLoadingRef = useRef(false);
-	const overviewGenRef = useRef(0);
-	const overviewPromiseRef = useRef<Promise<void> | null>(null);
-
-	const providerFetchedRef = useRef(false);
-	const providerLoadingRef = useRef(false);
-	const providerGenRef = useRef(0);
-	const providerPromiseRef = useRef<Promise<void> | null>(null);
-
-	const mcpFetchedRef = useRef(false);
-	const mcpLoadingRef = useRef(false);
-	const mcpGenRef = useRef(0);
-	const mcpPromiseRef = useRef<Promise<void> | null>(null);
-
-	const rankingsFetchedRef = useRef(false);
-	const rankingsLoadingRef = useRef(false);
-	const rankingsGenRef = useRef(0);
-	const rankingsPromiseRef = useRef<Promise<void> | null>(null);
-
-	const teamRankingsFetchedRef = useRef(false);
-	const teamRankingsLoadingRef = useRef(false);
-	const teamRankingsGenRef = useRef(0);
-	const teamRankingsPromiseRef = useRef<Promise<void> | null>(null);
-
-	const customerRankingsFetchedRef = useRef(false);
-	const customerRankingsLoadingRef = useRef(false);
-	const customerRankingsGenRef = useRef(0);
-	const customerRankingsPromiseRef = useRef<Promise<void> | null>(null);
-
-	const buRankingsFetchedRef = useRef(false);
-	const buRankingsLoadingRef = useRef(false);
-	const buRankingsGenRef = useRef(0);
-	const buRankingsPromiseRef = useRef<Promise<void> | null>(null);
-
-	const userRankingsFetchedRef = useRef(false);
-	const userRankingsLoadingRef = useRef(false);
-	const userRankingsGenRef = useRef(0);
-	const userRankingsPromiseRef = useRef<Promise<void> | null>(null);
-
-	const ensureOverviewDataLoaded = useCallback(async () => {
-		if (overviewFetchedRef.current) return;
-		if (overviewLoadingRef.current) return overviewPromiseRef.current ?? undefined;
-		const gen = overviewGenRef.current;
-		overviewLoadingRef.current = true;
-		const promise = fetchOverviewData()
-			.then(() => {
-				if (gen === overviewGenRef.current) overviewFetchedRef.current = true;
-			})
-			.finally(() => {
-				if (gen === overviewGenRef.current) {
-					overviewLoadingRef.current = false;
-					overviewPromiseRef.current = null;
-				}
-			});
-		overviewPromiseRef.current = promise;
-		return promise;
-	}, [fetchOverviewData]);
-
-	const ensureProviderDataLoaded = useCallback(async () => {
-		if (providerFetchedRef.current) return;
-		if (providerLoadingRef.current) return providerPromiseRef.current ?? undefined;
-		const gen = providerGenRef.current;
-		providerLoadingRef.current = true;
-		const promise = fetchProviderData()
-			.then(() => {
-				if (gen === providerGenRef.current) providerFetchedRef.current = true;
-			})
-			.finally(() => {
-				if (gen === providerGenRef.current) {
-					providerLoadingRef.current = false;
-					providerPromiseRef.current = null;
-				}
-			});
-		providerPromiseRef.current = promise;
-		return promise;
-	}, [fetchProviderData]);
-
-	const ensureMcpDataLoaded = useCallback(async () => {
-		if (mcpFetchedRef.current) return;
-		if (mcpLoadingRef.current) return mcpPromiseRef.current ?? undefined;
-		const gen = mcpGenRef.current;
-		mcpLoadingRef.current = true;
-		const promise = fetchMcpData()
-			.then(() => {
-				if (gen === mcpGenRef.current) mcpFetchedRef.current = true;
-			})
-			.finally(() => {
-				if (gen === mcpGenRef.current) {
-					mcpLoadingRef.current = false;
-					mcpPromiseRef.current = null;
-				}
-			});
-		mcpPromiseRef.current = promise;
-		return promise;
-	}, [fetchMcpData]);
-
-	const ensureRankingsDataLoaded = useCallback(async () => {
-		if (rankingsFetchedRef.current) return;
-		if (rankingsLoadingRef.current) return rankingsPromiseRef.current ?? undefined;
-		const gen = rankingsGenRef.current;
-		rankingsLoadingRef.current = true;
-		const promise = fetchRankingsData()
-			.then(() => {
-				if (gen === rankingsGenRef.current) rankingsFetchedRef.current = true;
-			})
-			.finally(() => {
-				if (gen === rankingsGenRef.current) {
-					rankingsLoadingRef.current = false;
-					rankingsPromiseRef.current = null;
-				}
-			});
-		rankingsPromiseRef.current = promise;
-		return promise;
-	}, [fetchRankingsData]);
-
-	const ensureTeamRankingsLoaded = useCallback(async () => {
-		if (teamRankingsFetchedRef.current) return;
-		if (teamRankingsLoadingRef.current) return teamRankingsPromiseRef.current ?? undefined;
-		const gen = teamRankingsGenRef.current;
-		teamRankingsLoadingRef.current = true;
-		const promise = fetchTeamRankings()
-			.then(() => { if (gen === teamRankingsGenRef.current) teamRankingsFetchedRef.current = true; })
-			.finally(() => { if (gen === teamRankingsGenRef.current) { teamRankingsLoadingRef.current = false; teamRankingsPromiseRef.current = null; } });
-		teamRankingsPromiseRef.current = promise;
-		return promise;
-	}, [fetchTeamRankings]);
-
-	const ensureCustomerRankingsLoaded = useCallback(async () => {
-		if (customerRankingsFetchedRef.current) return;
-		if (customerRankingsLoadingRef.current) return customerRankingsPromiseRef.current ?? undefined;
-		const gen = customerRankingsGenRef.current;
-		customerRankingsLoadingRef.current = true;
-		const promise = fetchCustomerRankings()
-			.then(() => { if (gen === customerRankingsGenRef.current) customerRankingsFetchedRef.current = true; })
-			.finally(() => { if (gen === customerRankingsGenRef.current) { customerRankingsLoadingRef.current = false; customerRankingsPromiseRef.current = null; } });
-		customerRankingsPromiseRef.current = promise;
-		return promise;
-	}, [fetchCustomerRankings]);
-
-	const ensureBuRankingsLoaded = useCallback(async () => {
-		if (buRankingsFetchedRef.current) return;
-		if (buRankingsLoadingRef.current) return buRankingsPromiseRef.current ?? undefined;
-		const gen = buRankingsGenRef.current;
-		buRankingsLoadingRef.current = true;
-		const promise = fetchBuRankings()
-			.then(() => { if (gen === buRankingsGenRef.current) buRankingsFetchedRef.current = true; })
-			.finally(() => { if (gen === buRankingsGenRef.current) { buRankingsLoadingRef.current = false; buRankingsPromiseRef.current = null; } });
-		buRankingsPromiseRef.current = promise;
-		return promise;
-	}, [fetchBuRankings]);
-
-	const ensureUserRankingsLoaded = useCallback(async () => {
-		if (userRankingsFetchedRef.current) return;
-		if (userRankingsLoadingRef.current) return userRankingsPromiseRef.current ?? undefined;
-		const gen = userRankingsGenRef.current;
-		userRankingsLoadingRef.current = true;
-		const promise = fetchUserRankings()
-			.then(() => { if (gen === userRankingsGenRef.current) userRankingsFetchedRef.current = true; })
-			.finally(() => { if (gen === userRankingsGenRef.current) { userRankingsLoadingRef.current = false; userRankingsPromiseRef.current = null; } });
-		userRankingsPromiseRef.current = promise;
-		return promise;
-	}, [fetchUserRankings]);
-
-	// Reset all lazy-load flags when filters change (not on tab switch)
-	useEffect(() => {
-		overviewFetchedRef.current = false;
-		overviewLoadingRef.current = false;
-		overviewGenRef.current += 1;
-		providerFetchedRef.current = false;
-		providerLoadingRef.current = false;
-		providerGenRef.current += 1;
-		rankingsFetchedRef.current = false;
-		rankingsLoadingRef.current = false;
-		rankingsGenRef.current += 1;
-		teamRankingsFetchedRef.current = false;
-		teamRankingsLoadingRef.current = false;
-		teamRankingsGenRef.current += 1;
-		customerRankingsFetchedRef.current = false;
-		customerRankingsLoadingRef.current = false;
-		customerRankingsGenRef.current += 1;
-		buRankingsFetchedRef.current = false;
-		buRankingsLoadingRef.current = false;
-		buRankingsGenRef.current += 1;
-		userRankingsFetchedRef.current = false;
-		userRankingsLoadingRef.current = false;
-		userRankingsGenRef.current += 1;
-	}, [filters]);
-
-	useEffect(() => {
-		mcpFetchedRef.current = false;
-		mcpLoadingRef.current = false;
-		mcpGenRef.current += 1;
-	}, [mcpFilters]);
-
-	// Fetch current tab's data when filters change or tab switches
-	// The ensure* functions are no-ops if data is already loaded for the current filters
-	useEffect(() => {
-		const tab = urlState.tab || "overview";
-		if (tab === "overview") void ensureOverviewDataLoaded();
-		else if (tab === "provider-usage") void ensureProviderDataLoaded();
-		else if (tab === "rankings") void ensureRankingsDataLoaded();
-		else if (tab === "mcp") void ensureMcpDataLoaded();
-		else if (tab === "team-rankings") void ensureTeamRankingsLoaded();
-		else if (tab === "customer-rankings") void ensureCustomerRankingsLoaded();
-		else if (tab === "bu-rankings") void ensureBuRankingsLoaded();
-		else if (tab === "user-rankings") void ensureUserRankingsLoaded();
-	}, [urlState.tab, ensureOverviewDataLoaded, ensureProviderDataLoaded, ensureRankingsDataLoaded, ensureMcpDataLoaded, ensureTeamRankingsLoaded, ensureCustomerRankingsLoaded, ensureBuRankingsLoaded, ensureUserRankingsLoaded]);
-
-	// Warm other tabs in the background after 150ms
-	useEffect(() => {
-		const tab = urlState.tab || "overview";
-		const timeoutId = window.setTimeout(() => {
-			if (tab !== "overview") void ensureOverviewDataLoaded();
-			if (tab !== "provider-usage") void ensureProviderDataLoaded();
-			if (tab !== "mcp") void ensureMcpDataLoaded();
-			if (tab !== "rankings") void ensureRankingsDataLoaded();
-			if (tab !== "team-rankings") void ensureTeamRankingsLoaded();
-			if (tab !== "customer-rankings") void ensureCustomerRankingsLoaded();
-			if (tab !== "bu-rankings") void ensureBuRankingsLoaded();
-			if (tab !== "user-rankings") void ensureUserRankingsLoaded();
-		}, 150);
-		return () => window.clearTimeout(timeoutId);
-	}, [urlState.tab, ensureOverviewDataLoaded, ensureProviderDataLoaded, ensureMcpDataLoaded, ensureRankingsDataLoaded, ensureTeamRankingsLoaded, ensureCustomerRankingsLoaded, ensureBuRankingsLoaded, ensureUserRankingsLoaded]);
+	const handlePreloadData = useCallback(async () => {
+		await Promise.all(allRefs.map((r) => r.current?.loadData()));
+	}, []);
 
 	// Tab change handler
 	const handleTabChange = useCallback(
@@ -678,6 +253,27 @@ export default function DashboardPage() {
 	const handleCostChartToggle = useCallback((type: ChartType) => setUrlState({ cost_chart: type }), [setUrlState]);
 	const handleModelChartToggle = useCallback((type: ChartType) => setUrlState({ model_chart: type }), [setUrlState]);
 	const handleLatencyChartToggle = useCallback((type: ChartType) => setUrlState({ latency_chart: type }), [setUrlState]);
+	const handleProviderCostChartToggle = useCallback((type: ChartType) => setUrlState({ provider_cost_chart: type }), [setUrlState]);
+	const handleProviderTokenChartToggle = useCallback((type: ChartType) => setUrlState({ provider_token_chart: type }), [setUrlState]);
+	const handleProviderLatencyChartToggle = useCallback((type: ChartType) => setUrlState({ provider_latency_chart: type }), [setUrlState]);
+	const handleMcpVolumeChartToggle = useCallback((type: ChartType) => setUrlState({ mcp_volume_chart: type }), [setUrlState]);
+	const handleMcpCostChartToggle = useCallback((type: ChartType) => setUrlState({ mcp_cost_chart: type }), [setUrlState]);
+
+	// Model / provider filter changes
+	const handleCostModelChange = useCallback((model: string) => setUrlState({ cost_model: model }), [setUrlState]);
+	const handleUsageModelChange = useCallback((model: string) => setUrlState({ usage_model: model }), [setUrlState]);
+	const handleProviderCostProviderChange = useCallback(
+		(provider: string) => setUrlState({ provider_cost_provider: provider }),
+		[setUrlState],
+	);
+	const handleProviderTokenProviderChange = useCallback(
+		(provider: string) => setUrlState({ provider_token_provider: provider }),
+		[setUrlState],
+	);
+	const handleProviderLatencyProviderChange = useCallback(
+		(provider: string) => setUrlState({ provider_latency_provider: provider }),
+		[setUrlState],
+	);
 
 	// Adapter: converts a full LogFilters object to dashboard's CSV-based URL state
 	const setFilters = useCallback(
@@ -749,118 +345,21 @@ export default function DashboardPage() {
 		[setUrlState],
 	);
 
-	const handleProviderCostChartToggle = useCallback((type: ChartType) => setUrlState({ provider_cost_chart: type }), [setUrlState]);
-	const handleProviderTokenChartToggle = useCallback((type: ChartType) => setUrlState({ provider_token_chart: type }), [setUrlState]);
-	const handleProviderLatencyChartToggle = useCallback((type: ChartType) => setUrlState({ provider_latency_chart: type }), [setUrlState]);
-
-	// MCP chart type toggles
-	const handleMcpVolumeChartToggle = useCallback((type: ChartType) => setUrlState({ mcp_volume_chart: type }), [setUrlState]);
-	const handleMcpCostChartToggle = useCallback((type: ChartType) => setUrlState({ mcp_cost_chart: type }), [setUrlState]);
-
-	// Model filter changes
-	const handleCostModelChange = useCallback((model: string) => setUrlState({ cost_model: model }), [setUrlState]);
-	const handleUsageModelChange = useCallback((model: string) => setUrlState({ usage_model: model }), [setUrlState]);
-
-	// Provider filter changes
-	const handleProviderCostProviderChange = useCallback(
-		(provider: string) => setUrlState({ provider_cost_provider: provider }),
-		[setUrlState],
-	);
-	const handleProviderTokenProviderChange = useCallback(
-		(provider: string) => setUrlState({ provider_token_provider: provider }),
-		[setUrlState],
-	);
-	const handleProviderLatencyProviderChange = useCallback(
-		(provider: string) => setUrlState({ provider_latency_provider: provider }),
-		[setUrlState],
-	);
-
-	// Aggregate data object for export
-	const dashboardData = useMemo(
-		() => ({
-			histogramData,
-			tokenData,
-			costData,
-			modelData,
-			latencyData,
-			logsStats,
-			providerCostData,
-			providerTokenData,
-			providerLatencyData,
-			rankingsData,
-			mcpHistogramData,
-			mcpCostData,
-			mcpTopToolsData,
-			teamRankingsData,
-			customerRankingsData,
-			buRankingsData,
-			userRankingsData,
-		}),
-		[
-			histogramData,
-			tokenData,
-			costData,
-			modelData,
-			latencyData,
-			logsStats,
-			providerCostData,
-			providerTokenData,
-			providerLatencyData,
-			rankingsData,
-			mcpHistogramData,
-			mcpCostData,
-			mcpTopToolsData,
-			teamRankingsData,
-			customerRankingsData,
-			buRankingsData,
-			userRankingsData,
-		],
-	);
-
-	// Keep a ref in sync so export callbacks always read the latest data
-	const dashboardDataRef = useRef(dashboardData);
-	dashboardDataRef.current = dashboardData;
-	const getDashboardData = useCallback(() => dashboardDataRef.current, []);
-
-	// Preload all tab data (used by CSV and PDF export)
-	const handlePreloadData = useCallback(async () => {
-		await Promise.all([
-			ensureOverviewDataLoaded(),
-			ensureProviderDataLoaded(),
-			ensureRankingsDataLoaded(),
-			ensureMcpDataLoaded(),
-			ensureTeamRankingsLoaded(),
-			ensureCustomerRankingsLoaded(),
-			ensureBuRankingsLoaded(),
-			ensureUserRankingsLoaded(),
-		]);
-	}, [ensureOverviewDataLoaded, ensureProviderDataLoaded, ensureRankingsDataLoaded, ensureMcpDataLoaded, ensureTeamRankingsLoaded, ensureCustomerRankingsLoaded, ensureBuRankingsLoaded, ensureUserRankingsLoaded]);
-
-	// PDF export mode — when true, all TabsContent are force-mounted so
-	// html2canvas can capture every tab.
+	// PDF export mode
 	const [pdfMode, setPdfMode] = useState(false);
 	const dashboardMinHeightRef = useRef<string>("");
 	const hiddenTabsRef = useRef<HTMLElement[]>([]);
 
-	// Called by ExportPopover. Loads all data, force-mounts all tabs,
-	// unhides inactive tabs so html2canvas can capture them, then returns
-	// the 4 section DOM elements. Caller must invoke the returned cleanup
-	// function when done capturing.
 	const handlePdfExport = useCallback(async (): Promise<HTMLElement[]> => {
-		// Ensure every tab's data is loaded
 		await handlePreloadData();
-
 		setPdfMode(true);
 
-		// Wait for React to render the force-mounted tabs
 		await new Promise<void>((resolve) => {
 			requestAnimationFrame(() => {
 				requestAnimationFrame(() => resolve());
 			});
 		});
 
-		// Radix sets `hidden` on inactive force-mounted TabsContent.
-		// Temporarily remove it so html2canvas can capture them.
 		const hiddenTabs = document.querySelectorAll<HTMLElement>('[data-slot="tabs-content"][hidden]');
 		hiddenTabsRef.current = Array.from(hiddenTabs);
 		for (const tab of hiddenTabs) {
@@ -868,15 +367,12 @@ export default function DashboardPage() {
 			tab.style.display = "block";
 		}
 
-		// Collapse min-height on the dashboard container so captured
-		// sections wrap tightly around their content (no extra whitespace).
 		const dashboardEl = document.getElementById("dashboard-root");
 		if (dashboardEl) {
 			dashboardMinHeightRef.current = dashboardEl.style.minHeight;
 			dashboardEl.style.minHeight = "0";
 		}
 
-		// Let ResizeObserver-based charts (meter gauge) re-measure
 		window.dispatchEvent(new Event("resize"));
 		await new Promise<void>((resolve) => {
 			requestAnimationFrame(() => {
@@ -884,19 +380,25 @@ export default function DashboardPage() {
 			});
 		});
 
-		const ids = ["dashboard-section-overview", "dashboard-section-provider-usage", "dashboard-section-rankings", "dashboard-section-mcp", "dashboard-section-team-rankings", "dashboard-section-customer-rankings", "dashboard-section-bu-rankings", "dashboard-section-user-rankings"];
+		const ids = [
+			"dashboard-section-overview",
+			"dashboard-section-provider-usage",
+			"dashboard-section-rankings",
+			"dashboard-section-mcp",
+			"dashboard-section-team-rankings",
+			"dashboard-section-customer-rankings",
+			"dashboard-section-bu-rankings",
+			"dashboard-section-user-rankings",
+		];
 		return ids.map((id) => document.getElementById(id)).filter(Boolean) as HTMLElement[];
 	}, [handlePreloadData]);
 
-	// Cleanup after PDF capture is complete
 	const handlePdfExportDone = useCallback(() => {
-		// Restore minHeight on dashboard container
 		const dashboardEl = document.getElementById("dashboard-root");
 		if (dashboardEl) {
 			dashboardEl.style.minHeight = dashboardMinHeightRef.current;
 		}
 
-		// Re-hide tabs that were temporarily shown for capture
 		for (const tab of hiddenTabsRef.current) {
 			tab.setAttribute("hidden", "");
 			tab.style.display = "";
@@ -905,6 +407,8 @@ export default function DashboardPage() {
 
 		setPdfMode(false);
 	}, []);
+
+	const activeTab = urlState.tab || "overview";
 
 	return (
 		<div id="dashboard-root" className="no-padding-parent no-border-parent bg-background flex h-[calc(100vh_-_16px)] w-full gap-3">
@@ -925,7 +429,7 @@ export default function DashboardPage() {
 							onPdfExport={handlePdfExport}
 							onPdfExportDone={handlePdfExportDone}
 						/>
-						{urlState.tab === "mcp" && mcpFilterData && (
+						{activeTab === "mcp" && mcpFilterData && (
 							<div className="flex items-center gap-1">
 								{(mcpFilterData.tool_names?.length ?? 0) > 0 && (
 									<ModelFilterSelect
@@ -973,7 +477,7 @@ export default function DashboardPage() {
 
 				<div className="p-4">
 					{/* Tabs */}
-					<Tabs value={urlState.tab} onValueChange={handleTabChange}>
+					<Tabs value={activeTab} onValueChange={handleTabChange}>
 						<TabsList className="mb-2">
 							<TabsTrigger value="overview" data-testid="dashboard-tab-overview">
 								Overview
@@ -990,33 +494,24 @@ export default function DashboardPage() {
 							<TabsTrigger value="team-rankings" data-testid="dashboard-tab-team-rankings">
 								Team Rankings
 							</TabsTrigger>
+							<TabsTrigger value="user-rankings" data-testid="dashboard-tab-user-rankings">
+								User Rankings
+							</TabsTrigger>
 							<TabsTrigger value="customer-rankings" data-testid="dashboard-tab-customer-rankings">
 								Customer Rankings
 							</TabsTrigger>
 							<TabsTrigger value="bu-rankings" data-testid="dashboard-tab-bu-rankings">
 								BU Rankings
 							</TabsTrigger>
-							<TabsTrigger value="user-rankings" data-testid="dashboard-tab-user-rankings">
-								User Rankings
-							</TabsTrigger>
 						</TabsList>
 
 						{/* Overview Tab */}
 						<TabsContent value="overview" {...(pdfMode && { forceMount: true })}>
 							<div id="dashboard-section-overview">
-								<OverviewTab
-									histogramData={histogramData}
-									tokenData={tokenData}
-									costData={costData}
-									modelData={modelData}
-									latencyData={latencyData}
-									logsStats={logsStats}
-									loadingHistogram={loadingHistogram}
-									loadingTokens={loadingTokens}
-									loadingCost={loadingCost}
-									loadingModels={loadingModels}
-									loadingLatency={loadingLatency}
-									loadingStats={loadingStats}
+								<OverviewTabView
+									ref={overviewRef}
+									filters={filters}
+									active={activeTab === "overview" || pdfMode}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 									volumeChartType={toChartType(urlState.volume_chart)}
@@ -1026,9 +521,6 @@ export default function DashboardPage() {
 									latencyChartType={toChartType(urlState.latency_chart)}
 									costModel={urlState.cost_model}
 									usageModel={urlState.usage_model}
-									costModels={costModels}
-									usageModels={usageModels}
-									availableModels={availableModels}
 									onVolumeChartToggle={handleVolumeChartToggle}
 									onTokenChartToggle={handleTokenChartToggle}
 									onCostChartToggle={handleCostChartToggle}
@@ -1043,13 +535,10 @@ export default function DashboardPage() {
 						{/* Provider Usage Tab */}
 						<TabsContent value="provider-usage" {...(pdfMode && { forceMount: true })}>
 							<div id="dashboard-section-provider-usage">
-								<ProviderUsageTab
-									providerCostData={providerCostData}
-									providerTokenData={providerTokenData}
-									providerLatencyData={providerLatencyData}
-									loadingProviderCost={loadingProviderCost}
-									loadingProviderTokens={loadingProviderTokens}
-									loadingProviderLatency={loadingProviderLatency}
+								<ProviderUsageTabView
+									ref={providerRef}
+									filters={filters}
+									active={activeTab === "provider-usage" || pdfMode}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 									providerCostChartType={toChartType(urlState.provider_cost_chart)}
@@ -1058,10 +547,6 @@ export default function DashboardPage() {
 									providerCostProvider={urlState.provider_cost_provider}
 									providerTokenProvider={urlState.provider_token_provider}
 									providerLatencyProvider={urlState.provider_latency_provider}
-									availableProviders={availableProviders}
-									providerCostProviders={providerCostProviders}
-									providerTokenProviders={providerTokenProviders}
-									providerLatencyProviders={providerLatencyProviders}
 									onProviderCostChartToggle={handleProviderCostChartToggle}
 									onProviderTokenChartToggle={handleProviderTokenChartToggle}
 									onProviderLatencyChartToggle={handleProviderLatencyChartToggle}
@@ -1075,11 +560,10 @@ export default function DashboardPage() {
 						{/* Model Rankings Tab */}
 						<TabsContent value="rankings" {...(pdfMode && { forceMount: true })}>
 							<div id="dashboard-section-rankings">
-								<ModelRankingsTab
-									rankingsData={rankingsData}
-									loading={loadingRankings}
-									modelData={modelData}
-									loadingModels={loadingModels}
+								<ModelRankingsTabView
+									ref={modelRankingsRef}
+									filters={filters}
+									active={activeTab === "rankings" || pdfMode}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 								/>
@@ -1089,13 +573,10 @@ export default function DashboardPage() {
 						{/* MCP Tab */}
 						<TabsContent value="mcp" {...(pdfMode && { forceMount: true })}>
 							<div id="dashboard-section-mcp">
-								<MCPTab
-									mcpHistogramData={mcpHistogramData}
-									mcpCostData={mcpCostData}
-									mcpTopToolsData={mcpTopToolsData}
-									loadingMcpHistogram={loadingMcpHistogram}
-									loadingMcpCost={loadingMcpCost}
-									loadingMcpTopTools={loadingMcpTopTools}
+								<MCPTabView
+									ref={mcpRef}
+									filters={mcpFilters}
+									active={activeTab === "mcp" || pdfMode}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 									mcpVolumeChartType={toChartType(urlState.mcp_volume_chart)}
@@ -1109,11 +590,14 @@ export default function DashboardPage() {
 						{/* Team Rankings Tab */}
 						<TabsContent value="team-rankings" {...(pdfMode && { forceMount: true })}>
 							<div id="dashboard-section-team-rankings">
-								<DimensionRankingsTab
-									data={teamRankingsData}
-									loading={loadingTeamRankings}
+								<DimensionRankingsTabView
+									ref={teamRankingsRef}
+									filters={filters}
+									active={activeTab === "team-rankings" || pdfMode}
+									dimension="team"
 									dimensionLabel="Team"
 									testIdPrefix="dashboard-team-rankings"
+									dataKey="teamRankingsData"
 								/>
 							</div>
 						</TabsContent>
@@ -1121,11 +605,14 @@ export default function DashboardPage() {
 						{/* Customer Rankings Tab */}
 						<TabsContent value="customer-rankings" {...(pdfMode && { forceMount: true })}>
 							<div id="dashboard-section-customer-rankings">
-								<DimensionRankingsTab
-									data={customerRankingsData}
-									loading={loadingCustomerRankings}
+								<DimensionRankingsTabView
+									ref={customerRankingsRef}
+									filters={filters}
+									active={activeTab === "customer-rankings" || pdfMode}
+									dimension="customer"
 									dimensionLabel="Customer"
 									testIdPrefix="dashboard-customer-rankings"
+									dataKey="customerRankingsData"
 								/>
 							</div>
 						</TabsContent>
@@ -1133,11 +620,14 @@ export default function DashboardPage() {
 						{/* Business Unit Rankings Tab */}
 						<TabsContent value="bu-rankings" {...(pdfMode && { forceMount: true })}>
 							<div id="dashboard-section-bu-rankings">
-								<DimensionRankingsTab
-									data={buRankingsData}
-									loading={loadingBuRankings}
+								<DimensionRankingsTabView
+									ref={buRankingsRef}
+									filters={filters}
+									active={activeTab === "bu-rankings" || pdfMode}
+									dimension="business_unit"
 									dimensionLabel="Business Unit"
 									testIdPrefix="dashboard-bu-rankings"
+									dataKey="buRankingsData"
 								/>
 							</div>
 						</TabsContent>
@@ -1145,11 +635,14 @@ export default function DashboardPage() {
 						{/* User Rankings Tab */}
 						<TabsContent value="user-rankings" {...(pdfMode && { forceMount: true })}>
 							<div id="dashboard-section-user-rankings">
-								<DimensionRankingsTab
-									data={userRankingsData}
-									loading={loadingUserRankings}
+								<DimensionRankingsTabView
+									ref={userRankingsRef}
+									filters={filters}
+									active={activeTab === "user-rankings" || pdfMode}
+									dimension="user"
 									dimensionLabel="User"
 									testIdPrefix="dashboard-user-rankings"
+									dataKey="userRankingsData"
 								/>
 							</div>
 						</TabsContent>

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -397,6 +397,8 @@ export const {
 	useLazyGetLogsProviderCostHistogramQuery,
 	useLazyGetLogsProviderTokenHistogramQuery,
 	useLazyGetLogsProviderLatencyHistogramQuery,
+	useGetModelRankingsQuery,
+	useGetDimensionRankingsQuery,
 	useLazyGetModelRankingsQuery,
 	useLazyGetDimensionRankingsQuery,
 	useLazyGetDroppedRequestsQuery,

--- a/ui/lib/store/apis/mcpLogsApi.ts
+++ b/ui/lib/store/apis/mcpLogsApi.ts
@@ -216,6 +216,8 @@ export const {
 	useLazyGetMCPAvailableFilterDataQuery,
 	useGetMCPHistogramQuery,
 	useLazyGetMCPHistogramQuery,
+	useGetMCPCostHistogramQuery,
+	useGetMCPTopToolsQuery,
 	useLazyGetMCPCostHistogramQuery,
 	useLazyGetMCPTopToolsQuery,
 	useDeleteMCPLogsMutation,


### PR DESCRIPTION
## Summary

Refactors the dashboard page by extracting per-tab data fetching logic into dedicated `*TabView` wrapper components, replacing the large collection of manual state variables, lazy query hooks, and `ensure*DataLoaded` ref-tracking functions that previously lived directly in `page.tsx`.

## Changes

- Introduced five new `forwardRef` tab view components (`OverviewTabView`, `ProviderUsageTabView`, `MCPTabView`, `ModelRankingsTabView`, `DimensionRankingsTabView`), each owning its own RTK Query subscriptions, loading state, and `getData`/`loadData` imperative handle.
- Replaced ~300 lines of manual state, lazy hooks, fetch functions, and generation-counter deduplication logic in `page.tsx` with refs to the new tab view components. Export data aggregation now iterates over those refs rather than a large `useMemo` object.
- Each tab view uses an `active` prop (driven by the current tab value or `pdfMode`) to skip fetching when the tab is not visible, delegating the skip logic to RTK Query's built-in `skip` option instead of manual `fetchedRef`/`loadingRef` guards.
- Exported `useGetModelRankingsQuery`, `useGetDimensionRankingsQuery`, `useGetMCPCostHistogramQuery`, and `useGetMCPTopToolsQuery` non-lazy hooks from the store APIs to support the new subscription-based approach.
- Moved `sanitizeSeriesLabels` into the tab views that need it (`OverviewTabView`, `ProviderUsageTabView`) rather than keeping it in the page.
- Reordered the "User Rankings" tab trigger to appear before "Customer Rankings" and "BU Rankings" in the tab list.
- Removed the background warm-up `setTimeout` effect and the filter-change `useEffect` that reset all fetch flags, as RTK Query cache invalidation now handles re-fetching automatically.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Open the dashboard and verify each tab loads its data correctly when first visited.
2. Change a filter (e.g., time range or provider) and confirm all visible and previously loaded tabs refresh.
3. Trigger a CSV and PDF export and confirm all tab data is included.
4. Verify PDF export correctly force-mounts all tabs and captures each section.

## Screenshots/Recordings

No visual changes expected; this is a pure refactor of data-fetching logic.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable