### PR TITLE
chore: bump Bifrost Helm chart to 2.1.20 with `authServerType` and attribute mapping schema fixes

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.19
+version: 2.1.20
 appVersion: "1.5.3"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,16 +4,18 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.19
+**Latest Version:** 2.1.20
 
 ## Changelog
 
-### Upcoming
+### 2.1.20
 
-- **[Upcoming]** Added `tlsConfig` to `bifrost.mcp.clientConfigs[]` for HTTP and SSE MCP connection types:
+- Added `tlsConfig` to `bifrost.mcp.clientConfigs[]` for HTTP and SSE MCP connection types:
   - `insecureSkipVerify` — disable TLS certificate verification (development/testing only; takes priority over `caCertPem`).
   - `caCertPem` — PEM-encoded CA certificate for MCP servers that use a self-signed or private CA. Accepts a literal PEM string or an `env.VAR_NAME` reference (e.g. `"env.MY_MCP_CA_CERT"`).
   - Chart maps `tlsConfig.insecureSkipVerify` → `tls_config.insecure_skip_verify` and `tlsConfig.caCertPem` → `tls_config.ca_cert_pem` in the generated config JSON.
+- Added `authServerType` to the Okta SCIM config in `values.schema.json` and `config.schema.json`. Accepts `"org"` (Org Authorization Server) or `"custom"` (Custom Authorization Server); auto-detected from the issuer URL when omitted. Previously the field was documented but rejected by `additionalProperties: false` in both schemas.
+- Added `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` to the Okta provider branch in `config.schema.json`, aligning the transport runtime schema with the Helm chart schema which already included them.
 
 ### 2.1.19
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1737,6 +1737,11 @@
                         "format": "uri",
                         "description": "Okta issuer URL (e.g., https://your-domain.okta.com/oauth2/default)"
                       },
+                      "authServerType": {
+                        "type": "string",
+                        "enum": ["org", "custom"],
+                        "description": "'org' for Org Authorization Server or 'custom' for Custom Authorization Server. Auto-detected from issuer URL when omitted."
+                      },
                       "clientId": {
                         "type": "string",
                         "description": "Okta application client ID"

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -633,6 +633,7 @@ bifrost:
     config: {}
       # Okta configuration:
       # issuerUrl: "https://your-domain.okta.com/oauth2/default"
+      # authServerType: "org"  # "org" or "custom"; auto-detected from issuer URL when omitted
       # clientId: ""
       # clientSecret: ""
       # apiToken: ""

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,30 @@ entries:
   bifrost:
     - apiVersion: v2
       appVersion: 1.5.3
+      created: "2026-05-28T22:00:26.010588+05:30"
+      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+        for multiple providers
+      digest: 7213e43fd8370d6b97a16b50ee8d2fa2089579ede9b6056a1041e0f11ce4316f
+      home: https://www.getmaxim.ai/bifrost
+      icon: https://www.getbifrost.ai/favicon.png
+      keywords:
+        - ai
+        - gateway
+        - llm
+        - openai
+        - anthropic
+      maintainers:
+        - email: support@getbifrost.ai
+          name: Bifrost Team
+      name: bifrost
+      sources:
+        - https://github.com/maximhq/bifrost
+      type: application
+      urls:
+        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.20.tgz
+      version: 2.1.20
+    - apiVersion: v2
+      appVersion: 1.5.3
       created: "2026-05-26T14:33:57.417916+05:30"
       description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
         for multiple providers
@@ -964,4 +988,4 @@ entries:
       urls:
         - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
       version: 1.3.36
-generated: "2026-05-26T14:33:57.415309+05:30"
+generated: "2026-05-28T22:00:26.010588+05:30"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3611,6 +3611,11 @@
           "format": "uri",
           "description": "Okta issuer URL (e.g., https://your-domain.okta.com/oauth2/default)"
         },
+        "authServerType": {
+          "type": "string",
+          "enum": ["org", "custom"],
+          "description": "'org' for Org Authorization Server or 'custom' for Custom Authorization Server. Auto-detected from issuer URL when omitted."
+        },
         "clientId": {
           "type": "string",
           "description": "Okta application client ID"
@@ -3641,6 +3646,48 @@
           "type": "string",
           "description": "JWT claim field for roles (default: 'roles')",
           "default": "roles"
+        },
+        "attributeRoleMappings": {
+          "type": "array",
+          "description": "Ordered list of attribute -> role mappings (first match wins). Requires an Okta Custom Authorization Server.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "attribute": { "type": "string", "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')" },
+              "value": { "type": "string", "description": "Claim value to match (case-insensitive)" },
+              "role": { "type": "string", "description": "Bifrost role to assign on match" }
+            },
+            "required": ["attribute", "value", "role"],
+            "additionalProperties": false
+          }
+        },
+        "attributeTeamMappings": {
+          "type": "array",
+          "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "attribute": { "type": "string" },
+              "value": { "type": "string" },
+              "team": { "type": "string" }
+            },
+            "required": ["attribute", "value", "team"],
+            "additionalProperties": false
+          }
+        },
+        "attributeBusinessUnitMappings": {
+          "type": "array",
+          "description": "Attribute -> business-unit mappings (all matches apply).",
+          "items": {
+            "type": "object",
+            "properties": {
+              "attribute": { "type": "string" },
+              "value": { "type": "string" },
+              "business_unit": { "type": "string" }
+            },
+            "required": ["attribute", "value", "business_unit"],
+            "additionalProperties": false
+          }
         }
       },
       "required": ["issuerUrl", "clientId", "clientSecret", "apiToken"],


### PR DESCRIPTION
## Summary

Bumps the Bifrost Helm chart to version `2.1.20`, fixing schema gaps in the Okta SCIM/SSO configuration that caused valid fields to be rejected at validation time, and aligning the transport runtime schema with the Helm chart schema.

## Changes

- Added `authServerType` (`"org"` | `"custom"`, default `"org"`) to the Okta SCIM config in both `values.schema.json` and `config.schema.json`. The field was previously documented but blocked by `additionalProperties: false` in both schemas.
- Added `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` to the Okta provider branch in `config.schema.json`, bringing the transport runtime schema into parity with the Helm chart schema which already included these fields.
- Exposed `authServerType` as a commented example in `values.yaml` for discoverability.
- Updated `helm-charts/index.yaml` with the new `2.1.20` chart entry.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Helm chart with an Okta SCIM configuration that includes `authServerType: "custom"` and verify that Helm schema validation passes without `additionalProperties` errors:

```sh
helm lint helm-charts/bifrost -f helm-charts/bifrost/values.yaml \
  --set bifrost.scim.config.issuerUrl="https://your-domain.okta.com/oauth2/default" \
  --set bifrost.scim.config.authServerType="custom" \
  --set bifrost.scim.config.clientId="test" \
  --set bifrost.scim.config.clientSecret="test" \
  --set bifrost.scim.config.apiToken="test"
```

Validate the transport config schema against a config file that includes `authServerType`, `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` under the Okta provider block and confirm no schema validation errors are returned.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`authServerType` controls whether Bifrost uses the Okta Org Authorization Server or a Custom Authorization Server for token validation. The `insecureSkipVerify` TLS option (introduced in `2.1.19`) should never be used in production. No new secrets or PII handling is introduced by this change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support to select Okta authorization server type (org or custom).
  * New Okta attribute mapping options to map claim attributes to roles, teams, and business units.

* **Documentation**
  * Helm chart and changelog updated for release 2.1.20, documenting the new Okta fields and mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->