### PR TITLE
Prevent stream hangs when SSE headers are missing

### DIFF
--- a/cli/changelog.md
+++ b/cli/changelog.md
@@ -1,7 +1,3 @@
-# Bifrost CLI Changelog
-
-## v0.10.5
-
 - feat: adds an interactive tab command popup invoked by the `Ctrl+B` prefix — lists every open tab plus a trailing "New tab" action row, supports arrow keys / `h`/`j`/`k`/`l` navigation, `Enter` to switch or open a tab, number keys (`1`–`9`) for direct jumps, and `Esc`/`Ctrl+B` to resume
 - feat: adds `Ctrl+G` as a tmux-safe alternate prefix key, giving users a one-press tab selector inside tmux sessions that already consume `Ctrl+B`
 - feat: adds a Home-screen Ctrl+C quit confirmation — when no tabs are open, the first `Ctrl+C` shows a centered "Quit Bifrost?" prompt and the second press exits, preventing accidental termination

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -558,7 +558,9 @@ func HandleOpenAITextCompletionStreaming(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		var drainedNonSSE bool
+		reader, drainedNonSSE = providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drainedNonSSE {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -1101,7 +1103,9 @@ func HandleOpenAIChatCompletionStreaming(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		var drainedNonSSE bool
+		reader, drainedNonSSE = providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drainedNonSSE {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -1740,7 +1744,9 @@ func HandleOpenAIResponsesStreaming(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		var drainedNonSSE bool
+		reader, drainedNonSSE = providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drainedNonSSE {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -2350,7 +2356,9 @@ func HandleOpenAISpeechStreamRequest(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		var drainedNonSSE bool
+		reader, drainedNonSSE = providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drainedNonSSE {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -2791,7 +2799,9 @@ func HandleOpenAITranscriptionStreamRequest(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		var drainedNonSSE bool
+		reader, drainedNonSSE = providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drainedNonSSE {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -3229,7 +3239,9 @@ func HandleOpenAIImageGenerationStreaming(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		var drainedNonSSE bool
+		reader, drainedNonSSE = providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drainedNonSSE {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -4467,7 +4479,9 @@ func HandleOpenAIImageEditStreamRequest(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		var drainedNonSSE bool
+		reader, drainedNonSSE = providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drainedNonSSE {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -996,18 +996,54 @@ func DecompressStreamBody(resp *fasthttp.Response) (io.Reader, func()) {
 // DrainNonSSEStreamResponse checks if the upstream response is a Server-Sent Events stream.
 // If not SSE, drains the body to io.Discard to prevent bufio.Scanner buffer bloat on
 // non-line-delimited data. Returns true if body was drained (caller should skip scanner).
-// We intentionally do not touch valid SSE bodies here: callers must continue reading from
-// the reader returned by DecompressStreamBody, and draining SSE in this helper would consume
-// the stream before the scanner/manual event loop starts.
+//
+// Prefer DrainNonSSEStreamReader when the caller has already wrapped the body stream
+// (gzip, idle timeout, cancellation, etc.). This compatibility helper can only preserve
+// sniffed bytes by replacing resp.BodyStream directly.
 func DrainNonSSEStreamResponse(resp *fasthttp.Response) bool {
+	reader, drained := DrainNonSSEStreamReader(resp, resp.BodyStream())
+	if !drained && reader != nil {
+		resp.SetBodyStream(reader, -1)
+	}
+	return drained
+}
+
+// DrainNonSSEStreamReader is the reader-preserving variant of DrainNonSSEStreamResponse.
+// Some OpenAI-compatible services emit valid SSE frames without a text/event-stream
+// Content-Type. In that case, sniff a small prefix and keep the stream readable.
+func DrainNonSSEStreamReader(resp *fasthttp.Response, reader io.Reader) (io.Reader, bool) {
+	if resp == nil || reader == nil {
+		return reader, true
+	}
+
 	ct := strings.ToLower(string(resp.Header.ContentType()))
 	if strings.Contains(ct, "text/event-stream") {
-		return false
+		return reader, false
 	}
-	if bodyStream := resp.BodyStream(); bodyStream != nil {
-		_, _ = io.Copy(io.Discard, bodyStream)
+
+	var buf [512]byte
+	n, readErr := reader.Read(buf[:])
+	if n > 0 {
+		prefix := append([]byte(nil), buf[:n]...)
+		reader = io.MultiReader(bytes.NewReader(prefix), reader)
+		if looksLikeSSEStreamPrefix(prefix) {
+			return reader, false
+		}
 	}
-	return true
+
+	if readErr != nil && readErr != io.EOF {
+		return reader, true
+	}
+
+	_, _ = io.Copy(io.Discard, reader)
+	return reader, true
+}
+
+func looksLikeSSEStreamPrefix(prefix []byte) bool {
+	trimmed := bytes.TrimLeft(prefix, "\xef\xbb\xbf \t\r\n")
+	return bytes.HasPrefix(trimmed, []byte("data:")) ||
+		bytes.HasPrefix(trimmed, []byte("event:")) ||
+		bytes.HasPrefix(trimmed, []byte(":"))
 }
 
 // MergeExtraParams merges extraParams into jsonMap, handling nested maps recursively.

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -748,6 +748,49 @@ func TestDrainNonSSEStreamResponse_SSEDoesNotDrain(t *testing.T) {
 	}
 }
 
+func TestDrainNonSSEStreamReader_SSEWithoutContentTypeDoesNotDrain(t *testing.T) {
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	body := []byte("event: response.completed\n" +
+		`data: {"type":"response.completed","sequence_number":1}` + "\n\n")
+	resp.SetBodyStream(bytes.NewReader(body), len(body))
+
+	reader, drained := DrainNonSSEStreamReader(resp, resp.BodyStream())
+	if drained {
+		t.Fatal("expected SSE-looking response without content type to remain readable")
+	}
+
+	remaining, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to read SSE body after guard: %v", err)
+	}
+	if string(remaining) != string(body) {
+		t.Fatalf("expected SSE body to remain intact, got %q", string(remaining))
+	}
+}
+
+func TestDrainNonSSEStreamResponse_SSEWithoutContentTypeDoesNotDrain(t *testing.T) {
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	body := []byte("data: hello\n\n")
+	resp.SetBodyStream(bytes.NewReader(body), len(body))
+
+	drained := DrainNonSSEStreamResponse(resp)
+	if drained {
+		t.Fatal("expected SSE-looking response without content type to remain readable")
+	}
+
+	remaining, err := io.ReadAll(resp.BodyStream())
+	if err != nil {
+		t.Fatalf("failed to read SSE body after guard: %v", err)
+	}
+	if string(remaining) != string(body) {
+		t.Fatalf("expected SSE body to remain intact, got %q", string(remaining))
+	}
+}
+
 func TestDrainNonSSEStreamResponse_NonSSEDrains(t *testing.T) {
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseResponse(resp)


### PR DESCRIPTION
## Summary
- preserve OpenAI-compatible streaming readers when upstream responses look like SSE but omit `Content-Type: text/event-stream`
- keep non-SSE drain behavior for JSON/non-line-delimited error bodies
- add regression coverage for both the reader-preserving helper and the legacy response helper

## Validation
- `docker run --rm -v /root/ws/ai/ai-gateway/bifrost:/src -w /src/core golang:1.26.3-alpine3.23 sh -lc '/usr/local/go/bin/gofmt -w providers/utils/utils.go providers/openai/openai.go providers/utils/utils_test.go && /usr/local/go/bin/go test ./providers/utils -run "TestDrainNonSSEStream"'`\n- `docker run --rm -v /root/ws/ai/ai-gateway/bifrost:/src -w /src/core golang:1.26.3-alpine3.23 sh -lc '/usr/local/go/bin/go test ./providers/openai ./providers/utils'`\n- manual gateway replay against patched container returned HTTP 200 and `event: response.completed` for `/v1/responses` routed to `codex-backend`\n\n## Notes\n- local request fixtures were not committed because they contain secrets\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection and handling of Server-Sent Events in streaming responses, including cases where content-type headers may be missing or incorrect
  * Improved robustness of non-SSE response detection and error handling across multiple streaming operations

* **Tests**
  * Added unit tests validating Server-Sent Events detection behavior in edge cases without proper headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->