### PR TITLE
fix: responses stream events

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -43,6 +43,7 @@ type AnthropicResponsesStreamState struct {
 	ReasoningSignatures       map[int]string                    // Maps output_index to reasoning signature
 	TextContentIndices        map[int]bool                      // Tracks which content indices are text blocks
 	ReasoningContentIndices   map[int]bool                      // Tracks which content indices are reasoning blocks
+	TextBuffers               map[int]*strings.Builder          // Maps output_index to accumulated text content for done events
 	CompactionContentIndices  map[int]*schemas.CacheControl     // Tracks pending compaction blocks with their cache control
 	CurrentOutputIndex        int                               // Current output index counter
 	MessageID                 *string                           // Message ID from message_start
@@ -71,6 +72,7 @@ var anthropicResponsesStreamStatePool = sync.Pool{
 			ReasoningContentIndices:   make(map[int]bool),
 			CompactionContentIndices:  make(map[int]*schemas.CacheControl),
 			OutputItems:               make(map[int]*schemas.ResponsesMessage),
+			TextBuffers:               make(map[int]*strings.Builder),
 			CurrentOutputIndex:        0,
 			CreatedAt:                 int(time.Now().Unix()),
 			HasEmittedCreated:         false,
@@ -147,6 +149,11 @@ func acquireAnthropicResponsesStreamState() *AnthropicResponsesStreamState {
 	} else {
 		clear(state.ReasoningContentIndices)
 	}
+	if state.TextBuffers == nil {
+		state.TextBuffers = make(map[int]*strings.Builder)
+	} else {
+		clear(state.TextBuffers)
+	}
 	if state.CompactionContentIndices == nil {
 		state.CompactionContentIndices = make(map[int]*schemas.CacheControl)
 	} else {
@@ -207,6 +214,7 @@ func (state *AnthropicResponsesStreamState) flush() {
 	state.ReasoningSignatures = nil
 	state.TextContentIndices = nil
 	state.ReasoningContentIndices = nil
+	state.TextBuffers = nil
 	state.CompactionContentIndices = nil
 	state.OutputItems = nil
 	state.CurrentOutputIndex = 0
@@ -837,6 +845,12 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				}
 			case AnthropicStreamDeltaTypeText:
 				if chunk.Delta.Text != nil && *chunk.Delta.Text != "" {
+					// Accumulate text for done events
+					if state.TextBuffers[outputIndex] == nil {
+						state.TextBuffers[outputIndex] = &strings.Builder{}
+					}
+					state.TextBuffers[outputIndex].WriteString(*chunk.Delta.Text)
+
 					// Text content delta - emit output_text.delta with item ID
 					itemID := state.ItemIDs[outputIndex]
 					response := &schemas.BifrostResponsesStreamResponse{
@@ -1124,29 +1138,44 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 			var responses []*schemas.BifrostResponsesStreamResponse
 			itemID := state.ItemIDs[outputIndex]
 
+			// Capture accumulated text once — shared by output_text.done and output_item.done
+			accText := ""
+			if buf := state.TextBuffers[outputIndex]; buf != nil {
+				accText = buf.String()
+			}
+
 			// Check if this content index is a text block
 			if chunk.Index != nil {
 				if state.TextContentIndices[*chunk.Index] {
-					// Emit output_text.done (without accumulated text, just the event)
-					emptyText := ""
+					// Emit output_text.done with full accumulated text
 					textDoneResponse := &schemas.BifrostResponsesStreamResponse{
 						Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
 						SequenceNumber: sequenceNumber + len(responses),
 						OutputIndex:    schemas.Ptr(outputIndex),
 						ContentIndex:   chunk.Index,
-						Text:           &emptyText,
+						Text:           &accText,
 					}
 					if itemID != "" {
 						textDoneResponse.ItemID = &itemID
 					}
 					responses = append(responses, textDoneResponse)
 
-					// Emit content_part.done
+					// Emit content_part.done with full accumulated text in Part
+					partText := accText
+					part := &schemas.ResponsesMessageContentBlock{
+						Type: schemas.ResponsesOutputMessageContentTypeText,
+						Text: &partText,
+						ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+							Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+							LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+						},
+					}
 					partDoneResponse := &schemas.BifrostResponsesStreamResponse{
 						Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
 						SequenceNumber: sequenceNumber + len(responses),
 						OutputIndex:    schemas.Ptr(outputIndex),
 						ContentIndex:   chunk.Index,
+						Part:           part,
 					}
 					if itemID != "" {
 						partDoneResponse.ItemID = &itemID
@@ -1292,16 +1321,41 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				}
 				doneItem = &copied
 			} else {
+				// Build content blocks from accumulated text (captured above)
+				contentBlocks := []schemas.ResponsesMessageContentBlock{}
+				if accText != "" {
+					textCopy := accText
+					contentBlocks = []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesOutputMessageContentTypeText,
+							Text: &textCopy,
+							ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+								Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+								LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+							},
+						},
+					}
+				}
+				delete(state.TextBuffers, outputIndex)
 				doneItem = &schemas.ResponsesMessage{
 					Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 					Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 					Status: &statusCompleted,
 					Content: &schemas.ResponsesMessageContent{
-						ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+						ContentBlocks: contentBlocks,
 					},
 				}
 				if doneItemID != "" {
 					doneItem.ID = &doneItemID
+				}
+				// Only persist synthesized items that actually have text content — reasoning
+				// and MCP blocks fall through here without storedItems but must not pollute
+				// response.completed with empty assistant message shells.
+				if len(contentBlocks) > 0 {
+					cloned := *doneItem
+					clonedContent := *doneItem.Content
+					cloned.Content = &clonedContent
+					state.OutputItems[outputIndex] = &cloned
 				}
 			}
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
@@ -5192,11 +5246,13 @@ func convertBifrostToolToAnthropic(model string, tool *schemas.ResponsesTool, pr
 		}
 	}
 
-	anthropicTool := &AnthropicTool{}
-
-	if tool.Name != nil {
-		anthropicTool.Name = *tool.Name
+	// Skip tools with no name — Anthropic rejects them
+	if tool.Name == nil || *tool.Name == "" {
+		return nil
 	}
+
+	anthropicTool := &AnthropicTool{}
+	anthropicTool.Name = *tool.Name
 
 	if tool.Description != nil {
 		anthropicTool.Description = tool.Description

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -30,6 +30,7 @@ type BedrockResponsesStreamState struct {
 	NovaGroundingCitations    map[int][]schemas.ResponsesWebSearchToolCallActionSearchSource // Collected citation sources per nova_grounding output index
 	CompletedOutputIndices    map[int]bool                                                   // Tracks which output indices have been completed
 	AnnotationIndices         map[int]int                                                    // Maps output_index to next annotation index for sequential citation numbering
+	TextBuffers               map[int]*strings.Builder                                       // Maps output_index to accumulated text content for done events
 	CurrentOutputIndex        int                                                            // Current output index counter
 	MessageID                 *string                                                        // Message ID (generated)
 	Model                     *string                                                        // Model name
@@ -55,6 +56,7 @@ var bedrockResponsesStreamStatePool = sync.Pool{
 			NovaGroundingCitations:    make(map[int][]schemas.ResponsesWebSearchToolCallActionSearchSource),
 			CompletedOutputIndices:    make(map[int]bool),
 			AnnotationIndices:         make(map[int]int),
+			TextBuffers:               make(map[int]*strings.Builder),
 			CurrentOutputIndex:        0,
 			CreatedAt:                 int(time.Now().Unix()),
 			HasEmittedCreated:         false,
@@ -122,6 +124,11 @@ func acquireBedrockResponsesStreamState() *BedrockResponsesStreamState {
 		state.AnnotationIndices = make(map[int]int)
 	} else {
 		clear(state.AnnotationIndices)
+	}
+	if state.TextBuffers == nil {
+		state.TextBuffers = make(map[int]*strings.Builder)
+	} else {
+		clear(state.TextBuffers)
 	}
 	// Reset other fields
 	state.CurrentOutputIndex = 0
@@ -199,6 +206,11 @@ func (state *BedrockResponsesStreamState) flush() {
 		state.AnnotationIndices = make(map[int]int)
 	} else {
 		clear(state.AnnotationIndices)
+	}
+	if state.TextBuffers == nil {
+		state.TextBuffers = make(map[int]*strings.Builder)
+	} else {
+		clear(state.TextBuffers)
 	}
 	state.CurrentOutputIndex = 0
 	state.MessageID = nil
@@ -377,22 +389,27 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 					continue
 				}
 
-				// Emit output_text.done
-				emptyText := ""
+				prevAccText := ""
+				if buf := state.TextBuffers[prevOutputIndex]; buf != nil {
+					prevAccText = buf.String()
+				}
+
+				// Emit output_text.done with accumulated text
 				responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
 					SequenceNumber: sequenceNumber + len(responses),
 					OutputIndex:    schemas.Ptr(prevOutputIndex),
 					ContentIndex:   &prevContentIndex,
 					ItemID:         &prevItemID,
-					Text:           &emptyText,
+					Text:           &prevAccText,
 					LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 				})
 
-				// Emit content_part.done for text
+				// Emit content_part.done for text with accumulated text
+				prevPartText := prevAccText
 				part := &schemas.ResponsesMessageContentBlock{
 					Type: schemas.ResponsesOutputMessageContentTypeText,
-					Text: &emptyText,
+					Text: &prevPartText,
 					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
 						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
 						Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
@@ -407,8 +424,22 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 					Part:           part,
 				})
 
-				// Emit output_item.done for text
+				// Emit output_item.done for text with content blocks
 				statusCompleted := "completed"
+				var prevContentBlocks []schemas.ResponsesMessageContentBlock
+				if prevAccText != "" {
+					prevItemText := prevAccText
+					prevContentBlocks = []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesOutputMessageContentTypeText,
+							Text: &prevItemText,
+							ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+								Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+								LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+							},
+						},
+					}
+				}
 				messageType := schemas.ResponsesMessageTypeMessage
 				role := schemas.ResponsesInputMessageRoleAssistant
 				doneItem := &schemas.ResponsesMessage{
@@ -416,7 +447,7 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 					Role:   &role,
 					Status: &statusCompleted,
 					Content: &schemas.ResponsesMessageContent{
-						ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+						ContentBlocks: prevContentBlocks,
 					},
 				}
 				if prevItemID != "" {
@@ -429,6 +460,7 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 					ContentIndex:   &prevContentIndex,
 					Item:           doneItem,
 				})
+				delete(state.TextBuffers, prevOutputIndex)
 
 				// Mark this output index as completed
 				state.CompletedOutputIndices[prevOutputIndex] = true
@@ -784,6 +816,11 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 			// If this is a text delta for a new content block, also emit the text delta in the same batch
 			if chunk.Delta.Text != nil && *chunk.Delta.Text != "" {
 				text := *chunk.Delta.Text
+				// Accumulate text for done events
+				if state.TextBuffers[outputIndex] == nil {
+					state.TextBuffers[outputIndex] = &strings.Builder{}
+				}
+				state.TextBuffers[outputIndex].WriteString(text)
 				itemID := state.ItemIDs[outputIndex]
 				textDeltaResponse := &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeOutputTextDelta,
@@ -810,6 +847,11 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 			// Handle text delta
 			text := *chunk.Delta.Text
 			if text != "" {
+				// Accumulate text for done events
+				if state.TextBuffers[outputIndex] == nil {
+					state.TextBuffers[outputIndex] = &strings.Builder{}
+				}
+				state.TextBuffers[outputIndex].WriteString(text)
 				itemID := state.ItemIDs[outputIndex]
 				response := &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeOutputTextDelta,
@@ -1253,23 +1295,27 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 			} // end else (regular function call)
 		} else {
 			// This is likely a text item that needs to be closed
+			accText := ""
+			if buf := state.TextBuffers[outputIndex]; buf != nil {
+				accText = buf.String()
+			}
 
-			// Emit output_text.done (without accumulated text, just the event)
-			emptyText := ""
+			// Emit output_text.done with accumulated text
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 				Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
 				SequenceNumber: sequenceNumber + len(responses),
 				OutputIndex:    schemas.Ptr(outputIndex),
 				ContentIndex:   &contentIndex,
 				ItemID:         &itemID,
-				Text:           &emptyText,
+				Text:           &accText,
 				LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 			})
 
-			// Emit content_part.done for text
+			// Emit content_part.done for text with accumulated text
+			partText := accText
 			part := &schemas.ResponsesMessageContentBlock{
 				Type: schemas.ResponsesOutputMessageContentTypeText,
-				Text: &emptyText,
+				Text: &partText,
 				ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
 					LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
 					Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
@@ -1284,8 +1330,22 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 				Part:           part,
 			})
 
-			// Emit output_item.done for text
+			// Emit output_item.done for text with content blocks
 			statusCompleted := "completed"
+			contentBlocks := []schemas.ResponsesMessageContentBlock{}
+			if accText != "" {
+				itemText := accText
+				contentBlocks = []schemas.ResponsesMessageContentBlock{
+					{
+						Type: schemas.ResponsesOutputMessageContentTypeText,
+						Text: &itemText,
+						ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+							Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+							LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+						},
+					},
+				}
+			}
 			messageType := schemas.ResponsesMessageTypeMessage
 			role := schemas.ResponsesInputMessageRoleAssistant
 			doneItem := &schemas.ResponsesMessage{
@@ -1293,7 +1353,7 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 				Role:   &role,
 				Status: &statusCompleted,
 				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+					ContentBlocks: contentBlocks,
 				},
 			}
 			if itemID != "" {
@@ -1306,6 +1366,7 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 				ContentIndex:   &contentIndex,
 				Item:           doneItem,
 			})
+			delete(state.TextBuffers, outputIndex)
 		}
 
 		// Mark this output index as completed

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -20,6 +20,7 @@ type CohereResponsesStreamState struct {
 	ItemIDs                       map[int]string // Maps output_index to item ID for stable IDs
 	ReasoningContentIndices       map[int]bool   // Tracks which content indices are reasoning blocks
 	AnnotationIndexToContentIndex map[int]int    // Maps annotation index to content index for citation pairing
+	TextBuffers                   map[int]*strings.Builder // Maps output_index to accumulated text content for done events
 	CurrentOutputIndex            int            // Current output index counter
 	MessageID                     *string        // Message ID from message_start
 	Model                         *string        // Model name from message_start
@@ -39,6 +40,7 @@ var cohereResponsesStreamStatePool = sync.Pool{
 			ItemIDs:                       make(map[int]string),
 			ReasoningContentIndices:       make(map[int]bool),
 			AnnotationIndexToContentIndex: make(map[int]int),
+			TextBuffers:                   make(map[int]*strings.Builder),
 			CurrentOutputIndex:            0,
 			CreatedAt:                     int(time.Now().Unix()),
 			HasEmittedCreated:             false,
@@ -82,6 +84,11 @@ func acquireCohereResponsesStreamState() *CohereResponsesStreamState {
 		state.AnnotationIndexToContentIndex = make(map[int]int)
 	} else {
 		clear(state.AnnotationIndexToContentIndex)
+	}
+	if state.TextBuffers == nil {
+		state.TextBuffers = make(map[int]*strings.Builder)
+	} else {
+		clear(state.TextBuffers)
 	}
 	// Reset other fields
 	state.CurrentOutputIndex = 0
@@ -134,6 +141,11 @@ func (state *CohereResponsesStreamState) flush() {
 		state.AnnotationIndexToContentIndex = make(map[int]int)
 	} else {
 		clear(state.AnnotationIndexToContentIndex)
+	}
+	if state.TextBuffers == nil {
+		state.TextBuffers = make(map[int]*strings.Builder)
+	} else {
+		clear(state.TextBuffers)
 	}
 	state.CurrentOutputIndex = 0
 	state.MessageID = nil
@@ -258,23 +270,27 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 		if state.ToolPlanOutputIndex != nil {
 			outputIndex := *state.ToolPlanOutputIndex
 			itemID := state.ItemIDs[outputIndex]
+			accText := ""
+			if buf := state.TextBuffers[outputIndex]; buf != nil {
+				accText = buf.String()
+			}
 
-			// Emit output_text.done (without accumulated text, just the event)
-			emptyText := ""
+			// Emit output_text.done with accumulated text
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 				Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
 				SequenceNumber: sequenceNumber + len(responses),
 				OutputIndex:    schemas.Ptr(outputIndex),
 				ContentIndex:   schemas.Ptr(0),
 				ItemID:         &itemID,
-				Text:           &emptyText,
+				Text:           &accText,
 				LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 			})
 
-			// Emit content_part.done
+			// Emit content_part.done with accumulated text
+			partText := accText
 			part := &schemas.ResponsesMessageContentBlock{
 				Type: schemas.ResponsesOutputMessageContentTypeText,
-				Text: &emptyText,
+				Text: &partText,
 				ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
 					LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
 					Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
@@ -289,7 +305,8 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				Part:           part,
 			})
 
-			// Emit output_item.done
+			// Emit output_item.done with content blocks
+			itemText := accText
 			statusCompleted := "completed"
 			messageType := schemas.ResponsesMessageTypeMessage
 			role := schemas.ResponsesInputMessageRoleAssistant
@@ -298,7 +315,16 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				Role:   &role,
 				Status: &statusCompleted,
 				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesOutputMessageContentTypeText,
+							Text: &itemText,
+							ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+								Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+								LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+							},
+						},
+					},
 				},
 			}
 			if itemID != "" {
@@ -311,6 +337,10 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				ContentIndex:   schemas.Ptr(0),
 				Item:           doneItem,
 			})
+			delete(state.TextBuffers, outputIndex)
+			if mapped, ok := state.ContentIndexToOutputIndex[0]; ok && mapped == outputIndex {
+				delete(state.ContentIndexToOutputIndex, 0)
+			}
 			state.ToolPlanOutputIndex = nil // Mark as closed
 		}
 
@@ -427,6 +457,12 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 
 			// Handle text content delta
 			if chunk.Delta.Message != nil && chunk.Delta.Message.Content != nil && chunk.Delta.Message.Content.CohereStreamContentObject != nil && chunk.Delta.Message.Content.CohereStreamContentObject.Text != nil && *chunk.Delta.Message.Content.CohereStreamContentObject.Text != "" {
+				// Accumulate text for done events
+				if state.TextBuffers[outputIndex] == nil {
+					state.TextBuffers[outputIndex] = &strings.Builder{}
+				}
+				state.TextBuffers[outputIndex].WriteString(*chunk.Delta.Message.Content.CohereStreamContentObject.Text)
+
 				// Emit output_text.delta (not reasoning_summary_text.delta for regular text)
 				itemID := state.ItemIDs[outputIndex]
 				response := &schemas.BifrostResponsesStreamResponse{
@@ -469,6 +505,12 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 			var responses []*schemas.BifrostResponsesStreamResponse
 			isReasoning := state.ReasoningContentIndices[*chunk.Index]
 
+			// Grab accumulated text up front (empty string for reasoning blocks)
+			accText := ""
+			if buf := state.TextBuffers[outputIndex]; buf != nil {
+				accText = buf.String()
+			}
+
 			// Check if this content index is a reasoning block
 			if isReasoning {
 				// Emit reasoning_summary_text.done (reasoning equivalent of output_text.done)
@@ -505,22 +547,22 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				// Clear the reasoning content index tracking
 				delete(state.ReasoningContentIndices, *chunk.Index)
 			} else {
-				// Regular text block - emit output_text.done (without accumulated text, just the event)
-				emptyText := ""
+				// Regular text block - emit output_text.done with accumulated text
 				responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
 					SequenceNumber: sequenceNumber + len(responses),
 					OutputIndex:    schemas.Ptr(outputIndex),
 					ContentIndex:   chunk.Index,
 					ItemID:         &itemID,
-					Text:           &emptyText,
+					Text:           &accText,
 					LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 				})
 
-				// Emit content_part.done
+				// Emit content_part.done with accumulated text
+				partText := accText
 				part := &schemas.ResponsesMessageContentBlock{
 					Type: schemas.ResponsesOutputMessageContentTypeText,
-					Text: &emptyText,
+					Text: &partText,
 					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
 						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
 						Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
@@ -534,6 +576,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 					ItemID:         &itemID,
 					Part:           part,
 				})
+				delete(state.TextBuffers, outputIndex)
 			}
 
 			// Emit output_item.done for all content blocks (text, reasoning, etc.)
@@ -551,6 +594,20 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 					},
 				}
 			} else {
+				contentBlocks := []schemas.ResponsesMessageContentBlock{}
+				if accText != "" {
+					itemText := accText
+					contentBlocks = []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesOutputMessageContentTypeText,
+							Text: &itemText,
+							ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+								Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+								LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+							},
+						},
+					}
+				}
 				messageType := schemas.ResponsesMessageTypeMessage
 				role := schemas.ResponsesInputMessageRoleAssistant
 				doneItem = &schemas.ResponsesMessage{
@@ -558,7 +615,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 					Role:   &role,
 					Status: &statusCompleted,
 					Content: &schemas.ResponsesMessageContent{
-						ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+						ContentBlocks: contentBlocks,
 					},
 				}
 			}
@@ -640,6 +697,12 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				})
 			}
 
+			// Accumulate tool plan text for done events
+			if state.TextBuffers[outputIndex] == nil {
+				state.TextBuffers[outputIndex] = &strings.Builder{}
+			}
+			state.TextBuffers[outputIndex].WriteString(*chunk.Delta.Message.ToolPlan)
+
 			// Emit output_text.delta (not reasoning_summary_text.delta)
 			itemID := state.ItemIDs[outputIndex]
 			response := &schemas.BifrostResponsesStreamResponse{
@@ -663,23 +726,27 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 		if state.ToolPlanOutputIndex != nil {
 			outputIndex := *state.ToolPlanOutputIndex
 			itemID := state.ItemIDs[outputIndex]
+			accText := ""
+			if buf := state.TextBuffers[outputIndex]; buf != nil {
+				accText = buf.String()
+			}
 
-			// Emit output_text.done (without accumulated text, just the event)
-			emptyText := ""
+			// Emit output_text.done with accumulated text
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 				Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
 				SequenceNumber: sequenceNumber + len(responses),
 				OutputIndex:    schemas.Ptr(outputIndex),
 				ContentIndex:   schemas.Ptr(0),
 				ItemID:         &itemID,
-				Text:           &emptyText,
+				Text:           &accText,
 				LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 			})
 
-			// Emit content_part.done
+			// Emit content_part.done with accumulated text
+			partText := accText
 			part := &schemas.ResponsesMessageContentBlock{
 				Type: schemas.ResponsesOutputMessageContentTypeText,
-				Text: &emptyText,
+				Text: &partText,
 				ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
 					LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
 					Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
@@ -694,7 +761,8 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				Part:           part,
 			})
 
-			// Emit output_item.done
+			// Emit output_item.done with content blocks
+			itemText := accText
 			statusCompleted := "completed"
 			messageType := schemas.ResponsesMessageTypeMessage
 			role := schemas.ResponsesInputMessageRoleAssistant
@@ -703,7 +771,16 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				Role:   &role,
 				Status: &statusCompleted,
 				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesOutputMessageContentTypeText,
+							Text: &itemText,
+							ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+								Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+								LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+							},
+						},
+					},
 				},
 			}
 			if itemID != "" {
@@ -716,6 +793,10 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				ContentIndex:   schemas.Ptr(0),
 				Item:           doneItem,
 			})
+			delete(state.TextBuffers, outputIndex)
+			if mapped, ok := state.ContentIndexToOutputIndex[0]; ok && mapped == outputIndex {
+				delete(state.ContentIndexToOutputIndex, 0)
+			}
 			state.ToolPlanOutputIndex = nil // Mark as closed
 		}
 

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -1651,10 +1651,11 @@ func closeGeminiTextItem(state *GeminiResponsesStreamState, sequenceNumber int) 
 		LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 	})
 
-	// Emit content_part.done
+	// Emit content_part.done with accumulated text
+	partText := fullText
 	part := &schemas.ResponsesMessageContentBlock{
 		Type: schemas.ResponsesOutputMessageContentTypeText,
-		Text: schemas.Ptr(""),
+		Text: &partText,
 		ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
 			LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
 			Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
@@ -1669,13 +1670,23 @@ func closeGeminiTextItem(state *GeminiResponsesStreamState, sequenceNumber int) 
 		Part:           part,
 	})
 
-	// Emit output_item.done
+	// Emit output_item.done with content blocks
+	itemText := fullText
 	doneItem := &schemas.ResponsesMessage{
 		Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 		Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 		Status: schemas.Ptr("completed"),
 		Content: &schemas.ResponsesMessageContent{
-			ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{
+				{
+					Type: schemas.ResponsesOutputMessageContentTypeText,
+					Text: &itemText,
+					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+						Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+					},
+				},
+			},
 		},
 	}
 	if itemID != "" {


### PR DESCRIPTION
## Summary

`output_text.done`, `content_part.done`, and `output_item.done` stream events were being emitted with empty text content instead of the full accumulated text. This PR fixes that by introducing a `TextBuffers` map in each provider's stream state to accumulate text deltas as they arrive, then populating the done events with the complete text.

Additionally, tools with a `nil` or empty name are now skipped before being sent to Anthropic, which previously caused Anthropic to reject the request.

## Changes

- Added `TextBuffers map[int]string` to the stream state structs for Anthropic, Bedrock, and Cohere providers, accumulating text deltas keyed by output index
- Updated `output_text.done`, `content_part.done`, and `output_item.done` events across all four providers (Anthropic, Bedrock, Cohere, Gemini) to include the full accumulated text in their payloads rather than empty strings
- Populated `ContentBlocks` in `output_item.done` messages with the actual text content block instead of an empty slice
- Cleaned up `TextBuffers` entries via `delete` after emitting done events to avoid stale state
- Ensured `TextBuffers` is properly initialized and cleared in pool acquire/flush paths
- Skipped Anthropic tool conversion when `tool.Name` is `nil` or empty to prevent Anthropic API rejections

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./...
```

Stream a response from each affected provider (Anthropic, Bedrock, Cohere, Gemini) using the Responses API and verify that:
- `output_text.done` events contain the full assembled text
- `content_part.done` events include a `Part` with the full text
- `output_item.done` events include a `Content.ContentBlocks` array with the complete text block
- Sending a tool with no name to Anthropic no longer causes a request rejection

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses now accumulate per-output text and include full text in final completion events (avoids empty text/content blocks) across provider integrations.
  * Tool entries with missing or empty names are skipped during processing.
  * Stream state pooling lifecycle fixed to prevent cross-request text reuse by allocating, clearing, and releasing per-output text buffers between requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->