### PR TITLE
feat: add `can_reauth` identity gate for user-mode MCP session rows

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -66500,7 +66500,8 @@
           "auth_kind",
           "auth_mode",
           "status",
-          "created_at"
+          "created_at",
+          "can_reauth"
         ],
         "properties": {
           "id": {
@@ -66593,6 +66594,10 @@
             "type": "string",
             "nullable": true,
             "description": "OAuth rows only"
+          },
+          "can_reauth": {
+            "type": "boolean",
+            "description": "Mirrors the server-side identity gate on POST /api/mcp/sessions/{id}/reauth.\nAlways true for vk- and session-mode rows. For user-mode rows, true only\nwhen the calling user matches the row's bound user — admin DAC scope is\nenough to see the row, but reauthing mints credentials under whoever clicks\nthe URL, so the server returns 403 to non-bound callers. The UI hides the\nRe-authenticate / Edit values action when this is false.\n"
           }
         }
       },

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -577,6 +577,7 @@ MCPSessionRow:
     - auth_mode
     - status
     - created_at
+    - can_reauth
   properties:
     id:
       type: string
@@ -646,6 +647,15 @@ MCPSessionRow:
       type: string
       nullable: true
       description: OAuth rows only
+    can_reauth:
+      type: boolean
+      description: |
+        Mirrors the server-side identity gate on POST /api/mcp/sessions/{id}/reauth.
+        Always true for vk- and session-mode rows. For user-mode rows, true only
+        when the calling user matches the row's bound user — admin DAC scope is
+        enough to see the row, but reauthing mints credentials under whoever clicks
+        the URL, so the server returns 403 to non-bound callers. The UI hides the
+        Re-authenticate / Edit values action when this is false.
 
 MCPSessionsListResponse:
   type: object

--- a/transports/bifrost-http/handlers/mcp_sessions.go
+++ b/transports/bifrost-http/handlers/mcp_sessions.go
@@ -78,6 +78,13 @@ type mcpSessionRow struct {
 	LastRefreshedAt *string            `json:"last_refreshed_at,omitempty"` // OAuth token rows only; nil if never refreshed
 	UpdatedAt       *string            `json:"updated_at,omitempty"`        // Headers rows: timestamp of last submission/edit
 	OauthConfigID   string             `json:"oauth_config_id,omitempty"`   // OAuth rows only
+	// CanReauth mirrors the server-side identity gate on POST /reauth: user-mode
+	// rows are only reauthable by the bound user (admin DAC scope is enough to
+	// see the row, but reauthing mints credentials for whoever clicks the URL).
+	// Non-user-mode rows are always reauthable. The UI hides the action when false.
+	// Always false for kind == "flow" — flow rows are completed via
+	// /api/oauth/per-user/flows/{id}/start, not /reauth.
+	CanReauth bool `json:"can_reauth"`
 }
 
 type mcpSessionsListResponse struct {
@@ -154,6 +161,17 @@ func (h *MCPSessionsHandler) list(ctx *fasthttp.RequestCtx) {
 		}
 		rows = append(rows, headerFlowRow(f))
 	}
+	caller := callerUserIDFromCtx(ctx)
+	for i := range rows {
+		// Flow rows are completed via /api/oauth/per-user/flows/{id}/start, not
+		// /reauth — passing a flow ID to /reauth always 404s before the identity
+		// gate runs. Leave CanReauth at its zero value so the wire field matches
+		// the endpoint's actual behavior.
+		if rows[i].Kind == "flow" {
+			continue
+		}
+		rows[i].CanReauth = canReauthRow(rows[i].AuthMode, rows[i].UserID, caller)
+	}
 	SendJSON(ctx, mcpSessionsListResponse{Sessions: rows})
 }
 
@@ -195,6 +213,30 @@ func bindingKeyFromFlow(f tables.TableOauthUserSession) sessionBindingKey {
 		k.Identity = f.SessionID
 	}
 	return k
+}
+
+// canReauthRow encodes the identity gate on POST /reauth. User-mode rows are
+// only reauthable by the bound user — admin DAC scope lets them see the row,
+// but the OAuth callback or header submission lands under whoever clicks the
+// URL, so an admin-initiated reauth would either overwrite identity or let
+// admin submit secret material in the bound user's name. VK / session rows
+// are intentionally shared and have no identity-of-clicker problem.
+func canReauthRow(authMode string, rowUserID *string, caller string) bool {
+	if authMode != string(schemas.MCPAuthModeUser) {
+		return true
+	}
+	if rowUserID == nil || *rowUserID == "" {
+		return false
+	}
+	return caller != "" && caller == *rowUserID
+}
+
+// callerUserIDFromCtx pulls the SCIM-authenticated user_id off the request
+// context. Returns "" when unauthenticated or in OSS — callers should treat
+// empty as "no user identity" (which fails the user-mode reauth gate).
+func callerUserIDFromCtx(ctx *fasthttp.RequestCtx) string {
+	v, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string)
+	return v
 }
 
 // reauth starts a fresh OAuth flow OR a fresh header-submission flow for
@@ -246,6 +288,16 @@ func (h *MCPSessionsHandler) reauth(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Identity gate: user-mode rows can only be reauthed by the bound user.
+	// Admin DAC scope is enough to see the row (revoke/list still work), but
+	// the OAuth callback lands under whoever clicks the authorize URL — an
+	// admin clicking would either get a "wrong user" credential or overwrite
+	// the row's identity. Mirrored on the wire via mcpSessionRow.CanReauth.
+	if !canReauthRow(tok.AuthMode, tok.UserID, callerUserIDFromCtx(ctx)) {
+		SendError(ctx, fasthttp.StatusForbidden, "Only the bound user can re-authenticate this session.")
+		return
+	}
+
 	// The new flow must reuse the existing row's identity so the callback's
 	// upsert lands on the same (identity, mcp_client) row. Inject the row's
 	// values into context; InitiateUserOAuthFlow reads them per-mode.
@@ -292,6 +344,14 @@ func (h *MCPSessionsHandler) reauth(ctx *fasthttp.RequestCtx) {
 func (h *MCPSessionsHandler) reauthHeaderCredential(ctx *fasthttp.RequestCtx, bfCtx *schemas.BifrostContext, cred *tables.TableMCPPerUserHeaderCredential) {
 	if cred.Status == "orphaned" {
 		SendError(ctx, fasthttp.StatusForbidden, "Access to this MCP has been revoked. Re-submitting headers will not restore access - contact your administrator.")
+		return
+	}
+	// Identity gate: user-mode header credentials can only be resubmitted by the
+	// bound user. An admin clicking through would submit secret material under
+	// their own identity, attached to the bound user's row. Same rule as the
+	// OAuth branch; surfaced to the UI via mcpSessionRow.CanReauth.
+	if !canReauthRow(cred.AuthMode, cred.UserID, callerUserIDFromCtx(ctx)) {
+		SendError(ctx, fasthttp.StatusForbidden, "Only the bound user can re-submit headers for this session.")
 		return
 	}
 	provider := h.store.MCPHeadersProvider

--- a/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
@@ -350,11 +350,13 @@ function RowActions({ row, reauthing, revoking, isPendingRow, onReauth, onRevoke
 					)
 				) : row.kind === "header" ? (
 					<>
-						{row.status !== "orphaned" && (
+						{row.status !== "orphaned" && row.can_reauth && (
 							// "Edit values" hits reauth server-side: the handler mints a
 							// fresh header submission flow + temp token and returns the
 							// auth-landing URL. Same single-click → redirect dance as the
-							// OAuth row's "Re-authenticate" action.
+							// OAuth row's "Re-authenticate" action. Hidden when can_reauth
+							// is false — user-bound credentials are only resubmittable by
+							// the bound user (server enforces with 403).
 							<DropdownMenuItem
 								className="cursor-pointer"
 								disabled={busy}
@@ -384,10 +386,12 @@ function RowActions({ row, reauthing, revoking, isPendingRow, onReauth, onRevoke
 					</>
 				) : (
 					<>
-						{row.status !== "orphaned" && (
+						{row.status !== "orphaned" && row.can_reauth && (
 							// Re-auth on an orphaned row wouldn't help: the upstream
 							// credential is intact, the user just no longer has any
 							// granting VK. Surface guidance instead of an action.
+							// Hidden when can_reauth is false — user-bound rows are only
+							// reauthable by the bound user (server enforces with 403).
 							<DropdownMenuItem
 								className="cursor-pointer"
 								disabled={busy}

--- a/ui/lib/types/mcpSessions.ts
+++ b/ui/lib/types/mcpSessions.ts
@@ -64,6 +64,13 @@ export interface MCPSessionRow {
 	// last submission/edit. OAuth rows omit this field.
 	updated_at?: string | null;
 	oauth_config_id?: string;
+	// can_reauth mirrors the server-side identity gate on POST /reauth. For
+	// user-bound rows it's true only when the calling user matches the row's
+	// bound user; for vk/session rows it's always true. The UI hides the
+	// Re-authenticate / Edit values action when false. Always false for
+	// kind === "flow" rows — those are completed via /api/oauth/per-user/
+	// flows/{id}/start, not /reauth, and the UI's flow branch ignores this field.
+	can_reauth: boolean;
 }
 
 export interface MCPSessionsListResponse {


### PR DESCRIPTION
## Summary

Adds a `can_reauth` field to `MCPSessionRow` that mirrors the server-side identity gate on `POST /api/mcp/sessions/{id}/reauth`. For user-mode rows, only the bound user may re-authenticate or re-submit headers — an admin with DAC scope can see and revoke the row, but initiating a reauth would either overwrite the row's identity or submit secret material under the wrong user. VK- and session-mode rows are always reauthable. The UI now reads this field to conditionally hide the "Re-authenticate" and "Edit values" actions, while the server enforces the same rule with a 403.

## Changes

- Added `can_reauth` boolean to `mcpSessionRow` in the Go handler, computed via a new `canReauthRow` helper that checks `auth_mode` and whether the calling user matches the row's bound user.
- Added `callerUserIDFromCtx` to extract the SCIM-authenticated user ID from the request context.
- Applied the identity gate in both the OAuth reauth branch and the header credential resubmission branch, returning `403 Forbidden` to non-bound callers.
- Populated `can_reauth` on all rows in the list handler after rows are assembled.
- Updated the `MCPSessionRow` TypeScript interface to include `can_reauth`.
- Updated the sessions table UI to hide the "Re-authenticate" and "Edit values" dropdown actions when `can_reauth` is false.
- Updated OpenAPI schema and generated JSON to include `can_reauth` as a required field with a full description.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

1. As an admin, create a user-mode MCP session bound to a specific user.
2. Log in as a different admin user and navigate to the MCP sessions table — confirm the "Re-authenticate" / "Edit values" action is hidden for that row.
3. Log in as the bound user and confirm the action is visible and functional.
4. Directly `POST /api/mcp/sessions/{id}/reauth` as a non-bound admin and confirm a `403` is returned.
5. Confirm VK- and session-mode rows always show the reauth action regardless of caller.

```sh
go test ./transports/bifrost-http/handlers/...

cd ui
pnpm i
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

`can_reauth` is now a required field in `MCPSessionRow`. Any client consuming the sessions list API must handle this new required field. Existing UI clients will receive it automatically; external API consumers should update their type definitions.

## Security considerations

This change closes an identity confusion vulnerability in the reauth flow. Without this gate, an admin could initiate a reauth for a user-mode row, causing OAuth credentials or secret header values to be minted or submitted under the admin's identity but attached to another user's session row. The server-side 403 is the authoritative enforcement point; the UI hiding the action is a secondary UX guard.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable