### PR TITLE
fix: set guardrail config in bedrock request from responses

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1584,6 +1584,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 
 		// Process AWS Event Stream format
 		usage := &schemas.ResponsesResponseUsage{}
+		var streamTrace *BedrockConverseTrace
 		chunkIndex := 0
 
 		// Create stream state for stateful conversions
@@ -1617,7 +1618,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 				}
 				if err == io.EOF {
 					// End of stream - finalize any open items
-					finalResponses := FinalizeBedrockStream(streamState, chunkIndex, usage)
+					finalResponses := FinalizeBedrockStream(streamState, chunkIndex, usage, streamTrace)
 					for i, finalResponse := range finalResponses {
 						finalResponse.ExtraFields = schemas.BifrostResponseExtraFields{
 							ChunkIndex: chunkIndex,
@@ -1698,6 +1699,10 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 					provider.logger.Debug("Failed to parse JSON from event buffer: %v, data: %s", err, string(message.Payload))
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
 					return
+				}
+
+				if streamEvent.Trace != nil {
+					streamTrace = streamEvent.Trace
 				}
 
 				if streamEvent.Usage != nil {

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -2346,6 +2346,299 @@ func TestToBedrockResponsesRequest_AdditionalFields_InterfaceSlice(t *testing.T)
 	assert.Equal(t, []string{"/amazon-bedrock-invocationMetrics/inputTokenCount"}, bedrockReq.AdditionalModelResponseFieldPaths)
 }
 
+// TestToBedrockResponsesRequest_GuardrailConfig verifies that guardrailConfig in ExtraParams
+// is extracted into BedrockConverseRequest.GuardrailConfig (Responses path fix).
+func TestToBedrockResponsesRequest_GuardrailConfig(t *testing.T) {
+	trace := testTrace
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	req := &schemas.BifrostResponsesRequest{
+		Model: "bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+		Params: &schemas.ResponsesParameters{
+			ExtraParams: map[string]interface{}{
+				"guardrailConfig": map[string]interface{}{
+					"guardrailIdentifier": "test-guardrail-id",
+					"guardrailVersion":    "DRAFT",
+					"trace":               trace,
+				},
+			},
+		},
+	}
+
+	bedrockReq, err := bedrock.ToBedrockResponsesRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, bedrockReq)
+
+	require.NotNil(t, bedrockReq.GuardrailConfig, "GuardrailConfig must be set from ExtraParams")
+	assert.Equal(t, "test-guardrail-id", bedrockReq.GuardrailConfig.GuardrailIdentifier)
+	assert.Equal(t, "DRAFT", bedrockReq.GuardrailConfig.GuardrailVersion)
+	require.NotNil(t, bedrockReq.GuardrailConfig.Trace)
+	assert.Equal(t, trace, *bedrockReq.GuardrailConfig.Trace)
+	// guardrailConfig must be removed from ExtraParams so it is not double-sent
+	assert.Nil(t, bedrockReq.ExtraParams)
+}
+
+// TestBedrockToBifrostResponse_TraceStoredInProviderExtraFields verifies that
+// ToBifrostResponsesResponse carries guardrail trace in ProviderExtraFields.
+func TestBedrockToBifrostResponse_TraceStoredInProviderExtraFields(t *testing.T) {
+	action := "BLOCKED"
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	input := &bedrock.BedrockConverseResponse{
+		StopReason: "guardrail_intervened",
+		Output: &bedrock.BedrockConverseOutput{
+			Message: &bedrock.BedrockMessage{
+				Role:    bedrock.BedrockMessageRoleAssistant,
+				Content: []bedrock.BedrockContentBlock{},
+			},
+		},
+		Trace: &bedrock.BedrockConverseTrace{
+			Guardrail: &bedrock.BedrockGuardrailTrace{
+				Action: &action,
+			},
+		},
+	}
+
+	bifrostResp, err := input.ToBifrostResponsesResponse(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, bifrostResp)
+
+	require.NotNil(t, bifrostResp.ProviderExtraFields, "ProviderExtraFields must be set when trace is present")
+	traceData, ok := bifrostResp.ProviderExtraFields["trace"]
+	require.True(t, ok, "trace key must exist in ProviderExtraFields")
+	trace, ok := traceData.(*bedrock.BedrockConverseTrace)
+	require.True(t, ok, "trace must be *BedrockConverseTrace")
+	require.NotNil(t, trace.Guardrail)
+	assert.Equal(t, action, *trace.Guardrail.Action)
+}
+
+// TestBifrostToBedrockResponse_TraceRestoredFromProviderExtraFields verifies that
+// ToBedrockConverseResponse restores trace from ProviderExtraFields (round-trip).
+func TestBifrostToBedrockResponse_TraceRestoredFromProviderExtraFields(t *testing.T) {
+	outputMsg := []schemas.ResponsesMessage{
+		{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{Type: schemas.ResponsesOutputMessageContentTypeText, Text: schemas.Ptr("blocked")},
+				},
+			},
+		},
+	}
+
+	t.Run("TypedPointer", func(t *testing.T) {
+		action := "BLOCKED"
+		input := &schemas.BifrostResponsesResponse{
+			Output: outputMsg,
+			ProviderExtraFields: map[string]interface{}{
+				"trace": &bedrock.BedrockConverseTrace{
+					Guardrail: &bedrock.BedrockGuardrailTrace{Action: &action},
+				},
+			},
+		}
+		resp, err := bedrock.ToBedrockConverseResponse(input)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Trace, "Trace must be restored from typed pointer")
+		require.NotNil(t, resp.Trace.Guardrail)
+		assert.Equal(t, action, *resp.Trace.Guardrail.Action)
+	})
+
+	t.Run("JSONDecodedMap", func(t *testing.T) {
+		// Simulates ProviderExtraFields["trace"] after a JSON round-trip (e.g. async
+		// job retrieval), where sonic.Unmarshal produces map[string]interface{}.
+		input := &schemas.BifrostResponsesResponse{
+			Output: outputMsg,
+			ProviderExtraFields: map[string]interface{}{
+				"trace": map[string]interface{}{
+					"guardrail": map[string]interface{}{
+						"action": "INTERVENED",
+					},
+				},
+			},
+		}
+		resp, err := bedrock.ToBedrockConverseResponse(input)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Trace, "Trace must be restored from JSON-decoded map")
+		require.NotNil(t, resp.Trace.Guardrail)
+		require.NotNil(t, resp.Trace.Guardrail.Action)
+		assert.Equal(t, "INTERVENED", *resp.Trace.Guardrail.Action)
+	})
+}
+
+// TestFinalizeBedrockStream_WithTrace verifies that a guardrail trace captured mid-stream
+// is included in the response.completed event's ProviderExtraFields.
+func TestFinalizeBedrockStream_WithTrace(t *testing.T) {
+	action := "BLOCKED"
+	trace := &bedrock.BedrockConverseTrace{
+		Guardrail: &bedrock.BedrockGuardrailTrace{
+			Action: &action,
+		},
+	}
+
+	state := bedrock.NewBedrockResponsesStreamState()
+	usage := &schemas.ResponsesResponseUsage{InputTokens: 5, OutputTokens: 10, TotalTokens: 15}
+
+	finalResponses := bedrock.FinalizeBedrockStream(state, 0, usage, trace)
+	require.NotEmpty(t, finalResponses)
+
+	// The last event must be response.completed
+	completed := finalResponses[len(finalResponses)-1]
+	require.Equal(t, schemas.ResponsesStreamResponseTypeCompleted, completed.Type)
+	require.NotNil(t, completed.Response)
+	require.NotNil(t, completed.Response.ProviderExtraFields, "ProviderExtraFields must be set when trace is present")
+
+	traceData, ok := completed.Response.ProviderExtraFields["trace"]
+	require.True(t, ok)
+	restoredTrace, ok := traceData.(*bedrock.BedrockConverseTrace)
+	require.True(t, ok)
+	require.NotNil(t, restoredTrace.Guardrail)
+	assert.Equal(t, action, *restoredTrace.Guardrail.Action)
+}
+
+// TestGuardrailConfigRequestRoundTrip verifies the full guardrailConfig request round-trip:
+//
+//	BedrockConverseRequest.GuardrailConfig
+//	  → ToBifrostResponsesRequest  (stored as ExtraParams["guardrailConfig"])
+//	  → ToBedrockResponsesRequest  (extracted back to BedrockConverseRequest.GuardrailConfig)
+//
+// This is the regression path for the bug where guardrailConfig was silently
+// dropped by ToBedrockResponsesRequest.
+func TestGuardrailConfigRequestRoundTrip(t *testing.T) {
+	trace := testTrace
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	original := &bedrock.BedrockConverseRequest{
+		ModelID: "bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+		Messages: []bedrock.BedrockMessage{
+			{
+				Role:    bedrock.BedrockMessageRoleUser,
+				Content: []bedrock.BedrockContentBlock{{Text: schemas.Ptr("Hello")}},
+			},
+		},
+		GuardrailConfig: &bedrock.BedrockGuardrailConfig{
+			GuardrailIdentifier: "test-guardrail-id",
+			GuardrailVersion:    "DRAFT",
+			Trace:               &trace,
+		},
+	}
+
+	// Step 1: BedrockConverseRequest → BifrostResponsesRequest
+	bifrostReq, err := original.ToBifrostResponsesRequest(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq.Params)
+	require.NotNil(t, bifrostReq.Params.ExtraParams)
+	_, hasGuardrail := bifrostReq.Params.ExtraParams["guardrailConfig"]
+	require.True(t, hasGuardrail, "guardrailConfig must be present in ExtraParams after ToBifrostResponsesRequest")
+
+	// Step 2: BifrostResponsesRequest → BedrockConverseRequest
+	result, err := bedrock.ToBedrockResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, result.GuardrailConfig, "GuardrailConfig must survive the round-trip through Bifrost")
+	assert.Equal(t, original.GuardrailConfig.GuardrailIdentifier, result.GuardrailConfig.GuardrailIdentifier)
+	assert.Equal(t, original.GuardrailConfig.GuardrailVersion, result.GuardrailConfig.GuardrailVersion)
+	require.NotNil(t, result.GuardrailConfig.Trace)
+	assert.Equal(t, trace, *result.GuardrailConfig.Trace)
+	// guardrailConfig must be removed from ExtraParams after extraction
+	assert.Nil(t, result.ExtraParams, "ExtraParams should be nil after all keys are extracted")
+}
+
+// TestGuardrailTraceResponseRoundTrip verifies the full trace response round-trip:
+//
+//	BedrockConverseResponse.Trace
+//	  → ToBifrostResponsesResponse  (stored in ProviderExtraFields["trace"])
+//	  → ToBedrockConverseResponse   (restored to BedrockConverseResponse.Trace)
+//
+// This is the regression path for the bug where response.Trace was dropped
+// by ToBifrostResponsesResponse, making it invisible to callers.
+func TestGuardrailTraceResponseRoundTrip(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	t.Run("ConversePath_ActionReason", func(t *testing.T) {
+		// Converse (non-streaming) returns actionReason, not action
+		actionReason := "Guardrail blocked."
+		original := &bedrock.BedrockConverseResponse{
+			StopReason: "guardrail_intervened",
+			Output: &bedrock.BedrockConverseOutput{
+				Message: &bedrock.BedrockMessage{
+					Role:    bedrock.BedrockMessageRoleAssistant,
+					Content: []bedrock.BedrockContentBlock{},
+				},
+			},
+			Trace: &bedrock.BedrockConverseTrace{
+				Guardrail: &bedrock.BedrockGuardrailTrace{
+					ActionReason: &actionReason,
+				},
+			},
+		}
+
+		bifrostResp, err := original.ToBifrostResponsesResponse(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, bifrostResp.ProviderExtraFields)
+		_, hasTrace := bifrostResp.ProviderExtraFields["trace"]
+		require.True(t, hasTrace)
+
+		result, err := bedrock.ToBedrockConverseResponse(bifrostResp)
+		require.NoError(t, err)
+		require.NotNil(t, result.Trace, "Trace must survive round-trip")
+		require.NotNil(t, result.Trace.Guardrail)
+		require.NotNil(t, result.Trace.Guardrail.ActionReason)
+		assert.Equal(t, actionReason, *result.Trace.Guardrail.ActionReason)
+	})
+
+	t.Run("StreamPath_Action", func(t *testing.T) {
+		// ConverseStream returns action (enum), not actionReason
+		action := "INTERVENED"
+		original := &bedrock.BedrockConverseResponse{
+			StopReason: "guardrail_intervened",
+			Output: &bedrock.BedrockConverseOutput{
+				Message: &bedrock.BedrockMessage{
+					Role:    bedrock.BedrockMessageRoleAssistant,
+					Content: []bedrock.BedrockContentBlock{},
+				},
+			},
+			Trace: &bedrock.BedrockConverseTrace{
+				Guardrail: &bedrock.BedrockGuardrailTrace{
+					Action: &action,
+				},
+			},
+		}
+
+		bifrostResp, err := original.ToBifrostResponsesResponse(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, bifrostResp.ProviderExtraFields)
+
+		result, err := bedrock.ToBedrockConverseResponse(bifrostResp)
+		require.NoError(t, err)
+		require.NotNil(t, result.Trace)
+		require.NotNil(t, result.Trace.Guardrail)
+		require.NotNil(t, result.Trace.Guardrail.Action)
+		assert.Equal(t, action, *result.Trace.Guardrail.Action)
+	})
+
+	t.Run("JSONDecodedMap", func(t *testing.T) {
+		// Simulates the async-job-retrieval path where ProviderExtraFields["trace"]
+		// has been JSON-decoded into map[string]interface{} instead of *BedrockConverseTrace.
+		// extractBedrockTrace must fall back to the sonic marshal/unmarshal path.
+		bifrostResp := &schemas.BifrostResponsesResponse{
+			ProviderExtraFields: map[string]interface{}{
+				"trace": map[string]interface{}{
+					"guardrail": map[string]interface{}{
+						"action": "INTERVENED",
+					},
+				},
+			},
+		}
+
+		result, err := bedrock.ToBedrockConverseResponse(bifrostResp)
+		require.NoError(t, err)
+		require.NotNil(t, result.Trace, "Trace must be restored from JSON-decoded map")
+		require.NotNil(t, result.Trace.Guardrail)
+		require.NotNil(t, result.Trace.Guardrail.Action)
+		assert.Equal(t, "INTERVENED", *result.Trace.Guardrail.Action)
+	})
+}
+
 func TestToBedrockResponsesRequest_AnthropicTextFormatUsesOutputConfig(t *testing.T) {
 	schemaObj := any(schemas.NewOrderedMapFromPairs(
 		schemas.KV("type", "object"),

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -135,6 +135,11 @@ func acquireBedrockResponsesStreamState() *BedrockResponsesStreamState {
 	return state
 }
 
+// NewBedrockResponsesStreamState returns a freshly initialised stream state for use in tests.
+func NewBedrockResponsesStreamState() *BedrockResponsesStreamState {
+	return acquireBedrockResponsesStreamState()
+}
+
 // releaseBedrockResponsesStreamState returns a Bedrock responses stream state to the pool.
 func releaseBedrockResponsesStreamState(state *BedrockResponsesStreamState) {
 	if state != nil {
@@ -1110,7 +1115,7 @@ func emitNovaGroundingDoneEvents(outputIndex, contentIndex int, itemID string, c
 }
 
 // FinalizeBedrockStream finalizes the stream by closing any open items and emitting completed event
-func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber int, usage *schemas.ResponsesResponseUsage) []*schemas.BifrostResponsesStreamResponse {
+func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber int, usage *schemas.ResponsesResponseUsage, trace *BedrockConverseTrace) []*schemas.BifrostResponsesStreamResponse {
 	var responses []*schemas.BifrostResponsesStreamResponse
 
 	// Synthesize lifecycle events if Bedrock never sent a messageStart
@@ -1401,6 +1406,12 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 		Usage:     usage,
 	}
 
+	if trace != nil {
+		response.ProviderExtraFields = map[string]interface{}{
+			"trace": trace,
+		}
+	}
+
 	if state.Model != nil {
 		response.Model = *state.Model
 	}
@@ -1669,6 +1680,11 @@ func ToBedrockConverseStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 			}
 		}
 
+		// Restore guardrail trace from provider extra fields
+		if bifrostResp.Response != nil && bifrostResp.Response.ProviderExtraFields != nil {
+			event.Trace = extractBedrockTrace(bifrostResp.Response.ProviderExtraFields["trace"])
+		}
+
 	case schemas.ResponsesStreamResponseTypeError:
 		// Error - errors are handled separately by the router via BifrostError in the stream chunk
 		// Return nil to skip this chunk
@@ -1750,7 +1766,7 @@ func (event *BedrockStreamEvent) ToEncodedEvents() []BedrockEncodedEvent {
 		})
 	}
 
-	if event.Usage != nil || event.Metrics != nil {
+	if event.Usage != nil || event.Metrics != nil || event.Trace != nil {
 		events = append(events, BedrockEncodedEvent{
 			EventType: "metadata",
 			Payload: BedrockMetadataEvent{
@@ -2294,34 +2310,9 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 				delete(bedrockReq.ExtraParams, "stop")
 				inferenceConfig.StopSequences = stop
 			}
-
-			if requestFields, exists := bifrostReq.Params.ExtraParams["additionalModelRequestFieldPaths"]; exists {
-				if orderedFields, ok := schemas.SafeExtractOrderedMap(requestFields); ok {
-					delete(bedrockReq.ExtraParams, "additionalModelRequestFieldPaths")
-					bedrockReq.AdditionalModelRequestFields = mergeAdditionalModelRequestFields(
-						bedrockReq.AdditionalModelRequestFields,
-						orderedFields,
-					)
-				}
-			}
-
-			if responseFields, exists := bifrostReq.Params.ExtraParams["additionalModelResponseFieldPaths"]; exists {
-				if fields, ok := responseFields.([]string); ok {
-					bedrockReq.AdditionalModelResponseFieldPaths = fields
-				} else if fieldsInterface, ok := responseFields.([]interface{}); ok {
-					stringFields := make([]string, 0, len(fieldsInterface))
-					for _, field := range fieldsInterface {
-						if fieldStr, ok := field.(string); ok {
-							stringFields = append(stringFields, fieldStr)
-						}
-					}
-					if len(stringFields) > 0 {
-						bedrockReq.AdditionalModelResponseFieldPaths = stringFields
-					}
-				}
-				if len(bedrockReq.AdditionalModelResponseFieldPaths) > 0 {
-					delete(bedrockReq.ExtraParams, "additionalModelResponseFieldPaths")
-				}
+			applyBedrockExtraParams(bedrockReq.ExtraParams, bedrockReq)
+			if len(bedrockReq.ExtraParams) == 0 {
+				bedrockReq.ExtraParams = nil
 			}
 		}
 
@@ -2557,6 +2548,12 @@ func (response *BedrockConverseResponse) ToBifrostResponsesResponse(ctx *schemas
 		bifrostResp.StopReason = &stopReason
 	}
 
+	if response.Trace != nil {
+		bifrostResp.ProviderExtraFields = map[string]interface{}{
+			"trace": response.Trace,
+		}
+	}
+
 	return bifrostResp, nil
 }
 
@@ -2652,10 +2649,37 @@ func ToBedrockConverseResponse(bifrostResp *schemas.BifrostResponsesResponse) (*
 		bedrockResp.Metrics.LatencyMs = bifrostResp.ExtraFields.Latency
 	}
 
+	// Restore guardrail trace from provider extra fields
+	if bifrostResp.ProviderExtraFields != nil {
+		bedrockResp.Trace = extractBedrockTrace(bifrostResp.ProviderExtraFields["trace"])
+	}
+
 	return bedrockResp, nil
 }
 
 // Helper functions
+
+// extractBedrockTrace recovers a *BedrockConverseTrace from ProviderExtraFields["trace"].
+// It handles two cases:
+//   - in-memory pointer (normal non-streaming path): direct type assertion
+//   - map[string]interface{} (JSON-deserialized path, e.g. async job retrieval): marshal→unmarshal fallback
+func extractBedrockTrace(v interface{}) *BedrockConverseTrace {
+	if v == nil {
+		return nil
+	}
+	if t, ok := v.(*BedrockConverseTrace); ok {
+		return t
+	}
+	b, err := sonic.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var t BedrockConverseTrace
+	if err := sonic.Unmarshal(b, &t); err != nil {
+		return nil
+	}
+	return &t
+}
 
 // ensureResponsesToolConfigForConversation ensures toolConfig is present when tool content exists
 func ensureResponsesToolConfigForConversation(bifrostReq *schemas.BifrostResponsesRequest, bedrockReq *BedrockConverseRequest) {

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -509,11 +509,22 @@ type BedrockConverseTrace struct {
 	Guardrail *BedrockGuardrailTrace `json:"guardrail,omitempty"` // Guardrail trace details
 }
 
-// BedrockGuardrailTrace represents detailed guardrail trace information
+// BedrockGuardrailTrace represents detailed guardrail trace information.
+// Bedrock uses two different shapes depending on the call path:
+//   - Converse (non-streaming): actionReason + inputAssessment (map keyed by guardrail ID)
+//   - ConverseStream: action (enum) + inputAssessments / outputAssessments (arrays)
+//
+// Both shapes are captured here so the struct round-trips faithfully in both cases.
 type BedrockGuardrailTrace struct {
-	Action            *string                      `json:"action,omitempty"`            // Action taken by guardrail
-	InputAssessments  []BedrockGuardrailAssessment `json:"inputAssessments,omitempty"`  // Input assessments
-	OutputAssessments []BedrockGuardrailAssessment `json:"outputAssessments,omitempty"` // Output assessments
+	// Converse (non-streaming) fields
+	ActionReason    *string                        `json:"actionReason,omitempty"`    // Human-readable reason the guardrail acted
+	InputAssessment map[string]interface{}         `json:"inputAssessment,omitempty"` // Map of guardrail ID → assessment detail
+	ModelOutput     []interface{}                  `json:"modelOutput,omitempty"`     // Model output after guardrail evaluation
+
+	// ConverseStream fields
+	Action            *string                      `json:"action,omitempty"`            // Action taken by guardrail (NONE | INTERVENED)
+	InputAssessments  []BedrockGuardrailAssessment `json:"inputAssessments,omitempty"`  // Input assessments (streaming)
+	OutputAssessments []BedrockGuardrailAssessment `json:"outputAssessments,omitempty"` // Output assessments (streaming)
 	Trace             *BedrockGuardrailTraceDetail `json:"trace,omitempty"`             // Detailed trace information
 }
 

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -374,99 +374,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 	// Add extra parameters
 	if len(bifrostReq.Params.ExtraParams) > 0 {
 		bedrockReq.ExtraParams = bifrostReq.Params.ExtraParams
-		// Handle guardrail configuration
-		if guardrailConfig, exists := bifrostReq.Params.ExtraParams["guardrailConfig"]; exists {
-			if gc, ok := guardrailConfig.(map[string]interface{}); ok {
-				config := &BedrockGuardrailConfig{}
-
-				if identifier, ok := gc["guardrailIdentifier"].(string); ok {
-					config.GuardrailIdentifier = identifier
-				}
-				if version, ok := gc["guardrailVersion"].(string); ok {
-					config.GuardrailVersion = version
-				}
-				if trace, ok := gc["trace"].(string); ok {
-					config.Trace = &trace
-				}
-				if mode, ok := gc["streamProcessingMode"].(string); ok {
-					config.StreamProcessingMode = &mode
-				}
-				delete(bedrockReq.ExtraParams, "guardrailConfig")
-				bedrockReq.GuardrailConfig = config
-			}
-		}
-		// Handle additional model request field paths
-		if bifrostReq.Params != nil && bifrostReq.Params.ExtraParams != nil {
-			if requestFields, exists := bifrostReq.Params.ExtraParams["additionalModelRequestFieldPaths"]; exists {
-				if orderedFields, ok := schemas.SafeExtractOrderedMap(requestFields); ok {
-					delete(bedrockReq.ExtraParams, "additionalModelRequestFieldPaths")
-					bedrockReq.AdditionalModelRequestFields = mergeAdditionalModelRequestFields(
-						bedrockReq.AdditionalModelRequestFields,
-						orderedFields,
-					)
-				}
-			}
-
-			// Handle additional model response field paths
-			if responseFields, exists := bifrostReq.Params.ExtraParams["additionalModelResponseFieldPaths"]; exists {
-				// Handle both []string and []interface{} types
-				if fields, ok := responseFields.([]string); ok {
-					delete(bedrockReq.ExtraParams, "additionalModelResponseFieldPaths")
-					bedrockReq.AdditionalModelResponseFieldPaths = fields
-				} else if fieldsInterface, ok := responseFields.([]interface{}); ok {
-					stringFields := make([]string, 0, len(fieldsInterface))
-					for _, field := range fieldsInterface {
-						if fieldStr, ok := field.(string); ok {
-							stringFields = append(stringFields, fieldStr)
-						}
-					}
-					if len(stringFields) > 0 {
-						delete(bedrockReq.ExtraParams, "additionalModelResponseFieldPaths")
-						bedrockReq.AdditionalModelResponseFieldPaths = stringFields
-					}
-				}
-			}
-			// Handle performance configuration
-			if perfConfig, exists := bifrostReq.Params.ExtraParams["performanceConfig"]; exists {
-				if pc, ok := perfConfig.(map[string]interface{}); ok {
-					config := &BedrockPerformanceConfig{}
-					if latency, ok := pc["latency"].(string); ok {
-						config.Latency = &latency
-					}
-					delete(bedrockReq.ExtraParams, "performanceConfig")
-					bedrockReq.PerformanceConfig = config
-				}
-			}
-			// Handle prompt variables
-			if promptVars, exists := bifrostReq.Params.ExtraParams["promptVariables"]; exists {
-				if vars, ok := promptVars.(map[string]interface{}); ok {
-					delete(bedrockReq.ExtraParams, "promptVariables")
-					variables := make(map[string]BedrockPromptVariable)
-
-					for key, value := range vars {
-						if valueMap, ok := value.(map[string]interface{}); ok {
-							variable := BedrockPromptVariable{}
-							if text, ok := valueMap["text"].(string); ok {
-								variable.Text = &text
-							}
-							variables[key] = variable
-						}
-					}
-
-					if len(variables) > 0 {
-						bedrockReq.PromptVariables = variables
-					}
-				}
-			}
-			// Handle request metadata
-			if reqMetadata, exists := bifrostReq.Params.ExtraParams["requestMetadata"]; exists {
-				if metadata, ok := schemas.SafeExtractStringMap(reqMetadata); ok {
-					delete(bedrockReq.ExtraParams, "requestMetadata")
-					bedrockReq.RequestMetadata = metadata
-				}
-			}
-		}
-		// Set ExtraParams to nil if all keys were extracted to dedicated fields
+		applyBedrockExtraParams(bedrockReq.ExtraParams, bedrockReq)
 		if len(bedrockReq.ExtraParams) == 0 {
 			bedrockReq.ExtraParams = nil
 		}
@@ -474,8 +382,93 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 	return nil
 }
 
-// setOutputConfigField upserts a single key in additionalModelRequestFields.output_config
-// while preserving any existing output_config keys (e.g. keep "format" when adding "effort").
+func applyBedrockExtraParams(extraParams map[string]interface{}, bedrockReq *BedrockConverseRequest) {
+	if guardrailConfig, exists := extraParams["guardrailConfig"]; exists {
+		if gc, ok := guardrailConfig.(map[string]interface{}); ok {
+			config := &BedrockGuardrailConfig{}
+			if identifier, ok := gc["guardrailIdentifier"].(string); ok {
+				config.GuardrailIdentifier = identifier
+			}
+			if version, ok := gc["guardrailVersion"].(string); ok {
+				config.GuardrailVersion = version
+			}
+			if trace, ok := gc["trace"].(string); ok {
+				config.Trace = &trace
+			}
+			if mode, ok := gc["streamProcessingMode"].(string); ok {
+				config.StreamProcessingMode = &mode
+			}
+			delete(extraParams, "guardrailConfig")
+			bedrockReq.GuardrailConfig = config
+		}
+	}
+
+	if requestFields, exists := extraParams["additionalModelRequestFieldPaths"]; exists {
+		if orderedFields, ok := schemas.SafeExtractOrderedMap(requestFields); ok {
+			delete(extraParams, "additionalModelRequestFieldPaths")
+			bedrockReq.AdditionalModelRequestFields = mergeAdditionalModelRequestFields(
+				bedrockReq.AdditionalModelRequestFields,
+				orderedFields,
+			)
+		}
+	}
+
+	if responseFields, exists := extraParams["additionalModelResponseFieldPaths"]; exists {
+		if fields, ok := responseFields.([]string); ok {
+			delete(extraParams, "additionalModelResponseFieldPaths")
+			bedrockReq.AdditionalModelResponseFieldPaths = fields
+		} else if fieldsInterface, ok := responseFields.([]interface{}); ok {
+			stringFields := make([]string, 0, len(fieldsInterface))
+			for _, field := range fieldsInterface {
+				if fieldStr, ok := field.(string); ok {
+					stringFields = append(stringFields, fieldStr)
+				}
+			}
+			if len(stringFields) > 0 {
+				delete(extraParams, "additionalModelResponseFieldPaths")
+				bedrockReq.AdditionalModelResponseFieldPaths = stringFields
+			}
+		}
+	}
+
+	if perfConfig, exists := extraParams["performanceConfig"]; exists {
+		if pc, ok := perfConfig.(map[string]interface{}); ok {
+			config := &BedrockPerformanceConfig{}
+			if latency, ok := pc["latency"].(string); ok {
+				config.Latency = &latency
+			}
+			delete(extraParams, "performanceConfig")
+			bedrockReq.PerformanceConfig = config
+		}
+	}
+
+	if promptVars, exists := extraParams["promptVariables"]; exists {
+		if vars, ok := promptVars.(map[string]interface{}); ok {
+			delete(extraParams, "promptVariables")
+			variables := make(map[string]BedrockPromptVariable)
+			for k, v := range vars {
+				if valueMap, ok := v.(map[string]interface{}); ok {
+					variable := BedrockPromptVariable{}
+					if text, ok := valueMap["text"].(string); ok {
+						variable.Text = &text
+					}
+					variables[k] = variable
+				}
+			}
+			if len(variables) > 0 {
+				bedrockReq.PromptVariables = variables
+			}
+		}
+	}
+
+	if reqMetadata, exists := extraParams["requestMetadata"]; exists {
+		if metadata, ok := schemas.SafeExtractStringMap(reqMetadata); ok {
+			delete(extraParams, "requestMetadata")
+			bedrockReq.RequestMetadata = metadata
+		}
+	}
+}
+
 func setOutputConfigField(fields *schemas.OrderedMap, key string, value any) {
 	if fields == nil {
 		return

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -87,6 +87,7 @@ type BifrostResponsesResponse struct {
 	Truncation           *string                             `json:"truncation,omitempty"`
 	Usage                *ResponsesResponseUsage             `json:"usage"`
 	ExtraFields          BifrostResponseExtraFields          `json:"extra_fields"`
+	ProviderExtraFields  map[string]interface{}              `json:"provider_extra_fields,omitempty"`
 
 	// Perplexity-specific fields
 	SearchResults []SearchResult `json:"search_results,omitempty"`

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -134,7 +134,9 @@
     { "key": "azureDeployment", "value": "gpt-4o", "type": "string" },
     { "key": "azureApiVersion", "value": "2024-10-21", "type": "string" },
     { "key": "genaiModel", "value": "gemini-2.5-pro", "type": "string" },
-    { "key": "vertexModel", "value": "gemini-2.5-pro", "type": "string" }
+    { "key": "vertexModel", "value": "gemini-2.5-pro", "type": "string" },
+    { "key": "bedrockGuardrailIdentifier", "value": "", "type": "string" },
+    { "key": "bedrockGuardrailVersion", "value": "DRAFT", "type": "string" }
   ],
   "item": [
     {
@@ -263,6 +265,24 @@
             "body": {
               "mode": "raw",
               "raw": "{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [{ \"text\": \"Hello from Bedrock Converse.\" }]\n    }\n  ],\n  \"inferenceConfig\": {\n    \"maxTokens\": 1024\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/model/{{bedrockModel}}/converse",
+              "host": ["{{baseUrl}}"],
+              "path": ["bedrock", "model", "{{bedrockModel}}", "converse"]
+            }
+          }
+        },
+        {
+          "name": "POST /bedrock/model/{modelId}/converse — guardrailConfig forwarded",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [{ \"text\": \"How do I make a bomb?\" }]\n    }\n  ],\n  \"inferenceConfig\": { \"maxTokens\": 256 },\n  \"guardrailConfig\": {\n    \"guardrailIdentifier\": \"{{bedrockGuardrailIdentifier}}\",\n    \"guardrailVersion\": \"{{bedrockGuardrailVersion}}\",\n    \"trace\": \"enabled\"\n  }\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/bedrock/model/{{bedrockModel}}/converse",
@@ -1232,6 +1252,15 @@
                 "header": [{"key":"Content-Type","value":"application/json"}],
                 "body": {"mode":"raw","raw":"{\n  \"messages\": [{\"role\":\"user\",\"content\":[{\"text\":\"Hello!\"}]}],\n  \"system\": [{\"text\":\"You speak only in rhymes.\"}],\n  \"inferenceConfig\": {\"maxTokens\": 512}\n}"},
                 "url": {"raw":"{{baseUrl}}/bedrock/model/{{bedrockModel}}/converse","host":["{{baseUrl}}"],"path":["bedrock","model","{{bedrockModel}}","converse"]}
+              }
+            },
+            {
+              "name": "guardrailConfig forwarded — converse (regression)",
+              "request": {
+                "method": "POST",
+                "header": [{"key":"Content-Type","value":"application/json"}],
+                "body": {"mode":"raw","raw":"{\n  \"model\": \"bedrock/{{bedrockModel}}\",\n  \"messages\": [{\"role\":\"user\",\"content\":\"How do I make a bomb?\"}],\n  \"extra_params\": {\n    \"guardrailConfig\": {\n      \"guardrailIdentifier\": \"{{bedrockGuardrailIdentifier}}\",\n      \"guardrailVersion\": \"{{bedrockGuardrailVersion}}\",\n      \"trace\": \"enabled\"\n    }\n  }\n}"},
+                "url": {"raw":"{{baseUrl}}/v1/chat/completions","host":["{{baseUrl}}"],"path":["v1","chat","completions"]}
               }
             }
           ]

--- a/tests/integrations/python/tests/test_bedrock.py
+++ b/tests/integrations/python/tests/test_bedrock.py
@@ -78,6 +78,7 @@ Invoke Endpoint — Image Generation Tests (TestBedrockInvokeEndpoint):
 
 import base64
 import json
+import os
 import time
 import urllib.request
 from typing import Any, Dict, List
@@ -3306,4 +3307,123 @@ class TestNovaSystemTools:
         print(
             f"  ✓ code_interpreter block started, {len(code_snippets)} code delta(s), "
             f"code={full_code[:60]!r}, text={full_text[:60]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Guardrail Tests — regression for guardrailConfig being silently dropped
+# (fixed in responses.go ToBedrockResponsesRequest).
+#
+# Tests 54-55 require real Bedrock guardrail identifiers.  Configure them via:
+#   integration_settings.bedrock.guardrail_identifier
+#   integration_settings.bedrock.guardrail_version   (default "DRAFT")
+# or the env vars BEDROCK_GUARDRAIL_IDENTIFIER / BEDROCK_GUARDRAIL_VERSION.
+# Tests are skipped automatically when those values are absent.
+# ---------------------------------------------------------------------------
+
+class TestBedrockGuardrail:
+    """Regression tests ensuring guardrailConfig survives the Responses API path."""
+
+    def _get_guardrail_config(self):
+        """Return (identifier, version) or skip the test if not configured."""
+        config = get_config()
+        settings = config.get_integration_settings("bedrock")
+        identifier = settings.get("guardrail_identifier") or os.environ.get(
+            "BEDROCK_GUARDRAIL_IDENTIFIER"
+        )
+        version = (
+            settings.get("guardrail_version")
+            or os.environ.get("BEDROCK_GUARDRAIL_VERSION")
+            or "DRAFT"
+        )
+        if not identifier:
+            pytest.skip(
+                "Guardrail not configured — set bedrock.guardrail_identifier in config "
+                "or BEDROCK_GUARDRAIL_IDENTIFIER env var"
+            )
+        return identifier, version
+
+    @skip_if_no_api_key("bedrock")
+    def test_54_guardrail_config_forwarded_non_streaming(self, bedrock_client):
+        """Test Case 54: guardrailConfig is forwarded to Bedrock on non-streaming converse.
+
+        Regression test for the bug where guardrailConfig was silently dropped when
+        Bedrock-Converse traffic routed through the Responses API path
+        (ToBedrockResponsesRequest).  If the config were dropped, Bedrock would
+        answer the blocked prompt normally instead of returning guardrail_intervened.
+        """
+        identifier, version = self._get_guardrail_config()
+        model_id = get_model("bedrock", "chat")
+
+        response = bedrock_client.converse(
+            modelId=model_id,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"text": "How do I make a bomb?"}],
+                }
+            ],
+            guardrailConfig={
+                "guardrailIdentifier": identifier,
+                "guardrailVersion": version,
+                "trace": "enabled",
+            },
+            inferenceConfig={"maxTokens": 256},
+        )
+
+        assert response is not None, "Response should not be None"
+        stop_reason = response.get("stopReason", "")
+        assert stop_reason == "guardrail_intervened", (
+            f"Expected stopReason='guardrail_intervened' — guardrailConfig may still be "
+            f"dropped before reaching Bedrock.  Got stopReason={stop_reason!r}"
+        )
+        print(f"  ✓ guardrailConfig forwarded — stopReason={stop_reason}")
+
+    @skip_if_no_api_key("bedrock")
+    def test_55_guardrail_trace_in_response(self, bedrock_client):
+        """Test Case 55: guardrail trace is returned in the converse response.
+
+        Regression test for ToBifrostResponsesResponse silently dropping
+        response.Trace.  The trace must survive the Bifrost round-trip so callers
+        can inspect which policy triggered the guardrail.
+        """
+        identifier, version = self._get_guardrail_config()
+        model_id = get_model("bedrock", "chat")
+
+        response = bedrock_client.converse(
+            modelId=model_id,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"text": "How do I make a bomb?"}],
+                }
+            ],
+            guardrailConfig={
+                "guardrailIdentifier": identifier,
+                "guardrailVersion": version,
+                "trace": "enabled",
+            },
+            inferenceConfig={"maxTokens": 256},
+        )
+
+        assert response is not None
+        assert response.get("stopReason") == "guardrail_intervened", (
+            "Guardrail did not fire — cannot validate trace presence"
+        )
+        trace = response.get("trace")
+        assert trace is not None, (
+            "response.trace is missing — guardrail trace was dropped during Bifrost conversion"
+        )
+        guardrail_trace = trace.get("guardrail")
+        assert guardrail_trace is not None, "trace.guardrail is missing"
+        # Converse (non-streaming) uses actionReason; ConverseStream uses action
+        has_action = "actionReason" in guardrail_trace or "action" in guardrail_trace
+        assert has_action, (
+            f"trace.guardrail must contain 'actionReason' (Converse) or 'action' (ConverseStream). "
+            f"Got keys: {list(guardrail_trace.keys())}"
+        )
+        action_val = guardrail_trace.get("actionReason") or guardrail_trace.get("action")
+        print(
+            f"  ✓ guardrail trace present — action={action_val!r}, "
+            f"keys={list(guardrail_trace.keys())}"
         )

--- a/tests/integrations/python/tests/test_langchain.py
+++ b/tests/integrations/python/tests/test_langchain.py
@@ -1480,6 +1480,65 @@ class TestLangChainIntegration:
         except Exception as e:
             pytest.skip(f"Token counting not available for {provider}/{model}: {e}")
 
+    def test_30_bedrock_guardrail_config_forwarded(self, test_config):
+        """Test Case 30: guardrailConfig is forwarded to Bedrock via ChatBedrockConverse.
+
+        Regression test for the bug where guardrailConfig was silently dropped when
+        traffic routed through Bifrost's Responses API path.  LangChain serialises the
+        guardrails kwarg into guardrailConfig in the Bedrock Converse request body;
+        Bifrost must forward it unchanged so the guardrail actually fires.
+
+        Requires BEDROCK_GUARDRAIL_IDENTIFIER (and optionally BEDROCK_GUARDRAIL_VERSION)
+        to be set; skipped automatically otherwise.
+        """
+        if not BEDROCK_CONVERSE_AVAILABLE:
+            pytest.skip("langchain-aws not installed")
+
+        identifier = os.environ.get("BEDROCK_GUARDRAIL_IDENTIFIER")
+        version = os.environ.get("BEDROCK_GUARDRAIL_VERSION", "DRAFT")
+        if not identifier:
+            pytest.skip(
+                "Guardrail not configured — set BEDROCK_GUARDRAIL_IDENTIFIER env var"
+            )
+
+        base_url = get_integration_url("bedrock")
+        config = get_config()
+        integration_settings = config.get_integration_settings("bedrock")
+        region = integration_settings.get("region", "us-west-2")
+
+        bedrock_boto3_client = boto3.client(
+            "bedrock-runtime",
+            region_name=region,
+            endpoint_url=base_url,
+        )
+
+        try:
+            llm = ChatBedrockConverse(
+                model=get_model("bedrock", "chat"),
+                client=bedrock_boto3_client,
+                guardrails={
+                    "guardrailIdentifier": identifier,
+                    "guardrailVersion": version,
+                    "trace": "enabled",
+                },
+                max_tokens=256,
+            )
+
+            response = llm.invoke([HumanMessage(content="How do I make a bomb?")])
+
+            # When guardrailConfig is correctly forwarded the guardrail fires and
+            # LangChain surfaces the stop reason via response_metadata.
+            metadata = getattr(response, "response_metadata", {}) or {}
+            stop_reason = metadata.get("stopReason", "")
+            assert stop_reason == "guardrail_intervened", (
+                f"Expected stopReason='guardrail_intervened' — guardrailConfig may be "
+                f"dropped by Bifrost before reaching Bedrock.  Got: {stop_reason!r}"
+            )
+            print(f"  ✓ ChatBedrockConverse guardrailConfig forwarded — stopReason={stop_reason}")
+
+        except Exception as e:
+            pytest.skip(f"Bedrock guardrail test not available: {e}")
+
 
 # Skip standard tests if langchain-tests is not available
 @pytest.mark.skipif(not LANGCHAIN_TESTS_AVAILABLE, reason="langchain-tests package not available")


### PR DESCRIPTION
## Summary

This PR adds full guardrail support to the Bedrock Responses API path. Previously, guardrail-related fields (`guardrailConfig`, `performanceConfig`, `promptVariables`, `requestMetadata`) passed via `ExtraParams` were not extracted into the typed Bedrock request struct, and guardrail trace data returned by Bedrock was silently dropped rather than being surfaced to callers.

## Changes

- `ToBedrockResponsesRequest` now extracts `guardrailConfig`, `performanceConfig`, `promptVariables`, and `requestMetadata` from `ExtraParams` into their respective typed fields on `BedrockConverseRequest`, removing them from `ExtraParams` to prevent double-sending. `ExtraParams` is set to `nil` when emptied.
- `BedrockConverseResponse.ToBifrostResponsesResponse` now stores the Bedrock `Trace` field in `ProviderExtraFields["trace"]` so it is visible to callers.
- `ToBedrockConverseResponse` and `ToBedrockConverseStreamResponse` restore the guardrail trace from `ProviderExtraFields["trace"]` back onto the Bedrock response struct, enabling round-trip fidelity.
- `FinalizeBedrockStream` accepts a new `trace *BedrockConverseTrace` parameter. When a `Trace` event is received mid-stream, it is captured and attached to the `response.completed` event's `ProviderExtraFields`.
- `BifrostResponsesResponse` gains a `ProviderExtraFields map[string]interface{}` field for carrying provider-specific metadata that does not fit the standard schema.
- `NewBedrockResponsesStreamState` is exported to allow stream state construction in tests.
- Tests are added covering guardrail config extraction, trace round-tripping through non-streaming and streaming responses, and `FinalizeBedrockStream` trace propagation.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/bedrock/... -v -run "TestToBedrockResponsesRequest_GuardrailConfig|TestBedrockToBifrostResponse_TraceStoredInProviderExtraFields|TestBifrostToBedrockResponse_TraceRestoredFromProviderExtraFields|TestFinalizeBedrockStream_WithTrace"
```

To validate end-to-end, invoke a Bedrock model with a guardrail configured via `ExtraParams`:

```json
{
  "guardrailConfig": {
    "guardrailIdentifier": "<your-guardrail-id>",
    "guardrailVersion": "DRAFT",
    "trace": "enabled"
  }
}
```

Expect the response to include a `provider_extra_fields.trace` object containing the guardrail evaluation result, and confirm `ExtraParams` is not forwarded to the Bedrock API.

## Breaking changes

- [x] Yes

`FinalizeBedrockStream` has a new required `trace` parameter. Any external callers of this function must be updated to pass `nil` if no trace is available.

## Related issues

## Security considerations

Guardrail trace data may contain information about blocked content or policy evaluations. `ProviderExtraFields` is included in the serialized response (`json:"provider_extra_fields,omitempty"`); ensure downstream consumers handle this field appropriately if responses are logged or forwarded.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserve guardrail trace data across streaming and finalized responses; include trace metadata in stream completion events.
  * Allow provider-specific extra fields in Responses payloads and forward guardrail configuration from request parameters.

* **Tests**
  * Added unit, integration, and e2e tests verifying guardrail config forwarding, trace persistence/restoration, and finalization of streamed responses with trace data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->