### PR TITLE
fix: extend pending_verification bootstrap path to cover per_user_oauth clients

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -353,6 +353,32 @@ func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPCl
 	// This is to avoid deadlocks when the connection attempt is made
 	m.mu.Unlock()
 
+	// OAuth-type clients with PendingOAuthConfig set carry the inline
+	// `oauth_config` block from config.json but have not yet been
+	// authorized by an admin. For shared OAuth there is no oauth_configs
+	// row or token; for per-user OAuth admin verification + tool discovery
+	// has not run. In both cases the normal connect / per-call paths would
+	// either fail or land the client in a state that misrepresents the
+	// missing admin step. Park them in pending_verification until an admin
+	// completes the browser flow via
+	// POST /api/mcp/client/{id}/initiate-verification. PendingOAuthConfig
+	// is cleared once the OAuth callback completes; the subsequent
+	// reconnect skips this branch and the normal path runs.
+	if config.PendingOAuthConfig != nil &&
+		(config.AuthType == schemas.MCPAuthTypeOauth || config.AuthType == schemas.MCPAuthTypePerUserOauth) {
+		m.mu.Lock()
+		if client, exists := m.clientMap[config.ID]; exists {
+			if config.ConnectionString != nil {
+				url := config.ConnectionString.GetValue()
+				client.ConnectionInfo.ConnectionURL = &url
+			}
+			client.State = schemas.MCPConnectionStatePendingVerification
+		}
+		m.mu.Unlock()
+		m.logger.Debug("%s OAuth MCP client '%s' (auth_type=%s) registered in pending_verification (awaiting admin authorization)", MCPLogPrefix, config.Name, config.AuthType)
+		return nil
+	}
+
 	// Per-user auth types: skip persistent connection. Auth is per-request at
 	// runtime. The admin verifies the configuration via a sample login before
 	// this is called, and tools are populated separately via SetClientTools().
@@ -380,29 +406,6 @@ func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPCl
 			}
 		}
 		m.mu.Unlock()
-		return nil
-	}
-
-	// Shared-OAuth clients with PendingOAuthConfig set carry the inline
-	// `oauth_config` block from config.json but have no oauth_configs row
-	// or token yet. Attempting to connect would fail in ConnectionHeaders
-	// → GetAccessToken. Park them in pending_verification until an admin
-	// completes the browser OAuth flow via
-	// POST /api/mcp/client/{id}/initiate-verification. PendingOAuthConfig
-	// is cleared once the OAuth callback marks the linked oauth_configs
-	// row authorized; the subsequent reconnect skips this branch and
-	// connectToMCPClient runs normally.
-	if config.AuthType == schemas.MCPAuthTypeOauth && config.PendingOAuthConfig != nil {
-		m.mu.Lock()
-		if client, exists := m.clientMap[config.ID]; exists {
-			if config.ConnectionString != nil {
-				url := config.ConnectionString.GetValue()
-				client.ConnectionInfo.ConnectionURL = &url
-			}
-			client.State = schemas.MCPConnectionStatePendingVerification
-		}
-		m.mu.Unlock()
-		m.logger.Debug("%s Shared-OAuth MCP client '%s' registered in pending_verification (awaiting admin authorization)", MCPLogPrefix, config.Name)
 		return nil
 	}
 

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -172,8 +172,8 @@ func (h *MCPHandler) initiateMCPClientVerification(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if clientConfig.AuthType != schemas.MCPAuthTypeOauth {
-		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("initiate-verification only applies to auth_type='oauth' clients, got %q", clientConfig.AuthType))
+	if clientConfig.AuthType != schemas.MCPAuthTypeOauth && clientConfig.AuthType != schemas.MCPAuthTypePerUserOauth {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("initiate-verification only applies to OAuth-based clients (oauth, per_user_oauth), got %q", clientConfig.AuthType))
 		return
 	}
 	if clientConfig.PendingOAuthConfig == nil {
@@ -982,6 +982,10 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			return
 		}
 
+		// Mirror the server-level OAuth response's next-step hints so API/CLI
+		// users can complete the flow without consulting docs.
+		completeURL := fmt.Sprintf("/api/mcp/client/%s/complete-oauth", flowInitiation.OauthConfigID)
+		statusURL := fmt.Sprintf("/api/oauth/config/%s/status", flowInitiation.OauthConfigID)
 		SendJSON(ctx, map[string]any{
 			"status":          "pending_oauth",
 			"message":         "Test OAuth configuration: please authorize to verify the setup. This login is only used to verify connectivity and discover available tools — it will not be saved.",
@@ -989,6 +993,13 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			"authorize_url":   flowInitiation.AuthorizeURL,
 			"expires_at":      flowInitiation.ExpiresAt,
 			"mcp_client_id":   req.ClientID,
+			"complete_url":    completeURL,
+			"status_url":      statusURL,
+			"next_steps": []string{
+				"1. Open authorize_url in a browser to approve access",
+				"2. Poll status_url to check when status becomes 'authorized'",
+				"3. POST complete_url to verify connectivity and activate the MCP client",
+			},
 		})
 		return
 	}
@@ -1926,9 +1937,12 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		// Gate the fallback to genuine bootstrap completions:
-		// 1. AuthType must be shared OAuth — per_user_oauth completions
-		//    route through a different verification path that treats the
-		//    upstream token as an admin temp credential and revokes it.
+		// 1. AuthType must be one of the OAuth-based types. The downstream
+		//    handler branches on AuthType to take the per-user verification
+		//    path (which treats the upstream token as an admin temp
+		//    credential and revokes it) vs the shared completion path.
+		//    per_user_headers and other non-OAuth types cannot complete
+		//    through this endpoint.
 		// 2. PendingOAuthConfigJSON must still be set — once cleared, the
 		//    client has already completed bootstrap, and any further hit
 		//    on complete-oauth with this oauth_config_id is a replay (the
@@ -1936,8 +1950,8 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		//    bootstrap stash is gone because ClearMCPClientPendingOAuthConfig
 		//    ran). Reject with 409 so callers don't trigger redundant DB
 		//    writes + reconnects on an already-connected client.
-		if dbClient.AuthType != string(schemas.MCPAuthTypeOauth) {
-			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("OAuth config does not match a shared-OAuth MCP client (auth_type=%q)", dbClient.AuthType))
+		if dbClient.AuthType != string(schemas.MCPAuthTypeOauth) && dbClient.AuthType != string(schemas.MCPAuthTypePerUserOauth) {
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("OAuth config does not match an OAuth-based MCP client (auth_type=%q)", dbClient.AuthType))
 			return
 		}
 		if dbClient.PendingOAuthConfigJSON == nil || *dbClient.PendingOAuthConfigJSON == "" {
@@ -2057,6 +2071,28 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		// Set discovered tools on the client
 		h.mcpManager.SetClientTools(mcpClientConfig.ID, tools, toolNameMapping)
 
+		// For clients bootstrapped from config.json, drop the
+		// pending_oauth_config_json stash now that verification succeeded.
+		// This branch returns before the shared completion path below, so
+		// the stash must be cleared here as well; otherwise the next boot
+		// rehydrates it and parks the verified client back in
+		// pending_verification. A failed clear must surface as an error:
+		// a silent success would hide the drift until a restart re-parks
+		// the client. The replay guard reads the stash, which is still
+		// set, so re-running verification retries the whole flow
+		// including this clear.
+		if configBootstrap {
+			if err := h.store.ConfigStore.ClearMCPClientPendingOAuthConfig(ctx, mcpClientConfig.ID); err != nil {
+				logger.Error(fmt.Sprintf(
+					"[PARTIAL SUCCESS] Per-user OAuth MCP client %s was verified and activated but clearing the pending bootstrap config failed: %v. "+
+						"Runtime and database state have drifted: the client works now but will return to pending_verification on restart. Re-run verification to retry.",
+					mcpClientConfig.ID, err,
+				))
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Client verified and activated but clearing the pending bootstrap config failed, so it will return to pending_verification on restart. Re-run verification to retry: %v", err))
+				return
+			}
+		}
+
 		logger.Debug(fmt.Sprintf("[OAuth Complete] Per-user OAuth MCP client verified and created: %s (%d tools)", mcpClientConfig.ID, len(tools)))
 		message := fmt.Sprintf("OAuth configuration verified successfully. %d tools discovered. Each user will authenticate individually when using this MCP server.", len(tools))
 		if isUpdateFlow {
@@ -2136,18 +2172,18 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 	// For clients bootstrapped from config.json, drop the
 	// pending_oauth_config_json stash now that authorization succeeded so
 	// the runtime no longer treats the client as pending_verification.
-	//
-	// NOTE: Partial success — the MCP client is already connected in core
-	// and (for a create) persisted in DB above. Only the pending-bootstrap
-	// stash failed to clear, which would resurrect pending_verification on
-	// restart. Surface it as a failure so the caller retries rather than
-	// silently drifting core/DB state apart.
+	// A failed clear must surface as an error: a silent success would
+	// hide the drift until a restart re-parks the connected client. The
+	// stash is still set, so re-running verification retries the whole
+	// flow including this clear.
 	if configBootstrap {
 		if err := h.store.ConfigStore.ClearMCPClientPendingOAuthConfig(ctx, mcpClientConfig.ID); err != nil {
-			logger.Error(fmt.Sprintf("[PARTIAL SUCCESS] MCP client %s was connected successfully but clearing its pending oauth bootstrap stash failed: %v. "+
-				"The client will incorrectly show as pending_verification after a restart. Retry the request to clear the stash.",
-				mcpClientConfig.ID, err))
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("MCP client connected but clearing its pending OAuth bootstrap config failed: %v", err))
+			logger.Error(fmt.Sprintf(
+				"[PARTIAL SUCCESS] OAuth MCP client %s completed authorization but clearing the pending bootstrap config failed: %v. "+
+					"Runtime and database state have drifted: the client is connected now but will return to pending_verification on restart. Re-run verification to retry.",
+				mcpClientConfig.ID, err,
+			))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Client connected but clearing the pending bootstrap config failed, so it will return to pending_verification on restart. Re-run verification to retry: %v", err))
 			return
 		}
 	}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1724,6 +1724,28 @@ func loadMCPConfig(ctx context.Context, config *Config, configData *ConfigData) 
 				logger.Warn("skipping MCP client config %q from config file: %v", c.Name, err)
 				continue
 			}
+			// oauth_config_id is server-managed state — a credentials-row
+			// reference produced by admin authorization — not a declarative
+			// input. A file-supplied value is at best redundant (the sync
+			// preserves the server-side link) and at worst repoints the
+			// client at a stale or foreign-deployment row. Ignore it; the
+			// synthesis below then parks unauthorized clients in
+			// pending_verification, where the admin flow can mint a real one.
+			if c.OauthConfigID != nil {
+				logger.Warn("ignoring oauth_config_id on MCP client %q from config file: this field is managed by Bifrost and cannot be set via config.json", c.Name)
+				c.OauthConfigID = nil
+			}
+			// OAuth-based auth types with no inline `oauth_config` still
+			// need the bootstrap-pending marker so the client lands in
+			// pending_verification and the initiate-verification endpoint
+			// can run discovery + dynamic client registration off the
+			// connection_string at admin-click time. Synthesize an empty
+			// OAuth2Config so the runtime gate and the handler see the same
+			// shape they do when the block was provided.
+			if (c.AuthType == schemas.MCPAuthTypeOauth || c.AuthType == schemas.MCPAuthTypePerUserOauth) &&
+				c.PendingOAuthConfig == nil {
+				c.PendingOAuthConfig = &schemas.OAuth2Config{}
+			}
 			valid = append(valid, c)
 		}
 		configData.MCP.ClientConfigs = valid

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -3004,6 +3004,97 @@ func TestMergeMCPConfig_HashReconciliationUpdatesAndCreates(t *testing.T) {
 	require.NotEmpty(t, byName["filesystem_tools"].ConfigHash)
 }
 
+func TestPinMCPClientImmutableFields(t *testing.T) {
+	initTestLogger()
+
+	oauthID := "oauth-row-1"
+	baseExisting := func() *schemas.MCPClientConfig {
+		return &schemas.MCPClientConfig{
+			ID:               "mcp-1",
+			Name:             "notion",
+			ConnectionType:   schemas.MCPConnectionTypeHTTP,
+			ConnectionString: schemas.NewSecretVar("https://mcp.notion.so/sse"),
+			AuthType:         schemas.MCPAuthTypeOauth,
+			OauthConfigID:    &oauthID,
+			DiscoveredTools:  map[string]schemas.ChatTool{"notion-search": {}},
+		}
+	}
+	fileClientFor := func(existing *schemas.MCPClientConfig) *schemas.MCPClientConfig {
+		return &schemas.MCPClientConfig{
+			Name:             existing.Name,
+			ConnectionType:   existing.ConnectionType,
+			ConnectionString: schemas.NewSecretVar("https://mcp.notion.so/sse"),
+			AuthType:         existing.AuthType,
+		}
+	}
+
+	t.Run("immutable changes are pinned to stored values and reported", func(t *testing.T) {
+		existing := baseExisting()
+		fileClient := &schemas.MCPClientConfig{
+			Name:             "notion",
+			ConnectionType:   schemas.MCPConnectionTypeSSE,
+			ConnectionString: schemas.NewSecretVar("https://elsewhere.example.com"),
+			AuthType:         schemas.MCPAuthTypePerUserOauth,
+		}
+		changed := pinMCPClientImmutableFields(fileClient, existing, nil)
+		require.ElementsMatch(t, []string{"auth_type", "connection_type", "connection_string"}, changed)
+		require.Equal(t, existing.ConnectionType, fileClient.ConnectionType)
+		require.True(t, fileClient.ConnectionString.Equals(existing.ConnectionString))
+		require.Equal(t, schemas.MCPAuthTypeOauth, fileClient.AuthType)
+		require.Equal(t, &oauthID, fileClient.OauthConfigID, "server-side oauth link must be carried")
+		require.Len(t, fileClient.DiscoveredTools, 1, "discovered tools must be carried")
+	})
+
+	t.Run("unchanged entry reports nothing", func(t *testing.T) {
+		existing := baseExisting()
+		require.Empty(t, pinMCPClientImmutableFields(fileClientFor(existing), existing, nil))
+	})
+
+	t.Run("pending stash edits are detected and the stored stash kept", func(t *testing.T) {
+		existing := baseExisting()
+		existing.OauthConfigID = nil
+		existing.PendingOAuthConfig = &schemas.OAuth2Config{ClientID: "abc", Scopes: []string{"read"}}
+		fileClient := fileClientFor(existing)
+		fileClient.PendingOAuthConfig = &schemas.OAuth2Config{ClientID: "xyz", Scopes: []string{"read"}}
+		changed := pinMCPClientImmutableFields(fileClient, existing, nil)
+		require.Equal(t, []string{"oauth_config"}, changed)
+		require.Equal(t, "abc", fileClient.PendingOAuthConfig.ClientID)
+	})
+
+	t.Run("authorized oauth drift detected via oauth row, absent fields not drift", func(t *testing.T) {
+		existing := baseExisting()
+		row := &tables.TableOauthConfig{
+			ID:           oauthID,
+			ClientID:     schemas.NewSecretVar("dcr-client"),
+			AuthorizeURL: "https://auth.example.com/authorize",
+			Scopes:       `["read","write"]`,
+		}
+
+		// File omits client_id (DCR-provisioned) and reorders scopes — not drift.
+		fileClient := fileClientFor(existing)
+		fileClient.PendingOAuthConfig = &schemas.OAuth2Config{Scopes: []string{"write", "read"}}
+		require.Empty(t, pinMCPClientImmutableFields(fileClient, existing, row))
+		require.Nil(t, fileClient.PendingOAuthConfig, "authorized client keeps a cleared stash")
+
+		// An explicitly different client_id is drift.
+		fileClient = fileClientFor(existing)
+		fileClient.PendingOAuthConfig = &schemas.OAuth2Config{ClientID: "different"}
+		require.Equal(t, []string{"oauth_config"}, pinMCPClientImmutableFields(fileClient, existing, row))
+		require.Nil(t, fileClient.PendingOAuthConfig)
+	})
+
+	t.Run("per_user_headers key schema cannot be emptied", func(t *testing.T) {
+		existing := baseExisting()
+		existing.AuthType = schemas.MCPAuthTypePerUserHeaders
+		existing.OauthConfigID = nil
+		existing.DiscoveredTools = nil
+		existing.PerUserHeaderKeys = []string{"x-api-key"}
+		fileClient := fileClientFor(existing)
+		require.Empty(t, pinMCPClientImmutableFields(fileClient, existing, nil))
+		require.Equal(t, []string{"x-api-key"}, fileClient.PerUserHeaderKeys)
+	})
+}
+
 // TestSourceOfTruthConfigJSON_MCPMissingLeavesDBUntouched verifies missing mcp does not prune DB MCP clients.
 func TestSourceOfTruthConfigJSON_MCPMissingLeavesDBUntouched(t *testing.T) {
 	initTestLogger()

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -455,7 +455,9 @@ export default function MCPClientSheet({
 								</SheetTitle>
 								<SheetDescription>
 									{mcpClient.state === "pending_verification"
-										? "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
+										? mcpClient.config.auth_type === "per_user_oauth"
+											? "This client was declared in config.json. A one-time admin test login is needed to verify the OAuth setup and discover tools — each user will authenticate individually afterward."
+											: "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
 										: "MCP server configuration and available tools"}
 								</SheetDescription>
 							</div>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -109,7 +109,7 @@ function MCPClientActionsMenu({
 						}}
 					>
 						<KeyRound className="h-4 w-4" />
-						Authorize
+						{client.config.auth_type === "per_user_oauth" ? "Verify" : "Authorize"}
 					</DropdownMenuItem>
 				)}
 				{hasUpdateAccess && (
@@ -194,6 +194,7 @@ export default function MCPClientsTable({
 		oauthConfigId: string;
 		mcpClientId: string;
 		popup: Window | null;
+		isPerUserOauth: boolean;
 	} | null>(null);
 
 	// RTK Query mutations
@@ -222,16 +223,23 @@ export default function MCPClientsTable({
 	};
 
 	const handleStartBootstrap = async (client: MCPClient) => {
+		const isPerUserOauth = client.config.auth_type === "per_user_oauth";
 		// Open a blank popup synchronously, before the initiateVerification
 		// await, so the click's transient user-activation is captured here
 		// rather than consumed by the network round-trip — otherwise the
 		// browser can block OAuth2Authorizer's later window.open entirely.
 		// OAuth2Authorizer navigates this handle once authorize_url is known.
-		const width = 600;
-		const height = 700;
-		const left = window.screen.width / 2 - width / 2;
-		const top = window.screen.height / 2 - height / 2;
-		const popup = window.open("", "oauth_popup", `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`);
+		// Not needed for per_user_oauth: that flow shows a confirm step first
+		// and opens its own popup synchronously from that step's own button
+		// click, so pre-opening one here would just leak an unused window.
+		let popup: Window | null = null;
+		if (!isPerUserOauth) {
+			const width = 600;
+			const height = 700;
+			const left = window.screen.width / 2 - width / 2;
+			const top = window.screen.height / 2 - height / 2;
+			popup = window.open("", "oauth_popup", `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`);
+		}
 		try {
 			setAuthorizingClients((prev) => [...prev, client.config.client_id]);
 			const response = await initiateVerification(client.config.client_id).unwrap();
@@ -241,6 +249,7 @@ export default function MCPClientsTable({
 					oauthConfigId: response.oauth_config_id,
 					mcpClientId: client.config.client_id,
 					popup,
+					isPerUserOauth,
 				});
 			} else {
 				popup?.close();
@@ -417,7 +426,12 @@ export default function MCPClientsTable({
 					open={!!bootstrapAuthorize}
 					onClose={() => setBootstrapAuthorize(null)}
 					onSuccess={async () => {
-						toast({ title: "Success", description: "MCP client connected successfully" });
+						toast({
+							title: "Success",
+							description: bootstrapAuthorize.isPerUserOauth
+								? "OAuth setup verified successfully. Each user will authenticate individually."
+								: "MCP client connected successfully",
+						});
 						setBootstrapAuthorize(null);
 						if (refetch) {
 							await refetch();
@@ -434,6 +448,7 @@ export default function MCPClientsTable({
 					oauthConfigId={bootstrapAuthorize.oauthConfigId}
 					mcpClientId={bootstrapAuthorize.mcpClientId}
 					initialPopup={bootstrapAuthorize.popup}
+					isPerUserOauth={bootstrapAuthorize.isPerUserOauth}
 				/>
 			)}
 


### PR DESCRIPTION
## Summary

Extends the `pending_verification` bootstrap flow to cover `per_user_oauth` clients in addition to shared `oauth` clients. Previously, only shared OAuth clients declared in `config.json` were parked in `pending_verification` awaiting admin authorization. Per-user OAuth clients loaded from config were not handled the same way, meaning they could end up in an inconsistent state before an admin completed the verification step.

## Changes

- Unified the `pending_verification` gate in `AddClient` to apply to both `oauth` and `per_user_oauth` auth types when `PendingOAuthConfig` is set, replacing the previous shared-OAuth-only check.
- The `initiate-verification` endpoint now accepts both `oauth` and `per_user_oauth` auth types instead of rejecting the latter.
- The `complete-oauth` callback handler now permits both OAuth-based auth types to complete through the endpoint, with downstream branching handling the per-user vs. shared distinction.
- When loading MCP config from `config.json`, OAuth-based clients (`oauth` or `per_user_oauth`) that have no inline `oauth_config` block and no existing `oauth_config_id` now have an empty `OAuth2Config` synthesized so they consistently land in `pending_verification` and the `initiate-verification` endpoint can run discovery and dynamic client registration at admin-click time.
- UI updated to show auth-type-aware labels and descriptions: `per_user_oauth` clients in `pending_verification` show a "Verify" button and a description clarifying that the admin test login is a one-time setup step and each user will authenticate individually afterward. The success toast message is similarly differentiated.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Declare a `per_user_oauth` MCP client in `config.json` with a `connection_string` but no `oauth_config` block.
2. Start the server and confirm the client appears in `pending_verification` state.
3. As an admin, open the client sheet and confirm the "Verify" button and per-user description are shown.
4. Click "Verify" and complete the browser OAuth flow.
5. Confirm the client transitions out of `pending_verification` and tools are discovered.
6. Confirm that subsequent user requests trigger individual per-user authentication rather than reusing the admin token.
7. Repeat steps 1–6 for a shared `oauth` client to confirm existing behavior is unchanged.

```sh
go test ./core/mcp/... ./transports/bifrost-http/...

cd ui
pnpm i
pnpm build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The admin verification flow for `per_user_oauth` uses the upstream token only as a temporary credential to validate the OAuth configuration and discover tools, then revokes it. The token is not persisted or reused for end-user requests. No end-user credentials are stored as a result of the admin verification step.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable