### PR TITLE
fix: drain non sse stream reader

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -558,7 +558,8 @@ func HandleOpenAITextCompletionStreaming(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		reader, drained := providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drained {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -1101,7 +1102,8 @@ func HandleOpenAIChatCompletionStreaming(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		reader, drained := providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drained {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -1740,7 +1742,8 @@ func HandleOpenAIResponsesStreaming(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		reader, drained := providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drained {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -2350,7 +2353,8 @@ func HandleOpenAISpeechStreamRequest(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		reader, drained := providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drained {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -2791,7 +2795,8 @@ func HandleOpenAITranscriptionStreamRequest(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		reader, drained := providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drained {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -3229,7 +3234,8 @@ func HandleOpenAIImageGenerationStreaming(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		reader, drained := providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drained {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return
@@ -4467,7 +4473,8 @@ func HandleOpenAIImageEditStreamRequest(
 
 		// Skip scanner for non-SSE responses — avoids bufio.Scanner buffer bloat
 		// on non-line-delimited data (e.g. provider returned JSON instead of SSE).
-		if providerUtils.DrainNonSSEStreamResponse(resp) {
+		reader, drained := providerUtils.DrainNonSSEStreamReader(resp, reader)
+		if drained {
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendError(ctx, postHookRunner, errors.New("provider returned non-SSE response for streaming request"), responseChan, logger, postHookSpanFinalizer)
 			return

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -3,6 +3,7 @@
 package utils
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -993,21 +994,55 @@ func DecompressStreamBody(resp *fasthttp.Response) (io.Reader, func()) {
 	}
 }
 
-// DrainNonSSEStreamResponse checks if the upstream response is a Server-Sent Events stream.
-// If not SSE, drains the body to io.Discard to prevent bufio.Scanner buffer bloat on
-// non-line-delimited data. Returns true if body was drained (caller should skip scanner).
-// We intentionally do not touch valid SSE bodies here: callers must continue reading from
-// the reader returned by DecompressStreamBody, and draining SSE in this helper would consume
-// the stream before the scanner/manual event loop starts.
-func DrainNonSSEStreamResponse(resp *fasthttp.Response) bool {
+// Some OpenAI-compatible backends return valid SSE frames without Content-Type:
+// text/event-stream. In that case, peek at the first field prefix without consuming
+// it so the downstream SSE parser sees the full stream.
+func DrainNonSSEStreamReader(resp *fasthttp.Response, reader io.Reader) (io.Reader, bool) {
 	ct := strings.ToLower(string(resp.Header.ContentType()))
 	if strings.Contains(ct, "text/event-stream") {
+		return reader, false
+	}
+	if reader == nil {
+		return nil, true
+	}
+
+	br := bufio.NewReaderSize(reader, sseInitialBufSize)
+	if hasSSEPrefix(br) {
+		return br, false
+	}
+
+	_, _ = io.Copy(io.Discard, br)
+	return nil, true
+}
+
+func hasSSEPrefix(reader *bufio.Reader) bool {
+	first, err := reader.Peek(1)
+	if err != nil || len(first) == 0 {
 		return false
 	}
-	if bodyStream := resp.BodyStream(); bodyStream != nil {
-		_, _ = io.Copy(io.Discard, bodyStream)
+	switch first[0] {
+	case ':', '\n', '\r':
+		return true
+	case 'd':
+		return peekHasPrefix(reader, []byte("data:"))
+	case 'e':
+		return peekHasPrefix(reader, []byte("event:"))
+	case 'i':
+		return peekHasPrefix(reader, []byte("id:"))
+	case 'r':
+		return peekHasPrefix(reader, []byte("retry:"))
+	default:
+		return false
 	}
-	return true
+}
+
+func peekHasPrefix(reader *bufio.Reader, prefix []byte) bool {
+	n := min(reader.Buffered(), len(prefix))
+	if n == 0 {
+		return false
+	}
+	peeked, err := reader.Peek(n)
+	return err == nil && bytes.Equal(peeked, prefix[:n])
 }
 
 // MergeExtraParams merges extraParams into jsonMap, handling nested maps recursively.

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -7,8 +7,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -726,20 +729,17 @@ func TestCheckAndDecodeBody_Concurrent(t *testing.T) {
 	}
 }
 
-func TestDrainNonSSEStreamResponse_SSEDoesNotDrain(t *testing.T) {
+func TestDrainNonSSEStreamReader_SSEWithoutContentTypeStillReadable(t *testing.T) {
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseResponse(resp)
 
-	body := []byte("data: hello\n\n")
-	resp.Header.SetContentType("text/event-stream")
-	resp.SetBodyStream(bytes.NewReader(body), len(body))
-
-	drained := DrainNonSSEStreamResponse(resp)
+	body := []byte("event: response.created\n\ndata: {\"type\":\"response.completed\"}\n\n")
+	reader, drained := DrainNonSSEStreamReader(resp, bytes.NewReader(body))
 	if drained {
-		t.Fatal("expected SSE response to remain readable")
+		t.Fatal("expected SSE-looking response without content type to remain readable")
 	}
 
-	remaining, err := io.ReadAll(resp.BodyStream())
+	remaining, err := io.ReadAll(reader)
 	if err != nil {
 		t.Fatalf("failed to read SSE body after guard: %v", err)
 	}
@@ -748,52 +748,300 @@ func TestDrainNonSSEStreamResponse_SSEDoesNotDrain(t *testing.T) {
 	}
 }
 
-func TestDrainNonSSEStreamResponse_NonSSEDrains(t *testing.T) {
+func TestDrainNonSSEStreamReader_GzipSSEWithoutContentTypeStillReadable(t *testing.T) {
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	body := []byte("data: {\"type\":\"response.completed\"}\n\n")
+	compressed := gzipCompress(body)
+	resp.Header.Set("Content-Encoding", "gzip")
+	resp.SetBodyStream(bytes.NewReader(compressed), len(compressed))
+
+	decompressed, releaseGzip := DecompressStreamBody(resp)
+	defer releaseGzip()
+
+	reader, drained := DrainNonSSEStreamReader(resp, decompressed)
+	if drained {
+		t.Fatal("expected decompressed SSE-looking response without content type to remain readable")
+	}
+
+	remaining, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to read decompressed SSE body after guard: %v", err)
+	}
+	if string(remaining) != string(body) {
+		t.Fatalf("expected decompressed SSE body %q, got %q", string(body), string(remaining))
+	}
+}
+
+func TestDrainNonSSEStreamReader_JSONWithoutContentTypeDrains(t *testing.T) {
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseResponse(resp)
 
 	body := []byte(`{"error":"not stream"}`)
-	resp.Header.SetContentType("application/json")
-	resp.SetBodyStream(bytes.NewReader(body), len(body))
-
-	drained := DrainNonSSEStreamResponse(resp)
+	reader, drained := DrainNonSSEStreamReader(resp, bytes.NewReader(body))
 	if !drained {
-		t.Fatal("expected non-SSE response to be drained")
+		t.Fatal("expected JSON response without content type to be drained")
 	}
-
-	remaining, err := io.ReadAll(resp.BodyStream())
-	if err != nil {
-		t.Fatalf("failed to read body after drain: %v", err)
-	}
-	if len(remaining) != 0 {
-		t.Fatalf("expected drained body to be empty, got %q", string(remaining))
+	if reader != nil {
+		t.Fatal("expected drained response to return nil reader")
 	}
 }
 
-func TestDrainNonSSEStreamResponse_GzipSSEStillReadable(t *testing.T) {
+func TestDrainNonSSEStreamReader_UppercaseSSEPrefixDrains(t *testing.T) {
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseResponse(resp)
 
-	body := []byte("data: hello\n\ndata: [DONE]\n\n")
-	compressed := gzipCompress(body)
-	resp.Header.SetContentType("text/event-stream")
-	resp.Header.Set("Content-Encoding", "gzip")
-	resp.SetBodyStream(bytes.NewReader(compressed), len(compressed))
-
-	drained := DrainNonSSEStreamResponse(resp)
-	if drained {
-		t.Fatal("expected gzip SSE response to remain readable")
+	body := []byte("DATA: {\"type\":\"response.completed\"}\n\n")
+	reader, drained := DrainNonSSEStreamReader(resp, bytes.NewReader(body))
+	if !drained {
+		t.Fatal("expected uppercase SSE-like prefix to be treated as non-SSE")
 	}
+	if reader != nil {
+		t.Fatal("expected drained response to return nil reader")
+	}
+}
 
-	reader, releaseGzip := DecompressStreamBody(resp)
-	defer releaseGzip()
+func TestDrainNonSSEStreamReader_ShortReadSSEPrefix(t *testing.T) {
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	body := []byte("event: response.created\n\ndata: {}\n\n")
+	reader, drained := DrainNonSSEStreamReader(resp, &shortReadReader{data: body, chunkSize: 3})
+	if drained {
+		t.Fatal("expected SSE stream with short-read prefix to remain readable")
+	}
 
 	remaining, err := io.ReadAll(reader)
 	if err != nil {
-		t.Fatalf("failed to read decompressed SSE body: %v", err)
+		t.Fatalf("failed to read after short-read guard: %v", err)
 	}
 	if string(remaining) != string(body) {
-		t.Fatalf("expected decompressed SSE body %q, got %q", string(body), string(remaining))
+		t.Fatalf("expected body %q, got %q", body, remaining)
+	}
+}
+
+func TestDrainNonSSEStreamReader_TinyOpenSSEPrefixReturnsPromptly(t *testing.T) {
+	tests := []struct {
+		name     string
+		fragment string
+	}{
+		{name: "comment", fragment: ":\n\n"},
+		{name: "id field", fragment: "id:"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := fasthttp.AcquireResponse()
+			defer fasthttp.ReleaseResponse(resp)
+
+			pr, pw := io.Pipe()
+			defer pr.Close()
+
+			writeErr := make(chan error, 1)
+			go func() {
+				_, err := pw.Write([]byte(tt.fragment))
+				writeErr <- err
+			}()
+
+			result := make(chan struct {
+				reader  io.Reader
+				drained bool
+			}, 1)
+			go func() {
+				reader, drained := DrainNonSSEStreamReader(resp, pr)
+				result <- struct {
+					reader  io.Reader
+					drained bool
+				}{reader: reader, drained: drained}
+			}()
+
+			var got struct {
+				reader  io.Reader
+				drained bool
+			}
+			select {
+			case got = <-result:
+			case <-time.After(200 * time.Millisecond):
+				_ = pw.Close()
+				t.Fatal("DrainNonSSEStreamReader blocked waiting for a larger prefix")
+			}
+
+			if got.drained {
+				_ = pw.Close()
+				t.Fatal("expected tiny SSE prefix to remain readable")
+			}
+
+			preserved := make([]byte, len(tt.fragment))
+			if _, err := io.ReadFull(got.reader, preserved); err != nil {
+				_ = pw.Close()
+				t.Fatalf("failed to read preserved SSE prefix: %v", err)
+			}
+			if string(preserved) != tt.fragment {
+				_ = pw.Close()
+				t.Fatalf("expected preserved prefix %q, got %q", tt.fragment, string(preserved))
+			}
+
+			if err := pw.Close(); err != nil {
+				t.Fatalf("failed to close pipe writer: %v", err)
+			}
+			if err := <-writeErr; err != nil {
+				t.Fatalf("failed to write prefix: %v", err)
+			}
+		})
+	}
+}
+
+func TestDrainNonSSEStreamReader_FragmentedFieldPrefixReturnsPromptly(t *testing.T) {
+	tests := []struct {
+		name   string
+		first  string
+		suffix string
+	}{
+		{name: "data field", first: "d", suffix: "ata: {}\n\n"},
+		{name: "event field", first: "e", suffix: "vent: response.completed\n\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := fasthttp.AcquireResponse()
+			defer fasthttp.ReleaseResponse(resp)
+
+			pr, pw := io.Pipe()
+			defer pr.Close()
+
+			firstWriteErr := make(chan error, 1)
+			go func() {
+				_, err := pw.Write([]byte(tt.first))
+				firstWriteErr <- err
+			}()
+
+			result := make(chan struct {
+				reader  io.Reader
+				drained bool
+			}, 1)
+			go func() {
+				reader, drained := DrainNonSSEStreamReader(resp, pr)
+				result <- struct {
+					reader  io.Reader
+					drained bool
+				}{reader: reader, drained: drained}
+			}()
+
+			var got struct {
+				reader  io.Reader
+				drained bool
+			}
+			select {
+			case got = <-result:
+			case <-time.After(200 * time.Millisecond):
+				_ = pw.Close()
+				t.Fatal("DrainNonSSEStreamReader blocked waiting for a full SSE field name")
+			}
+			if got.drained {
+				_ = pw.Close()
+				t.Fatal("expected fragmented SSE field prefix to remain readable")
+			}
+			if err := <-firstWriteErr; err != nil {
+				_ = pw.Close()
+				t.Fatalf("failed to write first byte: %v", err)
+			}
+
+			suffixWriteErr := make(chan error, 1)
+			go func() {
+				_, err := pw.Write([]byte(tt.suffix))
+				if err == nil {
+					err = pw.Close()
+				}
+				suffixWriteErr <- err
+			}()
+
+			remaining, err := io.ReadAll(got.reader)
+			if err != nil {
+				t.Fatalf("failed to read preserved fragmented SSE stream: %v", err)
+			}
+			if string(remaining) != tt.first+tt.suffix {
+				t.Fatalf("expected preserved stream %q, got %q", tt.first+tt.suffix, string(remaining))
+			}
+			if err := <-suffixWriteErr; err != nil {
+				t.Fatalf("failed to write suffix: %v", err)
+			}
+		})
+	}
+}
+
+// shortReadReader returns at most chunkSize bytes per Read call, simulating
+// a network reader that delivers data in small segments (short reads).
+type shortReadReader struct {
+	data      []byte
+	chunkSize int
+	pos       int
+}
+
+func (r *shortReadReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	end := r.pos + r.chunkSize
+	if end > len(r.data) {
+		end = len(r.data)
+	}
+	n := copy(p, r.data[r.pos:end])
+	r.pos += n
+	return n, nil
+}
+
+// TestDrainNonSSEStreamReader_CodexNoContentType reproduces the original Codex hang:
+// a real HTTP server streams valid SSE events but omits Content-Type: text/event-stream.
+// Before the fix, DrainNonSSEStreamResponse would drain the body to /dev/null and the
+// client would hang waiting for events that never arrived.
+func TestDrainNonSSEStreamReader_CodexNoContentType(t *testing.T) {
+	const sseBody = "event: response.created\n\ndata: {\"type\":\"response.created\"}\n\nevent: response.completed\n\ndata: {\"type\":\"response.completed\"}\n\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Codex backend: valid SSE, but Content-Type is application/json — not text/event-stream.
+		// Setting it explicitly prevents Go's httptest from auto-detecting text/plain.
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		fmt.Fprint(w, sseBody)
+		if ok {
+			flusher.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+	req.SetRequestURI(srv.URL)
+	req.Header.SetMethod(http.MethodGet)
+	resp.StreamBody = true
+
+	if err := (&fasthttp.Client{}).Do(req, resp); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.StatusCode())
+	}
+
+	// Mirror the streaming goroutine path in openai.go
+	reader, releaseGzip := DecompressStreamBody(resp)
+	defer releaseGzip()
+
+	reader, drained := DrainNonSSEStreamReader(resp, reader)
+	if drained {
+		t.Fatal("SSE body without Content-Type was drained — reproduces the original Codex hang")
+	}
+
+	all, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading SSE body failed: %v", err)
+	}
+	if string(all) != sseBody {
+		t.Fatalf("SSE body corrupted\nwant: %q\n got: %q", sseBody, string(all))
 	}
 }
 


### PR DESCRIPTION
## Summary

Some OpenAI-compatible backends return valid SSE frames without a `Content-Type: text/event-stream` header. The previous `DrainNonSSEStreamResponse` helper would unconditionally drain and discard the response body in this case, causing the downstream SSE parser to receive an empty stream. This PR introduces a reader-preserving variant that peeks at the first bytes of the stream to detect SSE field prefixes (`data:`, `event:`, `id:`, `retry:`, `:`, or leading newlines) before deciding whether to drain or pass the reader through intact.

## Changes

- Introduced `DrainNonSSEStreamReader(resp, reader)` which accepts an `io.Reader` (e.g. a decompressed stream) and returns a potentially buffered reader alongside a `drained` boolean, preserving the stream when it looks like SSE even if the content type header is absent.
- `DrainNonSSEStreamResponse` is retained as a thin wrapper delegating to `DrainNonSSEStreamReader` for backward compatibility.
- All streaming handlers in the OpenAI provider (`text completion`, `chat completion`, `responses`, `speech`, `transcription`, `image generation`, `image edit`) now use `DrainNonSSEStreamReader` and reassign the reader from its return value so the buffered peek bytes are not lost.
- Added `looksLikeSSEPrefix` to perform a case-sensitive, 16-byte peek-based heuristic for SSE field prefixes.
- Added tests covering: SSE without content type remains readable, gzip-compressed SSE without content type remains readable, JSON without content type is drained, and uppercase SSE-like prefixes are treated as non-SSE.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/utils/... -run TestDrainNonSSEStreamReader
go test ./...
```

Expected: all new `TestDrainNonSSEStreamReader_*` tests pass, and existing streaming tests remain green. To validate end-to-end, route a streaming request through a backend that returns SSE without `Content-Type: text/event-stream` and confirm the response is streamed correctly rather than returning an error.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The peek reads at most 16 bytes from the stream and does not log or expose any content.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming across text, chat, responses, speech, transcription, image generation and edit flows to detect SSE-like streams, avoid prematurely draining them, and prevent stream hangs or unexpected termination.

* **Tests**
  * Added and updated unit tests for SSE detection, compressed-stream handling, fragmented/tiny-prefix delivery, and correct draining behavior for non-SSE payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->