### PR TITLE
feat: add OAuth authorization flow for config.json-bootstrapped pending_verification MCP clients

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -30,7 +30,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useSheetNavigation } from "@/hooks/useSheetNavigation";
 import { MCP_STATUS_COLORS } from "@/lib/constants/config";
 import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
-import { getErrorMessage, useGetCoreConfigQuery, useUpdateMCPClientMutation } from "@/lib/store";
+import { getErrorMessage, useGetCoreConfigQuery, useGetVirtualKeysQuery, useUpdateMCPClientMutation } from "@/lib/store";
 import { MCPClient, MCPVKConfig } from "@/lib/types/mcp";
 import { mcpClientUpdateSchema, type MCPClientUpdateSchema } from "@/lib/types/schemas";
 import { parseArrayFromText } from "@/lib/utils/array";
@@ -92,12 +92,13 @@ export default function MCPClientSheet({
 	const hasUpdateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Update);
 	const [updateMCPClient, { isLoading: isUpdating }] = useUpdateMCPClientMutation();
 
+	const { toast } = useToast();
+
 	const [pendingNavDirection, setPendingNavDirection] = useState<"prev" | "next" | null>(null);
 
 	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
 	const globalToolSyncInterval = bifrostConfig?.client_config?.mcp_tool_sync_interval ?? 10;
 	const globalToolExecutionTimeout = bifrostConfig?.client_config?.mcp_tool_execution_timeout ?? 30;
-	const { toast } = useToast();
 	const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
 
 	const allToolNames = useMemo(() => mcpClient.tools?.map((t) => t.name) ?? [], [mcpClient.tools]);
@@ -201,16 +202,16 @@ export default function MCPClientSheet({
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
-				tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
+			tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
-						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
-						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
-					}
+					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+					ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+				}
 				: undefined,
 		},
 	});
@@ -230,16 +231,16 @@ export default function MCPClientSheet({
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
-				tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
+			tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
-						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
-						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
-					}
+					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+					ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+				}
 				: undefined,
 		});
 	}, [form, mcpClient]);
@@ -298,16 +299,16 @@ export default function MCPClientSheet({
 					allowed_extra_headers: data.allowed_extra_headers,
 					oauth_config: shouldRotateOAuthCredentials
 						? {
-								client_id: oauthClientID,
-								client_secret: oauthClientSecret,
-							}
+							client_id: oauthClientID,
+							client_secret: oauthClientSecret,
+						}
 						: undefined,
 					tls_config:
 						data.tls_config !== undefined
 							? {
-									insecure_skip_verify: data.tls_config.insecure_skip_verify ?? false,
-									ca_cert_pem: data.tls_config.ca_cert_pem,
-								}
+								insecure_skip_verify: data.tls_config.insecure_skip_verify ?? false,
+								ca_cert_pem: data.tls_config.ca_cert_pem,
+							}
 							: undefined,
 					vk_configs: vkConfigsDirty ? vkConfigs : undefined,
 				},
@@ -452,7 +453,11 @@ export default function MCPClientSheet({
 									{mcpClient.config.name}
 									<Badge className={MCP_STATUS_COLORS[mcpClient.state]}>{mcpClient.state}</Badge>
 								</SheetTitle>
-								<SheetDescription>MCP server configuration and available tools</SheetDescription>
+								<SheetDescription>
+									{mcpClient.state === "pending_verification"
+										? "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
+										: "MCP server configuration and available tools"}
+								</SheetDescription>
 							</div>
 							<SheetNavigationButtons
 								hasPrev={hasPrev}
@@ -518,7 +523,7 @@ export default function MCPClientSheet({
 											<span className="font-mono break-all">
 												{mcpClient.config.connection_type === "stdio"
 													? `${mcpClient.config.stdio_config?.command ?? ""} ${(mcpClient.config.stdio_config?.args ?? []).join(" ")}`.trim() ||
-														"-"
+													"-"
 													: mcpClient.config.connection_string?.type === "env" || mcpClient.config.connection_string?.type === "vault"
 														? mcpClient.config.connection_string.ref
 														: mcpClient.config.connection_string?.value || "-"}
@@ -537,7 +542,7 @@ export default function MCPClientSheet({
 															return [name, valueParts.join("=")];
 														}),
 													)}
-													onChange={() => {}}
+													onChange={() => { }}
 													fixedKeys={mcpClient.config.stdio_config.envs.map((env) => env.split("=")[0])}
 													valuePlaceholder="—"
 													label=""
@@ -935,9 +940,9 @@ export default function MCPClientSheet({
 														onBlur={() => {
 															const parsed = allowedExtraHeadersRaw.trim()
 																? allowedExtraHeadersRaw
-																		.split(",")
-																		.map((h) => h.trim())
-																		.filter(Boolean)
+																	.split(",")
+																	.map((h) => h.trim())
+																	.filter(Boolean)
 																: [];
 															field.onChange(parsed);
 															field.onBlur();

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -18,33 +18,44 @@ import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
 import { MCP_STATUS_COLORS } from "@/lib/constants/config";
-import { getErrorMessage, useDeleteMCPClientMutation, useReconnectMCPClientMutation, useUpdateMCPClientMutation } from "@/lib/store";
+import {
+	getErrorMessage,
+	useDeleteMCPClientMutation,
+	useInitiateMCPClientVerificationMutation,
+	useReconnectMCPClientMutation,
+	useUpdateMCPClientMutation,
+} from "@/lib/store";
 import { MCPClient } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
-import { Box, ChevronLeft, ChevronRight, Loader2, MoreHorizontal, PencilIcon, Plus, RefreshCcw, Search, Trash2, X } from "lucide-react";
+import { Box, ChevronLeft, ChevronRight, KeyRound, Loader2, MoreHorizontal, PencilIcon, Plus, RefreshCcw, Search, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import MCPClientSheet from "./mcpClientSheet";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
 import { MCPUsageGuideSheet } from "./mcpUsageGuide";
+import { OAuth2Authorizer } from "./oauth2Authorizer";
 
 function MCPClientActionsMenu({
 	client,
 	hasUpdateAccess,
 	hasDeleteAccess,
 	isReconnecting,
+	isAuthorizing,
 	isPerUserAuth,
 	onEdit,
 	onReconnect,
+	onAuthorize,
 	onDelete,
 }: {
 	client: MCPClient;
 	hasUpdateAccess: boolean;
 	hasDeleteAccess: boolean;
 	isReconnecting: boolean;
+	isAuthorizing: boolean;
 	isPerUserAuth: boolean;
 	onEdit: (client: MCPClient) => void;
 	onReconnect: (client: MCPClient) => void;
+	onAuthorize: (client: MCPClient) => void;
 	onDelete: (client: MCPClient) => void;
 }) {
 	const [isOpen, setIsOpen] = useState(false);
@@ -59,7 +70,7 @@ function MCPClientActionsMenu({
 					aria-label="MCP server actions"
 					data-testid={`mcp-client-actions-${client.config.client_id}-btn`}
 				>
-					{isReconnecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
+					{isReconnecting || isAuthorizing ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent
@@ -86,10 +97,25 @@ function MCPClientActionsMenu({
 						Edit
 					</DropdownMenuItem>
 				)}
+				{hasUpdateAccess && client.state === "pending_verification" && (
+					<DropdownMenuItem
+						className="cursor-pointer"
+						disabled={isAuthorizing}
+						data-testid={`mcp-client-authorize-${client.config.client_id}-menu-item`}
+						onSelect={(e) => {
+							e.preventDefault();
+							onAuthorize(client);
+							setIsOpen(false);
+						}}
+					>
+						<KeyRound className="h-4 w-4" />
+						Authorize
+					</DropdownMenuItem>
+				)}
 				{hasUpdateAccess && (
 					<DropdownMenuItem
 						className="cursor-pointer"
-						disabled={isPerUserAuth || client.config.disabled || isReconnecting}
+						disabled={isPerUserAuth || client.config.disabled || isReconnecting || client.state === "pending_verification"}
 						onSelect={(e) => {
 							e.preventDefault();
 							onReconnect(client);
@@ -159,12 +185,22 @@ export default function MCPClientsTable({
 	const { toast } = useToast();
 
 	const [reconnectingClients, setReconnectingClients] = useState<string[]>([]);
+	const [authorizingClients, setAuthorizingClients] = useState<string[]>([]);
 	const [togglingClientIds, setTogglingClientIds] = useState<Set<string>>(new Set());
+	// Drives the OAuth2Authorizer dialog for a config.json-bootstrapped client
+	// sitting in pending_verification, triggered from the row actions menu.
+	const [bootstrapAuthorize, setBootstrapAuthorize] = useState<{
+		authorizeUrl: string;
+		oauthConfigId: string;
+		mcpClientId: string;
+		popup: Window | null;
+	} | null>(null);
 
 	// RTK Query mutations
 	const [reconnectMCPClient] = useReconnectMCPClientMutation();
 	const [deleteMCPClient] = useDeleteMCPClientMutation();
 	const [updateMCPClient] = useUpdateMCPClientMutation();
+	const [initiateVerification] = useInitiateMCPClientVerificationMutation();
 
 	const handleCreate = () => {
 		setFormOpen(true);
@@ -182,6 +218,43 @@ export default function MCPClientsTable({
 		} catch (error) {
 			setReconnectingClients((prev) => prev.filter((id) => id !== client.config.client_id));
 			toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
+		}
+	};
+
+	const handleStartBootstrap = async (client: MCPClient) => {
+		// Open a blank popup synchronously, before the initiateVerification
+		// await, so the click's transient user-activation is captured here
+		// rather than consumed by the network round-trip — otherwise the
+		// browser can block OAuth2Authorizer's later window.open entirely.
+		// OAuth2Authorizer navigates this handle once authorize_url is known.
+		const width = 600;
+		const height = 700;
+		const left = window.screen.width / 2 - width / 2;
+		const top = window.screen.height / 2 - height / 2;
+		const popup = window.open("", "oauth_popup", `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`);
+		try {
+			setAuthorizingClients((prev) => [...prev, client.config.client_id]);
+			const response = await initiateVerification(client.config.client_id).unwrap();
+			if (response.status === "pending_oauth" && response.authorize_url) {
+				setBootstrapAuthorize({
+					authorizeUrl: response.authorize_url,
+					oauthConfigId: response.oauth_config_id,
+					mcpClientId: client.config.client_id,
+					popup,
+				});
+			} else {
+				popup?.close();
+				toast({
+					title: "Authorization failed",
+					description: "Unexpected response from server. Please try again.",
+					variant: "destructive",
+				});
+			}
+		} catch (error) {
+			popup?.close();
+			toast({ title: "Authorization failed", description: getErrorMessage(error), variant: "destructive" });
+		} finally {
+			setAuthorizingClients((prev) => prev.filter((id) => id !== client.config.client_id));
 		}
 	};
 
@@ -339,6 +412,30 @@ export default function MCPClientsTable({
 					</AlertDialogFooter>
 				</AlertDialogContent>
 			</AlertDialog>
+			{bootstrapAuthorize && (
+				<OAuth2Authorizer
+					open={!!bootstrapAuthorize}
+					onClose={() => setBootstrapAuthorize(null)}
+					onSuccess={async () => {
+						toast({ title: "Success", description: "MCP client connected successfully" });
+						setBootstrapAuthorize(null);
+						if (refetch) {
+							await refetch();
+						}
+					}}
+					onError={(error) => {
+						toast({ title: "Authorization failed", description: error, variant: "destructive" });
+					}}
+					onConflict={(error) => {
+						setBootstrapAuthorize(null);
+						toast({ title: "Authorization failed", description: error, variant: "destructive" });
+					}}
+					authorizeUrl={bootstrapAuthorize.authorizeUrl}
+					oauthConfigId={bootstrapAuthorize.oauthConfigId}
+					mcpClientId={bootstrapAuthorize.mcpClientId}
+					initialPopup={bootstrapAuthorize.popup}
+				/>
+			)}
 
 			<div className="mb-4 flex items-center justify-between gap-4">
 				<div>
@@ -532,9 +629,11 @@ export default function MCPClientsTable({
 													hasUpdateAccess={hasUpdateMCPClientAccess}
 													hasDeleteAccess={hasDeleteMCPClientAccess}
 													isReconnecting={reconnectingClients.includes(c.config.client_id)}
+													isAuthorizing={authorizingClients.includes(c.config.client_id)}
 													isPerUserAuth={isPerUserAuth}
 													onEdit={handleRowClick}
 													onReconnect={(client) => void handleReconnect(client)}
+													onAuthorize={(client) => void handleStartBootstrap(client)}
 													onDelete={setClientToDelete}
 												/>
 											</TableCell>

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -16,6 +16,12 @@ interface OAuth2AuthorizerProps {
 	oauthConfigId: string;
 	mcpClientId: string;
 	isPerUserOauth?: boolean;
+	// A popup the caller already opened synchronously (before any await), to
+	// preserve the triggering click's transient user-activation. When
+	// present, openPopup navigates this handle instead of calling
+	// window.open itself — a fresh window.open after an awaited network
+	// round-trip risks the browser blocking it outright.
+	initialPopup?: Window | null;
 }
 
 type Status = "confirm" | "polling" | "blocked" | "success" | "failed";
@@ -112,6 +118,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	authorizeUrl,
 	oauthConfigId,
 	isPerUserOauth,
+	initialPopup,
 }) => {
 	const [status, setStatus] = useState<Status>(isPerUserOauth ? "confirm" : "polling");
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -119,6 +126,10 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
 	const isCompletingRef = useRef(false);
 	const cancelledRef = useRef(false);
+	// initialPopup is only good for one use — a retry must open a fresh
+	// window rather than re-navigating a handle already spent on a prior
+	// (blocked or failed) attempt.
+	const initialPopupConsumedRef = useRef(false);
 
 	const [getOAuthStatus] = useLazyGetOAuthConfigStatusQuery();
 	const [completeOAuth] = useCompleteOAuthFlowMutation();
@@ -222,11 +233,23 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		const height = 700;
 		const left = window.screen.width / 2 - width / 2;
 		const top = window.screen.height / 2 - height / 2;
-		const popup = window.open(
-			authorizeUrl,
-			"oauth_popup",
-			`width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`,
-		);
+
+		let popup: Window | null = null;
+		if (!initialPopupConsumedRef.current && initialPopup && !initialPopup.closed) {
+			initialPopupConsumedRef.current = true;
+			popup = initialPopup;
+			try {
+				popup.location.href = authorizeUrl;
+			} catch {
+				popup = null;
+			}
+		} else {
+			popup = window.open(
+				authorizeUrl,
+				"oauth_popup",
+				`width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`,
+			);
+		}
 
 		if (!popup || popup.closed) {
 			popupRef.current = null;
@@ -237,7 +260,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		popupRef.current = popup;
 		setStatus("polling");
 		startPolling();
-	}, [authorizeUrl, startPolling]);
+	}, [authorizeUrl, startPolling, initialPopup]);
 
 	useEffect(() => {
 		const handleMessage = (event: MessageEvent) => {

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -126,6 +126,7 @@ export const MCP_STATUS_COLORS: Record<string, string> = {
 	error: "bg-red-100 text-red-800",
 	disconnected: "bg-gray-100 text-gray-800",
 	pending_tools: "bg-yellow-100 text-yellow-800",
+	pending_verification: "bg-yellow-100 text-yellow-800",
 	disabled: "bg-orange-100 text-orange-800",
 };
 

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -16,6 +16,15 @@ import { baseApi } from "./baseApi";
 type CreateMCPClientResponse = { status: "success"; message: string } | OAuthFlowResponse;
 type UpdateMCPClientResponse = { status: "success"; message: string } | OAuthFlowResponse;
 
+// Response of POST /mcp/client/{id}/initiate-verification — same flow fields as
+// OAuthFlowResponse but without a required message, plus polling/completion hints.
+type InitiateMCPClientVerificationResponse = Omit<OAuthFlowResponse, "message"> & {
+	message?: string;
+	status_url?: string;
+	complete_url?: string;
+	next_steps?: string[];
+};
+
 export const mcpApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
 		// Get MCP clients with pagination
@@ -243,6 +252,16 @@ export const mcpApi = baseApi.injectEndpoints({
 			}),
 			invalidatesTags: ["MCPClients"],
 		}),
+
+		// Initiate verification for a pending_verification MCP client (config.json bootstrap).
+		// Returns authorize_url + oauth_config_id; the caller drives the same
+		// OAuth2Authorizer dialog the UI Create flow uses.
+		initiateMCPClientVerification: builder.mutation<InitiateMCPClientVerificationResponse, string>({
+			query: (mcpClientId) => ({
+				url: `/mcp/client/${mcpClientId}/initiate-verification`,
+				method: "POST",
+			}),
+		}),
 	}),
 });
 
@@ -260,4 +279,5 @@ export const {
 	useLazyGetMCPClientsQuery,
 	useLazyGetOAuthConfigStatusQuery,
 	useCompleteOAuthFlowMutation,
+	useInitiateMCPClientVerificationMutation,
 } = mcpApi;

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -3,7 +3,7 @@ import { SecretVar } from "./schemas";
 
 export type MCPConnectionType = "http" | "stdio" | "sse";
 
-export type MCPConnectionState = "connected" | "disconnected" | "error" | "pending_tools" | "disabled";
+export type MCPConnectionState = "connected" | "disconnected" | "error" | "pending_tools" | "pending_verification" | "disabled";
 
 export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth" | "per_user_headers";
 


### PR DESCRIPTION
## Summary

MCP clients declared via `config.json` can be bootstrapped into a `pending_verification` state that requires a one-time OAuth authorization before they can be used. Previously, there was no way to complete this authorization from the UI. This PR adds an **Authorize** button to the MCP client detail sheet for clients in the `pending_verification` state, which triggers the same OAuth2 popup flow used during UI-based client creation.

## Changes

- Added `initiateMCPClientVerification` API mutation that calls `POST /mcp/client/:id/initiate-verification`, returning an `OAuthFlowResponse` with an `authorize_url` and `oauth_config_id`.
- Added `pending_verification` to the `MCPConnectionState` type and its corresponding badge color (`bg-yellow-100 text-yellow-800`).
- In `MCPClientSheet`, when a client is in `pending_verification` state and the user has update access, an **Authorize** button is shown in the sheet header. Clicking it calls `initiate-verification` and opens the `OAuth2Authorizer` dialog on success.
- The sheet description is contextually updated for `pending_verification` clients to explain that a one-time OAuth authorization is required.
- The sheet's close handler is guarded against closing while the bootstrap OAuth dialog is open.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Bootstrap an MCP client via `config.json` with an OAuth-based server so it lands in `pending_verification` state.
2. Open the MCP Registry in the UI and click on the client.
3. Verify the sheet header shows the `pending_verification` badge and an **Authorize** button.
4. Verify the sheet description reads: *"This client was declared in config.json and needs a one-time OAuth authorization before it can be used."*
5. Click **Authorize** and confirm the OAuth popup opens.
6. Complete the OAuth flow and verify the client transitions out of `pending_verification` and the sheet closes.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the MCP client sheet in `pending_verification` state._

## Breaking changes

- [x] No

## Related issues

## Security considerations

The **Authorize** button is gated behind `RbacResource.MCPGateway` / `RbacOperation.Update` access, ensuring only authorized admins can initiate the OAuth verification flow for config-bootstrapped clients.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable