### PR TITLE
adds otel spec compatible metrics (backward compatible)

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2891,7 +2891,8 @@ func completeDeferredSpan(ctx *schemas.BifrostContext, result *schemas.BifrostRe
 	// Set TTFT and chunk count attributes regardless of accumulated response availability
 	// (GetAccumulatedChunks may return nil response while still providing valid metrics)
 	if ttftNs > 0 {
-		tracer.SetAttribute(handle, schemas.AttrTimeToFirstToken, ttftNs)
+		tracer.SetAttribute(handle, schemas.AttrTimeToFirstToken, ttftNs)              // legacy: nanoseconds; replaced by gen_ai.response.time_to_first_chunk
+		tracer.SetAttribute(handle, schemas.AttrTimeToFirstChunk, float64(ttftNs)/1e9) // spec: seconds
 	}
 	if chunkCount > 0 {
 		tracer.SetAttribute(handle, schemas.AttrTotalChunks, chunkCount)

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -247,7 +247,8 @@ const (
 	AttrServiceTier      = "gen_ai.response.service_tier"
 	AttrCreated          = "gen_ai.response.created"
 	AttrObject           = "gen_ai.response.object"
-	AttrTimeToFirstToken = "gen_ai.response.time_to_first_token"
+	AttrTimeToFirstToken = "gen_ai.response.time_to_first_token" // legacy: nanoseconds; replaced by gen_ai.response.time_to_first_chunk (seconds)
+	AttrTimeToFirstChunk = "gen_ai.response.time_to_first_chunk"
 	AttrTotalChunks      = "gen_ai.response.total_chunks"
 
 	// Plugin Attributes (for aggregated streaming post-hook spans)
@@ -268,6 +269,8 @@ const (
 	// OTel GenAI spec keys for cache tokens (flat namespace).
 	AttrUsageCacheReadInputTokens     = "gen_ai.usage.cache_read.input_tokens"
 	AttrUsageCacheCreationInputTokens = "gen_ai.usage.cache_creation.input_tokens"
+	// OTel GenAI spec key for reasoning tokens (flat namespace).
+	AttrUsageReasoningOutputTokens = "gen_ai.usage.reasoning.output_tokens"
 	// Chat completion usage detail attributes
 	// legacy: nested namespace; OTel spec uses flat gen_ai.usage.cache_read.input_tokens
 	// and gen_ai.usage.cache_creation.input_tokens for the cached_* entries. The

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -343,7 +343,8 @@ func PopulateChatResponseAttributes(resp *schemas.BifrostChatResponse, attrs map
 				attrs[schemas.AttrCompletionTokenDetailsImage] = *resp.Usage.CompletionTokensDetails.ImageTokens
 			}
 			if resp.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
-				attrs[schemas.AttrCompletionTokenDetailsReason] = resp.Usage.CompletionTokensDetails.ReasoningTokens
+				attrs[schemas.AttrCompletionTokenDetailsReason] = resp.Usage.CompletionTokensDetails.ReasoningTokens // legacy: nested key; replaced by gen_ai.usage.reasoning.output_tokens
+				attrs[schemas.AttrUsageReasoningOutputTokens] = resp.Usage.CompletionTokensDetails.ReasoningTokens
 			}
 			if resp.Usage.CompletionTokensDetails.AcceptedPredictionTokens > 0 {
 				attrs[schemas.AttrCompletionTokenDetailsAccept] = resp.Usage.CompletionTokensDetails.AcceptedPredictionTokens
@@ -899,7 +900,8 @@ func PopulateResponsesResponseAttributes(resp *schemas.BifrostResponsesResponse,
 				attrs[schemas.AttrOutputTokenDetailsImage] = *d.ImageTokens
 			}
 			if d.ReasoningTokens > 0 {
-				attrs[schemas.AttrOutputTokenDetailsReason] = d.ReasoningTokens
+				attrs[schemas.AttrOutputTokenDetailsReason] = d.ReasoningTokens // legacy: nested key; replaced by gen_ai.usage.reasoning.output_tokens
+				attrs[schemas.AttrUsageReasoningOutputTokens] = d.ReasoningTokens
 			}
 			if d.AcceptedPredictionTokens > 0 {
 				attrs[schemas.AttrOutputTokenDetailsAccept] = d.AcceptedPredictionTokens

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -248,7 +248,9 @@ func (t *Tracer) PopulateLLMResponseAttributes(ctx *schemas.BifrostContext, hand
 	respAttrs := PopulateResponseAttributes(resp)
 	for k, v := range respAttrs {
 		if k == schemas.AttrFinishReasons {
-			// llm.call span gets the singular finish_reason (first element only)
+			// Spec: gen_ai.response.finish_reasons (string[]) belongs on the GenAI (llm.call) span.
+			span.SetAttribute(schemas.AttrFinishReasons, v)
+			// legacy: also expose the singular scalar finish_reason (first element) for back-compat.
 			if reasons, ok := v.([]string); ok && len(reasons) > 0 {
 				span.SetAttribute(schemas.AttrFinishReason, reasons[0])
 			}


### PR DESCRIPTION
## Summary

Aligns tracing attributes with the OpenTelemetry GenAI semantic conventions by introducing spec-compliant attribute keys alongside the existing legacy ones, ensuring backward compatibility while moving toward standardized observability.

## Changes

- Added `AttrTimeToFirstChunk` (`gen_ai.response.time_to_first_chunk`) emitted in **seconds** (float64) alongside the existing `AttrTimeToFirstToken` which remains in nanoseconds for backward compatibility.
- Added `AttrUsageReasoningOutputTokens` (`gen_ai.usage.reasoning.output_tokens`) emitted alongside the legacy nested `AttrCompletionTokenDetailsReason` and `AttrOutputTokenDetailsReason` keys for both Chat and Responses API spans.
- Fixed `gen_ai.response.finish_reasons` (string array) to be set directly on the GenAI span per spec, while still exposing the scalar `gen_ai.response.finish_reason` (first element only) for backward compatibility.
- Annotated all legacy attribute constants and usages with comments clarifying their deprecated status and their spec-compliant replacements.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that traces emitted for streaming responses include both `gen_ai.response.time_to_first_token` (nanoseconds) and `gen_ai.response.time_to_first_chunk` (seconds). Verify that reasoning token usage emits both the legacy nested key and `gen_ai.usage.reasoning.output_tokens`. Verify that `gen_ai.response.finish_reasons` is present as a string array on the GenAI span.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded GenAI operation tracing with new metrics: time-to-first-chunk measurement and reasoning output tokens tracking for enhanced observability.
  * Introduced structured finish reasons attribute on GenAI spans, providing clearer insights into completion behaviors.
  * All new tracing attributes maintain full backward compatibility, allowing existing implementations to continue working without modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->