### PR TITLE
feat: add `mcp_library` table schema and sync config

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -866,6 +866,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddModelConfigBudgetsFKConstraint(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddMCPLibraryTable(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -9772,6 +9775,40 @@ func migrationAddCustomerBudgetsToBudgetsTable(ctx context.Context, db *gorm.DB)
 	}
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_customer_budgets_to_budgets_table migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPLibraryTable creates the mcp_library table, the synced-only
+// catalog of discoverable MCP servers. Rows are populated from the external MCP
+// library datasheet on a configurable interval (mirroring the model-pricing
+// sync), so this migration only stands up the schema; no rows exist yet.
+func migrationAddMCPLibraryTable(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_mcp_library_table",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasTable(&tables.TableMCPLibrary{}) {
+				if err := mg.CreateTable(&tables.TableMCPLibrary{}); err != nil {
+					return fmt.Errorf("create mcp_library table: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasTable(&tables.TableMCPLibrary{}) {
+				if err := mg.DropTable(&tables.TableMCPLibrary{}); err != nil {
+					return fmt.Errorf("drop mcp_library table: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_library_table migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/mcp_library.go
+++ b/framework/configstore/tables/mcp_library.go
@@ -1,0 +1,65 @@
+package tables
+
+import (
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TableMCPLibrary represents a single discoverable MCP server in the MCP
+// library catalog. Rows are synced from the external MCP library datasheet
+// (see modelcatalog.DefaultMCPLibraryURL) on a configurable interval — this is
+// a read-only, synced-only catalog that users browse and install from,
+// mirroring the governance_model_pricing / governance_model_parameters tables.
+//
+// A row is a *template* for an schemas.MCPClientConfig: it carries the
+// connection details a user needs to install the server, shaped the same way
+// the live config is. The connection fields are mutually exclusive by
+// ConnectionType — ConnectionURL for http/sse, StdioConfig for stdio — matching
+// MCPClientConfig.ConnectionString / MCPClientConfig.StdioConfig.
+//
+// Each row is keyed by a stable slug derived from the display name so the sync
+// upsert is idempotent.
+type TableMCPLibrary struct {
+	ID          uint   `gorm:"primaryKey;autoIncrement" json:"id"`
+	Slug        string `gorm:"type:varchar(255);not null;uniqueIndex:idx_mcp_library_slug" json:"slug"`
+	Name        string `gorm:"type:varchar(255);not null" json:"name"`
+	Description string `gorm:"type:text" json:"description,omitempty"`
+	Category    string `gorm:"type:varchar(100);index:idx_mcp_library_category" json:"category,omitempty"`
+
+	// ConnectionType is one of schemas.MCPConnectionType ("http" | "stdio" |
+	// "sse") and selects which connection field below is populated.
+	ConnectionType schemas.MCPConnectionType `gorm:"type:varchar(20);not null" json:"connection_type"`
+
+	// ConnectionURL is the server endpoint for http/sse entries (parallel to
+	// MCPClientConfig.ConnectionString). Empty for stdio entries. Stored as a
+	// plain template string — the catalog publishes no secrets, so callers
+	// supply auth at install time.
+	ConnectionURL string `gorm:"type:text" json:"connection_url,omitempty"`
+
+	// StdioConfig holds the command/args/env names for stdio entries (parallel
+	// to MCPClientConfig.StdioConfig). Nil for http/sse entries. Envs lists the
+	// environment variable *names* the user must provide locally; no values are
+	// ever published in the catalog.
+	StdioConfig *schemas.MCPStdioConfig `gorm:"type:text;serializer:json;default:null" json:"stdio_config,omitempty"`
+
+	// AuthType declares what authentication the server expects (none, headers,
+	// oauth, ...) so the install UI can prompt accordingly. RequiredHeaderKeys
+	// lists the header names a headers/per-user-headers server needs — values
+	// are supplied by the user at install time, never stored in the catalog.
+	AuthType           schemas.MCPAuthType `gorm:"type:varchar(20);default:'none'" json:"auth_type,omitempty"`
+	RequiredHeaderKeys []string            `gorm:"type:text;serializer:json;default:null" json:"required_header_keys,omitempty"`
+
+	// Presentation / discovery metadata.
+	IconURL   string         `gorm:"type:text" json:"icon_url,omitempty"`
+	DocsURL   string         `gorm:"type:text" json:"docs_url,omitempty"`
+	Publisher string         `gorm:"type:varchar(255)" json:"publisher,omitempty"`
+	Tags      []string       `gorm:"type:text;serializer:json;default:null" json:"tags,omitempty"`
+	Metadata  map[string]any `gorm:"type:text;serializer:json;default:null" json:"metadata,omitempty"`
+
+	CreatedAt time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
+}
+
+// TableName sets the table name for the MCP library catalog.
+func (TableMCPLibrary) TableName() string { return "mcp_library" }

--- a/framework/modelcatalog/config.go
+++ b/framework/modelcatalog/config.go
@@ -12,8 +12,9 @@ const (
 	DefaultSyncInterval           = datasheet.DefaultSyncInterval
 	MinimumPricingSyncIntervalSec = int64(3600)
 
-	ConfigLastPricingSyncKey = "LastModelPricingSync"
-	ConfigLastParamsSyncKey  = "LastModelParametersSync"
+	ConfigLastPricingSyncKey     = "LastModelPricingSync"
+	ConfigLastParamsSyncKey     = "LastModelParametersSync"
+	ConfigLastMCPLibrarySyncKey = "LastMCPLibrarySync"
 )
 
 // Config is the model pricing configuration.
@@ -21,6 +22,12 @@ type Config struct {
 	PricingURL          *string `json:"pricing_url,omitempty"`
 	PricingSyncInterval *int64  `json:"pricing_sync_interval,omitempty"` // seconds
 	ModelParametersURL  *string `json:"model_parameters_url,omitempty"`
+
+	// MCPLibraryURL overrides the endpoint the MCP server library catalog is
+	// synced from. Empty/nil uses DefaultMCPLibraryURL. Mirrors PricingURL: the
+	// default ships out of the box and the user can point it at a custom source.
+	MCPLibraryURL          *string `json:"mcp_library_url,omitempty"`
+	MCPLibrarySyncInterval *int64  `json:"mcp_library_sync_interval,omitempty"` // seconds
 }
 
 // Type re-exports so external callers can continue importing the legacy


### PR DESCRIPTION
## Summary

Introduces the `mcp_library` database table and its associated schema, laying the groundwork for a discoverable MCP server catalog. The table is designed to be populated via a periodic sync from an external MCP library datasheet (mirroring the existing model pricing/parameters sync pattern), and serves as a read-only catalog that users can browse and install MCP servers from.

## Changes

- Added `TableMCPLibrary` struct defining the `mcp_library` table schema, keyed by a stable slug for idempotent upserts. Stores connection details (HTTP/SSE URL or stdio config), auth metadata (type and required header key names), and presentation fields (icon, docs, publisher, tags).
- Added `migrationAddMCPLibraryTable` migration with both `Migrate` and `Rollback` paths to create/drop the `mcp_library` table, registered in the `triggerMigrations` chain.
- Extended `modelcatalog.Config` with `MCPLibraryURL` and `MCPLibrarySyncInterval` fields, and added `ConfigLastMCPLibrarySyncKey` to track the last sync timestamp — mirroring the existing pricing and model parameters sync configuration.

No rows are inserted by this migration; the schema is stood up here and data population is handled separately by the sync process.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./framework/modelcatalog/...
```

- Verify the `mcp_library` table is created on a fresh migration run.
- Verify the rollback drops the table cleanly.
- Verify re-running the migration is idempotent (no error if table already exists).

New config fields available in `modelcatalog.Config`:
- `mcp_library_url` — overrides the default MCP library datasheet endpoint.
- `mcp_library_sync_interval` — sync frequency in seconds (mirrors `pricing_sync_interval`).

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- `RequiredHeaderKeys` stores only header *names*, never values. Auth credentials are supplied by the user at install time and are never persisted in the catalog, matching the stated design intent.
- `StdioConfig` stores command/args/env variable *names* only; no secrets are published in the catalog rows.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP library catalog with persistent database storage and migration support.
  * Introduced configurable MCP library source URL and synchronization interval settings for catalog sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->