### PR TITLE
fix: URI-encode search query params to prevent special characters breaking navigation

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
@@ -3,6 +3,7 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { parseAsSafeString } from "@/lib/queryParamsParser";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
@@ -18,7 +19,7 @@ export function TeamsView() {
 
 	const [urlState, setUrlState] = useQueryStates(
 		{
-			search: parseAsString.withDefault(""),
+			search: parseAsSafeString.withDefault(""),
 			offset: parseAsInteger.withDefault(0),
 			selected_team: parseAsString.withDefault(""),
 		},

--- a/ui/app/workspace/governance/customers/page.tsx
+++ b/ui/app/workspace/governance/customers/page.tsx
@@ -3,6 +3,7 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { parseAsSafeString } from "@/lib/queryParamsParser";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
@@ -18,7 +19,7 @@ export default function GovernanceCustomersPage() {
 
 	const [urlState, setUrlState] = useQueryStates(
 		{
-			search: parseAsString.withDefault(""),
+			search: parseAsSafeString.withDefault(""),
 			offset: parseAsInteger.withDefault(0),
 		},
 		{ history: "push" },

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -8,6 +8,7 @@ import {
   useGetVirtualKeysQuery,
 } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { parseAsSafeString } from "@/lib/queryParamsParser";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
@@ -29,7 +30,7 @@ export default function GovernanceVirtualKeysPage() {
 
   const [urlState, setUrlState] = useQueryStates(
     {
-      search: parseAsString.withDefault(""),
+      search: parseAsSafeString.withDefault(""),
       customer_id: parseAsString.withDefault(""),
       team_id: parseAsString.withDefault(""),
       offset: parseAsInteger.withDefault(0),

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -26,6 +26,7 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import NumberFlow from "@number-flow/react";
 import { useLocation } from "@tanstack/react-router";
 import { AlertCircle, BarChart, CheckCircle, Clock, DollarSign, Hash, Info } from "lucide-react";
+import { parseAsSafeString } from "@/lib/queryParamsParser";
 import { parseAsArrayOf, parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -85,7 +86,7 @@ export default function LogsPage() {
 			team_ids: parseAsArrayOf(parseAsString).withDefault([]),
 			customer_ids: parseAsArrayOf(parseAsString).withDefault([]),
 			business_unit_ids: parseAsArrayOf(parseAsString).withDefault([]),
-			content_search: parseAsString.withDefault(""),
+			content_search: parseAsSafeString.withDefault(""),
 			start_time: parseAsInteger.withDefault(defaultTimeRange.startTime),
 			end_time: parseAsInteger.withDefault(defaultTimeRange.endTime),
 			limit: parseAsInteger.withDefault(25), // Default fallback, actual value calculated based on table height

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -19,6 +19,7 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import NumberFlow from "@number-flow/react";
 import { useLocation } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle, Clock, DollarSign, Hash } from "lucide-react";
+import { parseAsSafeString } from "@/lib/queryParamsParser";
 import { parseAsArrayOf, parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createMCPColumns } from "./views/columns";
@@ -52,7 +53,7 @@ export default function MCPLogsPage() {
 			server_labels: parseAsArrayOf(parseAsString).withDefault([]),
 			status: parseAsArrayOf(parseAsString).withDefault([]),
 			virtual_key_ids: parseAsArrayOf(parseAsString).withDefault([]),
-			content_search: parseAsString.withDefault(""),
+			content_search: parseAsSafeString.withDefault(""),
 			start_time: parseAsInteger.withDefault(defaultTimeRange.startTime),
 			end_time: parseAsInteger.withDefault(defaultTimeRange.endTime),
 			limit: parseAsInteger.withDefault(50),

--- a/ui/lib/queryParamsParser.ts
+++ b/ui/lib/queryParamsParser.ts
@@ -1,0 +1,21 @@
+import { createParser } from "nuqs";
+
+// nuqs's encodeQueryValue skips characters like "/" that TanStack Router's
+// navigate({ to }) interprets as path/query delimiters. Full URI-encoding
+// the value prevents any special character from breaking navigation.
+export const parseAsSafeString = createParser({
+  parse: (value: string) => {
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  },
+  serialize: (value: string) => {
+    try {
+      return encodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Search query parameters containing special characters (e.g., `/`) were being passed through nuqs's default string parser, which does not fully URI-encode values. TanStack Router's `navigate({ to })` interprets these characters as path or query delimiters, causing navigation to break when users search for content containing such characters.

## Changes

- Introduced a custom `parseAsSafeString` parser in `ui/lib/queryParamsParser.ts` that uses `encodeURIComponent` for serialization and `decodeURIComponent` for parsing, ensuring special characters in search inputs are safely encoded in the URL.
- Replaced `parseAsString` with `parseAsSafeString` for all `search` and `content_search` query state fields across the logs, MCP logs, virtual keys, customers, and teams views.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Logs, MCP Logs, Virtual Keys, Customers, or Teams pages.
2. Enter a search term containing special characters such as `/`, `?`, or `&`.
3. Verify that the page does not break or navigate to an unintended route.
4. Verify that the search term is correctly reflected in the URL and that the search functions as expected.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Full URI-encoding of user-supplied search input prevents special characters from being interpreted as URL structure, reducing the risk of URL manipulation via crafted query parameters.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable