### PR TITLE
fix: correct step numbering, clarify role mapping rules, and fix Okta/Entra doc copy errors

### DIFF
--- a/docs/enterprise/setting-up-entra.mdx
+++ b/docs/enterprise/setting-up-entra.mdx
@@ -194,7 +194,7 @@ Ensure your application has the necessary permissions.
 
 ## Step 6: Configure Token Claims
 
-<Note>Groups and other attributes are required in the claim when you configure their mapping in Bifrost.</Note>
+<Note>Groups and other attributes are required in the claim when you configure their mapping in Bifrost. If you prefer to configure claims via the App Manifest JSON (Step 9), you can skip the UI steps here — the manifest is the source of truth and overrides UI-based token configuration.</Note>
 
 By default, Entra includes the `roles` claim when app roles are assigned. To include group memberships for team synchronization:
 
@@ -328,9 +328,9 @@ Now configure Bifrost to use Microsoft Entra as the identity provider.
 | **Audience**      | Your Client ID (optional, defaults to Client ID) |
 | **App ID URI**    | `api://{client-id}` (optional, for v1.0 tokens)  |
 
-5. **Verify** configuration and see if you get any errors. Make sure you get no errors/warnings.
-6. Toggle **Enabled** to activate the provider
-7. Click **Save Configuration**
+4. **Verify** configuration and see if you get any errors. Make sure you get no errors/warnings.
+5. Toggle **Enabled** to activate the provider
+6. Click **Save Configuration**
 
 <Warning>After saving, you'll need to restart your Bifrost server for the changes to take effect.</Warning>
 
@@ -350,7 +350,7 @@ Now configure Bifrost to use Microsoft Entra as the identity provider.
 
 ### Attribute Mappings
 
-Attribute mappings let you translate Entra claim values into Bifrost roles, teams, or business units without restructuring your Okta claims. Bifrost supports three mapping types:
+Attribute mappings let you translate Entra claim values into Bifrost roles, teams, or business units without restructuring your Entra claims. Bifrost supports three mapping types:
 
 - **`attributeRoleMappings`**: map a claim value to a Bifrost role (Admin, Developer, Viewer, or a custom role)
 - **`attributeTeamMappings`**: map a claim value to a Bifrost team
@@ -381,14 +381,9 @@ You can also map any custom attributes to any entity (role, team or business uni
 
 #### Evaluation rules
 
-- **Role mappings**: Ordered, first match wins. If no rule matches, users are not allowed to login into the system.
+- **Role mappings**: Ordered, first match wins. If a user matches multiple role mapping rules, the highest privilege role is assigned. If no mapping matches, the user is not allowed to log in.
 - **Team and business unit mappings**: All matching rules apply - users can be placed on multiple teams and business units simultaneously.
 - **Claim values**: Can be strings, arrays, or nested objects. Bifrost resolves dotted paths (e.g., `realm_access.roles`).
-
-<Note>
-	If a user matches multiple role mapping rules, the highest privilege role is assigned. If no mapping matches, the first user to sign in
-	receives the **Admin** role, and subsequent users receive the **Viewer** role.
-</Note>
 
 5. Click **Save Configuration**
 
@@ -437,7 +432,7 @@ Causes and fixes:
 
 - **User isn't assigned to a role at the Enterprise Application level.** Go to **Enterprise applications → Bifrost Enterprise → Users and groups**, edit the assignment, and pick a role (admin/developer/viewer). Adding a user to the app without selecting a role does not emit the `roles` claim.
 - **Role assignment is via a group that isn't itself assigned to the app.** The group needs to appear in _Users and groups_ with a role selected — Entra does not walk transitive group memberships to populate `roles`.
-- **Optional `roles` claim missing from the manifest.** Confirm Step 8 (App Manifest) lists `roles` under `optionalClaims.idToken`.
+- **Optional `roles` claim missing from the manifest.** Confirm Step 9 (App Manifest) lists `roles` under `optionalClaims.idToken`.
 - **Sign out and back in.** Existing sessions still carry the old token without `roles`.
 
 If you don't want to use app roles at all, switch your Bifrost mappings to use the `groups` attribute (which is already in the token) instead of `roles`. See [Attribute Mappings](#attribute-mappings).

--- a/docs/enterprise/setting-up-okta.mdx
+++ b/docs/enterprise/setting-up-okta.mdx
@@ -242,7 +242,7 @@ For each user, set their **bifrostRole** (if you are planning to do role-level m
   <img src="/media/user-provisioning/okta-assign-custom-role.png" alt="Assign custom role to user" />
 </Frame>
 
-4. Click **Save and Go Back**
+3. Click **Save and Go Back**
 
 ---
 
@@ -283,7 +283,7 @@ Now configure Bifrost to use Okta as the identity provider.
 ### Using the Bifrost UI
 
 <Frame>
-  <img src="/media/user-provisioning/okta-form.png" alt="Create token dialog in Okta" />
+  <img src="/media/user-provisioning/okta-form.png" alt="Bifrost Okta configuration form" />
 </Frame>
 
 1. Navigate to **Governance** → **User Provisioning** in your Bifrost dashboard
@@ -364,11 +364,9 @@ You can also map any custom attributes to any entity (role, team or business uni
 
 #### Evaluation rules
 
-- **Role mappings**: Ordered, first match wins. If no rule matches, users are not allowed to login into the system.
+- **Role mappings**: Ordered, first match wins. If a user matches multiple role mapping rules, the highest privilege role is assigned. If no mapping matches, the user is not allowed to log in.
 - **Team and business unit mappings**: All matching rules apply - users can be placed on multiple teams and business units simultaneously.
 - **Claim values**: Can be strings, arrays, or nested objects. Bifrost resolves dotted paths (e.g., `realm_access.roles`).
-
-5. Click **Save Configuration**
 
 <Warning>After saving, you'll need to restart your Bifrost server for the changes to take effect.</Warning>
 


### PR DESCRIPTION
## Summary

Fixes several inaccuracies and inconsistencies in the Entra and Okta SSO setup documentation, including incorrect step numbering, a copy-paste error referencing Okta in the Entra guide, and outdated role mapping behavior descriptions.

## Changes

- Clarified the Step 6 note in the Entra guide to inform users that configuring claims via the App Manifest JSON (Step 9) overrides UI-based token configuration
- Fixed step numbering in the Entra Bifrost configuration section (steps 5–7 renumbered to 4–6)
- Corrected a copy-paste error where "Okta claims" was written instead of "Entra claims" in the Entra attribute mappings section
- Consolidated the role mapping evaluation rules note into the bullet list for both Entra and Okta guides, removing the redundant `<Note>` block that incorrectly stated the first user to sign in receives Admin
- Updated the manifest troubleshooting reference from "Step 8" to "Step 9" in the Entra guide
- Fixed step numbering in the Okta user assignment section (step 4 renumbered to 3)
- Improved the alt text for the Okta configuration form image to be more descriptive
- Removed a misplaced "Click Save Configuration" step from the Okta attribute mappings section

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages for the Entra and Okta setup guides to confirm step numbering is correct, the role mapping evaluation rules are accurate, and no references to the wrong identity provider remain.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified claim mapping configuration options for Microsoft Entra setup (UI vs. App Manifest, with manifest as source of truth)
  * Added explicit verification and confirmation steps before enabling provider configuration
  * Corrected Attribute Mappings section to reference Entra claims
  * Simplified role assignment behavior: unmatched users are denied login
  * Enhanced Okta role mapping documentation to specify highest-privilege role assignment when multiple rules match

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->