### PR TITLE
feat: add wildcard pattern support for logging header capture (e.g. `x-custom-*`)

### DIFF
--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -452,6 +452,19 @@ func (p *LoggerPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext,
 	return chunk, nil
 }
 
+// loggingHeaderMatchesPattern returns true if headerName matches pattern.
+// Supports trailing wildcard ("x-custom-*") and bare wildcard ("*").
+// Both pattern and headerName must be pre-lowercased by the caller.
+func loggingHeaderMatchesPattern(pattern, headerName string) bool {
+	if pattern == "*" {
+		return true
+	}
+	if strings.HasSuffix(pattern, "*") {
+		return strings.HasPrefix(headerName, pattern[:len(pattern)-1])
+	}
+	return pattern == headerName
+}
+
 // captureLoggingHeaders extracts configured logging headers and x-bf-lh-* prefixed headers
 // from the request context. Returns a new metadata map, or nil if no headers were captured.
 // System entries (e.g. isAsyncRequest) should be set AFTER calling this so they take precedence.
@@ -463,15 +476,17 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 
 	var metadata map[string]any
 
-	// Check configured logging headers
+	// Check configured logging headers (supports wildcard patterns like "x-custom-*")
 	if p.loggingHeaders != nil {
 		for _, h := range *p.loggingHeaders {
-			key := strings.ToLower(h)
-			if val, ok := allHeaders[key]; ok {
-				if metadata == nil {
-					metadata = make(map[string]any)
+			pattern := strings.ToLower(strings.TrimSpace(h))
+			for hKey, hVal := range allHeaders {
+				if loggingHeaderMatchesPattern(pattern, hKey) {
+					if metadata == nil {
+						metadata = make(map[string]any)
+					}
+					metadata[hKey] = hVal
 				}
-				metadata[key] = val
 			}
 		}
 	}

--- a/ui/app/workspace/config/views/loggingView.tsx
+++ b/ui/app/workspace/config/views/loggingView.tsx
@@ -234,15 +234,16 @@ export default function LoggingView() {
 							Logging Headers
 						</label>
 						<p className="text-muted-foreground text-sm">
-							Comma-separated list of request headers to capture in log metadata. Values are extracted from incoming requests and stored in
-							the metadata field of log entries. Headers with the <code className="text-xs">x-bf-lh-</code> prefix are always captured
-							automatically.
+							Comma-separated list of request headers to capture in log metadata. Supports exact names and wildcard patterns (e.g.{" "}
+							<code className="text-xs">x-custom-*</code> captures all headers with that prefix, <code className="text-xs">*</code> logs
+							all headers — note that <code className="text-xs">*</code> will capture sensitive headers like Authorization). Values are extracted from incoming requests and stored in the metadata field of log entries. Headers with the{" "}
+							<code className="text-xs">x-bf-lh-</code> prefix are always captured automatically.
 						</p>
 						<Textarea
 							id="logging-headers"
 							data-testid="workspace-logging-headers-textarea"
 							className="h-24"
-							placeholder="X-Tenant-ID, X-Request-Source, X-Correlation-ID"
+							placeholder="X-Tenant-ID, X-Request-Source, x-custom-*"
 							value={loggingHeadersText}
 							onChange={(e) => handleLoggingHeadersChange(e.target.value)}
 						/>

--- a/ui/app/workspace/model-catalog/views/attributesTab.tsx
+++ b/ui/app/workspace/model-catalog/views/attributesTab.tsx
@@ -119,7 +119,7 @@ export default function AttributesTab({ hasAccess }: AttributesTabProps) {
 					<div>
 						<h2 className="text-lg font-semibold">Models</h2>
 						<p className="text-muted-foreground text-sm">
-							Attach descriptions and tags to specific models. Editorial — decoupled from pricing sync.
+							Attach descriptions and tags to specific models.
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

Adds wildcard pattern support to the logging headers configuration, allowing users to capture groups of headers by prefix (e.g. `x-custom-*`) or all headers at once using `*`, rather than only exact header name matches.

## Changes

- Introduced `loggingHeaderMatchesPattern` to handle exact matches, trailing wildcard (`x-custom-*`), and bare wildcard (`*`) patterns against incoming header names
- Updated `captureLoggingHeaders` to iterate over all request headers and match each against configured patterns, replacing the previous single-key lookup
- Updated the UI description and placeholder text to document wildcard support

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Configure logging headers with a wildcard pattern such as `x-custom-*` or `*` and send requests with matching headers. Verify that the captured headers appear in the `metadata` field of log entries.

```sh
go test ./plugins/logging/...

cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

**Before:** Placeholder showed `X-Tenant-ID, X-Request-Source, X-Correlation-ID` with no mention of wildcard support.

**After:** Placeholder shows `X-Tenant-ID, X-Request-Source, x-custom-*` and the description explains exact names, prefix wildcards, and the bare `*` option.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Using `*` as a logging header pattern will capture all request headers, which may include sensitive values such as `Authorization` or session tokens. Users should be aware of the PII and secrets exposure risk when enabling broad wildcard patterns, and ensure log storage is appropriately access-controlled.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logging headers configuration now supports wildcard patterns (e.g., `x-custom-*`, `*`) as well as exact names.
  * Request headers matching configured patterns are automatically captured as metadata, with support for bare (`*`) and prefix (`prefix*`) wildcards.
  * Headers with the `x-bf-lh-` prefix are always captured.

* **Documentation**
  * Clarified logging configuration help text and updated placeholder examples for header input.
  * Shortened Models section copy to “Attach descriptions and tags to specific models.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->