### PR TITLE
feat: wires vk top-level and provider-level budgets from model configs table

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -834,6 +834,12 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationMigrateProviderGovernanceToModelConfigs(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddBudgetModelConfigIDColumn(ctx, db); err != nil {
+		return err
+	}
+	if err := migrationAddModelConfigCalendarAlignedColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3988,6 +3994,297 @@ func migrationMigrateProviderGovernanceToModelConfigs(ctx context.Context, db *g
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running migrate provider governance to model configs migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddBudgetModelConfigIDColumn adds governance_budgets.model_config_id and
+// backfills it from the legacy single governance_model_configs.budget_id, inverting
+// budget ownership so a model config can own multiple budgets via the FK.
+func migrationAddBudgetModelConfigIDColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_budget_model_config_id_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+
+			if !mig.HasColumn(&tables.TableBudget{}, "model_config_id") {
+				if err := mig.AddColumn(&tables.TableBudget{}, "model_config_id"); err != nil {
+					return fmt.Errorf("failed to add model_config_id column: %w", err)
+				}
+			}
+
+			// Backfill from the legacy single budget_id. Idempotent via the IS NULL guard.
+			if !mig.HasColumn(&tables.TableModelConfig{}, "budget_id") {
+				return nil
+			}
+			var mcs []tables.TableModelConfig
+			if err := tx.Where("budget_id IS NOT NULL").Find(&mcs).Error; err != nil {
+				return fmt.Errorf("failed to load model configs with budgets: %w", err)
+			}
+			for i := range mcs {
+				mc := &mcs[i]
+				if mc.BudgetID == nil {
+					continue
+				}
+				if err := tx.Exec(
+					"UPDATE governance_budgets SET model_config_id = ? WHERE id = ? AND model_config_id IS NULL",
+					mc.ID, *mc.BudgetID,
+				).Error; err != nil {
+					return fmt.Errorf("failed to backfill model_config_id for budget %q: %w", *mc.BudgetID, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return fmt.Errorf("add_budget_model_config_id_column is non-rollbackable: dropping model_config_id would permanently lose multi-budget ownership data that cannot be recovered from the legacy single budget_id column")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add budget model_config_id column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// ensureVKWildcardModelConfig returns the ID of the VK-scoped all-models wildcard model
+// config, creating it if absent.
+func ensureVKWildcardModelConfig(tx *gorm.DB, vkID string, provider *string, calendarAligned bool, now time.Time) (string, error) {
+	q := tx.Model(&tables.TableModelConfig{}).
+		Where("scope = ? AND scope_id = ? AND model_name = ?",
+			tables.ModelConfigScopeVirtualKey, vkID, tables.ModelConfigAllModels)
+	if provider == nil {
+		q = q.Where("provider IS NULL")
+	} else {
+		q = q.Where("provider = ?", *provider)
+	}
+	var existing []tables.TableModelConfig
+	if err := q.Limit(1).Find(&existing).Error; err != nil {
+		return "", fmt.Errorf("failed to look up VK wildcard model config: %w", err)
+	}
+	if len(existing) > 0 {
+		return existing[0].ID, nil
+	}
+	mc := tables.TableModelConfig{
+		ID:              uuid.NewString(),
+		ModelName:       tables.ModelConfigAllModels,
+		Provider:        provider,
+		Scope:           tables.ModelConfigScopeVirtualKey,
+		ScopeID:         &vkID,
+		CalendarAligned: calendarAligned,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := tx.Create(&mc).Error; err != nil {
+		return "", fmt.Errorf("failed to create VK wildcard model config: %w", err)
+	}
+	return mc.ID, nil
+}
+
+// migrationMigrateVirtualKeyGovernanceToModelConfigs folds VK-level governance into
+// model_configs as VK-scoped all-models wildcard rows:
+//   - VK top-level budgets/rate-limit -> (scope=virtual_key, scope_id=vk, model_name='*', provider=NULL)
+//   - per-provider-config budgets/rate-limit -> (..., provider=<that provider>)
+func migrationMigrateVirtualKeyGovernanceToModelConfigs(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "migrate_virtual_key_governance_to_model_configs",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			// Required tables/columns must exist (scope columns + the new owner FK).
+			if !tx.Migrator().HasTable(&tables.TableModelConfig{}) ||
+				!tx.Migrator().HasColumn(&tables.TableModelConfig{}, "scope") ||
+				!tx.Migrator().HasColumn(&tables.TableBudget{}, "model_config_id") {
+				return nil
+			}
+
+			var vks []tables.TableVirtualKey
+			if err := tx.Preload("Budgets").Preload("ProviderConfigs").Preload("ProviderConfigs.Budgets").
+				Find(&vks).Error; err != nil {
+				return fmt.Errorf("failed to load virtual keys: %w", err)
+			}
+
+			now := time.Now()
+			for i := range vks {
+				vk := &vks[i]
+
+				// VK top-level governance -> all-providers wildcard.
+				if len(vk.Budgets) > 0 || vk.RateLimitID != nil {
+					mcID, err := ensureVKWildcardModelConfig(tx, vk.ID, nil, vk.CalendarAligned, now)
+					if err != nil {
+						return err
+					}
+					for _, b := range vk.Budgets {
+						if err := tx.Exec(
+							"UPDATE governance_budgets SET model_config_id = ?, virtual_key_id = NULL WHERE id = ? AND model_config_id IS NULL",
+							mcID, b.ID,
+						).Error; err != nil {
+							return fmt.Errorf("failed to reparent VK budget %q: %w", b.ID, err)
+						}
+					}
+					if vk.RateLimitID != nil {
+						if err := tx.Exec("UPDATE governance_model_configs SET rate_limit_id = ? WHERE id = ?", *vk.RateLimitID, mcID).Error; err != nil {
+							return fmt.Errorf("failed to move VK rate limit to model config: %w", err)
+						}
+						if err := tx.Exec("UPDATE governance_virtual_keys SET rate_limit_id = NULL WHERE id = ?", vk.ID).Error; err != nil {
+							return fmt.Errorf("failed to clear VK rate limit FK: %w", err)
+						}
+					}
+				}
+
+				// Per-provider-config governance -> provider-specific wildcard.
+				for j := range vk.ProviderConfigs {
+					pc := &vk.ProviderConfigs[j]
+					if len(pc.Budgets) == 0 && pc.RateLimitID == nil {
+						continue
+					}
+					provider := pc.Provider
+					mcID, err := ensureVKWildcardModelConfig(tx, vk.ID, &provider, vk.CalendarAligned, now)
+					if err != nil {
+						return err
+					}
+					for _, b := range pc.Budgets {
+						if err := tx.Exec(
+							"UPDATE governance_budgets SET model_config_id = ?, provider_config_id = NULL WHERE id = ? AND model_config_id IS NULL",
+							mcID, b.ID,
+						).Error; err != nil {
+							return fmt.Errorf("failed to reparent provider-config budget %q: %w", b.ID, err)
+						}
+					}
+					if pc.RateLimitID != nil {
+						if err := tx.Exec("UPDATE governance_model_configs SET rate_limit_id = ? WHERE id = ?", *pc.RateLimitID, mcID).Error; err != nil {
+							return fmt.Errorf("failed to move provider-config rate limit to model config: %w", err)
+						}
+						if err := tx.Exec("UPDATE governance_virtual_key_provider_configs SET rate_limit_id = NULL WHERE id = ?", pc.ID).Error; err != nil {
+							return fmt.Errorf("failed to clear provider-config rate limit FK: %w", err)
+						}
+					}
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if !tx.Migrator().HasTable(&tables.TableModelConfig{}) ||
+				!tx.Migrator().HasColumn(&tables.TableModelConfig{}, "scope") {
+				return nil
+			}
+
+			// Only the VK-scoped all-models wildcards this migration creates.
+			var mcs []tables.TableModelConfig
+			if err := tx.Where("scope = ? AND model_name = ?",
+				tables.ModelConfigScopeVirtualKey, tables.ModelConfigAllModels).Find(&mcs).Error; err != nil {
+				return fmt.Errorf("failed to load VK wildcard model configs: %w", err)
+			}
+
+			for i := range mcs {
+				mc := &mcs[i]
+				if mc.ScopeID == nil {
+					continue
+				}
+				var budgets []tables.TableBudget
+				if err := tx.Where("model_config_id = ?", mc.ID).Find(&budgets).Error; err != nil {
+					return fmt.Errorf("failed to load budgets for model config %q: %w", mc.ID, err)
+				}
+
+				if mc.Provider == nil {
+					// VK top-level: restore VK ownership + rate limit.
+					for _, b := range budgets {
+						if err := tx.Exec("UPDATE governance_budgets SET virtual_key_id = ?, model_config_id = NULL WHERE id = ?", *mc.ScopeID, b.ID).Error; err != nil {
+							return fmt.Errorf("failed to restore VK budget %q: %w", b.ID, err)
+						}
+					}
+					if mc.RateLimitID != nil {
+						if err := tx.Exec("UPDATE governance_virtual_keys SET rate_limit_id = ? WHERE id = ?", *mc.RateLimitID, *mc.ScopeID).Error; err != nil {
+							return fmt.Errorf("failed to restore VK rate limit: %w", err)
+						}
+					}
+				} else {
+					// Provider-specific: find the matching provider config to restore onto.
+					var pcs []tables.TableVirtualKeyProviderConfig
+					if err := tx.Where("virtual_key_id = ? AND provider = ?", *mc.ScopeID, *mc.Provider).
+						Limit(1).Find(&pcs).Error; err != nil {
+						return fmt.Errorf("failed to find provider config for VK %q provider %q: %w", *mc.ScopeID, *mc.Provider, err)
+					}
+					if len(pcs) > 0 {
+						pcID := pcs[0].ID
+						for _, b := range budgets {
+							if err := tx.Exec("UPDATE governance_budgets SET provider_config_id = ?, model_config_id = NULL WHERE id = ?", pcID, b.ID).Error; err != nil {
+								return fmt.Errorf("failed to restore provider-config budget %q: %w", b.ID, err)
+							}
+						}
+						if mc.RateLimitID != nil {
+							if err := tx.Exec("UPDATE governance_virtual_key_provider_configs SET rate_limit_id = ? WHERE id = ?", *mc.RateLimitID, pcID).Error; err != nil {
+								return fmt.Errorf("failed to restore provider-config rate limit: %w", err)
+							}
+						}
+					}
+				}
+
+				if err := tx.Delete(&tables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
+					return fmt.Errorf("failed to delete VK wildcard model config %q: %w", mc.ID, err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running migrate virtual key governance to model configs migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddModelConfigCalendarAlignedColumn adds governance_model_configs.calendar_aligned
+// and backfills VK-scoped wildcards from their owning virtual key. Budgets folded out of a
+// calendar-aligned VK then keep snapping resets to calendar boundaries.
+func migrationAddModelConfigCalendarAlignedColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_model_config_calendar_aligned_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+
+			if !mig.HasColumn(&tables.TableModelConfig{}, "calendar_aligned") {
+				if err := mig.AddColumn(&tables.TableModelConfig{}, "calendar_aligned"); err != nil {
+					return fmt.Errorf("failed to add calendar_aligned column: %w", err)
+				}
+			}
+
+			// Backfill VK-scoped configs from their owning VK.
+			type vkRow struct {
+				ID              string
+				CalendarAligned bool
+			}
+			var rows []vkRow
+			if err := tx.Table("governance_virtual_keys").Select("id, calendar_aligned").Scan(&rows).Error; err != nil {
+				return fmt.Errorf("failed to load virtual keys for calendar_aligned backfill: %w", err)
+			}
+			for _, r := range rows {
+				if !r.CalendarAligned {
+					continue // default is already false
+				}
+				if err := tx.Exec(
+					"UPDATE governance_model_configs SET calendar_aligned = ? WHERE scope = ? AND scope_id = ?",
+					true, tables.ModelConfigScopeVirtualKey, r.ID,
+				).Error; err != nil {
+					return fmt.Errorf("failed to backfill calendar_aligned for VK %q: %w", r.ID, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if mig.HasColumn(&tables.TableModelConfig{}, "calendar_aligned") {
+				if err := mig.DropColumn(&tables.TableModelConfig{}, "calendar_aligned"); err != nil {
+					return fmt.Errorf("failed to drop calendar_aligned column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add model config calendar_aligned column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1155,15 +1155,20 @@ func (s *RDBConfigStore) DeleteProvider(ctx context.Context, provider schemas.Mo
 		}
 	}
 
-	// Clean up model configs scoped to this provider
+	// Clean up model configs scoped to this provider (and their owned budgets/rate-limits).
 	// Delete by snapshotted IDs rather than a second WHERE provider=? pass to avoid a race
 	// where a concurrent CreateModelConfig lands between the snapshot and the delete, leaving
 	// its owned budget/rate-limit rows dangling.
 	var providerModelConfigs []tables.TableModelConfig
-	if err := txDB.WithContext(ctx).Where("provider = ?", string(provider)).Find(&providerModelConfigs).Error; err != nil {
+	if err := txDB.WithContext(ctx).Preload("Budgets").Where("provider = ?", string(provider)).Find(&providerModelConfigs).Error; err != nil {
 		return err
 	}
 	for _, mc := range providerModelConfigs {
+		for i := range mc.Budgets {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", mc.Budgets[i].ID).Error; err != nil {
+				return err
+			}
+		}
 		if mc.BudgetID != nil {
 			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *mc.BudgetID).Error; err != nil {
 				return err
@@ -2997,6 +3002,12 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...
 		budgetIDs := make([]string, 0, len(scopedModelConfigs))
 		rateLimitIDs := make([]string, 0, len(scopedModelConfigs))
 		for _, mc := range scopedModelConfigs {
+			// Owned budgets via ModelConfigID plus the legacy single BudgetID for safety.
+			for i := range mc.Budgets {
+				if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", mc.Budgets[i].ID).Error; err != nil {
+					return err
+				}
+			}
 			if mc.BudgetID != nil {
 				budgetIDs = append(budgetIDs, *mc.BudgetID)
 			}
@@ -4244,7 +4255,7 @@ func (s *RDBConfigStore) DeleteRoutingRule(ctx context.Context, id string, tx ..
 // GetModelConfigs retrieves all model configs from the database.
 func (s *RDBConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
 	var modelConfigs []tables.TableModelConfig
-	if err := s.DB().WithContext(ctx).Preload("Budget").Preload("RateLimit").Find(&modelConfigs).Error; err != nil {
+	if err := s.DB().WithContext(ctx).Preload("Budgets").Preload("Budget").Preload("RateLimit").Find(&modelConfigs).Error; err != nil {
 		return nil, err
 	}
 	return modelConfigs, nil
@@ -4254,7 +4265,7 @@ func (s *RDBConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableMod
 func (s *RDBConfigStore) GetProviderGovernanceModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
 	var modelConfigs []tables.TableModelConfig
 	if err := s.DB().WithContext(ctx).
-		Preload("Budget").Preload("RateLimit").
+		Preload("Budgets").Preload("Budget").Preload("RateLimit").
 		Where("scope = ? AND model_name = ? AND provider IS NOT NULL", tables.ModelConfigScopeGlobal, tables.ModelConfigAllModels).
 		Find(&modelConfigs).Error; err != nil {
 		return nil, err
@@ -4291,6 +4302,7 @@ func (s *RDBConfigStore) GetModelConfigsPaginated(ctx context.Context, params Mo
 
 	var modelConfigs []tables.TableModelConfig
 	if err := baseQuery.
+		Preload("Budgets").
 		Preload("Budget").
 		Preload("RateLimit").
 		Order("created_at DESC, id DESC").
@@ -4317,7 +4329,7 @@ func (s *RDBConfigStore) GetModelConfig(ctx context.Context, scope string, scope
 	} else {
 		query = query.Where("provider IS NULL")
 	}
-	if err := query.Preload("Budget").Preload("RateLimit").First(&modelConfig).Error; err != nil {
+	if err := query.Preload("Budgets").Preload("Budget").Preload("RateLimit").First(&modelConfig).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -4329,7 +4341,7 @@ func (s *RDBConfigStore) GetModelConfig(ctx context.Context, scope string, scope
 // GetModelConfigByID retrieves a specific model config from the database by ID.
 func (s *RDBConfigStore) GetModelConfigByID(ctx context.Context, id string) (*tables.TableModelConfig, error) {
 	var modelConfig tables.TableModelConfig
-	if err := s.DB().WithContext(ctx).Preload("Budget").Preload("RateLimit").First(&modelConfig, "id = ?", id).Error; err != nil {
+	if err := s.DB().WithContext(ctx).Preload("Budgets").Preload("Budget").Preload("RateLimit").First(&modelConfig, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -4370,7 +4382,9 @@ func (s *RDBConfigStore) UpdateModelConfig(ctx context.Context, modelConfig *tab
 			return err
 		}
 	}
-	if err := txDB.WithContext(ctx).Save(modelConfig).Error; err != nil {
+	// Omit associations: budgets (has-many via ModelConfigID) and rate-limit are managed
+	// explicitly by callers. A cascading Save would otherwise clobber their usage counters.
+	if err := txDB.WithContext(ctx).Omit(clause.Associations).Save(modelConfig).Error; err != nil {
 		return s.parseGormError(err)
 	}
 	return nil
@@ -4404,16 +4418,23 @@ func (s *RDBConfigStore) DeleteModelConfig(ctx context.Context, id string, tx ..
 	}
 
 	txDB := tx[0]
-	// First fetch the model config to get budget and rate limit IDs
+	// Fetch the model config with its owned budgets to collect all IDs to clean up.
 	var modelConfig tables.TableModelConfig
-	if err := dbForUpdate(txDB.WithContext(ctx)).First(&modelConfig, "id = ?", id).Error; err != nil {
+	if err := dbForUpdate(txDB.WithContext(ctx)).Preload("Budgets").First(&modelConfig, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ErrNotFound
 		}
 		return err
 	}
-	// Store the budget and rate limit IDs before deleting
-	budgetID := modelConfig.BudgetID
+	// Collect budget IDs from both the Budgets slice (active path, owned via ModelConfigID)
+	// and the legacy single BudgetID column.
+	budgetIDs := make([]string, 0, len(modelConfig.Budgets)+1)
+	for i := range modelConfig.Budgets {
+		budgetIDs = append(budgetIDs, modelConfig.Budgets[i].ID)
+	}
+	if modelConfig.BudgetID != nil {
+		budgetIDs = append(budgetIDs, *modelConfig.BudgetID)
+	}
 	rateLimitID := modelConfig.RateLimitID
 	// Delete the model config first
 	if err := txDB.WithContext(ctx).Delete(&tables.TableModelConfig{}, "id = ?", id).Error; err != nil {
@@ -4422,9 +4443,10 @@ func (s *RDBConfigStore) DeleteModelConfig(ctx context.Context, id string, tx ..
 		}
 		return s.parseGormError(err)
 	}
-	// Delete the budget if it exists
-	if budgetID != nil {
-		if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *budgetID).Error; err != nil {
+	// Delete the owned budgets (don't rely on FK cascade — it isn't applied to
+	// pre-existing tables on all dialects).
+	if len(budgetIDs) > 0 {
+		if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id IN ?", budgetIDs).Error; err != nil {
 			return err
 		}
 	}

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -15,10 +15,11 @@ type TableBudget struct {
 	LastReset     time.Time `gorm:"index" json:"last_reset"`                         // Last time budget was reset
 	CurrentUsage  float64   `gorm:"default:0" json:"current_usage"`                  // Current usage in dollars
 
-	// Owner FKs: a budget belongs to at most one Team, one VK, or one ProviderConfig
+	// Owner FKs: a budget belongs to at most one Team, one VK, one ProviderConfig, or one ModelConfig
 	TeamID           *string `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
 	VirtualKeyID     *string `gorm:"type:varchar(255);index" json:"virtual_key_id,omitempty"`
 	ProviderConfigID *uint   `gorm:"index" json:"provider_config_id,omitempty"`
+	ModelConfigID    *string `gorm:"type:varchar(255);index" json:"model_config_id,omitempty"`
 
 	// Deprecated: set calendar_aligned on the parent access profile / VK / team
 	// instead. Kept for backward compatibility with older config.json files;
@@ -57,8 +58,11 @@ func (b *TableBudget) BeforeSave(tx *gorm.DB) error {
 	if b.ProviderConfigID != nil {
 		owners++
 	}
+	if b.ModelConfigID != nil {
+		owners++
+	}
 	if owners > 1 {
-		return fmt.Errorf("budget cannot have more than one owner (team/virtual key/provider config)")
+		return fmt.Errorf("budget cannot have more than one owner (team/virtual key/provider config/model config)")
 	}
 	// Validate that ResetDuration is in correct format (e.g., "30s", "5m", "1h", "1d", "1w", "1M", "1Y")
 	if d, err := ParseDuration(b.ResetDuration); err != nil {

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -38,9 +38,13 @@ type TableModelConfig struct {
 	// Scope determines where this config applies: "global" (default) or "virtual_key".
 	Scope string `gorm:"type:varchar(50);not null;default:'global';uniqueIndex:idx_model_scope_provider,priority:1" json:"scope"`
 	// ScopeID is the target of a non-global scope (e.g. the virtual key ID). NULL for global.
-	ScopeID     *string `gorm:"type:varchar(255);uniqueIndex:idx_model_scope_provider,priority:2" json:"scope_id,omitempty"`
-	BudgetID    *string `gorm:"type:varchar(255);index:idx_model_config_budget" json:"budget_id,omitempty"`
-	RateLimitID *string `gorm:"type:varchar(255);index:idx_model_config_rate_limit" json:"rate_limit_id,omitempty"`
+	ScopeID *string `gorm:"type:varchar(255);uniqueIndex:idx_model_scope_provider,priority:2" json:"scope_id,omitempty"`
+	// CalendarAligned snaps this config's budget resets to calendar boundaries (e.g. a
+	// monthly budget resets on the 1st) rather than rolling windows. Propagated to owned
+	// budgets via AfterFind. For virtual_key-scoped configs it inherits the VK's setting.
+	CalendarAligned bool    `gorm:"not null;default:false" json:"calendar_aligned"`
+	BudgetID        *string `gorm:"type:varchar(255);index:idx_model_config_budget" json:"budget_id,omitempty"`
+	RateLimitID     *string `gorm:"type:varchar(255);index:idx_model_config_rate_limit" json:"rate_limit_id,omitempty"`
 
 	// ScopeName is a non-persisted, API-only field carrying the human-readable name of
 	// the scope target (e.g. the virtual key's name) so the UI can render a label
@@ -48,6 +52,13 @@ type TableModelConfig struct {
 	ScopeName string `gorm:"-" json:"scope_name,omitempty"`
 
 	// Relationships
+	// Budgets are owned by this model config via TableBudget.ModelConfigID (a model
+	// config may carry multiple budgets with different reset windows). This is the
+	// active representation. The legacy single Budget/BudgetID below is kept inert
+	// for backward compatibility and is no longer read by enforcement.
+	Budgets []TableBudget `gorm:"foreignKey:ModelConfigID;constraint:OnDelete:CASCADE" json:"budgets,omitempty"`
+	// Legacy (inert): superseded by Budgets. Retained so existing rows/columns keep
+	// parsing; not read by the governance store after the multi-budget cutover.
 	Budget    *TableBudget    `gorm:"foreignKey:BudgetID;onDelete:CASCADE" json:"budget,omitempty"`
 	RateLimit *TableRateLimit `gorm:"foreignKey:RateLimitID;onDelete:CASCADE" json:"rate_limit,omitempty"`
 
@@ -62,6 +73,16 @@ type TableModelConfig struct {
 // TableName sets the table name for each model
 func (TableModelConfig) TableName() string {
 	return "governance_model_configs"
+}
+
+// AfterFind propagates calendar_aligned down to owned budgets so the reset path reads
+// the stamped value off each budget. Mirrors TableTeam/TableVirtualKey. The governance
+// store's Update*InMemory paths re-stamp on every model-config update.
+func (mc *TableModelConfig) AfterFind(tx *gorm.DB) error {
+	for i := range mc.Budgets {
+		mc.Budgets[i].IsCalendarAligned = mc.CalendarAligned
+	}
+	return nil
 }
 
 // BeforeSave hook for ModelConfig to validate required fields

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -218,6 +218,74 @@ func TestStore_CheckModelBudget_ModelOnly_Exceeded(t *testing.T) {
 	assert.Contains(t, err.Error(), "budget exceeded")
 }
 
+// buildModelConfigMultiBudget builds a global model config owning multiple budgets
+// (via TableBudget.ModelConfigID), for multi-budget enforcement tests.
+func buildModelConfigMultiBudget(id, model string, provider *string, budgets []*configstoreTables.TableBudget) *configstoreTables.TableModelConfig {
+	mc := &configstoreTables.TableModelConfig{
+		ID:        id,
+		ModelName: model,
+		Provider:  provider,
+		Scope:     configstoreTables.ModelConfigScopeGlobal,
+	}
+	for _, b := range budgets {
+		b.ModelConfigID = &mc.ID
+		mc.Budgets = append(mc.Budgets, *b)
+	}
+	return mc
+}
+
+func TestStore_CheckModelBudget_MultiBudget_OneExceededBlocks(t *testing.T) {
+	logger := NewMockLogger()
+	within := buildBudget("b-day", 100.0, "1d")             // plenty of headroom
+	exceeded := buildBudgetWithUsage("b-hour", 10.0, 10.0, "1h") // at limit
+	mc := buildModelConfigMultiBudget("mc-multi", "gpt-4", nil, []*configstoreTables.TableBudget{within, exceeded})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*within, *exceeded},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	assert.Error(t, err, "the exceeded budget among several on one config must block")
+	assert.Contains(t, err.Error(), "budget exceeded")
+}
+
+func TestStore_CheckModelBudget_MultiBudget_AllWithinPasses(t *testing.T) {
+	logger := NewMockLogger()
+	b1 := buildBudget("b-day", 100.0, "1d")
+	b2 := buildBudget("b-hour", 10.0, "1h")
+	mc := buildModelConfigMultiBudget("mc-multi", "gpt-4", nil, []*configstoreTables.TableBudget{b1, b2})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*b1, *b2},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	assert.NoError(t, err, "all budgets within limit should pass")
+}
+
+func TestStore_UpdateModelBudgetUsage_MultiBudget_BumpsAll(t *testing.T) {
+	logger := NewMockLogger()
+	b1 := buildBudget("b-day", 100.0, "1d")
+	b2 := buildBudget("b-hour", 50.0, "1h")
+	mc := buildModelConfigMultiBudget("mc-multi", "gpt-4", nil, []*configstoreTables.TableBudget{b1, b2})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*b1, *b2},
+	}, nil)
+	require.NoError(t, err)
+
+	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "gpt-4", schemas.OpenAI, 7.5)
+	require.NoError(t, err)
+
+	for _, id := range []string{"b-day", "b-hour"} {
+		b := store.LoadBudget(context.Background(), id)
+		require.NotNil(t, b, "budget %s should be loadable", id)
+		assert.InDelta(t, 7.5, b.CurrentUsage, 0.001, "every budget on the config must be bumped (budget %s)", id)
+	}
+}
+
 func TestStore_CheckModelBudget_ModelWithProvider_WithinLimit(t *testing.T) {
 	logger := NewMockLogger()
 	budget := buildBudget("budget1", 100.0, "1h")
@@ -2351,4 +2419,60 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_BudgetTrips(t *testing.T) {
 
 	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, req, nil)
 	assert.Error(t, err, "scoped budget should trip once usage exceeds the cap")
+}
+
+// TestStore_VKGovernanceBudget_NoDoubleCount is the double-count guard: after the cutover a
+// VK's budget lives only on its VK-scoped all-models wildcard model config (vk.Budgets is
+// empty). The tracker invokes both the scoped-model path and the VK hierarchy path on every
+// request; only the scoped path may charge the budget — never both.
+func TestStore_VKGovernanceBudget_NoDoubleCount(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKey("vk1", "vk1-value", "vk1", true)
+	vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{buildProviderConfig("openai", []string{"*"})}
+	budget := buildBudget("vkb", 100.0, "1h")
+	// Owned by the VK-scoped all-models wildcard (provider=nil), not by the VK directly.
+	mc := buildVKScopedModelConfig("mc-vk", "*", nil, vk.ID, budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	// Mirror tracker.UpdateUsage: scoped-model path + hierarchy path, same request/cost.
+	require.NoError(t, store.UpdateVirtualKeyScopedModelBudgetUsageInMemory(context.Background(), vk, "gpt-4", schemas.OpenAI, 10.0))
+	require.NoError(t, store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 10.0))
+
+	b := store.LoadBudget(context.Background(), "vkb")
+	require.NotNil(t, b)
+	assert.InDelta(t, 10.0, b.CurrentUsage, 0.001, "VK governance budget must be charged exactly once (no hierarchy+scoped double count)")
+}
+
+// TestStore_CheckVirtualKeyScopedModelBudget_MultiBudget_OneExceededBlocks exercises the
+// scope-chain path that production VK governance flows through after cutover, with multiple
+// budgets on one VK-scoped wildcard config.
+func TestStore_CheckVirtualKeyScopedModelBudget_MultiBudget_OneExceededBlocks(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKey("vk1", "vk1-value", "vk1", true)
+	within := buildBudget("b-day", 100.0, "1d")
+	exceeded := buildBudgetWithUsage("b-hour", 10.0, 10.0, "1h")
+	mcID := "mc-vk-multi"
+	mc := &configstoreTables.TableModelConfig{
+		ID:        mcID,
+		ModelName: configstoreTables.ModelConfigAllModels,
+		Scope:     configstoreTables.ModelConfigScopeVirtualKey,
+		ScopeID:   &vk.ID,
+	}
+	for _, b := range []*configstoreTables.TableBudget{within, exceeded} {
+		b.ModelConfigID = &mcID
+		mc.Budgets = append(mc.Budgets, *b)
+	}
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*within, *exceeded},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	assert.Error(t, err, "an exceeded budget among several on a VK-scoped config must block")
 }

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -744,15 +744,18 @@ func (gs *LocalGovernanceStore) GetGovernanceData(ctx context.Context) *Governan
 		if !ok || mc == nil {
 			return true // continue
 		}
-		// Cross-reference live budget/rate limit from standalone maps
-		// (usage updates clone into budgets/rateLimits maps, so embedded pointers go stale)
+		// Cross-reference live budgets/rate limit from standalone maps.
 		clone := *mc
-		if clone.BudgetID != nil {
-			if liveBudget, exists := gs.budgets.Load(*clone.BudgetID); exists && liveBudget != nil {
-				if b, ok := liveBudget.(*configstoreTables.TableBudget); ok {
-					clone.Budget = b
+		if len(clone.Budgets) > 0 {
+			liveBudgets := make([]configstoreTables.TableBudget, 0, len(clone.Budgets))
+			for _, b := range clone.Budgets {
+				if lb, exists := gs.budgets.Load(b.ID); exists && lb != nil {
+					if budget, ok := lb.(*configstoreTables.TableBudget); ok {
+						liveBudgets = append(liveBudgets, *budget)
+					}
 				}
 			}
+			clone.Budgets = liveBudgets
 		}
 		if clone.RateLimitID != nil {
 			if liveRL, exists := gs.rateLimits.Load(*clone.RateLimitID); exists && liveRL != nil {
@@ -1140,6 +1143,20 @@ func modelConfigEntityKey(mc *configstoreTables.TableModelConfig) string {
 	return key
 }
 
+// loadModelConfigBudgets returns the hot in-memory budget rows owned by a model config
+func (gs *LocalGovernanceStore) loadModelConfigBudgets(ctx context.Context, mc *configstoreTables.TableModelConfig) []*configstoreTables.TableBudget {
+	if mc == nil || len(mc.Budgets) == 0 {
+		return nil
+	}
+	out := make([]*configstoreTables.TableBudget, 0, len(mc.Budgets))
+	for i := range mc.Budgets {
+		if budget := gs.LoadBudget(ctx, mc.Budgets[i].ID); budget != nil {
+			out = append(out, budget)
+		}
+	}
+	return out
+}
+
 // CheckModelBudget performs budget checking for global-scope model-level configs, across all
 // four tiers (exact model±provider and all-models "*"±provider).
 func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
@@ -1149,11 +1166,8 @@ func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *E
 	model, provider := modelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
-		if mc.BudgetID == nil {
-			continue
-		}
-		if budget := gs.LoadBudget(ctx, *mc.BudgetID); budget != nil {
-			entityWiseBudgets[modelConfigEntityKey(mc)] = []*configstoreTables.TableBudget{budget}
+		if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
+			entityWiseBudgets[modelConfigEntityKey(mc)] = budgets
 		}
 	}
 	return gs.CheckBudget(ctx, entityWiseBudgets, baselines)
@@ -1307,11 +1321,8 @@ func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelBudget(ctx context.Con
 	entityWiseBudgets := EntityWiseBudgets{}
 	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
 		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, provider) {
-			if mc.BudgetID == nil {
-				continue
-			}
-			if budget := gs.LoadBudget(ctx, *mc.BudgetID); budget != nil {
-				entityWiseBudgets[modelConfigEntityKey(mc)] = []*configstoreTables.TableBudget{budget}
+			if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
+				entityWiseBudgets[modelConfigEntityKey(mc)] = budgets
 			}
 		}
 	}
@@ -1407,11 +1418,10 @@ func (gs *LocalGovernanceStore) UpdateProviderAndModelBudgetUsageInMemory(ctx co
 		providerStr = &p
 	}
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
-		if mc.BudgetID == nil {
-			continue
-		}
-		if err := gs.BumpBudgetUsage(ctx, *mc.BudgetID, cost); err != nil {
-			return err
+		for i := range mc.Budgets {
+			if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1471,11 +1481,10 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelBudgetUsageInMemory(c
 	}
 	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
 		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
-			if mc.BudgetID == nil {
-				continue
-			}
-			if err := gs.BumpBudgetUsage(ctx, *mc.BudgetID, cost); err != nil {
-				return err
+			for i := range mc.Budgets {
+				if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -1960,11 +1969,20 @@ func (gs *LocalGovernanceStore) loadFromConfigMemory(ctx context.Context, config
 	// Load routing rules
 	routingRules := config.RoutingRules
 
-	// Populate model configs with their relationships (Budget and RateLimit)
+	// Populate model configs with their relationships (Budgets and RateLimit)
 	for i := range modelConfigs {
 		mc := &modelConfigs[i]
 
-		// Populate budget
+		// Populate multi-budgets owned via TableBudget.ModelConfigID (the active path).
+		if len(mc.Budgets) == 0 {
+			for j := range budgets {
+				if budgets[j].ModelConfigID != nil && *budgets[j].ModelConfigID == mc.ID {
+					mc.Budgets = append(mc.Budgets, budgets[j])
+				}
+			}
+		}
+
+		// Legacy single-budget linking (inert; kept for backward-compatible config.json).
 		if mc.BudgetID != nil {
 			for j := range budgets {
 				if budgets[j].ID == *mc.BudgetID {
@@ -2112,6 +2130,13 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 	// (e.g., "openai/gpt-4o" and "gpt-4o" both store under base "gpt-4o").
 	for i := range modelConfigs {
 		mc := &modelConfigs[i]
+		// Stamp calendar alignment onto owned budgets and rate limit so the reset path
+		// reads the right window (the flat budgets/rate-limits list lacks owner context).
+		// Mirrors how VK/team budgets are stamped from their owner.
+		for j := range mc.Budgets {
+			mc.Budgets[j].IsCalendarAligned = mc.CalendarAligned
+			gs.budgets.Store(mc.Budgets[j].ID, &mc.Budgets[j])
+		}
 		scopeID := ""
 		if mc.ScopeID != nil {
 			scopeID = *mc.ScopeID
@@ -2448,40 +2473,44 @@ func (gs *LocalGovernanceStore) CollectApplicableGovernanceIDs(ctx context.Conte
 		}
 	}
 
-	// --- Model-level ---
-	if model != "" {
-		// model+provider specific config
-		if provider != "" {
-			key := fmt.Sprintf("%s:%s", model, string(provider))
-			if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-				if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil {
-					if mc.BudgetID != nil && !seenBudgets[*mc.BudgetID] {
-						budgetIDs = append(budgetIDs, *mc.BudgetID)
-						seenBudgets[*mc.BudgetID] = true
-					}
-					if mc.RateLimitID != nil && !seenRateLimits[*mc.RateLimitID] {
-						rateLimitIDs = append(rateLimitIDs, *mc.RateLimitID)
-						seenRateLimits[*mc.RateLimitID] = true
-					}
-				}
+	var providerStr *string
+	if provider != "" {
+		p := string(provider)
+		providerStr = &p
+	}
+	// addModelConfigIDs accumulates the (multi-)budget and rate-limit IDs owned by a
+	// model config, matching what the enforcement/recording paths count.
+	addModelConfigIDs := func(mc *configstoreTables.TableModelConfig) {
+		for i := range mc.Budgets {
+			if id := mc.Budgets[i].ID; !seenBudgets[id] {
+				budgetIDs = append(budgetIDs, id)
+				seenBudgets[id] = true
 			}
 		}
-		// model-only config
-		if mc, _ := gs.findModelOnlyConfig(ctx, model); mc != nil {
-			if mc.BudgetID != nil && !seenBudgets[*mc.BudgetID] {
-				budgetIDs = append(budgetIDs, *mc.BudgetID)
-				seenBudgets[*mc.BudgetID] = true
-			}
-			if mc.RateLimitID != nil && !seenRateLimits[*mc.RateLimitID] {
-				rateLimitIDs = append(rateLimitIDs, *mc.RateLimitID)
-				seenRateLimits[*mc.RateLimitID] = true
-			}
+		if mc.RateLimitID != nil && !seenRateLimits[*mc.RateLimitID] {
+			rateLimitIDs = append(rateLimitIDs, *mc.RateLimitID)
+			seenRateLimits[*mc.RateLimitID] = true
 		}
 	}
 
-	// --- VK hierarchy (provider-config → VK → team → customer) ---
+	// --- Model-level (global scope), all four tiers incl. provider/all-models wildcards ---
+	if model != "" {
+		for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
+			addModelConfigIDs(mc)
+		}
+	}
+
+	// --- VK hierarchy (VK-scoped model configs + team/customer) ---
 	if virtualKey != "" {
 		if vk, exists := gs.GetVirtualKey(ctx, virtualKey); exists && vk != nil {
+			// VK-scoped model configs (provider-level + all-models wildcards).
+			if model != "" {
+				for _, scope := range nonGlobalModelConfigScopeChain(vk) {
+					for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
+						addModelConfigIDs(mc)
+					}
+				}
+			}
 			for _, id := range gs.collectBudgetIDsFromMemory(ctx, vk, provider) {
 				if !seenBudgets[id] {
 					budgetIDs = append(budgetIDs, id)
@@ -2771,8 +2800,8 @@ func (gs *LocalGovernanceStore) DeleteVirtualKeyInMemory(ctx context.Context, vk
 			return true
 		}
 		if mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ScopeID != nil && *mc.ScopeID == vkID {
-			if mc.BudgetID != nil {
-				gs.DeleteBudget(ctx, *mc.BudgetID)
+			for i := range mc.Budgets {
+				gs.DeleteBudget(ctx, mc.Budgets[i].ID)
 			}
 			if mc.RateLimitID != nil {
 				gs.DeleteRateLimit(ctx, *mc.RateLimitID)
@@ -3080,14 +3109,18 @@ func (gs *LocalGovernanceStore) UpdateModelConfigInMemory(ctx context.Context, m
 	// Clone to avoid modifying the original
 	clone := *mc
 
-	// Store associated budget if exists, preserving existing in-memory usage
-	if clone.Budget != nil {
-		if existingBudgetValue, exists := gs.budgets.Load(clone.Budget.ID); exists && existingBudgetValue != nil {
+	// Store associated budgets, preserving existing in-memory usage per budget ID and
+	// stamping calendar alignment from the model config (consumed by the reset path).
+	for i := range clone.Budgets {
+		b := &clone.Budgets[i]
+		b.IsCalendarAligned = clone.CalendarAligned
+		if existingBudgetValue, exists := gs.budgets.Load(b.ID); exists && existingBudgetValue != nil {
 			if eb, ok := existingBudgetValue.(*configstoreTables.TableBudget); ok && eb != nil {
-				clone.Budget.CurrentUsage = eb.CurrentUsage
+				b.CurrentUsage = eb.CurrentUsage
+				b.LastReset = eb.LastReset
 			}
 		}
-		gs.budgets.Store(clone.Budget.ID, clone.Budget)
+		gs.budgets.Store(b.ID, b)
 	}
 
 	// Store associated rate limit if exists, preserving existing in-memory usage
@@ -3137,9 +3170,9 @@ func (gs *LocalGovernanceStore) DeleteModelConfigInMemory(ctx context.Context, m
 		}
 
 		if mc.ID == mcID {
-			// Delete associated budget if exists
-			if mc.BudgetID != nil {
-				gs.DeleteBudget(ctx, *mc.BudgetID)
+			// Delete associated budgets if any
+			for i := range mc.Budgets {
+				gs.DeleteBudget(ctx, mc.Budgets[i].ID)
 			}
 
 			// Delete associated rate limit if exists
@@ -3482,62 +3515,7 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 
 	// Check model-specific rate limits and budgets (takes precedence)
 	if model != "" {
-		// Check model+provider config first (most specific)
-		key := fmt.Sprintf("%s:%s", model, string(provider))
-		if modelValue, ok := gs.modelConfigs.Load(key); ok && modelValue != nil {
-			if modelConfig, ok := modelValue.(*configstoreTables.TableModelConfig); ok && modelConfig != nil {
-				// Get rate limit status
-				if modelConfig.RateLimitID != nil {
-					if rateLimitValue, ok := gs.rateLimits.Load(*modelConfig.RateLimitID); ok && rateLimitValue != nil {
-						if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
-							tokensBaseline, exists := tokenBaselines[rateLimit.ID]
-							if !exists {
-								tokensBaseline = 0
-							}
-							requestsBaseline, exists := requestBaselines[rateLimit.ID]
-							if !exists {
-								requestsBaseline = 0
-							}
-							// Calculate token percent used
-							if rateLimit.TokenMaxLimit != nil && *rateLimit.TokenMaxLimit > 0 {
-								tokenPercent := float64(rateLimit.TokenCurrentUsage+tokensBaseline) / float64(*rateLimit.TokenMaxLimit) * 100
-								if tokenPercent > result.RateLimitTokenPercentUsed {
-									result.RateLimitTokenPercentUsed = tokenPercent
-								}
-							}
-							// Calculate request percent used
-							if rateLimit.RequestMaxLimit != nil && *rateLimit.RequestMaxLimit > 0 {
-								requestPercent := float64(rateLimit.RequestCurrentUsage+requestsBaseline) / float64(*rateLimit.RequestMaxLimit) * 100
-								if requestPercent > result.RateLimitRequestPercentUsed {
-									result.RateLimitRequestPercentUsed = requestPercent
-								}
-							}
-						}
-					}
-				}
-				// Get budget status
-				if modelConfig.BudgetID != nil {
-					if budgetValue, ok := gs.budgets.Load(*modelConfig.BudgetID); ok && budgetValue != nil {
-						if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-							baseline, exists := budgetBaselines[budget.ID]
-							if !exists {
-								baseline = 0
-							}
-							if budget.MaxLimit > 0 {
-								budgetPercent := float64(budget.CurrentUsage+baseline) / budget.MaxLimit * 100
-								if budgetPercent > result.BudgetPercentUsed {
-									result.BudgetPercentUsed = budgetPercent
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		// Fall back to model-only config (if exists)
-		// Uses findModelOnlyConfig for cross-provider model name normalization
-		if modelConfig, _ := gs.findModelOnlyConfig(ctx, model); modelConfig != nil {
+		if modelConfig, _ := gs.findScopedModelOnlyConfig(ctx, configstoreTables.ModelConfigScopeGlobal, "", model); modelConfig != nil {
 			// Get rate limit status
 			if modelConfig.RateLimitID != nil {
 				if rateLimitValue, ok := gs.rateLimits.Load(*modelConfig.RateLimitID); ok && rateLimitValue != nil {
@@ -3567,14 +3545,11 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 					}
 				}
 			}
-			// Get budget status
-			if modelConfig.BudgetID != nil {
-				if budgetValue, ok := gs.budgets.Load(*modelConfig.BudgetID); ok && budgetValue != nil {
+			// Get budget status (max percent across the config's budgets)
+			for bi := range modelConfig.Budgets {
+				if budgetValue, ok := gs.budgets.Load(modelConfig.Budgets[bi].ID); ok && budgetValue != nil {
 					if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-						baseline, exists := budgetBaselines[budget.ID]
-						if !exists {
-							baseline = 0
-						}
+						baseline := budgetBaselines[budget.ID]
 						if budget.MaxLimit > 0 {
 							budgetPercent := float64(budget.CurrentUsage+baseline) / budget.MaxLimit * 100
 							if budgetPercent > result.BudgetPercentUsed {

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -253,8 +253,9 @@ func buildModelConfig(id, modelName string, provider *string, budget *configstor
 		UpdatedAt: time.Now(),
 	}
 	if budget != nil {
-		mc.Budget = budget
-		mc.BudgetID = &budget.ID
+		// Model configs now own budgets via TableBudget.ModelConfigID (multi-budget).
+		budget.ModelConfigID = &mc.ID
+		mc.Budgets = []configstoreTables.TableBudget{*budget}
 	}
 	if rateLimit != nil {
 		mc.RateLimit = rateLimit

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -342,6 +342,385 @@ func isRateLimitRemovalRequest(req *UpdateRateLimitRequest) bool {
 		req.TokenResetDuration == nil && req.RequestResetDuration == nil
 }
 
+// reconcileModelConfigBudgets upserts the desired set of budgets owned by a model config
+// (via TableBudget.ModelConfigID), preserving usage on matched rows and deleting removed
+// ones. It mutates mc.Budgets to the reconciled set. The model config row must already
+// exist (callers create it first). Mirrors the VK/team multi-budget reconciliation.
+func (h *GovernanceHandler) reconcileModelConfigBudgets(ctx context.Context, tx *gorm.DB, mc *configstoreTables.TableModelConfig, requests []CreateBudgetRequest) error {
+	seenDurations := make(map[string]bool, len(requests))
+	for _, b := range requests {
+		if b.MaxLimit < 0 {
+			return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
+		}
+		if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
+			return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
+		}
+		if seenDurations[b.ResetDuration] {
+			return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
+		}
+		seenDurations[b.ResetDuration] = true
+	}
+
+	existingByID, existingByDuration := buildBudgetLookup(mc.Budgets, requests)
+	var reconciled []configstoreTables.TableBudget
+	matchedIDs := make(map[string]bool)
+	for _, b := range requests {
+		existing, found, err := findExistingBudget(b, existingByID, existingByDuration)
+		if err != nil {
+			return err
+		}
+		if found {
+			existing.MaxLimit = b.MaxLimit
+			existing.ResetDuration = b.ResetDuration
+			if err := validateBudget(&existing); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateBudget(ctx, &existing, tx); err != nil {
+				return err
+			}
+			reconciled = append(reconciled, existing)
+			matchedIDs[existing.ID] = true
+		} else {
+			budget := configstoreTables.TableBudget{
+				ID:            uuid.NewString(),
+				MaxLimit:      b.MaxLimit,
+				ResetDuration: b.ResetDuration,
+				LastReset:     budgetLastReset(mc.CalendarAligned, b.ResetDuration),
+				CurrentUsage:  0,
+				ModelConfigID: &mc.ID,
+			}
+			inheritUsageFromClosestShorterBudget(&budget, mc.Budgets, false)
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			reconciled = append(reconciled, budget)
+		}
+	}
+	// Delete budgets no longer present.
+	for _, existing := range mc.Budgets {
+		if !matchedIDs[existing.ID] {
+			if err := h.configStore.DeleteBudget(ctx, existing.ID, tx); err != nil {
+				return fmt.Errorf("failed to delete removed model config budget: %w", err)
+			}
+		}
+	}
+	mc.Budgets = reconciled
+	return nil
+}
+
+// vkWildcardDesired is the desired governance state for one VK-scoped all-models wildcard
+// model config (provider=nil for the VK top-level, or a specific provider). The *Provided
+// flags distinguish "leave unchanged" (false, used by partial VK updates) from "set to the
+// given value" (true). The rateLimit carries only the limit/duration fields (no ID/usage).
+type vkWildcardDesired struct {
+	provider          *string
+	budgetsProvided   bool
+	budgets           []CreateBudgetRequest
+	rateLimitProvided bool
+	rateLimitRemove   bool
+	rateLimit         *configstoreTables.TableRateLimit
+}
+
+// syncVKGovernanceToModelConfigs folds a virtual key's governance (top-level + per-provider
+// budgets/rate-limits) into VK-scoped all-models wildcard model configs, the single source of
+// truth. It upserts the top-level and per-provider wildcards and deletes wildcards for
+// providers no longer configured. Must run inside the VK create/update transaction.
+// reconcileProviders controls per-provider handling: true treats perProvider as the full
+// desired set (upserting them and deleting wildcards for absent providers); false leaves all
+// per-provider wildcards untouched (for a partial VK update that omits provider_configs).
+func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, top vkWildcardDesired, perProvider []vkWildcardDesired, reconcileProviders bool) error {
+	if err := h.upsertVKWildcard(ctx, tx, vk, top); err != nil {
+		return err
+	}
+	if !reconcileProviders {
+		return nil
+	}
+	keep := make(map[string]bool, len(perProvider))
+	for _, pg := range perProvider {
+		if pg.provider == nil {
+			continue
+		}
+		keep[*pg.provider] = true
+		if err := h.upsertVKWildcard(ctx, tx, vk, pg); err != nil {
+			return err
+		}
+	}
+	// Delete VK-scoped provider wildcards whose provider is no longer configured.
+	var existing []configstoreTables.TableModelConfig
+	if err := tx.Preload("Budgets").
+		Where("scope = ? AND scope_id = ? AND model_name = ? AND provider IS NOT NULL",
+			configstoreTables.ModelConfigScopeVirtualKey, vk.ID, configstoreTables.ModelConfigAllModels).
+		Find(&existing).Error; err != nil {
+		return err
+	}
+	for i := range existing {
+		mc := &existing[i]
+		if mc.Provider != nil && !keep[*mc.Provider] {
+			if err := h.deleteVKWildcardModelConfig(ctx, tx, mc); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// upsertVKWildcard reconciles a single VK-scoped wildcard model config to the desired state.
+func (h *GovernanceHandler) upsertVKWildcard(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, d vkWildcardDesired) error {
+	q := tx.Preload("Budgets").Where("scope = ? AND scope_id = ? AND model_name = ?",
+		configstoreTables.ModelConfigScopeVirtualKey, vk.ID, configstoreTables.ModelConfigAllModels)
+	if d.provider == nil {
+		q = q.Where("provider IS NULL")
+	} else {
+		q = q.Where("provider = ?", *d.provider)
+	}
+	var existingList []configstoreTables.TableModelConfig
+	if err := q.Limit(1).Find(&existingList).Error; err != nil {
+		return err
+	}
+	isNew := len(existingList) == 0
+
+	var mc configstoreTables.TableModelConfig
+	if isNew {
+		mc = configstoreTables.TableModelConfig{
+			ID:              uuid.NewString(),
+			ModelName:       configstoreTables.ModelConfigAllModels,
+			Provider:        d.provider,
+			Scope:           configstoreTables.ModelConfigScopeVirtualKey,
+			ScopeID:         &vk.ID,
+			CalendarAligned: vk.CalendarAligned,
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+	} else {
+		mc = existingList[0]
+		mc.CalendarAligned = vk.CalendarAligned // keep in sync with the owning VK
+	}
+
+	// Rate limit (mc references it via RateLimitID, so resolve before persisting the mc).
+	var rateLimitIDToDelete string
+	if d.rateLimitProvided {
+		switch {
+		case d.rateLimitRemove:
+			if mc.RateLimitID != nil {
+				rateLimitIDToDelete = *mc.RateLimitID
+				mc.RateLimitID = nil
+				mc.RateLimit = nil
+			}
+		case mc.RateLimitID != nil:
+			rl := configstoreTables.TableRateLimit{}
+			if err := tx.First(&rl, "id = ?", *mc.RateLimitID).Error; err != nil {
+				return err
+			}
+			rl.TokenMaxLimit = d.rateLimit.TokenMaxLimit
+			rl.TokenResetDuration = d.rateLimit.TokenResetDuration
+			rl.RequestMaxLimit = d.rateLimit.RequestMaxLimit
+			rl.RequestResetDuration = d.rateLimit.RequestResetDuration
+			if err := validateRateLimit(&rl); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateRateLimit(ctx, &rl, tx); err != nil {
+				return err
+			}
+			mc.RateLimit = &rl
+		default:
+			rl := configstoreTables.TableRateLimit{
+				ID:                   uuid.NewString(),
+				TokenMaxLimit:        d.rateLimit.TokenMaxLimit,
+				TokenResetDuration:   d.rateLimit.TokenResetDuration,
+				RequestMaxLimit:      d.rateLimit.RequestMaxLimit,
+				RequestResetDuration: d.rateLimit.RequestResetDuration,
+				TokenLastReset:       time.Now(),
+				RequestLastReset:     time.Now(),
+			}
+			if err := validateRateLimit(&rl); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateRateLimit(ctx, &rl, tx); err != nil {
+				return err
+			}
+			mc.RateLimitID = &rl.ID
+			mc.RateLimit = &rl
+		}
+	}
+
+	// Resulting budget count: the desired set if provided, else the existing set.
+	finalBudgetCount := len(mc.Budgets)
+	if d.budgetsProvided {
+		finalBudgetCount = len(d.budgets)
+	}
+	hasGovernance := mc.RateLimitID != nil || finalBudgetCount > 0
+
+	if !hasGovernance {
+		// No governance left → drop the wildcard (and its budgets) if it existed.
+		if !isNew {
+			for i := range mc.Budgets {
+				if err := h.configStore.DeleteBudget(ctx, mc.Budgets[i].ID, tx); err != nil {
+					return err
+				}
+			}
+			if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
+				return err
+			}
+		}
+		if rateLimitIDToDelete != "" {
+			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Persist the mc (create or update) before touching budgets, which FK to it.
+	if isNew {
+		if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
+			return err
+		}
+	} else {
+		mc.UpdatedAt = time.Now()
+		if err := h.configStore.UpdateModelConfig(ctx, &mc, tx); err != nil {
+			return err
+		}
+	}
+
+	if d.budgetsProvided {
+		if err := h.reconcileModelConfigBudgets(ctx, tx, &mc, d.budgets); err != nil {
+			return err
+		}
+	}
+
+	if rateLimitIDToDelete != "" {
+		if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteVKWildcardModelConfig removes a VK-scoped wildcard model config and its owned
+// budgets/rate-limit (used when a provider config is removed from the VK).
+func (h *GovernanceHandler) deleteVKWildcardModelConfig(ctx context.Context, tx *gorm.DB, mc *configstoreTables.TableModelConfig) error {
+	for i := range mc.Budgets {
+		if err := h.configStore.DeleteBudget(ctx, mc.Budgets[i].ID, tx); err != nil {
+			return err
+		}
+	}
+	rlID := mc.RateLimitID
+	if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
+		return err
+	}
+	if rlID != nil {
+		if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", *rlID).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// rateLimitFromRequestFields builds a transient TableRateLimit (limit/duration fields only)
+// for the VK governance sync, from the shared rate-limit request field shape.
+func rateLimitFromRequestFields(tokenMax *int64, tokenDur *string, reqMax *int64, reqDur *string) *configstoreTables.TableRateLimit {
+	return &configstoreTables.TableRateLimit{
+		TokenMaxLimit:        tokenMax,
+		TokenResetDuration:   tokenDur,
+		RequestMaxLimit:      reqMax,
+		RequestResetDuration: reqDur,
+	}
+}
+
+// vkWildcardIndexKey keys a VK-scoped all-models wildcard by scope target + provider
+func vkWildcardIndexKey(scopeID string, provider *string) string {
+	if provider == nil {
+		return scopeID + "|"
+	}
+	return scopeID + "|" + *provider
+}
+
+// applyVKGovernanceFromWildcards repopulates a VK's (and each provider config's) budgets and
+// rate-limit FROM the VK-scoped wildcard model configs that now own them — for serialization
+// only (so the VK sheet still renders the governance it edits). byKey indexes the wildcards by
+// vkWildcardIndexKey. The reverse of syncVKGovernanceToModelConfigs.
+func applyVKGovernanceFromWildcards(vk *configstoreTables.TableVirtualKey, byKey map[string]*configstoreTables.TableModelConfig) {
+	if mc := byKey[vkWildcardIndexKey(vk.ID, nil)]; mc != nil {
+		vk.Budgets = mc.Budgets
+		vk.RateLimit = mc.RateLimit
+		vk.RateLimitID = mc.RateLimitID
+	} else {
+		vk.Budgets = nil
+		vk.RateLimit = nil
+		vk.RateLimitID = nil
+	}
+	for i := range vk.ProviderConfigs {
+		pc := &vk.ProviderConfigs[i]
+		if mc := byKey[vkWildcardIndexKey(vk.ID, &pc.Provider)]; mc != nil {
+			pc.Budgets = mc.Budgets
+			pc.RateLimit = mc.RateLimit
+			pc.RateLimitID = mc.RateLimitID
+		} else {
+			pc.Budgets = nil
+			pc.RateLimit = nil
+			pc.RateLimitID = nil
+		}
+	}
+}
+
+// hydrateVKGovernance reverse-maps a single VK's governance from its wildcard model configs.
+func (h *GovernanceHandler) hydrateVKGovernance(ctx context.Context, vk *configstoreTables.TableVirtualKey) {
+	if vk == nil {
+		return
+	}
+	byKey := make(map[string]*configstoreTables.TableModelConfig)
+	add := func(provider *string) {
+		mc, err := h.configStore.GetModelConfig(ctx, configstoreTables.ModelConfigScopeVirtualKey, &vk.ID, configstoreTables.ModelConfigAllModels, provider)
+		if err == nil && mc != nil {
+			byKey[vkWildcardIndexKey(vk.ID, provider)] = mc
+		}
+	}
+	add(nil)
+	for i := range vk.ProviderConfigs {
+		prov := vk.ProviderConfigs[i].Provider
+		add(&prov)
+	}
+	applyVKGovernanceFromWildcards(vk, byKey)
+}
+
+// vkWildcardIndexFromModelConfigs builds an index of VK-scoped all-models wildcard model
+// configs keyed by vkWildcardIndexKey, from a slice of model-config pointers.
+func vkWildcardIndexFromModelConfigs(mcs []*configstoreTables.TableModelConfig) map[string]*configstoreTables.TableModelConfig {
+	byKey := make(map[string]*configstoreTables.TableModelConfig)
+	for _, mc := range mcs {
+		if mc != nil && mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ModelName == configstoreTables.ModelConfigAllModels && mc.ScopeID != nil {
+			byKey[vkWildcardIndexKey(*mc.ScopeID, mc.Provider)] = mc
+		}
+	}
+	return byKey
+}
+
+// hydrateVKListGovernance reverse-maps governance for a list of VKs using a single bulk load
+// of all VK-scoped wildcard model configs (avoids per-VK/per-provider queries).
+func (h *GovernanceHandler) hydrateVKListGovernance(ctx context.Context, vks []configstoreTables.TableVirtualKey) {
+	if len(vks) == 0 {
+		return
+	}
+	allMCs, err := h.configStore.GetModelConfigs(ctx)
+	if err != nil {
+		logger.Error("failed to load model configs for VK governance hydration: %v", err)
+		return
+	}
+	byKey := make(map[string]*configstoreTables.TableModelConfig)
+	for i := range allMCs {
+		mc := &allMCs[i]
+		if mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ModelName == configstoreTables.ModelConfigAllModels && mc.ScopeID != nil {
+			byKey[vkWildcardIndexKey(*mc.ScopeID, mc.Provider)] = mc
+		}
+	}
+	for i := range vks {
+		applyVKGovernanceFromWildcards(&vks[i], byKey)
+	}
+}
+
 func collectProviderConfigDeleteIDs(
 	config configstoreTables.TableVirtualKeyProviderConfig,
 	budgetIDs []string,
@@ -394,7 +773,7 @@ type CreateModelConfigRequest struct {
 	Provider  *string                 `json:"provider,omitempty"` // Optional provider, nil means all providers
 	Scope     string                  `json:"scope,omitempty"`    // Defaults to "global" if not provided
 	ScopeID   *string                 `json:"scope_id,omitempty"` // Required for non-global scopes (e.g. the virtual key ID)
-	Budget    *CreateBudgetRequest    `json:"budget,omitempty"`
+	Budgets   []CreateBudgetRequest   `json:"budgets,omitempty"`  // A model config may carry multiple budgets (distinct reset windows)
 	RateLimit *CreateRateLimitRequest `json:"rate_limit,omitempty"`
 }
 
@@ -404,7 +783,7 @@ type CreateModelConfigRequest struct {
 type UpdateModelConfigRequest struct {
 	ModelName *string                 `json:"model_name,omitempty"`
 	Provider  *string                 `json:"provider,omitempty"` // Optional provider, nil means no change
-	Budget    *UpdateBudgetRequest    `json:"budget,omitempty"`
+	Budgets   []CreateBudgetRequest   `json:"budgets,omitempty"`  // Full desired set of budgets (reconciled against existing)
 	RateLimit *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
 }
 
@@ -477,6 +856,35 @@ func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 
 // getVirtualKeys handles GET /api/governance/virtual-keys - Get all virtual keys with relationships
 func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
+	// Check if "from_memory" query parameter is set to true
+	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
+	if fromMemory {
+		data := h.governanceManager.GetGovernanceData(ctx)
+		if data == nil {
+			SendError(ctx, 500, "Governance data is not available")
+			return
+		}
+		// Convert map to slice to match the non-memory response format (array)
+		virtualKeys := make([]*configstoreTables.TableVirtualKey, 0, len(data.VirtualKeys))
+		for _, vk := range data.VirtualKeys {
+			virtualKeys = append(virtualKeys, vk)
+		}
+		sort.Slice(virtualKeys, func(i, j int) bool {
+			return virtualKeys[i].CreatedAt.Before(virtualKeys[j].CreatedAt)
+		})
+		byKey := vkWildcardIndexFromModelConfigs(data.ModelConfigs)
+		for _, vk := range virtualKeys {
+			applyVKGovernanceFromWildcards(vk, byKey)
+		}
+		SendJSON(ctx, map[string]interface{}{
+			"virtual_keys": hydratedVKs,
+			"count":        len(hydratedVKs),
+			"total_count":  len(hydratedVKs),
+			"limit":        len(hydratedVKs),
+			"offset":       0,
+		})
+		return
+	}
 	// Check for pagination/filter parameters
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
@@ -535,6 +943,8 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 500, "Failed to retrieve virtual keys")
 			return
 		}
+		// Reverse-map governance from VK-scoped wildcard model configs for display.
+		h.hydrateVKListGovernance(ctx, virtualKeys)
 		SendJSON(ctx, map[string]interface{}{
 			"virtual_keys": virtualKeys,
 			"count":        len(virtualKeys),
@@ -552,6 +962,7 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 500, "Failed to retrieve virtual keys")
 		return
 	}
+	h.hydrateVKListGovernance(ctx, virtualKeys)
 	SendJSON(ctx, map[string]interface{}{
 		"virtual_keys": virtualKeys,
 		"count":        len(virtualKeys),
@@ -624,46 +1035,13 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 			IsActive:        isActive,
 			CalendarAligned: req.CalendarAligned,
 		}
-		if req.RateLimit != nil {
-			rateLimit := configstoreTables.TableRateLimit{
-				ID:                   uuid.NewString(),
-				TokenMaxLimit:        req.RateLimit.TokenMaxLimit,
-				TokenResetDuration:   req.RateLimit.TokenResetDuration,
-				RequestMaxLimit:      req.RateLimit.RequestMaxLimit,
-				RequestResetDuration: req.RateLimit.RequestResetDuration,
-				TokenLastReset:       time.Now(),
-				RequestLastReset:     time.Now(),
-			}
-			if err := validateRateLimit(&rateLimit); err != nil {
-				return err
-			}
-			if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-				return err
-			}
-			vk.RateLimitID = &rateLimit.ID
-		}
 		if err := h.configStore.CreateVirtualKey(ctx, &vk, tx); err != nil {
 			return err
 		}
-		// Create multi-budgets for VK
-		if len(req.Budgets) > 0 {
-			for _, b := range req.Budgets {
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      b.MaxLimit,
-					ResetDuration: b.ResetDuration,
-					LastReset:     budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-					CurrentUsage:  0,
-					VirtualKeyID:  &vk.ID,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-			}
-		}
+		// VK top-level and per-provider budgets/rate-limits are the single-source-of-truth
+		// VK-scoped wildcard model configs, written via syncVKGovernanceToModelConfigs below.
+		// The per-provider desired state is accumulated while creating the provider configs.
+		var vkGovProviders []vkWildcardDesired
 		if req.ProviderConfigs != nil {
 			for _, pc := range req.ProviderConfigs {
 				providerName := schemas.ModelProvider(strings.TrimSpace(pc.Provider))
@@ -709,54 +1087,37 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 					Keys:              keys,
 				}
 
-				// Create rate limit for provider config if provided
-				if pc.RateLimit != nil {
-					rateLimit := configstoreTables.TableRateLimit{
-						ID:                   uuid.NewString(),
-						TokenMaxLimit:        pc.RateLimit.TokenMaxLimit,
-						TokenResetDuration:   pc.RateLimit.TokenResetDuration,
-						RequestMaxLimit:      pc.RateLimit.RequestMaxLimit,
-						RequestResetDuration: pc.RateLimit.RequestResetDuration,
-						TokenLastReset:       time.Now(),
-						RequestLastReset:     time.Now(),
-					}
-					if err := validateRateLimit(&rateLimit); err != nil {
-						return err
-					}
-					if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-						return err
-					}
-					providerConfig.RateLimitID = &rateLimit.ID
-				}
-
 				if err := h.configStore.CreateVirtualKeyProviderConfig(ctx, providerConfig, tx); err != nil {
 					return err
 				}
-				// Create multi-budgets for provider config
-				if len(pc.Budgets) > 0 {
-					seenDurations := make(map[string]bool)
-					for _, b := range pc.Budgets {
-						if seenDurations[b.ResetDuration] {
-							return &badRequestError{err: fmt.Errorf("duplicate reset_duration in provider config budgets: %s", b.ResetDuration)}
-						}
-						seenDurations[b.ResetDuration] = true
-						budget := configstoreTables.TableBudget{
-							ID:               uuid.NewString(),
-							MaxLimit:         b.MaxLimit,
-							ResetDuration:    b.ResetDuration,
-							LastReset:        budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-							CurrentUsage:     0,
-							ProviderConfigID: &providerConfig.ID,
-						}
-						if err := validateBudget(&budget); err != nil {
-							return err
-						}
-						if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-							return err
-						}
-					}
+				// Provider-config budgets/rate-limit are folded into a VK-scoped wildcard
+				// model config for this provider (written by syncVKGovernanceToModelConfigs).
+				providerNameStr := string(providerName)
+				var pcRateLimit *configstoreTables.TableRateLimit
+				if pc.RateLimit != nil {
+					pcRateLimit = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 				}
+				vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+					provider:          &providerNameStr,
+					budgetsProvided:   true,
+					budgets:           pc.Budgets,
+					rateLimitProvided: pc.RateLimit != nil,
+					rateLimit:         pcRateLimit,
+				})
 			}
+		}
+		// Fold VK top-level + per-provider governance into VK-scoped wildcard model configs.
+		var topRateLimit *configstoreTables.TableRateLimit
+		if req.RateLimit != nil {
+			topRateLimit = rateLimitFromRequestFields(req.RateLimit.TokenMaxLimit, req.RateLimit.TokenResetDuration, req.RateLimit.RequestMaxLimit, req.RateLimit.RequestResetDuration)
+		}
+		if err := h.syncVKGovernanceToModelConfigs(ctx, tx, &vk, vkWildcardDesired{
+			budgetsProvided:   true,
+			budgets:           req.Budgets,
+			rateLimitProvided: req.RateLimit != nil,
+			rateLimit:         topRateLimit,
+		}, vkGovProviders, true); err != nil {
+			return err
 		}
 		if req.MCPConfigs != nil {
 			// Check for duplicate MCPClientName values before processing
@@ -800,6 +1161,8 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		logger.Error("failed to reload virtual key: %v", err)
 		preloadedVk = &vk
 	}
+	// Reverse-map governance from the wildcard model configs just written, for display.
+	h.hydrateVKGovernance(ctx, preloadedVk)
 
 	SendJSON(ctx, map[string]any{
 		"message":     "Virtual key created successfully",
@@ -810,6 +1173,27 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 // getVirtualKey handles GET /api/governance/virtual-keys/{vk_id} - Get a specific virtual key
 func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 	vkID := ctx.UserValue("vk_id").(string)
+	// Check if "from_memory" query parameter is set to true
+	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
+	if fromMemory {
+		data := h.governanceManager.GetGovernanceData(ctx)
+		if data == nil {
+			SendError(ctx, 500, "Governance data is not available")
+			return
+		}
+		byKey := vkWildcardIndexFromModelConfigs(data.ModelConfigs)
+		for _, vk := range data.VirtualKeys {
+			if vk.ID == vkID {
+				applyVKGovernanceFromWildcards(vk, byKey)
+				SendJSON(ctx, map[string]interface{}{
+					"virtual_key": &clone,
+				})
+				return
+			}
+		}
+		SendError(ctx, 404, "Virtual key not found")
+		return
+	}
 	vk, err := h.configStore.GetVirtualKey(ctx, vkID)
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
@@ -819,6 +1203,8 @@ func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 500, "Failed to retrieve virtual key")
 		return
 	}
+	// Reverse-map governance from the VK-scoped wildcard model configs for display.
+	h.hydrateVKGovernance(ctx, vk)
 
 	SendJSON(ctx, map[string]interface{}{
 		"virtual_key": vk,
@@ -897,130 +1283,11 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		if req.CalendarAligned != nil {
 			vk.CalendarAligned = *req.CalendarAligned
 		}
-		// Handle multi-budget updates
-		if req.Budgets != nil {
-			// Validate multi-budgets
-			seenDurations := make(map[string]bool)
-			requestBudgets := append([]CreateBudgetRequest(nil), req.Budgets...)
-			sort.Slice(requestBudgets, func(i, j int) bool {
-				return compareBudgetRequestDurations(requestBudgets[i], requestBudgets[j])
-			})
-			for _, b := range requestBudgets {
-				if b.MaxLimit < 0 {
-					return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
-				}
-				if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
-					return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
-				}
-				if seenDurations[b.ResetDuration] {
-					return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
-				}
-				seenDurations[b.ResetDuration] = true
-			}
-
-			existingByID, existingByDuration := buildBudgetLookup(vk.Budgets, requestBudgets)
-			resetBudgetUsage := req.ResetBudgetUsage != nil && *req.ResetBudgetUsage
-			var reconciledBudgets []configstoreTables.TableBudget
-			matchedIDs := make(map[string]bool)
-			for _, b := range requestBudgets {
-				existing, found, err := findExistingBudget(b, existingByID, existingByDuration)
-				if err != nil {
-					return err
-				}
-				if found {
-					existing.MaxLimit = b.MaxLimit
-					existing.ResetDuration = b.ResetDuration
-					resetBudgetUsageIfRequested(&existing, resetBudgetUsage, vk.CalendarAligned)
-					if err := validateBudget(&existing); err != nil {
-						return err
-					}
-					if err := h.configStore.UpdateBudget(ctx, &existing, tx); err != nil {
-						return err
-					}
-					reconciledBudgets = append(reconciledBudgets, existing)
-					matchedIDs[existing.ID] = true
-				} else {
-					// New budget duration — create fresh
-					budget := configstoreTables.TableBudget{
-						ID:            uuid.NewString(),
-						MaxLimit:      b.MaxLimit,
-						ResetDuration: b.ResetDuration,
-						LastReset:     budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-						CurrentUsage:  0,
-						VirtualKeyID:  &vk.ID,
-					}
-					inheritUsageFromClosestShorterBudget(&budget, vk.Budgets, resetBudgetUsage)
-					if err := validateBudget(&budget); err != nil {
-						return err
-					}
-					if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-						return err
-					}
-					reconciledBudgets = append(reconciledBudgets, budget)
-				}
-			}
-			// Delete budgets that are no longer present
-			for _, existing := range vk.Budgets {
-				if !matchedIDs[existing.ID] {
-					if err := h.configStore.DeleteBudget(ctx, existing.ID, tx); err != nil {
-						return fmt.Errorf("failed to delete removed VK budget: %w", err)
-					}
-				}
-			}
-			vk.Budgets = reconciledBudgets
-		}
-
-		// Handle rate limit updates
-		if req.RateLimit != nil {
-			if isRateLimitRemovalRequest(req.RateLimit) {
-				if vk.RateLimitID != nil {
-					rateLimitIDToDelete = *vk.RateLimitID
-					vk.RateLimitID = nil
-					vk.RateLimit = nil
-				}
-			} else if vk.RateLimitID != nil {
-				// Update existing rate limit
-				rateLimit := configstoreTables.TableRateLimit{}
-				if err := tx.First(&rateLimit, "id = ?", *vk.RateLimitID).Error; err != nil {
-					return err
-				}
-
-				if req.RateLimit.TokenMaxLimit != nil {
-					rateLimit.TokenMaxLimit = req.RateLimit.TokenMaxLimit
-				}
-				if req.RateLimit.TokenResetDuration != nil {
-					rateLimit.TokenResetDuration = req.RateLimit.TokenResetDuration
-				}
-				if req.RateLimit.RequestMaxLimit != nil {
-					rateLimit.RequestMaxLimit = req.RateLimit.RequestMaxLimit
-				}
-				if req.RateLimit.RequestResetDuration != nil {
-					rateLimit.RequestResetDuration = req.RateLimit.RequestResetDuration
-				}
-
-				if err := h.configStore.UpdateRateLimit(ctx, &rateLimit, tx); err != nil {
-					return err
-				}
-			} else {
-				// Create new rate limit
-				rateLimit := configstoreTables.TableRateLimit{
-					ID:                   uuid.NewString(),
-					TokenMaxLimit:        req.RateLimit.TokenMaxLimit,
-					TokenResetDuration:   req.RateLimit.TokenResetDuration,
-					RequestMaxLimit:      req.RateLimit.RequestMaxLimit,
-					RequestResetDuration: req.RateLimit.RequestResetDuration,
-					TokenLastReset:       time.Now(),
-					RequestLastReset:     time.Now(),
-				}
-				if err := validateRateLimit(&rateLimit); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-					return err
-				}
-				vk.RateLimitID = &rateLimit.ID
-			}
-		}
+		// VK top-level and per-provider budgets/rate-limits are folded into VK-scoped
+		// wildcard model configs (the single source of truth), written by
+		// syncVKGovernanceToModelConfigs below. Per-provider desired state is accumulated
+		// while reconciling provider config rows.
+		var vkGovProviders []vkWildcardDesired
 
 		if err := h.configStore.UpdateVirtualKey(ctx, vk, tx); err != nil {
 			return err
@@ -1098,56 +1365,22 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 						AllowAllKeys:      allowAllKeys,
 						Keys:              keys,
 					}
-					// Create rate limit for provider config if provided
-					if pc.RateLimit != nil {
-						rateLimit := configstoreTables.TableRateLimit{
-							ID:                   uuid.NewString(),
-							TokenMaxLimit:        pc.RateLimit.TokenMaxLimit,
-							TokenResetDuration:   pc.RateLimit.TokenResetDuration,
-							RequestMaxLimit:      pc.RateLimit.RequestMaxLimit,
-							RequestResetDuration: pc.RateLimit.RequestResetDuration,
-							TokenLastReset:       time.Now(),
-							RequestLastReset:     time.Now(),
-						}
-						if err := validateRateLimit(&rateLimit); err != nil {
-							return err
-						}
-						if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-							return err
-						}
-						providerConfig.RateLimitID = &rateLimit.ID
-					}
 					if err := h.configStore.CreateVirtualKeyProviderConfig(ctx, providerConfig, tx); err != nil {
 						return err
 					}
-					// Create multi-budgets for new provider config in update
-					if len(pc.Budgets) > 0 {
-						seenDurations := make(map[string]bool)
-						pcBudgets := append([]CreateBudgetRequest(nil), pc.Budgets...)
-						sort.Slice(pcBudgets, func(i, j int) bool {
-							return compareBudgetRequestDurations(pcBudgets[i], pcBudgets[j])
-						})
-						for _, b := range pcBudgets {
-							if seenDurations[b.ResetDuration] {
-								return &badRequestError{err: fmt.Errorf("duplicate reset_duration in provider config budgets: %s", b.ResetDuration)}
-							}
-							seenDurations[b.ResetDuration] = true
-							budget := configstoreTables.TableBudget{
-								ID:               uuid.NewString(),
-								MaxLimit:         b.MaxLimit,
-								ResetDuration:    b.ResetDuration,
-								LastReset:        budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-								CurrentUsage:     0,
-								ProviderConfigID: &providerConfig.ID,
-							}
-							if err := validateBudget(&budget); err != nil {
-								return err
-							}
-							if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-								return err
-							}
-						}
+					// Provider-config governance is folded into a VK-scoped wildcard model config.
+					pName := string(providerName)
+					var pcRL *configstoreTables.TableRateLimit
+					if pc.RateLimit != nil {
+						pcRL = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 					}
+					vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+						provider:          &pName,
+						budgetsProvided:   true,
+						budgets:           pc.Budgets,
+						rateLimitProvided: pc.RateLimit != nil,
+						rateLimit:         pcRL,
+					})
 				} else {
 					// Update existing provider config
 					existing, ok := existingConfigsMap[*pc.ID]
@@ -1187,134 +1420,27 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					existing.AllowAllKeys = allowAllKeys
 					existing.Keys = keys
 
-					// Handle multi-budget updates for existing provider config
-					if pc.Budgets != nil {
-						// Validate
-						seenDurations := make(map[string]bool)
-						pcBudgets := append([]CreateBudgetRequest(nil), pc.Budgets...)
-						sort.Slice(pcBudgets, func(i, j int) bool {
-							return compareBudgetRequestDurations(pcBudgets[i], pcBudgets[j])
-						})
-						for _, b := range pcBudgets {
-							if b.MaxLimit < 0 {
-								return &badRequestError{err: fmt.Errorf("provider config budget max_limit cannot be negative: %.2f", b.MaxLimit)}
-							}
-							if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
-								return &badRequestError{err: fmt.Errorf("invalid provider config budget reset duration format: %s", b.ResetDuration)}
-							}
-							if seenDurations[b.ResetDuration] {
-								return &badRequestError{err: fmt.Errorf("duplicate reset_duration in provider config budgets: %s", b.ResetDuration)}
-							}
-							seenDurations[b.ResetDuration] = true
-						}
-
-						sort.Slice(existing.Budgets, func(i, j int) bool {
-							if existing.Budgets[i].ResetDuration == existing.Budgets[j].ResetDuration {
-								return existing.Budgets[i].ID < existing.Budgets[j].ID
-							}
-							return existing.Budgets[i].ResetDuration < existing.Budgets[j].ResetDuration
-						})
-
-						pcExistingByID, pcExistingByDuration := buildBudgetLookup(existing.Budgets, pcBudgets)
-						resetBudgetUsage := req.ResetBudgetUsage != nil && *req.ResetBudgetUsage
-						var pcReconciledBudgets []configstoreTables.TableBudget
-						pcMatchedIDs := make(map[string]bool)
-						for _, b := range pcBudgets {
-							eb, found, err := findExistingBudget(b, pcExistingByID, pcExistingByDuration)
-							if err != nil {
-								return err
-							}
-							if found {
-								eb.MaxLimit = b.MaxLimit
-								eb.ResetDuration = b.ResetDuration
-								resetBudgetUsageIfRequested(&eb, resetBudgetUsage, vk.CalendarAligned)
-								if err := validateBudget(&eb); err != nil {
-									return err
-								}
-								if err := h.configStore.UpdateBudget(ctx, &eb, tx); err != nil {
-									return err
-								}
-								pcReconciledBudgets = append(pcReconciledBudgets, eb)
-								pcMatchedIDs[eb.ID] = true
-							} else {
-								// New budget duration — create fresh
-								budget := configstoreTables.TableBudget{
-									ID:               uuid.NewString(),
-									MaxLimit:         b.MaxLimit,
-									ResetDuration:    b.ResetDuration,
-									LastReset:        budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-									CurrentUsage:     0,
-									ProviderConfigID: &existing.ID,
-								}
-								inheritUsageFromClosestShorterBudget(&budget, existing.Budgets, resetBudgetUsage)
-								if err := validateBudget(&budget); err != nil {
-									return err
-								}
-								if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-									return err
-								}
-								pcReconciledBudgets = append(pcReconciledBudgets, budget)
-							}
-						}
-						// Delete budgets that are no longer present
-						for _, eb := range existing.Budgets {
-							if !pcMatchedIDs[eb.ID] {
-								if err := h.configStore.DeleteBudget(ctx, eb.ID, tx); err != nil {
-									return fmt.Errorf("failed to delete removed provider config budget: %w", err)
-								}
-							}
-						}
-						existing.Budgets = pcReconciledBudgets
-					}
-					// Handle rate limit updates for provider config
+					// Provider-config governance is folded into a VK-scoped wildcard model
+					// config (written by syncVKGovernanceToModelConfigs). pc.Budgets == nil
+					// leaves the wildcard's budgets unchanged; an explicit set reconciles them.
+					pName := string(providerName)
+					rlRemove := false
+					var pcRL *configstoreTables.TableRateLimit
 					if pc.RateLimit != nil {
 						if isRateLimitRemovalRequest(pc.RateLimit) {
-							if existing.RateLimitID != nil {
-								providerRateLimitIDsToDelete = append(providerRateLimitIDsToDelete, *existing.RateLimitID)
-								existing.RateLimitID = nil
-								existing.RateLimit = nil
-							}
-						} else if existing.RateLimitID != nil {
-							// Update existing rate limit
-							rateLimit := configstoreTables.TableRateLimit{}
-							if err := tx.First(&rateLimit, "id = ?", *existing.RateLimitID).Error; err != nil {
-								return err
-							}
-							if pc.RateLimit.TokenMaxLimit != nil {
-								rateLimit.TokenMaxLimit = pc.RateLimit.TokenMaxLimit
-							}
-							if pc.RateLimit.TokenResetDuration != nil {
-								rateLimit.TokenResetDuration = pc.RateLimit.TokenResetDuration
-							}
-							if pc.RateLimit.RequestMaxLimit != nil {
-								rateLimit.RequestMaxLimit = pc.RateLimit.RequestMaxLimit
-							}
-							if pc.RateLimit.RequestResetDuration != nil {
-								rateLimit.RequestResetDuration = pc.RateLimit.RequestResetDuration
-							}
-							if err := h.configStore.UpdateRateLimit(ctx, &rateLimit, tx); err != nil {
-								return err
-							}
+							rlRemove = true
 						} else {
-							// Create new rate limit for existing provider config
-							rateLimit := configstoreTables.TableRateLimit{
-								ID:                   uuid.NewString(),
-								TokenMaxLimit:        pc.RateLimit.TokenMaxLimit,
-								TokenResetDuration:   pc.RateLimit.TokenResetDuration,
-								RequestMaxLimit:      pc.RateLimit.RequestMaxLimit,
-								RequestResetDuration: pc.RateLimit.RequestResetDuration,
-								TokenLastReset:       time.Now(),
-								RequestLastReset:     time.Now(),
-							}
-							if err := validateRateLimit(&rateLimit); err != nil {
-								return err
-							}
-							if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-								return err
-							}
-							existing.RateLimitID = &rateLimit.ID
+							pcRL = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 						}
 					}
+					vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+						provider:          &pName,
+						budgetsProvided:   pc.Budgets != nil,
+						budgets:           pc.Budgets,
+						rateLimitProvided: pc.RateLimit != nil,
+						rateLimitRemove:   rlRemove,
+						rateLimit:         pcRL,
+					})
 					if err := h.configStore.UpdateVirtualKeyProviderConfig(ctx, &existing, tx); err != nil {
 						return err
 					}
@@ -1338,6 +1464,24 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					}
 				}
 			}
+		}
+		// Fold VK governance into VK-scoped wildcard model configs. The top-level is always
+		// reconciled (provided-aware); per-provider wildcards are reconciled only when the
+		// request supplied provider_configs (else they're left untouched).
+		top := vkWildcardDesired{
+			budgetsProvided:   req.Budgets != nil,
+			budgets:           req.Budgets,
+			rateLimitProvided: req.RateLimit != nil,
+		}
+		if req.RateLimit != nil {
+			if isRateLimitRemovalRequest(req.RateLimit) {
+				top.rateLimitRemove = true
+			} else {
+				top.rateLimit = rateLimitFromRequestFields(req.RateLimit.TokenMaxLimit, req.RateLimit.TokenResetDuration, req.RateLimit.RequestMaxLimit, req.RateLimit.RequestResetDuration)
+			}
+		}
+		if err := h.syncVKGovernanceToModelConfigs(ctx, tx, vk, top, vkGovProviders, req.ProviderConfigs != nil); err != nil {
+			return err
 		}
 		if req.MCPConfigs != nil {
 			// Check for duplicate MCPClientName values among all configs before processing
@@ -1454,6 +1598,8 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		logger.Error("failed to load relationships for updated VK: %v", err)
 		preloadedVk = vk
 	}
+	// Reverse-map governance from the VK-scoped wildcard model configs for display.
+	h.hydrateVKGovernance(ctx, preloadedVk)
 	if _, err := h.governanceManager.ReloadVirtualKey(ctx, vk.ID); err != nil {
 		// Should never happen but just in case
 		logger.Error("failed to reload virtual key after update: %v", err)
@@ -2648,6 +2794,8 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 	}
 	// Default and validate scope. Global is the implicit default (preserves
 	// pre-scope behavior). Non-global scopes require a scope_id naming the target.
+	// scopeCalendarAligned is inherited from the owning VK for virtual_key scope.
+	scopeCalendarAligned := false
 	if req.Scope == "" {
 		req.Scope = configstoreTables.ModelConfigScopeGlobal
 	}
@@ -2664,7 +2812,8 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 		}
 		// For the virtual_key scope, the scope_id must reference an existing VK.
 		if req.Scope == configstoreTables.ModelConfigScopeVirtualKey {
-			if _, vkErr := h.configStore.GetVirtualKey(ctx, *req.ScopeID); vkErr != nil {
+			vk, vkErr := h.configStore.GetVirtualKey(ctx, *req.ScopeID)
+			if vkErr != nil {
 				if errors.Is(vkErr, configstore.ErrNotFound) {
 					SendError(ctx, 400, fmt.Sprintf("Virtual key '%s' not found", *req.ScopeID))
 				} else {
@@ -2673,6 +2822,8 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 				}
 				return
 			}
+			// Inherit calendar alignment from the owning VK so budgets reset consistently.
+			scopeCalendarAligned = vk.CalendarAligned
 		}
 	}
 	// Check if a model config with the same identity (scope, scope_id, model_name, provider) already exists
@@ -2694,47 +2845,31 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 		}
 		return
 	}
-	// Validate budget if provided
-	if req.Budget != nil {
-		if req.Budget.MaxLimit < 0 {
-			SendError(ctx, 400, fmt.Sprintf("Budget max_limit cannot be negative: %.2f", req.Budget.MaxLimit))
+	// Validate budgets if provided
+	seenDurations := make(map[string]bool, len(req.Budgets))
+	for i := range req.Budgets {
+		if req.Budgets[i].MaxLimit < 0 {
+			SendError(ctx, 400, fmt.Sprintf("Budget max_limit cannot be negative: %.2f", req.Budgets[i].MaxLimit))
 			return
 		}
-		if _, err := configstoreTables.ParseDuration(req.Budget.ResetDuration); err != nil {
-			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", req.Budget.ResetDuration))
+		if _, err := configstoreTables.ParseDuration(req.Budgets[i].ResetDuration); err != nil {
+			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", req.Budgets[i].ResetDuration))
 			return
 		}
 	}
 	var mc configstoreTables.TableModelConfig
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		mc = configstoreTables.TableModelConfig{
-			ID:        uuid.NewString(),
-			ModelName: req.ModelName,
-			Provider:  req.Provider,
-			Scope:     req.Scope,
-			ScopeID:   req.ScopeID,
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
+			ID:              uuid.NewString(),
+			ModelName:       req.ModelName,
+			Provider:        req.Provider,
+			Scope:           req.Scope,
+			ScopeID:         req.ScopeID,
+			CalendarAligned: scopeCalendarAligned,
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
 		}
-		// Create budget if provided
-		if req.Budget != nil {
-			budget := configstoreTables.TableBudget{
-				ID:            uuid.NewString(),
-				MaxLimit:      req.Budget.MaxLimit,
-				ResetDuration: req.Budget.ResetDuration,
-				LastReset:     budgetLastReset(false, req.Budget.ResetDuration),
-				CurrentUsage:  0,
-			}
-			if err := validateBudget(&budget); err != nil {
-				return err
-			}
-			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-				return err
-			}
-			mc.BudgetID = &budget.ID
-			mc.Budget = &budget
-		}
-		// Create rate limit if provided
+		// Create rate limit if provided (mc references it via RateLimitID, so create first).
 		if req.RateLimit != nil {
 			rateLimit := configstoreTables.TableRateLimit{
 				ID:                   uuid.NewString(),
@@ -2754,8 +2889,27 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 			mc.RateLimitID = &rateLimit.ID
 			mc.RateLimit = &rateLimit
 		}
+		// Create the model config row first so its budgets can reference it via ModelConfigID.
 		if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
 			return err
+		}
+		// Create owned budgets (a model config may carry multiple).
+		for _, b := range req.Budgets {
+			budget := configstoreTables.TableBudget{
+				ID:            uuid.NewString(),
+				MaxLimit:      b.MaxLimit,
+				ResetDuration: b.ResetDuration,
+				LastReset:     budgetLastReset(mc.CalendarAligned, b.ResetDuration),
+				CurrentUsage:  0,
+				ModelConfigID: &mc.ID,
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			mc.Budgets = append(mc.Budgets, budget)
 		}
 		return nil
 	}); err != nil {
@@ -2794,8 +2948,8 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		// Track IDs to delete after updating the model config (to avoid FK constraint)
-		var budgetIDToDelete, rateLimitIDToDelete string
+		// Track rate-limit ID to delete after updating the model config (to avoid FK constraint).
+		var rateLimitIDToDelete string
 
 		// Update fields if provided
 		if req.ModelName != nil {
@@ -2805,62 +2959,12 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 		if req.Provider != nil {
 			mc.Provider = req.Provider
 		}
-		// Handle budget updates
-		if req.Budget != nil {
-			// Check if budget removal is requested (all fields nil)
-			budgetIsEmpty := isBudgetRemovalRequest(req.Budget)
-			if budgetIsEmpty {
-				// Mark budget for deletion after FK is removed
-				if mc.BudgetID != nil {
-					budgetIDToDelete = *mc.BudgetID
-					mc.BudgetID = nil
-					mc.Budget = nil
-				}
-			} else if mc.BudgetID != nil {
-				// Update existing budget — all fields are optional (partial update)
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *mc.BudgetID).Error; err != nil {
-					return err
-				}
-				if req.Budget.MaxLimit != nil {
-					budget.MaxLimit = *req.Budget.MaxLimit
-				}
-				if req.Budget.ResetDuration != nil {
-					budget.ResetDuration = *req.Budget.ResetDuration
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.Budget = &budget
-			} else {
-				// Create new budget
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
-				}
-				if *req.Budget.MaxLimit < 0 {
-					return fmt.Errorf("budget max_limit cannot be negative: %.2f", *req.Budget.MaxLimit)
-				}
-				if _, err := configstoreTables.ParseDuration(*req.Budget.ResetDuration); err != nil {
-					return fmt.Errorf("invalid reset duration format: %s", *req.Budget.ResetDuration)
-				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.BudgetID = &budget.ID
-				mc.Budget = &budget
+		// Handle budget updates: req.Budgets is the full desired set. A non-nil empty
+		// slice removes all budgets; omitting the field leaves them unchanged. Budgets
+		// are owned via ModelConfigID, so no model-config FK juggling is needed.
+		if req.Budgets != nil {
+			if err := h.reconcileModelConfigBudgets(ctx, tx, mc, req.Budgets); err != nil {
+				return err
 			}
 		}
 		// Handle rate limit updates
@@ -2918,12 +3022,7 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 			return err
 		}
 
-		// Now that FK references are removed, delete the orphaned budget/rate limit
-		if budgetIDToDelete != "" {
-			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", budgetIDToDelete).Error; err != nil {
-				return err
-			}
-		}
+		// Now that the FK reference is removed, delete the orphaned rate limit.
 		if rateLimitIDToDelete != "" {
 			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
 				return err
@@ -3000,7 +3099,12 @@ func providerGovernanceFromWildcard(mc *configstoreTables.TableModelConfig) (Pro
 		mc.ModelName != configstoreTables.ModelConfigAllModels || mc.Provider == nil {
 		return ProviderGovernanceResponse{}, false
 	}
-	return ProviderGovernanceResponse{Provider: *mc.Provider, Budget: mc.Budget, RateLimit: mc.RateLimit}, true
+	// Provider governance is single-budget by API; surface the first owned budget.
+	var budget *configstoreTables.TableBudget
+	if len(mc.Budgets) > 0 {
+		budget = &mc.Budgets[0]
+	}
+	return ProviderGovernanceResponse{Provider: *mc.Provider, Budget: budget, RateLimit: mc.RateLimit}, true
 }
 
 // getProviderGovernance handles GET /api/governance/providers - returns provider-level governance,
@@ -3083,58 +3187,18 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 		mc = *existing
 	}
 
+	// Existing single owned budget, if any (provider governance is single-budget by API).
+	var existingBudget *configstoreTables.TableBudget
+	if len(mc.Budgets) > 0 {
+		existingBudget = &mc.Budgets[0]
+	}
+
 	deleted := false
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		var budgetIDToDelete, rateLimitIDToDelete string
 
-		// Budget lifecycle (owner is the wildcard model config).
-		if req.Budget != nil {
-			if isBudgetRemovalRequest(req.Budget) {
-				if mc.BudgetID != nil {
-					budgetIDToDelete = *mc.BudgetID
-					mc.BudgetID = nil
-					mc.Budget = nil
-				}
-			} else if mc.BudgetID != nil {
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *mc.BudgetID).Error; err != nil {
-					return err
-				}
-				if req.Budget.MaxLimit != nil {
-					budget.MaxLimit = *req.Budget.MaxLimit
-				}
-				if req.Budget.ResetDuration != nil {
-					budget.ResetDuration = *req.Budget.ResetDuration
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.Budget = &budget
-			} else {
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
-				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.BudgetID = &budget.ID
-				mc.Budget = &budget
-			}
-		}
-		// Rate limit lifecycle (owner is the wildcard model config).
+		// Rate limit lifecycle (mc references it via RateLimitID, so resolve it before
+		// persisting the model config below).
 		if req.RateLimit != nil {
 			if isRateLimitRemovalRequest(req.RateLimit) {
 				if mc.RateLimitID != nil {
@@ -3179,23 +3243,80 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			}
 		}
 
-		hasGovernance := mc.BudgetID != nil || mc.RateLimitID != nil
+		// Determine the budget outcome (without writing yet — budgets reference the mc,
+		// which may not exist yet for a new provider governance row).
+		removeBudget := req.Budget != nil && isBudgetRemovalRequest(req.Budget)
+		willHaveBudget := existingBudget != nil && !removeBudget
+		if req.Budget != nil && !removeBudget && existingBudget == nil {
+			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
+				return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
+			}
+			willHaveBudget = true
+		}
+
+		hasGovernance := mc.RateLimitID != nil || willHaveBudget
 		switch {
 		case !hasGovernance && isNew:
 			// Nothing to persist (removal request on a provider with no governance).
+			return nil
 		case !hasGovernance && !isNew:
-			// All governance removed → delete the wildcard config and its orphaned rows.
+			// All governance removed → delete the wildcard config and its owned/orphaned rows.
+			if existingBudget != nil {
+				budgetIDToDelete = existingBudget.ID
+			}
 			if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
 				return err
 			}
 			deleted = true
 		case isNew:
+			// Create the model config first so its budget can reference it.
 			if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
 				return err
 			}
 		default:
 			if err := h.configStore.UpdateModelConfig(ctx, &mc, tx); err != nil {
 				return err
+			}
+		}
+
+		// Budget lifecycle (owned via ModelConfigID; the mc row now exists for create cases).
+		if !deleted && req.Budget != nil {
+			if removeBudget {
+				if existingBudget != nil {
+					budgetIDToDelete = existingBudget.ID
+					mc.Budgets = nil
+				}
+			} else if existingBudget != nil {
+				budget := *existingBudget
+				if req.Budget.MaxLimit != nil {
+					budget.MaxLimit = *req.Budget.MaxLimit
+				}
+				if req.Budget.ResetDuration != nil {
+					budget.ResetDuration = *req.Budget.ResetDuration
+				}
+				if err := validateBudget(&budget); err != nil {
+					return err
+				}
+				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
+					return err
+				}
+				mc.Budgets = []configstoreTables.TableBudget{budget}
+			} else {
+				budget := configstoreTables.TableBudget{
+					ID:            uuid.NewString(),
+					MaxLimit:      *req.Budget.MaxLimit,
+					ResetDuration: *req.Budget.ResetDuration,
+					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
+					CurrentUsage:  0,
+					ModelConfigID: &mc.ID,
+				}
+				if err := validateBudget(&budget); err != nil {
+					return err
+				}
+				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+					return err
+				}
+				mc.Budgets = []configstoreTables.TableBudget{budget}
 			}
 		}
 
@@ -3223,12 +3344,15 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 		if err := h.governanceManager.RemoveModelConfig(ctx, mc.ID); err != nil {
 			logger.Error("failed to remove provider governance from memory: %v", err)
 		}
-	} else if mc.BudgetID != nil || mc.RateLimitID != nil {
+	} else if len(mc.Budgets) > 0 || mc.RateLimitID != nil {
 		if reloaded, err := h.governanceManager.ReloadModelConfig(ctx, mc.ID); err != nil {
 			logger.Error("failed to reload provider governance in memory: %v", err)
-			resp.Budget, resp.RateLimit = mc.Budget, mc.RateLimit
-		} else {
-			resp.Budget, resp.RateLimit = reloaded.Budget, reloaded.RateLimit
+			if len(mc.Budgets) > 0 {
+				resp.Budget = &mc.Budgets[0]
+			}
+			resp.RateLimit = mc.RateLimit
+		} else if r, ok := providerGovernanceFromWildcard(reloaded); ok {
+			resp.Budget, resp.RateLimit = r.Budget, r.RateLimit
 		}
 	}
 	SendJSON(ctx, map[string]interface{}{

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -389,6 +389,17 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 		}
 	}
 	governancePlugin.GetGovernanceStore().UpdateVirtualKeyInMemory(ctx, virtualKey, nil, nil, nil)
+	// Also reload any model configs scoped to this VK so governance changes made
+	// via the VK sheet (syncVKGovernanceToModelConfigs) are reflected in memory
+	// immediately — both on the node that handled the update and on peers that
+	// receive this reload via the cluster gossip broadcast.
+	if mcs, err := s.Config.ConfigStore.GetModelConfigsByScopeAndScopeIDs(
+		ctx, tables.ModelConfigScopeVirtualKey, []string{id},
+	); err == nil {
+		for i := range mcs {
+			governancePlugin.GetGovernanceStore().UpdateModelConfigInMemory(ctx, &mcs[i])
+		}
+	}
 	s.MCPServerHandler.SyncVKMCPServer(virtualKey)
 	return virtualKey, nil
 }
@@ -507,10 +518,16 @@ func (s *BifrostHTTPServer) ReloadModelConfig(ctx context.Context, id string) (*
 		return preloadedMC, nil
 	}
 
-	// Sync updated usage values back to database if they changed
-	if updatedMC.Budget != nil && preloadedMC.Budget != nil {
-		if updatedMC.Budget.CurrentUsage != preloadedMC.Budget.CurrentUsage {
-			if err := s.Config.ConfigStore.UpdateBudgetUsage(ctx, updatedMC.Budget.ID, updatedMC.Budget.CurrentUsage); err != nil {
+	// Sync updated budget usage values back to database if they changed (per budget ID,
+	// since a model config may own multiple budgets).
+	preloadedUsage := make(map[string]float64, len(preloadedMC.Budgets))
+	for i := range preloadedMC.Budgets {
+		preloadedUsage[preloadedMC.Budgets[i].ID] = preloadedMC.Budgets[i].CurrentUsage
+	}
+	for i := range updatedMC.Budgets {
+		b := &updatedMC.Budgets[i]
+		if old, ok := preloadedUsage[b.ID]; ok && old != b.CurrentUsage {
+			if err := s.Config.ConfigStore.UpdateBudgetUsage(ctx, b.ID, b.CurrentUsage); err != nil {
 				logger.Error("failed to sync budget usage to database: %v", err)
 			}
 		}

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -3,6 +3,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Label } from "@/components/ui/label";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
+import MultiBudgetLines from "@/components/ui/multibudgets";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -39,8 +40,15 @@ const formSchema = z
 		provider: z.string().optional(),
 		scope: z.string().optional(),
 		scopeId: z.string().optional(),
-		budgetMaxLimit: z.number().nonnegative().optional(),
-		budgetResetDuration: z.string().optional(),
+		budgets: z
+			.array(
+				z.object({
+					id: z.string().optional(),
+					max_limit: z.number().nonnegative().optional(),
+					reset_duration: z.string().optional(),
+				}),
+			)
+			.optional(),
 		tokenMaxLimit: z.number().int().nonnegative().optional(),
 		tokenResetDuration: z.string().optional(),
 		requestMaxLimit: z.number().int().nonnegative().optional(),
@@ -106,8 +114,11 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 			provider: modelConfig?.provider || "",
 			scope: modelConfig?.scope || "global",
 			scopeId: modelConfig?.scope_id || "",
-			budgetMaxLimit: modelConfig?.budget?.max_limit ?? undefined,
-			budgetResetDuration: modelConfig?.budget?.reset_duration || "1M",
+			budgets: (modelConfig?.budgets ?? []).map((b) => ({
+				id: b.id,
+				max_limit: b.max_limit,
+				reset_duration: b.reset_duration,
+			})),
 			tokenMaxLimit: modelConfig?.rate_limit?.token_max_limit ?? undefined,
 			tokenResetDuration: modelConfig?.rate_limit?.token_reset_duration || "1h",
 			requestMaxLimit: modelConfig?.rate_limit?.request_max_limit ?? undefined,
@@ -115,8 +126,9 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 		},
 	});
 
+	const watchedBudgets = form.watch("budgets");
 	const hasAnyLimit =
-		(form.watch("budgetMaxLimit") !== undefined && form.watch("budgetMaxLimit") !== null) ||
+		(watchedBudgets?.some((b) => b.max_limit !== undefined && b.max_limit !== null) ?? false) ||
 		(form.watch("tokenMaxLimit") !== undefined && form.watch("tokenMaxLimit") !== null) ||
 		(form.watch("requestMaxLimit") !== undefined && form.watch("requestMaxLimit") !== null);
 
@@ -135,8 +147,11 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 				provider: modelConfig.provider || "",
 				scope: modelConfig.scope || "global",
 				scopeId: modelConfig.scope_id || "",
-				budgetMaxLimit: modelConfig.budget?.max_limit ?? undefined,
-				budgetResetDuration: modelConfig.budget?.reset_duration || "1M",
+				budgets: (modelConfig.budgets ?? []).map((b) => ({
+					id: b.id,
+					max_limit: b.max_limit,
+					reset_duration: b.reset_duration,
+				})),
 				tokenMaxLimit: modelConfig.rate_limit?.token_max_limit ?? undefined,
 				tokenResetDuration: modelConfig.rate_limit?.token_reset_duration || "1h",
 				requestMaxLimit: modelConfig.rate_limit?.request_max_limit ?? undefined,
@@ -159,23 +174,17 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 		try {
 			const provider = data.provider && data.provider.trim() !== "" ? data.provider : undefined;
 
+			// Full desired set of budgets (kept lines with a max_limit). For updates this is
+			// reconciled server-side; an empty array removes all budgets.
+			const budgetsPayload = (data.budgets ?? [])
+				.filter((b) => b.max_limit !== undefined && b.max_limit !== null)
+				.map((b) => ({ id: b.id, max_limit: b.max_limit as number, reset_duration: b.reset_duration || "1M" }));
+
 			if (isEditing && modelConfig) {
-				const hadBudget = !!modelConfig.budget;
-				const hasBudget = data.budgetMaxLimit !== undefined && data.budgetMaxLimit !== null;
 				const hadRateLimit = !!modelConfig.rate_limit;
 				const hasRateLimit =
 					(data.tokenMaxLimit !== undefined && data.tokenMaxLimit !== null) ||
 					(data.requestMaxLimit !== undefined && data.requestMaxLimit !== null);
-
-				let budgetPayload: { max_limit?: number; reset_duration?: string } | undefined;
-				if (hasBudget) {
-					budgetPayload = {
-						max_limit: data.budgetMaxLimit,
-						reset_duration: data.budgetResetDuration || "1M",
-					};
-				} else if (hadBudget) {
-					budgetPayload = {};
-				}
 
 				let rateLimitPayload:
 					| {
@@ -202,7 +211,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 					data: {
 						model_name: data.modelName,
 						provider: provider,
-						budget: budgetPayload,
+						budgets: budgetsPayload,
 						rate_limit: rateLimitPayload,
 					},
 				}).unwrap();
@@ -213,13 +222,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 					provider,
 					scope: data.scope || "global",
 					scope_id: data.scope === "virtual_key" ? data.scopeId : undefined,
-					budget:
-						data.budgetMaxLimit !== undefined && data.budgetMaxLimit !== null
-							? {
-									max_limit: data.budgetMaxLimit,
-									reset_duration: data.budgetResetDuration || "1M",
-								}
-							: undefined,
+					budgets: budgetsPayload.length > 0 ? budgetsPayload : undefined,
 					rate_limit:
 						(data.tokenMaxLimit !== undefined && data.tokenMaxLimit !== null) ||
 						(data.requestMaxLimit !== undefined && data.requestMaxLimit !== null)
@@ -403,27 +406,17 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 
 							<DottedSeparator />
 
-							{/* Budget Configuration */}
+							{/* Budget Configuration (multi-budget) */}
 							<div className="space-y-4">
-								<Label className="text-sm font-medium">Budget</Label>
-								<FormField
-									control={form.control}
-									name="budgetMaxLimit"
-									render={({ field }) => (
-										<FormItem>
-											<NumberAndSelect
-												id="modelBudgetMaxLimit"
-												labelClassName="font-normal"
-												label="Maximum Spend (USD)"
-												value={field.value}
-												selectValue={form.watch("budgetResetDuration") || "1M"}
-												onChangeNumber={(value) => field.onChange(value)}
-												onChangeSelect={(value) => form.setValue("budgetResetDuration", value, { shouldDirty: true })}
-												options={resetDurationOptions}
-											/>
-											<FormMessage />
-										</FormItem>
-									)}
+								<MultiBudgetLines
+									data-testid="model-limit-budget-lines"
+									label="Budget"
+									lines={(form.watch("budgets") ?? []).map((b) => ({
+										id: b.id,
+										max_limit: b.max_limit,
+										reset_duration: b.reset_duration ?? "1M",
+									}))}
+									onChange={(lines) => form.setValue("budgets", lines, { shouldDirty: true })}
 								/>
 							</div>
 
@@ -476,20 +469,20 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 							</div>
 
 							{/* Current Usage Display (for editing) */}
-							{isEditing && (modelConfig?.budget || modelConfig?.rate_limit) && (
+							{isEditing && ((modelConfig?.budgets?.length ?? 0) > 0 || modelConfig?.rate_limit) && (
 								<>
 									<DottedSeparator />
 									<div className="space-y-3">
 										<Label className="text-sm font-medium">Current Usage</Label>
 										<div className="bg-muted/50 grid grid-cols-2 gap-4 rounded-lg p-4">
-											{modelConfig?.budget && (
-												<div className="space-y-1">
-													<p className="text-muted-foreground text-xs">Budget</p>
+											{(modelConfig?.budgets ?? []).map((b) => (
+												<div key={b.id} className="space-y-1">
+													<p className="text-muted-foreground text-xs">Budget ({b.reset_duration})</p>
 													<p className="text-sm font-medium">
-														${modelConfig.budget.current_usage.toFixed(2)} / ${modelConfig.budget.max_limit.toFixed(2)}
+														${b.current_usage.toFixed(2)} / ${b.max_limit.toFixed(2)}
 													</p>
 												</div>
-											)}
+											))}
 											{modelConfig?.rate_limit?.token_max_limit && (
 												<div className="space-y-1">
 													<p className="text-muted-foreground text-xs">Tokens</p>

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -15,7 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { resetDurationLabels } from "@/lib/constants/governance";
+import { resetDurationLabels, supportsCalendarAlignment } from "@/lib/constants/governance";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { getErrorMessage, useDeleteModelConfigMutation } from "@/lib/store";
@@ -23,12 +23,13 @@ import { ModelConfig } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
+import { ArrowUpRight, ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
 import { ModelLimitsEmptyState } from "./modelLimitsEmptyState";
 import { getScopeLabel } from "@/lib/utils/labels";
+import { useNavigate } from "@tanstack/react-router";
 
 // Helper to format reset duration for display
 const formatResetDuration = (duration: string) => {
@@ -123,6 +124,7 @@ export default function ModelLimitsTable({
 	limit,
 	onOffsetChange,
 }: ModelLimitsTableProps) {
+	const navigate = useNavigate();
 	const [showModelLimitSheet, setShowModelLimitSheet] = useState(false);
 	const [editingModelConfigId, setEditingModelConfigId] = useState<string | null>(null);
 	const [deleteModelConfigId, setDeleteModelConfigId] = useState<string | null>(null);
@@ -248,6 +250,7 @@ export default function ModelLimitsTable({
 								<TableHead className="font-medium">Model</TableHead>
 								<TableHead className="font-medium">Provider</TableHead>
 								<TableHead className="font-medium">Scope</TableHead>
+								<TableHead className="font-medium">Scope Target</TableHead>
 								<TableHead className="font-medium">Budget</TableHead>
 								<TableHead className="font-medium">Rate Limit</TableHead>
 								<TableHead className="w-[100px]"></TableHead>
@@ -256,14 +259,15 @@ export default function ModelLimitsTable({
 						<TableBody>
 							{modelConfigs.length === 0 ? (
 								<TableRow>
-									<TableCell colSpan={6} className="h-24 text-center">
+									<TableCell colSpan={7} className="h-24 text-center">
 										<span className="text-muted-foreground text-sm">No matching model limits found.</span>
 									</TableCell>
 								</TableRow>
 							) : (
 								modelConfigs.map((config) => {
-									const isBudgetExhausted =
-										config.budget?.max_limit && config.budget.max_limit > 0 && config.budget.current_usage >= config.budget.max_limit;
+									// Model configs can own multiple budgets; show all (like the VK table).
+									const budgets = config.budgets ?? (config.budget ? [config.budget] : []);
+									const isBudgetExhausted = budgets.some((b) => b.max_limit > 0 && b.current_usage >= b.max_limit);
 									const isRateLimitExhausted =
 										(config.rate_limit?.token_max_limit &&
 											config.rate_limit.token_max_limit > 0 &&
@@ -274,10 +278,6 @@ export default function ModelLimitsTable({
 									const isExhausted = isBudgetExhausted || isRateLimitExhausted;
 
 									// Compute safe percentages to avoid division by zero
-									const budgetPercentage =
-										config.budget?.max_limit && config.budget.max_limit > 0
-											? Math.min((config.budget.current_usage / config.budget.max_limit) * 100, 100)
-											: 0;
 									const tokenPercentage =
 										config.rate_limit?.token_max_limit && config.rate_limit.token_max_limit > 0
 											? Math.min((config.rate_limit.token_current_usage / config.rate_limit.token_max_limit) * 100, 100)
@@ -318,41 +318,45 @@ export default function ModelLimitsTable({
 											<TableCell>
 												<Badge variant="secondary">{getScopeLabel(config.scope ?? "global")}</Badge>
 											</TableCell>
-											<TableCell className="min-w-[180px]">
-												{config.budget ? (
+											<TableCell>
+												{config.scope !== "global" && config.scope_id && config.scope_name ? (
 													<TooltipProvider>
 														<Tooltip>
 															<TooltipTrigger asChild>
-																<div className="space-y-2">
-																	<div className="flex items-center justify-between gap-4">
-																		<span className="font-medium">{formatCurrency(config.budget.max_limit)}</span>
-																		<span className="text-muted-foreground text-xs">
-																			{formatResetDuration(config.budget.reset_duration)}
-																		</span>
-																	</div>
-																	<Progress
-																		value={budgetPercentage}
-																		className={cn(
-																			"bg-muted/70 dark:bg-muted/30 h-1.5",
-																			isBudgetExhausted
-																				? "[&>div]:bg-red-500/70"
-																				: budgetPercentage > 80
-																					? "[&>div]:bg-amber-500/70"
-																					: "[&>div]:bg-emerald-500/70",
-																		)}
-																	/>
-																</div>
+																<Badge
+																	variant="secondary"
+																	className="flex max-w-[160px] cursor-pointer items-center gap-1 hover:opacity-80"
+																	data-testid={`model-limit-scope-target-${config.scope_id}`}
+																	onClick={() => navigate({ to: "/workspace/governance/virtual-keys", search: { vk: config.scope_id } })}
+																>
+																	<span className="truncate">{config.scope_name}</span>
+																	<ArrowUpRight className="h-3 w-3 shrink-0" />
+																</Badge>
 															</TooltipTrigger>
-															<TooltipContent>
-																<p className="font-medium">
-																	{formatCurrency(config.budget.current_usage)} / {formatCurrency(config.budget.max_limit)}
-																</p>
-																<p className="text-primary-foreground/80 text-xs">
-																	Resets {formatResetDuration(config.budget.reset_duration)}
-																</p>
-															</TooltipContent>
+															<TooltipContent className="max-w-[320px] break-all">{config.scope_name}</TooltipContent>
 														</Tooltip>
 													</TooltipProvider>
+												) : (
+													<span className="text-muted-foreground text-sm">—</span>
+												)}
+											</TableCell>
+											<TableCell className="min-w-[180px]">
+												{budgets.length > 0 ? (
+													<div className="flex flex-col gap-1">
+														{budgets.map((b, idx) => (
+															<div key={b.id ?? idx} className="flex flex-col">
+																<span
+																	className={cn("font-mono text-sm", b.max_limit > 0 && b.current_usage >= b.max_limit && "text-red-400")}
+																>
+																	{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
+																</span>
+																<span className="text-muted-foreground text-xs">
+																	Resets {formatResetDuration(b.reset_duration)}
+																	{config.calendar_aligned && supportsCalendarAlignment(b.reset_duration) && " (calendar)"}
+																</span>
+															</div>
+														))}
+													</div>
 												) : (
 													<span className="text-muted-foreground text-sm">-</span>
 												)}

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -27,6 +27,7 @@ import {
 	getErrorMessage,
 	useBulkRotateVirtualKeysMutation,
 	useDeleteVirtualKeyMutation,
+	useGetVirtualKeyQuery,
 	useLazyGetVirtualKeysQuery,
 	useUpdateVirtualKeyMutation,
 } from "@/lib/store";
@@ -53,6 +54,7 @@ import {
 	ShieldCheck,
 	Trash2,
 } from "lucide-react";
+import { useQueryState } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useVirtualKeyUsage } from "../hooks/useVirtualKeyUsage";
@@ -335,10 +337,22 @@ export default function VirtualKeysTable({
 		() => (editingVirtualKeyId ? (virtualKeys.find((vk) => vk.id === editingVirtualKeyId) ?? null) : null),
 		[editingVirtualKeyId, virtualKeys],
 	);
-	const selectedVirtualKey = useMemo(
+	const selectedVkInList = useMemo(
 		() => (selectedVkId ? (virtualKeys.find((vk) => vk.id === selectedVkId) ?? null) : null),
 		[selectedVkId, virtualKeys],
 	);
+	// Deep-link support: another page (e.g. Model Limits) can open a VK via ?vk=<id>.
+	// The target may not be on the current page/filter, so fetch it by id as a fallback.
+	const [vkParam, setVkParam] = useQueryState("vk");
+	const needsVkFetch = !!selectedVkId && !selectedVkInList;
+	const { data: fetchedVkData } = useGetVirtualKeyQuery(selectedVkId ?? "", { skip: !needsVkFetch });
+	const selectedVirtualKey = selectedVkInList ?? (needsVkFetch ? (fetchedVkData?.virtual_key ?? null) : null);
+
+	useEffect(() => {
+		if (!vkParam) return;
+		onSelectedVkChange(vkParam);
+		setVkParam(null); // consume the param; selection is held in parent state from here
+	}, [vkParam, setVkParam, onSelectedVkChange]);
 
 	const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create);
 	const hasUpdateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Update);

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -85,7 +85,8 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
-			invalidatesTags: ["VirtualKeys"],
+			// VK governance is backed by VK-scoped model configs; refresh Model Limits too.
+			invalidatesTags: ["VirtualKeys", "ModelConfigs"],
 		}),
 
 		updateVirtualKey: builder.mutation<{ message: string; virtual_key: VirtualKey }, { vkId: string; data: UpdateVirtualKeyRequest }>({
@@ -94,7 +95,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			invalidatesTags: ["VirtualKeys"],
+			invalidatesTags: ["VirtualKeys", "ModelConfigs"],
 		}),
 
 		rotateVirtualKey: builder.mutation<{ message: string; virtual_key: VirtualKey }, string>({
@@ -119,7 +120,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/virtual-keys/${vkId}`,
 				method: "DELETE",
 			}),
-			invalidatesTags: ["VirtualKeys"],
+			invalidatesTags: ["VirtualKeys", "ModelConfigs"],
 		}),
 
 		// Teams
@@ -517,7 +518,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				body: data,
 			}),
 			// Wildcard model configs back provider governance; refresh the provider page too.
-			invalidatesTags: ["ProviderGovernance"],
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
 			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -547,7 +548,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			invalidatesTags: ["ProviderGovernance"],
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
 			async onQueryStarted({ id }, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -581,7 +582,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "DELETE",
 			}),
 			// Wildcard model configs back provider governance; refresh the provider page too.
-			invalidatesTags: ["ProviderGovernance"],
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
 			async onQueryStarted(id, { dispatch, getState, queryFulfilled }) {
 				try {
 					await queryFulfilled;

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -350,10 +350,11 @@ export interface ModelConfig {
 	scope?: string; // "global" (default) or "virtual_key"
 	scope_id?: string; // Target of a non-global scope (e.g. the virtual key ID)
 	scope_name?: string; // Resolved, human-readable name of the scope target (read-only)
-	budget_id?: string;
+	calendar_aligned?: boolean; // Snap budget resets to calendar boundaries (inherited from VK for vk scope)
 	rate_limit_id?: string;
 	// Populated relationships
-	budget?: Budget;
+	budgets?: Budget[]; // Multi-budget: each with a distinct reset_duration
+	budget?: Budget; // Deprecated: superseded by budgets (kept for back-compat reads)
 	rate_limit?: RateLimit;
 	created_at: string;
 	updated_at: string;
@@ -365,14 +366,14 @@ export interface CreateModelConfigRequest {
 	provider?: string; // Optional provider - if empty/null, applies to all providers
 	scope?: string; // Defaults to "global" if omitted
 	scope_id?: string; // Required for non-global scopes (e.g. the virtual key ID)
-	budget?: CreateBudgetRequest;
+	budgets?: CreateBudgetRequest[];
 	rate_limit?: CreateRateLimitRequest;
 }
 
 export interface UpdateModelConfigRequest {
 	model_name?: string;
 	provider?: string; // Optional provider - if empty/null, applies to all providers
-	budget?: UpdateBudgetRequest;
+	budgets?: CreateBudgetRequest[]; // Full desired set; reconciled against existing
 	rate_limit?: UpdateRateLimitRequest;
 }
 


### PR DESCRIPTION
## Summary

This PR migrates virtual key (VK) governance (budgets and rate limits) from being owned directly by VK and provider-config rows into VK-scoped all-models wildcard model configs. It also upgrades model configs from a single `budget_id` FK to a `has-many` `Budgets` relationship via `TableBudget.ModelConfigID`, enabling multiple budgets with distinct reset windows on a single model config.

## Changes

- **New `governance_budgets.model_config_id` column**: Adds a `ModelConfigID` FK on `TableBudget`, making model configs the owner of budgets rather than the reverse. Three new migrations handle the column addition, backfill from the legacy `budget_id`, VK governance cutover, and a new `calendar_aligned` column on model configs.
- **VK governance folded into wildcard model configs**: VK top-level budgets/rate-limits move to a `(scope=virtual_key, model_name='*', provider=NULL)` model config; per-provider-config budgets/rate-limits move to `(scope=virtual_key, model_name='*', provider=<provider>)` configs. `syncVKGovernanceToModelConfigs` and `upsertVKWildcard` handle create/update; `hydrateVKGovernance` / `hydrateVKListGovernance` reverse-map them back onto VK responses for display.
- **Multi-budget enforcement**: `CheckModelBudget`, `CheckVirtualKeyScopedModelBudget`, `UpdateProviderAndModelBudgetUsageInMemory`, and `UpdateVirtualKeyScopedModelBudgetUsageInMemory` now iterate `mc.Budgets` instead of reading a single `BudgetID`. All budget checks block if any one budget is exceeded.
- **`CollectApplicableGovernanceIDs` rewrite**: Uses `collectModelConfigsFor` across all four tiers (exact model+provider, model-only, all-models+provider, all-models wildcard) and the full VK scope chain, replacing the previous partial lookup.
- **`DeleteModelConfig` / `DeleteVirtualKey` / `DeleteProvider` cleanup**: Now preload and delete all owned budgets (via `ModelConfigID`) in addition to the legacy single `BudgetID`.
- **`UpdateModelConfig` association safety**: Uses `Omit(clause.Associations)` on save to prevent cascading saves from clobbering live budget usage counters.
- **`calendar_aligned` on model configs**: Propagated from the owning VK for VK-scoped configs; stamped onto owned budgets via `AfterFind` and `rebuildInMemoryStructures` so the reset path reads the correct window.
- **API shape changes**: `CreateModelConfigRequest.budget` → `budgets []CreateBudgetRequest`; `UpdateModelConfigRequest.budget` → `budgets []CreateBudgetRequest` (full desired set, reconciled server-side). `reconcileModelConfigBudgets` handles upsert/delete of the set.
- **UI**: Model limit sheet replaced the single budget field with a `MultiBudgetLines` component. The model limits table now shows all budgets per config, a "Scope Target" column with a deep-link to the VK page, and calendar-alignment labels. VK table gains deep-link support via a `?vk=` query param consumed from the model limits table.
- **Cache invalidation**: VK create/update/delete mutations now also invalidate `ModelConfigs`; model config mutations invalidate `VirtualKeys`; provider governance mutations invalidate `VirtualKeys`.
- **Tests**: New unit tests cover multi-budget enforcement (one exceeded blocks, all within passes, all budgets bumped on usage update), no-double-count guard for VK governance budgets, and multi-budget VK-scoped model config blocking.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Create a VK with top-level budgets and per-provider budgets via the API or UI.
2. Verify that `GET /api/governance/virtual-keys/:id` returns the budgets and rate limits hydrated from the VK-scoped wildcard model configs.
3. Verify that `GET /api/governance/model-configs` shows the VK-scoped wildcard rows with their owned budgets.
4. Make requests through the VK and confirm usage is charged to the wildcard model config budgets exactly once (not double-counted via both the VK hierarchy and scoped-model paths).
5. Delete the VK and confirm no orphaned budget or rate-limit rows remain.
6. In the UI, open Model Limits, confirm multi-budget lines render and the Scope Target column links to the correct VK.

## Breaking changes

- [x] Yes
- [ ] No

The `CreateModelConfigRequest` and `UpdateModelConfigRequest` API shapes change: the single `budget` field is replaced by a `budgets` array. Callers using the single-budget field must migrate to the array form. Existing database rows are backfilled automatically by the migrations; the legacy `budget_id` column and `Budget` association are retained as inert for backward compatibility.

## Related issues

## Security considerations

No new auth surfaces or secrets handling. Budget ownership is enforced via a `BeforeSave` hook that rejects a budget row with more than one owner FK set, preventing accidental cross-owner budget sharing.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Model configs now support multiple budgets for more granular control over API usage
  * Virtual-key governance is now organized within model configurations
  * Added deep-link support for virtual keys via URL parameter
  * Model limits table now displays "Scope Target" with clickable navigation

* **Tests**
  * Added multi-budget governance test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->