### PR TITLE
feat: Add v2 API for governance and update UI to use the multi budget lines

### DIFF
--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -841,60 +841,85 @@ type UpdateProviderGovernanceRequest struct {
 	RateLimit *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
 }
 
-// RegisterRoutes registers all governance-related routes for the new hierarchical system
+// versionedRoute declares a single API route with optional v2 handler override.
+// path is relative to /api (e.g. "/governance/virtual-keys").
+// v2 nil means the route is absent from /api/v2 — callers get 404.
+type versionedRoute struct {
+	method string
+	path   string
+	v1     func(*fasthttp.RequestCtx)
+	v2     func(*fasthttp.RequestCtx)
+}
+
+// routes returns the full route table. Every entry is registered under /api (compat) and
+// /api/v1. Entries with a non-nil v2 field are also registered under /api/v2.
+// getVirtualKeyQuota is intentionally absent — it bypasses admin middlewares and is
+// registered separately in RegisterRoutes.
+func (h *GovernanceHandler) routes() []versionedRoute {
+	return []versionedRoute{
+		// Virtual Keys
+		{method: "GET", path: "/governance/virtual-keys", v1: h.getVirtualKeys},
+		{method: "POST", path: "/governance/virtual-keys", v1: h.createVirtualKey},
+		{method: "POST", path: "/governance/virtual-keys/rotate", v1: h.rotateVirtualKeys},
+		{method: "GET", path: "/governance/virtual-keys/{vk_id}", v1: h.getVirtualKey},
+		{method: "PUT", path: "/governance/virtual-keys/{vk_id}", v1: h.updateVirtualKey},
+		{method: "POST", path: "/governance/virtual-keys/{vk_id}/rotate", v1: h.rotateVirtualKey},
+		{method: "DELETE", path: "/governance/virtual-keys/{vk_id}", v1: h.deleteVirtualKey},
+		// Teams
+		{method: "GET", path: "/governance/teams", v1: h.getTeams},
+		{method: "POST", path: "/governance/teams", v1: h.createTeam},
+		{method: "GET", path: "/governance/teams/{team_id}", v1: h.getTeam},
+		{method: "PUT", path: "/governance/teams/{team_id}", v1: h.updateTeam},
+		{method: "DELETE", path: "/governance/teams/{team_id}", v1: h.deleteTeam},
+		// Customers
+		{method: "GET", path: "/governance/customers", v1: h.getCustomers},
+		{method: "POST", path: "/governance/customers", v1: h.createCustomer},
+		{method: "GET", path: "/governance/customers/{customer_id}", v1: h.getCustomer},
+		{method: "PUT", path: "/governance/customers/{customer_id}", v1: h.updateCustomer},
+		{method: "DELETE", path: "/governance/customers/{customer_id}", v1: h.deleteCustomer},
+		// Budgets and Rate Limits
+		{method: "GET", path: "/governance/budgets", v1: h.getBudgets},
+		{method: "GET", path: "/governance/rate-limits", v1: h.getRateLimits},
+		// Routing Rules
+		{method: "GET", path: "/governance/routing-rules", v1: h.getRoutingRules},
+		{method: "POST", path: "/governance/routing-rules", v1: h.createRoutingRule},
+		{method: "GET", path: "/governance/routing-rules/{rule_id}", v1: h.getRoutingRule},
+		{method: "PUT", path: "/governance/routing-rules/{rule_id}", v1: h.updateRoutingRule},
+		{method: "DELETE", path: "/governance/routing-rules/{rule_id}", v1: h.deleteRoutingRule},
+		// Model Configs
+		{method: "GET", path: "/governance/model-configs", v1: h.getModelConfigs},
+		{method: "POST", path: "/governance/model-configs", v1: h.createModelConfig},
+		{method: "GET", path: "/governance/model-configs/{mc_id}", v1: h.getModelConfig},
+		{method: "PUT", path: "/governance/model-configs/{mc_id}", v1: h.updateModelConfig},
+		{method: "DELETE", path: "/governance/model-configs/{mc_id}", v1: h.deleteModelConfig},
+		// Provider Governance — GET and PUT have v2 handlers; DELETE reuses v1.
+		{method: "GET", path: "/governance/providers", v1: h.getProviderGovernance, v2: h.getProviderGovernanceV2},
+		{method: "PUT", path: "/governance/providers/{provider_name}", v1: h.updateProviderGovernance, v2: h.updateProviderGovernanceV2},
+		{method: "DELETE", path: "/governance/providers/{provider_name}", v1: h.deleteProviderGovernance},
+		// Pricing Overrides
+		{method: "GET", path: "/governance/pricing-overrides", v1: h.getPricingOverrides},
+		{method: "POST", path: "/governance/pricing-overrides", v1: h.createPricingOverride},
+		{method: "PUT", path: "/governance/pricing-overrides/{id}", v1: h.updatePricingOverride},
+		{method: "DELETE", path: "/governance/pricing-overrides/{id}", v1: h.deletePricingOverride},
+	}
+}
+
+// RegisterRoutes registers all governance-related routes for the new hierarchical system.
+// Every route is registered under /api (compat, always = v1) and /api/v1 (explicit v1).
+// Routes with a non-nil v2 handler are also registered under /api/v2; all others return 404
+// under /api/v2 — no implicit v1 fallback.
 func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
-	// Virtual Key CRUD operations
-	r.GET("/api/governance/virtual-keys", lib.ChainMiddlewares(h.getVirtualKeys, middlewares...))
-	r.POST("/api/governance/virtual-keys", lib.ChainMiddlewares(h.createVirtualKey, middlewares...))
-	r.POST("/api/governance/virtual-keys/rotate", lib.ChainMiddlewares(h.rotateVirtualKeys, middlewares...))
-	r.GET("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.getVirtualKey, middlewares...))
-	r.PUT("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.updateVirtualKey, middlewares...))
-	r.POST("/api/governance/virtual-keys/{vk_id}/rotate", lib.ChainMiddlewares(h.rotateVirtualKey, middlewares...))
-	r.DELETE("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.deleteVirtualKey, middlewares...))
-
-	// Team CRUD operations
-	r.GET("/api/governance/teams", lib.ChainMiddlewares(h.getTeams, middlewares...))
-	r.POST("/api/governance/teams", lib.ChainMiddlewares(h.createTeam, middlewares...))
-	r.GET("/api/governance/teams/{team_id}", lib.ChainMiddlewares(h.getTeam, middlewares...))
-	r.PUT("/api/governance/teams/{team_id}", lib.ChainMiddlewares(h.updateTeam, middlewares...))
-	r.DELETE("/api/governance/teams/{team_id}", lib.ChainMiddlewares(h.deleteTeam, middlewares...))
-
-	// Customer CRUD operations
-	r.GET("/api/governance/customers", lib.ChainMiddlewares(h.getCustomers, middlewares...))
-	r.POST("/api/governance/customers", lib.ChainMiddlewares(h.createCustomer, middlewares...))
-	r.GET("/api/governance/customers/{customer_id}", lib.ChainMiddlewares(h.getCustomer, middlewares...))
-	r.PUT("/api/governance/customers/{customer_id}", lib.ChainMiddlewares(h.updateCustomer, middlewares...))
-	r.DELETE("/api/governance/customers/{customer_id}", lib.ChainMiddlewares(h.deleteCustomer, middlewares...))
-
-	// Budget and Rate Limit GET operations
-	r.GET("/api/governance/budgets", lib.ChainMiddlewares(h.getBudgets, middlewares...))
-	r.GET("/api/governance/rate-limits", lib.ChainMiddlewares(h.getRateLimits, middlewares...))
-
-	// Routing Rules CRUD operations
-	r.GET("/api/governance/routing-rules", lib.ChainMiddlewares(h.getRoutingRules, middlewares...))
-	r.POST("/api/governance/routing-rules", lib.ChainMiddlewares(h.createRoutingRule, middlewares...))
-	r.GET("/api/governance/routing-rules/{rule_id}", lib.ChainMiddlewares(h.getRoutingRule, middlewares...))
-	r.PUT("/api/governance/routing-rules/{rule_id}", lib.ChainMiddlewares(h.updateRoutingRule, middlewares...))
-	r.DELETE("/api/governance/routing-rules/{rule_id}", lib.ChainMiddlewares(h.deleteRoutingRule, middlewares...))
-
-	// Model Config CRUD operations
-	r.GET("/api/governance/model-configs", lib.ChainMiddlewares(h.getModelConfigs, middlewares...))
-	r.POST("/api/governance/model-configs", lib.ChainMiddlewares(h.createModelConfig, middlewares...))
-	r.GET("/api/governance/model-configs/{mc_id}", lib.ChainMiddlewares(h.getModelConfig, middlewares...))
-	r.PUT("/api/governance/model-configs/{mc_id}", lib.ChainMiddlewares(h.updateModelConfig, middlewares...))
-	r.DELETE("/api/governance/model-configs/{mc_id}", lib.ChainMiddlewares(h.deleteModelConfig, middlewares...))
-
-	// Provider Governance operations
-	r.GET("/api/governance/providers", lib.ChainMiddlewares(h.getProviderGovernance, middlewares...))
-	r.PUT("/api/governance/providers/{provider_name}", lib.ChainMiddlewares(h.updateProviderGovernance, middlewares...))
-	r.DELETE("/api/governance/providers/{provider_name}", lib.ChainMiddlewares(h.deleteProviderGovernance, middlewares...))
-
-	// Pricing override operations
-	r.GET("/api/governance/pricing-overrides", lib.ChainMiddlewares(h.getPricingOverrides, middlewares...))
-	r.POST("/api/governance/pricing-overrides", lib.ChainMiddlewares(h.createPricingOverride, middlewares...))
-	r.PUT("/api/governance/pricing-overrides/{id}", lib.ChainMiddlewares(h.updatePricingOverride, middlewares...))
-	r.DELETE("/api/governance/pricing-overrides/{id}", lib.ChainMiddlewares(h.deletePricingOverride, middlewares...))
-
+	chain := func(fn func(*fasthttp.RequestCtx)) fasthttp.RequestHandler {
+		return lib.ChainMiddlewares(fn, middlewares...)
+	}
+	for _, route := range h.routes() {
+		v1h := chain(route.v1)
+		r.Handle(route.method, "/api"+route.path, v1h)
+		r.Handle(route.method, "/api/v1"+route.path, v1h)
+		if route.v2 != nil {
+			r.Handle(route.method, "/api/v2"+route.path, chain(route.v2))
+		}
+	}
 	// Self-service endpoint — no admin auth, VK in header is the credential.
 	// Registered without admin middlewares; only common middlewares (telemetry) are applied.
 	r.GET("/api/governance/virtual-keys/quota", h.getVirtualKeyQuota)
@@ -3201,6 +3226,23 @@ type ProviderGovernanceResponse struct {
 	RateLimit *configstoreTables.TableRateLimit `json:"rate_limit,omitempty"`
 }
 
+// ProviderGovernanceResponseV2 is the v2 response: exposes all budgets and calendar_aligned.
+type ProviderGovernanceResponseV2 struct {
+	Provider        string                            `json:"provider"`
+	Budgets         []configstoreTables.TableBudget   `json:"budgets,omitempty"`
+	RateLimit       *configstoreTables.TableRateLimit `json:"rate_limit,omitempty"`
+	CalendarAligned bool                              `json:"calendar_aligned"`
+}
+
+// UpdateProviderGovernanceRequestV2 is the v2 request body.
+// Budgets is *[]  so nil (field absent) means "no change" while a non-nil empty slice means
+// "remove all budgets" — a plain []T would collapse both cases to nil after JSON unmarshal.
+type UpdateProviderGovernanceRequestV2 struct {
+	Budgets         *[]CreateBudgetRequest  `json:"budgets,omitempty"`
+	RateLimit       *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	CalendarAligned *bool                   `json:"calendar_aligned,omitempty"`
+}
+
 // modelConfigToProviderGovernance converts a model config to a ProviderGovernanceResponse.
 // Returns false if the config does not represent provider-level governance
 // (i.e. not scope=global, model_name="*", with a provider set).
@@ -3209,13 +3251,28 @@ func modelConfigToProviderGovernance(mc *configstoreTables.TableModelConfig) (Pr
 		mc.ModelName != configstoreTables.ModelConfigAllModels || mc.Provider == nil {
 		return ProviderGovernanceResponse{}, false
 	}
-	// Provider governance is single-budget by API; surface the first owned budget.
-	// This will be updated with the v2 endpoint, which can surface all budgets
+	// Provider governance is single-budget by the v1 API; surface the first owned budget.
 	var budget *configstoreTables.TableBudget
 	if len(mc.Budgets) > 0 {
 		budget = &mc.Budgets[0]
 	}
 	return ProviderGovernanceResponse{Provider: *mc.Provider, Budget: budget, RateLimit: mc.RateLimit}, true
+}
+
+// modelConfigToProviderGovernanceV2 is the v2 equivalent: returns all budgets and calendar_aligned.
+func modelConfigToProviderGovernanceV2(mc *configstoreTables.TableModelConfig) (ProviderGovernanceResponseV2, bool) {
+	if mc == nil || mc.Scope != configstoreTables.ModelConfigScopeGlobal ||
+		mc.ModelName != configstoreTables.ModelConfigAllModels || mc.Provider == nil {
+		return ProviderGovernanceResponseV2{}, false
+	}
+	budgets := make([]configstoreTables.TableBudget, len(mc.Budgets))
+	copy(budgets, mc.Budgets)
+	return ProviderGovernanceResponseV2{
+		Provider:        *mc.Provider,
+		Budgets:         budgets,
+		RateLimit:       mc.RateLimit,
+		CalendarAligned: mc.CalendarAligned,
+	}, true
 }
 
 // getProviderGovernance handles GET /api/governance/providers - returns provider-level governance,
@@ -3243,6 +3300,41 @@ func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
 		}
 		for i := range configs {
 			if r, ok := modelConfigToProviderGovernance(&configs[i]); ok {
+				result = append(result, r)
+			}
+		}
+	}
+	SendJSON(ctx, map[string]interface{}{
+		"providers": result,
+		"count":     len(result),
+	})
+}
+
+// getProviderGovernanceV2 handles GET /api/v2/governance/providers — identical to v1 but returns
+// all budgets (ProviderGovernanceResponseV2) instead of a single budget.
+func (h *GovernanceHandler) getProviderGovernanceV2(ctx *fasthttp.RequestCtx) {
+	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
+	var result []ProviderGovernanceResponseV2
+	if fromMemory {
+		data := h.governanceManager.GetGovernanceData(ctx)
+		if data == nil {
+			SendError(ctx, 500, "Governance data is not available")
+			return
+		}
+		for _, mc := range data.ModelConfigs {
+			if r, ok := modelConfigToProviderGovernanceV2(mc); ok {
+				result = append(result, r)
+			}
+		}
+	} else {
+		configs, err := h.configStore.GetProviderGovernanceModelConfigs(ctx)
+		if err != nil {
+			logger.Error("failed to retrieve model configs: %v", err)
+			SendError(ctx, 500, "Failed to retrieve providers")
+			return
+		}
+		for i := range configs {
+			if r, ok := modelConfigToProviderGovernanceV2(&configs[i]); ok {
 				result = append(result, r)
 			}
 		}
@@ -3464,6 +3556,175 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			resp.RateLimit = mc.RateLimit
 		} else if r, ok := modelConfigToProviderGovernance(reloaded); ok {
 			resp.Budget, resp.RateLimit = r.Budget, r.RateLimit
+		}
+	}
+	SendJSON(ctx, map[string]interface{}{
+		"message":  "Provider governance updated successfully",
+		"provider": resp,
+	})
+}
+
+// updateProviderGovernanceV2 handles PUT /api/v2/governance/providers/{provider_name}.
+// Differs from v1 in three ways: multi-budget via reconcileModelConfigBudgets, calendar_aligned
+// field, and ProviderGovernanceResponseV2 response shape.
+func (h *GovernanceHandler) updateProviderGovernanceV2(ctx *fasthttp.RequestCtx) {
+	providerName := ctx.UserValue("provider_name").(string)
+	var req UpdateProviderGovernanceRequestV2
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, 400, "Invalid JSON")
+		return
+	}
+	providers, err := h.configStore.GetProviders(ctx)
+	if err != nil {
+		SendError(ctx, 500, "Failed to retrieve providers")
+		return
+	}
+	providerExists := false
+	for i := range providers {
+		if providers[i].Name == providerName {
+			providerExists = true
+			break
+		}
+	}
+	if !providerExists {
+		SendError(ctx, 404, "Provider not found")
+		return
+	}
+
+	existing, err := h.configStore.GetModelConfig(ctx, configstoreTables.ModelConfigScopeGlobal, nil, configstoreTables.ModelConfigAllModels, &providerName)
+	if err != nil && err != configstore.ErrNotFound {
+		logger.Error("failed to load provider governance: %v", err)
+		SendError(ctx, 500, fmt.Sprintf("Failed to load provider governance: %v", err))
+		return
+	}
+	isNew := existing == nil
+	mc := configstoreTables.TableModelConfig{
+		ID:        uuid.NewString(),
+		ModelName: configstoreTables.ModelConfigAllModels,
+		Provider:  &providerName,
+		Scope:     configstoreTables.ModelConfigScopeGlobal,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if existing != nil {
+		mc = *existing
+	}
+
+	deleted := false
+	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		var rateLimitIDToDelete string
+
+		// Rate limit lifecycle (same as v1 — resolve before the mc row is persisted).
+		if req.RateLimit != nil {
+			if isRateLimitRemovalRequest(req.RateLimit) {
+				if mc.RateLimitID != nil {
+					rateLimitIDToDelete = *mc.RateLimitID
+					mc.RateLimitID = nil
+					mc.RateLimit = nil
+				}
+			} else if mc.RateLimitID != nil {
+				rateLimit := configstoreTables.TableRateLimit{}
+				if err := tx.First(&rateLimit, "id = ?", *mc.RateLimitID).Error; err != nil {
+					return err
+				}
+				rateLimit.TokenMaxLimit = req.RateLimit.TokenMaxLimit
+				rateLimit.TokenResetDuration = req.RateLimit.TokenResetDuration
+				rateLimit.RequestMaxLimit = req.RateLimit.RequestMaxLimit
+				rateLimit.RequestResetDuration = req.RateLimit.RequestResetDuration
+				if err := validateRateLimit(&rateLimit); err != nil {
+					return err
+				}
+				if err := h.configStore.UpdateRateLimit(ctx, &rateLimit, tx); err != nil {
+					return err
+				}
+				mc.RateLimit = &rateLimit
+			} else {
+				rateLimit := configstoreTables.TableRateLimit{
+					ID:                   uuid.NewString(),
+					TokenMaxLimit:        req.RateLimit.TokenMaxLimit,
+					TokenResetDuration:   req.RateLimit.TokenResetDuration,
+					RequestMaxLimit:      req.RateLimit.RequestMaxLimit,
+					RequestResetDuration: req.RateLimit.RequestResetDuration,
+					TokenLastReset:       time.Now(),
+					RequestLastReset:     time.Now(),
+				}
+				if err := validateRateLimit(&rateLimit); err != nil {
+					return err
+				}
+				if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
+					return err
+				}
+				mc.RateLimitID = &rateLimit.ID
+				mc.RateLimit = &rateLimit
+			}
+		}
+
+		if req.CalendarAligned != nil {
+			mc.CalendarAligned = *req.CalendarAligned
+		}
+
+		// nil Budgets = no change; non-nil empty = remove all; non-nil non-empty = set to that list.
+		willHaveBudget := (req.Budgets == nil && len(mc.Budgets) > 0) ||
+			(req.Budgets != nil && len(*req.Budgets) > 0)
+
+		hasGovernance := mc.RateLimitID != nil || willHaveBudget
+		switch {
+		case !hasGovernance && isNew:
+			return nil
+		case !hasGovernance && !isNew:
+			for i := range mc.Budgets {
+				if err := h.configStore.DeleteBudget(ctx, mc.Budgets[i].ID, tx); err != nil {
+					return err
+				}
+			}
+			if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
+				return err
+			}
+			deleted = true
+		case isNew:
+			if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
+				return err
+			}
+		default:
+			if err := h.configStore.UpdateModelConfig(ctx, &mc, tx); err != nil {
+				return err
+			}
+		}
+
+		// Multi-budget lifecycle — mc row exists at this point for create cases.
+		if !deleted && req.Budgets != nil {
+			if err := h.reconcileModelConfigBudgets(ctx, tx, &mc, *req.Budgets); err != nil {
+				return err
+			}
+		}
+
+		if rateLimitIDToDelete != "" {
+			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		logger.Error("failed to update provider governance: %v", err)
+		SendError(ctx, 500, fmt.Sprintf("Failed to update provider governance: %v", err))
+		return
+	}
+
+	resp := ProviderGovernanceResponseV2{Provider: providerName}
+	if deleted {
+		if err := h.governanceManager.RemoveModelConfig(ctx, mc.ID); err != nil {
+			logger.Error("failed to remove provider governance from memory: %v", err)
+		}
+	} else if len(mc.Budgets) > 0 || mc.RateLimitID != nil {
+		if reloaded, err := h.governanceManager.ReloadModelConfig(ctx, mc.ID); err != nil {
+			logger.Error("failed to reload provider governance in memory: %v", err)
+			budgets := make([]configstoreTables.TableBudget, len(mc.Budgets))
+			copy(budgets, mc.Budgets)
+			resp.Budgets = budgets
+			resp.RateLimit = mc.RateLimit
+			resp.CalendarAligned = mc.CalendarAligned
+		} else if r, ok := modelConfigToProviderGovernanceV2(reloaded); ok {
+			resp = r
 		}
 	}
 	SendJSON(ctx, map[string]interface{}{

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1510,6 +1510,355 @@ func TestCollectProviderConfigDeleteIDs(t *testing.T) {
 	}
 }
 
+// ---- Provider Governance V2 tests ----
+
+// mockGovernanceManagerForProviderV2 implements only GetGovernanceData.
+type mockGovernanceManagerForProviderV2 struct {
+	GovernanceManager
+	data *governance.GovernanceData
+}
+
+func (m *mockGovernanceManagerForProviderV2) GetGovernanceData(_ context.Context) *governance.GovernanceData {
+	return m.data
+}
+
+// mockConfigStoreForProviderV2 implements only GetProviderGovernanceModelConfigs.
+type mockConfigStoreForProviderV2 struct {
+	configstore.ConfigStore
+	configs []configstoreTables.TableModelConfig
+	err     error
+}
+
+func (m *mockConfigStoreForProviderV2) GetProviderGovernanceModelConfigs(_ context.Context) ([]configstoreTables.TableModelConfig, error) {
+	return m.configs, m.err
+}
+
+func newProviderMC(provider string, budgets []configstoreTables.TableBudget, calendarAligned bool) *configstoreTables.TableModelConfig {
+	return &configstoreTables.TableModelConfig{
+		ID:              "mc-" + provider,
+		Scope:           configstoreTables.ModelConfigScopeGlobal,
+		ModelName:       configstoreTables.ModelConfigAllModels,
+		Provider:        &provider,
+		Budgets:         budgets,
+		CalendarAligned: calendarAligned,
+	}
+}
+
+func TestModelConfigToProviderGovernanceV2_FiltersNonProviderConfigs(t *testing.T) {
+	tests := []struct {
+		name    string
+		mc      *configstoreTables.TableModelConfig
+		wantOK  bool
+	}{
+		{name: "nil", mc: nil, wantOK: false},
+		{
+			name:   "wrong scope",
+			mc:     &configstoreTables.TableModelConfig{Scope: "virtual_key", ModelName: "*", Provider: strPtr("openai")},
+			wantOK: false,
+		},
+		{
+			name:   "wrong model name",
+			mc:     &configstoreTables.TableModelConfig{Scope: configstoreTables.ModelConfigScopeGlobal, ModelName: "gpt-4o", Provider: strPtr("openai")},
+			wantOK: false,
+		},
+		{
+			name:   "nil provider",
+			mc:     &configstoreTables.TableModelConfig{Scope: configstoreTables.ModelConfigScopeGlobal, ModelName: "*"},
+			wantOK: false,
+		},
+		{
+			name:   "valid provider config",
+			mc:     newProviderMC("openai", nil, false),
+			wantOK: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := modelConfigToProviderGovernanceV2(tt.mc)
+			if ok != tt.wantOK {
+				t.Fatalf("modelConfigToProviderGovernanceV2() ok = %v, want %v", ok, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestModelConfigToProviderGovernanceV2_MapsAllFields(t *testing.T) {
+	provider := "openai"
+	rl := &configstoreTables.TableRateLimit{ID: "rl-1"}
+	budgets := []configstoreTables.TableBudget{
+		{ID: "b-1", MaxLimit: 100, ResetDuration: "1d"},
+		{ID: "b-2", MaxLimit: 500, ResetDuration: "1w"},
+	}
+	mc := &configstoreTables.TableModelConfig{
+		Scope:           configstoreTables.ModelConfigScopeGlobal,
+		ModelName:       configstoreTables.ModelConfigAllModels,
+		Provider:        &provider,
+		Budgets:         budgets,
+		RateLimit:       rl,
+		CalendarAligned: true,
+	}
+
+	resp, ok := modelConfigToProviderGovernanceV2(mc)
+	if !ok {
+		t.Fatal("expected ok=true for valid config")
+	}
+	if resp.Provider != provider {
+		t.Errorf("Provider = %q, want %q", resp.Provider, provider)
+	}
+	if len(resp.Budgets) != 2 {
+		t.Fatalf("Budgets len = %d, want 2", len(resp.Budgets))
+	}
+	if resp.Budgets[0].ID != "b-1" || resp.Budgets[1].ID != "b-2" {
+		t.Errorf("Budgets IDs = %v/%v, want b-1/b-2", resp.Budgets[0].ID, resp.Budgets[1].ID)
+	}
+	if resp.RateLimit != rl {
+		t.Errorf("RateLimit not preserved")
+	}
+	if !resp.CalendarAligned {
+		t.Errorf("CalendarAligned = false, want true")
+	}
+}
+
+func TestModelConfigToProviderGovernanceV2_BudgetsAreCopied(t *testing.T) {
+	provider := "openai"
+	mc := newProviderMC(provider, []configstoreTables.TableBudget{{ID: "b-1", MaxLimit: 100}}, false)
+
+	resp, _ := modelConfigToProviderGovernanceV2(mc)
+	// Mutate the returned slice — original must not change.
+	resp.Budgets[0].MaxLimit = 999
+	if mc.Budgets[0].MaxLimit == 999 {
+		t.Fatal("modelConfigToProviderGovernanceV2 returned a slice alias; expected a copy")
+	}
+}
+
+func TestGetProviderGovernanceV2_FromMemory(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	provider := "openai"
+	configs := []*configstoreTables.TableModelConfig{
+		newProviderMC(provider, []configstoreTables.TableBudget{
+			{ID: "b-1", MaxLimit: 100, ResetDuration: "1d"},
+			{ID: "b-2", MaxLimit: 500, ResetDuration: "1w"},
+		}, true),
+		// Non-provider config — should be filtered out.
+		{ID: "mc-vk", Scope: "virtual_key", ModelName: "*"},
+	}
+	h := &GovernanceHandler{
+		governanceManager: &mockGovernanceManagerForProviderV2{
+			data: &governance.GovernanceData{ModelConfigs: configs},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/api/v2/governance/providers?from_memory=true")
+
+	h.getProviderGovernanceV2(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+
+	var resp struct {
+		Providers []ProviderGovernanceResponseV2 `json:"providers"`
+		Count     int                            `json:"count"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if resp.Count != 1 {
+		t.Fatalf("count = %d, want 1", resp.Count)
+	}
+	p := resp.Providers[0]
+	if p.Provider != provider {
+		t.Errorf("provider = %q, want %q", p.Provider, provider)
+	}
+	if len(p.Budgets) != 2 {
+		t.Fatalf("budgets len = %d, want 2", len(p.Budgets))
+	}
+	if p.Budgets[0].ID != "b-1" || p.Budgets[1].ID != "b-2" {
+		t.Errorf("budget IDs = %v/%v, want b-1/b-2", p.Budgets[0].ID, p.Budgets[1].ID)
+	}
+	if !p.CalendarAligned {
+		t.Errorf("CalendarAligned = false, want true")
+	}
+}
+
+func TestGetProviderGovernanceV2_FromMemory_NilDataReturns500(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &GovernanceHandler{
+		governanceManager: &mockGovernanceManagerForProviderV2{data: nil},
+	}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/api/v2/governance/providers?from_memory=true")
+
+	h.getProviderGovernanceV2(ctx)
+
+	if ctx.Response.StatusCode() != 500 {
+		t.Fatalf("expected 500, got %d", ctx.Response.StatusCode())
+	}
+}
+
+func TestGetProviderGovernanceV2_FromDB(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	provider := "anthropic"
+	mc := configstoreTables.TableModelConfig{
+		ID:        "mc-anthropic",
+		Scope:     configstoreTables.ModelConfigScopeGlobal,
+		ModelName: configstoreTables.ModelConfigAllModels,
+		Provider:  &provider,
+		Budgets: []configstoreTables.TableBudget{
+			{ID: "b-1", MaxLimit: 200, ResetDuration: "1M"},
+		},
+	}
+	h := &GovernanceHandler{
+		configStore: &mockConfigStoreForProviderV2{configs: []configstoreTables.TableModelConfig{mc}},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/api/v2/governance/providers")
+
+	h.getProviderGovernanceV2(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+
+	var resp struct {
+		Providers []ProviderGovernanceResponseV2 `json:"providers"`
+		Count     int                            `json:"count"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if resp.Count != 1 || len(resp.Providers) != 1 {
+		t.Fatalf("expected 1 provider, got count=%d len=%d", resp.Count, len(resp.Providers))
+	}
+	if len(resp.Providers[0].Budgets) != 1 || resp.Providers[0].Budgets[0].ID != "b-1" {
+		t.Errorf("unexpected budgets: %#v", resp.Providers[0].Budgets)
+	}
+}
+
+func TestGetProviderGovernanceV2_DBError(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &GovernanceHandler{
+		configStore: &mockConfigStoreForProviderV2{err: errors.New("db down")},
+	}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI("/api/v2/governance/providers")
+
+	h.getProviderGovernanceV2(ctx)
+
+	if ctx.Response.StatusCode() != 500 {
+		t.Fatalf("expected 500, got %d", ctx.Response.StatusCode())
+	}
+}
+
+func TestUpdateProviderGovernanceRequestV2_BudgetsPointerSemantics(t *testing.T) {
+	tests := []struct {
+		name            string
+		body            string
+		wantBudgetsNil  bool
+		wantBudgetsLen  int
+	}{
+		{
+			name:           "absent field leaves budgets nil (no change)",
+			body:           `{}`,
+			wantBudgetsNil: true,
+		},
+		{
+			name:           "explicit null leaves budgets nil (no change)",
+			body:           `{"budgets":null}`,
+			wantBudgetsNil: true,
+		},
+		{
+			name:           "empty array signals remove all",
+			body:           `{"budgets":[]}`,
+			wantBudgetsNil: false,
+			wantBudgetsLen: 0,
+		},
+		{
+			name:           "one budget entry",
+			body:           `{"budgets":[{"max_limit":100,"reset_duration":"1d"}]}`,
+			wantBudgetsNil: false,
+			wantBudgetsLen: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req UpdateProviderGovernanceRequestV2
+			if err := json.Unmarshal([]byte(tt.body), &req); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if tt.wantBudgetsNil && req.Budgets != nil {
+				t.Fatalf("expected Budgets nil, got %#v", req.Budgets)
+			}
+			if !tt.wantBudgetsNil {
+				if req.Budgets == nil {
+					t.Fatal("expected Budgets non-nil")
+				}
+				if len(*req.Budgets) != tt.wantBudgetsLen {
+					t.Fatalf("budgets len = %d, want %d", len(*req.Budgets), tt.wantBudgetsLen)
+				}
+			}
+		})
+	}
+}
+
+func TestRoutesTable_V2ContractIsExplicit(t *testing.T) {
+	h := &GovernanceHandler{}
+	routes := h.routes()
+
+	// Every route must have a non-nil v1 handler.
+	for _, r := range routes {
+		if r.v1 == nil {
+			t.Errorf("route %s %s has nil v1 handler", r.method, r.path)
+		}
+	}
+
+	type routeKey struct{ method, path string }
+	byKey := make(map[routeKey]versionedRoute, len(routes))
+	for _, r := range routes {
+		byKey[routeKey{r.method, r.path}] = r
+	}
+
+	// Provider governance GET and PUT must have v2 handlers.
+	for _, want := range []routeKey{
+		{"GET", "/governance/providers"},
+		{"PUT", "/governance/providers/{provider_name}"},
+	} {
+		r, ok := byKey[want]
+		if !ok {
+			t.Errorf("route %s %s missing from table", want.method, want.path)
+			continue
+		}
+		if r.v2 == nil {
+			t.Errorf("route %s %s expected non-nil v2 handler", want.method, want.path)
+		}
+	}
+
+	// DELETE for provider governance must NOT have a v2 handler — DELETE semantics
+	// are unchanged and registering it under v2 would create a brittle implicit promise.
+	delKey := routeKey{"DELETE", "/governance/providers/{provider_name}"}
+	if r, ok := byKey[delKey]; ok && r.v2 != nil {
+		t.Errorf("DELETE /governance/providers/{provider_name} should have nil v2 (no v2 contract for delete)")
+	}
+
+	// No duplicate method+path pairs.
+	seen := make(map[routeKey]bool)
+	for _, r := range routes {
+		k := routeKey{r.method, r.path}
+		if seen[k] {
+			t.Errorf("duplicate route %s %s in routes table", r.method, r.path)
+		}
+		seen[k] = true
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
 func TestValidateRoutingFallbacks(t *testing.T) {
 
 	tests := []struct {

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -269,8 +269,10 @@ export default function ModelLimitsTable({
 								</TableRow>
 							) : (
 								modelConfigs.map((config) => {
-									// Model configs can own multiple budgets; show all (like the VK table).
-									const budgets = config.budgets ?? (config.budget ? [config.budget] : []);
+									// Model configs can own multiple budgets; show all newest-first (like the VK table).
+									const budgets = [...(config.budgets ?? (config.budget ? [config.budget] : []))].sort(
+										(a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
+									);
 									const isBudgetExhausted = budgets.some((b) => b.max_limit > 0 && b.current_usage >= b.max_limit);
 									const isRateLimitExhausted =
 										(config.rate_limit?.token_max_limit &&

--- a/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
@@ -1,9 +1,9 @@
 import { Button } from "@/components/ui/button";
-import { Form, FormField, FormItem } from "@/components/ui/form";
-import { Label } from "@/components/ui/label";
+import { Form } from "@/components/ui/form";
+import MultiBudgetLines, { BudgetLineEntry } from "@/components/ui/multibudgets";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { DottedSeparator } from "@/components/ui/separator";
-import { resetDurationOptions } from "@/lib/constants/governance";
+import { resetDurationLabels } from "@/lib/constants/governance";
 import {
 	getErrorMessage,
 	useDeleteProviderGovernanceMutation,
@@ -13,6 +13,7 @@ import {
 import { ModelProvider } from "@/lib/types/config";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Label } from "@radix-ui/react-label";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -22,10 +23,14 @@ interface GovernanceFormFragmentProps {
 	provider: ModelProvider;
 }
 
+const budgetLineSchema = z.object({
+	id: z.string().optional(),
+	max_limit: z.number({ invalid_type_error: "Budget limit must be a number" }).nonnegative("Budget limit cannot be negative").optional(),
+	reset_duration: z.string({ required_error: "Reset duration is required" }),
+});
+
 const formSchema = z.object({
-	// Budget
-	budgetMaxLimit: z.number().nonnegative().optional(),
-	budgetResetDuration: z.string().optional(),
+	budgets: z.array(budgetLineSchema).optional(),
 	// Token limits
 	tokenMaxLimit: z.number().int().nonnegative().optional(),
 	tokenResetDuration: z.string().optional(),
@@ -37,8 +42,7 @@ const formSchema = z.object({
 type FormData = z.infer<typeof formSchema>;
 
 const DEFAULT_GOVERNANCE_FORM_VALUES: FormData = {
-	budgetMaxLimit: undefined,
-	budgetResetDuration: "1M",
+	budgets: [],
 	tokenMaxLimit: undefined,
 	tokenResetDuration: "1h",
 	requestMaxLimit: undefined,
@@ -58,61 +62,49 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 
 	// Find governance data for this provider
 	const providerGovernance = providerGovernanceData?.providers?.find((p) => p.provider === provider.name);
-	const hasExistingGovernance = !!(providerGovernance?.budget || providerGovernance?.rate_limit);
+	const hasExistingGovernance = !!(providerGovernance?.budgets?.length || providerGovernance?.rate_limit);
 
 	const form = useForm<FormData>({
 		resolver: zodResolver(formSchema),
 		defaultValues: DEFAULT_GOVERNANCE_FORM_VALUES,
 	});
 
+	const governanceToFormValues = (pg: typeof providerGovernance): FormData => ({
+		budgets: pg?.budgets?.map((b) => ({ id: b.id, max_limit: b.max_limit, reset_duration: b.reset_duration })) ?? [],
+		tokenMaxLimit: pg?.rate_limit?.token_max_limit ?? undefined,
+		tokenResetDuration: pg?.rate_limit?.token_reset_duration || "1h",
+		requestMaxLimit: pg?.rate_limit?.request_max_limit ?? undefined,
+		requestResetDuration: pg?.rate_limit?.request_reset_duration || "1h",
+	});
+
 	// Update form values when provider governance data is loaded (polling)
 	useEffect(() => {
-		// Never reset form during polling if user is editing
 		if (providerGovernance && !form.formState.isDirty) {
-			form.reset({
-				budgetMaxLimit: providerGovernance.budget?.max_limit ?? undefined,
-				budgetResetDuration: providerGovernance.budget?.reset_duration || "1M",
-				tokenMaxLimit: providerGovernance.rate_limit?.token_max_limit ?? undefined,
-				tokenResetDuration: providerGovernance.rate_limit?.token_reset_duration || "1h",
-				requestMaxLimit: providerGovernance.rate_limit?.request_max_limit ?? undefined,
-				requestResetDuration: providerGovernance.rate_limit?.request_reset_duration || "1h",
-			});
+			form.reset(governanceToFormValues(providerGovernance));
 		}
 	}, [providerGovernance, form]);
 
 	// Reset form when provider changes
 	useEffect(() => {
-		// Never reset form if user is editing - just skip the reset
-		if (form.formState.isDirty) {
-			return;
-		}
+		if (form.formState.isDirty) return;
 		const newProvGov = providerGovernanceData?.providers?.find((p) => p.provider === provider.name);
-		form.reset({
-			budgetMaxLimit: newProvGov?.budget?.max_limit ?? undefined,
-			budgetResetDuration: newProvGov?.budget?.reset_duration || "1M",
-			tokenMaxLimit: newProvGov?.rate_limit?.token_max_limit ?? undefined,
-			tokenResetDuration: newProvGov?.rate_limit?.token_reset_duration || "1h",
-			requestMaxLimit: newProvGov?.rate_limit?.request_max_limit ?? undefined,
-			requestResetDuration: newProvGov?.rate_limit?.request_reset_duration || "1h",
-		});
+		form.reset(governanceToFormValues(newProvGov));
 	}, [provider.name, form]);
 
 	const onSubmit = async (data: FormData) => {
 		try {
-			// Determine if we need to send empty objects to signal removal
-			const hadBudget = !!providerGovernance?.budget;
-			const hasBudget = data.budgetMaxLimit !== undefined;
+			const hadBudgets = (providerGovernance?.budgets?.length ?? 0) > 0;
+			const validBudgets = (data.budgets ?? []).filter((b): b is BudgetLineEntry & { max_limit: number } => b.max_limit !== undefined);
+			const hasBudgets = validBudgets.length > 0;
 			const hadRateLimit = !!providerGovernance?.rate_limit;
 			const hasRateLimit = data.tokenMaxLimit !== undefined || data.requestMaxLimit !== undefined;
 
-			let budgetPayload: { max_limit?: number; reset_duration?: string } | undefined;
-			if (hasBudget) {
-				budgetPayload = {
-					max_limit: data.budgetMaxLimit,
-					reset_duration: data.budgetResetDuration || "1M",
-				};
-			} else if (hadBudget) {
-				budgetPayload = {};
+			// absent = no change; [] = remove all; [...] = set to this list
+			let budgetsPayload: { id?: string; max_limit: number; reset_duration: string }[] | undefined;
+			if (hasBudgets) {
+				budgetsPayload = validBudgets.map((b) => ({ id: b.id, max_limit: b.max_limit, reset_duration: b.reset_duration }));
+			} else if (hadBudgets) {
+				budgetsPayload = [];
 			}
 
 			let rateLimitPayload:
@@ -137,7 +129,7 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 			await updateProviderGovernance({
 				provider: provider.name,
 				data: {
-					budget: budgetPayload,
+					budgets: budgetsPayload,
 					rate_limit: rateLimitPayload,
 				},
 			}).unwrap();
@@ -165,32 +157,18 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 		}
 	};
 
+	const watchedBudgets = form.watch("budgets") ?? [];
+
 	// Always show the form
 	return (
 		<Form {...form}>
 			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6">
 				{/* Budget Configuration */}
-				<div className="space-y-4">
-					<Label className="text-sm font-medium">Budget Configuration</Label>
-					<FormField
-						control={form.control}
-						name="budgetMaxLimit"
-						render={({ field }) => (
-							<FormItem>
-								<NumberAndSelect
-									id="providerBudgetMaxLimit"
-									labelClassName="font-normal"
-									label="Maximum Spend (USD)"
-									value={field.value}
-									selectValue={form.watch("budgetResetDuration") || "1M"}
-									onChangeNumber={(value) => field.onChange(value)}
-									onChangeSelect={(value) => form.setValue("budgetResetDuration", value, { shouldDirty: true })}
-									options={resetDurationOptions}
-								/>
-							</FormItem>
-						)}
-					/>
-				</div>
+				<MultiBudgetLines
+					data-testid="provider-budgets"
+					lines={watchedBudgets}
+					onChange={(lines) => form.setValue("budgets", lines, { shouldDirty: true })}
+				/>
 
 				<DottedSeparator />
 
@@ -198,60 +176,59 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 				<div className="space-y-4">
 					<Label className="text-sm font-medium">Rate Limiting Configuration</Label>
 
-					<FormField
-						control={form.control}
-						name="tokenMaxLimit"
-						render={({ field }) => (
-							<FormItem>
-								<NumberAndSelect
-									id="providerTokenMaxLimit"
-									labelClassName="font-normal"
-									label="Maximum Tokens"
-									value={field.value}
-									selectValue={form.watch("tokenResetDuration") || "1h"}
-									onChangeNumber={(value) => field.onChange(value)}
-									onChangeSelect={(value) => form.setValue("tokenResetDuration", value, { shouldDirty: true })}
-									options={resetDurationOptions}
-								/>
-							</FormItem>
-						)}
+					<NumberAndSelect
+						id="providerTokenMaxLimit"
+						labelClassName="font-normal"
+						label="Maximum Tokens"
+						value={form.watch("tokenMaxLimit")}
+						selectValue={form.watch("tokenResetDuration") || "1h"}
+						onChangeNumber={(value) => form.setValue("tokenMaxLimit", value, { shouldDirty: true })}
+						onChangeSelect={(value) => form.setValue("tokenResetDuration", value, { shouldDirty: true })}
+						options={[
+							{ label: "per hour", value: "1h" },
+							{ label: "per day", value: "1d" },
+							{ label: "per week", value: "1w" },
+							{ label: "per month", value: "1M" },
+						]}
 					/>
 
-					<FormField
-						control={form.control}
-						name="requestMaxLimit"
-						render={({ field }) => (
-							<FormItem>
-								<NumberAndSelect
-									id="providerRequestMaxLimit"
-									labelClassName="font-normal"
-									label="Maximum Requests"
-									value={field.value}
-									selectValue={form.watch("requestResetDuration") || "1h"}
-									onChangeNumber={(value) => field.onChange(value)}
-									onChangeSelect={(value) => form.setValue("requestResetDuration", value, { shouldDirty: true })}
-									options={resetDurationOptions}
-								/>
-							</FormItem>
-						)}
+					<NumberAndSelect
+						id="providerRequestMaxLimit"
+						labelClassName="font-normal"
+						label="Maximum Requests"
+						value={form.watch("requestMaxLimit")}
+						selectValue={form.watch("requestResetDuration") || "1h"}
+						onChangeNumber={(value) => form.setValue("requestMaxLimit", value, { shouldDirty: true })}
+						onChangeSelect={(value) => form.setValue("requestResetDuration", value, { shouldDirty: true })}
+						options={[
+							{ label: "per hour", value: "1h" },
+							{ label: "per day", value: "1d" },
+							{ label: "per week", value: "1w" },
+							{ label: "per month", value: "1M" },
+						]}
 					/>
 				</div>
 
 				{/* Current Usage Display - only when editing existing */}
-				{hasExistingGovernance && (providerGovernance?.budget || providerGovernance?.rate_limit) && (
+				{hasExistingGovernance && (
 					<>
 						<DottedSeparator />
 						<div className="space-y-4">
 							<Label className="text-sm font-medium">Current Usage</Label>
 							<div className="bg-muted/50 grid grid-cols-2 gap-4 rounded-lg p-4">
-								{providerGovernance?.budget && (
-									<div className="space-y-1">
-										<p className="text-muted-foreground text-xs">Budget Usage</p>
+								{[...(providerGovernance?.budgets ?? [])]
+								.sort((a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime())
+								.map((budget, i) => (
+									<div key={budget.id ?? i} className="space-y-1">
+										<p className="text-muted-foreground text-xs">
+											Budget Usage
+											{(providerGovernance.budgets?.length ?? 0) > 1 && ` (${resetDurationLabels[budget.reset_duration] ?? budget.reset_duration})`}
+										</p>
 										<p className="text-sm font-medium">
-											${providerGovernance.budget.current_usage.toFixed(2)} / ${providerGovernance.budget.max_limit.toFixed(2)}
+											${budget.current_usage.toFixed(2)} / ${budget.max_limit.toFixed(2)}
 										</p>
 									</div>
-								)}
+								))}
 								{providerGovernance?.rate_limit?.token_max_limit && (
 									<div className="space-y-1">
 										<p className="text-muted-foreground text-xs">Token Usage</p>

--- a/ui/app/workspace/providers/views/providerGovernanceTable.tsx
+++ b/ui/app/workspace/providers/views/providerGovernanceTable.tsx
@@ -163,7 +163,7 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 	const providerGovernance = providerGovernanceData?.providers?.find((p) => p.provider === provider.name);
 
 	// Check if any governance is configured
-	const hasGovernance = providerGovernance?.budget || providerGovernance?.rate_limit;
+	const hasGovernance = (providerGovernance?.budgets?.length ?? 0) > 0 || !!providerGovernance?.rate_limit;
 
 	if (isLoading) {
 		return (
@@ -185,10 +185,14 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 		return null;
 	}
 
-	const budget = providerGovernance?.budget;
+	const budgets = [...(providerGovernance?.budgets ?? [])].sort((a, b) => {
+		const aTime = a.created_at ? new Date(a.created_at).getTime() : Number.MAX_SAFE_INTEGER;
+		const bTime = b.created_at ? new Date(b.created_at).getTime() : Number.MAX_SAFE_INTEGER;
+		return bTime - aTime;
+	});
 	const rateLimit = providerGovernance?.rate_limit;
+	const multipleBudgets = budgets.length > 1;
 
-	const isBudgetExhausted = !!(budget?.max_limit && budget.max_limit > 0 && budget.current_usage >= budget.max_limit);
 	const isTokenExhausted = !!(
 		rateLimit?.token_max_limit &&
 		rateLimit.token_max_limit > 0 &&
@@ -209,17 +213,24 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 			</CardHeader>
 
 			<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-				{/* Budget Card */}
-				{budget && (
-					<MetricCard
-						title="Budget"
-						value={budget.current_usage}
-						max={budget.max_limit}
-						unit="$"
-						resetDuration={budget.reset_duration}
-						isExhausted={isBudgetExhausted}
-					/>
-				)}
+				{/* Budget Cards — one per budget */}
+				{budgets.map((budget, i) => {
+					const isExhausted = !!(budget.max_limit > 0 && budget.current_usage >= budget.max_limit);
+					const title = multipleBudgets
+						? `Budget (${formatResetDuration(budget.reset_duration)})`
+						: "Budget";
+					return (
+						<MetricCard
+							key={budget.id ?? i}
+							title={title}
+							value={budget.current_usage}
+							max={budget.max_limit}
+							unit="$"
+							resetDuration={budget.reset_duration}
+							isExhausted={isExhausted}
+						/>
+					);
+				})}
 
 				{/* Token Rate Limit Card */}
 				{rateLimit?.token_max_limit && (

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -747,7 +747,7 @@ export const governanceApi = baseApi.injectEndpoints({
 		// Provider Governance
 		getProviderGovernance: builder.query<GetProviderGovernanceResponse, { fromMemory?: boolean } | void>({
 			query: (params) => ({
-				url: "/governance/providers",
+				url: "/v2/governance/providers",
 				params: { from_memory: params?.fromMemory ?? false },
 			}),
 			providesTags: ["ProviderGovernance"],
@@ -758,7 +758,7 @@ export const governanceApi = baseApi.injectEndpoints({
 			{ provider: string; data: UpdateProviderGovernanceRequest }
 		>({
 			query: ({ provider, data }) => ({
-				url: `/governance/providers/${encodeURIComponent(provider)}`,
+				url: `/v2/governance/providers/${encodeURIComponent(provider)}`,
 				method: "PUT",
 				body: data,
 			}),

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -8,6 +8,7 @@ export interface Budget {
 	reset_duration: string; // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
 	current_usage: number; // In dollars
 	last_reset: string; // ISO timestamp
+	created_at?: string; // ISO timestamp
 }
 
 export interface RateLimit {
@@ -522,18 +523,18 @@ export interface GetPricingOverridesResponse {
 	offset: number;
 }
 
-// Provider governance - for extending provider with budget/rate limit
+// Provider governance - for extending provider with budget/rate limit (v2: multi-budget)
 export interface ProviderGovernance {
 	provider: string;
-	budget_id?: string;
-	rate_limit_id?: string;
-	budget?: Budget;
+	budgets?: Budget[];
 	rate_limit?: RateLimit;
+	calendar_aligned?: boolean;
 }
 
 export interface UpdateProviderGovernanceRequest {
-	budget?: UpdateBudgetRequest;
+	budgets?: CreateBudgetRequest[]; // absent = no change; [] = remove all
 	rate_limit?: UpdateRateLimitRequest;
+	calendar_aligned?: boolean;
 }
 
 export interface GetProviderGovernanceResponse {


### PR DESCRIPTION
## Summary

This PR introduces a v2 API for provider governance that supports multiple budgets per provider, alongside a `calendar_aligned` field. Previously, the provider governance API exposed only a single budget; the v2 endpoints expose the full list. The UI is updated to consume the v2 endpoints and render all budgets.

## Changes

- Introduced `versionedRoute` struct and a `routes()` method on `GovernanceHandler` to declare the full route table in one place. Each route registers under `/api` (compat), `/api/v1`, and optionally `/api/v2` when a v2 handler is explicitly provided — no implicit v1 fallback under `/api/v2`.
- Added `getProviderGovernanceV2` and `updateProviderGovernanceV2` handlers. The v2 GET returns `ProviderGovernanceResponseV2` (all budgets + `calendar_aligned`); the v2 PUT accepts `UpdateProviderGovernanceRequestV2` where `Budgets` is `*[]` so a nil field means "no change" and a non-nil empty slice means "remove all".
- Added `modelConfigToProviderGovernanceV2` which returns all budgets (copied, not aliased) and `calendar_aligned`, replacing the v1 single-budget surface.
- The v1 comment was updated to clarify it intentionally surfaces only the first budget.
- `UpdateProviderGovernanceRequestV2.Budgets` uses a pointer-to-slice to distinguish "absent" from "empty array" after JSON unmarshal.
- The UI `governanceApi` GET and PUT provider governance queries now target `/v2/governance/providers`.
- `ProviderGovernance` type updated to `budgets?: Budget[]` (dropping the single `budget` field) and `UpdateProviderGovernanceRequest` updated to `budgets?: CreateBudgetRequest[]`.
- Provider governance table and form updated to iterate over all budgets, sorted newest-first by `created_at`. Budget cards are labeled with their reset duration when multiple budgets exist.
- `GovernanceFormFragment` replaced the single-budget `FormField` with the `MultiBudgetLines` component and simplified the two `useEffect` reset blocks via a shared `governanceToFormValues` helper.
- Model limits table budgets are also sorted newest-first.
- Tests added for `modelConfigToProviderGovernanceV2` (filter logic, field mapping, copy semantics), `getProviderGovernanceV2` (from-memory, nil data, DB path, DB error), `UpdateProviderGovernanceRequestV2` pointer semantics, and the routes table contract (every route has a v1 handler, provider GET/PUT have v2 handlers, DELETE does not, no duplicates).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

To validate the v2 endpoints manually:

```sh
# GET all provider governance (multi-budget response)
curl -s http://localhost:PORT/api/v2/governance/providers | jq .

# PUT provider governance with multiple budgets
curl -s -X PUT http://localhost:PORT/api/v2/governance/providers/openai \
  -H 'Content-Type: application/json' \
  -d '{"budgets":[{"max_limit":100,"reset_duration":"1d"},{"max_limit":500,"reset_duration":"1M"}]}'

# PUT with empty budgets array to remove all budgets
curl -s -X PUT http://localhost:PORT/api/v2/governance/providers/openai \
  -H 'Content-Type: application/json' \
  -d '{"budgets":[]}'

# Confirm v1 compat path still works
curl -s http://localhost:PORT/api/governance/providers | jq .
curl -s http://localhost:PORT/api/v1/governance/providers | jq .
```

## Screenshots/Recordings

Provider governance table and form now display one card/row per budget, labeled with the reset duration when more than one budget is present.

## Breaking changes

- [x] Yes
- [ ] No

The `ProviderGovernance` TypeScript type drops the single `budget` field in favour of `budgets: Budget[]`. Any UI code referencing `providerGovernance.budget` directly will need to be updated to use `providerGovernance.budgets?.[0]` or iterate the array. The backend v1 endpoint is unchanged and continues to return a single `budget` field; only the UI now calls v2.

## Related issues

## Security considerations

No new auth surfaces. The v2 endpoints are registered with the same admin middleware chain as v1. The self-service `/api/governance/virtual-keys/quota` endpoint continues to bypass admin middlewares as before.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable