### PR TITLE
fix: truncate long Y-axis labels with ellipsis and tooltip in dimension rankings chart

### DIFF
--- a/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
@@ -84,7 +84,7 @@ function TopDimensionChart({
 							<BarChart
 								data={chartData}
 								layout="vertical"
-								margin={{ top: 6, right: 20, left: 4, bottom: 0 }}
+								margin={{ top: 6, right: 20, left: 0, bottom: 0 }}
 								barCategoryGap={4}
 							>
 								<CartesianGrid strokeDasharray="3 3" horizontal={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
@@ -98,10 +98,23 @@ function TopDimensionChart({
 								<YAxis
 									type="category"
 									dataKey="displayName"
-									tick={{ fontSize: 11, className: "fill-zinc-500" }}
+									tick={(props: any) => {
+										const { x, y, payload } = props;
+										const maxChars = 14;
+										const label =
+											payload.value.length > maxChars
+												? `${payload.value.slice(0, maxChars)}…`
+												: payload.value;
+										return (
+											<text x={x} y={y} dy={4} textAnchor="end" fontSize={11} className="fill-zinc-500">
+												<title>{payload.value}</title>
+												{label}
+											</text>
+										);
+									}}
 									tickLine={false}
 									axisLine={false}
-									width={110}
+									width={92}
 								/>
 								<Tooltip content={<TopDimensionTooltip />} />
 								<Bar


### PR DESCRIPTION
## Summary

Y-axis labels in the dimension rankings bar chart were taking up too much horizontal space and could overflow without truncation. This PR truncates long dimension names in the chart's Y-axis labels and adds a tooltip `<title>` element so users can still see the full name on hover.

## Changes

- Y-axis labels longer than 14 characters are now truncated with an ellipsis (`…`), with the full value exposed via an SVG `<title>` for accessibility and hover visibility
- Y-axis width reduced from `110` to `92` to match the shorter label space
- Left margin reduced from `4` to `0` to reclaim horizontal space

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the workspace dashboard and open the Dimension Rankings tab. Find a dimension with a long name (more than 14 characters) and verify:
1. The label is truncated with an ellipsis in the chart
2. Hovering over the label shows the full name via the browser's native tooltip

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Add before/after screenshots showing the truncated Y-axis labels vs. the previous full-length labels.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  - Improved dimension ranking chart layout with optimized spacing
  - Long category labels now display with ellipsis truncation for better readability, with full text visible on hover
<!-- end of auto-generated comment: release notes by coderabbit.ai -->