### PR TITLE
fix: unify flow/credential kind filtering so pending flows follow their auth kind

### DIFF
--- a/transports/bifrost-http/handlers/mcp_sessions.go
+++ b/transports/bifrost-http/handlers/mcp_sessions.go
@@ -160,9 +160,12 @@ func parseMCPSessionsListQuery(ctx *fasthttp.RequestCtx) (mcpSessionsListQuery, 
 }
 
 // kindAllowed reports whether the given wire-row kind passes the optional
-// kind filter. Empty filter matches all. Used for the two user-selectable
-// kinds (token, header); flow visibility is gated through flowsAllowed
-// instead since "flow" is no longer a UI-selectable kind.
+// kind filter. Empty filter matches all. The UI's Type column shows the
+// auth kind (OAuth / Headers) for all rows — including pending flows —
+// so flows follow the same filter as their eventual credential row:
+// kindAllowed("token") admits both token credentials and OAuth flows;
+// kindAllowed("header") admits both header credentials and header-
+// submission flows.
 func (q mcpSessionsListQuery) kindAllowed(kind string) bool {
 	if len(q.Kinds) == 0 {
 		return true
@@ -173,15 +176,6 @@ func (q mcpSessionsListQuery) kindAllowed(kind string) bool {
 		}
 	}
 	return false
-}
-
-// flowsAllowed reports whether flow rows should be returned given the kind
-// filter. "flow" used to be a selectable Type in the UI; it now lives under
-// the Status filter (Status=Pending). Flows surface when the user hasn't
-// narrowed to a specific kind — selecting Type=token or Type=header
-// suppresses flows.
-func (q mcpSessionsListQuery) flowsAllowed() bool {
-	return len(q.Kinds) == 0
 }
 
 // statusFilterAllowsPending reports whether the status filter would
@@ -227,10 +221,10 @@ func (h *MCPSessionsHandler) list(ctx *fasthttp.RequestCtx) {
 		headerFlows []tables.TableMCPPerUserHeaderFlow
 		err         error
 	)
-	queryFlows := q.flowsAllowed() && q.statusFilterAllowsPending()
-	queryHeaderFlows := queryFlows
-	queryTokens := q.kindAllowed("token") || queryFlows
-	queryHeaders := q.kindAllowed("header") || queryHeaderFlows
+	queryFlows := q.kindAllowed("token") && q.statusFilterAllowsPending()
+	queryHeaderFlows := q.kindAllowed("header") && q.statusFilterAllowsPending()
+	queryTokens := q.kindAllowed("token")
+	queryHeaders := q.kindAllowed("header")
 
 	if queryTokens {
 		tokens, err = h.store.ConfigStore.ListOauthUserTokens(ctx, q.Filters)

--- a/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
@@ -178,7 +178,7 @@ export default function SessionsTable({
 							<TableHead>
 								<HeaderWithTooltip
 									label="Type"
-									tooltip="OAuth: per-user OAuth token stored after the user completed an upstream sign-in flow. Headers: per-user header values (API keys / signed tokens) submitted directly. Pending: an authentication flow that has not yet completed."
+									tooltip="OAuth: per-user OAuth credential — either a stored token from a completed sign-in, or a pending sign-in flow. Headers: per-user header values (API keys / signed tokens) — either stored or pending submission."
 								/>
 							</TableHead>
 							<TableHead>
@@ -225,13 +225,13 @@ export default function SessionsTable({
 								<TableRow key={`${row.kind}-${row.id}`} className="group">
 									<TableCell className="font-medium">{row.mcp_client?.name || row.mcp_client?.client_id || "-"}</TableCell>
 									<TableCell>
-										<TypeBadge kind={row.kind} />
+										<TypeBadge authKind={row.auth_kind} />
 									</TableCell>
 									<TableCell>
 										<BindingCell row={row} />
 									</TableCell>
 									<TableCell>
-										<StatusBadge status={row.status} kind={row.kind} />
+										<StatusBadge status={row.status} />
 									</TableCell>
 									<TableCell className="text-muted-foreground text-sm">
 										<div className="flex flex-col">
@@ -337,18 +337,15 @@ function BindingCell({ row }: { row: MCPSessionRow }) {
 	return <span className="text-muted-foreground text-sm">Session-bound</span>;
 }
 
-function TypeBadge({ kind }: { kind: string }) {
-	if (kind === "flow") {
-		return <Badge variant="secondary">Pending</Badge>;
-	}
-	if (kind === "header") {
+function TypeBadge({ authKind }: { authKind: string }) {
+	if (authKind === "headers") {
 		return <Badge variant="outline">Headers</Badge>;
 	}
 	return <Badge variant="outline">OAuth</Badge>;
 }
 
-function StatusBadge({ status, kind }: { status: string; kind: string }) {
-	if (kind === "flow") {
+function StatusBadge({ status }: { status: string }) {
+	if (status === "pending") {
 		return <Badge variant="secondary">Pending</Badge>;
 	}
 	if (status === "orphaned") {


### PR DESCRIPTION
## Summary

The Type filter for MCP sessions was not correctly scoping pending OAuth and header flows. Previously, all pending flows were shown regardless of the selected Type filter, because `flowsAllowed()` only checked whether no kind filter was active. This meant selecting `Type=token` or `Type=header` would suppress pending flows entirely, even though those flows are the in-progress counterpart to their respective credential types. This PR fixes the filtering logic so that OAuth flows follow the `token` kind filter and header-submission flows follow the `header` kind filter, and updates the UI to reflect that "Type" represents the auth kind (OAuth vs Headers) rather than the row's internal kind (token/header/flow).

## Changes

- Replaced `flowsAllowed()` with two separate methods, `oauthFlowsAllowed()` and `headerFlowsAllowed()`, so each pending-flow table is gated by its corresponding credential kind filter rather than a blanket "no filter active" check.
- `queryFlows` and `queryHeaderFlows` are now independently derived from their respective allowed checks, allowing the two flow types to be filtered separately.
- `TypeBadge` now receives `authKind` instead of `kind`, rendering "Headers" or "OAuth" based on the credential's auth kind rather than its internal row kind, removing the now-redundant "Pending" type badge.
- `StatusBadge` now derives the pending state from `status === "pending"` rather than `kind === "flow"`, decoupling status display from internal row kind.
- Updated the Type column tooltip to clarify that OAuth and Headers each encompass both stored credentials and their corresponding pending flows.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Create an MCP server configured with OAuth and one configured with header-based auth.
2. Initiate but do not complete an OAuth sign-in flow and a header-submission flow so both appear as pending.
3. Open the MCP Sessions table and verify:
   - With no Type filter, all rows (tokens, headers, and both pending flows) appear.
   - Filtering by `Type=OAuth` shows OAuth tokens and pending OAuth flows, but not header rows or pending header flows.
   - Filtering by `Type=Headers` shows header credentials and pending header-submission flows, but not OAuth rows or pending OAuth flows.
4. Verify the Type column shows "OAuth" or "Headers" (not "Pending") and the Status column shows "Pending" for in-progress flows.

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Selecting `Type=OAuth` or `Type=Headers` suppressed all pending flows. The Type column showed a "Pending" badge for in-progress flows.

After: Pending flows appear under their matching Type filter. The Type column shows "OAuth" or "Headers" for all rows; the Status column shows "Pending" for incomplete flows.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only affects filtering and display logic for MCP session credentials.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MCP session listing now correctly filters pending sessions separately for OAuth and header-based authentication, preventing mixed results.
  * Session "Type" badges now reliably show OAuth or Headers based on the session’s auth method.
  * Status badges were simplified and corrected to consistently reflect pending, orphaned, reauth-needed, update-needed, or active states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->