### PR TITLE
avoid overriding optional fields in virtual key update

### DIFF
--- a/core/schemas/optionaljson.go
+++ b/core/schemas/optionaljson.go
@@ -1,0 +1,39 @@
+package schemas
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// OptionalJSON tracks whether a JSON field was omitted, null, or set to a value.
+type OptionalJSON[T any] struct {
+	Set   bool
+	Null  bool
+	Value T
+}
+
+// UnmarshalJSON records field presence and decodes a non-null field value.
+func (o *OptionalJSON[T]) UnmarshalJSON(data []byte) error {
+	o.Set = true
+	o.Null = false
+	var zero T
+	o.Value = zero
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		o.Null = true
+		return nil
+	}
+	return json.Unmarshal(data, &o.Value)
+}
+
+// MarshalJSON encodes null for omitted/null fields and the wrapped value otherwise.
+func (o OptionalJSON[T]) MarshalJSON() ([]byte, error) {
+	if !o.Set || o.Null {
+		return []byte("null"), nil
+	}
+	return Marshal(o.Value)
+}
+
+// IsZero reports whether the JSON field was omitted during decoding.
+func (o OptionalJSON[T]) IsZero() bool {
+	return !o.Set
+}

--- a/core/schemas/optionaljson_test.go
+++ b/core/schemas/optionaljson_test.go
@@ -1,0 +1,64 @@
+package schemas
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOptionalJSONDistinguishesOmittedNullAndValue(t *testing.T) {
+	var omitted struct {
+		Name OptionalJSON[string] `json:"name,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(`{}`), &omitted); err != nil {
+		t.Fatalf("unmarshal omitted: %v", err)
+	}
+	if omitted.Name.Set || omitted.Name.Null || omitted.Name.Value != "" {
+		t.Fatalf("omitted field = %#v, want unset zero value", omitted.Name)
+	}
+
+	var nullValue struct {
+		Name OptionalJSON[string] `json:"name,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(`{"name": null}`), &nullValue); err != nil {
+		t.Fatalf("unmarshal null: %v", err)
+	}
+	if !nullValue.Name.Set || !nullValue.Name.Null || nullValue.Name.Value != "" {
+		t.Fatalf("null field = %#v, want set null", nullValue.Name)
+	}
+
+	var concrete struct {
+		Name OptionalJSON[string] `json:"name,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(`{"name": "alice"}`), &concrete); err != nil {
+		t.Fatalf("unmarshal value: %v", err)
+	}
+	if !concrete.Name.Set || concrete.Name.Null || concrete.Name.Value != "alice" {
+		t.Fatalf("value field = %#v, want set value alice", concrete.Name)
+	}
+}
+
+func TestOptionalJSONMarshalDoesNotLeakInternalState(t *testing.T) {
+	unset, err := json.Marshal(OptionalJSON[string]{})
+	if err != nil {
+		t.Fatalf("marshal unset: %v", err)
+	}
+	if string(unset) != "null" {
+		t.Fatalf("unset marshaled as %s, want null", unset)
+	}
+
+	nullValue, err := json.Marshal(OptionalJSON[string]{Set: true, Null: true})
+	if err != nil {
+		t.Fatalf("marshal null: %v", err)
+	}
+	if string(nullValue) != "null" {
+		t.Fatalf("null marshaled as %s, want null", nullValue)
+	}
+
+	value, err := json.Marshal(OptionalJSON[string]{Set: true, Value: "alice"})
+	if err != nil {
+		t.Fatalf("marshal value: %v", err)
+	}
+	if string(value) != `"alice"` {
+		t.Fatalf("value marshaled as %s, want alice string", value)
+	}
+}

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -119,13 +119,42 @@ type UpdateVirtualKeyRequest struct {
 		MCPClientName  string            `json:"mcp_client_name" validate:"required"`
 		ToolsToExecute schemas.WhiteList `json:"tools_to_execute,omitempty"`
 	} `json:"mcp_configs,omitempty"`
-	TeamID           *string                 `json:"team_id,omitempty"`
-	CustomerID       *string                 `json:"customer_id,omitempty"`
-	Budgets          []CreateBudgetRequest   `json:"budgets,omitempty"` // Multi-budget: replaces all VK-level budgets
-	RateLimit        *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
-	IsActive         *bool                   `json:"is_active,omitempty"`
-	CalendarAligned  *bool                   `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
-	ResetBudgetUsage *bool                   `json:"reset_budget_usage,omitempty"`
+	TeamID           schemas.OptionalJSON[string] `json:"team_id,omitempty"`
+	CustomerID       schemas.OptionalJSON[string] `json:"customer_id,omitempty"`
+	Budgets          []CreateBudgetRequest        `json:"budgets,omitempty"` // Multi-budget: replaces all VK-level budgets
+	RateLimit        *UpdateRateLimitRequest      `json:"rate_limit,omitempty"`
+	IsActive         *bool                        `json:"is_active,omitempty"`
+	CalendarAligned  *bool                        `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
+	ResetBudgetUsage *bool                        `json:"reset_budget_usage,omitempty"`
+}
+
+var errVirtualKeyDualAssociation = errors.New("VirtualKey cannot be attached to both Team and Customer")
+
+// optionalJSONStringHasValue reports whether a presence-aware string contains a non-empty value.
+func optionalJSONStringHasValue(value schemas.OptionalJSON[string]) bool {
+	return value.Set && !value.Null && value.Value != ""
+}
+
+// applyVirtualKeyOwnershipUpdate applies presence-aware team/customer ownership changes.
+func applyVirtualKeyOwnershipUpdate(vk *configstoreTables.TableVirtualKey, req *UpdateVirtualKeyRequest) error {
+	if optionalJSONStringHasValue(req.TeamID) && optionalJSONStringHasValue(req.CustomerID) {
+		return errVirtualKeyDualAssociation
+	}
+	if optionalJSONStringHasValue(req.TeamID) {
+		vk.TeamID = new(req.TeamID.Value)
+		vk.CustomerID = nil
+		return nil
+	}
+	if optionalJSONStringHasValue(req.CustomerID) {
+		vk.CustomerID = new(req.CustomerID.Value)
+		vk.TeamID = nil
+		return nil
+	}
+	if req.TeamID.Set || req.CustomerID.Set {
+		vk.TeamID = nil
+		vk.CustomerID = nil
+	}
+	return nil
 }
 
 type BulkRotateVirtualKeysRequest struct {
@@ -845,7 +874,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	// Validate mutually exclusive TeamID and CustomerID
-	if req.TeamID != nil && req.CustomerID != nil {
+	if optionalJSONStringHasValue(req.TeamID) && optionalJSONStringHasValue(req.CustomerID) {
 		SendError(ctx, 400, "VirtualKey cannot be attached to both Team and Customer")
 		return
 	}
@@ -896,18 +925,11 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		if req.Description != nil {
 			vk.Description = *req.Description
 		}
-		if req.TeamID != nil {
-			vk.TeamID = req.TeamID
-			vk.CustomerID = nil // Clear CustomerID if setting TeamID
-		}
-		if req.CustomerID != nil {
-			vk.CustomerID = req.CustomerID
-			vk.TeamID = nil // Clear TeamID if setting CustomerID
-		}
-		// When both TeamID and CustomerID are nil
-		if req.TeamID == nil && req.CustomerID == nil {
-			vk.TeamID = nil
-			vk.CustomerID = nil
+		if err := applyVirtualKeyOwnershipUpdate(vk, &req); err != nil {
+			if errors.Is(err, errVirtualKeyDualAssociation) {
+				return &badRequestError{err: err}
+			}
+			return err
 		}
 		if req.IsActive != nil {
 			vk.IsActive = req.IsActive

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -97,6 +97,127 @@ func (m *mockRotateGovernanceManager) ReloadVirtualKey(ctx context.Context, id s
 	return m.store.GetVirtualKey(ctx, id)
 }
 
+func TestApplyVirtualKeyOwnershipUpdatePreservesOmittedAssociation(t *testing.T) {
+	teamID := "team-1"
+	customerID := "customer-1"
+	vk := &configstoreTables.TableVirtualKey{ID: "vk-1", TeamID: &teamID, CustomerID: &customerID}
+	var req UpdateVirtualKeyRequest
+	if err := json.Unmarshal([]byte(`{"name":"renamed"}`), &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+
+	if err := applyVirtualKeyOwnershipUpdate(vk, &req); err != nil {
+		t.Fatalf("apply ownership update: %v", err)
+	}
+	if vk.TeamID == nil || *vk.TeamID != teamID || vk.CustomerID == nil || *vk.CustomerID != customerID {
+		t.Fatalf("omitted ownership fields changed association: %#v", vk)
+	}
+}
+
+func TestApplyVirtualKeyOwnershipUpdateSwitchesAndClearsAssociation(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		initialTeam  *string
+		initialCust  *string
+		wantTeam     *string
+		wantCustomer *string
+	}{
+		{
+			name:         "set team clears customer",
+			body:         `{"team_id":"team-2"}`,
+			initialCust:  schemas.Ptr("customer-1"),
+			wantTeam:     schemas.Ptr("team-2"),
+			wantCustomer: nil,
+		},
+		{
+			name:         "set customer clears team",
+			body:         `{"customer_id":"customer-2"}`,
+			initialTeam:  schemas.Ptr("team-1"),
+			wantTeam:     nil,
+			wantCustomer: schemas.Ptr("customer-2"),
+		},
+		{
+			name:         "null team clears both",
+			body:         `{"team_id":null}`,
+			initialTeam:  schemas.Ptr("team-1"),
+			initialCust:  schemas.Ptr("customer-1"),
+			wantTeam:     nil,
+			wantCustomer: nil,
+		},
+		{
+			name:         "empty customer clears both",
+			body:         `{"customer_id":""}`,
+			initialTeam:  schemas.Ptr("team-1"),
+			initialCust:  schemas.Ptr("customer-1"),
+			wantTeam:     nil,
+			wantCustomer: nil,
+		},
+		{
+			name:         "null team and customer clears both",
+			body:         `{"team_id":null,"customer_id":null}`,
+			initialTeam:  schemas.Ptr("team-1"),
+			initialCust:  schemas.Ptr("customer-1"),
+			wantTeam:     nil,
+			wantCustomer: nil,
+		},
+		{
+			name:         "empty team and customer clears both",
+			body:         `{"team_id":"","customer_id":""}`,
+			initialTeam:  schemas.Ptr("team-1"),
+			initialCust:  schemas.Ptr("customer-1"),
+			wantTeam:     nil,
+			wantCustomer: nil,
+		},
+		{
+			name:         "team with null customer sets team",
+			body:         `{"team_id":"team-2","customer_id":null}`,
+			initialCust:  schemas.Ptr("customer-1"),
+			wantTeam:     schemas.Ptr("team-2"),
+			wantCustomer: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vk := &configstoreTables.TableVirtualKey{ID: "vk-1", TeamID: tt.initialTeam, CustomerID: tt.initialCust}
+			var req UpdateVirtualKeyRequest
+			if err := json.Unmarshal([]byte(tt.body), &req); err != nil {
+				t.Fatalf("unmarshal request: %v", err)
+			}
+			if err := applyVirtualKeyOwnershipUpdate(vk, &req); err != nil {
+				t.Fatalf("apply ownership update: %v", err)
+			}
+			assertStringPtrEqual(t, "team", vk.TeamID, tt.wantTeam)
+			assertStringPtrEqual(t, "customer", vk.CustomerID, tt.wantCustomer)
+		})
+	}
+}
+
+func TestApplyVirtualKeyOwnershipUpdateRejectsDualAssociation(t *testing.T) {
+	vk := &configstoreTables.TableVirtualKey{ID: "vk-1"}
+	var req UpdateVirtualKeyRequest
+	if err := json.Unmarshal([]byte(`{"team_id":"team-1","customer_id":"customer-1"}`), &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if err := applyVirtualKeyOwnershipUpdate(vk, &req); !errors.Is(err, errVirtualKeyDualAssociation) {
+		t.Fatalf("expected dual-association error, got %v", err)
+	}
+}
+
+func assertStringPtrEqual(t *testing.T, label string, got *string, want *string) {
+	t.Helper()
+	if got == nil || want == nil {
+		if got != want {
+			t.Fatalf("%s pointer nil mismatch: got %v, want %v", label, got, want)
+		}
+		return
+	}
+	if *got != *want {
+		t.Fatalf("%s value = %q, want %q", label, *got, *want)
+	}
+}
+
 func TestFindExistingBudgetPrefersIDOverResetDuration(t *testing.T) {
 	monthlyBudget := configstoreTables.TableBudget{
 		ID:            "budget-monthly",

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -856,13 +856,17 @@ export default function VirtualKeySheet({
             data.teamId &&
             data.teamId.trim() !== ""
               ? data.teamId
-              : undefined,
+              : data.entityType === "none"
+                ? null
+                : undefined,
           customer_id:
             data.entityType === "customer" &&
             data.customerId &&
             data.customerId.trim() !== ""
               ? data.customerId
-              : undefined,
+              : data.entityType === "none"
+                ? null
+                : undefined,
           is_active: data.isActive,
           calendar_aligned: data.budgetCalendarAligned,
           reset_budget_usage: resetBudgetUsage,

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -171,8 +171,8 @@ export interface UpdateVirtualKeyRequest {
 	description?: string;
 	provider_configs?: VirtualKeyProviderConfigUpdateRequest[];
 	mcp_configs?: VirtualKeyMCPConfigRequest[];
-	team_id?: string;
-	customer_id?: string;
+	team_id?: string | null;
+	customer_id?: string | null;
 	budgets?: CreateBudgetRequest[];
 	rate_limit?: UpdateRateLimitRequest;
 	is_active?: boolean;


### PR DESCRIPTION
## Summary

Previously, `UpdateVirtualKeyRequest` used `*string` for `TeamID` and `CustomerID`, making it impossible to distinguish between a field being omitted from the request body and a field being explicitly set to `null` or an empty string. This caused unintended clearing of ownership associations when neither field was included in a PATCH request.

## Changes

- Introduced a generic `OptionalJSON[T]` type in `core/schemas` that tracks three distinct JSON field states: omitted, explicitly `null`, and set to a value.
- Replaced `*string` with `schemas.OptionalJSON[string]` for `TeamID` and `CustomerID` in `UpdateVirtualKeyRequest`.
- Extracted ownership update logic into `applyVirtualKeyOwnershipUpdate`, which only modifies `TeamID`/`CustomerID` on the virtual key when the corresponding field was explicitly present in the request. Setting either field to `null` or `""` clears both associations.
- The dual-association guard (rejecting requests that set both `TeamID` and `CustomerID`) is preserved and now applies only when both fields are explicitly present.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/...
go test ./transports/bifrost-http/handlers/...
```

Key scenarios covered by tests:
- Omitting `team_id` and `customer_id` from the request body leaves existing associations unchanged.
- Setting `team_id` to a value clears `customer_id`, and vice versa.
- Setting either field to `null` or `""` clears both associations.
- Providing both `team_id` and `customer_id` in the same request returns a `400` dual-association error.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. The change narrows the surface for unintended data mutation on virtual key ownership updates.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API now distinguishes omitted vs explicitly null/empty fields for ownership, enabling requests to set, switch, or clear team/customer associations and adding an explicit reset-budget option.
  * Ownership updates enforce mutual-exclusivity and surface clear validation errors for conflicting assignments.

* **Tests**
  * Added tests validating presence-aware JSON behavior (omitted vs null vs value) and ownership update scenarios (omission, set/switch, explicit clearing, and dual-association error).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->