### PR TITLE
fix(helm): pass through encryption_status on governance.virtualKeys

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -456,6 +456,7 @@ false
 {{- if .rate_limit_id }}{{- $_ := set $vk "rate_limit_id" .rate_limit_id }}{{- end }}
 {{- if .provider_configs }}{{- $_ := set $vk "provider_configs" .provider_configs }}{{- end }}
 {{- if .mcp_configs }}{{- $_ := set $vk "mcp_configs" .mcp_configs }}{{- end }}
+{{- if .encryption_status }}{{- $_ := set $vk "encryption_status" .encryption_status }}{{- end }}
 {{- $vks = append $vks $vk }}
 {{- end }}
 {{- $_ := set $governance "virtual_keys" $vks }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1227,6 +1227,10 @@
                   "calendar_aligned": {
                     "type": "boolean"
                   },
+                  "encryption_status": {
+                    "type": "string",
+                    "enum": ["plain_text", "encrypted"]
+                  },
                   "provider_configs": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
## Summary

`bifrost.config` (in `_helpers.tpl`) explicitly enumerates which fields on each virtual key get rendered into `config.json`. The `encryption_status` field is missing from the enumeration, so even when users set it in `values.yaml` the chart silently drops it.

## Effect on consumers

A rendered `config.json` shows `encryption_status: null` (or omitted) on every VK regardless of what `values.yaml` declares. Bifrost's governance auth path then treats null/empty `encryption_status` as the VK being in an indeterminate state and silently denies access to non-Anthropic providers — the Anthropic auth path doesn't read this field, which is why anthropic-routed inference still appears to work while OpenAI/Ollama/etc. fail with `403 model_blocked`.

This is hard to diagnose because the user-visible failure mode is "Model X is not allowed for this virtual key" with no hint that the root cause is a chart-render bug.

## Fix

- `helm-charts/bifrost/templates/_helpers.tpl` — one-line addition inside the `virtualKeys` range block, matching the surrounding conditional-set pattern:
  ```
  {{- if .encryption_status }}{{- $_ := set $vk "encryption_status" .encryption_status }}{{- end }}
  ```
- `helm-charts/bifrost/values.schema.json` — declare `encryption_status` on the VK item schema with `enum: ["plain_text", "encrypted"]` so JSON Schema validation accepts the field.

## Verification

Reproduced + verified locally with `helm template`:

**Before:**
```bash
$ helm template test ./helm-charts/bifrost -f values.yaml \
    | jq '.governance.virtual_keys[0].encryption_status'
null   # field dropped
```

**After:**
```bash
$ helm template test ./helm-charts/bifrost -f values.yaml \
    | jq '.governance.virtual_keys[0].encryption_status'
"plain_text"   # field flows through
```

Negative case (VK with no `encryption_status` in values.yaml) — field is omitted from the rendered output rather than written as null, matching the surrounding fields' behaviour.

## Test plan

- [x] `helm template` with `encryption_status: "plain_text"` set — field appears in rendered config.json
- [x] `helm template` with `encryption_status` unset — field is omitted (not null)
- [ ] CI green on this PR

## Related

This was the root cause of a multi-day debugging incident downstream where autonomous-agent workers couldn't reach the OpenAI provider despite the VK config saying `allowed_models: ["*"]` for openai. The DB-patch workaround documented in some downstream notes only persists until the next Bifrost restart re-syncs from the broken `config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for specifying encryption status on governance virtual keys in Bifrost configurations. Users can now designate keys as either plain text or encrypted to better manage their security posture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->