### PR TITLE
fix: mcp auth session UI improvements

### DIFF
--- a/plugins/semanticcache/go.sum
+++ b/plugins/semanticcache/go.sum
@@ -181,14 +181,10 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/maximhq/bifrost/core v1.5.12 h1:tm4FVr9Vyy4Srr4Gg91kLrXFuZrMytGV6Rkrdpw3kXI=
-github.com/maximhq/bifrost/core v1.5.12/go.mod h1:bzcFxKjI2NCRtOeQOwA0KxKJkjsY/UgnXd/cmg7Q+4U=
 github.com/maximhq/bifrost/core v1.5.13 h1:pQ346iplgE8nxxhcrtkb6r/e/FGnLnDqTFo1eVkZDbc=
 github.com/maximhq/bifrost/core v1.5.13/go.mod h1:bzcFxKjI2NCRtOeQOwA0KxKJkjsY/UgnXd/cmg7Q+4U=
 github.com/maximhq/bifrost/framework v1.3.12 h1:SltXjv2/pIpsUSY9tLWStDi953WxoKd6ilbAn7ZF6VA=
 github.com/maximhq/bifrost/framework v1.3.12/go.mod h1:Hq14kw/qyQvB3Ti4Wjo/wsYbeZJ+ZtKtj3E8tJ23zUw=
-github.com/maximhq/bifrost/plugins/mocker v1.5.3 h1:PuQShiJS6jbI1S0XAnwtB9dfiYC+TSbxbjJ1FWOb2aE=
-github.com/maximhq/bifrost/plugins/mocker v1.5.3/go.mod h1:Ob9R3faldCd1EnTfuPqkLK4CbjA1nLe4e2/Onf/Kk7E=
 github.com/maximhq/bifrost/plugins/mocker v1.5.13 h1:GQMBOcY38F7eVwLQ4iB7JkOfCmgntK9nUoMukyhwsRY=
 github.com/maximhq/bifrost/plugins/mocker v1.5.13/go.mod h1:SoTaDzUU4PIsNgskBZiaFu3JtQ8HBKsDieXYqg3i4kY=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=

--- a/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
@@ -128,7 +128,7 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 				<Table>
 					<TableHeader>
 						<TableRow>
-							<TableHead>MCP Client</TableHead>
+							<TableHead>MCP server</TableHead>
 							<TableHead>
 								<HeaderWithTooltip
 									label="Type"
@@ -282,9 +282,14 @@ function StatusBadge({ status, kind }: { status: string; kind: string }) {
 		return <Badge variant="destructive">Needs re-auth</Badge>;
 	}
 	if (status === "needs_update") {
-		// Same destructive treatment as needs_reauth — user action required.
-		// Distinct copy so the row affordance ("Edit") matches.
-		return <Badge variant="destructive">Needs update</Badge>;
+		// Outlined red: signals user action required, but visually distinct from
+		// needs_reauth's solid destructive badge (which represents a hard auth failure).
+		// Distinct copy so the row affordance ("Update values") matches.
+		return (
+			<Badge variant="outline" className="border-red-500 bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-200">
+				Needs update
+			</Badge>
+		);
 	}
 	return <Badge>Active</Badge>;
 }
@@ -439,7 +444,7 @@ function formatAccessExpiry(row: MCPSessionRow): string {
 	// column already conveys lifecycle state (Active / Needs update /
 	// Orphaned), so this column collapses to a dash for headers.
 	if (row.kind === "header") {
-		return "—";
+		return "-";
 	}
 	if (!row.expires_at) return "-";
 	try {


### PR DESCRIPTION
## Summary

This PR bumps the `bifrost/core` and `bifrost/plugins/mocker` dependency versions in the semantic cache plugin and makes minor UI fixes to the MCP sessions table for label accuracy and badge styling consistency.

## Changes

- Updated `bifrost/core` from `v1.5.12` to `v1.5.13` and `bifrost/plugins/mocker` from `v1.5.3` to `v1.5.13` in `plugins/semanticcache/go.sum`
- Renamed the "MCP Client" column header to "MCP server" to better reflect what is being displayed
- Replaced the destructive `Badge` variant for the "Needs update" status with an outlined badge using red border/background styling, distinguishing it visually from hard errors while still signaling user action is required
- Changed the em dash (`—`) used as a placeholder in the access expiry column for header rows to a regular hyphen (`-`) for consistency with other placeholder values in the table

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Navigate to the MCP Sessions page and verify:
- The first column header reads "MCP server"
- Rows with a "Needs update" status display an outlined red badge rather than a solid destructive badge
- Header rows in the access expiry column show a plain hyphen

## Screenshots/Recordings

Before/after screenshots of the "Needs update" badge and column header rename recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable