### PR TITLE
fix: reorder `migrationReAddAllowDirectKeysColumn` before config hash refresh migration and update schema with new fields

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -801,6 +801,15 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddCreatedByUserIDColumnForVirtualKeys(ctx, db); err != nil {
 		return err
 	}
+	// Must run before migrationRefreshConfigHashAfterMCPExternalServerURLRemoval:
+	// that migration SELECTs config_client using the column list derived from
+	// the TableClientConfig struct, which still declares allow_direct_keys.
+	// Without re-adding the column first, the SELECT fails with
+	// "no such column: allow_direct_keys" on any DB where the earlier
+	// drop_allow_direct_keys_column_ddl migration has run.
+	if err := migrationReAddAllowDirectKeysColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationRefreshConfigHashAfterMCPExternalServerURLRemoval(ctx, db); err != nil {
 		return err
 	}
@@ -811,9 +820,6 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 		return err
 	}
 	if err := migrationAddPerUserHeadersFlowsTable(ctx, db); err != nil {
-		return err
-	}
-	if err := migrationReAddAllowDirectKeysColumn(ctx, db); err != nil {
 		return err
 	}
 	if err := migrationAddMCPClientTLSConfigColumn(ctx, db); err != nil {

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -15766,6 +15766,9 @@ var excludedSchemaFields = map[string]map[string]bool{
 		"budget_id":        true, // Replaced by budgets[] relationship with team_id FK on TableBudget
 		"business_unit_id": true, // Enterprise feature; not in OSS TableTeam
 	},
+	"governance.virtual_keys": {
+		"access_profile_id": true, // Enterprise access-profile assignment; not on OSS TableVirtualKey
+	},
 	"governance.virtual_keys.provider_configs": {
 		"keys":    true, // Complex nested type, validated separately
 		"key_ids": true, // Config-file format; handled via custom UnmarshalJSON into allow_all_keys/keys

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -190,6 +190,11 @@
           },
           "description": "Additional allowed headers for CORS and WebSocket"
         },
+        "allow_direct_keys": {
+          "type": "boolean",
+          "description": "Allow callers to bypass the registered key pool by supplying x-bf-direct-key: true and an Authorization header carrying the provider's raw API key.",
+          "default": false
+        },
         "mcp_agent_depth": {
           "type": "integer",
           "minimum": 1,
@@ -484,6 +489,10 @@
               "name": {
                 "type": "string",
                 "description": "Team name"
+              },
+              "source_id": {
+                "type": "string",
+                "description": "Optional external source identifier (e.g. SCIM group ID) used to map this team to an upstream system. Unique when set."
               },
               "customer_id": {
                 "type": "string",
@@ -1908,6 +1917,13 @@
             "type": "string"
           }
         },
+        "blacklisted_models": {
+          "type": "array",
+          "description": "Models blocked for this provider config even if matched by allowed_models. Use [\"*\"] to block all; empty array blocks none.",
+          "items": {
+            "type": "string"
+          }
+        },
         "rate_limit_id": {
           "type": "string",
           "description": "Associated rate limit ID"
@@ -2816,7 +2832,7 @@
         },
         "auth_type": {
           "type": "string",
-          "enum": ["none", "headers", "oauth", "per_user_oauth"],
+          "enum": ["none", "headers", "oauth", "per_user_oauth", "per_user_headers"],
           "description": "Authentication type for MCP connection"
         },
         "oauth_config_id": {
@@ -2827,6 +2843,13 @@
           "type": "object",
           "description": "Headers to send with the request (for headers auth type)",
           "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "per_user_header_keys": {
+          "type": "array",
+          "description": "Header names each caller must supply when auth_type is 'per_user_headers'. Required (non-empty) for that auth type.",
+          "items": {
             "type": "string"
           }
         },


### PR DESCRIPTION
## Summary

Fixes a migration ordering bug where `migrationReAddAllowDirectKeysColumn` was running after `migrationRefreshConfigHashAfterMCPExternalServerURLRemoval`, causing a `"no such column: allow_direct_keys"` failure on databases where the earlier drop migration had already run. The fix moves `migrationReAddAllowDirectKeysColumn` to execute before the config hash refresh migration. Additionally, several schema additions are included to keep the config schema in sync with current struct definitions.

## Changes

- Moved `migrationReAddAllowDirectKeysColumn` to run before `migrationRefreshConfigHashAfterMCPExternalServerURLRemoval` in the migration chain, since the hash refresh migration SELECTs `config_client` using the `TableClientConfig` struct which still declares `allow_direct_keys`
- Added `allow_direct_keys` to the config schema under the client config section
- Added `source_id` field to the team schema for optional external source identifier (e.g. SCIM group ID) mapping
- Added `blacklisted_models` array field to the provider config schema for blocking specific models even when matched by `allowed_models`
- Added `per_user_headers` as a valid `auth_type` enum value for MCP connections
- Added `per_user_header_keys` array field to MCP connection config for specifying required caller-supplied headers when using `per_user_headers` auth
- Added `governance.virtual_keys` exclusion for `access_profile_id` in the schema field test, as it is an enterprise-only field not present on the OSS `TableVirtualKey`

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
go test ./framework/configstore/...
go test ./transports/bifrost-http/lib/...
```

Verify that on a database where `drop_allow_direct_keys_column_ddl` has previously run, the full migration chain completes without a `"no such column: allow_direct_keys"` error. Confirm the config schema validates correctly against the updated `config.schema.json`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

The migration ordering issue would cause startup failures on any deployment that had previously run the column-drop migration before the config hash refresh migration was introduced.

## Security considerations

The `allow_direct_keys` feature permits callers to bypass the registered key pool by supplying a raw provider API key via `x-bf-direct-key`. Ensure this field defaults to `false` and is only enabled intentionally, as it bypasses key management controls.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `allow_direct_keys` setting for direct API key usage
  * Added `source_id` field for mapping teams to external systems
  * Added `blacklisted_models` option to restrict model access in virtual key providers
  * Added `per_user_headers` authentication option for MCP client connections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->