### PR TITLE
removes from_memory for APIs

### DIFF
--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -473,31 +473,6 @@ func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 
 // getVirtualKeys handles GET /api/governance/virtual-keys - Get all virtual keys with relationships
 func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		// Convert map to slice to match the non-memory response format (array)
-		virtualKeys := make([]*configstoreTables.TableVirtualKey, 0, len(data.VirtualKeys))
-		for _, vk := range data.VirtualKeys {
-			virtualKeys = append(virtualKeys, vk)
-		}
-		sort.Slice(virtualKeys, func(i, j int) bool {
-			return virtualKeys[i].CreatedAt.Before(virtualKeys[j].CreatedAt)
-		})
-		SendJSON(ctx, map[string]interface{}{
-			"virtual_keys": virtualKeys,
-			"count":        len(virtualKeys),
-			"total_count":  len(virtualKeys),
-			"limit":        len(virtualKeys),
-			"offset":       0,
-		})
-		return
-	}
 	// Check for pagination/filter parameters
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
@@ -831,25 +806,6 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 // getVirtualKey handles GET /api/governance/virtual-keys/{vk_id} - Get a specific virtual key
 func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 	vkID := ctx.UserValue("vk_id").(string)
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		for _, vk := range data.VirtualKeys {
-			if vk.ID == vkID {
-				SendJSON(ctx, map[string]interface{}{
-					"virtual_key": vk,
-				})
-				return
-			}
-		}
-		SendError(ctx, 404, "Virtual key not found")
-		return
-	}
 	vk, err := h.configStore.GetVirtualKey(ctx, vkID)
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
@@ -1657,39 +1613,6 @@ func (h *GovernanceHandler) deleteVirtualKey(ctx *fasthttp.RequestCtx) {
 // getTeams handles GET /api/governance/teams - Get all teams
 func (h *GovernanceHandler) getTeams(ctx *fasthttp.RequestCtx) {
 	customerID := string(ctx.QueryArgs().Peek("customer_id"))
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		if customerID != "" {
-			teams := make(map[string]*configstoreTables.TableTeam)
-			for _, team := range data.Teams {
-				if team.CustomerID != nil && *team.CustomerID == customerID {
-					teams[team.ID] = team
-				}
-			}
-			SendJSON(ctx, map[string]interface{}{
-				"teams":       teams,
-				"count":       len(teams),
-				"total_count": len(teams),
-				"limit":       len(teams),
-				"offset":      0,
-			})
-		} else {
-			SendJSON(ctx, map[string]interface{}{
-				"teams":       data.Teams,
-				"count":       len(data.Teams),
-				"total_count": len(data.Teams),
-				"limit":       len(data.Teams),
-				"offset":      0,
-			})
-		}
-		return
-	}
 
 	// Check for pagination parameters
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
@@ -1845,24 +1768,6 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 // getTeam handles GET /api/governance/teams/{team_id} - Get a specific team
 func (h *GovernanceHandler) getTeam(ctx *fasthttp.RequestCtx) {
 	teamID := ctx.UserValue("team_id").(string)
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		team, ok := data.Teams[teamID]
-		if !ok {
-			SendError(ctx, 404, "Team not found")
-			return
-		}
-		SendJSON(ctx, map[string]interface{}{
-			"team": team,
-		})
-		return
-	}
 	team, err := h.configStore.GetTeam(ctx, teamID)
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
@@ -2150,23 +2055,6 @@ func (h *GovernanceHandler) deleteTeam(ctx *fasthttp.RequestCtx) {
 
 // getCustomers handles GET /api/governance/customers - Get all customers
 func (h *GovernanceHandler) getCustomers(ctx *fasthttp.RequestCtx) {
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		SendJSON(ctx, map[string]interface{}{
-			"customers":   data.Customers,
-			"count":       len(data.Customers),
-			"total_count": len(data.Customers),
-			"limit":       len(data.Customers),
-			"offset":      0,
-		})
-		return
-	}
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
 	search := string(ctx.QueryArgs().Peek("search"))
@@ -2295,24 +2183,6 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 // getCustomer handles GET /api/governance/customers/{customer_id} - Get a specific customer
 func (h *GovernanceHandler) getCustomer(ctx *fasthttp.RequestCtx) {
 	customerID := ctx.UserValue("customer_id").(string)
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		customer, ok := data.Customers[customerID]
-		if !ok {
-			SendError(ctx, 404, "Customer not found")
-			return
-		}
-		SendJSON(ctx, map[string]interface{}{
-			"customer": customer,
-		})
-		return
-	}
 	customer, err := h.configStore.GetCustomer(ctx, customerID)
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
@@ -2530,20 +2400,6 @@ func (h *GovernanceHandler) deleteCustomer(ctx *fasthttp.RequestCtx) {
 
 // getBudgets handles GET /api/governance/budgets - Get all budgets
 func (h *GovernanceHandler) getBudgets(ctx *fasthttp.RequestCtx) {
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		SendJSON(ctx, map[string]interface{}{
-			"budgets": data.Budgets,
-			"count":   len(data.Budgets),
-		})
-		return
-	}
 	budgets, err := h.configStore.GetBudgets(ctx)
 	if err != nil {
 		logger.Error("failed to retrieve budgets: %v", err)
@@ -2558,20 +2414,6 @@ func (h *GovernanceHandler) getBudgets(ctx *fasthttp.RequestCtx) {
 
 // getRateLimits handles GET /api/governance/rate-limits - Get all rate limits
 func (h *GovernanceHandler) getRateLimits(ctx *fasthttp.RequestCtx) {
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		SendJSON(ctx, map[string]interface{}{
-			"rate_limits": data.RateLimits,
-			"count":       len(data.RateLimits),
-		})
-		return
-	}
 	rateLimits, err := h.configStore.GetRateLimits(ctx)
 	if err != nil {
 		logger.Error("failed to retrieve rate limits: %v", err)
@@ -2647,23 +2489,6 @@ func validateBudget(budget *configstoreTables.TableBudget) error {
 
 // getModelConfigs handles GET /api/governance/model-configs - Get all model configs
 func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		SendJSON(ctx, map[string]any{
-			"model_configs": data.ModelConfigs,
-			"count":         len(data.ModelConfigs),
-			"total_count":   len(data.ModelConfigs),
-			"limit":         len(data.ModelConfigs),
-			"offset":        0,
-		})
-		return
-	}
-
 	// Check for pagination parameters
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
@@ -3071,29 +2896,6 @@ type ProviderGovernanceResponse struct {
 
 // getProviderGovernance handles GET /api/governance/providers - Get all providers with governance settings
 func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		var result []ProviderGovernanceResponse
-		for _, p := range data.Providers {
-			if p.Budget != nil || p.RateLimit != nil {
-				result = append(result, ProviderGovernanceResponse{
-					Provider:  p.Name,
-					Budget:    p.Budget,
-					RateLimit: p.RateLimit,
-				})
-			}
-		}
-		SendJSON(ctx, map[string]interface{}{
-			"providers": result,
-			"count":     len(result),
-		})
-		return
-	}
 	providers, err := h.configStore.GetProviders(ctx)
 	if err != nil {
 		logger.Error("failed to retrieve providers: %v", err)
@@ -3365,44 +3167,6 @@ func (h *GovernanceHandler) getRoutingRules(ctx *fasthttp.RequestCtx) {
 	scope := string(ctx.QueryArgs().Peek("scope"))
 	scopeID := string(ctx.QueryArgs().Peek("scope_id"))
 
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		gd := h.governanceManager.GetGovernanceData(ctx)
-		if gd == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		inMemoryRules := gd.RoutingRules
-
-		// Filter rules by scope and scopeID
-		var rules []configstoreTables.TableRoutingRule
-		for _, rule := range inMemoryRules {
-			if scope != "" && rule.Scope != scope {
-				continue
-			}
-			if scopeID != "" {
-				ruleScope := ""
-				if rule.ScopeID != nil {
-					ruleScope = *rule.ScopeID
-				}
-				if ruleScope != scopeID {
-					continue
-				}
-			}
-			rules = append(rules, *rule)
-		}
-
-		SendJSON(ctx, map[string]interface{}{
-			"rules":       rules,
-			"count":       len(rules),
-			"total_count": len(rules),
-			"limit":       len(rules),
-			"offset":      0,
-		})
-		return
-	}
-
 	// If scope/scopeID filters are specified, use the existing non-paginated path
 	if scope != "" || scopeID != "" {
 		rules, err := h.configStore.GetRoutingRulesByScope(ctx, scope, scopeID)
@@ -3496,41 +3260,15 @@ func (h *GovernanceHandler) getRoutingRules(ctx *fasthttp.RequestCtx) {
 func (h *GovernanceHandler) getRoutingRule(ctx *fasthttp.RequestCtx) {
 	ruleID := ctx.UserValue("rule_id").(string)
 
-	var rule *configstoreTables.TableRoutingRule
-	var err error
-
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		gd := h.governanceManager.GetGovernanceData(ctx)
-		if gd == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		inMemoryRules := gd.RoutingRules
-
-		// Find rule by ID in memory
-		for _, r := range inMemoryRules {
-			if r.ID == ruleID {
-				rule = r
-				break
-			}
-		}
-		if rule == nil {
+	rule, err := h.configStore.GetRoutingRule(ctx, ruleID)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
 			SendError(ctx, 404, "Routing rule not found")
 			return
 		}
-	} else {
-		rule, err = h.configStore.GetRoutingRule(ctx, ruleID)
-		if err != nil {
-			if errors.Is(err, configstore.ErrNotFound) {
-				SendError(ctx, 404, "Routing rule not found")
-				return
-			}
-			logger.Error("failed to get routing rule: %v", err)
-			SendError(ctx, 500, "Failed to retrieve routing rule")
-			return
-		}
+		logger.Error("failed to get routing rule: %v", err)
+		SendError(ctx, 500, "Failed to retrieve routing rule")
+		return
 	}
 
 	SendJSON(ctx, map[string]interface{}{

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -21,23 +21,29 @@ import (
 // Only GetGovernanceData is needed for the getVirtualKeys handler path.
 type mockGovernanceManagerForVK struct {
 	GovernanceManager
+	getGovernanceDataCalls int
 }
 
 func (m *mockGovernanceManagerForVK) GetGovernanceData(ctx context.Context) *governance.GovernanceData {
+	m.getGovernanceDataCalls++
 	return nil
 }
 
 // mockConfigStoreForVK embeds the interface so unimplemented methods panic.
-// Only GetVirtualKeysPaginated is called in the non-from_memory path.
+// Only GetVirtualKeysPaginated is called in the paginated path.
 type mockConfigStoreForVK struct {
 	configstore.ConfigStore
+	getVirtualKeysCalls          int
+	getVirtualKeysPaginatedCalls int
 }
 
 func (m *mockConfigStoreForVK) GetVirtualKeysPaginated(_ context.Context, _ configstore.VirtualKeyQueryParams) ([]configstoreTables.TableVirtualKey, int64, error) {
+	m.getVirtualKeysPaginatedCalls++
 	return nil, 0, nil
 }
 
 func (m *mockConfigStoreForVK) GetVirtualKeys(_ context.Context) ([]configstoreTables.TableVirtualKey, error) {
+	m.getVirtualKeysCalls++
 	return nil, nil
 }
 
@@ -1288,6 +1294,70 @@ func TestGetVirtualKeys_PaginatedEndpoint_QueryParams(t *testing.T) {
 				t.Errorf("offset: got %v, want %v", got, tt.wantOffset)
 			}
 		})
+	}
+}
+
+// TestGetVirtualKeys_FromMemoryUsesConfigStore verifies the legacy
+// from_memory flag no longer bypasses the DB-backed ConfigStore path.
+func TestGetVirtualKeys_FromMemoryUsesConfigStore(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &mockConfigStoreForVK{}
+	manager := &mockGovernanceManagerForVK{}
+	h := &GovernanceHandler{
+		configStore:       store,
+		governanceManager: manager,
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/governance/virtual-keys?from_memory=true")
+
+	h.getVirtualKeys(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if manager.getGovernanceDataCalls != 0 {
+		t.Fatalf("from_memory path called GetGovernanceData %d times", manager.getGovernanceDataCalls)
+	}
+	if store.getVirtualKeysCalls != 1 {
+		t.Fatalf("expected GetVirtualKeys to be called once, got %d", store.getVirtualKeysCalls)
+	}
+	if store.getVirtualKeysPaginatedCalls != 0 {
+		t.Fatalf("unexpected paginated call count %d", store.getVirtualKeysPaginatedCalls)
+	}
+}
+
+// TestGetVirtualKeys_FromMemoryWithLimitUsesPaginatedConfigStore verifies
+// limit=0 plus from_memory still follows the DB-backed paginated path.
+func TestGetVirtualKeys_FromMemoryWithLimitUsesPaginatedConfigStore(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &mockConfigStoreForVK{}
+	manager := &mockGovernanceManagerForVK{}
+	h := &GovernanceHandler{
+		configStore:       store,
+		governanceManager: manager,
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/governance/virtual-keys?limit=0&from_memory=true")
+
+	h.getVirtualKeys(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if manager.getGovernanceDataCalls != 0 {
+		t.Fatalf("from_memory path called GetGovernanceData %d times", manager.getGovernanceDataCalls)
+	}
+	if store.getVirtualKeysPaginatedCalls != 1 {
+		t.Fatalf("expected GetVirtualKeysPaginated to be called once, got %d", store.getVirtualKeysPaginatedCalls)
+	}
+	if store.getVirtualKeysCalls != 0 {
+		t.Fatalf("unexpected non-paginated call count %d", store.getVirtualKeysCalls)
 	}
 }
 

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -17,6 +17,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/queryscope"
 	"github.com/maximhq/bifrost/plugins/logging"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
@@ -47,6 +48,12 @@ const filterDataCacheTTL = 30 * time.Second
 const filterDataFanOutLimit = 4
 
 const defaultFilterDataLimit = 1000
+
+// shouldUseFilterDataCache reports whether a filterdata response can be shared
+// across callers without bypassing DAC-scoped query constraints.
+func shouldUseFilterDataCache(ctx context.Context, query string) bool {
+	return strings.TrimSpace(query) == "" && queryscope.FromContext(ctx) == nil
+}
 
 // Filter dimension names accepted by the ?dimensions= query param on
 // /api/logs/filterdata. Each maps to one DB call and one response field.
@@ -1110,7 +1117,7 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	dims := parseFilterDimensions(string(ctx.QueryArgs().Peek("dimensions")), allFilterDimensions)
 	want := dimSet(dims)
 	query := strings.TrimSpace(string(ctx.QueryArgs().Peek("q")))
-	useCache := query == ""
+	useCache := shouldUseFilterDataCache(ctx, query)
 
 	var entry *filterDataCacheEntry
 	if useCache {
@@ -1919,7 +1926,7 @@ func (h *LoggingHandler) getMCPLogsFilterData(ctx *fasthttp.RequestCtx) {
 	dims := parseFilterDimensions(string(ctx.QueryArgs().Peek("dimensions")), allMCPFilterDimensions)
 	want := dimSet(dims)
 	query := strings.TrimSpace(string(ctx.QueryArgs().Peek("q")))
-	useCache := query == ""
+	useCache := shouldUseFilterDataCache(ctx, query)
 
 	var entry *filterDataCacheEntry
 	if useCache {

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/framework/queryscope"
+	"gorm.io/gorm"
+)
+
+// TestShouldUseFilterDataCacheAllowsUnscopedEmptyQuery verifies unscoped
+// requests can still share the no-query filterdata cache.
+func TestShouldUseFilterDataCacheAllowsUnscopedEmptyQuery(t *testing.T) {
+	if !shouldUseFilterDataCache(context.Background(), "") {
+		t.Fatal("expected unscoped empty-query request to use filterdata cache")
+	}
+	if !shouldUseFilterDataCache(context.Background(), "   ") {
+		t.Fatal("expected whitespace-only query to use filterdata cache")
+	}
+}
+
+// TestShouldUseFilterDataCacheRejectsSearchQuery verifies search requests are
+// request-specific and must not share the empty-query cache.
+func TestShouldUseFilterDataCacheRejectsSearchQuery(t *testing.T) {
+	if shouldUseFilterDataCache(context.Background(), "vk") {
+		t.Fatal("expected non-empty query to bypass filterdata cache")
+	}
+}
+
+// TestShouldUseFilterDataCacheRejectsScopedContext verifies DAC-scoped
+// requests never consume or populate the shared all-data cache.
+func TestShouldUseFilterDataCacheRejectsScopedContext(t *testing.T) {
+	ctx := queryscope.WithQueryScope(context.Background(), func(db *gorm.DB) *gorm.DB {
+		return db.Where("1 = 0")
+	})
+	if shouldUseFilterDataCache(ctx, "") {
+		t.Fatal("expected scoped request to bypass filterdata cache")
+	}
+}

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -161,17 +161,8 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 		connectedClientsMap[client.Config.ID] = client
 	}
 
-	// Build VK id→name lookup from in-memory governance data (no extra DB queries)
-	vkNameByID := make(map[string]string)
-	if h.governanceManager != nil {
-		if gd := h.governanceManager.GetGovernanceData(ctx); gd != nil {
-			for _, vk := range gd.VirtualKeys {
-				vkNameByID[vk.ID] = vk.Name
-			}
-		}
-	}
-
 	// Batch-fetch all VK assignments for this page in a single query, then group by client ID.
+	vkNameByID := make(map[string]string)
 	assignmentsByClientID := make(map[uint][]configstoreTables.TableVirtualKeyMCPConfig)
 	if h.store.ConfigStore != nil {
 		dbClientIDs := make([]uint, 0, len(dbClients))
@@ -181,6 +172,28 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 		if allAssignments, err := h.store.ConfigStore.GetVirtualKeyMCPConfigsByMCPClientIDs(ctx, dbClientIDs); err == nil {
 			for _, a := range allAssignments {
 				assignmentsByClientID[a.MCPClientID] = append(assignmentsByClientID[a.MCPClientID], a)
+			}
+		}
+		// Collect unique VK IDs across all assignments, then batch-fetch their names
+		// in a single query (avoids one GetVirtualKey round trip per unique VK ID).
+		uniqueVKIDs := make([]string, 0)
+		seenVirtualKeyIDs := make(map[string]struct{})
+		for _, assignments := range assignmentsByClientID {
+			for _, assignment := range assignments {
+				if _, ok := seenVirtualKeyIDs[assignment.VirtualKeyID]; ok {
+					continue
+				}
+				seenVirtualKeyIDs[assignment.VirtualKeyID] = struct{}{}
+				uniqueVKIDs = append(uniqueVKIDs, assignment.VirtualKeyID)
+			}
+		}
+		if len(uniqueVKIDs) > 0 {
+			if virtualKeys, err := h.store.ConfigStore.GetRedactedVirtualKeys(ctx, uniqueVKIDs); err == nil {
+				for _, virtualKey := range virtualKeys {
+					vkNameByID[virtualKey.ID] = virtualKey.Name
+				}
+			} else {
+				logger.Error("failed to batch-retrieve virtual keys for MCP client assignments: %v", err)
 			}
 		}
 	}
@@ -239,7 +252,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 				clientConfig.OauthClientSecret = oauthCfg.GetClientSecretAsEnvVar()
 			}
 		}
-		// Enrich VK assignments using the pre-fetched batch result (no extra DB call per client)
+		// Enrich VK assignments using the pre-fetched batch result.
 		vkConfigs := []MCPVKConfigResponse{}
 		for _, a := range assignmentsByClientID[dbClient.ID] {
 			vkConfigs = append(vkConfigs, MCPVKConfigResponse{
@@ -1377,7 +1390,6 @@ func validateAllowedExtraHeaders(allowedExtraHeaders schemas.WhiteList) error {
 	}
 	return nil
 }
-
 
 func validateToolsToAutoExecute(toolsToAutoExecute schemas.WhiteList, toolsToExecute schemas.WhiteList) error {
 	if err := toolsToAutoExecute.Validate(); err != nil {


### PR DESCRIPTION
## Summary

Removes the `from_memory` query parameter shortcut from all governance API endpoints and fixes a cache-poisoning risk in the filter data handler. Previously, callers could pass `?from_memory=true` to bypass the database and read directly from the in-memory governance snapshot. This path is now removed entirely — all reads go through the `ConfigStore` — ensuring responses always reflect persisted state. Additionally, the filter data cache is now skipped for DAC-scoped requests to prevent scoped data from being served to unscoped callers (or vice versa).

## Changes

- Removed `from_memory` branch from `getVirtualKeys`, `getVirtualKey`, `getTeams`, `getTeam`, `getCustomers`, `getCustomer`, `getBudgets`, `getRateLimits`, `getModelConfigs`, `getProviderGovernance`, `getRoutingRules`, and `getRoutingRule` — all now unconditionally delegate to `ConfigStore`.
- Replaced the in-memory VK name lookup in `getMCPClientsPaginated` with targeted `GetVirtualKey` calls per unique VK ID found in the fetched assignments, removing the dependency on `governanceManager.GetGovernanceData`.
- Introduced `shouldUseFilterDataCache` to gate the shared filterdata cache on both an empty query string and the absence of a DAC query scope in the request context, preventing cross-scope cache hits.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

- Confirm that `GET /api/governance/virtual-keys?from_memory=true` returns the same DB-backed response as without the parameter.
- Confirm that `GET /api/logs/filterdata` with a DAC-scoped request context does not return cached data from an unscoped request.
- Confirm that `GET /api/governance/routing-rules/{id}` returns 404 for a missing rule and the correct rule for a valid ID.

## Breaking changes

- [x] Yes
- [ ] No

The `from_memory=true` query parameter is no longer honored on any governance endpoint. Clients relying on this parameter will continue to receive valid responses, but data will always be sourced from the database rather than the in-memory snapshot.

## Security considerations

The filter data cache fix prevents a DAC-scoped request from populating or consuming the shared all-data cache, closing a potential data leakage path where one tenant's scope constraints could be bypassed by a cache hit populated under a different (or no) scope.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Governance API endpoints now consistently use database-backed responses for all requests, ensuring data consistency
  * Filter data caching now properly respects query scoping constraints
  * Virtual key enrichment improved with batch fetching for better reliability

* **Tests**
  * Added test coverage for governance endpoint caching behavior and filter data caching logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->