### PR TITLE
fix: cap JSON editor max height at 400px in message views

### DIFF
--- a/ui/components/prompts/components/messagesView/assistantMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/assistantMessageView.tsx
@@ -165,6 +165,7 @@ export function AssistantMessageView({
 						lang="json"
 						readonly={disabled}
 						autoResize
+						maxHeight={400}
 						onChange={(value) => {
 							jsonBufferRef.current = value ?? "";
 						}}

--- a/ui/components/prompts/components/messagesView/systemMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/systemMessageView.tsx
@@ -166,6 +166,7 @@ export function SystemMessageView({
 						lang="json"
 						readonly={disabled}
 						autoResize
+						maxHeight={400}
 						onChange={(value) => {
 							jsonBufferRef.current = value ?? "";
 						}}

--- a/ui/components/prompts/components/messagesView/toolCallResultView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallResultView.tsx
@@ -140,6 +140,7 @@ export default function ToolResultMessageView({
 						lang="json"
 						readonly={disabled}
 						autoResize
+						maxHeight={400}
 						onChange={(value) => {
 							jsonBufferRef.current = value ?? "";
 						}}

--- a/ui/components/prompts/components/messagesView/toolCallView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallView.tsx
@@ -225,6 +225,7 @@ export default function ToolCallMessageView({
 												lang="json"
 												readonly={disabled}
 												autoResize
+												maxHeight={400}
 												onChange={(value) => {
 													jsonBufferRef.current[tc.id] = value ?? "";
 												}}

--- a/ui/components/prompts/components/messagesView/userMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/userMessageView.tsx
@@ -282,6 +282,7 @@ export function UserMessageView({
 						lang="json"
 						readonly={disabled}
 						autoResize
+						maxHeight={400}
 						onChange={(value) => {
 							jsonBufferRef.current = value ?? "";
 						}}


### PR DESCRIPTION
## Summary

JSON editors in the message views (assistant, system, user, tool call, and tool call result) could grow unbounded when displaying large JSON payloads, making the UI difficult to use. This PR caps the auto-resizing height of those editors at 400px.

## Changes

- Added `maxHeight={400}` to the auto-resizing JSON editor in each message view component, preventing the editor from expanding beyond 400px regardless of content size.

## Type of change

- [x] Bug fix

## Affected areas

- [x] UI (React)

## How to test

1. Open a prompt with a message containing a large JSON payload (assistant, system, user, tool call, or tool call result).
2. Verify that the JSON editor expands as content grows but stops at 400px and becomes scrollable rather than continuing to expand.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: JSON editors expand to the full height of the content, pushing other elements far down the page.

After: JSON editors cap at 400px and scroll internally for content that exceeds that height.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable