### PR TITLE
logs adds support for rendering file attachments

### DIFF
--- a/core/providers/anthropic/requestbuilder_test.go
+++ b/core/providers/anthropic/requestbuilder_test.go
@@ -125,6 +125,37 @@ func TestBuildAnthropicResponsesRequestBody_RawBodyPath(t *testing.T) {
 		}
 	})
 
+	t.Run("azure_strips_claude_code_diagnostics", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Azure,
+			Model:    "claude-opus-4-7",
+			RawRequestBody: []byte(`{
+				"model":"claude-opus-4-7",
+				"max_tokens":64000,
+				"messages":[{"role":"user","content":"hi"}],
+				"diagnostics":{"previous_message_id":null}
+			}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:   schemas.Azure,
+			Deployment: "my-azure-deployment",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if providerUtils.JSONFieldExists(result, "diagnostics") {
+			t.Fatalf("expected diagnostics to be stripped for Azure, got: %s", string(result))
+		}
+		if providerUtils.GetJSONField(result, "model").String() != "my-azure-deployment" {
+			t.Fatalf("expected Azure deployment model rewrite, got: %s", string(result))
+		}
+	})
+
 	t.Run("adds_max_tokens_if_missing", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
 		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -135,6 +135,7 @@ type ProviderFeatureSupport struct {
 	FileSearch             bool // file_search server tool (OpenAI-only)
 	ImageGeneration        bool // image_generation server tool (OpenAI-only)
 	ServiceTier            bool // service_tier request field — strip when false (Vertex uses headers instead)
+	Diagnostics            bool // diagnostics request field — undocumented Claude Code session-continuity field (diagnostics.previous_message_id); not in the public Messages API reference, so treated as Claude API only and stripped elsewhere (fail-closed). Azure rejects it; Bedrock/Vertex undocumented.
 }
 
 // ProviderFeatures maps each provider to its supported Anthropic features.
@@ -153,6 +154,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		FastMode: true, RedactThinking: true, TaskBudgets: true,
 		InferenceGeo: true, EagerInputStreaming: true, AdvisorTool: true,
 		ServiceTier: true,
+		Diagnostics: true, // Claude Code talks to the direct API and sends diagnostics.previous_message_id; only this provider keeps it.
 	},
 	// Google Vertex AI — cite: A (overview table) and V-platform.
 	// Notably NOT supported: MCP (MCP-excl), Skills/container.skills,

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -372,6 +372,15 @@ func StripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelPr
 
 	var err error
 
+	// diagnostics — undocumented Claude Code field; gated through the feature
+	// map like every other field. Only Anthropic direct keeps it (fail-closed).
+	if !features.Diagnostics && providerUtils.JSONFieldExists(jsonBody, "diagnostics") {
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "diagnostics")
+		if err != nil {
+			return nil, fmt.Errorf("strip raw diagnostics: %w", err)
+		}
+	}
+
 	// speed — provider AND model gate
 	if providerUtils.JSONFieldExists(jsonBody, "speed") {
 		if !features.FastMode || !SupportsFastMode(model) {

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1479,6 +1479,31 @@ func TestNetworkConfigBetaOverridesFlow(t *testing.T) {
 }
 
 func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
+	t.Run("diagnostics_gated_via_feature_map", func(t *testing.T) {
+		// diagnostics is an undocumented Claude Code session-continuity field
+		// (diagnostics.previous_message_id). Only Anthropic direct keeps it;
+		// every other provider strips it fail-closed via Diagnostics=false.
+		const body = `{"model":"claude-opus-4-7","diagnostics":{"previous_message_id":null}}`
+		// Anthropic keeps it.
+		result, err := StripUnsupportedFieldsFromRawBody([]byte(body), schemas.Anthropic, "claude-opus-4-7")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !providerUtils.JSONFieldExists(result, "diagnostics") {
+			t.Errorf("expected diagnostics to be kept for Anthropic, got: %s", string(result))
+		}
+		// Azure, Bedrock, Vertex strip it.
+		for _, provider := range []schemas.ModelProvider{schemas.Azure, schemas.Bedrock, schemas.Vertex} {
+			result, err := StripUnsupportedFieldsFromRawBody([]byte(body), provider, "claude-opus-4-7")
+			if err != nil {
+				t.Fatalf("unexpected error for %s: %v", provider, err)
+			}
+			if providerUtils.JSONFieldExists(result, "diagnostics") {
+				t.Errorf("expected diagnostics to be stripped for %s, got: %s", provider, string(result))
+			}
+		}
+	})
+
 	t.Run("bedrock_strips_new_request_level_fields", func(t *testing.T) {
 		// Raw body with every new typed field. Targeting Bedrock: speed (no FastMode),
 		// inference_geo (no InferenceGeo), mcp_servers (no MCP), container.skills

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -3014,8 +3014,8 @@ func completeDeferredSpan(ctx *schemas.BifrostContext, result *schemas.BifrostRe
 
 // CheckAndSetDefaultProvider checks if the default provider should be used based on the context.
 // It returns the default provider if it should be used, otherwise it returns an empty string.
-// Checks if key selection is skipped, or if the available providers are set in the context
-// and the default provider is in the list.
+// Checks if key selection is skipped, if a resolved provider was selected by routing,
+// or if the available providers are set in the context and the default provider is in the list.
 func CheckAndSetDefaultProvider(ctx *schemas.BifrostContext, defaultProvider schemas.ModelProvider) schemas.ModelProvider {
 	if ctx != nil {
 		if skip, ok := ctx.Value(schemas.BifrostContextKeySkipKeySelection).(bool); ok && skip {
@@ -3025,6 +3025,10 @@ func CheckAndSetDefaultProvider(ctx *schemas.BifrostContext, defaultProvider sch
 			availableProviders, ok := ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
 			if !ok || len(availableProviders) == 0 {
 				return ""
+			}
+			if resolvedProvider, ok := ctx.Value(schemas.BifrostContextKeyResolvedProvider).(schemas.ModelProvider); ok && slices.Contains(availableProviders, resolvedProvider) {
+				getLogger().Debug("[Provider] Using routing-resolved provider: %s (available: %v)", resolvedProvider, availableProviders)
+				return resolvedProvider
 			}
 			getLogger().Debug("[Provider] Available providers: %v, checking %s", availableProviders, defaultProvider)
 			if slices.Contains(availableProviders, defaultProvider) {

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1826,3 +1826,27 @@ func TestExtractProviderResponseHeaders_StripsProviderSecrets(t *testing.T) {
 		t.Fatalf("benign header x-request-id was dropped: %v", headers)
 	}
 }
+
+// TestCheckAndSetDefaultProviderUsesResolvedProvider verifies routing-selected
+// providers take precedence over the route default when still allowed.
+func TestCheckAndSetDefaultProviderUsesResolvedProvider(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{schemas.Anthropic, schemas.Azure})
+	ctx.SetValue(schemas.BifrostContextKeyResolvedProvider, schemas.Azure)
+
+	if got := CheckAndSetDefaultProvider(ctx, schemas.Anthropic); got != schemas.Azure {
+		t.Fatalf("CheckAndSetDefaultProvider() = %s, want %s", got, schemas.Azure)
+	}
+}
+
+// TestCheckAndSetDefaultProviderIgnoresDisallowedResolvedProvider verifies
+// selected-provider context cannot bypass available-provider constraints.
+func TestCheckAndSetDefaultProviderIgnoresDisallowedResolvedProvider(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{schemas.Anthropic})
+	ctx.SetValue(schemas.BifrostContextKeyResolvedProvider, schemas.Azure)
+
+	if got := CheckAndSetDefaultProvider(ctx, schemas.Anthropic); got != schemas.Anthropic {
+		t.Fatalf("CheckAndSetDefaultProvider() = %s, want %s", got, schemas.Anthropic)
+	}
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -257,6 +257,7 @@ const (
 	BifrostContextKeyPromptsPluginName                   BifrostContextKey = "prompts-plugin-name"                              // string (name of the prompts plugin to use - set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyIsEnterprise                        BifrostContextKey = "is-enterprise"                                    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyAvailableProviders                  BifrostContextKey = "available-providers"                              // []ModelProvider (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyResolvedProvider                    BifrostContextKey = "bifrost-resolved-provider"                        // ModelProvider (set by routing - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyStoreRawRequestResponse             BifrostContextKey = "bifrost-store-raw-request-response"               // bool (per-request override — read by bifrost.go, never overwritten)
 	BifrostContextKeyCaptureRawRequest                   BifrostContextKey = "bifrost-capture-raw-request"                      // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when providers should capture raw request bytes
 	BifrostContextKeyCaptureRawResponse                  BifrostContextKey = "bifrost-capture-raw-response"                     // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when providers should capture raw response bytes

--- a/plugins/governance/httptransportprehook_test.go
+++ b/plugins/governance/httptransportprehook_test.go
@@ -65,6 +65,92 @@ func TestHTTPTransportPreHook_VirtualKeyReplicateRefinesNestedModel(t *testing.T
 	require.Equal(t, "replicate/openai/gpt-5-nano", payload.Model)
 }
 
+func TestHTTPTransportPreHook_ModelOnlyVirtualKeySetsAvailableProviders(t *testing.T) {
+	logger := NewMockLogger()
+
+	openAIConfig := buildProviderConfig("openai", []string{"gpt-4o"})
+	openAIConfig.Weight = nil
+	anthropicConfig := buildProviderConfig("anthropic", []string{"claude-3-5-sonnet"})
+	anthropicConfig.Weight = nil
+
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-constraint",
+		"sk-bf-constraint-test",
+		"provider-constraint-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			openAIConfig,
+			anthropicConfig,
+		},
+	)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*virtualKey},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/v1/chat/completions"
+	req.Headers["Authorization"] = "Bearer sk-bf-constraint-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"Hello!"}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	allowedProviders, ok := bfCtx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	require.True(t, ok, "provider constraint should be set")
+	require.Equal(t, []schemas.ModelProvider{schemas.OpenAI}, allowedProviders)
+}
+
+func TestHTTPTransportPreHook_ModelOnlyVirtualKeySetsEmptyAvailableProvidersWhenNoProviderAllowsModel(t *testing.T) {
+	logger := NewMockLogger()
+
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-empty-constraint",
+		"sk-bf-empty-constraint-test",
+		"empty-provider-constraint-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("openai", []string{"gpt-4o"}),
+		},
+	)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*virtualKey},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/v1/chat/completions"
+	req.Headers["Authorization"] = "Bearer sk-bf-empty-constraint-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"model":"claude-3-5-sonnet","messages":[{"role":"user","content":"Hello!"}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	allowedProviders, ok := bfCtx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	require.True(t, ok, "provider constraint should be set")
+	require.Empty(t, allowedProviders)
+}
+
 // TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget verifies that when a routing rule
 // matches on the /genai path, governance load balancing does not override the routing-rule target
 // with a provider from the VK pool (regression test for issue #2516).

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -755,6 +755,7 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	// Get provider configs for this virtual key
 	providerConfigs := virtualKey.ProviderConfigs
 	if len(providerConfigs) == 0 {
+		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{})
 		ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelWarn, fmt.Sprintf("No provider configs on virtual key %s for model %s, skipping load balancing", virtualKey.Name, modelStr))
 		// No provider configs, continue without modification
 		return body, nil
@@ -818,9 +819,12 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	}
 
 	var allowedProviders []string
+	allowedModelProviders := make([]schemas.ModelProvider, 0, len(allowedProviderConfigs))
 	for _, pc := range allowedProviderConfigs {
 		allowedProviders = append(allowedProviders, pc.Provider)
+		allowedModelProviders = append(allowedModelProviders, schemas.ModelProvider(pc.Provider))
 	}
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, allowedModelProviders)
 	p.logger.Debug("[Governance] Allowed providers after filtering: %v", allowedProviders)
 	ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("Allowed providers after filtering: %v", allowedProviders))
 

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -279,6 +279,12 @@ func (p *LoggerPlugin) enqueueLogEntry(entry *logstore.Log, callback func(entry 
 	}
 }
 
+// EnqueueLogEntry pushes a complete log entry through the logging plugin's
+// normal async write queue.
+func (p *LoggerPlugin) EnqueueLogEntry(entry *logstore.Log) {
+	p.enqueueLogEntry(entry, p.makePostWriteCallback(nil))
+}
+
 // enqueueMCPToolLogEntry pushes a complete MCP tool log entry to the write queue.
 // If the queue is full, the entry is dropped to prevent store slowness from
 // cascading into request handling goroutines.

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -792,6 +792,18 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 			skipModelCatalogProviderSelection, _ := bifrostCtx.Value(schemas.BifrostContextKeySkipModelCatalogProviderSelection).(bool)
 			if extractedProvider == "" && !skipModelCatalogProviderSelection {
 				availableProviders := g.handlerStore.GetProvidersForModel(extractedModel)
+				existingProviders, hasExistingProviders := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+				if hasExistingProviders {
+					if len(existingProviders) == 0 {
+						availableProviders = []schemas.ModelProvider{}
+					} else if len(availableProviders) == 0 {
+						availableProviders = existingProviders
+					} else {
+						availableProviders = slices.DeleteFunc(availableProviders, func(provider schemas.ModelProvider) bool {
+							return !slices.Contains(existingProviders, provider)
+						})
+					}
+				}
 				availableProvidersStrs := make([]string, len(availableProviders))
 				for i, p := range availableProviders {
 					availableProvidersStrs[i] = string(p)
@@ -814,6 +826,8 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 						))
 					}
 					bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, availableProviders)
+				} else if hasExistingProviders {
+					bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{})
 				}
 				schemas.AppendToContextList(bifrostCtx, schemas.BifrostContextKeyRoutingEnginesUsed, schemas.RoutingEngineModelCatalog)
 			}
@@ -912,7 +926,7 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 		}
 
 		// Extract and parse fallbacks from the request if present
-		if err := g.extractAndParseFallbacks(req, bifrostReq); err != nil {
+		if err := g.extractAndParseFallbacks(bifrostCtx, req, bifrostReq); err != nil {
 			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to parse fallbacks: "+err.Error()))
 			return
 		}

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/openai"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
@@ -374,6 +375,95 @@ func TestOpenAIChatStructuredOutputRequestParserAndConverter(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "json_schema", responseFormat["type"])
 	assert.Contains(t, responseFormat, "json_schema")
+}
+
+func TestCreateHandler_AnthropicRouteConstrainsCatalogProvidersWhenAvailableProvidersSet(t *testing.T) {
+	handlerStore := &mockHandlerStore{
+		availableProviders: []schemas.ModelProvider{
+			schemas.Anthropic,
+			schemas.Azure,
+			schemas.Bedrock,
+			schemas.Vertex,
+		},
+	}
+
+	var capturedProviders []schemas.ModelProvider
+	route := RouteConfig{
+		Type:   RouteConfigTypeAnthropic,
+		Path:   "/v1/messages",
+		Method: fasthttp.MethodPost,
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ResponsesRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &anthropic.AnthropicMessageRequest{}
+		},
+		GetRequestModel: anthropicModelGetter,
+		PreCallback:     checkAnthropicPassthrough,
+		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
+			capturedProviders, _ = ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+			return nil, fmt.Errorf("stop before bifrost execution")
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		},
+	}
+
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.SetUserValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{
+		schemas.Azure,
+		schemas.OpenAI,
+		schemas.Ollama,
+	})
+	ctx.Request.SetBodyString(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
+
+	router.createHandler(route)(ctx)
+
+	require.Equal(t, fasthttp.StatusInternalServerError, ctx.Response.StatusCode())
+	require.Equal(t, []schemas.ModelProvider{schemas.Azure}, capturedProviders)
+}
+
+func TestCreateHandler_AnthropicRouteKeepsCatalogProvidersWhenAvailableProvidersUnset(t *testing.T) {
+	handlerStore := &mockHandlerStore{
+		availableProviders: []schemas.ModelProvider{
+			schemas.Bedrock,
+			schemas.Vertex,
+		},
+	}
+
+	var capturedProviders []schemas.ModelProvider
+	route := RouteConfig{
+		Type:   RouteConfigTypeAnthropic,
+		Path:   "/v1/messages",
+		Method: fasthttp.MethodPost,
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ResponsesRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &anthropic.AnthropicMessageRequest{}
+		},
+		GetRequestModel: anthropicModelGetter,
+		PreCallback:     checkAnthropicPassthrough,
+		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
+			capturedProviders, _ = ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+			return nil, fmt.Errorf("stop before bifrost execution")
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		},
+	}
+
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetBodyString(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
+
+	router.createHandler(route)(ctx)
+
+	require.Equal(t, fasthttp.StatusInternalServerError, ctx.Response.StatusCode())
+	require.Equal(t, []schemas.ModelProvider{schemas.Bedrock, schemas.Vertex}, capturedProviders)
 }
 
 func TestCreateHandler_CustomParserFailureClosesConnection(t *testing.T) {

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -236,11 +237,11 @@ func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.
 // Naming follows the existing `x-bf-*` request-side convention (see
 // `x-bf-vk`, `x-bf-key-id`, etc.).
 const (
-	HeaderBifrostProvider       = "x-bifrost-provider"
-	HeaderBifrostOriginalModel  = "x-bifrost-original-model"
-	HeaderBifrostResolvedModel  = "x-bifrost-resolved-model"
-	HeaderBifrostFallbackIndex  = "x-bifrost-fallback-index"
-	HeaderBifrostRequestType    = "x-bifrost-request-type"
+	HeaderBifrostProvider      = "x-bifrost-provider"
+	HeaderBifrostOriginalModel = "x-bifrost-original-model"
+	HeaderBifrostResolvedModel = "x-bifrost-resolved-model"
+	HeaderBifrostFallbackIndex = "x-bifrost-fallback-index"
+	HeaderBifrostRequestType   = "x-bifrost-request-type"
 )
 
 // applyBifrostResponseHeaders writes both the upstream provider response
@@ -335,8 +336,8 @@ func (g *GenericRouter) streamLargeResponse(ctx *fasthttp.RequestCtx, bifrostCtx
 	return true
 }
 
-// extractAndParseFallbacks extracts fallbacks from the integration request and adds them to the BifrostRequest
-func (g *GenericRouter) extractAndParseFallbacks(req interface{}, bifrostReq *schemas.BifrostRequest) error {
+// extractAndParseFallbacks extracts fallbacks from the integration request and adds them to the BifrostRequest.
+func (g *GenericRouter) extractAndParseFallbacks(ctx *schemas.BifrostContext, req interface{}, bifrostReq *schemas.BifrostRequest) error {
 	// Check if the request has a fallbacks field ([]string)
 	fallbacks, err := g.extractFallbacksFromRequest(req)
 	if err != nil {
@@ -348,6 +349,11 @@ func (g *GenericRouter) extractAndParseFallbacks(req interface{}, bifrostReq *sc
 	}
 
 	provider, _, _ := bifrostReq.GetRequestFields()
+	var availableProviders []schemas.ModelProvider
+	var hasAvailableProviders bool
+	if ctx != nil {
+		availableProviders, hasAvailableProviders = ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	}
 
 	// Parse fallbacks from strings to Fallback structs
 	parsedFallbacks := make([]schemas.Fallback, 0, len(fallbacks))
@@ -358,6 +364,9 @@ func (g *GenericRouter) extractAndParseFallbacks(req interface{}, bifrostReq *sc
 
 		// Use ParseModelString to extract provider and model
 		provider, model := schemas.ParseModelString(fallbackStr, provider)
+		if hasAvailableProviders && !slices.Contains(availableProviders, provider) {
+			continue
+		}
 
 		parsedFallback := schemas.Fallback{
 			Provider: provider,
@@ -367,6 +376,7 @@ func (g *GenericRouter) extractAndParseFallbacks(req interface{}, bifrostReq *sc
 	}
 
 	if len(parsedFallbacks) == 0 {
+		bifrostReq.SetFallbacks(nil)
 		return nil // No valid fallbacks found
 	}
 

--- a/transports/bifrost-http/integrations/utils_test.go
+++ b/transports/bifrost-http/integrations/utils_test.go
@@ -60,13 +60,66 @@ func TestExtractAndParseFallbacks_GeminiGenerationRequest(t *testing.T) {
 		},
 	}
 
-	err := router.extractAndParseFallbacks(geminiReq, bifrostReq)
+	err := router.extractAndParseFallbacks(newTestBifrostContext(), geminiReq, bifrostReq)
 
 	require.NoError(t, err)
 	require.NotNil(t, bifrostReq.ResponsesRequest)
 	require.Len(t, bifrostReq.ResponsesRequest.Fallbacks, 1)
 	assert.Equal(t, schemas.Vertex, bifrostReq.ResponsesRequest.Fallbacks[0].Provider)
 	assert.Equal(t, "gemini-3-flash-preview", bifrostReq.ResponsesRequest.Fallbacks[0].Model)
+}
+
+func TestExtractAndParseFallbacks_FiltersByAvailableProviders(t *testing.T) {
+	router := newTestGenericRouter()
+	geminiReq := &gemini.GeminiGenerationRequest{
+		Model: "gemini/gemini-3-flash-preview",
+		Fallbacks: []string{
+			"azure/claude-opus-4-8",
+			"bedrock/claude-opus-4-8",
+			"vertex/claude-opus-4-8",
+		},
+	}
+	bifrostReq := &schemas.BifrostRequest{
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.Gemini,
+			Model:    "gemini-3-flash-preview",
+		},
+	}
+	ctx := newTestBifrostContext()
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{schemas.Azure})
+
+	err := router.extractAndParseFallbacks(ctx, geminiReq, bifrostReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq.ResponsesRequest)
+	require.Len(t, bifrostReq.ResponsesRequest.Fallbacks, 1)
+	assert.Equal(t, schemas.Azure, bifrostReq.ResponsesRequest.Fallbacks[0].Provider)
+	assert.Equal(t, "claude-opus-4-8", bifrostReq.ResponsesRequest.Fallbacks[0].Model)
+}
+
+func TestExtractAndParseFallbacks_ClearsDisallowedPreparsedFallbacks(t *testing.T) {
+	router := newTestGenericRouter()
+	geminiReq := &gemini.GeminiGenerationRequest{
+		Model:     "gemini/gemini-3-flash-preview",
+		Fallbacks: []string{"bedrock/claude-opus-4-8"},
+	}
+	bifrostReq := &schemas.BifrostRequest{
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.Gemini,
+			Model:    "gemini-3-flash-preview",
+			Fallbacks: []schemas.Fallback{
+				{Provider: schemas.Bedrock, Model: "claude-opus-4-8"},
+			},
+		},
+	}
+	ctx := newTestBifrostContext()
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{schemas.Azure})
+
+	err := router.extractAndParseFallbacks(ctx, geminiReq, bifrostReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq.ResponsesRequest)
+	require.Empty(t, bifrostReq.ResponsesRequest.Fallbacks)
 }
 
 // TestSendStreamError_PropagatesProviderStatusCode verifies that sendStreamError

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -40,7 +40,7 @@ import { toast } from "sonner";
 import BlockHeader from "../views/blockHeader";
 import CollapsibleBox from "../views/collapsibleBox";
 import ImageView from "../views/imageView";
-import LogChatMessageView from "../views/logChatMessageView";
+import LogChatMessageView, { LogChatFileBlockView } from "../views/logChatMessageView";
 import LogEntryDetailsView from "../views/logEntryDetailsView";
 import OCRView from "../views/ocrView";
 import PluginLogsView from "../views/pluginLogsView";
@@ -1706,6 +1706,17 @@ export function LogDetailView({
 															if (!src) return null;
 															return <img key={`${i}-${src}`} src={src} alt="Attached image" className="mt-2 max-w-full rounded border" />;
 														})}
+												{text &&
+													Array.isArray(message.content) &&
+													(message.content as ContentBlock[])
+														.filter((b) => b.type === "file" && b.file)
+														.map((b, i) => (
+															<LogChatFileBlockView
+																key={`${i}-${b.file?.filename || b.file?.file_id || "file"}`}
+																block={b}
+																className="mt-2"
+															/>
+														))}
 												{hasToolCalls && text ? (
 													<div className="text-muted-foreground mt-2 text-[11px]">
 														{message

--- a/ui/app/workspace/logs/views/logChatMessageView.tsx
+++ b/ui/app/workspace/logs/views/logChatMessageView.tsx
@@ -1,12 +1,90 @@
+import { Button } from "@/components/ui/button";
 import { CodeEditor } from "@/components/ui/codeEditor";
 import { ChatMessage, ContentBlock } from "@/lib/types/logs";
+import { cn } from "@/lib/utils";
 import { cleanJson, isJson } from "@/lib/utils/validation";
+import { Download } from "lucide-react";
 import AudioPlayer from "./audioPlayer";
 import CollapsibleBox from "./collapsibleBox";
 
 interface LogChatMessageViewProps {
 	message: ChatMessage;
 	audioFormat?: string; // Optional audio format from request params
+}
+
+function isSafeHttpUrl(value: string) {
+	try {
+		const protocol = new URL(value).protocol;
+		return protocol === "https:" || protocol === "http:";
+	} catch {
+		return false;
+	}
+}
+
+function formatFileDataSize(fileData?: string) {
+	if (!fileData) return undefined;
+	const padding = fileData.endsWith("==") ? 2 : fileData.endsWith("=") ? 1 : 0;
+	const bytes = Math.max(0, Math.floor((fileData.length * 3) / 4) - padding);
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function downloadFileData(fileData: string, filename: string, fileType?: string) {
+	try {
+		const binary = atob(fileData);
+		const bytes = new Uint8Array(binary.length);
+		for (let i = 0; i < binary.length; i += 1) {
+			bytes[i] = binary.charCodeAt(i);
+		}
+		const blob = new Blob([bytes], { type: fileType || "application/octet-stream" });
+		const url = URL.createObjectURL(blob);
+		const anchor = document.createElement("a");
+		anchor.href = url;
+		anchor.download = filename;
+		document.body.appendChild(anchor);
+		anchor.click();
+		document.body.removeChild(anchor);
+		setTimeout(() => URL.revokeObjectURL(url), 0);
+	} catch {
+		console.error("Failed to decode file data for download");
+	}
+}
+
+export function LogChatFileBlockView({ block, className }: { block: ContentBlock; className?: string }) {
+	const file = block.file;
+	if (!file) return null;
+
+	const title = file.filename || file.file_id || "Attached file";
+	const size = formatFileDataSize(file.file_data);
+	const details = [file.file_type, size, file.file_id ? `ID: ${file.file_id}` : undefined].filter(Boolean);
+	const canDownload = !!file.file_data;
+
+	return (
+		<div className={cn("bg-muted/30 rounded border p-3 text-xs", className)}>
+			<div className="flex items-start justify-between gap-3">
+				<div className="min-w-0 font-medium break-all">{title}</div>
+				{canDownload && (
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="h-7 shrink-0 gap-1 px-2 text-xs"
+						onClick={() => downloadFileData(file.file_data!, title, file.file_type)}
+					>
+						<Download className="h-3.5 w-3.5" />
+						Download
+					</Button>
+				)}
+			</div>
+			{details.length > 0 && <div className="text-muted-foreground mt-1 break-all">{details.join(" · ")}</div>}
+			{file.file_url && isSafeHttpUrl(file.file_url) && (
+				<a href={file.file_url} target="_blank" rel="noreferrer" className="text-primary mt-2 inline-block hover:underline">
+					Open file
+				</a>
+			)}
+		</div>
+	);
 }
 
 function ContentBlockView({ block }: { block: ContentBlock; index: number }) {
@@ -46,6 +124,15 @@ function ContentBlockView({ block }: { block: ContentBlock; index: number }) {
 		if (src) {
 			return <img src={src} alt="Attached image" className="max-w-full rounded border" />;
 		}
+	}
+
+	// Handle file content
+	if (block.file) {
+		return (
+			<CollapsibleBox title={blockType} onCopy={() => JSON.stringify(block.file, null, 2)} collapsedHeight={100}>
+				<LogChatFileBlockView block={block} />
+			</CollapsibleBox>
+		);
 	}
 
 	// Handle audio content

--- a/ui/app/workspace/logs/views/logChatMessageView.tsx
+++ b/ui/app/workspace/logs/views/logChatMessageView.tsx
@@ -65,23 +65,24 @@ export function LogChatFileBlockView({ block, className }: { block: ContentBlock
 			<div className="flex items-start justify-between gap-3">
 				<div className="min-w-0 font-medium break-all">{title}</div>
 				{canDownload && (
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						className="h-7 shrink-0 gap-1 px-2 text-xs"
-						onClick={() => downloadFileData(file.file_data!, title, file.file_type)}
-					>
-						<Download className="h-3.5 w-3.5" />
-						Download
-					</Button>
-				)}
-			</div>
-			{details.length > 0 && <div className="text-muted-foreground mt-1 break-all">{details.join(" · ")}</div>}
-			{file.file_url && isSafeHttpUrl(file.file_url) && (
-				<a href={file.file_url} target="_blank" rel="noreferrer" className="text-primary mt-2 inline-block hover:underline">
-					Open file
-				</a>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="h-7 shrink-0 gap-1 px-2 text-xs"
+					onClick={() => downloadFileData(file.file_data!, title, file.file_type)}
+					data-testid="file-block-download-btn"
+				>
+					<Download className="h-3.5 w-3.5" />
+					Download
+				</Button>
+			)}
+		</div>
+		{details.length > 0 && <div className="text-muted-foreground mt-1 break-all">{details.join(" · ")}</div>}
+		{file.file_url && isSafeHttpUrl(file.file_url) && (
+			<a href={file.file_url} target="_blank" rel="noreferrer" className="text-primary mt-2 inline-block hover:underline" data-testid="file-block-open-link">
+				Open file
+			</a>
 			)}
 		</div>
 	);

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -142,6 +142,7 @@ export interface DefaultParameters {
 // Message content types
 export type MessageContentType =
 	| "text"
+	| "file"
 	| "image_url"
 	| "input_audio"
 	| "input_text"
@@ -156,6 +157,13 @@ export interface ContentBlock {
 	image_url?: {
 		url: string;
 		detail?: string;
+	};
+	file?: {
+		file_data?: string;
+		file_url?: string;
+		file_id?: string;
+		filename?: string;
+		file_type?: string;
 	};
 	input_audio?: {
 		data: string;


### PR DESCRIPTION
## Summary

Adds support for `file` content blocks in chat message logs. Users can now view file metadata and download attached files directly from the log detail view.

## Changes

- Added a `file` content type and corresponding `file` field to the `ContentBlock` type in `logs.ts`, enabling the frontend to parse file blocks from message content
- Introduced `LogChatFileBlockView`, a new exported component that renders file block metadata (filename, type, size, file ID) and provides a download button when inline file data is available
- Integrated `LogChatFileBlockView` into `ContentBlockView` to handle `file`-typed content blocks in the general message view
- Rendered attached file blocks in `logDetailView.tsx` alongside image attachments when a message contains `file`-typed content
- Exposed `EnqueueLogEntry` as a public method on `LoggerPlugin` to allow external callers to push complete log entries through the plugin's async write queue

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Send a request that includes a `file` content block in a chat message (e.g., using the Files API with an inline `file_data` payload or a `file_id` reference).
2. Open the log detail view for that request.
3. Verify the file block is rendered with its filename, type, size, and file ID.
4. If `file_data` is present, click **Download** and confirm the file downloads correctly.
5. If `file_url` is present, confirm the **Open file** link is rendered and navigates correctly.

```sh
# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots showing the file block rendered in the log detail view._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Inline `file_data` is base64-encoded and decoded entirely in the browser before being offered as a download. No file data is sent to any external endpoint. Care should be taken to ensure that `file_data` in logs does not inadvertently expose sensitive content to unauthorized users viewing logs.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File content blocks are now rendered and viewable within message histories
  * Files attached to messages can be downloaded directly from log entries
  * File details including name, type, and size are displayed alongside message content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->