### PR TITLE
feat: removes SSO gate check for temp token auth

### DIFF
--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -921,7 +921,6 @@ func generateSecureRandomString(length int) (string, error) {
 // The function errors out cleanly on any misconfig (missing identity, unknown
 // mode, missing template config) — no fallbacks, no generated identities.
 func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigID string, mcpClientID string, redirectURI string, flowMode schemas.MCPAuthMode) (*schemas.OAuth2FlowInitiation, string, error) {
-
 	// 1. Load template OAuth config.
 	templateConfig, err := p.configStore.GetOauthConfigByID(ctx, oauthConfigID)
 	if err != nil {

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1318,7 +1318,9 @@ func (m *MockConfigStore) UpdateMCPPerUserHeaderFlow(ctx context.Context, flow *
 func (m *MockConfigStore) DeleteMCPPerUserHeaderFlowsByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) error {
 	return nil
 }
-func (m *MockConfigStore) DeleteMCPPerUserHeaderFlow(ctx context.Context, id string) error { return nil }
+func (m *MockConfigStore) DeleteMCPPerUserHeaderFlow(ctx context.Context, id string) error {
+	return nil
+}
 func (m *MockConfigStore) ListAllPendingMCPPerUserHeaderFlows(ctx context.Context) ([]tables.TableMCPPerUserHeaderFlow, error) {
 	return nil, nil
 }

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -16,7 +16,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { IS_ENTERPRISE } from "@/lib/constants/config";
 import {
   getErrorMessage,
   useGetCoreConfigQuery,
@@ -25,7 +24,6 @@ import {
 import { CoreConfig, DefaultCoreConfig } from "@/lib/types/config";
 import { EnvVar } from "@/lib/types/schemas";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useGetAuthTypeQuery } from "@enterprise/lib/store/apis/scimApi";
 import { AlertTriangle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -41,13 +39,9 @@ export default function MCPView() {
     RbacOperation.Update,
   );
   const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
-  const { data: authType } = useGetAuthTypeQuery(undefined, {
-    skip: !IS_ENTERPRISE,
-  });
   const config = bifrostConfig?.client_config;
   const [updateCoreConfig, { isLoading }] = useUpdateCoreConfigMutation();
   const [localConfig, setLocalConfig] = useState<CoreConfig>(DefaultCoreConfig);
-  const isSCIMEnabled = IS_ENTERPRISE && authType?.type === "sso";
 
   const [localValues, setLocalValues] = useState<{
     mcp_agent_depth: string;
@@ -292,32 +286,30 @@ export default function MCPView() {
           />
         </div>
 
-        {isSCIMEnabled && (
-          /* Temp Token Auth */
-          <div className="flex items-center justify-between space-x-2 rounded-sm border p-4">
-            <div className="space-y-0.5">
-              <label
-                htmlFor="mcp-enable-temp-token-auth"
-                className="text-sm font-medium"
-              >
-                Allow Temp Token Auth Links
-              </label>
-              <p className="text-muted-foreground text-sm">
-                When enabled, per-user MCP OAuth links can include a short-lived
-                scoped token so someone without an active Bifrost dashboard
-                session can complete the flow. Keep disabled to require normal
-                dashboard authentication.
-              </p>
-            </div>
-            <Switch
-              id="mcp-enable-temp-token-auth"
-              checked={localConfig.mcp_enable_temp_token_auth ?? false}
-              onCheckedChange={handleTempTokenAuthChange}
-              disabled={!hasSettingsUpdateAccess}
-              data-testid="mcp-enable-temp-token-auth-switch"
-            />
+        {/* Temp Token Auth */}
+        <div className="flex items-center justify-between space-x-2 rounded-sm border p-4">
+          <div className="space-y-0.5">
+            <label
+              htmlFor="mcp-enable-temp-token-auth"
+              className="text-sm font-medium"
+            >
+              Allow Temp Token Auth Links
+            </label>
+            <p className="text-muted-foreground text-sm">
+              When enabled, per-user MCP OAuth links can include a short-lived
+              scoped token so someone without an active Bifrost dashboard
+              session can complete the flow. Keep disabled to require normal
+              dashboard authentication.
+            </p>
           </div>
-        )}
+          <Switch
+            id="mcp-enable-temp-token-auth"
+            checked={localConfig.mcp_enable_temp_token_auth ?? false}
+            onCheckedChange={handleTempTokenAuthChange}
+            disabled={!hasSettingsUpdateAccess}
+            data-testid="mcp-enable-temp-token-auth-switch"
+          />
+        </div>
 
         {/* Code Mode Binding Level */}
         <div className="space-y-4 rounded-sm border p-4">


### PR DESCRIPTION
## Summary

The "Allow Temp Token Auth Links" toggle in the MCP settings view was previously gated behind a SCIM/SSO enterprise check. This PR removes that gate so the setting is visible and configurable for all users, regardless of enterprise tier or SSO configuration.

## Changes

- Removed the `isSCIMEnabled` conditional that wrapped the Temp Token Auth UI section, making it always visible in the MCP settings view.
- Removed the unused `IS_ENTERPRISE` import and `useGetAuthTypeQuery` hook from `mcpView.tsx` since they were only used to compute `isSCIMEnabled`.
- Minor formatting cleanup: removed a blank line at the start of `InitiateUserOAuthFlow` and reformatted a single-line mock method in the config test file.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the MCP settings view in the Bifrost dashboard on a non-enterprise or non-SSO instance.
2. Confirm the "Allow Temp Token Auth Links" toggle is now visible and functional.
3. Toggle the setting and verify it saves correctly.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

The "Allow Temp Token Auth Links" section should now appear unconditionally in the MCP settings view, rather than only when SCIM/SSO is enabled.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The Temp Token Auth feature issues short-lived scoped tokens to allow unauthenticated users to complete MCP OAuth flows. Exposing this toggle to all users does not change the underlying token security model, but operators should be aware of the implications of enabling this setting in their environment.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable