### PR TITLE
increases matview sync to 1 min

### DIFF
--- a/docs/deployment-guides/config-json/storage.mdx
+++ b/docs/deployment-guides/config-json/storage.mdx
@@ -210,7 +210,7 @@ Set `retention_days` to automatically purge old log entries. `0` disables retent
 
 ### Materialized View Refresh Interval (PostgreSQL only)
 
-The PostgreSQL logs store backs the dashboard's stats and histograms with materialized views, refreshed in the background. The default cadence is **30 seconds**, which keeps dashboard data near real-time but issues a `REFRESH MATERIALIZED VIEW CONCURRENTLY` every 30s — an expensive operation that can be too aggressive on smaller or CPU-constrained database instances.
+The PostgreSQL logs store backs the dashboard's stats and histograms with materialized views, refreshed in the background. The default cadence is **1 minute**, which keeps dashboard data near real-time but issues a `REFRESH MATERIALIZED VIEW CONCURRENTLY` every minute — an expensive operation that can be too aggressive on smaller or CPU-constrained database instances.
 
 Set `matview_refresh_interval` (Go duration string) to slow down refreshes when near-real-time accuracy isn't critical:
 
@@ -234,7 +234,7 @@ Set `matview_refresh_interval` (Go duration string) to slow down refreshes when 
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `matview_refresh_interval` | `"30s"` | How often to refresh dashboard materialized views. Accepts any Go duration string (`"30s"`, `"5m"`, `"1h"`). Minimum `5s`. |
+| `matview_refresh_interval` | `"1m"` | How often to refresh dashboard materialized views. Accepts any Go duration string (`"1m"`, `"5m"`, `"1h"`). Minimum `5s`. |
 
 **Notes**
 

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -375,7 +375,8 @@ var matviewRequiredColumns = func() map[string][]string {
 // Postgres-only — runs on a dedicated connection so the advisory lock + the
 // CONCURRENTLY DDL all share one session and live outside any migration
 // transaction. Multi-replica deployments serialize on the advisory lock so
-// only one instance does the work.
+// only one instance does the work. It shares the same advisory lock as
+// refreshMatViews so startup create/repair cannot overlap a periodic refresh.
 func ensureMatViews(ctx context.Context, db *gorm.DB) error {
 	if db.Dialector.Name() != "postgres" {
 		return nil
@@ -589,7 +590,8 @@ var refreshGate matViewRefreshGate
 
 // logsActivityCounter returns the cumulative INSERT+UPDATE+DELETE count for
 // the `logs` table from pg_stat_user_tables. The stat collector is eventually
-// consistent (lags a few seconds under load) which is fine for a 30s tick.
+// consistent (lags a few seconds under load) which is fine for the periodic
+// refresh tick.
 //
 // Returns (0, false) if the row is missing (fresh DB before any writes) or the
 // query fails — callers treat that as "fall back to always-refresh."
@@ -644,7 +646,8 @@ func (g *matViewRefreshGate) markRefreshed(activityAtStart int64, activityOK boo
 
 // refreshMatViews refreshes all materialized views concurrently (non-blocking
 // for readers). Uses a PostgreSQL advisory try-lock so that in multi-replica
-// deployments only one instance refreshes at a time — others skip silently.
+// deployments only one instance refreshes at a time — others skip silently and
+// try again on their next scheduled tick.
 //
 // Also short-circuits when pg_stat_user_tables reports no INSERT/UPDATE/DELETE
 // on `logs` since the last refresh. A periodic safety-interval refresh runs
@@ -748,7 +751,7 @@ func (s *RDBLogStore) canUseMatView(f SearchFilters) bool {
 // freshAggregateMatViewMinWindow is the minimum time-range size that justifies
 // serving user-visible aggregates (e.g. /api/logs/stats totals, /api/logs
 // pagination counts) from the materialized view. Below this, the raw `logs`
-// table is fast enough and avoids the up-to-30s freshness lag that would
+// table is fast enough and avoids the refresh-interval freshness lag that would
 // otherwise cause counts to disagree with the row-list view — a visible
 // inconsistency on short, low-traffic windows.
 const freshAggregateMatViewMinWindow = 24 * time.Hour

--- a/framework/logstore/matviews_lock_test.go
+++ b/framework/logstore/matviews_lock_test.go
@@ -1,0 +1,168 @@
+package logstore
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestResolveMatViewRefreshIntervalDefaults(t *testing.T) {
+	assert.Equal(t, time.Minute, resolveMatViewRefreshInterval("", testLogger{}))
+	assert.Equal(t, time.Minute, resolveMatViewRefreshInterval("not-a-duration", testLogger{}))
+	assert.Equal(t, minMatViewRefreshInterval, resolveMatViewRefreshInterval("1s", testLogger{}))
+	assert.Equal(t, 5*time.Minute, resolveMatViewRefreshInterval("5m", testLogger{}))
+}
+
+func TestRefreshMatViewsAdvisoryLockLifecycle(t *testing.T) {
+	_, db := setupPerfTestDB(t)
+
+	t.Run("normal refresh releases lock", func(t *testing.T) {
+		resetTestMatViewRefreshGate()
+
+		require.NoError(t, refreshMatViews(context.Background(), db))
+
+		conn := acquireTestAdvisoryLock(t, db, matviewRefreshAdvisoryLockKey)
+		releaseTestAdvisoryLock(t, conn, matviewRefreshAdvisoryLockKey)
+	})
+
+	t.Run("held lock makes refresh skip without blocking", func(t *testing.T) {
+		resetTestMatViewRefreshGate()
+		holder := acquireTestAdvisoryLock(t, db, matviewRefreshAdvisoryLockKey)
+		defer releaseTestAdvisoryLock(t, holder, matviewRefreshAdvisoryLockKey)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		start := time.Now()
+		require.NoError(t, refreshMatViews(ctx, db))
+		assert.Less(t, time.Since(start), time.Second)
+	})
+
+	t.Run("closed holder session lets later refresh acquire lock", func(t *testing.T) {
+		resetTestMatViewRefreshGate()
+		holderDB, holder := acquireTestAdvisoryLockOnIsolatedPool(t, matviewRefreshAdvisoryLockKey)
+		closeTestAdvisoryLockSession(t, holderDB, holder)
+
+		require.NoError(t, refreshMatViews(context.Background(), db))
+
+		conn := acquireTestAdvisoryLock(t, db, matviewRefreshAdvisoryLockKey)
+		releaseTestAdvisoryLock(t, conn, matviewRefreshAdvisoryLockKey)
+	})
+}
+
+func TestEnsureMatViewsSharesRefreshAdvisoryLock(t *testing.T) {
+	_, db := setupPerfTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Exec("DROP MATERIALIZED VIEW IF EXISTS mv_filter_users CASCADE").Error)
+	require.False(t, testMatViewExists(t, db, "mv_filter_users"))
+
+	holder := acquireTestAdvisoryLock(t, db, matviewRefreshAdvisoryLockKey)
+	require.NoError(t, ensureMatViews(ctx, db))
+	require.False(t, testMatViewExists(t, db, "mv_filter_users"), "ensureMatViews should skip while refresh lock is held elsewhere")
+
+	releaseTestAdvisoryLock(t, holder, matviewRefreshAdvisoryLockKey)
+	require.NoError(t, ensureMatViews(ctx, db))
+	require.True(t, testMatViewExists(t, db, "mv_filter_users"))
+}
+
+func TestMigrationLockContextCancellationAndSessionRelease(t *testing.T) {
+	db := trySetupPostgresDB(t)
+	if db == nil {
+		t.Skip("Postgres not available, skipping test")
+	}
+
+	holderDB, holder := acquireTestAdvisoryLockOnIsolatedPool(t, migrationAdvisoryLockKey)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	lock, err := acquireMigrationLock(ctx, db)
+	require.Error(t, err)
+	require.Nil(t, lock)
+
+	closeTestAdvisoryLockSession(t, holderDB, holder)
+
+	lock, err = acquireMigrationLock(context.Background(), db)
+	require.NoError(t, err)
+	lock.release(context.Background())
+}
+
+func resetTestMatViewRefreshGate() {
+	refreshGate.mu.Lock()
+	refreshGate.lastActivity = 0
+	refreshGate.lastForcedAt = time.Time{}
+	refreshGate.initialized = false
+	refreshGate.mu.Unlock()
+}
+
+func acquireTestAdvisoryLock(t *testing.T, db *gorm.DB, key int64) *sql.Conn {
+	t.Helper()
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	conn, err := sqlDB.Conn(context.Background())
+	require.NoError(t, err)
+
+	var acquired bool
+	err = conn.QueryRowContext(context.Background(), "SELECT pg_try_advisory_lock($1)", key).Scan(&acquired)
+	if err != nil {
+		_ = conn.Close()
+	}
+	require.NoError(t, err)
+	if !acquired {
+		_ = conn.Close()
+	}
+	require.Truef(t, acquired, "expected to acquire advisory lock %d", key)
+
+	return conn
+}
+
+func acquireTestAdvisoryLockOnIsolatedPool(t *testing.T, key int64) (*gorm.DB, *sql.Conn) {
+	t.Helper()
+
+	db := trySetupPostgresDB(t)
+	require.NotNil(t, db, "Postgres not available")
+
+	return db, acquireTestAdvisoryLock(t, db, key)
+}
+
+func closeTestAdvisoryLockSession(t *testing.T, db *gorm.DB, conn *sql.Conn) {
+	t.Helper()
+
+	require.NoError(t, conn.Close())
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+}
+
+func releaseTestAdvisoryLock(t *testing.T, conn *sql.Conn, key int64) {
+	t.Helper()
+	if conn == nil {
+		return
+	}
+	_, err := conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", key)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+}
+
+func testMatViewExists(t *testing.T, db *gorm.DB, view string) bool {
+	t.Helper()
+
+	var exists bool
+	err := db.Raw(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_class
+			WHERE relkind = 'm'
+			  AND relname = ?
+		)
+	`, view).Scan(&exists).Error
+	require.NoError(t, err)
+	return exists
+}

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -31,13 +31,10 @@ const (
 	// does not block other pods from running their (fast) migrations on startup.
 	indexAdvisoryLockKey = 1000002
 
-	// matviewRefreshAdvisoryLockKey serializes periodic materialized view
-	// refreshes across cluster nodes so only one replica refreshes at a time.
+	// matviewRefreshAdvisoryLockKey serializes materialized view maintenance
+	// across cluster nodes. Startup create/repair and periodic refresh both use
+	// this key so they never overlap.
 	matviewRefreshAdvisoryLockKey = 1000005
-
-	// matviewEnsureAdvisoryLockKey serializes startup materialized view
-	// creation/repair without contending with the periodic refresh lock.
-	matviewEnsureAdvisoryLockKey = 1000006
 
 	// advisoryLockRetryInterval is how long to wait between lock acquisition attempts.
 	advisoryLockRetryInterval = 5 * time.Second

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -33,9 +33,8 @@ type PostgresConfig struct {
 }
 
 // defaultMatViewRefreshInterval is used when MatViewRefreshInterval is unset
-// or unparseable. Matches the prior hardcoded value so existing deployments
-// see no behavior change.
-const defaultMatViewRefreshInterval = 30 * time.Second
+// or unparseable.
+const defaultMatViewRefreshInterval = time.Minute
 
 // minMatViewRefreshInterval is a floor to prevent pathological configs that
 // would refresh more often than the refresh itself takes — anything below

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -41,8 +41,7 @@ type LoggingHandler struct {
 const sessionLogPageLimit = 500
 
 // filterDataCacheTTL is short enough that newly used models/keys appear in
-// dropdowns within ~half a minute — matview refresh runs every 30s anyway, so a
-// longer TTL would just hide stale results.
+// dropdowns promptly without hiding results beyond the matview refresh cadence.
 const filterDataCacheTTL = 30 * time.Second
 
 const filterDataFanOutLimit = 4

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1037,9 +1037,9 @@
                   },
                   "matview_refresh_interval": {
                     "type": "string",
-                    "description": "How often to refresh dashboard materialized views. Go duration string (e.g. '30s', '5m', '1h'). Default 30s. Raise this when matview refresh CPU cost is material on the database instance. Minimum 5s.",
+                    "description": "How often to refresh dashboard materialized views. Go duration string (e.g. '1m', '5m', '1h'). Default 1m. Raise this when matview refresh CPU cost is material on the database instance. Minimum 5s.",
                     "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
-                    "default": "30s"
+                    "default": "1m"
                   }
                 },
                 "required": [


### PR DESCRIPTION
## Summary

The default materialized view refresh interval for the PostgreSQL log store has been changed from 30 seconds to 1 minute. This reduces the frequency of `REFRESH MATERIALIZED VIEW CONCURRENTLY` operations, which are expensive and can be too aggressive on smaller or CPU-constrained database instances.

Additionally, `ensureMatViews` (startup create/repair) and `refreshMatViews` (periodic refresh) have been consolidated to share a single advisory lock key (`matviewRefreshAdvisoryLockKey`), eliminating the separate `matviewEnsureAdvisoryLockKey`. This prevents startup maintenance from overlapping with a periodic refresh in multi-replica deployments.

## Changes

- Default `matview_refresh_interval` changed from `30s` to `1m` in code, config schema, and documentation.
- Removed the separate `matviewEnsureAdvisoryLockKey` (`1000006`); `ensureMatViews` now uses the same advisory lock as `refreshMatViews` (`1000005`) so the two operations are mutually exclusive.
- Updated `filterDataCacheTTL` comment in the logging handler to remove the hardcoded reference to the 30s cadence.
- Added `matviews_lock_test.go` with tests covering advisory lock lifecycle for both `refreshMatViews` and `ensureMatViews`, including: normal lock acquisition and release, skipping when the lock is held, recovery after a session closes, and context cancellation behavior for the migration lock.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./framework/logstore/... -run TestResolveMatViewRefreshIntervalDefaults
go test ./framework/logstore/... -run TestRefreshMatViewsAdvisoryLockLifecycle
go test ./framework/logstore/... -run TestEnsureMatViewsSharesRefreshAdvisoryLock
go test ./framework/logstore/... -run TestMigrationLockContextCancellationAndSessionRelease
```

These tests require a running PostgreSQL instance. Verify that:
- The default refresh interval resolves to `1m`.
- A held advisory lock causes `refreshMatViews` to skip without blocking.
- `ensureMatViews` skips materialized view creation while the refresh lock is held, and proceeds once released.
- Context cancellation on `acquireMigrationLock` returns an error and the lock is acquirable after the blocking session closes.

If deploying to an existing instance, note that the effective refresh cadence will double from 30s to 1m. Dashboard stats and histograms will have up to 1 minute of lag instead of 30 seconds.

## Breaking changes

- [x] Yes
- [ ] No

Existing deployments will see the materialized view refresh cadence change from 30 seconds to 1 minute. Dashboard stats freshness lag increases accordingly. Operators who require sub-minute freshness should explicitly set `matview_refresh_interval: "30s"` in their config.

## Related issues

## Security considerations

None. This change affects only internal database maintenance scheduling and advisory lock coordination.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated PostgreSQL logs_store materialized view refresh interval default from 30 seconds to 1 minute in configuration documentation and schema.

* **Tests**
  * Added comprehensive test coverage for materialized view refresh advisory lock behavior, interval defaults, and migration locking mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->