### PR TITLE
migration rollback warnings for codereviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,22 +20,30 @@ reviews:
     - path: "core/**"
       instructions: |
         Review Go core changes for concurrency safety, provider isolation, pooled object reset discipline, and plugin hook ordering.
+        Apply standard Go review practices: small interfaces, clear error wrapping, context propagation, race-safe shared state, goroutine/channel cleanup, and table-driven tests for behavior changes.
+        Apply Go security practices: avoid logging secrets or request bodies by default, validate untrusted input before provider calls, use constant-time comparison for secrets/tokens, and prefer well-reviewed standard-library crypto primitives over custom crypto.
         Flag channel lifecycle changes that do not follow the ProviderQueue atomic closing/sync.Once pattern.
         For provider changes, verify streaming paths use the streaming client and preserve response/error metadata.
     - path: "framework/**"
       instructions: |
         Review persistence, streaming, and shared framework changes for backward-compatible data formats and careful memory ownership.
+        Apply standard Go review practices: explicit error handling, correct context cancellation, bounded resource usage, race-safe maps/slices, and tests that cover edge cases and failure paths.
+        Apply security practices for persistence and storage: parameterized queries, safe file permissions, secret redaction, encryption key handling, path traversal prevention, and least-privilege access to external stores.
         For logstore/configstore changes, check migration behavior, duration serialization, and map-copy race prevention.
         When migrations are added or changed, verify they avoid deadlocks on large tables and create indexes concurrently.
+        If a migration cannot be rolled back, explicitly flag it as non-rollbackable.
     - path: "transports/**"
       instructions: |
         Treat transports/config.schema.json as the source of truth for config fields.
+        Apply HTTP/API security review: authentication and authorization checks, fail-closed behavior, input size limits, request validation, SSRF/path traversal/header injection defenses, CORS/cookie safety, and secret redaction in logs/errors.
         Verify HTTP handlers preserve SDK compatibility, middleware ordering, context conversion, and route-level middleware behavior.
     - path: "plugins/**"
       instructions: |
         Review plugin changes for hook symmetry, nil response/error handling, fallback behavior, and module-local dependency hygiene.
+        Apply standard Go and security review practices: context propagation, race-safe shared state, bounded goroutines, least-privilege defaults, fail-closed auth/rate-limit behavior, secret redaction, and dependency vulnerability awareness.
         Each plugin has its own go.mod; do not assume root-level Go module commands apply.
         When migrations are added or changed, verify they avoid deadlocks on large tables and create indexes concurrently.
+        If a migration cannot be rolled back, explicitly flag it as non-rollbackable.
     - path: "ui/**"
       instructions: |
         Preserve existing UI conventions and data-testid attributes used by Playwright tests.

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -17,6 +17,9 @@ When reviewing a PR, first identify which Bifrost area is touched:
 ## Repository Rules
 
 - Cross-module imports work locally through `go.work`, but releaseable module changes still need explicit `require` entries in the relevant module.
+- Apply standard Go review practices where they affect correctness or maintainability: clear ownership, small interfaces, explicit error handling and wrapping, context propagation and cancellation, bounded goroutines/channels, race-safe shared state, deterministic tests, and table-driven coverage for behavior changes.
+- Apply Go security practices: do not log secrets or sensitive request/response bodies by default, use constant-time comparison for secrets/tokens, prefer standard-library or well-reviewed crypto over custom crypto, validate all untrusted input, enforce timeouts and size limits, and avoid unsafe reflection or `unsafe` unless clearly justified.
+- Apply general security review for auth, authorization, and data handling: fail closed on ambiguous permissions, enforce least privilege, redact sensitive values in logs/errors, prevent SSRF/path traversal/header injection, avoid SQL injection via parameterized queries, use safe file permissions, and check new dependencies for supply-chain and vulnerability risk.
 - For provider-level tests, prefer `make test-core` over bare `go test` because the Make target runs the shared provider scenario suite.
 - Provider converters must remain pure transformation functions with no HTTP calls, logging, or side effects.
 - OpenAI provider converter changes affect OpenAI-compatible providers that delegate to OpenAI helpers, including Groq, Cerebras, Ollama, Perplexity, OpenRouter, Parasail, Nebius, xAI, and SGL.
@@ -28,6 +31,7 @@ When reviewing a PR, first identify which Bifrost area is touched:
 - Do not set Bifrost reserved context keys from handlers or plugins.
 - `transports/config.schema.json` is the source of truth for config fields.
 - Whenever a migration is added or changed, verify it avoids deadlocks and long blocking locks on large tables. Index creation in migrations must be concurrent where the database supports it.
+- If a migration cannot be rolled back, explicitly flag it as non-rollbackable.
 - Alert when frontend code uses browser crypto APIs such as `crypto`, `crypto.subtle`, or `globalThis.crypto` because they can fail in non-HTTPS contexts, except localhost and other secure contexts.
 - UI changes must preserve `data-testid` attributes used by E2E tests.
 - E2E API payloads must be constructed directly as object literals. Do not serialize through maps, Records, `Object.fromEntries`, or JSON round trips.


### PR DESCRIPTION
## Summary

Expands the automated review guidelines in `.coderabbit.yaml` and `.greptile/rules.md` to include explicit Go best-practice and security review instructions across all major areas of the codebase. This ensures reviewers and AI tools consistently apply correctness, maintainability, and security checks without relying on implicit knowledge.

## Changes

- Added Go review practice instructions (small interfaces, error wrapping, context propagation, race-safe state, table-driven tests) to the `core/**`, `framework/**`, and `plugins/**` CodeRabbit path rules.
- Added security review instructions to each path rule covering secrets redaction, constant-time comparisons, input validation, timeouts, and safe crypto usage.
- Added HTTP/API security review guidance (auth checks, fail-closed behavior, SSRF/path traversal/header injection defenses, CORS/cookie safety) to the `transports/**` rule.
- Added a non-rollbackable migration flag requirement to `framework/**` and `plugins/**` rules, and to the global Greptile rules.
- Added three new global rules to `.greptile/rules.md` covering standard Go practices, Go security practices, and general auth/authorization/data-handling security review.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

No runtime code was changed. Validate by inspecting that CodeRabbit and Greptile pick up the updated rule files on the next PR review cycle.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

These changes introduce explicit security review requirements for secrets handling, constant-time comparisons, input validation, SSRF/path traversal defenses, and safe file permissions. No runtime security surface is modified.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable