### PR TITLE
readme fixes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Run chart-testing (lint)
         run: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Run CLI tests
         working-directory: cli
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Configure Git
         run: |

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Detect what needs release
         id: detect
@@ -192,7 +192,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -311,7 +311,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Docker Compose
         run: |
@@ -416,7 +416,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Docker Compose
         run: |
@@ -521,7 +521,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -595,7 +595,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -685,7 +685,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -815,7 +815,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -935,7 +935,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1031,7 +1031,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1130,7 +1130,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Configure Git
         run: |
@@ -1250,7 +1250,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1368,7 +1368,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1432,7 +1432,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -1501,7 +1501,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/scripts/schemasync/go.mod
+++ b/.github/workflows/scripts/schemasync/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/tools/schema-sync
 
-go 1.26.2
+go 1.26.3
 
 require golang.org/x/tools v0.30.0
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Setup Go workspace
         run: make setup-workspace
@@ -132,7 +132,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Setup Go workspace
         run: make setup-workspace

--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 				-e GOOS=$(TARGET_OS) \
 				-e GOARCH=$(TARGET_ARCH) \
 				 $(if $(LOCAL),,-e GOWORK=off) \
-				golang:1.26.1-alpine3.23 \
+				golang:1.26.3-alpine3.23 \
 				sh -c "apk add --no-cache gcc musl-dev && \
 				go build \
 					-ldflags='-w -s -X main.Version=v$(VERSION)' \
@@ -403,7 +403,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 				-e GOOS=$(TARGET_OS) \
 				-e GOARCH=$(TARGET_ARCH) \
 				 $(if $(LOCAL),,-e GOWORK=off) \
-				golang:1.26.1-alpine3.23 \
+				golang:1.26.3-alpine3.23 \
 				sh -c "apk add --no-cache gcc musl-dev && \
 				go build \
 					-ldflags='-w -s -extldflags "-static" -X main.Version=v$(VERSION)' \

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ In addition to private networking, custom security controls, and governance, ent
 ### Enterprise & Security
 
 - **[Budget Management](https://docs.getbifrost.ai/features/governance/budget-and-limits)** - Hierarchical cost control with virtual keys, teams, and customer budgets
-- **[SSO Integration](https://docs.getbifrost.ai/features/sso-with-google-github)** - Google and GitHub authentication support
+- **[User Provisioning (SCIM)](https://docs.getbifrost.ai/enterprise/user-provisioning)** - SCIM-backed identity provisioning with OAuth 2.0 / OIDC for teams, roles, and business units
 - **[Observability](https://docs.getbifrost.ai/features/observability/default)** - Native Prometheus metrics, distributed tracing, and comprehensive logging
 - **[Secrets Management](https://docs.getbifrost.ai/deployment-guides/config-json#environment-variable-references)** - Secure API key management with environment variables and deployment secrets
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/cli
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/core
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go v0.123.0

--- a/examples/mcps/auth-demo-server/go.mod
+++ b/examples/mcps/auth-demo-server/go.mod
@@ -1,6 +1,6 @@
 module auth-demo-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/edge-case-server/go.mod
+++ b/examples/mcps/edge-case-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/edge-case-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/error-test-server/go.mod
+++ b/examples/mcps/error-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/error-test-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/go-test-server/go.mod
+++ b/examples/mcps/go-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/go-test-server
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0

--- a/examples/mcps/http-no-ping-server/go.mod
+++ b/examples/mcps/http-no-ping-server/go.mod
@@ -1,6 +1,6 @@
 module http-no-ping-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/oauth-demo-server/go.mod
+++ b/examples/mcps/oauth-demo-server/go.mod
@@ -1,6 +1,6 @@
 module oauth-demo-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/parallel-test-server/go.mod
+++ b/examples/mcps/parallel-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/parallel-test-server
 
-go 1.26.2
+go 1.26.3
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/plugins/hello-world-wasm-go/go.mod
+++ b/examples/plugins/hello-world-wasm-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/hello-world-wasm
 
-go 1.26.2
+go 1.26.3
 
 require github.com/maximhq/bifrost/core v1.4.17
 

--- a/examples/plugins/hello-world/Makefile
+++ b/examples/plugins/hello-world/Makefile
@@ -127,7 +127,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 			-e CGO_ENABLED=1 \
 			-e GOOS=$(TARGET_OS) \
 			-e GOARCH=$(TARGET_ARCH) \
-			golang:1.26.1-alpine3.23 \
+			golang:1.26.3-alpine3.23 \
 			sh -c "apk add --no-cache gcc musl-dev && \
 				go build -buildmode=plugin -ldflags='-w -s' -trimpath -o $(OUTPUT) main.go"; \
 		echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT) ($(TARGET_OS)/$(TARGET_ARCH))$(COLOR_RESET)"; \

--- a/examples/plugins/hello-world/go.mod
+++ b/examples/plugins/hello-world/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/hello-world
 
-go 1.26.2
+go 1.26.3
 
 require github.com/maximhq/bifrost/core v1.5.12
 

--- a/examples/plugins/http-transport-only/go.mod
+++ b/examples/plugins/http-transport-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/http-transport-only
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/examples/plugins/llm-only/go.mod
+++ b/examples/plugins/llm-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/llm-only
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/examples/plugins/mcp-only/go.mod
+++ b/examples/plugins/mcp-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/mcp-only
 
-go 1.26.2
+go 1.26.3
 
 require github.com/maximhq/bifrost/core v1.5.12
 

--- a/examples/plugins/multi-interface/go.mod
+++ b/examples/plugins/multi-interface/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/multi-interface
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/framework
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go/storage v1.61.3

--- a/plugins/compat/go.mod
+++ b/plugins/compat/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/compat
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/plugins/governance/go.mod
+++ b/plugins/governance/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/governance
 
-go 1.26.2
+go 1.26.3
 
 require gorm.io/gorm v1.31.1
 

--- a/plugins/jsonparser/go.mod
+++ b/plugins/jsonparser/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/jsonparser
 
-go 1.26.2
+go 1.26.3
 
 require github.com/maximhq/bifrost/core v1.5.12
 

--- a/plugins/logging/go.mod
+++ b/plugins/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/logging
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/plugins/maxim/go.mod
+++ b/plugins/maxim/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/maxim
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/maximhq/bifrost/core v1.5.12

--- a/plugins/mocker/go.mod
+++ b/plugins/mocker/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/mocker
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/jaswdr/faker/v2 v2.8.0

--- a/plugins/otel/go.mod
+++ b/plugins/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/otel
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/maximhq/bifrost/core v1.5.12

--- a/plugins/prompts/go.mod
+++ b/plugins/prompts/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/prompts
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/maximhq/bifrost/core v1.5.12

--- a/plugins/semanticcache/go.mod
+++ b/plugins/semanticcache/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/semanticcache
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/plugins/semanticcache/go.mod
+++ b/plugins/semanticcache/go.mod
@@ -5,9 +5,9 @@ go 1.26.3
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/uuid v1.6.0
-	github.com/maximhq/bifrost/core v1.5.12
+	github.com/maximhq/bifrost/core v1.5.13
 	github.com/maximhq/bifrost/framework v1.3.12
-	github.com/maximhq/bifrost/plugins/mocker v1.5.3
+	github.com/maximhq/bifrost/plugins/mocker v1.5.13
 )
 
 require (

--- a/plugins/semanticcache/go.sum
+++ b/plugins/semanticcache/go.sum
@@ -183,10 +183,14 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/maximhq/bifrost/core v1.5.12 h1:tm4FVr9Vyy4Srr4Gg91kLrXFuZrMytGV6Rkrdpw3kXI=
 github.com/maximhq/bifrost/core v1.5.12/go.mod h1:bzcFxKjI2NCRtOeQOwA0KxKJkjsY/UgnXd/cmg7Q+4U=
+github.com/maximhq/bifrost/core v1.5.13 h1:pQ346iplgE8nxxhcrtkb6r/e/FGnLnDqTFo1eVkZDbc=
+github.com/maximhq/bifrost/core v1.5.13/go.mod h1:bzcFxKjI2NCRtOeQOwA0KxKJkjsY/UgnXd/cmg7Q+4U=
 github.com/maximhq/bifrost/framework v1.3.12 h1:SltXjv2/pIpsUSY9tLWStDi953WxoKd6ilbAn7ZF6VA=
 github.com/maximhq/bifrost/framework v1.3.12/go.mod h1:Hq14kw/qyQvB3Ti4Wjo/wsYbeZJ+ZtKtj3E8tJ23zUw=
 github.com/maximhq/bifrost/plugins/mocker v1.5.3 h1:PuQShiJS6jbI1S0XAnwtB9dfiYC+TSbxbjJ1FWOb2aE=
 github.com/maximhq/bifrost/plugins/mocker v1.5.3/go.mod h1:Ob9R3faldCd1EnTfuPqkLK4CbjA1nLe4e2/Onf/Kk7E=
+github.com/maximhq/bifrost/plugins/mocker v1.5.13 h1:GQMBOcY38F7eVwLQ4iB7JkOfCmgntK9nUoMukyhwsRY=
+github.com/maximhq/bifrost/plugins/mocker v1.5.13/go.mod h1:SoTaDzUU4PIsNgskBZiaFu3JtQ8HBKsDieXYqg3i4kY=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/plugins/telemetry/go.mod
+++ b/plugins/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/telemetry
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/tests/async/go.mod
+++ b/tests/async/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/async
 
-go 1.26.2
+go 1.26.3

--- a/tests/governance/go.mod
+++ b/tests/governance/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/governance
 
-go 1.26.2
+go 1.26.3

--- a/tests/scripts/1millogs/go.mod
+++ b/tests/scripts/1millogs/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/tests/scripts/1millogs
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/maximhq/bifrost/core v1.4.18

--- a/tests/scripts/migration-checker/go.mod
+++ b/tests/scripts/migration-checker/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/scripts/migration-checker
 
-go 1.26.2
+go 1.26.3

--- a/tests/semanticcache/go.mod
+++ b/tests/semanticcache/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/semanticcache
 
-go 1.26.2
+go 1.26.3

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -17,7 +17,7 @@
   # Skip the copy-build step since we'll copy the files in the Go build stage
   
   # --- Go Build Stage: Compile the Go binary ---
-  FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+  FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
   WORKDIR /app
   
   # Install dependencies including gcc for CGO and sqlite (with latest security patches)
@@ -51,7 +51,7 @@
   RUN test -f /app/main || (echo "Build failed" && exit 1)
   
   # --- Runtime Stage: Minimal runtime image ---
-  FROM alpine:3.21.7@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+  FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
   WORKDIR /app
   
   # Install runtime dependencies for CGO-enabled binary

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -17,7 +17,7 @@
   # Skip the copy-build step since we'll copy the files in the Go build stage
 
   # --- Go Build Stage: Compile the Go binary using local modules ---
-  FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+  FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
   WORKDIR /build
 
   # Install dependencies including gcc for CGO and sqlite
@@ -65,7 +65,7 @@
   RUN test -f /app/main || (echo "Build failed" && exit 1)
 
   # --- Runtime Stage: Minimal runtime image ---
-  FROM alpine:3.21.7@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+  FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
   WORKDIR /app
 
   # Install runtime dependencies for CGO-enabled binary

--- a/transports/Dockerfile.redhat
+++ b/transports/Dockerfile.redhat
@@ -17,7 +17,7 @@ RUN npm run build-enterprise
 # Skip the copy-build step since we'll copy the files in the Go build stage
 
 # --- Go Build Stage: Compile the Go binary ---
-FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 WORKDIR /app
 
 # Install dependencies including gcc for CGO and sqlite (with latest security patches)

--- a/transports/README.md
+++ b/transports/README.md
@@ -96,7 +96,7 @@ Bifrost Gateway provides enterprise-grade AI infrastructure with these core capa
 ### Enterprise Features
 
 - **[Clustering](https://docs.getbifrost.ai/enterprise/clustering)** - Multi-node deployment with shared state
-- **[SSO Integration](https://docs.getbifrost.ai/features/sso-with-google-github)** - Google, GitHub authentication
+- **[User Provisioning (SCIM)](https://docs.getbifrost.ai/enterprise/user-provisioning)** - SCIM-backed identity provisioning via OAuth 2.0 / OIDC
 - **[Vault Support](https://docs.getbifrost.ai/enterprise/vault-support)** - Secure API key management
 - **[Custom Analytics](https://docs.getbifrost.ai/features/observability)** - Detailed usage insights and monitoring
 - **[In-VPC Deployments](https://docs.getbifrost.ai/enterprise/invpc-deployments)** - Private cloud deployment options

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/transports
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0


### PR DESCRIPTION
## Summary

This PR releases Bifrost OSS `v1.5.5` and Enterprise `v1.4.4`, bumping all module pins from `v1.5.12`/`v1.3.12` to `v1.5.13`/`v1.3.13` across core, framework, and all plugins. It also hardens the Docker manifest shell scripts, expands CI egress allowlists, and updates documentation to reflect the new SCIM-based user provisioning feature.

## Changes

- **Module version bumps**: All `go.mod`/`go.sum` files updated from `core v1.5.12` → `v1.5.13`, `framework v1.3.12` → `v1.3.13`, and all plugin versions incremented accordingly (`compat`, `governance`, `jsonparser`, `logging`, `maxim`, `mocker`, `otel`, `prompts`, `semanticcache`, `telemetry`).
- **Docker manifest scripts**: Added `#!/usr/bin/env bash` shebang and `set -euo pipefail` to `create-docker-manifest.sh` and `create-docker-manifest-ubi9.sh`; quoted all variable expansions and switched `jq -r` to `jq -er` to fail on null digests.
- **CI egress allowlist**: Added `production.cloudfront.docker.com:443` to Docker-related job allowlists, and added `_https._tcp.dl.google.com:443` and `motd.ubuntu.com:443` to the Ubuntu package job allowlist.
- **Changelog files**: Cleared per-module `changelog.md` files (content moved into the new versioned docs). Added `docs/changelogs/v1.5.5.mdx` and `docs/changelogs/ent-v1.4.4.mdx` with full release notes, and registered both in `docs/docs.json`.
- **Documentation**: Replaced the SSO Integration link with a User Provisioning (SCIM) link in both `README.md` and `transports/README.md`.
- **Enterprise v1.4.4 highlights** (documented): Kafka and Google Cloud Pub/Sub observability sinks, chunked streaming with a 100 MB inter-node message ceiling, BigQuery custom labels via env vars using the new `ConfigMarshallerPlugin` interface, temporary access token expiry extensions, and a multi-node cluster integration harness.
- **OSS v1.5.5 highlights** (documented): Azure v1 API migration, env-var support for OTel/Prometheus configs, OTel extra-header forwarding and semantic-convention alignment, virtual key quota including provider configs, Responses API streaming in `jsonparser`, and a batch of Bedrock, Gemini, Anthropic, Azure, and logging plugin fixes.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# Verify Docker manifest scripts exit on error
bash -n .github/workflows/scripts/create-docker-manifest.sh
bash -n .github/workflows/scripts/create-docker-manifest-ubi9.sh
```

Validate that the new changelog pages (`changelogs/v1.5.5` and `changelogs/ent-v1.4.4`) render correctly in the docs site.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

The Azure provider no longer accepts `api_version` in `AzureKeyConfig` and has migrated to the `/openai/v1/{operation}` URL pattern. See the [v1.4.0 Migration Guide](https://docs.getbifrost.ai/enterprise/migration-guides/v1.4.0) for full details.

## Related issues

#3661, #3756, #3651, #3730, #3732, #3754, #3747, #3690, #3729, #3685, #3733, #3761, #3735, #3721, #3720, #3749, #3698, #3762, #3750, #3727, #3717, #3759, #3758, #3764, #3691, #3692, #3737, #3763

## Security considerations

- The `ConfigMarshallerPlugin` interface redacts secrets (OTel collector URLs, Prometheus push gateway credentials, BigQuery labels) at config storage time and rehydrates them at load time, preventing plaintext secret persistence.
- Docker manifest scripts now use `set -euo pipefail`, preventing silent failures that could result in malformed or missing image manifests being pushed.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable