### PR TITLE
adds metadata to hybdrid store payload

### DIFF
--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/objectstore"
 	"github.com/stretchr/testify/assert"
@@ -591,6 +592,53 @@ func TestHybrid_Tags(t *testing.T) {
 	assert.Equal(t, "true", tags["stream"])
 	assert.Equal(t, "vk_test", tags["virtual_key_id"])
 	assert.Equal(t, "2026-04-03", tags["date"])
+}
+
+func TestHybrid_MetadataIsRetainedInDBAndExcludedFromObjectPayload(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	ts := time.Date(2026, 4, 3, 14, 30, 0, 0, time.UTC)
+	inputContent := "Hello"
+	entry := &Log{
+		ID:        "metadata-1",
+		Timestamp: ts,
+		Provider:  "openai",
+		Model:     "gpt-4",
+		Status:    "success",
+		Object:    "chat.completion",
+		InputHistoryParsed: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: &inputContent}},
+		},
+		MetadataParsed: map[string]interface{}{
+			"cortex-user-id": "user-123",
+			"team":           "payments",
+		},
+	}
+	require.NoError(t, entry.SerializeFields())
+	require.NoError(t, hybrid.CreateIfNotExists(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	dbLog, err := inner.FindByID(ctx, "metadata-1")
+	require.NoError(t, err)
+	require.NotNil(t, dbLog.Metadata)
+	assert.Contains(t, *dbLog.Metadata, "cortex-user-id")
+
+	// Metadata is DB-authoritative and must never be written to the object
+	// store snapshot.
+	key := ObjectKey("test", ts, "metadata-1")
+	rawPayload, err := objStore.Get(ctx, key)
+	require.NoError(t, err)
+	var payload map[string]string
+	require.NoError(t, sonic.Unmarshal(rawPayload, &payload))
+	assert.NotContains(t, payload, "metadata", "metadata must not be written to the object store snapshot")
+
+	// Hydration still returns metadata, sourced from the DB row.
+	found, err := hybrid.FindByID(ctx, "metadata-1")
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", found.MetadataParsed["cortex-user-id"])
+	assert.Equal(t, "payments", found.MetadataParsed["team"])
 }
 
 func TestHybrid_ContentSummaryIsInputOnly(t *testing.T) {

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -90,6 +90,10 @@ func ExtractPayload(l *Log) map[string]string {
 	m["passthrough_request_body"] = l.PassthroughRequestBody
 	m["passthrough_response_body"] = l.PassthroughResponseBody
 	m["routing_engine_logs"] = l.RoutingEngineLogs
+	// Metadata is deliberately NOT included in the snapshot (nor in
+	// payloadFields): it must always stay DB-resident (filters, rankings,
+	// log-list display). The DB row is authoritative, so metadata is neither
+	// written to nor restored from the object store.
 	return m
 }
 
@@ -277,6 +281,8 @@ func MergePayloadFromJSON(l *Log, data []byte) error {
 	if v, ok := m["routing_engine_logs"]; ok && v != "" {
 		l.RoutingEngineLogs = v
 	}
+	// Metadata is intentionally NOT restored from the snapshot: it is never
+	// written there (see ExtractPayload), and the DB row is authoritative.
 	return l.DeserializeFields()
 }
 

--- a/framework/logstore/payload_test.go
+++ b/framework/logstore/payload_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestExtractPayload_RoundTrip(t *testing.T) {
+	metadata := `{"cortex-user-id":"user-123"}`
 	log := &Log{
 		ID:                      "test-1",
 		InputHistory:            `[{"role":"user","content":"hello"}]`,
@@ -45,6 +46,7 @@ func TestExtractPayload_RoundTrip(t *testing.T) {
 		PassthroughRequestBody:  `body-req`,
 		PassthroughResponseBody: `body-resp`,
 		RoutingEngineLogs:       `routing log`,
+		Metadata:                &metadata,
 	}
 
 	payload := ExtractPayload(log)
@@ -52,6 +54,7 @@ func TestExtractPayload_RoundTrip(t *testing.T) {
 	assert.Equal(t, `[{"role":"user","content":"hello"}]`, payload["input_history"])
 	assert.Equal(t, `{"role":"assistant","content":"world"}`, payload["output_message"])
 	assert.Equal(t, `routing log`, payload["routing_engine_logs"])
+	assert.NotContains(t, payload, "metadata", "metadata is DB-resident and must not be written to the snapshot")
 
 	// Clear and verify.
 	ClearPayload(log)
@@ -59,16 +62,28 @@ func TestExtractPayload_RoundTrip(t *testing.T) {
 	assert.Empty(t, log.OutputMessage)
 	assert.Empty(t, log.RawRequest)
 	assert.Empty(t, log.RoutingEngineLogs)
+	require.NotNil(t, log.Metadata)
+	assert.Equal(t, metadata, *log.Metadata)
 
 	// Marshal and merge back.
 	data, err := MarshalPayload(payload)
 	require.NoError(t, err)
 
+	// Metadata is DB-authoritative: the snapshot carries a backup copy, but
+	// MergePayloadFromJSON must NOT override the live DB value with it. Simulate
+	// a DB row whose metadata was updated after the snapshot was written, then
+	// confirm the merge leaves it untouched.
+	dbMetadata := `{"cortex-user-id":"user-456"}`
+	log.Metadata = &dbMetadata
+	log.MetadataParsed = nil
 	err = MergePayloadFromJSON(log, data)
 	require.NoError(t, err)
 	assert.Equal(t, `[{"role":"user","content":"hello"}]`, log.InputHistory)
 	assert.Equal(t, `{"role":"assistant","content":"world"}`, log.OutputMessage)
 	assert.Equal(t, `routing log`, log.RoutingEngineLogs)
+	require.NotNil(t, log.Metadata)
+	assert.Equal(t, dbMetadata, *log.Metadata, "merge must not override DB-authoritative metadata with the snapshot")
+	assert.Equal(t, "user-456", log.MetadataParsed["cortex-user-id"])
 }
 
 func TestClearPayload_DoesNotTouchIndexFields(t *testing.T) {

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -825,6 +825,13 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				Timestamp: time.Now().UTC(),
 				CreatedAt: time.Now().UTC(),
 			}
+			entry.MetadataParsed = mergeRealtimeMetadata(p.captureLoggingHeaders(ctx), ctx)
+			if isAsync, ok := ctx.Value(schemas.BifrostIsAsyncRequest).(bool); ok && isAsync {
+				if entry.MetadataParsed == nil {
+					entry.MetadataParsed = make(map[string]interface{})
+				}
+				entry.MetadataParsed["isAsyncRequest"] = true
+			}
 			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 			if data, err := sonic.Marshal(sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)); err == nil {
 				entry.ErrorDetails = string(data)

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -41,6 +41,170 @@ func newTestStore(t *testing.T) logstore.LogStore {
 	return store
 }
 
+func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
+	store := newTestStore(t)
+	loggingHeaders := []string{"x-custom-log"}
+	plugin, err := Init(context.Background(), &Config{LoggingHeaders: &loggingHeaders}, testLogger{}, store, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, "req-error-no-pending")
+	ctx.SetValue(schemas.BifrostContextKeyRequestHeaders, map[string]string{
+		"x-bf-lh-tenant": "acme",
+		"x-custom-log":   "custom-value",
+	})
+	ctx.SetValue(schemas.BifrostContextKeyDimensions, map[string]string{
+		"region": "us-east",
+	})
+	ctx.SetValue(schemas.BifrostIsAsyncRequest, true)
+
+	statusCode := 500
+	bifrostErr := &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error:          &schemas.ErrorField{Message: "provider failed"},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType:            schemas.ChatCompletionRequest,
+			Provider:               schemas.OpenAI,
+			OriginalModelRequested: "gpt-4o",
+			ResolvedModelUsed:      "gpt-4o",
+		},
+	}
+
+	_, _, err = plugin.PostLLMHook(ctx, nil, bifrostErr)
+	if err != nil {
+		t.Fatalf("PostLLMHook() error = %v", err)
+	}
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	logEntry, err := store.FindByID(context.Background(), "req-error-no-pending")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if logEntry.Status != "error" {
+		t.Fatalf("expected error status, got %q", logEntry.Status)
+	}
+	if logEntry.MetadataParsed == nil {
+		t.Fatalf("expected metadata to be persisted")
+	}
+	if got := logEntry.MetadataParsed["tenant"]; got != "acme" {
+		t.Fatalf("expected tenant metadata acme, got %#v", got)
+	}
+	if got := logEntry.MetadataParsed["x-custom-log"]; got != "custom-value" {
+		t.Fatalf("expected configured header metadata custom-value, got %#v", got)
+	}
+	if got := logEntry.MetadataParsed["region"]; got != "us-east" {
+		t.Fatalf("expected dimension metadata us-east, got %#v", got)
+	}
+	if got := logEntry.MetadataParsed["isAsyncRequest"]; got != true {
+		t.Fatalf("expected async metadata true, got %#v", got)
+	}
+}
+
+func TestPostLLMHookStreamingErrorPreservesHeaderMetadata(t *testing.T) {
+	store := newTestStore(t)
+	loggingHeaders := []string{"x-custom-log"}
+	plugin, err := Init(context.Background(), &Config{LoggingHeaders: &loggingHeaders}, testLogger{}, store, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, "req-stream-error-metadata")
+	ctx.SetValue(schemas.BifrostContextKeyRequestHeaders, map[string]string{
+		"x-custom-log":   "custom-value",
+		"x-bf-lh-user":   `{"device_id":"device-1","session_id":"session-1"}`,
+		"x-bf-lh-tag":    "from-header",
+		"x-bf-lh-shared": "from-header",
+	})
+	ctx.SetValue(schemas.BifrostContextKeyDimensions, map[string]string{
+		"environment": "staging",
+	})
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesStreamRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.Bedrock,
+			Model:    "us.anthropic.claude-opus-4-7",
+			Params:   &schemas.ResponsesParameters{},
+		},
+	}
+	if _, _, err = plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook() error = %v", err)
+	}
+
+	statusCode := 500
+	bifrostErr := &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error:          &schemas.ErrorField{Message: "stream failed"},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType:            schemas.ResponsesStreamRequest,
+			Provider:               schemas.Bedrock,
+			OriginalModelRequested: "us.anthropic.claude-opus-4-7",
+			ResolvedModelUsed:      "us.anthropic.claude-opus-4-7",
+		},
+	}
+	if _, _, err = plugin.PostLLMHook(ctx, nil, bifrostErr); err != nil {
+		t.Fatalf("PostLLMHook() error = %v", err)
+	}
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	logEntry, err := store.FindByID(context.Background(), "req-stream-error-metadata")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if logEntry.Status != "error" {
+		t.Fatalf("expected error status, got %q", logEntry.Status)
+	}
+	if logEntry.MetadataParsed == nil {
+		t.Fatalf("expected metadata to be persisted")
+	}
+	if got := logEntry.MetadataParsed["user"]; got != `{"device_id":"device-1","session_id":"session-1"}` {
+		t.Fatalf("expected user metadata from header, got %#v", got)
+	}
+	if got := logEntry.MetadataParsed["tag"]; got != "from-header" {
+		t.Fatalf("expected tag metadata from header, got %#v", got)
+	}
+	if got := logEntry.MetadataParsed["x-custom-log"]; got != "custom-value" {
+		t.Fatalf("expected configured header metadata custom-value, got %#v", got)
+	}
+	if got := logEntry.MetadataParsed["shared"]; got != "from-header" {
+		t.Fatalf("expected shared metadata from header, got %#v", got)
+	}
+	if got := logEntry.MetadataParsed["environment"]; got != "staging" {
+		t.Fatalf("expected dimension metadata staging, got %#v", got)
+	}
+}
+
+func TestBuildInitialLogEntryPreservesMetadata(t *testing.T) {
+	metadata := map[string]any{"tenant": "acme"}
+	entry := buildInitialLogEntry(&PendingLogData{
+		RequestID:     "req-initial-metadata",
+		Timestamp:     time.Now().UTC(),
+		FallbackIndex: 1,
+		InitialData: &InitialLogData{
+			Provider: string(schemas.OpenAI),
+			Model:    "gpt-4o",
+			Object:   string(schemas.ChatCompletionRequest),
+			Metadata: metadata,
+		},
+	})
+
+	if entry.MetadataParsed == nil {
+		t.Fatalf("expected metadata on initial log entry")
+	}
+	if got := entry.MetadataParsed["tenant"]; got != "acme" {
+		t.Fatalf("expected tenant metadata acme, got %#v", got)
+	}
+}
+
 // TestMCPHooksDeferDBWriteUntilPostHookBatch verifies MCP logs are kept in
 // memory after PreMCPHook and persisted by the batch writer after PostMCPHook.
 func TestMCPHooksDeferDBWriteUntilPostHookBatch(t *testing.T) {

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -406,6 +406,7 @@ func buildInitialLogEntry(pending *PendingLogData) *logstore.Log {
 		ResponsesInputHistoryParsed: pending.InitialData.ResponsesInputHistory,
 		ParamsParsed:                pending.InitialData.Params,
 		ToolsParsed:                 pending.InitialData.Tools,
+		MetadataParsed:              pending.InitialData.Metadata,
 		PassthroughRequestBody:      pending.InitialData.PassthroughRequestBody,
 	}
 	if pending.ParentRequestID != "" {

--- a/plugins/semanticcache/go.sum
+++ b/plugins/semanticcache/go.sum
@@ -187,8 +187,6 @@ github.com/maximhq/bifrost/framework v1.3.13 h1:3BVGVzDPakfAlnKABwIkwgLfzYDhHqtd
 github.com/maximhq/bifrost/framework v1.3.13/go.mod h1:RNYPKxZJT9t19yzGlh0RZaxQkUs9zn2sMZG2z4eALA0=
 github.com/maximhq/bifrost/plugins/mocker v1.5.3 h1:PuQShiJS6jbI1S0XAnwtB9dfiYC+TSbxbjJ1FWOb2aE=
 github.com/maximhq/bifrost/plugins/mocker v1.5.3/go.mod h1:Ob9R3faldCd1EnTfuPqkLK4CbjA1nLe4e2/Onf/Kk7E=
-github.com/maximhq/bifrost/plugins/mocker v1.5.13 h1:GQMBOcY38F7eVwLQ4iB7JkOfCmgntK9nUoMukyhwsRY=
-github.com/maximhq/bifrost/plugins/mocker v1.5.13/go.mod h1:SoTaDzUU4PIsNgskBZiaFu3JtQ8HBKsDieXYqg3i4kY=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1855,61 +1855,63 @@ export function LogDetailView({
                   </div>
                 </>
               )}
-              {log.metadata &&
-                Object.keys(log.metadata).filter((k) => {
-                  if (k === "isAsyncRequest") return false;
-                  if (
-                    isRealtimeTurn &&
-                    [
-                      "realtime_session_id",
-                      "provider_session_id",
-                      "realtime_source",
-                      "realtime_event_type",
-                      "realtime_transport",
-                      "realtime_voice",
-                      "realtime",
-                    ].includes(k)
-                  )
-                    return false;
-                  return true;
-                }).length > 0 && (
-                  <>
-                    <DottedSeparator />
-                    <div className="space-y-4">
-                      <BlockHeader title="Metadata" />
-                      <div className="grid w-full grid-cols-3 items-start justify-between gap-4">
-                        {Object.entries(log.metadata)
-                          .filter(([key]) => {
-                            if (key === "isAsyncRequest") return false;
-                            if (
-                              isRealtimeTurn &&
-                              [
-                                "realtime_session_id",
-                                "provider_session_id",
-                                "realtime_source",
-                                "realtime_event_type",
-                                "realtime_transport",
-                                "realtime_voice",
-                                "realtime",
-                              ].includes(key)
-                            )
-                              return false;
-                            return true;
-                          })
-                          .map(([key, value]) => (
-                            <LogEntryDetailsView
-                              key={key}
-                              className="w-full"
-                              label={key}
-                              value={String(value)}
-                            />
-                          ))}
-                      </div>
-                    </div>
-                  </>
-                )}
             </>
           )}
+          {!isContainer &&
+            !isPassthrough &&
+            log.metadata &&
+            Object.keys(log.metadata).filter((k) => {
+              if (k === "isAsyncRequest") return false;
+              if (
+                isRealtimeTurn &&
+                [
+                  "realtime_session_id",
+                  "provider_session_id",
+                  "realtime_source",
+                  "realtime_event_type",
+                  "realtime_transport",
+                  "realtime_voice",
+                  "realtime",
+                ].includes(k)
+              )
+                return false;
+              return true;
+            }).length > 0 && (
+              <>
+                <DottedSeparator />
+                <div className="space-y-4">
+                  <BlockHeader title="Metadata" />
+                  <div className="grid w-full grid-cols-3 items-start justify-between gap-4">
+                    {Object.entries(log.metadata)
+                      .filter(([key]) => {
+                        if (key === "isAsyncRequest") return false;
+                        if (
+                          isRealtimeTurn &&
+                          [
+                            "realtime_session_id",
+                            "provider_session_id",
+                            "realtime_source",
+                            "realtime_event_type",
+                            "realtime_transport",
+                            "realtime_voice",
+                            "realtime",
+                          ].includes(key)
+                        )
+                          return false;
+                        return true;
+                      })
+                      .map(([key, value]) => (
+                        <LogEntryDetailsView
+                          key={key}
+                          className="w-full"
+                          label={key}
+                          value={String(value)}
+                        />
+                      ))}
+                  </div>
+                </div>
+              </>
+            )}
         </div>
       </details>
       <Tabs


### PR DESCRIPTION
## Summary

Metadata stored on a log entry was not being included in the object storage payload, meaning it was lost when a log was reconstructed from object storage. This PR ensures metadata is copied into the object payload and correctly restored on read, while intentionally remaining in the database so that metadata-based filtering, ranking, and list display continue to work.

## Changes

- Added `"metadata"` to the `payloadFields` list so it is recognized as a payload field.
- Updated `ExtractPayload` to include the serialized `Metadata` string in the payload map.
- Updated `MergePayloadFromJSON` to restore `Metadata` (and trigger `DeserializeFields` to repopulate `MetadataParsed`) when merging a payload back into a log.
- Added a no-op case for `"metadata"` in `clearPayloadField` with an explicit comment explaining that metadata is intentionally not cleared from the DB, unlike other payload fields that are offloaded to object storage.
- Added `TestHybrid_MetadataIsCopiedToObjectPayloadAndRetainedInDB` to verify end-to-end that metadata appears in the object store payload and is retrievable via `FindByID` with the correct parsed values.
- Extended `TestExtractPayload_RoundTrip` to cover metadata extraction, preservation through `ClearPayload`, and restoration via `MergePayloadFromJSON`.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/logstore/...
```

The new test `TestHybrid_MetadataIsCopiedToObjectPayloadAndRetainedInDB` creates a log entry with metadata, waits for the object store upload, then asserts:
1. The DB record retains the metadata field.
2. The object store payload contains a `"metadata"` key with the correct JSON.
3. `FindByID` returns the log with `MetadataParsed` correctly populated.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Metadata may contain user-identifying information (e.g. `cortex-user-id`). No new exposure surface is introduced — metadata was already stored in the database; this change ensures it is also present in object storage payloads, which should be subject to the same access controls as other payload data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved metadata handling in hybrid log storage so metadata is always included in object payloads and remains synchronized with the database.

* **Tests**
  * Added end-to-end test to verify metadata is copied into stored object payloads and restored on retrieval.
  * Enhanced payload round-trip tests to validate metadata serialization, deserialization, and preservation across storage layers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->