### PR TITLE
fix: makes mcp header temp token flow follow the UI toggle

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779887442,
-        "narHash": "sha256-eCUuOLWs77dwTqxIHTIZM4Wnxy+lirCLo6HjZr5dlgk=",
+        "lastModified": 1779952895,
+        "narHash": "sha256-j0P9+h7HX67KNlGki6puFfx8xO6wx4Jz23jXg3dpfCw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a90757c3affe4befdc02025c1ae72df4f2b4be9e",
+        "rev": "7bbe929cc678c8d32f0c23e2dffb5b4f2e68a9b5",
         "type": "github"
       },
       "original": {

--- a/framework/mcp_headers/main.go
+++ b/framework/mcp_headers/main.go
@@ -14,7 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,14 +35,15 @@ type Provider struct {
 	configStore configstore.ConfigStore
 	logger      schemas.Logger
 
-	// tempTokens, when non-nil, is used by InitiateUserSubmissionFlow to
-	// mint a short-lived mcp_headers_auth token and embed it in the
-	// returned auth-page URL as a fragment. Optional — when nil, the URL
-	// is returned without a fragment and the page works only for callers
-	// already authenticated to the dashboard. Mirrors
+	// tempTokens, when non-nil and enabled in client config, is used by
+	// InitiateUserSubmissionFlow to mint a short-lived mcp_headers_auth
+	// token and embed it in the returned auth-page URL as a fragment.
+	// Optional — when nil or disabled, the URL is returned without a
+	// fragment and the page works only for callers already authenticated
+	// to the dashboard. Held as an atomic.Pointer so it can be installed
+	// once at startup and read lock-free on the request path. Mirrors
 	// oauth2.OAuth2Provider.tempTokens exactly.
-	mu         sync.RWMutex
-	tempTokens *temptoken.Service
+	tempTokens atomic.Pointer[temptoken.Service]
 }
 
 // NewProvider constructs a configstore-backed MCPHeadersProvider. Mirrors
@@ -59,12 +60,31 @@ func NewProvider(configStore configstore.ConfigStore, logger schemas.Logger) *Pr
 // InitiateUserSubmissionFlow to mint the mcp_headers_auth token embedded
 // in the auth-page URL fragment. Called by server startup once both
 // services have been constructed (the provider is built first by
-// lib/config.go, the service later by the HTTP transport). Mirrors
-// oauth2.OAuth2Provider.SetTempTokenService.
+// lib/config.go, the service later by the HTTP transport).
 func (p *Provider) SetTempTokenService(svc *temptoken.Service) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.tempTokens = svc
+	p.tempTokens.Store(svc)
+}
+
+// tempTokenService returns the current temp-token service. Lock-free read
+// off the atomic.Pointer.
+func (p *Provider) tempTokenService() *temptoken.Service {
+	return p.tempTokens.Load()
+}
+
+// mcpTempTokenAuthEnabled reports whether MCP per-user-headers auth links may
+// include temp-token auth. Reads the same MCPEnableTempTokenAuth client-config
+// toggle the OAuth surface uses so the UI switch controls both per-user auth
+// kinds uniformly. Mirrors oauth2.OAuth2Provider.mcpTempTokenAuthEnabled.
+func (p *Provider) mcpTempTokenAuthEnabled(ctx context.Context) bool {
+	if p.configStore == nil {
+		return false
+	}
+	clientConfig, err := p.configStore.GetClientConfig(ctx)
+	if err != nil {
+		p.logger.Warn("Failed to read MCP temp-token auth setting: %v", err)
+		return false
+	}
+	return clientConfig != nil && clientConfig.MCPEnableTempTokenAuth
 }
 
 // GetCredentialByMode looks up the active credential row for the given
@@ -220,13 +240,14 @@ func (p *Provider) InitiateUserSubmissionFlow(ctx context.Context, mode schemas.
 	// endpoints. The fragment never leaves the browser (not in server
 	// logs, not in upstream Referer), unlike a query param. Best-effort:
 	// mint failure does not fail the flow init.
-	p.mu.RLock()
-	tempTokens := p.tempTokens
-	p.mu.RUnlock()
-	if tempTokens != nil {
+	//
+	// Gated by the same MCPEnableTempTokenAuth client-config toggle the
+	// OAuth surface reads, so the UI switch controls both per-user auth
+	// kinds uniformly.
+	if svc := p.tempTokenService(); svc != nil && p.mcpTempTokenAuthEnabled(ctx) {
 		ttl := time.Until(flow.ExpiresAt)
 		if ttl > 0 {
-			plaintext, mintErr := tempTokens.Mint(ctx, temptoken.MCPHeadersAuthScopeName, flow.ID, ttl)
+			plaintext, mintErr := svc.Mint(ctx, temptoken.MCPHeadersAuthScopeName, flow.ID, ttl)
 			if mintErr != nil {
 				p.logger.Warn("Failed to mint mcp_headers_auth temp token for flow %s: %v (link still usable for dashboard-authenticated callers)", flow.ID, mintErr)
 			} else {

--- a/framework/mcp_headers/main_test.go
+++ b/framework/mcp_headers/main_test.go
@@ -1,0 +1,221 @@
+package mcp_headers
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/temptoken"
+)
+
+// testConfigStore is a minimal in-memory implementation of configstore.ConfigStore
+// for use in mcp_headers tests. Embeds the interface so unneeded methods panic if
+// called. Mirrors framework/oauth2/sync_test.go's testConfigStore.
+type testConfigStore struct {
+	configstore.ConfigStore
+
+	mu           sync.Mutex
+	clientConfig *configstore.ClientConfig
+	headerFlows  map[string]*tables.TableMCPPerUserHeaderFlow
+	tempTokens   map[string]*tables.TempToken
+}
+
+func newTestConfigStore() *testConfigStore {
+	return &testConfigStore{
+		headerFlows: make(map[string]*tables.TableMCPPerUserHeaderFlow),
+		tempTokens:  make(map[string]*tables.TempToken),
+	}
+}
+
+func (s *testConfigStore) GetClientConfig(_ context.Context) (*configstore.ClientConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.clientConfig == nil {
+		return nil, nil
+	}
+	return bifrost.Ptr(*s.clientConfig), nil
+}
+
+func (s *testConfigStore) GetMCPPerUserHeaderFlowByModeIdentityAndMCPClient(_ context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPPerUserHeaderFlow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, flow := range s.headerFlows {
+		if flow.FlowMode != string(mode) || flow.MCPClientID != mcpClientID {
+			continue
+		}
+		switch mode {
+		case schemas.MCPAuthModeUser:
+			if flow.UserID != nil && *flow.UserID == identity {
+				return bifrost.Ptr(*flow), nil
+			}
+		case schemas.MCPAuthModeVK:
+			if flow.VirtualKeyID != nil && *flow.VirtualKeyID == identity {
+				return bifrost.Ptr(*flow), nil
+			}
+		case schemas.MCPAuthModeSession:
+			if flow.SessionID == identity {
+				return bifrost.Ptr(*flow), nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (s *testConfigStore) CreateMCPPerUserHeaderFlow(_ context.Context, flow *tables.TableMCPPerUserHeaderFlow) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.headerFlows[flow.ID] = bifrost.Ptr(*flow)
+	return nil
+}
+
+func (s *testConfigStore) UpdateMCPPerUserHeaderFlow(_ context.Context, flow *tables.TableMCPPerUserHeaderFlow) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.headerFlows[flow.ID] = bifrost.Ptr(*flow)
+	return nil
+}
+
+func (s *testConfigStore) CreateTempToken(_ context.Context, token *tables.TempToken, _ ...*gorm.DB) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tempTokens[token.ID] = bifrost.Ptr(*token)
+	return nil
+}
+
+func newTestProvider(store *testConfigStore) *Provider {
+	return NewProvider(store, bifrost.NewDefaultLogger(schemas.LogLevelError))
+}
+
+// newTempTokenService wires a temptoken.Service with the mcp_headers_auth scope
+// registered. Mirrors what handlers.RegisterTempTokenScopes does at server
+// startup, but kept local so this package has no dependency on the handlers
+// layer.
+func newTempTokenService(t *testing.T, store *testConfigStore) *temptoken.Service {
+	t.Helper()
+	svc := temptoken.NewService(store, temptoken.NewRegistry())
+	require.NoError(t, svc.Registry().Register(temptoken.Scope{
+		Name: temptoken.MCPHeadersAuthScopeName,
+		AllowedRoutes: []temptoken.RoutePattern{
+			{Method: "GET", Path: "/api/mcp/per-user-headers/flows/{id}"},
+			{Method: "PUT", Path: "/api/mcp/per-user-headers/flows/{id}"},
+		},
+		ResourceIDInPath: "{id}",
+		MaxTTL:           SubmissionFlowTTL,
+	}))
+	return svc
+}
+
+func TestMCPTempTokenAuthEnabled(t *testing.T) {
+	store := newTestConfigStore()
+	provider := newTestProvider(store)
+
+	assert.False(t, provider.mcpTempTokenAuthEnabled(context.Background()))
+
+	store.clientConfig = &configstore.ClientConfig{}
+	assert.False(t, provider.mcpTempTokenAuthEnabled(context.Background()))
+
+	store.clientConfig.MCPEnableTempTokenAuth = true
+	assert.True(t, provider.mcpTempTokenAuthEnabled(context.Background()))
+}
+
+func TestInitiateUserSubmissionFlow_TempTokenGatedByClientConfig(t *testing.T) {
+	// Verifies that the MCPEnableTempTokenAuth client-config toggle gates the
+	// URL fragment on the submit URL — the same behavior the OAuth surface
+	// already had and that headers must mirror for the UI switch to control
+	// both kinds uniformly.
+	const (
+		mcpClientID = "test-mcp-client"
+		identity    = "test-user"
+		baseURL     = "http://localhost:8080"
+	)
+
+	t.Run("toggle disabled: URL has no fragment", func(t *testing.T) {
+		store := newTestConfigStore()
+		store.clientConfig = &configstore.ClientConfig{MCPEnableTempTokenAuth: false}
+		provider := newTestProvider(store)
+		provider.SetTempTokenService(newTempTokenService(t, store))
+
+		initiation, err := provider.InitiateUserSubmissionFlow(context.Background(), schemas.MCPAuthModeUser, identity, mcpClientID, baseURL)
+		require.NoError(t, err)
+		assert.NotContains(t, initiation.FrontendURL, "#t=", "temp-token fragment must not be appended when toggle is off")
+		assert.Empty(t, store.tempTokens, "Mint must not be called when toggle is off")
+	})
+
+	t.Run("toggle enabled: URL carries fragment", func(t *testing.T) {
+		store := newTestConfigStore()
+		store.clientConfig = &configstore.ClientConfig{MCPEnableTempTokenAuth: true}
+		provider := newTestProvider(store)
+		provider.SetTempTokenService(newTempTokenService(t, store))
+
+		initiation, err := provider.InitiateUserSubmissionFlow(context.Background(), schemas.MCPAuthModeUser, identity, mcpClientID, baseURL)
+		require.NoError(t, err)
+		assert.Contains(t, initiation.FrontendURL, "#t=", "temp-token fragment must be appended when toggle is on")
+		require.Len(t, store.tempTokens, 1, "Mint must be called exactly once when toggle is on")
+		for _, tok := range store.tempTokens {
+			assert.Equal(t, temptoken.MCPHeadersAuthScopeName, tok.Scope)
+			assert.Equal(t, initiation.FlowID, tok.ResourceID, "minted token must be bound to the flow row's ID")
+		}
+	})
+
+	t.Run("no temp-token service installed: URL has no fragment", func(t *testing.T) {
+		store := newTestConfigStore()
+		store.clientConfig = &configstore.ClientConfig{MCPEnableTempTokenAuth: true}
+		provider := newTestProvider(store) // SetTempTokenService not called
+
+		initiation, err := provider.InitiateUserSubmissionFlow(context.Background(), schemas.MCPAuthModeUser, identity, mcpClientID, baseURL)
+		require.NoError(t, err)
+		assert.NotContains(t, initiation.FrontendURL, "#t=", "no fragment when temp-token service is unavailable")
+	})
+
+	t.Run("toggle enabled but client-config read fails: URL has no fragment", func(t *testing.T) {
+		// Same shape as oauth2.mcpTempTokenAuthEnabled: a configstore error is
+		// treated as 'disabled' (fail-closed) rather than panicking the flow.
+		store := &errClientConfigStore{testConfigStore: newTestConfigStore()}
+		provider := newTestProvider(store.testConfigStore)
+		provider.configStore = store // swap in the wrapper so GetClientConfig errors
+		provider.SetTempTokenService(newTempTokenService(t, store.testConfigStore))
+
+		initiation, err := provider.InitiateUserSubmissionFlow(context.Background(), schemas.MCPAuthModeUser, identity, mcpClientID, baseURL)
+		require.NoError(t, err, "flow init must still succeed even when client-config read fails")
+		assert.NotContains(t, initiation.FrontendURL, "#t=", "no fragment when client-config read errors")
+	})
+}
+
+// errClientConfigStore returns an error from GetClientConfig but otherwise
+// delegates to the embedded testConfigStore. Used to verify mcpTempTokenAuthEnabled
+// fails closed on read errors.
+type errClientConfigStore struct {
+	*testConfigStore
+}
+
+func (s *errClientConfigStore) GetClientConfig(_ context.Context) (*configstore.ClientConfig, error) {
+	return nil, assertErr("synthetic client-config read failure")
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }
+
+// sanity: the auth-page URL always carries the flow ID + kind=headers query
+// param, regardless of the temp-token toggle. Guards against URL-shape
+// regressions that would break the dashboard auth landing page.
+func TestInitiateUserSubmissionFlow_URLShape(t *testing.T) {
+	store := newTestConfigStore()
+	provider := newTestProvider(store)
+
+	initiation, err := provider.InitiateUserSubmissionFlow(context.Background(), schemas.MCPAuthModeUser, "u", "client", "http://localhost:8080/")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(initiation.FrontendURL, "http://localhost:8080/workspace/mcp-sessions/auth?flow="))
+	assert.Contains(t, initiation.FrontendURL, "&kind=headers")
+	assert.WithinDuration(t, time.Now().Add(SubmissionFlowTTL), initiation.ExpiresAt, time.Second)
+}

--- a/framework/temptoken/scope.go
+++ b/framework/temptoken/scope.go
@@ -15,7 +15,7 @@ import (
 const (
 	// MCPAuthScopeName names the scope that authorizes the MCP per-user OAuth
 	// auth page to call the per-user flow endpoints. Bound resource_id is the
-	// OAuth flow ID. See transports/bifrost-http/handlers/temp_token_scopes.go.
+	// OAuth flow ID.
 	MCPAuthScopeName = "mcp_auth"
 
 	// MCPHeadersAuthScopeName names the scope that authorizes the MCP


### PR DESCRIPTION
## Summary

The `mcp_headers` provider's `tempTokens` field was previously guarded by a `sync.RWMutex`. This PR replaces that mutex with an `atomic.Pointer[temptoken.Service]` for lock-free reads on the hot request path. Additionally, temp-token embedding in MCP per-user-headers auth links is now gated behind the `MCPEnableTempTokenAuth` client-config toggle, mirroring the existing OAuth surface behavior so the UI switch controls both per-user auth kinds uniformly.

## Changes

- Replaced `sync.RWMutex` + `*temptoken.Service` field with `atomic.Pointer[temptoken.Service]` in `mcp_headers.Provider`, enabling lock-free reads during request handling.
- Added `tempTokenService()` helper for clean atomic load access.
- Added `mcpTempTokenAuthEnabled()` which reads the `MCPEnableTempTokenAuth` client-config flag, mirroring `oauth2.OAuth2Provider.mcpTempTokenAuthEnabled`, so the same toggle governs both OAuth and MCP headers auth link generation.
- `InitiateUserSubmissionFlow` now checks both that the service is set and that `MCPEnableTempTokenAuth` is enabled before minting a temp token fragment.
- Updated `flake.lock` to latest nixpkgs revision.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/mcp_headers/...
go test ./framework/temptoken/...
go test ./...
```

Verify that:
- With `MCPEnableTempTokenAuth` disabled in client config, `InitiateUserSubmissionFlow` returns a URL without a temp-token fragment.
- With `MCPEnableTempTokenAuth` enabled and a valid `temptoken.Service` installed, the returned URL includes the auth fragment.
- No regressions in OAuth per-user auth flow behavior.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Temp-token fragments in MCP per-user-headers auth URLs are now explicitly gated behind the `MCPEnableTempTokenAuth` client-config toggle. This ensures operators have a single, consistent control surface for enabling short-lived token embedding across both OAuth and MCP headers auth flows, reducing the risk of unintended token issuance.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable