### PR TITLE
Fix raw mid-conversation system downgrade for Anthropic

### DIFF
--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -60,6 +60,9 @@ const (
 	// on custom tools (streams input_json_delta before full args are determined).
 	// Per Table 20: GA on Anthropic/Bedrock/Vertex, Beta on Azure.
 	AnthropicEagerInputStreamingBetaHeader = "fine-grained-tool-streaming-2025-05-14"
+	// AnthropicMidConversationSystemBetaHeader enables role:"system" entries
+	// inside messages[] for models that support mid-conversation system messages.
+	AnthropicMidConversationSystemBetaHeader = "mid-conversation-system-2026-04-07"
 
 	// AnthropicComputerUseBetaHeader is required for computer use (version-specific).
 	// computer_20251124 (Opus 4.6, Sonnet 4.6, Opus 4.5) uses the newer beta header.

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -344,7 +344,8 @@ func stripUnsupportedAnthropicFields(req *AnthropicMessageRequest, provider sche
 //   - top-level: speed (provider + model gated), container (.skills gated by
 //     features.Skills, bare string by features.ContainerBasic), mcp_servers,
 //     inference_geo, cache_control.scope, output_config.task_budget,
-//     context_management.edits[] (gated per edit type).
+//     context_management.edits[] (gated per edit type), messages[].role=system
+//     downgrade when mid-conversation system messages are unsupported.
 //   - nested: tool.CacheControl.Scope, system block scopes, message block
 //     scopes (all stripped when !features.PromptCachingScope).
 //   - per-tool: defer_loading, allowed_callers (AdvancedToolUse bundle),
@@ -371,6 +372,13 @@ func StripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelPr
 	}
 
 	var err error
+
+	if shouldDowngradeRawMidConversationSystem(jsonBody, provider, model) {
+		jsonBody, err = downgradeRawMidConversationSystemMessages(jsonBody)
+		if err != nil {
+			return nil, fmt.Errorf("downgrade raw mid-conversation system messages: %w", err)
+		}
+	}
 
 	// speed — provider AND model gate
 	if providerUtils.JSONFieldExists(jsonBody, "speed") {
@@ -1414,6 +1422,145 @@ func RemapRawToolVersionsForProvider(jsonBody []byte, provider schemas.ModelProv
 	}
 
 	return jsonBody, nil
+}
+
+func shouldDowngradeRawMidConversationSystem(jsonBody []byte, provider schemas.ModelProvider, model string) bool {
+	if SupportsMidConversationSystem(provider, model) || !rawHasBeta(jsonBody, AnthropicMidConversationSystemBetaHeader) {
+		return false
+	}
+
+	messagesResult := providerUtils.GetJSONField(jsonBody, "messages")
+	if !messagesResult.IsArray() {
+		return false
+	}
+	for _, msg := range messagesResult.Array() {
+		role := msg.Get("role").String()
+		if role == string(AnthropicMessageRoleSystem) || role == string(schemas.ResponsesInputMessageRoleDeveloper) {
+			return true
+		}
+	}
+	return false
+}
+
+func downgradeRawMidConversationSystemMessages(jsonBody []byte) ([]byte, error) {
+	messagesResult := providerUtils.GetJSONField(jsonBody, "messages")
+
+	remainingMessages := make([]string, 0, len(messagesResult.Array()))
+	var movedSystemBlocks []string
+
+	for _, msg := range messagesResult.Array() {
+		role := msg.Get("role").String()
+		if role != string(AnthropicMessageRoleSystem) && role != string(schemas.ResponsesInputMessageRoleDeveloper) {
+			remainingMessages = append(remainingMessages, msg.Raw)
+			continue
+		}
+		movedSystemBlocks = append(movedSystemBlocks, rawSystemBlocksFromMessageContent(msg.Get("content"))...)
+	}
+
+	var err error
+	jsonBody, err = sjson.SetRawBytes(jsonBody, "messages", []byte("["+strings.Join(remainingMessages, ",")+"]"))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(movedSystemBlocks) > 0 {
+		systemBlocks := rawTopLevelSystemBlocks(jsonBody)
+		systemBlocks = append(systemBlocks, movedSystemBlocks...)
+		jsonBody, err = sjson.SetRawBytes(jsonBody, "system", []byte("["+strings.Join(systemBlocks, ",")+"]"))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return removeRawBeta(jsonBody, AnthropicMidConversationSystemBetaHeader)
+}
+
+func rawSystemBlocksFromMessageContent(content gjson.Result) []string {
+	if !content.Exists() {
+		return nil
+	}
+	if content.Type == gjson.String {
+		return rawTextSystemBlock(content.String())
+	}
+	if !content.IsArray() {
+		return nil
+	}
+
+	var blocks []string
+	for _, block := range content.Array() {
+		if block.Get("type").String() != "text" {
+			continue
+		}
+		blocks = append(blocks, block.Raw)
+	}
+	return blocks
+}
+
+func rawTopLevelSystemBlocks(jsonBody []byte) []string {
+	systemResult := providerUtils.GetJSONField(jsonBody, "system")
+	if !systemResult.Exists() {
+		return nil
+	}
+	if systemResult.Type == gjson.String {
+		return rawTextSystemBlock(systemResult.String())
+	}
+	if !systemResult.IsArray() {
+		return []string{systemResult.Raw}
+	}
+
+	blocks := make([]string, 0, len(systemResult.Array()))
+	for _, block := range systemResult.Array() {
+		blocks = append(blocks, block.Raw)
+	}
+	return blocks
+}
+
+func rawTextSystemBlock(text string) []string {
+	block, err := sonic.Marshal(map[string]any{
+		"type": "text",
+		"text": text,
+	})
+	if err != nil {
+		return nil
+	}
+	return []string{string(block)}
+}
+
+func removeRawBeta(jsonBody []byte, beta string) ([]byte, error) {
+	betasResult := providerUtils.GetJSONField(jsonBody, "betas")
+	if !betasResult.IsArray() {
+		return jsonBody, nil
+	}
+
+	remaining := make([]string, 0, len(betasResult.Array()))
+	removed := false
+	for _, item := range betasResult.Array() {
+		if item.Type == gjson.String && item.String() == beta {
+			removed = true
+			continue
+		}
+		remaining = append(remaining, item.Raw)
+	}
+	if !removed {
+		return jsonBody, nil
+	}
+	if len(remaining) == 0 {
+		return providerUtils.DeleteJSONField(jsonBody, "betas")
+	}
+	return sjson.SetRawBytes(jsonBody, "betas", []byte("["+strings.Join(remaining, ",")+"]"))
+}
+
+func rawHasBeta(jsonBody []byte, beta string) bool {
+	betasResult := providerUtils.GetJSONField(jsonBody, "betas")
+	if !betasResult.IsArray() {
+		return false
+	}
+	for _, item := range betasResult.Array() {
+		if item.Type == gjson.String && item.String() == beta {
+			return true
+		}
+	}
+	return false
 }
 
 // betaHeaderPrefixToFeature maps each known beta header prefix to a function that checks

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1606,6 +1606,95 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 		}
 	})
 
+	t.Run("anthropic_downgrades_mid_conversation_system_for_unsupported_model", func(t *testing.T) {
+		input := []byte(`{
+			"model":"claude-sonnet-4-6",
+			"system":[{"type":"text","text":"top","cache_control":{"type":"ephemeral"}}],
+			"messages":[
+				{"role":"user","content":"hello"},
+				{"role":"system","content":"skills"},
+				{"role":"developer","content":[{"type":"text","text":"developer note","cache_control":{"type":"ephemeral"}}]},
+				{"role":"assistant","content":"hi"}
+			],
+			"betas":["` + AnthropicMidConversationSystemBetaHeader + `","other-beta-2026-01-01"]
+		}`)
+
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-sonnet-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		roles := providerUtils.GetJSONField(result, "messages.#.role").Array()
+		if len(roles) != 2 || roles[0].String() != "user" || roles[1].String() != "assistant" {
+			t.Fatalf("expected only user and assistant messages to remain, got %s", string(result))
+		}
+
+		systemTexts := providerUtils.GetJSONField(result, "system.#.text").Array()
+		gotTexts := make([]string, 0, len(systemTexts))
+		for _, text := range systemTexts {
+			gotTexts = append(gotTexts, text.String())
+		}
+		wantTexts := []string{"top", "skills", "developer note"}
+		if !slices.Equal(gotTexts, wantTexts) {
+			t.Fatalf("system texts = %v, want %v (full: %s)", gotTexts, wantTexts, string(result))
+		}
+		if !providerUtils.JSONFieldExists(result, "system.2.cache_control") {
+			t.Fatalf("expected cache_control on moved developer system block, got %s", string(result))
+		}
+
+		betas := providerUtils.GetJSONField(result, "betas").Array()
+		if len(betas) != 1 || betas[0].String() != "other-beta-2026-01-01" {
+			t.Fatalf("expected mid-conversation beta removed and other beta preserved, got %s", string(result))
+		}
+	})
+
+	t.Run("anthropic_keeps_mid_conversation_system_for_supported_model", func(t *testing.T) {
+		input := []byte(`{
+			"model":"claude-opus-4-8",
+			"system":[{"type":"text","text":"top"}],
+			"messages":[
+				{"role":"user","content":"hello"},
+				{"role":"system","content":"mid"},
+				{"role":"assistant","content":"hi"}
+			],
+			"betas":["` + AnthropicMidConversationSystemBetaHeader + `"]
+		}`)
+
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-opus-4-8")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		roles := providerUtils.GetJSONField(result, "messages.#.role").Array()
+		if len(roles) != 3 || roles[1].String() != "system" {
+			t.Fatalf("expected system message to remain for supported model, got %s", string(result))
+		}
+		if !providerUtils.JSONFieldExists(result, "betas.0") {
+			t.Fatalf("expected mid-conversation beta to remain for supported model, got %s", string(result))
+		}
+	})
+
+	t.Run("anthropic_leaves_system_role_without_mid_conversation_beta", func(t *testing.T) {
+		input := []byte(`{
+			"model":"claude-sonnet-4-6",
+			"system":[{"type":"text","text":"top"}],
+			"messages":[
+				{"role":"user","content":"hello"},
+				{"role":"system","content":"mid"}
+			]
+		}`)
+
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-sonnet-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		roles := providerUtils.GetJSONField(result, "messages.#.role").Array()
+		if len(roles) != 2 || roles[1].String() != "system" {
+			t.Fatalf("expected system message to remain without explicit mid-conversation beta, got %s", string(result))
+		}
+	})
+
 	t.Run("nested_scope_stripped_on_messages_and_system", func(t *testing.T) {
 		// Nested scope on system blocks and message blocks must also be stripped
 		// when the provider lacks PromptCachingScope.
@@ -2952,8 +3041,8 @@ func TestBudgetTokensMaxEffortCapsBelowMaxTokens(t *testing.T) {
 	const minBudget = MinimumReasoningMaxTokens
 
 	cases := []struct {
-		maxTokens    int
-		wantBudget   int
+		maxTokens  int
+		wantBudget int
 	}{
 		{maxTokens: 16000, wantBudget: 15999},
 		{maxTokens: 32000, wantBudget: 31999},


### PR DESCRIPTION
## Summary
- Downgrade raw Anthropic messages with unsupported mid-conversation system/developer roles into top-level system blocks.
- Preserve raw mid-conversation system messages only when the target provider/model supports them.
- Remove the legacy `mid-conversation-system-2026-04-07` beta from raw bodies after downgrading; beta presence is not used as a capability signal.

## Claude API compatibility
Anthropic docs for https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages state:
- "This feature is available on Claude Opus 4.8 only. No beta header is required."
- "They are not available on Amazon Bedrock, Vertex AI, or Microsoft Foundry."

That means the raw passthrough path must gate by provider/model capability (`Anthropic` + Opus 4.8) and by the actual presence of `messages[].role = "system"` or `developer`, not by the beta value.

Fixes #3879

## Tests
- `GOCACHE=/private/tmp/bifrost-pr-go-build GOMODCACHE=/private/tmp/bifrost-pr-gomod go test ./providers/anthropic`