### PR TITLE
refactor: makes scope-level check methods extensible

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -840,6 +840,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddModelConfigCalendarAlignedColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationMigrateVirtualKeyGovernanceToModelConfigs(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4047,9 +4050,9 @@ func migrationAddBudgetModelConfigIDColumn(ctx context.Context, db *gorm.DB) err
 	return nil
 }
 
-// ensureVKWildcardModelConfig returns the ID of the VK-scoped all-models wildcard model
-// config, creating it if absent.
-func ensureVKWildcardModelConfig(tx *gorm.DB, vkID string, provider *string, calendarAligned bool, now time.Time) (string, error) {
+// ensureVKModelConfig returns the ID of the VK-scoped model config for the given
+// (vkID, provider) pair, creating it if absent.
+func ensureVKModelConfig(tx *gorm.DB, vkID string, provider *string, calendarAligned bool, now time.Time) (string, error) {
 	q := tx.Model(&tables.TableModelConfig{}).
 		Where("scope = ? AND scope_id = ? AND model_name = ?",
 			tables.ModelConfigScopeVirtualKey, vkID, tables.ModelConfigAllModels)
@@ -4060,7 +4063,7 @@ func ensureVKWildcardModelConfig(tx *gorm.DB, vkID string, provider *string, cal
 	}
 	var existing []tables.TableModelConfig
 	if err := q.Limit(1).Find(&existing).Error; err != nil {
-		return "", fmt.Errorf("failed to look up VK wildcard model config: %w", err)
+		return "", fmt.Errorf("failed to look up VK model config: %w", err)
 	}
 	if len(existing) > 0 {
 		return existing[0].ID, nil
@@ -4076,7 +4079,7 @@ func ensureVKWildcardModelConfig(tx *gorm.DB, vkID string, provider *string, cal
 		UpdatedAt:       now,
 	}
 	if err := tx.Create(&mc).Error; err != nil {
-		return "", fmt.Errorf("failed to create VK wildcard model config: %w", err)
+		return "", fmt.Errorf("failed to create VK model config: %w", err)
 	}
 	return mc.ID, nil
 }
@@ -4110,7 +4113,7 @@ func migrationMigrateVirtualKeyGovernanceToModelConfigs(ctx context.Context, db 
 
 				// VK top-level governance -> all-providers wildcard.
 				if len(vk.Budgets) > 0 || vk.RateLimitID != nil {
-					mcID, err := ensureVKWildcardModelConfig(tx, vk.ID, nil, vk.CalendarAligned, now)
+					mcID, err := ensureVKModelConfig(tx, vk.ID, nil, vk.CalendarAligned, now)
 					if err != nil {
 						return err
 					}
@@ -4139,7 +4142,7 @@ func migrationMigrateVirtualKeyGovernanceToModelConfigs(ctx context.Context, db 
 						continue
 					}
 					provider := pc.Provider
-					mcID, err := ensureVKWildcardModelConfig(tx, vk.ID, &provider, vk.CalendarAligned, now)
+					mcID, err := ensureVKModelConfig(tx, vk.ID, &provider, vk.CalendarAligned, now)
 					if err != nil {
 						return err
 					}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1163,27 +1163,34 @@ func (s *RDBConfigStore) DeleteProvider(ctx context.Context, provider schemas.Mo
 	if err := txDB.WithContext(ctx).Preload("Budgets").Where("provider = ?", string(provider)).Find(&providerModelConfigs).Error; err != nil {
 		return err
 	}
-	for _, mc := range providerModelConfigs {
-		for i := range mc.Budgets {
-			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", mc.Budgets[i].ID).Error; err != nil {
-				return err
-			}
-		}
-		if mc.BudgetID != nil {
-			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *mc.BudgetID).Error; err != nil {
-				return err
-			}
-		}
-		if mc.RateLimitID != nil {
-			if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", *mc.RateLimitID).Error; err != nil {
-				return err
-			}
-		}
-	}
 	if len(providerModelConfigs) > 0 {
 		var mcIDs []string
+		var budgetIDs []string
+		var rateLimitIDs []string
+		for i := range providerModelConfigs {
+			mcIDs = append(mcIDs, providerModelConfigs[i].ID)
+			for j := range providerModelConfigs[i].Budgets {
+				budgetIDs = append(budgetIDs, providerModelConfigs[i].Budgets[j].ID)
+			}
+			if providerModelConfigs[i].BudgetID != nil {
+				budgetIDs = append(budgetIDs, *providerModelConfigs[i].BudgetID)
+			}
+			if providerModelConfigs[i].RateLimitID != nil {
+				rateLimitIDs = append(rateLimitIDs, *providerModelConfigs[i].RateLimitID)
+			}
+		}
 		if err := txDB.WithContext(ctx).Where("id IN ?", mcIDs).Delete(&tables.TableModelConfig{}).Error; err != nil {
 			return err
+		}
+		if len(budgetIDs) > 0 {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id IN ?", budgetIDs).Error; err != nil {
+				return err
+			}
+		}
+		if len(rateLimitIDs) > 0 {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id IN ?", rateLimitIDs).Error; err != nil {
+				return err
+			}
 		}
 	}
 
@@ -3002,12 +3009,6 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...
 		budgetIDs := make([]string, 0, len(scopedModelConfigs))
 		rateLimitIDs := make([]string, 0, len(scopedModelConfigs))
 		for _, mc := range scopedModelConfigs {
-			// Owned budgets via ModelConfigID plus the legacy single BudgetID for safety.
-			for i := range mc.Budgets {
-				if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", mc.Budgets[i].ID).Error; err != nil {
-					return err
-				}
-			}
 			if mc.BudgetID != nil {
 				budgetIDs = append(budgetIDs, *mc.BudgetID)
 			}
@@ -3019,6 +3020,16 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...
 			Where("scope = ? AND scope_id = ?", tables.ModelConfigScopeVirtualKey, id).
 			Delete(&tables.TableModelConfig{}).Error; err != nil {
 			return err
+		}
+		if len(budgetIDs) > 0 {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id IN ?", budgetIDs).Error; err != nil {
+				return err
+			}
+		}
+		if len(rateLimitIDs) > 0 {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id IN ?", rateLimitIDs).Error; err != nil {
+				return err
+			}
 		}
 		rateLimitID := virtualKey.RateLimitID
 		// Delete the virtual key
@@ -4256,6 +4267,20 @@ func (s *RDBConfigStore) DeleteRoutingRule(ctx context.Context, id string, tx ..
 func (s *RDBConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
 	var modelConfigs []tables.TableModelConfig
 	if err := s.DB().WithContext(ctx).Preload("Budgets").Preload("Budget").Preload("RateLimit").Find(&modelConfigs).Error; err != nil {
+		return nil, err
+	}
+	return modelConfigs, nil
+}
+
+// GetModelConfigsByScopeAndScopeIDs retrieves model configs for a specific scope limited to the given scope IDs.
+func (s *RDBConfigStore) GetModelConfigsByScopeAndScopeIDs(ctx context.Context, scope string, scopeIDs []string) ([]tables.TableModelConfig, error) {
+	if len(scopeIDs) == 0 {
+		return nil, nil
+	}
+	var modelConfigs []tables.TableModelConfig
+	if err := s.DB().WithContext(ctx).Preload("Budgets").Preload("Budget").Preload("RateLimit").
+		Where("scope = ? AND scope_id IN ?", scope, scopeIDs).
+		Find(&modelConfigs).Error; err != nil {
 		return nil, err
 	}
 	return modelConfigs, nil

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -256,6 +256,7 @@ type ConfigStore interface {
 
 	// Model config CRUD
 	GetModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error)
+	GetModelConfigsByScopeAndScopeIDs(ctx context.Context, scope string, scopeIDs []string) ([]tables.TableModelConfig, error)
 	GetProviderGovernanceModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error)
 	GetModelConfigsPaginated(ctx context.Context, params ModelConfigsQueryParams) ([]tables.TableModelConfig, int64, error)
 	GetModelConfig(ctx context.Context, scope string, scopeID *string, modelName string, provider *string) (*tables.TableModelConfig, error)

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -3,6 +3,7 @@ package tables
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"gorm.io/gorm"
@@ -12,6 +13,7 @@ import (
 const (
 	ModelConfigScopeGlobal     = "global"
 	ModelConfigScopeVirtualKey = "virtual_key"
+	ModelConfigScopeUser       = "user"
 )
 
 // ModelConfigAllModels is the model_name sentinel meaning "all models". Combined with a
@@ -19,14 +21,36 @@ const (
 // with a nil provider it means all models on all providers.
 const ModelConfigAllModels = "*"
 
-// validModelConfigScopes is the set of accepted scope values.
-var validModelConfigScopes = map[string]bool{
-	ModelConfigScopeGlobal:     true,
-	ModelConfigScopeVirtualKey: true,
+// validModelConfigScopes is the runtime registry of accepted scope values.
+// OSS seeds it with global + virtual_key; downstream consumers (e.g. the
+// enterprise build registering "user") extend it at startup via
+// RegisterModelConfigScope. Guarded by validModelConfigScopesMu.
+var (
+	validModelConfigScopesMu sync.RWMutex
+	validModelConfigScopes   = map[string]bool{
+		ModelConfigScopeGlobal:     true,
+		ModelConfigScopeVirtualKey: true,
+	}
+)
+
+// RegisterModelConfigScope adds scope to the allow-list consulted by
+// IsValidModelConfigScope and TableModelConfig.BeforeSave. Intended to be
+// called once at process startup; safe to call concurrently. Whitespace-
+// only input is ignored.
+func RegisterModelConfigScope(scope string) {
+	s := strings.TrimSpace(scope)
+	if s == "" {
+		return
+	}
+	validModelConfigScopesMu.Lock()
+	validModelConfigScopes[s] = true
+	validModelConfigScopesMu.Unlock()
 }
 
 // IsValidModelConfigScope reports whether scope is a recognized model config scope.
 func IsValidModelConfigScope(scope string) bool {
+	validModelConfigScopesMu.RLock()
+	defer validModelConfigScopesMu.RUnlock()
 	return validModelConfigScopes[scope]
 }
 

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -2247,7 +2247,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_NilVK(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), nil, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), "", "", &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -2258,7 +2258,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_NoConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	vk := buildVirtualKey("vk1", "vk1-value", "vk1", true)
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -2274,7 +2274,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_WithinLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	_, err = store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err, "Should allow when per-VK model budget is within limit")
 }
 
@@ -2289,7 +2289,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_Exceeded(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	_, err = store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "Should reject when per-VK model budget is exceeded")
 	assert.Contains(t, err.Error(), "budget exceeded")
 }
@@ -2307,7 +2307,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_OnlyAppliesToMatchingVK(t *testi
 	require.NoError(t, err)
 
 	// A request made with a DIFFERENT virtual key must not be affected by vk1's scoped config.
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), otherVK, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, otherVK.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -2326,7 +2326,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_IgnoresGlobalConfig(t *testing.T
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err, "Scoped check must not pick up the global config")
 	assert.Equal(t, DecisionAllow, decision)
 
@@ -2346,7 +2346,7 @@ func TestStore_CheckVirtualKeyScopedModelRateLimit_TokenLimitExceeded(t *testing
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckVirtualKeyScopedModelRateLimit(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
 	assert.Error(t, err, "Should reject when per-VK model token limit is exceeded")
 	assert.Equal(t, DecisionTokenLimited, decision)
 }
@@ -2362,7 +2362,7 @@ func TestStore_CheckVirtualKeyScopedModelRateLimit_WithinLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckVirtualKeyScopedModelRateLimit(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -2384,16 +2384,16 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_TokenLimitTrips(t *testing.
 	req := &EvaluationRequest{Model: "claude-opus-4-7", Provider: schemas.Anthropic}
 
 	// Initially within limit.
-	decision, err := store.CheckVirtualKeyScopedModelRateLimit(context.Background(), vk, req, nil, nil)
+	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, decision)
 
 	// Record usage above the limit (what the tracker does post-response). Provider differs from
 	// the config's (which is all-providers), exercising the model-only scoped lookup.
-	require.NoError(t, store.UpdateVirtualKeyScopedModelRateLimitUsageInMemory(context.Background(), vk, "claude-opus-4-7", schemas.Anthropic, 150, true, true))
+	require.NoError(t, store.UpdateScopedModelRateLimitUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "claude-opus-4-7", schemas.Anthropic, 150, true, true))
 
 	// Now the scoped check must trip.
-	decision, err = store.CheckVirtualKeyScopedModelRateLimit(context.Background(), vk, req, nil, nil)
+	decision, err = store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil, nil)
 	assert.Error(t, err)
 	assert.Equal(t, DecisionTokenLimited, decision)
 }
@@ -2411,13 +2411,13 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_BudgetTrips(t *testing.T) {
 
 	req := &EvaluationRequest{Model: "claude-opus-4-7", Provider: schemas.Anthropic}
 
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, req, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, decision)
 
-	require.NoError(t, store.UpdateVirtualKeyScopedModelBudgetUsageInMemory(context.Background(), vk, "claude-opus-4-7", schemas.Anthropic, 15.0))
+	require.NoError(t, store.UpdateScopedModelBudgetUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "claude-opus-4-7", schemas.Anthropic, 15.0))
 
-	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, req, nil)
+	_, err = store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil)
 	assert.Error(t, err, "scoped budget should trip once usage exceeds the cap")
 }
 
@@ -2440,7 +2440,7 @@ func TestStore_VKGovernanceBudget_NoDoubleCount(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mirror tracker.UpdateUsage: scoped-model path + hierarchy path, same request/cost.
-	require.NoError(t, store.UpdateVirtualKeyScopedModelBudgetUsageInMemory(context.Background(), vk, "gpt-4", schemas.OpenAI, 10.0))
+	require.NoError(t, store.UpdateScopedModelBudgetUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "gpt-4", schemas.OpenAI, 10.0))
 	require.NoError(t, store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 10.0))
 
 	b := store.LoadBudget(context.Background(), "vkb")
@@ -2473,6 +2473,6 @@ func TestStore_CheckVirtualKeyScopedModelBudget_MultiBudget_OneExceededBlocks(t 
 	}, nil)
 	require.NoError(t, err)
 
-	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	_, err = store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "an exceeded budget among several on a VK-scoped config must block")
 }

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -215,6 +215,24 @@ func (r *BudgetResolver) EvaluateUserRequest(ctx *schemas.BifrostContext, userID
 		}
 	}
 
+	// Check per-user-scoped model config rate limits and budgets. Mirrors the
+	// VK-scoped block in EvaluateVirtualKeyRequest. Gated on model being present —
+	// MCP tool execution (no model) is excluded naturally by this guard.
+	if request.Model != "" {
+		if decision, err := r.store.CheckScopedModelRateLimit(ctx, configstoreTables.ModelConfigScopeUser, userID, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+			return &EvaluationResult{
+				Decision: decision,
+				Reason:   fmt.Sprintf("User-level model rate limit exceeded: %s", reasonFromErr(err, decision)),
+			}
+		}
+		if decision, err := r.store.CheckScopedModelBudget(ctx, configstoreTables.ModelConfigScopeUser, userID, request, nil); err != nil || isBudgetViolation(decision) {
+			return &EvaluationResult{
+				Decision: decision,
+				Reason:   fmt.Sprintf("User-level model budget exceeded: %s", reasonFromErr(err, decision)),
+			}
+		}
+	}
+
 	return &EvaluationResult{
 		Decision: DecisionAllow,
 		Reason:   "User-level checks passed",
@@ -292,14 +310,14 @@ func (r *BudgetResolver) EvaluateVirtualKeyRequest(ctx *schemas.BifrostContext, 
 		// request must satisfy both (most-restrictive wins). Gated on a model being present,
 		// mirroring the global model checks.
 		if model != "" {
-			if decision, err := r.store.CheckVirtualKeyScopedModelRateLimit(ctx, vk, evaluationRequest, nil, nil); err != nil || isRateLimitViolation(decision) {
+			if decision, err := r.store.CheckScopedModelRateLimit(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, evaluationRequest, nil, nil); err != nil || isRateLimitViolation(decision) {
 				return &EvaluationResult{
 					Decision:   decision,
 					Reason:     fmt.Sprintf("Model-level rate limit check failed (virtual key scope): %s", reasonFromErr(err, decision)),
 					VirtualKey: vk,
 				}
 			}
-			if decision, err := r.store.CheckVirtualKeyScopedModelBudget(ctx, vk, evaluationRequest, nil); err != nil || isBudgetViolation(decision) {
+			if decision, err := r.store.CheckScopedModelBudget(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, evaluationRequest, nil); err != nil || isBudgetViolation(decision) {
 				return &EvaluationResult{
 					Decision:   decision,
 					Reason:     fmt.Sprintf("Model-level budget exceeded (virtual key scope): %s", reasonFromErr(err, decision)),

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -118,18 +118,22 @@ type GovernanceStore interface {
 	// Model-level governance checks
 	CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
 	CheckModelRateLimit(ctx context.Context, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
-	// Per-VK-scoped model-level governance checks (aggregate with the global model checks above)
-	CheckVirtualKeyScopedModelBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
-	CheckVirtualKeyScopedModelRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	// Scoped model-level governance checks (aggregate with the global model checks above).
+	// scope/scopeID identify the owning entity (e.g. "virtual_key" + VK.ID, or any other
+	// scope registered via tables.RegisterModelConfigScope). An empty scope or scopeID
+	// is a no-op (returns DecisionAllow).
+	CheckScopedModelBudget(ctx context.Context, scope, scopeID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
+	CheckScopedModelRateLimit(ctx context.Context, scope, scopeID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
 	// VK-level governance checks
 	CheckVirtualKeyBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
 	CheckVirtualKeyRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
 	// In-memory usage updates (for VK-level)
 	UpdateVirtualKeyBudgetUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, cost float64) error
 	UpdateVirtualKeyRateLimitUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
-	// In-memory usage updates for per-VK-scoped model configs (mirror the global model updates)
-	UpdateVirtualKeyScopedModelBudgetUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, model string, provider schemas.ModelProvider, cost float64) error
-	UpdateVirtualKeyScopedModelRateLimitUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
+	// In-memory usage updates for scoped model configs (mirror the global model updates).
+	// scope/scopeID identify the owning entity; an empty scope or scopeID is a no-op.
+	UpdateScopedModelBudgetUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, cost float64) error
+	UpdateScopedModelRateLimitUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// In-memory reset checks (return items that need DB sync)
 	ResetExpiredRateLimitsInMemory(ctx context.Context) []*configstoreTables.TableRateLimit
 	ResetExpiredBudgetsInMemory(ctx context.Context) []*configstoreTables.TableBudget
@@ -1068,8 +1072,8 @@ func (gs *LocalGovernanceStore) findScopedModelOnlyConfig(ctx context.Context, s
 	return tryKey(model)
 }
 
-// modelAndProvider extracts the model name and optional provider from a request.
-func modelAndProvider(request *EvaluationRequest) (string, *string) {
+// extractModelAndProvider extracts the model name and optional provider from a request.
+func extractModelAndProvider(request *EvaluationRequest) (string, *string) {
 	if request == nil {
 		return "", nil
 	}
@@ -1160,10 +1164,11 @@ func (gs *LocalGovernanceStore) loadModelConfigBudgets(ctx context.Context, mc *
 // CheckModelBudget performs budget checking for global-scope model-level configs, across all
 // four tiers (exact model±provider and all-models "*"±provider).
 func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
+	// This is to prevent nil pointer dereference
 	if baselines == nil {
 		baselines = map[string]float64{}
 	}
-	model, provider := modelAndProvider(request)
+	model, provider := extractModelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
 		if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
@@ -1288,13 +1293,14 @@ func (gs *LocalGovernanceStore) CheckUserBudget(ctx context.Context, userID stri
 
 // CheckModelRateLimit checks global-scope model-level rate limits across all four tiers
 func (gs *LocalGovernanceStore) CheckModelRateLimit(ctx context.Context, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+	// This is to prevent nil pointer dereference
 	if tokensBaselines == nil {
 		tokensBaselines = map[string]int64{}
 	}
 	if requestsBaselines == nil {
 		requestsBaselines = map[string]int64{}
 	}
-	model, provider := modelAndProvider(request)
+	model, provider := extractModelAndProvider(request)
 	entityWiseRateLimits := make(EntityWiseRateLimits)
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
 		if mc.RateLimitID == nil {
@@ -1307,32 +1313,30 @@ func (gs *LocalGovernanceStore) CheckModelRateLimit(ctx context.Context, request
 	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
 }
 
-// CheckVirtualKeyScopedModelBudget enforces budgets from model configs scoped to the
-// request's virtual key. These are checked in addition to the global model budgets. A request
-// must satisfy both the global model config and any matching per-VK model config.
-func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
-	if vk == nil {
+// CheckScopedModelBudget enforces budgets from model configs scoped to the given
+// (scope, scopeID) — e.g. ("virtual_key", vk.ID). Checked in addition to the global
+// model budgets; a request must satisfy both. Empty scope or scopeID is a no-op.
+func (gs *LocalGovernanceStore) CheckScopedModelBudget(ctx context.Context, scope, scopeID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
+	if scope == "" || scopeID == "" {
 		return DecisionAllow, nil
 	}
 	if baselines == nil {
 		baselines = map[string]float64{}
 	}
-	model, provider := modelAndProvider(request)
+	model, provider := extractModelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
-	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, provider) {
-			if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
-				entityWiseBudgets[modelConfigEntityKey(mc)] = budgets
-			}
+	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, provider) {
+		if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
+			entityWiseBudgets[modelConfigEntityKey(mc)] = budgets
 		}
 	}
 	return gs.CheckBudget(ctx, entityWiseBudgets, baselines)
 }
 
-// CheckVirtualKeyScopedModelRateLimit enforces rate limits from model configs scoped to the
-// request's virtual key, in addition to the global model rate limits.
-func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
-	if vk == nil {
+// CheckScopedModelRateLimit enforces rate limits from model configs scoped to the given
+// (scope, scopeID), in addition to the global model rate limits.
+func (gs *LocalGovernanceStore) CheckScopedModelRateLimit(ctx context.Context, scope, scopeID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+	if scope == "" || scopeID == "" {
 		return DecisionAllow, nil
 	}
 	if tokensBaselines == nil {
@@ -1341,16 +1345,14 @@ func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelRateLimit(ctx context.
 	if requestsBaselines == nil {
 		requestsBaselines = map[string]int64{}
 	}
-	model, provider := modelAndProvider(request)
+	model, provider := extractModelAndProvider(request)
 	entityWiseRateLimits := make(EntityWiseRateLimits)
-	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, provider) {
-			if mc.RateLimitID == nil {
-				continue
-			}
-			if rateLimit := gs.LoadRateLimit(ctx, *mc.RateLimitID); rateLimit != nil {
-				entityWiseRateLimits[modelConfigEntityKey(mc)] = []*configstoreTables.TableRateLimit{rateLimit}
-			}
+	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, provider) {
+		if mc.RateLimitID == nil {
+			continue
+		}
+		if rateLimit := gs.LoadRateLimit(ctx, *mc.RateLimitID); rateLimit != nil {
+			entityWiseRateLimits[modelConfigEntityKey(mc)] = []*configstoreTables.TableRateLimit{rateLimit}
 		}
 	}
 	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
@@ -1467,11 +1469,11 @@ func (gs *LocalGovernanceStore) UpdateProviderAndModelRateLimitUsageInMemory(ctx
 	return nil
 }
 
-// UpdateVirtualKeyScopedModelBudgetUsageInMemory bumps budget usage for model configs scoped
-// to the request's virtual key. This is the post-response counterpart to
-// CheckVirtualKeyScopedModelBudget — without it, scoped budgets never increase and never trip.
-func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelBudgetUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, model string, provider schemas.ModelProvider, cost float64) error {
-	if vk == nil || model == "" {
+// UpdateScopedModelBudgetUsageInMemory bumps budget usage for model configs scoped to the
+// given (scope, scopeID). Post-response counterpart to CheckScopedModelBudget — without it,
+// scoped budgets never increase and never trip. Empty scope/scopeID/model is a no-op.
+func (gs *LocalGovernanceStore) UpdateScopedModelBudgetUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, cost float64) error {
+	if scope == "" || scopeID == "" {
 		return nil
 	}
 	var providerStr *string
@@ -1479,22 +1481,20 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelBudgetUsageInMemory(c
 		p := string(provider)
 		providerStr = &p
 	}
-	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
-			for i := range mc.Budgets {
-				if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
-					return err
-				}
+	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, providerStr) {
+		for i := range mc.Budgets {
+			if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
+				return err
 			}
 		}
 	}
 	return nil
 }
 
-// UpdateVirtualKeyScopedModelRateLimitUsageInMemory bumps rate limit counters for model configs
-// scoped to the request's virtual key. Post-response counterpart to CheckVirtualKeyScopedModelRateLimit.
-func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelRateLimitUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
-	if vk == nil || model == "" {
+// UpdateScopedModelRateLimitUsageInMemory bumps rate limit counters for model configs scoped
+// to the given (scope, scopeID). Post-response counterpart to CheckScopedModelRateLimit.
+func (gs *LocalGovernanceStore) UpdateScopedModelRateLimitUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
+	if scope == "" || scopeID == "" {
 		return nil
 	}
 	var providerStr *string
@@ -1502,14 +1502,12 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelRateLimitUsageInMemor
 		p := string(provider)
 		providerStr = &p
 	}
-	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
-			if mc.RateLimitID == nil {
-				continue
-			}
-			if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-				return err
-			}
+	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, providerStr) {
+		if mc.RateLimitID == nil {
+			continue
+		}
+		if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -2136,6 +2134,10 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 		for j := range mc.Budgets {
 			mc.Budgets[j].IsCalendarAligned = mc.CalendarAligned
 			gs.budgets.Store(mc.Budgets[j].ID, &mc.Budgets[j])
+		}
+		if mc.RateLimit != nil {
+			mc.RateLimit.IsCalendarAligned = mc.CalendarAligned
+			gs.rateLimits.Store(mc.RateLimit.ID, mc.RateLimit)
 		}
 		scopeID := ""
 		if mc.ScopeID != nil {
@@ -3123,8 +3125,10 @@ func (gs *LocalGovernanceStore) UpdateModelConfigInMemory(ctx context.Context, m
 		gs.budgets.Store(b.ID, b)
 	}
 
-	// Store associated rate limit if exists, preserving existing in-memory usage
+	// Store associated rate limit if exists, preserving existing in-memory usage and
+	// stamping calendar alignment from the owning model config.
 	if clone.RateLimit != nil {
+		clone.RateLimit.IsCalendarAligned = clone.CalendarAligned
 		if existingRateLimitValue, exists := gs.rateLimits.Load(clone.RateLimit.ID); exists && existingRateLimitValue != nil {
 			if erl, ok := existingRateLimitValue.(*configstoreTables.TableRateLimit); ok && erl != nil {
 				clone.RateLimit.TokenCurrentUsage = erl.TokenCurrentUsage
@@ -3513,10 +3517,17 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 		RateLimitRequestPercentUsed: 0,
 	}
 
-	// Check model-specific rate limits and budgets (takes precedence)
+	// Check model-level rate limits and budgets across all tiers (exact model+provider,
+	// model-only, and wildcard "*:provider" / "*:nil" from provider-governance migration).
+	// collectModelConfigsFor returns all four tiers so provider-level wildcard configs
+	// are included and status stays in sync with enforcement.
 	if model != "" {
-		if modelConfig, _ := gs.findScopedModelOnlyConfig(ctx, configstoreTables.ModelConfigScopeGlobal, "", model); modelConfig != nil {
-			// Get rate limit status
+		var providerStr *string
+		if provider != "" {
+			p := string(provider)
+			providerStr = &p
+		}
+		for _, modelConfig := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
 			if modelConfig.RateLimitID != nil {
 				if rateLimitValue, ok := gs.rateLimits.Load(*modelConfig.RateLimitID); ok && rateLimitValue != nil {
 					if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -81,8 +81,10 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 
 	// 1. Update rate limit usage for both provider-level and model-level
 	// This applies even when virtual keys are disabled or not present
-	// Guard: only update when both Provider and Model are set (MCP paths may not have these)
-	if update.Provider != "" && update.Model != "" {
+	// Guard: only update when Model is set (MCP paths may not have it); provider is optional —
+	// the underlying function handles empty provider by skipping provider-level and still
+	// updating any matching global model-only configs.
+	if update.Model != "" {
 		if err := t.store.UpdateProviderAndModelRateLimitUsageInMemory(ctx, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
 			t.logger.Error("failed to update rate limit usage for model %s, provider %s: %v", update.Model, update.Provider, err)
 		}
@@ -90,8 +92,10 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 
 	// 2. Update budget usage for both provider-level and model-level
 	// This applies even when virtual keys are disabled or not present
-	// Guard: only update when both Provider and Model are set (MCP paths may not have these)
-	if update.Provider != "" && update.Model != "" && shouldUpdateBudget && update.Cost > 0 {
+	// Guard: only update when Model is set (MCP paths may not have it); provider is optional —
+	// the underlying function handles empty provider by skipping provider-level and still
+	// updating any matching global model-only configs.
+	if update.Model != "" && shouldUpdateBudget && update.Cost > 0 {
 		if err := t.store.UpdateProviderAndModelBudgetUsageInMemory(ctx, update.Model, update.Provider, update.Cost); err != nil {
 			t.logger.Error("failed to update budget usage for model %s, provider %s: %v", update.Model, update.Provider, err)
 		}
@@ -107,6 +111,19 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 		if shouldUpdateBudget && update.Cost > 0 {
 			if err := t.store.UpdateUserBudgetUsageInMemory(ctx, update.UserID, update.Cost); err != nil {
 				t.logger.Error("failed to update user budget usage for user %s: %v", update.UserID, err)
+			}
+		}
+		// Update per-user-scoped model config rate limits and budgets. Mirrors the
+		// VK-scoped model block below. Gated on model being present — MCP tool
+		// execution paths (no model) are excluded naturally by this guard.
+		if update.Model != "" {
+			if err := t.store.UpdateScopedModelRateLimitUsageInMemory(ctx, configstoreTables.ModelConfigScopeUser, update.UserID, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
+				t.logger.Error("failed to update scoped model rate limit usage for user %s: %v", update.UserID, err)
+			}
+			if shouldUpdateBudget && update.Cost > 0 {
+				if err := t.store.UpdateScopedModelBudgetUsageInMemory(ctx, configstoreTables.ModelConfigScopeUser, update.UserID, update.Model, update.Provider, update.Cost); err != nil {
+					t.logger.Error("failed to update scoped model budget usage for user %s: %v", update.UserID, err)
+				}
 			}
 		}
 	}
@@ -127,11 +144,11 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 	// Update per-VK-scoped model config usage (counterpart to the global model updates above).
 	// Without this, per-VK model limits never increment and so never trip.
 	if update.Model != "" {
-		if err := t.store.UpdateVirtualKeyScopedModelRateLimitUsageInMemory(ctx, vk, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
+		if err := t.store.UpdateScopedModelRateLimitUsageInMemory(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
 			t.logger.Error("failed to update scoped model rate limit usage for VK %s: %v", vk.ID, err)
 		}
 		if shouldUpdateBudget && update.Cost > 0 {
-			if err := t.store.UpdateVirtualKeyScopedModelBudgetUsageInMemory(ctx, vk, update.Model, update.Provider, update.Cost); err != nil {
+			if err := t.store.UpdateScopedModelBudgetUsageInMemory(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, update.Model, update.Provider, update.Cost); err != nil {
 				t.logger.Error("failed to update scoped model budget usage for VK %s: %v", vk.ID, err)
 			}
 		}

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -56,12 +57,52 @@ type GovernanceManager interface {
 }
 
 // GovernanceHandler manages HTTP requests for governance operations
+// ScopeNameResolver returns the human-readable name for a non-global model
+// config scope target (e.g. a virtual key's Name given its ID). The second
+// return value is false when no name could be resolved; the UI then falls
+// back to rendering the raw scope_id. Implementations must be safe to call
+// concurrently.
+type ScopeNameResolver func(ctx context.Context, scopeID string) (string, bool)
+
+// scopeNameResolvers is the package-level registry consulted by
+// resolveModelConfigScopeName. OSS seeds it (virtual_key) the first time a
+// GovernanceHandler is constructed; downstream builds extend it via
+// RegisterScopeNameResolver at startup. Guarded by scopeNameResolversMu.
+var (
+	scopeNameResolversMu sync.RWMutex
+	scopeNameResolvers   = map[string]ScopeNameResolver{}
+)
+
+// RegisterScopeNameResolver wires a resolver for a model_config scope value.
+// Intended to be called once at process startup, before serving requests
+// (e.g. an enterprise build registering a "user" resolver). Overwrites any
+// previously registered resolver for the same scope. Safe to call
+// concurrently.
+func RegisterScopeNameResolver(scope string, fn ScopeNameResolver) {
+	if scope == "" || fn == nil {
+		return
+	}
+	scopeNameResolversMu.Lock()
+	scopeNameResolvers[scope] = fn
+	scopeNameResolversMu.Unlock()
+}
+
+func lookupScopeNameResolver(scope string) (ScopeNameResolver, bool) {
+	scopeNameResolversMu.RLock()
+	defer scopeNameResolversMu.RUnlock()
+	fn, ok := scopeNameResolvers[scope]
+	return fn, ok
+}
+
 type GovernanceHandler struct {
 	configStore       configstore.ConfigStore
 	governanceManager GovernanceManager
 }
 
-// NewGovernanceHandler creates a new governance handler instance
+// NewGovernanceHandler creates a new governance handler instance.
+// Side effect: ensures the default virtual_key scope-name resolver is
+// registered against the supplied configStore, so resolveModelConfigScopeName
+// can render VK names for OSS-only builds without further wiring.
 func NewGovernanceHandler(manager GovernanceManager, configStore configstore.ConfigStore) (*GovernanceHandler, error) {
 	if manager == nil {
 		return nil, fmt.Errorf("governance manager is required")
@@ -69,6 +110,13 @@ func NewGovernanceHandler(manager GovernanceManager, configStore configstore.Con
 	if configStore == nil {
 		return nil, fmt.Errorf("config store is required")
 	}
+	RegisterScopeNameResolver(configstoreTables.ModelConfigScopeVirtualKey, func(ctx context.Context, scopeID string) (string, bool) {
+		vk, err := configStore.GetVirtualKey(ctx, scopeID)
+		if err != nil || vk == nil {
+			return "", false
+		}
+		return vk.Name, true
+	})
 	return &GovernanceHandler{
 		governanceManager: manager,
 		configStore:       configStore,
@@ -411,11 +459,11 @@ func (h *GovernanceHandler) reconcileModelConfigBudgets(ctx context.Context, tx 
 	return nil
 }
 
-// vkWildcardDesired is the desired governance state for one VK-scoped all-models wildcard
-// model config (provider=nil for the VK top-level, or a specific provider). The *Provided
-// flags distinguish "leave unchanged" (false, used by partial VK updates) from "set to the
-// given value" (true). The rateLimit carries only the limit/duration fields (no ID/usage).
-type vkWildcardDesired struct {
+// vkModelConfigDesired is the desired governance state for one VK-scoped model config tier
+// (provider=nil for the VK top-level, or a specific provider). The *Provided flags distinguish
+// "leave unchanged" (false, used by partial VK updates) from "set to the given value" (true).
+// The rateLimit carries only the limit/duration fields (no ID/usage).
+type vkModelConfigDesired struct {
 	provider          *string
 	budgetsProvided   bool
 	budgets           []CreateBudgetRequest
@@ -425,14 +473,14 @@ type vkWildcardDesired struct {
 }
 
 // syncVKGovernanceToModelConfigs folds a virtual key's governance (top-level + per-provider
-// budgets/rate-limits) into VK-scoped all-models wildcard model configs, the single source of
-// truth. It upserts the top-level and per-provider wildcards and deletes wildcards for
-// providers no longer configured. Must run inside the VK create/update transaction.
-// reconcileProviders controls per-provider handling: true treats perProvider as the full
-// desired set (upserting them and deleting wildcards for absent providers); false leaves all
-// per-provider wildcards untouched (for a partial VK update that omits provider_configs).
-func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, top vkWildcardDesired, perProvider []vkWildcardDesired, reconcileProviders bool) error {
-	if err := h.upsertVKWildcard(ctx, tx, vk, top); err != nil {
+// budgets/rate-limits) into VK-scoped model configs, the single source of truth. It reconciles
+// the top-level and per-provider configs and removes configs for providers no longer configured.
+// Must run inside the VK create/update transaction. reconcileProviders controls per-provider
+// handling: true treats perProvider as the full desired set (reconciling and removing absent
+// providers); false leaves all per-provider configs untouched (for a partial VK update that
+// omits provider_configs).
+func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, top vkModelConfigDesired, perProvider []vkModelConfigDesired, reconcileProviders bool) error {
+	if err := h.reconcileVKModelConfig(ctx, tx, vk, top); err != nil {
 		return err
 	}
 	if !reconcileProviders {
@@ -444,11 +492,11 @@ func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, 
 			continue
 		}
 		keep[*pg.provider] = true
-		if err := h.upsertVKWildcard(ctx, tx, vk, pg); err != nil {
+		if err := h.reconcileVKModelConfig(ctx, tx, vk, pg); err != nil {
 			return err
 		}
 	}
-	// Delete VK-scoped provider wildcards whose provider is no longer configured.
+	// Delete VK-scoped provider model configs whose provider is no longer configured.
 	var existing []configstoreTables.TableModelConfig
 	if err := tx.Preload("Budgets").
 		Where("scope = ? AND scope_id = ? AND model_name = ? AND provider IS NOT NULL",
@@ -459,7 +507,7 @@ func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, 
 	for i := range existing {
 		mc := &existing[i]
 		if mc.Provider != nil && !keep[*mc.Provider] {
-			if err := h.deleteVKWildcardModelConfig(ctx, tx, mc); err != nil {
+			if err := h.deleteVKModelConfig(ctx, tx, mc); err != nil {
 				return err
 			}
 		}
@@ -467,8 +515,8 @@ func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, 
 	return nil
 }
 
-// upsertVKWildcard reconciles a single VK-scoped wildcard model config to the desired state.
-func (h *GovernanceHandler) upsertVKWildcard(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, d vkWildcardDesired) error {
+// reconcileVKModelConfig reconciles a single VK-scoped model config to the desired state.
+func (h *GovernanceHandler) reconcileVKModelConfig(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, d vkModelConfigDesired) error {
 	q := tx.Preload("Budgets").Where("scope = ? AND scope_id = ? AND model_name = ?",
 		configstoreTables.ModelConfigScopeVirtualKey, vk.ID, configstoreTables.ModelConfigAllModels)
 	if d.provider == nil {
@@ -554,7 +602,7 @@ func (h *GovernanceHandler) upsertVKWildcard(ctx context.Context, tx *gorm.DB, v
 	hasGovernance := mc.RateLimitID != nil || finalBudgetCount > 0
 
 	if !hasGovernance {
-		// No governance left → drop the wildcard (and its budgets) if it existed.
+		// No governance left → drop the model config (and its budgets) if it existed.
 		if !isNew {
 			for i := range mc.Budgets {
 				if err := h.configStore.DeleteBudget(ctx, mc.Budgets[i].ID, tx); err != nil {
@@ -599,9 +647,9 @@ func (h *GovernanceHandler) upsertVKWildcard(ctx context.Context, tx *gorm.DB, v
 	return nil
 }
 
-// deleteVKWildcardModelConfig removes a VK-scoped wildcard model config and its owned
+// deleteVKModelConfig removes a VK-scoped model config and its owned
 // budgets/rate-limit (used when a provider config is removed from the VK).
-func (h *GovernanceHandler) deleteVKWildcardModelConfig(ctx context.Context, tx *gorm.DB, mc *configstoreTables.TableModelConfig) error {
+func (h *GovernanceHandler) deleteVKModelConfig(ctx context.Context, tx *gorm.DB, mc *configstoreTables.TableModelConfig) error {
 	for i := range mc.Budgets {
 		if err := h.configStore.DeleteBudget(ctx, mc.Budgets[i].ID, tx); err != nil {
 			return err
@@ -630,20 +678,20 @@ func rateLimitFromRequestFields(tokenMax *int64, tokenDur *string, reqMax *int64
 	}
 }
 
-// vkWildcardIndexKey keys a VK-scoped all-models wildcard by scope target + provider
-func vkWildcardIndexKey(scopeID string, provider *string) string {
+// vkModelConfigIndexKey builds a lookup key for a VK-scoped model config by scope target + provider.
+func vkModelConfigIndexKey(scopeID string, provider *string) string {
 	if provider == nil {
 		return scopeID + "|"
 	}
 	return scopeID + "|" + *provider
 }
 
-// applyVKGovernanceFromWildcards repopulates a VK's (and each provider config's) budgets and
-// rate-limit FROM the VK-scoped wildcard model configs that now own them — for serialization
-// only (so the VK sheet still renders the governance it edits). byKey indexes the wildcards by
-// vkWildcardIndexKey. The reverse of syncVKGovernanceToModelConfigs.
-func applyVKGovernanceFromWildcards(vk *configstoreTables.TableVirtualKey, byKey map[string]*configstoreTables.TableModelConfig) {
-	if mc := byKey[vkWildcardIndexKey(vk.ID, nil)]; mc != nil {
+// applyVKGovernanceFromModelConfigs repopulates a VK's (and each provider config's) budgets and
+// rate-limit from the VK-scoped model configs that own them — for serialization only (so the VK
+// sheet still renders the governance it edits). byKey is keyed by vkModelConfigIndexKey.
+// The reverse of syncVKGovernanceToModelConfigs.
+func applyVKGovernanceFromModelConfigs(vk *configstoreTables.TableVirtualKey, byKey map[string]*configstoreTables.TableModelConfig) {
+	if mc := byKey[vkModelConfigIndexKey(vk.ID, nil)]; mc != nil {
 		vk.Budgets = mc.Budgets
 		vk.RateLimit = mc.RateLimit
 		vk.RateLimitID = mc.RateLimitID
@@ -654,7 +702,7 @@ func applyVKGovernanceFromWildcards(vk *configstoreTables.TableVirtualKey, byKey
 	}
 	for i := range vk.ProviderConfigs {
 		pc := &vk.ProviderConfigs[i]
-		if mc := byKey[vkWildcardIndexKey(vk.ID, &pc.Provider)]; mc != nil {
+		if mc := byKey[vkModelConfigIndexKey(vk.ID, &pc.Provider)]; mc != nil {
 			pc.Budgets = mc.Budgets
 			pc.RateLimit = mc.RateLimit
 			pc.RateLimitID = mc.RateLimitID
@@ -666,7 +714,7 @@ func applyVKGovernanceFromWildcards(vk *configstoreTables.TableVirtualKey, byKey
 	}
 }
 
-// hydrateVKGovernance reverse-maps a single VK's governance from its wildcard model configs.
+// hydrateVKGovernance reverse-maps a single VK's governance from its VK-scoped model configs.
 func (h *GovernanceHandler) hydrateVKGovernance(ctx context.Context, vk *configstoreTables.TableVirtualKey) {
 	if vk == nil {
 		return
@@ -675,7 +723,7 @@ func (h *GovernanceHandler) hydrateVKGovernance(ctx context.Context, vk *configs
 	add := func(provider *string) {
 		mc, err := h.configStore.GetModelConfig(ctx, configstoreTables.ModelConfigScopeVirtualKey, &vk.ID, configstoreTables.ModelConfigAllModels, provider)
 		if err == nil && mc != nil {
-			byKey[vkWildcardIndexKey(vk.ID, provider)] = mc
+			byKey[vkModelConfigIndexKey(vk.ID, provider)] = mc
 		}
 	}
 	add(nil)
@@ -683,23 +731,23 @@ func (h *GovernanceHandler) hydrateVKGovernance(ctx context.Context, vk *configs
 		prov := vk.ProviderConfigs[i].Provider
 		add(&prov)
 	}
-	applyVKGovernanceFromWildcards(vk, byKey)
+	applyVKGovernanceFromModelConfigs(vk, byKey)
 }
 
-// vkWildcardIndexFromModelConfigs builds an index of VK-scoped all-models wildcard model
-// configs keyed by vkWildcardIndexKey, from a slice of model-config pointers.
-func vkWildcardIndexFromModelConfigs(mcs []*configstoreTables.TableModelConfig) map[string]*configstoreTables.TableModelConfig {
+// buildVKModelConfigIndex builds a lookup map of VK-scoped model configs keyed by
+// vkModelConfigIndexKey, from a slice of model-config pointers.
+func buildVKModelConfigIndex(mcs []*configstoreTables.TableModelConfig) map[string]*configstoreTables.TableModelConfig {
 	byKey := make(map[string]*configstoreTables.TableModelConfig)
 	for _, mc := range mcs {
 		if mc != nil && mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ModelName == configstoreTables.ModelConfigAllModels && mc.ScopeID != nil {
-			byKey[vkWildcardIndexKey(*mc.ScopeID, mc.Provider)] = mc
+			byKey[vkModelConfigIndexKey(*mc.ScopeID, mc.Provider)] = mc
 		}
 	}
 	return byKey
 }
 
 // hydrateVKListGovernance reverse-maps governance for a list of VKs using a single bulk load
-// of all VK-scoped wildcard model configs (avoids per-VK/per-provider queries).
+// of all VK-scoped model configs (avoids per-VK/per-provider queries).
 func (h *GovernanceHandler) hydrateVKListGovernance(ctx context.Context, vks []configstoreTables.TableVirtualKey) {
 	if len(vks) == 0 {
 		return
@@ -713,11 +761,11 @@ func (h *GovernanceHandler) hydrateVKListGovernance(ctx context.Context, vks []c
 	for i := range allMCs {
 		mc := &allMCs[i]
 		if mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ModelName == configstoreTables.ModelConfigAllModels && mc.ScopeID != nil {
-			byKey[vkWildcardIndexKey(*mc.ScopeID, mc.Provider)] = mc
+			byKey[vkModelConfigIndexKey(*mc.ScopeID, mc.Provider)] = mc
 		}
 	}
 	for i := range vks {
-		applyVKGovernanceFromWildcards(&vks[i], byKey)
+		applyVKGovernanceFromModelConfigs(&vks[i], byKey)
 	}
 }
 
@@ -872,9 +920,15 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 		sort.Slice(virtualKeys, func(i, j int) bool {
 			return virtualKeys[i].CreatedAt.Before(virtualKeys[j].CreatedAt)
 		})
-		byKey := vkWildcardIndexFromModelConfigs(data.ModelConfigs)
-		for _, vk := range virtualKeys {
-			applyVKGovernanceFromWildcards(vk, byKey)
+		byKey := buildVKModelConfigIndex(data.ModelConfigs)
+		hydratedVKs := make([]*configstoreTables.TableVirtualKey, len(virtualKeys))
+		for i, vk := range virtualKeys {
+			clone := *vk
+			pcs := make([]configstoreTables.TableVirtualKeyProviderConfig, len(vk.ProviderConfigs))
+			copy(pcs, vk.ProviderConfigs)
+			clone.ProviderConfigs = pcs
+			applyVKGovernanceFromModelConfigs(&clone, byKey)
+			hydratedVKs[i] = &clone
 		}
 		SendJSON(ctx, map[string]interface{}{
 			"virtual_keys": hydratedVKs,
@@ -943,7 +997,7 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 500, "Failed to retrieve virtual keys")
 			return
 		}
-		// Reverse-map governance from VK-scoped wildcard model configs for display.
+		// Reverse-map governance from VK-scoped model configs for display.
 		h.hydrateVKListGovernance(ctx, virtualKeys)
 		SendJSON(ctx, map[string]interface{}{
 			"virtual_keys": virtualKeys,
@@ -1038,10 +1092,10 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		if err := h.configStore.CreateVirtualKey(ctx, &vk, tx); err != nil {
 			return err
 		}
-		// VK top-level and per-provider budgets/rate-limits are the single-source-of-truth
-		// VK-scoped wildcard model configs, written via syncVKGovernanceToModelConfigs below.
+		// VK top-level and per-provider budgets/rate-limits are stored in VK-scoped model configs,
+		// the single source of truth, written via syncVKGovernanceToModelConfigs below.
 		// The per-provider desired state is accumulated while creating the provider configs.
-		var vkGovProviders []vkWildcardDesired
+		var vkGovProviders []vkModelConfigDesired
 		if req.ProviderConfigs != nil {
 			for _, pc := range req.ProviderConfigs {
 				providerName := schemas.ModelProvider(strings.TrimSpace(pc.Provider))
@@ -1090,14 +1144,14 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 				if err := h.configStore.CreateVirtualKeyProviderConfig(ctx, providerConfig, tx); err != nil {
 					return err
 				}
-				// Provider-config budgets/rate-limit are folded into a VK-scoped wildcard
-				// model config for this provider (written by syncVKGovernanceToModelConfigs).
+				// Provider-config budgets/rate-limit are stored in the VK-scoped model config
+				// for this provider (written by syncVKGovernanceToModelConfigs).
 				providerNameStr := string(providerName)
 				var pcRateLimit *configstoreTables.TableRateLimit
 				if pc.RateLimit != nil {
 					pcRateLimit = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 				}
-				vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+				vkGovProviders = append(vkGovProviders, vkModelConfigDesired{
 					provider:          &providerNameStr,
 					budgetsProvided:   true,
 					budgets:           pc.Budgets,
@@ -1106,12 +1160,12 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 				})
 			}
 		}
-		// Fold VK top-level + per-provider governance into VK-scoped wildcard model configs.
+		// Fold VK top-level + per-provider governance into VK-scoped model configs.
 		var topRateLimit *configstoreTables.TableRateLimit
 		if req.RateLimit != nil {
 			topRateLimit = rateLimitFromRequestFields(req.RateLimit.TokenMaxLimit, req.RateLimit.TokenResetDuration, req.RateLimit.RequestMaxLimit, req.RateLimit.RequestResetDuration)
 		}
-		if err := h.syncVKGovernanceToModelConfigs(ctx, tx, &vk, vkWildcardDesired{
+		if err := h.syncVKGovernanceToModelConfigs(ctx, tx, &vk, vkModelConfigDesired{
 			budgetsProvided:   true,
 			budgets:           req.Budgets,
 			rateLimitProvided: req.RateLimit != nil,
@@ -1161,7 +1215,7 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		logger.Error("failed to reload virtual key: %v", err)
 		preloadedVk = &vk
 	}
-	// Reverse-map governance from the wildcard model configs just written, for display.
+	// Reverse-map governance from the model configs just written, for display.
 	h.hydrateVKGovernance(ctx, preloadedVk)
 
 	SendJSON(ctx, map[string]any{
@@ -1181,10 +1235,14 @@ func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 500, "Governance data is not available")
 			return
 		}
-		byKey := vkWildcardIndexFromModelConfigs(data.ModelConfigs)
+		byKey := buildVKModelConfigIndex(data.ModelConfigs)
 		for _, vk := range data.VirtualKeys {
 			if vk.ID == vkID {
-				applyVKGovernanceFromWildcards(vk, byKey)
+				clone := *vk
+				pcs := make([]configstoreTables.TableVirtualKeyProviderConfig, len(vk.ProviderConfigs))
+				copy(pcs, vk.ProviderConfigs)
+				clone.ProviderConfigs = pcs
+				applyVKGovernanceFromModelConfigs(&clone, byKey)
 				SendJSON(ctx, map[string]interface{}{
 					"virtual_key": &clone,
 				})
@@ -1203,7 +1261,7 @@ func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 500, "Failed to retrieve virtual key")
 		return
 	}
-	// Reverse-map governance from the VK-scoped wildcard model configs for display.
+	// Reverse-map governance from VK-scoped model configs for display.
 	h.hydrateVKGovernance(ctx, vk)
 
 	SendJSON(ctx, map[string]interface{}{
@@ -1283,11 +1341,10 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		if req.CalendarAligned != nil {
 			vk.CalendarAligned = *req.CalendarAligned
 		}
-		// VK top-level and per-provider budgets/rate-limits are folded into VK-scoped
-		// wildcard model configs (the single source of truth), written by
-		// syncVKGovernanceToModelConfigs below. Per-provider desired state is accumulated
-		// while reconciling provider config rows.
-		var vkGovProviders []vkWildcardDesired
+		// VK top-level and per-provider budgets/rate-limits are stored in VK-scoped model
+		// configs (the single source of truth), written by syncVKGovernanceToModelConfigs
+		// below. Per-provider desired state is accumulated while reconciling provider config rows.
+		var vkGovProviders []vkModelConfigDesired
 
 		if err := h.configStore.UpdateVirtualKey(ctx, vk, tx); err != nil {
 			return err
@@ -1368,13 +1425,13 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					if err := h.configStore.CreateVirtualKeyProviderConfig(ctx, providerConfig, tx); err != nil {
 						return err
 					}
-					// Provider-config governance is folded into a VK-scoped wildcard model config.
+					// Provider-config governance is stored in the VK-scoped model config for this provider.
 					pName := string(providerName)
 					var pcRL *configstoreTables.TableRateLimit
 					if pc.RateLimit != nil {
 						pcRL = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 					}
-					vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+					vkGovProviders = append(vkGovProviders, vkModelConfigDesired{
 						provider:          &pName,
 						budgetsProvided:   true,
 						budgets:           pc.Budgets,
@@ -1420,9 +1477,9 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					existing.AllowAllKeys = allowAllKeys
 					existing.Keys = keys
 
-					// Provider-config governance is folded into a VK-scoped wildcard model
-					// config (written by syncVKGovernanceToModelConfigs). pc.Budgets == nil
-					// leaves the wildcard's budgets unchanged; an explicit set reconciles them.
+					// Provider-config governance is stored in the VK-scoped model config for this
+					// provider (written by syncVKGovernanceToModelConfigs). pc.Budgets == nil
+					// leaves existing budgets unchanged; an explicit set reconciles them.
 					pName := string(providerName)
 					rlRemove := false
 					var pcRL *configstoreTables.TableRateLimit
@@ -1433,7 +1490,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 							pcRL = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 						}
 					}
-					vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+					vkGovProviders = append(vkGovProviders, vkModelConfigDesired{
 						provider:          &pName,
 						budgetsProvided:   pc.Budgets != nil,
 						budgets:           pc.Budgets,
@@ -1465,10 +1522,10 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 				}
 			}
 		}
-		// Fold VK governance into VK-scoped wildcard model configs. The top-level is always
-		// reconciled (provided-aware); per-provider wildcards are reconciled only when the
-		// request supplied provider_configs (else they're left untouched).
-		top := vkWildcardDesired{
+		// Fold VK governance into VK-scoped model configs. The top-level is always reconciled
+		// (provided-aware); per-provider configs are reconciled only when the request supplied
+		// provider_configs (else they're left untouched).
+		top := vkModelConfigDesired{
 			budgetsProvided:   req.Budgets != nil,
 			budgets:           req.Budgets,
 			rateLimitProvided: req.RateLimit != nil,
@@ -1598,7 +1655,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		logger.Error("failed to load relationships for updated VK: %v", err)
 		preloadedVk = vk
 	}
-	// Reverse-map governance from the VK-scoped wildcard model configs for display.
+	// Reverse-map governance from VK-scoped model configs for display.
 	h.hydrateVKGovernance(ctx, preloadedVk)
 	if _, err := h.governanceManager.ReloadVirtualKey(ctx, vk.ID); err != nil {
 		// Should never happen but just in case
@@ -2646,22 +2703,64 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 500, "Governance data is not available")
 			return
 		}
-		// Copy into a value slice before enriching: never mutate ScopeName on the
-		// pointers returned here, so we don't risk racing the in-memory store regardless
-		// of whether the manager hands back shared pointers or clones.
-		modelConfigs := make([]configstoreTables.TableModelConfig, 0, len(data.ModelConfigs))
+		search := string(ctx.QueryArgs().Peek("search"))
+		// Deep-copy into a value slice: top-level struct copy + nested pointer/slice fields
+		// so we never alias or mutate live governance state during serialization.
+		all := make([]configstoreTables.TableModelConfig, 0, len(data.ModelConfigs))
 		for _, mc := range data.ModelConfigs {
-			if mc != nil {
-				modelConfigs = append(modelConfigs, *mc)
+			if mc == nil {
+				continue
+			}
+			if search != "" && !strings.Contains(strings.ToLower(mc.ModelName), strings.ToLower(search)) {
+				continue
+			}
+			clone := *mc
+			if len(mc.Budgets) > 0 {
+				bs := make([]configstoreTables.TableBudget, len(mc.Budgets))
+				copy(bs, mc.Budgets)
+				clone.Budgets = bs
+			}
+			if mc.Budget != nil {
+				b := *mc.Budget
+				clone.Budget = &b
+			}
+			if mc.RateLimit != nil {
+				rl := *mc.RateLimit
+				clone.RateLimit = &rl
+			}
+			all = append(all, clone)
+		}
+		totalCount := len(all)
+		// Apply pagination if requested, otherwise return all (consistent with DB path).
+		limitStr := string(ctx.QueryArgs().Peek("limit"))
+		offsetStr := string(ctx.QueryArgs().Peek("offset"))
+		offset := 0
+		limit := totalCount
+		if offsetStr != "" {
+			if n, err := strconv.Atoi(offsetStr); err == nil && n >= 0 {
+				offset = n
 			}
 		}
-		h.enrichModelConfigScopeNames(ctx, modelConfigs)
+		if limitStr != "" {
+			if n, err := strconv.Atoi(limitStr); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		if offset > totalCount {
+			offset = totalCount
+		}
+		end := offset + limit
+		if end > totalCount {
+			end = totalCount
+		}
+		page := all[offset:end]
+		h.enrichModelConfigScopeNames(ctx, page)
 		SendJSON(ctx, map[string]any{
-			"model_configs": modelConfigs,
-			"count":         len(modelConfigs),
-			"total_count":   len(modelConfigs),
-			"limit":         len(modelConfigs),
-			"offset":        0,
+			"model_configs": page,
+			"count":         len(page),
+			"total_count":   totalCount,
+			"limit":         limit,
+			"offset":        offset,
 		})
 		return
 	}
@@ -2755,19 +2854,26 @@ func (h *GovernanceHandler) getModelConfig(ctx *fasthttp.RequestCtx) {
 }
 
 // resolveModelConfigScopeName populates the transient ScopeName for a single non-global
-// model config (currently resolves a virtual_key scope_id to the VK's name). The cache
-// lets callers dedupe lookups across many configs. Resolution failures are non-fatal.
+// model config by dispatching to the resolver registered for mc.Scope. Unknown scopes
+// (no resolver registered) and resolution failures are non-fatal — ScopeName stays empty
+// and the UI falls back to rendering the scope_id. The cache lets callers dedupe lookups
+// across many configs; it is keyed by (scope, scope_id) so distinct scopes never collide.
 func (h *GovernanceHandler) resolveModelConfigScopeName(ctx context.Context, mc *configstoreTables.TableModelConfig, cache map[string]string) {
-	if mc == nil || mc.Scope != configstoreTables.ModelConfigScopeVirtualKey || mc.ScopeID == nil {
+	if mc == nil || mc.Scope == "" || mc.ScopeID == nil {
+		return
+	}
+	resolver, ok := lookupScopeNameResolver(mc.Scope)
+	if !ok {
 		return
 	}
 	id := *mc.ScopeID
-	name, ok := cache[id]
-	if !ok {
-		if vk, err := h.configStore.GetVirtualKey(ctx, id); err == nil && vk != nil {
-			name = vk.Name
+	key := mc.Scope + "|" + id
+	name, cached := cache[key]
+	if !cached {
+		if resolved, found := resolver(ctx, id); found {
+			name = resolved
 		}
-		cache[id] = name
+		cache[key] = name
 	}
 	mc.ScopeName = name
 }
@@ -2856,6 +2962,11 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", req.Budgets[i].ResetDuration))
 			return
 		}
+		if seenDurations[req.Budgets[i].ResetDuration] {
+			SendError(ctx, 400, fmt.Sprintf("Duplicate reset_duration in budgets: %s", req.Budgets[i].ResetDuration))
+			return
+		}
+		seenDurations[req.Budgets[i].ResetDuration] = true
 	}
 	var mc configstoreTables.TableModelConfig
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
@@ -3090,16 +3201,16 @@ type ProviderGovernanceResponse struct {
 	RateLimit *configstoreTables.TableRateLimit `json:"rate_limit,omitempty"`
 }
 
-// providerGovernanceFromWildcard maps an "all models on a provider" model config
-// (scope=global, model_name="*", provider set) to a ProviderGovernanceResponse. Provider
-// governance now lives in governance_model_configs as these wildcard rows,
-// this endpoint is a compatibility facade over them.
-func providerGovernanceFromWildcard(mc *configstoreTables.TableModelConfig) (ProviderGovernanceResponse, bool) {
+// modelConfigToProviderGovernance converts a model config to a ProviderGovernanceResponse.
+// Returns false if the config does not represent provider-level governance
+// (i.e. not scope=global, model_name="*", with a provider set).
+func modelConfigToProviderGovernance(mc *configstoreTables.TableModelConfig) (ProviderGovernanceResponse, bool) {
 	if mc == nil || mc.Scope != configstoreTables.ModelConfigScopeGlobal ||
 		mc.ModelName != configstoreTables.ModelConfigAllModels || mc.Provider == nil {
 		return ProviderGovernanceResponse{}, false
 	}
 	// Provider governance is single-budget by API; surface the first owned budget.
+	// This will be updated with the v2 endpoint, which can surface all budgets
 	var budget *configstoreTables.TableBudget
 	if len(mc.Budgets) > 0 {
 		budget = &mc.Budgets[0]
@@ -3108,7 +3219,7 @@ func providerGovernanceFromWildcard(mc *configstoreTables.TableModelConfig) (Pro
 }
 
 // getProviderGovernance handles GET /api/governance/providers - returns provider-level governance,
-// now backed by the wildcard ("all models on a provider") model configs.
+// now backed by all-models model configs scoped per provider.
 func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
 	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
 	var result []ProviderGovernanceResponse
@@ -3119,7 +3230,7 @@ func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		for _, mc := range data.ModelConfigs {
-			if r, ok := providerGovernanceFromWildcard(mc); ok {
+			if r, ok := modelConfigToProviderGovernance(mc); ok {
 				result = append(result, r)
 			}
 		}
@@ -3131,7 +3242,7 @@ func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		for i := range configs {
-			if r, ok := providerGovernanceFromWildcard(&configs[i]); ok {
+			if r, ok := modelConfigToProviderGovernance(&configs[i]); ok {
 				result = append(result, r)
 			}
 		}
@@ -3260,7 +3371,7 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			// Nothing to persist (removal request on a provider with no governance).
 			return nil
 		case !hasGovernance && !isNew:
-			// All governance removed → delete the wildcard config and its owned/orphaned rows.
+			// All governance removed → delete the model config and its owned/orphaned rows.
 			if existingBudget != nil {
 				budgetIDToDelete = existingBudget.ID
 			}
@@ -3351,7 +3462,7 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 				resp.Budget = &mc.Budgets[0]
 			}
 			resp.RateLimit = mc.RateLimit
-		} else if r, ok := providerGovernanceFromWildcard(reloaded); ok {
+		} else if r, ok := modelConfigToProviderGovernance(reloaded); ok {
 			resp.Budget, resp.RateLimit = r.Budget, r.RateLimit
 		}
 	}
@@ -3362,7 +3473,7 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 }
 
 // deleteProviderGovernance handles DELETE /api/governance/providers/{provider_name} - removes
-// provider-level governance by deleting the wildcard ("all models on this provider") model config.
+// provider-level governance by deleting the all-models model config for that provider.
 func (h *GovernanceHandler) deleteProviderGovernance(ctx *fasthttp.RequestCtx) {
 	providerName := ctx.UserValue("provider_name").(string)
 	mc, err := h.configStore.GetModelConfig(ctx, configstoreTables.ModelConfigScopeGlobal, nil, configstoreTables.ModelConfigAllModels, &providerName)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1115,6 +1115,10 @@ func (m *MockConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableMo
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetModelConfigsByScopeAndScopeIDs(ctx context.Context, scope string, scopeIDs []string) ([]tables.TableModelConfig, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) GetProviderGovernanceModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
 	return nil, nil
 }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -693,6 +693,15 @@
                 "type": "string",
                 "description": "Optional provider name to scope this config"
               },
+              "scope": {
+                "type": "string",
+                "description": "Scope where this config applies: \"global\" (default) or \"virtual_key\"",
+                "default": "global"
+              },
+              "scope_id": {
+                "type": "string",
+                "description": "Target entity ID for non-global scopes (e.g. virtual key ID). Required when scope != \"global\""
+              },
               "budget_id": {
                 "type": "string",
                 "description": "Budget ID to associate with this model"

--- a/ui/app/_fallbacks/enterprise/lib/registrations/modelLimitScopes.ts
+++ b/ui/app/_fallbacks/enterprise/lib/registrations/modelLimitScopes.ts
@@ -1,0 +1,7 @@
+// OSS-build fallback for the enterprise scope registrations.
+//
+// Side-effect imports of this module from OSS code (e.g. from the Model
+// Limits page) compile to a no-op when the @enterprise alias resolves to
+// _fallbacks/. The enterprise build replaces this module with one that
+// registers the "user" scope (and its picker + deep-link).
+export {};

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -7,15 +7,17 @@ import MultiBudgetLines from "@/components/ui/multibudgets";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { ComboboxSelect } from "@/components/ui/combobox";
-import { MODEL_LIMIT_SCOPES, resetDurationOptions } from "@/lib/constants/governance";
+import { resetDurationOptions } from "@/lib/constants/governance";
 import { RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import { getModelLimitScope, getModelLimitScopes } from "@/lib/registries/modelLimitScopes";
+// Side-effect import: pulls in downstream scope registrations (e.g. enterprise
+// registers "user" + user picker). The OSS-build fallback is an empty module.
+import "@enterprise/lib/registrations/modelLimitScopes";
 import {
 	getErrorMessage,
 	useCreateModelConfigMutation,
 	useGetProvidersQuery,
-	useGetVirtualKeysQuery,
 	useLazyGetModelsQuery,
 	useUpdateModelConfigMutation,
 } from "@/lib/store";
@@ -77,7 +79,6 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 	};
 
 	const { data: providersData } = useGetProvidersQuery();
-	const { data: vksData = { virtual_keys: [] } } = useGetVirtualKeysQuery();
 	const [createModelConfig, { isLoading: isCreating }] = useCreateModelConfigMutation();
 	const [updateModelConfig, { isLoading: isUpdating }] = useUpdateModelConfigMutation();
 	const [getModels] = useLazyGetModelsQuery();
@@ -221,7 +222,11 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 					model_name: data.modelName,
 					provider,
 					scope: data.scope || "global",
-					scope_id: data.scope === "virtual_key" ? data.scopeId : undefined,
+					// Any scope with a registered PickerComponent carries a target;
+					// global (no picker) sends no scope_id. Mirrors the registry
+					// shape, so adding a new scope (e.g. enterprise's "user")
+					// doesn't need a branch here.
+					scope_id: getModelLimitScope(data.scope || "global")?.PickerComponent ? data.scopeId : undefined,
 					budgets: budgetsPayload.length > 0 ? budgetsPayload : undefined,
 					rate_limit:
 						(data.tokenMaxLimit !== undefined && data.tokenMaxLimit !== null) ||
@@ -357,7 +362,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 												</SelectTrigger>
 											</FormControl>
 											<SelectContent>
-												{MODEL_LIMIT_SCOPES.map((option) => (
+												{getModelLimitScopes().map((option) => (
 													<SelectItem key={option.value} value={option.value}>
 														{option.label}
 													</SelectItem>
@@ -369,40 +374,41 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 								)}
 							/>
 
-							{/* Virtual Key picker (only for the Virtual Key scope) */}
-							{form.watch("scope") === "virtual_key" && (
-								<FormField
-									control={form.control}
-									name="scopeId"
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>Virtual Key</FormLabel>
-											<FormControl>
-												<div data-testid="model-limit-scope-id-select">
-													<ComboboxSelect
-														options={[
-															// Guarantee the currently-selected VK is selectable even if it
-															// falls outside the first page of fetched virtual keys.
-															...(modelConfig?.scope_id && modelConfig?.scope_name
-																? [{ label: modelConfig.scope_name, value: modelConfig.scope_id }]
-																: []),
-															...vksData.virtual_keys
-																.filter((vk) => vk.id !== modelConfig?.scope_id)
-																.map((vk) => ({ label: vk.name, value: vk.id })),
-														]}
-														value={field.value || null}
-														onValueChange={(value) => field.onChange(value ?? "")}
-														placeholder="Select a virtual key..."
-														disabled={isEditing}
-														noPortal
-													/>
-												</div>
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							)}
+							{/* Scope-target picker — driven by the scope registry.
+								Each non-global scope (virtual_key, user, …) registers its
+								own PickerComponent; we render whichever the current scope
+								provides. */}
+							{(() => {
+								const scopeEntry = getModelLimitScope(form.watch("scope") || "global");
+								const Picker = scopeEntry?.PickerComponent;
+								if (!Picker) return null;
+								return (
+									<FormField
+										control={form.control}
+										name="scopeId"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>{scopeEntry.label}</FormLabel>
+												<FormControl>
+													<div data-testid="model-limit-scope-id-select">
+														<Picker
+															value={field.value || ""}
+															onChange={(v) => field.onChange(v ?? "")}
+															disabled={isEditing}
+															fallbackOption={
+																modelConfig?.scope === scopeEntry.value && modelConfig?.scope_id && modelConfig?.scope_name
+																	? { value: modelConfig.scope_id, label: modelConfig.scope_name }
+																	: null
+															}
+														/>
+													</div>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								);
+							})()}
 
 							<DottedSeparator />
 

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -29,6 +29,10 @@ import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
 import { ModelLimitsEmptyState } from "./modelLimitsEmptyState";
 import { getScopeLabel } from "@/lib/utils/labels";
+import { getModelLimitScope } from "@/lib/registries/modelLimitScopes";
+// Side-effect import: pull in downstream scope registrations (enterprise
+// "user" deep-link, etc.). No-op for OSS builds.
+import "@enterprise/lib/registrations/modelLimitScopes";
 import { useNavigate } from "@tanstack/react-router";
 
 // Helper to format reset duration for display
@@ -327,7 +331,11 @@ export default function ModelLimitsTable({
 																	variant="secondary"
 																	className="flex max-w-[160px] cursor-pointer items-center gap-1 hover:opacity-80"
 																	data-testid={`model-limit-scope-target-${config.scope_id}`}
-																	onClick={() => navigate({ to: "/workspace/governance/virtual-keys", search: { vk: config.scope_id } })}
+																	onClick={() => {
+																		if (!config.scope_id) return;
+																		const target = getModelLimitScope(config.scope ?? "global")?.buildDeepLink?.(config.scope_id);
+																		if (target) navigate(target as never);
+																	}}
 																>
 																	<span className="truncate">{config.scope_name}</span>
 																	<ArrowUpRight className="h-3 w-3 shrink-0" />

--- a/ui/lib/constants/governance.ts
+++ b/ui/lib/constants/governance.ts
@@ -23,13 +23,6 @@ export const budgetDurationOptions = [
 // Must stay in sync with IsCalendarAlignableDuration in framework/configstore/tables/utils.go.
 export const supportsCalendarAlignment = (duration: string): boolean => duration.length > 0 && /[dwMY]$/.test(duration);
 
-// Scopes available for model limits. "global" applies to all traffic; "virtual_key"
-// applies only when a specific virtual key is used. Extensible (team/customer/user) later.
-export const MODEL_LIMIT_SCOPES = [
-	{ label: "Global", value: "global" },
-	{ label: "Virtual Key", value: "virtual_key" },
-];
-
 // Map of duration values to short labels for display
 export const resetDurationLabels: Record<string, string> = {
 	"1m": "Every Minute",

--- a/ui/lib/registries/modelLimitScopes.tsx
+++ b/ui/lib/registries/modelLimitScopes.tsx
@@ -1,0 +1,105 @@
+// Runtime registry of model_config scopes available to the UI.
+//
+// OSS ships the base set (global + virtual_key) registered at module load.
+// Downstream builds (enterprise) extend the registry by importing their
+// registration module via the @enterprise alias — see
+// ui/app/_fallbacks/enterprise/lib/registrations/modelLimitScopes.ts
+// for the OSS-build fallback.
+//
+// Each entry can supply:
+//   - PickerComponent: the React component used by the Model Limit sheet to
+//     pick the scope target (e.g. a VK picker). Scopes without a target —
+//     e.g. global — omit this.
+//   - buildDeepLink: a function returning the route to navigate to when the
+//     user clicks the Scope Target badge on the Model Limits table.
+
+import type { ComponentType } from "react";
+import { ComboboxSelect } from "@/components/ui/combobox";
+import { useGetVirtualKeysQuery } from "@/lib/store";
+
+export interface ScopePickerProps {
+	value: string;
+	onChange: (value: string) => void;
+	disabled?: boolean;
+	// Optional fallback option to guarantee the currently-selected target is
+	// always selectable, even if it falls outside the first page fetched by
+	// the picker. The Model Limit sheet passes the model_config's own
+	// scope_id/scope_name when editing an existing row.
+	fallbackOption?: { value: string; label: string } | null;
+}
+
+export interface ScopeDeepLink {
+	to: string;
+	search?: Record<string, string>;
+}
+
+export interface ModelLimitScopeEntry {
+	value: string;
+	label: string;
+	// Optional. Scopes without a target (e.g. global) omit this.
+	PickerComponent?: ComponentType<ScopePickerProps>;
+	// Optional. Scopes without a navigable target omit this.
+	buildDeepLink?: (scopeId: string) => ScopeDeepLink;
+}
+
+const registry = new Map<string, ModelLimitScopeEntry>();
+
+/**
+ * Registers (or replaces) a scope entry. Intended to be called at module
+ * load — once, before the first render that reads the registry.
+ */
+export function registerModelLimitScope(entry: ModelLimitScopeEntry): void {
+	if (!entry.value) {
+		return;
+	}
+	registry.set(entry.value, entry);
+}
+
+/** Returns all registered scope entries, in registration order. */
+export function getModelLimitScopes(): ModelLimitScopeEntry[] {
+	return Array.from(registry.values());
+}
+
+export function getModelLimitScope(value: string): ModelLimitScopeEntry | undefined {
+	return registry.get(value);
+}
+
+// ---------------------------------------------------------------------------
+// OSS default registrations.
+// ---------------------------------------------------------------------------
+
+function VirtualKeyPicker({ value, onChange, disabled, fallbackOption }: ScopePickerProps) {
+	const { data: vksData } = useGetVirtualKeysQuery();
+	const virtualKeys = vksData?.virtual_keys ?? [];
+	const options = [
+		...(fallbackOption && !virtualKeys.some((vk) => vk.id === fallbackOption.value) ? [fallbackOption] : []),
+		...virtualKeys
+			.filter((vk) => vk.id !== fallbackOption?.value)
+			.map((vk) => ({ label: vk.name, value: vk.id })),
+	];
+	return (
+		<ComboboxSelect
+			options={options}
+			value={value || null}
+			onValueChange={(v: string | null) => onChange(v ?? "")}
+			placeholder="Select a virtual key..."
+			disabled={disabled}
+			noPortal
+		/>
+	);
+}
+
+registerModelLimitScope({
+	value: "global",
+	label: "Global",
+});
+
+registerModelLimitScope({
+	value: "virtual_key",
+	label: "Virtual Key",
+	PickerComponent: VirtualKeyPicker,
+	buildDeepLink: (scopeId) => ({
+		to: "/workspace/governance/virtual-keys",
+		search: { vk: scopeId },
+	}),
+});

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -517,8 +517,10 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
-			// Wildcard model configs back provider governance; refresh the provider page too.
-			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
+			// Wildcard model configs back provider/VK/user governance; refresh those pages too.
+			// "Users" + "UserGovernance" are no-op tags in OSS builds (no consumer registers them);
+			// enterprise consumers pick them up via the userGovernanceApi / usersApi tag wiring.
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys", "Users", "UserGovernance"],
 			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -548,7 +550,10 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
+			// Wildcard model configs back provider/VK/user governance; refresh those pages too.
+			// "Users" + "UserGovernance" are no-op tags in OSS builds (no consumer registers them);
+			// enterprise consumers pick them up via the userGovernanceApi / usersApi tag wiring.
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys", "Users", "UserGovernance"],
 			async onQueryStarted({ id }, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -581,8 +586,10 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/model-configs/${id}`,
 				method: "DELETE",
 			}),
-			// Wildcard model configs back provider governance; refresh the provider page too.
-			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
+			// Wildcard model configs back provider/VK/user governance; refresh those pages too.
+			// "Users" + "UserGovernance" are no-op tags in OSS builds (no consumer registers them);
+			// enterprise consumers pick them up via the userGovernanceApi / usersApi tag wiring.
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys", "Users", "UserGovernance"],
 			async onQueryStarted(id, { dispatch, getState, queryFulfilled }) {
 				try {
 					await queryFulfilled;

--- a/ui/lib/utils/labels.ts
+++ b/ui/lib/utils/labels.ts
@@ -1,14 +1,20 @@
+import { getModelLimitScope } from "@/lib/registries/modelLimitScopes";
+
 /**
- * Gets a friendly display name for a scope
- * @param scope - The scope value (global|team|customer|virtual_key)
- * @returns Friendly display name
+ * Gets a friendly display name for a scope.
+ *
+ * Consults the model_limit scope registry first.
+ * Falls back to a small built-in map of historical labels,
+ * then to the raw scope value.
  */
 export function getScopeLabel(scope: string): string {
-	const labels: Record<string, string> = {
-		global: "Global",
+	const entry = getModelLimitScope(scope);
+	if (entry) {
+		return entry.label;
+	}
+	const legacy: Record<string, string> = {
 		team: "Team",
 		customer: "Customer",
-		virtual_key: "Virtual Key",
 	};
-	return labels[scope] || scope;
+	return legacy[scope] || scope;
 }


### PR DESCRIPTION
## Summary

This PR generalizes the virtual-key-scoped model governance system into a scope-agnostic framework, enabling any registered scope (e.g. `user`) to carry per-scope model rate limits and budgets — not just virtual keys. It also introduces a runtime scope registry on both the backend and frontend so downstream (enterprise) builds can extend the system without modifying OSS code.

## Changes

- **`CheckVirtualKeyScopedModelBudget` / `CheckVirtualKeyScopedModelRateLimit`** and their `UpdateVirtualKeyScoped*` counterparts are replaced by `CheckScopedModelBudget`, `CheckScopedModelRateLimit`, `UpdateScopedModelBudgetUsageInMemory`, and `UpdateScopedModelRateLimitUsageInMemory`. These accept a `(scope, scopeID)` pair instead of a `*TableVirtualKey`, making them scope-agnostic. An empty scope or scopeID is a no-op.
- **`ModelConfigScopeUser`** constant added to `tables/modelconfig.go`, along with a `RegisterModelConfigScope` function and a `sync.RWMutex`-guarded registry so downstream builds can add scopes at startup without forking the OSS validation logic.
- **`EvaluateUserRequest`** in `resolver.go` and `UpdateUsage` in `tracker.go` now invoke the scoped model check/update paths for the `user` scope, mirroring the existing VK-scoped block.
- **`DeleteProvider`** in `rdb.go` is refactored to batch-delete budgets and rate limits with `IN` clauses instead of one-by-one, and the model config row is deleted before its owned resources to avoid constraint issues.
- **`DeleteVirtualKey`** removes the loop that deleted budgets via `ModelConfigID`; only the `BudgetID` foreign key path is retained.
- Internal naming throughout `migrations.go`, `governance.go`, and `store.go` drops the "wildcard" terminology (`ensureVKWildcardModelConfig` → `ensureVKModelConfig`, `vkWildcardDesired` → `vkModelConfigDesired`, `upsertVKWildcard` → `reconcileVKModelConfig`, etc.) to reflect that these configs are not exclusively wildcard rows.
- **`RegisterScopeNameResolver`** added to `handlers/governance.go` with a package-level `sync.RWMutex`-guarded map. `resolveModelConfigScopeName` now dispatches to the registered resolver for any scope rather than hard-coding the VK lookup. The VK resolver is wired automatically in `NewGovernanceHandler`.
- **UI scope registry** (`ui/lib/registries/modelLimitScopes.tsx`) replaces the static `MODEL_LIMIT_SCOPES` constant. Each entry can declare a `PickerComponent` and a `buildDeepLink` function. The OSS build registers `global` and `virtual_key` at module load; enterprise builds extend the registry via the `@enterprise` alias side-effect import.
- The Model Limit sheet's VK picker is replaced by a registry-driven `PickerComponent` render, and the deep-link navigation in the table is driven by `buildDeepLink`, so adding a new scope (e.g. `user`) requires no changes to OSS sheet or table code.
- `invalidatesTags` for model config mutations now includes `"Users"` and `"UserGovernance"` (no-op in OSS; picked up by enterprise tag wiring).

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

Existing governance tests in `modelprovidergovernance_test.go` have been updated to call the new `CheckScopedModel*` / `UpdateScopedModel*` signatures and continue to cover the VK-scoped budget and rate-limit paths.

## Breaking changes

- [x] Yes
- [ ] No

The `GovernanceStore` interface methods `CheckVirtualKeyScopedModelBudget`, `CheckVirtualKeyScopedModelRateLimit`, `UpdateVirtualKeyScopedModelBudgetUsageInMemory`, and `UpdateVirtualKeyScopedModelRateLimitUsageInMemory` are removed and replaced by their scope-agnostic equivalents. Any downstream implementation of `GovernanceStore` must be updated to implement `CheckScopedModelBudget`, `CheckScopedModelRateLimit`, `UpdateScopedModelBudgetUsageInMemory`, and `UpdateScopedModelRateLimitUsageInMemory`.

## Security considerations

The new `RegisterModelConfigScope` and `RegisterScopeNameResolver` functions are intended to be called once at process startup before serving requests. No user-supplied input reaches the registry directly.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-scoped model budget and rate-limit enforcement.
  * UI: runtime-extensible scope registry with scope-specific pickers and deep-linking.
  * Config schema: model configs now support scope and scope_id targets.

* **Bug Fixes**
  * Improved bulk cleanup for provider- and virtual-key-scoped model configs.
  * Ensured consistent calendar-aligned timestamps when creating scoped model configs.

* **Refactor**
  * Migrated virtual-key governance to model-config-backed storage and unified scoped checks/usage to (scope, scope_id).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->