### PR TITLE
fix: add http logs back

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -50,34 +50,32 @@ func SecurityHeadersMiddleware() schemas.BifrostHTTPMiddleware {
 func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
-			// startTime := time.Now()
-			// skip logging if it's a /health check request
-			if slices.IndexFunc(loggingSkipPaths, func(path string) bool {
+			shouldLog := slices.IndexFunc(loggingSkipPaths, func(path string) bool {
 				return strings.HasPrefix(string(ctx.RequestURI()), path)
-			}) != -1 {
-				goto corsFlow
+			}) == -1
+			if shouldLog {
+				startTime := time.Now()
+				defer func() {
+					statusCode := ctx.Response.Header.StatusCode()
+					level := schemas.LogLevelInfo
+					if statusCode >= 500 {
+						level = schemas.LogLevelError
+					} else if statusCode >= 400 {
+						level = schemas.LogLevelWarn
+					}
+					logBuilder := logger.LogHTTPRequest(level, "request completed").
+						Str("http.method", string(ctx.Method())).
+						Str("http.target", string(ctx.RequestURI())).
+						Int("http.status_code", statusCode).
+						Int64("http.request_duration_ms", time.Since(startTime).Milliseconds()).
+						Str("http.remote_addr", ctx.RemoteAddr().String()).
+						Str("http.user_agent", string(ctx.Request.Header.UserAgent()))
+					if traceID, ok := ctx.UserValue(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
+						logBuilder = logBuilder.Str("trace_id", traceID)
+					}
+					logBuilder.Send()
+				}()
 			}
-			// defer func() {
-			// 	statusCode := ctx.Response.Header.StatusCode()
-			// 	level := schemas.LogLevelInfo
-			// 	if statusCode >= 500 {
-			// 		level = schemas.LogLevelError
-			// 	} else if statusCode >= 400 {
-			// 		level = schemas.LogLevelWarn
-			// 	}
-			// 	logBuilder := logger.LogHTTPRequest(level, "request completed").
-			// 		Str("http.method", string(ctx.Method())).
-			// 		Str("http.target", string(ctx.RequestURI())).
-			// 		Int("http.status_code", statusCode).
-			// 		Int64("http.request_duration_ms", time.Since(startTime).Milliseconds()).
-			// 		Str("http.remote_addr", ctx.RemoteAddr().String()).
-			// 		Str("http.user_agent", string(ctx.Request.Header.UserAgent()))
-			// 	if traceID, ok := ctx.UserValue(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
-			// 		logBuilder = logBuilder.Str("trace_id", traceID)
-			// 	}
-			// 	logBuilder.Send()
-			// }()
-		corsFlow:
 			origin := string(ctx.Request.Header.Peek("Origin"))
 			allowed := IsOriginAllowed(origin, config.ClientConfig.AllowedOrigins)
 			// Credentialed responses are sent when the origin is not matched solely by a


### PR DESCRIPTION
## Summary

Re-enables HTTP request logging in the CORS middleware that was previously commented out. Each completed request is now logged with method, URI, status code, duration, remote address, user agent, and trace ID (when available).

## Changes

- Uncommented the `startTime` initialization and the deferred logging block in `CorsMiddleware`
- Log level is set dynamically based on response status: `error` for 5xx, `warn` for 4xx, and `info` for all others
- Trace ID is included in the log entry when present in the request context
- Requests matching `loggingSkipPaths` (e.g. `/health`) continue to bypass logging

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send requests to the HTTP transport and verify log output appears for non-health-check endpoints.

```sh
go test ./...
```

- Make a successful request and confirm an `info`-level log entry is emitted with correct fields
- Make a request that returns a 4xx and confirm a `warn`-level log is emitted
- Make a request that returns a 5xx and confirm an `error`-level log is emitted
- Hit `/health` and confirm no log entry is produced

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Logged fields include remote address and user agent. Ensure these are acceptable to log in your deployment environment, particularly in contexts with strict PII or data residency requirements.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled HTTP request logging that records method, request URI, response status, processing duration (ms), remote address, user agent, and optional trace identifier.
  * Logging is skipped for health and internal asset/dev endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->