### PR TITLE
feat: url validation

### DIFF
--- a/core/network/utils.go
+++ b/core/network/utils.go
@@ -1,0 +1,49 @@
+package network
+
+import "net"
+
+// IsLocalhost reports whether hostname is localhost or a loopback literal.
+func IsLocalhost(hostname string) bool {
+	return hostname == "localhost" ||
+		hostname == "127.0.0.1" ||
+		hostname == "::1" ||
+		hostname == "0.0.0.0" ||
+		hostname == "::"
+}
+
+var privateSubnets []*net.IPNet
+
+func init() {
+	for _, cidr := range []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"169.254.0.0/16", // link-local / AWS metadata
+		"127.0.0.0/8",    // loopback
+	} {
+		_, subnet, _ := net.ParseCIDR(cidr)
+		privateSubnets = append(privateSubnets, subnet)
+	}
+}
+
+// IsPrivateIP reports whether ip falls in a private, loopback, or link-local range.
+func IsPrivateIP(ip net.IP) bool {
+	if ip == nil || ip.IsUnspecified() {
+		return true
+	}
+	for _, subnet := range privateSubnets {
+		if subnet.Contains(ip) {
+			return true
+		}
+	}
+	// IPv6: loopback, link-local, unique-local (fc00::/7)
+	if ip.To4() == nil {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+			return true
+		}
+		if len(ip) == 16 && (ip[0]&0xfe) == 0xfc {
+			return true
+		}
+	}
+	return false
+}

--- a/core/providers/utils/dialer_test.go
+++ b/core/providers/utils/dialer_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -103,28 +104,11 @@ func TestConfigureDialer_TCPKeepAliveEnabled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Test without existing dial (direct connection path)
-	t.Run("without_existing_dial", func(t *testing.T) {
-		client := &fasthttp.Client{}
-		ConfigureDialer(client)
+	// The default (no-proxy) path enforces SSRF protection and blocks loopback,
+	// so test servers on 127.0.0.1 are unreachable via that path. Keepalive is
+	// verified through the existingDial path below, which also applies it.
 
-		// The Dial function should create connections with keepalive
-		// We can verify by making a connection and checking the TCP options
-		req := fasthttp.AcquireRequest()
-		resp := fasthttp.AcquireResponse()
-		defer fasthttp.ReleaseRequest(req)
-		defer fasthttp.ReleaseResponse(resp)
-
-		req.SetRequestURI(server.URL)
-		req.Header.SetMethod(http.MethodGet)
-
-		if err := client.Do(req, resp); err != nil {
-			t.Fatalf("request failed: %v", err)
-		}
-		if resp.StatusCode() != 200 {
-			t.Fatalf("expected 200, got %d", resp.StatusCode())
-		}
-	})
+	// Test with existing dial (proxy composition path)
 
 	// Test with existing dial (proxy composition path)
 	t.Run("with_existing_dial", func(t *testing.T) {
@@ -179,7 +163,10 @@ func TestConfigureDialer_Idempotent(t *testing.T) {
 	}))
 	defer server.Close()
 
+	// Pre-set existingDial so the proxy path is used — httptest binds to
+	// 127.0.0.1, which the default SSRF-safe path blocks.
 	client := &fasthttp.Client{}
+	client.Dial = func(addr string) (net.Conn, error) { return net.Dial("tcp", addr) }
 	ConfigureDialer(client)
 	ConfigureDialer(client) // called again
 
@@ -230,7 +217,10 @@ func TestConfigureDialer_WithRetryOnStaleConnection(t *testing.T) {
 		MaxIdleConnDuration: clientIdleTimeout,
 		MaxConnsPerHost:     10,
 	}
-	// Use ConfigureDialer (the function under test) instead of manually setting RetryIfErr
+	// Pre-set existingDial so the proxy path is used — httptest binds to
+	// 127.0.0.1, which the default SSRF-safe path blocks.
+	client.Dial = func(addr string) (net.Conn, error) { return net.Dial("tcp", addr) }
+	// Use ConfigureDialer (the function under test) to install RetryIfErr + keepalive
 	ConfigureDialer(client)
 
 	// First request: establish connection in pool
@@ -290,6 +280,109 @@ func TestConfigureRetry_Deprecated(t *testing.T) {
 	reset, retry := client.RetryIfErr(nil, 1, fmt.Errorf("cannot find whitespace"))
 	if !reset || !retry {
 		t.Error("ConfigureRetry should install StaleConnectionRetryIfErr")
+	}
+}
+
+// TestConfigureDialer_SSRFProtection verifies that the default (no-proxy) dial
+// path rejects connections to private, loopback, and link-local addresses before
+// any TCP socket is opened.
+func TestConfigureDialer_SSRFProtection(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr string
+	}{
+		// Localhost / loopback — rejected by IsLocalhost before DNS is touched
+		{"localhost name", "localhost:80", "not allowed"},
+		{"127.0.0.1 literal", "127.0.0.1:80", "not allowed"},
+		{"[::1] loopback", "[::1]:80", "not allowed"},
+		{"0.0.0.0 all-zeros", "0.0.0.0:80", "not allowed"},
+		{"[::] unspecified short", "[::]:80", "not allowed"},
+
+		// RFC 1918 private ranges — LookupIP returns the literal IP, IsPrivateIP rejects it
+		{"10.x.x.x", "10.0.0.1:80", "private IP"},
+		{"172.16.x.x", "172.16.0.1:80", "private IP"},
+		{"192.168.x.x", "192.168.1.1:80", "private IP"},
+
+		// Link-local / cloud metadata
+		{"169.254.169.254 AWS metadata", "169.254.169.254:80", "private IP"},
+		{"169.254.x.x link-local", "169.254.1.1:80", "private IP"},
+
+		// IPv6 private
+		{"[fc00::1] unique-local", "[fc00::1]:80", "private IP"},
+		{"[fd00::1] unique-local", "[fd00::1]:80", "private IP"},
+
+		// Unspecified IPv6 long form — regression for bypass via 0:0:0:0:0:0:0:0
+		{"[0:0:0:0:0:0:0:0] unspecified long form", "[0:0:0:0:0:0:0:0]:80", "private IP"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fasthttp.Client{ReadTimeout: time.Second}
+			ConfigureDialer(client)
+			_, err := client.Dial(tt.addr)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+// TestConfigureDialer_SSRFProxyBypass verifies that when an existingDial is set
+// (proxy path), SSRF checks are intentionally skipped — the proxy owns routing.
+func TestConfigureDialer_SSRFProxyBypass(t *testing.T) {
+	var proxyCalled bool
+	client := &fasthttp.Client{}
+	client.Dial = func(addr string) (net.Conn, error) {
+		proxyCalled = true
+		return nil, fmt.Errorf("proxy handled: %s", addr)
+	}
+	ConfigureDialer(client)
+
+	_, err := client.Dial("10.0.0.1:80")
+	if !proxyCalled {
+		t.Error("expected proxy dial to be called for private IP")
+	}
+	if err == nil || !strings.Contains(err.Error(), "proxy handled") {
+		t.Errorf("expected proxy error, got %v", err)
+	}
+}
+
+// TestConfigureDialer_SSRFZeroTimeout verifies that SSRF protection is active
+// even when ReadTimeout is 0 (context.Background() is used instead of WithTimeout).
+func TestConfigureDialer_SSRFZeroTimeout(t *testing.T) {
+	client := &fasthttp.Client{ReadTimeout: 0}
+	ConfigureDialer(client)
+
+	_, err := client.Dial("169.254.169.254:80")
+	if err == nil {
+		t.Fatal("expected SSRF rejection with zero ReadTimeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "private IP") {
+		t.Errorf("expected 'private IP' error, got %q", err.Error())
+	}
+}
+
+// TestConfigureDialer_SSRFMultiIPAllFail verifies that when all resolved IPs
+// fail to connect, the last dial error is returned (not a generic message).
+func TestConfigureDialer_SSRFMultiIPAllFail(t *testing.T) {
+	// 192.0.2.0/24 is TEST-NET-1 (RFC 5737) — documentation-only, never routed.
+	// A connection attempt to it will fail (refused or timeout) without any
+	// private-IP rejection, letting us exercise the lastErr return path.
+	client := &fasthttp.Client{ReadTimeout: 200 * time.Millisecond}
+	ConfigureDialer(client)
+
+	_, err := client.Dial("192.0.2.1:9")
+	if err == nil {
+		t.Fatal("expected connection error for unroutable TEST-NET address")
+	}
+	// Must not be the generic "no usable address" sentinel — a real dial error
+	// was returned.
+	if strings.Contains(err.Error(), "no usable address resolved") {
+		t.Errorf("expected a real dial error, got generic sentinel: %v", err)
 	}
 }
 

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -278,10 +278,48 @@ func ConfigureDialer(client *fasthttp.Client) *fasthttp.Client {
 			// Preserve dial-timeout behavior
 			conn, err = existingDialTimeout(addr, client.ReadTimeout)
 		default:
-			conn, err = (&net.Dialer{
+			// resolve DNS ourselves, reject private IPs, then dial
+			// the IP literal directly — closes the DNS rebinding window that exists
+			// between ValidateExternalURL (save time) and this connection.
+			host, port, splitErr := net.SplitHostPort(addr)
+			if splitErr != nil {
+				return nil, splitErr
+			}
+			if network.IsLocalhost(host) {
+				return nil, fmt.Errorf("connection to %s is not allowed", host)
+			}
+			// Bound DNS resolution with the same timeout that governs the TCP
+			resolveCtx := context.Background()
+			if client.ReadTimeout > 0 {
+				var cancel context.CancelFunc
+				resolveCtx, cancel = context.WithTimeout(resolveCtx, client.ReadTimeout)
+				defer cancel()
+			}
+			ips, resolveErr := net.DefaultResolver.LookupIP(resolveCtx, "ip", host)
+			if resolveErr != nil {
+				return nil, resolveErr
+			}
+			dialer := &net.Dialer{
 				Timeout:         client.ReadTimeout,
 				KeepAliveConfig: keepAliveCfg,
-			}).Dial("tcp", addr)
+			}
+			var lastErr error
+			for _, ip := range ips {
+				if network.IsPrivateIP(ip) {
+					return nil, fmt.Errorf("connection to private IP %s is not allowed", ip)
+				}
+				conn, err = dialer.Dial("tcp", net.JoinHostPort(ip.String(), port))
+				if err == nil {
+					break
+				}
+				lastErr = err
+			}
+			if conn == nil {
+				if lastErr != nil {
+					return nil, lastErr
+				}
+				return nil, fmt.Errorf("no usable address resolved for %s", host)
+			}
 		}
 		if err != nil {
 			return nil, err

--- a/core/utils.go
+++ b/core/utils.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/core/mcp"
+	"github.com/maximhq/bifrost/core/network"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -494,7 +495,7 @@ func ValidateExternalURL(urlStr string) error {
 		return fmt.Errorf("URL must have a hostname")
 	}
 	// Block localhost and loopback addresses
-	if isLocalhost(hostname) {
+	if network.IsLocalhost(hostname) {
 		return fmt.Errorf("localhost and loopback addresses are not allowed")
 	}
 	// Resolve hostname to IP addresses
@@ -504,50 +505,11 @@ func ValidateExternalURL(urlStr string) error {
 	}
 	// Check if any resolved IP is private
 	for _, ip := range ips {
-		if isPrivateIP(ip) {
+		if network.IsPrivateIP(ip) {
 			return fmt.Errorf("private IP addresses are not allowed")
 		}
 	}
 	return nil
-}
-
-// isLocalhost checks if a hostname is localhost or a loopback address
-func isLocalhost(hostname string) bool {
-	return hostname == "localhost" ||
-		hostname == "127.0.0.1" ||
-		hostname == "::1" ||
-		hostname == "0.0.0.0" ||
-		hostname == "::"
-}
-
-// isPrivateIP checks if an IP address is in a private range
-func isPrivateIP(ip net.IP) bool {
-	// Private IPv4 ranges
-	privateRanges := []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"169.254.0.0/16", // Link-local
-		"127.0.0.0/8",    // Loopback
-	}
-	for _, cidr := range privateRanges {
-		_, subnet, _ := net.ParseCIDR(cidr)
-		if subnet.Contains(ip) {
-			return true
-		}
-	}
-	// Check for private IPv6
-	if ip.To4() == nil {
-		// Check for IPv6 loopback and link-local
-		if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
-			return true
-		}
-		// Check for IPv6 unique local addresses (fc00::/7)
-		if len(ip) == 16 && (ip[0]&0xfe) == 0xfc {
-			return true
-		}
-	}
-	return false
 }
 
 // sanitizeSpanName sanitizes a span name to remove capital letters and spaces to make it a valid span name

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -1,0 +1,250 @@
+package bifrost
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/network"
+)
+
+func TestValidateExternalURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		// Valid URLs
+		{
+			name:    "valid https URL",
+			url:     "https://api.openai.com",
+			wantErr: false,
+		},
+		{
+			name:    "valid http URL",
+			url:     "http://api.openai.com",
+			wantErr: false,
+		},
+		{
+			name:    "valid https URL with path",
+			url:     "https://api.openai.com/v1",
+			wantErr: false,
+		},
+		{
+			name:    "valid https URL with port",
+			url:     "https://api.openai.com:443",
+			wantErr: false,
+		},
+
+		// Empty / malformed
+		{
+			name:    "empty URL",
+			url:     "",
+			wantErr: true,
+			errMsg:  "URL cannot be empty",
+		},
+		{
+			name:    "no scheme",
+			url:     "api.openai.com",
+			wantErr: true,
+			errMsg:  "only https and http schemes are allowed",
+		},
+		{
+			name:    "ftp scheme",
+			url:     "ftp://api.openai.com",
+			wantErr: true,
+			errMsg:  "only https and http schemes are allowed",
+		},
+		{
+			name:    "file scheme",
+			url:     "file:///etc/passwd",
+			wantErr: true,
+			errMsg:  "only https and http schemes are allowed",
+		},
+		{
+			name:    "missing hostname",
+			url:     "http://",
+			wantErr: true,
+			errMsg:  "URL must have a hostname",
+		},
+
+		// Localhost / loopback by name
+		{
+			name:    "localhost",
+			url:     "http://localhost",
+			wantErr: true,
+			errMsg:  "localhost and loopback addresses are not allowed",
+		},
+		{
+			name:    "localhost with port",
+			url:     "http://localhost:8080",
+			wantErr: true,
+			errMsg:  "localhost and loopback addresses are not allowed",
+		},
+		{
+			name:    "loopback 127.0.0.1",
+			url:     "http://127.0.0.1",
+			wantErr: true,
+			errMsg:  "localhost and loopback addresses are not allowed",
+		},
+		{
+			name:    "loopback ::1",
+			url:     "http://[::1]",
+			wantErr: true,
+			errMsg:  "localhost and loopback addresses are not allowed",
+		},
+		{
+			name:    "all-zeros 0.0.0.0",
+			url:     "http://0.0.0.0",
+			wantErr: true,
+			errMsg:  "localhost and loopback addresses are not allowed",
+		},
+
+		// Private IP ranges (RFC 1918)
+		{
+			name:    "private 10.x.x.x",
+			url:     "http://10.0.0.1",
+			wantErr: true,
+			errMsg:  "private IP addresses are not allowed",
+		},
+		{
+			name:    "private 172.16.x.x",
+			url:     "http://172.16.0.1",
+			wantErr: true,
+			errMsg:  "private IP addresses are not allowed",
+		},
+		{
+			name:    "private 192.168.x.x",
+			url:     "http://192.168.1.1",
+			wantErr: true,
+			errMsg:  "private IP addresses are not allowed",
+		},
+
+		// Link-local / cloud metadata
+		{
+			name:    "AWS metadata service",
+			url:     "http://169.254.169.254",
+			wantErr: true,
+			errMsg:  "private IP addresses are not allowed",
+		},
+		{
+			name:    "AWS metadata with path",
+			url:     "http://169.254.169.254/latest/meta-data/",
+			wantErr: true,
+			errMsg:  "private IP addresses are not allowed",
+		},
+		{
+			name:    "link-local 169.254.x.x",
+			url:     "http://169.254.1.1",
+			wantErr: true,
+			errMsg:  "private IP addresses are not allowed",
+		},
+
+		// Query-parameter injection (the PoC vector from the advisory)
+		{
+			name:    "query param injection targeting metadata service",
+			url:     "http://169.254.169.254/latest/meta-data/iam/security-credentials/role?x=",
+			wantErr: true,
+			errMsg:  "private IP addresses are not allowed",
+		},
+		{
+			name:    "query param injection targeting internal host",
+			url:     "http://10.0.0.1/arbitrary/path?x=",
+			wantErr: true,
+			errMsg:  "private IP addresses are not allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExternalURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errMsg)
+					return
+				}
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got %q", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestIsLocalhost(t *testing.T) {
+	tests := []struct {
+		hostname string
+		want     bool
+	}{
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"0.0.0.0", true},
+		{"::", true},
+		{"api.openai.com", false},
+		{"10.0.0.1", false}, // private but not localhost — handled by IsPrivateIP
+		{"169.254.169.254", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			if got := network.IsLocalhost(tt.hostname); got != tt.want {
+				t.Errorf("IsLocalhost(%q) = %v, want %v", tt.hostname, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		// Private IPv4 (RFC 1918)
+		{"10.0.0.1", true},
+		{"10.255.255.255", true},
+		{"172.16.0.1", true},
+		{"172.31.255.255", true},
+		{"192.168.0.1", true},
+		{"192.168.255.255", true},
+		// Link-local
+		{"169.254.0.1", true},
+		{"169.254.169.254", true},
+		// Loopback
+		{"127.0.0.1", true},
+		{"127.255.255.255", true},
+		// Public IPv4
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"104.21.0.1", false},
+		// Private IPv6
+		{"::1", true},     // loopback
+		{"fe80::1", true}, // link-local
+		{"fc00::1", true}, // unique local
+		{"fd00::1", true}, // unique local
+		// Public IPv6
+		{"2606:4700::1", false},
+		// Unspecified addresses (fail-closed)
+		{"0.0.0.0", true},                   // IPv4 unspecified
+		{"0:0:0:0:0:0:0:0", true},           // IPv6 unspecified long form
+		{"::", true},                         // IPv6 unspecified short form
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse IP %q", tt.ip)
+			}
+			if got := network.IsPrivateIP(ip); got != tt.want {
+				t.Errorf("IsPrivateIP(%q) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -281,6 +281,12 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid retry backoff: %v", err))
 			return
 		}
+		if payload.NetworkConfig.BaseURL != "" {
+			if err := bifrost.ValidateExternalURL(payload.NetworkConfig.BaseURL); err != nil {
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid base URL: %v", err))
+				return
+			}
+		}
 	}
 	// Check if provider already exists
 	if _, err := h.inMemoryStore.GetProviderConfigRedacted(payload.Provider); err != nil {
@@ -448,6 +454,12 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 	if err := validateRetryBackoff(&nc); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid retry backoff: %v", err))
 		return
+	}
+	if nc.BaseURL != "" {
+		if err := bifrost.ValidateExternalURL(nc.BaseURL); err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid base URL: %v", err))
+			return
+		}
 	}
 
 	config.ConcurrencyAndBufferSize = &payload.ConcurrencyAndBufferSize


### PR DESCRIPTION
## Summary

This PR closes a DNS rebinding vulnerability that existed between the time `ValidateExternalURL` validated a URL and the time the HTTP client actually opened a TCP connection. An attacker could exploit this window by having a hostname resolve to a public IP during validation and then to a private/internal IP at dial time, bypassing SSRF protections.

## Changes

- Extracted `IsLocalhost` and `IsPrivateIP` into a new `core/network` package so they can be shared across validation and dialing layers.
- Updated `ConfigureDialer` to perform its own DNS resolution at dial time, reject any resolved private or loopback IPs, and dial the resolved IP literal directly — eliminating the TOCTOU window between URL validation and connection.
- Added `ValidateExternalURL` calls in the HTTP transport's `addProvider` and `updateProvider` handlers to reject private or loopback `BaseURL` values at the API boundary.
- Added `core/utils_test.go` with comprehensive tests covering `ValidateExternalURL`, `IsLocalhost`, and `IsPrivateIP`, including RFC 1918 ranges, link-local addresses, the AWS metadata endpoint (`169.254.169.254`), IPv6 private ranges, and query-parameter injection vectors.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
go version
go test ./...
```

Key scenarios validated by the test suite:
- `http://169.254.169.254/latest/meta-data/` → rejected as private IP
- `http://10.0.0.1/path?x=` → rejected as private IP
- `http://localhost:8080` → rejected as loopback
- `https://api.openai.com` → allowed
- IPv6 loopback (`::1`), link-local (`fe80::1`), and unique-local (`fc00::/7`) → all rejected

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change directly addresses an SSRF / DNS rebinding attack vector. Previously, a malicious actor could register a hostname that resolved to a public IP during `ValidateExternalURL` and then switch the DNS record to an internal address (e.g., `169.254.169.254`, `10.x.x.x`) before the dialer connected. The dialer now resolves DNS independently, validates every returned IP against private ranges, and dials the IP literal, closing this window entirely. The `BaseURL` field on provider add/update endpoints is also now validated at the API layer.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened SSRF protections: centralized hostname/IP checks now block localhost, link-local, unspecified, and private IPs when validating external URLs and provider Base URLs.
  * Provider create/update endpoints validate Base URLs and return clear Bad Request responses for unsafe targets.
  * Network dialing now resolves hosts and rejects disallowed/private addresses early to prevent unsafe connections.

* **Tests**
  * Added extensive unit tests for URL validation, network address classification, and dialer SSRF behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->