### PR TITLE
feat: adds support for multiple otel collectors

### DIFF
--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -127,15 +127,17 @@ func (p *OtelPlugin) buildReparentMap(spans []*schemas.Span) map[string]string {
 	return filtered
 }
 
-// convertTraceToResourceSpan converts a Bifrost trace to OTEL ResourceSpan
-func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceSpan {
+// convertTraceToResourceSpan converts a Bifrost trace to OTEL ResourceSpan for the given
+// profile service name. Span filtering and instance attributes are shared across profiles;
+// only the resource service name differs per profile.
+func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace) *ResourceSpan {
 	reparent := p.buildReparentMap(trace.Spans)
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
 		if !p.shouldExportSpan(span) {
 			continue
 		}
-		otelSpan := p.convertSpanToOTELSpan(trace.TraceID, span)
+		otelSpan := convertSpanToOTELSpan(trace.TraceID, span)
 		// If the span's direct parent was filtered, rewrite its parent ID to the
 		// nearest exported ancestor so the hierarchy stays connected.
 		if effectiveParent, ok := reparent[span.ParentID]; ok {
@@ -160,17 +162,17 @@ func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceS
 	}
 	return &ResourceSpan{
 		Resource: &resourcepb.Resource{
-			Attributes: p.getResourceAttributes(),
+			Attributes: p.getResourceAttributes(serviceName),
 		},
 		ScopeSpans: []*ScopeSpan{{
-			Scope: p.getInstrumentationScope(),
+			Scope: p.getInstrumentationScope(serviceName),
 			Spans: otelSpans,
 		}},
 	}
 }
 
 // convertSpanToOTELSpan converts a single Bifrost span to OTEL format
-func (p *OtelPlugin) convertSpanToOTELSpan(traceID string, span *schemas.Span) *Span {
+func convertSpanToOTELSpan(traceID string, span *schemas.Span) *Span {
 	otelSpan := &Span{
 		TraceId:           hexToBytes(traceID, 16),
 		SpanId:            hexToBytes(span.SpanID, 8),
@@ -192,9 +194,9 @@ func (p *OtelPlugin) convertSpanToOTELSpan(traceID string, span *schemas.Span) *
 }
 
 // getResourceAttributes returns the resource attributes for the OTEL span
-func (p *OtelPlugin) getResourceAttributes() []*KeyValue {
+func (p *OtelPlugin) getResourceAttributes(serviceName string) []*KeyValue {
 	attrs := []*KeyValue{
-		kvStr("service.name", p.serviceName),
+		kvStr("service.name", serviceName),
 		kvStr("service.version", p.bifrostVersion),
 		kvStr("telemetry.sdk.name", "bifrost"),
 		kvStr("telemetry.sdk.language", "go"),
@@ -205,9 +207,9 @@ func (p *OtelPlugin) getResourceAttributes() []*KeyValue {
 }
 
 // getInstrumentationScope returns the instrumentation scope for OTEL
-func (p *OtelPlugin) getInstrumentationScope() *commonpb.InstrumentationScope {
+func (p *OtelPlugin) getInstrumentationScope(serviceName string) *commonpb.InstrumentationScope {
 	return &commonpb.InstrumentationScope{
-		Name:    p.serviceName,
+		Name:    serviceName,
 		Version: p.bifrostVersion,
 	}
 }

--- a/plugins/otel/grpc.go
+++ b/plugins/otel/grpc.go
@@ -2,10 +2,6 @@ package otel
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"fmt"
-	"os"
 
 	collectorpb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
@@ -24,33 +20,15 @@ type OtelClientGRPC struct {
 // NewOtelClientGRPC creates a new OpenTelemetry client for gRPC
 func NewOtelClientGRPC(endpoint string, headers map[string]string, tlsCACert string, insecureMode bool) (*OtelClientGRPC, error) {
 	var creds credentials.TransportCredentials
-	// TLS priority: custom CA > system roots > insecure
-	if tlsCACert != "" {
-		// Validate the CA cert path to prevent path traversal attacks
-		if err := validateCACertPath(tlsCACert); err != nil {
-			return nil, err
-		}
-		// Use custom CA certificate with MinVersion
-		caCert, err := os.ReadFile(tlsCACert)
-		if err != nil {
-			return nil, fmt.Errorf("fail to load provided CA cert: %w", err)
-		}
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("fail to parse provided CA cert")
-		}
-		tlsConfig := &tls.Config{
-			RootCAs:    caCertPool,
-			MinVersion: tls.VersionTLS12,
-		}
-		creds = credentials.NewTLS(tlsConfig)
-	} else if insecureMode {
-		// Skip TLS entirely
+
+	// gRPC insecure mode uses plaintext (no TLS at all), not just skip-verify.
+	// buildTLSConfig is bypassed here to preserve that behaviour.
+	if tlsCACert == "" && insecureMode {
 		creds = insecure.NewCredentials()
 	} else {
-		// Use system root CAs with MinVersion
-		tlsConfig := &tls.Config{
-			MinVersion: tls.VersionTLS12,
+		tlsConfig, err := buildTLSConfig(tlsCACert, false)
+		if err != nil {
+			return nil, err
 		}
 		creds = credentials.NewTLS(tlsConfig)
 	}

--- a/plugins/otel/http.go
+++ b/plugins/otel/http.go
@@ -3,12 +3,9 @@ package otel
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -30,35 +27,11 @@ func NewOtelClientHTTP(endpoint string, headers map[string]string, tlsCACert str
 	transport.MaxIdleConnsPerHost = 10
 	transport.IdleConnTimeout = 120 * time.Second
 
-	// TLS priority: custom CA > system roots > insecure
-	if tlsCACert != "" {
-		// Validate the CA cert path to prevent path traversal attacks
-		if err := validateCACertPath(tlsCACert); err != nil {
-			return nil, err
-		}
-		caCert, err := os.ReadFile(tlsCACert)
-		if err != nil {
-			return nil, fmt.Errorf("fail to load provided CA cert: %w", err)
-		}
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("fail to add provided CA cert")
-		}
-		transport.TLSClientConfig = &tls.Config{
-			RootCAs:    caCertPool,
-			MinVersion: tls.VersionTLS12,
-		}
-	} else if insecureMode {
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true, // #nosec G402
-			MinVersion:         tls.VersionTLS12,
-		}
-	} else {
-		// Use system root CAs with MinVersion
-		transport.TLSClientConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}
+	tlsConfig, err := buildTLSConfig(tlsCACert, insecureMode)
+	if err != nil {
+		return nil, err
 	}
+	transport.TLSClientConfig = tlsConfig
 
 	return &OtelClientHTTP{client: &http.Client{
 		Timeout:   30 * time.Second,

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -4,8 +4,10 @@ package otel
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
@@ -30,20 +32,13 @@ type TraceType string
 // TraceTypeGenAIExtension is the type of trace to use for the OTEL collector
 const TraceTypeGenAIExtension TraceType = "genai_extension"
 
-// TraceTypeVercel is the type of trace to use for the OTEL collector
-const TraceTypeVercel TraceType = "vercel"
-
-// TraceTypeOpenInference is the type of trace to use for the OTEL collector
-const TraceTypeOpenInference TraceType = "open_inference"
-
 // Protocol is the protocol to use for the OTEL collector
 type Protocol string
 
-// ProtocolHTTP is the default protocol
-const ProtocolHTTP Protocol = "http"
-
-// ProtocolGRPC is the second protocol
-const ProtocolGRPC Protocol = "grpc"
+const (
+	ProtocolHTTP Protocol = "http" // default
+	ProtocolGRPC Protocol = "grpc"
+)
 
 // PluginSpanFilterMode controls whether the plugins list is an allowlist or denylist.
 type PluginSpanFilterMode string
@@ -60,82 +55,227 @@ type PluginSpanFilter struct {
 	Plugins []string             `json:"plugins"`
 }
 
-type Config struct {
-	ServiceName  string                     `json:"service_name"`
-	CollectorURL *schemas.EnvVar            `json:"collector_url"`
-	Headers      map[string]*schemas.EnvVar `json:"headers"`
-	TraceType    TraceType                  `json:"trace_type"`
-	Protocol     Protocol                   `json:"protocol"`
-	TLSCACert    string                     `json:"tls_ca_cert"`
-	Insecure     bool                       `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set. Defaults to true when omitted.
+// Profile is a single OTEL export target: a collector endpoint and an optional
+// metrics-push destination. A Config holds one or more profiles; each profile gets
+// its own trace client and (when enabled) metrics exporter at runtime.
+//
+// Headers are plain strings using the "env.VAR_NAME" convention; they are resolved
+// against the environment at Init time via injectEnvToHeaders.
+type Profile struct {
+	// Enabled gates whether this profile exports anything. The plugin itself is always on;
+	// a disabled profile builds no trace client or metrics exporter, so no traces/metrics
+	// are sent for it. Defaults to true when omitted.
+	Enabled      bool              `json:"enabled"`
+	ServiceName  string            `json:"service_name"`
+	CollectorURL *schemas.EnvVar   `json:"collector_url"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	TraceType    TraceType         `json:"trace_type"`
+	Protocol     Protocol          `json:"protocol"`
+	TLSCACert    string            `json:"tls_ca_cert,omitempty"`
+	Insecure     bool              `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set. Defaults to true when omitted.
 
 	// Metrics push configuration
 	MetricsEnabled      bool            `json:"metrics_enabled"`
-	MetricsEndpoint     *schemas.EnvVar `json:"metrics_endpoint"`
-	MetricsPushInterval int             `json:"metrics_push_interval"` // in seconds, default 15
+	MetricsEndpoint     *schemas.EnvVar `json:"metrics_endpoint,omitempty"`
+	MetricsPushInterval int             `json:"metrics_push_interval,omitempty"` // in seconds, default 15
+}
 
-	// PluginSpanFilter is the DB-stored fallback when otel_plugin_span_filter is absent in config.json.
-	// The top-level config.json field takes precedence and is passed via Init's pluginSpanFilter param.
+// UnmarshalJSON applies field defaults that the zero-value wouldn't capture.
+// Specifically, Insecure defaults to true when the key is omitted so http://
+// collectors work out-of-the-box without forcing users to set it explicitly.
+func (p *Profile) UnmarshalJSON(data []byte) error {
+	type alias Profile
+	aux := struct {
+		Enabled  *bool `json:"enabled"`
+		Insecure *bool `json:"insecure"`
+		*alias
+	}{
+		alias: (*alias)(p),
+	}
+	if err := sonic.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Insecure == nil {
+		p.Insecure = true
+	} else {
+		p.Insecure = *aux.Insecure
+	}
+	if aux.Enabled == nil {
+		p.Enabled = true
+	} else {
+		p.Enabled = *aux.Enabled
+	}
+	return nil
+}
+
+// Config is the OTEL plugin configuration: a set of export profiles plus a single
+// shared span filter. It accepts two JSON shapes (see UnmarshalJSON):
+//   - the canonical wrapper {"profiles": [ ... ], "plugin_span_filter": { ... }}
+//   - a legacy single profile object, which is normalized into a one-element Profiles slice.
+type Config struct {
+	Profiles []*Profile `json:"profiles"`
+
+	// PluginSpanFilter is a single policy applied across every profile. In a legacy
+	// single-object config it is read from the object; in a profiles wrapper it is read
+	// from the top-level field (or hoisted from the first profile that carries one).
 	PluginSpanFilter *PluginSpanFilter `json:"plugin_span_filter,omitempty"`
 }
 
-// MarshalForStorage serializes Config to JSON with *EnvVar fields as plain strings
-// ("env.VAR_NAME" or the literal value) for database/config-file persistence.
-// For HTTP API responses use json.Marshal directly so clients receive full EnvVar objects.
-func (c *Config) MarshalForStorage() ([]byte, error) {
-	type alias struct {
-		ServiceName         string            `json:"service_name"`
-		CollectorURL        string            `json:"collector_url"`
-		Headers             map[string]string `json:"headers,omitempty"`
-		TraceType           TraceType         `json:"trace_type"`
-		Protocol            Protocol          `json:"protocol"`
-		TLSCACert           string            `json:"tls_ca_cert,omitempty"`
-		Insecure            bool              `json:"insecure"`
-		MetricsEnabled      bool              `json:"metrics_enabled"`
-		MetricsEndpoint     string            `json:"metrics_endpoint,omitempty"`
-		MetricsPushInterval int               `json:"metrics_push_interval,omitempty"`
-		PluginSpanFilter    *PluginSpanFilter `json:"plugin_span_filter,omitempty"`
-	}
-	a := alias{
-		ServiceName:         c.ServiceName,
-		CollectorURL:        schemas.EnvVarAsString(c.CollectorURL),
-		TraceType:           c.TraceType,
-		Protocol:            c.Protocol,
-		TLSCACert:           c.TLSCACert,
-		Insecure:            c.Insecure,
-		MetricsEnabled:      c.MetricsEnabled,
-		MetricsEndpoint:     schemas.EnvVarAsString(c.MetricsEndpoint),
-		MetricsPushInterval: c.MetricsPushInterval,
-		PluginSpanFilter:    c.PluginSpanFilter,
-	}
-	if c.Headers != nil {
-		a.Headers = make(map[string]string, len(c.Headers))
-		for k, v := range c.Headers {
-			a.Headers[k] = schemas.EnvVarAsString(v)
+// UnmarshalJSON normalizes both supported config shapes into Profiles. A wrapper object
+// (one with a "profiles" key) is read directly; any other object is treated as a single
+// legacy profile, with its plugin_span_filter hoisted to the shared Config level.
+func (c *Config) UnmarshalJSON(data []byte) error {
+	// Canonical wrapper shape.
+	if node, err := sonic.Get(data, "profiles"); err == nil && node.Exists() {
+		type wrapper Config
+		var w wrapper
+		if err := sonic.Unmarshal(data, &w); err != nil {
+			return err
 		}
+		*c = Config(w)
+		// Allow plugin_span_filter to live on the first profile too; hoist it if the
+		// top-level field was omitted.
+		if c.PluginSpanFilter == nil {
+			c.PluginSpanFilter = hoistSpanFilter(data)
+		}
+		return nil
 	}
-	return sonic.Marshal(a)
+
+	// Legacy single-object shape: the whole object is one profile.
+	var prof Profile
+	if err := sonic.Unmarshal(data, &prof); err != nil {
+		return err
+	}
+	c.Profiles = []*Profile{&prof}
+	c.PluginSpanFilter = spanFilterFrom(data)
+	return nil
 }
 
-// Redacted returns a copy of the config with sensitive EnvVar fields redacted for API responses.
+// spanFilterCarrier captures only the plugin_span_filter field from a config or profile object.
+type spanFilterCarrier struct {
+	PluginSpanFilter *PluginSpanFilter `json:"plugin_span_filter,omitempty"`
+}
+
+// spanFilterFrom extracts a top-level plugin_span_filter from a JSON object, or nil.
+func spanFilterFrom(data []byte) *PluginSpanFilter {
+	var c spanFilterCarrier
+	if err := sonic.Unmarshal(data, &c); err != nil {
+		return nil
+	}
+	return c.PluginSpanFilter
+}
+
+// hoistSpanFilter returns the first plugin_span_filter found among the profiles of a
+// wrapper-shaped config, used as a fallback when the top-level field is absent.
+func hoistSpanFilter(data []byte) *PluginSpanFilter {
+	var w struct {
+		Profiles []spanFilterCarrier `json:"profiles"`
+	}
+	if err := sonic.Unmarshal(data, &w); err != nil {
+		return nil
+	}
+	for _, p := range w.Profiles {
+		if p.PluginSpanFilter != nil {
+			return p.PluginSpanFilter
+		}
+	}
+	return nil
+}
+
+// profileForStorage is the persisted form of a single profile: *EnvVar fields are
+// flattened to plain strings ("env.VAR_NAME" or the literal value) for DB/config-file
+// persistence.
+type profileForStorage struct {
+	Enabled             bool              `json:"enabled"`
+	ServiceName         string            `json:"service_name"`
+	CollectorURL        string            `json:"collector_url"`
+	Headers             map[string]string `json:"headers,omitempty"`
+	TraceType           TraceType         `json:"trace_type"`
+	Protocol            Protocol          `json:"protocol"`
+	TLSCACert           string            `json:"tls_ca_cert,omitempty"`
+	Insecure            bool              `json:"insecure"`
+	MetricsEnabled      bool              `json:"metrics_enabled"`
+	MetricsEndpoint     string            `json:"metrics_endpoint,omitempty"`
+	MetricsPushInterval int               `json:"metrics_push_interval,omitempty"`
+}
+
+// configForStorage is the persisted wrapper shape.
+type configForStorage struct {
+	Profiles         []profileForStorage `json:"profiles"`
+	PluginSpanFilter *PluginSpanFilter   `json:"plugin_span_filter,omitempty"`
+}
+
+// MarshalForStorage serializes Config to JSON with *EnvVar fields as plain strings
+// ("env.VAR_NAME" or the literal value) for database/config-file persistence. Output is
+// always the canonical {"profiles": [...]} wrapper regardless of the input shape.
+// For HTTP API responses use json.Marshal directly so clients receive full EnvVar objects.
+func (c *Config) MarshalForStorage() ([]byte, error) {
+	out := configForStorage{
+		Profiles:         make([]profileForStorage, 0, len(c.Profiles)),
+		PluginSpanFilter: c.PluginSpanFilter,
+	}
+	for _, p := range c.Profiles {
+		if p == nil {
+			continue
+		}
+		out.Profiles = append(out.Profiles, profileForStorage{
+			Enabled:             p.Enabled,
+			ServiceName:         p.ServiceName,
+			CollectorURL:        schemas.EnvVarAsString(p.CollectorURL),
+			Headers:             p.Headers,
+			TraceType:           p.TraceType,
+			Protocol:            p.Protocol,
+			TLSCACert:           p.TLSCACert,
+			Insecure:            p.Insecure,
+			MetricsEnabled:      p.MetricsEnabled,
+			MetricsEndpoint:     schemas.EnvVarAsString(p.MetricsEndpoint),
+			MetricsPushInterval: p.MetricsPushInterval,
+		})
+	}
+	return sonic.Marshal(out)
+}
+
+// Redacted returns a copy of the config with sensitive fields redacted for API responses.
 // URLs (CollectorURL, MetricsEndpoint) are not secrets and are returned unchanged so the UI
 // can display and re-submit them without failing URL validation. For env var references on
 // those fields, only the resolved value is hidden; the env_var name is preserved.
-// Header values may carry auth tokens and are masked.
+// Header values may carry auth tokens, so literal values are masked while "env." references
+// are preserved.
 func (c *Config) Redacted() *Config {
 	if c == nil {
 		return nil
 	}
-	redacted := *c
-	redacted.CollectorURL = hideResolvedEnvValue(c.CollectorURL)
-	redacted.MetricsEndpoint = hideResolvedEnvValue(c.MetricsEndpoint)
-	if c.Headers != nil {
-		redacted.Headers = make(map[string]*schemas.EnvVar, len(c.Headers))
-		for k, v := range c.Headers {
-			redacted.Headers[k] = v.Redacted()
+	redacted := &Config{PluginSpanFilter: c.PluginSpanFilter}
+	if c.Profiles != nil {
+		redacted.Profiles = make([]*Profile, 0, len(c.Profiles))
+		for _, p := range c.Profiles {
+			if p == nil {
+				redacted.Profiles = append(redacted.Profiles, nil)
+				continue
+			}
+			rp := *p
+			rp.CollectorURL = hideResolvedEnvValue(p.CollectorURL)
+			rp.MetricsEndpoint = hideResolvedEnvValue(p.MetricsEndpoint)
+			if p.Headers != nil {
+				rp.Headers = make(map[string]string, len(p.Headers))
+				for k, v := range p.Headers {
+					rp.Headers[k] = redactHeaderValue(v)
+				}
+			}
+			redacted.Profiles = append(redacted.Profiles, &rp)
 		}
 	}
-	return &redacted
+	return redacted
+}
+
+// redactHeaderValue masks a plain-string header value for API responses. "env." references
+// are returned unchanged (they are not secrets), while literal values are masked using the
+// same scheme as EnvVar.Redacted so the API surface stays consistent.
+func redactHeaderValue(v string) string {
+	if strings.HasPrefix(v, "env.") {
+		return v
+	}
+	return schemas.EnvVarAsString(schemas.NewEnvVar(v).Redacted())
 }
 
 // hideResolvedEnvValue returns v unchanged for literal values (URLs are not secrets).
@@ -149,52 +289,34 @@ func hideResolvedEnvValue(v *schemas.EnvVar) *schemas.EnvVar {
 	return v.Redacted()
 }
 
-// UnmarshalJSON applies field defaults that the zero-value wouldn't capture.
-// Specifically, Insecure defaults to true when the key is omitted so http://
-// collectors work out-of-the-box without forcing users to set it explicitly.
-func (c *Config) UnmarshalJSON(data []byte) error {
-	type alias Config
-	aux := struct {
-		Insecure *bool `json:"insecure"`
-		*alias
-	}{
-		alias: (*alias)(c),
-	}
-	if err := sonic.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	if aux.Insecure == nil {
-		c.Insecure = true
-	} else {
-		c.Insecure = *aux.Insecure
-	}
-	return nil
+// otelTarget is the runtime state for a single configured profile: one trace client
+// plus an optional metrics exporter, along with the per-profile identity (service name)
+// used when converting traces for this destination.
+type otelTarget struct {
+	serviceName     string
+	url             string
+	traceType       TraceType
+	client          OtelClient
+	metricsExporter *MetricsExporter
 }
 
 // OtelPlugin is the plugin for OpenTelemetry.
 // It implements the ObservabilityPlugin interface to receive completed traces
-// from the tracing middleware and forward them to an OTEL collector.
+// from the tracing middleware and forward them to one or more OTEL collectors.
 type OtelPlugin struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	serviceName string
-	url         string
-	headers     map[string]string
-	traceType   TraceType
-	protocol    Protocol
+	// targets holds one runtime per configured profile. Each completed trace is exported
+	// to every target's collector, and metrics are recorded against every target's exporter.
+	targets []*otelTarget
 
 	bifrostVersion string
 
 	attributesFromEnvironment []*commonpb.KeyValue
 	instanceAttrs             []*commonpb.KeyValue // machine ID + pod labels, added only to root spans
 
-	client OtelClient
-
 	pricingManager *modelcatalog.ModelCatalog
-
-	// Metrics push support
-	metricsExporter *MetricsExporter
 
 	pluginSpanFilter *PluginSpanFilter
 }
@@ -208,7 +330,9 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 	if pricingManager == nil {
 		logger.Warn("otel plugin requires model catalog to calculate cost, all cost calculations will be skipped.")
 	}
-	var err error
+	if len(config.Profiles) == 0 {
+		return nil, fmt.Errorf("at least one otel profile is required")
+	}
 	if config.PluginSpanFilter != nil {
 		switch config.PluginSpanFilter.Mode {
 		case PluginSpanFilterModeInclude, PluginSpanFilterModeExclude:
@@ -216,9 +340,6 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 			return nil, fmt.Errorf("plugin_span_filter.mode %q is invalid: must be %q or %q",
 				config.PluginSpanFilter.Mode, PluginSpanFilterModeInclude, PluginSpanFilterModeExclude)
 		}
-	}
-	if config.ServiceName == "" {
-		config.ServiceName = "bifrost"
 	}
 	// Loading attributes from environment
 	attributesFromEnvironment := make([]*commonpb.KeyValue, 0)
@@ -248,11 +369,6 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 	}
 	// Preparing the plugin
 	p := &OtelPlugin{
-		serviceName:               config.ServiceName,
-		url:                       config.CollectorURL.GetValue(),
-		traceType:                 config.TraceType,
-		headers:                   resolveHeaders(config.Headers),
-		protocol:                  config.Protocol,
 		pricingManager:            pricingManager,
 		bifrostVersion:            bifrostVersion,
 		attributesFromEnvironment: attributesFromEnvironment,
@@ -260,54 +376,102 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		pluginSpanFilter:          config.PluginSpanFilter,
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
-	if config.Protocol == ProtocolGRPC {
-		p.client, err = NewOtelClientGRPC(config.CollectorURL.GetValue(), p.headers, config.TLSCACert, config.Insecure)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if config.Protocol == ProtocolHTTP {
-		p.client, err = NewOtelClientHTTP(config.CollectorURL.GetValue(), p.headers, config.TLSCACert, config.Insecure)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if p.client == nil {
-		return nil, fmt.Errorf("otel client is not initialized. invalid protocol type")
-	}
 
-	// Initialize metrics exporter if enabled
-	if config.MetricsEnabled {
-		if config.MetricsEndpoint.GetValue() == "" {
-			return nil, fmt.Errorf("metrics_endpoint is required when metrics_enabled is true")
+	for i, profile := range config.Profiles {
+		// A disabled profile exports nothing — skip building its client/exporter entirely.
+		if profile != nil && !profile.Enabled {
+			logger.Info("OTEL profile %d is disabled, skipping", i)
+			continue
 		}
-		pushInterval := config.MetricsPushInterval
-		if pushInterval <= 0 {
-			pushInterval = 15 // default 15 seconds
-		} else if pushInterval > 300 {
-			return nil, fmt.Errorf("metrics_push_interval must be between 1 and 300 seconds, got %d", pushInterval)
-		}
-		metricsConfig := &MetricsConfig{
-			ServiceName:  config.ServiceName,
-			Endpoint:     config.MetricsEndpoint.GetValue(),
-			Headers:      p.headers,
-			Protocol:     config.Protocol,
-			TLSCACert:    config.TLSCACert,
-			Insecure:     config.Insecure,
-			PushInterval: pushInterval,
-		}
-		p.metricsExporter, err = NewMetricsExporter(p.ctx, metricsConfig)
+		target, err := p.buildTarget(i, profile)
 		if err != nil {
-			// Clean up trace client if metrics exporter fails
-			if p.client != nil {
-				p.client.Close()
-			}
-			return nil, fmt.Errorf("failed to initialize metrics exporter: %w", err)
+			// Tear down any targets already initialized so we don't leak clients/exporters.
+			_ = p.Cleanup()
+			return nil, err
 		}
-		logger.Info("OTEL metrics push enabled, pushing to %s every %d seconds", config.MetricsEndpoint.GetValue(), pushInterval)
+		p.targets = append(p.targets, target)
 	}
 
 	return p, nil
+}
+
+// buildTarget constructs the runtime for a single profile: it resolves headers, validates
+// the protocol, opens the trace client, and (when enabled) starts the metrics exporter.
+func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, error) {
+	if profile == nil {
+		return nil, fmt.Errorf("profile %d is nil", index)
+	}
+	if profile.CollectorURL == nil || profile.CollectorURL.GetValue() == "" {
+		return nil, fmt.Errorf("profile %d: collector url is required", index)
+	}
+
+	serviceName := profile.ServiceName
+	if serviceName == "" {
+		serviceName = "bifrost"
+	}
+
+	// Copy headers before resolving so the stored config is never mutated, then resolve
+	// any "env." references against the environment (errors if a referenced var is unset).
+	headers := make(map[string]string, len(profile.Headers))
+	maps.Copy(headers, profile.Headers)
+	if err := injectEnvToHeaders(headers); err != nil {
+		return nil, fmt.Errorf("profile %d: %w", index, err)
+	}
+
+	url := profile.CollectorURL.GetValue()
+	target := &otelTarget{
+		serviceName: serviceName,
+		url:         url,
+		traceType:   profile.TraceType,
+	}
+
+	var err error
+	switch profile.Protocol {
+	case ProtocolGRPC:
+		target.client, err = NewOtelClientGRPC(url, headers, profile.TLSCACert, profile.Insecure)
+	case ProtocolHTTP:
+		target.client, err = NewOtelClientHTTP(url, headers, profile.TLSCACert, profile.Insecure)
+	default:
+		return nil, fmt.Errorf("profile %d: invalid protocol type %q", index, profile.Protocol)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("profile %d: %w", index, err)
+	}
+
+	// Initialize metrics exporter if enabled
+	if profile.MetricsEnabled {
+		if profile.MetricsEndpoint.GetValue() == "" {
+			target.client.Close()
+			return nil, fmt.Errorf("profile %d: metrics_endpoint is required when metrics_enabled is true", index)
+		}
+		pushInterval := profile.MetricsPushInterval
+		if pushInterval <= 0 {
+			pushInterval = 15 // default 15 seconds
+		} else if pushInterval > 300 {
+			target.client.Close()
+			return nil, fmt.Errorf("profile %d: metrics_push_interval must be between 1 and 300 seconds, got %d", index, pushInterval)
+		}
+		metricsConfig := &MetricsConfig{
+			ServiceName:  serviceName,
+			Endpoint:     profile.MetricsEndpoint.GetValue(),
+			Headers:      headers,
+			Protocol:     profile.Protocol,
+			TLSCACert:    profile.TLSCACert,
+			Insecure:     profile.Insecure,
+			PushInterval: pushInterval,
+		}
+		target.metricsExporter, err = NewMetricsExporter(p.ctx, metricsConfig)
+		if err != nil {
+			// Clean up trace client if metrics exporter fails
+			if target.client != nil {
+				target.client.Close()
+			}
+			return nil, fmt.Errorf("profile %d: failed to initialize metrics exporter: %w", index, err)
+		}
+		logger.Info("OTEL metrics push enabled for profile %d, pushing to %s every %d seconds", index, profile.MetricsEndpoint.GetValue(), pushInterval)
+	}
+
+	return target, nil
 }
 
 // GetName function for the OTEL plugin
@@ -372,50 +536,6 @@ func (p *OtelPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, r
 	return chunk, nil
 }
 
-// ValidateConfig function for the OTEL plugin
-func (p *OtelPlugin) ValidateConfig(config any) (*Config, error) {
-	var otelConfig Config
-	// Checking if its a string, then we will JSON parse and confirm
-	if configStr, ok := config.(string); ok {
-		if err := sonic.Unmarshal([]byte(configStr), &otelConfig); err != nil {
-			return nil, err
-		}
-	}
-	// Checking if its a map[string]any, then we will JSON parse and confirm
-	if configMap, ok := config.(map[string]any); ok {
-		configString, err := sonic.Marshal(configMap)
-		if err != nil {
-			return nil, err
-		}
-		if err := sonic.Unmarshal([]byte(configString), &otelConfig); err != nil {
-			return nil, err
-		}
-	}
-	// Checking if its a Config, then we will confirm
-	if config, ok := config.(*Config); ok {
-		otelConfig = *config
-	}
-	// Validating fields
-	if otelConfig.CollectorURL == nil || otelConfig.CollectorURL.GetValue() == "" {
-		return nil, fmt.Errorf("collector url is required")
-	}
-	if otelConfig.TraceType == "" {
-		return nil, fmt.Errorf("trace type is required")
-	}
-	if otelConfig.Protocol == "" {
-		return nil, fmt.Errorf("protocol is required")
-	}
-	if otelConfig.PluginSpanFilter != nil {
-		switch otelConfig.PluginSpanFilter.Mode {
-		case PluginSpanFilterModeInclude, PluginSpanFilterModeExclude:
-		default:
-			return nil, fmt.Errorf("plugin_span_filter.mode %q is invalid: must be %q or %q",
-				otelConfig.PluginSpanFilter.Mode, PluginSpanFilterModeInclude, PluginSpanFilterModeExclude)
-		}
-	}
-	return &otelConfig, nil
-}
-
 // PreLLMHook is a no-op - tracing is handled via the Inject method.
 // The OTEL plugin receives completed traces from TracingMiddleware.
 func (p *OtelPlugin) PreLLMHook(_ *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
@@ -431,7 +551,7 @@ func (p *OtelPlugin) PreLLMHook(_ *schemas.BifrostContext, req *schemas.BifrostR
 // This is the ONLY place RecordCacheHit is called — do not also emit it from
 // recordMetricsFromTrace, or cache hits will double-count.
 func (p *OtelPlugin) PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
-	if p.metricsExporter == nil || resp == nil {
+	if resp == nil || !p.anyMetricsEnabled() {
 		return resp, bifrostErr, nil
 	}
 	extra := resp.GetExtraFields()
@@ -449,9 +569,23 @@ func (p *OtelPlugin) PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.Bifr
 	// cache hit has no span to read.
 	attrs := append(buildContextAttrs(ctx, resp, bifrostErr), attribute.String("cache_type", cacheType))
 
-	p.metricsExporter.RecordCacheHit(ctx, attrs...)
+	for _, t := range p.targets {
+		if t.metricsExporter != nil {
+			t.metricsExporter.RecordCacheHit(ctx, attrs...)
+		}
+	}
 
 	return resp, bifrostErr, nil
+}
+
+// anyMetricsEnabled reports whether at least one profile has a metrics exporter running.
+func (p *OtelPlugin) anyMetricsEnabled() bool {
+	for _, t := range p.targets {
+		if t.metricsExporter != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // Inject receives a completed trace and sends it to the OTEL collector.
@@ -462,19 +596,26 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 	if trace == nil {
 		return nil
 	}
-	// Emit trace to collector if client is initialized
-	if p.client != nil {
-		// Convert schemas.Trace to OTEL ResourceSpan
-		resourceSpan := p.convertTraceToResourceSpan(trace)
-		// Emit to collector
-		if err := p.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
-			logger.Error("failed to emit trace %s: %v", trace.TraceID, err)
-		}
+	// Emit the trace to every configured profile's collector, and record metrics against
+	// each profile's exporter. Conversion is per-target because the resource service name
+	// differs per profile; everything else (filter, instance attrs) is shared.
+	var wg sync.WaitGroup
+	for _, t := range p.targets {
+		wg.Add(1)
+		go func(t *otelTarget) {
+			defer wg.Done()
+			if t.client != nil {
+				resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace)
+				if err := t.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
+					logger.Error("failed to emit trace %s to %s: %v", trace.TraceID, t.url, err)
+				}
+			}
+			if t.metricsExporter != nil {
+				p.recordMetricsFromTrace(ctx, t.metricsExporter, trace)
+			}
+		}(t)
 	}
-	// Record metrics if metrics exporter is enabled
-	if p.metricsExporter != nil {
-		p.recordMetricsFromTrace(ctx, trace)
-	}
+	wg.Wait()
 	return nil
 }
 
@@ -574,8 +715,8 @@ func buildContextAttrs(ctx context.Context, resp *schemas.BifrostResponse, bifro
 // per llm.call/retry span so fallback attempts and failed retries are counted with
 // their own provider/model/fallback_index labels. Per-trace metrics (tokens, cost,
 // TTFT) are recorded once, keyed off the final (latest) attempt span.
-func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, trace *schemas.Trace) {
-	if trace == nil || p.metricsExporter == nil {
+func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *MetricsExporter, trace *schemas.Trace) {
+	if trace == nil || exporter == nil {
 		return
 	}
 
@@ -587,17 +728,17 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, trace *schemas.
 
 		spanAttrs := buildSpanAttrs(span)
 
-		p.metricsExporter.RecordUpstreamRequest(ctx, spanAttrs...)
+		exporter.RecordUpstreamRequest(ctx, spanAttrs...)
 
 		if !span.StartTime.IsZero() && !span.EndTime.IsZero() {
 			latencySeconds := span.EndTime.Sub(span.StartTime).Seconds()
-			p.metricsExporter.RecordUpstreamLatency(ctx, latencySeconds, spanAttrs...)
+			exporter.RecordUpstreamLatency(ctx, latencySeconds, spanAttrs...)
 		}
 
 		if span.Status == schemas.SpanStatusError {
-			p.metricsExporter.RecordErrorRequest(ctx, spanAttrs...)
+			exporter.RecordErrorRequest(ctx, spanAttrs...)
 		} else {
-			p.metricsExporter.RecordSuccessRequest(ctx, spanAttrs...)
+			exporter.RecordSuccessRequest(ctx, spanAttrs...)
 		}
 
 		if finalSpan == nil || span.EndTime.After(finalSpan.EndTime) {
@@ -618,7 +759,7 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, trace *schemas.
 	// Record retries used for this request. Read off the final span (the last attempt's
 	// attempt index) so the value is "total retries used", matching the Prometheus side.
 	retries := getIntAttr(attrs, schemas.AttrNumberOfRetries)
-	p.metricsExporter.RecordRequestRetries(ctx, float64(retries), otelAttrs...)
+	exporter.RecordRequestRetries(ctx, float64(retries), otelAttrs...)
 
 	// Record token usage - try both naming conventions
 	inputTokens := getIntAttr(attrs, schemas.AttrPromptTokens)
@@ -626,7 +767,7 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, trace *schemas.
 		inputTokens = getIntAttr(attrs, schemas.AttrInputTokens)
 	}
 	if inputTokens > 0 {
-		p.metricsExporter.RecordInputTokens(ctx, int64(inputTokens), otelAttrs...)
+		exporter.RecordInputTokens(ctx, int64(inputTokens), otelAttrs...)
 	}
 
 	outputTokens := getIntAttr(attrs, schemas.AttrCompletionTokens)
@@ -634,20 +775,20 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, trace *schemas.
 		outputTokens = getIntAttr(attrs, schemas.AttrOutputTokens)
 	}
 	if outputTokens > 0 {
-		p.metricsExporter.RecordOutputTokens(ctx, int64(outputTokens), otelAttrs...)
+		exporter.RecordOutputTokens(ctx, int64(outputTokens), otelAttrs...)
 	}
 
 	// Record cost if available
 	cost := getFloat64Attr(attrs, schemas.AttrUsageCost)
 	if cost > 0 {
-		p.metricsExporter.RecordCost(ctx, cost, otelAttrs...)
+		exporter.RecordCost(ctx, cost, otelAttrs...)
 	}
 
 	// Record streaming latency metrics if available
 	ttft := getFloat64Attr(attrs, schemas.AttrTimeToFirstToken)
 	if ttft > 0 {
 		// Convert from nanoseconds to seconds if needed (check the unit)
-		p.metricsExporter.RecordStreamFirstTokenLatency(ctx, ttft/1e9, otelAttrs...)
+		exporter.RecordStreamFirstTokenLatency(ctx, ttft/1e9, otelAttrs...)
 	}
 
 	// Record provider-side prompt cache tokens (cache_read / cache_creation). Unlike the
@@ -657,59 +798,59 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, trace *schemas.
 	// API-family-specific keys that are mutually exclusive per request, so a fallback read
 	// covers both.
 	if n := getIntAttr(attrs, schemas.AttrUsageCacheReadInputTokens); n > 0 {
-		p.metricsExporter.RecordCacheReadInputTokens(ctx, int64(n), otelAttrs...)
+		exporter.RecordCacheReadInputTokens(ctx, int64(n), otelAttrs...)
 	}
 	if n := getIntAttr(attrs, schemas.AttrUsageCacheCreationInputTokens); n > 0 {
-		p.metricsExporter.RecordCacheWriteInputTokens(ctx, int64(n), otelAttrs...)
+		exporter.RecordCacheWriteInputTokens(ctx, int64(n), otelAttrs...)
 	}
 	cacheWrite5m := getIntAttr(attrs, schemas.AttrPromptTokenDetailsCachedWrite5m)
 	if cacheWrite5m == 0 {
 		cacheWrite5m = getIntAttr(attrs, schemas.AttrInputTokenDetailsCachedWrite5m)
 	}
 	if cacheWrite5m > 0 {
-		p.metricsExporter.RecordCacheWriteInputTokens5m(ctx, int64(cacheWrite5m), otelAttrs...)
+		exporter.RecordCacheWriteInputTokens5m(ctx, int64(cacheWrite5m), otelAttrs...)
 	}
 	cacheWrite1h := getIntAttr(attrs, schemas.AttrPromptTokenDetailsCachedWrite1h)
 	if cacheWrite1h == 0 {
 		cacheWrite1h = getIntAttr(attrs, schemas.AttrInputTokenDetailsCachedWrite1h)
 	}
 	if cacheWrite1h > 0 {
-		p.metricsExporter.RecordCacheWriteInputTokens1h(ctx, int64(cacheWrite1h), otelAttrs...)
+		exporter.RecordCacheWriteInputTokens1h(ctx, int64(cacheWrite1h), otelAttrs...)
 	}
 }
 
-// Cleanup function for the OTEL plugin
+// Cleanup function for the OTEL plugin. It shuts down every profile's metrics exporter
+// and closes every trace client, returning the first client-close error encountered.
 func (p *OtelPlugin) Cleanup() error {
 	if p.cancel != nil {
 		p.cancel()
 	}
-	// Shutdown metrics exporter first
-	if p.metricsExporter != nil {
-		if err := p.metricsExporter.Shutdown(context.Background()); err != nil {
-			logger.Error("failed to shutdown metrics exporter: %v", err)
+	var firstErr error
+	for _, t := range p.targets {
+		// Shutdown metrics exporter first
+		if t.metricsExporter != nil {
+			if err := t.metricsExporter.Shutdown(context.Background()); err != nil {
+				logger.Error("failed to shutdown metrics exporter: %v", err)
+			}
+		}
+		if t.client != nil {
+			if err := t.client.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
-	if p.client != nil {
-		return p.client.Close()
+	return firstErr
+}
+
+// GetMetricsExporter returns the first profile's metrics exporter for external use
+// (e.g., by the telemetry plugin). Returns nil if no profile has metrics enabled.
+func (p *OtelPlugin) GetMetricsExporter() *MetricsExporter {
+	for _, t := range p.targets {
+		if t.metricsExporter != nil {
+			return t.metricsExporter
+		}
 	}
 	return nil
-}
-
-// GetMetricsExporter returns the metrics exporter for external use (e.g., by telemetry plugin)
-func (p *OtelPlugin) GetMetricsExporter() *MetricsExporter {
-	return p.metricsExporter
-}
-
-// resolveHeaders converts a map of EnvVar header values to plain strings for use in HTTP/gRPC clients.
-func resolveHeaders(in map[string]*schemas.EnvVar) map[string]string {
-	if in == nil {
-		return nil
-	}
-	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v.GetValue()
-	}
-	return out
 }
 
 // firstNonEmpty returns the first non-empty string from the provided values.

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -2,11 +2,8 @@ package otel
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -244,43 +241,6 @@ func NewMetricsExporter(ctx context.Context, config *MetricsConfig) (*MetricsExp
 	return m, nil
 }
 
-// validateCACertPath validates the CA certificate path to prevent path traversal attacks.
-// It ensures the path is absolute, cleaned of traversal sequences, and exists as a regular file.
-func validateCACertPath(certPath string) error {
-	if certPath == "" {
-		return nil
-	}
-
-	// Clean the path to resolve any .. or . components
-	cleanPath := filepath.Clean(certPath)
-
-	// Require absolute paths to prevent relative path attacks
-	if !filepath.IsAbs(cleanPath) {
-		return fmt.Errorf("TLS CA cert path must be absolute: %s", certPath)
-	}
-
-	// Check that the cleaned path doesn't differ significantly from input
-	// (indicates attempted traversal)
-	if cleanPath != filepath.Clean(filepath.FromSlash(certPath)) {
-		return fmt.Errorf("invalid TLS CA cert path: %s", certPath)
-	}
-
-	// Verify the file exists and is not a symlink
-	info, err := os.Lstat(cleanPath)
-	if err != nil {
-		return fmt.Errorf("TLS CA cert path not accessible: %w", err)
-	}
-	// Reject symlinks to prevent symlink-based path traversal
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("TLS CA cert path cannot be a symlink: %s", certPath)
-	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("TLS CA cert path is not a regular file: %s", certPath)
-	}
-
-	return nil
-}
-
 func createHTTPExporter(ctx context.Context, config *MetricsConfig) (sdkmetric.Exporter, error) {
 	opts := []otlpmetrichttp.Option{
 		otlpmetrichttp.WithEndpointURL(config.Endpoint),
@@ -290,34 +250,16 @@ func createHTTPExporter(ctx context.Context, config *MetricsConfig) (sdkmetric.E
 		opts = append(opts, otlpmetrichttp.WithHeaders(config.Headers))
 	}
 
-	// TLS priority: custom CA > system roots > insecure
-	if config.TLSCACert != "" {
-		// Validate the CA cert path to prevent path traversal attacks
-		if err := validateCACertPath(config.TLSCACert); err != nil {
-			return nil, err
-		}
-		// Use custom CA certificate
-		caCert, err := os.ReadFile(config.TLSCACert)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CA cert: %w", err)
-		}
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("failed to parse CA cert")
-		}
-		tlsConfig := &tls.Config{
-			RootCAs:    caCertPool,
-			MinVersion: tls.VersionTLS12,
-		}
-		opts = append(opts, otlpmetrichttp.WithTLSClientConfig(tlsConfig))
-	} else if config.Insecure {
-		// Skip TLS entirely
+	// HTTP metrics insecure mode disables TLS entirely (unlike the trace HTTP client
+	// which uses InsecureSkipVerify). buildTLSConfig is bypassed for that case.
+	if config.TLSCACert == "" && config.Insecure {
 		opts = append(opts, otlpmetrichttp.WithInsecure())
 	} else {
-		// Use system root CAs (empty tls.Config uses system roots)
-		opts = append(opts, otlpmetrichttp.WithTLSClientConfig(&tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}))
+		tlsConfig, err := buildTLSConfig(config.TLSCACert, false)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, otlpmetrichttp.WithTLSClientConfig(tlsConfig))
 	}
 
 	return otlpmetrichttp.New(ctx, opts...)
@@ -332,37 +274,15 @@ func createGRPCExporter(ctx context.Context, config *MetricsConfig) (sdkmetric.E
 		opts = append(opts, otlpmetricgrpc.WithHeaders(config.Headers))
 	}
 
-	// TLS priority: custom CA > system roots > insecure
-	if config.TLSCACert != "" {
-		// Validate the CA cert path to prevent path traversal attacks
-		if err := validateCACertPath(config.TLSCACert); err != nil {
-			return nil, err
-		}
-		// Use custom CA certificate with MinVersion
-		caCert, err := os.ReadFile(config.TLSCACert)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CA cert: %w", err)
-		}
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("failed to parse CA cert")
-		}
-		tlsConfig := &tls.Config{
-			RootCAs:    caCertPool,
-			MinVersion: tls.VersionTLS12,
-		}
-		creds := credentials.NewTLS(tlsConfig)
-		opts = append(opts, otlpmetricgrpc.WithTLSCredentials(creds))
-	} else if config.Insecure {
-		// Skip TLS entirely
+	// gRPC insecure mode uses plaintext (no TLS at all). buildTLSConfig is bypassed for that case.
+	if config.TLSCACert == "" && config.Insecure {
 		opts = append(opts, otlpmetricgrpc.WithTLSCredentials(insecure.NewCredentials()))
 	} else {
-		// Use system root CAs with MinVersion
-		tlsConfig := &tls.Config{
-			MinVersion: tls.VersionTLS12,
+		tlsConfig, err := buildTLSConfig(config.TLSCACert, false)
+		if err != nil {
+			return nil, err
 		}
-		creds := credentials.NewTLS(tlsConfig)
-		opts = append(opts, otlpmetricgrpc.WithTLSCredentials(creds))
+		opts = append(opts, otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
 	}
 
 	return otlpmetricgrpc.New(ctx, opts...)

--- a/plugins/otel/utils.go
+++ b/plugins/otel/utils.go
@@ -1,0 +1,91 @@
+package otel
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// injectEnvToHeaders converts any headers that start with "env." with their corresponding environment variable value
+// errors out if any environment variable is not found
+func injectEnvToHeaders(headers map[string]string) error {
+	if headers == nil {
+		return nil
+	}
+	for k, v := range headers {
+		if envKey, ok := strings.CutPrefix(v, "env."); ok {
+			envVal, found := os.LookupEnv(envKey)
+			if !found {
+				return fmt.Errorf("environment variable %s not found", envKey)
+			}
+			headers[k] = envVal
+		}
+	}
+	return nil
+}
+
+// validateCACertPath validates the CA certificate path to prevent path traversal attacks.
+// It ensures the path is absolute, cleaned of traversal sequences, and exists as a regular file.
+func validateCACertPath(certPath string) error {
+	if certPath == "" {
+		return nil
+	}
+
+	// Clean the path to resolve any .. or . components
+	cleanPath := filepath.Clean(certPath)
+
+	// Require absolute paths to prevent relative path attacks
+	if !filepath.IsAbs(cleanPath) {
+		return fmt.Errorf("TLS CA cert path must be absolute: %s", certPath)
+	}
+
+	// Verify the file exists and is not a symlink
+	info, err := os.Lstat(cleanPath)
+	if err != nil {
+		return fmt.Errorf("TLS CA cert path not accessible: %w", err)
+	}
+	// Reject symlinks to prevent symlink-based path traversal
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("TLS CA cert path cannot be a symlink: %s", certPath)
+	}
+	// Ensure path is a regular file, not directories, sockets, pipes, devices, etc.
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("TLS CA cert path is not a regular file: %s", certPath)
+	}
+
+	return nil
+}
+
+// Builds a TLS config with custom CA, insecure mode, or system roots CAs
+// - use a custom CA pool if tlsCACert is provided
+// - otherwise skip verification if insecureMode is enabled
+// - otherwise use the system root CAs
+func buildTLSConfig(tlsCACert string, insecureMode bool) (*tls.Config, error) {
+	cfg := tls.Config{
+		InsecureSkipVerify: false,
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	// TLS priority: custom CA > system roots > insecure
+	if tlsCACert != "" {
+		if err := validateCACertPath(tlsCACert); err != nil {
+			return nil, err
+		}
+		caCert, err := os.ReadFile(tlsCACert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load provided CA cert: %w", err)
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to add provided CA cert")
+		}
+		cfg.RootCAs = caCertPool
+	} else if insecureMode {
+		cfg.InsecureSkipVerify = true // #nosec G402
+	}
+
+	return &cfg, nil
+}

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { EnvVarInput } from "@/components/ui/envVarInput";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
@@ -8,28 +9,40 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { otelFormSchema, type EnvVar, type OtelFormSchema } from "@/lib/types/schemas";
-import { toEnvVarFormValue, toEnvVarMapFormValue } from "@/lib/utils/envVarForm";
+import { emptyEnvVar, toEnvVarFormValue, toEnvVarMapFormValue } from "@/lib/utils/envVarForm";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Trash2 } from "lucide-react";
+import { ChevronDown, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useForm, type Resolver } from "react-hook-form";
+import { useFieldArray, useForm, type Control, type Resolver, type UseFormReturn } from "react-hook-form";
+
+// ProfileForm is a single profile's form shape, derived from the form schema.
+type ProfileForm = OtelFormSchema["profiles"][number];
+
+// StoredOtelProfile is one profile as persisted/returned by the API (headers are strings,
+// EnvVar fields may be plain strings or full objects).
+interface StoredOtelProfile {
+	enabled?: boolean;
+	service_name?: string;
+	collector_url?: string | EnvVar;
+	headers?: Record<string, string | EnvVar>;
+	trace_type?: "genai_extension" | "vercel" | "open_inference";
+	protocol?: "http" | "grpc";
+	tls_ca_cert?: string;
+	insecure?: boolean;
+	metrics_enabled?: boolean;
+	metrics_endpoint?: string | EnvVar;
+	metrics_push_interval?: number;
+}
+
+// StoredOtelConfig is either the canonical { profiles: [...] } wrapper or a legacy single
+// profile object (no "profiles" key).
+type StoredOtelConfig = (StoredOtelProfile & { profiles?: StoredOtelProfile[] }) | undefined;
 
 interface OtelFormFragmentProps {
 	currentConfig?: {
 		enabled?: boolean;
-		service_name?: string;
-		collector_url?: string | EnvVar;
-		headers?: Record<string, string | EnvVar>;
-		trace_type?: "genai_extension" | "vercel" | "open_inference";
-		protocol?: "http" | "grpc";
-		// TLS configuration
-		tls_ca_cert?: string;
-		insecure?: boolean;
-		// Metrics push configuration
-		metrics_enabled?: boolean;
-		metrics_endpoint?: string | EnvVar;
-		metrics_push_interval?: number;
+		config?: StoredOtelConfig;
 	};
 	onSave: (config: OtelFormSchema) => Promise<void>;
 	onDelete?: () => void;
@@ -37,21 +50,82 @@ interface OtelFormFragmentProps {
 	isLoading?: boolean;
 }
 
-const buildDefaults = (initialConfig?: OtelFormFragmentProps["currentConfig"]): OtelFormSchema => ({
-	enabled: initialConfig?.enabled ?? true,
-	otel_config: {
-		service_name: initialConfig?.service_name ?? "bifrost",
-		collector_url: toEnvVarFormValue(initialConfig?.collector_url),
-		headers: toEnvVarMapFormValue(initialConfig?.headers),
-		trace_type: initialConfig?.trace_type ?? "genai_extension",
-		protocol: initialConfig?.protocol ?? "http",
-		tls_ca_cert: initialConfig?.tls_ca_cert ?? "",
-		insecure: initialConfig?.insecure ?? true,
-		metrics_enabled: initialConfig?.metrics_enabled ?? false,
-		metrics_endpoint: toEnvVarFormValue(initialConfig?.metrics_endpoint),
-		metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
+const traceTypeOptions: {
+	value: string;
+	label: string;
+	disabled?: boolean;
+	disabledReason?: string;
+}[] = [
+	{ value: "genai_extension", label: "OTel GenAI Extension (Recommended)" },
+	{
+		value: "vercel",
+		label: "Vercel AI SDK",
+		disabled: true,
+		disabledReason: "Coming soon",
 	},
+	{
+		value: "open_inference",
+		label: "Arize OpenInference",
+		disabled: true,
+		disabledReason: "Coming soon",
+	},
+];
+const protocolOptions: {
+	value: string;
+	label: string;
+	disabled?: boolean;
+	disabledReason?: string;
+}[] = [
+	{ value: "http", label: "HTTP" },
+	{ value: "grpc", label: "GRPC" },
+];
+
+// emptyProfile returns a fresh profile with the same defaults a newly created collector uses.
+const emptyProfile = (): ProfileForm => ({
+	enabled: true,
+	service_name: "bifrost",
+	collector_url: emptyEnvVar(),
+	headers: {},
+	trace_type: "genai_extension",
+	protocol: "http",
+	tls_ca_cert: "",
+	insecure: true,
+	metrics_enabled: false,
+	metrics_endpoint: emptyEnvVar(),
+	metrics_push_interval: 15,
 });
+
+// toProfileForm normalizes a stored profile into the EnvVar-based form representation.
+const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
+	enabled: p?.enabled ?? true,
+	service_name: p?.service_name ?? "bifrost",
+	collector_url: toEnvVarFormValue(p?.collector_url),
+	headers: toEnvVarMapFormValue(p?.headers),
+	trace_type: p?.trace_type ?? "genai_extension",
+	protocol: p?.protocol ?? "http",
+	tls_ca_cert: p?.tls_ca_cert ?? "",
+	insecure: p?.insecure ?? true,
+	metrics_enabled: p?.metrics_enabled ?? false,
+	metrics_endpoint: toEnvVarFormValue(p?.metrics_endpoint),
+	metrics_push_interval: p?.metrics_push_interval ?? 15,
+});
+
+// buildDefaults handles both stored shapes: the { profiles: [...] } wrapper and the legacy
+// single-object config. Always yields at least one profile.
+const buildDefaults = (initial?: OtelFormFragmentProps["currentConfig"]): OtelFormSchema => {
+	const cfg = initial?.config;
+	let profiles: ProfileForm[];
+	if (cfg && Array.isArray(cfg.profiles)) {
+		profiles = cfg.profiles.map(toProfileForm);
+	} else if (cfg && (cfg.collector_url || cfg.service_name || cfg.protocol || cfg.trace_type)) {
+		// Legacy single-object config.
+		profiles = [toProfileForm(cfg)];
+	} else {
+		profiles = [];
+	}
+	if (profiles.length === 0) profiles = [emptyProfile()];
+	return { enabled: initial?.enabled ?? true, profiles };
+};
 
 export function OtelFormFragment({
 	currentConfig: initialConfig,
@@ -62,11 +136,17 @@ export function OtelFormFragment({
 }: OtelFormFragmentProps) {
 	const hasOtelAccess = useRbac(RbacResource.Observability, RbacOperation.Update);
 	const [isSaving, setIsSaving] = useState(false);
-	const form = useForm<OtelFormSchema, any, OtelFormSchema>({
-		resolver: zodResolver(otelFormSchema) as Resolver<OtelFormSchema, any, OtelFormSchema>,
+	const [profileOpenState, setProfileOpenState] = useState<Record<number, boolean>>({});
+	const form = useForm<OtelFormSchema, unknown, OtelFormSchema>({
+		resolver: zodResolver(otelFormSchema) as Resolver<OtelFormSchema, unknown, OtelFormSchema>,
 		mode: "onChange",
 		reValidateMode: "onChange",
 		defaultValues: buildDefaults(initialConfig),
+	});
+
+	const { fields, append, remove } = useFieldArray({
+		control: form.control,
+		name: "profiles",
 	});
 
 	const onSubmit = (data: OtelFormSchema) => {
@@ -74,294 +154,62 @@ export function OtelFormFragment({
 		onSave(data).finally(() => setIsSaving(false));
 	};
 
-	// Re-run validation on collector_url when protocol changes so cross-field
-	// refinement in the schema is applied immediately
-	const protocol = form.watch("otel_config.protocol");
-	const metricsEnabled = form.watch("otel_config.metrics_enabled");
-	useEffect(() => {
-		if (form.getValues("enabled") === false) return;
-		form.trigger("otel_config.collector_url");
-		// Also re-validate metrics_endpoint when protocol changes
-		if (metricsEnabled) {
-			form.trigger("otel_config.metrics_endpoint");
-		}
-	}, [protocol, form, metricsEnabled]);
+	const handleProfileOpenChange = (index: number, open: boolean) => {
+		setProfileOpenState((prev) => ({ ...prev, [index]: open }));
+	};
 
-	// Re-run validation on metrics_endpoint when metrics_enabled changes
-	useEffect(() => {
-		if (metricsEnabled) {
-			form.trigger("otel_config.metrics_endpoint");
-		}
-	}, [metricsEnabled, form]);
+	const handleRemoveProfile = (index: number) => {
+		remove(index);
+		setProfileOpenState((prev) => {
+			const next: Record<number, boolean> = {};
+			for (const [key, value] of Object.entries(prev)) {
+				const profileIndex = Number(key);
+				if (profileIndex < index) {
+					next[profileIndex] = value;
+				} else if (profileIndex > index) {
+					next[profileIndex - 1] = value;
+				}
+			}
+			return next;
+		});
+	};
 
 	useEffect(() => {
 		form.reset(buildDefaults(initialConfig));
 	}, [form, initialConfig]);
 
-	const traceTypeOptions: { value: string; label: string; disabled?: boolean; disabledReason?: string }[] = [
-		{ value: "genai_extension", label: "OTel GenAI Extension (Recommended)" },
-		{ value: "vercel", label: "Vercel AI SDK", disabled: true, disabledReason: "Coming soon" },
-		{ value: "open_inference", label: "Arize OpenInference", disabled: true, disabledReason: "Coming soon" },
-	];
-	const protocolOptions: { value: string; label: string; disabled?: boolean; disabledReason?: string }[] = [
-		{ value: "http", label: "HTTP" },
-		{ value: "grpc", label: "GRPC" },
-	];
-
 	return (
 		<Form {...form}>
 			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-				{/* OTEL Configuration */}
-				<div className="space-y-4">
-					<div className="flex flex-col gap-4">
-						<FormField
+				<div className="flex flex-col gap-3">
+					{fields.map((field, index) => (
+						<OtelProfileSection
+							key={field.id}
+							form={form}
 							control={form.control}
-							name="otel_config.service_name"
-							render={({ field }) => (
-								<FormItem className="w-full">
-									<FormLabel>Service Name</FormLabel>
-									<FormDescription>If kept empty, the service name will be set to "bifrost"</FormDescription>
-									<FormControl>
-										<Input placeholder="bifrost" disabled={!hasOtelAccess} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
+							index={index}
+							hasOtelAccess={hasOtelAccess}
+							canRemove={fields.length > 1}
+							open={profileOpenState[index] ?? true}
+							onOpenChange={(open) => handleProfileOpenChange(index, open)}
+							onRemove={() => handleRemoveProfile(index)}
 						/>
-						<FormField
-							control={form.control}
-							name="otel_config.collector_url"
-							render={({ field }) => (
-								<FormItem className="w-full">
-									<FormLabel>OTLP Collector URL</FormLabel>
-									<div className="text-muted-foreground text-xs">
-										<code>{form.watch("otel_config.protocol") === "http" ? "http(s)://<host>:<port>/v1/traces" : "<host>:<port>"}</code>
-									</div>
-									<FormControl>
-										<EnvVarInput
-											placeholder={
-												form.watch("otel_config.protocol") === "http"
-													? "https://otel-collector.example.com:4318/v1/traces or env.OTEL_COLLECTOR_URL"
-													: "otel-collector.example.com:4317 or env.OTEL_COLLECTOR_URL"
-											}
-											disabled={!hasOtelAccess}
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="otel_config.headers"
-							render={({ field }) => (
-								<FormItem className="w-full">
-									<FormControl>
-										<HeadersTable value={field.value || {}} onChange={field.onChange} disabled={!hasOtelAccess} useEnvVarInput />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<div className="flex flex-row gap-4">
-							<FormField
-								control={form.control}
-								name="otel_config.trace_type"
-								render={({ field }) => (
-									<FormItem className="flex-1">
-										<FormLabel>Format</FormLabel>
-										<Select onValueChange={field.onChange} value={field.value ?? traceTypeOptions[0].value} disabled={!hasOtelAccess}>
-											<FormControl>
-												<SelectTrigger className="w-full">
-													<SelectValue placeholder="Select trace type" />
-												</SelectTrigger>
-											</FormControl>
-											<SelectContent>
-												{traceTypeOptions.map((option) => (
-													<SelectItem
-														key={option.value}
-														value={option.value}
-														disabled={option.disabled}
-														disabledReason={option.disabledReason}
-													>
-														{option.label}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							<FormField
-								control={form.control}
-								name="otel_config.protocol"
-								render={({ field }) => (
-									<FormItem className="flex-1">
-										<FormLabel>Protocol</FormLabel>
-										<Select onValueChange={field.onChange} value={field.value} disabled={!hasOtelAccess}>
-											<FormControl>
-												<SelectTrigger className="w-full">
-													<SelectValue placeholder="Select protocol" />
-												</SelectTrigger>
-											</FormControl>
-											<SelectContent>
-												{protocolOptions.map((option) => (
-													<SelectItem
-														key={option.value}
-														value={option.value}
-														disabled={option.disabled}
-														disabledReason={option.disabledReason}
-													>
-														{option.label}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						</div>
-
-						{/* TLS Configuration */}
-						<div className="flex flex-col gap-4">
-							<FormField
-								control={form.control}
-								name="otel_config.insecure"
-								render={({ field }) => (
-									<FormItem className="flex flex-row items-center gap-2">
-										<div className="flex w-full flex-row items-center gap-2">
-											<div className="flex flex-col gap-1">
-												<FormLabel>Insecure (Skip TLS)</FormLabel>
-												<FormDescription>
-													Skip TLS verification. Disable this to use TLS with system root CAs or a custom CA certificate.
-												</FormDescription>
-											</div>
-											<div className="ml-auto">
-												<Switch
-													checked={field.value}
-													onCheckedChange={(checked) => {
-														field.onChange(checked);
-														if (checked) {
-															form.setValue("otel_config.tls_ca_cert", "");
-														}
-													}}
-													disabled={!hasOtelAccess}
-												/>
-											</div>
-										</div>
-									</FormItem>
-								)}
-							/>
-							{!form.watch("otel_config.insecure") && (
-								<FormField
-									control={form.control}
-									name="otel_config.tls_ca_cert"
-									render={({ field }) => (
-										<FormItem className="w-full">
-											<FormLabel>TLS CA Certificate Path</FormLabel>
-											<FormDescription>
-												File path to the CA certificate on the Bifrost server. Leave empty to use system root CAs.
-											</FormDescription>
-											<FormControl>
-												<Input placeholder="/path/to/ca.crt" disabled={!hasOtelAccess} {...field} />
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							)}
-						</div>
-					</div>
+					))}
 				</div>
 
-				{/* Metrics Push Configuration */}
-				<div className="space-y-4 border-t pt-4">
-					<FormField
-						control={form.control}
-						name="otel_config.metrics_enabled"
-						render={({ field }) => (
-							<FormItem className="flex flex-row items-center gap-2">
-								<div className="flex w-full flex-row items-center gap-2">
-									<div className="flex flex-col gap-1">
-										<h3 className="flex flex-row items-center gap-2 text-sm font-medium">
-											Enable Metrics Export <Badge variant="secondary">BETA</Badge>
-										</h3>
-										<p className="text-muted-foreground text-xs">
-											Push metrics to an OTEL Collector for proper aggregation in cluster deployments
-										</p>
-									</div>
-									<div className="ml-auto">
-										<Switch
-											data-testid="otel-metrics-export-toggle"
-											checked={field.value}
-											onCheckedChange={field.onChange}
-											disabled={!hasOtelAccess}
-										/>
-									</div>
-								</div>
-							</FormItem>
-						)}
-					/>
-
-					{form.watch("otel_config.metrics_enabled") && (
-						<div className="border-muted flex flex-col gap-4">
-							<FormField
-								control={form.control}
-								name="otel_config.metrics_endpoint"
-								render={({ field }) => (
-									<FormItem className="w-full">
-										<FormLabel>Metrics Endpoint</FormLabel>
-										<div className="text-muted-foreground text-xs">
-											<code>{form.watch("otel_config.protocol") === "http" ? "http(s)://<host>:<port>/v1/metrics" : "<host>:<port>"}</code>
-										</div>
-										<FormControl>
-											<EnvVarInput
-												placeholder={
-													form.watch("otel_config.protocol") === "http"
-														? "https://otel-collector:4318/v1/metrics or env.OTEL_METRICS_ENDPOINT"
-														: "otel-collector:4317 or env.OTEL_METRICS_ENDPOINT"
-												}
-												disabled={!hasOtelAccess}
-												{...field}
-											/>
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							<FormField
-								control={form.control}
-								name="otel_config.metrics_push_interval"
-								render={({ field }) => (
-									<FormItem className="w-full max-w-xs">
-										<FormLabel>Push Interval (seconds)</FormLabel>
-										<FormControl>
-											<Input
-												type="number"
-												min={1}
-												max={300}
-												disabled={!hasOtelAccess}
-												{...field}
-												value={field.value ?? ""}
-												onChange={(e) => field.onChange(e.target.value === "" ? null : Number(e.target.value))}
-											/>
-										</FormControl>
-										<FormDescription>How often to push metrics (1-300 seconds)</FormDescription>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						</div>
-					)}
-				</div>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={() => append(emptyProfile())}
+					disabled={!hasOtelAccess}
+					data-testid="otel-add-profile-btn"
+				>
+					<Plus className="size-4" /> Add Profile
+				</Button>
 
 				{/* Form Actions */}
-				<div className="flex w-full flex-row items-center">
+				<div className="flex w-full flex-row items-center border-t pt-4">
 					<FormField
 						control={form.control}
 						name="enabled"
@@ -427,5 +275,336 @@ export function OtelFormFragment({
 				</div>
 			</form>
 		</Form>
+	);
+}
+
+interface OtelProfileSectionProps {
+	form: UseFormReturn<OtelFormSchema, unknown, OtelFormSchema>;
+	control: Control<OtelFormSchema, unknown, OtelFormSchema>;
+	index: number;
+	hasOtelAccess: boolean;
+	canRemove: boolean;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onRemove: () => void;
+}
+
+// OtelProfileSection renders one collapsible profile. The header stays visible when collapsed
+// and surfaces the profile identity plus its enable toggle and remove control.
+function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, open, onOpenChange, onRemove }: OtelProfileSectionProps) {
+	const base = `profiles.${index}` as const;
+	const protocol = form.watch(`${base}.protocol`);
+	const metricsEnabled = form.watch(`${base}.metrics_enabled`);
+	const insecure = form.watch(`${base}.insecure`);
+	const enabled = form.watch(`${base}.enabled`);
+	const serviceName = form.watch(`${base}.service_name`);
+	const collectorUrl = form.watch(`${base}.collector_url`);
+
+	// Surface whether this profile currently has any validation errors so the user can find it
+	// without expanding every collapsed section.
+	const hasError = Boolean(form.formState.errors?.profiles?.[index]);
+
+	const collectorPreview = collectorUrl?.from_env ? collectorUrl.env_var : collectorUrl?.value;
+
+	return (
+		<Collapsible open={open} onOpenChange={onOpenChange} className="rounded-lg border" data-testid={`otel-profile-${index}`}>
+			<div className="flex flex-row items-center gap-2 px-4 py-3">
+				<CollapsibleTrigger asChild>
+					<button type="button" className="flex min-w-0 flex-1 items-center gap-2 text-left">
+						<ChevronDown className={`size-4 shrink-0 transition-transform ${open ? "" : "-rotate-90"}`} />
+						<div className="flex min-w-0 flex-col">
+							<span className="flex items-center gap-2 truncate text-sm font-medium">
+								{serviceName || `Profile ${index + 1}`}
+								{!enabled && <Badge variant="secondary">Disabled</Badge>}
+								{hasError && <Badge variant="destructive">Error</Badge>}
+							</span>
+							{collectorPreview && <span className="text-muted-foreground truncate text-xs">{collectorPreview}</span>}
+						</div>
+					</button>
+				</CollapsibleTrigger>
+
+				<FormField
+					control={control}
+					name={`${base}.enabled`}
+					render={({ field }) => (
+						<FormItem className="flex items-center">
+							<FormControl>
+								<Switch
+									checked={field.value}
+									onCheckedChange={field.onChange}
+									disabled={!hasOtelAccess}
+									data-testid={`otel-profile-${index}-enable-toggle`}
+									aria-label="Enable profile"
+								/>
+							</FormControl>
+						</FormItem>
+					)}
+				/>
+
+				{canRemove && (
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon"
+						onClick={onRemove}
+						disabled={!hasOtelAccess}
+						data-testid={`otel-profile-${index}-remove-btn`}
+						title="Remove profile"
+						aria-label="Remove profile"
+					>
+						<Trash2 className="size-4" />
+					</Button>
+				)}
+			</div>
+
+			<CollapsibleContent className="border-t px-4 py-4">
+				<div className="flex flex-col gap-4">
+					<FormField
+						control={control}
+						name={`${base}.service_name`}
+						render={({ field }) => (
+							<FormItem className="w-full">
+								<FormLabel>Service Name</FormLabel>
+								<FormDescription>If kept empty, the service name will be set to "bifrost"</FormDescription>
+								<FormControl>
+									<Input placeholder="bifrost" disabled={!hasOtelAccess} {...field} />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={control}
+						name={`${base}.collector_url`}
+						render={({ field }) => (
+							<FormItem className="w-full">
+								<FormLabel>OTLP Collector URL</FormLabel>
+								<div className="text-muted-foreground text-xs">
+									<code>{protocol === "http" ? "http(s)://<host>:<port>/v1/traces" : "<host>:<port>"}</code>
+								</div>
+								<FormControl>
+									<EnvVarInput
+										placeholder={
+											protocol === "http"
+												? "https://otel-collector.example.com:4318/v1/traces or env.OTEL_COLLECTOR_URL"
+												: "otel-collector.example.com:4317 or env.OTEL_COLLECTOR_URL"
+										}
+										disabled={!hasOtelAccess}
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={control}
+						name={`${base}.headers`}
+						render={({ field }) => (
+							<FormItem className="w-full">
+								<FormControl>
+									<HeadersTable value={field.value || {}} onChange={field.onChange} disabled={!hasOtelAccess} useEnvVarInput />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<div className="flex flex-row gap-4">
+						<FormField
+							control={control}
+							name={`${base}.trace_type`}
+							render={({ field }) => (
+								<FormItem className="flex-1">
+									<FormLabel>Format</FormLabel>
+									<Select onValueChange={field.onChange} value={field.value ?? traceTypeOptions[0].value} disabled={!hasOtelAccess}>
+										<FormControl>
+											<SelectTrigger className="w-full">
+												<SelectValue placeholder="Select trace type" />
+											</SelectTrigger>
+										</FormControl>
+										<SelectContent>
+											{traceTypeOptions.map((option) => (
+												<SelectItem
+													key={option.value}
+													value={option.value}
+													disabled={option.disabled}
+													disabledReason={option.disabledReason}
+												>
+													{option.label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							control={control}
+							name={`${base}.protocol`}
+							render={({ field }) => (
+								<FormItem className="flex-1">
+									<FormLabel>Protocol</FormLabel>
+									<Select onValueChange={field.onChange} value={field.value} disabled={!hasOtelAccess}>
+										<FormControl>
+											<SelectTrigger className="w-full">
+												<SelectValue placeholder="Select protocol" />
+											</SelectTrigger>
+										</FormControl>
+										<SelectContent>
+											{protocolOptions.map((option) => (
+												<SelectItem
+													key={option.value}
+													value={option.value}
+													disabled={option.disabled}
+													disabledReason={option.disabledReason}
+												>
+													{option.label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+					</div>
+
+					{/* TLS Configuration */}
+					<div className="flex flex-col gap-4">
+						<FormField
+							control={control}
+							name={`${base}.insecure`}
+							render={({ field }) => (
+								<FormItem className="flex flex-row items-center gap-2">
+									<div className="flex w-full flex-row items-center gap-2">
+										<div className="flex flex-col gap-1">
+											<FormLabel>Insecure (Skip TLS)</FormLabel>
+											<FormDescription>
+												Skip TLS verification. Disable this to use TLS with system root CAs or a custom CA certificate.
+											</FormDescription>
+										</div>
+										<div className="ml-auto">
+											<Switch
+												checked={field.value}
+												onCheckedChange={(checked) => {
+													field.onChange(checked);
+													if (checked) {
+														form.setValue(`${base}.tls_ca_cert`, "");
+													}
+												}}
+												disabled={!hasOtelAccess}
+											/>
+										</div>
+									</div>
+								</FormItem>
+							)}
+						/>
+						{!insecure && (
+							<FormField
+								control={control}
+								name={`${base}.tls_ca_cert`}
+								render={({ field }) => (
+									<FormItem className="w-full">
+										<FormLabel>TLS CA Certificate Path</FormLabel>
+										<FormDescription>
+											File path to the CA certificate on the Bifrost server. Leave empty to use system root CAs.
+										</FormDescription>
+										<FormControl>
+											<Input placeholder="/path/to/ca.crt" disabled={!hasOtelAccess} {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						)}
+					</div>
+
+					{/* Metrics Push Configuration */}
+					<div className="flex flex-col gap-4 border-t pt-4">
+						<FormField
+							control={control}
+							name={`${base}.metrics_enabled`}
+							render={({ field }) => (
+								<FormItem className="flex flex-row items-center gap-2">
+									<div className="flex w-full flex-row items-center gap-2">
+										<div className="flex flex-col gap-1">
+											<h3 className="flex flex-row items-center gap-2 text-sm font-medium">
+												Enable Metrics Export <Badge variant="secondary">BETA</Badge>
+											</h3>
+											<p className="text-muted-foreground text-xs">
+												Push metrics to an OTEL Collector for proper aggregation in cluster deployments
+											</p>
+										</div>
+										<div className="ml-auto">
+											<Switch
+												// First profile keeps the legacy testid for existing e2e coverage.
+												data-testid={index === 0 ? "otel-metrics-export-toggle" : `otel-profile-${index}-metrics-export-toggle`}
+												checked={field.value}
+												onCheckedChange={field.onChange}
+												disabled={!hasOtelAccess}
+											/>
+										</div>
+									</div>
+								</FormItem>
+							)}
+						/>
+
+						{metricsEnabled && (
+							<div className="border-muted flex flex-col gap-4">
+								<FormField
+									control={control}
+									name={`${base}.metrics_endpoint`}
+									render={({ field }) => (
+										<FormItem className="w-full">
+											<FormLabel>Metrics Endpoint</FormLabel>
+											<div className="text-muted-foreground text-xs">
+												<code>{protocol === "http" ? "http(s)://<host>:<port>/v1/metrics" : "<host>:<port>"}</code>
+											</div>
+											<FormControl>
+												<EnvVarInput
+													placeholder={
+														protocol === "http"
+															? "https://otel-collector:4318/v1/metrics or env.OTEL_METRICS_ENDPOINT"
+															: "otel-collector:4317 or env.OTEL_METRICS_ENDPOINT"
+													}
+													disabled={!hasOtelAccess}
+													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+
+								<FormField
+									control={control}
+									name={`${base}.metrics_push_interval`}
+									render={({ field }) => (
+										<FormItem className="w-full max-w-xs">
+											<FormLabel>Push Interval (seconds)</FormLabel>
+											<FormControl>
+												<Input
+													type="number"
+													min={1}
+													max={300}
+													disabled={!hasOtelAccess}
+													{...field}
+													value={field.value ?? ""}
+													onChange={(e) => field.onChange(e.target.value === "" ? null : Number(e.target.value))}
+												/>
+											</FormControl>
+											<FormDescription>How often to push metrics (1-300 seconds)</FormDescription>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</div>
+						)}
+					</div>
+				</div>
+			</CollapsibleContent>
+		</Collapsible>
 	);
 }

--- a/ui/app/workspace/observability/views/plugins/otelView.tsx
+++ b/ui/app/workspace/observability/views/plugins/otelView.tsx
@@ -1,5 +1,6 @@
 import { getErrorMessage, useAppSelector, useUpdatePluginMutation } from "@/lib/store";
-import { OtelConfigSchema, OtelFormSchema } from "@/lib/types/schemas";
+import { OtelFormSchema } from "@/lib/types/schemas";
+import { toHeaderStringMap } from "@/lib/utils/envVarForm";
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { OtelFormFragment } from "../../fragments/otelFormFragment";
@@ -11,20 +12,23 @@ interface OtelViewProps {
 
 export default function OtelView({ onDelete, isDeleting }: OtelViewProps) {
 	const selectedPlugin = useAppSelector((state) => state.plugin.selectedPlugin);
-	const currentConfig = useMemo(
-		() => ({ ...((selectedPlugin?.config as OtelConfigSchema) ?? {}), enabled: selectedPlugin?.enabled }),
-		[selectedPlugin],
-	);
+	const currentConfig = useMemo(() => ({ config: selectedPlugin?.config, enabled: selectedPlugin?.enabled }), [selectedPlugin]);
 	const [updatePlugin] = useUpdatePluginMutation();
-	const baseUrl = `${window.location.protocol}//${window.location.host}`;
 
 	const handleOtelConfigSave = (config: OtelFormSchema): Promise<void> => {
+		// The backend stores headers as a plain "env.VAR"/literal string map, so flatten the
+		// EnvVar form values here. The config is sent as the { profiles: [...] } wrapper.
+		const profiles = config.profiles.map((profile) => ({
+			...profile,
+			headers: toHeaderStringMap(profile.headers),
+		}));
+
 		return new Promise((resolve, reject) => {
 			updatePlugin({
 				name: "otel",
 				data: {
 					enabled: config.enabled,
-					config: config.otel_config,
+					config: { profiles },
 				},
 			})
 				.unwrap()

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -739,6 +739,8 @@ export type BetaHeadersFormSchema = z.infer<typeof betaHeadersFormSchema>;
 // OTEL Configuration Schema
 export const otelConfigSchema = z
 	.object({
+		// Per-profile enable toggle. A disabled profile exports nothing and is not validated.
+		enabled: z.boolean().default(true),
 		service_name: z.string().optional(),
 		collector_url: envVarSchema.default({ value: "", env_var: "", from_env: false }),
 		trace_type: z
@@ -761,6 +763,9 @@ export const otelConfigSchema = z
 		metrics_push_interval: z.number().int().min(1).max(300).default(15),
 	})
 	.superRefine((data, ctx) => {
+		// A disabled profile is not sent anywhere, so skip all validation for it.
+		if (data.enabled === false) return;
+
 		const protocol = data.protocol;
 		const hostPortRegex = /^(?!https?:\/\/)([a-zA-Z0-9.-]+|\[[0-9a-fA-F:]+\]|\d{1,3}(?:\.\d{1,3}){3}):(\d{1,5})$/;
 
@@ -810,6 +815,15 @@ export const otelConfigSchema = z
 			return true;
 		};
 
+		// Collector address is required for an enabled profile.
+		if (!isEnvVarSet(data.collector_url)) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["collector_url"],
+				message: "Collector address is required",
+			});
+		}
+
 		// Validate collector_url format — skip format check for env var references
 		const collectorUrl = (data.collector_url?.value || "").trim();
 		if (collectorUrl && !data.collector_url?.from_env && protocol === "http") {
@@ -835,23 +849,12 @@ export const otelConfigSchema = z
 		}
 	});
 
-// OTEL form schema for the OtelFormFragment
-export const otelFormSchema = z
-	.object({
-		enabled: z.boolean().default(true),
-		otel_config: otelConfigSchema,
-	})
-	.superRefine((data, ctx) => {
-		if (data.enabled) {
-			if (!isEnvVarSet(data.otel_config.collector_url)) {
-				ctx.addIssue({
-					code: "custom",
-					path: ["otel_config", "collector_url"],
-					message: "Collector address is required",
-				});
-			}
-		}
-	});
+// OTEL form schema for the OtelFormFragment. The plugin itself is gated by `enabled`;
+// it carries one or more export profiles, each independently enable-able.
+export const otelFormSchema = z.object({
+	enabled: z.boolean().default(true),
+	profiles: z.array(otelConfigSchema).min(1, "At least one profile is required"),
+});
 
 // Maxim Configuration Schema
 export const maximConfigSchema = z.object({

--- a/ui/lib/utils/envVarForm.ts
+++ b/ui/lib/utils/envVarForm.ts
@@ -26,6 +26,28 @@ export const toEnvVarMapFormValue = (map?: Record<string, string | EnvVar>): Rec
 	return Object.fromEntries(Object.entries(map).map(([k, v]) => [k, toEnvVarFormValue(v)]));
 };
 
+// toEnvRefString flattens an EnvVar form value to its persisted string form:
+// the "env.VAR" reference when sourced from the environment, otherwise the literal value.
+export const toEnvRefString = (field?: EnvVar): string => {
+	if (!field) return "";
+	if (field.from_env) return (field.env_var || "").trim();
+	return (field.value || "").trim();
+};
+
+// toHeaderStringMap converts a map of EnvVar header values into the plain-string map the
+// OTEL backend expects (Profile.Headers is map[string]string using the "env.VAR" convention).
+// Empty entries are dropped.
+export const toHeaderStringMap = (headers?: Record<string, EnvVar>): Record<string, string> => {
+	if (!headers) return {};
+	const out: Record<string, string> = {};
+	for (const [k, v] of Object.entries(headers)) {
+		const key = k.trim();
+		const value = toEnvRefString(v);
+		if (key && value) out[key] = value;
+	}
+	return out;
+};
+
 export const toOptionalEnvVarPayload = (field?: { value?: string; env_var?: string; from_env?: boolean }) => {
 	const envVar = field?.env_var?.trim();
 	const value = field?.value?.trim();


### PR DESCRIPTION
## Summary

The OTEL plugin previously supported a single collector target per configuration. This PR introduces multi-profile support, allowing Bifrost to export traces and metrics to multiple OTEL collectors simultaneously, each with its own service name, endpoint, TLS settings, headers, and metrics configuration.

## Changes

- Introduced a `Profile` struct to hold per-collector configuration, replacing the flat fields on `Config`. `Config` now holds a `Profiles []*Profile` slice plus a shared `PluginSpanFilter`.
- `Config.UnmarshalJSON` normalizes both the new `{"profiles": [...]}` wrapper shape and the legacy single-object shape, so existing stored configs continue to work without migration.
- Added an `otelTarget` runtime struct that pairs a trace client with an optional metrics exporter and a resolved service name. `OtelPlugin` now holds a `targets` slice instead of a single client/exporter.
- `convertTraceToResourceSpan`, `getResourceAttributes`, and `getInstrumentationScope` now accept a `serviceName` argument so each profile's resource attributes reflect its own identity. `convertSpanToOTELSpan` was promoted to a package-level function since it no longer needs plugin state.
- TLS config construction was consolidated into a single `buildTLSConfig` helper in a new `utils.go`, eliminating duplicated `crypto/tls` and `crypto/x509` setup across `grpc.go`, `http.go`, and `metrics.go`. `validateCACertPath` was also moved there.
- `injectEnvToHeaders` replaces `resolveHeaders`: headers are now stored as plain strings using the `"env.VAR_NAME"` convention and resolved at `Init` time, removing the `map[string]*schemas.EnvVar` header type from `Profile`.
- `MarshalForStorage` always emits the canonical `{"profiles": [...]}` wrapper regardless of input shape.
- `Redacted` and `redactHeaderValue` were updated to operate over the profiles slice; literal header values are masked while `"env."` references are preserved.
- `recordMetricsFromTrace` now accepts an explicit `*MetricsExporter` argument instead of reading from plugin state, allowing it to be called once per target.
- `Cleanup` shuts down every target's metrics exporter and closes every trace client, returning the first close error.
- The UI form was refactored around a `profiles` field array. Each profile renders as a collapsible `OtelProfileSection` with its own enable toggle and remove button. An "Add Profile" button appends a new empty profile. Both the new wrapper shape and the legacy single-object shape are normalized on load via `buildDefaults`. `toHeaderStringMap` and `toEnvRefString` helpers were added to `envVarForm.ts` to flatten `EnvVar` form values to the plain-string map the backend expects. The `otelFormSchema` was updated to validate a `profiles` array, with per-profile `enabled` gating skipping validation for disabled profiles.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```
- [x] https
    - [x] single config (legacy)
    - [x] multiple services, singe collector
    - [x] multiple collector
    - [x] with tls, multiple services + multiple collector
- [x] grpc (same setup should work)
    - [x] single config (legacy)
    - [x] multiple services, singe collector
    - [x] multiple collector
    - [x] with tls, multiple services + multiple collector
- [x] with single collector config
- [x] with multiple collector config
- [x] instance attributes intact
- [x] header injection logic intact
- [x] helm (single + multiple)
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- `validateCACertPath` rejects relative paths, symlinks, and non-regular files to prevent path traversal when loading custom CA certificates.
- `buildTLSConfig` enforces `tls.VersionTLS12` as the minimum TLS version across all transports.
- Header values that are literal strings are masked in `Redacted()` API responses; `"env."` references are returned as-is since they do not expose the secret value.
- `injectEnvToHeaders` errors if a referenced environment variable is unset, preventing silent misconfiguration.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multi-profile OTEL support: add/remove/manage multiple independent export profiles with per-profile collector, service name, headers, protocol, TLS, and metrics toggles.

- **Behavior Changes**
  - TLS handling consolidated: custom CA and insecure modes only permit plaintext/insecure when no CA is provided; TLS config centrally built otherwise.
  - Export/metrics now operate per-profile.

- **Validation**
  - Per-profile enabled flag (default true); enabled profiles require a collector URL.

- **UX**
  - Form and header env-var handling improved for persistence and submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->