### PR TITLE
feat: direct api key header

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -7237,6 +7237,12 @@ func (bifrost *Bifrost) releaseBifrostRequest(req *schemas.BifrostRequest) {
 // getAllSupportedKeys retrieves all valid keys for a ListModels request.
 // allowing the provider to aggregate results from multiple keys.
 func (bifrost *Bifrost) getAllSupportedKeys(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider, baseProviderType schemas.ModelProvider) ([]schemas.Key, error) {
+	if ctx != nil {
+		if key, ok := ctx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+			return []schemas.Key{key}, nil
+		}
+	}
+
 	keys, err := bifrost.account.GetKeysForProvider(ctx, providerKey)
 	if err != nil {
 		return nil, err
@@ -7275,6 +7281,12 @@ func (bifrost *Bifrost) getAllSupportedKeys(ctx *schemas.BifrostContext, provide
 // For batch operations, only keys with UseForBatchAPI enabled are included.
 // Model filtering: if model is specified and key has model restrictions, only include if model is in list.
 func (bifrost *Bifrost) getKeysForBatchAndFileOps(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider, baseProviderType schemas.ModelProvider, model *string, isBatchOp bool) ([]schemas.Key, error) {
+	if ctx != nil {
+		if key, ok := ctx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+			return []schemas.Key{key}, nil
+		}
+	}
+
 	keys, err := bifrost.account.GetKeysForProvider(ctx, providerKey)
 	if err != nil {
 		return nil, err
@@ -7354,6 +7366,13 @@ func (bifrost *Bifrost) getKeysForBatchAndFileOps(ctx *schemas.BifrostContext, p
 // canRotate=true is returned when there are two or more eligible keys and no pinning
 // or stickiness constraint is in effect.
 func (bifrost *Bifrost) selectKeyFromProviderForModelWithPool(ctx *schemas.BifrostContext, requestType schemas.RequestType, providerKey schemas.ModelProvider, model string, baseProviderType schemas.ModelProvider) ([]schemas.Key, bool, error) {
+	// Direct key bypass: caller supplied a raw API key via x-bf-direct-key header.
+	if ctx != nil {
+		if key, ok := ctx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+			return []schemas.Key{key}, false, nil
+		}
+	}
+
 	// SkipKeySelection: provider allows keyless requests — return empty pool, no rotation.
 	if skipKeySelection, ok := ctx.Value(schemas.BifrostContextKeySkipKeySelection).(bool); ok && skipKeySelection && isKeySkippingAllowed(providerKey) {
 		return []schemas.Key{}, false, nil

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -193,6 +193,7 @@ const (
 	BifrostContextKeyVirtualKey        BifrostContextKey = "x-bf-vk"               // string
 	BifrostContextKeyAPIKeyName        BifrostContextKey = "x-bf-api-key"          // string (explicit key name selection)
 	BifrostContextKeyAPIKeyID          BifrostContextKey = "x-bf-api-key-id"       // string (explicit key ID selection, takes priority over name)
+	BifrostContextKeyDirectKey         BifrostContextKey = "x-bf-direct-key"       // schemas.Key (raw key supplied via x-bf-direct-key: true header; bypasses registered key pool)
 	BifrostContextKeyRequestID         BifrostContextKey = "request-id"            // string
 	BifrostContextKeyFallbackRequestID BifrostContextKey = "fallback-request-id"   // string
 

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -14,6 +14,7 @@ var reservedKeys = []any{
 	BifrostContextKeyVirtualKey,
 	BifrostContextKeyAPIKeyName,
 	BifrostContextKeyAPIKeyID,
+	BifrostContextKeyDirectKey,
 	BifrostContextKeyRequestID,
 	BifrostContextKeyFallbackRequestID,
 	BifrostContextKeySelectedKeyID,

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -73,6 +73,7 @@ type ClientConfig struct {
 	DisableContentLogging                 bool                             `json:"disable_content_logging"`                    // Disable logging of content
 	AllowPerRequestContentStorageOverride bool                             `json:"allow_per_request_content_storage_override"` // Allow per-request override of content storage via x-bf-disable-content-logging header/context
 	AllowPerRequestRawOverride            bool                             `json:"allow_per_request_raw_override"`             // Allow per-request override of raw request/response visibility via x-bf-send-back-raw-request and x-bf-send-back-raw-response headers
+	AllowDirectKeys                       bool                             `json:"allow_direct_keys"`                          // Allow callers to bypass the registered key pool via x-bf-direct-key: true header
 	DisableDBPingsInHealth                bool                             `json:"disable_db_pings_in_health"`
 	LogRetentionDays                      int                              `json:"log_retention_days" validate:"min=1"`  // Number of days to retain logs (minimum 1 day)
 	EnforceAuthOnInference                bool                             `json:"enforce_auth_on_inference"`            // Require auth (VK, API key, or user token) on inference endpoints
@@ -221,6 +222,11 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 
 	if c.AllowPerRequestRawOverride {
 		hash.Write([]byte("allowPerRequestRawOverride:true"))
+	}
+
+	// Only hash non-default value to avoid legacy config hash churn on upgrade.
+	if c.AllowDirectKeys {
+		hash.Write([]byte("allowDirectKeys:true"))
 	}
 
 	if c.AsyncJobResultTTL > 0 {

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -813,6 +813,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPerUserHeadersFlowsTable(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationReAddAllowDirectKeysColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddMCPClientTLSConfigColumn(ctx, db); err != nil {
 		return err
 	}
@@ -8894,6 +8897,37 @@ func migrationDropAzureAPIVersionColumn(ctx context.Context, db *gorm.DB) error 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running drop_azure_api_version_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationReAddAllowDirectKeysColumn re-adds the allow_direct_keys column to config_client.
+// The column was originally added then dropped in v1.5.0 when the direct key bypass feature
+// was removed. It is re-added here as the feature is being restored with header-gated access.
+func migrationReAddAllowDirectKeysColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "re_add_allow_direct_keys_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if !tx.Migrator().HasColumn(&tables.TableClientConfig{}, "allow_direct_keys") {
+				if err := tx.Exec("ALTER TABLE config_client ADD COLUMN allow_direct_keys BOOLEAN DEFAULT FALSE").Error; err != nil {
+					return fmt.Errorf("failed to re-add allow_direct_keys column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if tx.Migrator().HasColumn(&tables.TableClientConfig{}, "allow_direct_keys") {
+				if err := tx.Migrator().DropColumn(&tables.TableClientConfig{}, "allow_direct_keys"); err != nil {
+					return fmt.Errorf("failed to drop allow_direct_keys column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running re_add_allow_direct_keys_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -257,6 +257,7 @@ func (s *RDBConfigStore) UpdateClientConfig(ctx context.Context, config *ClientC
 		HeaderFilterConfig:                    config.HeaderFilterConfig,
 		AllowPerRequestContentStorageOverride: config.AllowPerRequestContentStorageOverride,
 		AllowPerRequestRawOverride:            config.AllowPerRequestRawOverride,
+		AllowDirectKeys:                       config.AllowDirectKeys,
 		ConfigHash:                            config.ConfigHash,
 	}
 	// Delete existing client config and create new one in a transaction.
@@ -520,6 +521,7 @@ func (s *RDBConfigStore) GetClientConfig(ctx context.Context) (*ClientConfig, er
 		HeaderFilterConfig:                    dbConfig.HeaderFilterConfig,
 		AllowPerRequestContentStorageOverride: dbConfig.AllowPerRequestContentStorageOverride,
 		AllowPerRequestRawOverride:            dbConfig.AllowPerRequestRawOverride,
+		AllowDirectKeys:                       dbConfig.AllowDirectKeys,
 		ConfigHash:                            dbConfig.ConfigHash,
 	}, nil
 }

--- a/framework/configstore/tables/clientconfig.go
+++ b/framework/configstore/tables/clientconfig.go
@@ -38,8 +38,9 @@ type TableClientConfig struct {
 	RoutingChainMaxDepth                  int    `gorm:"default:10" json:"routing_chain_max_depth"`                       // Maximum depth for routing rule chain evaluation (default: 10)
 	MCPExternalClientURL                  string `gorm:"type:varchar(512)" json:"mcp_external_client_url,omitempty"`      // Public base URL used as redirect_uri when Bifrost acts as an OAuth client to upstream MCP servers
 	WhitelistedRoutesJSON                 string `gorm:"type:text" json:"-"`                                              // JSON serialized []string
-	AllowPerRequestContentStorageOverride bool   `gorm:"default:false" json:"allow_per_request_content_storage_override"` // Allow per-request override for content storage (e.g. long-term vs ephemeral)
-	AllowPerRequestRawOverride            bool   `gorm:"default:false" json:"allow_per_request_raw_override"`             // Allow per-request override for raw request/response storage
+	AllowPerRequestContentStorageOverride bool `gorm:"default:false" json:"allow_per_request_content_storage_override"` // Allow per-request override for content storage (e.g. long-term vs ephemeral)
+	AllowPerRequestRawOverride            bool `gorm:"default:false" json:"allow_per_request_raw_override"`             // Allow per-request override for raw request/response storage
+	AllowDirectKeys                       bool `gorm:"default:false" json:"allow_direct_keys"`                          // Allow callers to bypass the registered key pool via x-bf-direct-key header
 
 	// Compat plugin feature flags
 	CompatConvertTextToChat      bool `gorm:"column:compat_convert_text_to_chat;default:false" json:"-"`

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -486,6 +486,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	// Toggle allowing per-request override for raw request/response exposure
 	updatedConfig.AllowPerRequestRawOverride = payload.ClientConfig.AllowPerRequestRawOverride
 
+	// Toggle allowing direct key bypass via x-bf-direct-key header
+	updatedConfig.AllowDirectKeys = payload.ClientConfig.AllowDirectKeys
+
 	// No restart needed - routing engine reads via pointer, change is effective immediately.
 	if payload.ClientConfig.RoutingChainMaxDepth > 0 {
 		updatedConfig.RoutingChainMaxDepth = payload.ClientConfig.RoutingChainMaxDepth

--- a/transports/bifrost-http/handlers/webrtc_realtime_test.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime_test.go
@@ -29,6 +29,7 @@ func (s testHandlerStore) GetKVStore() *kvstore.Store                       { re
 func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList { return nil }
 func (s testHandlerStore) ShouldAllowPerRequestStorageOverride() bool       { return false }
 func (s testHandlerStore) ShouldAllowPerRequestRawOverride() bool           { return false }
+func (s testHandlerStore) ShouldAllowDirectKeys() bool                      { return false }
 func (s testHandlerStore) GetMCPExternalServerURL() string                  { return "" }
 func (s testHandlerStore) GetMCPExternalClientURL() string                  { return "" }
 

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -50,6 +50,7 @@ func (s testWSHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 
 func (s testWSHandlerStore) ShouldAllowPerRequestStorageOverride() bool { return false }
 func (s testWSHandlerStore) ShouldAllowPerRequestRawOverride() bool     { return false }
+func (s testWSHandlerStore) ShouldAllowDirectKeys() bool                { return false }
 func (s testWSHandlerStore) GetMCPExternalServerURL() string            { return "" }
 func (s testWSHandlerStore) GetMCPExternalClientURL() string            { return "" }
 

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -57,6 +57,10 @@ func (m *mockHandlerStore) ShouldAllowPerRequestRawOverride() bool {
 	return false
 }
 
+func (m *mockHandlerStore) ShouldAllowDirectKeys() bool {
+	return false
+}
+
 func (m *mockHandlerStore) GetMCPExternalServerURL() string {
 	return ""
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -84,6 +84,8 @@ type HandlerStore interface {
 	ShouldAllowPerRequestStorageOverride() bool
 	// ShouldAllowPerRequestRawOverride returns whether per-request overrides for raw request/response visibility are permitted
 	ShouldAllowPerRequestRawOverride() bool
+	// ShouldAllowDirectKeys returns whether callers may bypass the registered key pool via x-bf-direct-key header
+	ShouldAllowDirectKeys() bool
 	// GetMCPExternalClientURL returns the configured external base URL Bifrost uses as the
 	// redirect_uri when acting as an OAuth client to upstream MCP servers, or empty string
 	// if not configured (falls back to dynamic Host-header-based URL).
@@ -3524,6 +3526,11 @@ func (c *Config) ShouldAllowPerRequestStorageOverride() bool {
 // ShouldAllowPerRequestRawOverride returns whether per-request raw request/response overrides are permitted.
 func (c *Config) ShouldAllowPerRequestRawOverride() bool {
 	return c.ClientConfig.AllowPerRequestRawOverride
+}
+
+// ShouldAllowDirectKeys returns whether callers may bypass the registered key pool via x-bf-direct-key header.
+func (c *Config) ShouldAllowDirectKeys() bool {
+	return c.ClientConfig.AllowDirectKeys
 }
 
 // GetMCPExternalClientURL returns the configured external base URL Bifrost uses as the

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -243,6 +243,7 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 		"x-bf-api-key":    true,
 		"x-bf-api-key-id": true,
 		"x-bf-vk":         true,
+		"x-bf-direct-key": true,
 	}
 
 	// Debug: Log header matcher state
@@ -636,6 +637,44 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 
 	bifrostCtx.SetValue(schemas.BifrostContextKeyAllowPerRequestStorageOverride, allowPerRequestStorageOverride)
 	bifrostCtx.SetValue(schemas.BifrostContextKeyAllowPerRequestRawOverride, allowPerRequestRawOverride)
+
+	// Direct key bypass: requires both the server-side AllowDirectKeys setting and the
+	// per-request x-bf-direct-key: true header. The server setting is the admin opt-in;
+	// the header is the per-request opt-in from the caller.
+	if store != nil && store.ShouldAllowDirectKeys() && string(ctx.Request.Header.Peek("x-bf-direct-key")) == "true" {
+		var apiKey string
+		authHeader := string(ctx.Request.Header.Peek("Authorization"))
+		if authHeader != "" {
+			if strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+				authHeaderValue := strings.TrimSpace(authHeader[7:])
+				if authHeaderValue != "" && !strings.HasPrefix(strings.ToLower(authHeaderValue), governance.VirtualKeyPrefix) {
+					apiKey = authHeaderValue
+				}
+			}
+		}
+		if apiKey == "" {
+			xAPIKey := strings.TrimSpace(string(ctx.Request.Header.Peek("x-api-key")))
+			if xAPIKey != "" && !strings.HasPrefix(strings.ToLower(xAPIKey), governance.VirtualKeyPrefix) {
+				apiKey = xAPIKey
+			} else {
+				xGoogleAPIKey := strings.TrimSpace(string(ctx.Request.Header.Peek("x-goog-api-key")))
+				if xGoogleAPIKey != "" && !strings.HasPrefix(strings.ToLower(xGoogleAPIKey), governance.VirtualKeyPrefix) {
+					apiKey = xGoogleAPIKey
+				}
+			}
+		}
+		if apiKey != "" {
+			key := schemas.Key{
+				ID:     "header-provided",
+				Name:   "header-provided",
+				Value:  schemas.EnvVar{Val: apiKey},
+				Models: []string{},
+				Weight: 1.0,
+			}
+			bifrostCtx.SetValue(schemas.BifrostContextKeyDirectKey, key)
+		}
+	}
+
 	return bifrostCtx, cancel
 }
 

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -14,7 +14,8 @@ import (
 
 // testHandlerStore is a minimal HandlerStore for ctx tests.
 type testHandlerStore struct {
-	matcher *HeaderMatcher
+	matcher         *HeaderMatcher
+	allowDirectKeys bool
 }
 
 func (s testHandlerStore) GetHeaderMatcher() *HeaderMatcher                      { return s.matcher }
@@ -28,6 +29,7 @@ func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 }
 func (s testHandlerStore) ShouldAllowPerRequestStorageOverride() bool { return false }
 func (s testHandlerStore) ShouldAllowPerRequestRawOverride() bool     { return false }
+func (s testHandlerStore) ShouldAllowDirectKeys() bool                { return s.allowDirectKeys }
 func (s testHandlerStore) GetMCPExternalServerURL() string            { return "" }
 func (s testHandlerStore) GetMCPExternalClientURL() string            { return "" }
 
@@ -376,5 +378,161 @@ func TestConvertToBifrostContext_DimAndPromCanCoexistWithoutCrossing(t *testing.
 	}
 	if len(dimensions) != 2 {
 		t.Fatalf("expected only dim headers in unified dimensions, got %#v", dimensions)
+	}
+}
+
+func TestConvertToBifrostContext_DirectKey_ServerDisabled(t *testing.T) {
+	// x-bf-direct-key: true present but server setting is off — no direct key should be set.
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-direct-key", "true")
+	ctx.Request.Header.Set("Authorization", "Bearer sk-real-openai-key")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{allowDirectKeys: false})
+	defer cancel()
+
+	if _, ok := bifrostCtx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+		t.Error("expected no direct key when server setting is disabled")
+	}
+}
+
+func TestConvertToBifrostContext_DirectKey_HeaderAbsent(t *testing.T) {
+	// Server allows direct keys but caller did not send x-bf-direct-key header.
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Authorization", "Bearer sk-real-openai-key")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{allowDirectKeys: true})
+	defer cancel()
+
+	if _, ok := bifrostCtx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+		t.Error("expected no direct key when x-bf-direct-key header is absent")
+	}
+}
+
+func TestConvertToBifrostContext_DirectKey_BearerRealKey(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-direct-key", "true")
+	ctx.Request.Header.Set("Authorization", "Bearer sk-real-openai-key")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{allowDirectKeys: true})
+	defer cancel()
+
+	key, ok := bifrostCtx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key)
+	if !ok {
+		t.Fatal("expected direct key to be set")
+	}
+	if key.Value.GetValue() != "sk-real-openai-key" {
+		t.Errorf("direct key value = %q, want %q", key.Value.GetValue(), "sk-real-openai-key")
+	}
+	if key.ID != "header-provided" {
+		t.Errorf("direct key ID = %q, want %q", key.ID, "header-provided")
+	}
+}
+
+func TestConvertToBifrostContext_DirectKey_VirtualKeyNotBypassed(t *testing.T) {
+	// A virtual key (sk-bf-*) in Authorization must not be treated as a direct key.
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-direct-key", "true")
+	ctx.Request.Header.Set("Authorization", "Bearer sk-bf-virtual-key-here")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{allowDirectKeys: true})
+	defer cancel()
+
+	if _, ok := bifrostCtx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+		t.Error("expected virtual key not to be treated as a direct key")
+	}
+	// The virtual key should still be set normally.
+	if vk, ok := bifrostCtx.Value(schemas.BifrostContextKeyVirtualKey).(string); !ok || vk == "" {
+		t.Error("expected virtual key to be set in context")
+	}
+}
+
+func TestConvertToBifrostContext_DirectKey_XAPIKey(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-direct-key", "true")
+	ctx.Request.Header.Set("x-api-key", "sk-ant-real-anthropic-key")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{allowDirectKeys: true})
+	defer cancel()
+
+	key, ok := bifrostCtx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key)
+	if !ok {
+		t.Fatal("expected direct key to be set from x-api-key")
+	}
+	if key.Value.GetValue() != "sk-ant-real-anthropic-key" {
+		t.Errorf("direct key value = %q, want %q", key.Value.GetValue(), "sk-ant-real-anthropic-key")
+	}
+}
+
+func TestConvertToBifrostContext_DirectKey_XGoogAPIKey(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-direct-key", "true")
+	ctx.Request.Header.Set("x-goog-api-key", "AIza-real-gemini-key")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{allowDirectKeys: true})
+	defer cancel()
+
+	key, ok := bifrostCtx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key)
+	if !ok {
+		t.Fatal("expected direct key to be set from x-goog-api-key")
+	}
+	if key.Value.GetValue() != "AIza-real-gemini-key" {
+		t.Errorf("direct key value = %q, want %q", key.Value.GetValue(), "AIza-real-gemini-key")
+	}
+}
+
+func TestConvertToBifrostContext_DirectKey_CannotBeSpoofedViaEHPrefix(t *testing.T) {
+	// x-bf-eh-x-bf-direct-key must be blocked by the security denylist.
+	matcher := NewHeaderMatcher(&configstoreTables.GlobalHeaderFilterConfig{
+		Allowlist: []string{"*"},
+	})
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-eh-x-bf-direct-key", "true")
+	ctx.Request.Header.Set("Authorization", "Bearer sk-real-openai-key")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{matcher: matcher, allowDirectKeys: true})
+	defer cancel()
+
+	if _, ok := bifrostCtx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+		t.Error("expected x-bf-direct-key to be blocked when injected via x-bf-eh- prefix")
+	}
+	extraHeaders, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+	if _, ok := extraHeaders["x-bf-direct-key"]; ok {
+		t.Error("expected x-bf-direct-key to be absent from extra headers (denylist)")
+	}
+}
+
+func TestConvertToBifrostContext_DirectKey_RawVirtualKeyNotBypassed(t *testing.T) {
+	// VK sent without Bearer prefix must also be excluded from direct key path.
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-direct-key", "true")
+	ctx.Request.Header.Set("Authorization", "sk-bf-virtual-key-no-bearer-prefix")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{allowDirectKeys: true})
+	defer cancel()
+
+	if _, ok := bifrostCtx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+		t.Error("expected raw VK (no Bearer prefix) to be excluded from direct key path")
+	}
+}
+
+func TestConvertToBifrostContext_DirectKey_EnvPrefixNotResolved(t *testing.T) {
+	// A caller sending "env.SOME_VAR" must get that literal string as the key value,
+	// not the server env var it might reference.
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-direct-key", "true")
+	ctx.Request.Header.Set("Authorization", "Bearer env.SOME_SECRET")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{allowDirectKeys: true})
+	defer cancel()
+
+	key, ok := bifrostCtx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key)
+	if !ok {
+		t.Fatal("expected direct key to be set")
+	}
+	if key.Value.GetValue() != "env.SOME_SECRET" {
+		t.Errorf("direct key value = %q, want literal %q (must not resolve env vars)", key.Value.GetValue(), "env.SOME_SECRET")
+	}
+	if key.Value.IsFromEnv() {
+		t.Error("direct key must not be marked as from-env")
 	}
 }

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -95,8 +95,9 @@ export default function SecurityView() {
 		const whitelistedRoutesChanged = localWhitelistedRoutes !== serverWhitelistedRoutes;
 
 		const enforceAuthOnInferenceChanged = localConfig.enforce_auth_on_inference !== config.enforce_auth_on_inference;
+		const allowDirectKeysChanged = localConfig.allow_direct_keys !== config.allow_direct_keys;
 
-		return originsChanged || headersChanged || requiredChanged || whitelistedRoutesChanged || authChanged || enforceAuthOnInferenceChanged;
+		return originsChanged || headersChanged || requiredChanged || whitelistedRoutesChanged || authChanged || enforceAuthOnInferenceChanged || allowDirectKeysChanged;
 	}, [config, localConfig, authConfig, bifrostConfig, showPasswordSection]);
 
 	const needsRestart = useMemo(() => {
@@ -311,6 +312,25 @@ export default function SecurityView() {
 						data-testid="enforce-auth-on-inference-switch"
 						checked={localConfig.enforce_auth_on_inference}
 						onCheckedChange={(checked) => handleConfigChange("enforce_auth_on_inference", checked)}
+					/>
+				</div>
+				{/* Allow Direct API Keys */}
+				<div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
+					<div className="space-y-0.5">
+						<label htmlFor="allow-direct-keys" className="text-sm font-medium">
+							Allow Direct API Keys
+						</label>
+						<p className="text-muted-foreground text-sm">
+							When enabled, callers can pass a provider API key directly in the{" "}
+							<b>Authorization</b>, <b>x-api-key</b>, or <b>x-goog-api-key</b> header alongside{" "}
+							<b>x-bf-direct-key: true</b>. Bifrost will use that key directly, bypassing the registered key pool.
+						</p>
+					</div>
+					<Switch
+						id="allow-direct-keys"
+						data-testid="security-allow-direct-keys-switch"
+						checked={localConfig.allow_direct_keys}
+						onCheckedChange={(checked) => handleConfigChange("allow_direct_keys", checked)}
 					/>
 				</div>
 				{/* Allowed Origins */}

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -481,6 +481,7 @@ export interface CoreConfig {
 	disable_content_logging: boolean;
 	allow_per_request_content_storage_override: boolean;
 	allow_per_request_raw_override: boolean;
+	allow_direct_keys: boolean;
 	disable_db_pings_in_health: boolean;
 	log_retention_days: number;
 	enforce_auth_on_inference: boolean;
@@ -512,6 +513,7 @@ export const DefaultCoreConfig: CoreConfig = {
 	disable_content_logging: false,
 	allow_per_request_content_storage_override: false,
 	allow_per_request_raw_override: false,
+	allow_direct_keys: false,
 	disable_db_pings_in_health: false,
 	log_retention_days: 365,
 	enforce_auth_on_inference: false,


### PR DESCRIPTION
## Summary

Re-introduces the direct API key bypass feature, allowing callers to supply a raw provider API key via standard auth headers (`Authorization`, `x-api-key`, `x-goog-api-key`) and have Bifrost use it directly, skipping the registered key pool entirely. This is gated behind a new server-side `allow_direct_keys` config flag and a per-request `x-bf-direct-key: true` header, requiring both to be present before the bypass takes effect.

## Changes

- Added `BifrostContextKeyDirectKey` context key (`x-bf-direct-key`) and registered it in the reserved keys denylist to prevent spoofing via the `x-bf-eh-` extra-header prefix.
- `ConvertToBifrostContext` now reads the `x-bf-direct-key: true` header and, when `AllowDirectKeys` is enabled server-side, extracts the raw API key from `Authorization` (Bearer), `x-api-key`, or `x-goog-api-key` — explicitly rejecting virtual keys (`sk-bf-*`).
- `selectKeyFromProviderForModelWithPool`, `getAllSupportedKeys`, and `getKeysForBatchAndFileOps` all short-circuit to return the direct key when it is present in the context, bypassing normal key pool selection and rotation.
- Added `AllowDirectKeys` to `ClientConfig`, `TableClientConfig`, `HandlerStore`, and the config update/read paths.
- Added a `migrationReAddAllowDirectKeysColumn` migration that re-adds the `allow_direct_keys` boolean column to `config_client` (the column existed briefly in v1.5.0 before being dropped).
- Config hash updated to include `allowDirectKeys:true` only when non-default, avoiding hash churn on upgrade.
- UI security settings page exposes a new "Allow Direct API Keys" toggle with descriptive copy.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

**Manual validation:**

1. Enable `allow_direct_keys` via the Security settings page or API.
2. Send a request with `x-bf-direct-key: true` and a real provider key in `Authorization: Bearer <key>` — confirm the request succeeds using that key directly.
3. Send the same request without `x-bf-direct-key: true` — confirm the registered key pool is used as normal.
4. Send with a virtual key (`sk-bf-*`) in `Authorization` and `x-bf-direct-key: true` — confirm the virtual key is not treated as a direct key and the context key is absent.
5. Attempt to inject `x-bf-direct-key` via `x-bf-eh-x-bf-direct-key` — confirm it is blocked by the denylist.
6. Disable `allow_direct_keys` server-side and confirm the bypass is inoperative even when the header is present.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- The bypass is double-gated: the server admin must explicitly enable `allow_direct_keys`, and the caller must send `x-bf-direct-key: true` on each request. Neither alone is sufficient.
- Virtual keys are explicitly excluded from being treated as direct keys to prevent privilege escalation.
- `x-bf-direct-key` is added to the reserved key denylist, blocking injection via the `x-bf-eh-` extra-header forwarding mechanism.
- The raw API key value is stored only in the request-scoped context and is never persisted or logged beyond existing key handling paths.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable