### PR TITLE
read me updates and hardening fixes

### DIFF
--- a/.github/workflows/configs/docker-compose.yml
+++ b/.github/workflows/configs/docker-compose.yml
@@ -17,7 +17,15 @@ services:
       retries: 5
     restart: unless-stopped
     networks:
-      - bifrost_network
+      bifrost_network:
+        # PINNED IP - harden-runner (egress-policy: block) filters on the
+        # post-NAT destination IP. Host processes dial 127.0.0.1:5432, which
+        # Docker DNATs to this bridge IP, so this exact IP must appear in the
+        # allowed-endpoints of every release-pipeline job that talks to Postgres
+        # over the published port (test-migrations, test-bifrost-http,
+        # test-api-integrations). Keep in sync with the 172.38.0.11:5432 entries
+        # in .github/workflows/release-pipeline.yml.
+        ipv4_address: 172.38.0.11
 
   weaviate:
     image: cr.weaviate.io/semitechnologies/weaviate:1.32.4

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -478,14 +478,16 @@ jobs:
         with:
           egress-policy: block
           # bifrost-http binary runs on the host and connects to Postgres via
-          # the published port mapping (5432:5432) at 127.0.0.1. The integration
-          # test configs in .github/workflows/configs/*/config.json use
-          # "host": "localhost". The 172.38.0.12 entries below are weaviate's
-          # pinned bridge IP from .github/workflows/configs/docker-compose.yml;
-          # they are kept for any container-to-container traffic but the binary
-          # itself reaches weaviate via 127.0.0.1:9000 (published port).
+          # the published port mapping (5432:5432) at 127.0.0.1. harden-runner
+          # filters on the post-NAT destination IP, so the published port DNATs
+          # to Postgres's pinned bridge IP 172.38.0.11 - that IP:port (not
+          # 127.0.0.1:5432) is what must be allowed. The 172.38.0.12 entries are
+          # weaviate's pinned bridge IP from
+          # .github/workflows/configs/docker-compose.yml (gossip + published
+          # 9000->8080). Keep all *.0.11/*.0.12 entries in sync with that file.
           allowed-endpoints: >
             127.0.0.1:5432
+            172.38.0.11:5432
             172.38.0.12:8080
             172.38.0.12:8301
             iojs.org:443
@@ -563,10 +565,15 @@ jobs:
           egress-policy: block
           # Migration test binary runs on the host (not in a container) and
           # connects to Postgres via the published port mapping (5432:5432) at
-          # 127.0.0.1. See run-migration-tests.sh:46 (POSTGRES_HOST defaults to
-          # localhost).
+          # 127.0.0.1 (see run-migration-tests.sh:46, POSTGRES_HOST defaults to
+          # localhost). harden-runner filters on the post-NAT destination IP, so
+          # the published port DNATs to Postgres's pinned bridge IP 172.38.0.11 -
+          # that IP:port must be allowed. Keep in sync with the pinned IP in
+          # .github/workflows/configs/docker-compose.yml. (The 172.38.0.12
+          # weaviate entries are vestigial here - this job only starts postgres.)
           allowed-endpoints: >
             127.0.0.1:5432
+            172.38.0.11:5432
             172.38.0.12:8080
             172.38.0.12:8301
             api.anthropic.com:443
@@ -636,9 +643,19 @@ jobs:
           # API integrations test compiles bifrost-http and runs it on the host
           # (not in a container), connecting to Postgres via the published port
           # mapping (5432:5432) at 127.0.0.1. See test-api-integrations.sh which
-          # defaults POSTGRES_HOST to localhost.
+          # defaults POSTGRES_HOST to localhost. harden-runner filters on the
+          # post-NAT destination IP, so the published port DNATs to Postgres's
+          # pinned bridge IP 172.38.0.11 - that IP:port must be allowed. This
+          # script does `docker compose up -d` (ALL services) and waits for them
+          # to be healthy, so weaviate's gossip to its own advertise address
+          # 172.38.0.12:8301 (and 8080) must also be allowed or weaviate never
+          # becomes healthy. Keep the pinned IPs in sync with
+          # .github/workflows/configs/docker-compose.yml.
           allowed-endpoints: >
             127.0.0.1:5432
+            172.38.0.11:5432
+            172.38.0.12:8080
+            172.38.0.12:8301
             iojs.org:443
             api.anthropic.com:443
             api.cerebras.ai:443

--- a/docs/changelogs/ent-v1.4.5.mdx
+++ b/docs/changelogs/ent-v1.4.5.mdx
@@ -1,0 +1,505 @@
+---
+title: "v1.4.5"
+description: "Enterprise v1.4.5 changelog - 2026-05-29"
+---
+
+<Update label="Bifrost Enterprise" description="v1.4.5">
+
+<Warning>
+  **Breaking changes in v1.4.0.** See the [v1.4.0 Migration
+  Guide](/enterprise/migration-guides/v1.4.0) for full before/after examples, automatic migration
+  details, and a step-by-step checklist before upgrading.
+</Warning>
+
+## Changelog
+
+Bifrost Enterprise v1.4.5 is a release on `transports/v1.5.6` centered on **identity lifecycle** and **MCP per-user authentication**. Headline items: new **onboarding and IdP deprovisioning flows** that sync user activeness on login, token refresh, and a periodic 15-minute reconcile (with Okta scoped to app-associated groups and users), end-to-end **MCP per-user header auth** with credential storage, lazy submission, TLS configuration, and sessions filtering, and a large **governance UI overhaul** that moves users, teams, business units, RBAC, and access profiles off dialogs onto keyboard-navigable sheets. The release also brings OSS additions like a direct API-key request header, dimension rankings dashboards, key rotation on auth failures, model pricing attributes, Opus 4.8 support, and OTel spec-compatible metrics.
+
+## ✨ Features
+
+### Access & Identity
+
+- **Onboarding and IdP deprovisioning flows** : new user onboarding and extension flows, with deprovisioning wired into login, token refresh, and a periodic sync so accounts removed at the IdP are reconciled automatically.
+- **User activeness sync** : user active state is checked on each session refresh and synced with the IdP every 15 minutes, so disabled users lose access promptly.
+- **Okta app-scoped sync** : Okta now syncs only the groups and users associated with the app, rather than the entire directory.
+- **App removal deletes the user** : removing an app now deletes the associated user even on app disassociation, keeping membership consistent.
+
+### MCP
+
+- **MCP per-user authentication** : new per-user header auth type with credential storage, lazy-auth submission, and reconciliation of per-user credentials on virtual-key and MCP-client changes (OSS + enterprise).
+- **MCP TLS configuration** : configurable TLS (`insecureSkipVerify`, `caCertPem`) for HTTP/SSE MCP client connections (OSS).
+- **MCP sessions filtering** : filter, search, and pagination on the MCP sessions list API and table, plus a `can_reauth` identity gate (OSS + enterprise).
+
+### Governance UI
+
+- **Governance UI moved to sheets** : users, teams, business units, RBAC, and access profiles moved off dialogs onto sheets, with full prev/next keyboard navigation and URL state across each sheet (OSS + enterprise).
+- **Attach business units from teams** : teams can attach to a business unit directly from the teams sheet, with a warning surfaced for teams already attached.
+- **SearchSelect adoption** : governance pages start using the `SearchSelect` component for faster filtering, alongside assorted governance view fixes.
+
+### OSS Base (`transports/v1.5.6`)
+
+- **Direct API key header** : pass a provider API key directly via a request header.
+- **Dimension rankings dashboard** : new dashboard tabs for team, customer, business-unit, and user rankings, backed by a `GetDimensionRankings` API.
+- **Tool-call execution UI** : inline tool-call execution, stop streaming, bulk execute and submit, and a redesigned tool-call UI.
+- **Model pricing attributes** : `additional_attributes` on model pricing rows, with a management API and UI editor.
+- **Key rotation on auth failures** : rotate keys on 401/402/403 and return a 502 `upstream_credentials_exhausted` when all keys are permanently dead.
+- **Opus 4.8 support** : system-message handling and compatibility for Opus 4.8.
+- **OTel spec-compatible metrics** : OTel-spec metrics with provider and semantic-cache attributes in the metrics export, backward compatible with existing dashboards.
+- **Prompt cache retention** : prompt cache retention parameter on responses requests.
+- **Go 1.26.3** : toolchain upgraded to Go 1.26.3.
+
+## 🐞 Fixed
+
+### Guardrails
+
+- **Grayswan full conversation history** : the outbound side of the Grayswan guardrail provider now receives the full conversation history rather than a truncated view.
+
+### MCP & Access
+
+- **MCP per-user OAuth deferred flow** : removed the deferred user-id flow in MCP per-user OAuth and the deferred-fill user-mode OAuth flow, gating user-mode flows on the caller `user_id` and skipping temp-token mint where it does not apply.
+- **MCP header temp-token toggle** : the MCP header temp-token flow now follows the UI toggle.
+- **Models endpoint allowlist** : `/v1/models` is allowed through the access-profile model allowlist check.
+- **PKCE code challenge** : code-challenge generation moved to the backend.
+
+### Cluster & Config
+
+- **URL query escaping** : escaped characters in URL query parameters are now supported.
+- **Broadcast model attribute updates** : model attribute updates are broadcast across the cluster.
+- **Tool attribute data** : tool attribute data is no longer sent.
+
+### OSS Base (`transports/v1.5.6`)
+
+- **Virtual-key associations** : removed `created_by` as a user association for virtual keys; optional fields are no longer overridden during virtual-key update.
+- **Matview sync interval** : materialized-view sync interval increased to 1 minute.
+- **Bedrock tool names and guardrails** : Bedrock function/tool names are truncated to the provider length limit, and guardrail config is set in Bedrock requests built from responses.
+- **Anthropic tool use** : Anthropic `tool_use` input defaults to `{}` when arguments are absent.
+- **Responses streaming** : fixed responses stream events.
+- **Compat flow parsing** : fixed missing parameter parsing on the compat flow.
+- **Passthrough API version** : a default API version is set in passthrough requests as a fallback.
+- **Partial tool calls** : partial tool-call execution failures are handled and successful results returned.
+- **MCP auth errors** : inline banner and retry support for MCP auth-required errors.
+- **UI nitpicks** : assorted UI fixes and build fixes.
+
+## 📀 Base OSS version
+
+`transports/v1.5.6`
+
+This release pins clean tagged OSS modules:
+
+```
+github.com/maximhq/bifrost/core                  v1.5.14
+github.com/maximhq/bifrost/framework             v1.3.14
+github.com/maximhq/bifrost/transports            v1.5.6
+github.com/maximhq/bifrost/plugins/governance    v1.5.14
+github.com/maximhq/bifrost/plugins/logging       v1.5.14
+github.com/maximhq/bifrost/plugins/prompts       v1.0.14
+github.com/maximhq/bifrost/plugins/semanticcache v1.5.14
+github.com/maximhq/bifrost/plugins/compat        v0.1.13
+github.com/maximhq/bifrost/plugins/maxim         v1.6.14
+github.com/maximhq/bifrost/plugins/mocker        v1.5.14
+github.com/maximhq/bifrost/plugins/otel          v1.2.14
+github.com/maximhq/bifrost/plugins/telemetry     v1.5.14
+```
+
+## 🔌 If you are compiling plugin against this release - use following deps
+
+```
+module github.com/maximhq/bifrost-enterprise
+
+go 1.26.3
+
+require (
+	cloud.google.com/go/bigquery v1.74.0
+	cloud.google.com/go/pubsub/v2 v2.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/DataDog/datadog-go/v5 v5.6.0
+	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/aws/aws-sdk-go-v2 v1.41.7
+	github.com/aws/aws-sdk-go-v2/config v1.32.11
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.6
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
+	github.com/bytedance/sonic v1.15.0
+	github.com/coreos/go-oidc/v3 v3.12.0
+	github.com/fasthttp/router v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/cel-go v0.26.1
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/consul/api v1.28.2
+	github.com/hashicorp/memberlist v0.5.4
+	github.com/maximhq/bifrost/core v1.5.14
+	github.com/maximhq/bifrost/framework v1.3.14
+	github.com/maximhq/bifrost/plugins/governance v1.5.14
+	github.com/maximhq/bifrost/plugins/logging v1.5.14
+	github.com/maximhq/bifrost/plugins/prompts v1.0.14
+	github.com/maximhq/bifrost/plugins/semanticcache v1.5.14
+	github.com/maximhq/bifrost/transports v1.5.6
+	github.com/nakabonne/tstorage v0.3.6
+	github.com/segmentio/kafka-go v0.4.47
+	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.40.0
+	github.com/tetratelabs/wazero v1.11.0
+	github.com/valyala/fasthttp v1.68.0
+	github.com/zricethezav/gitleaks/v8 v8.30.1
+	go.etcd.io/etcd/client/v3 v3.6.6
+	golang.org/x/crypto v0.49.0
+	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
+	google.golang.org/api v0.274.0
+	google.golang.org/grpc v1.80.0
+	google.golang.org/protobuf v1.36.11
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+	k8s.io/api v0.34.1
+	k8s.io/apimachinery v0.34.1
+	k8s.io/client-go v0.34.1
+)
+
+require (
+	cel.dev/expr v0.25.1 // indirect
+	cloud.google.com/go v0.123.0 // indirect
+	cloud.google.com/go/auth v0.18.2 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/iam v1.5.3 // indirect
+	cloud.google.com/go/monitoring v1.24.3 // indirect
+	cloud.google.com/go/storage v1.61.3 // indirect
+	dario.cat/mergo v1.0.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/BobuSumisu/aho-corasick v1.0.3 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/proto v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.73.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/log v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.71.0 // indirect
+	github.com/DataDog/go-libddwaf/v4 v4.6.1 // indirect
+	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633 // indirect
+	github.com/DataDog/go-sqllexer v0.1.8 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
+	github.com/DataDog/sketches-go v1.4.7 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.3.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/STARRY-S/zip v0.2.1 // indirect
+	github.com/andybalholm/brotli v1.2.0 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/apache/arrow/go/v15 v15.0.2 // indirect
+	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/armon/go-metrics v0.4.1 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bodgit/plumbing v1.3.0 // indirect
+	github.com/bodgit/sevenzip v1.6.0 // indirect
+	github.com/bodgit/windows v1.0.1 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charmbracelet/lipgloss v0.5.0 // indirect
+	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
+	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
+	github.com/containerd/errdefs v1.0.0 // indirect
+	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/containerd/log v0.1.0 // indirect
+	github.com/containerd/platforms v0.2.1 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/docker v28.5.2+incompatible // indirect
+	github.com/docker/go-connections v0.6.0 // indirect
+	github.com/docker/go-units v0.5.0 // indirect
+	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/ebitengine/purego v0.9.1 // indirect
+	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
+	github.com/fasthttp/websocket v1.5.12 // indirect
+	github.com/fatih/color v1.17.0 // indirect
+	github.com/fatih/semgroup v1.2.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
+	github.com/gitleaks/go-gitdiff v0.9.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/go-openapi/analysis v0.24.2 // indirect
+	github.com/go-openapi/errors v0.22.5 // indirect
+	github.com/go-openapi/jsonpointer v0.22.4 // indirect
+	github.com/go-openapi/jsonreference v0.21.4 // indirect
+	github.com/go-openapi/loads v0.23.2 // indirect
+	github.com/go-openapi/runtime v0.29.2 // indirect
+	github.com/go-openapi/spec v0.22.2 // indirect
+	github.com/go-openapi/strfmt v0.25.0 // indirect
+	github.com/go-openapi/swag v0.25.4 // indirect
+	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
+	github.com/go-openapi/swag/conv v0.25.4 // indirect
+	github.com/go-openapi/swag/fileutils v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonname v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonutils v0.25.4 // indirect
+	github.com/go-openapi/swag/loading v0.25.4 // indirect
+	github.com/go-openapi/swag/mangling v0.25.4 // indirect
+	github.com/go-openapi/swag/netutils v0.25.4 // indirect
+	github.com/go-openapi/swag/stringutils v0.25.4 // indirect
+	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
+	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
+	github.com/go-openapi/validate v0.25.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.1.3 // indirect
+	github.com/google/flatbuffers v23.5.26+incompatible // indirect
+	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
+	github.com/googleapis/gax-go/v2 v2.19.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/h2non/filetype v1.1.3 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-hclog v1.6.3 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-metrics v0.5.4 // indirect
+	github.com/hashicorp/go-msgpack/v2 v2.1.5 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
+	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/serf v0.10.1 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/jaswdr/faker/v2 v2.8.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.2 // indirect
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
+	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mailru/easyjson v0.9.1 // indirect
+	github.com/mark3labs/mcp-go v0.43.2 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mattn/go-sqlite3 v1.14.32 // indirect
+	github.com/maximhq/bifrost/plugins/compat v0.1.13 // indirect
+	github.com/maximhq/bifrost/plugins/maxim v1.6.14 // indirect
+	github.com/maximhq/bifrost/plugins/mocker v1.5.14 // indirect
+	github.com/maximhq/bifrost/plugins/otel v1.2.14 // indirect
+	github.com/maximhq/bifrost/plugins/telemetry v1.5.14 // indirect
+	github.com/maximhq/maxim-go v0.2.1 // indirect
+	github.com/mholt/archives v0.1.2 // indirect
+	github.com/miekg/dns v1.1.68 // indirect
+	github.com/minio/minlz v1.0.0 // indirect
+	github.com/minio/simdjson-go v0.4.5 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/go-archive v0.1.0 // indirect
+	github.com/moby/patternmatcher v0.6.0 // indirect
+	github.com/moby/sys/sequential v0.6.0 // indirect
+	github.com/moby/sys/user v0.4.0 // indirect
+	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/moby/term v0.5.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nwaples/rardecode/v2 v2.2.2 // indirect
+	github.com/oapi-codegen/runtime v1.1.1 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/outcaste-io/ristretto v0.2.3 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.21 // indirect
+	github.com/pinecone-io/go-pinecone/v5 v5.3.0 // indirect
+	github.com/pion/datachannel v1.6.0 // indirect
+	github.com/pion/dtls/v3 v3.1.2 // indirect
+	github.com/pion/ice/v4 v4.2.1 // indirect
+	github.com/pion/interceptor v0.1.44 // indirect
+	github.com/pion/logging v0.2.4 // indirect
+	github.com/pion/mdns/v2 v2.1.0 // indirect
+	github.com/pion/randutil v0.1.0 // indirect
+	github.com/pion/rtcp v1.2.16 // indirect
+	github.com/pion/rtp v1.10.1 // indirect
+	github.com/pion/sctp v1.9.2 // indirect
+	github.com/pion/sdp/v3 v3.0.18 // indirect
+	github.com/pion/srtp/v3 v3.0.10 // indirect
+	github.com/pion/stun/v3 v3.1.1 // indirect
+	github.com/pion/transport/v4 v4.0.1 // indirect
+	github.com/pion/turn/v4 v4.1.4 // indirect
+	github.com/pion/webrtc/v4 v4.2.9 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.66.1 // indirect
+	github.com/prometheus/procfs v0.17.0 // indirect
+	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
+	github.com/qdrant/go-client v1.16.2 // indirect
+	github.com/redis/go-redis/v9 v9.17.2 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rs/zerolog v1.34.0 // indirect
+	github.com/sagikazarmark/locafero v0.7.0 // indirect
+	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 // indirect
+	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	github.com/secure-systems-lab/go-securesystemslib v0.9.0 // indirect
+	github.com/shirou/gopsutil/v4 v4.25.10 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/sorairolake/lzip-go v0.3.5 // indirect
+	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
+	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/spf13/viper v1.19.0 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
+	github.com/stoewer/go-strcase v1.3.1 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/theckman/httpforwarded v0.4.0 // indirect
+	github.com/therootcompany/xz v1.0.1 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
+	github.com/tinylib/msgp v1.3.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.16 // indirect
+	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/wasilibs/go-re2 v1.9.0 // indirect
+	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
+	github.com/weaviate/weaviate v1.36.5 // indirect
+	github.com/weaviate/weaviate-go-client/v5 v5.7.1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	github.com/wlynxg/anet v0.0.5 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	github.com/zeebo/xxh3 v1.0.2 // indirect
+	go.einride.tech/aip v0.83.0 // indirect
+	go.etcd.io/etcd/api/v3 v3.6.6 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.6.6 // indirect
+	go.mongodb.org/mongo-driver v1.17.6 // indirect
+	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/component v1.39.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.39.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.133.0 // indirect
+	go.opentelemetry.io/collector/pdata v1.39.0 // indirect
+	go.opentelemetry.io/contrib/bridges/otelzap v0.12.0 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.40.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
+	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
+	go.opentelemetry.io/otel/log v0.14.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.starlark.net v0.0.0-20260102030733-3fee463870c9 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
+	golang.org/x/arch v0.23.0 // indirect
+	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect
+	golang.org/x/mod v0.33.0 // indirect
+	golang.org/x/net v0.52.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 // indirect
+	golang.org/x/term v0.41.0 // indirect
+	golang.org/x/text v0.35.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/tools v0.42.0 // indirect
+	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
+	google.golang.org/genproto v0.0.0-20260316180232-0b37fe3546d5 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/postgres v1.6.0 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
+)
+```
+
+</Update>

--- a/docs/changelogs/helm-v2.1.20.mdx
+++ b/docs/changelogs/helm-v2.1.20.mdx
@@ -1,0 +1,13 @@
+---
+title: "v2.1.20"
+description: "Helm v2.1.20 changelog - 2026-05-29"
+---
+
+<Update label="Bifrost Helm" description="v2.1.20">
+
+## Changelog
+
+- Added `authServerType` (`"org"` or `"custom"`) to the Okta SCIM/SSO config in `values.schema.json`. The field was documented but previously rejected at validation time by `additionalProperties: false`. Defaults to auto-detection from the issuer URL when omitted.
+- Exposed `authServerType` as a commented example under `bifrost.scim.config` in `values.yaml` for discoverability.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -751,6 +751,7 @@
             "item": "Enterprise",
             "icon": "building",
             "pages": [
+              "changelogs/ent-v1.4.5",
               "changelogs/ent-v1.4.4",
               "changelogs/ent-v1.4.3",
               "changelogs/ent-v1.4.2",
@@ -809,6 +810,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.20",
               "changelogs/helm-v2.1.19",
               "changelogs/helm-v2.1.18",
               "changelogs/helm-v2.1.17",


### PR DESCRIPTION
## Summary

Fixes CI failures caused by `harden-runner`'s egress-policy blocking Postgres connections in the release pipeline. Because `harden-runner` filters on the post-NAT destination IP, host processes dialing `127.0.0.1:5432` are actually reaching Postgres at its Docker bridge IP after DNAT. The Postgres container now has a pinned bridge IP (`172.38.0.11`) and that IP:port is explicitly added to the `allowed-endpoints` list for every release-pipeline job that connects to Postgres (`test-migrations`, `test-bifrost-http`, `test-api-integrations`). This PR also adds the `ent-v1.4.5` and `helm-v2.1.20` changelogs.

## Changes

- Assigned a static IPv4 address (`172.38.0.11`) to the Postgres container in `docker-compose.yml` so the post-NAT bridge IP is deterministic and can be allowlisted.
- Added `172.38.0.11:5432` to the `harden-runner` `allowed-endpoints` in the `test-migrations`, `test-bifrost-http`, and `test-api-integrations` jobs in `release-pipeline.yml`. Added inline comments explaining the DNAT behaviour and the requirement to keep the pinned IPs in sync.
- Added `172.38.0.12:8080` and `172.38.0.12:8301` (Weaviate's pinned bridge IP) to the `test-api-integrations` job, which starts all Compose services and waits for Weaviate to become healthy.
- Added `docs/changelogs/ent-v1.4.5.mdx` covering identity lifecycle, MCP per-user auth, governance UI sheets, and OSS base `transports/v1.5.6` additions.
- Added `docs/changelogs/helm-v2.1.20.mdx` documenting the `authServerType` field addition to the Okta SCIM/SSO schema.
- Registered both new changelog pages in `docs/docs.json`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Trigger the release pipeline and confirm the `test-migrations`, `test-bifrost-http`, and `test-api-integrations` jobs complete without `harden-runner` blocking egress to `172.38.0.11:5432`. Verify Weaviate health checks pass in `test-api-integrations` with the newly added `172.38.0.12` entries.

```sh
# Verify Postgres container receives the pinned IP at runtime
docker compose -f .github/workflows/configs/docker-compose.yml up -d postgres
docker inspect <postgres_container> | grep '"IPAddress"'
# Expected: 172.38.0.11
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The pinned IPs are internal Docker bridge addresses scoped to the CI runner's network namespace. Allowlisting them in `harden-runner` does not expose any additional external endpoints; it only permits loopback-equivalent container-to-host traffic that was already implicitly occurring via the published port mapping.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Enterprise v1.4.5 release notes covering identity lifecycle management, per-user authentication, Okta synchronization enhancements, and governance UI improvements.
  * Added Helm v2.1.20 release notes with new Okta SCIM/SSO configuration support.
  * Updated documentation navigation.

* **Chores**
  * Updated CI/workflow infrastructure configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->