### PR TITLE
changelogs

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
 - fix: send Authorization Bearer header on Ollama streaming text and chat completion requests (#3906)
 - fix: SGL provider now sends Authorization header on streaming requests (#3307) (thanks [@hensapir](https://github.com/hensapir)!)
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/compat/changelog.md
+++ b/plugins/compat/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/jsonparser/changelog.md
+++ b/plugins/jsonparser/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/maxim/changelog.md
+++ b/plugins/maxim/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/mocker/changelog.md
+++ b/plugins/mocker/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/otel/changelog.md
+++ b/plugins/otel/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/prompts/changelog.md
+++ b/plugins/prompts/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/semanticcache/changelog.md
+++ b/plugins/semanticcache/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/plugins/telemetry/changelog.md
+++ b/plugins/telemetry/changelog.md
@@ -1,0 +1,1 @@
+- chore: bumped transitive golang.org/x dependencies (crypto, net, sys, text) for Docker Scout CVE remediation (#3900)

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -59,7 +59,7 @@
   # libgcc: GCC runtime library
   # ca-certificates: For HTTPS connections
   RUN apk upgrade --no-cache && \
-    apk add --no-cache musl libgcc ca-certificates wget zlib
+    apk add --no-cache musl libgcc ca-certificates zlib
   
   # Create data directory and set up user
   COPY --from=builder /app/main .
@@ -103,8 +103,10 @@
   EXPOSE $APP_PORT
   
   # Health check for container status monitoring
+  # Uses busybox wget (built into alpine) instead of the standalone wget package
+  # to avoid CVE-2025-69194; busybox wget supports -q/-O but not --no-verbose/--tries.
   HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 -O /dev/null http://127.0.0.1:${APP_PORT}/health || exit 1
+    CMD wget -q -O /dev/null http://127.0.0.1:${APP_PORT}/health || exit 1
   
   # Use entrypoint script that handles volume permissions and argument processing
   ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -72,7 +72,7 @@
   # musl: C standard library (required for CGO binaries)
   # libgcc: GCC runtime library
   # ca-certificates: For HTTPS connections
-  RUN apk add --no-cache musl libgcc ca-certificates wget zlib=1.3.2-r0
+  RUN apk add --no-cache musl libgcc ca-certificates zlib=1.3.2-r0
 
   # Create data directory and set up user
   COPY --from=builder /app/main .
@@ -106,8 +106,10 @@
   EXPOSE $APP_PORT
 
   # Health check for container status monitoring
+  # Uses busybox wget (built into alpine) instead of the standalone wget package
+  # to avoid CVE-2025-69194; busybox wget supports -q/-O but not --no-verbose/--tries.
   HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 -O /dev/null http://127.0.0.1:${APP_PORT}/health || exit 1
+    CMD wget -q -O /dev/null http://127.0.0.1:${APP_PORT}/health || exit 1
 
   # Use entrypoint script that handles volume permissions and argument processing
   ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,10 @@
+## 🔒 Security
+
+- **Go Dependency CVE Remediation** — Updated `golang.org/x` dependencies flagged by Docker Scout, clearing 20 advisories (severity up to 10.0): `crypto` v0.49.0 → v0.52.0, `net` v0.52.0 → v0.55.0, `sys` v0.42.0 → v0.45.0, `text` v0.35.0 → v0.37.0, `term` v0.41.0 → v0.43.0 (cli). Verified with `govulncheck` against the live Go vulnerability database: zero vulnerabilities remain in any module (#3900)
+- **Hardened Container Image** — Removed the standalone GNU `wget` package from the Alpine runtime image, eliminating CVE-2025-69194 (8.8); the `HEALTHCHECK` now uses the built-in busybox `wget` applet, with no functional change
+
+## 🐞 Fixed
+
+- **Ollama Streaming Auth** — Ollama streaming text and chat requests now forward the configured API key as an `Authorization: Bearer` header (#3906)
+- **SGL Streaming Auth** — SGL provider now sends the `Authorization` header on streaming requests (#3307) (thanks [@hensapir](https://github.com/hensapir)!)
+- **Governance & Logging APIs** — Removed the `from_memory` query parameter; virtual key and config list APIs now return consistent DB-backed results, with VK names batch-fetched in a single query (#3903)


### PR DESCRIPTION
## Summary

Remediates Docker Scout CVE findings by upgrading transitive `golang.org/x` dependencies and removing the standalone GNU `wget` package from Alpine runtime images, replacing it with the built-in busybox `wget` applet.

## Changes

- Bumped `golang.org/x` transitive dependencies (`crypto`, `net`, `sys`, `text`, `term`) across all modules to clear 20 Docker Scout advisories (severity up to 10.0), verified clean with `govulncheck`
- Removed standalone `wget` package from Alpine runtime images in `Dockerfile` and `Dockerfile.local`, eliminating CVE-2025-69194 (CVSS 8.8)
- Updated `HEALTHCHECK` command from `wget --no-verbose --tries=1` to `wget -q` to use busybox-compatible flags with no functional change in behavior

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Verify no vulnerabilities remain
govulncheck ./...

# Build Docker image and confirm wget healthcheck works
docker build -f transports/Dockerfile -t gateway-test .
docker run --rm gateway-test
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #3900

## Security considerations

- Clears 20 Docker Scout CVE advisories on `golang.org/x` packages, with severities up to 10.0
- Removes CVE-2025-69194 (CVSS 8.8) by eliminating the standalone GNU `wget` package; busybox `wget` is used instead and is not affected by this CVE

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable