### PR TITLE
feat: add `pending_verification` state and `initiate-verification` endpoint for config.json shared-OAuth MCP clients

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -253,6 +253,15 @@ func (m *MCPManager) ReconnectClient(id string) error {
 		m.mu.Unlock()
 		return fmt.Errorf("per-user auth clients do not maintain a shared upstream connection (each user manages their own auth): %w", schemas.ErrMCPReconnectNotApplicable)
 	}
+	// Clients awaiting admin OAuth authorization have no token to connect
+	// with; a reconnect attempt would only flip them out of
+	// pending_verification into an error state and hide the authorization
+	// prompt in the UI.
+	if client.ExecutionConfig != nil && client.ExecutionConfig.PendingOAuthConfig != nil &&
+		(client.ExecutionConfig.AuthType == schemas.MCPAuthTypeOauth || client.ExecutionConfig.AuthType == schemas.MCPAuthTypePerUserOauth) {
+		m.mu.Unlock()
+		return fmt.Errorf("client is awaiting admin OAuth authorization; complete authorization instead of reconnecting: %w", schemas.ErrMCPReconnectNotApplicable)
+	}
 	config := client.ExecutionConfig
 	m.mu.Unlock()
 
@@ -371,6 +380,29 @@ func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPCl
 			}
 		}
 		m.mu.Unlock()
+		return nil
+	}
+
+	// Shared-OAuth clients with PendingOAuthConfig set carry the inline
+	// `oauth_config` block from config.json but have no oauth_configs row
+	// or token yet. Attempting to connect would fail in ConnectionHeaders
+	// → GetAccessToken. Park them in pending_verification until an admin
+	// completes the browser OAuth flow via
+	// POST /api/mcp/client/{id}/initiate-verification. PendingOAuthConfig
+	// is cleared once the OAuth callback marks the linked oauth_configs
+	// row authorized; the subsequent reconnect skips this branch and
+	// connectToMCPClient runs normally.
+	if config.AuthType == schemas.MCPAuthTypeOauth && config.PendingOAuthConfig != nil {
+		m.mu.Lock()
+		if client, exists := m.clientMap[config.ID]; exists {
+			if config.ConnectionString != nil {
+				url := config.ConnectionString.GetValue()
+				client.ConnectionInfo.ConnectionURL = &url
+			}
+			client.State = schemas.MCPConnectionStatePendingVerification
+		}
+		m.mu.Unlock()
+		m.logger.Debug("%s Shared-OAuth MCP client '%s' registered in pending_verification (awaiting admin authorization)", MCPLogPrefix, config.Name)
 		return nil
 	}
 
@@ -987,6 +1019,7 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 		Disabled:              updatedConfig.Disabled,
 		TLSConfig:             updatedConfig.TLSConfig,
 		PerUserHeaderKeys:     slices.Clone(updatedConfig.PerUserHeaderKeys),
+		PendingOAuthConfig:    updatedConfig.PendingOAuthConfig,
 	}
 
 	// Atomically replace the config pointer
@@ -1027,8 +1060,9 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 //
 // Parameters:
 //   - id: ID of the client whose credentials should be updated
-//   - newConfig: Partial config carrying the updated auth fields (Headers). All other fields
-//     are ignored and taken from the current execution config.
+//   - newConfig: Partial config carrying the updated auth fields (Headers, OauthConfigID,
+//     PendingOAuthConfig). All other fields are ignored and taken from the current
+//     execution config.
 //
 // Returns:
 //   - error: Any connection error; nil on success
@@ -1069,6 +1103,11 @@ func (m *MCPManager) UpdateClientConnection(id string, newConfig *schemas.MCPCli
 	if newConfig.OauthConfigID != nil {
 		mergedConfig.OauthConfigID = newConfig.OauthConfigID
 	}
+	// PendingOAuthConfig is taken verbatim, not merged: nil is meaningful
+	// (authorization completed, stash cleared). Carrying the old value
+	// forward would make connectToMCPClient park the client back in
+	// pending_verification instead of connecting.
+	mergedConfig.PendingOAuthConfig = newConfig.PendingOAuthConfig
 	m.mu.RUnlock()
 
 	// connectToMCPClient will close the current connection and create a new clientMap entry.

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -298,19 +298,19 @@ const (
 
 // MCPClientConfig defines tool filtering for an MCP client.
 type MCPClientConfig struct {
-	ID                  string            `json:"client_id"`                       // Client ID
-	Name                string            `json:"name"`                            // Client name
-	IsCodeModeClient    bool              `json:"is_code_mode_client"`             // Whether the client is a code mode client
-	ConnectionType      MCPConnectionType `json:"connection_type"`                 // How to connect (HTTP, STDIO, SSE, or InProcess)
-	ConnectionString    *SecretVar           `json:"connection_string,omitempty"`     // HTTP or SSE URL (required for HTTP or SSE connections)
-	StdioConfig         *MCPStdioConfig   `json:"stdio_config,omitempty"`          // STDIO configuration (required for STDIO connections)
-	TLSConfig           *MCPTLSConfig     `json:"tls_config,omitempty"`            // TLS configuration for HTTP/SSE connections
-	AuthType            MCPAuthType       `json:"auth_type"`                       // Authentication type (none, headers, or oauth)
-	OauthConfigID       *string           `json:"oauth_config_id,omitempty"`       // OAuth config ID (references oauth_configs table)
-	OauthClientID       *SecretVar           `json:"oauth_client_id,omitempty"`       // Redacted OAuth client ID (populated on GET, not stored here)
-	OauthClientSecret   *SecretVar           `json:"oauth_client_secret,omitempty"`   // Redacted OAuth client secret (populated on GET, not stored here)
-	State               string            `json:"state,omitempty"`                 // Connection state (connected, disconnected, error)
-	Headers             map[string]SecretVar `json:"headers,omitempty"`               // Headers to send with the request (for headers auth type)
+	ID                string               `json:"client_id"`                     // Client ID
+	Name              string               `json:"name"`                          // Client name
+	IsCodeModeClient  bool                 `json:"is_code_mode_client"`           // Whether the client is a code mode client
+	ConnectionType    MCPConnectionType    `json:"connection_type"`               // How to connect (HTTP, STDIO, SSE, or InProcess)
+	ConnectionString  *SecretVar           `json:"connection_string,omitempty"`   // HTTP or SSE URL (required for HTTP or SSE connections)
+	StdioConfig       *MCPStdioConfig      `json:"stdio_config,omitempty"`        // STDIO configuration (required for STDIO connections)
+	TLSConfig         *MCPTLSConfig        `json:"tls_config,omitempty"`          // TLS configuration for HTTP/SSE connections
+	AuthType          MCPAuthType          `json:"auth_type"`                     // Authentication type (none, headers, or oauth)
+	OauthConfigID     *string              `json:"oauth_config_id,omitempty"`     // OAuth config ID (references oauth_configs table)
+	OauthClientID     *SecretVar           `json:"oauth_client_id,omitempty"`     // Redacted OAuth client ID (populated on GET, not stored here)
+	OauthClientSecret *SecretVar           `json:"oauth_client_secret,omitempty"` // Redacted OAuth client secret (populated on GET, not stored here)
+	State             string               `json:"state,omitempty"`               // Connection state (connected, disconnected, error)
+	Headers           map[string]SecretVar `json:"headers,omitempty"`             // Headers to send with the request (for headers auth type)
 	// PerUserHeaderKeys lists the header *names* each caller must supply for
 	// MCPAuthTypePerUserHeaders clients. Admin-declared schema only — the
 	// values live per-user in the mcp_per_user_header_credentials table and
@@ -345,6 +345,23 @@ type MCPClientConfig struct {
 	// Discovered tools for per-user OAuth clients (persisted so they survive restart)
 	DiscoveredTools           map[string]ChatTool `json:"-"` // Discovered tool schemas keyed by prefixed name
 	DiscoveredToolNameMapping map[string]string   `json:"-"` // Mapping from sanitized tool names to original MCP names
+
+	// PendingOAuthConfig holds the inline `oauth_config` block declared in
+	// config.json for shared-OAuth MCP clients (auth_type == "oauth").
+	//
+	// Lifecycle: populated by the config.json loader when an entry has
+	// AuthType==oauth without an OauthConfigID; persisted on the DB row as
+	// TableMCPClient.PendingOAuthConfigJSON; consumed at admin-click time by
+	// the initiate-verification endpoint to call InitiateOAuthFlow; cleared
+	// by the OAuth callback once oauth_configs.status='authorized'.
+	//
+	// Mirrors the UI Create-MCP-Client form's `oauth_config` block on the
+	// wire — same field set, same optionality (all inner fields can be
+	// omitted; discovery + dynamic registration fill them in at admin-click
+	// time). Nil for clients whose OAuth has already been authorized.
+	// Stored values are plaintext; env-var-reference resolution is not
+	// applied to fields inside this block.
+	PendingOAuthConfig *OAuth2Config `json:"oauth_config,omitempty"`
 }
 
 // UnmarshalJSON supports Go duration strings (e.g. "10m") for tool_sync_interval and
@@ -554,7 +571,7 @@ type MCPStdioConfig struct {
 // MCPTLSConfig holds TLS options for HTTP and SSE MCP connections.
 // InsecureSkipVerify takes priority over CACertPEM when both are set.
 type MCPTLSConfig struct {
-	InsecureSkipVerify bool    `json:"insecure_skip_verify,omitempty"` // Disable TLS certificate verification (development only)
+	InsecureSkipVerify bool       `json:"insecure_skip_verify,omitempty"` // Disable TLS certificate verification (development only)
 	CACertPEM          *SecretVar `json:"ca_cert_pem,omitempty"`          // PEM-encoded CA certificate to trust (supports env.*)
 }
 
@@ -579,11 +596,12 @@ func (t *MCPTLSConfig) MarshalForStorage() ([]byte, error) {
 type MCPConnectionState string
 
 const (
-	MCPConnectionStateConnected    MCPConnectionState = "connected"     // Client is connected and ready to use
-	MCPConnectionStateDisconnected MCPConnectionState = "disconnected"  // Client is not connected
-	MCPConnectionStateError        MCPConnectionState = "error"         // Client is in an error state, and cannot be used
-	MCPConnectionStatePendingTools MCPConnectionState = "pending_tools" // Connected but tools not yet populated
-	MCPConnectionStateDisabled     MCPConnectionState = "disabled"      // Client is intentionally disabled by the user
+	MCPConnectionStateConnected           MCPConnectionState = "connected"            // Client is connected and ready to use
+	MCPConnectionStateDisconnected        MCPConnectionState = "disconnected"         // Client is not connected
+	MCPConnectionStateError               MCPConnectionState = "error"                // Client is in an error state, and cannot be used
+	MCPConnectionStatePendingTools        MCPConnectionState = "pending_tools"        // Connected but tools not yet populated
+	MCPConnectionStatePendingVerification MCPConnectionState = "pending_verification" // Declared (typically via config.json) but the one-time auth/test flow has not been completed by an admin yet
+	MCPConnectionStateDisabled            MCPConnectionState = "disabled"             // Client is intentionally disabled by the user
 )
 
 // MCPClientState represents a connected MCP client with its configuration and tools.

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1508,6 +1508,32 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 		}
 	}
 
+	// Hash AuthType so switching a client's auth scheme in config.json
+	// drifts the hash and triggers reconciliation. Normalize the empty
+	// value to the column default so a row hashed before save matches the
+	// same row hashed after load.
+	authType := m.AuthType
+	if authType == "" {
+		authType = string(schemas.MCPAuthTypeHeaders)
+	}
+	hash.Write([]byte("auth_type:" + authType))
+
+	// Hash PendingOAuthConfig so edits to the inline `oauth_config` block
+	// in config.json drift the hash and trigger reconciliation. Rows built
+	// from config.json carry only the runtime struct (the JSON column is
+	// populated later, by BeforeSave), so fall back to marshaling it with
+	// encoding/json — the same encoder BeforeSave uses to write the column
+	// — keeping both forms byte-identical.
+	if m.PendingOAuthConfigJSON != nil && *m.PendingOAuthConfigJSON != "" {
+		hash.Write([]byte(*m.PendingOAuthConfigJSON))
+	} else if m.PendingOAuthConfig != nil {
+		data, err := json.Marshal(m.PendingOAuthConfig)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+
 	// will enable it in the future with a migration
 	// hash.Write([]byte("disabled:" + strconv.FormatBool(m.Disabled)))
 	return hex.EncodeToString(hash.Sum(nil)), nil

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -457,6 +457,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_budget_override_anchor_columns"}, run: migrationAddBudgetOverrideAnchorColumns},
 	{IDs: []string{"add_live_models_sync_interval_column"}, run: migrationAddLiveModelsSyncIntervalColumn},
 	{IDs: []string{"add_pricing_override_user_id_column"}, run: migrationAddPricingOverrideUserIDColumn},
+	{IDs: []string{"add_mcp_client_pending_oauth_config_json_column"}, run: migrationAddMCPClientPendingOAuthConfigJSONColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -9953,6 +9954,45 @@ func migrationDropAzureAPIVersionColumn(ctx context.Context, db *gorm.DB, logger
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running drop_azure_api_version_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPClientPendingOAuthConfigJSONColumn adds the
+// pending_oauth_config_json column to config_mcp_clients. It stashes the
+// inline `oauth_config` block declared in config.json for shared-OAuth MCP
+// clients (auth_type='oauth') that have not yet been authorized by an admin.
+// The column is read at admin-click time by the initiate-verification
+// endpoint and cleared by the OAuth callback on status='authorized'.
+func migrationAddMCPClientPendingOAuthConfigJSONColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_mcp_client_pending_oauth_config_json_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if !mig.HasColumn(&tables.TableMCPClient{}, "pending_oauth_config_json") {
+				if err := mig.AddColumn(&tables.TableMCPClient{}, "pending_oauth_config_json"); err != nil {
+					return fmt.Errorf("failed to add pending_oauth_config_json column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if mig.HasColumn(&tables.TableMCPClient{}, "pending_oauth_config_json") {
+				if err := mig.DropColumn(&tables.TableMCPClient{}, "pending_oauth_config_json"); err != nil {
+					return fmt.Errorf("failed to drop pending_oauth_config_json column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_client_pending_oauth_config_json_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1562,6 +1562,12 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 					DiscoveredTools:           dbClient.DiscoveredTools,
 					DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
 					PerUserHeaderKeys:         dbClient.PerUserHeaderKeys,
+					PendingOAuthConfig:        dbClient.PendingOAuthConfig,
+					// ConfigHash must round-trip so config-file reconciliation
+					// can compare the stored hash against the file hash; an
+					// empty hash reads as "changed" and re-syncs every client
+					// on every boot, clobbering server-side auth state.
+					ConfigHash: dbClient.ConfigHash,
 				}
 			}
 			return &schemas.MCPConfig{
@@ -1605,6 +1611,12 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			DiscoveredTools:           dbClient.DiscoveredTools,
 			DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
 			PerUserHeaderKeys:         dbClient.PerUserHeaderKeys,
+			PendingOAuthConfig:        dbClient.PendingOAuthConfig,
+			// ConfigHash must round-trip so config-file reconciliation can
+			// compare the stored hash against the file hash; an empty hash
+			// reads as "changed" and re-syncs every client on every boot,
+			// clobbering server-side auth state.
+			ConfigHash: dbClient.ConfigHash,
 		}
 	}
 	return &schemas.MCPConfig{
@@ -2029,6 +2041,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 		DiscoveredTools:           dbClient.DiscoveredTools,
 		DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
 		PerUserHeaderKeys:         dbClient.PerUserHeaderKeys,
+		PendingOAuthConfig:        dbClient.PendingOAuthConfig,
 	}, nil
 }
 
@@ -2042,6 +2055,63 @@ func (s *RDBConfigStore) GetMCPClientByName(ctx context.Context, name string) (*
 		return nil, err
 	}
 	return &mcpClient, nil
+}
+
+// GetMCPClientByOauthConfigID retrieves the MCP client row linked to the given
+// oauth_config_id. Used by the OAuth callback to resolve config.json-originated
+// pending clients, where the oauth_configs.mcp_client_config_json blob is nil
+// because the MCP client row is persisted upfront in pending_verification state.
+func (s *RDBConfigStore) GetMCPClientByOauthConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPClient, error) {
+	var mcpClient tables.TableMCPClient
+	if err := s.DB().WithContext(ctx).Where("oauth_config_id = ?", oauthConfigID).First(&mcpClient).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &mcpClient, nil
+}
+
+// UpdateMCPClientOAuthConfigID writes only the oauth_config_id column for the
+// given client. Pass nil to NULL the column. Used by the initiate-verification
+// endpoint to link a freshly-initiated oauth_configs row to the persisted
+// pending_verification MCP client without touching any other fields.
+func (s *RDBConfigStore) UpdateMCPClientOAuthConfigID(ctx context.Context, clientID string, oauthConfigID *string) error {
+	res := s.DB().WithContext(ctx).
+		Model(&tables.TableMCPClient{}).
+		Where("client_id = ?", clientID).
+		Updates(map[string]interface{}{
+			"oauth_config_id": oauthConfigID,
+			"updated_at":      time.Now(),
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ClearMCPClientPendingOAuthConfig sets pending_oauth_config_json to NULL for
+// the given client. Called once OAuth authorization succeeds so the runtime no
+// longer sees the bootstrap stash and the next reconnect runs the normal
+// connect path instead of parking the client in pending_verification.
+func (s *RDBConfigStore) ClearMCPClientPendingOAuthConfig(ctx context.Context, clientID string) error {
+	res := s.DB().WithContext(ctx).
+		Model(&tables.TableMCPClient{}).
+		Where("client_id = ?", clientID).
+		Updates(map[string]interface{}{
+			"pending_oauth_config_json": nil,
+			"updated_at":                time.Now(),
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // CreateMCPClientConfig creates a new MCP client configuration in the database.
@@ -2088,8 +2158,14 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 			// hook persists an empty column, and on restart AddClient's
 			// validation rejects the row (empty PerUserHeaderKeys is
 			// invalid for per_user_headers), leaving the client orphaned.
-			PerUserHeaderKeys: clientConfigCopy.PerUserHeaderKeys,
-			Disabled:          clientConfigCopy.Disabled,
+			PerUserHeaderKeys:  clientConfigCopy.PerUserHeaderKeys,
+			PendingOAuthConfig: clientConfigCopy.PendingOAuthConfig,
+			Disabled:           clientConfigCopy.Disabled,
+			// ConfigHash has json:"-" so deepCopy loses it; use original
+			// clientConfig. Empty for dashboard-created clients; set for
+			// config-file clients so the next boot's reconciliation sees
+			// the row as in-sync instead of re-writing it.
+			ConfigHash: clientConfig.ConfigHash,
 		}
 		if err := tx.WithContext(ctx).Create(&dbClient).Error; err != nil {
 			return s.parseGormError(err)
@@ -2281,6 +2357,26 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			updates["auth_type"] = clientConfigCopy.AuthType
 			updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
 			updates["per_user_header_keys_json"] = perUserHeaderKeysJSON
+			// Mirror BeforeSave: nil → NULL; non-nil → serialised JSON,
+			// encrypted at rest (the stash can carry an inline OAuth
+			// client_secret).
+			var pendingOAuthConfigJSON *string
+			if clientConfigCopy.PendingOAuthConfig != nil {
+				data, marshalErr := json.Marshal(clientConfigCopy.PendingOAuthConfig)
+				if marshalErr != nil {
+					return fmt.Errorf("failed to marshal pending_oauth_config: %w", marshalErr)
+				}
+				s := string(data)
+				if encrypt.IsEnabled() && s != "" {
+					encrypted, encErr := encrypt.Encrypt(s)
+					if encErr != nil {
+						return fmt.Errorf("failed to encrypt mcp pending oauth config: %w", encErr)
+					}
+					s = encrypted
+				}
+				pendingOAuthConfigJSON = &s
+			}
+			updates["pending_oauth_config_json"] = pendingOAuthConfigJSON
 		}
 
 		// Only update is_ping_available if explicitly provided (non-nil)

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -253,6 +253,9 @@ type ConfigStore interface {
 	GetMCPClientByID(ctx context.Context, id string) (*tables.TableMCPClient, error)
 	GetMCPClientConfigByID(ctx context.Context, id string) (*schemas.MCPClientConfig, error)
 	GetMCPClientByName(ctx context.Context, name string) (*tables.TableMCPClient, error)
+	GetMCPClientByOauthConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPClient, error)
+	UpdateMCPClientOAuthConfigID(ctx context.Context, clientID string, oauthConfigID *string) error
+	ClearMCPClientPendingOAuthConfig(ctx context.Context, clientID string) error
 	GetMCPClientsPaginated(ctx context.Context, params MCPClientsQueryParams) ([]tables.TableMCPClient, int64, error)
 	CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error
 	UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient) error

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -48,6 +48,21 @@ type TableMCPClient struct {
 	AllowOnAllVirtualKeys bool `gorm:"default:false" json:"allow_on_all_virtual_keys"` // Whether to allow the MCP client to run on all virtual keys
 	Disabled              bool `gorm:"default:false" json:"disabled"`                  // Whether the client is intentionally disabled
 
+	// PendingOAuthConfigJSON stashes the inline `oauth_config` block from
+	// config.json for shared-OAuth MCP clients (auth_type='oauth') that have
+	// not yet been authorized by an admin. NULL on UI-created clients and on
+	// rows whose OAuth has already been authorized — cleared by the OAuth
+	// callback once oauth_configs.status='authorized'.
+	//
+	// Deserialised into PendingOAuthConfig by AfterFind; serialised back by
+	// BeforeSave. Wire-side it surfaces as `oauth_config` (UI form parity).
+	//
+	// The column name is pinned explicitly: GORM's naming strategy would
+	// otherwise derive pending_o_auth_config_json from the Go field name,
+	// breaking the add-column migration and every raw map update that
+	// addresses the column as pending_oauth_config_json.
+	PendingOAuthConfigJSON *string `gorm:"column:pending_oauth_config_json;type:text" json:"-"`
+
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
 	ConfigHash string `gorm:"type:varchar(255);null" json:"config_hash"`
@@ -68,6 +83,7 @@ type TableMCPClient struct {
 	DiscoveredTools           map[string]schemas.ChatTool  `gorm:"-" json:"-"`
 	DiscoveredToolNameMapping map[string]string            `gorm:"-" json:"-"`
 	PerUserHeaderKeys         []string                     `gorm:"-" json:"per_user_header_keys"`
+	PendingOAuthConfig        *schemas.OAuth2Config        `gorm:"-" json:"oauth_config,omitempty"` // Runtime mirror of PendingOAuthConfigJSON
 }
 
 // TableName sets the table name for each model
@@ -192,6 +208,20 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		c.PerUserHeaderKeysJSON = ""
 	}
 
+	// Persist the inline `oauth_config` block. Rehydrated by AfterFind so
+	// the initiate-verification endpoint can feed it to InitiateOAuthFlow
+	// the same way the UI Create handler does.
+	if c.PendingOAuthConfig != nil {
+		data, err := json.Marshal(c.PendingOAuthConfig)
+		if err != nil {
+			return err
+		}
+		s := string(data)
+		c.PendingOAuthConfigJSON = &s
+	} else {
+		c.PendingOAuthConfigJSON = nil
+	}
+
 	// Encrypt sensitive fields after serialization.
 	// Always set EncryptionStatus when encryption is enabled so the startup
 	// batch pass does not re-process this row indefinitely.
@@ -212,6 +242,15 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 				return fmt.Errorf("failed to encrypt mcp headers: %w", err)
 			}
 			c.HeadersJSON = enc
+		}
+		// The stash can carry an inline OAuth client_secret — encrypt it at
+		// rest like the other credential-bearing columns.
+		if c.PendingOAuthConfigJSON != nil && *c.PendingOAuthConfigJSON != "" {
+			enc, err := encrypt.Encrypt(*c.PendingOAuthConfigJSON)
+			if err != nil {
+				return fmt.Errorf("failed to encrypt mcp pending oauth config: %w", err)
+			}
+			c.PendingOAuthConfigJSON = &enc
 		}
 		c.EncryptionStatus = EncryptionStatusEncrypted
 	}
@@ -236,6 +275,13 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 				return fmt.Errorf("failed to decrypt mcp connection string: %w", err)
 			}
 			c.ConnectionString.Val = decrypted
+		}
+		if c.PendingOAuthConfigJSON != nil && *c.PendingOAuthConfigJSON != "" {
+			decrypted, err := encrypt.Decrypt(*c.PendingOAuthConfigJSON)
+			if err != nil {
+				return fmt.Errorf("failed to decrypt mcp pending oauth config: %w", err)
+			}
+			c.PendingOAuthConfigJSON = &decrypted
 		}
 	}
 	if c.StdioConfigJSON != nil {
@@ -291,6 +337,13 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 		if err := sonic.Unmarshal([]byte(c.PerUserHeaderKeysJSON), &c.PerUserHeaderKeys); err != nil {
 			return err
 		}
+	}
+	if c.PendingOAuthConfigJSON != nil && *c.PendingOAuthConfigJSON != "" {
+		var cfg schemas.OAuth2Config
+		if err := sonic.Unmarshal([]byte(*c.PendingOAuthConfigJSON), &cfg); err != nil {
+			return err
+		}
+		c.PendingOAuthConfig = &cfg
 	}
 	return nil
 }

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -82,6 +82,49 @@ func (h *MCPHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.Bif
 	r.DELETE("/api/mcp/client/{id}", lib.ChainMiddlewares(h.deleteMCPClient, middlewares...))
 	r.POST("/api/mcp/client/{id}/reconnect", lib.ChainMiddlewares(h.reconnectMCPClient, middlewares...))
 	r.POST("/api/mcp/client/{id}/complete-oauth", lib.ChainMiddlewares(h.completeMCPClientOAuth, middlewares...))
+	r.POST("/api/mcp/client/{id}/initiate-verification", lib.ChainMiddlewares(h.initiateMCPClientVerification, middlewares...))
+}
+
+// runOAuthBootstrap kicks off the shared-OAuth flow for an MCP client and
+// returns the OAuth provider's authorize URL.
+//
+// Behavior:
+//   - Computes the OAuth callback redirect URI from the request context,
+//     honouring any admin-configured external base URL via
+//     BuildBaseURL → GetMCPExternalClientURL.
+//   - Calls InitiateOAuthFlow, which generates the CSRF state + PKCE
+//     verifier/challenge, runs RFC 8414 metadata discovery on serverURL
+//     when authorize_url/token_url are missing, runs RFC 7591 dynamic
+//     client registration when client_id is missing, and inserts a fresh
+//     oauth_configs row in status='pending' with a 15-minute expiry.
+//
+// Callers (addMCPClient via the UI Create flow, and
+// initiateMCPClientVerification via the config.json bootstrap flow)
+// exercise the exact same OAuth dance and differ only in how they manage
+// the config_mcp_clients row lifecycle. This helper centralises the
+// shared half so the two flows cannot drift (e.g. a discovery fix in one
+// caller missed by the other).
+//
+// Inputs: the resolved OAuth config and the MCP server URL
+// (config.ConnectionString.GetValue()). The returned flowInitiation
+// carries oauth_config_id, authorize_url, state, and expires_at.
+//
+// This helper does NOT touch config_mcp_clients or
+// oauth_configs.mcp_client_config_json — row-lifecycle management is the
+// caller's concern.
+func (h *MCPHandler) runOAuthBootstrap(ctx *fasthttp.RequestCtx, oauthCfg *OAuthConfigRequest, serverURL string) (*schemas.OAuth2FlowInitiation, error) {
+	redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
+	return h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
+		ClientID:        oauthCfg.ClientID,
+		ClientSecret:    oauthCfg.ClientSecret,
+		AuthorizeURL:    oauthCfg.AuthorizeURL,
+		TokenURL:        oauthCfg.TokenURL,
+		RegistrationURL: oauthCfg.RegistrationURL,
+		RedirectURI:     redirectURI,
+		Scopes:          oauthCfg.Scopes,
+		ServerURL:       serverURL,
+		Resource:        oauthCfg.Resource,
+	})
 }
 
 // MCPVKConfigResponse is a VK assignment enriched with the VK's display name.
@@ -89,6 +132,111 @@ type MCPVKConfigResponse struct {
 	VirtualKeyID   string            `json:"virtual_key_id"`
 	VirtualKeyName string            `json:"virtual_key_name"`
 	ToolsToExecute schemas.WhiteList `json:"tools_to_execute"`
+}
+
+// initiateMCPClientVerification handles
+// POST /api/mcp/client/{id}/initiate-verification.
+//
+// Surfaced on shared-OAuth MCP clients sitting in pending_verification —
+// i.e. clients whose row was persisted with a PendingOAuthConfig stash but
+// no linked oauth_configs row yet. The admin clicks Authorize in the UI;
+// this handler reads the stash, runs the same OAuth init the UI Create
+// flow runs (via runOAuthBootstrap), links the freshly created
+// oauth_configs row to the MCP client, and returns the authorize URL.
+//
+// Retry semantics: if the admin started a previous attempt that expired
+// or was abandoned, the linked oauth_configs row may still exist with a
+// non-authorized status. We always create a fresh row on every click —
+// once oauth_config_id is repointed the previous row is unreferenced and
+// inert (its status can never become authorized), it is just not cleaned
+// up automatically.
+func (h *MCPHandler) initiateMCPClientVerification(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
+		return
+	}
+
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid mcp client id: %v", err))
+		return
+	}
+
+	clientConfig, err := h.store.ConfigStore.GetMCPClientConfigByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("MCP client '%s' not found", id))
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load MCP client: %v", err))
+		return
+	}
+
+	if clientConfig.AuthType != schemas.MCPAuthTypeOauth {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("initiate-verification only applies to auth_type='oauth' clients, got %q", clientConfig.AuthType))
+		return
+	}
+	if clientConfig.PendingOAuthConfig == nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP client has no pending OAuth bootstrap config to initiate from")
+		return
+	}
+	if clientConfig.ConnectionString == nil || clientConfig.ConnectionString.GetValue() == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP client connection_string is required to initiate OAuth discovery")
+		return
+	}
+
+	oauthCfg := pendingOAuthConfigToRequest(clientConfig.PendingOAuthConfig)
+	flowInitiation, err := h.runOAuthBootstrap(ctx, oauthCfg, clientConfig.ConnectionString.GetValue())
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
+		return
+	}
+
+	if err := h.store.ConfigStore.UpdateMCPClientOAuthConfigID(ctx, clientConfig.ID, &flowInitiation.OauthConfigID); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to link OAuth config to MCP client: %v", err))
+		return
+	}
+
+	completeURL := fmt.Sprintf("/api/mcp/client/%s/complete-oauth", flowInitiation.OauthConfigID)
+	statusURL := fmt.Sprintf("/api/oauth/config/%s/status", flowInitiation.OauthConfigID)
+	SendJSON(ctx, map[string]any{
+		"status":          "pending_oauth",
+		"oauth_config_id": flowInitiation.OauthConfigID,
+		"authorize_url":   flowInitiation.AuthorizeURL,
+		"expires_at":      flowInitiation.ExpiresAt,
+		"mcp_client_id":   clientConfig.ID,
+		"complete_url":    completeURL,
+		"status_url":      statusURL,
+		"next_steps": []string{
+			"1. Open authorize_url in a browser to approve access",
+			"2. Poll status_url to check when status becomes 'authorized'",
+			"3. POST complete_url to activate the MCP client",
+		},
+	})
+}
+
+// pendingOAuthConfigToRequest converts the persisted shared-OAuth bootstrap
+// shape (plain strings on OAuth2Config) into the request shape consumed by
+// runOAuthBootstrap / InitiateOAuthFlow (*EnvVar on credentials). The
+// non-empty Val / empty EnvVar combination is the canonical "plaintext
+// value, not an env reference" form.
+func pendingOAuthConfigToRequest(cfg *schemas.OAuth2Config) *OAuthConfigRequest {
+	req := &OAuthConfigRequest{
+		AuthorizeURL: cfg.AuthorizeURL,
+		TokenURL:     cfg.TokenURL,
+		Scopes:       cfg.Scopes,
+		Resource:     cfg.Resource,
+	}
+	if cfg.ClientID != "" {
+		req.ClientID = &schemas.SecretVar{Val: cfg.ClientID}
+	}
+	if cfg.ClientSecret != "" {
+		req.ClientSecret = &schemas.SecretVar{Val: cfg.ClientSecret}
+	}
+	if cfg.RegistrationURL != nil {
+		req.RegistrationURL = *cfg.RegistrationURL
+	}
+	return req
 }
 
 // MCPClientResponse represents the response structure for MCP clients
@@ -864,23 +1012,11 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			// and return a clear error if dynamic registration is not supported
 		}
 
-		// Build redirect URI - use Bifrost's own callback endpoint
-		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
-
-		// Initiate OAuth flow
-		// ServerURL comes from ConnectionString (MCP server URL for OAuth discovery)
-		// ClientID is optional - will be obtained via dynamic registration if not provided
-		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
-			ClientID:        req.OauthConfig.ClientID,
-			ClientSecret:    req.OauthConfig.ClientSecret,
-			AuthorizeURL:    req.OauthConfig.AuthorizeURL,
-			TokenURL:        req.OauthConfig.TokenURL,
-			RegistrationURL: req.OauthConfig.RegistrationURL,
-			RedirectURI:     redirectURI,
-			Scopes:          req.OauthConfig.Scopes,
-			ServerURL:       req.ConnectionString.GetValue(),
-			Resource:        req.OauthConfig.Resource,
-		})
+		// Kick off the shared OAuth flow. See runOAuthBootstrap for the
+		// rationale on the helper split. ServerURL is the MCP server URL
+		// used for RFC 8414 discovery; ClientID is optional and will be
+		// obtained via RFC 7591 dynamic registration when absent.
+		flowInitiation, err := h.runOAuthBootstrap(ctx, req.OauthConfig, req.ConnectionString.GetValue())
 		if err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
 			return
@@ -1772,9 +1908,53 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get pending MCP client: %v", err))
 		return
 	}
+	// Config-bootstrap fallback: the inline mcp_client_config_json blob on
+	// oauth_configs is populated only by the UI Create flow's
+	// StorePendingMCPClient. For clients bootstrapped from config.json the
+	// MCP client row already exists in pending_verification, linked to this
+	// oauth_configs row via oauth_config_id; resolve it that way instead.
+	configBootstrap := false
 	if mcpClientConfig == nil {
-		SendError(ctx, fasthttp.StatusNotFound, "MCP client not found in pending OAuth clients. The OAuth flow may have expired or already been completed.")
-		return
+		dbClient, lookupErr := h.store.ConfigStore.GetMCPClientByOauthConfigID(ctx, oauthConfigID)
+		if lookupErr != nil && !errors.Is(lookupErr, configstore.ErrNotFound) {
+			logger.Error(fmt.Sprintf("[OAuth Complete] Failed to look up MCP client by oauth_config_id: %v", lookupErr))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to look up MCP client: %v", lookupErr))
+			return
+		}
+		if dbClient == nil {
+			SendError(ctx, fasthttp.StatusNotFound, "MCP client not found for this OAuth flow. The flow may have expired or already been completed.")
+			return
+		}
+		// Gate the fallback to genuine bootstrap completions:
+		// 1. AuthType must be shared OAuth — per_user_oauth completions
+		//    route through a different verification path that treats the
+		//    upstream token as an admin temp credential and revokes it.
+		// 2. PendingOAuthConfigJSON must still be set — once cleared, the
+		//    client has already completed bootstrap, and any further hit
+		//    on complete-oauth with this oauth_config_id is a replay (the
+		//    JSON blob is gone because RemovePendingMCPClient ran, and the
+		//    bootstrap stash is gone because ClearMCPClientPendingOAuthConfig
+		//    ran). Reject with 409 so callers don't trigger redundant DB
+		//    writes + reconnects on an already-connected client.
+		if dbClient.AuthType != string(schemas.MCPAuthTypeOauth) {
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("OAuth config does not match a shared-OAuth MCP client (auth_type=%q)", dbClient.AuthType))
+			return
+		}
+		if dbClient.PendingOAuthConfigJSON == nil || *dbClient.PendingOAuthConfigJSON == "" {
+			SendError(ctx, fasthttp.StatusConflict, "OAuth flow has already been completed for this MCP client")
+			return
+		}
+		mcpClientConfig, err = h.store.ConfigStore.GetMCPClientConfigByID(ctx, dbClient.ClientID)
+		if err != nil || mcpClientConfig == nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load MCP client: %v", err))
+			return
+		}
+		mcpClientConfig.OauthConfigID = &oauthConfigID
+		// Drop the bootstrap stash from the in-memory config so the MCP
+		// manager's reconnect path takes the normal connect branch instead
+		// of re-parking the client in pending_verification.
+		mcpClientConfig.PendingOAuthConfig = nil
+		configBootstrap = true
 	}
 
 	// If pending config points to an existing client, this is an OAuth credential update.
@@ -1951,6 +2131,25 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 	if err := h.oauthHandler.RemovePendingMCPClient(oauthConfigID); err != nil {
 		logger.Warn(fmt.Sprintf("[OAuth Complete] Failed to clear pending MCP client config: %v", err))
 		// Don't fail the request - the MCP client was successfully created
+	}
+
+	// For clients bootstrapped from config.json, drop the
+	// pending_oauth_config_json stash now that authorization succeeded so
+	// the runtime no longer treats the client as pending_verification.
+	//
+	// NOTE: Partial success — the MCP client is already connected in core
+	// and (for a create) persisted in DB above. Only the pending-bootstrap
+	// stash failed to clear, which would resurrect pending_verification on
+	// restart. Surface it as a failure so the caller retries rather than
+	// silently drifting core/DB state apart.
+	if configBootstrap {
+		if err := h.store.ConfigStore.ClearMCPClientPendingOAuthConfig(ctx, mcpClientConfig.ID); err != nil {
+			logger.Error(fmt.Sprintf("[PARTIAL SUCCESS] MCP client %s was connected successfully but clearing its pending oauth bootstrap stash failed: %v. "+
+				"The client will incorrectly show as pending_verification after a restart. Retry the request to clear the stash.",
+				mcpClientConfig.ID, err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("MCP client connected but clearing its pending OAuth bootstrap config failed: %v", err))
+			return
+		}
 	}
 
 	logger.Debug(fmt.Sprintf("[OAuth Complete] MCP client connected successfully: %s", mcpClientConfig.ID))

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1769,6 +1769,193 @@ func loadMCPConfig(ctx context.Context, config *Config, configData *ConfigData) 
 	applyMCPGlobalSettingsToClientConfig(ctx, config, configData.MCP)
 }
 
+// pinMCPClientImmutableFields rewrites a file-declared client so that fields
+// which are immutable after creation keep their stored values, mirroring the
+// update API: MCPClientUpdateRequest accepts none of these fields, so an API
+// caller sending them has them silently dropped, and the file sync applies
+// the same rule. It also carries server-side verification state that
+// config.json cannot express (it is produced by admin verification at
+// runtime):
+//   - OauthConfigID links the oauth_configs row (token / provider config)
+//     created by the admin's browser flow.
+//   - DiscoveredTools / DiscoveredToolNameMapping are populated by the
+//     one-time admin verification for per-user auth types.
+//   - PendingOAuthConfig stays whatever the store holds: the stash declared
+//     at creation while verification is pending, nil once the OAuth callback
+//     has cleared it.
+//
+// The returned list names the immutable fields whose file values differ from
+// the stored ones, for the caller's advisory log. authorizedOauth is the
+// oauth_configs row backing an already-authorized client (nil when the client
+// is unauthorized or the row is unavailable); it is only read, and only to
+// detect oauth_config drift.
+func pinMCPClientImmutableFields(fileClient, existing *schemas.MCPClientConfig, authorizedOauth *configstoreTables.TableOauthConfig) []string {
+	if fileClient == nil || existing == nil {
+		return nil
+	}
+	var changed []string
+
+	fileAuth := fileClient.AuthType
+	if fileAuth == "" {
+		fileAuth = schemas.MCPAuthTypeHeaders
+	}
+	existingAuth := existing.AuthType
+	if existingAuth == "" {
+		existingAuth = schemas.MCPAuthTypeHeaders
+	}
+	if fileAuth != existingAuth {
+		changed = append(changed, "auth_type")
+	}
+	fileClient.AuthType = existingAuth
+
+	if fileClient.ConnectionType != existing.ConnectionType {
+		changed = append(changed, "connection_type")
+	}
+	fileClient.ConnectionType = existing.ConnectionType
+
+	if !fileClient.ConnectionString.Equals(existing.ConnectionString) {
+		changed = append(changed, "connection_string")
+	}
+	fileClient.ConnectionString = existing.ConnectionString
+
+	if !reflect.DeepEqual(fileClient.StdioConfig, existing.StdioConfig) {
+		changed = append(changed, "stdio_config")
+	}
+	fileClient.StdioConfig = existing.StdioConfig
+
+	if mcpOauthBlockChanged(fileClient.PendingOAuthConfig, existing.PendingOAuthConfig, authorizedOauth) {
+		changed = append(changed, "oauth_config")
+	}
+	fileClient.PendingOAuthConfig = existing.PendingOAuthConfig
+
+	// Not immutable, but a per_user_headers client must keep a non-empty key
+	// schema — the update API rejects emptying it for the same reason.
+	if fileClient.AuthType == schemas.MCPAuthTypePerUserHeaders &&
+		len(fileClient.PerUserHeaderKeys) == 0 && len(existing.PerUserHeaderKeys) > 0 {
+		logger.Warn("per_user_header_keys cannot be emptied for MCP client %q (auth_type 'per_user_headers'); keeping the stored keys", existing.Name)
+		fileClient.PerUserHeaderKeys = existing.PerUserHeaderKeys
+	}
+
+	fileClient.OauthConfigID = existing.OauthConfigID
+	if len(fileClient.DiscoveredTools) == 0 {
+		fileClient.DiscoveredTools = existing.DiscoveredTools
+		fileClient.DiscoveredToolNameMapping = existing.DiscoveredToolNameMapping
+	}
+	return changed
+}
+
+// mcpOauthBlockChanged reports whether the file's inline oauth_config block
+// drifts from the OAuth configuration the client actually runs on. Only
+// fields the file explicitly sets are compared: absent fields are filled in
+// by discovery / dynamic client registration at authorization time, so a
+// stored value with no file counterpart is not drift. The reference is the
+// stored pending stash while verification is pending, and the authorized
+// oauth_configs row afterwards; with neither available there is nothing to
+// compare against.
+func mcpOauthBlockChanged(fileBlock, storedStash *schemas.OAuth2Config, authorizedOauth *configstoreTables.TableOauthConfig) bool {
+	if fileBlock == nil {
+		return false
+	}
+	var refClientID, refClientSecret, refAuthorizeURL, refTokenURL string
+	var refScopes []string
+	switch {
+	case storedStash != nil:
+		refClientID = storedStash.ClientID
+		refClientSecret = storedStash.ClientSecret
+		refAuthorizeURL = storedStash.AuthorizeURL
+		refTokenURL = storedStash.TokenURL
+		refScopes = storedStash.Scopes
+	case authorizedOauth != nil:
+		refClientID = authorizedOauth.GetResolvedClientID()
+		refClientSecret = authorizedOauth.GetResolvedClientSecret()
+		refAuthorizeURL = authorizedOauth.AuthorizeURL
+		refTokenURL = authorizedOauth.TokenURL
+		if authorizedOauth.Scopes != "" {
+			_ = json.Unmarshal([]byte(authorizedOauth.Scopes), &refScopes)
+		}
+	default:
+		return false
+	}
+	if fileBlock.ClientID != "" && fileBlock.ClientID != refClientID {
+		return true
+	}
+	if fileBlock.ClientSecret != "" && fileBlock.ClientSecret != refClientSecret {
+		return true
+	}
+	if fileBlock.AuthorizeURL != "" && fileBlock.AuthorizeURL != refAuthorizeURL {
+		return true
+	}
+	if fileBlock.TokenURL != "" && fileBlock.TokenURL != refTokenURL {
+		return true
+	}
+	if len(fileBlock.Scopes) > 0 {
+		fileScopes := slices.Clone(fileBlock.Scopes)
+		storedScopes := slices.Clone(refScopes)
+		slices.Sort(fileScopes)
+		slices.Sort(storedScopes)
+		if !slices.Equal(fileScopes, storedScopes) {
+			return true
+		}
+	}
+	return false
+}
+
+// authorizedOauthRowForComparison loads the oauth_configs row backing an
+// already-authorized client so an edited file oauth_config block can be
+// detected by pinMCPClientImmutableFields. Returns nil whenever there is
+// nothing to compare (no file block, verification still pending, no store)
+// or the lookup fails — pinning still applies either way, only the drift
+// warning loses the oauth_config detail.
+func authorizedOauthRowForComparison(ctx context.Context, store configstore.ConfigStore, fileClient, existing *schemas.MCPClientConfig) *configstoreTables.TableOauthConfig {
+	if store == nil || fileClient == nil || existing == nil {
+		return nil
+	}
+	if fileClient.PendingOAuthConfig == nil || existing.PendingOAuthConfig != nil || existing.OauthConfigID == nil {
+		return nil
+	}
+	row, err := store.GetOauthConfigByID(ctx, *existing.OauthConfigID)
+	if err != nil {
+		logger.Debug("failed to load oauth config %s for MCP client %q immutable-field check: %v", *existing.OauthConfigID, existing.Name, err)
+		return nil
+	}
+	return row
+}
+
+// warnIgnoredImmutableMCPFields emits the advisory line for a config.json
+// edit that touched fields which cannot change after creation. The update
+// API drops the same fields silently (MCPClientUpdateRequest does not accept
+// them); the file path gets this log line because a file editor has no
+// response channel.
+func warnIgnoredImmutableMCPFields(clientName string, fields []string) {
+	if len(fields) == 0 {
+		return
+	}
+	logger.Warn("ignoring changes to immutable fields [%s] on MCP client %q from config file: these cannot be changed after creation; delete and recreate the client to change them", strings.Join(fields, ", "), clientName)
+}
+
+// applyMCPClientPinnedStateToRow mirrors the pinned immutable fields and
+// preserved server-side state onto the table row that will be persisted,
+// keeping the row and the in-memory config consistent (the row was built
+// from the raw file entry before pinning). The row's ConfigHash
+// intentionally stays the raw-file hash: the stored hash always reflects
+// the file entry as last synced, so the immutable-field warning fires once
+// per file edit instead of on every boot.
+func applyMCPClientPinnedStateToRow(row *configstoreTables.TableMCPClient, clientConfig *schemas.MCPClientConfig) {
+	authType := string(clientConfig.AuthType)
+	if authType == "" {
+		authType = string(schemas.MCPAuthTypeHeaders)
+	}
+	row.AuthType = authType
+	row.ConnectionType = string(clientConfig.ConnectionType)
+	row.ConnectionString = clientConfig.ConnectionString
+	row.StdioConfig = clientConfig.StdioConfig
+	row.PerUserHeaderKeys = mcputils.CanonicalizeHeaderKeys(clientConfig.PerUserHeaderKeys)
+	row.OauthConfigID = clientConfig.OauthConfigID
+	row.DiscoveredTools = clientConfig.DiscoveredTools
+	row.DiscoveredToolNameMapping = clientConfig.DiscoveredToolNameMapping
+	row.PendingOAuthConfig = clientConfig.PendingOAuthConfig
+}
+
 // mergeMCPConfig merges MCP config from file with store
 func mergeMCPConfig(ctx context.Context, config *Config, configData *ConfigData, mcpConfig *schemas.MCPConfig) {
 	logger.Debug("merging MCP config from config file with store")
@@ -1812,6 +1999,13 @@ func mergeMCPConfig(ctx context.Context, config *Config, configData *ConfigData,
 					logger.Debug("config hash mismatch for MCP client %q, syncing from config file", newClientConfig.Name)
 					newClientConfig.ID = existingClientConfig.ID
 					newClientConfig.ConfigHash = fileHash
+					// Pin immutable fields to their stored values and carry
+					// server-side verification state (authorized OAuth link,
+					// discovered tools) the file cannot express, so a config
+					// edit does not reset a verified client.
+					authorizedOauth := authorizedOauthRowForComparison(ctx, config.ConfigStore, newClientConfig, existingClientConfig)
+					warnIgnoredImmutableMCPFields(existingClientConfig.Name, pinMCPClientImmutableFields(newClientConfig, existingClientConfig, authorizedOauth))
+					applyMCPClientPinnedStateToRow(&fileClientRow, newClientConfig)
 					fileClientRow.ClientID = existingClientConfig.ID
 					fileClientRow.ConfigHash = fileHash
 					clientConfigsToUpdate = append(clientConfigsToUpdate, fileClientRow)
@@ -1939,6 +2133,7 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 		DiscoveredTools:           clientConfig.DiscoveredTools,
 		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
 		PerUserHeaderKeys:         mcputils.CanonicalizeHeaderKeys(clientConfig.PerUserHeaderKeys),
+		PendingOAuthConfig:        clientConfig.PendingOAuthConfig,
 		ConfigHash:                clientConfig.ConfigHash,
 	}, nil
 }
@@ -2010,6 +2205,22 @@ func syncMCPConfigFromFile(ctx context.Context, config *Config, configData *Conf
 		if existing == nil {
 			adds = append(adds, fileClient)
 		} else {
+			// Pin immutable fields to their stored values and carry
+			// server-side verification state (authorized OAuth link,
+			// discovered tools) the file cannot express, so the every-boot
+			// overwrite does not reset a verified client. The advisory log
+			// is gated on the stored hash so it fires once per file edit,
+			// not on every boot.
+			var authorizedOauth *configstoreTables.TableOauthConfig
+			fileEdited := existing.ConfigHash != fileHash
+			if fileEdited {
+				authorizedOauth = authorizedOauthRowForComparison(ctx, config.ConfigStore, fileClient, existing)
+			}
+			changedImmutable := pinMCPClientImmutableFields(fileClient, existing, authorizedOauth)
+			if fileEdited {
+				warnIgnoredImmutableMCPFields(existing.Name, changedImmutable)
+			}
+			applyMCPClientPinnedStateToRow(&fileRow, fileClient)
 			fileRow.ClientID = existing.ID
 			updates = append(updates, fileRow)
 		}
@@ -6491,6 +6702,22 @@ func (c *Config) RedactMCPClientConfig(config *schemas.MCPClientConfig) *schemas
 	}
 	if config.OauthClientSecret != nil {
 		configCopy.OauthClientSecret = config.OauthClientSecret.Redacted()
+	}
+
+	// Redact credentials inside the inline `oauth_config` bootstrap block.
+	// Its fields are plain strings, so route them through the SecretVar
+	// redaction to keep the wire format identical to the sibling
+	// oauth_client_id / oauth_client_secret fields. Copy the struct first —
+	// configCopy shares the pointer with the live config.
+	if config.PendingOAuthConfig != nil {
+		pendingCopy := *config.PendingOAuthConfig
+		if pendingCopy.ClientID != "" {
+			pendingCopy.ClientID = (&schemas.SecretVar{Val: pendingCopy.ClientID}).Redacted().Val
+		}
+		if pendingCopy.ClientSecret != "" {
+			pendingCopy.ClientSecret = (&schemas.SecretVar{Val: pendingCopy.ClientSecret}).Redacted().Val
+		}
+		configCopy.PendingOAuthConfig = &pendingCopy
 	}
 
 	// Redact TLS CA cert PEM if present

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -642,6 +642,18 @@ func (m *MockConfigStore) GetMCPClientByName(ctx context.Context, name string) (
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetMCPClientByOauthConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPClient, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) UpdateMCPClientOAuthConfigID(ctx context.Context, clientID string, oauthConfigID *string) error {
+	return nil
+}
+
+func (m *MockConfigStore) ClearMCPClientPendingOAuthConfig(ctx context.Context, clientID string) error {
+	return nil
+}
+
 func (m *MockConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error {
 	m.mcpConfig.ClientConfigs = append(m.mcpConfig.ClientConfigs, clientConfig)
 	m.mcpConfigsCreated = append(m.mcpConfigsCreated, clientConfig)


### PR DESCRIPTION
## Summary

Shared-OAuth MCP clients declared in `config.json` (i.e. `auth_type: oauth` with an inline `oauth_config` block but no pre-existing `oauth_configs` row or token) previously had no path to complete authorization — attempting to connect would fail immediately in `ConnectionHeaders → GetAccessToken`. This PR introduces a `pending_verification` state and a new `POST /api/mcp/client/{id}/initiate-verification` endpoint so an admin can trigger the browser OAuth flow for these config-file-originated clients after the server starts.

## Changes

- **New `MCPConnectionStatePendingVerification` state**: clients with `PendingOAuthConfig` set are parked in this state on startup instead of attempting a connection that would fail. Once the OAuth callback marks the linked `oauth_configs` row authorized, the stash is cleared and the next reconnect takes the normal connect path.

- **`PendingOAuthConfig` field on `MCPClientConfig` and `TableMCPClient`**: holds the inline `oauth_config` block from `config.json`. Serialized to/from a new `pending_oauth_config_json` column via `BeforeSave`/`AfterFind` hooks. Cleared by `ClearMCPClientPendingOAuthConfig` once authorization succeeds.

- **DB migration** (`migrationAddMCPClientPendingOAuthConfigJSONColumn`): adds the nullable `pending_oauth_config_json` text column to `config_mcp_clients`.

- **`POST /api/mcp/client/{id}/initiate-verification` endpoint**: reads the persisted `PendingOAuthConfig` stash, runs the same OAuth bootstrap dance as the UI Create flow (via the new shared `runOAuthBootstrap` helper), links the freshly created `oauth_configs` row to the MCP client via `UpdateMCPClientOAuthConfigID`, and returns the authorize URL.

- **`runOAuthBootstrap` helper**: extracts the shared OAuth initiation logic (redirect URI construction, `InitiateOAuthFlow` call) from `addMCPClient` so both the UI Create flow and the config-bootstrap flow use identical code paths and cannot drift.

- **`completeMCPClientOAuth` config-bootstrap fallback**: when `mcp_client_config_json` on the `oauth_configs` row is nil (config.json-originated clients don't populate it), the handler now resolves the MCP client by `oauth_config_id` instead of returning 404. After authorization, `ClearMCPClientPendingOAuthConfig` drops the stash so the client reconnects normally.

- **New `ConfigStore` methods**: `GetMCPClientByOauthConfigID`, `UpdateMCPClientOAuthConfigID`, `ClearMCPClientPendingOAuthConfig`.

- **Hash coverage**: `GenerateMCPClientHash` now includes `PendingOAuthConfigJSON` so edits to the inline `oauth_config` block in `config.json` trigger reconciliation.

- **`pendingOAuthConfigToRequest` converter**: maps the plain-string `OAuth2Config` fields to the `*EnvVar`-typed `OAuthConfigRequest` shape expected by `InitiateOAuthFlow`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Declare a shared-OAuth MCP client in `config.json` with `auth_type: oauth` and an inline `oauth_config` block (no `oauth_config_id`).
2. Start the server — the client should appear in `pending_verification` state rather than erroring.
3. Call `POST /api/mcp/client/{id}/initiate-verification` as an admin. Expect a `200` response containing `authorize_url`, `oauth_config_id`, and `expires_at`.
4. Complete the browser OAuth flow via the returned `authorize_url`.
5. Confirm the OAuth callback transitions the client out of `pending_verification` and into `connected`.
6. Restart the server and confirm the client connects normally (no longer parks in `pending_verification`).

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- `PendingOAuthConfig` stores OAuth client credentials as plaintext in the `pending_oauth_config_json` column. This mirrors the existing behavior for other credential columns in the same table (which are encrypted at rest via the existing `EncryptionStatus` mechanism). Env-var reference resolution is intentionally not applied to fields inside this block, consistent with the documented behavior.
- The `completeMCPClientOAuth` fallback path gates on `auth_type='oauth'` and a non-null `PendingOAuthConfigJSON` to prevent replay attacks and cross-type misuse, returning `409 Conflict` if the bootstrap has already been completed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable