### PR TITLE
feat: add `additional_attributes` to model pricing rows with management API and UI editor

### DIFF
--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -153,6 +153,11 @@ type Model struct {
 	HuggingFaceID       *string            `json:"hugging_face_id,omitempty"`
 	Description         *string            `json:"description,omitempty"`
 
+	// AdditionalAttributes carries editorial per-model metadata stored on the
+	// governance_model_pricing row (e.g. description, tags). Preserved across
+	// the 24-hour pricing sync.
+	AdditionalAttributes map[string]string `json:"additional_attributes,omitempty"`
+
 	OwnedBy          *string  `json:"owned_by,omitempty"`
 	SupportedMethods []string `json:"supported_methods,omitempty"`
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -816,6 +816,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddMCPClientTLSConfigColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddAdditionalAttributesToPricing(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -8923,6 +8926,39 @@ func migrationAddMCPClientTLSConfigColumn(ctx context.Context, db *gorm.DB) erro
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_mcp_client_tls_config_json_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddAdditionalAttributesToPricing adds the additional_attributes
+// column to governance_model_pricing. The column stores editorial per-model
+// metadata (e.g. description) as a JSON blob. It is intentionally excluded
+// from UpsertModelPrices' update list so the 24-hour pricing sync never
+// overwrites it.
+func migrationAddAdditionalAttributesToPricing(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_additional_attributes_to_pricing",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if !tx.Migrator().HasColumn(&tables.TableModelPricing{}, "additional_attributes") {
+				if err := tx.Migrator().AddColumn(&tables.TableModelPricing{}, "AdditionalAttributesJSON"); err != nil {
+					return fmt.Errorf("failed to add additional_attributes column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if tx.Migrator().HasColumn(&tables.TableModelPricing{}, "additional_attributes") {
+				if err := tx.Migrator().DropColumn(&tables.TableModelPricing{}, "AdditionalAttributesJSON"); err != nil {
+					return fmt.Errorf("failed to drop additional_attributes column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_additional_attributes_to_pricing migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -700,7 +700,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 			// Handle Azure config
 			if key.AzureKeyConfig != nil {
 				dbKey.AzureEndpoint = &key.AzureKeyConfig.Endpoint
-				}
+			}
 
 			// Handle Vertex config
 			if key.VertexKeyConfig != nil {
@@ -2053,9 +2053,103 @@ func (s *RDBConfigStore) GetModelPrices(ctx context.Context) ([]tables.TableMode
 	return modelPrices, nil
 }
 
+// pricingSyncUpdateColumns is the explicit set of governance_model_pricing
+// columns the pricing sync is allowed to overwrite via ON CONFLICT. Mirrors
+// every column on TableModelPricing except `id` (the primary key) and
+// `additional_attributes` (editorial metadata that must survive sync).
+// Keep this list in lockstep with the table definition in
+// framework/configstore/tables/modelpricing.go.
+var pricingSyncUpdateColumns = []string{
+	"model",
+	"base_model",
+	"provider",
+	"mode",
+	"context_length",
+	"max_input_tokens",
+	"max_output_tokens",
+	"architecture",
+	// Costs - Text
+	"input_cost_per_token",
+	"output_cost_per_token",
+	"input_cost_per_token_batches",
+	"output_cost_per_token_batches",
+	"input_cost_per_token_priority",
+	"output_cost_per_token_priority",
+	"input_cost_per_token_flex",
+	"output_cost_per_token_flex",
+	"input_cost_per_character",
+	// Costs - 128k Tier
+	"input_cost_per_token_above_128k_tokens",
+	"input_cost_per_image_above_128k_tokens",
+	"input_cost_per_video_per_second_above_128k_tokens",
+	"input_cost_per_audio_per_second_above_128k_tokens",
+	"output_cost_per_token_above_128k_tokens",
+	// Costs - 200k Tier
+	"input_cost_per_token_above_200k_tokens",
+	"input_cost_per_token_above_200k_tokens_priority",
+	"output_cost_per_token_above_200k_tokens",
+	"output_cost_per_token_above_200k_tokens_priority",
+	// Costs - 272k Tier
+	"input_cost_per_token_above_272k_tokens",
+	"input_cost_per_token_above_272k_tokens_priority",
+	"output_cost_per_token_above_272k_tokens",
+	"output_cost_per_token_above_272k_tokens_priority",
+	// Costs - Cache
+	"cache_creation_input_token_cost",
+	"cache_read_input_token_cost",
+	"cache_creation_input_token_cost_above_200k_tokens",
+	"cache_read_input_token_cost_above_200k_tokens",
+	"cache_read_input_token_cost_above_200k_tokens_priority",
+	"cache_creation_input_token_cost_above_1hr",
+	"cache_creation_input_token_cost_above_1hr_above_200k_tokens",
+	"cache_creation_input_audio_token_cost",
+	"cache_read_input_token_cost_priority",
+	"cache_read_input_token_cost_flex",
+	"cache_read_input_image_token_cost",
+	"cache_read_input_token_cost_above_272k_tokens",
+	"cache_read_input_token_cost_above_272k_tokens_priority",
+	// Costs - Image
+	"input_cost_per_image",
+	"input_cost_per_pixel",
+	"output_cost_per_image",
+	"output_cost_per_pixel",
+	"output_cost_per_image_premium_image",
+	"output_cost_per_image_above_512_and_512_pixels",
+	"output_cost_per_image_above_512x512_pixels_premium",
+	"output_cost_per_image_above_1024_and_1024_pixels",
+	"output_cost_per_image_above_1024x1024_pixels_premium",
+	"output_cost_per_image_above_2048_and_2048_pixels",
+	"output_cost_per_image_above_4096_and_4096_pixels",
+	"output_cost_per_image_low_quality",
+	"output_cost_per_image_medium_quality",
+	"output_cost_per_image_high_quality",
+	"output_cost_per_image_auto_quality",
+	"input_cost_per_image_token",
+	"output_cost_per_image_token",
+	// Costs - Audio/Video
+	"input_cost_per_audio_token",
+	"input_cost_per_audio_per_second",
+	"input_cost_per_second",
+	"input_cost_per_video_per_second",
+	"output_cost_per_audio_token",
+	"output_cost_per_video_per_second",
+	"output_cost_per_second",
+	// Costs - Other
+	"search_context_cost_per_query",
+	"code_interpreter_cost_per_session",
+	// Costs - OCR
+	"ocr_cost_per_page",
+	"annotation_cost_per_page",
+}
+
 // UpsertModelPrices creates or updates a model pricing record in the database.
 // Uses a single atomic ON CONFLICT statement to avoid deadlocks in multinode deployments
 // where multiple nodes may attempt concurrent upserts for the same model on startup.
+//
+// The update list is intentionally explicit (pricingSyncUpdateColumns) rather
+// than UpdateAll: every datasheet-sourced column is enumerated, but
+// `additional_attributes` is omitted so the 24-hour pricing sync never
+// overwrites editorial metadata set via UpsertModelPricingAttributes.
 func (s *RDBConfigStore) UpsertModelPrices(ctx context.Context, pricing *tables.TableModelPricing, tx ...*gorm.DB) error {
 	var txDB *gorm.DB
 	if len(tx) > 0 {
@@ -2067,11 +2161,44 @@ func (s *RDBConfigStore) UpsertModelPrices(ctx context.Context, pricing *tables.
 
 	if err := db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "model"}, {Name: "provider"}, {Name: "mode"}},
-		UpdateAll: true,
+		DoUpdates: clause.AssignmentColumns(pricingSyncUpdateColumns),
 	}).Create(pricing).Error; err != nil {
 		return s.parseGormError(err)
 	}
 	return nil
+}
+
+// UpsertModelPricingAttributes writes only the additional_attributes column
+// for the pricing row keyed by (model, provider). The row must already exist
+// — callers may not seed pricing rows through this path; the management API
+// enforces that. A nil/empty attrs map clears the column to an empty JSON object.
+func (s *RDBConfigStore) UpsertModelPricingAttributes(ctx context.Context, model, provider string, attrs map[string]string, tx ...*gorm.DB) (int64, error) {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+	db := txDB.WithContext(ctx)
+
+	var value string
+	if len(attrs) == 0 {
+		value = "{}"
+	} else {
+		encoded, err := json.Marshal(attrs)
+		if err != nil {
+			return 0, fmt.Errorf("marshal additional_attributes: %w", err)
+		}
+		value = string(encoded)
+	}
+
+	res := db.Model(&tables.TableModelPricing{}).
+		Where("model = ? AND provider = ?", model, provider).
+		Update("additional_attributes", value)
+	if res.Error != nil {
+		return 0, s.parseGormError(res.Error)
+	}
+	return res.RowsAffected, nil
 }
 
 // DeleteModelPrices deletes all model pricing records from the database.

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -300,6 +300,11 @@ type ConfigStore interface {
 	UpsertModelPrices(ctx context.Context, pricing *tables.TableModelPricing, tx ...*gorm.DB) error
 	DeleteModelPrices(ctx context.Context, tx ...*gorm.DB) error
 
+	// UpsertModelPricingAttributes writes only the additional_attributes column
+	// on the pricing rows keyed by (model, provider). Returns the number of
+	// rows updated; 0 means no such pricing row exists.
+	UpsertModelPricingAttributes(ctx context.Context, model, provider string, attrs map[string]string, tx ...*gorm.DB) (int64, error)
+
 	// Governance pricing overrides CRUD
 	GetPricingOverrides(ctx context.Context, filters PricingOverrideFilters) ([]tables.TablePricingOverride, error)
 	GetPricingOverridesPaginated(ctx context.Context, params PricingOverridesQueryParams) ([]tables.TablePricingOverride, int64, error)

--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -1,6 +1,11 @@
 package tables
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"encoding/json"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"gorm.io/gorm"
+)
 
 // TableModelPricing represents pricing information for AI models
 type TableModelPricing struct {
@@ -91,7 +96,48 @@ type TableModelPricing struct {
 	// Costs - OCR
 	OCRCostPerPage        *float64 `gorm:"default:null;column:ocr_cost_per_page" json:"ocr_cost_per_page,omitempty"`
 	AnnotationCostPerPage *float64 `gorm:"default:null;column:annotation_cost_per_page" json:"annotation_cost_per_page,omitempty"`
+
+	// AdditionalAttributes holds editorial per-model metadata (e.g. description,
+	// tags). Persisted as a JSON string in the additional_attributes column and
+	// surfaced as a typed map via BeforeSave/AfterFind. This column is
+	// intentionally excluded from the pricing-sync upsert path so the 24-hour
+	// datasheet sync never overwrites user-set values.
+	AdditionalAttributesJSON string            `gorm:"type:text;column:additional_attributes" json:"-"`
+	AdditionalAttributes     map[string]string `gorm:"-" json:"additional_attributes,omitempty"`
 }
 
 // TableName sets the table name for each model
 func (TableModelPricing) TableName() string { return "governance_model_pricing" }
+
+// BeforeSave marshals AdditionalAttributes → AdditionalAttributesJSON. A nil
+// or empty map serializes to "{}" so the column always holds a valid JSON
+// object; reads round-trip back to a nil map via AfterFind. Mirrors the
+// convention used by TableMCPClient.HeadersJSON.
+func (p *TableModelPricing) BeforeSave(tx *gorm.DB) error {
+	if len(p.AdditionalAttributes) == 0 {
+		p.AdditionalAttributesJSON = "{}"
+		return nil
+	}
+	data, err := json.Marshal(p.AdditionalAttributes)
+	if err != nil {
+		return err
+	}
+	p.AdditionalAttributesJSON = string(data)
+	return nil
+}
+
+// AfterFind unmarshals AdditionalAttributesJSON → AdditionalAttributes.
+// Empty/missing JSON resolves to a nil map so callers can use len() and
+// idiomatic nil checks.
+func (p *TableModelPricing) AfterFind(tx *gorm.DB) error {
+	if p.AdditionalAttributesJSON == "" || p.AdditionalAttributesJSON == "{}" {
+		p.AdditionalAttributes = nil
+		return nil
+	}
+	var attrs map[string]string
+	if err := json.Unmarshal([]byte(p.AdditionalAttributesJSON), &attrs); err != nil {
+		return err
+	}
+	p.AdditionalAttributes = attrs
+	return nil
+}

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -1,6 +1,8 @@
 package modelcatalog
 
 import (
+	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -18,6 +20,7 @@ const (
 
 // PricingEntry represents a single model's pricing information.
 // Field names and JSON tags match the datasheet schema exactly.
+// AdditionalAttributes carries editorial metadata stored on the pricing row, never populated from the URL datasheet — only from DB reads via the management API.
 type PricingEntry struct {
 	BaseModel string `json:"base_model,omitempty"`
 	Provider  string `json:"provider"`
@@ -27,6 +30,12 @@ type PricingEntry struct {
 	MaxInputTokens  *int                  `json:"max_input_tokens,omitempty"`
 	MaxOutputTokens *int                  `json:"max_output_tokens,omitempty"`
 	Architecture    *schemas.Architecture `json:"architecture,omitempty"`
+
+	// AdditionalAttributes carries editorial metadata stored on the pricing
+	// row (e.g. description). Populated from the DB read path only; the
+	// json:"-" tag prevents URL datasheet payloads from ever feeding into
+	// this field via json.Unmarshal.
+	AdditionalAttributes map[string]string `json:"-"`
 
 	PricingOptions
 }
@@ -1303,4 +1312,26 @@ func (mc *ModelCatalog) getBasePricing(model, provider string, requestType schem
 	}
 
 	return nil, false
+}
+
+// UpsertModelPricingAttributes writes the additional_attributes column for
+// every pricing row that matches (model, provider), then reloads the pricing
+// cache so the new values are immediately visible to list-models. Returns
+// the number of rows updated (0 = no such pricing row, which callers must
+// surface as a validation error). An empty/nil attrs map clears the column.
+func (mc *ModelCatalog) UpsertModelPricingAttributes(ctx context.Context, model string, provider schemas.ModelProvider, attrs map[string]string) (int64, error) {
+	if mc.configStore == nil {
+		return 0, fmt.Errorf("model catalog requires a config store")
+	}
+	rows, err := mc.configStore.UpsertModelPricingAttributes(ctx, model, string(provider), attrs)
+	if err != nil {
+		return 0, err
+	}
+	if rows == 0 {
+		return 0, nil
+	}
+	if err := mc.loadPricingFromDatabase(ctx); err != nil {
+		return rows, fmt.Errorf("failed to reload pricing cache after attribute write: %w", err)
+	}
+	return rows, nil
 }

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -170,6 +170,14 @@ func (mc *ModelCatalog) loadPricingIntoMemoryFromURL(ctx context.Context) error 
 	return nil
 }
 
+// ReloadPricing re-reads the pricing table into the in-memory cache. The
+// management API uses this after a batched write so the new attributes are
+// observable immediately. The existing 24-hour sync owns refreshing pricing
+// fields from the upstream datasheet; this method just refreshes the cache.
+func (mc *ModelCatalog) ReloadPricing(ctx context.Context) error {
+	return mc.loadPricingFromDatabase(ctx)
+}
+
 // loadPricingFromDatabase loads pricing data from database into memory cache
 func (mc *ModelCatalog) loadPricingFromDatabase(ctx context.Context) error {
 	if mc.configStore == nil {

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -319,14 +319,15 @@ func convertTableModelPricingToPricingData(pricing *configstoreTables.TableModel
 		AnnotationCostPerPage: pricing.AnnotationCostPerPage,
 	}
 	return &PricingEntry{
-		BaseModel:       pricing.BaseModel,
-		Provider:        pricing.Provider,
-		Mode:            pricing.Mode,
-		ContextLength:   pricing.ContextLength,
-		MaxInputTokens:  pricing.MaxInputTokens,
-		MaxOutputTokens: pricing.MaxOutputTokens,
-		Architecture:    pricing.Architecture,
-		PricingOptions:  options,
+		BaseModel:            pricing.BaseModel,
+		Provider:             pricing.Provider,
+		Mode:                 pricing.Mode,
+		ContextLength:        pricing.ContextLength,
+		MaxInputTokens:       pricing.MaxInputTokens,
+		MaxOutputTokens:      pricing.MaxOutputTokens,
+		Architecture:         pricing.Architecture,
+		AdditionalAttributes: pricing.AdditionalAttributes,
+		PricingOptions:       options,
 	}
 }
 

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -857,6 +857,9 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 				if pricingEntry.BaseModel != "" && resp.Data[i].NormalizedName == nil {
 					resp.Data[i].NormalizedName = bifrost.Ptr(providerUtils.NormalizeBaseModelSlug(pricingEntry.BaseModel))
 				}
+				if len(pricingEntry.AdditionalAttributes) > 0 && resp.Data[i].AdditionalAttributes == nil {
+					resp.Data[i].AdditionalAttributes = pricingEntry.AdditionalAttributes
+				}
 				if modelEntry.Pricing == nil {
 					pricing := &schemas.Pricing{}
 					if pricingEntry.InputCostPerToken != nil {

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -30,6 +30,15 @@ type ModelsManager interface {
 	RemoveProvider(ctx context.Context, provider schemas.ModelProvider) error
 	GetModelsForProvider(provider schemas.ModelProvider) []string
 	GetUnfilteredModelsForProvider(provider schemas.ModelProvider) []string
+	UpsertModelPricingAttributes(ctx context.Context, entries []ModelPricingAttributesEntry) error
+}
+
+// ModelPricingAttributesEntry is the wire shape for PUT /api/model-catalog.
+// (model, provider) is the natural key on governance_model_pricing.
+type ModelPricingAttributesEntry struct {
+	Model                string            `json:"model"`
+	Provider             string            `json:"provider"`
+	AdditionalAttributes map[string]string `json:"additional_attributes,omitempty"`
 }
 
 // ProviderHandler manages HTTP requests for provider operations
@@ -128,6 +137,7 @@ func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...schema
 	r.GET("/api/models/details", lib.ChainMiddlewares(h.listModelDetails, middlewares...))
 	r.GET("/api/models/parameters", lib.ChainMiddlewares(h.getModelParameters, middlewares...))
 	r.GET("/api/models/base", lib.ChainMiddlewares(h.listBaseModels, middlewares...))
+	r.PUT("/api/model-catalog", lib.ChainMiddlewares(h.upsertModelCatalogEntries, middlewares...))
 }
 
 // listProviders handles GET /api/providers - List all providers
@@ -595,13 +605,14 @@ type ListModelsResponse struct {
 
 // ModelDetailsResponse represents a model with capability metadata.
 type ModelDetailsResponse struct {
-	Name             string                `json:"name"`
-	Provider         string                `json:"provider"`
-	ContextLength    *int                  `json:"context_length,omitempty"`
-	MaxInputTokens   *int                  `json:"max_input_tokens,omitempty"`
-	MaxOutputTokens  *int                  `json:"max_output_tokens,omitempty"`
-	Architecture     *schemas.Architecture `json:"architecture,omitempty"`
-	AccessibleByKeys []string              `json:"accessible_by_keys,omitempty"`
+	Name                 string                `json:"name"`
+	Provider             string                `json:"provider"`
+	ContextLength        *int                  `json:"context_length,omitempty"`
+	MaxInputTokens       *int                  `json:"max_input_tokens,omitempty"`
+	MaxOutputTokens      *int                  `json:"max_output_tokens,omitempty"`
+	Architecture         *schemas.Architecture `json:"architecture,omitempty"`
+	AdditionalAttributes map[string]string     `json:"additional_attributes,omitempty"`
+	AccessibleByKeys     []string              `json:"accessible_by_keys,omitempty"`
 }
 
 // ListModelDetailsResponse represents the response for listing detailed models.
@@ -615,6 +626,7 @@ type modelListQuery struct {
 	Query      string
 	KeyIDs     []string
 	Limit      int
+	Offset     int
 	Unfiltered bool
 	// VK-based filtering: populated when a virtual key is found in request headers.
 	// HasVKFilter=true restricts providers/models to those allowed by the VK.
@@ -676,6 +688,7 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 //   - keys: Comma-separated list of key IDs to filter models accessible by those keys
 //   - unfiltered: If true, bypass provider-level model pool restrictions only
 //   - limit: Maximum number of results to return (default: 20)
+//   - offset: Number of results to skip (for pagination)
 //
 // Request headers:
 //   - x-bf-vk / Authorization: Bearer / x-api-key / x-goog-api-key: Virtual key (sk-bf-…) to scope
@@ -712,6 +725,7 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 			details.MaxInputTokens = capabilities.MaxInputTokens
 			details.MaxOutputTokens = capabilities.MaxOutputTokens
 			details.Architecture = capabilities.Architecture
+			details.AdditionalAttributes = capabilities.AdditionalAttributes
 		}
 		responseModels = append(responseModels, details)
 	}
@@ -748,6 +762,11 @@ func (h *ProviderHandler) parseModelListQuery(ctx *fasthttp.RequestCtx, defaultL
 	if len(queryArgs.Peek("limit")) > 0 {
 		if limit, err := queryArgs.GetUint("limit"); err == nil {
 			query.Limit = limit
+		}
+	}
+	if len(queryArgs.Peek("offset")) > 0 {
+		if offset, err := queryArgs.GetUint("offset"); err == nil {
+			query.Offset = offset
 		}
 	}
 
@@ -801,12 +820,21 @@ func (h *ProviderHandler) listManagementModels(query modelListQuery) ([]listedMo
 		})
 	}
 
+	slices.Sort(providers)
+
 	models := make([]listedModel, 0)
 	for _, provider := range providers {
 		models = append(models, h.listManagementModelsForProvider(provider, query)...)
 	}
 
 	total := len(models)
+	if query.Offset > 0 {
+		if query.Offset >= len(models) {
+			models = models[:0]
+		} else {
+			models = models[query.Offset:]
+		}
+	}
 	if query.Limit > 0 && query.Limit < len(models) {
 		models = models[:query.Limit]
 	}
@@ -1192,4 +1220,32 @@ func validateRetryBackoff(networkConfig *schemas.NetworkConfig) error {
 		}
 	}
 	return nil
+}
+
+// upsertModelCatalogEntries handles PUT /api/model-catalog — batch-upserts
+// the additional_attributes JSON on the pricing rows keyed by
+// (model, provider). Every requested (model, provider) must already exist in
+// governance_model_pricing; the whole batch is rejected atomically if any
+// entry is missing. An entry with an empty AdditionalAttributes map clears
+// the column for that (model, provider).
+func (h *ProviderHandler) upsertModelCatalogEntries(ctx *fasthttp.RequestCtx) {
+	var payload []ModelPricingAttributesEntry
+	if err := sonic.Unmarshal(ctx.PostBody(), &payload); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid JSON: %v", err))
+		return
+	}
+	for i := range payload {
+		payload[i].Model = strings.TrimSpace(payload[i].Model)
+		payload[i].Provider = strings.TrimSpace(payload[i].Provider)
+		if payload[i].Model == "" || payload[i].Provider == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "model and provider are required for every catalog entry")
+			return
+		}
+	}
+
+	if err := h.modelsManager.UpsertModelPricingAttributes(ctx, payload); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to upsert catalog entries: %v", err))
+		return
+	}
+	ctx.SetStatusCode(fasthttp.StatusNoContent)
 }

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -50,6 +50,10 @@ func (m *mockModelsManager) GetUnfilteredModelsForProvider(provider schemas.Mode
 	return result
 }
 
+func (m *mockModelsManager) UpsertModelPricingAttributes(_ context.Context, _ []ModelPricingAttributesEntry) error {
+	return nil
+}
+
 // providerHandlerForTest builds a handler with fixed provider config and model sets.
 func providerHandlerForTest(provider schemas.ModelProvider, keys []schemas.Key, filtered, unfiltered []string) *ProviderHandler {
 	return &ProviderHandler{

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1016,6 +1016,10 @@ func (m *MockConfigStore) DeleteModelPrices(ctx context.Context, tx ...*gorm.DB)
 	return nil
 }
 
+func (m *MockConfigStore) UpsertModelPricingAttributes(ctx context.Context, model, provider string, attrs map[string]string, tx ...*gorm.DB) (int64, error) {
+	return 0, nil
+}
+
 func (m *MockConfigStore) GetPricingOverrides(ctx context.Context, filter configstore.PricingOverrideFilters) ([]tables.TablePricingOverride, error) {
 	return []tables.TablePricingOverride{}, nil
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -39,6 +39,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpadaptor"
+	"gorm.io/gorm"
 )
 
 // Constants
@@ -73,6 +74,11 @@ type ServerCallbacks interface {
 	ForceReloadPricing(ctx context.Context) error
 	UpsertPricingOverride(ctx context.Context, override *tables.TablePricingOverride) error
 	DeletePricingOverride(ctx context.Context, id string) error
+	// UpsertModelPricingAttributes writes the additional_attributes JSON on
+	// pricing rows. Enterprise wraps this so that after the local DB write
+	// succeeds it can broadcast a peer reload via the existing pricing
+	// EntityTypeModelCatalog/ActionReloadFromDB gossip path.
+	UpsertModelPricingAttributes(ctx context.Context, entries []handlers.ModelPricingAttributesEntry) error
 	// Proxy related callbacks
 	ReloadProxyConfig(ctx context.Context, config *tables.GlobalProxyConfig) error
 	// Client config related callbacks
@@ -942,6 +948,44 @@ func (s *BifrostHTTPServer) DeletePricingOverride(ctx context.Context, id string
 		return fmt.Errorf("pricing manager not found")
 	}
 	s.Config.ModelCatalog.DeletePricingOverride(id)
+	return nil
+}
+
+// UpsertModelPricingAttributes writes the additional_attributes JSON for the
+// pricing rows keyed by (model, provider) for every entry in the batch. The
+// whole batch is wrapped in a single transaction so a missing pricing row
+// rolls back the lot. After a successful commit the in-memory pricing cache
+// is reloaded once. Enterprise overrides this method to broadcast a peer
+// reload after commit.
+func (s *BifrostHTTPServer) UpsertModelPricingAttributes(ctx context.Context, entries []handlers.ModelPricingAttributesEntry) error {
+	if s.Config == nil || s.Config.ModelCatalog == nil {
+		return fmt.Errorf("model catalog not initialized")
+	}
+	if s.Config.ConfigStore == nil {
+		return fmt.Errorf("model catalog requires a config store")
+	}
+	var missing []string
+	err := s.Config.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		for _, e := range entries {
+			rows, err := s.Config.ConfigStore.UpsertModelPricingAttributes(ctx, e.Model, e.Provider, e.AdditionalAttributes, tx)
+			if err != nil {
+				return err
+			}
+			if rows == 0 {
+				missing = append(missing, fmt.Sprintf("%s/%s", e.Provider, e.Model))
+			}
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("no pricing row for one or more (model, provider) entries: %s", strings.Join(missing, ", "))
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if err := s.Config.ModelCatalog.ReloadPricing(ctx); err != nil {
+		return fmt.Errorf("failed to reload pricing cache after attribute write: %w", err)
+	}
 	return nil
 }
 

--- a/ui/app/workspace/model-catalog/views/attributeSheet.tsx
+++ b/ui/app/workspace/model-catalog/views/attributeSheet.tsx
@@ -1,0 +1,241 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { DottedSeparator } from "@/components/ui/separator";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import { getErrorMessage, ModelDetails, useUpsertModelCatalogEntriesMutation } from "@/lib/store";
+import { KnownProvider } from "@/lib/types/config";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { Plus, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+
+interface AttributeSheetProps {
+	model: ModelDetails;
+	onClose: () => void;
+}
+
+// Local row type for the extra-attributes editor. We keep these outside any
+// schema because empty rows are valid during editing — we filter them at
+// submit time. The id is a render-stable identifier (not persisted) so React
+// keeps DOM nodes pinned to the right row across add/remove.
+interface AttributeRow {
+	id: string;
+	key: string;
+	value: string;
+}
+
+let rowIdCounter = 0;
+function newRowId(): string {
+	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+		return crypto.randomUUID();
+	}
+	rowIdCounter += 1;
+	return `row-${rowIdCounter}`;
+}
+
+function rowsFromAttributes(attrs?: Record<string, string>): AttributeRow[] {
+	if (!attrs) return [];
+	return Object.entries(attrs)
+		.filter(([k]) => k !== "description")
+		.map(([key, value]) => ({ id: newRowId(), key, value }));
+}
+
+export default function AttributeSheet({ model, onClose }: AttributeSheetProps) {
+	const [isOpen, setIsOpen] = useState(true);
+	const hasUpdateAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+
+	const [upsertEntries, { isLoading }] = useUpsertModelCatalogEntriesMutation();
+
+	const initialDescription = model.additional_attributes?.description ?? "";
+	const [description, setDescription] = useState(initialDescription);
+
+	const initialRows = useMemo(() => rowsFromAttributes(model.additional_attributes), [model.additional_attributes]);
+	const stripIds = (rows: AttributeRow[]) => rows.map(({ key, value }) => ({ key, value }));
+	const [initialRowsKey] = useState(() => JSON.stringify(stripIds(initialRows)));
+	const [extraRows, setExtraRows] = useState<AttributeRow[]>(initialRows);
+
+	const rowsDirty = JSON.stringify(stripIds(extraRows)) !== initialRowsKey;
+	const isDirty = description !== initialDescription || rowsDirty;
+
+	const handleClose = () => {
+		setIsOpen(false);
+		setTimeout(() => onClose(), 150);
+	};
+
+	const handleAddRow = () => setExtraRows((prev) => [...prev, { id: newRowId(), key: "", value: "" }]);
+	const handleRowChange = (id: string, field: "key" | "value", val: string) =>
+		setExtraRows((prev) => prev.map((row) => (row.id === id ? { ...row, [field]: val } : row)));
+	const handleRemoveRow = (id: string) => setExtraRows((prev) => prev.filter((row) => row.id !== id));
+
+	const handleSubmit = async () => {
+		if (!hasUpdateAccess) {
+			toast.error("You don't have permission to perform this action");
+			return;
+		}
+
+		// Validate that extra rows have non-empty keys when they have any value.
+		// Empty rows are fine — we drop them.
+		const cleaned = extraRows.map((r) => ({ key: r.key.trim(), value: r.value })).filter((r) => r.key !== "" || r.value !== "");
+		const missingKey = cleaned.find((r) => r.key === "");
+		if (missingKey) {
+			toast.error("Attribute rows must have a key");
+			return;
+		}
+		const dupKey = cleaned.find((r, i) => cleaned.findIndex((other) => other.key === r.key) !== i);
+		if (dupKey) {
+			toast.error(`Duplicate attribute key: ${dupKey.key}`);
+			return;
+		}
+		// "description" is the special-cased field above — disallow it as an extra row.
+		const reservedClash = cleaned.find((r) => r.key === "description");
+		if (reservedClash) {
+			toast.error("Use the Description field instead of a 'description' attribute row");
+			return;
+		}
+
+		const attributes: Record<string, string> = {};
+		const desc = description.trim();
+		if (desc !== "") attributes.description = desc;
+		for (const r of cleaned) attributes[r.key] = r.value;
+
+		try {
+			await upsertEntries([
+				{
+					model: model.name,
+					provider: model.provider,
+					additional_attributes: Object.keys(attributes).length > 0 ? attributes : undefined,
+				},
+			]).unwrap();
+			toast.success("Attributes saved");
+			handleClose();
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		}
+	};
+
+	return (
+		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+			<SheetContent
+				className="flex w-full flex-col overflow-x-hidden pt-4"
+				onInteractOutside={(e) => {
+					if (isDirty) e.preventDefault();
+				}}
+				onEscapeKeyDown={(e) => {
+					if (isDirty) e.preventDefault();
+				}}
+				data-testid="model-catalog-attribute-sheet"
+			>
+				<SheetHeader className="flex flex-col items-start p-0 px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+					<SheetTitle>Edit Model Attributes</SheetTitle>
+					<SheetDescription>
+						Update the description and other attributes for this model. These attributes are stored on the pricing row and
+						preserved across the pricing sync.
+					</SheetDescription>
+				</SheetHeader>
+
+				<div className="flex h-full flex-col gap-6">
+					<div className="grow space-y-4 px-8">
+						{/* Read-only provider / model header */}
+						<div className="grid grid-cols-2 gap-4">
+							<div>
+								<Label className="text-sm font-medium">Provider</Label>
+								<div className="bg-muted/30 mt-2 flex items-center gap-2 rounded-sm border px-3 py-2 text-sm">
+									<RenderProviderIcon provider={model.provider as KnownProvider} size="sm" className="h-4 w-4" />
+									<span>{ProviderLabels[model.provider as ProviderName] || model.provider}</span>
+								</div>
+							</div>
+							<div>
+								<Label className="text-sm font-medium">Model</Label>
+								<div className="bg-muted/30 mt-2 rounded-sm border px-3 py-2 font-mono text-sm">{model.name}</div>
+							</div>
+						</div>
+
+						<DottedSeparator />
+
+						{/* Description */}
+						<div>
+							<Label className="text-sm font-medium">Description</Label>
+							<Textarea
+								className="mt-2"
+								value={description}
+								onChange={(e) => setDescription(e.target.value)}
+								rows={4}
+								placeholder="A short description of this model — shown anywhere additional_attributes.description is consumed."
+								data-testid="model-catalog-description-textarea"
+							/>
+						</div>
+
+						<DottedSeparator />
+
+						{/* Other attributes */}
+						<div className="space-y-3">
+							<div className="flex items-center justify-between">
+								<Label className="text-sm font-medium">Other Attributes</Label>
+								<Button type="button" variant="outline" size="sm" onClick={handleAddRow} data-testid="model-catalog-add-attribute-row">
+									<Plus className="mr-1 h-3 w-3" />
+									Add
+								</Button>
+							</div>
+							{extraRows.length === 0 ? (
+								<p className="text-muted-foreground text-xs">
+									No additional attributes. Add a key-value pair for anything beyond description.
+								</p>
+							) : (
+								<div className="space-y-2">
+									{extraRows.map((row, i) => (
+										<div key={row.id} className="flex items-start gap-2">
+											<Input
+												value={row.key}
+												onChange={(e) => handleRowChange(row.id, "key", e.target.value)}
+												placeholder="key"
+												className="flex-1"
+												data-testid={`model-catalog-attribute-key-${i}`}
+											/>
+											<Input
+												value={row.value}
+												onChange={(e) => handleRowChange(row.id, "value", e.target.value)}
+												placeholder="value"
+												className="flex-1"
+												data-testid={`model-catalog-attribute-value-${i}`}
+											/>
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon"
+												onClick={() => handleRemoveRow(row.id)}
+												data-testid={`model-catalog-attribute-remove-${i}`}
+											>
+												<Trash2 className="h-4 w-4" />
+											</Button>
+										</div>
+									))}
+								</div>
+							)}
+						</div>
+					</div>
+
+					<div className="bg-card sticky bottom-0 shrink-0 border-t px-8 py-4">
+						<div className="flex items-center justify-end gap-3">
+							{!hasUpdateAccess && <p className="text-destructive text-sm">You don't have permission to perform this action</p>}
+							<Button type="button" variant="outline" onClick={handleClose} data-testid="model-catalog-attribute-cancel">
+								Cancel
+							</Button>
+							<Button
+								type="button"
+								onClick={handleSubmit}
+								disabled={isLoading || !isDirty || !hasUpdateAccess}
+								data-testid="model-catalog-attribute-submit"
+							>
+								{isLoading ? "Saving..." : "Save Changes"}
+							</Button>
+						</div>
+					</div>
+				</div>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/model-catalog/views/attributesTab.tsx
+++ b/ui/app/workspace/model-catalog/views/attributesTab.tsx
@@ -1,0 +1,262 @@
+import FullPageLoader from "@/components/fullPageLoader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useDebouncedValue } from "@/hooks/useDebounce";
+import { RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import {
+	ModelDetails,
+	useGetModelDetailsQuery,
+	useGetProvidersQuery,
+} from "@/lib/store";
+import { KnownProvider } from "@/lib/types/config";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { ChevronLeft, ChevronRight, Edit, Search } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import AttributeSheet from "./attributeSheet";
+
+const PAGE_SIZE = 25;
+
+const toTestIdPart = (value: string) =>
+	value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "");
+
+function DescriptionCell({ description }: { description?: string }) {
+	if (!description) return <span className="text-muted-foreground text-sm">—</span>;
+	const truncated = description.length > 80;
+	const text = truncated ? `${description.slice(0, 80)}…` : description;
+	if (!truncated) return <span className="text-sm">{text}</span>;
+	return (
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span className="text-sm">{text}</span>
+				</TooltipTrigger>
+				<TooltipContent className="max-w-md">{description}</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}
+
+interface AttributesTabProps {
+	hasAccess: boolean;
+}
+
+export default function AttributesTab({ hasAccess }: AttributesTabProps) {
+	const hasUpdateAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+
+	const [search, setSearch] = useState("");
+	const [providerFilter, setProviderFilter] = useState<string>("");
+	const [offset, setOffset] = useState(0);
+	const [editing, setEditing] = useState<ModelDetails | null>(null);
+
+	const debouncedSearch = useDebouncedValue(search, 300);
+
+	// Reset to first page when filters change
+	useEffect(() => {
+		setOffset(0);
+	}, [debouncedSearch, providerFilter]);
+
+	const { data: providersData } = useGetProvidersQuery(undefined, { skip: !hasAccess });
+	const { data, isLoading, error, refetch } = useGetModelDetailsQuery(
+		{
+			query: debouncedSearch || undefined,
+			provider: providerFilter || undefined,
+			limit: PAGE_SIZE,
+			offset,
+			unfiltered: true,
+		},
+		{ skip: !hasAccess },
+	);
+
+	const models = data?.models ?? [];
+	const totalCount = data?.total ?? 0;
+
+	// Snap offset back when total shrinks past current page
+	useEffect(() => {
+		if (offset < totalCount) return;
+		setOffset(totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE);
+	}, [totalCount, offset]);
+
+	const providerOptions = useMemo(
+		() => Array.from(new Set((providersData ?? []).map((p) => p.name))).sort(),
+		[providersData],
+	);
+
+	// Clear the provider filter if the selected provider is no longer in the list
+	useEffect(() => {
+		if (!providerFilter || !providersData) return;
+		if (!providersData.some((p) => p.name === providerFilter)) {
+			setProviderFilter("");
+		}
+	}, [providersData, providerFilter]);
+
+	if (isLoading && !data) return <FullPageLoader />;
+
+	if (error) {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+				<p className="text-muted-foreground text-sm">Failed to load models</p>
+				<button type="button" onClick={refetch} className="text-sm underline" data-testid="model-catalog-retry-button">
+					Retry
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			{editing && <AttributeSheet model={editing} onClose={() => setEditing(null)} />}
+
+			<div className="flex min-h-0 w-full grow flex-col overflow-hidden">
+				<div className="mb-4 flex shrink-0 items-center justify-between">
+					<div>
+						<h2 className="text-lg font-semibold">Models</h2>
+						<p className="text-muted-foreground text-sm">
+							Attach descriptions and tags to specific models. Editorial — decoupled from pricing sync.
+						</p>
+					</div>
+				</div>
+
+				<div className="mb-4 flex shrink-0 items-center gap-3">
+					<div className="relative max-w-sm flex-1">
+						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+						<Input
+							aria-label="Search models"
+							placeholder="Search by model name..."
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							className="pl-9"
+							data-testid="model-catalog-search-input"
+						/>
+					</div>
+					<Select value={providerFilter || "__all__"} onValueChange={(v) => setProviderFilter(v === "__all__" ? "" : v)}>
+						<SelectTrigger className="w-[200px]" data-testid="model-catalog-provider-filter">
+							<SelectValue placeholder="All providers" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="__all__">All providers</SelectItem>
+							{providerOptions.map((p) => (
+								<SelectItem key={p} value={p}>
+									{ProviderLabels[p as ProviderName] || p}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				<div className="mb-2 min-h-0 grow overflow-hidden rounded-sm border" data-testid="model-catalog-attributes-table">
+					<Table containerClassName="h-full overflow-auto">
+						<TableHeader className="bg-muted sticky top-0 z-20">
+							<TableRow className="hover:bg-transparent">
+								<TableHead className="font-medium">Provider</TableHead>
+								<TableHead className="font-medium">Model</TableHead>
+								<TableHead className="font-medium">Description</TableHead>
+								<TableHead className="font-medium">Other</TableHead>
+								<TableHead className="w-[60px]"></TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{models.length === 0 ? (
+								<TableRow>
+									<TableCell colSpan={5} className="h-24 text-center">
+										<span className="text-muted-foreground text-sm">
+											{!debouncedSearch && !providerFilter ? "No models loaded yet." : "No matching models."}
+										</span>
+									</TableCell>
+								</TableRow>
+							) : (
+								models.map((m) => {
+									const attrs = m.additional_attributes ?? {};
+									const extraKeys = Object.keys(attrs).filter((k) => k !== "description");
+									const testKey = `${toTestIdPart(m.name)}-${toTestIdPart(m.provider)}`;
+									return (
+										<TableRow key={`${m.provider}|${m.name}`} data-testid={`model-catalog-row-${testKey}`}>
+											<TableCell className="py-3">
+												<div className="flex items-center gap-2">
+													<RenderProviderIcon
+														provider={m.provider as KnownProvider}
+														size="sm"
+														className="h-4 w-4"
+													/>
+													<span className="text-sm">{ProviderLabels[m.provider as ProviderName] || m.provider}</span>
+												</div>
+											</TableCell>
+											<TableCell className="py-3 font-mono text-sm">{m.name}</TableCell>
+											<TableCell className="max-w-[400px] py-3">
+												<DescriptionCell description={attrs.description} />
+											</TableCell>
+											<TableCell className="py-3">
+												{extraKeys.length === 0 ? (
+													<span className="text-muted-foreground text-sm">—</span>
+												) : (
+													<Badge variant="secondary">
+														{extraKeys.length} {extraKeys.length === 1 ? "attribute" : "attributes"}
+													</Badge>
+												)}
+											</TableCell>
+											<TableCell className="py-3">
+												<Button
+													variant="ghost"
+													size="icon"
+													className="h-8 w-8"
+													disabled={!hasUpdateAccess}
+													onClick={() => setEditing(m)}
+													aria-label={`Edit attributes for ${m.name}`}
+													data-testid={`model-catalog-edit-${testKey}`}
+												>
+													<Edit className="h-4 w-4" />
+												</Button>
+											</TableCell>
+										</TableRow>
+									);
+								})
+							)}
+						</TableBody>
+					</Table>
+				</div>
+
+				{totalCount > 0 && (
+					<div className="flex shrink-0 items-center justify-between text-xs" data-testid="model-catalog-pagination">
+						<div className="text-muted-foreground">
+							{(offset + 1).toLocaleString()}–{Math.min(offset + PAGE_SIZE, totalCount).toLocaleString()} of {totalCount.toLocaleString()} entries
+						</div>
+						<div className="flex items-center gap-2">
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+								disabled={offset === 0}
+								data-testid="model-catalog-pagination-prev-btn"
+								aria-label="Previous page"
+							>
+								<ChevronLeft className="size-3" />
+							</Button>
+							<div className="flex items-center gap-1">
+								<span>Page</span>
+								<span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
+								<span>of {Math.ceil(totalCount / PAGE_SIZE)}</span>
+							</div>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => setOffset(offset + PAGE_SIZE)}
+								disabled={offset + PAGE_SIZE >= totalCount}
+								data-testid="model-catalog-pagination-next-btn"
+								aria-label="Next page"
+							>
+								<ChevronRight className="size-3" />
+							</Button>
+						</div>
+					</div>
+				)}
+			</div>
+		</>
+	);
+}

--- a/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
@@ -1,170 +1,34 @@
-import FullPageLoader from "@/components/fullPageLoader";
 import { NoPermissionView } from "@/components/noPermissionView";
-import { ProviderNames } from "@/lib/constants/logs";
-import { useGetModelsQuery, useGetProvidersQuery, useLazyGetLogsModelHistogramQuery, useLazyGetLogsStatsQuery } from "@/lib/store";
-import { KnownProvider } from "@/lib/types/config";
-import { LogStats } from "@/lib/types/logs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useEffect, useMemo, useState } from "react";
-import { ModelCatalogEmptyState } from "./modelCatalogEmptyState";
-import ModelCatalogTable, { ModelCatalogRow } from "./modelCatalogTable";
+import AttributesTab from "./attributesTab";
+import OverviewTab from "./overviewTab";
 
 export default function ModelCatalogView() {
 	const hasAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
-
-	const [providerFilter, setProviderFilter] = useState("");
-	const [statsMap, setStatsMap] = useState<Map<string, LogStats>>(new Map());
-	const [modelsUsedMap, setModelsUsedMap] = useState<Map<string, string[]>>(new Map());
-	const [isLoadingModels, setIsLoadingModels] = useState(true);
-
-	const {
-		data: providers,
-		isLoading: isLoadingProviders,
-		error: providersError,
-		refetch: refetchProviders,
-	} = useGetProvidersQuery(undefined, { skip: !hasAccess });
-	const { data: modelsData } = useGetModelsQuery({ unfiltered: true }, { skip: !hasAccess });
-
-	// Global 24h stats for summary cards (lazy so we get fresh timestamps)
-	const [triggerGlobalStats, { data: globalStats }] = useLazyGetLogsStatsQuery();
-
-	// Per-provider traffic stats (lazy, fired when providers load)
-	const [triggerStats] = useLazyGetLogsStatsQuery();
-	const [triggerModelHistogram] = useLazyGetLogsModelHistogramQuery();
-
-	useEffect(() => {
-		if (!hasAccess) return;
-		const now = new Date().toISOString();
-		const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-		triggerGlobalStats({ filters: { start_time: dayAgo, end_time: now } });
-	}, [hasAccess, triggerGlobalStats]);
-
-	useEffect(() => {
-		if (!providers || providers.length === 0) return;
-		let cancelled = false;
-		const now = new Date().toISOString();
-		const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-
-		Promise.all(
-			providers.map((p) =>
-				triggerStats({ filters: { providers: [p.name], start_time: dayAgo, end_time: now } })
-					.unwrap()
-					.then((stats) => [p.name, stats] as const)
-					.catch(
-						() =>
-							[
-								p.name,
-								{
-									total_requests: 0,
-									success_rate: 0,
-									user_facing_success_rate: 0,
-									average_latency: 0,
-									user_facing_total_requests: 0,
-									total_tokens: 0,
-									total_cost: 0,
-								},
-							] as const,
-					),
-			),
-		).then((results) => {
-			if (!cancelled) setStatsMap(new Map(results));
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, [providers, triggerStats]);
-
-	// Per-provider models used in last 30 days
-	useEffect(() => {
-		if (!providers || providers.length === 0) return;
-		let cancelled = false;
-		setIsLoadingModels(true);
-		const now = new Date().toISOString();
-		const monthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-
-		Promise.all(
-			providers.map((p) =>
-				triggerModelHistogram({ filters: { providers: [p.name], start_time: monthAgo, end_time: now } })
-					.unwrap()
-					.then((data): [string, string[]] => [p.name, data.models ?? []])
-					.catch((): [string, string[]] => [p.name, []]),
-			),
-		).then((results) => {
-			if (!cancelled) {
-				setModelsUsedMap(new Map(results));
-				setIsLoadingModels(false);
-			}
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, [providers, triggerModelHistogram]);
-
-	// Build table rows
-	const rows: ModelCatalogRow[] = useMemo(() => {
-		if (!providers) return [];
-
-		return providers.map((p) => {
-			const isCustom = !ProviderNames.includes(p.name as KnownProvider);
-			const modelsUsed = modelsUsedMap.get(p.name) ?? [];
-
-			const providerStats = statsMap.get(p.name);
-			const totalTraffic24h = providerStats?.total_requests ?? 0;
-			const totalCost24h = providerStats?.total_cost ?? 0;
-
-			return {
-				providerName: p.name,
-				isCustom,
-				baseProviderType: p.custom_provider_config?.base_provider_type,
-				modelsUsed,
-				totalTraffic24h,
-				totalCost24h,
-			};
-		});
-	}, [providers, statsMap, modelsUsedMap]);
-
-	// Filter rows by provider
-	const filteredRows = useMemo(() => {
-		if (!providerFilter) return rows;
-		return rows.filter((r) => r.providerName === providerFilter);
-	}, [rows, providerFilter]);
-
-	if (isLoadingProviders) {
-		return <FullPageLoader />;
-	}
 
 	if (!hasAccess) {
 		return <NoPermissionView entity="model catalog" />;
 	}
 
-	if (providersError) {
-		return (
-			<div className="flex h-full flex-col items-center justify-center gap-4 text-center">
-				<p className="text-muted-foreground text-sm">Failed to load providers</p>
-				<button type="button" data-testid="model-catalog-retry-btn" onClick={refetchProviders} className="text-sm underline">
-					Retry
-				</button>
-			</div>
-		);
-	}
-
-	if (!providers || providers.length === 0) {
-		return <ModelCatalogEmptyState />;
-	}
-
 	return (
-		<div className="mx-auto w-full max-w-7xl">
-			<ModelCatalogTable
-				rows={filteredRows}
-				providers={(providers ?? []).map((p) => p.name)}
-				providerFilter={providerFilter}
-				onProviderFilterChange={setProviderFilter}
-				totalProviders={(providers ?? []).length}
-				totalModels={modelsData?.total ?? 0}
-				totalRequests24h={globalStats?.total_requests ?? 0}
-				totalCost24h={globalStats?.total_cost ?? 0}
-				isLoadingModels={isLoadingModels}
-			/>
+		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full max-w-7xl flex-col overflow-hidden p-4">
+			<Tabs defaultValue="overview" className="flex min-h-0 grow flex-col gap-4">
+				<TabsList className="shrink-0">
+					<TabsTrigger value="overview" data-testid="model-catalog-tab-overview">
+						Overview
+					</TabsTrigger>
+					<TabsTrigger value="attributes" data-testid="model-catalog-tab-attributes">
+						Models
+					</TabsTrigger>
+				</TabsList>
+				<TabsContent value="overview" className="min-h-0 overflow-auto">
+					<OverviewTab hasAccess={hasAccess} />
+				</TabsContent>
+				<TabsContent value="attributes" className="flex min-h-0 flex-col">
+					<AttributesTab hasAccess={hasAccess} />
+				</TabsContent>
+			</Tabs>
 		</div>
 	);
 }

--- a/ui/app/workspace/model-catalog/views/overviewTab.tsx
+++ b/ui/app/workspace/model-catalog/views/overviewTab.tsx
@@ -1,0 +1,165 @@
+import FullPageLoader from "@/components/fullPageLoader";
+import { ProviderNames } from "@/lib/constants/logs";
+import { useGetModelsQuery, useGetProvidersQuery, useLazyGetLogsModelHistogramQuery, useLazyGetLogsStatsQuery } from "@/lib/store";
+import { KnownProvider } from "@/lib/types/config";
+import { LogStats } from "@/lib/types/logs";
+import { useEffect, useMemo, useState } from "react";
+import { ModelCatalogEmptyState } from "./modelCatalogEmptyState";
+import ModelCatalogTable, { ModelCatalogRow } from "./modelCatalogTable";
+
+interface OverviewTabProps {
+	hasAccess: boolean;
+}
+
+export default function OverviewTab({ hasAccess }: OverviewTabProps) {
+	const [providerFilter, setProviderFilter] = useState("");
+	const [statsMap, setStatsMap] = useState<Map<string, LogStats>>(new Map());
+	const [modelsUsedMap, setModelsUsedMap] = useState<Map<string, string[]>>(new Map());
+	const [isLoadingModels, setIsLoadingModels] = useState(true);
+
+	const {
+		data: providers,
+		isLoading: isLoadingProviders,
+		error: providersError,
+		refetch: refetchProviders,
+	} = useGetProvidersQuery(undefined, { skip: !hasAccess });
+	const { data: modelsData } = useGetModelsQuery({ unfiltered: true }, { skip: !hasAccess });
+
+	const [triggerGlobalStats, { data: globalStats }] = useLazyGetLogsStatsQuery();
+	const [triggerStats] = useLazyGetLogsStatsQuery();
+	const [triggerModelHistogram] = useLazyGetLogsModelHistogramQuery();
+
+	useEffect(() => {
+		if (!hasAccess) return;
+		const now = new Date().toISOString();
+		const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+		triggerGlobalStats({ filters: { start_time: dayAgo, end_time: now } });
+	}, [hasAccess, triggerGlobalStats]);
+
+	useEffect(() => {
+		if (!providers || providers.length === 0) return;
+		let cancelled = false;
+		const now = new Date().toISOString();
+		const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+		Promise.all(
+			providers.map((p) =>
+				triggerStats({ filters: { providers: [p.name], start_time: dayAgo, end_time: now } })
+					.unwrap()
+					.then((stats) => [p.name, stats] as const)
+					.catch(
+						() =>
+							[
+								p.name,
+								{
+									total_requests: 0,
+									success_rate: 0,
+									user_facing_success_rate: 0,
+									average_latency: 0,
+									user_facing_total_requests: 0,
+									total_tokens: 0,
+									total_cost: 0,
+								},
+							] as const,
+					),
+			),
+		).then((results) => {
+			if (!cancelled) setStatsMap(new Map(results));
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [providers, triggerStats]);
+
+	useEffect(() => {
+		if (!providers || providers.length === 0) return;
+		let cancelled = false;
+		setIsLoadingModels(true);
+		const now = new Date().toISOString();
+		const monthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+		Promise.all(
+			providers.map((p) =>
+				triggerModelHistogram({ filters: { providers: [p.name], start_time: monthAgo, end_time: now } })
+					.unwrap()
+					.then((data): [string, string[]] => [p.name, data.models ?? []])
+					.catch((): [string, string[]] => [p.name, []]),
+			),
+		).then((results) => {
+			if (!cancelled) {
+				setModelsUsedMap(new Map(results));
+				setIsLoadingModels(false);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [providers, triggerModelHistogram]);
+
+	const rows: ModelCatalogRow[] = useMemo(() => {
+		if (!providers) return [];
+		return providers.map((p) => {
+			const isCustom = !ProviderNames.includes(p.name as KnownProvider);
+			const modelsUsed = modelsUsedMap.get(p.name) ?? [];
+			const providerStats = statsMap.get(p.name);
+			const totalTraffic24h = providerStats?.total_requests ?? 0;
+			const totalCost24h = providerStats?.total_cost ?? 0;
+			return {
+				providerName: p.name,
+				isCustom,
+				baseProviderType: p.custom_provider_config?.base_provider_type,
+				modelsUsed,
+				totalTraffic24h,
+				totalCost24h,
+			};
+		});
+	}, [providers, statsMap, modelsUsedMap]);
+
+	// Clear the provider filter if the selected provider is no longer in the
+	// list (e.g. deleted in another tab / via gossip) — otherwise the table
+	// silently shows zero rows with no way back except clicking the dropdown.
+	useEffect(() => {
+		if (!providerFilter || !providers) return;
+		if (!providers.some((p) => p.name === providerFilter)) {
+			setProviderFilter("");
+		}
+	}, [providers, providerFilter]);
+
+	const filteredRows = useMemo(() => {
+		if (!providerFilter) return rows;
+		return rows.filter((r) => r.providerName === providerFilter);
+	}, [rows, providerFilter]);
+
+	if (isLoadingProviders) {
+		return <FullPageLoader />;
+	}
+
+	if (providersError) {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+				<p className="text-muted-foreground text-sm">Failed to load providers</p>
+				<button type="button" data-testid="model-catalog-retry-btn" onClick={refetchProviders} className="text-sm underline">
+					Retry
+				</button>
+			</div>
+		);
+	}
+
+	if (!providers || providers.length === 0) {
+		return <ModelCatalogEmptyState />;
+	}
+
+	return (
+		<ModelCatalogTable
+			rows={filteredRows}
+			providers={(providers ?? []).map((p) => p.name)}
+			providerFilter={providerFilter}
+			onProviderFilterChange={setProviderFilter}
+			totalProviders={(providers ?? []).length}
+			totalModels={modelsData?.total ?? 0}
+			totalRequests24h={globalStats?.total_requests ?? 0}
+			totalCost24h={globalStats?.total_cost ?? 0}
+			isLoadingModels={isLoadingModels}
+		/>
+	);
+}

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -24,11 +24,40 @@ export interface ModelResponse {
 	name: string;
 	provider: string;
 	accessible_by_keys?: string[];
+	additional_attributes?: Record<string, string>;
 }
 
 export interface ListModelsResponse {
 	models: ModelResponse[];
 	total: number;
+}
+
+// ModelDetails is the shape returned by /api/models/details — used by the
+// model-catalog Models tab to list (model, provider) entries with their
+// additional_attributes.
+export interface ModelDetails {
+	name: string;
+	provider: string;
+	context_length?: number;
+	max_input_tokens?: number;
+	max_output_tokens?: number;
+	architecture?: unknown;
+	additional_attributes?: Record<string, string>;
+	accessible_by_keys?: string[];
+}
+
+export interface ListModelDetailsResponse {
+	models: ModelDetails[];
+	total: number;
+}
+
+// ModelPricingAttributesEntry is the body element for PUT /api/model-catalog.
+// (model, provider) is the natural key on governance_model_pricing. An empty
+// or omitted additional_attributes clears the column for that row.
+export interface ModelPricingAttributesEntry {
+	model: string;
+	provider: string;
+	additional_attributes?: Record<string, string>;
 }
 
 export interface GetModelsRequest {
@@ -346,6 +375,38 @@ export const providersApi = baseApi.injectEndpoints({
 				return { data: result.data as ModelDatasheetResponse };
 			},
 		}),
+
+		// List models with capability metadata + additional_attributes via the
+		// existing /api/models/details endpoint. Backs the model-catalog
+		// Models tab. Server filters by model-name substring (`query`) and by
+		// exact provider; the high default limit covers the typical catalog
+		// size (under 1500 rows).
+		getModelDetails: builder.query<ListModelDetailsResponse, { query?: string; provider?: string; limit?: number; offset?: number; unfiltered?: boolean }>({
+			query: ({ query, provider, limit, offset, unfiltered }) => {
+				const params = new URLSearchParams();
+				if (query) params.append("query", query);
+				if (provider) params.append("provider", provider);
+				if (limit !== undefined) params.append("limit", String(limit));
+				if (offset !== undefined && offset > 0) params.append("offset", String(offset));
+				if (unfiltered !== undefined) params.append("unfiltered", String(unfiltered));
+				const qs = params.toString();
+				return `/models/details${qs ? `?${qs}` : ""}`;
+			},
+			providesTags: ["Models"],
+		}),
+
+		// Batch upsert additional_attributes on existing pricing rows. The
+		// pricing row must already exist for each (model, provider); a missing
+		// row surfaces as a 400. An entry with an empty additional_attributes
+		// map clears the column for that row.
+		upsertModelCatalogEntries: builder.mutation<void, ModelPricingAttributesEntry[]>({
+			query: (entries) => ({
+				url: "/model-catalog",
+				method: "PUT",
+				body: entries,
+			}),
+			invalidatesTags: ["Models"],
+		}),
 	}),
 });
 
@@ -372,4 +433,7 @@ export const {
 	useLazyGetBaseModelsQuery,
 	useGetModelParametersQuery,
 	useLazyGetModelParametersQuery,
+	useGetModelDetailsQuery,
+	useLazyGetModelDetailsQuery,
+	useUpsertModelCatalogEntriesMutation,
 } = providersApi;


### PR DESCRIPTION
## Summary

Adds an `additional_attributes` column to `governance_model_pricing` that stores editorial per-model metadata (e.g. description, arbitrary key-value tags) as a JSON blob. This column is intentionally excluded from the 24-hour pricing sync upsert path, so values written through the management API are never overwritten by datasheet refreshes. A new `PUT /api/model-catalog` endpoint allows batch-writing these attributes, and the model catalog UI gains a dedicated "Models" tab for viewing and editing them.

## Changes

- **Database**: Adds `additional_attributes` (JSON blob) to `governance_model_pricing` via a new migration. The column is excluded from `pricingSyncUpdateColumns`, which replaces the previous `UpdateAll: true` on the pricing upsert clause.
- **ConfigStore**: Adds `UpsertModelPricingAttributes` to write only the `additional_attributes` column for rows keyed by `(model, provider)`. Returns the number of rows affected so callers can detect missing pricing rows.
- **ModelCatalog**: Adds `UpsertModelPricingAttributes` and `ReloadPricing` methods. After a successful attribute write the in-memory pricing cache is reloaded immediately.
- **HTTP transport**: Adds `PUT /api/model-catalog` handler that batch-upserts `additional_attributes`. The entire batch is wrapped in a single transaction — any missing `(model, provider)` pricing row rolls back the whole request and returns a 400. The `ServerCallbacks` interface gains `UpsertModelPricingAttributes` so enterprise deployments can broadcast a peer cache reload after commit.
- **List-models / model-details**: `additional_attributes` is now propagated from the pricing cache into `GET /api/models` and `GET /api/models/details` responses.
- **UI**: The model catalog view is split into two tabs — "Overview" (existing provider traffic table, extracted to `OverviewTab`) and "Models" (new `AttributesTab`). The attributes tab lists all known models with their description and extra attribute count, and opens an `AttributeSheet` slide-over for editing. The RTK Query layer gains `getModelDetails` and `upsertModelCatalogEntries` endpoints.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./framework/modelcatalog/... ./transports/bifrost-http/...

# Verify migration runs cleanly against a local DB
# Start the server — governance_model_pricing should gain an additional_attributes column.

# Write attributes for an existing model
curl -X PUT http://localhost:8080/api/model-catalog \
  -H 'Content-Type: application/json' \
  -d '[{"model":"gpt-4o","provider":"openai","additional_attributes":{"description":"Flagship GPT-4o model"}}]'
# Expect: 204 No Content

# Verify the attribute is returned in list-models
curl http://localhost:8080/api/models?unfiltered=true | jq '.data[] | select(.name=="gpt-4o") | .additional_attributes'

# Attempt to write attributes for a non-existent pricing row
curl -X PUT http://localhost:8080/api/model-catalog \
  -H 'Content-Type: application/json' \
  -d '[{"model":"does-not-exist","provider":"openai","additional_attributes":{"description":"x"}}]'
# Expect: 400 with error message referencing the missing row

# UI
cd ui
pnpm i
pnpm build
```

Navigate to the Model Catalog page and confirm the "Overview" and "Models" tabs are present. On the "Models" tab, click the edit icon for any model, update the description, save, and verify the value persists after a page reload and after a pricing sync cycle.

## Screenshots/Recordings

_Add before/after screenshots of the model catalog tabs and the attribute edit sheet._

## Breaking changes

- [x] No

The `UpsertModelPrices` ON CONFLICT clause changes from `UpdateAll: true` to an explicit column list. Any column added to `TableModelPricing` in the future must also be added to `pricingSyncUpdateColumns` to be included in pricing sync updates.

## Related issues

## Security considerations

The `PUT /api/model-catalog` endpoint is gated behind the existing `ModelProvider` RBAC resource with the `Update` operation, consistent with other provider management endpoints. No secrets or PII are stored in `additional_attributes`; values are arbitrary strings supplied by administrators.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable