### PR TITLE
fix: handle partial tool call execution failures and return successful results

### DIFF
--- a/ui/components/prompts/components/messagesView/toolCallView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallView.tsx
@@ -27,7 +27,7 @@ export default function ToolCallMessageView({
 	onSubmitToolResult?: (toolCallId: string, content: string) => void;
 	onExecuteToolCall?: (toolCall: ToolCall) => Promise<void>;
 	onSubmitAllToolResults?: (results: { toolCallId: string; content: string }[]) => Promise<void>;
-	onExecuteAllToolCalls?: (toolCalls: ToolCall[]) => Promise<void>;
+	onExecuteAllToolCalls?: (toolCalls: ToolCall[]) => Promise<{ toolCallId: string; content: string }[] | undefined>;
 	fetchToolResult?: (toolCall: ToolCall) => Promise<string>;
 	respondedToolCallIds?: Set<string>;
 }) {
@@ -166,7 +166,21 @@ export default function ToolCallMessageView({
 		);
 		setIsExecutingAll(true);
 		try {
-			await onExecuteAllToolCalls(latestCalls);
+			const partialResults = await onExecuteAllToolCalls(latestCalls);
+			if (partialResults) {
+				const newResponses: Record<string, string> = {};
+				const newResolved = new Set<string>();
+				for (const r of partialResults) {
+					newResponses[r.toolCallId] = r.content;
+					newResolved.add(r.toolCallId);
+				}
+				setResponses((prev) => ({ ...prev, ...newResponses }));
+				setResolvedIds((prev) => {
+					const next = new Set(prev);
+					for (const id of newResolved) next.add(id);
+					return next;
+				});
+			}
 		} finally {
 			setIsExecutingAll(false);
 		}

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -1,6 +1,7 @@
 import { extractVariablesFromMessages, mergeVariables, Message, MessageRole, MessageType, type ToolCall, type VariableMap } from "@/lib/message";
 import { getErrorMessage } from "@/lib/store";
 import { useGetCoreConfigQuery } from "@/lib/store/apis/configApi";
+import { v4 as uuidv4 } from "uuid";
 import {
 	useDeleteFolderMutation,
 	useDeletePromptMutation,
@@ -98,7 +99,7 @@ interface PromptContextValue {
 	handleSubmitToolResult: (afterIndex: number, toolCallId: string, content: string) => Promise<void>;
 	handleExecuteToolCall: (afterIndex: number, toolCall: ToolCall) => Promise<void>;
 	handleSubmitAllToolResults: (afterIndex: number, results: { toolCallId: string; content: string }[]) => Promise<void>;
-	handleExecuteAllToolCalls: (afterIndex: number, toolCalls: ToolCall[]) => Promise<void>;
+	handleExecuteAllToolCalls: (afterIndex: number, toolCalls: ToolCall[]) => Promise<{ toolCallId: string; content: string }[] | undefined>;
 	fetchToolResult: (toolCall: ToolCall) => Promise<string>;
 
 	// RBAC permissions
@@ -534,7 +535,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			abortRef.current = abortController;
 			const isActive = () => activeRunRef.current === runToken;
 
-			const toolResultMsg = new Message(crypto.randomUUID(), 0, MessageType.ToolResult, {
+			const toolResultMsg = new Message(uuidv4(), 0, MessageType.ToolResult, {
 				role: MessageRole.TOOL,
 				content,
 				tool_call_id: toolCallId,
@@ -641,7 +642,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 				insertAt++;
 			}
 			for (const { toolCallId, content } of results) {
-				const toolResultMsg = new Message(crypto.randomUUID(), 0, MessageType.ToolResult, {
+				const toolResultMsg = new Message(uuidv4(), 0, MessageType.ToolResult, {
 					role: MessageRole.TOOL,
 					content,
 					tool_call_id: toolCallId,
@@ -711,25 +712,51 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 	);
 
 	const handleExecuteAllToolCalls = useCallback(
-		async (afterIndex: number, toolCalls: ToolCall[]) => {
-			if (toolCalls.length === 0) return;
+		async (afterIndex: number, toolCalls: ToolCall[]): Promise<{ toolCallId: string; content: string }[] | undefined> => {
+			if (toolCalls.length === 0) return undefined;
 			if (toolCalls.length === 1) {
-				return handleExecuteToolCall(afterIndex, toolCalls[0]);
+				await handleExecuteToolCall(afterIndex, toolCalls[0]);
+				return undefined;
 			}
 
-			try {
-				const results = await Promise.all(
-					toolCalls.map(async (tc) => {
-						const content = await executeToolCall(tc, { apiKeyId, customHeaders });
-						return { toolCallId: tc.id, content };
-					}),
-				);
-				await handleSubmitAllToolResults(afterIndex, results);
-			} catch (err) {
-				toast.error("Failed to execute tools", {
-					description: getErrorMessage(err),
+			const settled = await Promise.allSettled(
+				toolCalls.map(async (tc) => {
+					const content = await executeToolCall(tc, { apiKeyId, customHeaders });
+					return { toolCallId: tc.id, content };
+				}),
+			);
+
+			const successes = settled
+				.filter((r): r is PromiseFulfilledResult<{ toolCallId: string; content: string }> => r.status === "fulfilled")
+				.map((r) => r.value);
+
+			const failures = settled
+				.filter((r): r is PromiseRejectedResult => r.status === "rejected")
+				.map((r) => getErrorMessage(r.reason));
+
+			if (failures.length > 0) {
+				const detail = failures.length <= 3
+					? failures.join("; ")
+					: `${failures.slice(0, 2).join("; ")} and ${failures.length - 2} more`;
+				toast.error(`${failures.length} of ${toolCalls.length} tool executions failed`, {
+					description: failures.length === toolCalls.length
+						? detail
+						: `${detail}. Successful results were kept — fill the rest manually.`,
 				});
 			}
+
+			if (successes.length === toolCalls.length) {
+				try {
+					await handleSubmitAllToolResults(afterIndex, successes);
+				} catch (err) {
+					toast.error("Failed to submit tool results", {
+						description: getErrorMessage(err),
+					});
+				}
+				return undefined;
+			}
+
+			return successes.length > 0 ? successes : undefined;
 		},
 		[apiKeyId, customHeaders, handleExecuteToolCall, handleSubmitAllToolResults],
 	);


### PR DESCRIPTION
## Summary

When executing multiple tool calls in parallel, if some succeed and others fail, the successful results were previously discarded entirely. This PR improves partial failure handling so that successful tool call results are preserved and surfaced back to the UI, allowing users to manually fill in only the failed ones.

## Changes

- `handleExecuteAllToolCalls` now uses `Promise.allSettled` instead of `Promise.all`, so individual failures no longer abort the entire batch.
- On partial failure, successful results are returned to the caller instead of being immediately submitted, allowing the UI to pre-populate those responses while leaving failed ones editable.
- The error toast now reports how many of the total tool calls failed and hints that successful results were kept when it's a partial failure.
- `onExecuteAllToolCalls` return type updated from `Promise<void>` to `Promise<{ toolCallId: string; content: string }[] | undefined>` to carry partial results back to `ToolCallMessageView`.
- `ToolCallMessageView` now handles the returned partial results by updating its local `responses` and `resolvedIds` state, so successfully executed tools appear filled in immediately.
- Replaced `crypto.randomUUID()` with `uuidv4()` from the `uuid` package for consistency.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a prompt with multiple tool calls that can be executed directly.
2. Intentionally cause one tool call to fail (e.g., misconfigure one tool's endpoint or parameters).
3. Click "Execute All" on the tool call message.
4. Verify that the successfully executed tools show their results pre-filled in the UI.
5. Verify that the failed tool call(s) remain editable and a toast appears indicating how many failed.
6. Verify that when all tool calls succeed, behavior is unchanged — results are submitted automatically.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable