### PR TITLE
restrict fallbacks and provider selection to vk boundry

### DIFF
--- a/core/providers/anthropic/requestbuilder_test.go
+++ b/core/providers/anthropic/requestbuilder_test.go
@@ -125,6 +125,37 @@ func TestBuildAnthropicResponsesRequestBody_RawBodyPath(t *testing.T) {
 		}
 	})
 
+	t.Run("azure_strips_claude_code_diagnostics", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Azure,
+			Model:    "claude-opus-4-7",
+			RawRequestBody: []byte(`{
+				"model":"claude-opus-4-7",
+				"max_tokens":64000,
+				"messages":[{"role":"user","content":"hi"}],
+				"diagnostics":{"previous_message_id":null}
+			}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:   schemas.Azure,
+			Deployment: "my-azure-deployment",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if providerUtils.JSONFieldExists(result, "diagnostics") {
+			t.Fatalf("expected diagnostics to be stripped for Azure, got: %s", string(result))
+		}
+		if providerUtils.GetJSONField(result, "model").String() != "my-azure-deployment" {
+			t.Fatalf("expected Azure deployment model rewrite, got: %s", string(result))
+		}
+	})
+
 	t.Run("adds_max_tokens_if_missing", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
 		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -135,6 +135,7 @@ type ProviderFeatureSupport struct {
 	FileSearch             bool // file_search server tool (OpenAI-only)
 	ImageGeneration        bool // image_generation server tool (OpenAI-only)
 	ServiceTier            bool // service_tier request field — strip when false (Vertex uses headers instead)
+	Diagnostics            bool // diagnostics request field — undocumented Claude Code session-continuity field (diagnostics.previous_message_id); not in the public Messages API reference, so treated as Claude API only and stripped elsewhere (fail-closed). Azure rejects it; Bedrock/Vertex undocumented.
 }
 
 // ProviderFeatures maps each provider to its supported Anthropic features.
@@ -153,6 +154,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		FastMode: true, RedactThinking: true, TaskBudgets: true,
 		InferenceGeo: true, EagerInputStreaming: true, AdvisorTool: true,
 		ServiceTier: true,
+		Diagnostics: true, // Claude Code talks to the direct API and sends diagnostics.previous_message_id; only this provider keeps it.
 	},
 	// Google Vertex AI — cite: A (overview table) and V-platform.
 	// Notably NOT supported: MCP (MCP-excl), Skills/container.skills,

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -372,6 +372,15 @@ func StripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelPr
 
 	var err error
 
+	// diagnostics — undocumented Claude Code field; gated through the feature
+	// map like every other field. Only Anthropic direct keeps it (fail-closed).
+	if !features.Diagnostics && providerUtils.JSONFieldExists(jsonBody, "diagnostics") {
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "diagnostics")
+		if err != nil {
+			return nil, fmt.Errorf("strip raw diagnostics: %w", err)
+		}
+	}
+
 	// speed — provider AND model gate
 	if providerUtils.JSONFieldExists(jsonBody, "speed") {
 		if !features.FastMode || !SupportsFastMode(model) {

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1479,6 +1479,31 @@ func TestNetworkConfigBetaOverridesFlow(t *testing.T) {
 }
 
 func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
+	t.Run("diagnostics_gated_via_feature_map", func(t *testing.T) {
+		// diagnostics is an undocumented Claude Code session-continuity field
+		// (diagnostics.previous_message_id). Only Anthropic direct keeps it;
+		// every other provider strips it fail-closed via Diagnostics=false.
+		const body = `{"model":"claude-opus-4-7","diagnostics":{"previous_message_id":null}}`
+		// Anthropic keeps it.
+		result, err := StripUnsupportedFieldsFromRawBody([]byte(body), schemas.Anthropic, "claude-opus-4-7")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !providerUtils.JSONFieldExists(result, "diagnostics") {
+			t.Errorf("expected diagnostics to be kept for Anthropic, got: %s", string(result))
+		}
+		// Azure, Bedrock, Vertex strip it.
+		for _, provider := range []schemas.ModelProvider{schemas.Azure, schemas.Bedrock, schemas.Vertex} {
+			result, err := StripUnsupportedFieldsFromRawBody([]byte(body), provider, "claude-opus-4-7")
+			if err != nil {
+				t.Fatalf("unexpected error for %s: %v", provider, err)
+			}
+			if providerUtils.JSONFieldExists(result, "diagnostics") {
+				t.Errorf("expected diagnostics to be stripped for %s, got: %s", provider, string(result))
+			}
+		}
+	})
+
 	t.Run("bedrock_strips_new_request_level_fields", func(t *testing.T) {
 		// Raw body with every new typed field. Targeting Bedrock: speed (no FastMode),
 		// inference_geo (no InferenceGeo), mcp_servers (no MCP), container.skills

--- a/plugins/governance/httptransportprehook_test.go
+++ b/plugins/governance/httptransportprehook_test.go
@@ -65,6 +65,92 @@ func TestHTTPTransportPreHook_VirtualKeyReplicateRefinesNestedModel(t *testing.T
 	require.Equal(t, "replicate/openai/gpt-5-nano", payload.Model)
 }
 
+func TestHTTPTransportPreHook_ModelOnlyVirtualKeySetsAvailableProviders(t *testing.T) {
+	logger := NewMockLogger()
+
+	openAIConfig := buildProviderConfig("openai", []string{"gpt-4o"})
+	openAIConfig.Weight = nil
+	anthropicConfig := buildProviderConfig("anthropic", []string{"claude-3-5-sonnet"})
+	anthropicConfig.Weight = nil
+
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-constraint",
+		"sk-bf-constraint-test",
+		"provider-constraint-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			openAIConfig,
+			anthropicConfig,
+		},
+	)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*virtualKey},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/v1/chat/completions"
+	req.Headers["Authorization"] = "Bearer sk-bf-constraint-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"Hello!"}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	allowedProviders, ok := bfCtx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	require.True(t, ok, "provider constraint should be set")
+	require.Equal(t, []schemas.ModelProvider{schemas.OpenAI}, allowedProviders)
+}
+
+func TestHTTPTransportPreHook_ModelOnlyVirtualKeySetsEmptyAvailableProvidersWhenNoProviderAllowsModel(t *testing.T) {
+	logger := NewMockLogger()
+
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-empty-constraint",
+		"sk-bf-empty-constraint-test",
+		"empty-provider-constraint-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("openai", []string{"gpt-4o"}),
+		},
+	)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*virtualKey},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/v1/chat/completions"
+	req.Headers["Authorization"] = "Bearer sk-bf-empty-constraint-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"model":"claude-3-5-sonnet","messages":[{"role":"user","content":"Hello!"}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	allowedProviders, ok := bfCtx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	require.True(t, ok, "provider constraint should be set")
+	require.Empty(t, allowedProviders)
+}
+
 // TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget verifies that when a routing rule
 // matches on the /genai path, governance load balancing does not override the routing-rule target
 // with a provider from the VK pool (regression test for issue #2516).

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -755,6 +755,7 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	// Get provider configs for this virtual key
 	providerConfigs := virtualKey.ProviderConfigs
 	if len(providerConfigs) == 0 {
+		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{})
 		ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelWarn, fmt.Sprintf("No provider configs on virtual key %s for model %s, skipping load balancing", virtualKey.Name, modelStr))
 		// No provider configs, continue without modification
 		return body, nil
@@ -818,9 +819,12 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	}
 
 	var allowedProviders []string
+	allowedModelProviders := make([]schemas.ModelProvider, 0, len(allowedProviderConfigs))
 	for _, pc := range allowedProviderConfigs {
 		allowedProviders = append(allowedProviders, pc.Provider)
+		allowedModelProviders = append(allowedModelProviders, schemas.ModelProvider(pc.Provider))
 	}
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, allowedModelProviders)
 	p.logger.Debug("[Governance] Allowed providers after filtering: %v", allowedProviders)
 	ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("Allowed providers after filtering: %v", allowedProviders))
 

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -792,6 +792,18 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 			skipModelCatalogProviderSelection, _ := bifrostCtx.Value(schemas.BifrostContextKeySkipModelCatalogProviderSelection).(bool)
 			if extractedProvider == "" && !skipModelCatalogProviderSelection {
 				availableProviders := g.handlerStore.GetProvidersForModel(extractedModel)
+				existingProviders, hasExistingProviders := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+				if hasExistingProviders {
+					if len(existingProviders) == 0 {
+						availableProviders = []schemas.ModelProvider{}
+					} else if len(availableProviders) == 0 {
+						availableProviders = existingProviders
+					} else {
+						availableProviders = slices.DeleteFunc(availableProviders, func(provider schemas.ModelProvider) bool {
+							return !slices.Contains(existingProviders, provider)
+						})
+					}
+				}
 				availableProvidersStrs := make([]string, len(availableProviders))
 				for i, p := range availableProviders {
 					availableProvidersStrs[i] = string(p)
@@ -814,6 +826,8 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 						))
 					}
 					bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, availableProviders)
+				} else if hasExistingProviders {
+					bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{})
 				}
 				schemas.AppendToContextList(bifrostCtx, schemas.BifrostContextKeyRoutingEnginesUsed, schemas.RoutingEngineModelCatalog)
 			}
@@ -912,7 +926,7 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 		}
 
 		// Extract and parse fallbacks from the request if present
-		if err := g.extractAndParseFallbacks(req, bifrostReq); err != nil {
+		if err := g.extractAndParseFallbacks(bifrostCtx, req, bifrostReq); err != nil {
 			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to parse fallbacks: "+err.Error()))
 			return
 		}

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/openai"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
@@ -374,6 +375,95 @@ func TestOpenAIChatStructuredOutputRequestParserAndConverter(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "json_schema", responseFormat["type"])
 	assert.Contains(t, responseFormat, "json_schema")
+}
+
+func TestCreateHandler_AnthropicRouteConstrainsCatalogProvidersWhenAvailableProvidersSet(t *testing.T) {
+	handlerStore := &mockHandlerStore{
+		availableProviders: []schemas.ModelProvider{
+			schemas.Anthropic,
+			schemas.Azure,
+			schemas.Bedrock,
+			schemas.Vertex,
+		},
+	}
+
+	var capturedProviders []schemas.ModelProvider
+	route := RouteConfig{
+		Type:   RouteConfigTypeAnthropic,
+		Path:   "/v1/messages",
+		Method: fasthttp.MethodPost,
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ResponsesRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &anthropic.AnthropicMessageRequest{}
+		},
+		GetRequestModel: anthropicModelGetter,
+		PreCallback:     checkAnthropicPassthrough,
+		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
+			capturedProviders, _ = ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+			return nil, fmt.Errorf("stop before bifrost execution")
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		},
+	}
+
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.SetUserValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{
+		schemas.Azure,
+		schemas.OpenAI,
+		schemas.Ollama,
+	})
+	ctx.Request.SetBodyString(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
+
+	router.createHandler(route)(ctx)
+
+	require.Equal(t, fasthttp.StatusInternalServerError, ctx.Response.StatusCode())
+	require.Equal(t, []schemas.ModelProvider{schemas.Azure}, capturedProviders)
+}
+
+func TestCreateHandler_AnthropicRouteKeepsCatalogProvidersWhenAvailableProvidersUnset(t *testing.T) {
+	handlerStore := &mockHandlerStore{
+		availableProviders: []schemas.ModelProvider{
+			schemas.Bedrock,
+			schemas.Vertex,
+		},
+	}
+
+	var capturedProviders []schemas.ModelProvider
+	route := RouteConfig{
+		Type:   RouteConfigTypeAnthropic,
+		Path:   "/v1/messages",
+		Method: fasthttp.MethodPost,
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ResponsesRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &anthropic.AnthropicMessageRequest{}
+		},
+		GetRequestModel: anthropicModelGetter,
+		PreCallback:     checkAnthropicPassthrough,
+		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
+			capturedProviders, _ = ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+			return nil, fmt.Errorf("stop before bifrost execution")
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		},
+	}
+
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetBodyString(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
+
+	router.createHandler(route)(ctx)
+
+	require.Equal(t, fasthttp.StatusInternalServerError, ctx.Response.StatusCode())
+	require.Equal(t, []schemas.ModelProvider{schemas.Bedrock, schemas.Vertex}, capturedProviders)
 }
 
 func TestCreateHandler_CustomParserFailureClosesConnection(t *testing.T) {

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -236,11 +237,11 @@ func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.
 // Naming follows the existing `x-bf-*` request-side convention (see
 // `x-bf-vk`, `x-bf-key-id`, etc.).
 const (
-	HeaderBifrostProvider       = "x-bifrost-provider"
-	HeaderBifrostOriginalModel  = "x-bifrost-original-model"
-	HeaderBifrostResolvedModel  = "x-bifrost-resolved-model"
-	HeaderBifrostFallbackIndex  = "x-bifrost-fallback-index"
-	HeaderBifrostRequestType    = "x-bifrost-request-type"
+	HeaderBifrostProvider      = "x-bifrost-provider"
+	HeaderBifrostOriginalModel = "x-bifrost-original-model"
+	HeaderBifrostResolvedModel = "x-bifrost-resolved-model"
+	HeaderBifrostFallbackIndex = "x-bifrost-fallback-index"
+	HeaderBifrostRequestType   = "x-bifrost-request-type"
 )
 
 // applyBifrostResponseHeaders writes both the upstream provider response
@@ -335,8 +336,8 @@ func (g *GenericRouter) streamLargeResponse(ctx *fasthttp.RequestCtx, bifrostCtx
 	return true
 }
 
-// extractAndParseFallbacks extracts fallbacks from the integration request and adds them to the BifrostRequest
-func (g *GenericRouter) extractAndParseFallbacks(req interface{}, bifrostReq *schemas.BifrostRequest) error {
+// extractAndParseFallbacks extracts fallbacks from the integration request and adds them to the BifrostRequest.
+func (g *GenericRouter) extractAndParseFallbacks(ctx *schemas.BifrostContext, req interface{}, bifrostReq *schemas.BifrostRequest) error {
 	// Check if the request has a fallbacks field ([]string)
 	fallbacks, err := g.extractFallbacksFromRequest(req)
 	if err != nil {
@@ -348,6 +349,11 @@ func (g *GenericRouter) extractAndParseFallbacks(req interface{}, bifrostReq *sc
 	}
 
 	provider, _, _ := bifrostReq.GetRequestFields()
+	var availableProviders []schemas.ModelProvider
+	var hasAvailableProviders bool
+	if ctx != nil {
+		availableProviders, hasAvailableProviders = ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	}
 
 	// Parse fallbacks from strings to Fallback structs
 	parsedFallbacks := make([]schemas.Fallback, 0, len(fallbacks))
@@ -358,6 +364,9 @@ func (g *GenericRouter) extractAndParseFallbacks(req interface{}, bifrostReq *sc
 
 		// Use ParseModelString to extract provider and model
 		provider, model := schemas.ParseModelString(fallbackStr, provider)
+		if hasAvailableProviders && !slices.Contains(availableProviders, provider) {
+			continue
+		}
 
 		parsedFallback := schemas.Fallback{
 			Provider: provider,
@@ -367,6 +376,7 @@ func (g *GenericRouter) extractAndParseFallbacks(req interface{}, bifrostReq *sc
 	}
 
 	if len(parsedFallbacks) == 0 {
+		bifrostReq.SetFallbacks(nil)
 		return nil // No valid fallbacks found
 	}
 

--- a/transports/bifrost-http/integrations/utils_test.go
+++ b/transports/bifrost-http/integrations/utils_test.go
@@ -60,13 +60,66 @@ func TestExtractAndParseFallbacks_GeminiGenerationRequest(t *testing.T) {
 		},
 	}
 
-	err := router.extractAndParseFallbacks(geminiReq, bifrostReq)
+	err := router.extractAndParseFallbacks(newTestBifrostContext(), geminiReq, bifrostReq)
 
 	require.NoError(t, err)
 	require.NotNil(t, bifrostReq.ResponsesRequest)
 	require.Len(t, bifrostReq.ResponsesRequest.Fallbacks, 1)
 	assert.Equal(t, schemas.Vertex, bifrostReq.ResponsesRequest.Fallbacks[0].Provider)
 	assert.Equal(t, "gemini-3-flash-preview", bifrostReq.ResponsesRequest.Fallbacks[0].Model)
+}
+
+func TestExtractAndParseFallbacks_FiltersByAvailableProviders(t *testing.T) {
+	router := newTestGenericRouter()
+	geminiReq := &gemini.GeminiGenerationRequest{
+		Model: "gemini/gemini-3-flash-preview",
+		Fallbacks: []string{
+			"azure/claude-opus-4-8",
+			"bedrock/claude-opus-4-8",
+			"vertex/claude-opus-4-8",
+		},
+	}
+	bifrostReq := &schemas.BifrostRequest{
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.Gemini,
+			Model:    "gemini-3-flash-preview",
+		},
+	}
+	ctx := newTestBifrostContext()
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{schemas.Azure})
+
+	err := router.extractAndParseFallbacks(ctx, geminiReq, bifrostReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq.ResponsesRequest)
+	require.Len(t, bifrostReq.ResponsesRequest.Fallbacks, 1)
+	assert.Equal(t, schemas.Azure, bifrostReq.ResponsesRequest.Fallbacks[0].Provider)
+	assert.Equal(t, "claude-opus-4-8", bifrostReq.ResponsesRequest.Fallbacks[0].Model)
+}
+
+func TestExtractAndParseFallbacks_ClearsDisallowedPreparsedFallbacks(t *testing.T) {
+	router := newTestGenericRouter()
+	geminiReq := &gemini.GeminiGenerationRequest{
+		Model:     "gemini/gemini-3-flash-preview",
+		Fallbacks: []string{"bedrock/claude-opus-4-8"},
+	}
+	bifrostReq := &schemas.BifrostRequest{
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.Gemini,
+			Model:    "gemini-3-flash-preview",
+			Fallbacks: []schemas.Fallback{
+				{Provider: schemas.Bedrock, Model: "claude-opus-4-8"},
+			},
+		},
+	}
+	ctx := newTestBifrostContext()
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{schemas.Azure})
+
+	err := router.extractAndParseFallbacks(ctx, geminiReq, bifrostReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq.ResponsesRequest)
+	require.Empty(t, bifrostReq.ResponsesRequest.Fallbacks)
 }
 
 // TestSendStreamError_PropagatesProviderStatusCode verifies that sendStreamError


### PR DESCRIPTION
## Summary

When a virtual key has provider constraints (but no weights), the governance plugin now propagates the list of allowed providers into the Bifrost context. The router then intersects that list with the model catalog's provider list, ensuring that only providers permitted by the virtual key are considered for routing and fallbacks.

## Changes

- The governance plugin sets `BifrostContextKeyAvailableProviders` on the context after filtering provider configs, including setting an empty slice when no provider configs exist or when no providers pass the model filter.
- The router's `createHandler` intersects the catalog-derived provider list with any pre-existing `BifrostContextKeyAvailableProviders` value set by upstream plugins (e.g., governance). If the intersection is empty, an empty provider list is stored rather than falling back to the full catalog set.
- `extractAndParseFallbacks` now accepts a `BifrostContext` and filters parsed fallbacks to only those whose provider appears in `BifrostContextKeyAvailableProviders`. If all fallbacks are filtered out, the fallback list on the request is explicitly cleared to `nil`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins

## How to test

```sh
go test ./plugins/governance/...
go test ./transports/bifrost-http/integrations/...
```

- A virtual key with `openai/gpt-4o` and `anthropic/claude-3-5-sonnet` provider configs (no weights) and a request for `gpt-4o` should result in `BifrostContextKeyAvailableProviders` containing only `openai`.
- A virtual key with only `openai/gpt-4o` and a request for `claude-3-5-sonnet` should result in an empty `BifrostContextKeyAvailableProviders`.
- A request with fallbacks that include providers not in the allowed list should have those fallbacks stripped before the request is dispatched.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2516

## Security considerations

Provider constraints enforced by virtual keys are now respected end-to-end through routing and fallback resolution, preventing requests from being routed to providers that the virtual key does not permit.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for governance HTTP transport pre-hook with provider-constrained virtual keys.
  * Added router tests verifying proper provider constraint enforcement during request handling.

* **Bug Fixes**
  * Router now correctly respects provider availability constraints when selecting providers for requests.
  * Fallback extraction now filters to only providers permitted by governance constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->