### PR TITLE
feat: add MCP auth required error handling with inline banner and retry support

### DIFF
--- a/ui/components/prompts/components/messagesView/toolCallView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallView.tsx
@@ -4,7 +4,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Message, MessageRole, SerializedMessage, type ToolCall } from "@/lib/message";
 import { cn } from "@/lib/utils";
 import { isJson } from "@/lib/utils/validation";
-import { Check, Loader2, PencilLine, Play, Send, Wrench, XIcon } from "lucide-react";
+import { MCPAuthRequiredError } from "../../utils/executor";
+import { Check, ExternalLink, Loader2, PencilLine, Play, RefreshCw, Send, ShieldAlert, Wrench, XIcon } from "lucide-react";
 import { useRef, useState } from "react";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
 
@@ -36,6 +37,7 @@ export default function ToolCallMessageView({
 	const [executingIds, setExecutingIds] = useState<Set<string>>(new Set());
 	const [resolvedIds, setResolvedIds] = useState<Set<string>>(new Set());
 	const [manualEntryIds, setManualEntryIds] = useState<Set<string>>(new Set());
+	const [authErrors, setAuthErrors] = useState<Record<string, MCPAuthRequiredError>>({});
 	const [isExecutingAll, setIsExecutingAll] = useState(false);
 	const [isSubmittingAll, setIsSubmittingAll] = useState(false);
 	const messageRef = useRef(message);
@@ -129,6 +131,10 @@ export default function ToolCallMessageView({
 		setExecutingIds((prev) => new Set(prev).add(tc.id));
 		try {
 			await onExecuteToolCall(latestTc);
+		} catch (err) {
+			if (err instanceof MCPAuthRequiredError) {
+				setAuthErrors((prev) => ({ ...prev, [tc.id]: err }));
+			}
 		} finally {
 			setExecutingIds((prev) => {
 				const next = new Set(prev);
@@ -148,6 +154,10 @@ export default function ToolCallMessageView({
 			const content = await fetchToolResult(latestTc);
 			setResponses((prev) => ({ ...prev, [tc.id]: content }));
 			setResolvedIds((prev) => new Set(prev).add(tc.id));
+		} catch (err) {
+			if (err instanceof MCPAuthRequiredError) {
+				setAuthErrors((prev) => ({ ...prev, [tc.id]: err }));
+			}
 		} finally {
 			setExecutingIds((prev) => {
 				const next = new Set(prev);
@@ -164,6 +174,7 @@ export default function ToolCallMessageView({
 		const latestCalls = pendingToolCalls.map(
 			(tc) => messageRef.current.toolCalls?.find((t) => t.id === tc.id) ?? tc,
 		);
+		setAuthErrors({});
 		setIsExecutingAll(true);
 		try {
 			const partialResults = await onExecuteAllToolCalls(latestCalls);
@@ -234,6 +245,19 @@ export default function ToolCallMessageView({
 	};
 
 	const tcHasResult = (tcId: string) => resolvedIds.has(tcId) || (manualEntryIds.has(tcId) && !!responses[tcId]?.trim());
+
+	const handleRetry = (tc: ToolCall) => {
+		setAuthErrors((prev) => {
+			const next = { ...prev };
+			delete next[tc.id];
+			return next;
+		});
+		if (isMultiple) {
+			handleExecuteOne(tc);
+		} else {
+			handleExecuteSingle(tc);
+		}
+	};
 
 	return (
 		<div className="group rounded-lg border border-transparent px-3 py-2 transition-colors hover:border-border/80 focus-within:border-border/80">
@@ -421,8 +445,51 @@ export default function ToolCallMessageView({
 								</div>
 							)}
 
+							{/* Auth error inline banner */}
+							{!disabled && authErrors[tc.id] && !isResponded && (
+								<div className="animate-in fade-in-0 duration-150 motion-reduce:animate-none border-t border-amber-500/30 bg-amber-500/5 px-3 py-2.5">
+									<div className="flex flex-wrap items-center gap-2">
+										<div className="flex min-w-0 items-center gap-2">
+											<div className="rounded-md bg-amber-500/10 p-1 shrink-0">
+												<ShieldAlert className="size-3.5 text-amber-600 dark:text-amber-400" />
+											</div>
+											<div className="min-w-0">
+												<div className="text-xs font-medium text-foreground">
+													Authentication required for {authErrors[tc.id].mcpClientName}
+												</div>
+												<div className="text-[10px] text-muted-foreground">
+													Connect your account to execute this tool.
+												</div>
+											</div>
+										</div>
+										<div className="ml-auto flex items-center gap-1.5">
+											{authErrors[tc.id].authorizeUrl && (
+												<Button
+													size="sm"
+													className="h-8 active:scale-[0.97] transition-transform bg-primary text-primary-foreground hover:bg-primary/90"
+													onClick={() => window.open(authErrors[tc.id].authorizeUrl, "_blank", "noopener,noreferrer")}
+												>
+													<ExternalLink className="size-3.5" />
+													Authenticate
+												</Button>
+											)}
+											<Button
+												variant="secondary"
+												size="sm"
+												className="h-8 active:scale-[0.97] transition-transform"
+												onClick={() => handleRetry(tc)}
+												disabled={isBusy}
+											>
+												<RefreshCw className="size-3.5" />
+												Retry
+											</Button>
+										</div>
+									</div>
+								</div>
+							)}
+
 							{/* Per-card action bar (single mode: full actions, multi mode: per-card execute/manual) */}
-							{!disabled && onSubmitToolResult && !isResponded && !hasResult && !isManualEntryOpen && (
+							{!disabled && onSubmitToolResult && !isResponded && !hasResult && !isManualEntryOpen && !authErrors[tc.id] && (
 								<div className="animate-in fade-in-0 slide-in-from-bottom-1 duration-150 motion-reduce:animate-none border-t bg-muted/20 px-3 py-2">
 									<div className="flex flex-wrap items-center gap-2">
 										{!isMultiple && (

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -17,7 +17,7 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
-import { executePrompt, executeToolCall } from "./utils/executor";
+import { executePrompt, executeToolCall, MCPAuthRequiredError } from "./utils/executor";
 
 interface PromptContextValue {
 	// Data
@@ -615,6 +615,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 				const content = await executeToolCall(toolCall, { apiKeyId, customHeaders });
 				await handleSubmitToolResult(afterIndex, toolCall.id, content);
 			} catch (err) {
+				if (err instanceof MCPAuthRequiredError) throw err;
 				toast.error("Failed to execute tool", {
 					description: getErrorMessage(err),
 				});

--- a/ui/components/prompts/utils/executor.ts
+++ b/ui/components/prompts/utils/executor.ts
@@ -207,6 +207,20 @@ export async function executePrompt(
 	}
 }
 
+export class MCPAuthRequiredError extends Error {
+	kind: "oauth" | "headers";
+	mcpClientName: string;
+	authorizeUrl: string;
+
+	constructor(opts: { kind: "oauth" | "headers"; mcpClientName: string; authorizeUrl: string; message: string }) {
+		super(opts.message);
+		this.name = "MCPAuthRequiredError";
+		this.kind = opts.kind;
+		this.mcpClientName = opts.mcpClientName;
+		this.authorizeUrl = opts.authorizeUrl;
+	}
+}
+
 export async function executeToolCall(
 	toolCall: ToolCall,
 	config: Pick<ExecutionConfig, "apiKeyId" | "customHeaders">,
@@ -232,8 +246,18 @@ export async function executeToolCall(
 		try {
 			const data = await response.json();
 			errorMessage = data.error?.message || data.error?.error || errorMessage;
-		} catch {
-			// keep default message
+
+			const authRequired = data.extra_fields?.mcp_auth_required;
+			if (authRequired) {
+				throw new MCPAuthRequiredError({
+					kind: authRequired.kind,
+					mcpClientName: authRequired.mcp_client_name || "MCP server",
+					authorizeUrl: authRequired.authorize_url || authRequired.submit_url || "",
+					message: authRequired.message || errorMessage,
+				});
+			}
+		} catch (e) {
+			if (e instanceof MCPAuthRequiredError) throw e;
 		}
 		throw new Error(errorMessage);
 	}


### PR DESCRIPTION
## Summary

When a tool call fails because an MCP server requires OAuth authentication, the error was previously swallowed and shown only as a generic toast. This PR surfaces MCP authentication errors directly in the tool call UI, allowing users to authenticate and retry without losing context.

## Changes

- Introduced a `MCPAuthRequiredError` class in `executor.ts` that captures the auth kind (`oauth` or `headers`), the MCP client name, and the authorization URL parsed from the `extra_fields.mcp_auth_required` field in the error response.
- Updated `executeToolCall` to detect and throw `MCPAuthRequiredError` when the API response indicates authentication is required.
- Updated the prompt context's tool call handler to re-throw `MCPAuthRequiredError` instead of catching it as a generic error toast.
- Added `authErrors` state to `ToolCallMessageView` to track per-tool-call authentication errors.
- Rendered an inline amber banner within the tool call card when an auth error is present, showing the MCP client name, a prompt to authenticate, an "Authenticate" button that opens the authorization URL in a new tab, and a "Retry" button to re-execute the tool call after authenticating.
- Hid the normal action bar when an auth error is active to avoid conflicting UI states.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a prompt with an MCP tool that requires OAuth authentication.
2. Execute the tool call without being authenticated.
3. Verify that an inline amber banner appears on the tool call card with the MCP client name and an "Authenticate" button.
4. Click "Authenticate" and confirm it opens the authorization URL in a new tab.
5. After authenticating, click "Retry" and confirm the tool call executes successfully.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

#### Screenshots/Recordings

Before

![image.png](https://app.graphite.com/user-attachments/assets/6264d53c-eca6-47e0-b22a-c33865053606.png)



#### After

![image.png](https://app.graphite.com/user-attachments/assets/47ce1087-28d8-47b8-a06e-0542bac68b80.png)

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The authorization URL is opened via `window.open(..., "_blank")`, which is consistent with standard OAuth redirect flows. No tokens or credentials are stored in component state; only the error metadata (client name and URL) is retained until the error is cleared on retry.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool calls now show inline "authentication required" banners with optional authorize links and a Retry button.
  - Users can follow authorize URLs and retry individual tool executions.
  - Improved execution flow: bulk execution clears prior auth states before running.

- **Bug Fixes**
  - Per-tool action controls are suppressed while a tool awaits authentication to prevent conflicting actions.
  - Authentication failures are surfaced distinctly instead of a generic error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->