### PR TITLE
feat: adding filters in budgets & limits UI for scope and providers

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4306,6 +4306,12 @@ func (s *RDBConfigStore) GetModelConfigsPaginated(ctx context.Context, params Mo
 		search := "%" + strings.ToLower(params.Search) + "%"
 		baseQuery = baseQuery.Where("LOWER(model_name) LIKE ?", search)
 	}
+	if params.Scope != "" {
+		baseQuery = baseQuery.Where("scope = ?", params.Scope)
+	}
+	if params.Provider != "" {
+		baseQuery = baseQuery.Where("provider = ?", params.Provider)
+	}
 
 	var totalCount int64
 	if err := baseQuery.Count(&totalCount).Error; err != nil {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -28,9 +28,11 @@ type VirtualKeyQueryParams struct {
 
 // ModelConfigsQueryParams holds pagination, filtering, and search parameters for model configs queries.
 type ModelConfigsQueryParams struct {
-	Limit  int
-	Offset int
-	Search string
+	Limit    int
+	Offset   int
+	Search   string
+	Scope    string // optional; filters to an exact scope value (e.g. "global", "virtual_key")
+	Provider string // optional; filters to an exact provider value (e.g. "openai")
 }
 
 // RoutingRulesQueryParams holds pagination, filtering, and search parameters for routing rules queries.

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -2704,6 +2704,8 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		search := string(ctx.QueryArgs().Peek("search"))
+		scopeFilter := string(ctx.QueryArgs().Peek("scope"))
+		providerFilter := string(ctx.QueryArgs().Peek("provider"))
 		// Deep-copy into a value slice: top-level struct copy + nested pointer/slice fields
 		// so we never alias or mutate live governance state during serialization.
 		all := make([]configstoreTables.TableModelConfig, 0, len(data.ModelConfigs))
@@ -2713,6 +2715,14 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 			}
 			if search != "" && !strings.Contains(strings.ToLower(mc.ModelName), strings.ToLower(search)) {
 				continue
+			}
+			if scopeFilter != "" && mc.Scope != scopeFilter {
+				continue
+			}
+			if providerFilter != "" {
+				if mc.Provider == nil || *mc.Provider != providerFilter {
+					continue
+				}
 			}
 			clone := *mc
 			if len(mc.Budgets) > 0 {
@@ -2769,11 +2779,15 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
 	search := string(ctx.QueryArgs().Peek("search"))
+	scope := string(ctx.QueryArgs().Peek("scope"))
+	provider := string(ctx.QueryArgs().Peek("provider"))
 
-	if limitStr != "" || offsetStr != "" || search != "" {
+	if limitStr != "" || offsetStr != "" || search != "" || scope != "" || provider != "" {
 		// Paginated path
 		params := configstore.ModelConfigsQueryParams{
-			Search: search,
+			Search:   search,
+			Scope:    scope,
+			Provider: provider,
 		}
 		if limitStr != "" {
 			n, err := strconv.Atoi(limitStr)

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -20,6 +20,8 @@ import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { getErrorMessage, useDeleteModelConfigMutation } from "@/lib/store";
 import { ModelConfig } from "@/lib/types/governance";
+import { ModelProvider } from "@/lib/types/config";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -29,7 +31,7 @@ import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
 import { ModelLimitsEmptyState } from "./modelLimitsEmptyState";
 import { getScopeLabel } from "@/lib/utils/labels";
-import { getModelLimitScope } from "@/lib/registries/modelLimitScopes";
+import { getModelLimitScope, getModelLimitScopes } from "@/lib/registries/modelLimitScopes";
 // Side-effect import: pull in downstream scope registrations (enterprise
 // "user" deep-link, etc.). No-op for OSS builds.
 import "@enterprise/lib/registrations/modelLimitScopes";
@@ -110,9 +112,14 @@ function ModelLimitActionsMenu({
 interface ModelLimitsTableProps {
 	modelConfigs: ModelConfig[];
 	totalCount: number;
+	providers: ModelProvider[];
 	search: string;
 	debouncedSearch: string;
 	onSearchChange: (value: string) => void;
+	scope: string;
+	onScopeChange: (value: string) => void;
+	provider: string;
+	onProviderChange: (value: string) => void;
 	offset: number;
 	limit: number;
 	onOffsetChange: (offset: number) => void;
@@ -121,9 +128,14 @@ interface ModelLimitsTableProps {
 export default function ModelLimitsTable({
 	modelConfigs,
 	totalCount,
+	providers,
 	search,
 	debouncedSearch,
 	onSearchChange,
+	scope,
+	onScopeChange,
+	provider,
+	onProviderChange,
 	offset,
 	limit,
 	onOffsetChange,
@@ -174,7 +186,7 @@ export default function ModelLimitsTable({
 		setEditingModelConfigId(null);
 	};
 
-	const hasActiveFilters = debouncedSearch;
+	const hasActiveFilters = debouncedSearch || scope || provider;
 
 	// True empty state: no model limits at all (not just filtered to zero)
 	if (totalCount === 0 && !hasActiveFilters) {
@@ -232,9 +244,9 @@ export default function ModelLimitsTable({
 					</Button>
 				</div>
 
-				{/* Toolbar: Search */}
-				<div className="flex items-center gap-3">
-					<div className="relative max-w-sm flex-1">
+				{/* Toolbar: Search + Filters */}
+				<div className="flex flex-wrap items-center gap-3">
+					<div className="relative min-w-[220px] flex-1">
 						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 						<Input
 							aria-label="Search model limits by model name"
@@ -245,6 +257,48 @@ export default function ModelLimitsTable({
 							data-testid="model-limits-search-input"
 						/>
 					</div>
+
+					<Select value={scope || "all"} onValueChange={(v) => onScopeChange(v === "all" ? "" : v)}>
+						<SelectTrigger className="w-[160px]" data-testid="model-limits-filter-scope">
+							<SelectValue placeholder="All Scopes" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">All Scopes</SelectItem>
+							{getModelLimitScopes().map((o) => (
+								<SelectItem key={o.value} value={o.value}>
+									{o.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+
+					<Select value={provider || "all"} onValueChange={(v) => onProviderChange(v === "all" ? "" : v)}>
+						<SelectTrigger className="w-[160px]" data-testid="model-limits-filter-provider">
+							<SelectValue placeholder="All Providers" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">All Providers</SelectItem>
+							{(providers ?? []).map((p) => (
+								<SelectItem key={p.name} value={p.name}>
+									<div className="flex items-center gap-2">
+										<RenderProviderIcon provider={p.name as ProviderIconType} size="sm" className="h-4 w-4" />
+										<span>{ProviderLabels[p.name as ProviderName] || p.name}</span>
+									</div>
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+
+					{hasActiveFilters && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => { onSearchChange(""); onScopeChange(""); onProviderChange(""); }}
+							data-testid="model-limits-filter-clear"
+						>
+							Clear filters
+						</Button>
+					)}
 				</div>
 
 				<div className="rounded-sm border" data-testid="model-limits-table">

--- a/ui/app/workspace/model-limits/views/modelLimitsView.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsView.tsx
@@ -1,4 +1,4 @@
-import { getErrorMessage, useGetModelConfigsQuery } from "@/lib/store";
+import { getErrorMessage, useGetModelConfigsQuery, useGetProvidersQuery } from "@/lib/store";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useEffect, useState } from "react";
@@ -12,20 +12,26 @@ export default function ModelLimitsView() {
 	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
 
 	const [search, setSearch] = useState("");
+	const [scope, setScope] = useState("");
+	const [provider, setProvider] = useState("");
 	const [offset, setOffset] = useState(0);
 
 	const debouncedSearch = useDebouncedValue(search, 300);
 
-	// Reset to first page when search changes
+	// Reset to first page when any filter changes
 	useEffect(() => {
 		setOffset(0);
-	}, [debouncedSearch]);
+	}, [debouncedSearch, scope, provider]);
+
+	const { data: providers } = useGetProvidersQuery();
 
 	const { data: modelConfigsData, error: modelConfigsError } = useGetModelConfigsQuery(
 		{
 			limit: PAGE_SIZE,
 			offset,
 			search: debouncedSearch || undefined,
+			scope: scope || undefined,
+			provider: provider || undefined,
 		},
 		{
 			skip: !hasGovernanceAccess,
@@ -53,9 +59,14 @@ export default function ModelLimitsView() {
 			<ModelLimitsTable
 				modelConfigs={modelConfigsData?.model_configs || []}
 				totalCount={modelConfigsData?.total_count || 0}
+				providers={providers ?? []}
 				search={search}
 				debouncedSearch={debouncedSearch}
 				onSearchChange={setSearch}
+				scope={scope}
+				onScopeChange={setScope}
+				provider={provider}
+				onProviderChange={setProvider}
 				offset={offset}
 				limit={PAGE_SIZE}
 				onOffsetChange={setOffset}

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -501,6 +501,8 @@ export const governanceApi = baseApi.injectEndpoints({
 					...(params?.limit && { limit: params.limit }),
 					...(params?.offset !== undefined && { offset: params.offset }),
 					...(params?.search && { search: params.search }),
+					...(params?.scope && { scope: params.scope }),
+					...(params?.provider && { provider: params.provider }),
 				},
 			}),
 			providesTags: ["ModelConfigs"],
@@ -524,15 +526,18 @@ export const governanceApi = baseApi.injectEndpoints({
 			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
+					const mc = data.model_config;
 					const queries = (getState() as any).api.queries;
 					for (const entry of Object.values(queries) as any[]) {
 						if (entry?.endpointName !== "getModelConfigs" || entry?.status !== "fulfilled") continue;
-						const search = entry.originalArgs?.search as string | undefined;
-						if (search && !data.model_config.model_name.toLowerCase().includes(search.toLowerCase())) continue;
+						const args = entry.originalArgs as GetModelConfigsParams | undefined;
+						if (args?.search && !mc.model_name.toLowerCase().includes(args.search.toLowerCase())) continue;
+						if (args?.scope && mc.scope !== args.scope) continue;
+						if (args?.provider && mc.provider !== args.provider) continue;
 						dispatch(
 							governanceApi.util.updateQueryData("getModelConfigs", entry.originalArgs, (draft) => {
 								if (!draft.model_configs) draft.model_configs = [];
-								draft.model_configs.unshift(data.model_config);
+								draft.model_configs.unshift(mc);
 								draft.count = (draft.count || 0) + 1;
 								draft.total_count = (draft.total_count || 0) + 1;
 							}),

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -381,6 +381,8 @@ export interface GetModelConfigsParams {
 	limit?: number;
 	offset?: number;
 	search?: string;
+	scope?: string;
+	provider?: string;
 }
 
 // Response types for model configs


### PR DESCRIPTION
## Summary

Adds `scope` and `provider` filter support to the Model Limits (Model Configs) list, allowing users to narrow results by scope (e.g. `global`, `virtual_key`) and provider (e.g. `openai`) independently of the existing search filter.

## Changes

- Added `Scope` and `Provider` fields to `ModelConfigsQueryParams` and wired them into the RDB query as exact-match `WHERE` clauses.
- Extended the HTTP handler to read `scope` and `provider` query parameters and apply them on both the in-memory (non-paginated) path and the paginated database path.
- Added `scope` and `provider` to `GetModelConfigsParams` and passed them through the RTK Query API call, including query string serialization.
- Updated the optimistic cache update on model config creation to skip inserting a newly created config into cached query results when its `scope` or `provider` does not match the active filter arguments.
- Added Scope and Provider `<Select>` dropdowns to the model limits toolbar. The scope options are sourced from the existing `getModelLimitScopes` registry; provider options are sourced from the providers API with icons and labels.
- Added a "Clear filters" button that appears when any filter (search, scope, or provider) is active and resets all three at once.
- Pagination offset resets to 0 when scope or provider filters change, consistent with existing search behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Navigate to the Model Limits page.
2. Use the **Scope** dropdown to select a scope (e.g. `global`) — only model configs with that scope should appear.
3. Use the **Provider** dropdown to select a provider (e.g. `openai`) — only model configs for that provider should appear.
4. Combine scope and provider filters together and verify results are correctly intersected.
5. Verify the **Clear filters** button resets all three filters and restores the full list.
6. Verify pagination resets to page 1 when either filter changes.
7. Create a new model config while a scope/provider filter is active and confirm it only appears in the cached list if it matches the active filters.

## Screenshots/Recordings

_Add before/after screenshots of the model limits toolbar showing the new Scope and Provider dropdowns._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions.

## Security considerations

The new `scope` and `provider` query parameters are passed as parameterized query arguments (`WHERE scope = ?`, `WHERE provider = ?`), preventing SQL injection.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scope and provider filtering to model configuration listings with dropdowns in the UI.
  * “Clear filters” now resets search, scope, and provider.

* **Improvements**
  * Filters apply both in-memory and server-side, and pagination resets when search/scope/provider change.
  * Creation of a new model config updates visible lists immediately when relevant filters match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->