### PR TITLE
feat: add tool call execution, stop streaming, and redesign tool call UI

### DIFF
--- a/ui/components/prompts/components/messagesView/rootMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/rootMessageView.tsx
@@ -14,7 +14,15 @@ import ErrorMessageView from "./errorMessageView";
  * @returns A React element that renders the messages list and provides handlers for message changes, removals, tool submissions, and variable updates.
  */
 export function MessagesView() {
-	const { messages, setMessages: onUpdateMessages, setVariables, isStreaming, supportsVision, handleSubmitToolResult } = usePromptContext();
+	const {
+		messages,
+		setMessages: onUpdateMessages,
+		setVariables,
+		isStreaming,
+		supportsVision,
+		handleSubmitToolResult,
+		handleExecuteToolCall,
+	} = usePromptContext();
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const prevLengthRef = useRef(messages.length);
 	const prevLastIdRef = useRef(messages[messages.length - 1]?.id);
@@ -107,6 +115,7 @@ export function MessagesView() {
 									onChange={(s) => handleMessageChange(index, s)}
 									onRemove={canRemove ? () => handleRemoveMessage(index) : undefined}
 									onSubmitToolResult={(toolCallId, content) => handleSubmitToolResult(index, toolCallId, content)}
+									onExecuteToolCall={(toolCall) => handleExecuteToolCall(index, toolCall)}
 									respondedToolCallIds={respondedIds}
 								/>
 							);

--- a/ui/components/prompts/components/messagesView/toolCallView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallView.tsx
@@ -1,9 +1,10 @@
-import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { Message, SerializedMessage } from "@/lib/message";
-import { isJson } from "@/lib/utils/validation";
 import { CodeEditor } from "@/components/ui/codeEditor";
-import { Wrench, XIcon } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { Message, MessageRole, SerializedMessage, type ToolCall } from "@/lib/message";
+import { isJson } from "@/lib/utils/validation";
+import { Loader2, PencilLine, Play, Send, Wrench, XIcon } from "lucide-react";
 import { useRef, useState } from "react";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
 
@@ -27,6 +28,7 @@ export default function ToolCallMessageView({
 	onChange,
 	onRemove,
 	onSubmitToolResult,
+	onExecuteToolCall,
 	respondedToolCallIds,
 }: {
 	message: Message;
@@ -34,10 +36,13 @@ export default function ToolCallMessageView({
 	onChange: (serialized: SerializedMessage) => void;
 	onRemove?: () => void;
 	onSubmitToolResult?: (toolCallId: string, content: string) => void;
+	onExecuteToolCall?: (toolCall: ToolCall) => Promise<void>;
 	respondedToolCallIds?: Set<string>;
 }) {
 	const toolCalls = message.toolCalls ?? [];
 	const [responses, setResponses] = useState<Record<string, string>>({});
+	const [executingIds, setExecutingIds] = useState<Set<string>>(new Set());
+	const [manualEntryIds, setManualEntryIds] = useState<Set<string>>(new Set());
 	const messageRef = useRef(message);
 	messageRef.current = message;
 	const jsonBufferRef = useRef<Record<string, string>>({});
@@ -71,7 +76,7 @@ export default function ToolCallMessageView({
 	const handleRoleChange = (role: string) => {
 		const latest = applyPendingJsonBuffers(messageRef.current);
 		const clone = latest.clone();
-		clone.role = role as any;
+		clone.role = role as MessageRole;
 		onChange(clone.serialized);
 	};
 
@@ -88,30 +93,72 @@ export default function ToolCallMessageView({
 			delete next[toolCallId];
 			return next;
 		});
+		setManualEntryIds((prev) => {
+			const next = new Set(prev);
+			next.delete(toolCallId);
+			return next;
+		});
+	};
+
+	const handleExecute = async (tc: ToolCall) => {
+		if (!onExecuteToolCall) return;
+		flushJsonBuffer(tc.id);
+		const latestTc = messageRef.current.toolCalls?.find((t) => t.id === tc.id) ?? tc;
+		setExecutingIds((prev) => new Set(prev).add(tc.id));
+		try {
+			await onExecuteToolCall(latestTc);
+		} finally {
+			setExecutingIds((prev) => {
+				const next = new Set(prev);
+				next.delete(tc.id);
+				return next;
+			});
+		}
+	};
+
+	const showManualEntry = (toolCallId: string) => {
+		setManualEntryIds((prev) => new Set(prev).add(toolCallId));
+	};
+
+	const hideManualEntry = (toolCallId: string) => {
+		setManualEntryIds((prev) => {
+			const next = new Set(prev);
+			next.delete(toolCallId);
+			return next;
+		});
 	};
 
 	return (
-		<div className="group hover:border-border focus-within:border-border rounded-sm border border-transparent px-3 py-2 transition-colors">
-			<div className="mb-1 flex items-center">
+		<div className="group rounded-lg border border-transparent px-3 py-2 transition-colors hover:border-border/80 focus-within:border-border/80">
+			<div className="mb-2 flex items-center gap-1">
 				<MessageRoleSwitcher role={message.role ?? ""} disabled={disabled} onRoleChange={handleRoleChange} />
-				<div className="ml-auto h-5">
+
+				{toolCalls.length > 0 && (
+					<span className="animate-in fade-in-0 zoom-in-95 duration-200 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground motion-reduce:animate-none">
+						{toolCalls.length} tool call{toolCalls.length > 1 ? "s" : ""}
+					</span>
+				)}
+
+				<div className="ml-auto h-6">
 					{!disabled && onRemove && (
 						<button
 							type="button"
 							aria-label="Delete message"
 							data-testid="tool-call-msg-delete"
 							onClick={onRemove}
-							className="hover:bg-muted focus:bg-muted rounded-sm p-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus:opacity-100"
+							className="rounded-md p-1 opacity-0 transition hover:bg-destructive/10 focus:bg-destructive/10 focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100"
 						>
-							<XIcon className="text-muted-foreground hover:text-foreground size-3 shrink-0 cursor-pointer" />
+							<XIcon className="size-3.5 shrink-0 cursor-pointer text-muted-foreground transition-colors hover:text-destructive" />
 						</button>
 					)}
 				</div>
 			</div>
-			<div className="space-y-2">
-				{toolCalls.map((tc) => {
+
+			<div className="space-y-2.5">
+				{toolCalls.map((tc, i) => {
 					const argsIsJson = isJson(tc.function.arguments);
 					let formattedArgs = tc.function.arguments;
+
 					if (argsIsJson) {
 						try {
 							formattedArgs = JSON.stringify(JSON.parse(tc.function.arguments), null, 2);
@@ -119,59 +166,174 @@ export default function ToolCallMessageView({
 							// keep raw string
 						}
 					}
+
+					const isExecuting = executingIds.has(tc.id);
+					const isResponded = respondedToolCallIds?.has(tc.id);
+					const isManualEntryOpen = manualEntryIds.has(tc.id);
+
 					return (
-						<div key={tc.id} className="bg-muted/50 mt-2 rounded-sm border px-3 py-2">
-							<div className="flex items-center gap-2">
-								<Wrench className="text-muted-foreground size-3 shrink-0" />
-								<span className="mr-4 shrink-0 font-mono text-xs font-medium">{tc.function.name}</span>
-								<span className="text-muted-foreground ml-auto truncate font-mono text-[10px]">{tc.id}</span>
+						<div
+							key={tc.id}
+							className={cn(
+								"animate-in fade-in-0 slide-in-from-bottom-1 duration-200 fill-mode-both motion-reduce:animate-none overflow-hidden rounded-lg border bg-card transition-[border-color,box-shadow]",
+								isExecuting
+									? "border-primary/40 shadow-[0_0_0_1px_var(--color-primary)/0.1]"
+									: "hover:border-border",
+							)}
+							style={{ animationDelay: `${i * 75}ms` }}
+						>
+							<div className="flex items-start gap-2 border-b bg-muted/40 px-3 py-2">
+								<div className="min-w-0 flex-1 items-center flex justify-between">
+									<div className="flex min-w-0 items-center gap-2">
+										<div className={cn(
+											"rounded-md bg-background p-1 shrink-0 transition-colors duration-150",
+											isExecuting && "bg-primary/10",
+										)}>
+											<Wrench className={cn(
+												"size-3.5 shrink-0 transition-colors duration-150",
+												isExecuting ? "text-primary" : "text-muted-foreground",
+											)} />
+										</div>
+										<span className="truncate font-mono text-xs font-semibold text-foreground">
+											{tc.function.name}
+										</span>
+
+										{isResponded && (
+											<span className="animate-in fade-in-0 zoom-in-90 duration-200 motion-reduce:animate-none shrink-0 rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[9px] font-medium text-emerald-600 dark:text-emerald-400">
+												Responded
+											</span>
+										)}
+									</div>
+
+									<div className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground">
+										{tc.id}
+									</div>
+								</div>
 							</div>
-							{formattedArgs &&
-								(argsIsJson ? (
-									<div className="mt-2">
-										<CodeEditor
-											wrap
-											code={formattedArgs}
-											lang="json"
-											readonly={disabled}
-											autoResize
-											onChange={(value) => {
-												jsonBufferRef.current[tc.id] = value ?? "";
-											}}
-											options={{
-												showIndentLines: false,
-												disableHover: true,
-											}}
-											onBlur={() => flushJsonBuffer(tc.id)}
-										/>
+
+							{formattedArgs && (
+								<div className="px-3 py-2">
+									<div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+										Arguments
 									</div>
-								) : (
-									<pre className="text-muted-foreground bg-card mt-2 overflow-x-auto rounded p-2 text-xs leading-relaxed">
-										{formattedArgs}
-									</pre>
-								))}
-							{!disabled && onSubmitToolResult && !respondedToolCallIds?.has(tc.id) && (
-								<div className="mt-2 border-t pt-2">
-									<div className="text-muted-foreground mb-1 text-[10px] font-semibold tracking-wide uppercase">Response</div>
-									<div className="flex items-end gap-2">
-										<Textarea
-											placeholder="Enter tool response..."
-											value={responses[tc.id] ?? ""}
-											onChange={(e) => handleResponseChange(tc.id, e.target.value)}
-											data-testid="tool-call-response-textarea"
-											className="min-h-[36px] resize-none font-mono text-xs"
-											rows={2}
-										/>
-										<Button
-											variant="secondary"
-											size="sm"
-											data-testid="tool-call-response-submit"
-											disabled={!responses[tc.id]?.trim()}
-											onClick={() => handleSubmitResponse(tc.id)}
-										>
-											Submit
-										</Button>
-									</div>
+
+									{argsIsJson ? (
+										<div className="overflow-hidden rounded-md border bg-background">
+											<CodeEditor
+												wrap
+												code={formattedArgs}
+												lang="json"
+												readonly={disabled}
+												autoResize
+												onChange={(value) => {
+													jsonBufferRef.current[tc.id] = value ?? "";
+												}}
+												options={{
+													showIndentLines: false,
+													disableHover: true,
+												}}
+												onBlur={() => flushJsonBuffer(tc.id)}
+											/>
+										</div>
+									) : (
+										<pre className="max-h-56 overflow-auto rounded-md border bg-muted/40 p-2 font-mono text-xs leading-relaxed text-muted-foreground">
+											{formattedArgs}
+										</pre>
+									)}
+								</div>
+							)}
+
+							{!disabled && onSubmitToolResult && !isResponded && (
+								<div className="animate-in fade-in-0 slide-in-from-bottom-1 duration-150 motion-reduce:animate-none border-t bg-muted/20 px-3 py-2">
+									{isManualEntryOpen ? (
+										<div className="animate-in fade-in-0 duration-150 motion-reduce:animate-none space-y-2">
+											<div className="flex items-center gap-2">
+												<div>
+													<div className="text-xs font-medium text-foreground">Tool result</div>
+													<div className="text-[10px] text-muted-foreground">
+														Paste the result returned by this tool call.
+													</div>
+												</div>
+
+												<Button
+													variant="ghost"
+													size="sm"
+													className="ml-auto h-7 px-2 text-xs text-muted-foreground"
+													data-testid="tool-call-response-cancel"
+													onClick={() => hideManualEntry(tc.id)}
+													disabled={isExecuting}
+												>
+													Cancel
+												</Button>
+											</div>
+
+											<Textarea
+												autoFocus
+												placeholder="Paste tool result..."
+												value={responses[tc.id] ?? ""}
+												onChange={(e) => handleResponseChange(tc.id, e.target.value)}
+												data-testid="tool-call-response-textarea"
+												className="min-h-[84px] resize-none rounded-md bg-background font-mono text-xs"
+												rows={4}
+												disabled={isExecuting}
+											/>
+
+											<div className="flex justify-end">
+												<Button
+													variant="secondary"
+													size="sm"
+													className="h-8 active:scale-[0.97] transition-transform"
+													data-testid="tool-call-response-submit"
+													disabled={!responses[tc.id]?.trim() || isExecuting}
+													onClick={() => handleSubmitResponse(tc.id)}
+												>
+													<Send className="size-3.5" />
+													Submit result
+												</Button>
+											</div>
+										</div>
+									) : (
+										<div className="flex flex-wrap items-center gap-2">
+											<div className="min-w-0">
+												<div className="text-xs font-medium text-foreground">Awaiting tool result</div>
+												<div className="text-[10px] text-muted-foreground">
+													Execute the call or add the result manually.
+												</div>
+											</div>
+
+											<div className="ml-auto flex items-center gap-1.5">
+												{onExecuteToolCall && (
+													<Button
+														variant="secondary"
+														size="sm"
+														className="h-8 active:scale-[0.97] transition-transform"
+														data-testid="tool-call-execute"
+														disabled={isExecuting}
+														onClick={() => handleExecute(tc)}
+													>
+														{isExecuting ? (
+															<Loader2 className="size-3.5 animate-spin" />
+														) : (
+															<Play className="size-3.5" />
+														)}
+														{isExecuting ? "Executing" : "Execute"}
+													</Button>
+												)}
+
+												<Button
+													variant="ghost"
+													size="sm"
+													className="h-8 active:scale-[0.97] transition-transform"
+													data-testid="tool-call-response-add-manually"
+													disabled={isExecuting}
+													onClick={() => showManualEntry(tc.id)}
+												>
+													<PencilLine className="size-3.5" />
+													Add manually
+												</Button>
+											</div>
+										</div>
+									)}
 								</div>
 							)}
 						</div>

--- a/ui/components/prompts/components/newMessageInputView.tsx
+++ b/ui/components/prompts/components/newMessageInputView.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Message, type MessageContent } from "@/lib/message";
-import { Loader2, Paperclip, Play, Plus } from "lucide-react";
+import { Paperclip, Play, Plus, Square } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { usePromptContext } from "../context";
 import { fileToAttachment } from "../utils/attachment";
@@ -14,6 +14,7 @@ export function NewMessageInputView() {
 		messages,
 		setMessages: onUpdateMessages,
 		handleSendMessage: onSendMessage,
+		handleStopStreaming: onStopStreaming,
 		isStreaming,
 		supportsVision,
 		provider,
@@ -168,11 +169,11 @@ export function NewMessageInputView() {
 			className="group relative max-h-[500px] shrink-0 overflow-y-auto border-t px-4 py-2"
 			{...(supportsVision
 				? {
-						onDragEnter: handleDragEnter,
-						onDragLeave: handleDragLeave,
-						onDragOver: handleDragOver,
-						onDrop: handleDrop,
-					}
+					onDragEnter: handleDragEnter,
+					onDragLeave: handleDragLeave,
+					onDragOver: handleDragOver,
+					onDrop: handleDrop,
+				}
 				: {})}
 		>
 			{supportsVision && isDragging && (
@@ -245,24 +246,36 @@ export function NewMessageInputView() {
 						<Plus className="h-3.5 w-3.5" />
 						Add
 					</Button>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								onClick={handleRun}
-								disabled={isStreaming || !canRun}
-								variant={"ghost"}
-								data-testid="new-message-run"
-								className="text-muted-foreground hover:text-foreground flex items-center gap-1 rounded px-1.5 py-1 text-xs disabled:pointer-events-none disabled:opacity-50"
-							>
-								{isStreaming ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
-								Run
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="top">
-							{!canRun ? <span>Select a provider and model to run</span> : <span>Run prompt</span>}
-							<kbd className="bg-primary-foreground/20 ml-1.5 rounded px-1 py-0.5 font-mono text-[10px]">↵</kbd>
-						</TooltipContent>
-					</Tooltip>
+					{isStreaming ? (
+						<Button
+							onClick={onStopStreaming}
+							variant={"ghost"}
+							data-testid="new-message-stop"
+							className="text-destructive hover:text-destructive hover:bg-destructive/10 flex items-center gap-1 rounded px-1.5 py-1 text-xs"
+						>
+							<Square className="!h-3 !w-3 fill-current" />
+							Stop
+						</Button>
+					) : (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									onClick={handleRun}
+									disabled={!canRun}
+									variant={"ghost"}
+									data-testid="new-message-run"
+									className="text-muted-foreground hover:text-foreground flex items-center gap-1 rounded px-1.5 py-1 text-xs disabled:pointer-events-none disabled:opacity-50"
+								>
+									<Play className="h-3.5 w-3.5" />
+									Run
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="top">
+								{!canRun ? <span>Select a provider and model to run</span> : <span>Run prompt</span>}
+								<kbd className="bg-primary-foreground/20 ml-1.5 rounded px-1 py-0.5 font-mono text-[10px]">↵</kbd>
+							</TooltipContent>
+						</Tooltip>
+					)}
 				</div>
 			</div>
 		</div>

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -1,4 +1,4 @@
-import { extractVariablesFromMessages, mergeVariables, Message, MessageRole, MessageType, type VariableMap } from "@/lib/message";
+import { extractVariablesFromMessages, mergeVariables, Message, MessageRole, MessageType, type ToolCall, type VariableMap } from "@/lib/message";
 import { getErrorMessage } from "@/lib/store";
 import { useGetCoreConfigQuery } from "@/lib/store/apis/configApi";
 import {
@@ -16,7 +16,7 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
-import { executePrompt } from "./utils/executor";
+import { executePrompt, executeToolCall } from "./utils/executor";
 
 interface PromptContextValue {
 	// Data
@@ -94,7 +94,9 @@ interface PromptContextValue {
 	handleDeleteFolder: () => Promise<void>;
 	handleDeletePrompt: () => Promise<void>;
 	handleSendMessage: (pendingMessage?: Message) => Promise<void>;
+	handleStopStreaming: () => void;
 	handleSubmitToolResult: (afterIndex: number, toolCallId: string, content: string) => Promise<void>;
+	handleExecuteToolCall: (afterIndex: number, toolCall: ToolCall) => Promise<void>;
 
 	// RBAC permissions
 	canCreate: boolean;
@@ -160,6 +162,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 	const [apiKeyId, setApiKeyId] = useState("__auto__");
 	const [isStreaming, setIsStreaming] = useState(false);
 	const activeRunRef = useRef<symbol | null>(null);
+	const abortRef = useRef<AbortController | null>(null);
 	const [variables, setVariables] = useState<VariableMap>({});
 	const [customHeaders, setCustomHeaders] = useState<Record<string, string>>({});
 
@@ -457,6 +460,8 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 		async (pendingMessage?: Message) => {
 			const runToken = Symbol();
 			activeRunRef.current = runToken;
+			const abortController = new AbortController();
+			abortRef.current = abortController;
 			const isActive = () => activeRunRef.current === runToken;
 
 			setIsStreaming(true);
@@ -512,6 +517,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 						setIsStreaming(false);
 					},
 				},
+				abortController.signal,
 			);
 		},
 		[messages, provider, model, modelParams, apiKeyId, variables, customHeaders],
@@ -521,6 +527,8 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 		async (afterIndex: number, toolCallId: string, content: string) => {
 			const runToken = Symbol();
 			activeRunRef.current = runToken;
+			const abortController = new AbortController();
+			abortRef.current = abortController;
 			const isActive = () => activeRunRef.current === runToken;
 
 			const toolResultMsg = new Message(crypto.randomUUID(), 0, MessageType.ToolResult, {
@@ -591,10 +599,32 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 						setIsStreaming(false);
 					},
 				},
+				abortController.signal,
 			);
 		},
 		[messages, provider, model, modelParams, apiKeyId, variables, customHeaders],
 	);
+
+	const handleExecuteToolCall = useCallback(
+		async (afterIndex: number, toolCall: ToolCall) => {
+			try {
+				const content = await executeToolCall(toolCall, { apiKeyId, customHeaders });
+				await handleSubmitToolResult(afterIndex, toolCall.id, content);
+			} catch (err) {
+				toast.error("Failed to execute tool", {
+					description: getErrorMessage(err),
+				});
+			}
+		},
+		[apiKeyId, customHeaders, handleSubmitToolResult],
+	);
+
+	const handleStopStreaming = useCallback(() => {
+		abortRef.current?.abort();
+		abortRef.current = null;
+		activeRunRef.current = null;
+		setIsStreaming(false);
+	}, []);
 
 	const value: PromptContextValue = {
 		folders,
@@ -649,7 +679,9 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 		handleDeleteFolder,
 		handleDeletePrompt,
 		handleSendMessage,
+		handleStopStreaming,
 		handleSubmitToolResult,
+		handleExecuteToolCall,
 		canCreate,
 		canUpdate,
 		canDelete,

--- a/ui/components/prompts/utils/executor.ts
+++ b/ui/components/prompts/utils/executor.ts
@@ -19,6 +19,31 @@ function getBaseUrl() {
 	}
 }
 
+function buildHeaders(config: Pick<ExecutionConfig, "apiKeyId" | "customHeaders">): Record<string, string> {
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+	if (config.apiKeyId && config.apiKeyId !== "__auto__") {
+		if (config.apiKeyId.startsWith("sk-bf-")) {
+			headers["Authorization"] = `Bearer ${config.apiKeyId}`;
+		} else {
+			headers["x-bf-api-key-id"] = config.apiKeyId;
+		}
+	}
+	if (config.customHeaders) {
+		const reserved = new Set(["content-type", "authorization", "x-bf-api-key-id"]);
+		for (const [name, value] of Object.entries(config.customHeaders)) {
+			const trimmedName = name.trim();
+			const trimmedValue = value.trim();
+			if (!trimmedName || !trimmedValue) continue;
+			if (reserved.has(trimmedName.toLowerCase())) {
+				console.warn(`Ignoring custom header "${trimmedName}" — reserved by the playground.`);
+				continue;
+			}
+			headers[trimmedName] = trimmedValue;
+		}
+	}
+	return headers;
+}
+
 export interface ExecutionCallbacks {
 	onStreamingStart: (allMessages: Message[], placeholder: Message) => void;
 	onStreamChunk: (content: string) => void;
@@ -34,6 +59,7 @@ export async function executePrompt(
 	pendingMessage: Message | undefined,
 	config: ExecutionConfig,
 	callbacks: ExecutionCallbacks,
+	signal?: AbortSignal,
 ) {
 	let allMessages: Message[];
 	if (pendingMessage) {
@@ -49,34 +75,13 @@ export async function executePrompt(
 	const resolvedMessages = config.variables ? replaceVariablesInMessages(allMessages, config.variables) : allMessages;
 
 	try {
-		const headers: Record<string, string> = { "Content-Type": "application/json" };
-		if (config.apiKeyId && config.apiKeyId !== "__auto__") {
-			if (config.apiKeyId.startsWith("sk-bf-")) {
-				headers["Authorization"] = `Bearer ${config.apiKeyId}`;
-			} else {
-				headers["x-bf-api-key-id"] = config.apiKeyId;
-			}
-		}
-		if (config.customHeaders) {
-			// System headers we set above; custom headers must not overwrite them — doing
-			// so would break JSON parsing (Content-Type) or silently swap auth credentials.
-			const reserved = new Set(["content-type", "authorization", "x-bf-api-key-id"]);
-			for (const [name, value] of Object.entries(config.customHeaders)) {
-				const trimmedName = name.trim();
-				const trimmedValue = value.trim();
-				if (!trimmedName || !trimmedValue) continue;
-				if (reserved.has(trimmedName.toLowerCase())) {
-					console.warn(`Ignoring custom header "${trimmedName}" — reserved by the playground.`);
-					continue;
-				}
-				headers[trimmedName] = trimmedValue;
-			}
-		}
+		const headers = buildHeaders(config);
 
 		const { api_key_id: _, ...requestParams } = config.modelParams;
 		const response = await fetch(`${getBaseUrl()}/v1/chat/completions`, {
 			method: "POST",
 			headers,
+			signal,
 			body: JSON.stringify({
 				model: `${config.provider}/${config.model}`,
 				messages: Message.toAPIMessages(resolvedMessages),
@@ -192,8 +197,47 @@ export async function executePrompt(
 			}
 		}
 	} catch (err) {
-		callbacks.onError(getErrorMessage(err));
+		if (err instanceof DOMException && err.name === "AbortError") {
+			// User cancelled — no error to display
+		} else {
+			callbacks.onError(getErrorMessage(err));
+		}
 	} finally {
 		callbacks.onFinally();
 	}
+}
+
+export async function executeToolCall(
+	toolCall: ToolCall,
+	config: Pick<ExecutionConfig, "apiKeyId" | "customHeaders">,
+): Promise<string> {
+	const headers = buildHeaders(config);
+
+	const response = await fetch(`${getBaseUrl()}/v1/mcp/tool/execute`, {
+		method: "POST",
+		headers,
+		body: JSON.stringify({
+			id: toolCall.id,
+			type: toolCall.type,
+			index: 0,
+			function: {
+				name: toolCall.function.name,
+				arguments: toolCall.function.arguments,
+			},
+		}),
+	});
+
+	if (!response.ok) {
+		let errorMessage = `HTTP error! status: ${response.status}`;
+		try {
+			const data = await response.json();
+			errorMessage = data.error?.message || data.error?.error || errorMessage;
+		} catch {
+			// keep default message
+		}
+		throw new Error(errorMessage);
+	}
+
+	const data = await response.json();
+	return typeof data.content === "string" ? data.content : JSON.stringify(data.content);
 }


### PR DESCRIPTION
## Summary

Adds the ability to directly execute MCP tool calls from the prompt playground, and introduces a **Stop** button to cancel in-flight streaming requests. Previously, users could only submit tool results manually; now they can execute a tool call against the backend and have the result automatically submitted, or fall back to manual entry.

## Changes

- Added `executeToolCall` in `executor.ts` that POSTs to `/v1/mcp/tool/execute` and returns the tool result as a string. Header-building logic was extracted into a shared `buildHeaders` helper to avoid duplication between `executePrompt` and `executeToolCall`.
- Added `AbortController` support to `executePrompt` so streaming requests can be cancelled. `AbortError` exceptions are silently swallowed since they represent intentional user cancellation.
- Added `handleExecuteToolCall` to the prompt context, which calls `executeToolCall` and then pipes the result into the existing `handleSubmitToolResult` flow.
- Added `handleStopStreaming` to the prompt context, which aborts the active `AbortController` and resets streaming state.
- Replaced the spinner-disabled Run button with a dedicated **Stop** button (destructive styling) that appears while streaming is active.
- Redesigned `ToolCallMessageView` to show an "Awaiting tool result" state with two actions: **Execute** (runs the tool call automatically, showing a spinner while in progress) and **Add manually** (opens the existing textarea flow). The card layout, animations, and status badges were also refreshed.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the prompt playground and configure a model that supports tool/function calling.
2. Add a system prompt and user message that triggers a tool call, then click **Run**.
3. Once the assistant responds with a tool call, verify the card shows **Execute** and **Add manually** buttons.
4. Click **Execute** — confirm the spinner appears, the call is sent to `/v1/mcp/tool/execute`, and the result is automatically submitted and the conversation continues.
5. On a separate tool call, click **Add manually**, paste a result, and click **Submit result** — confirm the existing flow still works.
6. Start a streaming run and click **Stop** — confirm streaming halts immediately with no error toast.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Before/after screenshots of the tool call card and the Stop button should be attached._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`buildHeaders` preserves the existing guard that prevents custom headers from overwriting `Content-Type`, `Authorization`, or `x-bf-api-key-id`, so API key handling is unchanged. The new `executeToolCall` endpoint uses the same auth headers as the rest of the playground.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable