### PR TITLE
feat: add filter/search/pagination to MCP sessions list API

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -5138,33 +5138,45 @@ func (s *RDBConfigStore) GetOauthUserTokenByID(ctx context.Context, id string) (
 	return &token, nil
 }
 
-// ListAllOauthUserTokens returns every token row regardless of status. Used by
-// the sessions tab UI, which renders distinct affordances per state; filtering
-// here would only hide rows the user needs to see (especially needs_reauth).
-// Runtime lookups apply their own status='active' filter and don't use this.
-func (s *RDBConfigStore) ListAllOauthUserTokens(ctx context.Context) ([]tables.TableOauthUserToken, error) {
+// ListOauthUserTokens returns token rows matching params, regardless of status.
+// The sessions tab UI renders distinct affordances per state; default status
+// filtering here would only hide rows the user needs to see (especially
+// needs_reauth). Runtime lookups apply their own status='active' filter and
+// don't use this. Pagination is handler-side because cross-table de-dup with
+// the pending-session list happens after the merge.
+func (s *RDBConfigStore) ListOauthUserTokens(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableOauthUserToken, error) {
+	query := s.ScopedDB(ctx).Model(&tables.TableOauthUserToken{})
+	query = applyMCPSessionFilters(query, params, mcpSessionFilterTable{
+		table:          "oauth_user_tokens",
+		authModeColumn: "auth_mode",
+	})
 	var tokens []tables.TableOauthUserToken
-	if err := s.ScopedDB(ctx).
+	if err := query.
 		Preload("MCPClient", func(db *gorm.DB) *gorm.DB { return db.Select("client_id, name") }).
 		Preload("VirtualKey", func(db *gorm.DB) *gorm.DB { return db.Select("id, name") }).
-		Order("created_at DESC").
+		Order("oauth_user_tokens.created_at DESC").
 		Find(&tokens).Error; err != nil {
-		return nil, fmt.Errorf("failed to list all oauth user tokens: %w", err)
+		return nil, fmt.Errorf("failed to list oauth user tokens: %w", err)
 	}
 	return tokens, nil
 }
 
-// ListAllPendingOauthUserSessions returns all pending OAuth flow rows whose
-// expiry is in the future. Companion to ListAllOauthUserTokens.
-func (s *RDBConfigStore) ListAllPendingOauthUserSessions(ctx context.Context) ([]tables.TableOauthUserSession, error) {
+// ListPendingOauthUserSessions returns pending OAuth flow rows matching params
+// whose expiry is in the future. Companion to ListOauthUserTokens.
+func (s *RDBConfigStore) ListPendingOauthUserSessions(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableOauthUserSession, error) {
+	query := s.ScopedDB(ctx).Model(&tables.TableOauthUserSession{}).
+		Where("oauth_user_sessions.status = ? AND oauth_user_sessions.expires_at > ?", "pending", time.Now())
+	query = applyMCPSessionFilters(query, params, mcpSessionFilterTable{
+		table:          "oauth_user_sessions",
+		authModeColumn: "flow_mode",
+	})
 	var sessions []tables.TableOauthUserSession
-	if err := s.ScopedDB(ctx).
+	if err := query.
 		Preload("MCPClient", func(db *gorm.DB) *gorm.DB { return db.Select("client_id, name") }).
 		Preload("VirtualKey", func(db *gorm.DB) *gorm.DB { return db.Select("id, name") }).
-		Where("status = ? AND expires_at > ?", "pending", time.Now()).
-		Order("created_at DESC").
+		Order("oauth_user_sessions.created_at DESC").
 		Find(&sessions).Error; err != nil {
-		return nil, fmt.Errorf("failed to list all pending oauth user sessions: %w", err)
+		return nil, fmt.Errorf("failed to list pending oauth user sessions: %w", err)
 	}
 	return sessions, nil
 }
@@ -5317,19 +5329,25 @@ func (s *RDBConfigStore) DeleteMCPPerUserHeaderCredential(ctx context.Context, i
 	return nil
 }
 
-// ListAllMCPPerUserHeaderCredentials returns every row regardless of status.
-// The sessions UI surfaces non-active states (needs_update / orphaned) with
-// distinct affordances; filtering here would only hide rows the user needs to
-// act on. Runtime lookups apply their own status='active' filter and don't go
-// through this method.
-func (s *RDBConfigStore) ListAllMCPPerUserHeaderCredentials(ctx context.Context) ([]tables.TableMCPPerUserHeaderCredential, error) {
+// ListMCPPerUserHeaderCredentials returns credential rows matching params,
+// regardless of status. The sessions UI surfaces non-active states
+// (needs_update / orphaned) with distinct affordances; default status
+// filtering here would only hide rows the user needs to act on. Runtime
+// lookups apply their own status='active' filter and don't go through
+// this method.
+func (s *RDBConfigStore) ListMCPPerUserHeaderCredentials(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPPerUserHeaderCredential, error) {
+	query := s.ScopedDB(ctx).Model(&tables.TableMCPPerUserHeaderCredential{})
+	query = applyMCPSessionFilters(query, params, mcpSessionFilterTable{
+		table:          "mcp_per_user_header_credentials",
+		authModeColumn: "auth_mode",
+	})
 	var creds []tables.TableMCPPerUserHeaderCredential
-	if err := s.ScopedDB(ctx).
+	if err := query.
 		Preload("MCPClient", func(db *gorm.DB) *gorm.DB { return db.Select("client_id, name") }).
 		Preload("VirtualKey", func(db *gorm.DB) *gorm.DB { return db.Select("id, name") }).
-		Order("created_at DESC").
+		Order("mcp_per_user_header_credentials.created_at DESC").
 		Find(&creds).Error; err != nil {
-		return nil, fmt.Errorf("failed to list all mcp per-user header credentials: %w", err)
+		return nil, fmt.Errorf("failed to list mcp per-user header credentials: %w", err)
 	}
 	return creds, nil
 }
@@ -5485,21 +5503,67 @@ func (s *RDBConfigStore) DeleteMCPPerUserHeaderFlowsByModeIdentityAndMCPClient(c
 	return nil
 }
 
-// ListAllPendingMCPPerUserHeaderFlows returns all pending header-submission
-// flow rows whose expiry is in the future. Uses ScopedDB so a query-scope
-// stashed on ctx (if any) narrows the result; otherwise returns every row.
-// Mirrors ListAllPendingOauthUserSessions.
-func (s *RDBConfigStore) ListAllPendingMCPPerUserHeaderFlows(ctx context.Context) ([]tables.TableMCPPerUserHeaderFlow, error) {
+// ListPendingMCPPerUserHeaderFlows returns pending header-submission flow rows
+// matching params whose expiry is in the future. Uses ScopedDB so a
+// query-scope stashed on ctx (if any) narrows the result; otherwise returns
+// every matching pending row. Mirrors ListPendingOauthUserSessions.
+func (s *RDBConfigStore) ListPendingMCPPerUserHeaderFlows(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPPerUserHeaderFlow, error) {
+	query := s.ScopedDB(ctx).Model(&tables.TableMCPPerUserHeaderFlow{}).
+		Where("mcp_per_user_header_flows.status = ? AND mcp_per_user_header_flows.expires_at > ?", "pending", time.Now())
+	query = applyMCPSessionFilters(query, params, mcpSessionFilterTable{
+		table:          "mcp_per_user_header_flows",
+		authModeColumn: "flow_mode",
+	})
 	var flows []tables.TableMCPPerUserHeaderFlow
-	if err := s.ScopedDB(ctx).
+	if err := query.
 		Preload("MCPClient", func(db *gorm.DB) *gorm.DB { return db.Select("client_id, name") }).
 		Preload("VirtualKey", func(db *gorm.DB) *gorm.DB { return db.Select("id, name") }).
-		Where("status = ? AND expires_at > ?", "pending", time.Now()).
-		Order("created_at DESC").
+		Order("mcp_per_user_header_flows.created_at DESC").
 		Find(&flows).Error; err != nil {
-		return nil, fmt.Errorf("failed to list all pending mcp per-user header flows: %w", err)
+		return nil, fmt.Errorf("failed to list pending mcp per-user header flows: %w", err)
 	}
 	return flows, nil
+}
+
+// mcpSessionFilterTable carries the table-specific column names needed to
+// build a generic filter chain. The auth-mode column is named differently
+// on the credential tables ("auth_mode") and the pending-flow tables
+// ("flow_mode"), but the value space is identical.
+type mcpSessionFilterTable struct {
+	table          string
+	authModeColumn string // "auth_mode" or "flow_mode"
+}
+
+// applyMCPSessionFilters appends the shared MCP-sessions WHERE clauses and
+// the search LEFT JOINs to a query. The search JOINs (config_mcp_clients,
+// governance_virtual_keys) and the LIKE WHERE are emitted only when
+// params.Search is non-empty; when absent the columns are never referenced
+// and no JOIN is added. The join cardinality is 1:1 on FK columns, so
+// Count is safe without DISTINCT.
+func applyMCPSessionFilters(query *gorm.DB, params MCPSessionsFilterParams, t mcpSessionFilterTable) *gorm.DB {
+	if len(params.Statuses) > 0 {
+		query = query.Where(t.table+".status IN ?", params.Statuses)
+	}
+	if len(params.AuthModes) > 0 {
+		query = query.Where(t.table+"."+t.authModeColumn+" IN ?", params.AuthModes)
+	}
+	if len(params.MCPClientIDs) > 0 {
+		query = query.Where(t.table+".mcp_client_id IN ?", params.MCPClientIDs)
+	}
+	if params.Search != "" {
+		needle := "%" + strings.ToLower(params.Search) + "%"
+		query = query.
+			Joins("LEFT JOIN config_mcp_clients ON config_mcp_clients.client_id = " + t.table + ".mcp_client_id").
+			Joins("LEFT JOIN governance_virtual_keys ON governance_virtual_keys.id = " + t.table + ".virtual_key_id")
+		whereClause := "LOWER(config_mcp_clients.name) LIKE ? OR LOWER(config_mcp_clients.client_id) LIKE ? OR LOWER(" + t.table + ".user_id) LIKE ? OR LOWER(" + t.table + ".session_id) LIKE ? OR LOWER(governance_virtual_keys.id) LIKE ? OR LOWER(governance_virtual_keys.name) LIKE ?"
+		whereArgs := []any{needle, needle, needle, needle, needle, needle}
+		if len(params.MatchedUserIDs) > 0 {
+			whereClause += " OR " + t.table + ".user_id IN ?"
+			whereArgs = append(whereArgs, params.MatchedUserIDs)
+		}
+		query = query.Where(whereClause, whereArgs...)
+	}
+	return query
 }
 
 // DeleteExpiredMCPPerUserHeaderFlows hard-deletes pending flow rows whose

--- a/framework/configstore/rdb_mcp_sessions_test.go
+++ b/framework/configstore/rdb_mcp_sessions_test.go
@@ -1,0 +1,255 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/require"
+)
+
+// setupMCPSessionsTestStore extends setupRDBTestStore with the two
+// per-user-headers tables. The shared setup intentionally leaves these
+// off to keep unrelated tests fast.
+func setupMCPSessionsTestStore(t *testing.T) *RDBConfigStore {
+	store := setupRDBTestStore(t)
+	require.NoError(t, store.DB().AutoMigrate(
+		&tables.TableMCPPerUserHeaderCredential{},
+		&tables.TableMCPPerUserHeaderFlow{},
+	))
+	return store
+}
+
+// seedMCPSessionsFixture creates one MCP client, one VK, and one row in
+// each of the four sessions tables — wired together so search/filter
+// tests have a meaningful joined dataset.
+func seedMCPSessionsFixture(t *testing.T, store *RDBConfigStore) {
+	t.Helper()
+	ctx := context.Background()
+	// MCP client
+	mcp := &tables.TableMCPClient{
+		ClientID:       "github-prod",
+		Name:           "GitHub (Prod)",
+		ConnectionType: "stdio",
+	}
+	require.NoError(t, store.DB().WithContext(ctx).Create(mcp).Error)
+
+	// Virtual key
+	vk := &tables.TableVirtualKey{
+		ID:    "vk-alpha",
+		Name:  "Alpha VK",
+		Value: "sk-bf-alpha",
+	}
+	require.NoError(t, store.DB().WithContext(ctx).Create(vk).Error)
+
+	// OAuth token rows — one active vk-mode, one orphaned user-mode, one needs_reauth session-mode
+	vkID := "vk-alpha"
+	uid := "user-42"
+	tok1 := &tables.TableOauthUserToken{
+		ID: "tok-active", MCPClientID: "github-prod", VirtualKeyID: &vkID, AuthMode: "vk",
+		Status: "active", AccessToken: "x", TokenType: "Bearer", OauthConfigID: "cfg-1",
+	}
+	tok2 := &tables.TableOauthUserToken{
+		ID: "tok-orphan", MCPClientID: "github-prod", UserID: &uid, AuthMode: "user",
+		Status: "orphaned", AccessToken: "x", TokenType: "Bearer", OauthConfigID: "cfg-1",
+	}
+	tok3 := &tables.TableOauthUserToken{
+		ID: "tok-reauth", MCPClientID: "github-prod", SessionID: "sess-xyz", AuthMode: "session",
+		Status: "needs_reauth", AccessToken: "x", TokenType: "Bearer", OauthConfigID: "cfg-1",
+	}
+	require.NoError(t, store.DB().WithContext(ctx).Create(tok1).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(tok2).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(tok3).Error)
+
+	// Pending OAuth session
+	sess := &tables.TableOauthUserSession{
+		ID: "sess-pending", MCPClientID: "github-prod", OauthConfigID: "cfg-1",
+		FlowMode: "user", Status: "pending", UserID: &uid,
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	require.NoError(t, store.DB().WithContext(ctx).Create(sess).Error)
+
+	// Header credential
+	cred := &tables.TableMCPPerUserHeaderCredential{
+		ID: "cred-1", MCPClientID: "github-prod", VirtualKeyID: &vkID, AuthMode: "vk",
+		Status: "active", HeadersJSON: "{}",
+	}
+	require.NoError(t, store.DB().WithContext(ctx).Create(cred).Error)
+
+	// Pending header flow
+	hf := &tables.TableMCPPerUserHeaderFlow{
+		ID: "hf-1", MCPClientID: "github-prod", FlowMode: "user", Status: "pending",
+		UserID: &uid, ExpiresAt: time.Now().Add(time.Hour),
+	}
+	require.NoError(t, store.DB().WithContext(ctx).Create(hf).Error)
+}
+
+func TestListOauthUserTokens_NoFilters(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+}
+
+func TestListOauthUserTokens_FilterByStatus(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		Statuses: []string{"orphaned", "needs_reauth"},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, r := range got {
+		require.NotEqual(t, "active", r.Status)
+	}
+}
+
+func TestListOauthUserTokens_FilterByAuthMode(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		AuthModes: []string{"vk"},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "tok-active", got[0].ID)
+}
+
+func TestListOauthUserTokens_FilterByMCPClient(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		MCPClientIDs: []string{"github-prod"},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	got, err = store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		MCPClientIDs: []string{"slack-dev"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestListOauthUserTokens_SearchMatchesMCPClientName(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		Search: "GitHub",
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 3, "all three tokens have github mcp client; search by name should match all")
+}
+
+func TestListOauthUserTokens_SearchMatchesVKName(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		Search: "Alpha VK",
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "tok-active", got[0].ID, "only vk-mode token has a virtual_key_id; vk-name search should match only it")
+}
+
+func TestListOauthUserTokens_SearchMatchesUserID(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		Search: "user-42",
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "tok-orphan", got[0].ID)
+}
+
+func TestListOauthUserTokens_MatchedUserIDsBroadensSearch(t *testing.T) {
+	// Search string "Alice" doesn't match any column on the row, but
+	// MatchedUserIDs surfaces tok-orphan because its user_id ("user-42")
+	// is in the supplied set — mirrors the caller-resolved-from-directory
+	// case.
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		Search:         "Alice",
+		MatchedUserIDs: []string{"user-42"},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "tok-orphan", got[0].ID)
+}
+
+func TestListOauthUserTokens_MatchedUserIDsIgnoredWhenSearchEmpty(t *testing.T) {
+	// Empty Search means the search WHERE branch never runs, so
+	// MatchedUserIDs has no effect — the filter returns all rows.
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		MatchedUserIDs: []string{"user-42"},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 3) // all seeded tokens
+}
+
+func TestListOauthUserTokens_SearchMatchesSessionID(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		Search: "sess-xyz",
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "tok-reauth", got[0].ID)
+}
+
+func TestListOauthUserTokens_PreloadsMCPClientAndVK(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListOauthUserTokens(context.Background(), MCPSessionsFilterParams{
+		AuthModes: []string{"vk"},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].MCPClient, "MCPClient preload should populate")
+	require.Equal(t, "GitHub (Prod)", got[0].MCPClient.Name)
+	require.NotNil(t, got[0].VirtualKey, "VirtualKey preload should populate")
+	require.Equal(t, "Alpha VK", got[0].VirtualKey.Name)
+}
+
+func TestListPendingOauthUserSessions_OnlyReturnsPending(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListPendingOauthUserSessions(context.Background(), MCPSessionsFilterParams{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "sess-pending", got[0].ID)
+}
+
+func TestListPendingOauthUserSessions_FlowModeFilter(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListPendingOauthUserSessions(context.Background(), MCPSessionsFilterParams{
+		AuthModes: []string{"vk"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got, "fixture's only session is user-mode; vk filter should match none")
+}
+
+func TestListMCPPerUserHeaderCredentials_NoFilters(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListMCPPerUserHeaderCredentials(context.Background(), MCPSessionsFilterParams{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "cred-1", got[0].ID)
+}
+
+func TestListPendingMCPPerUserHeaderFlows_NoFilters(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	got, err := store.ListPendingMCPPerUserHeaderFlows(context.Background(), MCPSessionsFilterParams{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "hf-1", got[0].ID)
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -62,6 +62,35 @@ type CustomersQueryParams struct {
 	Search string
 }
 
+// MCPSessionsFilterParams is the filter set shared across the four
+// MCP-sessions list methods (oauth tokens, pending oauth sessions,
+// per-user header credentials, pending per-user header flows).
+//
+// Pagination is intentionally omitted: the four sources are merged and
+// de-duped in the handler before the page slice, so per-table LIMIT/OFFSET
+// would not compose into a correct global page. These methods are filter
+// pushdown only; the handler paginates the merged result.
+//
+// Search is a case-insensitive substring matched against the MCP client's
+// name/client_id, the row's identity columns (user_id, session_id), and
+// the virtual key's id/name (joined). Empty filter slices match all
+// values for that field.
+type MCPSessionsFilterParams struct {
+	Search       string
+	Statuses     []string
+	AuthModes    []string // matched against auth_mode (tokens, credentials) or flow_mode (sessions, flows)
+	MCPClientIDs []string
+	// MatchedUserIDs is an optional set of user_ids that should be treated
+	// as a positive search hit alongside Search. Callers that maintain a
+	// user directory (display names, emails) resolve the search string
+	// against that directory and pass the resulting user_ids in here so
+	// rows owned by those users surface even though the search columns on
+	// these tables only carry the opaque user_id. When non-empty the
+	// filter ORs `{table}.user_id IN (matched)` into the search WHERE.
+	// Only consulted when Search is non-empty.
+	MatchedUserIDs []string
+}
+
 // PricingOverrideFilters holds the filters for pricing overrides.
 type PricingOverrideFilters struct {
 	ScopeKind     *string
@@ -369,16 +398,20 @@ type ConfigStore interface {
 	// GetOauthUserTokenByID looks up a single token row by primary key.
 	// Returns nil, nil when not found.
 	GetOauthUserTokenByID(ctx context.Context, id string) (*tables.TableOauthUserToken, error)
-	// ListAllOauthUserTokens returns every token row regardless of status.
-	// The sessions UI renders all three states (active / orphaned /
-	// needs_reauth) with distinct affordances, so hiding any of them only
-	// breaks the user's ability to act on rows that need their attention.
-	// Runtime token lookups apply their own status='active' filter and don't
-	// go through this method.
-	ListAllOauthUserTokens(ctx context.Context) ([]tables.TableOauthUserToken, error)
-	// ListAllPendingOauthUserSessions returns all pending OAuth flow rows.
-	// Companion to ListAllOauthUserTokens for the admin view.
-	ListAllPendingOauthUserSessions(ctx context.Context) ([]tables.TableOauthUserSession, error)
+	// ListOauthUserTokens returns token rows matching the supplied filters,
+	// regardless of status. The sessions UI renders all three states
+	// (active / orphaned / needs_reauth) with distinct affordances, so
+	// hiding any of them by default would only break the user's ability
+	// to act on rows that need their attention; status filtering is the
+	// caller's responsibility via params.Statuses. Runtime token lookups
+	// apply their own status='active' filter and don't go through this
+	// method.
+	ListOauthUserTokens(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableOauthUserToken, error)
+	// ListPendingOauthUserSessions returns pending OAuth flow rows matching
+	// the supplied filters. Companion to ListOauthUserTokens for the admin
+	// view. Always restricted to status='pending' AND expires_at > now;
+	// params.Statuses further narrows within that set.
+	ListPendingOauthUserSessions(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableOauthUserSession, error)
 	// DeleteExpiredOauthUserSessions hard-deletes pending OAuth flow rows
 	// whose ExpiresAt has passed. Returns the number of rows removed.
 	DeleteExpiredOauthUserSessions(ctx context.Context) (int64, error)
@@ -394,10 +427,12 @@ type ConfigStore interface {
 	GetMCPPerUserHeaderCredentialByID(ctx context.Context, id string) (*tables.TableMCPPerUserHeaderCredential, error)
 	UpsertMCPPerUserHeaderCredential(ctx context.Context, cred *tables.TableMCPPerUserHeaderCredential) error
 	DeleteMCPPerUserHeaderCredential(ctx context.Context, id string) error
-	// ListAllMCPPerUserHeaderCredentials returns every row regardless of
-	// status. Mirrors ListAllOauthUserTokens — the sessions UI surfaces
-	// non-active states (needs_update / orphaned) with distinct affordances.
-	ListAllMCPPerUserHeaderCredentials(ctx context.Context) ([]tables.TableMCPPerUserHeaderCredential, error)
+	// ListMCPPerUserHeaderCredentials returns credential rows matching the
+	// supplied filters, regardless of status. Mirrors ListOauthUserTokens —
+	// the sessions UI surfaces non-active states (needs_update / orphaned)
+	// with distinct affordances, so status filtering is the caller's
+	// responsibility via params.Statuses.
+	ListMCPPerUserHeaderCredentials(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPPerUserHeaderCredential, error)
 	// MarkMCPPerUserHeaderCredentialsNeedsUpdate flips status to 'needs_update'
 	// for every row tied to mcpClientID. Called when the admin changes
 	// PerUserHeaderKeys on the MCP client config: existing user submissions
@@ -430,14 +465,14 @@ type ConfigStore interface {
 	// DeleteOauthUserSessionsByModeIdentityAndMCPClient.
 	DeleteMCPPerUserHeaderFlowsByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) error
 	DeleteMCPPerUserHeaderFlow(ctx context.Context, id string) error
-	// ListAllPendingMCPPerUserHeaderFlows returns every non-expired flow row
-	// with status='pending'. Used by the sessions list endpoint to surface
-	// pending submission flows alongside completed credentials. Mirrors
-	// ListAllPendingOauthUserSessions on the OAuth side. The implementation
-	// reads via ScopedDB(ctx), so a query-scope stashed on ctx (e.g. by
-	// enterprise DAC) narrows the result; with no scope, every pending
-	// row is returned.
-	ListAllPendingMCPPerUserHeaderFlows(ctx context.Context) ([]tables.TableMCPPerUserHeaderFlow, error)
+	// ListPendingMCPPerUserHeaderFlows returns non-expired pending header
+	// submission flow rows matching the supplied filters. Mirrors
+	// ListPendingOauthUserSessions on the OAuth side. Always restricted to
+	// status='pending' AND expires_at > now; params.Statuses further
+	// narrows within that set. The implementation reads via ScopedDB(ctx),
+	// so a query-scope stashed on ctx (e.g. by enterprise DAC) narrows the
+	// result; with no scope, every matching pending row is returned.
+	ListPendingMCPPerUserHeaderFlows(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPPerUserHeaderFlow, error)
 	// DeleteExpiredMCPPerUserHeaderFlows hard-deletes pending flow rows whose
 	// ExpiresAt has passed. Returns the number of rows removed.
 	DeleteExpiredMCPPerUserHeaderFlows(ctx context.Context) (int64, error)

--- a/transports/bifrost-http/handlers/mcp_sessions.go
+++ b/transports/bifrost-http/handlers/mcp_sessions.go
@@ -10,9 +10,13 @@ package handlers
 
 import (
 	"errors"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/fasthttp/router"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
@@ -88,29 +92,157 @@ type mcpSessionRow struct {
 }
 
 type mcpSessionsListResponse struct {
-	Sessions []mcpSessionRow `json:"sessions"`
+	Sessions   []mcpSessionRow `json:"sessions"`
+	Count      int             `json:"count"`
+	TotalCount int             `json:"total_count"`
+	Limit      int             `json:"limit"`
+	Offset     int             `json:"offset"`
 }
 
-// list returns sessions visible to the caller. Each row's identity column
-// matches the caller's derived AuthMode + identity.
+const (
+	mcpSessionsDefaultLimit = 50
+	mcpSessionsMaxLimit     = 500
+)
+
+// mcpSessionsListQuery is the parsed query string for GET /api/mcp/sessions.
+// Filters is forwarded to the four store list methods. Kinds is a wire-row
+// taxonomy filter (token/header/flow) applied in the handler — it doesn't
+// map to a column, just decides which store calls to skip. Limit/Offset
+// apply to the merged result after cross-table de-dup, so they're handled
+// here rather than in the store params struct.
+type mcpSessionsListQuery struct {
+	Filters configstore.MCPSessionsFilterParams
+	Kinds   []string
+	Limit   int
+	Offset  int
+}
+
+// parseMCPSessionsListQuery extracts and validates pagination + filter params
+// from the request query string. On validation failure it writes a 400
+// response and returns ok=false — the caller must early-return without
+// further writes.
+func parseMCPSessionsListQuery(ctx *fasthttp.RequestCtx) (mcpSessionsListQuery, bool) {
+	q := mcpSessionsListQuery{Limit: mcpSessionsDefaultLimit}
+	args := ctx.QueryArgs()
+	q.Filters.Search = strings.TrimSpace(string(args.Peek("q")))
+	q.Filters.Statuses = parseCommaSeparated(string(args.Peek("status")))
+	q.Filters.AuthModes = parseCommaSeparated(string(args.Peek("auth_mode")))
+	q.Filters.MCPClientIDs = parseCommaSeparated(string(args.Peek("mcp_client_id")))
+	q.Kinds = parseCommaSeparated(string(args.Peek("kind")))
+	if s := string(args.Peek("limit")); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid limit parameter: must be a number")
+			return q, false
+		}
+		if n <= 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid limit parameter: must be greater than zero")
+			return q, false
+		}
+		if n > mcpSessionsMaxLimit {
+			n = mcpSessionsMaxLimit
+		}
+		q.Limit = n
+	}
+	if s := string(args.Peek("offset")); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid offset parameter: must be a number")
+			return q, false
+		}
+		if n < 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid offset parameter: must be non-negative")
+			return q, false
+		}
+		q.Offset = n
+	}
+	return q, true
+}
+
+// kindAllowed reports whether the given wire-row kind passes the optional
+// kind filter. Empty filter matches all. Used for the two user-selectable
+// kinds (token, header); flow visibility is gated through flowsAllowed
+// instead since "flow" is no longer a UI-selectable kind.
+func (q mcpSessionsListQuery) kindAllowed(kind string) bool {
+	if len(q.Kinds) == 0 {
+		return true
+	}
+	for _, k := range q.Kinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// flowsAllowed reports whether flow rows should be returned given the kind
+// filter. "flow" used to be a selectable Type in the UI; it now lives under
+// the Status filter (Status=Pending). Flows surface when the user hasn't
+// narrowed to a specific kind — selecting Type=token or Type=header
+// suppresses flows.
+func (q mcpSessionsListQuery) flowsAllowed() bool {
+	return len(q.Kinds) == 0
+}
+
+// statusFilterAllowsPending reports whether the status filter would
+// admit a row with status='pending'. Empty filter (no filter) admits
+// everything, so returns true.
+func (q mcpSessionsListQuery) statusFilterAllowsPending() bool {
+	if len(q.Filters.Statuses) == 0 {
+		return true
+	}
+	for _, s := range q.Filters.Statuses {
+		if s == "pending" {
+			return true
+		}
+	}
+	return false
+}
+
+// list returns sessions visible to the caller, filtered + paginated. Each
+// row's identity column matches the caller's derived AuthMode + identity
+// (enforced by DAC scope at the configstore layer). Filtering is pushed
+// to SQL via the four List* store methods; pagination + cross-table
+// de-dup + sort happens here because per-table LIMIT/OFFSET would not
+// compose into a correct global page.
 func (h *MCPSessionsHandler) list(ctx *fasthttp.RequestCtx) {
-	// Always call the unfiltered list methods. Row visibility is handled
-	// by DAC scope at the enterprise configstore layer (own-data narrows
-	// to the caller's identity + owned VKs; team-data widens to members;
-	// all-data / OSS-only sees everything). Matches the canonical pattern
-	// used by getVirtualKeys, getPrompts, getTeams, etc.
-	tokens, err := h.store.ConfigStore.ListAllOauthUserTokens(ctx)
-	var flows []tables.TableOauthUserSession
-	var headerCreds []tables.TableMCPPerUserHeaderCredential
-	var headerFlows []tables.TableMCPPerUserHeaderFlow
-	if err == nil {
-		flows, err = h.store.ConfigStore.ListAllPendingOauthUserSessions(ctx)
+	q, ok := parseMCPSessionsListQuery(ctx)
+	if !ok {
+		return
 	}
-	if err == nil {
-		headerCreds, err = h.store.ConfigStore.ListAllMCPPerUserHeaderCredentials(ctx)
+
+	// Skip store calls we know can't contribute rows. Cuts pointless DB
+	// work for common filter shapes:
+	//   - kind=token only → only the tokens table
+	//   - kind=header only → only the headers table
+	//   - status excludes pending → skip both flow tables (flow rows are
+	//     always status='pending')
+	// We still fetch tokens/headers when their corresponding flow table is
+	// queried, because cross-table de-dup (suppress a flow row when a
+	// matching token/header credential exists) needs that data.
+	var (
+		tokens      []tables.TableOauthUserToken
+		flows       []tables.TableOauthUserSession
+		headerCreds []tables.TableMCPPerUserHeaderCredential
+		headerFlows []tables.TableMCPPerUserHeaderFlow
+		err         error
+	)
+	queryFlows := q.flowsAllowed() && q.statusFilterAllowsPending()
+	queryHeaderFlows := queryFlows
+	queryTokens := q.kindAllowed("token") || queryFlows
+	queryHeaders := q.kindAllowed("header") || queryHeaderFlows
+
+	if queryTokens {
+		tokens, err = h.store.ConfigStore.ListOauthUserTokens(ctx, q.Filters)
 	}
-	if err == nil {
-		headerFlows, err = h.store.ConfigStore.ListAllPendingMCPPerUserHeaderFlows(ctx)
+	if err == nil && queryFlows {
+		flows, err = h.store.ConfigStore.ListPendingOauthUserSessions(ctx, q.Filters)
+	}
+	if err == nil && queryHeaders {
+		headerCreds, err = h.store.ConfigStore.ListMCPPerUserHeaderCredentials(ctx, q.Filters)
+	}
+	if err == nil && queryHeaderFlows {
+		headerFlows, err = h.store.ConfigStore.ListPendingMCPPerUserHeaderFlows(ctx, q.Filters)
 	}
 	if err != nil {
 		logger.Error("[mcp/sessions] list failed: %v", err)
@@ -137,30 +269,46 @@ func (h *MCPSessionsHandler) list(ctx *fasthttp.RequestCtx) {
 	}
 
 	rows := make([]mcpSessionRow, 0, len(tokens)+len(flows)+len(headerCreds)+len(headerFlows))
-	for _, t := range tokens {
-		rows = append(rows, tokenRow(t))
-	}
-	for _, f := range flows {
-		if _, hasToken := tokenBindings[bindingKeyFromFlow(f)]; hasToken {
-			continue
+	if q.kindAllowed("token") {
+		for _, t := range tokens {
+			rows = append(rows, tokenRow(t))
 		}
-		// Skip deferred-fill user-mode flow rows (user_id not yet stamped).
-		// They have no concrete binding to render, and surfacing them in
-		// the table forces an ambiguous label.
-		if f.FlowMode == string(schemas.MCPAuthModeUser) && (f.UserID == nil || *f.UserID == "") {
-			continue
+	}
+	if queryFlows {
+		for _, f := range flows {
+			if _, hasToken := tokenBindings[bindingKeyFromFlow(f)]; hasToken {
+				continue
+			}
+			// Skip deferred-fill user-mode flow rows (user_id not yet stamped).
+			// They have no concrete binding to render, and surfacing them in
+			// the table forces an ambiguous label.
+			if f.FlowMode == string(schemas.MCPAuthModeUser) && (f.UserID == nil || *f.UserID == "") {
+				continue
+			}
+			rows = append(rows, flowRow(f))
 		}
-		rows = append(rows, flowRow(f))
 	}
-	for _, c := range headerCreds {
-		rows = append(rows, headerCredentialRow(c))
-	}
-	for _, f := range headerFlows {
-		if _, hasCred := headerCredBindings[bindingKeyFromHeaderFlow(f)]; hasCred {
-			continue
+	if q.kindAllowed("header") {
+		for _, c := range headerCreds {
+			rows = append(rows, headerCredentialRow(c))
 		}
-		rows = append(rows, headerFlowRow(f))
 	}
+	if queryHeaderFlows {
+		for _, f := range headerFlows {
+			if _, hasCred := headerCredBindings[bindingKeyFromHeaderFlow(f)]; hasCred {
+				continue
+			}
+			rows = append(rows, headerFlowRow(f))
+		}
+	}
+
+	// Stable sort across the merged set so pagination is deterministic.
+	// The per-table queries each ORDER BY created_at DESC, but cross-table
+	// merge order is undefined without this step.
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].CreatedAt > rows[j].CreatedAt
+	})
+
 	caller := callerUserIDFromCtx(ctx)
 	for i := range rows {
 		// Flow rows are completed via /api/oauth/per-user/flows/{id}/start, not
@@ -172,7 +320,22 @@ func (h *MCPSessionsHandler) list(ctx *fasthttp.RequestCtx) {
 		}
 		rows[i].CanReauth = canReauthRow(rows[i].AuthMode, rows[i].UserID, caller)
 	}
-	SendJSON(ctx, mcpSessionsListResponse{Sessions: rows})
+
+	totalCount := len(rows)
+	start := min(q.Offset, totalCount)
+	end := start + q.Limit
+	if end > totalCount {
+		end = totalCount
+	}
+	page := rows[start:end]
+
+	SendJSON(ctx, mcpSessionsListResponse{
+		Sessions:   page,
+		Count:      len(page),
+		TotalCount: totalCount,
+		Limit:      q.Limit,
+		Offset:     q.Offset,
+	})
 }
 
 type sessionBindingKey struct {

--- a/transports/bifrost-http/handlers/mcp_sessions_test.go
+++ b/transports/bifrost-http/handlers/mcp_sessions_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+)
+
+func TestParseMCPSessionsListQuery_Defaults(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/api/mcp/sessions")
+	q, ok := parseMCPSessionsListQuery(ctx)
+	if !ok {
+		t.Fatalf("expected parse to succeed: body=%s", string(ctx.Response.Body()))
+	}
+	if q.Limit != mcpSessionsDefaultLimit {
+		t.Fatalf("expected default limit %d, got %d", mcpSessionsDefaultLimit, q.Limit)
+	}
+	if q.Offset != 0 {
+		t.Fatalf("expected default offset 0, got %d", q.Offset)
+	}
+	if q.Filters.Search != "" || len(q.Filters.Statuses) != 0 || len(q.Filters.AuthModes) != 0 || len(q.Filters.MCPClientIDs) != 0 || len(q.Kinds) != 0 {
+		t.Fatalf("expected zero-value filters, got %#v", q)
+	}
+}
+
+func TestParseMCPSessionsListQuery_AllParams(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/api/mcp/sessions?q=hello&kind=token,header&status=active,orphaned&auth_mode=user,vk&mcp_client_id=c1,c2&limit=25&offset=50")
+	q, ok := parseMCPSessionsListQuery(ctx)
+	if !ok {
+		t.Fatalf("parse failed: body=%s", string(ctx.Response.Body()))
+	}
+	if q.Filters.Search != "hello" {
+		t.Fatalf("search=%q", q.Filters.Search)
+	}
+	if strings.Join(q.Kinds, ",") != "token,header" {
+		t.Fatalf("kinds=%v", q.Kinds)
+	}
+	if strings.Join(q.Filters.Statuses, ",") != "active,orphaned" {
+		t.Fatalf("statuses=%v", q.Filters.Statuses)
+	}
+	if strings.Join(q.Filters.AuthModes, ",") != "user,vk" {
+		t.Fatalf("auth_modes=%v", q.Filters.AuthModes)
+	}
+	if strings.Join(q.Filters.MCPClientIDs, ",") != "c1,c2" {
+		t.Fatalf("mcp_client_ids=%v", q.Filters.MCPClientIDs)
+	}
+	if q.Limit != 25 {
+		t.Fatalf("limit=%d", q.Limit)
+	}
+	if q.Offset != 50 {
+		t.Fatalf("offset=%d", q.Offset)
+	}
+}
+
+func TestParseMCPSessionsListQuery_LimitCappedAtMax(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/api/mcp/sessions?limit=9999")
+	q, ok := parseMCPSessionsListQuery(ctx)
+	if !ok {
+		t.Fatalf("parse failed")
+	}
+	if q.Limit != mcpSessionsMaxLimit {
+		t.Fatalf("expected limit capped at %d, got %d", mcpSessionsMaxLimit, q.Limit)
+	}
+}
+
+func TestParseMCPSessionsListQuery_InvalidLimit(t *testing.T) {
+	for _, raw := range []string{"abc", "-5", "0"} {
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.SetRequestURI("/api/mcp/sessions?limit=" + raw)
+		if _, ok := parseMCPSessionsListQuery(ctx); ok {
+			t.Fatalf("limit=%q should have failed validation", raw)
+		}
+		if code := ctx.Response.StatusCode(); code != fasthttp.StatusBadRequest {
+			t.Fatalf("limit=%q: expected 400, got %d", raw, code)
+		}
+	}
+}
+
+func TestParseMCPSessionsListQuery_InvalidOffset(t *testing.T) {
+	for _, raw := range []string{"abc", "-1"} {
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.SetRequestURI("/api/mcp/sessions?offset=" + raw)
+		if _, ok := parseMCPSessionsListQuery(ctx); ok {
+			t.Fatalf("offset=%q should have failed validation", raw)
+		}
+		if code := ctx.Response.StatusCode(); code != fasthttp.StatusBadRequest {
+			t.Fatalf("offset=%q: expected 400, got %d", raw, code)
+		}
+	}
+}
+
+func TestMCPSessionsListQuery_KindAllowed(t *testing.T) {
+	empty := mcpSessionsListQuery{}
+	if !empty.kindAllowed("token") || !empty.kindAllowed("flow") {
+		t.Fatalf("empty filter must allow all kinds")
+	}
+	q := mcpSessionsListQuery{Kinds: []string{"token", "header"}}
+	if !q.kindAllowed("token") || !q.kindAllowed("header") {
+		t.Fatalf("filter should match listed kinds")
+	}
+	if q.kindAllowed("flow") {
+		t.Fatalf("flow should not match {token, header}")
+	}
+}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1265,11 +1265,11 @@ func (m *MockConfigStore) GetOauthUserTokenByID(ctx context.Context, id string) 
 	return nil, nil
 }
 
-func (m *MockConfigStore) ListAllOauthUserTokens(ctx context.Context) ([]tables.TableOauthUserToken, error) {
+func (m *MockConfigStore) ListOauthUserTokens(ctx context.Context, params configstore.MCPSessionsFilterParams) ([]tables.TableOauthUserToken, error) {
 	return nil, nil
 }
 
-func (m *MockConfigStore) ListAllPendingOauthUserSessions(ctx context.Context) ([]tables.TableOauthUserSession, error) {
+func (m *MockConfigStore) ListPendingOauthUserSessions(ctx context.Context, params configstore.MCPSessionsFilterParams) ([]tables.TableOauthUserSession, error) {
 	return nil, nil
 }
 
@@ -1294,7 +1294,7 @@ func (m *MockConfigStore) UpsertMCPPerUserHeaderCredential(ctx context.Context, 
 func (m *MockConfigStore) DeleteMCPPerUserHeaderCredential(ctx context.Context, id string) error {
 	return nil
 }
-func (m *MockConfigStore) ListAllMCPPerUserHeaderCredentials(ctx context.Context) ([]tables.TableMCPPerUserHeaderCredential, error) {
+func (m *MockConfigStore) ListMCPPerUserHeaderCredentials(ctx context.Context, params configstore.MCPSessionsFilterParams) ([]tables.TableMCPPerUserHeaderCredential, error) {
 	return nil, nil
 }
 func (m *MockConfigStore) MarkMCPPerUserHeaderCredentialsNeedsUpdate(ctx context.Context, mcpClientID string) error {
@@ -1321,7 +1321,7 @@ func (m *MockConfigStore) DeleteMCPPerUserHeaderFlowsByModeIdentityAndMCPClient(
 func (m *MockConfigStore) DeleteMCPPerUserHeaderFlow(ctx context.Context, id string) error {
 	return nil
 }
-func (m *MockConfigStore) ListAllPendingMCPPerUserHeaderFlows(ctx context.Context) ([]tables.TableMCPPerUserHeaderFlow, error) {
+func (m *MockConfigStore) ListPendingMCPPerUserHeaderFlows(ctx context.Context, params configstore.MCPSessionsFilterParams) ([]tables.TableMCPPerUserHeaderFlow, error) {
 	return nil, nil
 }
 func (m *MockConfigStore) DeleteExpiredMCPPerUserHeaderFlows(ctx context.Context) (int64, error) {


### PR DESCRIPTION
## Summary

The four MCP sessions list methods (`ListAllOauthUserTokens`, `ListAllPendingOauthUserSessions`, `ListAllMCPPerUserHeaderCredentials`, `ListAllPendingMCPPerUserHeaderFlows`) previously fetched all rows unconditionally and left all filtering to the handler. This PR pushes filtering down to SQL by introducing a shared `MCPSessionsFilterParams` struct and a reusable `applyMCPSessionFilters` helper, and adds server-side pagination to the merged sessions list endpoint.

## Changes

- Renamed the four `ListAll*` store methods to `List*` and added a `MCPSessionsFilterParams` parameter to each. Filters for status, auth mode, MCP client ID, and a case-insensitive search string (matched against MCP client name/ID, user ID, session ID, and virtual key name/ID via LEFT JOIN) are now applied in SQL rather than in the handler.
- Introduced `MCPSessionsFilterParams` in `store.go` with documentation explaining why pagination is intentionally omitted from the struct (cross-table de-dup must happen before slicing).
- Added `applyMCPSessionFilters` in `rdb.go` as a shared helper that appends the WHERE clauses and search JOINs to a GORM query, parameterised by a `mcpSessionFilterTable` descriptor that carries the table name and the auth-mode column name (which differs between credential tables and flow tables).
- Qualified all `ORDER BY` and `WHERE` column references with their table names to avoid ambiguity after the search JOINs are added.
- Updated the `list` handler in `mcp_sessions.go` to parse query-string filters (`q`, `status`, `auth_mode`, `mcp_client_id`, `kind`, `limit`, `offset`) via a new `parseMCPSessionsListQuery` function, skip store calls that cannot contribute rows given the filter shape, perform a stable cross-table sort by `created_at DESC` after merging, and return a paginated response with `count`, `total_count`, `limit`, and `offset` fields.
- Added `kindAllowed`, `flowsAllowed`, and `statusFilterAllowsPending` helpers on `mcpSessionsListQuery` to cleanly express which store calls to skip.
- Updated `MockConfigStore` in `config_test.go` to match the new method signatures.
- Added `rdb_mcp_sessions_test.go` with integration-style tests covering no-filter listing, status/auth-mode/MCP-client-ID filtering, search by MCP client name, virtual key name, user ID, and session ID, preload population, and pending-only enforcement.
- Added `mcp_sessions_test.go` with unit tests for `parseMCPSessionsListQuery` covering defaults, all parameters, limit capping, invalid limit/offset values, and `kindAllowed` logic.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./transports/bifrost-http/handlers/... ./transports/bifrost-http/lib/...
```

Validate filtering via the sessions endpoint:

```sh
# All sessions (default limit 50)
GET /api/mcp/sessions

# Filter by status and auth mode with pagination
GET /api/mcp/sessions?status=active,needs_reauth&auth_mode=vk&limit=25&offset=0

# Search by MCP client name
GET /api/mcp/sessions?q=GitHub

# Only token-kind rows
GET /api/mcp/sessions?kind=token
```

Expected: response includes `sessions`, `count`, `total_count`, `limit`, and `offset` fields; rows match the supplied filters; `total_count` reflects the full unsliced result.

## Breaking changes

- [x] Yes
- [ ] No

The four `ListAll*` store methods on the `ConfigStore` interface have been renamed and their signatures changed to accept `MCPSessionsFilterParams`. Any external implementations of `ConfigStore` must be updated to match the new signatures. The sessions list API response now includes additional pagination fields (`count`, `total_count`, `limit`, `offset`) alongside `sessions`.

## Related issues

N/A

## Security considerations

Search JOINs use parameterised LIKE queries; no raw user input is interpolated into SQL. Table and column names in `applyMCPSessionFilters` are hardcoded constants, not user-supplied. DAC scope enforcement remains at the `ScopedDB(ctx)` layer and is unaffected by this change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable