### PR TITLE
fixes missing parameter parsing on compat flow

### DIFF
--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -518,6 +518,24 @@ func convertMCPToolToBifrostSchema(mcpTool *mcp.Tool, logger schemas.Logger) sch
 		properties = schemas.NewOrderedMap()
 	}
 
+	// Preserve JSON Schema definitions ($defs). The MCP SDK already folds legacy
+	// "definitions" into Defs on unmarshal, so we only need to handle Defs here.
+	// Without this, any $ref pointing at #/$defs/... rides along inside Properties
+	// while the definitions it targets are dropped, leaving a dangling $ref that
+	// providers reject (e.g. Vertex Gemini returns INVALID_ARGUMENT).
+	var defs *schemas.OrderedMap
+	if len(mcpTool.InputSchema.Defs) > 0 {
+		// Normalize array schemas inside each definition, mirroring the fix applied
+		// to Properties above.
+		FixArraySchemas(mcpTool.InputSchema.Defs, logger)
+
+		orderedDefs := schemas.NewOrderedMapWithCapacity(len(mcpTool.InputSchema.Defs))
+		for k, v := range mcpTool.InputSchema.Defs {
+			orderedDefs.Set(k, v)
+		}
+		defs = orderedDefs
+	}
+
 	// Preserve MCP tool annotations if any are set.
 	// Clone bool pointers so Bifrost's copy is independent of the upstream mcp.Tool lifetime.
 	var annotations *schemas.MCPToolAnnotations
@@ -548,6 +566,7 @@ func convertMCPToolToBifrostSchema(mcpTool *mcp.Tool, logger schemas.Logger) sch
 				Type:       mcpTool.InputSchema.Type,
 				Properties: properties,
 				Required:   mcpTool.InputSchema.Required,
+				Defs:       defs,
 			},
 		},
 		Annotations: annotations,

--- a/core/mcp/utils_test.go
+++ b/core/mcp/utils_test.go
@@ -169,3 +169,44 @@ func TestConvertMCPToolToBifrostSchema_WithParameters(t *testing.T) {
 		t.Errorf("Expected required field 'param1', got '%s'", bifrostTool.Function.Parameters.Required[0])
 	}
 }
+
+// TestConvertMCPToolToBifrostSchema_PreservesDefs verifies that top-level JSON
+// Schema definitions ($defs) on an MCP tool's input schema survive conversion.
+// Without this, a $ref inside a property (which rides along in Properties) would
+// be left dangling once the definitions it targets are dropped — the cause of
+// Vertex Gemini rejecting such tools with INVALID_ARGUMENT.
+func TestConvertMCPToolToBifrostSchema_PreservesDefs(t *testing.T) {
+	mcpTool := &mcp.Tool{
+		Name:        "suggest_time",
+		Description: "Suggests time periods",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]interface{}{
+				"preferences": map[string]interface{}{
+					"$ref": "#/$defs/Preferences",
+				},
+			},
+			Required: []string{"preferences"},
+			Defs: map[string]interface{}{
+				"Preferences": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"startHour": map[string]interface{}{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+
+	bifrostTool := convertMCPToolToBifrostSchema(mcpTool, defaultLogger)
+	require.NotNil(t, bifrostTool.Function)
+	require.NotNil(t, bifrostTool.Function.Parameters)
+	require.NotNil(t, bifrostTool.Function.Parameters.Defs, "$defs must be preserved on conversion")
+
+	data, err := json.Marshal(bifrostTool.Function.Parameters)
+	require.NoError(t, err)
+	s := string(data)
+	assert.Contains(t, s, `"$defs"`, "marshalled schema must carry $defs")
+	assert.Contains(t, s, "Preferences", "definition name must be present")
+	assert.Contains(t, s, `"$ref"`, "the property $ref must still be present (resolution happens per-provider)")
+}

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -25,32 +25,7 @@ func convertFunctionToolToAnthropic(tool schemas.ChatTool) AnthropicTool {
 
 	// Convert function parameters to input_schema
 	if tool.Function.Parameters != nil && (tool.Function.Parameters.Type != "" || tool.Function.Parameters.Properties != nil) {
-		anthropicTool.InputSchema = &schemas.ToolFunctionParameters{
-			Type:                 tool.Function.Parameters.Type,
-			Description:          tool.Function.Parameters.Description,
-			Properties:           tool.Function.Parameters.Properties,
-			Required:             tool.Function.Parameters.Required,
-			Enum:                 tool.Function.Parameters.Enum,
-			AdditionalProperties: tool.Function.Parameters.AdditionalProperties,
-			Defs:                 tool.Function.Parameters.Defs,
-			Definitions:          tool.Function.Parameters.Definitions,
-			Ref:                  tool.Function.Parameters.Ref,
-			Items:                tool.Function.Parameters.Items,
-			MinItems:             tool.Function.Parameters.MinItems,
-			MaxItems:             tool.Function.Parameters.MaxItems,
-			AnyOf:                tool.Function.Parameters.AnyOf,
-			OneOf:                tool.Function.Parameters.OneOf,
-			AllOf:                tool.Function.Parameters.AllOf,
-			Format:               tool.Function.Parameters.Format,
-			Pattern:              tool.Function.Parameters.Pattern,
-			MinLength:            tool.Function.Parameters.MinLength,
-			MaxLength:            tool.Function.Parameters.MaxLength,
-			Minimum:              tool.Function.Parameters.Minimum,
-			Maximum:              tool.Function.Parameters.Maximum,
-			Title:                tool.Function.Parameters.Title,
-			Default:              tool.Function.Parameters.Default,
-			Nullable:             tool.Function.Parameters.Nullable,
-		}
+		anthropicTool.InputSchema = schemas.DeepCopyToolFunctionParameters(tool.Function.Parameters)
 	}
 
 	if anthropicTool.InputSchema != nil {

--- a/core/providers/gemini/uniontype_test.go
+++ b/core/providers/gemini/uniontype_test.go
@@ -347,3 +347,23 @@ func TestConvertBifrostToolsToGemini_WirePayload(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertBifrostToolsToGemini_WirePayloadPreservesDefs(t *testing.T) {
+	toolJSON := `{"type":"function","function":{"name":"suggest_time","parameters":{"type":"object","properties":{"attendeeEmails":{"type":"array","items":{"type":"string"},"description":"The attendee emails to find free time for."},"preferences":{"$ref":"#/$defs/Preferences"}},"required":["attendeeEmails"],"$defs":{"Preferences":{"type":"object","properties":{"startHour":{"type":"string"}}}}}}}`
+
+	var chatTool schemas.ChatTool
+	require.NoError(t, json.Unmarshal([]byte(toolJSON), &chatTool))
+
+	copied := schemas.DeepCopyChatTool(chatTool)
+	geminiTools, err := convertBifrostToolsToGemini([]schemas.ChatTool{copied})
+	require.NoError(t, err)
+	require.Len(t, geminiTools, 1)
+
+	wire, err := providerUtils.MarshalSorted(geminiTools[0])
+	require.NoError(t, err)
+	wireStr := string(wire)
+
+	assert.Contains(t, wireStr, `"$defs"`)
+	assert.Contains(t, wireStr, `"Preferences"`)
+	assert.Contains(t, wireStr, `"$ref":"#/$defs/Preferences"`)
+}

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -843,11 +843,11 @@ func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
 			Type:     ChatToolTypeFunction,
 			Function: &ChatToolFunction{Name: "get_weather"},
 			// Mixed state: server-tool + custom fields also populated.
-			Custom:        &ChatToolCustom{},
-			Name:          "leaked_name",
-			MaxUses:       Ptr(5),
+			Custom:         &ChatToolCustom{},
+			Name:           "leaked_name",
+			MaxUses:        Ptr(5),
 			DisplayWidthPx: Ptr(1280),
-			MCPServerName: "leaked_server",
+			MCPServerName:  "leaked_server",
 		}
 		data, err := Marshal(tool)
 		require.NoError(t, err)
@@ -874,8 +874,8 @@ func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
 		raw := string(data)
 
 		assert.Contains(t, raw, `"type":"custom"`)
-		assert.Contains(t, raw, `"my_custom"`)    // custom tool retains top-level Name
-		assert.Contains(t, raw, `"format"`)       // custom's format field
+		assert.Contains(t, raw, `"my_custom"`) // custom tool retains top-level Name
+		assert.Contains(t, raw, `"format"`)    // custom's format field
 		assert.NotContains(t, raw, `"function"`)
 		assert.NotContains(t, raw, `"should_be_stripped"`)
 		assert.NotContains(t, raw, `"max_uses"`)
@@ -883,9 +883,9 @@ func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
 
 	t.Run("server_tool_type_clears_function_and_custom", func(t *testing.T) {
 		tool := ChatTool{
-			Type:    "web_search_20260209",
-			Name:    "web_search",
-			MaxUses: Ptr(5),
+			Type:           "web_search_20260209",
+			Name:           "web_search",
+			MaxUses:        Ptr(5),
 			AllowedCallers: []string{"direct"},
 			// Leaks
 			Function: &ChatToolFunction{Name: "should_be_stripped"},
@@ -1353,4 +1353,71 @@ func TestSonic_ChatTool_DeepCopy_NilAnnotationsStaysNil(t *testing.T) {
 	copied := DeepCopyChatTool(original)
 
 	assert.Nil(t, copied.Annotations, "Annotations should stay nil when original has none")
+}
+
+func TestSonic_ChatTool_DeepCopy_PreservesFullParameterSchema(t *testing.T) {
+	ref := "#/$defs/Preferences"
+	minItems := int64(1)
+	nullable := true
+	original := ChatTool{
+		Type: ChatToolTypeFunction,
+		Function: &ChatToolFunction{
+			Name: "suggest_time",
+			Parameters: &ToolFunctionParameters{
+				Type: "object",
+				Properties: NewOrderedMapFromPairs(
+					KV("preferences", NewOrderedMapFromPairs(KV("$ref", ref))),
+				),
+				Required: []string{"preferences"},
+				Defs: NewOrderedMapFromPairs(
+					KV("Preferences", NewOrderedMapFromPairs(
+						KV("type", "object"),
+						KV("properties", NewOrderedMapFromPairs(
+							KV("startHour", NewOrderedMapFromPairs(KV("type", "string"))),
+						)),
+					)),
+				),
+				Ref:      &ref,
+				Items:    NewOrderedMapFromPairs(KV("type", "string")),
+				MinItems: &minItems,
+				AnyOf: []OrderedMap{
+					*NewOrderedMapFromPairs(KV("type", "string")),
+				},
+				Nullable: &nullable,
+			},
+		},
+	}
+
+	copied := DeepCopyChatTool(original)
+
+	require.NotNil(t, copied.Function)
+	require.NotNil(t, copied.Function.Parameters)
+	data, err := Marshal(copied.Function.Parameters)
+	require.NoError(t, err)
+	s := string(data)
+	assert.Contains(t, s, `"$defs"`)
+	assert.Contains(t, s, `"Preferences"`)
+	assert.Contains(t, s, `"$ref":"#/$defs/Preferences"`)
+	assert.Contains(t, s, `"items"`)
+	assert.Contains(t, s, `"anyOf"`)
+	assert.Contains(t, s, `"nullable":true`)
+
+	copied.Function.Parameters.Defs.Set("Mutated", map[string]any{"type": "object"})
+	_, exists := original.Function.Parameters.Defs.Get("Mutated")
+	assert.False(t, exists, "copy must not share $defs map with original")
+}
+
+func TestSonic_ToolFunctionParameters_DeepCopy_KeyOrderIndependent(t *testing.T) {
+	var original ToolFunctionParameters
+	require.NoError(t, Unmarshal([]byte(`{"$defs":{"Preferences":{"type":"object"}},"type":"object","properties":{"preferences":{"$ref":"#/$defs/Preferences"}}}`), &original))
+	require.NotEmpty(t, original.keyOrder.keys)
+
+	copied := DeepCopyToolFunctionParameters(&original)
+	require.NotNil(t, copied)
+	require.Equal(t, original.keyOrder.keys, copied.keyOrder.keys)
+
+	original.keyOrder.keys[0] = "mutated"
+
+	assert.NotEqual(t, original.keyOrder.keys[0], copied.keyOrder.keys[0], "copy must not share JSONKeyOrder.keys backing array")
+	assert.Equal(t, "$defs", copied.keyOrder.keys[0])
 }

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -845,43 +845,7 @@ func DeepCopyChatTool(original ChatTool) ChatTool {
 		}
 
 		if original.Function.Parameters != nil {
-			copyParams := &ToolFunctionParameters{
-				Type:                original.Function.Parameters.Type,
-				keyOrder:            original.Function.Parameters.keyOrder,
-				explicitEmptyObject: original.Function.Parameters.explicitEmptyObject,
-			}
-
-			if original.Function.Parameters.Description != nil {
-				copyParamDesc := *original.Function.Parameters.Description
-				copyParams.Description = &copyParamDesc
-			}
-
-			if original.Function.Parameters.Required != nil {
-				copyParams.Required = make([]string, len(original.Function.Parameters.Required))
-				copy(copyParams.Required, original.Function.Parameters.Required)
-			}
-
-			if original.Function.Parameters.Properties != nil {
-				// Deep copy preserving insertion order
-				copyProps := NewOrderedMapWithCapacity(original.Function.Parameters.Properties.Len())
-				original.Function.Parameters.Properties.Range(func(k string, v interface{}) bool {
-					copyProps.Set(k, DeepCopy(v))
-					return true
-				})
-				copyParams.Properties = copyProps
-			}
-
-			if original.Function.Parameters.Enum != nil {
-				copyParams.Enum = make([]string, len(original.Function.Parameters.Enum))
-				copy(copyParams.Enum, original.Function.Parameters.Enum)
-			}
-
-			if original.Function.Parameters.AdditionalProperties != nil {
-				copyAdditionalProps := *original.Function.Parameters.AdditionalProperties
-				copyParams.AdditionalProperties = &copyAdditionalProps
-			}
-
-			copyTool.Function.Parameters = copyParams
+			copyTool.Function.Parameters = DeepCopyToolFunctionParameters(original.Function.Parameters)
 		}
 
 		if original.Function.Strict != nil {
@@ -950,6 +914,153 @@ func DeepCopyChatTool(original ChatTool) ChatTool {
 	}
 
 	return copyTool
+}
+
+// DeepCopyToolFunctionParameters creates a deep copy of ToolFunctionParameters,
+// preserving all JSON Schema fields so references and validation metadata are
+// not dropped during tool cloning.
+func DeepCopyToolFunctionParameters(original *ToolFunctionParameters) *ToolFunctionParameters {
+	if original == nil {
+		return nil
+	}
+
+	copyParams := &ToolFunctionParameters{
+		Type:                original.Type,
+		keyOrder:            JSONKeyOrder{keys: append([]string(nil), original.keyOrder.keys...)},
+		explicitEmptyObject: original.explicitEmptyObject,
+	}
+
+	if original.Description != nil {
+		copyParamDesc := *original.Description
+		copyParams.Description = &copyParamDesc
+	}
+	if original.Required != nil {
+		copyParams.Required = append([]string(nil), original.Required...)
+	}
+	if original.Properties != nil {
+		copyParams.Properties = deepCopyOrderedMap(original.Properties)
+	}
+	if original.AdditionalProperties != nil {
+		copyAdditionalProps := AdditionalPropertiesStruct{}
+		if original.AdditionalProperties.AdditionalPropertiesBool != nil {
+			b := *original.AdditionalProperties.AdditionalPropertiesBool
+			copyAdditionalProps.AdditionalPropertiesBool = &b
+		}
+		if original.AdditionalProperties.AdditionalPropertiesMap != nil {
+			copyAdditionalProps.AdditionalPropertiesMap = deepCopyOrderedMap(original.AdditionalProperties.AdditionalPropertiesMap)
+		}
+		copyParams.AdditionalProperties = &copyAdditionalProps
+	}
+	if original.Enum != nil {
+		copyParams.Enum = append([]string(nil), original.Enum...)
+	}
+	if original.Defs != nil {
+		copyParams.Defs = deepCopyOrderedMap(original.Defs)
+	}
+	if original.Definitions != nil {
+		copyParams.Definitions = deepCopyOrderedMap(original.Definitions)
+	}
+	if original.Ref != nil {
+		ref := *original.Ref
+		copyParams.Ref = &ref
+	}
+	if original.Items != nil {
+		copyParams.Items = deepCopyOrderedMap(original.Items)
+	}
+	if original.MinItems != nil {
+		minItems := *original.MinItems
+		copyParams.MinItems = &minItems
+	}
+	if original.MaxItems != nil {
+		maxItems := *original.MaxItems
+		copyParams.MaxItems = &maxItems
+	}
+	copyParams.AnyOf = deepCopyOrderedMapSlice(original.AnyOf)
+	copyParams.OneOf = deepCopyOrderedMapSlice(original.OneOf)
+	copyParams.AllOf = deepCopyOrderedMapSlice(original.AllOf)
+	if original.Format != nil {
+		format := *original.Format
+		copyParams.Format = &format
+	}
+	if original.Pattern != nil {
+		pattern := *original.Pattern
+		copyParams.Pattern = &pattern
+	}
+	if original.MinLength != nil {
+		minLength := *original.MinLength
+		copyParams.MinLength = &minLength
+	}
+	if original.MaxLength != nil {
+		maxLength := *original.MaxLength
+		copyParams.MaxLength = &maxLength
+	}
+	if original.Minimum != nil {
+		minimum := *original.Minimum
+		copyParams.Minimum = &minimum
+	}
+	if original.Maximum != nil {
+		maximum := *original.Maximum
+		copyParams.Maximum = &maximum
+	}
+	if original.Title != nil {
+		title := *original.Title
+		copyParams.Title = &title
+	}
+	copyParams.Default = DeepCopy(original.Default)
+	if original.Nullable != nil {
+		nullable := *original.Nullable
+		copyParams.Nullable = &nullable
+	}
+
+	return copyParams
+}
+
+func deepCopyOrderedMap(original *OrderedMap) *OrderedMap {
+	if original == nil {
+		return nil
+	}
+	copyMap := NewOrderedMapWithCapacity(original.Len())
+	original.Range(func(k string, v interface{}) bool {
+		copyMap.Set(k, deepCopySchemaValue(v))
+		return true
+	})
+	return copyMap
+}
+
+func deepCopyOrderedMapSlice(original []OrderedMap) []OrderedMap {
+	if original == nil {
+		return nil
+	}
+	copied := make([]OrderedMap, len(original))
+	for i := range original {
+		if copyMap := deepCopyOrderedMap(&original[i]); copyMap != nil {
+			copied[i] = *copyMap
+		}
+	}
+	return copied
+}
+
+func deepCopySchemaValue(original interface{}) interface{} {
+	switch v := original.(type) {
+	case *OrderedMap:
+		return deepCopyOrderedMap(v)
+	case OrderedMap:
+		return deepCopyOrderedMap(&v)
+	case map[string]interface{}:
+		copied := make(map[string]interface{}, len(v))
+		for key, value := range v {
+			copied[key] = deepCopySchemaValue(value)
+		}
+		return copied
+	case []interface{}:
+		copied := make([]interface{}, len(v))
+		for i, value := range v {
+			copied[i] = deepCopySchemaValue(value)
+		}
+		return copied
+	default:
+		return DeepCopy(v)
+	}
 }
 
 // DeepCopyResponsesMessage creates a deep copy of a ResponsesMessage

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -413,27 +413,7 @@ func (h *MCPServerHandler) syncServer(server *server.MCPServer, availableTools [
 			description = *tool.Function.Description
 		}
 
-		// Convert Parameters to mcp.ToolInputSchema
-		var inputSchema mcp.ToolInputSchema
-		if tool.Function.Parameters != nil {
-			inputSchema.Type = tool.Function.Parameters.Type
-			if tool.Function.Parameters.Properties != nil {
-				// Convert *map[string]interface{} to map[string]any
-				props := make(map[string]any)
-				tool.Function.Parameters.Properties.Range(func(key string, value interface{}) bool {
-					props[key] = value
-					return true
-				})
-				inputSchema.Properties = props
-			}
-			if tool.Function.Parameters.Required != nil {
-				inputSchema.Required = tool.Function.Parameters.Required
-			}
-		} else {
-			// Default to empty object schema if no parameters
-			inputSchema.Type = "object"
-			inputSchema.Properties = make(map[string]any)
-		}
+		inputSchema := convertToolFunctionParametersToMCPInputSchema(tool.Function.Parameters)
 
 		// Map Bifrost annotations back to MCP tool annotations
 		var toolAnnotation mcp.ToolAnnotation
@@ -455,6 +435,47 @@ func (h *MCPServerHandler) syncServer(server *server.MCPServer, availableTools [
 			Annotations: toolAnnotation,
 		}, handler)
 	}
+}
+
+func convertToolFunctionParametersToMCPInputSchema(params *schemas.ToolFunctionParameters) mcp.ToolInputSchema {
+	if params == nil {
+		return mcp.ToolInputSchema{
+			Type:       "object",
+			Properties: make(map[string]any),
+		}
+	}
+
+	inputSchema := mcp.ToolInputSchema{
+		Type:     params.Type,
+		Required: params.Required,
+	}
+
+	if params.Properties != nil {
+		props := make(map[string]any, params.Properties.Len())
+		params.Properties.Range(func(key string, value interface{}) bool {
+			props[key] = value
+			return true
+		})
+		inputSchema.Properties = props
+	}
+
+	if params.Defs != nil {
+		defs := make(map[string]any, params.Defs.Len())
+		params.Defs.Range(func(key string, value interface{}) bool {
+			defs[key] = value
+			return true
+		})
+		inputSchema.Defs = defs
+	} else if params.Definitions != nil {
+		defs := make(map[string]any, params.Definitions.Len())
+		params.Definitions.Range(func(key string, value interface{}) bool {
+			defs[key] = value
+			return true
+		})
+		inputSchema.Defs = defs
+	}
+
+	return inputSchema
 }
 
 // fetchToolsForVK fetches the tools for a given virtual key value.

--- a/transports/bifrost-http/handlers/mcpserver_test.go
+++ b/transports/bifrost-http/handlers/mcpserver_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToolFunctionParametersToMCPInputSchemaPreservesDefs(t *testing.T) {
+	params := &schemas.ToolFunctionParameters{
+		Type: "object",
+		Properties: schemas.NewOrderedMapFromPairs(
+			schemas.KV("preferences", map[string]any{"$ref": "#/$defs/Preferences"}),
+		),
+		Required: []string{"preferences"},
+		Defs: schemas.NewOrderedMapFromPairs(
+			schemas.KV("Preferences", map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"startHour": map[string]any{"type": "string"},
+				},
+			}),
+		),
+	}
+
+	inputSchema := convertToolFunctionParametersToMCPInputSchema(params)
+
+	require.Contains(t, inputSchema.Defs, "Preferences")
+	data, err := json.Marshal(inputSchema)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"$defs"`)
+	assert.Contains(t, string(data), `"$ref":"#/$defs/Preferences"`)
+}
+
+func TestConvertToolFunctionParametersToMCPInputSchemaPreservesLegacyDefinitionsAsDefs(t *testing.T) {
+	params := &schemas.ToolFunctionParameters{
+		Type: "object",
+		Properties: schemas.NewOrderedMapFromPairs(
+			schemas.KV("preferences", map[string]any{"$ref": "#/$defs/Preferences"}),
+		),
+		Definitions: schemas.NewOrderedMapFromPairs(
+			schemas.KV("Preferences", map[string]any{"type": "object"}),
+		),
+	}
+
+	inputSchema := convertToolFunctionParametersToMCPInputSchema(params)
+
+	require.Contains(t, inputSchema.Defs, "Preferences")
+	data, err := json.Marshal(inputSchema)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"$defs"`)
+}


### PR DESCRIPTION
## Summary

JSON Schema `$defs` (and legacy `definitions`) were being silently dropped when MCP tools were converted to Bifrost's internal schema representation and when Bifrost tools were cloned or forwarded to providers. This left `$ref` pointers inside `properties` dangling, causing providers such as Vertex Gemini to reject the tool schema with `INVALID_ARGUMENT`.

## Changes

- **MCP → Bifrost conversion** (`core/mcp/utils.go`): `$defs` from `mcp.ToolInputSchema.Defs` are now preserved and carried through to `ToolFunctionParameters.Defs`, with the same array-schema normalization applied to definitions as to properties.

- **Deep copy** (`core/schemas/utils.go`): Extracted a standalone `DeepCopyToolFunctionParameters` function that copies every JSON Schema field (`$defs`, `definitions`, `$ref`, `items`, `minItems`, `maxItems`, `anyOf`, `oneOf`, `allOf`, `format`, `pattern`, `minLength`, `maxLength`, `minimum`, `maximum`, `title`, `default`, `nullable`). The previous implementation only copied a small subset of fields. Helper functions `deepCopyOrderedMap`, `deepCopyOrderedMapSlice`, and `deepCopySchemaValue` were added to support recursive deep copying of `OrderedMap` values.

- **Anthropic provider** (`core/providers/anthropic/chat.go`): Replaced the manual field-by-field struct copy with a call to `DeepCopyToolFunctionParameters`, ensuring all schema fields are forwarded.

- **MCP server handler** (`transports/bifrost-http/handlers/mcpserver.go`): Extracted `convertToolFunctionParametersToMCPInputSchema`, which maps `Defs` (and falls back to `Definitions`) back onto `mcp.ToolInputSchema.Defs` so that round-tripped tools retain their definitions.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/mcp/...
go test ./core/schemas/...
go test ./core/providers/gemini/...
go test ./transports/bifrost-http/handlers/...
```

New tests cover:
- `TestConvertMCPToolToBifrostSchema_PreservesDefs` — verifies `$defs` survive MCP → Bifrost conversion and appear in marshalled output.
- `TestSonic_ChatTool_DeepCopy_PreservesFullParameterSchema` — verifies all schema fields are deep-copied independently (mutation of the copy does not affect the original).
- `TestConvertBifrostToolsToGemini_WirePayloadPreservesDefs` — verifies `$defs` and `$ref` appear in the Gemini wire payload.
- `TestConvertToolFunctionParametersToMCPInputSchemaPreservesDefs` / `...PreservesLegacyDefinitionsAsDefs` — verifies both `Defs` and `Definitions` are mapped correctly when converting back to MCP input schema.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes Vertex Gemini `INVALID_ARGUMENT` errors caused by dangling `$ref` pointers in tool schemas.

## Security considerations

No auth, secrets, PII, or sandboxing changes. The fix is limited to schema field propagation during tool conversion and cloning.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable