### PR TITLE
fix: add Model field to TextCompletionChunkResponse

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -708,7 +708,7 @@ func HandleOpenAITextCompletionStreaming(
 			}
 		}
 
-		response := providerUtils.CreateBifrostTextCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, schemas.TextCompletionStreamRequest)
+		response := providerUtils.CreateBifrostTextCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, schemas.TextCompletionStreamRequest, request.Model)
 		if postResponseConverter != nil {
 			response = postResponseConverter(response)
 			if response == nil {

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -731,7 +731,8 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 					nil, // usage - not available in done event
 					finishReason,
 					chunkIndex,
-					schemas.TextCompletionStreamRequest)
+					schemas.TextCompletionStreamRequest,
+					request.Model)
 
 				// Set raw request if enabled
 				if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2385,9 +2385,11 @@ func CreateBifrostTextCompletionChunkResponse(
 	finishReason *string,
 	currentChunkIndex int,
 	requestType schemas.RequestType,
+	model string,
 ) *schemas.BifrostTextCompletionResponse {
 	response := &schemas.BifrostTextCompletionResponse{
 		ID:     id,
+		Model:  model,
 		Object: "text_completion",
 		Usage:  usage,
 		Choices: []schemas.BifrostResponseChoice{


### PR DESCRIPTION
## Summary

Adds the `Model` field to `CreateBifrostTextCompletionChunkResponse` function and passes it from all callers.

This is a follow-up to #2623 which was approved but had merge conflicts. The ChatCompletion changes from that PR have already been merged upstream, so this PR only contains the TextCompletion fix.

### Changes
- `core/providers/utils/utils.go`: Added `model string` parameter to `CreateBifrostTextCompletionChunkResponse` and set `Model` field in response
- `core/providers/openai/openai.go`: Updated caller to pass `request.Model`
- `core/providers/replicate/replicate.go`: Updated caller to pass `request.Model`

The `BifrostTextCompletionResponse` schema already has a `Model` field defined (see `core/schemas/textcompletions.go:70`), so only the function and its callers needed updating.

Closes #2623

Co-authored-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>
Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>