### PR TITLE
fix(bedrock): populate Cohere embedding token usage from response headers

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1909,6 +1909,9 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 		}
 		bifrostResponse = converted
 		bifrostResponse.Model = request.Model
+		// Cohere embedding responses do not include token counts in the body.
+		// Bedrock returns them on the invoke response in X-Amzn-Bedrock-Input-Token-Count.
+		bifrostResponse.Usage = parseBedrockInvokeUsageFromHeaders(providerResponseHeaders)
 		// For embeddings_by_type responses preserve the raw Bedrock payload so the
 		// invoke-endpoint converter can return all encoding variants verbatim, since
 		// the internal BifrostEmbeddingResponse only has float32 and string fields.

--- a/core/providers/bedrock/embedding_test.go
+++ b/core/providers/bedrock/embedding_test.go
@@ -112,3 +112,76 @@ func TestToBedrockCohereEmbeddingRequestBodyOmitsModel(t *testing.T) {
 		"embedding_types": ["float"]
 	}`, string(wireBody))
 }
+
+func TestParseBedrockInvokeUsageFromHeaders(t *testing.T) {
+	t.Run("returns nil for empty headers", func(t *testing.T) {
+		assert.Nil(t, parseBedrockInvokeUsageFromHeaders(nil))
+		assert.Nil(t, parseBedrockInvokeUsageFromHeaders(map[string]string{}))
+	})
+
+	t.Run("returns nil when neither token header is present", func(t *testing.T) {
+		headers := map[string]string{
+			"Content-Type":     "application/json",
+			"X-Amzn-Requestid": "abc-123",
+		}
+		assert.Nil(t, parseBedrockInvokeUsageFromHeaders(headers))
+	})
+
+	t.Run("parses input token count from canonical header", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Amzn-Bedrock-Input-Token-Count": "42",
+		}
+		usage := parseBedrockInvokeUsageFromHeaders(headers)
+		require.NotNil(t, usage)
+		assert.Equal(t, 42, usage.PromptTokens)
+		assert.Equal(t, 0, usage.CompletionTokens)
+		assert.Equal(t, 42, usage.TotalTokens)
+	})
+
+	t.Run("parses both input and output token counts", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Amzn-Bedrock-Input-Token-Count":  "100",
+			"X-Amzn-Bedrock-Output-Token-Count": "25",
+		}
+		usage := parseBedrockInvokeUsageFromHeaders(headers)
+		require.NotNil(t, usage)
+		assert.Equal(t, 100, usage.PromptTokens)
+		assert.Equal(t, 25, usage.CompletionTokens)
+		assert.Equal(t, 125, usage.TotalTokens)
+	})
+
+	t.Run("header lookup is case insensitive", func(t *testing.T) {
+		headers := map[string]string{
+			"x-amzn-bedrock-input-token-count": "7",
+		}
+		usage := parseBedrockInvokeUsageFromHeaders(headers)
+		require.NotNil(t, usage)
+		assert.Equal(t, 7, usage.PromptTokens)
+		assert.Equal(t, 7, usage.TotalTokens)
+	})
+
+	t.Run("tolerates whitespace around values", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Amzn-Bedrock-Input-Token-Count": " 9 ",
+		}
+		usage := parseBedrockInvokeUsageFromHeaders(headers)
+		require.NotNil(t, usage)
+		assert.Equal(t, 9, usage.PromptTokens)
+	})
+
+	t.Run("returns nil when values are unparsable", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Amzn-Bedrock-Input-Token-Count":  "not-a-number",
+			"X-Amzn-Bedrock-Output-Token-Count": "",
+		}
+		assert.Nil(t, parseBedrockInvokeUsageFromHeaders(headers))
+	})
+
+	t.Run("returns nil when both counts are zero", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Amzn-Bedrock-Input-Token-Count":  "0",
+			"X-Amzn-Bedrock-Output-Token-Count": "0",
+		}
+		assert.Nil(t, parseBedrockInvokeUsageFromHeaders(headers))
+	})
+}

--- a/core/providers/bedrock/embedding_test.go
+++ b/core/providers/bedrock/embedding_test.go
@@ -138,6 +138,29 @@ func TestParseBedrockInvokeUsageFromHeaders(t *testing.T) {
 		assert.Equal(t, 42, usage.TotalTokens)
 	})
 
+	t.Run("parses output-only token count when input header is absent", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Amzn-Bedrock-Output-Token-Count": "17",
+		}
+		usage := parseBedrockInvokeUsageFromHeaders(headers)
+		require.NotNil(t, usage)
+		assert.Equal(t, 0, usage.PromptTokens)
+		assert.Equal(t, 17, usage.CompletionTokens)
+		assert.Equal(t, 17, usage.TotalTokens)
+	})
+
+	t.Run("preserves zero input alongside positive output", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Amzn-Bedrock-Input-Token-Count":  "0",
+			"X-Amzn-Bedrock-Output-Token-Count": "12",
+		}
+		usage := parseBedrockInvokeUsageFromHeaders(headers)
+		require.NotNil(t, usage)
+		assert.Equal(t, 0, usage.PromptTokens)
+		assert.Equal(t, 12, usage.CompletionTokens)
+		assert.Equal(t, 12, usage.TotalTokens)
+	})
+
 	t.Run("parses both input and output token counts", func(t *testing.T) {
 		headers := map[string]string{
 			"X-Amzn-Bedrock-Input-Token-Count":  "100",

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -50,10 +50,10 @@ func parseBedrockInvokeUsageFromHeaders(headers map[string]string) *schemas.Bifr
 	}
 
 	usage := &schemas.BifrostLLMUsage{}
-	if n, err := strconv.Atoi(strings.TrimSpace(inStr)); err == nil && n > 0 {
+	if n, err := strconv.Atoi(strings.TrimSpace(inStr)); err == nil {
 		usage.PromptTokens = n
 	}
-	if n, err := strconv.Atoi(strings.TrimSpace(outStr)); err == nil && n > 0 {
+	if n, err := strconv.Atoi(strings.TrimSpace(outStr)); err == nil {
 		usage.CompletionTokens = n
 	}
 	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 {

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -29,9 +29,10 @@ const (
 )
 
 // parseBedrockInvokeUsageFromHeaders extracts token counts from Bedrock invoke
-// response headers. Returns nil when neither header is present or parsable.
-// Header lookup is case-insensitive to tolerate non-canonical capitalisation
-// from intermediate proxies.
+// response headers. Returns nil when both headers are absent, both fail to
+// parse, or both resolve to zero; a legitimate zero in one header is preserved
+// when the other is non-zero. Header lookup is case-insensitive to tolerate
+// non-canonical capitalisation from intermediate proxies.
 func parseBedrockInvokeUsageFromHeaders(headers map[string]string) *schemas.BifrostLLMUsage {
 	if len(headers) == 0 {
 		return nil

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"mime"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -18,6 +19,49 @@ import (
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
+
+// Bedrock invoke API token-count response header names. Bedrock sets these
+// on every invoke response; some models (e.g. Cohere Embed) omit token counts
+// from the response body, so the headers are the only source.
+const (
+	bedrockInputTokenHeader  = "X-Amzn-Bedrock-Input-Token-Count"
+	bedrockOutputTokenHeader = "X-Amzn-Bedrock-Output-Token-Count"
+)
+
+// parseBedrockInvokeUsageFromHeaders extracts token counts from Bedrock invoke
+// response headers. Returns nil when neither header is present or parsable.
+// Header lookup is case-insensitive to tolerate non-canonical capitalisation
+// from intermediate proxies.
+func parseBedrockInvokeUsageFromHeaders(headers map[string]string) *schemas.BifrostLLMUsage {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	var inStr, outStr string
+	for k, v := range headers {
+		if strings.EqualFold(k, bedrockInputTokenHeader) {
+			inStr = v
+		} else if strings.EqualFold(k, bedrockOutputTokenHeader) {
+			outStr = v
+		}
+	}
+	if inStr == "" && outStr == "" {
+		return nil
+	}
+
+	usage := &schemas.BifrostLLMUsage{}
+	if n, err := strconv.Atoi(strings.TrimSpace(inStr)); err == nil && n > 0 {
+		usage.PromptTokens = n
+	}
+	if n, err := strconv.Atoi(strings.TrimSpace(outStr)); err == nil && n > 0 {
+		usage.CompletionTokens = n
+	}
+	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		return nil
+	}
+	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	return usage
+}
 
 // awsRegionRegex matches valid AWS region identifiers (e.g. "us-east-1", "eu-north-1", "us-gov-east-1").
 // (?:-[a-z]+)+ allows multi-segment directional parts so GovCloud regions (us-gov-east-1) are


### PR DESCRIPTION
## Summary

Closes #3917. When using `cohere.embed-*` models through the Bedrock provider, `BifrostEmbeddingResponse.Usage` was always `nil` — Bifrost logs and the Dimension Rankings dashboard showed `-` for prompt/total tokens and cost.

Bedrock's Cohere Embed response body doesn't include token counts. Bedrock does return them on every invoke response in the `X-Amzn-Bedrock-Input-Token-Count` and `X-Amzn-Bedrock-Output-Token-Count` HTTP headers, which the provider already captures into `providerResponseHeaders`. This change wires those headers through to `bifrostResponse.Usage` for the Cohere embedding branch.

## Changes

- New `parseBedrockInvokeUsageFromHeaders` helper in `core/providers/bedrock/utils.go`. Case-insensitive header lookup, trims whitespace around values, returns `nil` when neither count is present, parsable, or non-zero — so callers can keep `nil` as the unambiguous \"unknown\" sentinel.
- `Embedding()` in `core/providers/bedrock/bedrock.go` assigns `parseBedrockInvokeUsageFromHeaders(providerResponseHeaders)` to `bifrostResponse.Usage` in the Cohere case. Titan is unchanged: its response body already carries `inputTextTokenCount` and the existing converter populates `Usage`.
- 8 sub-test cases in `core/providers/bedrock/embedding_test.go` covering: nil/empty headers, missing token headers, input-only, both input+output, case-insensitive lookup, whitespace, unparsable values, and both-zero.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
cd core
go test ./providers/bedrock/ -run TestParseBedrockInvokeUsageFromHeaders -v
go test ./providers/bedrock/ -count=1
```

End-to-end verification requires an AWS Bedrock account with Cohere Embed access; after this change, `usage.prompt_tokens` and `usage.total_tokens` populate on the response and propagate to logs.

## Breaking changes

- [x] No

The change is strictly additive: when headers are missing, `Usage` stays `nil` (current behaviour). When headers are present, `Usage` is populated.

## Related issues

Closes #3917.

The issue also calls out Bedrock Cohere **Rerank**. Rerank goes through the bedrock-agent-runtime `/rerank` endpoint, which does not return `X-Amzn-Bedrock-*` token headers and whose response body has no usage block — that case needs a separate investigation (and likely an upstream AWS change) and is intentionally out of scope here.

## Security considerations

None.

## Checklist

- [x] I read \`docs/contributing/README.md\` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (no public API surface changed)
- [x] I verified builds succeed (Go)
- [x] I verified the bedrock test package passes locally (\`go test ./providers/bedrock/ -count=1\`)