### PR TITLE
feat: modifies governance API to have both budget and budgets support

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1082,6 +1082,11 @@ func GenerateModelConfigHash(m tables.TableModelConfig) (string, error) {
 	writeHashField(hash, "scope_id", derefStr(m.ScopeID))
 	writeHashField(hash, "budget_id", derefStr(m.BudgetID))
 	writeHashField(hash, "rate_limit_id", derefStr(m.RateLimitID))
+	sortedBudgetIDs := append([]string(nil), m.BudgetIDs...)
+	sort.Strings(sortedBudgetIDs)
+	for _, id := range sortedBudgetIDs {
+		writeHashField(hash, "budget_ids", id)
+	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -74,6 +74,10 @@ type TableModelConfig struct {
 	// the scope target (e.g. the virtual key's name) so the UI can render a label
 	// instead of an opaque scope_id. Populated by the HTTP layer on read.
 	ScopeName string `gorm:"-" json:"scope_name,omitempty"`
+	// BudgetIDs is a config-file-only field listing pre-declared budget IDs (from
+	// governance.budgets) to link to this model config. Not persisted; used by the
+	// config sync path to set model_config_id on each referenced budget row.
+	BudgetIDs []string `gorm:"-" json:"budget_ids,omitempty"`
 
 	// Relationships
 	// Budgets are owned by this model config via TableBudget.ModelConfigID (a model

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -385,6 +385,34 @@ func findExistingBudget(request CreateBudgetRequest, byID map[string]configstore
 	return existing, found, nil
 }
 
+// coerceLegacyBudget converts a single UpdateBudgetRequest into a *[]CreateBudgetRequest
+// so it can be handled uniformly via reconcileModelConfigBudgets. Returns nil when the
+// request carries no actionable change (e.g. only one field set but no existing budget to
+// merge with, leaving the budget list unchanged).
+func coerceLegacyBudget(req *UpdateBudgetRequest, existing *configstoreTables.TableBudget) *[]CreateBudgetRequest {
+	if isBudgetRemovalRequest(req) {
+		empty := []CreateBudgetRequest{}
+		return &empty
+	}
+	b := CreateBudgetRequest{}
+	if existing != nil {
+		b.ID = existing.ID
+		b.MaxLimit = existing.MaxLimit
+		b.ResetDuration = existing.ResetDuration
+	}
+	if req.MaxLimit != nil {
+		b.MaxLimit = *req.MaxLimit
+	}
+	if req.ResetDuration != nil {
+		b.ResetDuration = *req.ResetDuration
+	}
+	if b.MaxLimit == 0 || b.ResetDuration == "" {
+		return nil
+	}
+	result := []CreateBudgetRequest{b}
+	return &result
+}
+
 func isRateLimitRemovalRequest(req *UpdateRateLimitRequest) bool {
 	return req != nil && req.TokenMaxLimit == nil && req.RequestMaxLimit == nil &&
 		req.TokenResetDuration == nil && req.RequestResetDuration == nil
@@ -837,8 +865,10 @@ type UpdateModelConfigRequest struct {
 
 // UpdateProviderGovernanceRequest represents the request body for updating provider governance
 type UpdateProviderGovernanceRequest struct {
-	Budget    *UpdateBudgetRequest    `json:"budget,omitempty"`
-	RateLimit *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	Budget          *UpdateBudgetRequest    `json:"budget,omitempty"`          // deprecated; use budgets
+	Budgets         *[]CreateBudgetRequest  `json:"budgets,omitempty"`         // nil=no change, []=remove all
+	RateLimit       *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	CalendarAligned *bool                   `json:"calendar_aligned,omitempty"`
 }
 
 // RegisterRoutes registers all governance-related routes for the new hierarchical system
@@ -3210,9 +3240,11 @@ func (h *GovernanceHandler) deleteModelConfig(ctx *fasthttp.RequestCtx) {
 
 // ProviderGovernanceResponse represents a provider with its governance settings
 type ProviderGovernanceResponse struct {
-	Provider  string                            `json:"provider"`
-	Budget    *configstoreTables.TableBudget    `json:"budget,omitempty"`
-	RateLimit *configstoreTables.TableRateLimit `json:"rate_limit,omitempty"`
+	Provider        string                            `json:"provider"`
+	Budget          *configstoreTables.TableBudget    `json:"budget,omitempty"` // deprecated: use budgets
+	Budgets         []configstoreTables.TableBudget   `json:"budgets,omitempty"`
+	RateLimit       *configstoreTables.TableRateLimit `json:"rate_limit,omitempty"`
+	CalendarAligned bool                              `json:"calendar_aligned"`
 }
 
 // modelConfigToProviderGovernance converts a model config to a ProviderGovernanceResponse.
@@ -3223,13 +3255,19 @@ func modelConfigToProviderGovernance(mc *configstoreTables.TableModelConfig) (Pr
 		mc.ModelName != configstoreTables.ModelConfigAllModels || mc.Provider == nil {
 		return ProviderGovernanceResponse{}, false
 	}
-	// Provider governance is single-budget by API; surface the first owned budget.
-	// This will be updated with the v2 endpoint, which can surface all budgets
 	var budget *configstoreTables.TableBudget
 	if len(mc.Budgets) > 0 {
 		budget = &mc.Budgets[0]
 	}
-	return ProviderGovernanceResponse{Provider: *mc.Provider, Budget: budget, RateLimit: mc.RateLimit}, true
+	budgets := make([]configstoreTables.TableBudget, len(mc.Budgets))
+	copy(budgets, mc.Budgets)
+	return ProviderGovernanceResponse{
+		Provider:        *mc.Provider,
+		Budget:          budget,
+		Budgets:         budgets,
+		RateLimit:       mc.RateLimit,
+		CalendarAligned: mc.CalendarAligned,
+	}, true
 }
 
 // getProviderGovernance handles GET /api/governance/providers - returns provider-level governance,
@@ -3273,6 +3311,10 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 	var req UpdateProviderGovernanceRequest
 	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
 		SendError(ctx, 400, "Invalid JSON")
+		return
+	}
+	if req.Budget != nil && req.Budgets != nil {
+		SendError(ctx, 400, "only one of 'budget' or 'budgets' may be set")
 		return
 	}
 	// Validate the provider exists.
@@ -3320,7 +3362,12 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 
 	deleted := false
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		var budgetIDToDelete, rateLimitIDToDelete string
+		var rateLimitIDToDelete string
+
+		// Apply CalendarAligned if provided.
+		if req.CalendarAligned != nil {
+			mc.CalendarAligned = *req.CalendarAligned
+		}
 
 		// Rate limit lifecycle (mc references it via RateLimitID, so resolve it before
 		// persisting the model config below).
@@ -3368,15 +3415,22 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			}
 		}
 
-		// Determine the budget outcome (without writing yet — budgets reference the mc,
-		// which may not exist yet for a new provider governance row).
-		removeBudget := req.Budget != nil && isBudgetRemovalRequest(req.Budget)
-		willHaveBudget := existingBudget != nil && !removeBudget
-		if req.Budget != nil && !removeBudget && existingBudget == nil {
-			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-				return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
+		// Determine effective budgets: budgets field takes priority; budget field is coerced
+		// into a single-element slice for backward compatibility.
+		effectiveBudgets := req.Budgets
+		if effectiveBudgets == nil && req.Budget != nil {
+			if len(mc.Budgets) > 1 {
+				return &badRequestError{err: fmt.Errorf("deprecated 'budget' field cannot be used when multiple budgets already exist; use 'budgets'")}
 			}
-			willHaveBudget = true
+			effectiveBudgets = coerceLegacyBudget(req.Budget, existingBudget)
+			if effectiveBudgets == nil && !isBudgetRemovalRequest(req.Budget) {
+				return &badRequestError{err: fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")}
+			}
+		}
+
+		willHaveBudget := len(mc.Budgets) > 0
+		if effectiveBudgets != nil {
+			willHaveBudget = len(*effectiveBudgets) > 0
 		}
 
 		hasGovernance := mc.RateLimitID != nil || willHaveBudget
@@ -3385,16 +3439,18 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			// Nothing to persist (removal request on a provider with no governance).
 			return nil
 		case !hasGovernance && !isNew:
-			// All governance removed → delete the model config and its owned/orphaned rows.
-			if existingBudget != nil {
-				budgetIDToDelete = existingBudget.ID
+			// All governance removed → delete the model config and its owned budgets.
+			for _, b := range mc.Budgets {
+				if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", b.ID).Error; err != nil {
+					return err
+				}
 			}
 			if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
 				return err
 			}
 			deleted = true
 		case isNew:
-			// Create the model config first so its budget can reference it.
+			// Create the model config first so its budgets can reference it.
 			if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
 				return err
 			}
@@ -3404,53 +3460,14 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			}
 		}
 
-		// Budget lifecycle (owned via ModelConfigID; the mc row now exists for create cases).
-		if !deleted && req.Budget != nil {
-			if removeBudget {
-				if existingBudget != nil {
-					budgetIDToDelete = existingBudget.ID
-					mc.Budgets = nil
-				}
-			} else if existingBudget != nil {
-				budget := *existingBudget
-				if req.Budget.MaxLimit != nil {
-					budget.MaxLimit = *req.Budget.MaxLimit
-				}
-				if req.Budget.ResetDuration != nil {
-					budget.ResetDuration = *req.Budget.ResetDuration
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.Budgets = []configstoreTables.TableBudget{budget}
-			} else {
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
-					CurrentUsage:  0,
-					ModelConfigID: &mc.ID,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.Budgets = []configstoreTables.TableBudget{budget}
-			}
-		}
-
-		// Delete orphaned budget/rate-limit rows after the FK references are gone.
-		if budgetIDToDelete != "" {
-			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", budgetIDToDelete).Error; err != nil {
+		// Budget reconciliation (mc row exists at this point for create cases).
+		if !deleted && effectiveBudgets != nil {
+			if err := h.reconcileModelConfigBudgets(ctx, tx, &mc, *effectiveBudgets); err != nil {
 				return err
 			}
 		}
+
+		// Delete orphaned rate-limit row if it was unlinked.
 		if rateLimitIDToDelete != "" {
 			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
 				return err
@@ -3458,6 +3475,11 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 		}
 		return nil
 	}); err != nil {
+		var badReqErr *badRequestError
+		if errors.As(err, &badReqErr) {
+			SendError(ctx, 400, err.Error())
+			return
+		}
 		logger.Error("failed to update provider governance: %v", err)
 		SendError(ctx, 500, fmt.Sprintf("Failed to update provider governance: %v", err))
 		return
@@ -3472,12 +3494,11 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 	} else if len(mc.Budgets) > 0 || mc.RateLimitID != nil {
 		if reloaded, err := h.governanceManager.ReloadModelConfig(ctx, mc.ID); err != nil {
 			logger.Error("failed to reload provider governance in memory: %v", err)
-			if len(mc.Budgets) > 0 {
-				resp.Budget = &mc.Budgets[0]
+			if r, ok := modelConfigToProviderGovernance(&mc); ok {
+				resp = r
 			}
-			resp.RateLimit = mc.RateLimit
 		} else if r, ok := modelConfigToProviderGovernance(reloaded); ok {
-			resp.Budget, resp.RateLimit = r.Budget, r.RateLimit
+			resp = r
 		}
 	}
 	SendJSON(ctx, map[string]interface{}{

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1510,6 +1510,225 @@ func TestCollectProviderConfigDeleteIDs(t *testing.T) {
 	}
 }
 
+func TestCoerceLegacyBudget(t *testing.T) {
+	existing := &configstoreTables.TableBudget{ID: "bud-1", MaxLimit: 50, ResetDuration: "1d"}
+
+	tests := []struct {
+		name     string
+		req      *UpdateBudgetRequest
+		existing *configstoreTables.TableBudget
+		// nil wantResult means coerce returns nil (no actionable change)
+		wantNil    bool
+		wantEmpty  bool // non-nil but empty slice (removal)
+		wantID     string
+		wantLimit  float64
+		wantPeriod string
+	}{
+		{
+			name:      "empty object → removal, returns empty slice",
+			req:       &UpdateBudgetRequest{},
+			existing:  nil,
+			wantEmpty: true,
+		},
+		{
+			name:      "both fields set, no existing → new budget entry, no ID",
+			req:       &UpdateBudgetRequest{MaxLimit: schemas.Ptr(100.0), ResetDuration: schemas.Ptr("1w")},
+			existing:  nil,
+			wantLimit: 100,
+			wantPeriod: "1w",
+		},
+		{
+			name:       "update max_limit only, existing budget → merges ID and reset_duration",
+			req:        &UpdateBudgetRequest{MaxLimit: schemas.Ptr(200.0)},
+			existing:   existing,
+			wantID:     "bud-1",
+			wantLimit:  200,
+			wantPeriod: "1d",
+		},
+		{
+			name:       "update reset_duration only, existing budget → merges ID and max_limit",
+			req:        &UpdateBudgetRequest{ResetDuration: schemas.Ptr("1w")},
+			existing:   existing,
+			wantID:     "bud-1",
+			wantLimit:  50,
+			wantPeriod: "1w",
+		},
+		{
+			name:     "max_limit only, no existing → cannot build valid budget, returns nil",
+			req:      &UpdateBudgetRequest{MaxLimit: schemas.Ptr(100.0)},
+			existing: nil,
+			wantNil:  true,
+		},
+		{
+			name:     "reset_duration only, no existing → cannot build valid budget, returns nil",
+			req:      &UpdateBudgetRequest{ResetDuration: schemas.Ptr("1d")},
+			existing: nil,
+			wantNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := coerceLegacyBudget(tt.req, tt.existing)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if tt.wantEmpty {
+				if len(*got) != 0 {
+					t.Fatalf("expected empty slice, got %+v", *got)
+				}
+				return
+			}
+			if len(*got) != 1 {
+				t.Fatalf("expected 1-element slice, got %d elements", len(*got))
+			}
+			b := (*got)[0]
+			if b.ID != tt.wantID {
+				t.Errorf("ID = %q, want %q", b.ID, tt.wantID)
+			}
+			if b.MaxLimit != tt.wantLimit {
+				t.Errorf("MaxLimit = %v, want %v", b.MaxLimit, tt.wantLimit)
+			}
+			if b.ResetDuration != tt.wantPeriod {
+				t.Errorf("ResetDuration = %q, want %q", b.ResetDuration, tt.wantPeriod)
+			}
+		})
+	}
+}
+
+func TestModelConfigToProviderGovernanceNewFields(t *testing.T) {
+	provider := "openai"
+	base := configstoreTables.TableModelConfig{
+		Scope:     configstoreTables.ModelConfigScopeGlobal,
+		ModelName: configstoreTables.ModelConfigAllModels,
+		Provider:  &provider,
+	}
+
+	t.Run("nil mc returns false", func(t *testing.T) {
+		if _, ok := modelConfigToProviderGovernance(nil); ok {
+			t.Fatal("expected false for nil mc")
+		}
+	})
+
+	t.Run("wrong scope returns false", func(t *testing.T) {
+		mc := base
+		mc.Scope = "virtual_key"
+		if _, ok := modelConfigToProviderGovernance(&mc); ok {
+			t.Fatal("expected false for non-global scope")
+		}
+	})
+
+	t.Run("no budgets: Budget nil, Budgets empty, CalendarAligned false", func(t *testing.T) {
+		mc := base
+		r, ok := modelConfigToProviderGovernance(&mc)
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if r.Budget != nil {
+			t.Errorf("Budget should be nil, got %+v", r.Budget)
+		}
+		if len(r.Budgets) != 0 {
+			t.Errorf("Budgets should be empty, got %+v", r.Budgets)
+		}
+		if r.CalendarAligned {
+			t.Error("CalendarAligned should be false")
+		}
+	})
+
+	t.Run("single budget: Budget points to first, Budgets has one entry", func(t *testing.T) {
+		mc := base
+		mc.Budgets = []configstoreTables.TableBudget{{ID: "b1", MaxLimit: 100, ResetDuration: "1d"}}
+		r, ok := modelConfigToProviderGovernance(&mc)
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if r.Budget == nil || r.Budget.ID != "b1" {
+			t.Errorf("Budget = %+v, want ID=b1", r.Budget)
+		}
+		if len(r.Budgets) != 1 || r.Budgets[0].ID != "b1" {
+			t.Errorf("Budgets = %+v, want 1 entry with ID=b1", r.Budgets)
+		}
+	})
+
+	t.Run("multiple budgets: Budget is first, Budgets contains all", func(t *testing.T) {
+		mc := base
+		mc.Budgets = []configstoreTables.TableBudget{
+			{ID: "b1", MaxLimit: 100, ResetDuration: "1d"},
+			{ID: "b2", MaxLimit: 500, ResetDuration: "1w"},
+		}
+		r, ok := modelConfigToProviderGovernance(&mc)
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if r.Budget == nil || r.Budget.ID != "b1" {
+			t.Errorf("Budget should point to first budget, got %+v", r.Budget)
+		}
+		if len(r.Budgets) != 2 {
+			t.Fatalf("Budgets len = %d, want 2", len(r.Budgets))
+		}
+		if r.Budgets[0].ID != "b1" || r.Budgets[1].ID != "b2" {
+			t.Errorf("Budgets = %+v", r.Budgets)
+		}
+	})
+
+	t.Run("calendar_aligned is propagated", func(t *testing.T) {
+		mc := base
+		mc.CalendarAligned = true
+		r, ok := modelConfigToProviderGovernance(&mc)
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if !r.CalendarAligned {
+			t.Error("CalendarAligned should be true")
+		}
+	})
+
+	t.Run("Budgets slice is a copy, not a reference to mc.Budgets", func(t *testing.T) {
+		mc := base
+		mc.Budgets = []configstoreTables.TableBudget{{ID: "b1", MaxLimit: 100, ResetDuration: "1d"}}
+		r, _ := modelConfigToProviderGovernance(&mc)
+		r.Budgets[0].MaxLimit = 999
+		if mc.Budgets[0].MaxLimit == 999 {
+			t.Error("mutating response Budgets should not affect the original mc")
+		}
+	})
+}
+
+func TestUpdateProviderGovernance_BudgetMutualExclusion(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &GovernanceHandler{}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("provider_name", "openai")
+	ctx.Request.SetBodyString(`{
+		"budget":  {"max_limit": 100, "reset_duration": "1d"},
+		"budgets": [{"max_limit": 100, "reset_duration": "1d"}]
+	}`)
+
+	h.updateProviderGovernance(ctx)
+
+	if ctx.Response.StatusCode() != 400 {
+		t.Fatalf("expected 400, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+	if !strings.Contains(resp.Error.Message, "budget") {
+		t.Errorf("error message should mention 'budget', got: %q", resp.Error.Message)
+	}
+}
+
 func TestValidateRoutingFallbacks(t *testing.T) {
 
 	tests := []struct {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2717,6 +2717,11 @@ func updateGovernanceConfigInStore(
 			if err := config.ConfigStore.CreateModelConfig(ctx, &modelConfig, tx); err != nil {
 				return fmt.Errorf("failed to create model config %s: %w", modelConfig.ID, err)
 			}
+			if len(modelConfig.BudgetIDs) > 0 {
+				if err := linkModelConfigBudgets(tx, modelConfig.ID, modelConfig.BudgetIDs); err != nil {
+					return err
+				}
+			}
 		}
 
 		// Update model configs (config.json changed)
@@ -2726,6 +2731,11 @@ func updateGovernanceConfigInStore(
 			}
 			if err := config.ConfigStore.UpdateModelConfig(ctx, &modelConfig, tx); err != nil {
 				return fmt.Errorf("failed to update model config %s: %w", modelConfig.ID, err)
+			}
+			if len(modelConfig.BudgetIDs) > 0 {
+				if err := linkModelConfigBudgets(tx, modelConfig.ID, modelConfig.BudgetIDs); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -2797,6 +2807,50 @@ func validateModelConfigGovernanceOwnership(tx *gorm.DB, modelConfig configstore
 	}
 	if err := validateRateLimitLinkOwnership(tx, modelConfig.RateLimitID, "model config", modelConfig.ID); err != nil {
 		return err
+	}
+	for _, budgetID := range modelConfig.BudgetIDs {
+		id := budgetID
+		if err := validateBudgetLinkOwnership(tx, &id, "model config", modelConfig.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// linkModelConfigBudgets sets model_config_id on each budget in budgetIDs, and clears it from
+// any budgets previously owned by mcID that are no longer in the list.
+func linkModelConfigBudgets(tx *gorm.DB, mcID string, budgetIDs []string) error {
+	// Normalize: trim whitespace and deduplicate.
+	seen := make(map[string]struct{}, len(budgetIDs))
+	normalized := make([]string, 0, len(budgetIDs))
+	for _, raw := range budgetIDs {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		normalized = append(normalized, id)
+	}
+
+	// Clear ownership from budgets that are no longer referenced.
+	unlinkQ := tx.Model(&configstoreTables.TableBudget{}).
+		Where("model_config_id = ?", mcID)
+	if len(normalized) > 0 {
+		unlinkQ = unlinkQ.Where("id NOT IN ?", normalized)
+	}
+	if err := unlinkQ.Update("model_config_id", nil).Error; err != nil {
+		return fmt.Errorf("failed to unlink stale budgets from model config %q: %w", mcID, err)
+	}
+	// Link the declared budgets.
+	for _, id := range normalized {
+		if err := tx.Model(&configstoreTables.TableBudget{}).
+			Where("id = ?", id).
+			Update("model_config_id", mcID).Error; err != nil {
+			return fmt.Errorf("failed to link budget %q to model config %q: %w", id, mcID, err)
+		}
 	}
 	return nil
 }
@@ -2995,6 +3049,11 @@ func createGovernanceConfigInStore(ctx context.Context, config *Config) {
 			}
 			if err := config.ConfigStore.CreateModelConfig(ctx, modelConfig, tx); err != nil {
 				return fmt.Errorf("failed to create model config %s: %w", modelConfig.ID, err)
+			}
+			if len(modelConfig.BudgetIDs) > 0 {
+				if err := linkModelConfigBudgets(tx, modelConfig.ID, modelConfig.BudgetIDs); err != nil {
+					return err
+				}
 			}
 		}
 		for i := range config.GovernanceConfig.Providers {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -704,7 +704,12 @@
               },
               "budget_id": {
                 "type": "string",
-                "description": "Budget ID to associate with this model"
+                "description": "Deprecated — single budget reference. Use budget_ids instead."
+              },
+              "budget_ids": {
+                "type": "array",
+                "description": "List of budget IDs (from governance.budgets) to associate with this model config. Supports multiple budgets (e.g. daily + monthly). Replaces budget_id.",
+                "items": { "type": "string" }
               },
               "rate_limit_id": {
                 "type": "string",

--- a/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
@@ -1,9 +1,10 @@
 import { Button } from "@/components/ui/button";
-import { Form, FormField, FormItem } from "@/components/ui/form";
+import { Form } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
+import MultiBudgetLines, { BudgetLineEntry } from "@/components/ui/multibudgets";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { DottedSeparator } from "@/components/ui/separator";
-import { resetDurationOptions } from "@/lib/constants/governance";
+import { Switch } from "@/components/ui/switch";
 import {
 	getErrorMessage,
 	useDeleteProviderGovernanceMutation,
@@ -11,6 +12,7 @@ import {
 	useUpdateProviderGovernanceMutation,
 } from "@/lib/store";
 import { ModelProvider } from "@/lib/types/config";
+import { CreateBudgetRequest, ProviderGovernance } from "@/lib/types/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
@@ -22,14 +24,17 @@ interface GovernanceFormFragmentProps {
 	provider: ModelProvider;
 }
 
+const budgetLineSchema = z.object({
+	id: z.string().optional(),
+	max_limit: z.number({ error: "Budget limit must be a number" }).nonnegative("Budget limit cannot be negative").optional(),
+	reset_duration: z.string().min(1, "Reset duration is required"),
+});
+
 const formSchema = z.object({
-	// Budget
-	budgetMaxLimit: z.number().nonnegative().optional(),
-	budgetResetDuration: z.string().optional(),
-	// Token limits
+	budgets: z.array(budgetLineSchema),
+	calendarAligned: z.boolean(),
 	tokenMaxLimit: z.number().int().nonnegative().optional(),
 	tokenResetDuration: z.string().optional(),
-	// Request limits
 	requestMaxLimit: z.number().int().nonnegative().optional(),
 	requestResetDuration: z.string().optional(),
 });
@@ -37,13 +42,29 @@ const formSchema = z.object({
 type FormData = z.infer<typeof formSchema>;
 
 const DEFAULT_GOVERNANCE_FORM_VALUES: FormData = {
-	budgetMaxLimit: undefined,
-	budgetResetDuration: "1M",
+	budgets: [],
+	calendarAligned: false,
 	tokenMaxLimit: undefined,
 	tokenResetDuration: "1h",
 	requestMaxLimit: undefined,
 	requestResetDuration: "1h",
 };
+
+function governanceToFormValues(provGov: ProviderGovernance | undefined): FormData {
+	if (!provGov) return DEFAULT_GOVERNANCE_FORM_VALUES;
+	return {
+		budgets: (provGov.budgets ?? []).map((b) => ({
+			id: b.id,
+			max_limit: b.max_limit,
+			reset_duration: b.reset_duration,
+		})),
+		calendarAligned: provGov.calendar_aligned ?? false,
+		tokenMaxLimit: provGov.rate_limit?.token_max_limit ?? undefined,
+		tokenResetDuration: provGov.rate_limit?.token_reset_duration || "1h",
+		requestMaxLimit: provGov.rate_limit?.request_max_limit ?? undefined,
+		requestResetDuration: provGov.rate_limit?.request_reset_duration || "1h",
+	};
+}
 
 export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps) {
 	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
@@ -56,63 +77,45 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 	const [updateProviderGovernance, { isLoading: isUpdating }] = useUpdateProviderGovernanceMutation();
 	const [deleteProviderGovernance, { isLoading: isDeleting }] = useDeleteProviderGovernanceMutation();
 
-	// Find governance data for this provider
 	const providerGovernance = providerGovernanceData?.providers?.find((p) => p.provider === provider.name);
-	const hasExistingGovernance = !!(providerGovernance?.budget || providerGovernance?.rate_limit);
+	const hasExistingGovernance = !!((providerGovernance?.budgets?.length ?? 0) > 0 || providerGovernance?.rate_limit);
 
 	const form = useForm<FormData>({
 		resolver: zodResolver(formSchema),
 		defaultValues: DEFAULT_GOVERNANCE_FORM_VALUES,
 	});
 
-	// Update form values when provider governance data is loaded (polling)
+	const watchedBudgets = form.watch("budgets");
+	const watchedCalendarAligned = form.watch("calendarAligned");
+
 	useEffect(() => {
-		// Never reset form during polling if user is editing
 		if (providerGovernance && !form.formState.isDirty) {
-			form.reset({
-				budgetMaxLimit: providerGovernance.budget?.max_limit ?? undefined,
-				budgetResetDuration: providerGovernance.budget?.reset_duration || "1M",
-				tokenMaxLimit: providerGovernance.rate_limit?.token_max_limit ?? undefined,
-				tokenResetDuration: providerGovernance.rate_limit?.token_reset_duration || "1h",
-				requestMaxLimit: providerGovernance.rate_limit?.request_max_limit ?? undefined,
-				requestResetDuration: providerGovernance.rate_limit?.request_reset_duration || "1h",
-			});
+			form.reset(governanceToFormValues(providerGovernance));
 		}
 	}, [providerGovernance, form]);
 
-	// Reset form when provider changes
 	useEffect(() => {
-		// Never reset form if user is editing - just skip the reset
-		if (form.formState.isDirty) {
-			return;
-		}
+		if (form.formState.isDirty) return;
 		const newProvGov = providerGovernanceData?.providers?.find((p) => p.provider === provider.name);
-		form.reset({
-			budgetMaxLimit: newProvGov?.budget?.max_limit ?? undefined,
-			budgetResetDuration: newProvGov?.budget?.reset_duration || "1M",
-			tokenMaxLimit: newProvGov?.rate_limit?.token_max_limit ?? undefined,
-			tokenResetDuration: newProvGov?.rate_limit?.token_reset_duration || "1h",
-			requestMaxLimit: newProvGov?.rate_limit?.request_max_limit ?? undefined,
-			requestResetDuration: newProvGov?.rate_limit?.request_reset_duration || "1h",
-		});
+		form.reset(governanceToFormValues(newProvGov));
 	}, [provider.name, form]);
 
 	const onSubmit = async (data: FormData) => {
 		try {
-			// Determine if we need to send empty objects to signal removal
-			const hadBudget = !!providerGovernance?.budget;
-			const hasBudget = data.budgetMaxLimit !== undefined;
+			const validBudgets = data.budgets.filter((b) => b.max_limit !== undefined && b.max_limit > 0);
+			const hadBudgets = (providerGovernance?.budgets?.length ?? 0) > 0;
 			const hadRateLimit = !!providerGovernance?.rate_limit;
 			const hasRateLimit = data.tokenMaxLimit !== undefined || data.requestMaxLimit !== undefined;
 
-			let budgetPayload: { max_limit?: number; reset_duration?: string } | undefined;
-			if (hasBudget) {
-				budgetPayload = {
-					max_limit: data.budgetMaxLimit,
-					reset_duration: data.budgetResetDuration || "1M",
-				};
-			} else if (hadBudget) {
-				budgetPayload = {};
+			let budgetsPayload: CreateBudgetRequest[] | undefined;
+			if (validBudgets.length > 0) {
+				budgetsPayload = validBudgets.map((b) => ({
+					id: b.id,
+					max_limit: b.max_limit!,
+					reset_duration: b.reset_duration,
+				}));
+			} else if (hadBudgets) {
+				budgetsPayload = [];
 			}
 
 			let rateLimitPayload:
@@ -137,14 +140,13 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 			await updateProviderGovernance({
 				provider: provider.name,
 				data: {
-					budget: budgetPayload,
+					budgets: budgetsPayload,
+					...(budgetsPayload !== undefined ? { calendar_aligned: data.calendarAligned } : {}),
 					rate_limit: rateLimitPayload,
 				},
 			}).unwrap();
 
 			toast.success("Governance configuration saved successfully");
-
-			// Reset form with the saved values to update the initial state for change detection
 			form.reset(data);
 		} catch (error) {
 			toast.error("Failed to update provider governance", {
@@ -165,93 +167,76 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 		}
 	};
 
-	// Always show the form
 	return (
 		<Form {...form}>
 			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6">
 				{/* Budget Configuration */}
-				<div className="space-y-4">
-					<Label className="text-sm font-medium">Budget Configuration</Label>
-					<FormField
-						control={form.control}
-						name="budgetMaxLimit"
-						render={({ field }) => (
-							<FormItem>
-								<NumberAndSelect
-									id="providerBudgetMaxLimit"
-									labelClassName="font-normal"
-									label="Maximum Spend (USD)"
-									value={field.value}
-									selectValue={form.watch("budgetResetDuration") || "1M"}
-									onChangeNumber={(value) => field.onChange(value)}
-									onChangeSelect={(value) => form.setValue("budgetResetDuration", value, { shouldDirty: true })}
-									options={resetDurationOptions}
-								/>
-							</FormItem>
-						)}
-					/>
-				</div>
+				<MultiBudgetLines
+					data-testid="provider-governance-budgets"
+					lines={watchedBudgets as BudgetLineEntry[]}
+					onChange={(lines) => form.setValue("budgets", lines, { shouldDirty: true })}
+				/>
+
+				{/* Calendar Alignment — only shown when there are budgets */}
+				{watchedBudgets.length > 0 && (
+					<div className="flex items-center justify-between gap-4">
+						<div className="space-y-1">
+							<Label className="text-sm" htmlFor="provider-calendar-aligned">
+								Align to calendar cycle
+							</Label>
+							<p className="text-muted-foreground text-xs">
+								Reset budgets at the start of each period (e.g. 1st of month) instead of rolling from creation date.
+							</p>
+						</div>
+						<Switch
+							id="provider-calendar-aligned"
+							data-testid="provider-governance-calendar-aligned-switch"
+							checked={watchedCalendarAligned}
+							onCheckedChange={(checked) => form.setValue("calendarAligned", checked, { shouldDirty: true })}
+						/>
+					</div>
+				)}
 
 				<DottedSeparator />
 
 				{/* Rate Limiting Configuration */}
 				<div className="space-y-4">
 					<Label className="text-sm font-medium">Rate Limiting Configuration</Label>
-
-					<FormField
-						control={form.control}
-						name="tokenMaxLimit"
-						render={({ field }) => (
-							<FormItem>
-								<NumberAndSelect
-									id="providerTokenMaxLimit"
-									labelClassName="font-normal"
-									label="Maximum Tokens"
-									value={field.value}
-									selectValue={form.watch("tokenResetDuration") || "1h"}
-									onChangeNumber={(value) => field.onChange(value)}
-									onChangeSelect={(value) => form.setValue("tokenResetDuration", value, { shouldDirty: true })}
-									options={resetDurationOptions}
-								/>
-							</FormItem>
-						)}
+					<NumberAndSelect
+						id="providerTokenMaxLimit"
+						labelClassName="font-normal"
+						label="Maximum Tokens"
+						value={form.watch("tokenMaxLimit")}
+						selectValue={form.watch("tokenResetDuration") || "1h"}
+						onChangeNumber={(value) => form.setValue("tokenMaxLimit", value, { shouldDirty: true })}
+						onChangeSelect={(value) => form.setValue("tokenResetDuration", value, { shouldDirty: true })}
 					/>
-
-					<FormField
-						control={form.control}
-						name="requestMaxLimit"
-						render={({ field }) => (
-							<FormItem>
-								<NumberAndSelect
-									id="providerRequestMaxLimit"
-									labelClassName="font-normal"
-									label="Maximum Requests"
-									value={field.value}
-									selectValue={form.watch("requestResetDuration") || "1h"}
-									onChangeNumber={(value) => field.onChange(value)}
-									onChangeSelect={(value) => form.setValue("requestResetDuration", value, { shouldDirty: true })}
-									options={resetDurationOptions}
-								/>
-							</FormItem>
-						)}
+					<NumberAndSelect
+						id="providerRequestMaxLimit"
+						labelClassName="font-normal"
+						label="Maximum Requests"
+						value={form.watch("requestMaxLimit")}
+						selectValue={form.watch("requestResetDuration") || "1h"}
+						onChangeNumber={(value) => form.setValue("requestMaxLimit", value, { shouldDirty: true })}
+						onChangeSelect={(value) => form.setValue("requestResetDuration", value, { shouldDirty: true })}
 					/>
 				</div>
 
-				{/* Current Usage Display - only when editing existing */}
-				{hasExistingGovernance && (providerGovernance?.budget || providerGovernance?.rate_limit) && (
+				{/* Current Usage — only shown when governance exists */}
+				{hasExistingGovernance && (
 					<>
 						<DottedSeparator />
 						<div className="space-y-4">
 							<Label className="text-sm font-medium">Current Usage</Label>
 							<div className="bg-muted/50 grid grid-cols-2 gap-4 rounded-lg p-4">
-								{providerGovernance?.budget && (
-									<div className="space-y-1">
-										<p className="text-muted-foreground text-xs">Budget Usage</p>
+								{providerGovernance?.budgets?.map((b) => (
+									<div key={b.id} className="space-y-1">
+										<p className="text-muted-foreground text-xs">Budget ({b.reset_duration})</p>
 										<p className="text-sm font-medium">
-											${providerGovernance.budget.current_usage.toFixed(2)} / ${providerGovernance.budget.max_limit.toFixed(2)}
+											${b.current_usage.toFixed(2)} / ${b.max_limit.toFixed(2)}
 										</p>
 									</div>
-								)}
+								))}
 								{providerGovernance?.rate_limit?.token_max_limit && (
 									<div className="space-y-1">
 										<p className="text-muted-foreground text-xs">Token Usage</p>

--- a/ui/app/workspace/providers/views/providerGovernanceTable.tsx
+++ b/ui/app/workspace/providers/views/providerGovernanceTable.tsx
@@ -163,7 +163,7 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 	const providerGovernance = providerGovernanceData?.providers?.find((p) => p.provider === provider.name);
 
 	// Check if any governance is configured
-	const hasGovernance = providerGovernance?.budget || providerGovernance?.rate_limit;
+	const hasGovernance = (providerGovernance?.budgets?.length ?? 0) > 0 || providerGovernance?.rate_limit;
 
 	if (isLoading) {
 		return (
@@ -185,10 +185,9 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 		return null;
 	}
 
-	const budget = providerGovernance?.budget;
+	const budgets = providerGovernance?.budgets ?? [];
 	const rateLimit = providerGovernance?.rate_limit;
 
-	const isBudgetExhausted = !!(budget?.max_limit && budget.max_limit > 0 && budget.current_usage >= budget.max_limit);
 	const isTokenExhausted = !!(
 		rateLimit?.token_max_limit &&
 		rateLimit.token_max_limit > 0 &&
@@ -209,17 +208,18 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 			</CardHeader>
 
 			<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-				{/* Budget Card */}
-				{budget && (
+				{/* Budget Cards — one per budget window */}
+				{budgets.map((budget) => (
 					<MetricCard
-						title="Budget"
+						key={budget.id}
+						title={`Budget (${formatResetDuration(budget.reset_duration)})`}
 						value={budget.current_usage}
 						max={budget.max_limit}
 						unit="$"
 						resetDuration={budget.reset_duration}
-						isExhausted={isBudgetExhausted}
+						isExhausted={budget.max_limit > 0 && budget.current_usage >= budget.max_limit}
 					/>
-				)}
+				))}
 
 				{/* Token Rate Limit Card */}
 				{rateLimit?.token_max_limit && (

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -527,15 +527,16 @@ export interface GetPricingOverridesResponse {
 // Provider governance - for extending provider with budget/rate limit
 export interface ProviderGovernance {
 	provider: string;
-	budget_id?: string;
-	rate_limit_id?: string;
-	budget?: Budget;
+	budget?: Budget; // deprecated: use budgets
+	budgets?: Budget[];
 	rate_limit?: RateLimit;
+	calendar_aligned?: boolean;
 }
 
 export interface UpdateProviderGovernanceRequest {
-	budget?: UpdateBudgetRequest;
+	budgets?: CreateBudgetRequest[]; // [] = remove all
 	rate_limit?: UpdateRateLimitRequest;
+	calendar_aligned?: boolean;
 }
 
 export interface GetProviderGovernanceResponse {


### PR DESCRIPTION
## Summary

Provider governance previously supported only a single budget per provider. This PR upgrades the system to support multiple budgets per provider, adds a `calendar_aligned` flag to control whether budgets reset on a fixed calendar cycle or roll from creation date, and maintains full backward compatibility with the legacy single-`budget` field.

## Changes

- Added a `budgets` field (`*[]CreateBudgetRequest`) to `UpdateProviderGovernanceRequest` alongside the existing `budget` field (now deprecated). Sending both fields in the same request returns a 400 error.
- Introduced `coerceLegacyBudget` to convert a single `UpdateBudgetRequest` into a `*[]CreateBudgetRequest`, enabling the legacy `budget` field to be handled uniformly through `reconcileModelConfigBudgets`.
- `ProviderGovernanceResponse` now includes a `budgets []TableBudget` slice (all budgets) in addition to the deprecated `budget *TableBudget` (first entry, kept for backward compatibility), and exposes `calendar_aligned`.
- `modelConfigToProviderGovernance` now populates `Budgets` as a defensive copy and surfaces `CalendarAligned`.
- The `updateProviderGovernance` transaction was refactored: per-budget deletion now iterates `mc.Budgets` directly, and budget lifecycle management is delegated entirely to `reconcileModelConfigBudgets` when `effectiveBudgets` is non-nil.
- The UI governance form replaced the single budget input with a `MultiBudgetLines` component supporting multiple budget entries, and added a `calendar_aligned` toggle that appears only when at least one budget is configured.
- The provider governance table now renders one `MetricCard` per budget window instead of a single card.
- `ProviderGovernance` and `UpdateProviderGovernanceRequest` TypeScript types updated to reflect `budgets`, `calendar_aligned`, and `CreateBudgetRequest` usage; the deprecated `budget` field is retained with a comment.
- Unit tests added for `coerceLegacyBudget`, `modelConfigToProviderGovernance` new fields, and the mutual-exclusion validation between `budget` and `budgets`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

**Manual validation:**

1. `POST /api/governance/providers/{provider}` with `{"budgets": [{"max_limit": 100, "reset_duration": "1d"}, {"max_limit": 500, "reset_duration": "1w"}]}` — verify both budgets are persisted and returned.
2. `POST` with both `budget` and `budgets` set — verify a 400 is returned with a message mentioning `budget`.
3. `POST` with the legacy `{"budget": {"max_limit": 100, "reset_duration": "1d"}}` — verify backward compatibility: budget is created and returned in both `budget` and `budgets` fields.
4. `POST` with `{"calendar_aligned": true}` — verify the flag is persisted and reflected in the GET response.
5. In the UI, add multiple budget lines for a provider, toggle calendar alignment, save, and confirm the current usage section renders one card per budget.

## Breaking changes

- [ ] Yes
- [x] No

The `budget` field is deprecated but still accepted and returned. Clients using only `budget` continue to work without modification.

## Related issues

## Security considerations

No new authentication, secrets, or PII handling introduced. The mutual-exclusion check on `budget`/`budgets` prevents ambiguous requests from reaching the database layer.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Provider governance supports multiple budgets (including add/remove-all semantics) and a calendar-aligned toggle; UI shows per-budget metrics and exhaustion. Model configs can reference multiple budget IDs for config-driven governance.
- **Tests**
  - Added unit tests covering legacy-budget coercion, multi-budget response mapping, and mutual-exclusion validation for update requests.
- **Documentation**
  - Config schema updated: single-budget reference deprecated and replaced by a budget_ids array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->