### PR TITLE
feat: add per_user_headers bootstrap verification flow via submitHandler abstraction

### DIFF
--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
@@ -931,8 +931,10 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 						setHeadersFlow(null);
 						setError("name", { message: error });
 					}}
-					payload={headersFlow.payload}
 					perUserHeaderKeys={perUserHeaderKeys}
+					submitHandler={async (values) => {
+						await createMCPClient({ ...headersFlow.payload, user_headers: values }).unwrap();
+					}}
 				/>
 			)}
 		</Sheet>

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -241,36 +241,36 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			stdio_config:
 				connectionType === "stdio"
 					? {
-							command: data.stdio_config?.command || "",
-							args: parseArrayFromText(argsText),
-							// Each row becomes KEY=value, or a bare KEY when no value is given
-							// (read from Bifrost's host environment). Rows without a name are skipped.
-							envs: Object.entries(envVars)
-								.filter(([name]) => name.trim() !== "")
-								.map(([name, value]) => {
-									const v = value.trim();
-									return v ? `${name}=${v}` : name;
-								}),
-						}
+						command: data.stdio_config?.command || "",
+						args: parseArrayFromText(argsText),
+						// Each row becomes KEY=value, or a bare KEY when no value is given
+						// (read from Bifrost's host environment). Rows without a name are skipped.
+						envs: Object.entries(envVars)
+							.filter(([name]) => name.trim() !== "")
+							.map(([name, value]) => {
+								const v = value.trim();
+								return v ? `${name}=${v}` : name;
+							}),
+					}
 					: undefined,
 			tls_config: connectionType === "http" || connectionType === "sse" ? buildTLSConfigPayload(data.tls_config) : undefined,
 			oauth_config:
 				authType === "oauth" || authType === "per_user_oauth"
 					? {
-							client_id: data.oauth_config?.client_id ?? emptySecretVar,
-							client_secret:
-								data.oauth_config?.client_secret?.value ||
+						client_id: data.oauth_config?.client_id ?? emptySecretVar,
+						client_secret:
+							data.oauth_config?.client_secret?.value ||
 								data.oauth_config?.client_secret?.type === "env" ||
 								data.oauth_config?.client_secret?.type === "vault"
-									? data.oauth_config.client_secret
-									: undefined,
-							authorize_url: data.oauth_config?.authorize_url || undefined,
-							token_url: data.oauth_config?.token_url || undefined,
-							registration_url: data.oauth_config?.registration_url || undefined,
-							scopes: scopesText.trim() ? parseArrayFromText(scopesText) : undefined,
-							server_url: data.connection_string?.value || undefined,
-							resource: resourceText.trim() || undefined,
-						}
+								? data.oauth_config.client_secret
+								: undefined,
+						authorize_url: data.oauth_config?.authorize_url || undefined,
+						token_url: data.oauth_config?.token_url || undefined,
+						registration_url: data.oauth_config?.registration_url || undefined,
+						scopes: scopesText.trim() ? parseArrayFromText(scopesText) : undefined,
+						server_url: data.connection_string?.value || undefined,
+						resource: resourceText.trim() || undefined,
+					}
 					: undefined,
 			// "headers" and "per_user_headers" both can carry static admin
 			// headers on data.headers (per-user values are submitted
@@ -998,8 +998,10 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 						setHeadersFlow(null);
 						setError("name", { message: error });
 					}}
-					payload={headersFlow.payload}
 					perUserHeaderKeys={perUserHeaderKeys}
+					submitHandler={async (values) => {
+						await createMCPClient({ ...headersFlow.payload, user_headers: values }).unwrap();
+					}}
 				/>
 			)}
 		</Sheet>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -24,6 +24,7 @@ import {
 	useInitiateMCPClientVerificationMutation,
 	useReconnectMCPClientMutation,
 	useUpdateMCPClientMutation,
+	useVerifyMCPClientHeadersMutation,
 } from "@/lib/store";
 import { MCPClient } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -31,6 +32,7 @@ import { Link } from "@tanstack/react-router";
 import { Box, ChevronLeft, ChevronRight, KeyRound, Loader2, MoreHorizontal, PencilIcon, Plus, RefreshCcw, Search, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import MCPClientSheet from "./mcpClientSheet";
+import { MCPHeadersAuthorizer } from "./mcpHeadersAuthorizer";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
 import { MCPUsageGuideSheet } from "./mcpUsageGuide";
 import { OAuth2Authorizer } from "./oauth2Authorizer";
@@ -109,7 +111,7 @@ function MCPClientActionsMenu({
 						}}
 					>
 						<KeyRound className="h-4 w-4" />
-						{client.config.auth_type === "per_user_oauth" ? "Verify" : "Authorize"}
+						Authorize
 					</DropdownMenuItem>
 				)}
 				{hasUpdateAccess && (
@@ -196,12 +198,17 @@ export default function MCPClientsTable({
 		popup: Window | null;
 		isPerUserOauth: boolean;
 	} | null>(null);
+	// Drives the MCPHeadersAuthorizer dialog for a config.json-bootstrapped
+	// per_user_headers client sitting in pending_verification, triggered from
+	// the row actions menu.
+	const [bootstrapHeadersClient, setBootstrapHeadersClient] = useState<MCPClient | null>(null);
 
 	// RTK Query mutations
 	const [reconnectMCPClient] = useReconnectMCPClientMutation();
 	const [deleteMCPClient] = useDeleteMCPClientMutation();
 	const [updateMCPClient] = useUpdateMCPClientMutation();
 	const [initiateVerification] = useInitiateMCPClientVerificationMutation();
+	const [verifyMCPClientHeaders] = useVerifyMCPClientHeadersMutation();
 
 	const handleCreate = () => {
 		setFormOpen(true);
@@ -223,6 +230,12 @@ export default function MCPClientsTable({
 	};
 
 	const handleStartBootstrap = async (client: MCPClient) => {
+		// per_user_headers takes a synchronous form-based path; OAuth-based
+		// types kick off the existing browser flow below.
+		if (client.config.auth_type === "per_user_headers") {
+			setBootstrapHeadersClient(client);
+			return;
+		}
 		const isPerUserOauth = client.config.auth_type === "per_user_oauth";
 		// Open a blank popup synchronously, before the initiateVerification
 		// await, so the click's transient user-activation is captured here
@@ -449,6 +462,41 @@ export default function MCPClientsTable({
 					mcpClientId={bootstrapAuthorize.mcpClientId}
 					initialPopup={bootstrapAuthorize.popup}
 					isPerUserOauth={bootstrapAuthorize.isPerUserOauth}
+				/>
+			)}
+			{bootstrapHeadersClient && (
+				<MCPHeadersAuthorizer
+					open={!!bootstrapHeadersClient}
+					onClose={() => setBootstrapHeadersClient(null)}
+					onSuccess={async () => {
+						toast({
+							title: "Success",
+							description: "Headers verified successfully. Each user will submit their own values when using this MCP server.",
+						});
+						setBootstrapHeadersClient(null);
+						if (refetch) {
+							await refetch();
+						}
+					}}
+					onError={() => {
+						/* error state rendered by the dialog itself */
+					}}
+					onConflict={async (error) => {
+						// 409: tools were already discovered (e.g. double submit or a
+						// concurrent verification) — the client is verified; refresh.
+						toast({ title: "Already verified", description: error });
+						setBootstrapHeadersClient(null);
+						if (refetch) {
+							await refetch();
+						}
+					}}
+					perUserHeaderKeys={bootstrapHeadersClient.config.per_user_header_keys ?? []}
+					submitHandler={async (values) => {
+						await verifyMCPClientHeaders({
+							id: bootstrapHeadersClient.config.client_id,
+							userHeaders: values,
+						}).unwrap();
+					}}
 				/>
 			)}
 

--- a/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
@@ -10,8 +10,7 @@
 import HeadersForm from "@/components/headersForm";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { getErrorMessage, useCreateMCPClientMutation } from "@/lib/store";
-import { CreateMCPClientRequest } from "@/lib/types/mcp";
+import { getErrorMessage } from "@/lib/store";
 import { Loader2 } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
 
@@ -21,11 +20,13 @@ interface MCPHeadersAuthorizerProps {
 	onSuccess: () => void;
 	onError: (error: string) => void;
 	onConflict?: (error: string) => void;
-	// Full payload the parent has already assembled. The dialog adds
-	// user_headers (collected inline) and POSTs once.
-	payload: CreateMCPClientRequest;
 	// Required key schema, rendered as the form's input fields.
 	perUserHeaderKeys: string[];
+	// Called with the collected sample values once the admin clicks "Run
+	// Test". The handler decides what endpoint to hit (Create flow's
+	// /api/mcp/client vs bootstrap's /api/mcp/client/{id}/verify-headers).
+	// Throw to surface a failure in the dialog.
+	submitHandler: (values: Record<string, string>) => Promise<void>;
 }
 
 type Status = "confirm" | "input" | "testing" | "success" | "failed";
@@ -36,16 +37,14 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 	onSuccess,
 	onError,
 	onConflict,
-	payload,
 	perUserHeaderKeys,
+	submitHandler,
 }) => {
 	const [status, setStatus] = useState<Status>("confirm");
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	// Set to true when the user cancels so in-flight async callbacks do not
 	// invoke onSuccess / onError / onClose after the dialog is dismissed.
 	const cancelledRef = useRef(false);
-
-	const [createMCPClient] = useCreateMCPClientMutation();
 
 	// Reset state every time the dialog opens so a retry from a previous
 	// session doesn't carry over.
@@ -65,7 +64,7 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 		if (cancelledRef.current) return;
 		setStatus("testing");
 		try {
-			await createMCPClient({ ...payload, user_headers: values }).unwrap();
+			await submitHandler(values);
 			if (cancelledRef.current) return;
 			setStatus("success");
 			onSuccess();

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -262,6 +262,21 @@ export const mcpApi = baseApi.injectEndpoints({
 				method: "POST",
 			}),
 		}),
+
+		// Verify a pending_verification per_user_headers MCP client by submitting
+		// admin sample header values. Backend runs verify + discover synchronously,
+		// persists DiscoveredTools, and reconnects.
+		verifyMCPClientHeaders: builder.mutation<
+			{ status: string; message: string; tools_count: number },
+			{ id: string; userHeaders: Record<string, string> }
+		>({
+			query: ({ id, userHeaders }) => ({
+				url: `/mcp/client/${id}/verify-headers`,
+				method: "POST",
+				body: { user_headers: userHeaders },
+			}),
+			invalidatesTags: ["MCPClients"],
+		}),
 	}),
 });
 
@@ -280,4 +295,5 @@ export const {
 	useLazyGetOAuthConfigStatusQuery,
 	useCompleteOAuthFlowMutation,
 	useInitiateMCPClientVerificationMutation,
+	useVerifyMCPClientHeadersMutation,
 } = mcpApi;


### PR DESCRIPTION
## Summary

Adds support for verifying `per_user_headers` MCP clients that were bootstrapped via `config.json` and are sitting in `pending_verification` state. Previously, only OAuth-based clients had a verification flow in the sheet view. This PR introduces a `verifyMCPClientHeaders` API endpoint and wires up the `MCPHeadersAuthorizer` dialog for the bootstrap path, allowing an admin to submit sample header values once to verify the connection and discover tools.

## Changes

- Refactored `MCPHeadersAuthorizer` to accept a generic `submitHandler` callback instead of a hardcoded `payload` + `createMCPClient` call, decoupling the dialog from the specific API endpoint it targets. The Create flow passes a handler that calls `createMCPClient`, while the bootstrap/verify flow passes one that calls `verifyMCPClientHeaders`.
- Added a `verifyMCPClientHeaders` RTK mutation that `POST`s to `/mcp/client/{id}/verify-headers` with `user_headers`, invalidating the `MCPClients` cache tag on success.
- Added `bootstrapHeadersOpen` state to `MCPClientSheet` to drive the `MCPHeadersAuthorizer` dialog for `per_user_headers` clients in `pending_verification`.
- `handleStartBootstrap` now short-circuits for `per_user_headers` auth type, opening the headers dialog directly instead of calling `initiateVerification`.
- The sheet's `onOpenChange` handler now also guards against closing while the headers authorizer dialog is open.
- Updated the "Authorize/Verify" button label and the `pending_verification` description text to correctly reflect `per_user_headers` vs `oauth` auth types.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Declare a `per_user_headers` MCP client in `config.json` so it is created in `pending_verification` state.
2. Open the MCP Registry in the UI and click into the client's sheet.
3. Confirm the description reads: *"This client was declared in config.json. Submit sample header values once to verify the connection and discover tools — each user will submit their own values afterward."*
4. Click **Verify**. The `MCPHeadersAuthorizer` dialog should open.
5. Fill in the required header values and click **Run Test**.
6. Confirm the client transitions out of `pending_verification`, tools are discovered, and a success toast appears.
7. Confirm the Create flow (`mcpClientForm`) still works end-to-end for `per_user_headers` clients.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots of the MCP client sheet for a `per_user_headers` client in `pending_verification` state._

## Breaking changes

- [x] No

## Related issues

_Link related issues here._

## Security considerations

Sample header values submitted during verification are sent directly to the backend's `/api/mcp/client/{id}/verify-headers` endpoint. These values may contain API keys or credentials and should be treated as secrets. No values are persisted in frontend state beyond the lifetime of the dialog.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable