### PR TITLE
fix: remove max-width constraint, add className prop to FullPageLoader, and fix tool call border placement

### DIFF
--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -1,6 +1,7 @@
 import VirtualKeysTable from "@/app/workspace/virtual-keys/views/virtualKeysTable";
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
+import { parseAsSafeString } from "@/lib/queryParamsParser";
 import {
   getErrorMessage,
   useGetCustomersQuery,
@@ -8,7 +9,6 @@ import {
   useGetVirtualKeysQuery,
 } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { parseAsSafeString } from "@/lib/queryParamsParser";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
@@ -164,7 +164,7 @@ export default function GovernanceVirtualKeysPage() {
   };
 
   return (
-    <div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full max-w-7xl flex-col overflow-hidden p-4">
+    <div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
       <VirtualKeysTable
         virtualKeys={virtualKeysData?.virtual_keys || []}
         totalCount={virtualKeysData?.total_count || 0}

--- a/ui/components/fullPageLoader.tsx
+++ b/ui/components/fullPageLoader.tsx
@@ -1,8 +1,9 @@
+import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
 
-function FullPageLoader() {
+function FullPageLoader({ className }: { className?: string }) {
 	return (
-		<div className="h-base pb-1/2 flex items-center justify-center">
+		<div className={cn("h-base pb-1/2 flex items-center justify-center", className)}>
 			<Loader2 className="h-4 w-4 animate-spin" />
 		</div>
 	);

--- a/ui/components/prompts/components/messagesView/toolCallView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallView.tsx
@@ -4,9 +4,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { Message, MessageRole, SerializedMessage, type ToolCall } from "@/lib/message";
 import { cn } from "@/lib/utils";
 import { isJson } from "@/lib/utils/validation";
-import { MCPAuthRequiredError } from "../../utils/executor";
 import { Check, ExternalLink, Loader2, PencilLine, Play, RefreshCw, Send, ShieldAlert, Wrench, XIcon } from "lucide-react";
 import { useRef, useState } from "react";
+import { MCPAuthRequiredError } from "../../utils/executor";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
 
 export default function ToolCallMessageView({
@@ -316,7 +316,7 @@ export default function ToolCallMessageView({
 							style={{ animationDelay: `${i * 75}ms` }}
 						>
 							{/* Header */}
-							<div className="flex items-start gap-2 border-b bg-muted/40 px-3 py-2">
+							<div className="flex items-start gap-2 bg-muted/40 px-3 py-2">
 								<div className="min-w-0 flex-1 items-center flex justify-between">
 									<div className="flex min-w-0 items-center gap-2">
 										<div className={cn(
@@ -353,7 +353,7 @@ export default function ToolCallMessageView({
 
 							{/* Arguments */}
 							{formattedArgs && (
-								<div className="px-3 py-2">
+								<div className="px-3 py-2 border-t">
 									<div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
 										Arguments
 									</div>


### PR DESCRIPTION
## Summary

Minor UI polish fixes addressing layout constraints, component flexibility, and visual border placement in the tool call view.

## Changes

- Removed `max-w-7xl` constraint from the Governance Virtual Keys page container, allowing it to expand to full width
- Made `FullPageLoader` accept an optional `className` prop for external style overrides
- Removed the bottom border from the tool call header and moved the border to the top of the arguments section, so the divider only appears when arguments are present
- Reordered imports in two files to follow consistent ordering conventions

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Navigate to the Governance → Virtual Keys page and verify the table expands to full page width without a max-width cap.
2. Open a prompt with tool calls that have no arguments and confirm no stray border appears in the tool call card header.
3. Open a prompt with tool calls that do have arguments and confirm the divider border appears above the arguments section.

## Screenshots/Recordings

Before/after screenshots of the Virtual Keys page width and tool call card borders recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined layout styling on the virtual keys governance page to change content max-width behavior for improved responsive flow.
  * Adjusted visual dividers in tool-call cards to improve separation between header and arguments sections.

* **Other Changes**
  * Full-page loader now supports optional custom class names to allow easier styling customization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->