### PR TITLE
feat: add MCP library catalog sync, paginated listing, and filter data endpoints

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1609,7 +1609,204 @@ func (s *RDBConfigStore) GetMCPClientsPaginated(ctx context.Context, params MCPC
 	return clients, totalCount, nil
 }
 
-// GetMCPClientByID retrieves an MCP client by ID from the database.
+// mcpLibrarySortColumns whitelists the columns the MCP library list endpoint
+// may sort by. Restricting to a fixed set keeps the ORDER BY clause free of
+// caller-supplied identifiers.
+var mcpLibrarySortColumns = map[string]string{
+	"name":       "name",
+	"category":   "category",
+	"publisher":  "publisher",
+	"created_at": "created_at",
+	"updated_at": "updated_at",
+}
+
+// GetMCPLibraryPaginated retrieves MCP library catalog entries with optional
+// search, filtering, sorting, and pagination. Returns the page of rows and the
+// total count matching the filters (before pagination).
+func (s *RDBConfigStore) GetMCPLibraryPaginated(ctx context.Context, params MCPLibraryQueryParams) ([]tables.TableMCPLibrary, int64, error) {
+	baseQuery := s.DB().WithContext(ctx).Model(&tables.TableMCPLibrary{})
+
+	if params.Search != "" {
+		search := "%" + strings.ToLower(params.Search) + "%"
+		baseQuery = baseQuery.Where(
+			"LOWER(name) LIKE ? OR LOWER(description) LIKE ? OR LOWER(publisher) LIKE ?",
+			search, search, search,
+		)
+	}
+	if len(params.Categories) > 0 {
+		baseQuery = baseQuery.Where("category IN ?", params.Categories)
+	}
+	if len(params.ConnectionTypes) > 0 {
+		baseQuery = baseQuery.Where("connection_type IN ?", params.ConnectionTypes)
+	}
+	if len(params.AuthTypes) > 0 {
+		baseQuery = baseQuery.Where("auth_type IN ?", params.AuthTypes)
+	}
+	// Tags are stored as a JSON-encoded array string; match rows whose JSON
+	// contains any requested tag as a quoted token. This is a substring match
+	// over the serialized array, which is sufficient for the catalog's small,
+	// well-formed tag values and avoids a DB-specific JSON operator. LIKE
+	// metacharacters in the tag are escaped (with an explicit ESCAPE clause) so
+	// a tag containing % or _ matches literally instead of as a wildcard.
+	likeEscaper := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	for _, tag := range params.Tags {
+		if tag == "" {
+			continue
+		}
+		escapedTag := likeEscaper.Replace(tag)
+		baseQuery = baseQuery.Where(`tags LIKE ? ESCAPE '\'`, `%"`+escapedTag+`"%`)
+	}
+
+	var totalCount int64
+	if err := baseQuery.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+
+	limit := params.Limit
+	offset := params.Offset
+	if limit <= 0 {
+		limit = 25
+	} else if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	sortColumn := "name"
+	if col, ok := mcpLibrarySortColumns[params.SortBy]; ok {
+		sortColumn = col
+	}
+	dir := "ASC"
+	if strings.EqualFold(params.Order, "desc") {
+		dir = "DESC"
+	}
+	// id as a stable tiebreaker so paging is deterministic across equal keys.
+	orderClause := fmt.Sprintf("%s %s, id ASC", sortColumn, dir)
+
+	var entries []tables.TableMCPLibrary
+	if err := baseQuery.
+		Order(orderClause).
+		Offset(offset).
+		Limit(limit).
+		Find(&entries).Error; err != nil {
+		return nil, 0, err
+	}
+	return entries, totalCount, nil
+}
+
+// GetMCPLibraryFilterData returns the distinct facet values for the MCP library
+// filter sidebar: categories, connection types, auth types, and tags. Empty
+// values are skipped. Tags are stored as JSON arrays, so they are decoded and
+// unioned in Go rather than via a DB-specific JSON operator.
+func (s *RDBConfigStore) GetMCPLibraryFilterData(ctx context.Context) (*MCPLibraryFilterData, error) {
+	db := s.DB().WithContext(ctx)
+	result := &MCPLibraryFilterData{
+		Categories:      []string{},
+		ConnectionTypes: []string{},
+		AuthTypes:       []string{},
+		Tags:            []string{},
+	}
+
+	distinct := func(column string, dst *[]string) error {
+		var values []string
+		if err := db.Model(&tables.TableMCPLibrary{}).
+			Distinct(column).
+			Where(column+" IS NOT NULL AND "+column+" != ?", "").
+			Order(column+" ASC").
+			Pluck(column, &values).Error; err != nil {
+			return err
+		}
+		*dst = append(*dst, values...)
+		return nil
+	}
+
+	if err := distinct("category", &result.Categories); err != nil {
+		return nil, err
+	}
+	if err := distinct("connection_type", &result.ConnectionTypes); err != nil {
+		return nil, err
+	}
+	if err := distinct("auth_type", &result.AuthTypes); err != nil {
+		return nil, err
+	}
+
+	// Tags: gather distinct JSON blobs, decode, and union the values.
+	var tagBlobs []string
+	if err := db.Model(&tables.TableMCPLibrary{}).
+		Distinct("tags").
+		Where("tags IS NOT NULL AND tags != ?", "").
+		Pluck("tags", &tagBlobs).Error; err != nil {
+		return nil, err
+	}
+	tagSet := make(map[string]struct{})
+	for _, blob := range tagBlobs {
+		var tags []string
+		if err := json.Unmarshal([]byte(blob), &tags); err != nil {
+			continue // skip malformed blobs rather than failing the whole request
+		}
+		for _, tag := range tags {
+			if tag == "" {
+				continue
+			}
+			tagSet[tag] = struct{}{}
+		}
+	}
+	for tag := range tagSet {
+		result.Tags = append(result.Tags, tag)
+	}
+	sort.Strings(result.Tags)
+
+	return result, nil
+}
+
+// mcpLibrarySyncUpdateColumns enumerates the columns the MCP library sync may
+// overwrite on conflict. The list is explicit (not UpdateAll) so id/created_at
+// are preserved and any future editorial-only columns can be excluded.
+var mcpLibrarySyncUpdateColumns = []string{
+	"name",
+	"description",
+	"category",
+	"connection_type",
+	"connection_url",
+	"stdio_config",
+	"auth_type",
+	"required_header_keys",
+	"icon_url",
+	"docs_url",
+	"publisher",
+	"tags",
+	"metadata",
+	"updated_at",
+}
+
+// UpsertMCPLibraryEntry creates or updates an MCP library catalog row, keyed by
+// the unique slug. Mirrors UpsertModelPrices: a single atomic ON CONFLICT
+// statement so concurrent syncs across nodes don't deadlock.
+func (s *RDBConfigStore) UpsertMCPLibraryEntry(ctx context.Context, entry *tables.TableMCPLibrary, tx ...*gorm.DB) error {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+	db := txDB.WithContext(ctx)
+
+	if err := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "slug"}},
+		DoUpdates: clause.AssignmentColumns(mcpLibrarySyncUpdateColumns),
+		// Atomically protect custom/tombstoned rows: only overwrite an existing
+		// row if it is still a live remote row. This closes the TOCTOU race where
+		// a row turns custom or is soft-deleted between the snapshot taken by
+		// GetProtectedMCPLibrarySlugs and this upsert. INSERTs are unaffected.
+		Where: clause.Where{Exprs: []clause.Expression{
+			clause.Expr{SQL: "mcp_library.source = 'remote' AND mcp_library.deleted_at IS NULL"},
+		}},
+	}).Create(entry).Error; err != nil {
+		return s.parseGormError(err)
+	}
+	return nil
+}
 func (s *RDBConfigStore) GetMCPClientByID(ctx context.Context, id string) (*tables.TableMCPClient, error) {
 	var mcpClient tables.TableMCPClient
 	if err := s.DB().WithContext(ctx).Where("client_id = ?", id).First(&mcpClient).Error; err != nil {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -51,6 +51,30 @@ type MCPClientsQueryParams struct {
 	Search string
 }
 
+// MCPLibraryQueryParams holds pagination, filtering, search, and sort
+// parameters for MCP library catalog queries. All fields are optional — an
+// empty struct returns the first default-sized page ordered by name.
+type MCPLibraryQueryParams struct {
+	Limit          int
+	Offset         int
+	Search         string   // matches name/description/publisher (case-insensitive)
+	Categories     []string // exact category filter(s), OR semantics
+	ConnectionTypes []string // exact connection_type filter(s) (http | stdio | sse)
+	AuthTypes      []string // exact auth_type filter(s)
+	Tags           []string // match rows carrying any of these tags
+	SortBy         string // name, category, publisher, created_at, updated_at (default: name)
+	Order          string // asc, desc (default: asc)
+}
+
+// MCPLibraryFilterData holds the distinct facet values surfaced by the filter
+// sidebar on the MCP library page. Populated via GetMCPLibraryFilterData.
+type MCPLibraryFilterData struct {
+	Categories      []string `json:"categories"`
+	ConnectionTypes []string `json:"connection_types"`
+	AuthTypes       []string `json:"auth_types"`
+	Tags            []string `json:"tags"`
+}
+
 // TeamsQueryParams holds pagination, filtering, and search parameters for team queries.
 type TeamsQueryParams struct {
 	Limit      int
@@ -165,6 +189,11 @@ type ConfigStore interface {
 	CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error
 	UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient) error
 	DeleteMCPClientConfig(ctx context.Context, id string) error
+
+	// MCP library catalog (synced, read-only)
+	GetMCPLibraryPaginated(ctx context.Context, params MCPLibraryQueryParams) ([]tables.TableMCPLibrary, int64, error)
+	GetMCPLibraryFilterData(ctx context.Context) (*MCPLibraryFilterData, error)
+	UpsertMCPLibraryEntry(ctx context.Context, entry *tables.TableMCPLibrary, tx ...*gorm.DB) error
 
 	// Vector store config CRUD
 	UpdateVectorStoreConfig(ctx context.Context, config *vectorstore.Config) error

--- a/framework/modelcatalog/mcp_library_sync.go
+++ b/framework/modelcatalog/mcp_library_sync.go
@@ -1,0 +1,223 @@
+package modelcatalog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"gorm.io/gorm"
+)
+
+// MCPLibraryEntry is the JSON shape a single server has in the remote MCP
+// library catalog (the payload fetched from DefaultMCPLibraryURL / custom URL).
+// The catalog carries no slug; it is derived from Name at sync time via
+// Slugify. The remaining fields map onto TableMCPLibrary minus the DB-managed
+// fields (ID, Slug, CreatedAt, UpdatedAt).
+type MCPLibraryEntry struct {
+	Name               string                    `json:"name"`
+	Description        string                    `json:"description,omitempty"`
+	Category           string                    `json:"category,omitempty"`
+	ConnectionType     schemas.MCPConnectionType `json:"connection_type"`
+	ConnectionURL      string                    `json:"connection_url,omitempty"`
+	StdioConfig        *schemas.MCPStdioConfig   `json:"stdio_config,omitempty"`
+	AuthType           schemas.MCPAuthType       `json:"auth_type,omitempty"`
+	RequiredHeaderKeys []string                  `json:"required_header_keys,omitempty"`
+	IconURL            string                    `json:"icon_url,omitempty"`
+	DocsURL            string                    `json:"docs_url,omitempty"`
+	Publisher          string                    `json:"publisher,omitempty"`
+	Tags               []string                  `json:"tags,omitempty"`
+	Metadata           map[string]any            `json:"metadata,omitempty"`
+}
+
+// MCPLibraryPayload is the top-level JSON envelope returned by the remote
+// MCP library catalog endpoint.
+type MCPLibraryPayload struct {
+	Servers       []MCPLibraryEntry `json:"servers"`
+	LastUpdatedAt string            `json:"lastUpdatedAt,omitempty"`
+}
+
+// SyncMCPLibrary fetches the MCP server catalog from url, parses the JSON
+// payload, and upserts each row into the mcp_library table keyed by slug.
+// Returns the number of rows upserted.
+//
+// The function is intentionally stateless and operates directly on the
+// ConfigStore so it can be called from both the force-sync handler and the
+// background worker without needing a dedicated manager struct.
+func SyncMCPLibrary(ctx context.Context, url string, store configstore.ConfigStore) (int, error) {
+	if url == "" {
+		url = DefaultMCPLibraryURL
+	}
+
+	entries, err := WithRetries(ctx, urlFetchMaxRetries, urlFetchMaxBackoff, func() ([]MCPLibraryEntry, error) {
+		return fetchMCPLibrary(ctx, url)
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch MCP library from %s: %w", url, err)
+	}
+
+	if len(entries) == 0 {
+		return 0, nil
+	}
+
+	// Upsert all entries in a single transaction.
+	count := 0
+	err = store.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		seen := make(map[string]bool, len(entries))
+		for i := range entries {
+			e := &entries[i]
+			if e.Name == "" {
+				continue // skip malformed entries
+			}
+			if seen[slug] {
+				continue // deduplicate within the payload
+			}
+			seen[slug] = true
+
+			now := time.Now()
+			row := &configstoreTables.TableMCPLibrary{
+				Slug:               slug,
+				Name:               e.Name,
+				Description:        e.Description,
+				Category:           e.Category,
+				ConnectionType:     e.ConnectionType,
+				ConnectionURL:      e.ConnectionURL,
+				StdioConfig:        e.StdioConfig,
+				AuthType:           e.AuthType,
+				RequiredHeaderKeys: e.RequiredHeaderKeys,
+				IconURL:            e.IconURL,
+				DocsURL:            e.DocsURL,
+				Publisher:          e.Publisher,
+				Tags:               e.Tags,
+				Metadata:           e.Metadata,
+				CreatedAt:          now,
+				UpdatedAt:          now,
+			}
+			if err := store.UpsertMCPLibraryEntry(ctx, row, tx); err != nil {
+				return fmt.Errorf("failed to upsert MCP library entry %q: %w", slug, err)
+			}
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to sync MCP library to database: %w", err)
+	}
+
+	return count, nil
+}
+
+// syncMCPLibrary is the ModelCatalog method called by the background sync worker
+// and ForceReloadPricing. It delegates to the stateless SyncMCPLibrary function
+// using the catalog's configured URL and config store.
+func (mc *ModelCatalog) syncMCPLibrary(ctx context.Context) error {
+	if mc.shouldSyncGate != nil && !mc.shouldSyncGate(ctx) {
+		mc.logger.Debug("MCP library sync cancelled by custom gate")
+		return nil
+	}
+	_, err := mc.syncMCPLibraryNow(ctx)
+	return err
+}
+
+// ForceReloadMCPLibrary triggers an immediate MCP library sync from the current
+// configured source and advances the MCP library sync timer on success.
+func (mc *ModelCatalog) ForceReloadMCPLibrary(ctx context.Context) (int, error) {
+	if mc.shouldSyncGate != nil && !mc.shouldSyncGate(ctx) {
+		mc.logger.Debug("MCP library sync cancelled by custom gate")
+		return 0, nil
+	}
+	count, err := mc.syncMCPLibraryNow(ctx)
+	if err != nil {
+		return 0, err
+	}
+	mc.syncMu.Lock()
+	mc.lastMCPLibrarySyncedAt = time.Now()
+	mc.syncMu.Unlock()
+	return count, nil
+}
+
+func (mc *ModelCatalog) syncMCPLibraryNow(ctx context.Context) (int, error) {
+	if mc.configStore == nil {
+		return 0, nil
+	}
+	url := mc.getMCPLibraryURL()
+	count, err := SyncMCPLibrary(ctx, url, mc.configStore)
+	if err != nil {
+		return 0, err
+	}
+	mc.logger.Info("MCP library sync completed: %d entries synced from %s", count, url)
+	return count, nil
+}
+
+// getMCPLibraryURL returns a copy of the MCP library URL under mutex protection.
+func (mc *ModelCatalog) getMCPLibraryURL() string {
+	mc.syncMu.RLock()
+	defer mc.syncMu.RUnlock()
+	return mc.mcpLibraryURL
+}
+
+// fetchMCPLibrary downloads and parses the MCP library JSON from the given URL.
+func fetchMCPLibrary(ctx context.Context, rawURL string) ([]MCPLibraryEntry, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse MCP library URL: %w", err)
+	}
+
+	var data []byte
+	if parsed.Scheme == "file" {
+		f, err := os.Open(parsed.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open MCP library file: %w", err)
+		}
+		defer f.Close()
+		data, err = io.ReadAll(io.LimitReader(f, maxMCPLibraryBodyBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read MCP library file: %w", err)
+		}
+		if int64(len(data)) > maxMCPLibraryBodyBytes {
+			return nil, fmt.Errorf("MCP library file exceeds %d bytes", maxMCPLibraryBodyBytes)
+		}
+	} else {
+		if err := bifrost.ValidateExternalURL(rawURL, true); err != nil {
+			return nil, fmt.Errorf("MCP library URL validation failed: %w", err)
+		}
+		client := &http.Client{Timeout: DefaultMCPLibraryTimeout}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download MCP library data: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to download MCP library data: HTTP %d", resp.StatusCode)
+		}
+
+		data, err = io.ReadAll(io.LimitReader(resp.Body, maxMCPLibraryBodyBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read MCP library response: %w", err)
+		}
+		if int64(len(data)) > maxMCPLibraryBodyBytes {
+			return nil, fmt.Errorf("MCP library response exceeds %d bytes", maxMCPLibraryBodyBytes)
+		}
+	}
+
+	var payload MCPLibraryPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal MCP library data: %w", err)
+	}
+
+	return payload.Servers, nil
+}

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -20,6 +20,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 	"gorm.io/gorm"
@@ -69,6 +70,9 @@ func NewMCPHandler(mcpManager MCPManager, governanceManager GovernanceManager, c
 // RegisterRoutes registers all MCP-related routes
 func (h *MCPHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
 	r.GET("/api/mcp/clients", lib.ChainMiddlewares(h.getMCPClients, middlewares...))
+	r.GET("/api/mcp/library", lib.ChainMiddlewares(h.getMCPLibrary, middlewares...))
+	r.GET("/api/mcp/library/filterdata", lib.ChainMiddlewares(h.getMCPLibraryFilterData, middlewares...))
+	r.POST("/api/mcp/library/force-sync", lib.ChainMiddlewares(h.forceSyncMCPLibrary, middlewares...))
 	r.POST("/api/mcp/client", lib.ChainMiddlewares(h.addMCPClient, middlewares...))
 	r.PUT("/api/mcp/client/{id}", lib.ChainMiddlewares(h.updateMCPClient, middlewares...))
 	r.DELETE("/api/mcp/client/{id}", lib.ChainMiddlewares(h.deleteMCPClient, middlewares...))
@@ -110,6 +114,132 @@ func (h *MCPHandler) getMCPClients(ctx *fasthttp.RequestCtx) {
 	searchStr := string(ctx.QueryArgs().Peek("search"))
 
 	h.getMCPClientsPaginated(ctx, limitStr, offsetStr, searchStr)
+}
+
+// getMCPLibrary handles GET /api/mcp/library — paginated, searchable, filterable
+// listing of the synced MCP server catalog. All query parameters are optional.
+func (h *MCPHandler) getMCPLibrary(ctx *fasthttp.RequestCtx) {
+	emptyResponse := map[string]interface{}{
+		"servers":     []configstoreTables.TableMCPLibrary{},
+		"count":       0,
+		"total_count": 0,
+		"limit":       0,
+		"offset":      0,
+	}
+	if h.store.ConfigStore == nil {
+		SendJSON(ctx, emptyResponse)
+		return
+	}
+
+	params := configstore.MCPLibraryQueryParams{
+		Search:          string(ctx.QueryArgs().Peek("search")),
+		Categories:      parseCommaSeparated(string(ctx.QueryArgs().Peek("category"))),
+		ConnectionTypes: parseCommaSeparated(string(ctx.QueryArgs().Peek("connection_type"))),
+		AuthTypes:       parseCommaSeparated(string(ctx.QueryArgs().Peek("auth_type"))),
+		Tags:            parseCommaSeparated(string(ctx.QueryArgs().Peek("tags"))),
+		SortBy:          string(ctx.QueryArgs().Peek("sort_by")),
+		Order:           string(ctx.QueryArgs().Peek("order")),
+	}
+
+	if limitStr := string(ctx.QueryArgs().Peek("limit")); limitStr != "" {
+		n, err := strconv.Atoi(limitStr)
+		if err != nil {
+			SendError(ctx, 400, "Invalid limit parameter: must be a number")
+			return
+		}
+		if n < 0 {
+			SendError(ctx, 400, "Invalid limit parameter: must be non-negative")
+			return
+		}
+		params.Limit = n
+	}
+	if offsetStr := string(ctx.QueryArgs().Peek("offset")); offsetStr != "" {
+		n, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			SendError(ctx, 400, "Invalid offset parameter: must be a number")
+			return
+		}
+		if n < 0 {
+			SendError(ctx, 400, "Invalid offset parameter: must be non-negative")
+			return
+		}
+		params.Offset = n
+	}
+	params.Limit, params.Offset = ClampPaginationParams(params.Limit, params.Offset)
+
+	entries, totalCount, err := h.store.ConfigStore.GetMCPLibraryPaginated(ctx, params)
+	if err != nil {
+		logger.Error("failed to retrieve MCP library entries: %v", err)
+		SendError(ctx, 500, "Failed to retrieve MCP library entries")
+		return
+	}
+
+	SendJSON(ctx, map[string]interface{}{
+		"servers":     entries,
+		"count":       len(entries),
+		"total_count": totalCount,
+		"limit":       params.Limit,
+		"offset":      params.Offset,
+	})
+}
+
+// getMCPLibraryFilterData handles GET /api/mcp/library/filterdata — returns the
+// distinct facet values (categories, connection types, auth types, tags) that
+// drive the MCP library filter sidebar.
+func (h *MCPHandler) getMCPLibraryFilterData(ctx *fasthttp.RequestCtx) {
+	emptyResponse := configstore.MCPLibraryFilterData{
+		Categories:      []string{},
+		ConnectionTypes: []string{},
+		AuthTypes:       []string{},
+		Tags:            []string{},
+	}
+	if h.store.ConfigStore == nil {
+		SendJSON(ctx, emptyResponse)
+		return
+	}
+
+	data, err := h.store.ConfigStore.GetMCPLibraryFilterData(ctx)
+	if err != nil {
+		logger.Error("failed to retrieve MCP library filter data: %v", err)
+		SendError(ctx, 500, "Failed to retrieve MCP library filter data")
+		return
+	}
+	SendJSON(ctx, data)
+}
+
+// forceSyncMCPLibrary handles POST /api/mcp/library/force-sync — triggers an
+// immediate sync of the MCP server library catalog from the configured source.
+// Mirrors ConfigHandler.forceSyncPricing → ForceReloadPricing.
+func (h *MCPHandler) forceSyncMCPLibrary(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store not available")
+		return
+	}
+
+	var count int
+	var err error
+	if h.store.ModelCatalog != nil {
+		count, err = h.store.ModelCatalog.ForceReloadMCPLibrary(ctx)
+	} else {
+		// Resolve the effective MCP library URL from framework config (DB → file → default).
+		mcpLibraryURL := modelcatalog.DefaultMCPLibraryURL
+		if h.store.FrameworkConfig != nil && h.store.FrameworkConfig.Pricing != nil && h.store.FrameworkConfig.Pricing.MCPLibraryURL != nil {
+			if u := *h.store.FrameworkConfig.Pricing.MCPLibraryURL; u != "" {
+				mcpLibraryURL = u
+			}
+		}
+		count, err = modelcatalog.SyncMCPLibrary(ctx, mcpLibraryURL, h.store.ConfigStore)
+	}
+	if err != nil {
+		logger.Error("failed to sync MCP library: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to sync MCP library: %v", err))
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"status":  "success",
+		"message": fmt.Sprintf("MCP library sync completed, %d entries synced", count),
+	})
 }
 
 // getMCPClientsPaginated handles the paginated path for GET /api/mcp/clients

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -635,6 +635,10 @@ func (m *MockConfigStore) GetMCPClientsPaginated(ctx context.Context, params con
 	return nil, 0, nil
 }
 
+func (m *MockConfigStore) GetMCPLibraryPaginated(ctx context.Context, params configstore.MCPLibraryQueryParams) ([]tables.TableMCPLibrary, int64, error) {
+	return nil, 0, nil
+}
+
 func (m *MockConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) error {
 	if m.mcpConfig == nil {
 		return nil


### PR DESCRIPTION
## Summary

Adds a synced MCP server library catalog to Bifrost. The catalog is fetched from a remote (or local file) JSON endpoint, persisted in the `mcp_library` table via upsert, and exposed through three new HTTP endpoints for browsing and filtering. This enables users to discover pre-configured MCP servers without manually entering connection details.

## Changes

- Added `GetMCPLibraryPaginated`, `GetMCPLibraryFilterData`, and `UpsertMCPLibraryEntry` to the `ConfigStore` interface and their RDB implementations, supporting search, multi-value filtering (categories, connection types, auth types, tags), sorting with a stable tiebreaker, and safe pagination clamping.
- Introduced `MCPLibraryQueryParams` and `MCPLibraryFilterData` types to carry query and response shapes cleanly across the store/handler boundary.
- Added `SyncMCPLibrary` in `framework/modelcatalog/mcp_library_sync.go` — a stateless function that fetches the remote catalog (HTTP or `file://`), deduplicates by slug within the payload, and upserts all entries in a single transaction. Supports retry with backoff via the existing `WithRetries` helper.
- Exposed `syncMCPLibrary` and `ForceReloadMCPLibrary` methods on `ModelCatalog` so the background sync worker and force-sync handler share the same code path.
- Registered three new routes on `MCPHandler`:
  - `GET /api/mcp/library` — paginated, searchable, filterable catalog listing
  - `GET /api/mcp/library/filterdata` — distinct facet values for the filter sidebar
  - `POST /api/mcp/library/force-sync` — triggers an immediate catalog sync, delegating to `ModelCatalog` when available or falling back to the stateless `SyncMCPLibrary` directly
- Tag filtering uses a JSON substring match over the serialized array column to avoid DB-specific JSON operators, keeping the implementation portable across SQLite and Postgres.
- Sort columns are restricted to an explicit allowlist (`mcpLibrarySortColumns`) to prevent ORDER BY injection from caller-supplied identifiers.
- `id` is appended as a stable tiebreaker on all paginated queries so results are deterministic across equal sort keys.
- `mcpLibrarySyncUpdateColumns` is an explicit list (not `UpdateAll`) so `id` and `created_at` are preserved across syncs.
- Updated `MockConfigStore` in tests to satisfy the expanded `ConfigStore` interface.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

1. Start Bifrost with a config store enabled.
2. Trigger a catalog sync:
   ```sh
   curl -X POST http://localhost:PORT/api/mcp/library/force-sync
   # Expected: {"status":"success","message":"MCP library sync completed, N entries synced"}
   ```
3. Browse the catalog:
   ```sh
   curl "http://localhost:PORT/api/mcp/library?search=github&limit=10"
   curl "http://localhost:PORT/api/mcp/library?category=devtools&sort_by=name&order=desc"
   ```
4. Fetch filter facets:
   ```sh
   curl http://localhost:PORT/api/mcp/library/filterdata
   # Expected: {"categories":[...],"connection_types":[...],"auth_types":[...],"tags":[...]}
   ```

To use a local catalog file during development, set the MCP library URL to a `file:///path/to/catalog.json` path in the framework config.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

- Sort column names are validated against an explicit allowlist before being interpolated into the `ORDER BY` clause, preventing SQL injection via the `sort_by` query parameter.
- HTTP catalog URLs are validated through `bifrost.ValidateExternalURL` before any outbound request is made.
- `file://` scheme support is intentionally limited to the sync path and requires a valid local path, not a network resource.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP server library catalog with pagination, free-text search, facet filters (categories, connection types, auth types) and tag matching
  * Added facet-data endpoint returning distinct categories/connection/auth values and tags for UI filters
  * Added API endpoints to browse the catalog, fetch filter options, and trigger manual sync
  * Implemented catalog synchronization from remote or local sources; sync upserts only allowed syncable fields and avoids overwriting protected or soft-deleted rows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->