### PR TITLE
chore: resolve merge conflict by pinning `bifrost/plugins/mocker` to v1.5.13

### DIFF
--- a/transports/go.mod
+++ b/transports/go.mod
@@ -132,11 +132,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
-<<<<<<< HEAD
-	github.com/maximhq/bifrost/plugins/mocker v1.5.15 // indirect
-=======
 	github.com/maximhq/bifrost/plugins/mocker v1.5.13 // indirect
->>>>>>> fc63984b6 (docker scout fixes (#3900))
 	github.com/maximhq/maxim-go v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oapi-codegen/runtime v1.1.1 // indirect

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -271,8 +271,8 @@ github.com/maximhq/bifrost/plugins/logging v1.5.15 h1:BVmqWonOexdTq67HQXj+0lfRam
 github.com/maximhq/bifrost/plugins/logging v1.5.15/go.mod h1:jTTWW4T5NcrCt2J0Lm1tweod2sn8uQ+XdeTsVewP1YI=
 github.com/maximhq/bifrost/plugins/maxim v1.6.15 h1:kyP6/SaLQvpwx8nivcDQ/XbpK4xeUxl2cCy6hn3D4SA=
 github.com/maximhq/bifrost/plugins/maxim v1.6.15/go.mod h1:TgNAT7aneAIgIshX2eNz40PTllXI85fNl+kq7cjYiMw=
-github.com/maximhq/bifrost/plugins/mocker v1.5.15 h1:I9n/8BFC2mrTUkP1CZ6OnLX2QxvlTIcLMwNIdxwvOJI=
-github.com/maximhq/bifrost/plugins/mocker v1.5.15/go.mod h1:v769pFsggp1utwiI/sVMzA0lRxxWmojhG4O9G/+65vI=
+github.com/maximhq/bifrost/plugins/mocker v1.5.13 h1:GQMBOcY38F7eVwLQ4iB7JkOfCmgntK9nUoMukyhwsRY=
+github.com/maximhq/bifrost/plugins/mocker v1.5.13/go.mod h1:SoTaDzUU4PIsNgskBZiaFu3JtQ8HBKsDieXYqg3i4kY=
 github.com/maximhq/bifrost/plugins/otel v1.2.15 h1:lPzYVlGT4zv4FSv+W1Md69WTq9zVnfm9Od+V1EZ4dPI=
 github.com/maximhq/bifrost/plugins/otel v1.2.15/go.mod h1:TJAltUhE3M0o8lqwTonRrBENdBEWnHMDaD/aILQc/UY=
 github.com/maximhq/bifrost/plugins/prompts v1.0.15 h1:Ur+nRu+ZUxYD9HdM+geJuSnxuQLlLhReJZU/NW9c478=


### PR DESCRIPTION
## Summary

Resolves a merge conflict by pinning `github.com/maximhq/bifrost/plugins/mocker` to version `v1.5.13`, reverting an unintended bump to `v1.5.15` that was introduced during the merge.

## Changes

- Downgraded `github.com/maximhq/bifrost/plugins/mocker` from `v1.5.15` back to `v1.5.13` in both `go.mod` and `go.sum`
- Removed the leftover merge conflict markers that were present in `go.mod`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd transports
go mod tidy
go build ./...
go test ./...
```

Verify that `go.mod` no longer contains conflict markers and that `github.com/maximhq/bifrost/plugins/mocker` is pinned at `v1.5.13`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to #3900

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions for maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximhq/bifrost/pull/3914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->