### PR TITLE
feat: add `verify-headers` endpoint and pending_verification state for per-user-headers MCP clients

### DIFF
--- a/core/mcp/addclient_discoveredtools_test.go
+++ b/core/mcp/addclient_discoveredtools_test.go
@@ -1,0 +1,99 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// snapshotAddClientState copies the fields the assertions below care about while
+// holding the manager lock.
+func snapshotAddClientState(m *MCPManager, id string) (state schemas.MCPClientState, exists bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	cs, ok := m.clientMap[id]
+	if !ok {
+		return schemas.MCPClientState{}, false
+	}
+	return *cs, true
+}
+
+// TestAddClient_PerUserHeaders_DiscoveredToolsStateSelection covers
+// AddClient's per_user_headers registration path, where nil, non-nil-empty,
+// and populated DiscoveredTools carry three different lifecycle meanings: a
+// nil map means admin verification has never run (park in
+// pending_verification, before ever reaching the RequiresPerCallConnection
+// branch below); a non-nil empty map means verification ran but the server
+// legitimately exposes zero tools (pending_tools); and a populated map means
+// verification ran and discovered tools are restored (connected). All three
+// cases must also preserve ConnectionURL from ConnectionString.
+func TestAddClient_PerUserHeaders_DiscoveredToolsStateSelection(t *testing.T) {
+	tests := []struct {
+		name            string
+		clientID        string
+		clientName      string
+		discoveredTools map[string]schemas.ChatTool
+		wantState       schemas.MCPConnectionState
+		wantToolCount   int
+	}{
+		{
+			name:            "nil DiscoveredTools parks in pending_verification",
+			clientID:        "discovered-tools-nil",
+			clientName:      "discovered_tools_nil",
+			discoveredTools: nil,
+			wantState:       schemas.MCPConnectionStatePendingVerification,
+			wantToolCount:   0,
+		},
+		{
+			name:            "non-nil empty DiscoveredTools is pending_tools",
+			clientID:        "discovered-tools-empty",
+			clientName:      "discovered_tools_empty",
+			discoveredTools: map[string]schemas.ChatTool{},
+			wantState:       schemas.MCPConnectionStatePendingTools,
+			wantToolCount:   0,
+		},
+		{
+			name:       "populated DiscoveredTools restores tools as connected",
+			clientID:   "discovered-tools-populated",
+			clientName: "discovered_tools_populated",
+			discoveredTools: map[string]schemas.ChatTool{
+				"tool-a": {},
+				"tool-b": {},
+			},
+			wantState:     schemas.MCPConnectionStateConnected,
+			wantToolCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// nil credStore: NewMCPManager defaults to a real credstore.CredStore,
+			// whose RequiresPerCallConnection is what production AddClient calls
+			// resolve against for per_user_headers clients.
+			m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, &MockLogger{}, nil)
+
+			config := &schemas.MCPClientConfig{
+				ID:                tt.clientID,
+				Name:              tt.clientName,
+				ConnectionType:    schemas.MCPConnectionTypeHTTP,
+				ConnectionString:  schemas.NewSecretVar("https://example.invalid/mcp"),
+				AuthType:          schemas.MCPAuthTypePerUserHeaders,
+				PerUserHeaderKeys: []string{"X-User-Token"},
+				DiscoveredTools:   tt.discoveredTools,
+			}
+
+			require.NoError(t, m.AddClient(context.Background(), config))
+
+			state, ok := snapshotAddClientState(m, config.ID)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantState, state.State)
+			assert.Len(t, state.ToolMap, tt.wantToolCount)
+			require.NotNil(t, state.ConnectionInfo)
+			require.NotNil(t, state.ConnectionInfo.ConnectionURL)
+			assert.Equal(t, "https://example.invalid/mcp", *state.ConnectionInfo.ConnectionURL)
+		})
+	}
+}

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -379,6 +379,32 @@ func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPCl
 		return nil
 	}
 
+	// Per-user-headers clients whose DiscoveredTools has never been set
+	// have not had the one-time admin verification + discovery run yet.
+	// The UI Create flow runs that synchronously during create, so any
+	// per-user-headers row arriving here with a nil map was either
+	// declared in config.json or had its tools cleared by schema drift /
+	// manual edit. A verified server that legitimately exposes zero tools
+	// persists a non-nil empty map (see BeforeSave/AfterFind in
+	// framework/configstore/tables/mcp.go), so nil-check rather than
+	// len-check to avoid re-parking it in pending_verification on every
+	// reload. Park in pending_verification so the UI surfaces an admin
+	// "Verify" CTA that hits POST /api/mcp/client/{id}/verify-headers; the
+	// normal per-call path takes over once DiscoveredTools is set.
+	if config.AuthType == schemas.MCPAuthTypePerUserHeaders && config.DiscoveredTools == nil {
+		m.mu.Lock()
+		if client, exists := m.clientMap[config.ID]; exists {
+			if config.ConnectionString != nil {
+				url := config.ConnectionString.GetValue()
+				client.ConnectionInfo.ConnectionURL = &url
+			}
+			client.State = schemas.MCPConnectionStatePendingVerification
+		}
+		m.mu.Unlock()
+		m.logger.Debug("%s Per-user-headers MCP client '%s' registered in pending_verification (awaiting admin verification)", MCPLogPrefix, config.Name)
+		return nil
+	}
+
 	// Per-user auth types: skip persistent connection. Auth is per-request at
 	// runtime. The admin verifies the configuration via a sample login before
 	// this is called, and tools are populated separately via SetClientTools().

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1518,6 +1518,19 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 	}
 	hash.Write([]byte("auth_type:" + authType))
 
+	// Hash PerUserHeaderKeys (sorted for deterministic hashing) so edits to
+	// the declared header-name schema in config.json drift the hash.
+	if len(m.PerUserHeaderKeys) > 0 {
+		sortedKeys := make([]string, len(m.PerUserHeaderKeys))
+		copy(sortedKeys, m.PerUserHeaderKeys)
+		sort.Strings(sortedKeys)
+		data, err := sonic.Marshal(sortedKeys)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+
 	// Hash PendingOAuthConfig so edits to the inline `oauth_config` block
 	// in config.json drift the hash and trigger reconciliation. Rows built
 	// from config.json carry only the runtime struct (the JSON column is

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -83,6 +83,7 @@ func (h *MCPHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.Bif
 	r.POST("/api/mcp/client/{id}/reconnect", lib.ChainMiddlewares(h.reconnectMCPClient, middlewares...))
 	r.POST("/api/mcp/client/{id}/complete-oauth", lib.ChainMiddlewares(h.completeMCPClientOAuth, middlewares...))
 	r.POST("/api/mcp/client/{id}/initiate-verification", lib.ChainMiddlewares(h.initiateMCPClientVerification, middlewares...))
+	r.POST("/api/mcp/client/{id}/verify-headers", lib.ChainMiddlewares(h.verifyMCPClientHeaders, middlewares...))
 }
 
 // runOAuthBootstrap kicks off the shared-OAuth flow for an MCP client and
@@ -212,6 +213,201 @@ func (h *MCPHandler) initiateMCPClientVerification(ctx *fasthttp.RequestCtx) {
 			"2. Poll status_url to check when status becomes 'authorized'",
 			"3. POST complete_url to activate the MCP client",
 		},
+	})
+}
+
+// VerifyMCPClientHeadersRequest is the body for
+// POST /api/mcp/client/{id}/verify-headers. user_headers carries the
+// admin's sample header values for the one-time verification; the values
+// are used to open an upstream connection, call tools/list, and are then
+// discarded. Each end-user submits their own values at runtime.
+type VerifyMCPClientHeadersRequest struct {
+	UserHeaders map[string]string `json:"user_headers"`
+}
+
+// verifyMCPClientHeaders handles
+// POST /api/mcp/client/{id}/verify-headers.
+//
+// Surfaced on per-user-headers MCP clients sitting in pending_verification
+// — i.e. clients whose row was declared in config.json (or otherwise
+// persisted) without DiscoveredTools. The admin enters sample header
+// values in the UI form; this handler runs the same VerifyHeadersConnection
+// the UI Create flow runs (admin sample values → upstream connection →
+// tools/list → discovered tools), persists DiscoveredTools on the row,
+// triggers reconnect, and discards the sample values.
+//
+// Synchronous: no callback, no popup. On success the client transitions
+// to connected; on failure the row stays in pending_verification and the
+// admin can retry.
+func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
+		return
+	}
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.store)
+	defer cancel()
+
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid mcp client id: %v", err))
+		return
+	}
+
+	var req VerifyMCPClientHeadersRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request body: %v", err))
+		return
+	}
+
+	clientConfig, err := h.store.ConfigStore.GetMCPClientConfigByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("MCP client '%s' not found", id))
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load MCP client: %v", err))
+		return
+	}
+	if clientConfig.AuthType != schemas.MCPAuthTypePerUserHeaders {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("verify-headers only applies to auth_type='per_user_headers' clients, got %q", clientConfig.AuthType))
+		return
+	}
+	// Replay guard: once admin verification succeeds DiscoveredTools is set
+	// (non-nil, possibly empty for a server that legitimately exposes zero
+	// tools) and the client is usable. A second hit on this endpoint would
+	// re-run discovery and clobber the existing tool set, which is
+	// surprising and wasteful. Force callers to delete + recreate (or use
+	// the future "edit headers schema" path) to re-verify.
+	if clientConfig.DiscoveredTools != nil {
+		SendError(ctx, fasthttp.StatusConflict, "MCP client has already been verified; delete and recreate to re-verify")
+		return
+	}
+	if len(clientConfig.PerUserHeaderKeys) == 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP client has no per_user_header_keys declared; cannot verify")
+		return
+	}
+
+	// Canonicalize both sides so the missing-keys check matches by
+	// canonical form (lowercase + trim), mirroring the UI Create flow.
+	canonKeys := mcputils.CanonicalizeHeaderKeys(clientConfig.PerUserHeaderKeys)
+	canonUserHeaders := mcputils.CanonicalizeHeaderMap(req.UserHeaders)
+	if missing := missingPerUserHeaderValues(canonKeys, canonUserHeaders); len(missing) > 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("user_headers missing values for required keys: %s", strings.Join(missing, ", ")))
+		return
+	}
+
+	tools, toolNameMapping, verifyErr := h.mcpManager.VerifyHeadersConnection(bifrostCtx, clientConfig, canonUserHeaders)
+	if verifyErr != nil {
+		SendError(ctx, fasthttp.StatusUnprocessableEntity, fmt.Sprintf("Verification failed: %v", verifyErr))
+		return
+	}
+
+	// Re-load the row before activating and persisting: discovery above
+	// holds an upstream network round-trip, and pushing the pre-discovery
+	// snapshot into the runtime refresh and the full-row write below would
+	// silently restore any fields an admin edited in the meantime (name,
+	// filters, pricing, disabled). A fresh read narrows that window to the
+	// moments between this read and the write. Nothing has been activated
+	// or persisted yet, so a failed reload leaves the retry path open.
+	clientConfig, err = h.store.ConfigStore.GetMCPClientConfigByID(ctx, id)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Verification succeeded but reloading the client for activation failed: %v", err))
+		return
+	}
+	// Re-check the replay guard against the freshly reloaded row: a
+	// concurrent verify-headers call (e.g. a double-click) may have
+	// completed its own discovery and persisted DiscoveredTools during the
+	// network round-trip above. The reload already reads the current row,
+	// so this costs nothing extra and closes the double-submit race the
+	// guard at the top of this handler can't see. Treat it as this
+	// request's own success rather than an error: the desired end state
+	// (verified, tools discovered) was already reached by the other
+	// request, so there's nothing left to do here — redoing the
+	// persist/activation below would only risk clobbering its tool set.
+	if clientConfig.DiscoveredTools != nil {
+		SendJSON(ctx, map[string]any{
+			"status":      "success",
+			"message":     fmt.Sprintf("MCP client verified. %d tools discovered. Each user will submit their own header values on first tool use.", len(clientConfig.DiscoveredTools)),
+			"tools_count": len(clientConfig.DiscoveredTools),
+		})
+		return
+	}
+	clientConfig.DiscoveredTools = tools
+	clientConfig.DiscoveredToolNameMapping = toolNameMapping
+
+	// Activate the runtime client BEFORE persisting so a partial failure
+	// can always be retried through this endpoint. The replay guard above
+	// reads DiscoveredTools from the DB, so persisting first would turn an
+	// activation failure into a permanent 409 wedge (runtime still parked,
+	// DB claiming verified). In this order every partial failure leaves the
+	// DB row without tools and the retry path open:
+	//   - activation fails → nothing persisted → retry re-runs verification
+	//   - persistence fails → runtime works now, client re-parks on restart
+	//     and the retry re-runs verification
+	//
+	// Refresh the manager's config with the discovered tools, then set them
+	// on the client — SetClientTools populates the tool map and flips the
+	// state to connected. Per-user auth clients hold no shared upstream
+	// connection, so there is nothing to reconnect; this mirrors the
+	// per-user OAuth completion path.
+	if err := h.updateMCPClientWithRetry(bifrostCtx, clientConfig.ID, clientConfig); err != nil {
+		logger.Error(fmt.Sprintf("Failed to update MCP client after headers verification for client %s: %v", clientConfig.ID, err))
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Verified successfully but failed to activate the client: %v", err))
+		return
+	}
+	h.mcpManager.SetClientTools(clientConfig.ID, tools, toolNameMapping)
+
+	// Persist the discovered tools via UpdateMCPClientConfig. The store
+	// unconditionally writes every editable column from the given struct
+	// (ConfigHash only gates the connection-metadata block), so the update
+	// must carry the full config; a sparse struct would zero name,
+	// headers, pricing, and the other editable fields. clientConfig was
+	// re-loaded after discovery and carries the discovered tools.
+	updateReq := &configstoreTables.TableMCPClient{
+		ClientID:                  clientConfig.ID,
+		Name:                      clientConfig.Name,
+		IsCodeModeClient:          clientConfig.IsCodeModeClient,
+		ConnectionType:            string(clientConfig.ConnectionType),
+		ConnectionString:          clientConfig.ConnectionString,
+		StdioConfig:               clientConfig.StdioConfig,
+		TLSConfig:                 clientConfig.TLSConfig,
+		AuthType:                  string(clientConfig.AuthType),
+		OauthConfigID:             clientConfig.OauthConfigID,
+		ToolsToExecute:            clientConfig.ToolsToExecute,
+		ToolsToAutoExecute:        clientConfig.ToolsToAutoExecute,
+		Headers:                   clientConfig.Headers,
+		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
+		IsPingAvailable:           clientConfig.IsPingAvailable,
+		ToolPricing:               clientConfig.ToolPricing,
+		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
+		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
+		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
+		PerUserHeaderKeys:         clientConfig.PerUserHeaderKeys,
+		DiscoveredTools:           clientConfig.DiscoveredTools,
+		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
+		Disabled:                  clientConfig.Disabled,
+	}
+	if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, clientConfig.ID, updateReq); err != nil {
+		// NOTE: Partial success; the runtime client is connected and serving
+		// but the DB row still has no discovered tools, so runtime and
+		// database state have drifted. The replay guard reads DiscoveredTools
+		// from the DB, so retrying this endpoint re-runs verification and
+		// reconverges the two; a restart re-parks the client in
+		// pending_verification.
+		logger.Error(fmt.Sprintf(
+			"[PARTIAL SUCCESS] MCP client %s was activated after headers verification but persisting discovered tools failed: %v. "+
+				"Runtime and database state have drifted: the client is connected now but will return to pending_verification on restart. "+
+				"Retry this endpoint to re-verify and persist.",
+			clientConfig.ID, err,
+		))
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Client activated but discovered tools could not be persisted, so runtime and database state have drifted until re-verified. Retry this endpoint to re-run verification and persist: %v", err))
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"status":      "success",
+		"message":     fmt.Sprintf("MCP client verified. %d tools discovered. Each user will submit their own header values on first tool use.", len(tools)),
+		"tools_count": len(tools),
 	})
 }
 
@@ -2015,6 +2211,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 				ConnectionType:            string(mcpClientConfig.ConnectionType),
 				ConnectionString:          mcpClientConfig.ConnectionString,
 				StdioConfig:               mcpClientConfig.StdioConfig,
+				TLSConfig:                 mcpClientConfig.TLSConfig,
 				AuthType:                  string(mcpClientConfig.AuthType),
 				OauthConfigID:             mcpClientConfig.OauthConfigID,
 				ToolsToExecute:            mcpClientConfig.ToolsToExecute,
@@ -2024,7 +2221,9 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 				IsPingAvailable:           mcpClientConfig.IsPingAvailable,
 				ToolPricing:               mcpClientConfig.ToolPricing,
 				ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
+				ToolExecutionTimeout:      int(mcpClientConfig.ToolExecutionTimeout / time.Second),
 				AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
+				PerUserHeaderKeys:         mcpClientConfig.PerUserHeaderKeys,
 				DiscoveredTools:           mcpClientConfig.DiscoveredTools,
 				DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,
 				Disabled:                  mcpClientConfig.Disabled,


### PR DESCRIPTION
## Summary

Per-user-headers MCP clients declared via `config.json` (or otherwise persisted without `DiscoveredTools`) previously had no path to complete admin verification after initial load. This PR introduces a `pending_verification` state for such clients and a new `POST /api/mcp/client/{id}/verify-headers` endpoint that allows an admin to supply sample header values, run upstream discovery (`tools/list`), persist the discovered tools, and transition the client to a connected state.

## Changes

- When `AddClient` encounters a `per_user_headers` client with no `DiscoveredTools`, it now parks the client in `pending_verification` instead of proceeding, surfacing an admin "Verify" CTA in the UI rather than silently failing or partially initializing.
- Added `POST /api/mcp/client/{id}/verify-headers` route and `verifyMCPClientHeaders` handler that:
  - Validates the client exists and is of `auth_type=per_user_headers`
  - Guards against re-verification if `DiscoveredTools` is already populated (returns `409 Conflict`)
  - Canonicalizes and validates that all declared `per_user_header_keys` are present in the request body
  - Calls `VerifyHeadersConnection` with the admin's sample headers, discarding them after use
  - Persists `DiscoveredTools` and `DiscoveredToolNameMapping` to the config store
  - Triggers a reconnect so the client transitions to connected state

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Declare a `per_user_headers` MCP client in `config.json` without pre-populating `DiscoveredTools`.
2. Start the server and confirm the client appears in `pending_verification` state.
3. Call the new endpoint with valid sample headers:

```sh
curl -X POST http://localhost:PORT/api/mcp/client/{id}/verify-headers \
  -H "Content-Type: application/json" \
  -d '{"user_headers": {"X-My-Header": "sample-value"}}'
```

4. Confirm the response includes `"status": "success"` and a `tools_count` matching the upstream server's tool list.
5. Confirm the client transitions to `connected` state and `DiscoveredTools` is persisted.
6. Confirm a second call to the same endpoint returns `409 Conflict`.
7. Confirm calling the endpoint on a non-`per_user_headers` client returns `400 Bad Request`.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Sample header values submitted by the admin during verification are used solely to open the upstream connection and run `tools/list`. They are never stored or logged and are discarded immediately after discovery completes. Each end-user supplies their own header values at runtime on a per-request basis.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable