### PR TITLE
refactor: collapse TLS/Certificate section into accordion in MCP client form and sheet

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -730,56 +730,62 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 									)}
 
 									{/* TLS / Certificate */}
-									<div className="space-y-4 rounded-lg border p-4">
-										<h4 className="text-sm font-medium">TLS / Certificate</h4>
-										<FormField
-											control={control}
-											name="tls_config.insecure_skip_verify"
-											render={({ field }) => (
-												<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-													<div className="space-y-0.5">
-														<FormLabel>Skip TLS verification</FormLabel>
-														<p className="text-muted-foreground text-sm">
-															Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA certificate.
-														</p>
-													</div>
-													<FormControl>
-														<Switch
-															checked={field.value ?? false}
-															onCheckedChange={field.onChange}
-															data-testid="mcp-tls-insecure-skip-verify"
-														/>
-													</FormControl>
-												</FormItem>
-											)}
-										/>
-										<FormField
-											control={control}
-											name="tls_config.ca_cert_pem"
-											render={({ field }) => (
-												<FormItem>
-													<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
-													<FormControl>
-														<EnvVarInput
-															variant="textarea"
-															placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
-															className="font-mono text-xs"
-															rows={6}
-															hideValueWhenEnv
-															redactNonEnvValue
-															{...field}
-															value={field.value}
-															data-testid="mcp-tls-ca-cert-pem"
-														/>
-													</FormControl>
-													<p className="text-muted-foreground text-sm">
-														PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
-													</p>
-													<FormMessage />
-												</FormItem>
-											)}
-										/>
-									</div>
+									<Accordion type="single" collapsible className="w-full">
+										<AccordionItem value="tls-config" className="border-b-0">
+											<AccordionTrigger className="py-0" data-testid="tls-config-trigger">
+												<span className="text-sm font-medium">TLS / Certificate</span>
+											</AccordionTrigger>
+											<AccordionContent className="space-y-4 pt-4 pb-0">
+												<FormField
+													control={control}
+													name="tls_config.insecure_skip_verify"
+													render={({ field }) => (
+														<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+															<div className="space-y-0.5">
+																<FormLabel>Skip TLS verification</FormLabel>
+																<p className="text-muted-foreground text-sm">
+																	Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA certificate.
+																</p>
+															</div>
+															<FormControl>
+																<Switch
+																	checked={field.value ?? false}
+																	onCheckedChange={field.onChange}
+																	data-testid="mcp-tls-insecure-skip-verify"
+																/>
+															</FormControl>
+														</FormItem>
+													)}
+												/>
+												<FormField
+													control={control}
+													name="tls_config.ca_cert_pem"
+													render={({ field }) => (
+														<FormItem>
+															<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+															<FormControl>
+																<EnvVarInput
+																	variant="textarea"
+																	placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
+																	className="font-mono text-xs"
+																	rows={6}
+																	hideValueWhenEnv
+																	redactNonEnvValue
+																	{...field}
+																	value={field.value}
+																	data-testid="mcp-tls-ca-cert-pem"
+																/>
+															</FormControl>
+															<p className="text-muted-foreground text-sm">
+																PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
+															</p>
+															<FormMessage />
+														</FormItem>
+													)}
+												/>
+											</AccordionContent>
+										</AccordionItem>
+									</Accordion>
 								</>
 							)}
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -8,6 +8,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Fragment } from "react";
@@ -633,59 +634,65 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess, on
 									)}
 								/>
 								{(mcpClient.config.connection_type === "http" || mcpClient.config.connection_type === "sse") && (
-									<div className="space-y-4 rounded-lg border p-4">
-										<h4 className="text-sm font-medium">TLS / Certificate</h4>
-										<FormField
-											control={form.control}
-											name="tls_config.insecure_skip_verify"
-											render={({ field }) => (
-												<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-													<div className="space-y-0.5">
-														<FormLabel>Skip TLS verification</FormLabel>
-														<p className="text-muted-foreground text-sm">
-															Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA
-															certificate.
-														</p>
-													</div>
-													<FormControl>
-														<Switch
-															checked={field.value ?? false}
-															onCheckedChange={field.onChange}
-															disabled={!hasUpdateMCPClientAccess}
-															data-testid="mcp-tls-insecure-skip-verify"
-														/>
-													</FormControl>
-												</FormItem>
-											)}
-										/>
-										<FormField
-											control={form.control}
-											name="tls_config.ca_cert_pem"
-											render={({ field }) => (
-												<FormItem>
-													<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
-													<FormControl>
-														<EnvVarInput
-															variant="textarea"
-															placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
-															className="font-mono text-xs"
-															rows={6}
-															hideValueWhenEnv
-															redactNonEnvValue
-															{...field}
-															value={field.value}
-															disabled={!hasUpdateMCPClientAccess}
-															data-testid="mcp-tls-ca-cert-pem"
-														/>
-													</FormControl>
-													<p className="text-muted-foreground text-sm">
-														PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
-													</p>
-													<FormMessage />
-												</FormItem>
-											)}
-										/>
-									</div>
+									<Accordion type="single" collapsible className="w-full">
+										<AccordionItem value="tls-config" className="border-b-0">
+											<AccordionTrigger className="py-0" data-testid="tls-config-trigger">
+												<span className="text-sm font-medium">TLS / Certificate</span>
+											</AccordionTrigger>
+											<AccordionContent className="space-y-4 pt-4 pb-0">
+												<FormField
+													control={form.control}
+													name="tls_config.insecure_skip_verify"
+													render={({ field }) => (
+														<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+															<div className="space-y-0.5">
+																<FormLabel>Skip TLS verification</FormLabel>
+																<p className="text-muted-foreground text-sm">
+																	Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA
+																	certificate.
+																</p>
+															</div>
+															<FormControl>
+																<Switch
+																	checked={field.value ?? false}
+																	onCheckedChange={field.onChange}
+																	disabled={!hasUpdateMCPClientAccess}
+																	data-testid="mcp-tls-insecure-skip-verify"
+																/>
+															</FormControl>
+														</FormItem>
+													)}
+												/>
+												<FormField
+													control={form.control}
+													name="tls_config.ca_cert_pem"
+													render={({ field }) => (
+														<FormItem>
+															<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+															<FormControl>
+																<EnvVarInput
+																	variant="textarea"
+																	placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
+																	className="font-mono text-xs"
+																	rows={6}
+																	hideValueWhenEnv
+																	redactNonEnvValue
+																	{...field}
+																	value={field.value}
+																	disabled={!hasUpdateMCPClientAccess}
+																	data-testid="mcp-tls-ca-cert-pem"
+																/>
+															</FormControl>
+															<p className="text-muted-foreground text-sm">
+																PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
+															</p>
+															<FormMessage />
+														</FormItem>
+													)}
+												/>
+											</AccordionContent>
+										</AccordionItem>
+									</Accordion>
 								)}
 								<FormField
 									control={form.control}

--- a/ui/app/workspace/mcp-sessions/auth-success/page.tsx
+++ b/ui/app/workspace/mcp-sessions/auth-success/page.tsx
@@ -12,7 +12,7 @@ export default function MCPSessionsAuthSuccessPage() {
         </h1>
         <p className="text-muted-foreground mt-2 text-sm">
           Your credential has been stored. You can close this tab and return to
-          your MCP client — future requests will use this credential
+          your MCP client - future requests will use this credential
           automatically.
         </p>
       </div>

--- a/ui/app/workspace/mcp-sessions/auth/page.tsx
+++ b/ui/app/workspace/mcp-sessions/auth/page.tsx
@@ -220,32 +220,6 @@ function OAuthAuthView() {
 				)}
 			</p>
 
-      {showTempTokenSSOWarning ? (
-        <Alert variant="warning" className="mt-6">
-          <TriangleAlert />
-          <AlertTitle>Temporary token in use</AlertTitle>
-          <AlertDescription>
-            <p>
-              If you continue with the temporary link, activity from this
-              credential will be attributed to the bound key instead of your
-              user account.
-            </p>
-            <Button
-              asChild
-              variant="outline"
-              size="sm"
-              className="mt-2"
-              data-testid="mcp-auth-login-instead-warning-button"
-            >
-              <a href={loginHref}>
-                <LogIn className="size-4" />
-                Log in instead
-              </a>
-            </Button>
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
 			<dl className="bg-muted/40 mt-6 space-y-3 rounded-sm border p-4 text-sm">
 				<DetailRow
 					label="MCP client"


### PR DESCRIPTION
## Summary

The TLS / Certificate section in the MCP client form and sheet was always fully expanded, taking up visual space even when users don't need to configure TLS settings. This wraps the section in a collapsible `Accordion` component so it stays hidden by default and can be expanded on demand.

Additionally, the temporary-token SSO warning alert and its inline "Log in instead" button have been removed from the OAuth auth flow, and a minor punctuation fix was applied to the auth success page.

## Changes

- Replaced the static bordered `div` containing the TLS / Certificate fields with a collapsible `Accordion` in both `mcpClientForm.tsx` and `mcpClientSheet.tsx`
- The accordion is collapsed by default, reducing visual clutter for users who don't need TLS configuration
- The `AccordionTrigger` retains the "TLS / Certificate" label and includes a `data-testid` for test targeting
- Removed the temporary-token SSO warning `Alert` block from the OAuth auth view in `mcp-sessions/auth/page.tsx`
- Replaced an em dash with a hyphen in the auth success page copy

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the MCP client creation form or edit sheet for an HTTP or SSE connection type
2. Verify the "TLS / Certificate" section is collapsed by default
3. Click the accordion trigger to expand it and confirm the "Skip TLS verification" toggle and "CA Certificate (PEM)" textarea are visible and functional

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications. The underlying TLS fields and their behavior are unchanged. The removed temporary-token warning was UI-only and did not affect any auth logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable