### PR TITLE
feat: bringing provider governance to budget & limits

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -831,6 +831,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddModelConfigScopeColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationMigrateProviderGovernanceToModelConfigs(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3889,6 +3892,102 @@ func migrationAddModelConfigScopeColumns(ctx context.Context, db *gorm.DB) error
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running add model config scope columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationMigrateProviderGovernanceToModelConfigs folds provider-level governance
+// (config_providers.budget_id / rate_limit_id) into governance_model_configs as
+// (scope='global', provider=<name>, model_name='*') "all models on this provider" rows,
+// reusing the same budget/rate-limit rows. It then NULLs the provider FKs so the old
+// provider-governance enforcement path goes inert (single source of truth = model_configs).
+func migrationMigrateProviderGovernanceToModelConfigs(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "migrate_provider_governance_to_model_configs",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			// Guard: only run once the model-config table + scope columns exist.
+			if !tx.Migrator().HasTable(&tables.TableModelConfig{}) || !tx.Migrator().HasColumn(&tables.TableModelConfig{}, "scope") {
+				return nil
+			}
+
+			var providers []tables.TableProvider
+			if err := tx.Where("budget_id IS NOT NULL OR rate_limit_id IS NOT NULL").Find(&providers).Error; err != nil {
+				return fmt.Errorf("failed to load providers with governance: %w", err)
+			}
+
+			now := time.Now()
+			for i := range providers {
+				p := &providers[i]
+
+				// Idempotency: skip if a global all-models row already exists for this provider.
+				var existing int64
+				if err := tx.Model(&tables.TableModelConfig{}).
+					Where("scope = ? AND model_name = ? AND provider = ?", tables.ModelConfigScopeGlobal, tables.ModelConfigAllModels, p.Name).
+					Count(&existing).Error; err != nil {
+					return fmt.Errorf("failed to check existing wildcard config for provider %q: %w", p.Name, err)
+				}
+				if existing == 0 {
+					providerName := p.Name
+					mc := tables.TableModelConfig{
+						ID:          uuid.NewString(),
+						ModelName:   tables.ModelConfigAllModels,
+						Provider:    &providerName,
+						Scope:       tables.ModelConfigScopeGlobal,
+						BudgetID:    p.BudgetID,
+						RateLimitID: p.RateLimitID,
+						CreatedAt:   now,
+						UpdatedAt:   now,
+					}
+					if err := tx.Create(&mc).Error; err != nil {
+						return fmt.Errorf("failed to create wildcard model config for provider %q: %w", p.Name, err)
+					}
+				}
+
+				// Detach governance from the provider (FK rows are reused by the model config above).
+				if err := tx.Model(&tables.TableProvider{}).Where("name = ?", p.Name).
+					Updates(map[string]any{"budget_id": nil, "rate_limit_id": nil}).Error; err != nil {
+					return fmt.Errorf("failed to clear governance FKs for provider %q: %w", p.Name, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			// Nothing to reverse if the model-config table/scope columns are gone.
+			if !tx.Migrator().HasTable(&tables.TableModelConfig{}) || !tx.Migrator().HasColumn(&tables.TableModelConfig{}, "scope") {
+				return nil
+			}
+
+			// Reverse provider-level wildcards:
+			// (scope='global', scope_id IS NULL, model_name='*', provider IS NOT NULL).
+			var wildcards []tables.TableModelConfig
+			if err := tx.Where(
+				"scope = ? AND scope_id IS NULL AND model_name = ? AND provider IS NOT NULL",
+				tables.ModelConfigScopeGlobal, tables.ModelConfigAllModels,
+			).Find(&wildcards).Error; err != nil {
+				return fmt.Errorf("failed to load provider wildcard configs: %w", err)
+			}
+
+			for i := range wildcards {
+				mc := &wildcards[i]
+				// Re-attach the budget/rate-limit FK rows to the provider row.
+				if err := tx.Model(&tables.TableProvider{}).Where("name = ?", *mc.Provider).
+					Updates(map[string]any{"budget_id": mc.BudgetID, "rate_limit_id": mc.RateLimitID}).Error; err != nil {
+					return fmt.Errorf("failed to restore governance FKs for provider %q: %w", *mc.Provider, err)
+				}
+				// Drop the wildcard model config; its FK rows now live on the provider again.
+				if err := tx.Delete(&tables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
+					return fmt.Errorf("failed to delete wildcard config for provider %q: %w", *mc.Provider, err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running migrate provider governance to model configs migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -2442,3 +2442,43 @@ func TestMigrationAddModelConfigScopeColumns(t *testing.T) {
 	assert.True(t, db.Migrator().HasIndex(mc, "idx_model_scope_provider"))
 	assert.False(t, db.Migrator().HasIndex(mc, "idx_model_provider"))
 }
+
+// TestMigrationMigrateProviderGovernanceToModelConfigs verifies provider-level governance is
+// folded into a (global, provider, '*') model_config reusing the same budget/rate-limit rows,
+// and the provider FKs are cleared. Idempotent on re-run.
+func TestMigrationMigrateProviderGovernanceToModelConfigs(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.AutoMigrate(
+		&tables.TableProvider{}, &tables.TableModelConfig{}, &tables.TableBudget{}, &tables.TableRateLimit{},
+	))
+
+	now := time.Now()
+	require.NoError(t, db.Create(&tables.TableBudget{ID: "b1", MaxLimit: 100, ResetDuration: "1M", LastReset: now, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&tables.TableRateLimit{ID: "rl1", TokenMaxLimit: schemas.Ptr(int64(1000)), TokenResetDuration: schemas.Ptr("1h"), TokenLastReset: now, RequestLastReset: now, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&tables.TableProvider{Name: "openai", BudgetID: schemas.Ptr("b1"), RateLimitID: schemas.Ptr("rl1"), CreatedAt: now, UpdatedAt: now}).Error)
+
+	require.NoError(t, migrationMigrateProviderGovernanceToModelConfigs(ctx, db))
+
+	// A (global, openai, '*') model config now exists reusing the same budget/rate-limit IDs.
+	var mc tables.TableModelConfig
+	require.NoError(t, db.Where("scope = ? AND model_name = ? AND provider = ?", tables.ModelConfigScopeGlobal, tables.ModelConfigAllModels, "openai").First(&mc).Error)
+	require.NotNil(t, mc.BudgetID)
+	assert.Equal(t, "b1", *mc.BudgetID)
+	require.NotNil(t, mc.RateLimitID)
+	assert.Equal(t, "rl1", *mc.RateLimitID)
+
+	// Provider governance FKs are cleared (old path now inert).
+	var prov tables.TableProvider
+	require.NoError(t, db.Where("name = ?", "openai").First(&prov).Error)
+	assert.Nil(t, prov.BudgetID, "provider budget_id should be cleared")
+	assert.Nil(t, prov.RateLimitID, "provider rate_limit_id should be cleared")
+
+	// Idempotency: re-run creates no duplicate wildcard row.
+	require.NoError(t, migrationMigrateProviderGovernanceToModelConfigs(ctx, db))
+	var count int64
+	require.NoError(t, db.Model(&tables.TableModelConfig{}).
+		Where("scope = ? AND model_name = ? AND provider = ?", tables.ModelConfigScopeGlobal, tables.ModelConfigAllModels, "openai").
+		Count(&count).Error)
+	assert.Equal(t, int64(1), count, "re-run must not duplicate the wildcard config")
+}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1155,6 +1155,33 @@ func (s *RDBConfigStore) DeleteProvider(ctx context.Context, provider schemas.Mo
 		}
 	}
 
+	// Clean up model configs scoped to this provider
+	// Delete by snapshotted IDs rather than a second WHERE provider=? pass to avoid a race
+	// where a concurrent CreateModelConfig lands between the snapshot and the delete, leaving
+	// its owned budget/rate-limit rows dangling.
+	var providerModelConfigs []tables.TableModelConfig
+	if err := txDB.WithContext(ctx).Where("provider = ?", string(provider)).Find(&providerModelConfigs).Error; err != nil {
+		return err
+	}
+	for _, mc := range providerModelConfigs {
+		if mc.BudgetID != nil {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *mc.BudgetID).Error; err != nil {
+				return err
+			}
+		}
+		if mc.RateLimitID != nil {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", *mc.RateLimitID).Error; err != nil {
+				return err
+			}
+		}
+	}
+	if len(providerModelConfigs) > 0 {
+		var mcIDs []string
+		if err := txDB.WithContext(ctx).Where("id IN ?", mcIDs).Delete(&tables.TableModelConfig{}).Error; err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -4218,6 +4245,18 @@ func (s *RDBConfigStore) DeleteRoutingRule(ctx context.Context, id string, tx ..
 func (s *RDBConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
 	var modelConfigs []tables.TableModelConfig
 	if err := s.DB().WithContext(ctx).Preload("Budget").Preload("RateLimit").Find(&modelConfigs).Error; err != nil {
+		return nil, err
+	}
+	return modelConfigs, nil
+}
+
+// GetProviderGovernanceModelConfigs retrieves the wildcard "all models on a provider" configs
+func (s *RDBConfigStore) GetProviderGovernanceModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
+	var modelConfigs []tables.TableModelConfig
+	if err := s.DB().WithContext(ctx).
+		Preload("Budget").Preload("RateLimit").
+		Where("scope = ? AND model_name = ? AND provider IS NOT NULL", tables.ModelConfigScopeGlobal, tables.ModelConfigAllModels).
+		Find(&modelConfigs).Error; err != nil {
 		return nil, err
 	}
 	return modelConfigs, nil

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -692,6 +692,47 @@ func TestDeleteVirtualKey_CleansUpScopedModelConfigs(t *testing.T) {
 	assert.Equal(t, int64(0), rlCount, "owned rate limit should be deleted")
 }
 
+func TestDeleteProvider_CleansUpProviderModelConfigs(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	require.NoError(t, store.DB().Create(&tables.TableProvider{Name: "openai", CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, store.DB().Create(&tables.TableBudget{ID: "pb", MaxLimit: 100, ResetDuration: "1M", LastReset: now, CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, store.DB().Create(&tables.TableRateLimit{ID: "prl", TokenMaxLimit: schemas.Ptr(int64(1000)), TokenResetDuration: schemas.Ptr("1h"), TokenLastReset: now, RequestLastReset: now, CreatedAt: now, UpdatedAt: now}).Error)
+
+	providerName := "openai"
+	mc := &tables.TableModelConfig{
+		ID:          "mc-wildcard",
+		ModelName:   tables.ModelConfigAllModels,
+		Provider:    &providerName,
+		Scope:       tables.ModelConfigScopeGlobal,
+		BudgetID:    schemas.Ptr("pb"),
+		RateLimitID: schemas.Ptr("prl"),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	require.NoError(t, store.CreateModelConfig(ctx, mc))
+
+	require.NoError(t, store.DeleteProvider(ctx, schemas.ModelProvider("openai")))
+
+	// The provider's wildcard model config and its owned budget/rate-limit are cleaned up.
+	_, err := store.GetModelConfigByID(ctx, "mc-wildcard")
+	assert.Error(t, err, "provider-scoped model config should be deleted with the provider")
+	for _, q := range []struct {
+		model any
+		id    string
+		label string
+	}{
+		{&tables.TableBudget{}, "pb", "budget"},
+		{&tables.TableRateLimit{}, "prl", "rate limit"},
+	} {
+		var count int64
+		require.NoError(t, store.DB().Model(q.model).Where("id = ?", q.id).Count(&count).Error)
+		assert.Equal(t, int64(0), count, "owned "+q.label+" should be deleted")
+	}
+}
+
 // =============================================================================
 // Virtual Key Provider Config Tests
 // =============================================================================

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -256,6 +256,7 @@ type ConfigStore interface {
 
 	// Model config CRUD
 	GetModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error)
+	GetProviderGovernanceModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error)
 	GetModelConfigsPaginated(ctx context.Context, params ModelConfigsQueryParams) ([]tables.TableModelConfig, int64, error)
 	GetModelConfig(ctx context.Context, scope string, scopeID *string, modelName string, provider *string) (*tables.TableModelConfig, error)
 	GetModelConfigByID(ctx context.Context, id string) (*tables.TableModelConfig, error)

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -14,6 +14,11 @@ const (
 	ModelConfigScopeVirtualKey = "virtual_key"
 )
 
+// ModelConfigAllModels is the model_name sentinel meaning "all models". Combined with a
+// specific provider it expresses provider-level governance (all models on that provider);
+// with a nil provider it means all models on all providers.
+const ModelConfigAllModels = "*"
+
 // validModelConfigScopes is the set of accepted scope values.
 var validModelConfigScopes = map[string]bool{
 	ModelConfigScopeGlobal:     true,

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -2102,6 +2102,75 @@ func TestStore_CheckModelBudget_NoCatalog_NoMatch(t *testing.T) {
 }
 
 // ============================================================================
+// Store Tests - All-models ("*") wildcard tier (provider-level governance)
+// ============================================================================
+
+// TestStore_CheckModelBudget_AllModelsOnProvider_Exceeded verifies that an all-models
+// wildcard config (provider=openai, model_name="*") — the migrated provider-level budget —
+// applies to ANY model on that provider.
+func TestStore_CheckModelBudget_AllModelsOnProvider_Exceeded(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudgetWithUsage("b1", 100.0, 100.0, "1h") // exceeded
+	providerStr := "openai"
+	mc := buildModelConfig("mc-provider", configstoreTables.ModelConfigAllModels, &providerStr, budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	// A request for an arbitrary OpenAI model must be caught by the "*:openai" config.
+	_, err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: schemas.OpenAI}, nil)
+	assert.Error(t, err, "all-models budget for the provider should apply to any model on it")
+	assert.Contains(t, err.Error(), "budget exceeded")
+}
+
+// TestStore_CheckModelBudget_AllModelsOnProvider_OtherProviderPasses confirms the wildcard
+// is provider-scoped: it must NOT affect a different provider.
+func TestStore_CheckModelBudget_AllModelsOnProvider_OtherProviderPasses(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudgetWithUsage("b1", 100.0, 100.0, "1h") // exceeded
+	providerStr := "openai"
+	mc := buildModelConfig("mc-provider", configstoreTables.ModelConfigAllModels, &providerStr, budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	decision, err := store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "claude-opus-4-7", Provider: schemas.Anthropic}, nil)
+	assert.NoError(t, err, "an OpenAI all-models budget must not affect an Anthropic request")
+	assert.Equal(t, DecisionAllow, decision)
+}
+
+// TestStore_UpdateProviderModelUsage_BumpsAllModelsWildcard verifies usage recording reaches
+// the all-models wildcard config (record-then-check loop for provider-level governance).
+func TestStore_UpdateProviderModelUsage_BumpsAllModelsWildcard(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("rl1", 100, 0, 1000000, 0) // 100-token cap
+	providerStr := "openai"
+	mc := buildModelConfig("mc-provider", configstoreTables.ModelConfigAllModels, &providerStr, nil, rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	// Within limit initially.
+	decision, err := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: schemas.OpenAI}, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, DecisionAllow, decision)
+
+	// Record usage for a (different) model on the provider — must bump the "*:openai" config.
+	require.NoError(t, store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "gpt-4o", schemas.OpenAI, 150, true, true))
+
+	// Now the all-models rate limit trips for any model on the provider.
+	decision, err = store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "gpt-4o-mini", Provider: schemas.OpenAI}, nil, nil)
+	assert.Error(t, err)
+	assert.Equal(t, DecisionTokenLimited, decision)
+}
+
+// ============================================================================
 // Store Tests - Per-VK-Scoped Model Budget / Rate Limit
 // ============================================================================
 

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1009,6 +1009,8 @@ func (gs *LocalGovernanceStore) CheckProviderRateLimit(ctx context.Context, requ
 	return gs.CheckRateLimit(ctx, EntityWiseRateLimits{providerKey: []*configstoreTables.TableRateLimit{rateLimit}}, tokensBaselines, requestsBaselines)
 }
 
+const modelConfigWildcard = configstoreTables.ModelConfigAllModels
+
 // modelConfigStoreKey builds the in-memory cache key for a model config.
 func modelConfigStoreKey(scope, scopeID, modelKey string, provider *string) string {
 	base := modelKey
@@ -1063,43 +1065,95 @@ func (gs *LocalGovernanceStore) findScopedModelOnlyConfig(ctx context.Context, s
 	return tryKey(model)
 }
 
-// CheckModelBudget performs budget checking for model-level configs (lock-free for high performance)
+// modelAndProvider extracts the model name and optional provider from a request.
+func modelAndProvider(request *EvaluationRequest) (string, *string) {
+	if request == nil {
+		return "", nil
+	}
+	var provider *string
+	if request.Provider != "" {
+		p := string(request.Provider)
+		provider = &p
+	}
+	return request.Model, provider
+}
+
+// collectModelConfigsFor returns every model config that applies to a request for
+// (model, provider) within a single scope, across four tiers (most → least specific),
+// deduped by config ID:
+//  1. (model, provider)  exact model on this provider
+//  2. (model, nil)       exact model on all providers (base-name normalized)
+//  3. ("*", provider)    all models on this provider  (provider-level governance)
+//  4. ("*", nil)         all models on all providers
+//
+// This is the single source of truth for "which model configs apply"; every budget /
+// rate-limit check and usage-tracking site iterates it so the wildcard tiers are matched
+// consistently everywhere.
+func (gs *LocalGovernanceStore) collectModelConfigsFor(ctx context.Context, scope, scopeID, model string, provider *string) []*configstoreTables.TableModelConfig {
+	var out []*configstoreTables.TableModelConfig
+	seen := make(map[string]bool)
+	add := func(mc *configstoreTables.TableModelConfig) {
+		if mc == nil || seen[mc.ID] {
+			return
+		}
+		seen[mc.ID] = true
+		out = append(out, mc)
+	}
+	loadKey := func(modelKey string, prov *string) *configstoreTables.TableModelConfig {
+		if value, exists := gs.modelConfigs.Load(modelConfigStoreKey(scope, scopeID, modelKey, prov)); exists && value != nil {
+			if mc, ok := value.(*configstoreTables.TableModelConfig); ok {
+				return mc
+			}
+		}
+		return nil
+	}
+	if provider != nil {
+		add(loadKey(model, provider)) // tier 1: exact model + provider
+	}
+	if mc, _ := gs.findScopedModelOnlyConfig(ctx, scope, scopeID, model); mc != nil {
+		add(mc) // tier 2: exact model, all providers (normalized)
+	}
+	if provider != nil {
+		add(loadKey(modelConfigWildcard, provider)) // tier 3: all models on this provider
+	}
+	add(loadKey(modelConfigWildcard, nil)) // tier 4: all models, all providers
+	return out
+}
+
+// modelConfigEntityKey builds a stable, unique entity description for a model config
+func modelConfigEntityKey(mc *configstoreTables.TableModelConfig) string {
+	name := mc.ModelName
+	if name == modelConfigWildcard {
+		name = "AllModels"
+	}
+	key := "Model:" + name
+	if mc.Provider != nil {
+		key += ":Provider:" + *mc.Provider
+	}
+	if mc.Scope != "" && mc.Scope != configstoreTables.ModelConfigScopeGlobal {
+		scopeID := ""
+		if mc.ScopeID != nil {
+			scopeID = *mc.ScopeID
+		}
+		key += ":" + mc.Scope + ":" + scopeID
+	}
+	return key
+}
+
+// CheckModelBudget performs budget checking for global-scope model-level configs, across all
+// four tiers (exact model±provider and all-models "*"±provider).
 func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
-	// This is to prevent nil pointer dereference
 	if baselines == nil {
 		baselines = map[string]float64{}
 	}
-	// Extract model and provider from request
-	var model string
-	var provider *schemas.ModelProvider
-	if request != nil {
-		model = request.Model
-		if request.Provider != "" {
-			provider = &request.Provider
-		}
-	}
-	// Collect model configs to check: model+provider (if exists) AND model-only (if exists)
+	model, provider := modelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
-	// Check model+provider config first (more specific) - if provider is provided
-	if provider != nil {
-		key := fmt.Sprintf("%s:%s", model, string(*provider))
-		if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-			if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil && mc.Budget != nil {
-				budget := gs.LoadBudget(ctx, *mc.BudgetID)
-				if budget != nil {
-					key := fmt.Sprintf("Model:%s:Provider:%s", mc.ModelName, *provider)
-					entityWiseBudgets[key] = []*configstoreTables.TableBudget{budget}
-				}
-			}
+	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
+		if mc.BudgetID == nil {
+			continue
 		}
-	}
-	// Always check model-only config (if exists) - regardless of whether model+provider config exists
-	// Uses findModelOnlyConfig for cross-provider model name normalization
-	if mc, _ := gs.findModelOnlyConfig(ctx, model); mc != nil && mc.Budget != nil {
-		budget := gs.LoadBudget(ctx, *mc.BudgetID)
-		if budget != nil {
-			key := fmt.Sprintf("Model:%s", mc.ModelName)
-			entityWiseBudgets[key] = []*configstoreTables.TableBudget{budget}
+		if budget := gs.LoadBudget(ctx, *mc.BudgetID); budget != nil {
+			entityWiseBudgets[modelConfigEntityKey(mc)] = []*configstoreTables.TableBudget{budget}
 		}
 	}
 	return gs.CheckBudget(ctx, entityWiseBudgets, baselines)
@@ -1218,44 +1272,22 @@ func (gs *LocalGovernanceStore) CheckUserBudget(ctx context.Context, userID stri
 	return DecisionAllow, nil
 }
 
-// CheckModelRateLimit checks model-level rate limits and returns evaluation result if violated
+// CheckModelRateLimit checks global-scope model-level rate limits across all four tiers
 func (gs *LocalGovernanceStore) CheckModelRateLimit(ctx context.Context, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
-	// This is to prevent nil pointer dereference
 	if tokensBaselines == nil {
 		tokensBaselines = map[string]int64{}
 	}
 	if requestsBaselines == nil {
 		requestsBaselines = map[string]int64{}
 	}
-	// Extract model and provider from request
-	var model string
-	var provider *schemas.ModelProvider
-	if request != nil {
-		model = request.Model
-		if request.Provider != "" {
-			provider = &request.Provider
-		}
-	}
-	// Collect model configs to check: model+provider (if exists) AND model-only (if exists)
+	model, provider := modelAndProvider(request)
 	entityWiseRateLimits := make(EntityWiseRateLimits)
-	// Check model+provider config first (more specific) - if provider is provided
-	if provider != nil {
-		key := fmt.Sprintf("%s:%s", model, string(*provider))
-		if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-			if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil && mc.RateLimitID != nil {
-				rateLimit := gs.LoadRateLimit(ctx, *mc.RateLimitID)
-				if rateLimit != nil {
-					entityWiseRateLimits[fmt.Sprintf("Model:%s:Provider:%s", model, string(*provider))] = []*configstoreTables.TableRateLimit{rateLimit}
-				}
-			}
+	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
+		if mc.RateLimitID == nil {
+			continue
 		}
-	}
-	// Always check model-only config (if exists) - regardless of whether model+provider config exists
-	// Uses findModelOnlyConfig for cross-provider model name normalization
-	if mc, configKey := gs.findModelOnlyConfig(ctx, model); mc != nil && mc.RateLimitID != nil {
-		rateLimit := gs.LoadRateLimit(ctx, *mc.RateLimitID)
-		if rateLimit != nil {
-			entityWiseRateLimits[fmt.Sprintf("Model:%s", configKey)] = []*configstoreTables.TableRateLimit{rateLimit}
+		if rateLimit := gs.LoadRateLimit(ctx, *mc.RateLimitID); rateLimit != nil {
+			entityWiseRateLimits[modelConfigEntityKey(mc)] = []*configstoreTables.TableRateLimit{rateLimit}
 		}
 	}
 	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
@@ -1271,34 +1303,15 @@ func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelBudget(ctx context.Con
 	if baselines == nil {
 		baselines = map[string]float64{}
 	}
-	var model string
-	var providerStr *string
-	if request != nil {
-		model = request.Model
-		if request.Provider != "" {
-			p := string(request.Provider)
-			providerStr = &p
-		}
-	}
+	model, provider := modelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
 	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		// Scoped model+provider config first (more specific) - if provider is provided
-		if providerStr != nil {
-			key := modelConfigStoreKey(scope.name, scope.id, model, providerStr)
-			if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-				if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil && mc.Budget != nil {
-					if budget := gs.LoadBudget(ctx, *mc.BudgetID); budget != nil {
-						ewKey := fmt.Sprintf("Model:%s:Provider:%s:%s:%s", mc.ModelName, *providerStr, scope.name, scope.id)
-						entityWiseBudgets[ewKey] = []*configstoreTables.TableBudget{budget}
-					}
-				}
+		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, provider) {
+			if mc.BudgetID == nil {
+				continue
 			}
-		}
-		// Always check scoped model-only config (cross-provider normalization preserved)
-		if mc, _ := gs.findScopedModelOnlyConfig(ctx, scope.name, scope.id, model); mc != nil && mc.Budget != nil {
 			if budget := gs.LoadBudget(ctx, *mc.BudgetID); budget != nil {
-				ewKey := fmt.Sprintf("Model:%s:%s:%s", mc.ModelName, scope.name, scope.id)
-				entityWiseBudgets[ewKey] = []*configstoreTables.TableBudget{budget}
+				entityWiseBudgets[modelConfigEntityKey(mc)] = []*configstoreTables.TableBudget{budget}
 			}
 		}
 	}
@@ -1317,34 +1330,15 @@ func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelRateLimit(ctx context.
 	if requestsBaselines == nil {
 		requestsBaselines = map[string]int64{}
 	}
-	var model string
-	var providerStr *string
-	if request != nil {
-		model = request.Model
-		if request.Provider != "" {
-			p := string(request.Provider)
-			providerStr = &p
-		}
-	}
+	model, provider := modelAndProvider(request)
 	entityWiseRateLimits := make(EntityWiseRateLimits)
 	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		// Scoped model+provider config first - if provider is provided
-		if providerStr != nil {
-			key := modelConfigStoreKey(scope.name, scope.id, model, providerStr)
-			if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-				if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil && mc.RateLimitID != nil {
-					if rateLimit := gs.LoadRateLimit(ctx, *mc.RateLimitID); rateLimit != nil {
-						ewKey := fmt.Sprintf("Model:%s:Provider:%s:%s:%s", mc.ModelName, *providerStr, scope.name, scope.id)
-						entityWiseRateLimits[ewKey] = []*configstoreTables.TableRateLimit{rateLimit}
-					}
-				}
+		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, provider) {
+			if mc.RateLimitID == nil {
+				continue
 			}
-		}
-		// Always check scoped model-only config (cross-provider normalization preserved)
-		if mc, configKey := gs.findScopedModelOnlyConfig(ctx, scope.name, scope.id, model); mc != nil && mc.RateLimitID != nil {
 			if rateLimit := gs.LoadRateLimit(ctx, *mc.RateLimitID); rateLimit != nil {
-				ewKey := fmt.Sprintf("Model:%s:%s:%s", configKey, scope.name, scope.id)
-				entityWiseRateLimits[ewKey] = []*configstoreTables.TableRateLimit{rateLimit}
+				entityWiseRateLimits[modelConfigEntityKey(mc)] = []*configstoreTables.TableRateLimit{rateLimit}
 			}
 		}
 	}
@@ -1405,22 +1399,17 @@ func (gs *LocalGovernanceStore) UpdateProviderAndModelBudgetUsageInMemory(ctx co
 		}
 	}
 
-	// 2. Update model-level budgets
-	// Check model+provider config first (more specific) - if provider is provided
+	// 2. Update global-scope model-level budgets across all four tiers (incl. the
+	// all-models "*:provider" tier that now carries provider-level governance).
+	var providerStr *string
 	if provider != "" {
-		key := fmt.Sprintf("%s:%s", model, string(provider))
-		if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-			if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil && mc.BudgetID != nil {
-				if err := gs.BumpBudgetUsage(ctx, *mc.BudgetID, cost); err != nil {
-					return err
-				}
-			}
-		}
+		p := string(provider)
+		providerStr = &p
 	}
-
-	// Always check model-only config (if exists) - regardless of whether model+provider config exists
-	// Uses findModelOnlyConfig for cross-provider model name normalization
-	if mc, _ := gs.findModelOnlyConfig(ctx, model); mc != nil && mc.BudgetID != nil {
+	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
+		if mc.BudgetID == nil {
+			continue
+		}
 		if err := gs.BumpBudgetUsage(ctx, *mc.BudgetID, cost); err != nil {
 			return err
 		}
@@ -1449,22 +1438,17 @@ func (gs *LocalGovernanceStore) UpdateProviderAndModelRateLimitUsageInMemory(ctx
 		}
 	}
 
-	// 2. Update model-level rate limits
-	// Check model+provider config first (more specific) - if provider is provided
+	// 2. Update global-scope model-level rate limits across all four tiers (incl. the
+	// all-models "*:provider" tier that now carries provider-level governance).
+	var providerStr *string
 	if provider != "" {
-		key := fmt.Sprintf("%s:%s", model, string(provider))
-		if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-			if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil && mc.RateLimitID != nil {
-				if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-					return err
-				}
-			}
-		}
+		p := string(provider)
+		providerStr = &p
 	}
-
-	// Always check model-only config (if exists) - regardless of whether model+provider config exists
-	// Uses findModelOnlyConfig for cross-provider model name normalization
-	if mc, _ := gs.findModelOnlyConfig(ctx, model); mc != nil && mc.RateLimitID != nil {
+	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
+		if mc.RateLimitID == nil {
+			continue
+		}
 		if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
 			return err
 		}
@@ -1486,19 +1470,10 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelBudgetUsageInMemory(c
 		providerStr = &p
 	}
 	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		// Scoped model+provider config first (more specific) - if provider is set
-		if providerStr != nil {
-			key := modelConfigStoreKey(scope.name, scope.id, model, providerStr)
-			if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-				if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil && mc.BudgetID != nil {
-					if err := gs.BumpBudgetUsage(ctx, *mc.BudgetID, cost); err != nil {
-						return err
-					}
-				}
+		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
+			if mc.BudgetID == nil {
+				continue
 			}
-		}
-		// Always bump scoped model-only config (cross-provider normalization preserved)
-		if mc, _ := gs.findScopedModelOnlyConfig(ctx, scope.name, scope.id, model); mc != nil && mc.BudgetID != nil {
 			if err := gs.BumpBudgetUsage(ctx, *mc.BudgetID, cost); err != nil {
 				return err
 			}
@@ -1519,19 +1494,10 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelRateLimitUsageInMemor
 		providerStr = &p
 	}
 	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		// Scoped model+provider config first (more specific) - if provider is set
-		if providerStr != nil {
-			key := modelConfigStoreKey(scope.name, scope.id, model, providerStr)
-			if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-				if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil && mc.RateLimitID != nil {
-					if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-						return err
-					}
-				}
+		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
+			if mc.RateLimitID == nil {
+				continue
 			}
-		}
-		// Always bump scoped model-only config (cross-provider normalization preserved)
-		if mc, _ := gs.findScopedModelOnlyConfig(ctx, scope.name, scope.id, model); mc != nil && mc.RateLimitID != nil {
 			if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
 				return err
 			}
@@ -2155,9 +2121,10 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 			key := modelConfigStoreKey(mc.Scope, scopeID, mc.ModelName, mc.Provider)
 			gs.modelConfigs.Store(key, mc)
 		} else {
-			// All-provider config - store under normalized (scope-prefixed) model name
+			// All-provider config - store under normalized (scope-prefixed) model name.
+			// The "*" (all-models) sentinel is never normalized.
 			modelKey := mc.ModelName
-			if gs.modelCatalog != nil {
+			if gs.modelCatalog != nil && mc.ModelName != modelConfigWildcard {
 				modelKey = gs.modelCatalog.GetBaseModelName(mc.ModelName)
 			}
 			key := modelConfigStoreKey(mc.Scope, scopeID, modelKey, nil)
@@ -3146,7 +3113,7 @@ func (gs *LocalGovernanceStore) UpdateModelConfigInMemory(ctx context.Context, m
 		gs.modelConfigs.Store(key, &clone)
 	} else {
 		modelKey := clone.ModelName
-		if gs.modelCatalog != nil {
+		if gs.modelCatalog != nil && clone.ModelName != modelConfigWildcard {
 			modelKey = gs.modelCatalog.GetBaseModelName(clone.ModelName)
 		}
 		key := modelConfigStoreKey(clone.Scope, scopeID, modelKey, nil)

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -2991,23 +2991,45 @@ type ProviderGovernanceResponse struct {
 	RateLimit *configstoreTables.TableRateLimit `json:"rate_limit,omitempty"`
 }
 
-// getProviderGovernance handles GET /api/governance/providers - Get all providers with governance settings
-func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
-	providers, err := h.configStore.GetProviders(ctx)
-	if err != nil {
-		logger.Error("failed to retrieve providers: %v", err)
-		SendError(ctx, 500, "Failed to retrieve providers")
-		return
+// providerGovernanceFromWildcard maps an "all models on a provider" model config
+// (scope=global, model_name="*", provider set) to a ProviderGovernanceResponse. Provider
+// governance now lives in governance_model_configs as these wildcard rows,
+// this endpoint is a compatibility facade over them.
+func providerGovernanceFromWildcard(mc *configstoreTables.TableModelConfig) (ProviderGovernanceResponse, bool) {
+	if mc == nil || mc.Scope != configstoreTables.ModelConfigScopeGlobal ||
+		mc.ModelName != configstoreTables.ModelConfigAllModels || mc.Provider == nil {
+		return ProviderGovernanceResponse{}, false
 	}
-	// Transform to governance response format
+	return ProviderGovernanceResponse{Provider: *mc.Provider, Budget: mc.Budget, RateLimit: mc.RateLimit}, true
+}
+
+// getProviderGovernance handles GET /api/governance/providers - returns provider-level governance,
+// now backed by the wildcard ("all models on a provider") model configs.
+func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
+	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
 	var result []ProviderGovernanceResponse
-	for _, p := range providers {
-		if p.Budget != nil || p.RateLimit != nil {
-			result = append(result, ProviderGovernanceResponse{
-				Provider:  p.Name,
-				Budget:    p.Budget,
-				RateLimit: p.RateLimit,
-			})
+	if fromMemory {
+		data := h.governanceManager.GetGovernanceData(ctx)
+		if data == nil {
+			SendError(ctx, 500, "Governance data is not available")
+			return
+		}
+		for _, mc := range data.ModelConfigs {
+			if r, ok := providerGovernanceFromWildcard(mc); ok {
+				result = append(result, r)
+			}
+		}
+	} else {
+		configs, err := h.configStore.GetProviderGovernanceModelConfigs(ctx)
+		if err != nil {
+			logger.Error("failed to retrieve model configs: %v", err)
+			SendError(ctx, 500, "Failed to retrieve providers")
+			return
+		}
+		for i := range configs {
+			if r, ok := providerGovernanceFromWildcard(&configs[i]); ok {
+				result = append(result, r)
+			}
 		}
 	}
 	SendJSON(ctx, map[string]interface{}{
@@ -3024,42 +3046,58 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, "Invalid JSON")
 		return
 	}
-	// Get all providers and find the one we need
+	// Validate the provider exists.
 	providers, err := h.configStore.GetProviders(ctx)
 	if err != nil {
 		SendError(ctx, 500, "Failed to retrieve providers")
 		return
 	}
-	var provider *configstoreTables.TableProvider
+	providerExists := false
 	for i := range providers {
 		if providers[i].Name == providerName {
-			provider = &providers[i]
+			providerExists = true
 			break
 		}
 	}
-	if provider == nil {
+	if !providerExists {
 		SendError(ctx, 404, "Provider not found")
 		return
 	}
+
+	existing, err := h.configStore.GetModelConfig(ctx, configstoreTables.ModelConfigScopeGlobal, nil, configstoreTables.ModelConfigAllModels, &providerName)
+	if err != nil && err != configstore.ErrNotFound {
+		logger.Error("failed to load provider governance: %v", err)
+		SendError(ctx, 500, fmt.Sprintf("Failed to load provider governance: %v", err))
+		return
+	}
+	isNew := existing == nil
+	mc := configstoreTables.TableModelConfig{
+		ID:        uuid.NewString(),
+		ModelName: configstoreTables.ModelConfigAllModels,
+		Provider:  &providerName,
+		Scope:     configstoreTables.ModelConfigScopeGlobal,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if existing != nil {
+		mc = *existing
+	}
+
+	deleted := false
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		// Track IDs to delete after updating the provider (to avoid FK constraint)
 		var budgetIDToDelete, rateLimitIDToDelete string
 
-		// Handle budget updates
+		// Budget lifecycle (owner is the wildcard model config).
 		if req.Budget != nil {
-			// Check if budget removal is requested (all fields nil)
-			budgetIsEmpty := isBudgetRemovalRequest(req.Budget)
-			if budgetIsEmpty {
-				// Mark budget for deletion after FK is removed
-				if provider.BudgetID != nil {
-					budgetIDToDelete = *provider.BudgetID
-					provider.BudgetID = nil
-					provider.Budget = nil
+			if isBudgetRemovalRequest(req.Budget) {
+				if mc.BudgetID != nil {
+					budgetIDToDelete = *mc.BudgetID
+					mc.BudgetID = nil
+					mc.Budget = nil
 				}
-			} else if provider.BudgetID != nil {
-				// Update existing budget — all fields are optional (partial update)
+			} else if mc.BudgetID != nil {
 				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *provider.BudgetID).Error; err != nil {
+				if err := tx.First(&budget, "id = ?", *mc.BudgetID).Error; err != nil {
 					return err
 				}
 				if req.Budget.MaxLimit != nil {
@@ -3074,9 +3112,8 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
 					return err
 				}
-				provider.Budget = &budget
+				mc.Budget = &budget
 			} else {
-				// Create new budget
 				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
 					return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
 				}
@@ -3093,28 +3130,23 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
 					return err
 				}
-				provider.BudgetID = &budget.ID
-				provider.Budget = &budget
+				mc.BudgetID = &budget.ID
+				mc.Budget = &budget
 			}
 		}
-		// Handle rate limit updates
+		// Rate limit lifecycle (owner is the wildcard model config).
 		if req.RateLimit != nil {
-			// Check if rate limit values are empty - means remove rate limit (reset durations don't matter)
-			rateLimitIsEmpty := req.RateLimit.TokenMaxLimit == nil && req.RateLimit.RequestMaxLimit == nil
-			if rateLimitIsEmpty {
-				// Mark rate limit for deletion after FK is removed
-				if provider.RateLimitID != nil {
-					rateLimitIDToDelete = *provider.RateLimitID
-					provider.RateLimitID = nil
-					provider.RateLimit = nil
+			if isRateLimitRemovalRequest(req.RateLimit) {
+				if mc.RateLimitID != nil {
+					rateLimitIDToDelete = *mc.RateLimitID
+					mc.RateLimitID = nil
+					mc.RateLimit = nil
 				}
-			} else if provider.RateLimitID != nil {
-				// Update existing rate limit - set ALL fields from request (nil means clear)
+			} else if mc.RateLimitID != nil {
 				rateLimit := configstoreTables.TableRateLimit{}
-				if err := tx.First(&rateLimit, "id = ?", *provider.RateLimitID).Error; err != nil {
+				if err := tx.First(&rateLimit, "id = ?", *mc.RateLimitID).Error; err != nil {
 					return err
 				}
-				// Set all fields from request - nil values will clear the field
 				rateLimit.TokenMaxLimit = req.RateLimit.TokenMaxLimit
 				rateLimit.TokenResetDuration = req.RateLimit.TokenResetDuration
 				rateLimit.RequestMaxLimit = req.RateLimit.RequestMaxLimit
@@ -3125,9 +3157,8 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 				if err := h.configStore.UpdateRateLimit(ctx, &rateLimit, tx); err != nil {
 					return err
 				}
-				provider.RateLimit = &rateLimit
+				mc.RateLimit = &rateLimit
 			} else {
-				// Create new rate limit
 				rateLimit := configstoreTables.TableRateLimit{
 					ID:                   uuid.NewString(),
 					TokenMaxLimit:        req.RateLimit.TokenMaxLimit,
@@ -3143,16 +3174,32 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 				if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
 					return err
 				}
-				provider.RateLimitID = &rateLimit.ID
-				provider.RateLimit = &rateLimit
+				mc.RateLimitID = &rateLimit.ID
+				mc.RateLimit = &rateLimit
 			}
 		}
-		// Update only budget/rate limit FK references (avoid overwriting encrypted fields)
-		if err := tx.Model(provider).Select("budget_id", "rate_limit_id").Updates(provider).Error; err != nil {
-			return err
+
+		hasGovernance := mc.BudgetID != nil || mc.RateLimitID != nil
+		switch {
+		case !hasGovernance && isNew:
+			// Nothing to persist (removal request on a provider with no governance).
+		case !hasGovernance && !isNew:
+			// All governance removed → delete the wildcard config and its orphaned rows.
+			if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
+				return err
+			}
+			deleted = true
+		case isNew:
+			if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
+				return err
+			}
+		default:
+			if err := h.configStore.UpdateModelConfig(ctx, &mc, tx); err != nil {
+				return err
+			}
 		}
 
-		// Now that FK references are removed, delete the orphaned budget/rate limit
+		// Delete orphaned budget/rate-limit rows after the FK references are gone.
 		if budgetIDToDelete != "" {
 			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", budgetIDToDelete).Error; err != nil {
 				return err
@@ -3163,93 +3210,56 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 				return err
 			}
 		}
-
 		return nil
 	}); err != nil {
 		logger.Error("failed to update provider governance: %v", err)
 		SendError(ctx, 500, fmt.Sprintf("Failed to update provider governance: %v", err))
 		return
 	}
-	// Reload provider in memory
-	updatedProvider, err := h.governanceManager.ReloadProvider(ctx, schemas.ModelProvider(providerName))
-	if err != nil {
-		logger.Error("failed to reload provider in memory: %v", err)
-		// Use the local provider object if reload fails
-	} else {
-		provider = updatedProvider
+
+	// Sync the in-memory governance store with the change.
+	resp := ProviderGovernanceResponse{Provider: providerName}
+	if deleted {
+		if err := h.governanceManager.RemoveModelConfig(ctx, mc.ID); err != nil {
+			logger.Error("failed to remove provider governance from memory: %v", err)
+		}
+	} else if mc.BudgetID != nil || mc.RateLimitID != nil {
+		if reloaded, err := h.governanceManager.ReloadModelConfig(ctx, mc.ID); err != nil {
+			logger.Error("failed to reload provider governance in memory: %v", err)
+			resp.Budget, resp.RateLimit = mc.Budget, mc.RateLimit
+		} else {
+			resp.Budget, resp.RateLimit = reloaded.Budget, reloaded.RateLimit
+		}
 	}
 	SendJSON(ctx, map[string]interface{}{
-		"message": "Provider governance updated successfully",
-		"provider": ProviderGovernanceResponse{
-			Provider:  provider.Name,
-			Budget:    provider.Budget,
-			RateLimit: provider.RateLimit,
-		},
+		"message":  "Provider governance updated successfully",
+		"provider": resp,
 	})
 }
 
-// deleteProviderGovernance handles DELETE /api/governance/providers/{provider_name} - Remove governance from provider
+// deleteProviderGovernance handles DELETE /api/governance/providers/{provider_name} - removes
+// provider-level governance by deleting the wildcard ("all models on this provider") model config.
 func (h *GovernanceHandler) deleteProviderGovernance(ctx *fasthttp.RequestCtx) {
 	providerName := ctx.UserValue("provider_name").(string)
-	// Get all providers and find the one we need
-	providers, err := h.configStore.GetProviders(ctx)
+	mc, err := h.configStore.GetModelConfig(ctx, configstoreTables.ModelConfigScopeGlobal, nil, configstoreTables.ModelConfigAllModels, &providerName)
 	if err != nil {
-		SendError(ctx, 500, "Failed to retrieve providers")
+		if err == configstore.ErrNotFound {
+			// No provider-level governance to remove — treat as success (idempotent).
+			SendJSON(ctx, map[string]interface{}{"message": "Provider governance deleted successfully"})
+			return
+		}
+		logger.Error("failed to load provider governance: %v", err)
+		SendError(ctx, 500, "Failed to delete provider governance")
 		return
 	}
-	var provider *configstoreTables.TableProvider
-	for i := range providers {
-		if providers[i].Name == providerName {
-			provider = &providers[i]
-			break
-		}
-	}
-	if provider == nil {
-		SendError(ctx, 404, "Provider not found")
-		return
-	}
-	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		// Store IDs to delete after removing FK references
-		var budgetIDToDelete, rateLimitIDToDelete string
-
-		if provider.BudgetID != nil {
-			budgetIDToDelete = *provider.BudgetID
-			provider.BudgetID = nil
-			provider.Budget = nil
-		}
-		if provider.RateLimitID != nil {
-			rateLimitIDToDelete = *provider.RateLimitID
-			provider.RateLimitID = nil
-			provider.RateLimit = nil
-		}
-
-		// Update only budget/rate limit FK references (avoid overwriting encrypted fields)
-		if err := tx.Model(provider).Select("budget_id", "rate_limit_id").Updates(provider).Error; err != nil {
-			return err
-		}
-
-		// Now delete the orphaned budget/rate limit
-		if budgetIDToDelete != "" {
-			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", budgetIDToDelete).Error; err != nil {
-				return err
-			}
-		}
-		if rateLimitIDToDelete != "" {
-			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}); err != nil {
+	// DeleteModelConfig cascades to the owned budget/rate-limit rows.
+	if err := h.configStore.DeleteModelConfig(ctx, mc.ID); err != nil {
 		logger.Error("failed to delete provider governance: %v", err)
 		SendError(ctx, 500, "Failed to delete provider governance")
 		return
 	}
-	// Reload provider in memory (to clear the budget/rate limit)
-	if _, err := h.governanceManager.ReloadProvider(ctx, schemas.ModelProvider(providerName)); err != nil {
-		logger.Error("failed to reload provider in memory: %v", err)
-		// Continue anyway, the governance is deleted from DB
+	if err := h.governanceManager.RemoveModelConfig(ctx, mc.ID); err != nil {
+		logger.Error("failed to remove provider governance from memory: %v", err)
 	}
 	SendJSON(ctx, map[string]interface{}{
 		"message": "Provider governance deleted successfully",

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1115,6 +1115,10 @@ func (m *MockConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableMo
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetProviderGovernanceModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) GetModelConfigsPaginated(ctx context.Context, params configstore.ModelConfigsQueryParams) ([]tables.TableModelConfig, int64, error) {
 	return nil, 0, nil
 }

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -322,6 +322,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 													placeholder="Search for a model..."
 													isSingleSelect
 													loadModelsOnEmptyProvider="base_models"
+													allowAllOption
 													disabled={isEditing}
 												/>
 											</div>

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -295,7 +295,9 @@ export default function ModelLimitsTable({
 										>
 											<TableCell className="max-w-[280px] py-4">
 												<div className="flex flex-col gap-2">
-													<span className="truncate font-mono text-sm font-medium">{config.model_name}</span>
+													<span className="truncate font-mono text-sm font-medium">
+														{config.model_name === "*" ? "All Models" : config.model_name}
+													</span>
 													{isExhausted && (
 														<Badge variant="destructive" className="w-fit text-xs">
 															Limit Reached

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -516,6 +516,8 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
+			// Wildcard model configs back provider governance; refresh the provider page too.
+			invalidatesTags: ["ProviderGovernance"],
 			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -545,6 +547,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
+			invalidatesTags: ["ProviderGovernance"],
 			async onQueryStarted({ id }, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -577,6 +580,8 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/model-configs/${id}`,
 				method: "DELETE",
 			}),
+			// Wildcard model configs back provider governance; refresh the provider page too.
+			invalidatesTags: ["ProviderGovernance"],
 			async onQueryStarted(id, { dispatch, getState, queryFulfilled }) {
 				try {
 					await queryFulfilled;
@@ -749,6 +754,8 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
+			// Provider governance is now backed by wildcard model configs; refresh the Model Limits view too.
+			invalidatesTags: ["ModelConfigs"],
 			async onQueryStarted({ provider }, { dispatch, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -779,6 +786,8 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/providers/${encodeURIComponent(provider)}`,
 				method: "DELETE",
 			}),
+			// Provider governance is now backed by wildcard model configs; refresh the Model Limits view too.
+			invalidatesTags: ["ModelConfigs"],
 			async onQueryStarted(provider, { dispatch, queryFulfilled }) {
 				try {
 					await queryFulfilled;


### PR DESCRIPTION
## Summary

Provider-level governance (budget and rate limit) has been migrated from `config_providers.budget_id / rate_limit_id` into `governance_model_configs` as wildcard rows with `scope='global'`, `model_name='*'`, and `provider=<name>`. This makes `governance_model_configs` the single source of truth for all governance enforcement, eliminating the separate provider-governance enforcement path.

## Changes

- **Database migration** (`migrationMigrateProviderGovernanceToModelConfigs`): Folds existing provider-level budget/rate-limit FK references into new `(global, *, <provider>)` model config rows, reusing the same budget/rate-limit rows. Provider FKs are then nulled out. The migration is idempotent and includes a rollback path.
- **`ModelConfigAllModels = "*"` sentinel**: Introduced as a named constant to represent "all models" in a model config row. The `"*"` sentinel is excluded from catalog-based model name normalization.
- **`collectModelConfigsFor`**: New helper that resolves all applicable model configs for a request across four tiers — exact model+provider, exact model (all providers), all models on this provider (`*:provider`), and all models on all providers (`*:nil`) — deduped by config ID. All budget/rate-limit check and usage-tracking paths now use this helper instead of duplicating two-tier lookup logic.
- **`modelConfigEntityKey`**: New helper that builds a stable entity key for a model config, replacing ad-hoc `fmt.Sprintf` strings scattered across check and update functions.
- **`GetProviderGovernanceModelConfigs`**: New store method that queries the wildcard model config rows backing provider governance, with budget and rate-limit preloads.
- **`DeleteProvider` cleanup**: When a provider is deleted, its associated wildcard model configs (and their owned budget/rate-limit rows) are now cleaned up as part of the transaction.
- **Provider governance HTTP handlers**: `getProviderGovernance`, `updateProviderGovernance`, and `deleteProviderGovernance` are rewritten to operate on wildcard model config rows instead of provider FK columns. The GET endpoint gains a `from_memory` query parameter to serve data from the in-memory governance store.
- **UI**: The model limits table renders `"*"` as `"All Models"`. The model limit sheet exposes an `allowAllOption` on the model selector. RTK Query cache tags are cross-invalidated so that changes to model configs refresh the provider governance view and vice versa.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/...

# UI
cd ui
pnpm i
pnpm build
```

1. Start with a deployment that has providers with existing `budget_id` or `rate_limit_id` values. After the migration runs, verify those providers have `budget_id = NULL` and `rate_limit_id = NULL`, and that corresponding `(global, *, <provider>)` rows exist in `governance_model_configs` pointing to the same budget/rate-limit IDs.
2. Re-run the migration and confirm no duplicate wildcard rows are created (idempotency).
3. Make a request through a provider that had governance configured and confirm the budget/rate-limit is still enforced.
4. Use `GET /api/governance/providers` and `GET /api/governance/providers?from_memory=true` and confirm both return the expected provider governance data.
5. Use `PUT` and `DELETE` on `/api/governance/providers/{name}` and confirm the wildcard model config rows are created, updated, or removed accordingly, and that the Model Limits UI reflects the change without a manual refresh.
6. Delete a provider and confirm its wildcard model config and owned budget/rate-limit rows are removed.

## Breaking changes

- [x] Yes
- [ ] No

Provider governance is no longer stored in `config_providers.budget_id / rate_limit_id`. Any code or tooling that reads governance directly from the providers table will no longer find it there. All governance enforcement and management must go through `governance_model_configs`. The HTTP API surface is unchanged; the migration handles existing data automatically.

## Security considerations

Budget and rate-limit rows are reused (not duplicated) during migration. The rollback path restores FK references to the provider table and removes the wildcard model config rows, leaving no orphaned governance rows in either direction.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Governance policies can be configured for "All Models" on a specific provider, enabling provider-level budget and rate-limit controls.

* **UI Improvements**
  * Model limits table shows "All Models" for wildcard policies.
  * Model picker supports an "All" option for creating provider-scoped policies.
  * Changes now cause related views to refresh so updates appear immediately.

* **Bug Fixes**
  * Provider-scoped governance is applied and cleaned up reliably (including on provider removal).

* **Tests**
  * Added tests covering provider-scoped all-models governance and migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->