### PR TITLE
fix: gate user-mode flows on caller user_id and skip temp token mint

### DIFF
--- a/core/mcp/credstore/credstore.go
+++ b/core/mcp/credstore/credstore.go
@@ -39,8 +39,8 @@ func NewCredStore(oauth2Provider schemas.OAuth2Provider, headersProvider schemas
 	return &CredStore{
 		resolvers: map[schemas.MCPAuthType]resolver{
 			schemas.MCPAuthTypeNone:           &noneResolver{},
-			schemas.MCPAuthTypeHeaders:        &staticHeadersResolver{},
-			schemas.MCPAuthTypeOauth:          &serverOAuthResolver{provider: oauth2Provider},
+			schemas.MCPAuthTypeHeaders:        &sharedHeadersResolver{},
+			schemas.MCPAuthTypeOauth:          &sharedOAuthResolver{provider: oauth2Provider},
 			schemas.MCPAuthTypePerUserOauth:   &perUserOAuthResolver{provider: oauth2Provider},
 			schemas.MCPAuthTypePerUserHeaders: &perUserHeadersResolver{provider: headersProvider},
 		},

--- a/core/mcp/credstore/shared_headers.go
+++ b/core/mcp/credstore/shared_headers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// staticHeadersResolver handles MCPAuthTypeHeaders — the admin-configured
+// sharedHeadersResolver handles MCPAuthTypeHeaders — the admin-configured
 // static headers on the MCP client. ConnectionHeaders here returns ONLY the
 // Authorization header (if admin set one in config.Headers); other static
 // headers are layered by the caller via utils.StaticConfigHeaders so they
@@ -15,9 +15,9 @@ import (
 //
 // CredStore.resolverFor also normalizes empty AuthType to "headers" so this
 // resolver covers the legacy DB default.
-type staticHeadersResolver struct{}
+type sharedHeadersResolver struct{}
 
-func (r *staticHeadersResolver) ConnectionHeaders(_ *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+func (r *sharedHeadersResolver) ConnectionHeaders(_ *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
 	headers := http.Header{}
 	if config == nil {
 		return headers, nil
@@ -34,4 +34,4 @@ func (r *staticHeadersResolver) ConnectionHeaders(_ *schemas.BifrostContext, con
 	return headers, nil
 }
 
-func (r *staticHeadersResolver) RequiresPerCallConnection() bool { return false }
+func (r *sharedHeadersResolver) RequiresPerCallConnection() bool { return false }

--- a/core/mcp/credstore/shared_oauth.go
+++ b/core/mcp/credstore/shared_oauth.go
@@ -6,15 +6,15 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// serverOAuthResolver handles MCPAuthTypeOauth — admin-once OAuth where the
+// sharedOAuthResolver handles MCPAuthTypeOauth — admin-once OAuth where the
 // upstream token is shared across all callers. ConnectionHeaders returns
 // only the Authorization header; static config headers are layered
 // separately by the caller via utils.StaticConfigHeaders.
-type serverOAuthResolver struct {
+type sharedOAuthResolver struct {
 	provider schemas.OAuth2Provider
 }
 
-func (r *serverOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+func (r *sharedOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
 	if config.OauthConfigID == nil || *config.OauthConfigID == "" {
 		return nil, schemas.ErrOAuth2ConfigNotFound
 	}
@@ -31,4 +31,4 @@ func (r *serverOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, con
 	return headers, nil
 }
 
-func (r *serverOAuthResolver) RequiresPerCallConnection() bool { return false }
+func (r *sharedOAuthResolver) RequiresPerCallConnection() bool { return false }

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -165,7 +165,7 @@ type TableOauthUserSession struct {
 	CodeVerifier     string    `gorm:"type:text" json:"-"`                                      // PKCE code verifier (kept secret)
 	SessionID        string    `gorm:"type:varchar(255);index" json:"session_id,omitempty"`     // Session-mode identity: client-asserted x-bf-mcp-session-id. Empty for vk/user mode rows. Stored plaintext (not a bearer credential; same trust model as a VK value).
 	VirtualKeyID     *string   `gorm:"type:varchar(255);index" json:"virtual_key_id"`           // VK identity (propagated to oauth_user_tokens)
-	UserID           *string   `gorm:"type:varchar(255);index" json:"user_id"`                  // Enterprise user identity (propagated to oauth_user_tokens); nullable for deferred-fill user-mode flows
+	UserID           *string   `gorm:"type:varchar(255);index" json:"user_id"`                  // User identity (propagated to oauth_user_tokens); populated only for user-mode rows, nil for vk/session-mode
 	FlowMode         string    `gorm:"type:varchar(20);not null;default:'vk'" json:"flow_mode"` // 'user' | 'vk' | 'session' — mirrors the token row's AuthMode; immutable after creation
 	Status           string    `gorm:"type:varchar(50);not null;index" json:"status"`           // "pending", "authorized", "failed", "expired"
 	EncryptionStatus string    `gorm:"type:varchar(20);default:'plain_text'" json:"-"`

--- a/framework/mcp_headers/main.go
+++ b/framework/mcp_headers/main.go
@@ -241,10 +241,17 @@ func (p *Provider) InitiateUserSubmissionFlow(ctx context.Context, mode schemas.
 	// logs, not in upstream Referer), unlike a query param. Best-effort:
 	// mint failure does not fail the flow init.
 	//
+	// User-mode flows skip the mint: the handler-side identity gate requires
+	// caller's user_id to match flow.UserID, which is only populated by
+	// normal SCIM enforcement on the auth-page route. Minting a temp token
+	// would route the request through the temp-token middleware branch that
+	// bypasses cookie resolution, leaving caller user_id empty and the gate
+	// would 403 even legitimate users. VK and session-mode flows are
+	// intentionally shareable and continue to mint.
 	// Gated by the same MCPEnableTempTokenAuth client-config toggle the
 	// OAuth surface reads, so the UI switch controls both per-user auth
 	// kinds uniformly.
-	if svc := p.tempTokenService(); svc != nil && p.mcpTempTokenAuthEnabled(ctx) {
+	if svc := p.tempTokenService(); svc != nil && p.mcpTempTokenAuthEnabled(ctx) && mode != schemas.MCPAuthModeUser {
 		ttl := time.Until(flow.ExpiresAt)
 		if ttl > 0 {
 			plaintext, mintErr := svc.Mint(ctx, temptoken.MCPHeadersAuthScopeName, flow.ID, ttl)

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -1045,7 +1045,15 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 	// dashboard session can still call the per-user flow endpoints. The
 	// fragment never leaves the browser (not in server logs, not in the
 	// upstream-OAuth Referer), unlike a query param.
-	if svc := p.tempTokenService(); svc != nil && p.mcpTempTokenAuthEnabled(ctx) {
+	//
+	// User-mode flows skip the mint: the handler-side identity gate requires
+	// caller's user_id to match flow.UserID, which is only populated by normal
+	// SCIM enforcement on the auth-page route. Minting a temp token would
+	// route the request through the temp-token middleware branch that
+	// bypasses cookie resolution, leaving caller user_id empty and the gate
+	// would 403 even legitimate users. VK and session-mode flows are
+	// intentionally shareable and continue to mint.
+	if svc := p.tempTokenService(); svc != nil && p.mcpTempTokenAuthEnabled(ctx) && flowMode != schemas.MCPAuthModeUser {
 		ttl := time.Until(expiresAt)
 		if ttl > 0 {
 			plaintext, mintErr := svc.Mint(ctx, temptoken.MCPAuthScopeName, sessionID, ttl)

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -940,14 +940,10 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 	case schemas.MCPAuthModeUser:
 		v, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string)
 		if v == "" {
-			// Deferred-fill: external MCP client OAuth init where the user
-			// identity is stamped at completion time. No identity → no
-			// existing-row lookup; we always insert a fresh row.
-			uid = nil
-		} else {
-			uid = &v
-			lookupID = v
+			return nil, "", fmt.Errorf("user-mode flow requires a user identity in context")
 		}
+		uid = &v
+		lookupID = v
 	case schemas.MCPAuthModeVK:
 		v, _ := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string)
 		if v == "" {
@@ -978,7 +974,6 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 	expiresAt := time.Now().Add(15 * time.Minute)
 
 	// 4. Single canonical lookup: one flow row per (mode, identity, mcp_client).
-	//    Deferred-fill user-mode (lookupID empty) always inserts a fresh row.
 	//
 	//    Only treat a 'pending' hit as reusable. A 'claiming' row means an
 	//    upstream callback is mid-flight for this binding — rotating its
@@ -986,14 +981,12 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 	//    leave the user with an "OAuth flow not found" error. Falling through
 	//    to insert a fresh row lets both flows complete independently.
 	var existing *tables.TableOauthUserSession
-	if lookupID != "" {
-		found, lookupErr := p.configStore.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, flowMode, lookupID, mcpClientID)
-		if lookupErr != nil {
-			return nil, "", fmt.Errorf("failed to look up existing flow row: %w", lookupErr)
-		}
-		if found != nil && found.Status == "pending" {
-			existing = found
-		}
+	found, lookupErr := p.configStore.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, flowMode, lookupID, mcpClientID)
+	if lookupErr != nil {
+		return nil, "", fmt.Errorf("failed to look up existing flow row: %w", lookupErr)
+	}
+	if found != nil && found.Status == "pending" {
+		existing = found
 	}
 
 	var rowID string
@@ -1011,10 +1004,10 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 		}
 		rowID = existing.ID
 	} else {
-		// First-time auth (or deferred-fill user): insert a new row. SessionID
-		// is populated only for session-mode (the caller's x-bf-mcp-session-id);
-		// vk/user-mode rows have an empty SessionID — their identity lives in
-		// virtual_key_id / user_id.
+		// First-time auth: insert a new row. SessionID is populated only for
+		// session-mode (the caller's x-bf-mcp-session-id); vk/user-mode rows
+		// have an empty SessionID — their identity lives in virtual_key_id /
+		// user_id.
 		row := &tables.TableOauthUserSession{
 			ID:            uuid.New().String(),
 			MCPClientID:   mcpClientID,
@@ -1144,9 +1137,7 @@ func (p *OAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string
 
 	// Resolve identity columns from the flow row, honoring its flow_mode. Only
 	// the column that matches the mode is populated on the token row; the others
-	// stay nil to maintain the single-identity invariant. For user-mode flows
-	// where the row's UserID was deferred at init time, stamp from completer
-	// context here.
+	// stay nil to maintain the single-identity invariant.
 	flowMode := schemas.MCPAuthMode(session.FlowMode)
 	var (
 		tokenVKID   *string
@@ -1156,17 +1147,9 @@ func (p *OAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string
 	case schemas.MCPAuthModeUser:
 		tokenUserID = session.UserID
 		if tokenUserID == nil || *tokenUserID == "" {
-			// Deferred fill: pull from completer context.
-			if v, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string); v != "" {
-				tokenUserID = &v
-			}
-		}
-		if tokenUserID == nil || *tokenUserID == "" {
 			p.cleanupFlow(ctx, session.ID)
-			return "", fmt.Errorf("user-mode oauth flow has no user_id at completion (neither flow nor completer context)")
+			return "", fmt.Errorf("user-mode oauth flow has no user_id at completion")
 		}
-		// Stamp the resolved user_id back on the flow for audit.
-		session.UserID = tokenUserID
 	case schemas.MCPAuthModeVK:
 		tokenVKID = session.VirtualKeyID
 		if tokenVKID == nil || *tokenVKID == "" {

--- a/transports/bifrost-http/handlers/mcp_per_user_headers.go
+++ b/transports/bifrost-http/handlers/mcp_per_user_headers.go
@@ -105,6 +105,10 @@ func (h *MCPPerUserHeadersHandler) flowDetail(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusNotFound, "Headers submission flow not found")
 		return
 	}
+	if !canAccessUserFlow(flow.FlowMode, flow.UserID, callerUserIDFromCtx(ctx)) {
+		SendError(ctx, fasthttp.StatusForbidden, "This submission link is bound to a different user.")
+		return
+	}
 
 	config, cfgErr := h.loadMCPClientConfig(ctx, flow.MCPClientID)
 	if cfgErr != nil {
@@ -199,6 +203,10 @@ func (h *MCPPerUserHeadersHandler) flowSubmit(ctx *fasthttp.RequestCtx) {
 	}
 	if flow == nil {
 		SendError(ctx, fasthttp.StatusNotFound, "Headers submission flow not found")
+		return
+	}
+	if !canAccessUserFlow(flow.FlowMode, flow.UserID, callerUserIDFromCtx(ctx)) {
+		SendError(ctx, fasthttp.StatusForbidden, "This submission link is bound to a different user.")
 		return
 	}
 	if !flow.ExpiresAt.IsZero() && flow.ExpiresAt.Before(time.Now()) {

--- a/transports/bifrost-http/handlers/mcp_sessions.go
+++ b/transports/bifrost-http/handlers/mcp_sessions.go
@@ -279,12 +279,6 @@ func (h *MCPSessionsHandler) list(ctx *fasthttp.RequestCtx) {
 			if _, hasToken := tokenBindings[bindingKeyFromFlow(f)]; hasToken {
 				continue
 			}
-			// Skip deferred-fill user-mode flow rows (user_id not yet stamped).
-			// They have no concrete binding to render, and surfacing them in
-			// the table forces an ambiguous label.
-			if f.FlowMode == string(schemas.MCPAuthModeUser) && (f.UserID == nil || *f.UserID == "") {
-				continue
-			}
 			rows = append(rows, flowRow(f))
 		}
 	}
@@ -696,10 +690,8 @@ type mcpFlowDetailResponse struct {
 // flowDetail returns the pending flow row's metadata so the frontend sessions
 // auth page can render a "you're about to authenticate X" view.
 //
-// Permission model: deferred-fill flows (flow_mode='user' with user_id=nil)
-// are visible to any user-mode caller — the first SCIM-authenticated user to
-// open the URL will become the row's user_id at completion time. For all
-// other modes the caller's identity must match the row's identity column.
+// Permission model: the caller's identity must match the row's identity column
+// for the row's flow_mode. Enforced at the configstore layer via DAC scope.
 func (h *MCPSessionsHandler) flowDetail(ctx *fasthttp.RequestCtx) {
 	flowID, ok := ctx.UserValue("id").(string)
 	if !ok || flowID == "" {
@@ -748,17 +740,6 @@ func (h *MCPSessionsHandler) flowDetail(ctx *fasthttp.RequestCtx) {
 		case schemas.MCPAuthModeUser:
 			if flow.UserID != nil && *flow.UserID != "" {
 				identity = *flow.UserID
-			} else if v, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string); v != "" {
-				// Deferred-fill: flow.UserID is nil until completion. Fall
-				// back to the signed-in caller's user_id so HasActiveToken
-				// reflects whether THIS user already has a credential for
-				// the MCP client and we don't prompt an unnecessary re-auth.
-				//
-				// Use UserValue (not Value) — auth middleware stores via
-				// SetUserValue, and fasthttp's Value() only handles bare
-				// string keys, so a typed BifrostContextKey lookup via
-				// Value() always returns nil.
-				identity = v
 			}
 		case schemas.MCPAuthModeVK:
 			if flow.VirtualKeyID != nil {
@@ -817,9 +798,7 @@ func (h *MCPSessionsHandler) flowStart(ctx *fasthttp.RequestCtx) {
 // loadAuthorizedFlow looks up the pending flow row. Visibility is enforced
 // at the enterprise configstore layer via DAC scope on
 // GetOauthUserSessionByID: if the caller is not allowed to see this row,
-// the store returns (nil, nil) and we surface 404. Deferred-fill user-mode
-// flows (user_id IS NULL) are visible to any SCIM-authenticated caller by
-// the scope builder so they can claim the auth URL. Writes the appropriate
+// the store returns (nil, nil) and we surface 404. Writes the appropriate
 // HTTP error response and returns a sentinel error on failure.
 func (h *MCPSessionsHandler) loadAuthorizedFlow(ctx *fasthttp.RequestCtx, flowID string) (*tables.TableOauthUserSession, error) {
 	flow, err := h.store.ConfigStore.GetOauthUserSessionByID(ctx, flowID)

--- a/transports/bifrost-http/handlers/mcp_sessions.go
+++ b/transports/bifrost-http/handlers/mcp_sessions.go
@@ -312,7 +312,7 @@ func (h *MCPSessionsHandler) list(ctx *fasthttp.RequestCtx) {
 		if rows[i].Kind == "flow" {
 			continue
 		}
-		rows[i].CanReauth = canReauthRow(rows[i].AuthMode, rows[i].UserID, caller)
+		rows[i].CanReauth = canAccessUserFlow(rows[i].AuthMode, rows[i].UserID, caller)
 	}
 
 	totalCount := len(rows)
@@ -372,28 +372,34 @@ func bindingKeyFromFlow(f tables.TableOauthUserSession) sessionBindingKey {
 	return k
 }
 
-// canReauthRow encodes the identity gate on POST /reauth. User-mode rows are
-// only reauthable by the bound user — admin DAC scope lets them see the row,
-// but the OAuth callback or header submission lands under whoever clicks the
-// URL, so an admin-initiated reauth would either overwrite identity or let
-// admin submit secret material in the bound user's name. VK / session rows
-// are intentionally shared and have no identity-of-clicker problem.
-func canReauthRow(authMode string, rowUserID *string, caller string) bool {
+// callerUserIDFromCtx pulls the SCIM-authenticated user_id off the request
+// context. Returns "" when unauthenticated or in OSS — callers should treat
+// empty as "no user identity" (which fails the user-mode access gate).
+func callerUserIDFromCtx(ctx *fasthttp.RequestCtx) string {
+	v, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string)
+	return v
+}
+
+// canAccessUserFlow is the single identity gate for user-mode flow/credential
+// rows across every surface that lets a caller act on one: POST /reauth,
+// the per-user OAuth flow detail / start endpoints, and the per-user-headers
+// flow detail / submit endpoints. The CanReauth field on the sessions list
+// rows uses it too so the UI hides actions the caller cannot perform.
+//
+// For user-mode rows the caller's user_id must match the row's user_id —
+// admin DAC scope lets them see the row, but the OAuth callback or header
+// submission lands under whoever clicks the URL, so an admin acting here
+// would either overwrite identity or plant secret material under the bound
+// user's name. VK / session rows are intentionally shared and have no
+// identity-of-clicker problem; the gate passes through for those modes.
+func canAccessUserFlow(authMode string, rowUserID *string, callerUserID string) bool {
 	if authMode != string(schemas.MCPAuthModeUser) {
 		return true
 	}
 	if rowUserID == nil || *rowUserID == "" {
 		return false
 	}
-	return caller != "" && caller == *rowUserID
-}
-
-// callerUserIDFromCtx pulls the SCIM-authenticated user_id off the request
-// context. Returns "" when unauthenticated or in OSS — callers should treat
-// empty as "no user identity" (which fails the user-mode reauth gate).
-func callerUserIDFromCtx(ctx *fasthttp.RequestCtx) string {
-	v, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string)
-	return v
+	return callerUserID != "" && callerUserID == *rowUserID
 }
 
 // reauth starts a fresh OAuth flow OR a fresh header-submission flow for
@@ -450,7 +456,7 @@ func (h *MCPSessionsHandler) reauth(ctx *fasthttp.RequestCtx) {
 	// the OAuth callback lands under whoever clicks the authorize URL — an
 	// admin clicking would either get a "wrong user" credential or overwrite
 	// the row's identity. Mirrored on the wire via mcpSessionRow.CanReauth.
-	if !canReauthRow(tok.AuthMode, tok.UserID, callerUserIDFromCtx(ctx)) {
+	if !canAccessUserFlow(tok.AuthMode, tok.UserID, callerUserIDFromCtx(ctx)) {
 		SendError(ctx, fasthttp.StatusForbidden, "Only the bound user can re-authenticate this session.")
 		return
 	}
@@ -507,7 +513,7 @@ func (h *MCPSessionsHandler) reauthHeaderCredential(ctx *fasthttp.RequestCtx, bf
 	// bound user. An admin clicking through would submit secret material under
 	// their own identity, attached to the bound user's row. Same rule as the
 	// OAuth branch; surfaced to the UI via mcpSessionRow.CanReauth.
-	if !canReauthRow(cred.AuthMode, cred.UserID, callerUserIDFromCtx(ctx)) {
+	if !canAccessUserFlow(cred.AuthMode, cred.UserID, callerUserIDFromCtx(ctx)) {
 		SendError(ctx, fasthttp.StatusForbidden, "Only the bound user can re-submit headers for this session.")
 		return
 	}
@@ -704,6 +710,10 @@ func (h *MCPSessionsHandler) flowDetail(ctx *fasthttp.RequestCtx) {
 		_ = err
 		return
 	}
+	if !canAccessUserFlow(flow.FlowMode, flow.UserID, callerUserIDFromCtx(ctx)) {
+		SendError(ctx, fasthttp.StatusForbidden, "This authentication link is bound to a different user.")
+		return
+	}
 	resp := mcpFlowDetailResponse{
 		ID:            flow.ID,
 		FlowMode:      flow.FlowMode,
@@ -767,8 +777,13 @@ func (h *MCPSessionsHandler) flowStart(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, "Invalid flow id")
 		return
 	}
-	if _, err := h.loadAuthorizedFlow(ctx, flowID); err != nil {
+	flow, err := h.loadAuthorizedFlow(ctx, flowID)
+	if err != nil {
 		_ = err
+		return
+	}
+	if !canAccessUserFlow(flow.FlowMode, flow.UserID, callerUserIDFromCtx(ctx)) {
+		SendError(ctx, fasthttp.StatusForbidden, "This authentication link is bound to a different user.")
 		return
 	}
 	if h.store.OAuthProvider == nil {

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -89,7 +89,8 @@ const baseQueryWithErrorHandling: typeof baseQueryWithRefresh = async (
 			}
 			clearAuthStorage();
 			if (typeof window !== "undefined" && !window.location.pathname.includes("/login")) {
-				window.location.href = "/login";
+				const goto = window.location.pathname + window.location.search;
+				window.location.href = `/login?goto=${encodeURIComponent(goto)}`;
 			}
 			return result;
 		}


### PR DESCRIPTION
## Summary

User-mode MCP auth flows were not properly scoped to the user who initiated them. Any authenticated SSO user holding a user-mode auth URL could view, start, or submit a flow bound to a different user, potentially planting their upstream credentials under that user's identity. This PR adds an identity gate to all user-mode flow endpoints and fixes the temp token minting logic that was causing legitimate users to receive 403s on their own flows.

## Changes

- Added `canAccessUserFlow` helper that enforces caller `user_id` must match `flow.UserID` for user-mode flows; VK and session-mode flows remain intentionally shareable and pass through unchanged.
- Applied the identity gate to `flowDetail`, `flowSubmit`, and `flowStart` in both the OAuth sessions handler and the per-user headers handler, returning a 403 with a descriptive message when the check fails.
- Skipped temp token minting for user-mode flows in both `InitiateUserSubmissionFlow` and `InitiateUserOAuthFlow`. Minting a temp token routes requests through the temp-token middleware branch, which bypasses cookie resolution and leaves the caller `user_id` empty, causing the new identity gate to 403 even legitimate users.
- Updated the UI's 401 redirect to preserve the current path and query string as a `goto` parameter so users are returned to their original destination after logging in.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Create a user-mode MCP auth flow as User A and copy the auth URL.
2. Log in as User B and navigate to that URL — expect a 403 with `"This authentication link is bound to a different user."`.
3. Log in as User A and navigate to the same URL — expect normal flow behavior.
4. Verify VK-mode and session-mode flow URLs remain accessible across users.
5. Trigger a 401 response in the UI while on a non-login page and confirm the redirect lands on `/login?goto=<original-path>` and returns you there after login.

```sh
go test ./framework/... ./transports/...

cd ui
pnpm i
pnpm build
```

## Breaking changes

- [x] No

## Security considerations

Without this gate, any authenticated user holding a user-mode auth URL could complete a flow bound to a different user, injecting their upstream OAuth tokens or header credentials under that user's identity. The `canAccessUserFlow` check mirrors the post-claim gate already present in `CompleteUserOAuthFlow` and closes the same class of vulnerability on the flow detail, start, and submit endpoints. Temp token minting is intentionally skipped for user-mode flows to prevent the middleware bypass that would nullify the gate.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable