### PR TITLE
fix(batch): make model field optional on POST /v1/batches

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -2631,6 +2631,25 @@ func (h *CompletionHandler) videoRemix(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, resp)
 }
 
+// resolveBatchProvider resolves the provider (and optional model) for a batch
+// create request. Per the OpenAI spec, model is optional on POST /v1/batches —
+// it lives inside each JSONL request body. When model is present it is parsed
+// via resolveModelAndProvider; when absent the provider is taken from the
+// ?provider= query param or x-model-provider header (same as fileUpload).
+func resolveBatchProvider(ctx *fasthttp.RequestCtx, config *lib.Config, model string) (schemas.ModelProvider, string, error) {
+	if model != "" {
+		return resolveModelAndProvider(ctx, config, model)
+	}
+	p := string(ctx.QueryArgs().Peek("provider"))
+	if p == "" {
+		p = string(ctx.Request.Header.Peek("x-model-provider"))
+	}
+	if p == "" {
+		return "", "", fmt.Errorf("provider query parameter or x-model-provider header is required when model is not specified")
+	}
+	return schemas.ModelProvider(p), "", nil
+}
+
 // batchCreate handles POST /v1/batches - Create a new batch job
 func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 	var req BatchCreateRequest
@@ -2642,25 +2661,10 @@ func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 	// model is optional on POST /v1/batches per the OpenAI spec — the model lives
 	// inside each JSONL request body. When omitted, resolve the provider from the
 	// x-model-provider header or ?provider= query param (same as fileUpload).
-	var provider schemas.ModelProvider
-	var modelName string
-	if req.Model != "" {
-		var err error
-		provider, modelName, err = resolveModelAndProvider(ctx, h.config, req.Model)
-		if err != nil {
-			SendError(ctx, fasthttp.StatusBadRequest, err.Error())
-			return
-		}
-	} else {
-		p := string(ctx.QueryArgs().Peek("provider"))
-		if p == "" {
-			p = string(ctx.Request.Header.Peek("x-model-provider"))
-		}
-		if p == "" {
-			SendError(ctx, fasthttp.StatusBadRequest, "provider query parameter or x-model-provider header is required when model is not specified")
-			return
-		}
-		provider = schemas.ModelProvider(p)
+	provider, modelName, err := resolveBatchProvider(ctx, h.config, req.Model)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
 	}
 
 	// Validate that at least one of InputFileID or InputBlob or Requests is provided

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -2639,10 +2639,28 @@ func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	provider, modelName, err := resolveModelAndProvider(ctx, h.config, req.Model)
-	if err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
-		return
+	// model is optional on POST /v1/batches per the OpenAI spec — the model lives
+	// inside each JSONL request body. When omitted, resolve the provider from the
+	// x-model-provider header or ?provider= query param (same as fileUpload).
+	var provider schemas.ModelProvider
+	var modelName string
+	if req.Model != "" {
+		var err error
+		provider, modelName, err = resolveModelAndProvider(ctx, h.config, req.Model)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+			return
+		}
+	} else {
+		p := string(ctx.QueryArgs().Peek("provider"))
+		if p == "" {
+			p = string(ctx.Request.Header.Peek("x-model-provider"))
+		}
+		if p == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "provider query parameter or x-model-provider header is required when model is not specified")
+			return
+		}
+		provider = schemas.ModelProvider(p)
 	}
 
 	// Validate that at least one of InputFileID or InputBlob or Requests is provided

--- a/transports/bifrost-http/handlers/inference_batch_test.go
+++ b/transports/bifrost-http/handlers/inference_batch_test.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// TestResolveBatchProvider covers the three resolution paths introduced to make
+// model optional on POST /v1/batches (OpenAI spec: model lives in the JSONL body).
+func TestResolveBatchProvider(t *testing.T) {
+	config := &lib.Config{}
+
+	cases := []struct {
+		name         string
+		model        string
+		header       string // x-model-provider; empty = unset
+		query        string // ?provider=; empty = unset
+		wantProvider string
+		wantModel    string
+		wantErrMsg   string // non-empty = error expected, substring match
+	}{
+		{
+			name:         "model field: provider+model parsed",
+			model:        "openai/gpt-4o-mini",
+			wantProvider: "openai",
+			wantModel:    "gpt-4o-mini",
+		},
+		{
+			name:         "no model, x-model-provider header",
+			header:       "openai",
+			wantProvider: "openai",
+			wantModel:    "",
+		},
+		{
+			name:         "no model, ?provider= query param",
+			query:        "anthropic",
+			wantProvider: "anthropic",
+			wantModel:    "",
+		},
+		{
+			name:       "no model, no provider → error",
+			wantErrMsg: "provider query parameter or x-model-provider header is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			if tc.header != "" {
+				ctx.Request.Header.Set("x-model-provider", tc.header)
+			}
+			if tc.query != "" {
+				ctx.QueryArgs().Set("provider", tc.query)
+			}
+
+			provider, modelName, err := resolveBatchProvider(ctx, config, tc.model)
+
+			if tc.wantErrMsg != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrMsg)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrMsg) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(provider) != tc.wantProvider {
+				t.Fatalf("provider = %q, want %q", provider, tc.wantProvider)
+			}
+			if modelName != tc.wantModel {
+				t.Fatalf("modelName = %q, want %q", modelName, tc.wantModel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3972

## Problem

The [OpenAI batch spec](https://platform.openai.com/docs/api-reference/batch/create) does **not** include a `model` field on `POST /v1/batches` — the model lives inside each JSONL request body. The standard OpenAI SDK does not send `model` on batch create.

`batchCreate()` in `handlers/inference.go` called `resolveModelAndProvider()` unconditionally, which returns `"model is required"` whenever the field is absent:

```go
// before
provider, modelName, err := resolveModelAndProvider(ctx, h.config, req.Model)
if err != nil {
    SendError(ctx, fasthttp.StatusBadRequest, err.Error())  // always fires without model
    return
}
```

This was a partial miss from PR #1471 — that PR correctly updated the **governance plugin** to exempt batch requests from model validation, but the **HTTP transport handler** was not updated. The `"model is required"` error therefore still fires at the handler layer before governance is ever consulted.

Confirmed against a live deployment (`maximhq/bifrost:v1.5.4`):

```
POST /v1/batches   (no model field, x-model-provider: openai header set)
→ 400 {"is_bifrost_error":false,"status_code":400,"error":{"message":"model is required"}}

POST /v1/batches   (with model: "openai/gpt-4o-mini")
→ 200 OK
```

## Fix

When `model` is absent, resolve the provider from the `?provider=` query param or `x-model-provider` header — the same fallback pattern used by `fileUpload`. A provider is still required; only the model is now optional.

## Testing

- Standard OpenAI SDK batch create (no `model` field) now succeeds when `x-model-provider` header is set
- `model: "provider/model"` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)