### PR TITLE
adds helm changelogs to the docs

### DIFF
--- a/docs/changelogs/helm-v1.7.0.mdx
+++ b/docs/changelogs/helm-v1.7.0.mdx
@@ -1,0 +1,12 @@
+---
+title: "v1.7.0"
+description: "Helm v1.7.0 changelog - 2026-01-28"
+---
+
+<Update label="Bifrost Helm" description="v1.7.0">
+
+## Changelog
+
+- Previous stable release with Deployment-based architecture for all storage modes
+
+</Update>

--- a/docs/changelogs/helm-v2.0.0.mdx
+++ b/docs/changelogs/helm-v2.0.0.mdx
@@ -1,0 +1,43 @@
+---
+title: "v2.0.0"
+description: "Helm v2.0.0 changelog - 2026-01-31"
+---
+
+<Update label="Bifrost Helm" description="v2.0.0 (Breaking Change)">
+
+## Changelog
+
+#### StatefulSet for SQLite with Persistence
+
+This release fixes the multi-attach volume error when running multiple replicas with SQLite storage mode.
+
+#### What Changed
+
+- When using `storage.mode: sqlite` with `storage.persistence.enabled: true`, Bifrost now deploys as a **StatefulSet** instead of a Deployment
+- Each pod gets its own dedicated PersistentVolumeClaim (e.g., `data-bifrost-0`, `data-bifrost-1`, `data-bifrost-2`)
+- A headless service is created for StatefulSet DNS resolution
+- HorizontalPodAutoscaler now correctly references StatefulSet or Deployment based on storage configuration
+
+#### Who Is Affected
+
+- Users running SQLite mode with persistence enabled and multiple replicas
+- Users upgrading existing SQLite deployments need to migrate (see below)
+
+#### Who Is NOT Affected
+
+- Users running PostgreSQL mode (`storage.mode: postgres`) - no changes, still uses Deployment
+- Users running SQLite without persistence (`storage.persistence.enabled: false`)
+- Users running SQLite with an existing PVC claim (`storage.persistence.existingClaim`)
+
+#### Migration Guide for Existing SQLite Deployments
+
+Since Kubernetes doesn't allow in-place conversion from Deployment to StatefulSet, you need to:
+
+1. Back up your data (if needed)
+2. Uninstall the existing release: `helm uninstall bifrost`
+3. Delete the old PVC: `kubectl delete pvc bifrost-data`
+4. Install with the new chart version: `helm install bifrost bifrost/bifrost --set image.tag=<latest-image>`
+
+**Note:** For production high-availability setups, we recommend using PostgreSQL mode which scales horizontally without these concerns.
+
+</Update>

--- a/docs/changelogs/helm-v2.0.1.mdx
+++ b/docs/changelogs/helm-v2.0.1.mdx
@@ -1,0 +1,14 @@
+---
+title: "v2.0.1"
+description: "Helm v2.0.1 changelog - 2026-01-31"
+---
+
+<Update label="Bifrost Helm" description="v2.0.1">
+
+## Changelog
+
+- Added missing StatefulSet template for SQLite with persistence mode
+- Added headless service for StatefulSet DNS resolution
+- v2.0.0 documented StatefulSet support but the template was not included - this release fixes that
+
+</Update>

--- a/docs/changelogs/helm-v2.0.10.mdx
+++ b/docs/changelogs/helm-v2.0.10.mdx
@@ -1,0 +1,16 @@
+---
+title: "v2.0.10"
+description: "Helm v2.0.10 changelog - 2026-03-03"
+---
+
+<Update label="Bifrost Helm" description="v2.0.10">
+
+## Changelog
+
+- Added missing plugin config properties from Go implementations:
+  - governance: `required_headers`, `is_enterprise`
+  - logging: `disable_content_logging`, `logging_headers`
+  - otel: `headers`, `tls_ca_cert`, `insecure`
+  - telemetry: `custom_labels`
+
+</Update>

--- a/docs/changelogs/helm-v2.0.11.mdx
+++ b/docs/changelogs/helm-v2.0.11.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.0.11"
+description: "Helm v2.0.11 changelog - 2026-03-05"
+---
+
+<Update label="Bifrost Helm" description="v2.0.11">
+
+## Changelog
+
+- Bumped appVersion to 1.4.11
+
+</Update>

--- a/docs/changelogs/helm-v2.0.12.mdx
+++ b/docs/changelogs/helm-v2.0.12.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.0.12"
+description: "Helm v2.0.12 changelog - 2026-03-06"
+---
+
+<Update label="Bifrost Helm" description="v2.0.12">
+
+## Changelog
+
+- Fixed health probe paths to use `/health` instead of `/metrics`
+
+</Update>

--- a/docs/changelogs/helm-v2.0.13.mdx
+++ b/docs/changelogs/helm-v2.0.13.mdx
@@ -1,0 +1,20 @@
+---
+title: "v2.0.13"
+description: "Helm v2.0.13 changelog - 2026-03-11"
+---
+
+<Update label="Bifrost Helm" description="v2.0.13">
+
+## Changelog
+
+- Added missing client config properties: `asyncJobResultTTL`, `requiredHeaders`, `loggingHeaders`, `allowedHeaders`, `mcpAgentDepth`, `mcpToolExecutionTimeout`, `mcpCodeModeBindingLevel`, `mcpToolSyncInterval`, `hideDeletedVirtualKeysInFilters`
+- Added MCP new fields: top-level `toolSyncInterval`, per-client `clientId`, `isCodeModeClient`, `toolSyncInterval`, `isPingAvailable`, `toolPricing`, and `codeModeBindingLevel` in tool manager config
+- Added governance `modelConfigs` and `providers` top-level properties
+- Added cluster `region` property
+- Added guardrail provider `timeout` field (was missing from schema and template rendering)
+- Fixed `isPingAvailable` rendering bug in `_helpers.tpl` (was using wrong key name)
+- Added `is_ping_available` and `tool_pricing` to `config.schema.json` MCP client config
+- Added new CI script `validate-go-config-fields.sh` for Go struct-to-schema drift detection
+- Expanded all 3 existing CI validation scripts with Gap 1-8 property coverage
+
+</Update>

--- a/docs/changelogs/helm-v2.0.14.mdx
+++ b/docs/changelogs/helm-v2.0.14.mdx
@@ -1,0 +1,15 @@
+---
+title: "v2.0.14"
+description: "Helm v2.0.14 changelog - 2026-03-20"
+---
+
+<Update label="Bifrost Helm" description="v2.0.14">
+
+## Changelog
+
+- Added `placement` and `order` fields to custom plugin schema and template rendering
+- Added plugin property completeness check to `validate-helm-schema.sh`
+- Added custom plugin placement/order rendering tests to `validate-helm-templates.sh`
+- Added `PluginConfig` struct validation to `validate-go-config-fields.sh`
+
+</Update>

--- a/docs/changelogs/helm-v2.0.15.mdx
+++ b/docs/changelogs/helm-v2.0.15.mdx
@@ -1,0 +1,22 @@
+---
+title: "v2.0.15"
+description: "Helm v2.0.15 changelog - 2026-04-07"
+---
+
+<Update label="Bifrost Helm" description="v2.0.15">
+
+## Changelog
+
+- Synced helm schema with transport `config.schema.json` — added missing properties:
+  - `client.mcpDisableAutoToolInject` — disable automatic MCP tool injection
+  - `governance.budgets[].calendar_aligned` — snap budget resets to calendar boundaries
+  - `governance.pricingOverrides` — scoped pricing overrides for the model catalog
+  - `mcp.clientConfigs[].allowedExtraHeaders` — header allowlist per MCP client
+  - `mcp.clientConfigs[].allowOnAllVirtualKeys` — make MCP server accessible to all virtual keys
+  - `mcp.toolManagerConfig.disableAutoToolInject` — disable auto tool injection at manager level
+  - `networkConfig.beta_header_overrides` — override Anthropic beta header support per provider
+  - `websocket` — full WebSocket gateway tuning (connections, pool, transcript buffer)
+- Fixed SSE `connectionString` not being rendered in `_helpers.tpl` for MCP clients
+- Added template rendering for all new properties in `_helpers.tpl`
+
+</Update>

--- a/docs/changelogs/helm-v2.0.16.mdx
+++ b/docs/changelogs/helm-v2.0.16.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.0.16"
+description: "Helm v2.0.16 changelog - 2026-04-08"
+---
+
+<Update label="Bifrost Helm" description="v2.0.16">
+
+## Changelog
+
+- Fixed disabled custom plugins being completely removed from rendered config.json instead of being kept with `enabled: false`
+
+</Update>

--- a/docs/changelogs/helm-v2.0.17.mdx
+++ b/docs/changelogs/helm-v2.0.17.mdx
@@ -1,0 +1,16 @@
+---
+title: "v2.0.17"
+description: "Helm v2.0.17 changelog - 2026-04-08"
+---
+
+<Update label="Bifrost Helm" description="v2.0.17">
+
+## Changelog
+
+- Added object storage support (S3/GCS) for offloading log payloads from the database
+- Added `storage.logsStore.objectStorage` configuration with S3 and GCS backend support
+- Added object storage credential injection from Kubernetes secrets (`existingSecret`)
+- Added `object_storage` schema to `config.schema.json` under `logs_store`
+- Updated deployment and stateful templates with object storage secret env vars
+
+</Update>

--- a/docs/changelogs/helm-v2.0.2.mdx
+++ b/docs/changelogs/helm-v2.0.2.mdx
@@ -1,0 +1,14 @@
+---
+title: "v2.0.2"
+description: "Helm v2.0.2 changelog - 2026-01-31"
+---
+
+<Update label="Bifrost Helm" description="v2.0.2">
+
+## Changelog
+
+- Added Qdrant vector store support with deployment, service, and PVC templates
+- Added headless service template for StatefulSet DNS resolution
+- Fixed gitignore pattern that was excluding template files from version control
+
+</Update>

--- a/docs/changelogs/helm-v2.0.5.mdx
+++ b/docs/changelogs/helm-v2.0.5.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.0.5"
+description: "Helm v2.0.5 changelog - 2026-02-13"
+---
+
+<Update label="Bifrost Helm" description="v2.0.5">
+
+## Changelog
+
+- Fixes config field validation parity
+
+</Update>

--- a/docs/changelogs/helm-v2.0.6.mdx
+++ b/docs/changelogs/helm-v2.0.6.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.0.6"
+description: "Helm v2.0.6 changelog - 2026-02-17"
+---
+
+<Update label="Bifrost Helm" description="v2.0.6">
+
+## Changelog
+
+- Fixes MCP client config template to convert camelCase Helm values to snake_case config format
+
+</Update>

--- a/docs/changelogs/helm-v2.0.7.mdx
+++ b/docs/changelogs/helm-v2.0.7.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.0.7"
+description: "Helm v2.0.7 changelog - 2026-02-17"
+---
+
+<Update label="Bifrost Helm" description="v2.0.7">
+
+## Changelog
+
+- Previous release
+
+</Update>

--- a/docs/changelogs/helm-v2.0.8.mdx
+++ b/docs/changelogs/helm-v2.0.8.mdx
@@ -1,0 +1,19 @@
+---
+title: "v2.0.8"
+description: "Helm v2.0.8 changelog - 2026-02-19"
+---
+
+<Update label="Bifrost Helm" description="v2.0.8">
+
+## Changelog
+
+- Added comprehensive config field coverage for all `config.schema.json` fields
+- Added Pinecone vector store support (external only) with secret injection
+- Added governance routing rules template support
+- Added OTEL metrics fields (metrics_enabled, metrics_endpoint, metrics_push_interval)
+- Added advanced Redis connection pool fields (pool_size, timeouts, idle conns, etc.)
+- Added Weaviate timeout and className fields
+- Expanded values.yaml with commented examples for all provider types (Azure, Vertex, Bedrock), network config, concurrency, proxy config, and governance entities
+- Added helm config field validation CI test (246 assertions covering all config.schema.json fields)
+
+</Update>

--- a/docs/changelogs/helm-v2.0.9.mdx
+++ b/docs/changelogs/helm-v2.0.9.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.0.9"
+description: "Helm v2.0.9 changelog - 2026-02-26"
+---
+
+<Update label="Bifrost Helm" description="v2.0.9">
+
+## Changelog
+
+- Bumped appVersion to 1.4.8
+
+</Update>

--- a/docs/changelogs/helm-v2.1.0-prerelease2.mdx
+++ b/docs/changelogs/helm-v2.1.0-prerelease2.mdx
@@ -1,0 +1,17 @@
+---
+title: "v2.1.0-prerelease2"
+description: "Helm v2.1.0-prerelease2 changelog - 2026-04-15"
+---
+
+<Update label="Bifrost Helm" description="v2.1.0-prerelease2 (prerelease)">
+
+## Changelog
+
+- Synced helm `values.schema.json` with transport `config.schema.json` — fixed virtual key and budget drift:
+  - Removed `required: [mcp_client_id]` constraint on `virtualKeys[].mcp_configs[]` items — canonical schema accepts either `mcp_client_id` (DB form) or `mcp_client_name` (config-file form, resolved to ID at startup)
+  - Added `mcp_client_name` as an allowed property on `virtualKeys[].mcp_configs[]` items
+  - Added `calendar_aligned` (boolean) on `virtualKeys[]` — field now lives on the virtual key, applies uniformly to all budgets under it
+  - Removed stale `budget_id` from `virtualKeys[]` — `TableVirtualKey` has no `BudgetID`; budgets link via foreign key from the budget table
+  - Removed stale `calendar_aligned` from `budgets[]` — moved to virtual key level
+
+</Update>

--- a/docs/changelogs/helm-v2.1.1.mdx
+++ b/docs/changelogs/helm-v2.1.1.mdx
@@ -1,0 +1,13 @@
+---
+title: "v2.1.1"
+description: "Helm v2.1.1 changelog - 2026-04-15"
+---
+
+<Update label="Bifrost Helm" description="v2.1.1">
+
+## Changelog
+
+- Made `bifrost.governance.virtualKeys[].value` optional — template no longer fails when the field is omitted, allowing the backend to auto-generate the virtual key value
+- When `value` is absent, the rendered `config.json` omits the field entirely (consistent with other optional VK fields)
+
+</Update>

--- a/docs/changelogs/helm-v2.1.10.mdx
+++ b/docs/changelogs/helm-v2.1.10.mdx
@@ -1,0 +1,16 @@
+---
+title: "v2.1.10"
+description: "Helm v2.1.10 changelog - 2026-04-29"
+---
+
+<Update label="Bifrost Helm" description="v2.1.10">
+
+## Changelog
+
+- Added `bifrost.cluster.grpc` block for the cluster gRPC counter-sync transport (enterprise):
+  - New values: `bifrost.cluster.grpc.port` (default `10102`) and `bifrost.cluster.grpc.dialTimeoutSeconds` (default `5`).
+  - Rendered into `cluster_config.grpc` (`port`, `dial_timeout_seconds`) by `templates/_helpers.tpl`.
+  - StatefulSet exposes the port as a named `grpc` container port; `service-headless` exposes it as a named service port so peers can dial each other.
+  - Both port additions are guarded by `if .Values.bifrost.cluster.grpc` so values overrides that omit the block render cleanly.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.11.mdx
+++ b/docs/changelogs/helm-v2.1.11.mdx
@@ -1,0 +1,25 @@
+---
+title: "v2.1.11"
+description: "Helm v2.1.11 changelog - 2026-04-29"
+---
+
+<Update label="Bifrost Helm" description="v2.1.11">
+
+## Changelog
+
+- Added `description` and `default` fields to numerous properties that previously had neither, including `initialPoolSize`, `disableDbPingsInHealth`, `logRetentionDays`, `asyncJobResultTTL`, `mcpAgentDepth`, `mcpToolExecutionTimeout`, `hideDeletedVirtualKeysInFilters`, `mcpDisableAutoToolInject`, and MCP `toolManagerConfig` fields
+- Added `additionalProperties: false` to multiple objects (`bifrost.config`, `bifrost.pricing`, `proxyConfig`, `concurrencyConfig`, `providerConfig`, `credentialsSecret`, and auth provider configs) to reject unknown keys at validation time
+- Added three new `bifrost.client` fields:
+  - `allowPerRequestContentStorageOverride` — controls whether per-request headers can override content logging behavior
+  - `allowPerRequestRawOverride` — controls whether per-request headers can override raw provider request/response passthrough
+  - `mcpExternalBaseUrl` — public base URL for OAuth callbacks and discovery metadata behind a reverse proxy, supporting both string and env-var object forms
+- Added two new `bifrost.cluster.discovery` fields:
+  - `bindPort` — port to bind for cluster communication
+  - `dialTimeout` — timeout for discovery dial operations as a Go duration string
+- Changed `allowedOrigins` items from `oneOf` to `anyOf` and removed the redundant `not: { const: "*" }` constraint on the URI branch
+- Tightened the env-var pattern to require a valid identifier start character (`[A-Za-z_]`) for proxyConfig.url
+- Expanded `toolSyncInterval` to accept either a Go duration string (with a stricter regex) or a legacy integer (nanoseconds) for backward compatibility.
+- Marked `enforceGovernanceHeader` as deprecated in its description
+- Added `mdnsService` description for local network discovery
+
+</Update>

--- a/docs/changelogs/helm-v2.1.12.mdx
+++ b/docs/changelogs/helm-v2.1.12.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.1.12"
+description: "Helm v2.1.12 changelog - 2026-04-30"
+---
+
+<Update label="Bifrost Helm" description="v2.1.12">
+
+## Changelog
+
+- Added Helm support for `storage.logsStore.objectStorageExcludeFields` and render path to `logs_store.object_storage_exclude_fields` in generated config.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.13.mdx
+++ b/docs/changelogs/helm-v2.1.13.mdx
@@ -1,0 +1,13 @@
+---
+title: "v2.1.13"
+description: "Helm v2.1.13 changelog - 2026-05-02"
+---
+
+<Update label="Bifrost Helm" description="v2.1.13">
+
+## Changelog
+
+- Surfaced `bifrost.client.enforceAuthOnInference` in `values.yaml` as a commented default with usage notes. The field was already wired in `_helpers.tpl` to render to `client.enforce_auth_on_inference` and declared in `values.schema.json`; this change makes the knob discoverable without altering default rendered config.
+- Marked `bifrost.client.enforceGovernanceHeader` as deprecated in `values.yaml` (use `enforceAuthOnInference` instead). Schema description was already deprecated in 2.1.11.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.14.mdx
+++ b/docs/changelogs/helm-v2.1.14.mdx
@@ -1,0 +1,13 @@
+---
+title: "v2.1.14"
+description: "Helm v2.1.14 changelog - 2026-05-07"
+---
+
+<Update label="Bifrost Helm" description="v2.1.14">
+
+## Changelog
+
+- Removed the obsolete `bifrost.client.allowDirectKeys` assertion from `validate-helm-config-fields.sh`. The field was deleted from the chart schema and codebase in a prior release, so the test was rendering an invalid values file and helm was rejecting it via `additionalProperties: false`.
+- Hardened `render_config()` in `validate-helm-config-fields.sh` so a failing `helm template` actually surfaces its stderr instead of being swallowed by the script's `set -e` (the previous post-hoc `$?` check was unreachable).
+
+</Update>

--- a/docs/changelogs/helm-v2.1.15.mdx
+++ b/docs/changelogs/helm-v2.1.15.mdx
@@ -1,0 +1,14 @@
+---
+title: "v2.1.15"
+description: "Helm v2.1.15 changelog - 2026-05-11"
+---
+
+<Update label="Bifrost Helm" description="v2.1.15">
+
+## Changelog
+
+- Added `storage.logsStore.matviewRefreshInterval` to `values.yaml` and `values.schema.json`, letting operators control how often PostgreSQL materialized views are refreshed in the logs store (e.g. `"30s"`, `"5m"`, `"1h"`; minimum `5s`).
+- Wired `matviewRefreshInterval` through `_helpers.tpl` so it renders into the generated PostgreSQL `logs_store.matview_refresh_interval` field when set, and is omitted when not.
+- Bumped `appVersion` from `1.5.0-prerelease7` to `1.5.0` (first chart release pinned to the stable `1.5.0` app image).
+
+</Update>

--- a/docs/changelogs/helm-v2.1.16.mdx
+++ b/docs/changelogs/helm-v2.1.16.mdx
@@ -1,0 +1,14 @@
+---
+title: "v2.1.16"
+description: "Helm v2.1.16 changelog - 2026-05-12"
+---
+
+<Update label="Bifrost Helm" description="v2.1.16">
+
+## Changelog
+
+- Widened `bifrost.mcp.toolManagerConfig.toolExecutionTimeout` in `values.schema.json` from `integer` to `["integer", "string"]` so a Go duration string like `"30s"` or `"2m"` is accepted alongside the legacy bare integer. Updated the description to clarify "integer = seconds, string = Go duration" and recommend the string form, and changed the default from `30` to `"30s"`.
+- Updated the `values.yaml` example to use `toolExecutionTimeout: "30s"` instead of `toolExecutionTimeout: 30`, matching the new recommended form.
+- Paired with the upstream runtime fix (PR #3432) that reinterprets bare integers on this field as seconds rather than nanoseconds, and includes `mcp.tool_manager_config` in the client config hash so file-level changes survive the hash-based reconciliation pipeline on restart.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.17.mdx
+++ b/docs/changelogs/helm-v2.1.17.mdx
@@ -1,0 +1,18 @@
+---
+title: "v2.1.17"
+description: "Helm v2.1.17 changelog - 2026-05-17"
+---
+
+<Update label="Bifrost Helm" description="v2.1.17">
+
+## Changelog
+
+- Added `max_turns_to_send` to guardrail rules. The integer caps how many historical conversation turns are sent to the guardrail provider on apply; the latest message is always included on top, and `0` (default) sends all turns. Wired into `values.schema.json`, `config.schema.json`, and `templates/_helpers.tpl` so it renders into `guardrails_config.guardrail_rules[].max_turns_to_send`.
+- Extended SCIM/SSO support so attribute mappings work for every supported provider, not just Keycloak:
+  - Added `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` to `bifrost.scim.config` for the Okta and Entra (Azure AD) provider branches. Previously these fields were rejected by `additionalProperties: false` even though the enterprise runtime renders them into `config.json`.
+  - Tightened the existing Keycloak mapping items from the placeholder `{type: object}` to a strict shape (`attribute`, `value`, plus `role`/`team`/`business_unit`, `additionalProperties: false`) so typos surface at `helm template` time. The same strict item shape is applied to Okta, Entra, Zitadel, and Google.
+  - Added two more SCIM providers to the schema enum and provided full config blocks for them: `zitadel` (`domain`, `clientId`, optional `clientSecret`/`projectId`/`audience`, plus service-account fields for Management API access) and `google` (Google Workspace OIDC with `domain`, `clientId`, `credentialMode`, service-account sources, and `adminEmail` for domain-wide delegation).
+  - Added matching `helm template`-time validation in `_helpers.tpl` for Zitadel (requires `domain`, `clientId`) and Google Workspace (requires `domain`, `clientId`).
+  - Documented every new field as commented examples under `bifrost.scim.config` in `values.yaml`.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.18.mdx
+++ b/docs/changelogs/helm-v2.1.18.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.1.18"
+description: "Helm v2.1.18 changelog - 2026-05-22"
+---
+
+<Update label="Bifrost Helm" description="v2.1.18">
+
+## Changelog
+
+- Added `bifrost.framework.pricing.modelParametersUrl` to `values.yaml`, `values.schema.json`, and `_helpers.tpl`, allowing operators to override the URL Bifrost uses to fetch model parameter definitions.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.19.mdx
+++ b/docs/changelogs/helm-v2.1.19.mdx
@@ -1,0 +1,20 @@
+---
+title: "v2.1.19"
+description: "Helm v2.1.19 changelog - 2026-05-26"
+---
+
+<Update label="Bifrost Helm" description="v2.1.19">
+
+## Changelog
+
+- Added `bifrost.modelCatalog.modelParametersUrl` to `values.yaml`, `values.schema.json`, and `_helpers.tpl`, allowing operators to override the URL Bifrost uses to fetch model parameter definitions.
+- Added `existingSecret` support for hosted PostgreSQL (`postgresql.enabled: true`). Set `postgresql.auth.existingSecret` and `postgresql.auth.passwordKey` to reference a Kubernetes secret (e.g. from Vault Secrets Operator) instead of a plaintext password in values. Both the postgres pod and the bifrost pod will read the password from the secret; the chart-managed secret is not created when `existingSecret` is set.
+- Added `postgresql.primary.podSecurityContext` and `postgresql.primary.containerSecurityContext` to allow configuring pod- and container-level security contexts on the hosted PostgreSQL deployment. Defaults to `podSecurityContext: { fsGroup: 999 }` (preserving prior behaviour) and `containerSecurityContext: {}` (no container security context). Required for clusters enforcing strict Kyverno/OPA policies (e.g. `runAsNonRoot`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile`).
+- Added `bifrost.featureFlags` map to `values.yaml` and `_helpers.tpl`. Renders into `feature_flags.flags` in the generated config JSON. Each entry accepts a literal boolean or `"env.NAME"` string.
+- Fixed Deployment not exposing the cluster gRPC container port; fixed `service.yaml` missing the gRPC service port. Both now match StatefulSet/headless service behaviour.
+- Fixed Weaviate PVC rendering when `vectorStore.weaviate.persistence.enabled=false`; PVC is now gated on persistence being enabled.
+- Fixed Redis probes passing password via `-a` flag in process args; switched to `REDISCLI_AUTH` env var.
+- Fixed nondeterministic env var order for `providerSecrets` and `weaviate.env` map iterations; keys are now sorted with `sortAlpha`.
+- Corrected guardrail `timeout` examples in `values.yaml`: provider default is `30s`, rule default is `60s`.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.2.mdx
+++ b/docs/changelogs/helm-v2.1.2.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.1.2"
+description: "Helm v2.1.2 changelog - 2026-04-21"
+---
+
+<Update label="Bifrost Helm" description="v2.1.2">
+
+## Changelog
+
+- Removed `encryption_key` requirement — field is now optional; Bifrost will operate without encryption when omitted
+
+</Update>

--- a/docs/changelogs/helm-v2.1.3.mdx
+++ b/docs/changelogs/helm-v2.1.3.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.1.3"
+description: "Helm v2.1.3 changelog - 2026-04-22"
+---
+
+<Update label="Bifrost Helm" description="v2.1.3">
+
+## Changelog
+
+- For `bifrost.cluster.discovery.type` set to `consul`, `etcd`, or `udp`, set `bifrost.cluster.discovery.serviceName` explicitly during upgrade.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.4.mdx
+++ b/docs/changelogs/helm-v2.1.4.mdx
@@ -1,0 +1,17 @@
+---
+title: "v2.1.4"
+description: "Helm v2.1.4 changelog - 2026-04-24"
+---
+
+<Update label="Bifrost Helm" description="v2.1.4">
+
+## Changelog
+
+- Added stricter cluster discovery validation in Helm templates:
+  - Require `bifrost.cluster.discovery.serviceName` when `bifrost.cluster.discovery.type` is `consul`, `etcd`, or `udp`.
+  - For `udp` discovery, require both:
+    - `bifrost.cluster.discovery.udpBroadcastPort`
+    - `bifrost.cluster.discovery.allowedAddressSpace`
+- Added/updated template fail-fast errors so invalid discovery config is rejected at render time instead of failing later at runtime.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.6.mdx
+++ b/docs/changelogs/helm-v2.1.6.mdx
@@ -1,0 +1,42 @@
+---
+title: "v2.1.6"
+description: "Helm v2.1.6 changelog - 2026-04-24"
+---
+
+<Update label="Bifrost Helm" description="v2.1.6">
+
+## Changelog
+
+- Includes unreleased `2.1.5` changes
+- Built-in plugin versioning for DB-backed deployments:
+  - Added `version` field support for built-in plugins.
+  - Added default `version: 1` for built-in plugins in `values.yaml` (`telemetry`, `logging`, `governance`, `maxim`, `semanticCache`, `otel`, `datadog`).
+  - Updated `_helpers.tpl` to include plugin `version` in rendered config when set (cast as integer).
+- Updated StatefulSet PVC template labels to be immutable-safe:
+  - `spec.volumeClaimTemplates.metadata.labels` now uses stable selector labels (without chart/app version labels).
+- Governance schema and validation updates:
+  - Added `governance.budgets[].virtual_key_id` support.
+  - Removed stale `budget_id` references from virtual keys and provider configs in templates/tests.
+  - `validate-helm-config-fields.sh` assertions were updated accordingly.
+- Query/schema compatibility updates:
+  - Tightened `query` validation in `values.schema.json` and `config.schema.json` to valid RuleGroupType shape (`null` or `{ combinator, rules }`).
+- Config/input alias support updates:
+  - Added support for `env.*` references in proxy/TLS fields (`ca_cert_pem`, `url`, `username`, `password`).
+  - Added `provider_key_name` alias for routing targets and pricing overrides (resolved to `key_id` at config load time).
+- MCP config improvements:
+  - Added Go duration string support for `mcp.toolSyncInterval` (legacy numeric nanoseconds still supported).
+  - Added hash-based MCP client config reconciliation for DB-backed config store updates.
+- Upgrade impact:
+  - Existing SQLite StatefulSets created from older chart templates may require a one-time StatefulSet recreation during upgrade because `spec.volumeClaimTemplates` is immutable in Kubernetes.
+- Migration notes (only if upgrade fails with StatefulSet immutable-field error):
+  1. Identify StatefulSet name and namespace for your Helm release.
+  2. Delete only the StatefulSet while preserving dependents:
+     - `kubectl delete statefulset <statefulset-name> -n <namespace> --cascade=orphan`
+  3. Run Helm upgrade:
+     - `helm upgrade <release-name> bifrost/bifrost -n <namespace> -f <values-file> --set image.tag=<tag>`
+  4. If needed, re-apply/recreate the StatefulSet from the upgraded chart manifests.
+  5. Verify PVCs are preserved and pods become healthy:
+     - `kubectl get pvc -n <namespace>`
+     - `kubectl get pods -n <namespace>`
+
+</Update>

--- a/docs/changelogs/helm-v2.1.7.mdx
+++ b/docs/changelogs/helm-v2.1.7.mdx
@@ -1,0 +1,20 @@
+---
+title: "v2.1.7"
+description: "Helm v2.1.7 changelog - 2026-04-24"
+---
+
+<Update label="Bifrost Helm" description="v2.1.7">
+
+## Changelog
+
+- Added semantic cache Helm layers and examples:
+  - Added Redis deployment template for semantic cache.
+  - Extended Helm values/schema coverage for semantic cache and client-config examples.
+- Added enterprise/governance Helm support:
+  - Added governance `business_units` support in Helm schema/template rendering.
+  - Added deferred virtual-key/provider-config budget ordering handling in Helm rendering.
+- Added MCP tool-groups support in Helm:
+  - Added `mcp.tool_groups` config support with governance bindings.
+  - Added camelCase alias compatibility for related Helm config fields.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.8.mdx
+++ b/docs/changelogs/helm-v2.1.8.mdx
@@ -1,0 +1,14 @@
+---
+title: "v2.1.8"
+description: "Helm v2.1.8 changelog - 2026-04-26"
+---
+
+<Update label="Bifrost Helm" description="v2.1.8">
+
+## Changelog
+
+- Added provider key backward compatibility in Helm rendering:
+  - If `bifrost.providers.<provider>.keys[].id` is omitted and `name` is present, Helm now auto-populates `id = name`.
+  - This preserves legacy values files that only defined key names while still supporting `governance.virtualKeys[].provider_configs[].key_ids`.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.9.mdx
+++ b/docs/changelogs/helm-v2.1.9.mdx
@@ -1,0 +1,15 @@
+---
+title: "v2.1.9"
+description: "Helm v2.1.9 changelog - 2026-04-28"
+---
+
+<Update label="Bifrost Helm" description="v2.1.9">
+
+## Changelog
+
+- Added Kubernetes pod-discovery RBAC templates for cluster discovery:
+  - Added `templates/rbac.yaml` to render a namespaced `Role`/`RoleBinding` for pod `get/list/watch`.
+  - Added `rbac.podDiscovery.enabled` to `values.yaml` and `values.schema.json` for controlled enablement (defaults to `true`).
+  - RBAC resources render only when `rbac.podDiscovery.enabled`, `bifrost.cluster.enabled`, and `bifrost.cluster.discovery.enabled` are true, with discovery `type: kubernetes`.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -763,6 +763,68 @@
                 ]
               }
             ]
+          },
+          {
+            "item": "Helm",
+            "icon": "box",
+            "pages": [
+              "changelogs/helm-v2.1.19",
+              "changelogs/helm-v2.1.18",
+              "changelogs/helm-v2.1.17",
+              "changelogs/helm-v2.1.16",
+              "changelogs/helm-v2.1.15",
+              "changelogs/helm-v2.1.14",
+              "changelogs/helm-v2.1.13",
+              {
+                "group": "April 2026",
+                "pages": [
+                  "changelogs/helm-v2.1.12",
+                  "changelogs/helm-v2.1.11",
+                  "changelogs/helm-v2.1.10",
+                  "changelogs/helm-v2.1.9",
+                  "changelogs/helm-v2.1.8",
+                  "changelogs/helm-v2.1.7",
+                  "changelogs/helm-v2.1.6",
+                  "changelogs/helm-v2.1.4",
+                  "changelogs/helm-v2.1.3",
+                  "changelogs/helm-v2.1.2",
+                  "changelogs/helm-v2.1.1",
+                  "changelogs/helm-v2.1.0-prerelease2",
+                  "changelogs/helm-v2.0.17",
+                  "changelogs/helm-v2.0.16",
+                  "changelogs/helm-v2.0.15"
+                ]
+              },
+              {
+                "group": "March 2026",
+                "pages": [
+                  "changelogs/helm-v2.0.14",
+                  "changelogs/helm-v2.0.13",
+                  "changelogs/helm-v2.0.12",
+                  "changelogs/helm-v2.0.11",
+                  "changelogs/helm-v2.0.10"
+                ]
+              },
+              {
+                "group": "February 2026",
+                "pages": [
+                  "changelogs/helm-v2.0.9",
+                  "changelogs/helm-v2.0.8",
+                  "changelogs/helm-v2.0.7",
+                  "changelogs/helm-v2.0.6",
+                  "changelogs/helm-v2.0.5"
+                ]
+              },
+              {
+                "group": "January 2026",
+                "pages": [
+                  "changelogs/helm-v2.0.2",
+                  "changelogs/helm-v2.0.1",
+                  "changelogs/helm-v2.0.0",
+                  "changelogs/helm-v1.7.0"
+                ]
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
## Summary

Adds Bifrost Helm chart changelogs to the documentation site, covering all releases from v1.7.0 through v2.1.19. This brings the changelog history into the docs navigation so users can track what changed across each Helm chart release.

## Changes

- Added individual changelog pages for every Helm chart release from v1.7.0 through v2.1.19, including the v2.0.0 breaking change (StatefulSet migration for SQLite with persistence), all v2.0.x patch releases, and all v2.1.x releases up to v2.1.19.
- Registered all new changelog pages in `docs.json` under a new "Helm" navigation group, organized by month (January–May 2026), with the most recent releases surfaced at the top level outside the monthly groups.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the Changelogs section of the docs site and verify the new "Helm" group appears with all releases listed, grouped correctly by month, and that each page renders its changelog content without errors.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable