### PR TITLE
ollama streaming auth header

### DIFF
--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -153,12 +153,16 @@ func (provider *OllamaProvider) TextCompletionStream(ctx *schemas.BifrostContext
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
+	var authHeader map[string]string
+	if key.Value.GetValue() != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
+	}
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamingClient,
 		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
-		nil,
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -204,13 +208,17 @@ func (provider *OllamaProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
+	var authHeader map[string]string
+	if key.Value.GetValue() != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
 		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		nil,
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),


### PR DESCRIPTION
## Summary

Adds Bearer token authentication support to the Ollama provider's streaming endpoints. Previously, the streaming methods for text completion and chat completion always passed `nil` for the auth header, meaning API keys configured for Ollama were silently ignored during streaming requests.

## Issues

Closes #3905

## Changes

- When a non-empty key value is present, a `Bearer` token `Authorization` header is now constructed and passed to the OpenAI-compatible streaming handlers for both `TextCompletionStream` and `ChatCompletionStream`
- If no key is configured, the auth header remains `nil`, preserving backward compatibility with unauthenticated local Ollama instances

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Configure an Ollama provider with an API key (e.g., when using a hosted or authenticated Ollama instance) and issue a streaming chat or text completion request. Verify the `Authorization: Bearer <key>` header is included in the outgoing request.

```sh
go test ./core/providers/ollama/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

API keys are now correctly forwarded as Bearer tokens in streaming requests to Ollama. Ensure keys are stored and retrieved securely via the existing key management mechanism, as they will now be included in outbound HTTP headers for streaming calls.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ollama streaming requests now support authentication via bearer tokens for both text and chat completions, enabling proper token-based authentication when API keys are provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->