### PR TITLE
fix(mcp): allow inline stdio env assignments

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -1283,10 +1283,18 @@ func (m *MCPManager) createSTDIOConnection(_ context.Context, config *schemas.MC
 
 	cmdString := fmt.Sprintf("%s %s", cmd, strings.Join(args, " "))
 
-	// Check if environment variables are set (envs are not plugin-mutable)
+	// Check referenced environment variables are set. Inline KEY=value
+	// assignments are passed directly to the stdio transport.
 	for _, env := range config.StdioConfig.Envs {
-		if os.Getenv(env) == "" {
-			return nil, nil, fmt.Errorf("environment variable %s is not set for MCP client %s", env, config.Name)
+		envName, _, hasInlineValue := strings.Cut(env, "=")
+		if envName == "" {
+			return nil, nil, fmt.Errorf("environment variable name is empty for MCP client %s", config.Name)
+		}
+		if hasInlineValue {
+			continue
+		}
+		if os.Getenv(envName) == "" {
+			return nil, nil, fmt.Errorf("environment variable %s is not set for MCP client %s", envName, config.Name)
 		}
 	}
 

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSTDIOConnectionAllowsInlineEnvAssignments(t *testing.T) {
+	t.Parallel()
+
+	config := &schemas.MCPClientConfig{
+		Name:           "test-stdio-client",
+		ConnectionType: schemas.MCPConnectionTypeSTDIO,
+		StdioConfig: &schemas.MCPStdioConfig{
+			Command: "echo",
+			Envs:    []string{"TEST_STDIO_ENV_ASSIGNMENT=inline-value"},
+		},
+	}
+
+	_, _, err := (&MCPManager{}).createSTDIOConnection(context.Background(), config, nil)
+	require.NoError(t, err)
+}
+
+func TestCreateSTDIOConnectionAllowsSetReferencedEnvVars(t *testing.T) {
+	t.Setenv("TEST_STDIO_ENV_REFERENCE_SET", "set-value")
+
+	config := &schemas.MCPClientConfig{
+		Name:           "test-stdio-client",
+		ConnectionType: schemas.MCPConnectionTypeSTDIO,
+		StdioConfig: &schemas.MCPStdioConfig{
+			Command: "echo",
+			Envs:    []string{"TEST_STDIO_ENV_REFERENCE_SET"},
+		},
+	}
+
+	_, _, err := (&MCPManager{}).createSTDIOConnection(context.Background(), config, nil)
+	require.NoError(t, err)
+}
+
+func TestCreateSTDIOConnectionRequiresReferencedEnvVars(t *testing.T) {
+	t.Setenv("TEST_STDIO_ENV_REFERENCE_MISSING", "")
+
+	config := &schemas.MCPClientConfig{
+		Name:           "test-stdio-client",
+		ConnectionType: schemas.MCPConnectionTypeSTDIO,
+		StdioConfig: &schemas.MCPStdioConfig{
+			Command: "echo",
+			Envs:    []string{"TEST_STDIO_ENV_REFERENCE_MISSING"},
+		},
+	}
+
+	_, _, err := (&MCPManager{}).createSTDIOConnection(context.Background(), config, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "environment variable TEST_STDIO_ENV_REFERENCE_MISSING is not set")
+}
+
+func TestCreateSTDIOConnectionRejectsEmptyEnvAssignmentName(t *testing.T) {
+	t.Parallel()
+
+	config := &schemas.MCPClientConfig{
+		Name:           "test-stdio-client",
+		ConnectionType: schemas.MCPConnectionTypeSTDIO,
+		StdioConfig: &schemas.MCPStdioConfig{
+			Command: "echo",
+			Envs:    []string{"=inline-value"},
+		},
+	}
+
+	_, _, err := (&MCPManager{}).createSTDIOConnection(context.Background(), config, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "environment variable name is empty")
+}


### PR DESCRIPTION
### Summary

Fixes STDIO MCP env validation so inline KEY=value entries are treated as explicit environment assignments instead of looking up the full KEY=value string as an environment variable name.

### Changes

- Split STDIO env entries on the first =
- Skip host environment lookup for inline KEY=value assignments
- Preserve validation for referenced env vars like  API_KEY
- Reject empty env assignment names like =value
- Added regression tests for inline assignments, referenced env vars, and empty names

### Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

### Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

### How to test

Validated the focused MCP package tests from the core module.

```sh
cd core
go test ./mcp
