### PR TITLE
docs: add `config.json` bootstrap support for auth-aware MCP clients (`oauth`, `per_user_oauth`, `per_user_headers`)

### DIFF
--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -32,7 +32,7 @@ This page is a concise reference for every top-level key in `config.json`. Click
 | `vector_store` | object | Vector database for semantic cache - Weaviate, Redis, Qdrant, Pinecone, Valkey | [Storage](/deployment-guides/config-json/storage#vector_store) |
 | `plugins` | array | Opt-in plugins: `semantic_cache`, `otel`, `maxim`, `datadog`, custom | [Plugins](/deployment-guides/config-json/plugins) |
 | `framework` | object | Model pricing catalog URL and sync interval | [Framework](#framework) |
-| `mcp` | object | MCP server and tool configuration | - |
+| `mcp` | object | MCP server and tool configuration | [MCP](#mcp) |
 | `websocket` | object | WebSocket / Realtime API connection pool tuning | [WebSocket](#websocket) |
 | `auth_config` | object | **Deprecated** - use `governance.auth_config` | [Client](/deployment-guides/config-json/client#authentication) |
 
@@ -254,6 +254,57 @@ from calling every upstream at the same instant.
 Set it to `0` to turn the timer off entirely. Model discovery then happens only
 at startup and on key edits, and you can trigger it on demand from the
 **Providers** page.
+
+---
+
+## `mcp`
+
+Declares the catalog of MCP servers Bifrost connects to. Each entry in `client_configs` is one MCP server.
+
+```json
+{
+  "mcp": {
+    "client_configs": [
+      {
+        "name": "weather",
+        "connection_type": "http",
+        "connection_string": "https://mcp.example.com/weather",
+        "auth_type": "none",
+        "tools_to_execute": ["*"]
+      }
+    ]
+  }
+}
+```
+
+Common fields on each `client_configs` entry:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Unique display name |
+| `client_id` | string | Optional stable client identifier (defaults to a generated UUID) |
+| `connection_type` | string | `"http"`, `"sse"`, or `"stdio"` |
+| `connection_string` | object/string | HTTP/SSE URL or stdio command spec |
+| `auth_type` | string | `"none"`, `"headers"`, `"oauth"`, `"per_user_oauth"`, or `"per_user_headers"` |
+| `tools_to_execute` | array | Allow-list of tool names; `["*"]` for all |
+| `tools_to_auto_execute` | array | Subset of `tools_to_execute` that runs without user confirmation |
+| `headers` | object | Static admin headers (used by `headers` and as additions on `per_user_headers`) |
+| `is_code_mode_client` | boolean | Wrap tools as Python code-mode helpers instead of raw tool calls |
+
+Auth-type-specific fields:
+
+| Field | Auth type | Description |
+|-------|-----------|-------------|
+| `oauth_config` | `oauth`, `per_user_oauth` | Optional inline OAuth provider block. The whole block can be omitted, and any inner field (`client_id`, `client_secret`, `authorize_url`, `token_url`, `registration_url`, `scopes`) can be omitted individually — RFC 8414 metadata discovery + RFC 7591 dynamic client registration fill the gaps off `connection_string` at admin-click time. |
+| `per_user_header_keys` | `per_user_headers` | Required, non-empty. Array of header names each end-user must supply. |
+
+The schema enforces these pairings: `oauth_config` is rejected on non-OAuth auth types, and `per_user_header_keys` is rejected on any auth type other than `per_user_headers` — a misplaced block fails `$schema` validation instead of being silently ignored.
+
+<Warning>
+**Migration note:** `oauth_config_id` is no longer a valid field on MCP client entries in `config.json`. Older guidance for shared OAuth suggested checking it in after completing an OAuth flow — remove it from existing config files (declare an `oauth_config` block instead, or leave the client to the dashboard). Bifrost now **ignores** the field if present (with a warning at boot): the OAuth link is managed server-side and survives restarts and config re-syncs on its own, and `$schema`-based editor/CI validation rejects the field.
+</Warning>
+
+Clients declared with `auth_type` in `{oauth, per_user_oauth, per_user_headers}` boot into a **`pending_verification`** state. The MCP Gateway UI surfaces an **Authorize** / **Verify** CTA on each pending row; one admin click runs the same verification flow the Web UI Create form uses, after which the client transitions to `connected`. The same steps are scriptable via `POST /api/mcp/client/{id}/initiate-verification` (OAuth types) and `POST /api/mcp/client/{id}/verify-headers` (per-user headers). Verified state is server-side and survives restarts and config re-syncs. Immutable fields (`auth_type`, `connection_type`, `connection_string`, `stdio_config`, `oauth_config`) cannot be changed after creation — file edits to them are ignored with a boot warning naming the fields, matching the update API; delete and re-declare the client to change them. See [MCP Auth](/mcp/auth/overview).
 
 ---
 

--- a/docs/mcp/auth/oauth.mdx
+++ b/docs/mcp/auth/oauth.mdx
@@ -100,20 +100,31 @@ Response:
   "oauth_config_id": "oauth_cfg_abc123",
   "authorize_url": "https://auth.example.com/oauth/authorize?client_id=…&state=…",
   "expires_at": "2026-05-30T12:30:00Z",
-  "mcp_client_id": "mcp_client_abc123"
+  "mcp_client_id": "mcp_client_abc123",
+  "complete_url": "/api/mcp/client/oauth_cfg_abc123/complete-oauth",
+  "status_url": "/api/oauth/config/oauth_cfg_abc123/status",
+  "next_steps": [
+    "1. Open authorize_url in a browser to approve access",
+    "2. Poll status_url to check when status becomes 'authorized'",
+    "3. POST complete_url to activate the MCP client"
+  ]
 }
 ```
 
-Redirect the admin to `authorize_url`. After they authorize, the upstream redirects to `/api/oauth/callback`, Bifrost exchanges the code for tokens, and you finalize the client:
+Redirect the admin to `authorize_url`. After they authorize, the upstream redirects to `/api/oauth/callback`, Bifrost exchanges the code for tokens, and you finalize the client by POSTing `complete_url`:
 
 ```bash
-curl -X POST http://localhost:8080/api/mcp/client/mcp_client_abc123/complete-oauth
+curl -X POST http://localhost:8080/api/mcp/client/oauth_cfg_abc123/complete-oauth
 ```
+
+<Note>
+The path parameter of `complete-oauth` is the **`oauth_config_id`** from the response above — not the MCP client ID. Poll `status_url` until it reports `"authorized"` before calling it.
+</Note>
 
 </Tab>
 <Tab title="config.json">
 
-OAuth-based MCP clients are configured through the dashboard or API rather than file-based config, because the create call returns `pending_oauth` and needs an interactive authorize step. If you want a fully declarative setup, run the create + complete-oauth dance once via API, then check the resulting `oauth_config_id` into your config:
+Declare the client with an inline `oauth_config` block:
 
 ```json
 {
@@ -124,7 +135,11 @@ OAuth-based MCP clients are configured through the dashboard or API rather than 
         "connection_type": "http",
         "connection_string": "https://api.example.com/mcp",
         "auth_type": "oauth",
-        "oauth_config_id": "oauth_cfg_abc123",
+        "oauth_config": {
+          "client_id": "your-client-id",
+          "client_secret": "your-client-secret",
+          "scopes": ["mcp:read"]
+        },
         "tools_to_execute": ["*"]
       }
     ]
@@ -132,7 +147,15 @@ OAuth-based MCP clients are configured through the dashboard or API rather than 
 }
 ```
 
-The OAuth credentials themselves live in the encrypted `oauth_configs` table — they are not represented in `config.json`. Rotate them through the dashboard or API; see [Token management](#token-management).
+The `oauth_config` block itself is optional, and every inner field is optional. `authorize_url` / `token_url` come from RFC 8414 discovery off `connection_string` when the upstream supports it, and `client_id` / `client_secret` can be obtained via RFC 7591 Dynamic Client Registration. The minimum viable declaration is `{ "auth_type": "oauth", "connection_string": "..." }`.
+
+At boot the client lands in **`pending_verification`** state because the OAuth flow still needs a live admin browser session to complete. From the MCP Gateway UI, open the client and click **Authorize** — the same browser popup the Web UI Create flow uses. On success the OAuth tokens are stored, the tool list is discovered, and the client transitions to `connected`.
+
+The same flow is scriptable: `POST /api/mcp/client/{id}/initiate-verification` (this time `{id}` *is* the MCP client ID) returns the same `authorize_url` / `status_url` / `complete_url` payload as the create flow above — open `authorize_url` in a browser, poll `status_url`, then POST `complete_url`. Safe to call again if a previous attempt expired or was abandoned.
+
+Once authorized, the OAuth credentials live in the encrypted `oauth_configs` table and the `pending_oauth_config_json` stash is cleared from the row; see [Token management](#token-management).
+
+**Lifecycle across restarts and config edits:** the authorized state is server-side and survives restarts and config.json re-syncs. Mutable fields (tool lists, headers, pricing, etc.) can be edited freely in config.json. Immutable fields — `auth_type`, `connection_type`, `connection_string`, `stdio_config`, and the `oauth_config` block — cannot be changed after creation: file edits to them are **ignored**, matching the update API (which does not accept them), and Bifrost logs a warning naming the ignored fields at the next boot. To change any of them, delete the client, update the file entry, and restart (see [Rotation](#token-management)).
 
 </Tab>
 </Tabs>
@@ -241,7 +264,7 @@ Background refresh only runs while the MCP client is enabled. Disabling a client
 
 ### Rotation
 
-The MCP client edit flow lets you rotate `client_id` / `client_secret` while preserving the same client ID. `connection_type`, `auth_type`, and `connection_string` are immutable after creation.
+Editing `oauth_config` after setup is not currently supported — the edit flow rejects it (`connection_type`, `auth_type`, and `connection_string` are likewise immutable after creation). To change OAuth credentials, scopes, or endpoints: delete the client and recreate it (UI or API). For a config.json-declared client, delete it from the dashboard, update the `oauth_config` block in the file, and restart — the client re-enters `pending_verification` and can be authorized with the new options.
 
 ### Revoke
 
@@ -367,7 +390,8 @@ You changed Bifrost's public URL after the upstream client was registered. Clear
 | Endpoint                                         | Method | Purpose                                                                |
 | ------------------------------------------------ | ------ | ---------------------------------------------------------------------- |
 | `/api/mcp/client`                                | POST   | Create MCP client; returns `pending_oauth` + `authorize_url`           |
-| `/api/mcp/client/{id}/complete-oauth`            | POST   | Finalize after upstream redirect lands on `/api/oauth/callback`        |
+| `/api/mcp/client/{id}/initiate-verification`     | POST   | Start authorization for a `pending_verification` client declared in config.json (`{id}` = MCP client ID); returns `authorize_url` + `status_url` + `complete_url` |
+| `/api/mcp/client/{id}/complete-oauth`            | POST   | Finalize after upstream redirect lands on `/api/oauth/callback` (`{id}` = `oauth_config_id`) |
 | `/api/oauth/callback`                            | GET    | Upstream provider redirects here; handled internally                   |
 | `/api/oauth/config/{oauth_config_id}/status`     | GET    | Current OAuth config status + token metadata                           |
 | `/api/oauth/config/{oauth_config_id}`            | DELETE | Revoke token + remove OAuth config                                     |

--- a/docs/mcp/auth/overview.mdx
+++ b/docs/mcp/auth/overview.mdx
@@ -50,7 +50,10 @@ Per-user auth applies to the **HTTP** and **SSE** connection types. STDIO connec
 
 Per-user auth requires every request to carry an identity. See [Identity modes](#identity-modes) below.
 
-Connection-state semantics (`connected`, `disconnected`, `error`, `needs_reauth`, etc., shown on the MCP client list) describe a persistent upstream connection, so they only apply to server-level clients. Per-user clients are stateless by design: each tool call resolves and uses the caller's credential on its own, with nothing held open between calls, so the dashboard links a per-user client to its [MCP Sessions](../sessions) rows instead of showing a connection state for it.
+Connection-state semantics (`connected`, `disconnected`, `error`, shown on the MCP client list) describe a persistent upstream connection, so they only apply to server-level clients. Per-user clients are stateless by design: each tool call resolves and uses the caller's credential on its own, with nothing held open between calls, so the dashboard links a per-user client to its [MCP Sessions](../sessions) rows instead of showing a connection state for it. Two lifecycle states are the exception and appear for every auth type:
+
+- **`pending_verification`**: all five auth types, including `oauth`, `per_user_oauth`, and `per_user_headers`, can be declared in `config.json`, and the three that need an admin verification step (the two OAuth variants plus `per_user_headers`) land in this state at boot. The MCP Gateway UI surfaces an **Authorize** / **Verify** CTA on each pending row that runs the same verification flow the Web UI Create form uses. See each auth type's page for the `config.json` shape.
+- **`needs_reauth`**: on a server-level client, the connection credential itself died and must be reauthorized. On a per-user client, it means the admin credential Bifrost retains to refresh the server's tool list needs repair; end-user credentials and tool calls keep working, only tool-list refresh pauses until an admin repairs it from the client sheet.
 
 ---
 

--- a/docs/mcp/auth/per-user-headers.mdx
+++ b/docs/mcp/auth/per-user-headers.mdx
@@ -115,9 +115,46 @@ If the verify fails, the call returns `422 Unprocessable Entity` with the upstre
 </Tab>
 <Tab title="config.json">
 
-File-based config is **not supported** for `per_user_headers`. Bifrost needs to run the one-time upstream verify with the admin's sample values during create, which can only happen via an interactive admin step (Web UI or API).
+Declare the client with `auth_type: "per_user_headers"` and the required header-name schema. The admin's sample values aren't included in config.json — they're collected by the UI when verification runs.
 
-If you want a declarative-ish setup, run the API create once with your sample values, then check the resulting `mcp_client_id` into your config to reference it from other parts of the system. The MCP client itself stays in Bifrost's database.
+```json
+{
+  "mcp": {
+    "client_configs": [
+      {
+        "name": "acme_api",
+        "connection_type": "http",
+        "connection_string": "https://api.acme.example.com/mcp",
+        "auth_type": "per_user_headers",
+        "per_user_header_keys": ["X-API-Key", "X-Tenant-ID"],
+        "headers": {
+          "X-Region": "us-east-1"
+        },
+        "tools_to_execute": ["*"]
+      }
+    ]
+  }
+}
+```
+
+At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost opens the same sample-values dialog the Web UI Create flow uses. Submit values, the upstream verify runs, tools are discovered, the credentials are discarded, and the client transitions to `connected`.
+
+The same step is scriptable — no browser involved:
+
+```bash
+curl -X POST http://localhost:8080/api/mcp/client/{id}/verify-headers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_headers": {
+      "X-API-Key": "sample-admin-key",
+      "X-Tenant-ID": "verification-tenant"
+    }
+  }'
+```
+
+`user_headers` must cover every declared key. On success the response carries `tools_count` and the client transitions to `connected`; a `422` means the upstream verify failed (retry with different values); a `409` means the client was already verified — delete and recreate it to re-verify.
+
+**Lifecycle across restarts and config edits:** the verified state (discovered tools) is server-side and survives restarts and config.json re-syncs, including edits to `per_user_header_keys` — new keys apply to end-user submissions without re-verification. The key list cannot be *emptied*, though: an edit that removes all keys is ignored and the stored keys kept (with a warning at boot). Immutable fields — `auth_type`, `connection_type`, `connection_string`, `stdio_config` — cannot be changed after creation: file edits to them are ignored with a boot warning, matching the update API. Delete the client and re-declare it to change them.
 
 </Tab>
 </Tabs>
@@ -229,7 +266,7 @@ From the sessions table the user can **Edit values** (mints a fresh submission f
   "auth_type": "per_user_headers",
   "per_user_header_keys": ["X-API-Key", "X-Tenant-ID"],
   "headers": {
-    "X-Region": { "value": "us-east-1" }
+    "X-Region": "us-east-1"
   },
   "tools_to_execute": ["*"]
 }

--- a/docs/mcp/auth/per-user-oauth.mdx
+++ b/docs/mcp/auth/per-user-oauth.mdx
@@ -30,7 +30,9 @@ This is separate from Bifrost acting as an OAuth 2.1 Authorization Server *for i
 
 ## Setup
 
-Per-user OAuth is configured through the **Web UI** only. During setup Bifrost runs a test OAuth flow as the admin and pre-fetches the tool list from the upstream service — that's why file-based config is not supported for this auth type. (Once the MCP client is persisted, the admin's temp token is discarded; per-user tokens are minted lazily by end-users.)
+Per-user OAuth needs a one-time admin test login so Bifrost can verify the OAuth configuration and discover the tool list from the upstream service. The admin's temp token is discarded after verification; per-user tokens are minted lazily by end-users at runtime.
+
+You can run the admin verification either from the **Web UI** during create, or from a `config.json`-declared client by clicking **Verify** in the UI after Bifrost boots.
 
 <Tabs>
 <Tab title="Web UI">
@@ -51,6 +53,40 @@ Per-user OAuth is configured through the **Web UI** only. During setup Bifrost r
 <Frame>
   <img src="/media/ui-mcp-per-user-oauth-setup.png" alt="MCP client form with Auth Type set to Per-User OAuth 2.0 and the OAuth fields ready for setup" />
 </Frame>
+
+</Tab>
+
+<Tab title="config.json">
+
+Declare the client with an inline `oauth_config` block:
+
+```json
+{
+  "mcp": {
+    "client_configs": [
+      {
+        "name": "notion",
+        "connection_type": "http",
+        "connection_string": "https://mcp.notion.so/sse",
+        "auth_type": "per_user_oauth",
+        "oauth_config": {
+          "client_id": "your-client-id",
+          "scopes": ["read_user", "read_database"]
+        },
+        "tools_to_execute": ["*"]
+      }
+    ]
+  }
+}
+```
+
+The `oauth_config` block itself is optional, and every inner field is optional. `authorize_url` / `token_url` come from RFC 8414 discovery off `connection_string` when the upstream supports it, and `client_id` / `client_secret` can be obtained via RFC 7591 Dynamic Client Registration. The minimum viable declaration is `{ "auth_type": "per_user_oauth", "connection_string": "..." }`.
+
+At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost runs the same admin test login popup the Web UI flow uses. On success the client transitions to `connected` with the tool list discovered, and the admin's temp token is discarded.
+
+The same flow is scriptable: `POST /api/mcp/client/{id}/initiate-verification` (`{id}` = MCP client ID) returns `authorize_url` plus `status_url` / `complete_url` hints — open `authorize_url` in a browser for the one-time admin login, poll `status_url` until `authorized`, then POST `complete_url` to run verification and tool discovery.
+
+**Lifecycle across restarts and config edits:** the verified state (`oauth_config_id` + discovered tools) is server-side and survives restarts and config.json re-syncs. Mutable fields (tool lists, headers, pricing, etc.) can be edited freely in config.json. Immutable fields — `auth_type`, `connection_type`, `connection_string`, `stdio_config`, and the `oauth_config` block — cannot be changed after creation: file edits to them are **ignored**, matching the update API, and Bifrost logs a warning naming the ignored fields at the next boot. To change any of them, delete the client, update the block, and restart (the recreated client re-enters `pending_verification`).
 
 </Tab>
 </Tabs>
@@ -139,7 +175,7 @@ Tokens are stored against an **identity**, not against a gateway. As long as the
 
 ## Configuration reference
 
-Once an MCP client is created via the Web UI, its `auth_type` is `per_user_oauth` with an `oauth_config_id` linking to the OAuth credentials Bifrost stored. You'll see this shape in API responses:
+After an MCP client is verified (via Web UI Create or via the `config.json` bootstrap flow), its `auth_type` is `per_user_oauth` with an `oauth_config_id` linking to the OAuth credentials Bifrost stored. You'll see this shape in API responses:
 
 ```json
 {
@@ -152,10 +188,10 @@ Once an MCP client is created via the Web UI, its `auth_type` is `per_user_oauth
 }
 ```
 
-| Field             | Type   | Notes                                                                  |
-| ----------------- | ------ | ---------------------------------------------------------------------- |
-| `auth_type`       | string | `"per_user_oauth"`                                                     |
-| `oauth_config_id` | string | ID of the OAuth credentials row (set automatically by Web UI setup)   |
+| Field             | Type   | Notes                                                                                       |
+| ----------------- | ------ | ------------------------------------------------------------------------------------------- |
+| `auth_type`       | string | `"per_user_oauth"`                                                                          |
+| `oauth_config_id` | string | ID of the OAuth credentials row. Set automatically when admin verification completes; not a `config.json` input. |
 
 <Note>
 MCP client names cannot contain hyphens — Bifrost prefixes tools as `<client>-<tool>` and uses the hyphen to split the two halves at execution time.

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -251,6 +251,53 @@ Configure MCP clients in your `config.json`:
 Use `env.VARIABLE_NAME` syntax to reference environment variables for sensitive values like URLs with API keys.
 </Note>
 
+#### Auth-aware clients in `config.json`
+
+All five auth types can be declared in `config.json`. The three that need an admin verification step (`oauth`, `per_user_oauth`, `per_user_headers`) boot into a **`pending_verification`** runtime state and surface an admin CTA in the MCP Gateway UI:
+
+```json
+{
+  "mcp": {
+    "client_configs": [
+      {
+        "name": "google-drive-shared",
+        "connection_type": "http",
+        "connection_string": "https://mcp.google.com/drive",
+        "auth_type": "oauth",
+        "oauth_config": {
+          "client_id": "your-client-id",
+          "client_secret": "your-client-secret",
+          "scopes": ["drive.readonly"]
+        },
+        "tools_to_execute": ["*"]
+      },
+      {
+        "name": "github-per-user",
+        "connection_type": "http",
+        "connection_string": "https://mcp.github.com/v1",
+        "auth_type": "per_user_oauth",
+        "oauth_config": { "scopes": ["repo"] },
+        "tools_to_execute": ["*"]
+      },
+      {
+        "name": "internal-api",
+        "connection_type": "http",
+        "connection_string": "https://api.internal.example.com/mcp",
+        "auth_type": "per_user_headers",
+        "per_user_header_keys": ["authorization", "x-tenant-id"],
+        "tools_to_execute": ["*"]
+      }
+    ]
+  }
+}
+```
+
+For `oauth` / `per_user_oauth`, the `oauth_config` block is optional and each inner field is optional — RFC 8414 discovery and RFC 7591 dynamic client registration fill the gaps off `connection_string` at admin-click time. See [MCP Auth](/mcp/auth/overview) for the per-auth-type details and the post-boot verification UX.
+
+<Note>
+Deleting a config.json-declared client from the dashboard is temporary: the file entry recreates it at the next restart (freshly, in `pending_verification` for auth types that need verification). For a permanent delete, remove the entry from `config.json` as well.
+</Note>
+
 </Tab>
 </Tabs>
 
@@ -655,6 +702,7 @@ response, err := client.ChatCompletionRequest(bifrostCtx, request)
 | `connected` | Client is active and tools are available |
 | `connecting` | Client is establishing connection |
 | `disconnected` | Client lost connection but can be reconnected |
+| `pending_verification` | Declared (typically via config.json) with an auth type that needs a one-time admin step — complete it via the UI's Authorize/Verify button, `POST /api/mcp/client/{id}/initiate-verification` (OAuth types), or `POST /api/mcp/client/{id}/verify-headers` (per-user headers) |
 | `error` | Client configuration or connection failed |
 
 ### Managing Clients at Runtime
@@ -666,6 +714,10 @@ response, err := client.ChatCompletionRequest(bifrostCtx, request)
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client/{id}/reconnect
 ```
+
+<Note>
+Reconnect returns `400` for per-user auth clients (no shared upstream connection to re-establish) and for clients in `pending_verification` — complete the admin verification instead.
+</Note>
 
 **Edit client configuration:**
 ```bash
@@ -887,7 +939,7 @@ You can also trigger manual reconnection at any time:
 curl -X POST http://localhost:8080/api/mcp/client/{id}/reconnect
 ```
 
-Manual reconnection also uses the retry logic for robustness.
+Manual reconnection also uses the retry logic for robustness. Not applicable (`400`) to per-user auth clients — each user's connection is managed per request — or to clients in `pending_verification`, which need the one-time admin verification instead.
 
 </Tab>
 <Tab title="Go SDK">

--- a/examples/configs/withmcpbootstrapauth/config.json
+++ b/examples/configs/withmcpbootstrapauth/config.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://www.getbifrost.ai/schema",
+  "client": {
+    "allowed_origins": ["*"],
+    "enable_logging": true,
+    "initial_pool_size": 300
+  },
+  "config_store": {
+    "enabled": true,
+    "type": "sqlite",
+    "config": {
+      "path": "./data/bifrost.db"
+    }
+  },
+  "mcp": {
+    "client_configs": [
+      {
+        "name": "GoogleDriveShared",
+        "connection_type": "http",
+        "client_id": "gdrive-shared-oauth",
+        "connection_string": "https://mcp.google.com/drive",
+        "auth_type": "oauth",
+        "oauth_config": {
+          "client_id": "your-google-oauth-client-id",
+          "client_secret": "your-google-oauth-client-secret",
+          "scopes": ["https://www.googleapis.com/auth/drive.readonly"]
+        },
+        "tools_to_execute": ["*"]
+      },
+      {
+        "name": "GitHubPerUser",
+        "connection_type": "http",
+        "client_id": "github-per-user-oauth",
+        "connection_string": "https://mcp.github.com/v1",
+        "auth_type": "per_user_oauth",
+        "oauth_config": {
+          "scopes": ["repo", "read:user"]
+        },
+        "tools_to_execute": ["*"]
+      },
+      {
+        "name": "InternalAPIPerUser",
+        "connection_type": "http",
+        "client_id": "internal-api-per-user-headers",
+        "connection_string": "https://mcp.internal.example.com",
+        "auth_type": "per_user_headers",
+        "per_user_header_keys": ["authorization", "x-tenant-id"],
+        "tools_to_execute": ["*"]
+      }
+    ]
+  }
+}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4842,21 +4842,53 @@
           ],
           "description": "Authentication type for MCP connection"
         },
-        "oauth_config_id": {
-          "type": "string",
-          "description": "OAuth config ID reference (required when auth_type is 'oauth' or 'per_user_oauth')"
+        "oauth_config": {
+          "type": "object",
+          "description": "Inline OAuth provider configuration for auth_type 'oauth' or 'per_user_oauth'. All inner fields are optional — missing URLs are resolved via RFC 8414 discovery and a missing client_id triggers RFC 7591 dynamic client registration at admin-click time. The client lands in `pending_verification` state at boot; an admin runs the verification flow once from the MCP Gateway UI.",
+          "properties": {
+            "client_id": {
+              "type": "string",
+              "description": "OAuth client ID (optional — Dynamic Client Registration is used when omitted)"
+            },
+            "client_secret": {
+              "type": "string",
+              "description": "OAuth client secret (optional — omit for PKCE public clients or DCR)"
+            },
+            "authorize_url": {
+              "type": "string",
+              "description": "Provider authorize endpoint (optional — discovered from the MCP server URL when omitted)"
+            },
+            "token_url": {
+              "type": "string",
+              "description": "Provider token endpoint (optional — discovered when omitted)"
+            },
+            "registration_url": {
+              "type": "string",
+              "description": "Dynamic Client Registration endpoint (optional — discovered when omitted)"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "OAuth scopes to request"
+            }
+          },
+          "additionalProperties": false
+        },
+        "per_user_header_keys": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "description": "Required header names each end-user must supply when auth_type is 'per_user_headers'. Schema only — values are submitted per-user at runtime. The MCP client lands in `pending_verification` state at boot; an admin submits sample values once from the UI to verify the connection and discover tools."
         },
         "headers": {
           "type": "object",
           "description": "Headers to send with the request (for headers auth type)",
           "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "per_user_header_keys": {
-          "type": "array",
-          "description": "Header names each caller must supply when auth_type is 'per_user_headers'. Required (non-empty) for that auth type.",
-          "items": {
             "type": "string"
           }
         },
@@ -4972,17 +5004,58 @@
       },
       "required": ["name", "connection_type"],
       "additionalProperties": false,
-      "if": {
-        "properties": {
-          "auth_type": {
-            "enum": ["oauth", "per_user_oauth"]
+      "allOf": [
+        {
+          "$comment": "per_user_headers requires the admin to declare which header names users must submit. OAuth-based types have no required input — the connection_string drives RFC 8414 discovery + RFC 7591 dynamic client registration when oauth_config is omitted or its inner fields are blank.",
+          "if": {
+            "properties": {
+              "auth_type": {
+                "const": "per_user_headers"
+              }
+            },
+            "required": ["auth_type"]
+          },
+          "then": {
+            "required": ["per_user_header_keys"]
           }
         },
-        "required": ["auth_type"]
-      },
-      "then": {
-        "required": ["oauth_config_id"]
-      },
+        {
+          "$comment": "oauth_config only applies to OAuth-based auth types; forbid it elsewhere (including entries that omit auth_type, which defaults to headers) so a misplaced block fails validation instead of being silently ignored.",
+          "if": {
+            "not": {
+              "properties": {
+                "auth_type": {
+                  "enum": ["oauth", "per_user_oauth"]
+                }
+              },
+              "required": ["auth_type"]
+            }
+          },
+          "then": {
+            "not": {
+              "required": ["oauth_config"]
+            }
+          }
+        },
+        {
+          "$comment": "per_user_header_keys only applies to auth_type 'per_user_headers'; forbid it elsewhere so a misplaced declaration fails validation instead of being silently ignored.",
+          "if": {
+            "not": {
+              "properties": {
+                "auth_type": {
+                  "const": "per_user_headers"
+                }
+              },
+              "required": ["auth_type"]
+            }
+          },
+          "then": {
+            "not": {
+              "required": ["per_user_header_keys"]
+            }
+          }
+        }
+      ],
       "oneOf": [
         {
           "properties": {


### PR DESCRIPTION
## Summary

All five MCP auth types (`none`, `headers`, `oauth`, `per_user_oauth`, `per_user_headers`) can now be declared directly in `config.json`. Previously, OAuth-based and per-user auth types required interactive setup through the Web UI or API because there was no supported file-based path. This change introduces a bootstrap flow: clients declared with auth types that require an admin verification step (`oauth`, `per_user_oauth`, `per_user_headers`) boot into a `pending_verification` state, and the MCP Gateway UI surfaces an **Authorize** / **Verify** CTA that runs the same verification flow as the Web UI Create form.

## Changes

- Replaced `oauth_config_id` (a post-creation reference) with an inline `oauth_config` object in the JSON schema, making all OAuth fields optional — RFC 8414 metadata discovery and RFC 7591 Dynamic Client Registration fill gaps from `connection_string` at admin-click time.
- Added `per_user_headers` to the `auth_type` enum in the schema and introduced `per_user_header_keys` as a required field when that auth type is used.
- Replaced the single `if/then` schema constraint (which required `oauth_config_id` for OAuth types) with an `allOf` block that instead requires `per_user_header_keys` when `auth_type` is `per_user_headers`.
- Added a new example config (`examples/configs/withmcpbootstrapauth/config.json`) demonstrating all three auth-aware client types in a single file.
- Updated the `mcp` section of the schema reference with a full field table, auth-type-specific fields, and an explanation of the `pending_verification` boot state.
- Updated the OAuth, per-user OAuth, and per-user headers auth docs to document the `config.json` declaration path and the post-boot verification UX, replacing prior guidance that stated file-based config was unsupported for those auth types.
- Added a `config.json` tab to the per-user OAuth setup section, which previously only had a Web UI tab.
- Added an info callout to the auth overview page explaining the `pending_verification` state and the admin CTA for all three auth types that require it.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Declare an MCP client with `auth_type: "oauth"` or `auth_type: "per_user_headers"` in `config.json` using the new `oauth_config` / `per_user_header_keys` fields.
2. Boot Bifrost and confirm the client appears in the MCP Gateway UI with a `pending_verification` status and an **Authorize** / **Verify** CTA.
3. Click the CTA and complete the verification flow; confirm the client transitions to `connected` and the tool list is discovered.
4. Validate the JSON schema rejects a `per_user_headers` client missing `per_user_header_keys` and accepts an `oauth` client with an empty or omitted `oauth_config` block.

## Breaking changes

- [x] Yes
- [ ] No

`oauth_config_id` is removed from the `config.json` schema in favor of the inline `oauth_config` object. Any existing `config.json` files that reference `oauth_config_id` directly will fail schema validation. The field continues to appear in API responses (it is set automatically after admin verification completes) but is no longer a valid `config.json` input.

## Related issues

## Security considerations

Inline `oauth_config` blocks in `config.json` may contain `client_secret` in plaintext. Operators should use `env.VARIABLE_NAME` substitution for secrets rather than hardcoding them. The admin's temporary OAuth token used during verification is discarded immediately after the flow completes; per-user tokens are minted lazily at runtime and stored against user identities, not in config.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable