### PR TITLE
refactor: replace embedded `TableMCPClient` in `MCPClientUpdateRequest` with explicit optional fields and true PATCH semantics

### DIFF
--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -29,8 +29,8 @@ type TableMCPClient struct {
 	ToolSyncInterval        int             `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in seconds (0 = use global, negative = disabled)
 
 	// Per-user OAuth: discovered tools persisted so they survive restart
-	DiscoveredToolsJSON       string `gorm:"type:text" json:"-"`                              // JSON serialized map[string]schemas.ChatTool
-	ToolNameMappingJSON       string `gorm:"type:text" json:"-"`                              // JSON serialized map[string]string
+	DiscoveredToolsJSON string `gorm:"type:text" json:"-"` // JSON serialized map[string]schemas.ChatTool
+	ToolNameMappingJSON string `gorm:"type:text" json:"-"` // JSON serialized map[string]string
 
 	// OAuth authentication fields
 	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`                         // "none", "headers", "oauth", "per_user_oauth", "per_user_headers"
@@ -56,12 +56,12 @@ type TableMCPClient struct {
 	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
 
 	// Virtual fields for runtime use (not stored in DB)
-	StdioConfig               *schemas.MCPStdioConfig    `gorm:"-" json:"stdio_config,omitempty"`
-	ToolsToExecute            schemas.WhiteList          `gorm:"-" json:"tools_to_execute"`
-	ToolsToAutoExecute        schemas.WhiteList          `gorm:"-" json:"tools_to_auto_execute"`
-	Headers                   map[string]schemas.EnvVar  `gorm:"-" json:"headers"`
-	AllowedExtraHeaders       schemas.WhiteList          `gorm:"-" json:"allowed_extra_headers"`
-	ToolPricing               map[string]float64         `gorm:"-" json:"tool_pricing"`
+	StdioConfig               *schemas.MCPStdioConfig     `gorm:"-" json:"stdio_config,omitempty"`
+	ToolsToExecute            schemas.WhiteList           `gorm:"-" json:"tools_to_execute"`
+	ToolsToAutoExecute        schemas.WhiteList           `gorm:"-" json:"tools_to_auto_execute"`
+	Headers                   map[string]schemas.EnvVar   `gorm:"-" json:"headers"`
+	AllowedExtraHeaders       schemas.WhiteList           `gorm:"-" json:"allowed_extra_headers"`
+	ToolPricing               map[string]float64          `gorm:"-" json:"tool_pricing"`
 	DiscoveredTools           map[string]schemas.ChatTool `gorm:"-" json:"-"`
 	DiscoveredToolNameMapping map[string]string           `gorm:"-" json:"-"`
 	PerUserHeaderKeys         []string                    `gorm:"-" json:"per_user_header_keys"`

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -348,13 +348,25 @@ type MCPVKConfigRequest struct {
 	ToolsToExecute schemas.WhiteList `json:"tools_to_execute"`
 }
 
-// MCPClientUpdateRequest wraps TableMCPClient and adds optional VK assignment management, ToolsToExecute and ToolsToAutoExecute
+// MCPClientUpdateRequest is the body for PUT /api/mcp/client/{id}.
+// All fields are optional — omitting a field retains its existing value (PATCH semantics).
+// Immutable fields (connection_type, auth_type, connection_string, stdio_config) are not
+// accepted here; they cannot be changed after creation.
 type MCPClientUpdateRequest struct {
-	configstoreTables.TableMCPClient
-	VKConfigs          *[]MCPVKConfigRequest `json:"vk_configs,omitempty"`
-	ToolsToExecute     *schemas.WhiteList    `json:"tools_to_execute,omitempty"`
-	ToolsToAutoExecute *schemas.WhiteList    `json:"tools_to_auto_execute,omitempty"`
-	OauthConfig        *OAuthConfigRequest   `json:"oauth_config,omitempty"`
+	Name                  *string                   `json:"name,omitempty"`
+	Disabled              *bool                     `json:"disabled,omitempty"`
+	AllowOnAllVirtualKeys *bool                     `json:"allow_on_all_virtual_keys,omitempty"`
+	IsCodeModeClient      *bool                     `json:"is_code_mode_client,omitempty"`
+	IsPingAvailable       *bool                     `json:"is_ping_available,omitempty"`
+	ToolSyncInterval      *int                      `json:"tool_sync_interval,omitempty"`
+	Headers               map[string]schemas.EnvVar `json:"headers,omitempty"`
+	AllowedExtraHeaders   *schemas.WhiteList        `json:"allowed_extra_headers,omitempty"`
+	ToolPricing           map[string]float64        `json:"tool_pricing,omitempty"`
+	ToolsToExecute        *schemas.WhiteList        `json:"tools_to_execute,omitempty"`
+	ToolsToAutoExecute    *schemas.WhiteList        `json:"tools_to_auto_execute,omitempty"`
+	VKConfigs             *[]MCPVKConfigRequest     `json:"vk_configs,omitempty"`
+	OauthConfig           *OAuthConfigRequest       `json:"oauth_config,omitempty"`
+	PerUserHeaderKeys     *[]string                 `json:"per_user_header_keys,omitempty"`
 }
 
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client
@@ -765,13 +777,11 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid id: %v", err))
 		return
 	}
-	// Accept the full table client config to support tool_pricing, plus optional vk_configs
 	var req MCPClientUpdateRequest
 	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err))
 		return
 	}
-	req.ClientID = id
 
 	// Fetch existing config first — needed to resolve optional fields before validation.
 	var existingConfig *schemas.MCPClientConfig
@@ -799,22 +809,46 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	existingAllowOnAllVirtualKeys := existingConfig.AllowOnAllVirtualKeys
 	existingPerUserHeaderKeys := append([]string(nil), existingConfig.PerUserHeaderKeys...)
 
-	// connection_type and auth_type and connection string are permanently immutable
-	if req.ConnectionType != "" && req.ConnectionType != string(existingConfig.ConnectionType) {
-		SendError(ctx, fasthttp.StatusBadRequest, "connection_type cannot be changed for an existing MCP client")
-		return
+	// Resolve all mutable fields with PATCH semantics: use the provided value if present,
+	// otherwise fall back to the existing value.
+	name := existingConfig.Name
+	if req.Name != nil {
+		name = *req.Name
 	}
-	if req.AuthType != "" && req.AuthType != string(existingConfig.AuthType) {
-		SendError(ctx, fasthttp.StatusBadRequest, "auth_type cannot be changed for an existing MCP client")
-		return
+	disabled := existingConfig.Disabled
+	if req.Disabled != nil {
+		disabled = *req.Disabled
 	}
-	if req.ConnectionString != nil && !req.ConnectionString.Equals(existingConfig.ConnectionString) {
-		SendError(ctx, fasthttp.StatusBadRequest, "connection_string cannot be changed for an existing MCP client")
-		return
+	allowOnAllVKs := existingConfig.AllowOnAllVirtualKeys
+	if req.AllowOnAllVirtualKeys != nil {
+		allowOnAllVKs = *req.AllowOnAllVirtualKeys
 	}
-	if req.StdioConfig != nil && !stdioConfigsEqual(req.StdioConfig, existingConfig.StdioConfig) {
-		SendError(ctx, fasthttp.StatusBadRequest, "stdio_config cannot be changed for an existing MCP client")
-		return
+	isCodeMode := existingConfig.IsCodeModeClient
+	if req.IsCodeModeClient != nil {
+		isCodeMode = *req.IsCodeModeClient
+	}
+	isPingAvailable := existingConfig.IsPingAvailable
+	if req.IsPingAvailable != nil {
+		isPingAvailable = req.IsPingAvailable
+	}
+	toolPricing := existingConfig.ToolPricing
+	if req.ToolPricing != nil {
+		toolPricing = req.ToolPricing
+	}
+	allowedExtraHeaders := existingConfig.AllowedExtraHeaders
+	if req.AllowedExtraHeaders != nil {
+		allowedExtraHeaders = *req.AllowedExtraHeaders
+	}
+	// Headers: merge incoming with existing, preserving redacted values that are unchanged.
+	headers := existingConfig.Headers
+	if req.Headers != nil {
+		redactedExisting := h.store.RedactMCPClientConfig(existingConfig)
+		headers = mergeMCPRedactedValues(req.Headers, existingConfig.Headers, redactedExisting.Headers)
+	}
+	// ToolSyncInterval: 0 means "use global default"; retain existing if not provided.
+	toolSyncIntervalMinutes := int(existingConfig.ToolSyncInterval / time.Minute)
+	if req.ToolSyncInterval != nil {
+		toolSyncIntervalMinutes = *req.ToolSyncInterval
 	}
 
 	// Resolve tools_to_execute and tools_to_auto_execute.
@@ -829,22 +863,20 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		resolvedToolsToAutoExecute = *req.ToolsToAutoExecute
 	}
 
-	// Validate tools_to_execute
+	// Validate
 	if err := validateToolsToExecute(resolvedToolsToExecute); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid tools_to_execute: %v", err))
 		return
 	}
-	// Validate tools_to_auto_execute
 	if err := validateToolsToAutoExecute(resolvedToolsToAutoExecute, resolvedToolsToExecute); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid tools_to_auto_execute: %v", err))
 		return
 	}
-	// Validate client name
-	if err := mcp.ValidateMCPClientName(req.Name); err != nil {
+	if err := mcp.ValidateMCPClientName(name); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid client name: %v", err))
 		return
 	}
-	if err := validateAllowedExtraHeaders(req.AllowedExtraHeaders); err != nil {
+	if err := validateAllowedExtraHeaders(allowedExtraHeaders); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid allowed_extra_headers: %v", err))
 		return
 	}
@@ -862,11 +894,11 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		// auth types may legitimately carry no per_user_header_keys, but for
 		// per_user_headers an empty schema means the auth mode has nothing
 		// to collect or validate, which violates the feature contract.
-		if existingConfig.AuthType == schemas.MCPAuthTypePerUserHeaders && len(req.PerUserHeaderKeys) == 0 {
+		if existingConfig.AuthType == schemas.MCPAuthTypePerUserHeaders && len(*req.PerUserHeaderKeys) == 0 {
 			SendError(ctx, fasthttp.StatusBadRequest, "per_user_header_keys must be a non-empty list for per_user_headers clients")
 			return
 		}
-		canonHeaderKeys := mcputils.CanonicalizeHeaderKeys(req.PerUserHeaderKeys)
+		canonHeaderKeys := mcputils.CanonicalizeHeaderKeys(*req.PerUserHeaderKeys)
 		for i, key := range canonHeaderKeys {
 			if key == "" {
 				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("per_user_header_keys[%d] is empty", i))
@@ -895,7 +927,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// 	SendError(ctx, fasthttp.StatusBadRequest, "oauth_config can only be updated for MCP clients using auth_type 'oauth' or 'per_user_oauth'")
 	// 	return
 	// }
-	// if shouldRotateOAuthConfig && req.Disabled {
+	// if shouldRotateOAuthConfig && disabled {
 	// 	SendError(ctx, fasthttp.StatusBadRequest, "oauth credentials cannot be rotated while disabling a client; send these as two separate requests")
 	// 	return
 	// }
@@ -960,9 +992,6 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// 		return
 	// 	}
 	// }
-	// Merge redacted values - preserve old values if incoming values are redacted and unchanged
-	merged := mergeMCPRedactedValues(&req.TableMCPClient, existingConfig, h.store.RedactMCPClientConfig(existingConfig))
-	req.TableMCPClient = *merged
 
 	var oldDBConfig *configstoreTables.TableMCPClient
 	if h.store.ConfigStore != nil {
@@ -974,13 +1003,30 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	req.TableMCPClient.ToolsToExecute = resolvedToolsToExecute
-	req.TableMCPClient.ToolsToAutoExecute = resolvedToolsToAutoExecute
-	dbUpdateRecord := req.TableMCPClient
+	// Build the DB update record from all resolved values.
+	dbUpdateRecord := configstoreTables.TableMCPClient{
+		ClientID:              id,
+		Name:                  name,
+		IsCodeModeClient:      isCodeMode,
+		ConnectionType:        string(existingConfig.ConnectionType),
+		ConnectionString:      existingConfig.ConnectionString,
+		StdioConfig:           existingConfig.StdioConfig,
+		ToolsToExecute:        resolvedToolsToExecute,
+		ToolsToAutoExecute:    resolvedToolsToAutoExecute,
+		Headers:               headers,
+		AllowedExtraHeaders:   allowedExtraHeaders,
+		IsPingAvailable:       isPingAvailable,
+		ToolPricing:           toolPricing,
+		ToolSyncInterval:      toolSyncIntervalMinutes,
+		AuthType:              string(existingConfig.AuthType),
+		OauthConfigID:         existingConfig.OauthConfigID,
+		AllowOnAllVirtualKeys: allowOnAllVKs,
+		Disabled:              disabled,
+	}
 	// Rebind persisted discovered tool keys (and inner Function.Name) to the current
 	// client name so a restart restores them under the right prefix.
 	if oldDBConfig != nil && len(oldDBConfig.DiscoveredTools) > 0 {
-		newPrefix := req.TableMCPClient.Name + "-"
+		newPrefix := name + "-"
 		migrated := make(map[string]schemas.ChatTool, len(oldDBConfig.DiscoveredTools))
 		for oldKey, tool := range oldDBConfig.DiscoveredTools {
 			newKey := oldKey
@@ -1005,8 +1051,8 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 
 	toolSyncInterval := mcp.DefaultToolSyncInterval
-	if req.ToolSyncInterval != 0 {
-		toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
+	if toolSyncIntervalMinutes != 0 {
+		toolSyncInterval = time.Duration(toolSyncIntervalMinutes) * time.Minute
 	} else {
 		config, err := h.store.ConfigStore.GetClientConfig(ctx)
 		if err != nil {
@@ -1017,25 +1063,25 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 			toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
 		}
 	}
-	// Convert to schemas.MCPClientConfig for runtime bifrost client (without tool_pricing)
+	// Build in-memory config from resolved values.
 	schemasConfig := &schemas.MCPClientConfig{
-		ID:                    req.ClientID,
-		Name:                  req.Name,
-		IsCodeModeClient:      req.IsCodeModeClient,
+		ID:                    id,
+		Name:                  name,
+		IsCodeModeClient:      isCodeMode,
 		ConnectionType:        existingConfig.ConnectionType,
 		ConnectionString:      existingConfig.ConnectionString,
 		StdioConfig:           existingConfig.StdioConfig,
 		ToolsToExecute:        resolvedToolsToExecute,
 		ToolsToAutoExecute:    resolvedToolsToAutoExecute,
-		Headers:               req.Headers,
-		AllowedExtraHeaders:   req.AllowedExtraHeaders,
+		Headers:               headers,
+		AllowedExtraHeaders:   allowedExtraHeaders,
 		AuthType:              existingConfig.AuthType,
 		OauthConfigID:         existingConfig.OauthConfigID,
-		IsPingAvailable:       req.IsPingAvailable,
+		IsPingAvailable:       isPingAvailable,
 		ToolSyncInterval:      toolSyncInterval,
-		ToolPricing:           req.ToolPricing,
-		AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
-		Disabled:              req.Disabled,
+		ToolPricing:           toolPricing,
+		AllowOnAllVirtualKeys: allowOnAllVKs,
+		Disabled:              disabled,
 		PerUserHeaderKeys:     resolvePerUserHeaderKeys(existingConfig, req),
 	}
 
@@ -1234,7 +1280,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// ones whose MCP regained the grant. Both surfaces (OAuth + headers)
 	// are reconciled — they share the same VK→MCP allowlist model.
 	if h.store.ConfigStore != nil {
-		shouldReconcile := req.VKConfigs != nil || req.AllowOnAllVirtualKeys != existingAllowOnAllVirtualKeys
+		shouldReconcile := req.VKConfigs != nil || *req.AllowOnAllVirtualKeys != existingAllowOnAllVirtualKeys
 		if shouldReconcile {
 			if err := h.store.ConfigStore.ReconcileOauthAfterMCPChange(ctx, id); err != nil {
 				logger.Error(fmt.Sprintf("reconcile OAuth credentials after MCP %s update failed: %v", id, err))
@@ -1357,50 +1403,23 @@ func validateToolsToAutoExecute(toolsToAutoExecute schemas.WhiteList, toolsToExe
 	return nil
 }
 
-// mergeMCPRedactedValues merges incoming MCP client config with existing config,
-// preserving old values when incoming values are redacted and unchanged.
-// This follows the same pattern as provider config updates.
-func mergeMCPRedactedValues(incoming *configstoreTables.TableMCPClient, oldRaw, oldRedacted *schemas.MCPClientConfig) *configstoreTables.TableMCPClient {
-	merged := incoming
-
-	// Handle ConnectionString - if incoming is redacted and equals old redacted, keep old raw value
-	if incoming.ConnectionString != nil && oldRaw.ConnectionString != nil && oldRedacted.ConnectionString != nil {
-		if incoming.ConnectionString.IsRedacted() && incoming.ConnectionString.Equals(oldRedacted.ConnectionString) {
-			merged.ConnectionString = oldRaw.ConnectionString
-		}
-	}
-
-	// Handle Headers - merge incoming with old, preserving redacted values
-	if incoming.Headers != nil {
-		incomingHeaders := incoming.Headers
-		merged.Headers = make(map[string]schemas.EnvVar, len(incomingHeaders))
-		for key, incomingValue := range incomingHeaders {
-			if oldRaw.Headers != nil && oldRedacted.Headers != nil {
-				if oldRedactedValue, existsInRedacted := oldRedacted.Headers[key]; existsInRedacted {
-					if oldRawValue, existsInRaw := oldRaw.Headers[key]; existsInRaw {
-						if incomingValue.IsRedacted() && incomingValue.Equals(&oldRedactedValue) {
-							merged.Headers[key] = oldRawValue
-							continue
-						}
+// mergeMCPRedactedValues merges incoming request headers with the existing raw headers,
+// preserving stored raw values when an incoming header value is redacted and unchanged.
+func mergeMCPRedactedValues(incoming, rawExisting, redactedExisting map[string]schemas.EnvVar) map[string]schemas.EnvVar {
+	merged := make(map[string]schemas.EnvVar, len(incoming))
+	for key, incomingValue := range incoming {
+		if redactedExisting != nil && rawExisting != nil {
+			if redactedValue, ok := redactedExisting[key]; ok {
+				if rawValue, ok := rawExisting[key]; ok {
+					if incomingValue.IsRedacted() && incomingValue.Equals(&redactedValue) {
+						merged[key] = rawValue
+						continue
 					}
 				}
 			}
-			merged.Headers[key] = incomingValue
 		}
-	} else if oldRaw.Headers != nil {
-		merged.Headers = oldRaw.Headers
+		merged[key] = incomingValue
 	}
-
-	// Preserve IsPingAvailable if not explicitly set in incoming request
-	// This prevents the zero-value (false) from overwriting the existing DB value
-	if incoming.IsPingAvailable == nil {
-		merged.IsPingAvailable = oldRaw.IsPingAvailable
-	}
-	// Preserve AllowedExtraHeaders if not explicitly set in incoming request
-	if incoming.AllowedExtraHeaders == nil {
-		merged.AllowedExtraHeaders = oldRaw.AllowedExtraHeaders
-	}
-
 	return merged
 }
 
@@ -1684,7 +1703,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 // they pass through untouched.
 func resolvePerUserHeaderKeys(existing *schemas.MCPClientConfig, req MCPClientUpdateRequest) []string {
 	if req.PerUserHeaderKeys != nil {
-		return mcputils.CanonicalizeHeaderKeys(req.PerUserHeaderKeys)
+		return mcputils.CanonicalizeHeaderKeys(*req.PerUserHeaderKeys)
 	}
 	if existing != nil {
 		return existing.PerUserHeaderKeys


### PR DESCRIPTION
## Summary

`PUT /api/mcp/client/{id}` previously embedded `TableMCPClient` directly in `MCPClientUpdateRequest`, which meant callers had to send the full record and any omitted field would silently zero-out the existing value. This PR replaces that approach with true PATCH semantics: every mutable field is now an explicit pointer/nullable type, and the handler merges only the fields that are present in the request body, leaving everything else untouched.

## Changes

- `MCPClientUpdateRequest` no longer embeds `TableMCPClient`. It now declares each mutable field explicitly as a pointer (`*string`, `*bool`, `*int`, etc.) so that absent fields are distinguishable from zero values.
- Immutable fields (`connection_type`, `auth_type`, `connection_string`, `stdio_config`) are removed from the request struct entirely and are no longer validated for mutation — they are always carried forward from the existing record.
- The handler resolves each field individually: if the pointer is non-nil, the new value is used; otherwise the existing stored value is retained.
- `mergeMCPRedactedValues` is narrowed to operate only on `map[string]schemas.EnvVar` (headers), removing the now-unnecessary logic for `ConnectionString`, `IsPingAvailable`, and `AllowedExtraHeaders`, which are handled by the pointer-based merge above.
- The DB update record (`dbUpdateRecord`) is now constructed explicitly from all resolved values rather than mutating the embedded struct, making the data flow easier to follow and audit.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...

# Create an MCP client, then issue a partial update and confirm only the
# specified fields change while all others retain their existing values.
curl -X PUT /api/mcp/client/{id} \
  -H 'Content-Type: application/json' \
  -d '{"disabled": true}'

# Confirm that name, headers, tools_to_execute, etc. are unchanged.

# Attempt to pass connection_type or auth_type and confirm they are ignored
# (not rejected, simply not accepted in the struct).
```

## Breaking changes

- [x] Yes
- [ ] No

Callers that previously relied on sending the full `TableMCPClient` payload (including `connection_type`, `auth_type`, `connection_string`, or `stdio_config`) will have those fields silently ignored rather than validated. Any client that was relying on the old struct shape for field names should verify their payloads still map correctly to the new explicit field list.

## Related issues

## Security considerations

Redacted header values are still preserved correctly via `mergeMCPRedactedValues` — if an incoming header value matches the redacted form of the stored value, the original raw value is retained rather than overwritten with the redacted placeholder.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable