### PR TITLE
feat: xai x_search tool support

### DIFF
--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -178,7 +178,8 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 	params := bifrostReq.Params
 	// Create the responses request with properly mapped parameters
 	req := &OpenAIResponsesRequest{
-		Model: bifrostReq.Model,
+		Model:    bifrostReq.Model,
+		Provider: bifrostReq.Provider,
 		Input: OpenAIResponsesRequestInput{
 			OpenAIResponsesRequestInputArray: messages,
 		},
@@ -315,6 +316,11 @@ func (resp *OpenAIResponsesRequest) filterUnsupportedTools() {
 		schemas.ResponsesToolTypeNamespace:          true,
 	}
 
+	// Allow provider-native tools that are not part of the OpenAI spec
+	if resp.Provider == schemas.XAI {
+		supportedTypes[schemas.ResponsesToolTypeXSearch] = true
+	}
+
 	// Filter tools to only include supported types
 	filteredTools := make([]schemas.ResponsesTool, 0, len(resp.Tools))
 	for _, tool := range resp.Tools {
@@ -375,4 +381,10 @@ func (resp *OpenAIResponsesRequest) filterUnsupportedTools() {
 		}
 	}
 	resp.Tools = filteredTools
+
+	// If every tool was stripped, a leftover tool_choice would cause a 400 from
+	// the upstream ("tool_choice must be specified with tools").
+	if len(resp.Tools) == 0 {
+		resp.ToolChoice = nil
+	}
 }

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -706,7 +706,8 @@ type OpenAIResponsesRequest struct {
 	schemas.ResponsesParameters
 	Stream *bool `json:"stream,omitempty"`
 
-	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
+	// Bifrost specific fields (not serialized to wire)
+	Provider    schemas.ModelProvider  `json:"-"` // originating provider, used for provider-specific filtering
 	Fallbacks   []string               `json:"fallbacks,omitempty"`
 	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
 }

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -713,6 +713,29 @@ type ResponsesResponseUsage struct {
 	TotalTokens         int                            `json:"total_tokens"`          // Total number of tokens used
 	Cost                *BifrostCost                   `json:"cost,omitempty"`        // Only for the providers which support cost calculation
 	Iterations          []ResponsesResponseUsage       `json:"iterations,omitempty"`  // iterations field is sent by anthropic
+
+	// xAI-specific usage fields
+	NumSourcesUsed             *int                                 `json:"num_sources_used,omitempty"`
+	NumServerSideToolsUsed     *int                                 `json:"num_server_side_tools_used,omitempty"`
+	CostInUsdTicks             *int64                               `json:"cost_in_usd_ticks,omitempty"`
+	ServerSideToolUsageDetails *ResponsesServerSideToolUsageDetails `json:"server_side_tool_usage_details,omitempty"`
+	ContextDetails             *ResponsesContextDetails             `json:"context_details,omitempty"`
+}
+
+// ResponsesServerSideToolUsageDetails holds per-tool call counts returned by xAI.
+type ResponsesServerSideToolUsageDetails struct {
+	WebSearchCalls       int `json:"web_search_calls"`
+	XSearchCalls         int `json:"x_search_calls"`
+	CodeInterpreterCalls int `json:"code_interpreter_calls"`
+	FileSearchCalls      int `json:"file_search_calls"`
+	MCPCalls             int `json:"mcp_calls"`
+	DocumentSearchCalls  int `json:"document_search_calls"`
+}
+
+// ResponsesContextDetails holds the per-context token breakdown returned by xAI.
+type ResponsesContextDetails struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
 }
 
 type ResponsesResponseInputTokens struct {
@@ -1634,6 +1657,7 @@ const (
 	ResponsesToolTypeMemory             ResponsesToolType = "memory"
 	ResponsesToolTypeToolSearch         ResponsesToolType = "tool_search"
 	ResponsesToolTypeNamespace          ResponsesToolType = "namespace"
+	ResponsesToolTypeXSearch            ResponsesToolType = "x_search"
 )
 
 // normalizeResponsesToolType maps versioned/provider-specific tool type strings
@@ -1669,7 +1693,7 @@ func normalizeResponsesToolType(t ResponsesToolType) ResponsesToolType {
 
 // ResponsesTool represents a tool
 type ResponsesTool struct {
-	Type        ResponsesToolType `json:"type"`                  // "function" | "file_search" | "computer_use_preview" | "web_search" | "web_search_2025_08_26" | "mcp" | "code_interpreter" | "image_generation" | "local_shell" | "custom" | "web_search_preview" | "web_search_preview_2025_03_11"
+	Type        ResponsesToolType `json:"type"`                  // "function" | "file_search" | "computer_use_preview" | "web_search" | "web_search_2025_08_26" | "mcp" | "code_interpreter" | "image_generation" | "local_shell" | "custom" | "web_search_preview" | "web_search_preview_2025_03_11" | "x_search"
 	Name        *string           `json:"name,omitempty"`        // Common name field (Function, Custom tools)
 	Description *string           `json:"description,omitempty"` // Common description field (Function, Custom tools)
 
@@ -1697,6 +1721,7 @@ type ResponsesTool struct {
 	*ResponsesToolWebSearchPreview
 	*ResponsesToolToolSearch
 	*ResponsesToolNamespace
+	*ResponsesToolXSearch
 }
 
 // mergeJSONFields merges all top-level fields from src into dst using sjson,
@@ -1830,6 +1855,10 @@ func (t ResponsesTool) MarshalJSON() ([]byte, error) {
 	case ResponsesToolTypeNamespace:
 		if t.ResponsesToolNamespace != nil {
 			typeBytes, err = MarshalSorted(t.ResponsesToolNamespace)
+		}
+	case ResponsesToolTypeXSearch:
+		if t.ResponsesToolXSearch != nil {
+			typeBytes, err = MarshalSorted(t.ResponsesToolXSearch)
 		}
 	}
 	if err != nil {
@@ -2005,6 +2034,13 @@ func (t *ResponsesTool) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		t.ResponsesToolNamespace = &namespaceTool
+
+	case ResponsesToolTypeXSearch:
+		var xSearchTool ResponsesToolXSearch
+		if err := Unmarshal(data, &xSearchTool); err != nil {
+			return err
+		}
+		t.ResponsesToolXSearch = &xSearchTool
 	}
 
 	return nil
@@ -2429,6 +2465,26 @@ type ResponsesToolWebFetch struct {
 // ResponsesToolNamespace represents a namespace tool that groups related function tools.
 type ResponsesToolNamespace struct {
 	Tools []ResponsesTool `json:"tools,omitempty"`
+}
+
+// ResponsesToolXSearch represents the xAI-native x_search server-side tool.
+// All fields are optional; when omitted xAI searches without restrictions.
+// See https://docs.x.ai/developers/tools/x-search#x-search-parameters
+type ResponsesToolXSearch struct {
+	// AllowedXHandles restricts search to posts from these X accounts (max 10).
+	// Mutually exclusive with ExcludedXHandles.
+	AllowedXHandles []string `json:"allowed_x_handles,omitempty"`
+	// ExcludedXHandles excludes posts from these X accounts from results.
+	// Mutually exclusive with AllowedXHandles.
+	ExcludedXHandles []string `json:"excluded_x_handles,omitempty"`
+	// FromDate is the start date for tweet search (ISO 8601 date or datetime string).
+	FromDate *string `json:"from_date,omitempty"`
+	// ToDate is the end date for tweet search (ISO 8601 date or datetime string).
+	ToDate *string `json:"to_date,omitempty"`
+	// EnableImageUnderstanding controls whether images in tweets are analyzed.
+	EnableImageUnderstanding *bool `json:"enable_image_understanding,omitempty"`
+	// EnableVideoUnderstanding controls whether videos in tweets are analyzed.
+	EnableVideoUnderstanding *bool `json:"enable_video_understanding,omitempty"`
 }
 
 // ======================================================= Streaming Structs =======================================================

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -475,7 +475,8 @@
                 { "name": "bedrock/global.anthropic.claude-opus-4-7",       "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"bedrock/global.anthropic.claude-opus-4-7\",\n  \"input\": \"Hello\"\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } },
                 { "name": "bedrock/us.amazon.nova-lite-v1:0",               "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"bedrock/us.amazon.nova-lite-v1:0\",\n  \"input\": \"Hello\"\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } },
                 { "name": "azure/gpt-4o-mini",                              "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"azure/gpt-4o-mini\",\n  \"input\": \"Hello\"\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } },
-                { "name": "azure/gpt-4o",                                   "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"azure/gpt-4o\",\n  \"input\": \"Hello\"\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } }
+                { "name": "azure/gpt-4o",                                   "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"azure/gpt-4o\",\n  \"input\": \"Hello\"\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } },
+                { "name": "xai/grok-4-0709",                                "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"xai/grok-4-0709\",\n  \"input\": \"Hello\"\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } }
               ]
             },
             {
@@ -592,7 +593,8 @@
                 { "name": "gemini/gemini-2.5-flash",                        "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"input\": \"Count to 5\",\n  \"stream\": true\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } },
                 { "name": "vertex/gemini-2.5-flash",                        "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"vertex/gemini-2.5-flash\",\n  \"input\": \"Count to 5\",\n  \"stream\": true\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } },
                 { "name": "bedrock/us.amazon.nova-lite-v1:0",               "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"bedrock/us.amazon.nova-lite-v1:0\",\n  \"input\": \"Count to 5\",\n  \"stream\": true\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } },
-                { "name": "azure/gpt-4o-mini",                              "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"azure/gpt-4o-mini\",\n  \"input\": \"Count to 5\",\n  \"stream\": true\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } }
+                { "name": "azure/gpt-4o-mini",                              "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"azure/gpt-4o-mini\",\n  \"input\": \"Count to 5\",\n  \"stream\": true\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } },
+                { "name": "xai/grok-4-0709",                                "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"xai/grok-4-0709\",\n  \"input\": \"Count to 5\",\n  \"stream\": true\n}" }, "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] } } }
               ]
             },
             {
@@ -815,6 +817,216 @@
                 { "name": "8.6.4.A native chat → anthropic/claude-opus-4-8 (thinking)", "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"anthropic/claude-opus-4-8\",\n  \"messages\": [{ \"role\": \"user\", \"content\": \"What is 17 * 23? Think step by step.\" }],\n  \"max_tokens\": 2048,\n  \"thinking\": { \"type\": \"adaptive\" }\n}" }, "url": { "raw": "{{baseUrl}}/v1/chat/completions", "host": ["{{baseUrl}}"], "path": ["v1", "chat", "completions"] } } },
                 { "name": "8.6.4.A native chat → gemini/gemini-2.5-flash (reasoning_effort translated)", "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"messages\": [{ \"role\": \"user\", \"content\": \"What is 17 * 23? Think step by step.\" }],\n  \"reasoning_effort\": \"low\"\n}" }, "url": { "raw": "{{baseUrl}}/v1/chat/completions", "host": ["{{baseUrl}}"], "path": ["v1", "chat", "completions"] } } },
                 { "name": "8.6.4.E /anthropic/v1/messages → openai/gpt-5 (thinking translated)", "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"model\": \"openai/gpt-5\",\n  \"max_tokens\": 2048,\n  \"messages\": [{ \"role\": \"user\", \"content\": \"What is 17 * 23? Think step by step.\" }],\n  \"thinking\": { \"type\": \"enabled\", \"budget_tokens\": 1024 }\n}" }, "url": { "raw": "{{baseUrl}}/anthropic/v1/messages", "host": ["{{baseUrl}}"], "path": ["anthropic", "v1", "messages"] } } }
+              ]
+            },
+            {
+              "name": "8.6.5 xAI x_search (server-side tool)",
+              "description": "xAI-native x_search tool tests via the native /v1/responses endpoint.\n\nThe x_search tool is a server-side search tool exclusive to xAI (grok models). When invoked the model internally calls x_semantic_search and/or x_keyword_search, returning custom_tool_call output items. The final message output_text content block carries url_citation annotations pointing at the source tweets/posts.\n\nDocs: https://docs.x.ai/developers/tools/x-search\n\nCovered here:\n  8.6.5.A – basic x_search, no extra params → verifies custom_tool_call items + final message\n  8.6.5.B – x_search with allowed_x_handles filter → tool_choice=required, verifies sub-tool name\n  8.6.5.C – x_search with from_date/to_date → date-range filtering passes through\n  8.6.5.D – x_search with all optional params (exact bug-report repro)\n  8.6.5.E – x_search streaming → custom_tool_call_input events flow through the SSE stream\n  8.6.5.F – x_search with url_citation annotations → verifies annotations array in output_text block",
+              "item": [
+                {
+                  "name": "8.6.5.A x_search basic (no params)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('x_search: output contains at least one custom_tool_call', function () {",
+                          "  var j = pm.response.json();",
+                          "  var calls = (j.output || []).filter(function(o) { return o.type === 'custom_tool_call'; });",
+                          "  pm.expect(calls.length, 'expected ≥1 custom_tool_call in output').to.be.above(0);",
+                          "  calls.forEach(function(c) {",
+                          "    pm.expect(c.name, 'sub-tool name must start with x_').to.match(/^x_/);",
+                          "  });",
+                          "});",
+                          "pm.test('x_search: output contains a final message with text', function () {",
+                          "  var j = pm.response.json();",
+                          "  var msg = (j.output || []).find(function(o) { return o.type === 'message'; });",
+                          "  pm.expect(msg, 'expected a message item in output').to.exist;",
+                          "  var hasText = (msg.content || []).some(function(c) { return c.type === 'output_text' && c.text && c.text.length > 0; });",
+                          "  pm.expect(hasText, 'message should contain non-empty output_text').to.be.true;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [{ "key": "Content-Type", "value": "application/json" }],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"model\": \"xai/grok-4-0709\",\n  \"input\": \"What are people saying about artificial intelligence on X today?\",\n  \"tools\": [{ \"type\": \"x_search\" }],\n  \"max_output_tokens\": 500\n}"
+                    },
+                    "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] }
+                  }
+                },
+                {
+                  "name": "8.6.5.B x_search with allowed_x_handles (tool_choice=required)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('x_search handles: at least one custom_tool_call present', function () {",
+                          "  var j = pm.response.json();",
+                          "  var calls = (j.output || []).filter(function(o) { return o.type === 'custom_tool_call'; });",
+                          "  pm.expect(calls.length, 'tool_choice=required must produce ≥1 custom_tool_call').to.be.above(0);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [{ "key": "Content-Type", "value": "application/json" }],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"model\": \"xai/grok-4-0709\",\n  \"input\": \"What has xAI been posting about recently?\",\n  \"tools\": [{ \"type\": \"x_search\", \"allowed_x_handles\": [\"xai\", \"grok\"] }],\n  \"tool_choice\": \"required\",\n  \"max_output_tokens\": 500\n}"
+                    },
+                    "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] }
+                  }
+                },
+                {
+                  "name": "8.6.5.C x_search with from_date/to_date",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('x_search date range: custom_tool_call present', function () {",
+                          "  var j = pm.response.json();",
+                          "  var calls = (j.output || []).filter(function(o) { return o.type === 'custom_tool_call'; });",
+                          "  pm.expect(calls.length, 'expected ≥1 custom_tool_call').to.be.above(0);",
+                          "});",
+                          "pm.test('x_search date range: final message has content', function () {",
+                          "  var j = pm.response.json();",
+                          "  var msg = (j.output || []).find(function(o) { return o.type === 'message'; });",
+                          "  pm.expect(msg, 'expected a message item').to.exist;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [{ "key": "Content-Type", "value": "application/json" }],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"model\": \"xai/grok-4-0709\",\n  \"input\": \"What were people saying about machine learning on X recently?\",\n  \"tools\": [{ \"type\": \"x_search\", \"from_date\": \"2025-12-01\", \"to_date\": \"2025-12-15\" }],\n  \"max_output_tokens\": 500\n}"
+                    },
+                    "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] }
+                  }
+                },
+                {
+                  "name": "8.6.5.D x_search all optional params (bug-report repro)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('x_search all params: tool present in request and custom_tool_call in output', function () {",
+                          "  var j = pm.response.json();",
+                          "  pm.expect(j.output, 'output should be a non-empty array').to.be.an('array').with.length.above(0);",
+                          "  var calls = (j.output || []).filter(function(o) { return o.type === 'custom_tool_call'; });",
+                          "  pm.expect(calls.length, 'tool_choice=required must yield ≥1 custom_tool_call').to.be.above(0);",
+                          "});",
+                          "pm.test('x_search all params: usage reports x_search_calls > 0', function () {",
+                          "  var j = pm.response.json();",
+                          "  pm.expect(j.usage, 'response must include usage').to.exist;",
+                          "  if (j.usage.server_side_tool_usage_details) {",
+                          "    pm.expect(j.usage.server_side_tool_usage_details.x_search_calls, 'x_search_calls should be > 0').to.be.above(0);",
+                          "  }",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [{ "key": "Content-Type", "value": "application/json" }],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"model\": \"xai/grok-4-0709\",\n  \"input\": \"Find recent tweets about artificial intelligence developments.\",\n  \"tools\": [{\n    \"type\": \"x_search\",\n    \"allowed_x_handles\": [\"xai\", \"openai\", \"GoogleAI\"],\n    \"from_date\": \"2025-12-10\",\n    \"to_date\": \"2025-12-15\",\n    \"enable_image_understanding\": false,\n    \"enable_video_understanding\": false\n  }],\n  \"tool_choice\": \"required\",\n  \"max_output_tokens\": 500\n}"
+                    },
+                    "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] }
+                  }
+                },
+                {
+                  "name": "8.6.5.E x_search streaming",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "// Streaming responses return text/event-stream — the collection-level content check skips those.",
+                          "// We verify only that Bifrost emits a 200 and the SSE prefix.",
+                          "pm.test('x_search stream: 200 with SSE content-type', function () {",
+                          "  pm.expect(pm.response.code).to.equal(200);",
+                          "  var ct = pm.response.headers.get('content-type') || '';",
+                          "  pm.expect(ct, 'expected text/event-stream').to.include('text/event-stream');",
+                          "});",
+                          "pm.test('x_search stream: body includes x_search tool event', function () {",
+                          "  var body = pm.response.text() || '';",
+                          "  var hasToolEvent = body.indexOf('custom_tool_call_input') !== -1 || body.indexOf('\"type\":\"custom_tool_call\"') !== -1;",
+                          "  pm.expect(hasToolEvent, 'expected x_search tool event (custom_tool_call_input or custom_tool_call) in SSE body').to.be.true;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [{ "key": "Content-Type", "value": "application/json" }],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"model\": \"xai/grok-4-0709\",\n  \"input\": \"What are people saying about xAI on X?\",\n  \"tools\": [{ \"type\": \"x_search\" }],\n  \"tool_choice\": \"required\",\n  \"max_output_tokens\": 500,\n  \"stream\": true\n}"
+                    },
+                    "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] }
+                  }
+                },
+                {
+                  "name": "8.6.5.F x_search url_citation annotations",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "// x_search grounds its answer in real X posts and surfaces them as url_citation",
+                          "// annotations on the output_text content block. Verify the annotation array is",
+                          "// present and each entry has the required url/start_index/end_index fields.",
+                          "pm.test('x_search citations: output_text block has url_citation annotations', function () {",
+                          "  var j = pm.response.json();",
+                          "  var msg = (j.output || []).find(function(o) { return o.type === 'message'; });",
+                          "  pm.expect(msg, 'output must contain a message item').to.exist;",
+                          "  var textBlock = (msg.content || []).find(function(c) { return c.type === 'output_text'; });",
+                          "  pm.expect(textBlock, 'message must have an output_text block').to.exist;",
+                          "  pm.expect(textBlock.annotations, 'output_text must have annotations array').to.be.an('array').with.length.above(0);",
+                          "  textBlock.annotations.forEach(function(a) {",
+                          "    pm.expect(a.type, 'annotation type must be url_citation').to.equal('url_citation');",
+                          "    pm.expect(a.url, 'url_citation must have a url').to.be.a('string').with.length.above(0);",
+                          "    pm.expect(a).to.have.property('start_index');",
+                          "    pm.expect(a).to.have.property('end_index');",
+                          "  });",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "method": "POST",
+                    "header": [{ "key": "Content-Type", "value": "application/json" }],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n  \"model\": \"xai/grok-4-0709\",\n  \"input\": \"What are people saying about xAI on X? Summarise with sources.\",\n  \"tools\": [{ \"type\": \"x_search\" }],\n  \"tool_choice\": \"required\",\n  \"max_output_tokens\": 600\n}"
+                    },
+                    "url": { "raw": "{{baseUrl}}/v1/responses", "host": ["{{baseUrl}}"], "path": ["v1", "responses"] }
+                  }
+                }
               ]
             }
           ]

--- a/tests/integrations/python/tests/test_openai.py
+++ b/tests/integrations/python/tests/test_openai.py
@@ -76,6 +76,13 @@ Tests all core scenarios using OpenAI SDK directly:
 64. Realtime client secret HTTP API - raw routes
 65. Realtime client secret HTTP API - OpenAI constructor base_url compatibility
 66. Realtime client secret HTTP API - unsupported provider
+xAI x_search tool tests (xAI-only):
+- xai_x_search_basic: x_search with no params, non-streaming
+- xai_x_search_with_handles: x_search with allowed_x_handles, non-streaming
+- xai_x_search_with_date_range: x_search with from_date/to_date, non-streaming
+- xai_x_search_all_params: x_search with all optional params, non-streaming
+- xai_x_search_streaming: x_search streaming, no params
+- xai_x_search_streaming_with_params: x_search streaming with handles + date range
 
 Batch API uses OpenAI SDK with x-model-provider header to route to different providers.
 """
@@ -83,6 +90,7 @@ Batch API uses OpenAI SDK with x-model-provider header to route to different pro
 import json
 import os
 import time
+from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import quote
 
@@ -2504,6 +2512,234 @@ class TestOpenAIIntegration:
         assert chunk_count > 1, f"Streaming should have multiple chunks, got {chunk_count}"
 
         print(f"Success: Reasoning streaming with summary completed ({chunk_count} chunks)")
+
+    # =========================================================================
+    # XAI x_search TOOL TEST CASES
+    # Tested via the OpenAI integration — model "xai/<model>" routes through
+    # Bifrost to xAI's API.  The openai_client fixture hits Bifrost's /openai
+    # endpoint; the "xai/" prefix in the model name selects the xAI provider.
+    # =========================================================================
+
+    @skip_if_no_api_key("xai")
+    def test_xai_x_search_basic(self, openai_client, test_config):
+        """xAI x_search: non-streaming, no extra params — verifies custom_tool_call items appear."""
+        model = format_provider_model("xai", get_config().get_provider_model("xai", "chat"))
+
+        response = openai_client.responses.create(
+            model=model,
+            input="What are people saying about artificial intelligence on X today?",
+            tools=[{"type": "x_search"}],
+            max_output_tokens=500,
+        )
+
+        assert response is not None, "Response should not be None"
+        assert hasattr(response, "output") and len(response.output) > 0, "Output should not be empty"
+
+        x_search_calls = [
+            item for item in response.output
+            if getattr(item, "type", None) == "custom_tool_call"
+        ]
+        assert len(x_search_calls) > 0, (
+            f"Response should contain at least one custom_tool_call (x_semantic_search / "
+            f"x_keyword_search). Output types: {[getattr(i, 'type', None) for i in response.output]}"
+        )
+
+        for call in x_search_calls:
+            assert getattr(call, "name", None) in {"x_semantic_search", "x_keyword_search"}, (
+                f"Unexpected custom_tool_call name: {getattr(call, 'name', None)}"
+            )
+
+        message_content = ""
+        for item in response.output:
+            if getattr(item, "type", None) == "message" and hasattr(item, "content"):
+                for block in (item.content if isinstance(item.content, list) else []):
+                    if hasattr(block, "text") and block.text:
+                        message_content += block.text
+
+        assert len(message_content) > 20, (
+            f"Message content should be non-trivial. Got: {message_content!r}"
+        )
+
+    @skip_if_no_api_key("xai")
+    def test_xai_x_search_with_handles(self, openai_client, test_config):
+        """xAI x_search: non-streaming, restricted to specific X handles via allowed_x_handles."""
+        model = format_provider_model("xai", get_config().get_provider_model("xai", "chat"))
+
+        response = openai_client.responses.create(
+            model=model,
+            input="What has xAI been posting about recently?",
+            tools=[
+                {
+                    "type": "x_search",
+                    "allowed_x_handles": ["xai", "grok"],
+                }
+            ],
+            tool_choice="required",
+            max_output_tokens=500,
+        )
+
+        assert response is not None
+        assert len(response.output) > 0
+
+        x_search_calls = [
+            item for item in response.output
+            if getattr(item, "type", None) == "custom_tool_call"
+        ]
+        assert len(x_search_calls) > 0, (
+            "Response should contain at least one x_search call when tool_choice=required"
+        )
+
+    @skip_if_no_api_key("xai")
+    def test_xai_x_search_with_date_range(self, openai_client, test_config):
+        """xAI x_search: non-streaming, with from_date/to_date filters."""
+        model = format_provider_model("xai", get_config().get_provider_model("xai", "chat"))
+        _today = datetime.now().date()
+        _from_date = ((_today - timedelta(days=30)).isoformat())
+        _to_date = ((_today - timedelta(days=15)).isoformat())
+
+        response = openai_client.responses.create(
+            model=model,
+            input="What were people saying about machine learning on X recently?",
+            tools=[
+                {
+                    "type": "x_search",
+                    "from_date": _from_date,
+                    "to_date": _to_date,
+                }
+            ],
+            max_output_tokens=500,
+        )
+
+        assert response is not None
+        assert len(response.output) > 0
+
+        x_search_calls = [
+            item for item in response.output
+            if getattr(item, "type", None) == "custom_tool_call"
+        ]
+        assert len(x_search_calls) > 0, "Response should contain x_search calls"
+
+        message_content = ""
+        for item in response.output:
+            if getattr(item, "type", None) == "message" and hasattr(item, "content"):
+                for block in (item.content if isinstance(item.content, list) else []):
+                    if hasattr(block, "text") and block.text:
+                        message_content += block.text
+
+        assert len(message_content) > 20, f"Expected text content, got: {message_content!r}"
+
+    @skip_if_no_api_key("xai")
+    def test_xai_x_search_all_params(self, openai_client, test_config):
+        """xAI x_search: non-streaming, all optional parameters (exact repro of the bug report)."""
+        model = format_provider_model("xai", get_config().get_provider_model("xai", "chat"))
+        _today = datetime.now().date()
+        _from_date = ((_today - timedelta(days=30)).isoformat())
+        _to_date = ((_today - timedelta(days=15)).isoformat())
+
+        response = openai_client.responses.create(
+            model=model,
+            input="Find recent tweets about artificial intelligence developments.",
+            tools=[
+                {
+                    "type": "x_search",
+                    "allowed_x_handles": ["xai", "openai", "GoogleAI"],
+                    "from_date": _from_date,
+                    "to_date": _to_date,
+                    "enable_image_understanding": False,
+                    "enable_video_understanding": False,
+                }
+            ],
+            tool_choice="required",
+            max_output_tokens=500,
+        )
+
+        assert response is not None
+        assert len(response.output) > 0, "Output should not be empty"
+
+        x_search_calls = [
+            item for item in response.output
+            if getattr(item, "type", None) == "custom_tool_call"
+        ]
+        assert len(x_search_calls) > 0, (
+            "tool_choice=required with x_search must produce at least one custom_tool_call"
+        )
+
+        if hasattr(response, "usage") and response.usage is not None:
+            if hasattr(response.usage, "total_tokens"):
+                assert response.usage.total_tokens > 0, "Token usage should be reported"
+
+    @skip_if_no_api_key("xai")
+    def test_xai_x_search_streaming(self, openai_client, test_config):
+        """xAI x_search: streaming, no extra params — verifies custom_tool_call events flow through."""
+        model = format_provider_model("xai", get_config().get_provider_model("xai", "chat"))
+
+        stream = openai_client.responses.create(
+            model=model,
+            input="What are people saying about xAI on X?",
+            tools=[{"type": "x_search"}],
+            max_output_tokens=500,
+            stream=True,
+        )
+
+        content, chunk_count, _tool_calls_detected, event_types = (
+            collect_responses_streaming_content(stream, timeout=300)
+        )
+
+        assert chunk_count > 0, "Should receive at least one streaming chunk"
+        assert len(content) > 10, f"Should receive substantive text content. Got: {content!r}"
+
+        has_x_search_events = (
+            event_types.get("response.custom_tool_call_input.delta", 0) > 0
+            or event_types.get("response.custom_tool_call_input.done", 0) > 0
+            or any("custom_tool_call" in evt for evt in event_types)
+        )
+        has_output_item_events = event_types.get("response.output_item.added", 0) > 0
+
+        assert has_x_search_events or has_output_item_events, (
+            f"Expected x_search-related streaming events. Got: {list(event_types.keys())}"
+        )
+
+    @skip_if_no_api_key("xai")
+    def test_xai_x_search_streaming_with_params(self, openai_client, test_config):
+        """xAI x_search: streaming with allowed_x_handles, date range, and tool_choice=required."""
+        model = format_provider_model("xai", get_config().get_provider_model("xai", "chat"))
+        _today = datetime.now().date()
+        _from_date = ((_today - timedelta(days=30)).isoformat())
+        _to_date = ((_today - timedelta(days=15)).isoformat())
+
+        stream = openai_client.responses.create(
+            model=model,
+            input="What has the xAI team been posting about recently?",
+            tools=[
+                {
+                    "type": "x_search",
+                    "allowed_x_handles": ["xai", "grok"],
+                    "from_date": _from_date,
+                    "to_date": _to_date,
+                    "enable_image_understanding": False,
+                    "enable_video_understanding": False,
+                }
+            ],
+            tool_choice="required",
+            max_output_tokens=500,
+            stream=True,
+        )
+
+        content, chunk_count, _tool_calls_detected, event_types = (
+            collect_responses_streaming_content(stream, timeout=300)
+        )
+
+        assert chunk_count > 0, "Should receive at least one chunk"
+
+        has_output_events = any(
+            "output_item" in evt or "output_text" in evt or "custom_tool_call" in evt
+            for evt in event_types
+        )
+        assert has_output_events, (
+            f"Expected output-related events in stream. Got: {list(event_types.keys())}"
+        )
+
+        assert len(content) > 0, "Streaming response should contain content from x_search results"
 
     # =========================================================================
     # TEXT COMPLETIONS API TEST CASES


### PR DESCRIPTION
## Summary

Adds support for xAI's native `x_search` tool in the Responses API. Previously, the tool-type filter in `filterUnsupportedTools` would strip `x_search` from requests routed to xAI because it wasn't part of the OpenAI spec. This change propagates the originating provider through the request pipeline so provider-specific tools can be selectively allowed.

## Changes

- Added `ResponsesToolTypeXSearch` (`"x_search"`) as a recognized `ResponsesToolType` constant
- Defined `ResponsesToolXSearch` struct with all optional xAI-specific fields: `allowed_x_handles`, `excluded_x_handles`, `from_date`, `to_date`, `enable_image_understanding`, `enable_video_understanding`
- Wired `ResponsesToolXSearch` into `ResponsesTool` marshal/unmarshal logic
- Added a `Provider` field (tagged `json:"-"`) to `OpenAIResponsesRequest` so the originating provider is available during filtering without being serialized to the wire
- Populated `Provider` from `BifrostResponsesRequest` in `ToOpenAIResponsesRequest`
- Updated `filterUnsupportedTools` to allow `x_search` when the provider is `xAI`, keeping it stripped for all other providers
- Added six integration tests covering non-streaming and streaming `x_search` usage with various parameter combinations (no params, `allowed_x_handles`, date ranges, all params combined)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Core
go test ./...

# Integration tests (requires xAI API key)
cd tests/integrations/python
pytest tests/test_openai.py -k "xai_x_search" -v
```

The integration tests route through Bifrost's `/openai` endpoint using a model prefixed with `xai/`. Each test asserts that `custom_tool_call` output items (named `x_semantic_search` or `x_keyword_search`) appear in the response, confirming the tool was not filtered and xAI executed the search.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The `Provider` field is tagged `json:"-"` and is never serialized to the outbound request. No credentials or PII are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for X search tool (x_search) in Responses API and enabled xAI model integration with configurable params: allowed handles, date ranges, and image/video understanding.

* **Bug Fixes**
  * Prevents validation errors when no tools remain by clearing tool choice for empty-tool requests.

* **Tests**
  * Added comprehensive integration and end-to-end tests (non-streaming and streaming) covering x_search scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->