### PR TITLE
feat: add filtering and pagination to MCP sessions table

### DIFF
--- a/ui/app/workspace/mcp-sessions/page.tsx
+++ b/ui/app/workspace/mcp-sessions/page.tsx
@@ -1,9 +1,50 @@
 import FullPageLoader from "@/components/fullPageLoader";
+import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetMCPSessionsQuery } from "@/lib/store";
+import { AuthMode, MCPSessionKind, MCPSessionStatus } from "@/lib/types/mcpSessions";
+import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { useEffect } from "react";
 import SessionsTable from "./views/sessionsTable";
 
+// Page size larger than the governance default (25) since session rows are
+// denser than VK rows and the page is the only screen of MCP-auth content.
+const PAGE_SIZE = 50;
+
 export default function MCPSessionsPage() {
-	const { data, isLoading, isError, error } = useGetMCPSessionsQuery();
+	const [urlState, setUrlState] = useQueryStates(
+		{
+			q: parseAsString.withDefault(""),
+			kind: parseAsArrayOf(parseAsString).withDefault([]),
+			status: parseAsArrayOf(parseAsString).withDefault([]),
+			auth_mode: parseAsArrayOf(parseAsString).withDefault([]),
+			mcp_client_id: parseAsArrayOf(parseAsString).withDefault([]),
+			offset: parseAsInteger.withDefault(0),
+		},
+		{ history: "push" },
+	);
+
+	const debouncedSearch = useDebouncedValue(urlState.q, 300);
+
+	const { data, isLoading, isFetching, isError, error } = useGetMCPSessionsQuery({
+		q: debouncedSearch || undefined,
+		kind: urlState.kind.length ? (urlState.kind as MCPSessionKind[]) : undefined,
+		status: urlState.status.length ? (urlState.status as MCPSessionStatus[]) : undefined,
+		auth_mode: urlState.auth_mode.length ? (urlState.auth_mode as AuthMode[]) : undefined,
+		mcp_client_id: urlState.mcp_client_id.length ? urlState.mcp_client_id : undefined,
+		limit: PAGE_SIZE,
+		offset: urlState.offset,
+	});
+
+	const totalCount = data?.total_count ?? 0;
+
+	// Snap offset back if the total shrinks past the current page (e.g. a
+	// revoke removed the last row on the last page). Same logic as VKs.
+	useEffect(() => {
+		if (!data || urlState.offset < totalCount) return;
+		setUrlState({
+			offset: totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE,
+		});
+	}, [totalCount, urlState.offset, data, setUrlState]);
 
 	if (isLoading) {
 		return <FullPageLoader />;
@@ -19,9 +60,41 @@ export default function MCPSessionsPage() {
 		);
 	}
 
+	const hasActiveFilters =
+		!!urlState.q ||
+		urlState.kind.length > 0 ||
+		urlState.status.length > 0 ||
+		urlState.auth_mode.length > 0 ||
+		urlState.mcp_client_id.length > 0;
+
+	const handleSearchChange = (value: string) => setUrlState({ q: value || null, offset: 0 });
+	const handleKindChange = (value: string[]) => setUrlState({ kind: value.length ? value : null, offset: 0 });
+	const handleStatusChange = (value: string[]) => setUrlState({ status: value.length ? value : null, offset: 0 });
+	const handleAuthModeChange = (value: string[]) => setUrlState({ auth_mode: value.length ? value : null, offset: 0 });
+	const handleOffsetChange = (offset: number) => setUrlState({ offset });
+	const handleClearFilters = () =>
+		setUrlState({ q: null, kind: null, status: null, auth_mode: null, mcp_client_id: null, offset: 0 });
+
 	return (
 		<div className="mx-auto w-full max-w-7xl">
-			<SessionsTable sessions={data?.sessions ?? []} />
+			<SessionsTable
+				sessions={data?.sessions ?? []}
+				totalCount={totalCount}
+				isFetching={isFetching}
+				search={urlState.q}
+				onSearchChange={handleSearchChange}
+				kindFilter={urlState.kind}
+				onKindFilterChange={handleKindChange}
+				statusFilter={urlState.status}
+				onStatusFilterChange={handleStatusChange}
+				authModeFilter={urlState.auth_mode}
+				onAuthModeFilterChange={handleAuthModeChange}
+				hasActiveFilters={hasActiveFilters}
+				onClearFilters={handleClearFilters}
+				offset={urlState.offset}
+				limit={PAGE_SIZE}
+				onOffsetChange={handleOffsetChange}
+			/>
 		</div>
 	);
 }

--- a/ui/app/workspace/mcp-sessions/views/sessionsFilterBar.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsFilterBar.tsx
@@ -1,0 +1,113 @@
+// Inline filter row above the sessions table: search input + three multi-
+// selects (kind, status, auth_mode) + a clear-filters affordance shown
+// only when something is active.
+//
+// MCP-client filter is intentionally absent here. Adding it would need a
+// separate source for the dropdown options (the existing list response
+// only shows clients that have *sessions*, which is filter-dependent and
+// would cause the option list to collapse as filters narrow). When we
+// want it we'll piggyback on useGetMCPClientsQuery.
+
+import { Button } from "@/components/ui/button";
+import { ComboboxSelect } from "@/components/ui/combobox";
+import { Input } from "@/components/ui/input";
+import { Fingerprint, KeyRound, Search, UserRound, X } from "lucide-react";
+
+// Labels mirror the Type column's TypeBadge ("OAuth" / "Headers") so the
+// filter vocabulary matches what the user sees in the table.
+const KIND_OPTIONS = [
+	{ label: "OAuth", value: "token" },
+	{ label: "Headers", value: "header" },
+];
+
+const STATUS_OPTIONS = [
+	{ label: "Active", value: "active" },
+	{ label: "Orphaned", value: "orphaned" },
+	{ label: "Needs re-auth", value: "needs_reauth" },
+	{ label: "Needs update", value: "needs_update" },
+	{ label: "Pending", value: "pending" },
+];
+
+// Identity-mode icons match the glyphs used in BindingCell so the dropdown
+// reads as the same vocabulary as the rendered table column.
+const AUTH_MODE_OPTIONS = [
+	{ label: "User", value: "user", icon: <UserRound className="size-3.5" /> },
+	{ label: "Virtual key", value: "vk", icon: <KeyRound className="size-3.5" /> },
+	{ label: "Session", value: "session", icon: <Fingerprint className="size-3.5" /> },
+];
+
+export interface SessionsFilterBarProps {
+	search: string;
+	onSearchChange: (value: string) => void;
+	kindFilter: string[];
+	onKindFilterChange: (value: string[]) => void;
+	statusFilter: string[];
+	onStatusFilterChange: (value: string[]) => void;
+	authModeFilter: string[];
+	onAuthModeFilterChange: (value: string[]) => void;
+	hasActiveFilters: boolean;
+	onClearFilters: () => void;
+}
+
+export default function SessionsFilterBar(props: SessionsFilterBarProps) {
+	return (
+		<div className="flex shrink-0 flex-wrap items-center gap-3">
+			<div className="relative max-w-sm flex-1 min-w-[200px]">
+				<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+				<Input
+					aria-label="Search sessions"
+					placeholder="Search MCP, user, VK, session..."
+					value={props.search}
+					onChange={(e) => props.onSearchChange(e.target.value)}
+					className="pl-9"
+					data-testid="mcp-sessions-search-input"
+				/>
+			</div>
+			<ComboboxSelect
+				multiple
+				disableSearch
+				compactTrigger
+				data-testid="mcp-sessions-kind-filter"
+				options={KIND_OPTIONS}
+				value={props.kindFilter}
+				onValueChange={props.onKindFilterChange}
+				placeholder="All types"
+				className="h-9 w-[180px]"
+			/>
+			<ComboboxSelect
+				multiple
+				disableSearch
+				compactTrigger
+				data-testid="mcp-sessions-status-filter"
+				options={STATUS_OPTIONS}
+				value={props.statusFilter}
+				onValueChange={props.onStatusFilterChange}
+				placeholder="All statuses"
+				className="h-9 w-[180px]"
+			/>
+			<ComboboxSelect
+				multiple
+				disableSearch
+				compactTrigger
+				data-testid="mcp-sessions-auth-mode-filter"
+				options={AUTH_MODE_OPTIONS}
+				value={props.authModeFilter}
+				onValueChange={props.onAuthModeFilterChange}
+				placeholder="All identities"
+				className="h-9 w-[180px]"
+			/>
+			{props.hasActiveFilters && (
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={props.onClearFilters}
+					data-testid="mcp-sessions-clear-filters-btn"
+					className="h-9"
+				>
+					<X className="h-4 w-4" />
+					Clear filters
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
@@ -33,18 +33,51 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Info } from "lucide-react";
+import { ChevronLeft, ChevronRight, Info } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useReauthMCPSessionMutation, useRevokeMCPSessionMutation } from "@/lib/store";
 import { MCPSessionRow } from "@/lib/types/mcpSessions";
 import { ExternalLink, Fingerprint, KeyRound, Loader2, MoreHorizontal, Pencil, RefreshCcw, Trash2, UserRound } from "lucide-react";
 import { useState } from "react";
+import SessionsFilterBar from "./sessionsFilterBar";
 
 interface SessionsTableProps {
 	sessions: MCPSessionRow[];
+	totalCount: number;
+	isFetching: boolean;
+	search: string;
+	onSearchChange: (value: string) => void;
+	kindFilter: string[];
+	onKindFilterChange: (value: string[]) => void;
+	statusFilter: string[];
+	onStatusFilterChange: (value: string[]) => void;
+	authModeFilter: string[];
+	onAuthModeFilterChange: (value: string[]) => void;
+	hasActiveFilters: boolean;
+	onClearFilters: () => void;
+	offset: number;
+	limit: number;
+	onOffsetChange: (offset: number) => void;
 }
 
-export default function SessionsTable({ sessions }: SessionsTableProps) {
+export default function SessionsTable({
+	sessions,
+	totalCount,
+	isFetching,
+	search,
+	onSearchChange,
+	kindFilter,
+	onKindFilterChange,
+	statusFilter,
+	onStatusFilterChange,
+	authModeFilter,
+	onAuthModeFilterChange,
+	hasActiveFilters,
+	onClearFilters,
+	offset,
+	limit,
+	onOffsetChange,
+}: SessionsTableProps) {
 	const { toast } = useToast();
 	const [reauth, { isLoading: reauthing }] = useReauthMCPSessionMutation();
 	const [revoke, { isLoading: revoking }] = useRevokeMCPSessionMutation();
@@ -124,7 +157,20 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 				</div>
 			</div>
 
-			<div className="overflow-auto rounded-sm border">
+			<SessionsFilterBar
+				search={search}
+				onSearchChange={onSearchChange}
+				kindFilter={kindFilter}
+				onKindFilterChange={onKindFilterChange}
+				statusFilter={statusFilter}
+				onStatusFilterChange={onStatusFilterChange}
+				authModeFilter={authModeFilter}
+				onAuthModeFilterChange={onAuthModeFilterChange}
+				hasActiveFilters={hasActiveFilters}
+				onClearFilters={onClearFilters}
+			/>
+
+			<div className={`overflow-auto rounded-sm border ${isFetching ? "opacity-70 transition-opacity" : ""}`}>
 				<Table>
 					<TableHeader>
 						<TableRow>
@@ -161,10 +207,17 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 						{sessions.length === 0 ? (
 							<TableRow>
 								<TableCell colSpan={7} className="h-24 text-center">
-									<span className="text-muted-foreground text-sm">
-										No sessions yet. Sessions appear here when an inference request or MCP gateway call triggers per-user authentication
-										(OAuth or header submission).
-									</span>
+									{hasActiveFilters ? (
+										<div className="text-muted-foreground text-sm">
+										No sessions match these filters.
+								
+										</div>
+									) : (
+										<span className="text-muted-foreground text-sm">
+											No sessions yet. Sessions appear here when an inference request or MCP gateway call triggers per-user authentication
+											(OAuth or header submission).
+										</span>
+									)}
 								</TableCell>
 							</TableRow>
 						) : (
@@ -205,6 +258,36 @@ export default function SessionsTable({ sessions }: SessionsTableProps) {
 					</TableBody>
 				</Table>
 			</div>
+
+			{totalCount > 0 && (
+				<div className="flex shrink-0 items-center justify-between px-2 text-xs">
+					<p className="text-muted-foreground">
+						Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
+					</p>
+					<div className="flex gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={offset === 0}
+							onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+							data-testid="mcp-sessions-pagination-prev-btn"
+						>
+							<ChevronLeft className="mr-1 h-4 w-4" />
+							Previous
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={offset + limit >= totalCount}
+							onClick={() => onOffsetChange(offset + limit)}
+							data-testid="mcp-sessions-pagination-next-btn"
+						>
+							Next
+							<ChevronRight className="ml-1 h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/ui/components/ui/combobox.tsx
+++ b/ui/components/ui/combobox.tsx
@@ -285,6 +285,10 @@ function ComboboxEmpty({ className, ...props }: React.ComponentProps<typeof Comm
 interface ComboboxSelectOption {
 	label: string;
 	value: string;
+	// Optional leading icon rendered next to the label in the dropdown list.
+	// Useful for facet filters where the icon helps disambiguate values
+	// (e.g. identity-mode dropdown: user / vk / session glyphs).
+	icon?: React.ReactNode;
 }
 
 interface ComboboxSelectBaseProps {
@@ -295,6 +299,12 @@ interface ComboboxSelectBaseProps {
 	hideClear?: boolean;
 	className?: string;
 	emptyMessage?: string;
+	// compactTrigger swaps the multi-select trigger from a wrapping row of
+	// per-value badges to a single "N selected" summary. Useful in filter
+	// bars where the trigger has a fixed narrow width and a long badge list
+	// would overflow. No-op on the single-select variant.
+	compactTrigger?: boolean;
+	"data-testid"?: string;
 }
 
 interface ComboboxSelectSingleProps extends ComboboxSelectBaseProps {
@@ -320,6 +330,8 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 		className,
 		emptyMessage = "No results found.",
 		noPortal,
+		compactTrigger = false,
+		"data-testid": dataTestId,
 	} = props;
 
 	const [open, setOpen] = React.useState(false);
@@ -351,6 +363,7 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 						role="combobox"
 						aria-expanded={open}
 						disabled={disabled}
+						data-testid={dataTestId}
 						className={cn(
 							"h-8 w-full justify-between !bg-transparent font-normal active:scale-none",
 							selectedValues.length === 0 && "text-muted-foreground",
@@ -360,6 +373,8 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 						<div className="flex flex-1 flex-wrap gap-1 overflow-hidden">
 							{selectedValues.length === 0 ? (
 								<span>{placeholder}</span>
+							) : compactTrigger ? (
+								<span className="text-foreground truncate text-sm">{selectedValues.length} selected</span>
 							) : (
 								selectedValues.map((val) => (
 									<Badge key={val} variant="secondary" className="text-xs">
@@ -408,7 +423,8 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 											props.onValueChange?.(next);
 										}}
 									>
-										{option.label}
+										{option.icon ? <span className="text-muted-foreground flex shrink-0 items-center">{option.icon}</span> : null}
+										<span>{option.label}</span>
 										<span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
 											{isSelected && <CheckIcon className="size-4" />}
 										</span>
@@ -442,6 +458,7 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 					role="combobox"
 					aria-expanded={open}
 					disabled={disabled}
+					data-testid={dataTestId}
 					className={cn(
 						"h-8 w-full justify-between !bg-transparent font-normal active:scale-none",
 						!selectedLabel && "text-muted-foreground",

--- a/ui/lib/store/apis/mcpSessionsApi.ts
+++ b/ui/lib/store/apis/mcpSessionsApi.ts
@@ -6,14 +6,38 @@ import {
 	MCPFlowStartResponse,
 	MCPSessionReauthResponse,
 	MCPSessionsListResponse,
+	MCPSessionsQueryParams,
 } from "@/lib/types/mcpSessions";
 import { baseApi } from "./baseApi";
 
+// buildMCPSessionsListParams shapes the filter+page params for the URL.
+// Array filters are csv-joined (matches the backend's parseCommaSeparated)
+// and sorted so selection order doesn't fragment the RTK Query cache key
+// (same logical filter set always produces the same key + canonical URL).
+// Empty values are dropped so the key doesn't fragment on "" vs unset.
+function buildMCPSessionsListParams(params?: MCPSessionsQueryParams) {
+	if (!params) return {};
+	const out: Record<string, string | number> = {};
+	if (params.q) out.q = params.q;
+	if (params.kind?.length) out.kind = [...params.kind].sort().join(",");
+	if (params.status?.length) out.status = [...params.status].sort().join(",");
+	if (params.auth_mode?.length) out.auth_mode = [...params.auth_mode].sort().join(",");
+	if (params.mcp_client_id?.length) out.mcp_client_id = [...params.mcp_client_id].sort().join(",");
+	if (params.limit !== undefined) out.limit = params.limit;
+	if (params.offset !== undefined) out.offset = params.offset;
+	return out;
+}
+
 export const mcpSessionsApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
-		// List token rows + pending flow rows visible to the caller's identity.
-		getMCPSessions: builder.query<MCPSessionsListResponse, void>({
-			query: () => ({ url: "/mcp/sessions" }),
+		// List session rows visible to the caller's identity, with optional
+		// filters + pagination. Each filter combo gets its own cache entry
+		// (RTK Query auto-derives the key from the params object).
+		getMCPSessions: builder.query<MCPSessionsListResponse, MCPSessionsQueryParams | void>({
+			query: (params) => ({
+				url: "/mcp/sessions",
+				params: buildMCPSessionsListParams(params ?? undefined),
+			}),
 			providesTags: ["MCPSessions"],
 		}),
 
@@ -28,24 +52,16 @@ export const mcpSessionsApi = baseApi.injectEndpoints({
 			query: (rowId) => ({ url: `/mcp/sessions/${rowId}/reauth`, method: "POST" }),
 		}),
 
-		// Best-effort upstream revoke + hard-delete the row.
-		// Optimistic patch over invalidatesTags to avoid the cross-replica
-		// stale-list window in clustered deployments — drop the row from the
-		// cached list immediately and roll back if the server rejects.
+		// Best-effort upstream revoke + hard-delete the row. Invalidates the
+		// MCPSessions tag so all keyed cache entries (per filter combo)
+		// refetch. The previous optimistic patch only worked when the cache
+		// was singleton-keyed; with per-filter keys, iterating every keyed
+		// entry to splice the row out is more code than a single refetch is
+		// worth, especially for a destructive action where the user expects
+		// a tiny network roundtrip anyway.
 		revokeMCPSession: builder.mutation<void, string>({
 			query: (rowId) => ({ url: `/mcp/sessions/${rowId}`, method: "DELETE" }),
-			async onQueryStarted(rowId, { dispatch, queryFulfilled }) {
-				const patchResult = dispatch(
-					mcpSessionsApi.util.updateQueryData("getMCPSessions", undefined, (draft) => {
-						draft.sessions = draft.sessions.filter((s) => s.id !== rowId);
-					}),
-				);
-				try {
-					await queryFulfilled;
-				} catch {
-					patchResult.undo();
-				}
-			},
+			invalidatesTags: ["MCPSessions"],
 		}),
 
 		// Flow metadata for the auth landing page.

--- a/ui/lib/types/mcpSessions.ts
+++ b/ui/lib/types/mcpSessions.ts
@@ -75,6 +75,27 @@ export interface MCPSessionRow {
 
 export interface MCPSessionsListResponse {
 	sessions: MCPSessionRow[];
+	// Pagination envelope mirrors the backend in handlers/mcp_sessions.go.
+	// Optional on this interface so older deployments (or future callers
+	// that ignore paging) still type-check.
+	count?: number;
+	total_count?: number;
+	limit?: number;
+	offset?: number;
+}
+
+// MCPSessionsQueryParams maps to the query string accepted by
+// GET /api/mcp/sessions. Array fields are csv-encoded by the API layer.
+// Empty/omitted values are not sent on the wire — the backend treats
+// missing as "no filter" for that field.
+export interface MCPSessionsQueryParams {
+	q?: string;
+	kind?: MCPSessionKind[];
+	status?: MCPSessionStatus[];
+	auth_mode?: AuthMode[];
+	mcp_client_id?: string[];
+	limit?: number;
+	offset?: number;
 }
 
 export interface MCPSessionReauthResponse {

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./out/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Adds server-side filtering and pagination to the MCP Sessions page. Previously the page fetched all sessions in a single unfiltered request. This PR introduces a filter bar with search, type, status, and identity-mode dropdowns, plus previous/next pagination, all synced to the URL via query string so filters survive navigation and can be shared as links.

## Changes

- Added a `SessionsFilterBar` component with a search input and three multi-select dropdowns (type, status, identity mode). Filter values are URL-synced via `nuqs` with `history: "push"` so the back button restores previous filter state.
- Debounced the search input (300 ms) to avoid firing a request on every keystroke.
- Wired `getMCPSessions` to accept `MCPSessionsQueryParams` (search, kind, status, auth_mode, mcp_client_id, limit, offset). Array filters are CSV-joined to match the backend's `parseCommaSeparated` convention. Empty values are dropped so RTK Query's cache key doesn't fragment unnecessarily.
- Added a `total_count`-based pagination footer with Previous/Next buttons. The offset snaps back to the last valid page if a revoke removes the final row on the current page (same pattern used by the virtual keys page).
- Replaced the optimistic patch on `revokeMCPSession` with `invalidatesTags: ["MCPSessions"]`. The optimistic approach only worked with a singleton cache key; with per-filter cache entries, invalidating all keyed entries via a tag refetch is simpler and correct.
- Added an `icon` prop to `ComboboxSelectOption` and a `compactTrigger` prop to `ComboboxSelect`. `compactTrigger` renders "N selected" instead of a row of badges, preventing overflow in narrow filter-bar dropdowns.
- Added `MCPSessionsQueryParams` and pagination fields to `MCPSessionsListResponse` in the type definitions.
- Page size is set to 50 (larger than the governance default of 25) since session rows are denser than virtual key rows.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the MCP Sessions page.
2. Verify the filter bar appears above the table with a search input and Type, Status, and Identity dropdowns.
3. Enter a search term and confirm the table updates after ~300 ms with matching sessions.
4. Select one or more values in each dropdown and confirm the table filters accordingly.
5. Confirm filter state is reflected in the URL and survives a page refresh.
6. With more than 50 sessions, confirm the pagination footer shows the correct range and that Previous/Next navigate correctly.
7. Revoke a session on the last page (when it is the only row) and confirm the page snaps back to the previous page rather than showing an empty paginated view.
8. Confirm the "Clear filters" button appears only when a filter is active and resets all filters and offset.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the MCP Sessions page showing the filter bar and pagination footer._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Filter values are passed as query parameters to the existing authenticated `/api/mcp/sessions` endpoint. No new auth surface is introduced. Filter state stored in the URL does not include secrets.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable