### PR TITLE
feat: add `governance_model_catalog` table with CRUD API and UI for per-model editorial attributes

### DIFF
--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -139,7 +139,7 @@ type Model struct {
 	CanonicalSlug       *string            `json:"canonical_slug,omitempty"`
 	Name                *string            `json:"name,omitempty"`
 	NormalizedName      *string            `json:"normalized_name,omitempty"` // Human-readable name derived from the datasheet base_model (e.g. "Claude Sonnet 4.5")
-	Alias               *string            `json:"alias,omitempty"` // Provider API identifier this model alias maps to (e.g. Azure deployment name, Bedrock ARN)
+	Alias               *string            `json:"alias,omitempty"`           // Provider API identifier this model alias maps to (e.g. Azure deployment name, Bedrock ARN)
 	Created             *int64             `json:"created,omitempty"`
 	ContextLength       *int               `json:"context_length,omitempty"`
 	MaxInputTokens      *int               `json:"max_input_tokens,omitempty"`
@@ -152,6 +152,9 @@ type Model struct {
 	DefaultParameters   *DefaultParameters `json:"default_parameters,omitempty"`
 	HuggingFaceID       *string            `json:"hugging_face_id,omitempty"`
 	Description         *string            `json:"description,omitempty"`
+
+	// Attributes holds additional metadata from the model catalog (governance_model_catalog).
+	Attributes map[string]string `json:"attributes,omitempty"`
 
 	OwnedBy          *string  `json:"owned_by,omitempty"`
 	SupportedMethods []string `json:"supported_methods,omitempty"`

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -813,6 +813,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPerUserHeadersFlowsTable(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddModelCatalogTable(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -8891,6 +8894,34 @@ func migrationDropAzureAPIVersionColumn(ctx context.Context, db *gorm.DB) error 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running drop_azure_api_version_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddModelCatalogTable creates the governance_model_catalog table
+// holding per-model attribute blobs (e.g. {"description": "..."}). The table
+// is intentionally decoupled from governance_model_pricing so the pricing
+// sync's bulk delete-and-recreate cycle never wipes editorial content.
+func migrationAddModelCatalogTable(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_model_catalog_table",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return tx.AutoMigrate(&tables.TableModelCatalogEntry{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasTable(&tables.TableModelCatalogEntry{}) {
+				if err := mg.DropTable(&tables.TableModelCatalogEntry{}); err != nil {
+					return fmt.Errorf("drop governance_model_catalog: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_model_catalog_table migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2070,6 +2070,44 @@ func (s *RDBConfigStore) DeleteModelPrices(ctx context.Context, tx ...*gorm.DB) 
 	return txDB.WithContext(ctx).Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&tables.TableModelPricing{}).Error
 }
 
+// GetAllModelCatalogEntries retrieves every per-model catalog entry. The catalog
+// is small (one row per known model) so callers pull the full set and key by
+// (model, provider) in memory rather than issuing per-lookup queries.
+func (s *RDBConfigStore) GetAllModelCatalogEntries(ctx context.Context) ([]tables.TableModelCatalogEntry, error) {
+	var entries []tables.TableModelCatalogEntry
+	if err := s.DB().WithContext(ctx).Find(&entries).Error; err != nil {
+		return nil, s.parseGormError(err)
+	}
+	return entries, nil
+}
+
+// UpsertModelCatalogEntry creates or replaces a catalog entry keyed by
+// (model, provider). UpdateAll matches the pattern used by UpsertModelPrices
+// so that re-syncing from the remote datasheet idempotently refreshes content.
+func (s *RDBConfigStore) UpsertModelCatalogEntry(ctx context.Context, entry *tables.TableModelCatalogEntry, tx ...*gorm.DB) error {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+	if err := txDB.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "model"}, {Name: "provider"}},
+		UpdateAll: true,
+	}).Create(entry).Error; err != nil {
+		return s.parseGormError(err)
+	}
+	return nil
+}
+
+// DeleteModelCatalogEntry removes a single catalog entry by primary key.
+func (s *RDBConfigStore) DeleteModelCatalogEntry(ctx context.Context, id uint) error {
+	if err := s.DB().WithContext(ctx).Delete(&tables.TableModelCatalogEntry{}, id).Error; err != nil {
+		return s.parseGormError(err)
+	}
+	return nil
+}
+
 func (s *RDBConfigStore) GetPricingOverrides(ctx context.Context, filters PricingOverrideFilters) ([]tables.TablePricingOverride, error) {
 	var overrides []tables.TablePricingOverride
 	q := s.DB().WithContext(ctx).Model(&tables.TablePricingOverride{})

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -271,6 +271,11 @@ type ConfigStore interface {
 	UpsertModelPrices(ctx context.Context, pricing *tables.TableModelPricing, tx ...*gorm.DB) error
 	DeleteModelPrices(ctx context.Context, tx ...*gorm.DB) error
 
+	// Model catalog CRUD
+	GetAllModelCatalogEntries(ctx context.Context) ([]tables.TableModelCatalogEntry, error)
+	UpsertModelCatalogEntry(ctx context.Context, entry *tables.TableModelCatalogEntry, tx ...*gorm.DB) error
+	DeleteModelCatalogEntry(ctx context.Context, id uint) error
+
 	// Governance pricing overrides CRUD
 	GetPricingOverrides(ctx context.Context, filters PricingOverrideFilters) ([]tables.TablePricingOverride, error)
 	GetPricingOverridesPaginated(ctx context.Context, params PricingOverridesQueryParams) ([]tables.TablePricingOverride, int64, error)

--- a/framework/configstore/tables/modelcatalog.go
+++ b/framework/configstore/tables/modelcatalog.go
@@ -1,0 +1,52 @@
+package tables
+
+import (
+	"encoding/json"
+
+	"gorm.io/gorm"
+)
+
+// TableModelCatalogEntry stores arbitrary per-model key-value attributes
+// (e.g. {"description": "..."}). Decoupled from the pricing table so it is
+// safe from pricing sync's bulk delete-and-recreate path, and so new
+// attributes can be added without a schema migration.
+type TableModelCatalogEntry struct {
+	ID             uint              `gorm:"primaryKey;autoIncrement" json:"id"`
+	Model          string            `gorm:"type:varchar(255);not null;uniqueIndex:idx_catalog_model_provider" json:"model"`
+	Provider       string            `gorm:"type:varchar(50);not null;uniqueIndex:idx_catalog_model_provider" json:"provider"`
+	AttributesJSON string            `gorm:"type:text;not null;default:'{}'" json:"-"`
+	Attributes     map[string]string `gorm:"-" json:"attributes,omitempty"`
+}
+
+// TableName sets the table name.
+func (TableModelCatalogEntry) TableName() string { return "governance_model_catalog" }
+
+// BeforeSave marshals Attributes → AttributesJSON. A nil/empty map serializes
+// to "{}" so the not-null column constraint always holds.
+func (e *TableModelCatalogEntry) BeforeSave(tx *gorm.DB) error {
+	if e.Attributes == nil {
+		e.AttributesJSON = "{}"
+		return nil
+	}
+	data, err := json.Marshal(e.Attributes)
+	if err != nil {
+		return err
+	}
+	e.AttributesJSON = string(data)
+	return nil
+}
+
+// AfterFind unmarshals AttributesJSON → Attributes. Empty/missing JSON resolves
+// to a nil map so callers can use len() and idiomatic nil checks.
+func (e *TableModelCatalogEntry) AfterFind(tx *gorm.DB) error {
+	if e.AttributesJSON == "" || e.AttributesJSON == "{}" {
+		e.Attributes = nil
+		return nil
+	}
+	var attrs map[string]string
+	if err := json.Unmarshal([]byte(e.AttributesJSON), &attrs); err != nil {
+		return err
+	}
+	e.Attributes = attrs
+	return nil
+}

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -55,6 +55,13 @@ type ModelCatalog struct {
 	// Values are parameter names the model accepts (e.g., "temperature", "top_p", "tools")
 	supportedParams map[string][]string
 
+	// modelCatalogData holds per-(model, provider) attribute blobs surfaced
+	// from governance_model_catalog. The key is "<model>|<provider>" using the
+	// raw datasheet provider string (not the normalized one) — matches the
+	// upsert key. catalogMu guards reads and writes of the map.
+	modelCatalogData map[string]*configstoreTables.TableModelCatalogEntry
+	catalogMu        sync.RWMutex
+
 	// Background sync worker
 	syncTicker *time.Ticker
 	done       chan struct{}
@@ -96,6 +103,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		baseModelIndex:         make(map[string]string),
 		supportedResponseTypes: make(map[string][]string),
 		supportedParams:        make(map[string][]string),
+		modelCatalogData:       make(map[string]*configstoreTables.TableModelCatalogEntry),
 		done:                   make(chan struct{}),
 		distributedLockManager: configstore.NewDistributedLockManager(configStore, logger, configstore.WithDefaultTTL(30*time.Second)),
 	}
@@ -210,6 +218,13 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		if paramsErr != nil {
 			return nil, paramsErr
 		}
+
+		// Catalog load is sequenced after pricing/params: pricing sync may
+		// upsert catalog rows from PricingEntry.Description, and we want the
+		// in-memory map to observe those before the catalog is queried.
+		if err := mc.loadCatalogFromDatabase(ctx); err != nil {
+			return nil, fmt.Errorf("failed to load model catalog: %w", err)
+		}
 	} else {
 		// Load pricing and model parameters from URL into memory (no config store)
 		if err := mc.loadPricingIntoMemoryFromURL(ctx); err != nil {
@@ -254,8 +269,10 @@ func (mc *ModelCatalog) ReloadFromDB(ctx context.Context) error {
 		return err
 	}
 	mc.populateModelPoolFromPricingData()
-	_, err := mc.loadModelParametersFromDatabase(ctx)
-	return err
+	if _, err := mc.loadModelParametersFromDatabase(ctx); err != nil {
+		return err
+	}
+	return mc.loadCatalogFromDatabase(ctx)
 }
 
 // UpdateSyncConfig updates the pricing URL and sync interval, restarts the background sync worker,
@@ -465,6 +482,70 @@ func (mc *ModelCatalog) Cleanup() error {
 	return nil
 }
 
+// GetModelCatalogEntry returns the cached catalog entry for (model, provider),
+// or nil when no entry exists. The provider is matched against the raw upsert
+// key used when the entry was written (matches schemas.ModelProvider casing).
+func (mc *ModelCatalog) GetModelCatalogEntry(model string, provider schemas.ModelProvider) *configstoreTables.TableModelCatalogEntry {
+	mc.catalogMu.RLock()
+	defer mc.catalogMu.RUnlock()
+	return mc.modelCatalogData[catalogKey(model, string(provider))]
+}
+
+// UpsertModelCatalogEntry persists an entry and refreshes the in-memory cache.
+// Safe to call from both the management CRUD API and the pricing-sync path.
+func (mc *ModelCatalog) UpsertModelCatalogEntry(ctx context.Context, entry *configstoreTables.TableModelCatalogEntry) error {
+	if mc.configStore == nil {
+		// In-memory-only deployment: still maintain the cache so reads return
+		// the value the caller just wrote.
+		mc.catalogMu.Lock()
+		mc.modelCatalogData[catalogKey(entry.Model, entry.Provider)] = entry
+		mc.catalogMu.Unlock()
+		return nil
+	}
+	if err := mc.configStore.UpsertModelCatalogEntry(ctx, entry); err != nil {
+		return err
+	}
+	return mc.loadCatalogFromDatabase(ctx)
+}
+
+// DeleteModelCatalogEntry removes an entry by primary key and reloads the cache.
+func (mc *ModelCatalog) DeleteModelCatalogEntry(ctx context.Context, id uint) error {
+	if mc.configStore == nil {
+		return nil
+	}
+	if err := mc.configStore.DeleteModelCatalogEntry(ctx, id); err != nil {
+		return err
+	}
+	return mc.loadCatalogFromDatabase(ctx)
+}
+
+// ReloadCatalog re-reads the catalog table into the in-memory cache
+func (mc *ModelCatalog) ReloadCatalog(ctx context.Context) error {
+	return mc.loadCatalogFromDatabase(ctx)
+}
+
+// GetAllModelCatalogEntries returns every catalog row. Reads through the
+// configstore so callers always see committed state.
+func (mc *ModelCatalog) GetAllModelCatalogEntries(ctx context.Context) ([]configstoreTables.TableModelCatalogEntry, error) {
+	if mc.configStore == nil {
+		mc.catalogMu.RLock()
+		defer mc.catalogMu.RUnlock()
+		out := make([]configstoreTables.TableModelCatalogEntry, 0, len(mc.modelCatalogData))
+		for _, e := range mc.modelCatalogData {
+			out = append(out, *e)
+		}
+		return out, nil
+	}
+	return mc.configStore.GetAllModelCatalogEntries(ctx)
+}
+
+// catalogKey returns the lookup key used by modelCatalogData. Provider is the
+// raw datasheet/store value (not normalized) so upserts and reads agree on the
+// same key.
+func catalogKey(model, provider string) string {
+	return model + "|" + provider
+}
+
 // NewTestCatalog creates a minimal ModelCatalog for testing purposes.
 // It does not start background sync workers or connect to external services.
 func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
@@ -478,6 +559,7 @@ func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
 		pricingData:            make(map[string]configstoreTables.TableModelPricing),
 		supportedResponseTypes: make(map[string][]string),
 		supportedParams:        make(map[string][]string),
+		modelCatalogData:       make(map[string]*configstoreTables.TableModelCatalogEntry),
 		done:                   make(chan struct{}),
 	}
 }

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -170,6 +170,30 @@ func (mc *ModelCatalog) loadPricingIntoMemoryFromURL(ctx context.Context) error 
 	return nil
 }
 
+// loadCatalogFromDatabase loads catalog entries from the database into the
+// in-memory map. Companion to loadPricingFromDatabase — called on init,
+// after pricing sync, and on ReloadFromDB.
+func (mc *ModelCatalog) loadCatalogFromDatabase(ctx context.Context) error {
+	if mc.configStore == nil {
+		return nil
+	}
+
+	entries, err := mc.configStore.GetAllModelCatalogEntries(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load model catalog from database: %w", err)
+	}
+
+	mc.catalogMu.Lock()
+	defer mc.catalogMu.Unlock()
+	mc.modelCatalogData = make(map[string]*configstoreTables.TableModelCatalogEntry, len(entries))
+	for i := range entries {
+		e := entries[i]
+		mc.modelCatalogData[catalogKey(e.Model, e.Provider)] = &e
+	}
+	mc.logger.Debug("loaded %d model catalog entries from database", len(mc.modelCatalogData))
+	return nil
+}
+
 // loadPricingFromDatabase loads pricing data from database into memory cache
 func (mc *ModelCatalog) loadPricingFromDatabase(ctx context.Context) error {
 	if mc.configStore == nil {

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -877,6 +877,22 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 					resp.Data[i].Pricing = pricing
 				}
 			}
+
+			// Attributes from governance_model_catalog. The catalog stores
+			// editorial fields (description, etc.) decoupled from pricing so
+			// they survive the pricing sync's bulk overwrite.
+			if cat := h.config.ModelCatalog.GetModelCatalogEntry(modelName, provider); cat != nil {
+				if resp.Data[i].Attributes == nil && len(cat.Attributes) > 0 {
+					resp.Data[i].Attributes = cat.Attributes
+				}
+			}
+
+			// Supported parameters from the model-parameters catalog.
+			if resp.Data[i].SupportedParameters == nil {
+				if params := h.config.ModelCatalog.GetSupportedParameters(modelName); len(params) > 0 {
+					resp.Data[i].SupportedParameters = params
+				}
+			}
 		}
 	}
 	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,6 +31,11 @@ type ModelsManager interface {
 	RemoveProvider(ctx context.Context, provider schemas.ModelProvider) error
 	GetModelsForProvider(provider schemas.ModelProvider) []string
 	GetUnfilteredModelsForProvider(provider schemas.ModelProvider) []string
+	// Model catalog (per-model attributes) — funneled through the manager so
+	// enterprise can wrap these with cluster broadcasts.
+	UpsertModelCatalogEntries(ctx context.Context, entries []tables.TableModelCatalogEntry) error
+	DeleteModelCatalogEntry(ctx context.Context, id uint) error
+	ReloadModelCatalog(ctx context.Context) error
 }
 
 // ProviderHandler manages HTTP requests for provider operations
@@ -128,6 +134,9 @@ func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...schema
 	r.GET("/api/models/details", lib.ChainMiddlewares(h.listModelDetails, middlewares...))
 	r.GET("/api/models/parameters", lib.ChainMiddlewares(h.getModelParameters, middlewares...))
 	r.GET("/api/models/base", lib.ChainMiddlewares(h.listBaseModels, middlewares...))
+	r.GET("/api/model-catalog", lib.ChainMiddlewares(h.listModelCatalog, middlewares...))
+	r.PUT("/api/model-catalog", lib.ChainMiddlewares(h.upsertModelCatalogEntries, middlewares...))
+	r.DELETE("/api/model-catalog/{id}", lib.ChainMiddlewares(h.deleteModelCatalogEntry, middlewares...))
 }
 
 // listProviders handles GET /api/providers - List all providers
@@ -601,6 +610,7 @@ type ModelDetailsResponse struct {
 	MaxInputTokens   *int                  `json:"max_input_tokens,omitempty"`
 	MaxOutputTokens  *int                  `json:"max_output_tokens,omitempty"`
 	Architecture     *schemas.Architecture `json:"architecture,omitempty"`
+	Attributes       map[string]string     `json:"attributes,omitempty"`
 	AccessibleByKeys []string              `json:"accessible_by_keys,omitempty"`
 }
 
@@ -712,6 +722,9 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 			details.MaxInputTokens = capabilities.MaxInputTokens
 			details.MaxOutputTokens = capabilities.MaxOutputTokens
 			details.Architecture = capabilities.Architecture
+		}
+		if cat := modelCatalog.GetModelCatalogEntry(model.Name, model.Provider); cat != nil && len(cat.Attributes) > 0 {
+			details.Attributes = cat.Attributes
 		}
 		responseModels = append(responseModels, details)
 	}
@@ -1192,4 +1205,91 @@ func validateRetryBackoff(networkConfig *schemas.NetworkConfig) error {
 		}
 	}
 	return nil
+}
+
+// listModelCatalog handles GET /api/model-catalog - List all per-model
+// catalog entries (governance_model_catalog). The catalog stores editorial
+// attributes (e.g. "description") that are decoupled from pricing sync.
+func (h *ProviderHandler) listModelCatalog(ctx *fasthttp.RequestCtx) {
+	mc := h.inMemoryStore.ModelCatalog
+	if mc == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "model catalog not available")
+		return
+	}
+	entries, err := mc.GetAllModelCatalogEntries(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to list model catalog: %v", err))
+		return
+	}
+	if entries == nil {
+		entries = []tables.TableModelCatalogEntry{}
+	}
+	SendJSON(ctx, entries)
+}
+
+// upsertModelCatalogEntries handles PUT /api/model-catalog - Upsert a list
+// of catalog entries. The body is a JSON array of TableModelCatalogEntry
+// objects; (model, provider) is the natural key.
+//
+// The transactional write + cache reload live on the server callback so the
+// enterprise build can wrap them to broadcast peer reloads after the local
+// write succeeds. This handler keeps only the validation and serialization.
+func (h *ProviderHandler) upsertModelCatalogEntries(ctx *fasthttp.RequestCtx) {
+	mc := h.inMemoryStore.ModelCatalog
+	if mc == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "model catalog not available")
+		return
+	}
+	var payload []tables.TableModelCatalogEntry
+	if err := sonic.Unmarshal(ctx.PostBody(), &payload); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid JSON: %v", err))
+		return
+	}
+	for i := range payload {
+		if strings.TrimSpace(payload[i].Model) == "" || strings.TrimSpace(payload[i].Provider) == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "model and provider are required for every catalog entry")
+			return
+		}
+	}
+
+	if err := h.modelsManager.UpsertModelCatalogEntries(ctx, payload); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to upsert catalog entries: %v", err))
+		return
+	}
+
+	entries, err := mc.GetAllModelCatalogEntries(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to list model catalog: %v", err))
+		return
+	}
+	if entries == nil {
+		entries = []tables.TableModelCatalogEntry{}
+	}
+	SendJSON(ctx, entries)
+}
+
+// deleteModelCatalogEntry handles DELETE /api/model-catalog/{id} - Delete a
+// single catalog entry by primary key. The actual delete is delegated to the
+// server callback so the enterprise build can broadcast the change to peers.
+func (h *ProviderHandler) deleteModelCatalogEntry(ctx *fasthttp.RequestCtx) {
+	idVal := ctx.UserValue("id")
+	if idVal == nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "id is required")
+		return
+	}
+	idStr, ok := idVal.(string)
+	if !ok {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid id")
+		return
+	}
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid id: %v", err))
+		return
+	}
+	if err := h.modelsManager.DeleteModelCatalogEntry(ctx, uint(id)); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to delete catalog entry: %v", err))
+		return
+	}
+	ctx.SetStatusCode(fasthttp.StatusNoContent)
 }

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -50,6 +50,18 @@ func (m *mockModelsManager) GetUnfilteredModelsForProvider(provider schemas.Mode
 	return result
 }
 
+func (m *mockModelsManager) UpsertModelCatalogEntries(_ context.Context, _ []configstoreTables.TableModelCatalogEntry) error {
+	return nil
+}
+
+func (m *mockModelsManager) DeleteModelCatalogEntry(_ context.Context, _ uint) error {
+	return nil
+}
+
+func (m *mockModelsManager) ReloadModelCatalog(_ context.Context) error {
+	return nil
+}
+
 // providerHandlerForTest builds a handler with fixed provider config and model sets.
 func providerHandlerForTest(provider schemas.ModelProvider, keys []schemas.Key, filtered, unfiltered []string) *ProviderHandler {
 	return &ProviderHandler{

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -161,6 +161,20 @@ type ConfigData struct {
 	Plugins           []*schemas.PluginConfig               `json:"plugins,omitempty"`
 	WebSocket         *schemas.WebSocketConfig              `json:"websocket,omitempty"`
 	FeatureFlags      *FeatureFlagsFileConfig               `json:"feature_flags,omitempty"`
+
+	// ModelCatalog seeds editorial per-model attributes into the
+	// governance_model_catalog table at boot. Mirrored by the management
+	// CRUD API at /api/model-catalog — both share the same table, and
+	// (model, provider) is the natural key (last write wins).
+	ModelCatalog []ModelCatalogEntryConfig `json:"model_catalog,omitempty"`
+}
+
+// ModelCatalogEntryConfig is the config.json shape for a single
+// governance_model_catalog row.
+type ModelCatalogEntryConfig struct {
+	Model      string            `json:"model"`
+	Provider   string            `json:"provider"`
+	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 // FeatureFlagsFileConfig is the config.json / Helm shape for feature flag
@@ -239,6 +253,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 		Plugins           []*schemas.PluginConfig               `json:"plugins,omitempty"`
 		WebSocket         *schemas.WebSocketConfig              `json:"websocket,omitempty"`
 		FeatureFlags      *FeatureFlagsFileConfig               `json:"feature_flags,omitempty"`
+		ModelCatalog      []ModelCatalogEntryConfig             `json:"model_catalog,omitempty"`
 	}
 
 	var temp TempConfigData
@@ -257,6 +272,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 	cd.Plugins = temp.Plugins
 	cd.WebSocket = temp.WebSocket
 	cd.FeatureFlags = temp.FeatureFlags
+	cd.ModelCatalog = temp.ModelCatalog
 	// Initialize providers map if nil
 	if cd.Providers == nil {
 		cd.Providers = make(map[string]configstore.ProviderConfig)
@@ -3273,6 +3289,36 @@ func initFrameworkConfig(ctx context.Context, config *Config, configData *Config
 	if config.ModelCatalog != nil && config.GovernanceConfig != nil && len(config.GovernanceConfig.PricingOverrides) > 0 {
 		if err := config.ModelCatalog.SetPricingOverrides(config.GovernanceConfig.PricingOverrides); err != nil {
 			logger.Warn("failed to set pricing overrides from config file: %v", err)
+		}
+	}
+
+	// Apply config.json-sourced model catalog entries. Coexists with the
+	// management API: both write to the same table, last-write-wins on
+	// (model, provider). Skipped when no entries are declared so we don't
+	// run unnecessary upserts on every boot.
+	if config.ModelCatalog != nil && len(configData.ModelCatalog) > 0 {
+		applyModelCatalogFromConfig(ctx, config, configData.ModelCatalog)
+	}
+}
+
+// applyModelCatalogFromConfig upserts each ModelCatalogEntryConfig declared
+// in config.json into the model catalog. Errors are logged and continue
+// rather than fail boot — a misformatted entry should not block the gateway.
+func applyModelCatalogFromConfig(ctx context.Context, config *Config, entries []ModelCatalogEntryConfig) {
+	for _, e := range entries {
+		model := strings.TrimSpace(e.Model)
+		provider := strings.TrimSpace(e.Provider)
+		if model == "" || provider == "" {
+			logger.Warn("skipping model_catalog entry with empty model or provider")
+			continue
+		}
+		entry := &configstoreTables.TableModelCatalogEntry{
+			Model:      model,
+			Provider:   provider,
+			Attributes: e.Attributes,
+		}
+		if err := config.ModelCatalog.UpsertModelCatalogEntry(ctx, entry); err != nil {
+			logger.Warn("failed to upsert model_catalog entry %s/%s from config.json: %v", provider, model, err)
 		}
 	}
 }

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1016,6 +1016,19 @@ func (m *MockConfigStore) DeleteModelPrices(ctx context.Context, tx ...*gorm.DB)
 	return nil
 }
 
+// Model catalog
+func (m *MockConfigStore) GetAllModelCatalogEntries(ctx context.Context) ([]tables.TableModelCatalogEntry, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) UpsertModelCatalogEntry(ctx context.Context, entry *tables.TableModelCatalogEntry, tx ...*gorm.DB) error {
+	return nil
+}
+
+func (m *MockConfigStore) DeleteModelCatalogEntry(ctx context.Context, id uint) error {
+	return nil
+}
+
 func (m *MockConfigStore) GetPricingOverrides(ctx context.Context, filter configstore.PricingOverrideFilters) ([]tables.TablePricingOverride, error) {
 	return []tables.TablePricingOverride{}, nil
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -39,6 +39,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpadaptor"
+	"gorm.io/gorm"
 )
 
 // Constants
@@ -73,6 +74,12 @@ type ServerCallbacks interface {
 	ForceReloadPricing(ctx context.Context) error
 	UpsertPricingOverride(ctx context.Context, override *tables.TablePricingOverride) error
 	DeletePricingOverride(ctx context.Context, id string) error
+	// Model catalog (per-model attributes) callbacks. Enterprise wraps these
+	// to broadcast EntityTypeModelCatalog/ActionReloadFromDB to peers so the
+	// cluster converges on the latest table state without a URL re-fetch.
+	UpsertModelCatalogEntries(ctx context.Context, entries []tables.TableModelCatalogEntry) error
+	DeleteModelCatalogEntry(ctx context.Context, id uint) error
+	ReloadModelCatalog(ctx context.Context) error
 	// Proxy related callbacks
 	ReloadProxyConfig(ctx context.Context, config *tables.GlobalProxyConfig) error
 	// Client config related callbacks
@@ -943,6 +950,55 @@ func (s *BifrostHTTPServer) DeletePricingOverride(ctx context.Context, id string
 	}
 	s.Config.ModelCatalog.DeletePricingOverride(id)
 	return nil
+}
+
+// UpsertModelCatalogEntries persists a batch of catalog entries inside a
+// single transaction so a failure on any row rolls back the rest, then
+// reloads the in-memory cache once after commit. Enterprise overrides this
+// to also broadcast a peer reload after the local write succeeds.
+func (s *BifrostHTTPServer) UpsertModelCatalogEntries(ctx context.Context, entries []tables.TableModelCatalogEntry) error {
+	if s.Config == nil || s.Config.ModelCatalog == nil {
+		return fmt.Errorf("model catalog not initialized")
+	}
+	if s.Config.ConfigStore == nil {
+		return fmt.Errorf("model catalog requires a config store")
+	}
+	err := s.Config.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		for i := range entries {
+			entry := entries[i]
+			if err := s.Config.ConfigStore.UpsertModelCatalogEntry(ctx, &entry, tx); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to upsert catalog entries: %w", err)
+	}
+	if err := s.Config.ModelCatalog.ReloadCatalog(ctx); err != nil {
+		return fmt.Errorf("failed to reload catalog cache: %w", err)
+	}
+	return nil
+}
+
+// DeleteModelCatalogEntry removes a single catalog row by primary key. The
+// ModelCatalog wrapper handles the DB delete and the cache reload.
+func (s *BifrostHTTPServer) DeleteModelCatalogEntry(ctx context.Context, id uint) error {
+	if s.Config == nil || s.Config.ModelCatalog == nil {
+		return fmt.Errorf("model catalog not initialized")
+	}
+	return s.Config.ModelCatalog.DeleteModelCatalogEntry(ctx, id)
+}
+
+// ReloadModelCatalog refreshes the in-memory catalog cache from the database.
+// Peer nodes call this on receipt of an EntityTypeModelCatalog/ActionReloadFromDB
+// gossip message — the originator already committed the row, peers just need
+// to converge their caches.
+func (s *BifrostHTTPServer) ReloadModelCatalog(ctx context.Context) error {
+	if s.Config == nil || s.Config.ModelCatalog == nil {
+		return fmt.Errorf("model catalog not initialized")
+	}
+	return s.Config.ModelCatalog.ReloadCatalog(ctx)
 }
 
 // ReloadProxyConfig reloads the proxy configuration

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1711,6 +1711,32 @@
     },
     "feature_flags": {
       "$ref": "#/$defs/feature_flags_config"
+    },
+    "model_catalog": {
+      "type": "array",
+      "description": "Per-model editorial attributes (e.g. description) seeded into the governance_model_catalog table at boot. Coexists with the /api/model-catalog management API: both write to the same table and (model, provider) is the natural key — last write wins.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Model name (e.g. \"gpt-4o\")."
+          },
+          "provider": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Provider key (e.g. \"openai\")."
+          },
+          "attributes": {
+            "type": "object",
+            "description": "Arbitrary key-value attributes. Well-known key: \"description\".",
+            "additionalProperties": { "type": "string" }
+          }
+        },
+        "required": ["model", "provider"],
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false,

--- a/ui/app/workspace/model-catalog/views/attributeSheet.tsx
+++ b/ui/app/workspace/model-catalog/views/attributeSheet.tsx
@@ -1,0 +1,355 @@
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ModelMultiselect } from "@/components/ui/modelMultiselect";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { DottedSeparator } from "@/components/ui/separator";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import {
+	getErrorMessage,
+	ModelCatalogEntry,
+	useGetProvidersQuery,
+	useUpsertModelCatalogEntriesMutation,
+} from "@/lib/store";
+import { KnownProvider } from "@/lib/types/config";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+interface AttributeSheetProps {
+	entry?: ModelCatalogEntry | null;
+	onSave: () => void;
+	onCancel: () => void;
+}
+
+const formSchema = z.object({
+	model: z.string().min(1, "Model is required"),
+	provider: z.string().min(1, "Provider is required"),
+	description: z.string().optional(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+// Local row type for the extra-attributes editor. We keep these outside the
+// zod schema because empty rows are valid during editing — we filter them
+// out at submit time. The id is a render-stable identifier (not persisted)
+// so React keeps DOM nodes pinned to the right row across add/remove.
+interface AttributeRow {
+	id: string;
+	key: string;
+	value: string;
+}
+
+// newRowId mints a render-stable id for an AttributeRow. crypto.randomUUID
+// is available in modern browsers; we fall back to a counter for old ones
+// and SSR.
+let rowIdCounter = 0;
+function newRowId(): string {
+	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+		return crypto.randomUUID();
+	}
+	rowIdCounter += 1;
+	return `row-${rowIdCounter}`;
+}
+
+// Pulls non-description attributes out of the entry into editable rows.
+function rowsFromEntry(entry?: ModelCatalogEntry | null): AttributeRow[] {
+	if (!entry?.attributes) return [];
+	return Object.entries(entry.attributes)
+		.filter(([k]) => k !== "description")
+		.map(([key, value]) => ({ id: newRowId(), key, value }));
+}
+
+export default function AttributeSheet({ entry, onSave, onCancel }: AttributeSheetProps) {
+	const [isOpen, setIsOpen] = useState(true);
+	const isEditing = !!entry;
+
+	const hasCreateAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Create);
+	const hasUpdateAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+	const canSubmit = isEditing ? hasUpdateAccess : hasCreateAccess;
+
+	const { data: providersData } = useGetProvidersQuery();
+	const [upsertEntries, { isLoading }] = useUpsertModelCatalogEntriesMutation();
+
+	const availableProviders = providersData || [];
+
+	const form = useForm<FormData>({
+		mode: "onChange",
+		resolver: zodResolver(formSchema),
+		defaultValues: {
+			model: entry?.model || "",
+			provider: entry?.provider || "",
+			description: entry?.attributes?.description || "",
+		},
+	});
+
+	const [extraRows, setExtraRows] = useState<AttributeRow[]>(() => rowsFromEntry(entry));
+	// Compare without ids — ids are render-only state.
+	const stripIds = (rows: AttributeRow[]) => rows.map(({ key, value }) => ({ key, value }));
+	const [initialRowsKey, setInitialRowsKey] = useState(() => JSON.stringify(stripIds(rowsFromEntry(entry))));
+
+	useEffect(() => {
+		if (!entry) return;
+		if (form.formState.isDirty) return;
+		form.reset({
+			model: entry.model,
+			provider: entry.provider,
+			description: entry.attributes?.description || "",
+		});
+		const next = rowsFromEntry(entry);
+		setExtraRows(next);
+		setInitialRowsKey(JSON.stringify(stripIds(next)));
+	}, [entry, form]);
+
+	const rowsDirty = useMemo(() => JSON.stringify(stripIds(extraRows)) !== initialRowsKey, [extraRows, initialRowsKey]);
+	const isDirty = form.formState.isDirty || rowsDirty;
+
+	const handleClose = () => {
+		setIsOpen(false);
+		setTimeout(() => onCancel(), 150);
+	};
+
+	const handleAddRow = () => setExtraRows((prev) => [...prev, { id: newRowId(), key: "", value: "" }]);
+	const handleRowChange = (id: string, field: "key" | "value", val: string) => {
+		setExtraRows((prev) => prev.map((row) => (row.id === id ? { ...row, [field]: val } : row)));
+	};
+	const handleRemoveRow = (id: string) => setExtraRows((prev) => prev.filter((row) => row.id !== id));
+
+	const onSubmit = async (data: FormData) => {
+		if (!canSubmit) {
+			toast.error("You don't have permission to perform this action");
+			return;
+		}
+
+		// Validate that extra rows have non-empty keys when they have any value.
+		// Empty rows are fine — we drop them.
+		const cleaned = extraRows
+			.map((r) => ({ key: r.key.trim(), value: r.value }))
+			.filter((r) => r.key !== "" || r.value !== "");
+		const missingKey = cleaned.find((r) => r.key === "");
+		if (missingKey) {
+			toast.error("Attribute rows must have a key");
+			return;
+		}
+		const dupKey = cleaned.find((r, i) => cleaned.findIndex((other) => other.key === r.key) !== i);
+		if (dupKey) {
+			toast.error(`Duplicate attribute key: ${dupKey.key}`);
+			return;
+		}
+		// "description" is the special-cased field above — disallow it as an extra row.
+		const reservedClash = cleaned.find((r) => r.key === "description");
+		if (reservedClash) {
+			toast.error("Use the Description field instead of a 'description' attribute row");
+			return;
+		}
+
+		const attributes: Record<string, string> = {};
+		const desc = (data.description || "").trim();
+		if (desc !== "") attributes.description = desc;
+		for (const r of cleaned) {
+			attributes[r.key] = r.value;
+		}
+
+		try {
+			await upsertEntries([
+				{
+					// id is ignored on upsert when (model, provider) matches an
+					// existing row; including it for edits lets the backend
+					// keep the same row.
+					id: entry?.id ?? 0,
+					model: data.model,
+					provider: data.provider,
+					attributes: Object.keys(attributes).length > 0 ? attributes : undefined,
+				},
+			]).unwrap();
+			toast.success(isEditing ? "Catalog entry updated" : "Catalog entry created");
+			onSave();
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		}
+	};
+
+	return (
+		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+			<SheetContent
+				className="flex w-full flex-col overflow-x-hidden pt-4"
+				onInteractOutside={(e) => {
+					if (isDirty) e.preventDefault();
+				}}
+				onEscapeKeyDown={(e) => {
+					if (isDirty) e.preventDefault();
+				}}
+				data-testid="model-catalog-attribute-sheet"
+			>
+				<SheetHeader className="flex flex-col items-start p-0 px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+					<SheetTitle>{isEditing ? "Edit Model Attributes" : "Add Model Attributes"}</SheetTitle>
+					<SheetDescription>
+						{isEditing
+							? "Update the description and other attributes for this model."
+							: "Attach editorial attributes (description, tags) to a model. Decoupled from pricing — these survive the pricing sync."}
+					</SheetDescription>
+				</SheetHeader>
+
+				<Form {...form}>
+					<form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col gap-6">
+						<div className="grow space-y-4 px-8">
+							{/* Provider */}
+							<FormField
+								control={form.control}
+								name="provider"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Provider</FormLabel>
+										<Select value={field.value} onValueChange={field.onChange} disabled={isEditing}>
+											<FormControl>
+												<SelectTrigger className="w-full" data-testid="model-catalog-provider-select">
+													<SelectValue placeholder="Select a provider" />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												{availableProviders
+													.filter((p) => p.name)
+													.map((provider) => (
+														<SelectItem key={provider.name} value={provider.name}>
+															<RenderProviderIcon
+																provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
+																size="sm"
+																className="h-4 w-4"
+															/>
+															{provider.custom_provider_config
+																? provider.name
+																: ProviderLabels[provider.name as ProviderName] || provider.name}
+														</SelectItem>
+													))}
+											</SelectContent>
+										</Select>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							{/* Model */}
+							<FormField
+								control={form.control}
+								name="model"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Model</FormLabel>
+										<FormControl>
+											<div data-testid="model-catalog-model-select">
+												<ModelMultiselect
+													provider={form.watch("provider") || undefined}
+													value={field.value}
+													onChange={field.onChange}
+													placeholder="Search for a model..."
+													isSingleSelect
+													loadModelsOnEmptyProvider="base_models"
+													disabled={isEditing}
+												/>
+											</div>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							<DottedSeparator />
+
+							{/* Description */}
+							<FormField
+								control={form.control}
+								name="description"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Description</FormLabel>
+										<FormControl>
+											<Textarea
+												{...field}
+												rows={4}
+												placeholder="A short description of this model — shown anywhere attributes.description is consumed."
+												data-testid="model-catalog-description-textarea"
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							<DottedSeparator />
+
+							{/* Other attributes */}
+							<div className="space-y-3">
+								<div className="flex items-center justify-between">
+									<Label className="text-sm font-medium">Other Attributes</Label>
+									<Button type="button" variant="outline" size="sm" onClick={handleAddRow} data-testid="model-catalog-add-attribute-row">
+										<Plus className="mr-1 h-3 w-3" />
+										Add
+									</Button>
+								</div>
+								{extraRows.length === 0 ? (
+									<p className="text-muted-foreground text-xs">
+										No additional attributes. Add a key-value pair for anything beyond description.
+									</p>
+								) : (
+									<div className="space-y-2">
+										{extraRows.map((row, i) => (
+											<div key={row.id} className="flex items-start gap-2">
+												<Input
+													value={row.key}
+													onChange={(e) => handleRowChange(row.id, "key", e.target.value)}
+													placeholder="key"
+													className="flex-1"
+													data-testid={`model-catalog-attribute-key-${i}`}
+												/>
+												<Input
+													value={row.value}
+													onChange={(e) => handleRowChange(row.id, "value", e.target.value)}
+													placeholder="value"
+													className="flex-1"
+													data-testid={`model-catalog-attribute-value-${i}`}
+												/>
+												<Button
+													type="button"
+													variant="ghost"
+													size="icon"
+													onClick={() => handleRemoveRow(row.id)}
+													data-testid={`model-catalog-attribute-remove-${i}`}
+												>
+													<Trash2 className="h-4 w-4" />
+												</Button>
+											</div>
+										))}
+									</div>
+								)}
+							</div>
+						</div>
+
+						<div className="bg-card sticky bottom-0 shrink-0 border-t px-8 py-4">
+							<div className="flex items-center justify-end gap-3">
+								{!canSubmit && <p className="text-destructive text-sm">You don't have permission to perform this action</p>}
+								<Button type="button" variant="outline" onClick={handleClose} data-testid="model-catalog-attribute-cancel">
+									Cancel
+								</Button>
+								<Button
+									type="submit"
+									data-testid="model-catalog-attribute-submit"
+									disabled={isLoading || !isDirty || !canSubmit}
+								>
+									{isLoading ? "Saving..." : isEditing ? "Save Changes" : "Add Attributes"}
+								</Button>
+							</div>
+						</div>
+					</form>
+				</Form>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/model-catalog/views/attributesTab.tsx
+++ b/ui/app/workspace/model-catalog/views/attributesTab.tsx
@@ -1,0 +1,325 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { Input } from "@/components/ui/input";
+import FullPageLoader from "@/components/fullPageLoader";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import {
+	getErrorMessage,
+	ModelCatalogEntry,
+	useDeleteModelCatalogEntryMutation,
+	useGetModelCatalogQuery,
+} from "@/lib/store";
+import { KnownProvider } from "@/lib/types/config";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import AttributeSheet from "./attributeSheet";
+
+const toTestIdPart = (value: string) =>
+	value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "");
+
+// Renders the description column. Long descriptions are truncated to keep the
+// table scannable; the full text is reachable via tooltip.
+function DescriptionCell({ description }: { description?: string }) {
+	if (!description) return <span className="text-muted-foreground text-sm">—</span>;
+	const truncated = description.length > 80;
+	const text = truncated ? `${description.slice(0, 80)}…` : description;
+	if (!truncated) return <span className="text-sm">{text}</span>;
+	return (
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span className="text-sm">{text}</span>
+				</TooltipTrigger>
+				<TooltipContent className="max-w-md">{description}</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}
+
+function ActionsMenu({
+	entry,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	onEdit,
+	onDelete,
+}: {
+	entry: ModelCatalogEntry;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	onEdit: (entry: ModelCatalogEntry) => void;
+	onDelete: (entry: ModelCatalogEntry) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+	const testKey = `${toTestIdPart(entry.model)}-${toTestIdPart(entry.provider)}`;
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label={`Actions for ${entry.model}`}
+					data-testid={`model-catalog-actions-${testKey}`}
+				>
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					className="cursor-pointer"
+					disabled={!hasUpdateAccess}
+					data-testid={`model-catalog-edit-${testKey}`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onEdit(entry);
+						setIsOpen(false);
+					}}
+				>
+					<Edit className="h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					variant="destructive"
+					className="cursor-pointer"
+					disabled={!hasDeleteAccess}
+					data-testid={`model-catalog-delete-${testKey}`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(entry);
+						setIsOpen(false);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+interface AttributesTabProps {
+	hasAccess: boolean;
+}
+
+export default function AttributesTab({ hasAccess }: AttributesTabProps) {
+	const hasCreateAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Create);
+	const hasUpdateAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+	const hasDeleteAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Delete);
+
+	const { data: entries, isLoading, error, refetch } = useGetModelCatalogQuery(undefined, { skip: !hasAccess });
+	const [deleteEntry, { isLoading: isDeleting }] = useDeleteModelCatalogEntryMutation();
+
+	const [search, setSearch] = useState("");
+	const [showSheet, setShowSheet] = useState(false);
+	const [editingId, setEditingId] = useState<number | null>(null);
+	const [deleteCandidateId, setDeleteCandidateId] = useState<number | null>(null);
+
+	const filtered = useMemo(() => {
+		if (!entries) return [];
+		const q = search.trim().toLowerCase();
+		if (!q) return entries;
+		return entries.filter(
+			(e) =>
+				e.model.toLowerCase().includes(q) ||
+				e.provider.toLowerCase().includes(q) ||
+				(e.attributes?.description || "").toLowerCase().includes(q),
+		);
+	}, [entries, search]);
+
+	const editingEntry = useMemo(
+		() => (editingId !== null && entries ? entries.find((e) => e.id === editingId) ?? null : null),
+		[editingId, entries],
+	);
+	const deleteCandidate = useMemo(
+		() => (deleteCandidateId !== null && entries ? entries.find((e) => e.id === deleteCandidateId) ?? null : null),
+		[deleteCandidateId, entries],
+	);
+
+	const handleAdd = () => {
+		setEditingId(null);
+		setShowSheet(true);
+	};
+	const handleEdit = (entry: ModelCatalogEntry) => {
+		setEditingId(entry.id);
+		setShowSheet(true);
+	};
+	const handleSheetSaved = () => {
+		setShowSheet(false);
+		setEditingId(null);
+	};
+	const handleDelete = async () => {
+		if (!deleteCandidate) return;
+		try {
+			await deleteEntry(deleteCandidate.id).unwrap();
+			toast.success("Catalog entry deleted");
+			setDeleteCandidateId(null);
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		}
+	};
+
+	if (isLoading) return <FullPageLoader />;
+
+	if (error) {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+				<p className="text-muted-foreground text-sm">Failed to load model catalog</p>
+				<button type="button" onClick={refetch} className="text-sm underline" data-testid="model-catalog-retry-button">
+					Retry
+				</button>
+			</div>
+		);
+	}
+
+	const hasAnyEntries = (entries?.length ?? 0) > 0;
+
+	return (
+		<>
+			{showSheet && <AttributeSheet entry={editingEntry} onSave={handleSheetSaved} onCancel={() => setShowSheet(false)} />}
+
+			<AlertDialog open={!!deleteCandidate} onOpenChange={(open) => !open && setDeleteCandidateId(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete Model Attributes</AlertDialogTitle>
+						<AlertDialogDescription>
+							Remove attributes for &quot;{deleteCandidate?.provider}/{deleteCandidate?.model}&quot;? This cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel data-testid="model-catalog-delete-cancel">Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleDelete}
+							disabled={isDeleting}
+							className="bg-red-600 hover:bg-red-700"
+							data-testid="model-catalog-delete-confirm"
+						>
+							{isDeleting ? "Deleting..." : "Delete"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<div className="space-y-4">
+				<div className="flex items-center justify-between">
+					<div>
+						<h2 className="text-lg font-semibold">Model Attributes</h2>
+						<p className="text-muted-foreground text-sm">
+							Attach descriptions and tags to specific models. Editorial — decoupled from pricing sync.
+						</p>
+					</div>
+					<Button onClick={handleAdd} disabled={!hasCreateAccess} data-testid="model-catalog-button-create">
+						<Plus className="h-4 w-4" />
+						Add Attributes
+					</Button>
+				</div>
+
+				<div className="flex items-center gap-3">
+					<div className="relative max-w-sm flex-1">
+						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+						<Input
+							aria-label="Search model catalog"
+							placeholder="Search by model, provider, or description..."
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							className="pl-9"
+							data-testid="model-catalog-search-input"
+						/>
+					</div>
+				</div>
+
+				<div className="rounded-sm border" data-testid="model-catalog-attributes-table">
+					<Table>
+						<TableHeader>
+							<TableRow className="hover:bg-transparent">
+								<TableHead className="font-medium">Provider</TableHead>
+								<TableHead className="font-medium">Model</TableHead>
+								<TableHead className="font-medium">Description</TableHead>
+								<TableHead className="font-medium">Other</TableHead>
+								<TableHead className="w-[60px]"></TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{!hasAnyEntries ? (
+								<TableRow>
+									<TableCell colSpan={5} className="h-24 text-center">
+										<span className="text-muted-foreground text-sm">
+											No model attributes yet. Click &quot;Add Attributes&quot; to create the first one.
+										</span>
+									</TableCell>
+								</TableRow>
+							) : filtered.length === 0 ? (
+								<TableRow>
+									<TableCell colSpan={5} className="h-24 text-center">
+										<span className="text-muted-foreground text-sm">No matching entries.</span>
+									</TableCell>
+								</TableRow>
+							) : (
+								filtered.map((entry) => {
+									const extraKeys = Object.keys(entry.attributes || {}).filter((k) => k !== "description");
+									return (
+										<TableRow
+											key={entry.id}
+											data-testid={`model-catalog-row-${toTestIdPart(entry.model)}-${toTestIdPart(entry.provider)}`}
+										>
+											<TableCell className="py-3">
+												<div className="flex items-center gap-2">
+													<RenderProviderIcon
+														provider={entry.provider as KnownProvider}
+														size="sm"
+														className="h-4 w-4"
+													/>
+													<span className="text-sm">{ProviderLabels[entry.provider as ProviderName] || entry.provider}</span>
+												</div>
+											</TableCell>
+											<TableCell className="py-3 font-mono text-sm">{entry.model}</TableCell>
+											<TableCell className="max-w-[400px] py-3">
+												<DescriptionCell description={entry.attributes?.description} />
+											</TableCell>
+											<TableCell className="py-3">
+												{extraKeys.length === 0 ? (
+													<span className="text-muted-foreground text-sm">—</span>
+												) : (
+													<Badge variant="secondary">
+														{extraKeys.length} {extraKeys.length === 1 ? "attribute" : "attributes"}
+													</Badge>
+												)}
+											</TableCell>
+											<TableCell className="py-3">
+												<ActionsMenu
+													entry={entry}
+													hasUpdateAccess={hasUpdateAccess}
+													hasDeleteAccess={hasDeleteAccess}
+													onEdit={handleEdit}
+													onDelete={(e) => setDeleteCandidateId(e.id)}
+												/>
+											</TableCell>
+										</TableRow>
+									);
+								})
+							)}
+						</TableBody>
+					</Table>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
@@ -1,170 +1,34 @@
-import FullPageLoader from "@/components/fullPageLoader";
 import { NoPermissionView } from "@/components/noPermissionView";
-import { ProviderNames } from "@/lib/constants/logs";
-import { useGetModelsQuery, useGetProvidersQuery, useLazyGetLogsModelHistogramQuery, useLazyGetLogsStatsQuery } from "@/lib/store";
-import { KnownProvider } from "@/lib/types/config";
-import { LogStats } from "@/lib/types/logs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useEffect, useMemo, useState } from "react";
-import { ModelCatalogEmptyState } from "./modelCatalogEmptyState";
-import ModelCatalogTable, { ModelCatalogRow } from "./modelCatalogTable";
+import AttributesTab from "./attributesTab";
+import OverviewTab from "./overviewTab";
 
 export default function ModelCatalogView() {
 	const hasAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
-
-	const [providerFilter, setProviderFilter] = useState("");
-	const [statsMap, setStatsMap] = useState<Map<string, LogStats>>(new Map());
-	const [modelsUsedMap, setModelsUsedMap] = useState<Map<string, string[]>>(new Map());
-	const [isLoadingModels, setIsLoadingModels] = useState(true);
-
-	const {
-		data: providers,
-		isLoading: isLoadingProviders,
-		error: providersError,
-		refetch: refetchProviders,
-	} = useGetProvidersQuery(undefined, { skip: !hasAccess });
-	const { data: modelsData } = useGetModelsQuery({ unfiltered: true }, { skip: !hasAccess });
-
-	// Global 24h stats for summary cards (lazy so we get fresh timestamps)
-	const [triggerGlobalStats, { data: globalStats }] = useLazyGetLogsStatsQuery();
-
-	// Per-provider traffic stats (lazy, fired when providers load)
-	const [triggerStats] = useLazyGetLogsStatsQuery();
-	const [triggerModelHistogram] = useLazyGetLogsModelHistogramQuery();
-
-	useEffect(() => {
-		if (!hasAccess) return;
-		const now = new Date().toISOString();
-		const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-		triggerGlobalStats({ filters: { start_time: dayAgo, end_time: now } });
-	}, [hasAccess, triggerGlobalStats]);
-
-	useEffect(() => {
-		if (!providers || providers.length === 0) return;
-		let cancelled = false;
-		const now = new Date().toISOString();
-		const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-
-		Promise.all(
-			providers.map((p) =>
-				triggerStats({ filters: { providers: [p.name], start_time: dayAgo, end_time: now } })
-					.unwrap()
-					.then((stats) => [p.name, stats] as const)
-					.catch(
-						() =>
-							[
-								p.name,
-								{
-									total_requests: 0,
-									success_rate: 0,
-									user_facing_success_rate: 0,
-									average_latency: 0,
-									user_facing_total_requests: 0,
-									total_tokens: 0,
-									total_cost: 0,
-								},
-							] as const,
-					),
-			),
-		).then((results) => {
-			if (!cancelled) setStatsMap(new Map(results));
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, [providers, triggerStats]);
-
-	// Per-provider models used in last 30 days
-	useEffect(() => {
-		if (!providers || providers.length === 0) return;
-		let cancelled = false;
-		setIsLoadingModels(true);
-		const now = new Date().toISOString();
-		const monthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-
-		Promise.all(
-			providers.map((p) =>
-				triggerModelHistogram({ filters: { providers: [p.name], start_time: monthAgo, end_time: now } })
-					.unwrap()
-					.then((data): [string, string[]] => [p.name, data.models ?? []])
-					.catch((): [string, string[]] => [p.name, []]),
-			),
-		).then((results) => {
-			if (!cancelled) {
-				setModelsUsedMap(new Map(results));
-				setIsLoadingModels(false);
-			}
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, [providers, triggerModelHistogram]);
-
-	// Build table rows
-	const rows: ModelCatalogRow[] = useMemo(() => {
-		if (!providers) return [];
-
-		return providers.map((p) => {
-			const isCustom = !ProviderNames.includes(p.name as KnownProvider);
-			const modelsUsed = modelsUsedMap.get(p.name) ?? [];
-
-			const providerStats = statsMap.get(p.name);
-			const totalTraffic24h = providerStats?.total_requests ?? 0;
-			const totalCost24h = providerStats?.total_cost ?? 0;
-
-			return {
-				providerName: p.name,
-				isCustom,
-				baseProviderType: p.custom_provider_config?.base_provider_type,
-				modelsUsed,
-				totalTraffic24h,
-				totalCost24h,
-			};
-		});
-	}, [providers, statsMap, modelsUsedMap]);
-
-	// Filter rows by provider
-	const filteredRows = useMemo(() => {
-		if (!providerFilter) return rows;
-		return rows.filter((r) => r.providerName === providerFilter);
-	}, [rows, providerFilter]);
-
-	if (isLoadingProviders) {
-		return <FullPageLoader />;
-	}
 
 	if (!hasAccess) {
 		return <NoPermissionView entity="model catalog" />;
 	}
 
-	if (providersError) {
-		return (
-			<div className="flex h-full flex-col items-center justify-center gap-4 text-center">
-				<p className="text-muted-foreground text-sm">Failed to load providers</p>
-				<button type="button" data-testid="model-catalog-retry-btn" onClick={refetchProviders} className="text-sm underline">
-					Retry
-				</button>
-			</div>
-		);
-	}
-
-	if (!providers || providers.length === 0) {
-		return <ModelCatalogEmptyState />;
-	}
-
 	return (
 		<div className="mx-auto w-full max-w-7xl">
-			<ModelCatalogTable
-				rows={filteredRows}
-				providers={(providers ?? []).map((p) => p.name)}
-				providerFilter={providerFilter}
-				onProviderFilterChange={setProviderFilter}
-				totalProviders={(providers ?? []).length}
-				totalModels={modelsData?.total ?? 0}
-				totalRequests24h={globalStats?.total_requests ?? 0}
-				totalCost24h={globalStats?.total_cost ?? 0}
-				isLoadingModels={isLoadingModels}
-			/>
+			<Tabs defaultValue="overview" className="space-y-4">
+				<TabsList>
+					<TabsTrigger value="overview" data-testid="model-catalog-tab-overview">
+						Overview
+					</TabsTrigger>
+					<TabsTrigger value="attributes" data-testid="model-catalog-tab-attributes">
+						Attributes
+					</TabsTrigger>
+				</TabsList>
+				<TabsContent value="overview" className="mt-6">
+					<OverviewTab hasAccess={hasAccess} />
+				</TabsContent>
+				<TabsContent value="attributes" className="mt-6">
+					<AttributesTab hasAccess={hasAccess} />
+				</TabsContent>
+			</Tabs>
 		</div>
 	);
 }

--- a/ui/app/workspace/model-catalog/views/overviewTab.tsx
+++ b/ui/app/workspace/model-catalog/views/overviewTab.tsx
@@ -1,0 +1,155 @@
+import FullPageLoader from "@/components/fullPageLoader";
+import { ProviderNames } from "@/lib/constants/logs";
+import { useGetModelsQuery, useGetProvidersQuery, useLazyGetLogsModelHistogramQuery, useLazyGetLogsStatsQuery } from "@/lib/store";
+import { KnownProvider } from "@/lib/types/config";
+import { LogStats } from "@/lib/types/logs";
+import { useEffect, useMemo, useState } from "react";
+import { ModelCatalogEmptyState } from "./modelCatalogEmptyState";
+import ModelCatalogTable, { ModelCatalogRow } from "./modelCatalogTable";
+
+interface OverviewTabProps {
+	hasAccess: boolean;
+}
+
+export default function OverviewTab({ hasAccess }: OverviewTabProps) {
+	const [providerFilter, setProviderFilter] = useState("");
+	const [statsMap, setStatsMap] = useState<Map<string, LogStats>>(new Map());
+	const [modelsUsedMap, setModelsUsedMap] = useState<Map<string, string[]>>(new Map());
+	const [isLoadingModels, setIsLoadingModels] = useState(true);
+
+	const {
+		data: providers,
+		isLoading: isLoadingProviders,
+		error: providersError,
+		refetch: refetchProviders,
+	} = useGetProvidersQuery(undefined, { skip: !hasAccess });
+	const { data: modelsData } = useGetModelsQuery({ unfiltered: true }, { skip: !hasAccess });
+
+	const [triggerGlobalStats, { data: globalStats }] = useLazyGetLogsStatsQuery();
+	const [triggerStats] = useLazyGetLogsStatsQuery();
+	const [triggerModelHistogram] = useLazyGetLogsModelHistogramQuery();
+
+	useEffect(() => {
+		if (!hasAccess) return;
+		const now = new Date().toISOString();
+		const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+		triggerGlobalStats({ filters: { start_time: dayAgo, end_time: now } });
+	}, [hasAccess, triggerGlobalStats]);
+
+	useEffect(() => {
+		if (!providers || providers.length === 0) return;
+		let cancelled = false;
+		const now = new Date().toISOString();
+		const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+		Promise.all(
+			providers.map((p) =>
+				triggerStats({ filters: { providers: [p.name], start_time: dayAgo, end_time: now } })
+					.unwrap()
+					.then((stats) => [p.name, stats] as const)
+					.catch(
+						() =>
+							[
+								p.name,
+								{
+									total_requests: 0,
+									success_rate: 0,
+									user_facing_success_rate: 0,
+									average_latency: 0,
+									user_facing_total_requests: 0,
+									total_tokens: 0,
+									total_cost: 0,
+								},
+							] as const,
+					),
+			),
+		).then((results) => {
+			if (!cancelled) setStatsMap(new Map(results));
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [providers, triggerStats]);
+
+	useEffect(() => {
+		if (!providers || providers.length === 0) return;
+		let cancelled = false;
+		setIsLoadingModels(true);
+		const now = new Date().toISOString();
+		const monthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+		Promise.all(
+			providers.map((p) =>
+				triggerModelHistogram({ filters: { providers: [p.name], start_time: monthAgo, end_time: now } })
+					.unwrap()
+					.then((data): [string, string[]] => [p.name, data.models ?? []])
+					.catch((): [string, string[]] => [p.name, []]),
+			),
+		).then((results) => {
+			if (!cancelled) {
+				setModelsUsedMap(new Map(results));
+				setIsLoadingModels(false);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [providers, triggerModelHistogram]);
+
+	const rows: ModelCatalogRow[] = useMemo(() => {
+		if (!providers) return [];
+		return providers.map((p) => {
+			const isCustom = !ProviderNames.includes(p.name as KnownProvider);
+			const modelsUsed = modelsUsedMap.get(p.name) ?? [];
+			const providerStats = statsMap.get(p.name);
+			const totalTraffic24h = providerStats?.total_requests ?? 0;
+			const totalCost24h = providerStats?.total_cost ?? 0;
+			return {
+				providerName: p.name,
+				isCustom,
+				baseProviderType: p.custom_provider_config?.base_provider_type,
+				modelsUsed,
+				totalTraffic24h,
+				totalCost24h,
+			};
+		});
+	}, [providers, statsMap, modelsUsedMap]);
+
+	const filteredRows = useMemo(() => {
+		if (!providerFilter) return rows;
+		return rows.filter((r) => r.providerName === providerFilter);
+	}, [rows, providerFilter]);
+
+	if (isLoadingProviders) {
+		return <FullPageLoader />;
+	}
+
+	if (providersError) {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+				<p className="text-muted-foreground text-sm">Failed to load providers</p>
+				<button type="button" data-testid="model-catalog-retry-btn" onClick={refetchProviders} className="text-sm underline">
+					Retry
+				</button>
+			</div>
+		);
+	}
+
+	if (!providers || providers.length === 0) {
+		return <ModelCatalogEmptyState />;
+	}
+
+	return (
+		<ModelCatalogTable
+			rows={filteredRows}
+			providers={(providers ?? []).map((p) => p.name)}
+			providerFilter={providerFilter}
+			onProviderFilterChange={setProviderFilter}
+			totalProviders={(providers ?? []).length}
+			totalModels={modelsData?.total ?? 0}
+			totalRequests24h={globalStats?.total_requests ?? 0}
+			totalCost24h={globalStats?.total_cost ?? 0}
+			isLoadingModels={isLoadingModels}
+		/>
+	);
+}

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -159,6 +159,7 @@ export const baseApi = createApi({
     "Models",
     "BaseModels",
     "ModelConfigs",
+    "ModelCatalog",
     "ProviderGovernance",
     "Plugins",
     "SCIMProviders",

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -24,11 +24,21 @@ export interface ModelResponse {
 	name: string;
 	provider: string;
 	accessible_by_keys?: string[];
+	attributes?: Record<string, string>;
 }
 
 export interface ListModelsResponse {
 	models: ModelResponse[];
 	total: number;
+}
+
+// Per-model attribute blob from governance_model_catalog. (model, provider) is
+// the natural key; the table also exposes a numeric id used by DELETE.
+export interface ModelCatalogEntry {
+	id: number;
+	model: string;
+	provider: string;
+	attributes?: Record<string, string>;
 }
 
 export interface GetModelsRequest {
@@ -346,6 +356,28 @@ export const providersApi = baseApi.injectEndpoints({
 				return { data: result.data as ModelDatasheetResponse };
 			},
 		}),
+
+		// Model catalog CRUD. Backs the per-model attribute editor; entries
+		// are decoupled from pricing so they survive the pricing sync cycle.
+		getModelCatalog: builder.query<ModelCatalogEntry[], void>({
+			query: () => "/model-catalog",
+			providesTags: ["ModelCatalog"],
+		}),
+		upsertModelCatalogEntries: builder.mutation<ModelCatalogEntry[], ModelCatalogEntry[]>({
+			query: (entries) => ({
+				url: "/model-catalog",
+				method: "PUT",
+				body: entries,
+			}),
+			invalidatesTags: ["ModelCatalog", "Models"],
+		}),
+		deleteModelCatalogEntry: builder.mutation<void, number>({
+			query: (id) => ({
+				url: `/model-catalog/${id}`,
+				method: "DELETE",
+			}),
+			invalidatesTags: ["ModelCatalog", "Models"],
+		}),
 	}),
 });
 
@@ -372,4 +404,8 @@ export const {
 	useLazyGetBaseModelsQuery,
 	useGetModelParametersQuery,
 	useLazyGetModelParametersQuery,
+	useGetModelCatalogQuery,
+	useLazyGetModelCatalogQuery,
+	useUpsertModelCatalogEntriesMutation,
+	useDeleteModelCatalogEntryMutation,
 } = providersApi;


### PR DESCRIPTION
## Summary

Introduces a `governance_model_catalog` table and supporting infrastructure for storing per-model editorial attributes (e.g. `description`) that are intentionally decoupled from the pricing sync cycle. Because pricing sync uses a bulk delete-and-recreate pattern, any editorial content stored alongside pricing would be wiped on every sync. The catalog table solves this by living independently, surviving pricing refreshes while still being surfaced alongside pricing data in model list responses.

## Changes

- **New `governance_model_catalog` table** (`TableModelCatalogEntry`) with a `(model, provider)` unique index. Attributes are stored as a JSON blob in a `text` column and marshalled/unmarshalled via GORM hooks, allowing new fields without schema migrations.
- **Database migration** (`migrationAddModelCatalogTable`) creates the table on boot with a rollback path.
- **ConfigStore interface** extended with `GetAllModelCatalogEntries`, `UpsertModelCatalogEntry`, and `DeleteModelCatalogEntry`, implemented on `RDBConfigStore`.
- **`ModelCatalog`** gains an in-memory `modelCatalogData` map (keyed `<model>|<provider>`) with a read/write mutex, loaded from the database on init and after every `ReloadFromDB`. In-memory-only deployments (no configstore) maintain the cache locally.
- **`/api/model-catalog`** management endpoints added: `GET` lists all entries, `PUT` upserts a batch, `DELETE /{id}` removes by primary key.
- **Model list and model details responses** now include `attributes` from the catalog when present, and `supported_parameters` is populated in the list response.
- **`config.json` seeding** via a new `model_catalog` array field. Entries declared there are upserted at boot; errors are logged and do not block startup. The JSON schema is updated accordingly.
- **`Model` schema** gains an `Attributes map[string]string` field surfaced in API responses.
- **UI**: The Model Catalog page is refactored into two tabs — **Overview** (existing provider/traffic table, extracted to `OverviewTab`) and **Attributes** (new `AttributesTab` + `AttributeSheet` slide-over for creating and editing catalog entries). RTK Query endpoints (`getModelCatalog`, `upsertModelCatalogEntries`, `deleteModelCatalogEntry`) and the `ModelCatalogEntry` type are added to the providers API slice.

Notable design decision: the catalog table is kept entirely separate from `governance_model_pricing` so the pricing sync's destructive write path never touches editorial content.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./framework/modelcatalog/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Boot the gateway with a database-backed configstore. Confirm `governance_model_catalog` is created.
2. `PUT /api/model-catalog` with `[{"model":"gpt-4o","provider":"openai","attributes":{"description":"Test"}}]` — expect the entry returned in the response.
3. `GET /api/model-catalog` — confirm the entry is listed.
4. `GET /api/models` — confirm `attributes.description` appears on the matching model entry.
5. `DELETE /api/model-catalog/{id}` — confirm the entry is removed and no longer appears in model responses.
6. Add a `model_catalog` block to `config.json` and restart; confirm entries are seeded without blocking boot even if a row is malformed.
7. In the UI, navigate to Model Catalog → Attributes tab. Create, edit, and delete an entry; verify the Overview tab is unaffected.

**New config field:**
```json
"model_catalog": [
  {
    "model": "gpt-4o",
    "provider": "openai",
    "attributes": { "description": "OpenAI's flagship multimodal model." }
  }
]
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The new endpoints follow the same middleware chain as existing provider management routes. No new secrets or PII are introduced; attribute values are free-form strings stored and returned as-is, so operators should avoid placing sensitive data in attributes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable