### PR TITLE
feat: refactor MCP client form auth UX with split kind/scope dropdowns and accordion OAuth settings

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -5,13 +5,14 @@ import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useCreateMCPClientMutation } from "@/lib/store";
-import { CreateMCPClientRequest, EnvVar, MCPAuthType, MCPConnectionType, MCPStdioConfig } from "@/lib/types/mcp";
+import { CreateMCPClientRequest, EnvVar, MCPConnectionType, MCPStdioConfig } from "@/lib/types/mcp";
 import { parseArrayFromText } from "@/lib/utils/array";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Info } from "lucide-react";
@@ -70,12 +71,48 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 	const [newHeaderKeyInput, setNewHeaderKeyInput] = useState("");
 	const [headersFlow, setHeadersFlow] = useState<{ payload: CreateMCPClientRequest } | null>(null);
 
+	// UI splits the canonical `auth_type` into two dropdowns:
+	//   - authKind: none | headers | oauth
+	//   - authScope: shared | per_user (hidden when authKind = none)
+	// They recombine into the wire `auth_type` ("oauth", "per_user_oauth",
+	// "headers", "per_user_headers", "none") so the backend contract is
+	// unchanged.
+	const [authScope, setAuthScope] = useState<"shared" | "per_user">("shared");
+
 	const methods = useForm<CreateMCPClientRequest>({ defaultValues: emptyForm });
 	const { control, handleSubmit, setValue, watch, reset, setError, clearErrors } = methods;
 
 	const connectionType = watch("connection_type");
 	const authType = watch("auth_type");
 	const headers = watch("headers");
+
+	const authKind: "none" | "headers" | "oauth" =
+		authType === "oauth" || authType === "per_user_oauth"
+			? "oauth"
+			: authType === "headers" || authType === "per_user_headers"
+				? "headers"
+				: "none";
+
+	const applyAuthKind = (kind: "none" | "headers" | "oauth") => {
+		if (kind === "none") {
+			setValue("auth_type", "none");
+			return;
+		}
+		if (kind === "oauth") {
+			setValue("auth_type", authScope === "per_user" ? "per_user_oauth" : "oauth");
+			return;
+		}
+		setValue("auth_type", authScope === "per_user" ? "per_user_headers" : "headers");
+	};
+
+	const applyAuthScope = (scope: "shared" | "per_user") => {
+		setAuthScope(scope);
+		if (authKind === "oauth") {
+			setValue("auth_type", scope === "per_user" ? "per_user_oauth" : "oauth");
+		} else if (authKind === "headers") {
+			setValue("auth_type", scope === "per_user" ? "per_user_headers" : "headers");
+		}
+	};
 
 	// Inline header validation (shown live as user edits headers).
 	// Both "headers" and "per_user_headers" auth types persist the static
@@ -109,6 +146,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			setHeadersFlow(null);
 			setPerUserHeaderKeys([]);
 			setNewHeaderKeyInput("");
+			setAuthScope("shared");
 			setIsLoading(false);
 		}
 	}, [open, reset]);
@@ -311,6 +349,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 												</SelectItem>
 											</SelectContent>
 										</Select>
+										<p className="text-muted-foreground text-xs">Connection type and authentication settings cannot be changed later.</p>
 										<FormMessage />
 									</FormItem>
 								)}
@@ -389,24 +428,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 										name="connection_string"
 										render={({ field }) => (
 											<FormItem>
-												<div className="flex w-fit items-center gap-1">
-													<FormLabel>Connection URL</FormLabel>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<span>
-																	<Info className="text-muted-foreground ml-1 h-3 w-3" />
-																</span>
-															</TooltipTrigger>
-															<TooltipContent className="max-w-fit">
-																<p>
-																	Use <code className="rounded bg-neutral-100 px-1 py-0.5 text-neutral-800">env.&lt;VAR&gt;</code> to read
-																	the value from an environment variable.
-																</p>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</div>
+												<FormLabel>Connection URL</FormLabel>
 												<EnvVarInput
 													value={field.value}
 													onChange={(value) => {
@@ -422,40 +444,49 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 									/>
 
 									{/* Auth Type */}
-									<FormField
-										control={control}
-										name="auth_type"
-										render={({ field }) => (
-											<FormItem className="w-full">
-												<FormLabel>Authentication Type</FormLabel>
-												<Select value={field.value} onValueChange={(value: MCPAuthType) => field.onChange(value)}>
-													<FormControl>
-														<SelectTrigger className="w-full" data-testid="auth-type-select">
-															<SelectValue placeholder="Select authentication type" />
-														</SelectTrigger>
-													</FormControl>
-													<SelectContent>
-														<SelectItem value="none" data-testid="auth-type-none">
-															None
-														</SelectItem>
-														<SelectItem value="headers" data-testid="auth-type-headers">
-															Headers
-														</SelectItem>
-														<SelectItem value="per_user_headers" data-testid="auth-type-per-user-headers">
-															Per-User Headers
-														</SelectItem>
-														<SelectItem value="oauth" data-testid="auth-type-oauth">
-															OAuth 2.0
-														</SelectItem>
-														<SelectItem value="per_user_oauth" data-testid="auth-type-per-user-oauth">
-															Per-User OAuth 2.0
-														</SelectItem>
-													</SelectContent>
-												</Select>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
+									<FormItem className="w-full">
+										<FormLabel>Authentication Type</FormLabel>
+										<Select value={authKind} onValueChange={(value: "none" | "headers" | "oauth") => applyAuthKind(value)}>
+											<FormControl>
+												<SelectTrigger className="w-full" data-testid="auth-type-select">
+													<SelectValue placeholder="Select authentication type" />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												<SelectItem value="none" data-testid="auth-type-none">
+													None
+												</SelectItem>
+												<SelectItem value="headers" data-testid="auth-type-headers">
+													Headers
+												</SelectItem>
+												<SelectItem value="oauth" data-testid="auth-type-oauth">
+													OAuth 2.0
+												</SelectItem>
+											</SelectContent>
+										</Select>
+									</FormItem>
+
+									{/* Auth Scope — only meaningful when there's an auth flow */}
+									{authKind !== "none" && (
+										<FormItem className="w-full">
+											<FormLabel>Auth Scope</FormLabel>
+											<Select value={authScope} onValueChange={(value: "shared" | "per_user") => applyAuthScope(value)}>
+												<FormControl>
+													<SelectTrigger className="w-full" data-testid="auth-scope-select">
+														<SelectValue placeholder="Select auth scope" />
+													</SelectTrigger>
+												</FormControl>
+												<SelectContent>
+													<SelectItem value="shared" data-testid="auth-scope-shared">
+														Shared
+													</SelectItem>
+													<SelectItem value="per_user" data-testid="auth-scope-per-user">
+														Per-User
+													</SelectItem>
+												</SelectContent>
+											</Select>
+										</FormItem>
+									)}
 
 									{authType === "headers" && (
 										<FormField
@@ -492,7 +523,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 													</div>
 													<p className="text-muted-foreground text-sm">
 														Comma-separated list of header names each caller must supply when they first use this server (e.g.{" "}
-														<code>X-API-Key, X-Tenant-ID</code>). Values are submitted per user — never stored on this server config.
+														<code>X-API-Key, X-Tenant-ID</code>). Values are submitted per user - never stored on this server config.
 													</p>
 												</div>
 												<Textarea
@@ -536,150 +567,153 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 									)}
 
 									{(authType === "oauth" || authType === "per_user_oauth") && (
-										<>
-											{/* OAuth Client ID */}
-											<FormField
-												control={control}
-												name="oauth_config.client_id"
-												render={({ field }) => (
-													<FormItem>
-														<div className="flex items-center gap-2">
-															<FormLabel>OAuth Client ID (optional)</FormLabel>
-															<TooltipProvider>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-																	</TooltipTrigger>
-																	<TooltipContent className="max-w-xs">
-																		<p>
-																			Leave empty to use Dynamic Client Registration (RFC 7591). Bifrost will automatically register with
-																			the OAuth provider if supported.
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															</TooltipProvider>
-														</div>
-														<FormControl>
-															<EnvVarInput
-																value={field.value}
-																onChange={field.onChange}
-																placeholder="your-client-id (auto-generated if empty)"
-																data-testid="mcp-oauth-client-id"
-															/>
-														</FormControl>
-														<p className="text-muted-foreground text-xs">
-															Will be auto-generated via dynamic registration if left empty and provider supports it
-														</p>
-														<FormMessage />
-													</FormItem>
-												)}
-											/>
+										<Accordion type="single" collapsible className="w-full">
+											<AccordionItem value="oauth-advanced" className="border-b-0">
+												<AccordionTrigger className="py-0" data-testid="oauth-advanced-trigger">
+													<span className="text-sm font-medium">OAuth Client Advanced Settings</span>
+												</AccordionTrigger>
+												<AccordionContent className="space-y-4 pt-4 pb-0">
+													{/* OAuth Client ID */}
+													<FormField
+														control={control}
+														name="oauth_config.client_id"
+														render={({ field }) => (
+															<FormItem>
+																<div className="flex items-center gap-2">
+																	<FormLabel>OAuth Client ID (optional)</FormLabel>
+																	<TooltipProvider>
+																		<Tooltip>
+																			<TooltipTrigger asChild>
+																				<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																			</TooltipTrigger>
+																			<TooltipContent className="max-w-xs">
+																				<p>
+																					Leave empty to use Dynamic Client Registration (RFC 7591). Bifrost will automatically register
+																					with the OAuth provider if supported.
+																				</p>
+																			</TooltipContent>
+																		</Tooltip>
+																	</TooltipProvider>
+																</div>
+																<FormControl>
+																	<EnvVarInput
+																		value={field.value}
+																		onChange={field.onChange}
+																		placeholder="your-client-id (auto-generated if empty)"
+																		data-testid="mcp-oauth-client-id"
+																	/>
+																</FormControl>
+																<p className="text-muted-foreground text-xs">
+																	Will be auto-generated via dynamic registration if left empty and provider supports it
+																</p>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
 
-											{/* OAuth Client Secret */}
-											<FormField
-												control={control}
-												name="oauth_config.client_secret"
-												render={({ field }) => (
-													<FormItem>
-														<FormLabel>OAuth Client Secret (optional for PKCE)</FormLabel>
-														<FormControl>
-															<EnvVarInput
-																value={field.value}
-																onChange={field.onChange}
-																placeholder="your-client-secret"
-																hideValueWhenEnv
-																maskNonEnvValue
-																data-testid="mcp-oauth-client-secret"
-															/>
-														</FormControl>
-														<p className="text-muted-foreground text-xs">Leave empty for public clients using PKCE</p>
-														<FormMessage />
-													</FormItem>
-												)}
-											/>
+													{/* OAuth Client Secret */}
+													<FormField
+														control={control}
+														name="oauth_config.client_secret"
+														render={({ field }) => (
+															<FormItem>
+																<FormLabel>OAuth Client Secret (optional for PKCE)</FormLabel>
+																<FormControl>
+																	<EnvVarInput
+																		value={field.value}
+																		onChange={field.onChange}
+																		placeholder="your-client-secret"
+																		hideValueWhenEnv
+																		maskNonEnvValue
+																		data-testid="mcp-oauth-client-secret"
+																	/>
+																</FormControl>
+																<p className="text-muted-foreground text-xs">Leave empty for public clients using PKCE</p>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
 
-											{/* OAuth Authorize URL */}
-											<FormField
-												control={control}
-												name="oauth_config.authorize_url"
-												render={({ field }) => (
-													<FormItem>
-														<FormLabel>Authorization URL (optional, auto-discovered)</FormLabel>
-														<FormControl>
-															<Input
-																{...field}
-																value={field.value ?? ""}
-																onChange={(e) => {
-																	field.onChange(e);
-																	clearErrors("oauth_config.authorize_url");
-																}}
-																placeholder="https://provider.com/oauth/authorize"
-																data-testid="mcp-oauth-authorize-url"
-															/>
-														</FormControl>
-														<FormMessage />
-														<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
-													</FormItem>
-												)}
-											/>
+													{/* OAuth Authorize URL */}
+													<FormField
+														control={control}
+														name="oauth_config.authorize_url"
+														render={({ field }) => (
+															<FormItem>
+																<FormLabel>Authorization URL (optional, auto-discovered)</FormLabel>
+																<FormControl>
+																	<Input
+																		{...field}
+																		value={field.value ?? ""}
+																		onChange={(e) => {
+																			field.onChange(e);
+																			clearErrors("oauth_config.authorize_url");
+																		}}
+																		placeholder="https://provider.com/oauth/authorize"
+																		data-testid="mcp-oauth-authorize-url"
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
 
-											{/* OAuth Token URL */}
-											<FormField
-												control={control}
-												name="oauth_config.token_url"
-												render={({ field }) => (
-													<FormItem>
-														<FormLabel>Token URL (optional, auto-discovered)</FormLabel>
-														<FormControl>
-															<Input
-																{...field}
-																value={field.value ?? ""}
-																onChange={(e) => {
-																	field.onChange(e);
-																	clearErrors("oauth_config.token_url");
-																}}
-																placeholder="https://provider.com/oauth/token"
-															/>
-														</FormControl>
-														<FormMessage />
-														<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
-													</FormItem>
-												)}
-											/>
+													{/* OAuth Token URL */}
+													<FormField
+														control={control}
+														name="oauth_config.token_url"
+														render={({ field }) => (
+															<FormItem>
+																<FormLabel>Token URL (optional, auto-discovered)</FormLabel>
+																<FormControl>
+																	<Input
+																		{...field}
+																		value={field.value ?? ""}
+																		onChange={(e) => {
+																			field.onChange(e);
+																			clearErrors("oauth_config.token_url");
+																		}}
+																		placeholder="https://provider.com/oauth/token"
+																		data-testid="mcp-oauth-token-url"
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
 
-											{/* OAuth Registration URL */}
-											<FormField
-												control={control}
-												name="oauth_config.registration_url"
-												render={({ field }) => (
-													<FormItem>
-														<FormLabel>Registration URL (optional, auto-discovered)</FormLabel>
-														<FormControl>
-															<Input
-																{...field}
-																value={field.value ?? ""}
-																onChange={(e) => {
-																	field.onChange(e);
-																	clearErrors("oauth_config.registration_url");
-																}}
-																placeholder="https://provider.com/oauth/register"
-															/>
-														</FormControl>
-														<FormMessage />
-														<p className="text-muted-foreground text-xs">
-															For dynamic client registration, will be discovered if not provided
-														</p>
-													</FormItem>
-												)}
-											/>
+													{/* OAuth Registration URL */}
+													<FormField
+														control={control}
+														name="oauth_config.registration_url"
+														render={({ field }) => (
+															<FormItem>
+																<FormLabel>Registration URL (optional, auto-discovered)</FormLabel>
+																<FormControl>
+																	<Input
+																		{...field}
+																		value={field.value ?? ""}
+																		onChange={(e) => {
+																			field.onChange(e);
+																			clearErrors("oauth_config.registration_url");
+																		}}
+																		placeholder="https://provider.com/oauth/register"
+																		data-testid="mcp-oauth-registration-url"
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
 
-											{/* Scopes (local state, not RHF field) */}
-											<div className="space-y-2">
-												<Label>Scopes (optional, comma-separated)</Label>
-												<Input value={scopesText} onChange={(e) => setScopesText(e.target.value)} placeholder="read, write, admin" />
-												<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
-											</div>
-										</>
+													{/* Scopes (local state, not RHF field) */}
+													<div className="space-y-2">
+														<Label>Scopes (optional, comma-separated)</Label>
+														<Input value={scopesText} onChange={(e) => setScopesText(e.target.value)} placeholder="read, write, admin" data-testid="mcp-oauth-scopes-input" />
+													</div>
+												</AccordionContent>
+											</AccordionItem>
+										</Accordion>
 									)}
 								</>
 							)}

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -414,6 +414,30 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 										</FormItem>
 									)}
 								/>
+								{/* Read-only connection summary. Connection type and target
+								    can't be changed after create — surface them here for
+								    visibility without exposing edit controls. */}
+								<div className="flex flex-col gap-2">
+									<div className="text-sm font-medium">Connection</div>
+									<div className="bg-muted/40 text-muted-foreground rounded-md border px-3 py-2 text-sm">
+										<span className="text-foreground font-mono text-xs uppercase">
+											{mcpClient.config.connection_type === "stdio"
+												? "STDIO"
+												: mcpClient.config.connection_type === "sse"
+													? "SSE"
+													: "HTTP"}
+										</span>
+										<span className="mx-2">·</span>
+										<span className="font-mono break-all">
+											{mcpClient.config.connection_type === "stdio"
+												? `${mcpClient.config.stdio_config?.command ?? ""} ${(mcpClient.config.stdio_config?.args ?? []).join(" ")}`.trim() ||
+													"-"
+												: mcpClient.config.connection_string?.from_env
+													? `env.${mcpClient.config.connection_string.env_var}`
+													: mcpClient.config.connection_string?.value || "-"}
+										</span>
+									</div>
+								</div>
 								<FormField
 									control={form.control}
 									name="is_code_mode_client"
@@ -877,7 +901,33 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 													<TableHead className="w-10"></TableHead>
 													<TableHead className="max-w-[300px]">Tool Name</TableHead>
 													<TableHead className="w-24 text-center">Enabled</TableHead>
-													<TableHead className="w-28 text-center">Auto-execute</TableHead>
+													<TableHead className="w-28 text-center">
+														<div className="flex items-center justify-center gap-1.5">
+															<span>Auto-execute</span>
+															<TooltipProvider>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<a
+																			href="https://docs.getbifrost.ai/mcp/agent-mode"
+																			target="_blank"
+																			rel="noopener noreferrer"
+																			aria-label="Learn more about Auto-execute and Agent Mode"
+																			className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex rounded focus-visible:ring-2 focus-visible:outline-none"
+																		>
+																			<Info className="h-3.5 w-3.5 cursor-help" />
+																		</a>
+																	</TooltipTrigger>
+																	<TooltipContent className="max-w-xs">
+																		<p>
+																			Applies only when Bifrost runs the LLM loop in Agent Mode. In MCP Gateway mode, the connected
+																			client (Claude Desktop, Cursor, etc.) controls tool approval and this setting is ignored. Click
+																			to learn more.
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															</TooltipProvider>
+														</div>
+													</TableHead>
 													<TableHead className="w-32 text-center">Cost (USD)</TableHead>
 												</TableRow>
 											</TableHeader>
@@ -1019,7 +1069,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 								)}
 
 								{mcpClient.tools && mcpClient.tools.length > 0 && (
-									<div className="mt-6 space-y-4 pb-10">
+									<div className="mt-6 space-y-4">
 										<div className="flex flex-col gap-2">
 											<div className="flex items-center justify-between">
 												<div className="flex items-center gap-2">

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -20,7 +20,7 @@ import { MCP_STATUS_COLORS } from "@/lib/constants/config";
 import { getErrorMessage, useDeleteMCPClientMutation, useReconnectMCPClientMutation } from "@/lib/store";
 import { MCPClient } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ChevronLeft, ChevronRight, Loader2, MoreHorizontal, Plus, RefreshCcw, Search, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2, MoreHorizontal, PencilIcon, Plus, RefreshCcw, Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
 import MCPClientSheet from "./mcpClientSheet";
@@ -31,6 +31,7 @@ function MCPClientActionsMenu({
 	hasDeleteAccess,
 	isReconnecting,
 	isPerUserAuth,
+	onEdit,
 	onReconnect,
 	onDelete,
 }: {
@@ -39,6 +40,7 @@ function MCPClientActionsMenu({
 	hasDeleteAccess: boolean;
 	isReconnecting: boolean;
 	isPerUserAuth: boolean;
+	onEdit: (client: MCPClient) => void;
 	onReconnect: (client: MCPClient) => void;
 	onDelete: (client: MCPClient) => void;
 }) {
@@ -57,7 +59,30 @@ function MCPClientActionsMenu({
 					{isReconnecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
 				</Button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end">
+			<DropdownMenuContent
+				align="end"
+				onCloseAutoFocus={(e) => {
+					// Edit opens a Sheet; letting the dropdown restore focus to its
+					// trigger fights the Sheet's autofocus and leaves focus outside
+					// the dialog — which breaks ESC-to-close. Hand focus off to the
+					// Sheet by skipping the dropdown's auto-restore.
+					e.preventDefault();
+				}}
+			>
+				{hasUpdateAccess && (
+					<DropdownMenuItem
+						className="cursor-pointer"
+						data-testid={`mcp-client-edit-${client.config.client_id}-menu-item`}
+						onSelect={(e) => {
+							e.preventDefault();
+							onEdit(client);
+							setIsOpen(false);
+						}}
+					>
+						<PencilIcon className="h-4 w-4" />
+						Edit
+					</DropdownMenuItem>
+				)}
 				{hasUpdateAccess && (
 					<DropdownMenuItem
 						className="cursor-pointer"
@@ -167,18 +192,6 @@ export default function MCPClientsTable({
 		}
 	};
 
-	const getConnectionDisplay = (client: MCPClient) => {
-		if (client.config.connection_type === "stdio") {
-			return `${client.config.stdio_config?.command} ${client.config.stdio_config?.args.join(" ")}` || "STDIO";
-		}
-		// connection_string is now an EnvVar, display the value or env_var reference
-		const connStr = client.config.connection_string;
-		if (connStr) {
-			return connStr.from_env ? connStr.env_var : connStr.value || `${client.config.connection_type.toUpperCase()}`;
-		}
-		return `${client.config.connection_type.toUpperCase()}`;
-	};
-
 	const getConnectionTypeDisplay = (type: string) => {
 		switch (type) {
 			case "http":
@@ -199,15 +212,26 @@ export default function MCPClientsTable({
 			case "":
 				return "None";
 			case "headers":
+			case "per_user_headers":
 				return "Headers";
 			case "oauth":
-				return "OAuth";
 			case "per_user_oauth":
-				return "Per-user OAuth";
-			case "per_user_headers":
-				return "Per-user Headers";
+				return "OAuth";
 			default:
 				return type;
+		}
+	};
+
+	const getAuthScopeDisplay = (type: string | undefined) => {
+		switch (type) {
+			case "per_user_oauth":
+			case "per_user_headers":
+				return "Per-User";
+			case "oauth":
+			case "headers":
+				return "Shared";
+			default:
+				return "-";
 		}
 	};
 
@@ -307,9 +331,10 @@ export default function MCPClientsTable({
 						<TableRow className="bg-muted/50">
 							<TableHead className="font-semibold">Name</TableHead>
 							<TableHead className="font-semibold">Connection Type</TableHead>
-							<TableHead className="font-semibold">Auth</TableHead>
+							<TableHead className="font-semibold">Auth Type</TableHead>
+							<TableHead className="font-semibold">Auth Scope</TableHead>
 							<TableHead className="font-semibold">Code Mode</TableHead>
-							<TableHead className="font-semibold">Connection Info</TableHead>
+							<TableHead className="font-semibold">VK Access</TableHead>
 							<TableHead className="font-semibold">Enabled Tools</TableHead>
 							<TableHead className="font-semibold">Auto-execute Tools</TableHead>
 							<TableHead className="font-semibold">State</TableHead>
@@ -320,7 +345,7 @@ export default function MCPClientsTable({
 					<TableBody>
 						{mcpClients.length === 0 ? (
 							<TableRow>
-								<TableCell colSpan={10} className="h-24 text-center">
+								<TableCell colSpan={11} className="h-24 text-center">
 									<span className="text-muted-foreground text-sm">No matching MCP servers found.</span>
 								</TableCell>
 							</TableRow>
@@ -344,14 +369,15 @@ export default function MCPClientsTable({
 											: (c.config.tools_to_auto_execute?.length ?? 0)
 										: 0;
 								return (
-									<TableRow
-										key={c.config.client_id}
-										className="group hover:bg-muted/50 cursor-pointer transition-colors"
-										onClick={() => handleRowClick(c)}
-									>
+									<TableRow key={c.config.client_id} className="group hover:bg-muted/50 transition-colors">
 										<TableCell className="font-medium">{c.config.name}</TableCell>
-										<TableCell data-testid="mcp-client-connection-type">{getConnectionTypeDisplay(c.config.connection_type)}</TableCell>
+										<TableCell data-testid="mcp-client-connection-type">
+											<Badge variant="outline" className="font-mono">
+												{getConnectionTypeDisplay(c.config.connection_type)}
+											</Badge>
+										</TableCell>
 										<TableCell data-testid="mcp-client-auth-type">{getAuthTypeDisplay(c.config.auth_type)}</TableCell>
+										<TableCell data-testid="mcp-client-auth-scope">{getAuthScopeDisplay(c.config.auth_type)}</TableCell>
 										<TableCell>
 											<Badge
 												className={
@@ -361,7 +387,13 @@ export default function MCPClientsTable({
 												{c.state == "connected" ? <>{c.config.is_code_mode_client ? "Enabled" : "Disabled"}</> : "-"}
 											</Badge>
 										</TableCell>
-										<TableCell className="max-w-72 overflow-hidden text-ellipsis whitespace-nowrap">{getConnectionDisplay(c)}</TableCell>
+										<TableCell data-testid="mcp-client-vk-access">
+											{c.config.allow_on_all_virtual_keys
+												? "All"
+												: c.vk_configs?.length
+													? `${c.vk_configs.length} ${c.vk_configs.length === 1 ? "VK" : "VKs"}`
+													: "None"}
+										</TableCell>
 										<TableCell>
 											{c.state == "connected" ? (
 												<>
@@ -396,6 +428,7 @@ export default function MCPClientsTable({
 												hasDeleteAccess={hasDeleteMCPClientAccess}
 												isReconnecting={reconnectingClients.includes(c.config.client_id)}
 												isPerUserAuth={isPerUserAuth}
+												onEdit={handleRowClick}
 												onReconnect={(client) => void handleReconnect(client)}
 												onDelete={setClientToDelete}
 											/>


### PR DESCRIPTION
## Summary

Improves the MCP client creation and management UI by splitting the single `auth_type` dropdown into separate "Authentication Type" and "Auth Scope" selectors, making the distinction between shared and per-user auth more intuitive. Also improves the MCP clients table with better column organization and replaces the clickable row pattern with an explicit Edit action in the actions menu.

## Changes

- The `auth_type` field (which encodes both kind and scope, e.g. `per_user_oauth`) is now represented in the form as two independent dropdowns: **Authentication Type** (`none` / `headers` / `oauth`) and **Auth Scope** (`shared` / `per-user`). These recombine into the existing wire format so the backend contract is unchanged.
- OAuth advanced settings (client ID, client secret, authorize URL, token URL, registration URL, scopes) are collapsed into an `Accordion` component to reduce visual noise.
- The Connection URL field's tooltip explaining `env.<VAR>` syntax was removed from the label area.
- A read-only connection summary block is shown in the edit sheet, since connection type and target cannot be changed after creation. A helper note to that effect is also added to the creation form.
- The MCP clients table replaces the "Connection Info" column with a **VK Access** column showing whether the server is available to all virtual keys or a specific count. Auth is now split across two columns: **Auth Type** and **Auth Scope**.
- Connection type badges are now rendered with a monospace `Badge` component.
- Clicking a table row no longer opens the edit sheet; an explicit **Edit** item (with pencil icon) is added to the row actions dropdown menu.
- A tooltip with a link to Agent Mode docs is added to the "Auto-execute" column header in the tools table, clarifying that the setting only applies in Agent Mode.
- `getConnectionDisplay` helper removed from the table since connection info is no longer shown as a column.
- `authScope` state is reset to `"shared"` when the form is closed/reset.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the MCP Registry and click **Add Server**.
2. Select connection type **SSE** or **HTTP**.
3. Verify the **Authentication Type** dropdown shows `None`, `Headers`, and `OAuth 2.0` (no per-user variants).
4. Select `Headers` or `OAuth 2.0` and confirm an **Auth Scope** dropdown appears with `Shared` and `Per-User` options.
5. Confirm that toggling Auth Scope correctly maps to the underlying `auth_type` value (e.g. `per_user_oauth` when OAuth + Per-User).
6. Select `OAuth 2.0` and verify the advanced settings are hidden behind an accordion.
7. Save a client and confirm the table shows separate **Auth Type** and **Auth Scope** columns with correct values.
8. Confirm the **VK Access** column correctly shows `All`, `N VKs`, or `None`.
9. Confirm clicking a table row no longer opens the sheet; use the **⋯** menu → **Edit** instead.
10. Open an existing client's edit sheet and verify the read-only connection summary is displayed.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Before/after screenshots recommended for the form auth dropdowns, the accordion, and the updated table columns._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `per_user_*` auth types store credentials per user rather than in the shared server config. The refactored UI preserves this behavior — the split dropdowns recombine into the same wire values, so no change to how credentials are stored or transmitted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable