### PR TITLE
fix: rename `/api/model-catalog` route to `/api/models/catalog`

### DIFF
--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -33,7 +33,7 @@ type ModelsManager interface {
 	UpsertModelPricingAttributes(ctx context.Context, entries []ModelPricingAttributesEntry) error
 }
 
-// ModelPricingAttributesEntry is the wire shape for PUT /api/model-catalog.
+// ModelPricingAttributesEntry is the wire shape for PUT /api/models/catalog.
 // (model, provider) is the natural key on governance_model_pricing.
 type ModelPricingAttributesEntry struct {
 	Model                string            `json:"model"`
@@ -137,7 +137,7 @@ func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...schema
 	r.GET("/api/models/details", lib.ChainMiddlewares(h.listModelDetails, middlewares...))
 	r.GET("/api/models/parameters", lib.ChainMiddlewares(h.getModelParameters, middlewares...))
 	r.GET("/api/models/base", lib.ChainMiddlewares(h.listBaseModels, middlewares...))
-	r.PUT("/api/model-catalog", lib.ChainMiddlewares(h.upsertModelCatalogEntries, middlewares...))
+	r.PUT("/api/models/catalog", lib.ChainMiddlewares(h.upsertModelCatalogEntries, middlewares...))
 }
 
 // listProviders handles GET /api/providers - List all providers
@@ -1222,7 +1222,7 @@ func validateRetryBackoff(networkConfig *schemas.NetworkConfig) error {
 	return nil
 }
 
-// upsertModelCatalogEntries handles PUT /api/model-catalog — batch-upserts
+// upsertModelCatalogEntries handles PUT /api/models/catalog — batch-upserts
 // the additional_attributes JSON on the pricing rows keyed by
 // (model, provider). Every requested (model, provider) must already exist in
 // governance_model_pricing; the whole batch is rejected atomically if any

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -51,7 +51,7 @@ export interface ListModelDetailsResponse {
 	total: number;
 }
 
-// ModelPricingAttributesEntry is the body element for PUT /api/model-catalog.
+// ModelPricingAttributesEntry is the body element for PUT /api/models/catalog.
 // (model, provider) is the natural key on governance_model_pricing. An empty
 // or omitted additional_attributes clears the column for that row.
 export interface ModelPricingAttributesEntry {
@@ -401,7 +401,7 @@ export const providersApi = baseApi.injectEndpoints({
 		// map clears the column for that row.
 		upsertModelCatalogEntries: builder.mutation<void, ModelPricingAttributesEntry[]>({
 			query: (entries) => ({
-				url: "/model-catalog",
+				url: "/models/catalog",
 				method: "PUT",
 				body: entries,
 			}),


### PR DESCRIPTION
## Summary

Renames the model catalog API endpoint from `/api/model-catalog` to `/api/models/catalog` to align with the existing `/api/models/*` route namespace convention.

## Changes

- Updated the route registration in `providers.go` from `PUT /api/model-catalog` to `PUT /api/models/catalog`
- Updated the corresponding UI API client URL from `/model-catalog` to `/models/catalog`
- Updated comments and documentation strings to reflect the new endpoint path

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./transports/bifrost-http/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify that a `PUT` request to `/api/models/catalog` with a valid `ModelPricingAttributesEntry` payload succeeds, and that the old `/api/model-catalog` path returns a 404.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

Any clients calling `PUT /api/model-catalog` directly must update to `PUT /api/models/catalog`. The UI client has been updated accordingly.

## Related issues

N/A

## Security considerations

None. This is a route rename with no changes to authentication, authorization, or data handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized API endpoint path for model catalog management operations to follow naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->