### PR TITLE
docs: update docs for user-level model limit

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -227,6 +227,7 @@
                   "features/governance/virtual-keys",
                   "features/governance/routing",
                   "features/governance/budget-and-limits",
+                  "features/governance/model-limits",
                   "features/governance/mcp-tools",
                   "features/governance/required-headers"
                 ]

--- a/docs/enterprise/access-profiles.mdx
+++ b/docs/enterprise/access-profiles.mdx
@@ -171,6 +171,12 @@ When you edit an existing profile, the action bar shows **Save** (template-only 
 
 By default, propagation **preserves usage**: existing users keep their accumulated budget and rate-limit counters where the reset durations match.
 
+### Extend individual budgets for a user
+
+Access profile budgets apply uniformly to everyone assigned the template. When you need a one-off override for a specific user — without touching the template for the rest of the role — you can attach an additional per-model budget or rate limit directly to that user via [Model Limits](/features/governance/model-limits).
+
+For example, if Alice is on the Engineering profile but you want to add a separate $20/month cap on Claude Opus just for her, you can create a user-scoped model limit for Alice without changing what the Engineering profile gives everyone else. These limits stack independently alongside the profile budget; both must pass for a request to be allowed, and they are not affected by profile propagation. See [Give one user an individual per-model budget](#give-one-user-an-individual-per-model-budget) for steps for the above.
+
 ### Edit, duplicate, delete
 
 Each row action exposes:
@@ -225,6 +231,28 @@ Profiles can be cloned into new templates, propagated to user copies one field s
 1. Edit the template and replace the MCP tool group reference.
 2. Open the propagate dialog. Check **MCP Tool Groups**, **MCP Servers**, and **MCP Tool Overrides**. Leave budgets and rate limits unchecked.
 3. Click **Propagate**. Budgets and rate limits are not touched; only MCP access changes flow through.
+
+### Give one user an individual per-model budget
+
+1. Navigate to **Budget & Limits → Model Limits** and click **Add Model Limit**.
+2. Select a **Provider** and **Model Name**, set **Scope** to `User`, and pick the target user.
+3. Add one or more budget lines and any rate limits. Click **Create Limit**.
+
+Or via the API:
+
+```bash
+curl -X POST "http://localhost:8080/api/governance/model-configs" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "claude-opus-4-8",
+    "provider": "anthropic",
+    "scope": "user",
+    "scope_id": "<user-id>",
+    "budgets": [
+      { "max_limit": 20.00, "reset_duration": "1M" }
+    ]
+  }'
+```
 
 ---
 

--- a/docs/features/governance/model-limits.mdx
+++ b/docs/features/governance/model-limits.mdx
@@ -1,0 +1,377 @@
+---
+title: "Model Limits"
+description: "Set budget and rate limits at the model level — globally or per virtual key, optionally filtered to a specific provider — from a single unified interface."
+icon: "sliders"
+---
+
+## Overview
+
+Model limits let you enforce spending caps and rate limits keyed on a specific model (or all models), an optional provider, and a **scope** that determines who the limit applies to.
+
+They are the unified control plane for all model-level governance in Bifrost:
+
+- **Global provider budgets** — cap what OpenAI (or any provider) can spend across all traffic
+- **Virtual key top-level budgets** — limit how much a specific virtual key can spend across all its providers
+- **Virtual key per-provider budgets** — limit what a virtual key can spend on a single provider
+- **Per-model limits** — enforce fine-grained caps on individual models for any of the above scopes
+
+<Note>
+The `user` scope is available in Bifrost Enterprise. Support for **customer** and **team** scopes is coming soon.
+</Note>
+
+---
+
+## Scope system
+
+Every model limit has a **scope** that determines the audience it applies to.
+
+| Scope | Who it applies to | Scope Target required? |
+|-------|-------------------|----------------------|
+| `global` | All traffic through Bifrost | No |
+| `virtual_key` | All requests made with a specific virtual key | Yes — the virtual key ID |
+| `user` | All requests made by a specific user (Enterprise only) | Yes — the user ID |
+
+**Scope + model name combinations:**
+
+| model_name | provider | scope | What it governs |
+|------------|----------|-------|-----------------|
+| `*` (All Models) | `openai` | `global` | Global OpenAI provider budget |
+| `*` (All Models) | _(none)_ | `virtual_key` | That VK's top-level cross-provider budget |
+| `*` (All Models) | `anthropic` | `virtual_key` | That VK's Anthropic-only budget |
+| `gpt-4o` | `openai` | `global` | Hard cap on gpt-4o usage across all traffic |
+| `claude-3-5-sonnet-20241022` | _(none)_ | `virtual_key` | Per-VK cap on a specific model |
+
+---
+
+## Configuration
+
+<Tabs>
+<Tab title="Web UI">
+
+Navigate to **Budget & Limits → Model Limits** in the Bifrost dashboard.
+
+### Table view
+
+The table shows all configured model limits with their current usage. Use the toolbar to find what you need:
+
+- **Search** — filter by model name
+- **Scope** dropdown — show only `global` or `virtual_key` limits
+- **Provider** dropdown — show only limits for a specific provider
+
+The **Scope Target** column links directly back to the parent entity (e.g. clicking a virtual key badge takes you to that VK).
+
+![Model Limits Table](../../media/ui-model-limits-table.png)
+
+### Adding a model limit
+
+Click **Add Model Limit** to open the configuration sheet.
+
+1. **Provider** — select a specific provider or leave as _All Providers_
+2. **Model Name** — search and select a model, or pick _All Models_ to cover every model for the chosen provider/scope
+3. **Scope** — choose `Global` or `Virtual Key`
+4. **Scope Target** — appears when scope is `Virtual Key`; select the target virtual key
+5. **Budget** — add one or more budget lines, each with a dollar cap and reset duration. Multiple budgets per limit are supported (e.g. `$50/day` + `$500/month`).
+6. **Rate Limits** — optionally set token and/or request limits with their own reset durations
+
+Click **Create Limit** to save.
+
+![Model Limit Sheet](../../media/ui-model-limits-sheet.png)
+
+<Note>
+Model name and scope are locked after creation. To change them, delete the limit and recreate it.
+</Note>
+
+</Tab>
+<Tab title="API">
+
+### List model limits
+
+```bash
+curl "http://localhost:8080/api/governance/model-configs" \
+  -H "Content-Type: application/json"
+```
+
+With filters:
+
+```bash
+curl "http://localhost:8080/api/governance/model-configs?scope=virtual_key&provider=openai&limit=25&offset=0&search=gpt" \
+  -H "Content-Type: application/json"
+```
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `limit` | integer | Page size |
+| `offset` | integer | Page offset |
+| `search` | string | Filter by model name (case-insensitive) |
+| `scope` | string | Filter by scope (`global`, `virtual_key`) |
+| `provider` | string | Filter by provider name |
+| `from_memory` | boolean | Read from in-memory cache (faster, may lag DB by one poll cycle) |
+
+**Response:**
+
+```json
+{
+  "model_configs": [
+    {
+      "id": "mc_abc123",
+      "model_name": "*",
+      "provider": "openai",
+      "scope": "global",
+      "scope_id": null,
+      "scope_name": null,
+      "calendar_aligned": false,
+      "budgets": [
+        {
+          "id": "b_xyz",
+          "max_limit": 500.00,
+          "current_usage": 42.10,
+          "reset_duration": "1M",
+          "last_reset": "2026-06-01T00:00:00Z"
+        }
+      ],
+      "rate_limit": null,
+      "created_at": "2026-05-01T10:00:00Z",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ],
+  "total_count": 1
+}
+```
+
+### Create a model limit
+
+```bash
+curl -X POST "http://localhost:8080/api/governance/model-configs" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "gpt-4o",
+    "provider": "openai",
+    "scope": "global",
+    "budgets": [
+      { "max_limit": 200.00, "reset_duration": "1d" },
+      { "max_limit": 2000.00, "reset_duration": "1M" }
+    ],
+    "rate_limit": {
+      "request_max_limit": 1000,
+      "request_reset_duration": "1h"
+    }
+  }'
+```
+
+**Request fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `model_name` | string | Yes | Model name, or `*` for all models |
+| `provider` | string | No | Provider name; omit to cover all providers |
+| `scope` | string | No | `global` (default) or `virtual_key` |
+| `scope_id` | string | Conditional | Required when `scope` is not `global` |
+| `budgets` | array | No | One or more budget lines (each needs `max_limit` + `reset_duration`) |
+| `rate_limit` | object | No | Token and/or request rate limits |
+
+### Update a model limit
+
+Send the full desired set of budgets — the server reconciles additions, updates, and removals. Send an empty `budgets` array to remove all budgets.
+
+```bash
+curl -X PUT "http://localhost:8080/api/governance/model-configs/{mc_id}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "budgets": [
+      { "max_limit": 300.00, "reset_duration": "1d" },
+      { "max_limit": 3000.00, "reset_duration": "1M" }
+    ]
+  }'
+```
+
+### Delete a model limit
+
+```bash
+curl -X DELETE "http://localhost:8080/api/governance/model-configs/{mc_id}"
+```
+
+</Tab>
+<Tab title="config.json">
+
+Model limits are declared under `governance.model_configs`. Each entry references budgets and rate limits by ID from the sibling `governance.budgets` and `governance.rate_limits` arrays.
+
+```json
+{
+  "governance": {
+    "model_configs": [
+      {
+        "id": "mc-openai-global",
+        "model_name": "*",
+        "provider": "openai",
+        "scope": "global",
+        "budget_ids": ["b-openai-daily", "b-openai-monthly"]
+      },
+      {
+        "id": "mc-gpt4o-vk",
+        "model_name": "gpt-4o",
+        "provider": "openai",
+        "scope": "virtual_key",
+        "scope_id": "vk-production",
+        "budget_ids": ["b-gpt4o-daily"],
+        "rate_limit_id": "rl-gpt4o"
+      }
+    ],
+    "budgets": [
+      {
+        "id": "b-openai-daily",
+        "max_limit": 50.00,
+        "reset_duration": "1d"
+      },
+      {
+        "id": "b-openai-monthly",
+        "max_limit": 1000.00,
+        "reset_duration": "1M"
+      },
+      {
+        "id": "b-gpt4o-daily",
+        "max_limit": 50.00,
+        "reset_duration": "1d"
+      }
+    ],
+    "rate_limits": [
+      {
+        "id": "rl-gpt4o",
+        "request_max_limit": 500,
+        "request_reset_duration": "1h",
+        "token_max_limit": 500000,
+        "token_reset_duration": "1h"
+      }
+    ]
+  }
+}
+```
+
+**`model_configs` fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Unique identifier |
+| `model_name` | string | Yes | Model name, or `*` for all models |
+| `provider` | string | No | Provider name; omit to apply to all providers |
+| `scope` | string | No | `global` (default) or `virtual_key` |
+| `scope_id` | string | Conditional | Required when `scope` is not `global` |
+| `budget_ids` | string[] | No | List of `governance.budgets` IDs to attach. Supports multiple budgets (e.g. daily + monthly). Replaces `budget_id`. |
+| `budget_id` | string | No | Deprecated — single budget reference. Use `budget_ids` instead. |
+| `rate_limit_id` | string | No | References a `governance.rate_limits` entry |
+
+</Tab>
+</Tabs>
+
+---
+
+## Examples
+
+### Global provider cap
+
+Prevent OpenAI from exceeding $1,000/month regardless of which virtual key triggered the request:
+
+```bash
+curl -X POST "http://localhost:8080/api/governance/model-configs" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "*",
+    "provider": "openai",
+    "scope": "global",
+    "budgets": [
+      { "max_limit": 1000.00, "reset_duration": "1M" }
+    ]
+  }'
+```
+
+This is also manageable from the **Providers** page → **Governance** tab per provider, which writes to the same underlying entry.
+
+---
+
+### Virtual key top-level budget
+
+Cap the total spend for a virtual key across all its providers:
+
+```bash
+curl -X POST "http://localhost:8080/api/governance/model-configs" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "*",
+    "scope": "virtual_key",
+    "scope_id": "vk-staging-team",
+    "budgets": [
+      { "max_limit": 200.00, "reset_duration": "1M" }
+    ]
+  }'
+```
+
+---
+
+### Virtual key per-provider budget
+
+Let the staging VK use Anthropic up to $50/month independently of its OpenAI spend:
+
+```bash
+curl -X POST "http://localhost:8080/api/governance/model-configs" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "*",
+    "provider": "anthropic",
+    "scope": "virtual_key",
+    "scope_id": "vk-staging-team",
+    "budgets": [
+      { "max_limit": 50.00, "reset_duration": "1M" }
+    ]
+  }'
+```
+
+These VK governance limits are also editable through the **Virtual Keys** page → provider governance section.
+
+---
+
+### Multi-budget daily + monthly cap
+
+Protect against both runaway daily spikes and monthly overruns on a single model:
+
+```bash
+curl -X POST "http://localhost:8080/api/governance/model-configs" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "gpt-4o",
+    "provider": "openai",
+    "scope": "global",
+    "budgets": [
+      { "max_limit": 30.00, "reset_duration": "1d" },
+      { "max_limit": 500.00, "reset_duration": "1M" }
+    ]
+  }'
+```
+
+All budgets must pass for a request to be allowed — a spike that exhausts the daily cap blocks further requests until it resets, even if the monthly cap has room remaining.
+
+---
+
+## How limits interact
+
+When a request arrives, Bifrost checks every applicable model limit **independently**. All must pass:
+
+```
+Request: VK "staging" → openai → gpt-4o
+
+Checks run in order:
+  1. Global gpt-4o limit (if any)
+  2. Global openai limit (if any)
+  3. VK "staging" top-level limit (if any)
+  4. VK "staging" → openai limit (if any)
+```
+
+If any single limit is exhausted, the request is blocked. Costs are deducted from **all** matching limits after a successful response.
+
+---
+
+## Next Steps
+
+- **[Budget & Limits](./budget-and-limits)** — Budgets at the virtual key, team, and customer hierarchy level
+- **[Virtual Keys](./virtual-keys)** — Create and manage virtual keys with provider configs
+- **[Routing](./routing)** — Automatic failover when a limit is exhausted

--- a/docs/openapi/paths/management/governance.yaml
+++ b/docs/openapi/paths/management/governance.yaml
@@ -763,10 +763,45 @@ routing-rules-by-id:
 model-configs:
   get:
     operationId: listModelConfigs
-    summary: List model configs
-    description: Returns a list of all model configurations with their budget and rate limit settings.
+    summary: List model limits
+    description: Returns a paginated list of model limits with their budget and rate limit settings.
     tags:
       - Governance
+    parameters:
+      - name: limit
+        in: query
+        description: Maximum number of results to return
+        schema:
+          type: integer
+          minimum: 1
+      - name: offset
+        in: query
+        description: Number of results to skip (for pagination)
+        schema:
+          type: integer
+          minimum: 0
+      - name: search
+        in: query
+        description: Case-insensitive filter by model name
+        schema:
+          type: string
+      - name: scope
+        in: query
+        description: Filter by scope (`global` or `virtual_key`)
+        schema:
+          type: string
+          enum: [global, virtual_key]
+      - name: provider
+        in: query
+        description: Filter by provider name
+        schema:
+          type: string
+      - name: from_memory
+        in: query
+        description: If true, returns data from in-memory cache (faster, may lag DB by one poll cycle)
+        schema:
+          type: boolean
+          default: false
     responses:
       '200':
         description: Successful response

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -999,13 +999,35 @@ ModelConfig:
       description: Unique identifier for the model config
     model_name:
       type: string
-      description: Name of the model
+      description: Name of the model. Use `*` to match all models.
     provider:
       type: string
       description: Provider name (optional - applies to all providers if not specified)
+    scope:
+      type: string
+      description: Scope where this limit applies. `global` covers all traffic; `virtual_key` scopes to a single virtual key; `user` scopes to a single user (Enterprise only).
+      enum: [global, virtual_key, user]
+      default: global
+    scope_id:
+      type: string
+      nullable: true
+      description: ID of the scope target (e.g. virtual key ID or user ID). Required when scope is not `global`.
+    scope_name:
+      type: string
+      nullable: true
+      description: Resolved human-readable name of the scope target (read-only, set by server).
+    calendar_aligned:
+      type: boolean
+      description: When true, all budgets reset at clean calendar boundaries (midnight UTC for day, Monday for week, 1st for month, Jan 1 for year).
+      default: false
+    budgets:
+      type: array
+      description: Budget configurations for this model limit. Each entry must have a unique reset_duration.
+      items:
+        $ref: '#/Budget'
     budget:
       $ref: '#/Budget'
-      description: Budget configuration for this model
+      description: "Deprecated: use `budgets`. Returns the first budget for backward compatibility."
     rate_limit:
       $ref: '#/RateLimit'
       description: Rate limit configuration for this model
@@ -1035,9 +1057,9 @@ ListModelConfigsResponse:
       type: array
       items:
         $ref: '#/ModelConfig'
-    count:
+    total_count:
       type: integer
-      description: Number of model configs returned
+      description: Total number of model configs matching the filter (used for pagination)
 
 CreateModelConfigRequest:
   type: object
@@ -1047,20 +1069,30 @@ CreateModelConfigRequest:
   properties:
     model_name:
       type: string
-      description: Name of the model (required)
+      description: Name of the model (required). Use `*` to match all models.
     provider:
       type: string
       description: Provider name (optional - applies to all providers if not specified)
-    budget:
-      $ref: '#/CreateBudgetRequest'
-      description: Budget configuration
+    scope:
+      type: string
+      description: Scope where this limit applies. Defaults to `global`.
+      enum: [global, virtual_key, user]
+      default: global
+    scope_id:
+      type: string
+      description: ID of the scope target (e.g. virtual key ID or user ID). Required when scope is not `global`.
+    budgets:
+      type: array
+      description: Budget lines for this limit. Each entry must have a unique reset_duration.
+      items:
+        $ref: '#/CreateBudgetRequest'
     rate_limit:
       $ref: '#/CreateRateLimitRequest'
       description: Rate limit configuration
 
 UpdateModelConfigRequest:
   type: object
-  description: Request to update an existing model config
+  description: Request to update an existing model config. Scope and scope_id are identity fields and cannot be changed.
   properties:
     model_name:
       type: string
@@ -1068,9 +1100,11 @@ UpdateModelConfigRequest:
     provider:
       type: string
       description: Provider name
-    budget:
-      $ref: '#/UpdateBudgetRequest'
-      description: Budget configuration
+    budgets:
+      type: array
+      description: Full desired set of budgets (reconciled server-side). Send an empty array to remove all budgets.
+      items:
+        $ref: '#/CreateBudgetRequest'
     rate_limit:
       $ref: '#/UpdateRateLimitRequest'
       description: Rate limit configuration
@@ -1098,12 +1132,21 @@ ProviderGovernanceResponse:
     provider:
       type: string
       description: Provider name
+    budgets:
+      type: array
+      description: Budget configurations for this provider. Each entry has a unique reset_duration.
+      items:
+        $ref: '#/Budget'
     budget:
       $ref: '#/Budget'
-      description: Budget configuration
+      description: "Deprecated: use `budgets`. Returns the first budget for backward compatibility."
     rate_limit:
       $ref: '#/RateLimit'
       description: Rate limit configuration
+    calendar_aligned:
+      type: boolean
+      description: When true, all budgets reset at clean calendar boundaries (midnight UTC for day, Monday for week, 1st for month, Jan 1 for year).
+      default: false
 
 ListProviderGovernanceResponse:
   type: object
@@ -1121,12 +1164,25 @@ UpdateProviderGovernanceRequest:
   type: object
   description: Request to update provider governance settings
   properties:
+    budgets:
+      type: array
+      nullable: true
+      description: >
+        Full desired set of budgets. Pointer-to-slice semantics apply:
+        omitting the field leaves budgets unchanged; sending an empty array `[]` removes all budgets;
+        sending a non-empty array replaces all existing budgets with the provided set.
+      items:
+        $ref: '#/CreateBudgetRequest'
     budget:
       $ref: '#/UpdateBudgetRequest'
-      description: Budget configuration
+      description: "Deprecated: use `budgets`."
     rate_limit:
       $ref: '#/UpdateRateLimitRequest'
       description: Rate limit configuration
+    calendar_aligned:
+      type: boolean
+      nullable: true
+      description: When true, all budgets reset at clean calendar boundaries. Omit to leave unchanged.
 
 # Pricing Overrides
 

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1082,6 +1082,11 @@ func GenerateModelConfigHash(m tables.TableModelConfig) (string, error) {
 	writeHashField(hash, "scope_id", derefStr(m.ScopeID))
 	writeHashField(hash, "budget_id", derefStr(m.BudgetID))
 	writeHashField(hash, "rate_limit_id", derefStr(m.RateLimitID))
+	sortedBudgetIDs := append([]string(nil), m.BudgetIDs...)
+	sort.Strings(sortedBudgetIDs)
+	for _, id := range sortedBudgetIDs {
+		writeHashField(hash, "budget_ids", id)
+	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -834,6 +834,12 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationMigrateProviderGovernanceToModelConfigs(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddBudgetModelConfigIDColumn(ctx, db); err != nil {
+		return err
+	}
+	if err := migrationAddModelConfigCalendarAlignedColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3988,6 +3994,297 @@ func migrationMigrateProviderGovernanceToModelConfigs(ctx context.Context, db *g
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running migrate provider governance to model configs migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddBudgetModelConfigIDColumn adds governance_budgets.model_config_id and
+// backfills it from the legacy single governance_model_configs.budget_id, inverting
+// budget ownership so a model config can own multiple budgets via the FK.
+func migrationAddBudgetModelConfigIDColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_budget_model_config_id_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+
+			if !mig.HasColumn(&tables.TableBudget{}, "model_config_id") {
+				if err := mig.AddColumn(&tables.TableBudget{}, "model_config_id"); err != nil {
+					return fmt.Errorf("failed to add model_config_id column: %w", err)
+				}
+			}
+
+			// Backfill from the legacy single budget_id. Idempotent via the IS NULL guard.
+			if !mig.HasColumn(&tables.TableModelConfig{}, "budget_id") {
+				return nil
+			}
+			var mcs []tables.TableModelConfig
+			if err := tx.Where("budget_id IS NOT NULL").Find(&mcs).Error; err != nil {
+				return fmt.Errorf("failed to load model configs with budgets: %w", err)
+			}
+			for i := range mcs {
+				mc := &mcs[i]
+				if mc.BudgetID == nil {
+					continue
+				}
+				if err := tx.Exec(
+					"UPDATE governance_budgets SET model_config_id = ? WHERE id = ? AND model_config_id IS NULL",
+					mc.ID, *mc.BudgetID,
+				).Error; err != nil {
+					return fmt.Errorf("failed to backfill model_config_id for budget %q: %w", *mc.BudgetID, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return fmt.Errorf("add_budget_model_config_id_column is non-rollbackable: dropping model_config_id would permanently lose multi-budget ownership data that cannot be recovered from the legacy single budget_id column")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add budget model_config_id column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// ensureVKWildcardModelConfig returns the ID of the VK-scoped all-models wildcard model
+// config, creating it if absent.
+func ensureVKWildcardModelConfig(tx *gorm.DB, vkID string, provider *string, calendarAligned bool, now time.Time) (string, error) {
+	q := tx.Model(&tables.TableModelConfig{}).
+		Where("scope = ? AND scope_id = ? AND model_name = ?",
+			tables.ModelConfigScopeVirtualKey, vkID, tables.ModelConfigAllModels)
+	if provider == nil {
+		q = q.Where("provider IS NULL")
+	} else {
+		q = q.Where("provider = ?", *provider)
+	}
+	var existing []tables.TableModelConfig
+	if err := q.Limit(1).Find(&existing).Error; err != nil {
+		return "", fmt.Errorf("failed to look up VK wildcard model config: %w", err)
+	}
+	if len(existing) > 0 {
+		return existing[0].ID, nil
+	}
+	mc := tables.TableModelConfig{
+		ID:              uuid.NewString(),
+		ModelName:       tables.ModelConfigAllModels,
+		Provider:        provider,
+		Scope:           tables.ModelConfigScopeVirtualKey,
+		ScopeID:         &vkID,
+		CalendarAligned: calendarAligned,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if err := tx.Create(&mc).Error; err != nil {
+		return "", fmt.Errorf("failed to create VK wildcard model config: %w", err)
+	}
+	return mc.ID, nil
+}
+
+// migrationMigrateVirtualKeyGovernanceToModelConfigs folds VK-level governance into
+// model_configs as VK-scoped all-models wildcard rows:
+//   - VK top-level budgets/rate-limit -> (scope=virtual_key, scope_id=vk, model_name='*', provider=NULL)
+//   - per-provider-config budgets/rate-limit -> (..., provider=<that provider>)
+func migrationMigrateVirtualKeyGovernanceToModelConfigs(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "migrate_virtual_key_governance_to_model_configs",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			// Required tables/columns must exist (scope columns + the new owner FK).
+			if !tx.Migrator().HasTable(&tables.TableModelConfig{}) ||
+				!tx.Migrator().HasColumn(&tables.TableModelConfig{}, "scope") ||
+				!tx.Migrator().HasColumn(&tables.TableBudget{}, "model_config_id") {
+				return nil
+			}
+
+			var vks []tables.TableVirtualKey
+			if err := tx.Preload("Budgets").Preload("ProviderConfigs").Preload("ProviderConfigs.Budgets").
+				Find(&vks).Error; err != nil {
+				return fmt.Errorf("failed to load virtual keys: %w", err)
+			}
+
+			now := time.Now()
+			for i := range vks {
+				vk := &vks[i]
+
+				// VK top-level governance -> all-providers wildcard.
+				if len(vk.Budgets) > 0 || vk.RateLimitID != nil {
+					mcID, err := ensureVKWildcardModelConfig(tx, vk.ID, nil, vk.CalendarAligned, now)
+					if err != nil {
+						return err
+					}
+					for _, b := range vk.Budgets {
+						if err := tx.Exec(
+							"UPDATE governance_budgets SET model_config_id = ?, virtual_key_id = NULL WHERE id = ? AND model_config_id IS NULL",
+							mcID, b.ID,
+						).Error; err != nil {
+							return fmt.Errorf("failed to reparent VK budget %q: %w", b.ID, err)
+						}
+					}
+					if vk.RateLimitID != nil {
+						if err := tx.Exec("UPDATE governance_model_configs SET rate_limit_id = ? WHERE id = ?", *vk.RateLimitID, mcID).Error; err != nil {
+							return fmt.Errorf("failed to move VK rate limit to model config: %w", err)
+						}
+						if err := tx.Exec("UPDATE governance_virtual_keys SET rate_limit_id = NULL WHERE id = ?", vk.ID).Error; err != nil {
+							return fmt.Errorf("failed to clear VK rate limit FK: %w", err)
+						}
+					}
+				}
+
+				// Per-provider-config governance -> provider-specific wildcard.
+				for j := range vk.ProviderConfigs {
+					pc := &vk.ProviderConfigs[j]
+					if len(pc.Budgets) == 0 && pc.RateLimitID == nil {
+						continue
+					}
+					provider := pc.Provider
+					mcID, err := ensureVKWildcardModelConfig(tx, vk.ID, &provider, vk.CalendarAligned, now)
+					if err != nil {
+						return err
+					}
+					for _, b := range pc.Budgets {
+						if err := tx.Exec(
+							"UPDATE governance_budgets SET model_config_id = ?, provider_config_id = NULL WHERE id = ? AND model_config_id IS NULL",
+							mcID, b.ID,
+						).Error; err != nil {
+							return fmt.Errorf("failed to reparent provider-config budget %q: %w", b.ID, err)
+						}
+					}
+					if pc.RateLimitID != nil {
+						if err := tx.Exec("UPDATE governance_model_configs SET rate_limit_id = ? WHERE id = ?", *pc.RateLimitID, mcID).Error; err != nil {
+							return fmt.Errorf("failed to move provider-config rate limit to model config: %w", err)
+						}
+						if err := tx.Exec("UPDATE governance_virtual_key_provider_configs SET rate_limit_id = NULL WHERE id = ?", pc.ID).Error; err != nil {
+							return fmt.Errorf("failed to clear provider-config rate limit FK: %w", err)
+						}
+					}
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if !tx.Migrator().HasTable(&tables.TableModelConfig{}) ||
+				!tx.Migrator().HasColumn(&tables.TableModelConfig{}, "scope") {
+				return nil
+			}
+
+			// Only the VK-scoped all-models wildcards this migration creates.
+			var mcs []tables.TableModelConfig
+			if err := tx.Where("scope = ? AND model_name = ?",
+				tables.ModelConfigScopeVirtualKey, tables.ModelConfigAllModels).Find(&mcs).Error; err != nil {
+				return fmt.Errorf("failed to load VK wildcard model configs: %w", err)
+			}
+
+			for i := range mcs {
+				mc := &mcs[i]
+				if mc.ScopeID == nil {
+					continue
+				}
+				var budgets []tables.TableBudget
+				if err := tx.Where("model_config_id = ?", mc.ID).Find(&budgets).Error; err != nil {
+					return fmt.Errorf("failed to load budgets for model config %q: %w", mc.ID, err)
+				}
+
+				if mc.Provider == nil {
+					// VK top-level: restore VK ownership + rate limit.
+					for _, b := range budgets {
+						if err := tx.Exec("UPDATE governance_budgets SET virtual_key_id = ?, model_config_id = NULL WHERE id = ?", *mc.ScopeID, b.ID).Error; err != nil {
+							return fmt.Errorf("failed to restore VK budget %q: %w", b.ID, err)
+						}
+					}
+					if mc.RateLimitID != nil {
+						if err := tx.Exec("UPDATE governance_virtual_keys SET rate_limit_id = ? WHERE id = ?", *mc.RateLimitID, *mc.ScopeID).Error; err != nil {
+							return fmt.Errorf("failed to restore VK rate limit: %w", err)
+						}
+					}
+				} else {
+					// Provider-specific: find the matching provider config to restore onto.
+					var pcs []tables.TableVirtualKeyProviderConfig
+					if err := tx.Where("virtual_key_id = ? AND provider = ?", *mc.ScopeID, *mc.Provider).
+						Limit(1).Find(&pcs).Error; err != nil {
+						return fmt.Errorf("failed to find provider config for VK %q provider %q: %w", *mc.ScopeID, *mc.Provider, err)
+					}
+					if len(pcs) > 0 {
+						pcID := pcs[0].ID
+						for _, b := range budgets {
+							if err := tx.Exec("UPDATE governance_budgets SET provider_config_id = ?, model_config_id = NULL WHERE id = ?", pcID, b.ID).Error; err != nil {
+								return fmt.Errorf("failed to restore provider-config budget %q: %w", b.ID, err)
+							}
+						}
+						if mc.RateLimitID != nil {
+							if err := tx.Exec("UPDATE governance_virtual_key_provider_configs SET rate_limit_id = ? WHERE id = ?", *mc.RateLimitID, pcID).Error; err != nil {
+								return fmt.Errorf("failed to restore provider-config rate limit: %w", err)
+							}
+						}
+					}
+				}
+
+				if err := tx.Delete(&tables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
+					return fmt.Errorf("failed to delete VK wildcard model config %q: %w", mc.ID, err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running migrate virtual key governance to model configs migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddModelConfigCalendarAlignedColumn adds governance_model_configs.calendar_aligned
+// and backfills VK-scoped wildcards from their owning virtual key. Budgets folded out of a
+// calendar-aligned VK then keep snapping resets to calendar boundaries.
+func migrationAddModelConfigCalendarAlignedColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_model_config_calendar_aligned_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+
+			if !mig.HasColumn(&tables.TableModelConfig{}, "calendar_aligned") {
+				if err := mig.AddColumn(&tables.TableModelConfig{}, "calendar_aligned"); err != nil {
+					return fmt.Errorf("failed to add calendar_aligned column: %w", err)
+				}
+			}
+
+			// Backfill VK-scoped configs from their owning VK.
+			type vkRow struct {
+				ID              string
+				CalendarAligned bool
+			}
+			var rows []vkRow
+			if err := tx.Table("governance_virtual_keys").Select("id, calendar_aligned").Scan(&rows).Error; err != nil {
+				return fmt.Errorf("failed to load virtual keys for calendar_aligned backfill: %w", err)
+			}
+			for _, r := range rows {
+				if !r.CalendarAligned {
+					continue // default is already false
+				}
+				if err := tx.Exec(
+					"UPDATE governance_model_configs SET calendar_aligned = ? WHERE scope = ? AND scope_id = ?",
+					true, tables.ModelConfigScopeVirtualKey, r.ID,
+				).Error; err != nil {
+					return fmt.Errorf("failed to backfill calendar_aligned for VK %q: %w", r.ID, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if mig.HasColumn(&tables.TableModelConfig{}, "calendar_aligned") {
+				if err := mig.DropColumn(&tables.TableModelConfig{}, "calendar_aligned"); err != nil {
+					return fmt.Errorf("failed to drop calendar_aligned column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add model config calendar_aligned column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -840,6 +840,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddModelConfigCalendarAlignedColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationMigrateVirtualKeyGovernanceToModelConfigs(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4047,9 +4050,9 @@ func migrationAddBudgetModelConfigIDColumn(ctx context.Context, db *gorm.DB) err
 	return nil
 }
 
-// ensureVKWildcardModelConfig returns the ID of the VK-scoped all-models wildcard model
-// config, creating it if absent.
-func ensureVKWildcardModelConfig(tx *gorm.DB, vkID string, provider *string, calendarAligned bool, now time.Time) (string, error) {
+// ensureVKModelConfig returns the ID of the VK-scoped model config for the given
+// (vkID, provider) pair, creating it if absent.
+func ensureVKModelConfig(tx *gorm.DB, vkID string, provider *string, calendarAligned bool, now time.Time) (string, error) {
 	q := tx.Model(&tables.TableModelConfig{}).
 		Where("scope = ? AND scope_id = ? AND model_name = ?",
 			tables.ModelConfigScopeVirtualKey, vkID, tables.ModelConfigAllModels)
@@ -4060,7 +4063,7 @@ func ensureVKWildcardModelConfig(tx *gorm.DB, vkID string, provider *string, cal
 	}
 	var existing []tables.TableModelConfig
 	if err := q.Limit(1).Find(&existing).Error; err != nil {
-		return "", fmt.Errorf("failed to look up VK wildcard model config: %w", err)
+		return "", fmt.Errorf("failed to look up VK model config: %w", err)
 	}
 	if len(existing) > 0 {
 		return existing[0].ID, nil
@@ -4076,7 +4079,7 @@ func ensureVKWildcardModelConfig(tx *gorm.DB, vkID string, provider *string, cal
 		UpdatedAt:       now,
 	}
 	if err := tx.Create(&mc).Error; err != nil {
-		return "", fmt.Errorf("failed to create VK wildcard model config: %w", err)
+		return "", fmt.Errorf("failed to create VK model config: %w", err)
 	}
 	return mc.ID, nil
 }
@@ -4110,7 +4113,7 @@ func migrationMigrateVirtualKeyGovernanceToModelConfigs(ctx context.Context, db 
 
 				// VK top-level governance -> all-providers wildcard.
 				if len(vk.Budgets) > 0 || vk.RateLimitID != nil {
-					mcID, err := ensureVKWildcardModelConfig(tx, vk.ID, nil, vk.CalendarAligned, now)
+					mcID, err := ensureVKModelConfig(tx, vk.ID, nil, vk.CalendarAligned, now)
 					if err != nil {
 						return err
 					}
@@ -4139,7 +4142,7 @@ func migrationMigrateVirtualKeyGovernanceToModelConfigs(ctx context.Context, db 
 						continue
 					}
 					provider := pc.Provider
-					mcID, err := ensureVKWildcardModelConfig(tx, vk.ID, &provider, vk.CalendarAligned, now)
+					mcID, err := ensureVKModelConfig(tx, vk.ID, &provider, vk.CalendarAligned, now)
 					if err != nil {
 						return err
 					}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1163,27 +1163,34 @@ func (s *RDBConfigStore) DeleteProvider(ctx context.Context, provider schemas.Mo
 	if err := txDB.WithContext(ctx).Preload("Budgets").Where("provider = ?", string(provider)).Find(&providerModelConfigs).Error; err != nil {
 		return err
 	}
-	for _, mc := range providerModelConfigs {
-		for i := range mc.Budgets {
-			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", mc.Budgets[i].ID).Error; err != nil {
-				return err
-			}
-		}
-		if mc.BudgetID != nil {
-			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *mc.BudgetID).Error; err != nil {
-				return err
-			}
-		}
-		if mc.RateLimitID != nil {
-			if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", *mc.RateLimitID).Error; err != nil {
-				return err
-			}
-		}
-	}
 	if len(providerModelConfigs) > 0 {
 		var mcIDs []string
+		var budgetIDs []string
+		var rateLimitIDs []string
+		for i := range providerModelConfigs {
+			mcIDs = append(mcIDs, providerModelConfigs[i].ID)
+			for j := range providerModelConfigs[i].Budgets {
+				budgetIDs = append(budgetIDs, providerModelConfigs[i].Budgets[j].ID)
+			}
+			if providerModelConfigs[i].BudgetID != nil {
+				budgetIDs = append(budgetIDs, *providerModelConfigs[i].BudgetID)
+			}
+			if providerModelConfigs[i].RateLimitID != nil {
+				rateLimitIDs = append(rateLimitIDs, *providerModelConfigs[i].RateLimitID)
+			}
+		}
 		if err := txDB.WithContext(ctx).Where("id IN ?", mcIDs).Delete(&tables.TableModelConfig{}).Error; err != nil {
 			return err
+		}
+		if len(budgetIDs) > 0 {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id IN ?", budgetIDs).Error; err != nil {
+				return err
+			}
+		}
+		if len(rateLimitIDs) > 0 {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id IN ?", rateLimitIDs).Error; err != nil {
+				return err
+			}
 		}
 	}
 
@@ -3002,12 +3009,6 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...
 		budgetIDs := make([]string, 0, len(scopedModelConfigs))
 		rateLimitIDs := make([]string, 0, len(scopedModelConfigs))
 		for _, mc := range scopedModelConfigs {
-			// Owned budgets via ModelConfigID plus the legacy single BudgetID for safety.
-			for i := range mc.Budgets {
-				if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", mc.Budgets[i].ID).Error; err != nil {
-					return err
-				}
-			}
 			if mc.BudgetID != nil {
 				budgetIDs = append(budgetIDs, *mc.BudgetID)
 			}
@@ -3019,6 +3020,16 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...
 			Where("scope = ? AND scope_id = ?", tables.ModelConfigScopeVirtualKey, id).
 			Delete(&tables.TableModelConfig{}).Error; err != nil {
 			return err
+		}
+		if len(budgetIDs) > 0 {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id IN ?", budgetIDs).Error; err != nil {
+				return err
+			}
+		}
+		if len(rateLimitIDs) > 0 {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id IN ?", rateLimitIDs).Error; err != nil {
+				return err
+			}
 		}
 		rateLimitID := virtualKey.RateLimitID
 		// Delete the virtual key
@@ -4256,6 +4267,20 @@ func (s *RDBConfigStore) DeleteRoutingRule(ctx context.Context, id string, tx ..
 func (s *RDBConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
 	var modelConfigs []tables.TableModelConfig
 	if err := s.DB().WithContext(ctx).Preload("Budgets").Preload("Budget").Preload("RateLimit").Find(&modelConfigs).Error; err != nil {
+		return nil, err
+	}
+	return modelConfigs, nil
+}
+
+// GetModelConfigsByScopeAndScopeIDs retrieves model configs for a specific scope limited to the given scope IDs.
+func (s *RDBConfigStore) GetModelConfigsByScopeAndScopeIDs(ctx context.Context, scope string, scopeIDs []string) ([]tables.TableModelConfig, error) {
+	if len(scopeIDs) == 0 {
+		return nil, nil
+	}
+	var modelConfigs []tables.TableModelConfig
+	if err := s.DB().WithContext(ctx).Preload("Budgets").Preload("Budget").Preload("RateLimit").
+		Where("scope = ? AND scope_id IN ?", scope, scopeIDs).
+		Find(&modelConfigs).Error; err != nil {
 		return nil, err
 	}
 	return modelConfigs, nil

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1155,15 +1155,20 @@ func (s *RDBConfigStore) DeleteProvider(ctx context.Context, provider schemas.Mo
 		}
 	}
 
-	// Clean up model configs scoped to this provider
+	// Clean up model configs scoped to this provider (and their owned budgets/rate-limits).
 	// Delete by snapshotted IDs rather than a second WHERE provider=? pass to avoid a race
 	// where a concurrent CreateModelConfig lands between the snapshot and the delete, leaving
 	// its owned budget/rate-limit rows dangling.
 	var providerModelConfigs []tables.TableModelConfig
-	if err := txDB.WithContext(ctx).Where("provider = ?", string(provider)).Find(&providerModelConfigs).Error; err != nil {
+	if err := txDB.WithContext(ctx).Preload("Budgets").Where("provider = ?", string(provider)).Find(&providerModelConfigs).Error; err != nil {
 		return err
 	}
 	for _, mc := range providerModelConfigs {
+		for i := range mc.Budgets {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", mc.Budgets[i].ID).Error; err != nil {
+				return err
+			}
+		}
 		if mc.BudgetID != nil {
 			if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *mc.BudgetID).Error; err != nil {
 				return err
@@ -2997,6 +3002,12 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...
 		budgetIDs := make([]string, 0, len(scopedModelConfigs))
 		rateLimitIDs := make([]string, 0, len(scopedModelConfigs))
 		for _, mc := range scopedModelConfigs {
+			// Owned budgets via ModelConfigID plus the legacy single BudgetID for safety.
+			for i := range mc.Budgets {
+				if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", mc.Budgets[i].ID).Error; err != nil {
+					return err
+				}
+			}
 			if mc.BudgetID != nil {
 				budgetIDs = append(budgetIDs, *mc.BudgetID)
 			}
@@ -4244,7 +4255,7 @@ func (s *RDBConfigStore) DeleteRoutingRule(ctx context.Context, id string, tx ..
 // GetModelConfigs retrieves all model configs from the database.
 func (s *RDBConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
 	var modelConfigs []tables.TableModelConfig
-	if err := s.DB().WithContext(ctx).Preload("Budget").Preload("RateLimit").Find(&modelConfigs).Error; err != nil {
+	if err := s.DB().WithContext(ctx).Preload("Budgets").Preload("Budget").Preload("RateLimit").Find(&modelConfigs).Error; err != nil {
 		return nil, err
 	}
 	return modelConfigs, nil
@@ -4254,7 +4265,7 @@ func (s *RDBConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableMod
 func (s *RDBConfigStore) GetProviderGovernanceModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
 	var modelConfigs []tables.TableModelConfig
 	if err := s.DB().WithContext(ctx).
-		Preload("Budget").Preload("RateLimit").
+		Preload("Budgets").Preload("Budget").Preload("RateLimit").
 		Where("scope = ? AND model_name = ? AND provider IS NOT NULL", tables.ModelConfigScopeGlobal, tables.ModelConfigAllModels).
 		Find(&modelConfigs).Error; err != nil {
 		return nil, err
@@ -4291,6 +4302,7 @@ func (s *RDBConfigStore) GetModelConfigsPaginated(ctx context.Context, params Mo
 
 	var modelConfigs []tables.TableModelConfig
 	if err := baseQuery.
+		Preload("Budgets").
 		Preload("Budget").
 		Preload("RateLimit").
 		Order("created_at DESC, id DESC").
@@ -4317,7 +4329,7 @@ func (s *RDBConfigStore) GetModelConfig(ctx context.Context, scope string, scope
 	} else {
 		query = query.Where("provider IS NULL")
 	}
-	if err := query.Preload("Budget").Preload("RateLimit").First(&modelConfig).Error; err != nil {
+	if err := query.Preload("Budgets").Preload("Budget").Preload("RateLimit").First(&modelConfig).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -4329,7 +4341,7 @@ func (s *RDBConfigStore) GetModelConfig(ctx context.Context, scope string, scope
 // GetModelConfigByID retrieves a specific model config from the database by ID.
 func (s *RDBConfigStore) GetModelConfigByID(ctx context.Context, id string) (*tables.TableModelConfig, error) {
 	var modelConfig tables.TableModelConfig
-	if err := s.DB().WithContext(ctx).Preload("Budget").Preload("RateLimit").First(&modelConfig, "id = ?", id).Error; err != nil {
+	if err := s.DB().WithContext(ctx).Preload("Budgets").Preload("Budget").Preload("RateLimit").First(&modelConfig, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -4370,7 +4382,9 @@ func (s *RDBConfigStore) UpdateModelConfig(ctx context.Context, modelConfig *tab
 			return err
 		}
 	}
-	if err := txDB.WithContext(ctx).Save(modelConfig).Error; err != nil {
+	// Omit associations: budgets (has-many via ModelConfigID) and rate-limit are managed
+	// explicitly by callers. A cascading Save would otherwise clobber their usage counters.
+	if err := txDB.WithContext(ctx).Omit(clause.Associations).Save(modelConfig).Error; err != nil {
 		return s.parseGormError(err)
 	}
 	return nil
@@ -4404,16 +4418,23 @@ func (s *RDBConfigStore) DeleteModelConfig(ctx context.Context, id string, tx ..
 	}
 
 	txDB := tx[0]
-	// First fetch the model config to get budget and rate limit IDs
+	// Fetch the model config with its owned budgets to collect all IDs to clean up.
 	var modelConfig tables.TableModelConfig
-	if err := dbForUpdate(txDB.WithContext(ctx)).First(&modelConfig, "id = ?", id).Error; err != nil {
+	if err := dbForUpdate(txDB.WithContext(ctx)).Preload("Budgets").First(&modelConfig, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ErrNotFound
 		}
 		return err
 	}
-	// Store the budget and rate limit IDs before deleting
-	budgetID := modelConfig.BudgetID
+	// Collect budget IDs from both the Budgets slice (active path, owned via ModelConfigID)
+	// and the legacy single BudgetID column.
+	budgetIDs := make([]string, 0, len(modelConfig.Budgets)+1)
+	for i := range modelConfig.Budgets {
+		budgetIDs = append(budgetIDs, modelConfig.Budgets[i].ID)
+	}
+	if modelConfig.BudgetID != nil {
+		budgetIDs = append(budgetIDs, *modelConfig.BudgetID)
+	}
 	rateLimitID := modelConfig.RateLimitID
 	// Delete the model config first
 	if err := txDB.WithContext(ctx).Delete(&tables.TableModelConfig{}, "id = ?", id).Error; err != nil {
@@ -4422,9 +4443,10 @@ func (s *RDBConfigStore) DeleteModelConfig(ctx context.Context, id string, tx ..
 		}
 		return s.parseGormError(err)
 	}
-	// Delete the budget if it exists
-	if budgetID != nil {
-		if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *budgetID).Error; err != nil {
+	// Delete the owned budgets (don't rely on FK cascade — it isn't applied to
+	// pre-existing tables on all dialects).
+	if len(budgetIDs) > 0 {
+		if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id IN ?", budgetIDs).Error; err != nil {
 			return err
 		}
 	}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4306,6 +4306,12 @@ func (s *RDBConfigStore) GetModelConfigsPaginated(ctx context.Context, params Mo
 		search := "%" + strings.ToLower(params.Search) + "%"
 		baseQuery = baseQuery.Where("LOWER(model_name) LIKE ?", search)
 	}
+	if params.Scope != "" {
+		baseQuery = baseQuery.Where("scope = ?", params.Scope)
+	}
+	if params.Provider != "" {
+		baseQuery = baseQuery.Where("provider = ?", params.Provider)
+	}
 
 	var totalCount int64
 	if err := baseQuery.Count(&totalCount).Error; err != nil {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -28,9 +28,11 @@ type VirtualKeyQueryParams struct {
 
 // ModelConfigsQueryParams holds pagination, filtering, and search parameters for model configs queries.
 type ModelConfigsQueryParams struct {
-	Limit  int
-	Offset int
-	Search string
+	Limit    int
+	Offset   int
+	Search   string
+	Scope    string // optional; filters to an exact scope value (e.g. "global", "virtual_key")
+	Provider string // optional; filters to an exact provider value (e.g. "openai")
 }
 
 // RoutingRulesQueryParams holds pagination, filtering, and search parameters for routing rules queries.

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -256,6 +256,7 @@ type ConfigStore interface {
 
 	// Model config CRUD
 	GetModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error)
+	GetModelConfigsByScopeAndScopeIDs(ctx context.Context, scope string, scopeIDs []string) ([]tables.TableModelConfig, error)
 	GetProviderGovernanceModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error)
 	GetModelConfigsPaginated(ctx context.Context, params ModelConfigsQueryParams) ([]tables.TableModelConfig, int64, error)
 	GetModelConfig(ctx context.Context, scope string, scopeID *string, modelName string, provider *string) (*tables.TableModelConfig, error)

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -15,10 +15,11 @@ type TableBudget struct {
 	LastReset     time.Time `gorm:"index" json:"last_reset"`                         // Last time budget was reset
 	CurrentUsage  float64   `gorm:"default:0" json:"current_usage"`                  // Current usage in dollars
 
-	// Owner FKs: a budget belongs to at most one Team, one VK, or one ProviderConfig
+	// Owner FKs: a budget belongs to at most one Team, one VK, one ProviderConfig, or one ModelConfig
 	TeamID           *string `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
 	VirtualKeyID     *string `gorm:"type:varchar(255);index" json:"virtual_key_id,omitempty"`
 	ProviderConfigID *uint   `gorm:"index" json:"provider_config_id,omitempty"`
+	ModelConfigID    *string `gorm:"type:varchar(255);index" json:"model_config_id,omitempty"`
 
 	// Deprecated: set calendar_aligned on the parent access profile / VK / team
 	// instead. Kept for backward compatibility with older config.json files;
@@ -57,8 +58,11 @@ func (b *TableBudget) BeforeSave(tx *gorm.DB) error {
 	if b.ProviderConfigID != nil {
 		owners++
 	}
+	if b.ModelConfigID != nil {
+		owners++
+	}
 	if owners > 1 {
-		return fmt.Errorf("budget cannot have more than one owner (team/virtual key/provider config)")
+		return fmt.Errorf("budget cannot have more than one owner (team/virtual key/provider config/model config)")
 	}
 	// Validate that ResetDuration is in correct format (e.g., "30s", "5m", "1h", "1d", "1w", "1M", "1Y")
 	if d, err := ParseDuration(b.ResetDuration); err != nil {

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -74,6 +74,10 @@ type TableModelConfig struct {
 	// the scope target (e.g. the virtual key's name) so the UI can render a label
 	// instead of an opaque scope_id. Populated by the HTTP layer on read.
 	ScopeName string `gorm:"-" json:"scope_name,omitempty"`
+	// BudgetIDs is a config-file-only field listing pre-declared budget IDs (from
+	// governance.budgets) to link to this model config. Not persisted; used by the
+	// config sync path to set model_config_id on each referenced budget row.
+	BudgetIDs []string `gorm:"-" json:"budget_ids,omitempty"`
 
 	// Relationships
 	// Budgets are owned by this model config via TableBudget.ModelConfigID (a model

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -3,6 +3,7 @@ package tables
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"gorm.io/gorm"
@@ -12,6 +13,7 @@ import (
 const (
 	ModelConfigScopeGlobal     = "global"
 	ModelConfigScopeVirtualKey = "virtual_key"
+	ModelConfigScopeUser       = "user"
 )
 
 // ModelConfigAllModels is the model_name sentinel meaning "all models". Combined with a
@@ -19,14 +21,36 @@ const (
 // with a nil provider it means all models on all providers.
 const ModelConfigAllModels = "*"
 
-// validModelConfigScopes is the set of accepted scope values.
-var validModelConfigScopes = map[string]bool{
-	ModelConfigScopeGlobal:     true,
-	ModelConfigScopeVirtualKey: true,
+// validModelConfigScopes is the runtime registry of accepted scope values.
+// OSS seeds it with global + virtual_key; downstream consumers (e.g. the
+// enterprise build registering "user") extend it at startup via
+// RegisterModelConfigScope. Guarded by validModelConfigScopesMu.
+var (
+	validModelConfigScopesMu sync.RWMutex
+	validModelConfigScopes   = map[string]bool{
+		ModelConfigScopeGlobal:     true,
+		ModelConfigScopeVirtualKey: true,
+	}
+)
+
+// RegisterModelConfigScope adds scope to the allow-list consulted by
+// IsValidModelConfigScope and TableModelConfig.BeforeSave. Intended to be
+// called once at process startup; safe to call concurrently. Whitespace-
+// only input is ignored.
+func RegisterModelConfigScope(scope string) {
+	s := strings.TrimSpace(scope)
+	if s == "" {
+		return
+	}
+	validModelConfigScopesMu.Lock()
+	validModelConfigScopes[s] = true
+	validModelConfigScopesMu.Unlock()
 }
 
 // IsValidModelConfigScope reports whether scope is a recognized model config scope.
 func IsValidModelConfigScope(scope string) bool {
+	validModelConfigScopesMu.RLock()
+	defer validModelConfigScopesMu.RUnlock()
 	return validModelConfigScopes[scope]
 }
 

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -38,9 +38,13 @@ type TableModelConfig struct {
 	// Scope determines where this config applies: "global" (default) or "virtual_key".
 	Scope string `gorm:"type:varchar(50);not null;default:'global';uniqueIndex:idx_model_scope_provider,priority:1" json:"scope"`
 	// ScopeID is the target of a non-global scope (e.g. the virtual key ID). NULL for global.
-	ScopeID     *string `gorm:"type:varchar(255);uniqueIndex:idx_model_scope_provider,priority:2" json:"scope_id,omitempty"`
-	BudgetID    *string `gorm:"type:varchar(255);index:idx_model_config_budget" json:"budget_id,omitempty"`
-	RateLimitID *string `gorm:"type:varchar(255);index:idx_model_config_rate_limit" json:"rate_limit_id,omitempty"`
+	ScopeID *string `gorm:"type:varchar(255);uniqueIndex:idx_model_scope_provider,priority:2" json:"scope_id,omitempty"`
+	// CalendarAligned snaps this config's budget resets to calendar boundaries (e.g. a
+	// monthly budget resets on the 1st) rather than rolling windows. Propagated to owned
+	// budgets via AfterFind. For virtual_key-scoped configs it inherits the VK's setting.
+	CalendarAligned bool    `gorm:"not null;default:false" json:"calendar_aligned"`
+	BudgetID        *string `gorm:"type:varchar(255);index:idx_model_config_budget" json:"budget_id,omitempty"`
+	RateLimitID     *string `gorm:"type:varchar(255);index:idx_model_config_rate_limit" json:"rate_limit_id,omitempty"`
 
 	// ScopeName is a non-persisted, API-only field carrying the human-readable name of
 	// the scope target (e.g. the virtual key's name) so the UI can render a label
@@ -48,6 +52,13 @@ type TableModelConfig struct {
 	ScopeName string `gorm:"-" json:"scope_name,omitempty"`
 
 	// Relationships
+	// Budgets are owned by this model config via TableBudget.ModelConfigID (a model
+	// config may carry multiple budgets with different reset windows). This is the
+	// active representation. The legacy single Budget/BudgetID below is kept inert
+	// for backward compatibility and is no longer read by enforcement.
+	Budgets []TableBudget `gorm:"foreignKey:ModelConfigID;constraint:OnDelete:CASCADE" json:"budgets,omitempty"`
+	// Legacy (inert): superseded by Budgets. Retained so existing rows/columns keep
+	// parsing; not read by the governance store after the multi-budget cutover.
 	Budget    *TableBudget    `gorm:"foreignKey:BudgetID;onDelete:CASCADE" json:"budget,omitempty"`
 	RateLimit *TableRateLimit `gorm:"foreignKey:RateLimitID;onDelete:CASCADE" json:"rate_limit,omitempty"`
 
@@ -62,6 +73,16 @@ type TableModelConfig struct {
 // TableName sets the table name for each model
 func (TableModelConfig) TableName() string {
 	return "governance_model_configs"
+}
+
+// AfterFind propagates calendar_aligned down to owned budgets so the reset path reads
+// the stamped value off each budget. Mirrors TableTeam/TableVirtualKey. The governance
+// store's Update*InMemory paths re-stamp on every model-config update.
+func (mc *TableModelConfig) AfterFind(tx *gorm.DB) error {
+	for i := range mc.Budgets {
+		mc.Budgets[i].IsCalendarAligned = mc.CalendarAligned
+	}
+	return nil
 }
 
 // BeforeSave hook for ModelConfig to validate required fields

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -218,6 +218,74 @@ func TestStore_CheckModelBudget_ModelOnly_Exceeded(t *testing.T) {
 	assert.Contains(t, err.Error(), "budget exceeded")
 }
 
+// buildModelConfigMultiBudget builds a global model config owning multiple budgets
+// (via TableBudget.ModelConfigID), for multi-budget enforcement tests.
+func buildModelConfigMultiBudget(id, model string, provider *string, budgets []*configstoreTables.TableBudget) *configstoreTables.TableModelConfig {
+	mc := &configstoreTables.TableModelConfig{
+		ID:        id,
+		ModelName: model,
+		Provider:  provider,
+		Scope:     configstoreTables.ModelConfigScopeGlobal,
+	}
+	for _, b := range budgets {
+		b.ModelConfigID = &mc.ID
+		mc.Budgets = append(mc.Budgets, *b)
+	}
+	return mc
+}
+
+func TestStore_CheckModelBudget_MultiBudget_OneExceededBlocks(t *testing.T) {
+	logger := NewMockLogger()
+	within := buildBudget("b-day", 100.0, "1d")             // plenty of headroom
+	exceeded := buildBudgetWithUsage("b-hour", 10.0, 10.0, "1h") // at limit
+	mc := buildModelConfigMultiBudget("mc-multi", "gpt-4", nil, []*configstoreTables.TableBudget{within, exceeded})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*within, *exceeded},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	assert.Error(t, err, "the exceeded budget among several on one config must block")
+	assert.Contains(t, err.Error(), "budget exceeded")
+}
+
+func TestStore_CheckModelBudget_MultiBudget_AllWithinPasses(t *testing.T) {
+	logger := NewMockLogger()
+	b1 := buildBudget("b-day", 100.0, "1d")
+	b2 := buildBudget("b-hour", 10.0, "1h")
+	mc := buildModelConfigMultiBudget("mc-multi", "gpt-4", nil, []*configstoreTables.TableBudget{b1, b2})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*b1, *b2},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	assert.NoError(t, err, "all budgets within limit should pass")
+}
+
+func TestStore_UpdateModelBudgetUsage_MultiBudget_BumpsAll(t *testing.T) {
+	logger := NewMockLogger()
+	b1 := buildBudget("b-day", 100.0, "1d")
+	b2 := buildBudget("b-hour", 50.0, "1h")
+	mc := buildModelConfigMultiBudget("mc-multi", "gpt-4", nil, []*configstoreTables.TableBudget{b1, b2})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*b1, *b2},
+	}, nil)
+	require.NoError(t, err)
+
+	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "gpt-4", schemas.OpenAI, 7.5)
+	require.NoError(t, err)
+
+	for _, id := range []string{"b-day", "b-hour"} {
+		b := store.LoadBudget(context.Background(), id)
+		require.NotNil(t, b, "budget %s should be loadable", id)
+		assert.InDelta(t, 7.5, b.CurrentUsage, 0.001, "every budget on the config must be bumped (budget %s)", id)
+	}
+}
+
 func TestStore_CheckModelBudget_ModelWithProvider_WithinLimit(t *testing.T) {
 	logger := NewMockLogger()
 	budget := buildBudget("budget1", 100.0, "1h")
@@ -2351,4 +2419,60 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_BudgetTrips(t *testing.T) {
 
 	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, req, nil)
 	assert.Error(t, err, "scoped budget should trip once usage exceeds the cap")
+}
+
+// TestStore_VKGovernanceBudget_NoDoubleCount is the double-count guard: after the cutover a
+// VK's budget lives only on its VK-scoped all-models wildcard model config (vk.Budgets is
+// empty). The tracker invokes both the scoped-model path and the VK hierarchy path on every
+// request; only the scoped path may charge the budget — never both.
+func TestStore_VKGovernanceBudget_NoDoubleCount(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKey("vk1", "vk1-value", "vk1", true)
+	vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{buildProviderConfig("openai", []string{"*"})}
+	budget := buildBudget("vkb", 100.0, "1h")
+	// Owned by the VK-scoped all-models wildcard (provider=nil), not by the VK directly.
+	mc := buildVKScopedModelConfig("mc-vk", "*", nil, vk.ID, budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	// Mirror tracker.UpdateUsage: scoped-model path + hierarchy path, same request/cost.
+	require.NoError(t, store.UpdateVirtualKeyScopedModelBudgetUsageInMemory(context.Background(), vk, "gpt-4", schemas.OpenAI, 10.0))
+	require.NoError(t, store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 10.0))
+
+	b := store.LoadBudget(context.Background(), "vkb")
+	require.NotNil(t, b)
+	assert.InDelta(t, 10.0, b.CurrentUsage, 0.001, "VK governance budget must be charged exactly once (no hierarchy+scoped double count)")
+}
+
+// TestStore_CheckVirtualKeyScopedModelBudget_MultiBudget_OneExceededBlocks exercises the
+// scope-chain path that production VK governance flows through after cutover, with multiple
+// budgets on one VK-scoped wildcard config.
+func TestStore_CheckVirtualKeyScopedModelBudget_MultiBudget_OneExceededBlocks(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKey("vk1", "vk1-value", "vk1", true)
+	within := buildBudget("b-day", 100.0, "1d")
+	exceeded := buildBudgetWithUsage("b-hour", 10.0, 10.0, "1h")
+	mcID := "mc-vk-multi"
+	mc := &configstoreTables.TableModelConfig{
+		ID:        mcID,
+		ModelName: configstoreTables.ModelConfigAllModels,
+		Scope:     configstoreTables.ModelConfigScopeVirtualKey,
+		ScopeID:   &vk.ID,
+	}
+	for _, b := range []*configstoreTables.TableBudget{within, exceeded} {
+		b.ModelConfigID = &mcID
+		mc.Budgets = append(mc.Budgets, *b)
+	}
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*mc},
+		Budgets:      []configstoreTables.TableBudget{*within, *exceeded},
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	assert.Error(t, err, "an exceeded budget among several on a VK-scoped config must block")
 }

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -2247,7 +2247,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_NilVK(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), nil, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), "", "", &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -2258,7 +2258,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_NoConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	vk := buildVirtualKey("vk1", "vk1-value", "vk1", true)
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -2274,7 +2274,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_WithinLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	_, err = store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err, "Should allow when per-VK model budget is within limit")
 }
 
@@ -2289,7 +2289,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_Exceeded(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	_, err = store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "Should reject when per-VK model budget is exceeded")
 	assert.Contains(t, err.Error(), "budget exceeded")
 }
@@ -2307,7 +2307,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_OnlyAppliesToMatchingVK(t *testi
 	require.NoError(t, err)
 
 	// A request made with a DIFFERENT virtual key must not be affected by vk1's scoped config.
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), otherVK, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, otherVK.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -2326,7 +2326,7 @@ func TestStore_CheckVirtualKeyScopedModelBudget_IgnoresGlobalConfig(t *testing.T
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.NoError(t, err, "Scoped check must not pick up the global config")
 	assert.Equal(t, DecisionAllow, decision)
 
@@ -2346,7 +2346,7 @@ func TestStore_CheckVirtualKeyScopedModelRateLimit_TokenLimitExceeded(t *testing
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckVirtualKeyScopedModelRateLimit(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
 	assert.Error(t, err, "Should reject when per-VK model token limit is exceeded")
 	assert.Equal(t, DecisionTokenLimited, decision)
 }
@@ -2362,7 +2362,7 @@ func TestStore_CheckVirtualKeyScopedModelRateLimit_WithinLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	decision, err := store.CheckVirtualKeyScopedModelRateLimit(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
+	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, DecisionAllow, decision)
 }
@@ -2384,16 +2384,16 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_TokenLimitTrips(t *testing.
 	req := &EvaluationRequest{Model: "claude-opus-4-7", Provider: schemas.Anthropic}
 
 	// Initially within limit.
-	decision, err := store.CheckVirtualKeyScopedModelRateLimit(context.Background(), vk, req, nil, nil)
+	decision, err := store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, decision)
 
 	// Record usage above the limit (what the tracker does post-response). Provider differs from
 	// the config's (which is all-providers), exercising the model-only scoped lookup.
-	require.NoError(t, store.UpdateVirtualKeyScopedModelRateLimitUsageInMemory(context.Background(), vk, "claude-opus-4-7", schemas.Anthropic, 150, true, true))
+	require.NoError(t, store.UpdateScopedModelRateLimitUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "claude-opus-4-7", schemas.Anthropic, 150, true, true))
 
 	// Now the scoped check must trip.
-	decision, err = store.CheckVirtualKeyScopedModelRateLimit(context.Background(), vk, req, nil, nil)
+	decision, err = store.CheckScopedModelRateLimit(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil, nil)
 	assert.Error(t, err)
 	assert.Equal(t, DecisionTokenLimited, decision)
 }
@@ -2411,13 +2411,13 @@ func TestStore_VirtualKeyScopedModel_RecordThenCheck_BudgetTrips(t *testing.T) {
 
 	req := &EvaluationRequest{Model: "claude-opus-4-7", Provider: schemas.Anthropic}
 
-	decision, err := store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, req, nil)
+	decision, err := store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, decision)
 
-	require.NoError(t, store.UpdateVirtualKeyScopedModelBudgetUsageInMemory(context.Background(), vk, "claude-opus-4-7", schemas.Anthropic, 15.0))
+	require.NoError(t, store.UpdateScopedModelBudgetUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "claude-opus-4-7", schemas.Anthropic, 15.0))
 
-	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, req, nil)
+	_, err = store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, req, nil)
 	assert.Error(t, err, "scoped budget should trip once usage exceeds the cap")
 }
 
@@ -2440,7 +2440,7 @@ func TestStore_VKGovernanceBudget_NoDoubleCount(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mirror tracker.UpdateUsage: scoped-model path + hierarchy path, same request/cost.
-	require.NoError(t, store.UpdateVirtualKeyScopedModelBudgetUsageInMemory(context.Background(), vk, "gpt-4", schemas.OpenAI, 10.0))
+	require.NoError(t, store.UpdateScopedModelBudgetUsageInMemory(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, "gpt-4", schemas.OpenAI, 10.0))
 	require.NoError(t, store.UpdateVirtualKeyBudgetUsageInMemory(context.Background(), vk, schemas.OpenAI, 10.0))
 
 	b := store.LoadBudget(context.Background(), "vkb")
@@ -2473,6 +2473,6 @@ func TestStore_CheckVirtualKeyScopedModelBudget_MultiBudget_OneExceededBlocks(t 
 	}, nil)
 	require.NoError(t, err)
 
-	_, err = store.CheckVirtualKeyScopedModelBudget(context.Background(), vk, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
+	_, err = store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "an exceeded budget among several on a VK-scoped config must block")
 }

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -215,6 +215,24 @@ func (r *BudgetResolver) EvaluateUserRequest(ctx *schemas.BifrostContext, userID
 		}
 	}
 
+	// Check per-user-scoped model config rate limits and budgets. Mirrors the
+	// VK-scoped block in EvaluateVirtualKeyRequest. Gated on model being present —
+	// MCP tool execution (no model) is excluded naturally by this guard.
+	if request.Model != "" {
+		if decision, err := r.store.CheckScopedModelRateLimit(ctx, configstoreTables.ModelConfigScopeUser, userID, request, nil, nil); err != nil || isRateLimitViolation(decision) {
+			return &EvaluationResult{
+				Decision: decision,
+				Reason:   fmt.Sprintf("User-level model rate limit exceeded: %s", reasonFromErr(err, decision)),
+			}
+		}
+		if decision, err := r.store.CheckScopedModelBudget(ctx, configstoreTables.ModelConfigScopeUser, userID, request, nil); err != nil || isBudgetViolation(decision) {
+			return &EvaluationResult{
+				Decision: decision,
+				Reason:   fmt.Sprintf("User-level model budget exceeded: %s", reasonFromErr(err, decision)),
+			}
+		}
+	}
+
 	return &EvaluationResult{
 		Decision: DecisionAllow,
 		Reason:   "User-level checks passed",
@@ -292,14 +310,14 @@ func (r *BudgetResolver) EvaluateVirtualKeyRequest(ctx *schemas.BifrostContext, 
 		// request must satisfy both (most-restrictive wins). Gated on a model being present,
 		// mirroring the global model checks.
 		if model != "" {
-			if decision, err := r.store.CheckVirtualKeyScopedModelRateLimit(ctx, vk, evaluationRequest, nil, nil); err != nil || isRateLimitViolation(decision) {
+			if decision, err := r.store.CheckScopedModelRateLimit(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, evaluationRequest, nil, nil); err != nil || isRateLimitViolation(decision) {
 				return &EvaluationResult{
 					Decision:   decision,
 					Reason:     fmt.Sprintf("Model-level rate limit check failed (virtual key scope): %s", reasonFromErr(err, decision)),
 					VirtualKey: vk,
 				}
 			}
-			if decision, err := r.store.CheckVirtualKeyScopedModelBudget(ctx, vk, evaluationRequest, nil); err != nil || isBudgetViolation(decision) {
+			if decision, err := r.store.CheckScopedModelBudget(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, evaluationRequest, nil); err != nil || isBudgetViolation(decision) {
 				return &EvaluationResult{
 					Decision:   decision,
 					Reason:     fmt.Sprintf("Model-level budget exceeded (virtual key scope): %s", reasonFromErr(err, decision)),

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -744,15 +744,18 @@ func (gs *LocalGovernanceStore) GetGovernanceData(ctx context.Context) *Governan
 		if !ok || mc == nil {
 			return true // continue
 		}
-		// Cross-reference live budget/rate limit from standalone maps
-		// (usage updates clone into budgets/rateLimits maps, so embedded pointers go stale)
+		// Cross-reference live budgets/rate limit from standalone maps.
 		clone := *mc
-		if clone.BudgetID != nil {
-			if liveBudget, exists := gs.budgets.Load(*clone.BudgetID); exists && liveBudget != nil {
-				if b, ok := liveBudget.(*configstoreTables.TableBudget); ok {
-					clone.Budget = b
+		if len(clone.Budgets) > 0 {
+			liveBudgets := make([]configstoreTables.TableBudget, 0, len(clone.Budgets))
+			for _, b := range clone.Budgets {
+				if lb, exists := gs.budgets.Load(b.ID); exists && lb != nil {
+					if budget, ok := lb.(*configstoreTables.TableBudget); ok {
+						liveBudgets = append(liveBudgets, *budget)
+					}
 				}
 			}
+			clone.Budgets = liveBudgets
 		}
 		if clone.RateLimitID != nil {
 			if liveRL, exists := gs.rateLimits.Load(*clone.RateLimitID); exists && liveRL != nil {
@@ -1140,6 +1143,20 @@ func modelConfigEntityKey(mc *configstoreTables.TableModelConfig) string {
 	return key
 }
 
+// loadModelConfigBudgets returns the hot in-memory budget rows owned by a model config
+func (gs *LocalGovernanceStore) loadModelConfigBudgets(ctx context.Context, mc *configstoreTables.TableModelConfig) []*configstoreTables.TableBudget {
+	if mc == nil || len(mc.Budgets) == 0 {
+		return nil
+	}
+	out := make([]*configstoreTables.TableBudget, 0, len(mc.Budgets))
+	for i := range mc.Budgets {
+		if budget := gs.LoadBudget(ctx, mc.Budgets[i].ID); budget != nil {
+			out = append(out, budget)
+		}
+	}
+	return out
+}
+
 // CheckModelBudget performs budget checking for global-scope model-level configs, across all
 // four tiers (exact model±provider and all-models "*"±provider).
 func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
@@ -1149,11 +1166,8 @@ func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *E
 	model, provider := modelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
-		if mc.BudgetID == nil {
-			continue
-		}
-		if budget := gs.LoadBudget(ctx, *mc.BudgetID); budget != nil {
-			entityWiseBudgets[modelConfigEntityKey(mc)] = []*configstoreTables.TableBudget{budget}
+		if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
+			entityWiseBudgets[modelConfigEntityKey(mc)] = budgets
 		}
 	}
 	return gs.CheckBudget(ctx, entityWiseBudgets, baselines)
@@ -1307,11 +1321,8 @@ func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelBudget(ctx context.Con
 	entityWiseBudgets := EntityWiseBudgets{}
 	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
 		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, provider) {
-			if mc.BudgetID == nil {
-				continue
-			}
-			if budget := gs.LoadBudget(ctx, *mc.BudgetID); budget != nil {
-				entityWiseBudgets[modelConfigEntityKey(mc)] = []*configstoreTables.TableBudget{budget}
+			if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
+				entityWiseBudgets[modelConfigEntityKey(mc)] = budgets
 			}
 		}
 	}
@@ -1407,11 +1418,10 @@ func (gs *LocalGovernanceStore) UpdateProviderAndModelBudgetUsageInMemory(ctx co
 		providerStr = &p
 	}
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
-		if mc.BudgetID == nil {
-			continue
-		}
-		if err := gs.BumpBudgetUsage(ctx, *mc.BudgetID, cost); err != nil {
-			return err
+		for i := range mc.Budgets {
+			if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1471,11 +1481,10 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelBudgetUsageInMemory(c
 	}
 	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
 		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
-			if mc.BudgetID == nil {
-				continue
-			}
-			if err := gs.BumpBudgetUsage(ctx, *mc.BudgetID, cost); err != nil {
-				return err
+			for i := range mc.Budgets {
+				if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -1960,11 +1969,20 @@ func (gs *LocalGovernanceStore) loadFromConfigMemory(ctx context.Context, config
 	// Load routing rules
 	routingRules := config.RoutingRules
 
-	// Populate model configs with their relationships (Budget and RateLimit)
+	// Populate model configs with their relationships (Budgets and RateLimit)
 	for i := range modelConfigs {
 		mc := &modelConfigs[i]
 
-		// Populate budget
+		// Populate multi-budgets owned via TableBudget.ModelConfigID (the active path).
+		if len(mc.Budgets) == 0 {
+			for j := range budgets {
+				if budgets[j].ModelConfigID != nil && *budgets[j].ModelConfigID == mc.ID {
+					mc.Budgets = append(mc.Budgets, budgets[j])
+				}
+			}
+		}
+
+		// Legacy single-budget linking (inert; kept for backward-compatible config.json).
 		if mc.BudgetID != nil {
 			for j := range budgets {
 				if budgets[j].ID == *mc.BudgetID {
@@ -2112,6 +2130,13 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 	// (e.g., "openai/gpt-4o" and "gpt-4o" both store under base "gpt-4o").
 	for i := range modelConfigs {
 		mc := &modelConfigs[i]
+		// Stamp calendar alignment onto owned budgets and rate limit so the reset path
+		// reads the right window (the flat budgets/rate-limits list lacks owner context).
+		// Mirrors how VK/team budgets are stamped from their owner.
+		for j := range mc.Budgets {
+			mc.Budgets[j].IsCalendarAligned = mc.CalendarAligned
+			gs.budgets.Store(mc.Budgets[j].ID, &mc.Budgets[j])
+		}
 		scopeID := ""
 		if mc.ScopeID != nil {
 			scopeID = *mc.ScopeID
@@ -2448,40 +2473,44 @@ func (gs *LocalGovernanceStore) CollectApplicableGovernanceIDs(ctx context.Conte
 		}
 	}
 
-	// --- Model-level ---
-	if model != "" {
-		// model+provider specific config
-		if provider != "" {
-			key := fmt.Sprintf("%s:%s", model, string(provider))
-			if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
-				if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil {
-					if mc.BudgetID != nil && !seenBudgets[*mc.BudgetID] {
-						budgetIDs = append(budgetIDs, *mc.BudgetID)
-						seenBudgets[*mc.BudgetID] = true
-					}
-					if mc.RateLimitID != nil && !seenRateLimits[*mc.RateLimitID] {
-						rateLimitIDs = append(rateLimitIDs, *mc.RateLimitID)
-						seenRateLimits[*mc.RateLimitID] = true
-					}
-				}
+	var providerStr *string
+	if provider != "" {
+		p := string(provider)
+		providerStr = &p
+	}
+	// addModelConfigIDs accumulates the (multi-)budget and rate-limit IDs owned by a
+	// model config, matching what the enforcement/recording paths count.
+	addModelConfigIDs := func(mc *configstoreTables.TableModelConfig) {
+		for i := range mc.Budgets {
+			if id := mc.Budgets[i].ID; !seenBudgets[id] {
+				budgetIDs = append(budgetIDs, id)
+				seenBudgets[id] = true
 			}
 		}
-		// model-only config
-		if mc, _ := gs.findModelOnlyConfig(ctx, model); mc != nil {
-			if mc.BudgetID != nil && !seenBudgets[*mc.BudgetID] {
-				budgetIDs = append(budgetIDs, *mc.BudgetID)
-				seenBudgets[*mc.BudgetID] = true
-			}
-			if mc.RateLimitID != nil && !seenRateLimits[*mc.RateLimitID] {
-				rateLimitIDs = append(rateLimitIDs, *mc.RateLimitID)
-				seenRateLimits[*mc.RateLimitID] = true
-			}
+		if mc.RateLimitID != nil && !seenRateLimits[*mc.RateLimitID] {
+			rateLimitIDs = append(rateLimitIDs, *mc.RateLimitID)
+			seenRateLimits[*mc.RateLimitID] = true
 		}
 	}
 
-	// --- VK hierarchy (provider-config → VK → team → customer) ---
+	// --- Model-level (global scope), all four tiers incl. provider/all-models wildcards ---
+	if model != "" {
+		for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
+			addModelConfigIDs(mc)
+		}
+	}
+
+	// --- VK hierarchy (VK-scoped model configs + team/customer) ---
 	if virtualKey != "" {
 		if vk, exists := gs.GetVirtualKey(ctx, virtualKey); exists && vk != nil {
+			// VK-scoped model configs (provider-level + all-models wildcards).
+			if model != "" {
+				for _, scope := range nonGlobalModelConfigScopeChain(vk) {
+					for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
+						addModelConfigIDs(mc)
+					}
+				}
+			}
 			for _, id := range gs.collectBudgetIDsFromMemory(ctx, vk, provider) {
 				if !seenBudgets[id] {
 					budgetIDs = append(budgetIDs, id)
@@ -2771,8 +2800,8 @@ func (gs *LocalGovernanceStore) DeleteVirtualKeyInMemory(ctx context.Context, vk
 			return true
 		}
 		if mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ScopeID != nil && *mc.ScopeID == vkID {
-			if mc.BudgetID != nil {
-				gs.DeleteBudget(ctx, *mc.BudgetID)
+			for i := range mc.Budgets {
+				gs.DeleteBudget(ctx, mc.Budgets[i].ID)
 			}
 			if mc.RateLimitID != nil {
 				gs.DeleteRateLimit(ctx, *mc.RateLimitID)
@@ -3080,14 +3109,18 @@ func (gs *LocalGovernanceStore) UpdateModelConfigInMemory(ctx context.Context, m
 	// Clone to avoid modifying the original
 	clone := *mc
 
-	// Store associated budget if exists, preserving existing in-memory usage
-	if clone.Budget != nil {
-		if existingBudgetValue, exists := gs.budgets.Load(clone.Budget.ID); exists && existingBudgetValue != nil {
+	// Store associated budgets, preserving existing in-memory usage per budget ID and
+	// stamping calendar alignment from the model config (consumed by the reset path).
+	for i := range clone.Budgets {
+		b := &clone.Budgets[i]
+		b.IsCalendarAligned = clone.CalendarAligned
+		if existingBudgetValue, exists := gs.budgets.Load(b.ID); exists && existingBudgetValue != nil {
 			if eb, ok := existingBudgetValue.(*configstoreTables.TableBudget); ok && eb != nil {
-				clone.Budget.CurrentUsage = eb.CurrentUsage
+				b.CurrentUsage = eb.CurrentUsage
+				b.LastReset = eb.LastReset
 			}
 		}
-		gs.budgets.Store(clone.Budget.ID, clone.Budget)
+		gs.budgets.Store(b.ID, b)
 	}
 
 	// Store associated rate limit if exists, preserving existing in-memory usage
@@ -3137,9 +3170,9 @@ func (gs *LocalGovernanceStore) DeleteModelConfigInMemory(ctx context.Context, m
 		}
 
 		if mc.ID == mcID {
-			// Delete associated budget if exists
-			if mc.BudgetID != nil {
-				gs.DeleteBudget(ctx, *mc.BudgetID)
+			// Delete associated budgets if any
+			for i := range mc.Budgets {
+				gs.DeleteBudget(ctx, mc.Budgets[i].ID)
 			}
 
 			// Delete associated rate limit if exists
@@ -3482,62 +3515,7 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 
 	// Check model-specific rate limits and budgets (takes precedence)
 	if model != "" {
-		// Check model+provider config first (most specific)
-		key := fmt.Sprintf("%s:%s", model, string(provider))
-		if modelValue, ok := gs.modelConfigs.Load(key); ok && modelValue != nil {
-			if modelConfig, ok := modelValue.(*configstoreTables.TableModelConfig); ok && modelConfig != nil {
-				// Get rate limit status
-				if modelConfig.RateLimitID != nil {
-					if rateLimitValue, ok := gs.rateLimits.Load(*modelConfig.RateLimitID); ok && rateLimitValue != nil {
-						if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
-							tokensBaseline, exists := tokenBaselines[rateLimit.ID]
-							if !exists {
-								tokensBaseline = 0
-							}
-							requestsBaseline, exists := requestBaselines[rateLimit.ID]
-							if !exists {
-								requestsBaseline = 0
-							}
-							// Calculate token percent used
-							if rateLimit.TokenMaxLimit != nil && *rateLimit.TokenMaxLimit > 0 {
-								tokenPercent := float64(rateLimit.TokenCurrentUsage+tokensBaseline) / float64(*rateLimit.TokenMaxLimit) * 100
-								if tokenPercent > result.RateLimitTokenPercentUsed {
-									result.RateLimitTokenPercentUsed = tokenPercent
-								}
-							}
-							// Calculate request percent used
-							if rateLimit.RequestMaxLimit != nil && *rateLimit.RequestMaxLimit > 0 {
-								requestPercent := float64(rateLimit.RequestCurrentUsage+requestsBaseline) / float64(*rateLimit.RequestMaxLimit) * 100
-								if requestPercent > result.RateLimitRequestPercentUsed {
-									result.RateLimitRequestPercentUsed = requestPercent
-								}
-							}
-						}
-					}
-				}
-				// Get budget status
-				if modelConfig.BudgetID != nil {
-					if budgetValue, ok := gs.budgets.Load(*modelConfig.BudgetID); ok && budgetValue != nil {
-						if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-							baseline, exists := budgetBaselines[budget.ID]
-							if !exists {
-								baseline = 0
-							}
-							if budget.MaxLimit > 0 {
-								budgetPercent := float64(budget.CurrentUsage+baseline) / budget.MaxLimit * 100
-								if budgetPercent > result.BudgetPercentUsed {
-									result.BudgetPercentUsed = budgetPercent
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		// Fall back to model-only config (if exists)
-		// Uses findModelOnlyConfig for cross-provider model name normalization
-		if modelConfig, _ := gs.findModelOnlyConfig(ctx, model); modelConfig != nil {
+		if modelConfig, _ := gs.findScopedModelOnlyConfig(ctx, configstoreTables.ModelConfigScopeGlobal, "", model); modelConfig != nil {
 			// Get rate limit status
 			if modelConfig.RateLimitID != nil {
 				if rateLimitValue, ok := gs.rateLimits.Load(*modelConfig.RateLimitID); ok && rateLimitValue != nil {
@@ -3567,14 +3545,11 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 					}
 				}
 			}
-			// Get budget status
-			if modelConfig.BudgetID != nil {
-				if budgetValue, ok := gs.budgets.Load(*modelConfig.BudgetID); ok && budgetValue != nil {
+			// Get budget status (max percent across the config's budgets)
+			for bi := range modelConfig.Budgets {
+				if budgetValue, ok := gs.budgets.Load(modelConfig.Budgets[bi].ID); ok && budgetValue != nil {
 					if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-						baseline, exists := budgetBaselines[budget.ID]
-						if !exists {
-							baseline = 0
-						}
+						baseline := budgetBaselines[budget.ID]
 						if budget.MaxLimit > 0 {
 							budgetPercent := float64(budget.CurrentUsage+baseline) / budget.MaxLimit * 100
 							if budgetPercent > result.BudgetPercentUsed {

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -118,18 +118,22 @@ type GovernanceStore interface {
 	// Model-level governance checks
 	CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
 	CheckModelRateLimit(ctx context.Context, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
-	// Per-VK-scoped model-level governance checks (aggregate with the global model checks above)
-	CheckVirtualKeyScopedModelBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
-	CheckVirtualKeyScopedModelRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	// Scoped model-level governance checks (aggregate with the global model checks above).
+	// scope/scopeID identify the owning entity (e.g. "virtual_key" + VK.ID, or any other
+	// scope registered via tables.RegisterModelConfigScope). An empty scope or scopeID
+	// is a no-op (returns DecisionAllow).
+	CheckScopedModelBudget(ctx context.Context, scope, scopeID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
+	CheckScopedModelRateLimit(ctx context.Context, scope, scopeID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
 	// VK-level governance checks
 	CheckVirtualKeyBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
 	CheckVirtualKeyRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
 	// In-memory usage updates (for VK-level)
 	UpdateVirtualKeyBudgetUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, cost float64) error
 	UpdateVirtualKeyRateLimitUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
-	// In-memory usage updates for per-VK-scoped model configs (mirror the global model updates)
-	UpdateVirtualKeyScopedModelBudgetUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, model string, provider schemas.ModelProvider, cost float64) error
-	UpdateVirtualKeyScopedModelRateLimitUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
+	// In-memory usage updates for scoped model configs (mirror the global model updates).
+	// scope/scopeID identify the owning entity; an empty scope or scopeID is a no-op.
+	UpdateScopedModelBudgetUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, cost float64) error
+	UpdateScopedModelRateLimitUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// In-memory reset checks (return items that need DB sync)
 	ResetExpiredRateLimitsInMemory(ctx context.Context) []*configstoreTables.TableRateLimit
 	ResetExpiredBudgetsInMemory(ctx context.Context) []*configstoreTables.TableBudget
@@ -1068,8 +1072,8 @@ func (gs *LocalGovernanceStore) findScopedModelOnlyConfig(ctx context.Context, s
 	return tryKey(model)
 }
 
-// modelAndProvider extracts the model name and optional provider from a request.
-func modelAndProvider(request *EvaluationRequest) (string, *string) {
+// extractModelAndProvider extracts the model name and optional provider from a request.
+func extractModelAndProvider(request *EvaluationRequest) (string, *string) {
 	if request == nil {
 		return "", nil
 	}
@@ -1160,10 +1164,11 @@ func (gs *LocalGovernanceStore) loadModelConfigBudgets(ctx context.Context, mc *
 // CheckModelBudget performs budget checking for global-scope model-level configs, across all
 // four tiers (exact model±provider and all-models "*"±provider).
 func (gs *LocalGovernanceStore) CheckModelBudget(ctx context.Context, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
+	// This is to prevent nil pointer dereference
 	if baselines == nil {
 		baselines = map[string]float64{}
 	}
-	model, provider := modelAndProvider(request)
+	model, provider := extractModelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
 		if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
@@ -1288,13 +1293,14 @@ func (gs *LocalGovernanceStore) CheckUserBudget(ctx context.Context, userID stri
 
 // CheckModelRateLimit checks global-scope model-level rate limits across all four tiers
 func (gs *LocalGovernanceStore) CheckModelRateLimit(ctx context.Context, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+	// This is to prevent nil pointer dereference
 	if tokensBaselines == nil {
 		tokensBaselines = map[string]int64{}
 	}
 	if requestsBaselines == nil {
 		requestsBaselines = map[string]int64{}
 	}
-	model, provider := modelAndProvider(request)
+	model, provider := extractModelAndProvider(request)
 	entityWiseRateLimits := make(EntityWiseRateLimits)
 	for _, mc := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, provider) {
 		if mc.RateLimitID == nil {
@@ -1307,32 +1313,30 @@ func (gs *LocalGovernanceStore) CheckModelRateLimit(ctx context.Context, request
 	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
 }
 
-// CheckVirtualKeyScopedModelBudget enforces budgets from model configs scoped to the
-// request's virtual key. These are checked in addition to the global model budgets. A request
-// must satisfy both the global model config and any matching per-VK model config.
-func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelBudget(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
-	if vk == nil {
+// CheckScopedModelBudget enforces budgets from model configs scoped to the given
+// (scope, scopeID) — e.g. ("virtual_key", vk.ID). Checked in addition to the global
+// model budgets; a request must satisfy both. Empty scope or scopeID is a no-op.
+func (gs *LocalGovernanceStore) CheckScopedModelBudget(ctx context.Context, scope, scopeID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
+	if scope == "" || scopeID == "" {
 		return DecisionAllow, nil
 	}
 	if baselines == nil {
 		baselines = map[string]float64{}
 	}
-	model, provider := modelAndProvider(request)
+	model, provider := extractModelAndProvider(request)
 	entityWiseBudgets := EntityWiseBudgets{}
-	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, provider) {
-			if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
-				entityWiseBudgets[modelConfigEntityKey(mc)] = budgets
-			}
+	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, provider) {
+		if budgets := gs.loadModelConfigBudgets(ctx, mc); len(budgets) > 0 {
+			entityWiseBudgets[modelConfigEntityKey(mc)] = budgets
 		}
 	}
 	return gs.CheckBudget(ctx, entityWiseBudgets, baselines)
 }
 
-// CheckVirtualKeyScopedModelRateLimit enforces rate limits from model configs scoped to the
-// request's virtual key, in addition to the global model rate limits.
-func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelRateLimit(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
-	if vk == nil {
+// CheckScopedModelRateLimit enforces rate limits from model configs scoped to the given
+// (scope, scopeID), in addition to the global model rate limits.
+func (gs *LocalGovernanceStore) CheckScopedModelRateLimit(ctx context.Context, scope, scopeID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+	if scope == "" || scopeID == "" {
 		return DecisionAllow, nil
 	}
 	if tokensBaselines == nil {
@@ -1341,16 +1345,14 @@ func (gs *LocalGovernanceStore) CheckVirtualKeyScopedModelRateLimit(ctx context.
 	if requestsBaselines == nil {
 		requestsBaselines = map[string]int64{}
 	}
-	model, provider := modelAndProvider(request)
+	model, provider := extractModelAndProvider(request)
 	entityWiseRateLimits := make(EntityWiseRateLimits)
-	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, provider) {
-			if mc.RateLimitID == nil {
-				continue
-			}
-			if rateLimit := gs.LoadRateLimit(ctx, *mc.RateLimitID); rateLimit != nil {
-				entityWiseRateLimits[modelConfigEntityKey(mc)] = []*configstoreTables.TableRateLimit{rateLimit}
-			}
+	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, provider) {
+		if mc.RateLimitID == nil {
+			continue
+		}
+		if rateLimit := gs.LoadRateLimit(ctx, *mc.RateLimitID); rateLimit != nil {
+			entityWiseRateLimits[modelConfigEntityKey(mc)] = []*configstoreTables.TableRateLimit{rateLimit}
 		}
 	}
 	return gs.CheckRateLimit(ctx, entityWiseRateLimits, tokensBaselines, requestsBaselines)
@@ -1467,11 +1469,11 @@ func (gs *LocalGovernanceStore) UpdateProviderAndModelRateLimitUsageInMemory(ctx
 	return nil
 }
 
-// UpdateVirtualKeyScopedModelBudgetUsageInMemory bumps budget usage for model configs scoped
-// to the request's virtual key. This is the post-response counterpart to
-// CheckVirtualKeyScopedModelBudget — without it, scoped budgets never increase and never trip.
-func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelBudgetUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, model string, provider schemas.ModelProvider, cost float64) error {
-	if vk == nil || model == "" {
+// UpdateScopedModelBudgetUsageInMemory bumps budget usage for model configs scoped to the
+// given (scope, scopeID). Post-response counterpart to CheckScopedModelBudget — without it,
+// scoped budgets never increase and never trip. Empty scope/scopeID/model is a no-op.
+func (gs *LocalGovernanceStore) UpdateScopedModelBudgetUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, cost float64) error {
+	if scope == "" || scopeID == "" {
 		return nil
 	}
 	var providerStr *string
@@ -1479,22 +1481,20 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelBudgetUsageInMemory(c
 		p := string(provider)
 		providerStr = &p
 	}
-	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
-			for i := range mc.Budgets {
-				if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
-					return err
-				}
+	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, providerStr) {
+		for i := range mc.Budgets {
+			if err := gs.BumpBudgetUsage(ctx, mc.Budgets[i].ID, cost); err != nil {
+				return err
 			}
 		}
 	}
 	return nil
 }
 
-// UpdateVirtualKeyScopedModelRateLimitUsageInMemory bumps rate limit counters for model configs
-// scoped to the request's virtual key. Post-response counterpart to CheckVirtualKeyScopedModelRateLimit.
-func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelRateLimitUsageInMemory(ctx context.Context, vk *configstoreTables.TableVirtualKey, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
-	if vk == nil || model == "" {
+// UpdateScopedModelRateLimitUsageInMemory bumps rate limit counters for model configs scoped
+// to the given (scope, scopeID). Post-response counterpart to CheckScopedModelRateLimit.
+func (gs *LocalGovernanceStore) UpdateScopedModelRateLimitUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
+	if scope == "" || scopeID == "" {
 		return nil
 	}
 	var providerStr *string
@@ -1502,14 +1502,12 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyScopedModelRateLimitUsageInMemor
 		p := string(provider)
 		providerStr = &p
 	}
-	for _, scope := range nonGlobalModelConfigScopeChain(vk) {
-		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerStr) {
-			if mc.RateLimitID == nil {
-				continue
-			}
-			if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
-				return err
-			}
+	for _, mc := range gs.collectModelConfigsFor(ctx, scope, scopeID, model, providerStr) {
+		if mc.RateLimitID == nil {
+			continue
+		}
+		if err := gs.BumpRateLimitUsage(ctx, *mc.RateLimitID, tokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -2136,6 +2134,10 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 		for j := range mc.Budgets {
 			mc.Budgets[j].IsCalendarAligned = mc.CalendarAligned
 			gs.budgets.Store(mc.Budgets[j].ID, &mc.Budgets[j])
+		}
+		if mc.RateLimit != nil {
+			mc.RateLimit.IsCalendarAligned = mc.CalendarAligned
+			gs.rateLimits.Store(mc.RateLimit.ID, mc.RateLimit)
 		}
 		scopeID := ""
 		if mc.ScopeID != nil {
@@ -3123,8 +3125,10 @@ func (gs *LocalGovernanceStore) UpdateModelConfigInMemory(ctx context.Context, m
 		gs.budgets.Store(b.ID, b)
 	}
 
-	// Store associated rate limit if exists, preserving existing in-memory usage
+	// Store associated rate limit if exists, preserving existing in-memory usage and
+	// stamping calendar alignment from the owning model config.
 	if clone.RateLimit != nil {
+		clone.RateLimit.IsCalendarAligned = clone.CalendarAligned
 		if existingRateLimitValue, exists := gs.rateLimits.Load(clone.RateLimit.ID); exists && existingRateLimitValue != nil {
 			if erl, ok := existingRateLimitValue.(*configstoreTables.TableRateLimit); ok && erl != nil {
 				clone.RateLimit.TokenCurrentUsage = erl.TokenCurrentUsage
@@ -3513,10 +3517,17 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 		RateLimitRequestPercentUsed: 0,
 	}
 
-	// Check model-specific rate limits and budgets (takes precedence)
+	// Check model-level rate limits and budgets across all tiers (exact model+provider,
+	// model-only, and wildcard "*:provider" / "*:nil" from provider-governance migration).
+	// collectModelConfigsFor returns all four tiers so provider-level wildcard configs
+	// are included and status stays in sync with enforcement.
 	if model != "" {
-		if modelConfig, _ := gs.findScopedModelOnlyConfig(ctx, configstoreTables.ModelConfigScopeGlobal, "", model); modelConfig != nil {
-			// Get rate limit status
+		var providerStr *string
+		if provider != "" {
+			p := string(provider)
+			providerStr = &p
+		}
+		for _, modelConfig := range gs.collectModelConfigsFor(ctx, configstoreTables.ModelConfigScopeGlobal, "", model, providerStr) {
 			if modelConfig.RateLimitID != nil {
 				if rateLimitValue, ok := gs.rateLimits.Load(*modelConfig.RateLimitID); ok && rateLimitValue != nil {
 					if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -253,8 +253,9 @@ func buildModelConfig(id, modelName string, provider *string, budget *configstor
 		UpdatedAt: time.Now(),
 	}
 	if budget != nil {
-		mc.Budget = budget
-		mc.BudgetID = &budget.ID
+		// Model configs now own budgets via TableBudget.ModelConfigID (multi-budget).
+		budget.ModelConfigID = &mc.ID
+		mc.Budgets = []configstoreTables.TableBudget{*budget}
 	}
 	if rateLimit != nil {
 		mc.RateLimit = rateLimit

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -81,8 +81,10 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 
 	// 1. Update rate limit usage for both provider-level and model-level
 	// This applies even when virtual keys are disabled or not present
-	// Guard: only update when both Provider and Model are set (MCP paths may not have these)
-	if update.Provider != "" && update.Model != "" {
+	// Guard: only update when Model is set (MCP paths may not have it); provider is optional —
+	// the underlying function handles empty provider by skipping provider-level and still
+	// updating any matching global model-only configs.
+	if update.Model != "" {
 		if err := t.store.UpdateProviderAndModelRateLimitUsageInMemory(ctx, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
 			t.logger.Error("failed to update rate limit usage for model %s, provider %s: %v", update.Model, update.Provider, err)
 		}
@@ -90,8 +92,10 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 
 	// 2. Update budget usage for both provider-level and model-level
 	// This applies even when virtual keys are disabled or not present
-	// Guard: only update when both Provider and Model are set (MCP paths may not have these)
-	if update.Provider != "" && update.Model != "" && shouldUpdateBudget && update.Cost > 0 {
+	// Guard: only update when Model is set (MCP paths may not have it); provider is optional —
+	// the underlying function handles empty provider by skipping provider-level and still
+	// updating any matching global model-only configs.
+	if update.Model != "" && shouldUpdateBudget && update.Cost > 0 {
 		if err := t.store.UpdateProviderAndModelBudgetUsageInMemory(ctx, update.Model, update.Provider, update.Cost); err != nil {
 			t.logger.Error("failed to update budget usage for model %s, provider %s: %v", update.Model, update.Provider, err)
 		}
@@ -107,6 +111,19 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 		if shouldUpdateBudget && update.Cost > 0 {
 			if err := t.store.UpdateUserBudgetUsageInMemory(ctx, update.UserID, update.Cost); err != nil {
 				t.logger.Error("failed to update user budget usage for user %s: %v", update.UserID, err)
+			}
+		}
+		// Update per-user-scoped model config rate limits and budgets. Mirrors the
+		// VK-scoped model block below. Gated on model being present — MCP tool
+		// execution paths (no model) are excluded naturally by this guard.
+		if update.Model != "" {
+			if err := t.store.UpdateScopedModelRateLimitUsageInMemory(ctx, configstoreTables.ModelConfigScopeUser, update.UserID, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
+				t.logger.Error("failed to update scoped model rate limit usage for user %s: %v", update.UserID, err)
+			}
+			if shouldUpdateBudget && update.Cost > 0 {
+				if err := t.store.UpdateScopedModelBudgetUsageInMemory(ctx, configstoreTables.ModelConfigScopeUser, update.UserID, update.Model, update.Provider, update.Cost); err != nil {
+					t.logger.Error("failed to update scoped model budget usage for user %s: %v", update.UserID, err)
+				}
 			}
 		}
 	}
@@ -127,11 +144,11 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 	// Update per-VK-scoped model config usage (counterpart to the global model updates above).
 	// Without this, per-VK model limits never increment and so never trip.
 	if update.Model != "" {
-		if err := t.store.UpdateVirtualKeyScopedModelRateLimitUsageInMemory(ctx, vk, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
+		if err := t.store.UpdateScopedModelRateLimitUsageInMemory(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, update.Model, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
 			t.logger.Error("failed to update scoped model rate limit usage for VK %s: %v", vk.ID, err)
 		}
 		if shouldUpdateBudget && update.Cost > 0 {
-			if err := t.store.UpdateVirtualKeyScopedModelBudgetUsageInMemory(ctx, vk, update.Model, update.Provider, update.Cost); err != nil {
+			if err := t.store.UpdateScopedModelBudgetUsageInMemory(ctx, configstoreTables.ModelConfigScopeVirtualKey, vk.ID, update.Model, update.Provider, update.Cost); err != nil {
 				t.logger.Error("failed to update scoped model budget usage for VK %s: %v", vk.ID, err)
 			}
 		}

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -56,12 +57,52 @@ type GovernanceManager interface {
 }
 
 // GovernanceHandler manages HTTP requests for governance operations
+// ScopeNameResolver returns the human-readable name for a non-global model
+// config scope target (e.g. a virtual key's Name given its ID). The second
+// return value is false when no name could be resolved; the UI then falls
+// back to rendering the raw scope_id. Implementations must be safe to call
+// concurrently.
+type ScopeNameResolver func(ctx context.Context, scopeID string) (string, bool)
+
+// scopeNameResolvers is the package-level registry consulted by
+// resolveModelConfigScopeName. OSS seeds it (virtual_key) the first time a
+// GovernanceHandler is constructed; downstream builds extend it via
+// RegisterScopeNameResolver at startup. Guarded by scopeNameResolversMu.
+var (
+	scopeNameResolversMu sync.RWMutex
+	scopeNameResolvers   = map[string]ScopeNameResolver{}
+)
+
+// RegisterScopeNameResolver wires a resolver for a model_config scope value.
+// Intended to be called once at process startup, before serving requests
+// (e.g. an enterprise build registering a "user" resolver). Overwrites any
+// previously registered resolver for the same scope. Safe to call
+// concurrently.
+func RegisterScopeNameResolver(scope string, fn ScopeNameResolver) {
+	if scope == "" || fn == nil {
+		return
+	}
+	scopeNameResolversMu.Lock()
+	scopeNameResolvers[scope] = fn
+	scopeNameResolversMu.Unlock()
+}
+
+func lookupScopeNameResolver(scope string) (ScopeNameResolver, bool) {
+	scopeNameResolversMu.RLock()
+	defer scopeNameResolversMu.RUnlock()
+	fn, ok := scopeNameResolvers[scope]
+	return fn, ok
+}
+
 type GovernanceHandler struct {
 	configStore       configstore.ConfigStore
 	governanceManager GovernanceManager
 }
 
-// NewGovernanceHandler creates a new governance handler instance
+// NewGovernanceHandler creates a new governance handler instance.
+// Side effect: ensures the default virtual_key scope-name resolver is
+// registered against the supplied configStore, so resolveModelConfigScopeName
+// can render VK names for OSS-only builds without further wiring.
 func NewGovernanceHandler(manager GovernanceManager, configStore configstore.ConfigStore) (*GovernanceHandler, error) {
 	if manager == nil {
 		return nil, fmt.Errorf("governance manager is required")
@@ -69,6 +110,13 @@ func NewGovernanceHandler(manager GovernanceManager, configStore configstore.Con
 	if configStore == nil {
 		return nil, fmt.Errorf("config store is required")
 	}
+	RegisterScopeNameResolver(configstoreTables.ModelConfigScopeVirtualKey, func(ctx context.Context, scopeID string) (string, bool) {
+		vk, err := configStore.GetVirtualKey(ctx, scopeID)
+		if err != nil || vk == nil {
+			return "", false
+		}
+		return vk.Name, true
+	})
 	return &GovernanceHandler{
 		governanceManager: manager,
 		configStore:       configStore,
@@ -411,11 +459,11 @@ func (h *GovernanceHandler) reconcileModelConfigBudgets(ctx context.Context, tx 
 	return nil
 }
 
-// vkWildcardDesired is the desired governance state for one VK-scoped all-models wildcard
-// model config (provider=nil for the VK top-level, or a specific provider). The *Provided
-// flags distinguish "leave unchanged" (false, used by partial VK updates) from "set to the
-// given value" (true). The rateLimit carries only the limit/duration fields (no ID/usage).
-type vkWildcardDesired struct {
+// vkModelConfigDesired is the desired governance state for one VK-scoped model config tier
+// (provider=nil for the VK top-level, or a specific provider). The *Provided flags distinguish
+// "leave unchanged" (false, used by partial VK updates) from "set to the given value" (true).
+// The rateLimit carries only the limit/duration fields (no ID/usage).
+type vkModelConfigDesired struct {
 	provider          *string
 	budgetsProvided   bool
 	budgets           []CreateBudgetRequest
@@ -425,14 +473,14 @@ type vkWildcardDesired struct {
 }
 
 // syncVKGovernanceToModelConfigs folds a virtual key's governance (top-level + per-provider
-// budgets/rate-limits) into VK-scoped all-models wildcard model configs, the single source of
-// truth. It upserts the top-level and per-provider wildcards and deletes wildcards for
-// providers no longer configured. Must run inside the VK create/update transaction.
-// reconcileProviders controls per-provider handling: true treats perProvider as the full
-// desired set (upserting them and deleting wildcards for absent providers); false leaves all
-// per-provider wildcards untouched (for a partial VK update that omits provider_configs).
-func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, top vkWildcardDesired, perProvider []vkWildcardDesired, reconcileProviders bool) error {
-	if err := h.upsertVKWildcard(ctx, tx, vk, top); err != nil {
+// budgets/rate-limits) into VK-scoped model configs, the single source of truth. It reconciles
+// the top-level and per-provider configs and removes configs for providers no longer configured.
+// Must run inside the VK create/update transaction. reconcileProviders controls per-provider
+// handling: true treats perProvider as the full desired set (reconciling and removing absent
+// providers); false leaves all per-provider configs untouched (for a partial VK update that
+// omits provider_configs).
+func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, top vkModelConfigDesired, perProvider []vkModelConfigDesired, reconcileProviders bool) error {
+	if err := h.reconcileVKModelConfig(ctx, tx, vk, top); err != nil {
 		return err
 	}
 	if !reconcileProviders {
@@ -444,11 +492,11 @@ func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, 
 			continue
 		}
 		keep[*pg.provider] = true
-		if err := h.upsertVKWildcard(ctx, tx, vk, pg); err != nil {
+		if err := h.reconcileVKModelConfig(ctx, tx, vk, pg); err != nil {
 			return err
 		}
 	}
-	// Delete VK-scoped provider wildcards whose provider is no longer configured.
+	// Delete VK-scoped provider model configs whose provider is no longer configured.
 	var existing []configstoreTables.TableModelConfig
 	if err := tx.Preload("Budgets").
 		Where("scope = ? AND scope_id = ? AND model_name = ? AND provider IS NOT NULL",
@@ -459,7 +507,7 @@ func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, 
 	for i := range existing {
 		mc := &existing[i]
 		if mc.Provider != nil && !keep[*mc.Provider] {
-			if err := h.deleteVKWildcardModelConfig(ctx, tx, mc); err != nil {
+			if err := h.deleteVKModelConfig(ctx, tx, mc); err != nil {
 				return err
 			}
 		}
@@ -467,8 +515,8 @@ func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, 
 	return nil
 }
 
-// upsertVKWildcard reconciles a single VK-scoped wildcard model config to the desired state.
-func (h *GovernanceHandler) upsertVKWildcard(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, d vkWildcardDesired) error {
+// reconcileVKModelConfig reconciles a single VK-scoped model config to the desired state.
+func (h *GovernanceHandler) reconcileVKModelConfig(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, d vkModelConfigDesired) error {
 	q := tx.Preload("Budgets").Where("scope = ? AND scope_id = ? AND model_name = ?",
 		configstoreTables.ModelConfigScopeVirtualKey, vk.ID, configstoreTables.ModelConfigAllModels)
 	if d.provider == nil {
@@ -554,7 +602,7 @@ func (h *GovernanceHandler) upsertVKWildcard(ctx context.Context, tx *gorm.DB, v
 	hasGovernance := mc.RateLimitID != nil || finalBudgetCount > 0
 
 	if !hasGovernance {
-		// No governance left → drop the wildcard (and its budgets) if it existed.
+		// No governance left → drop the model config (and its budgets) if it existed.
 		if !isNew {
 			for i := range mc.Budgets {
 				if err := h.configStore.DeleteBudget(ctx, mc.Budgets[i].ID, tx); err != nil {
@@ -599,9 +647,9 @@ func (h *GovernanceHandler) upsertVKWildcard(ctx context.Context, tx *gorm.DB, v
 	return nil
 }
 
-// deleteVKWildcardModelConfig removes a VK-scoped wildcard model config and its owned
+// deleteVKModelConfig removes a VK-scoped model config and its owned
 // budgets/rate-limit (used when a provider config is removed from the VK).
-func (h *GovernanceHandler) deleteVKWildcardModelConfig(ctx context.Context, tx *gorm.DB, mc *configstoreTables.TableModelConfig) error {
+func (h *GovernanceHandler) deleteVKModelConfig(ctx context.Context, tx *gorm.DB, mc *configstoreTables.TableModelConfig) error {
 	for i := range mc.Budgets {
 		if err := h.configStore.DeleteBudget(ctx, mc.Budgets[i].ID, tx); err != nil {
 			return err
@@ -630,20 +678,20 @@ func rateLimitFromRequestFields(tokenMax *int64, tokenDur *string, reqMax *int64
 	}
 }
 
-// vkWildcardIndexKey keys a VK-scoped all-models wildcard by scope target + provider
-func vkWildcardIndexKey(scopeID string, provider *string) string {
+// vkModelConfigIndexKey builds a lookup key for a VK-scoped model config by scope target + provider.
+func vkModelConfigIndexKey(scopeID string, provider *string) string {
 	if provider == nil {
 		return scopeID + "|"
 	}
 	return scopeID + "|" + *provider
 }
 
-// applyVKGovernanceFromWildcards repopulates a VK's (and each provider config's) budgets and
-// rate-limit FROM the VK-scoped wildcard model configs that now own them — for serialization
-// only (so the VK sheet still renders the governance it edits). byKey indexes the wildcards by
-// vkWildcardIndexKey. The reverse of syncVKGovernanceToModelConfigs.
-func applyVKGovernanceFromWildcards(vk *configstoreTables.TableVirtualKey, byKey map[string]*configstoreTables.TableModelConfig) {
-	if mc := byKey[vkWildcardIndexKey(vk.ID, nil)]; mc != nil {
+// applyVKGovernanceFromModelConfigs repopulates a VK's (and each provider config's) budgets and
+// rate-limit from the VK-scoped model configs that own them — for serialization only (so the VK
+// sheet still renders the governance it edits). byKey is keyed by vkModelConfigIndexKey.
+// The reverse of syncVKGovernanceToModelConfigs.
+func applyVKGovernanceFromModelConfigs(vk *configstoreTables.TableVirtualKey, byKey map[string]*configstoreTables.TableModelConfig) {
+	if mc := byKey[vkModelConfigIndexKey(vk.ID, nil)]; mc != nil {
 		vk.Budgets = mc.Budgets
 		vk.RateLimit = mc.RateLimit
 		vk.RateLimitID = mc.RateLimitID
@@ -654,7 +702,7 @@ func applyVKGovernanceFromWildcards(vk *configstoreTables.TableVirtualKey, byKey
 	}
 	for i := range vk.ProviderConfigs {
 		pc := &vk.ProviderConfigs[i]
-		if mc := byKey[vkWildcardIndexKey(vk.ID, &pc.Provider)]; mc != nil {
+		if mc := byKey[vkModelConfigIndexKey(vk.ID, &pc.Provider)]; mc != nil {
 			pc.Budgets = mc.Budgets
 			pc.RateLimit = mc.RateLimit
 			pc.RateLimitID = mc.RateLimitID
@@ -666,7 +714,7 @@ func applyVKGovernanceFromWildcards(vk *configstoreTables.TableVirtualKey, byKey
 	}
 }
 
-// hydrateVKGovernance reverse-maps a single VK's governance from its wildcard model configs.
+// hydrateVKGovernance reverse-maps a single VK's governance from its VK-scoped model configs.
 func (h *GovernanceHandler) hydrateVKGovernance(ctx context.Context, vk *configstoreTables.TableVirtualKey) {
 	if vk == nil {
 		return
@@ -675,7 +723,7 @@ func (h *GovernanceHandler) hydrateVKGovernance(ctx context.Context, vk *configs
 	add := func(provider *string) {
 		mc, err := h.configStore.GetModelConfig(ctx, configstoreTables.ModelConfigScopeVirtualKey, &vk.ID, configstoreTables.ModelConfigAllModels, provider)
 		if err == nil && mc != nil {
-			byKey[vkWildcardIndexKey(vk.ID, provider)] = mc
+			byKey[vkModelConfigIndexKey(vk.ID, provider)] = mc
 		}
 	}
 	add(nil)
@@ -683,23 +731,23 @@ func (h *GovernanceHandler) hydrateVKGovernance(ctx context.Context, vk *configs
 		prov := vk.ProviderConfigs[i].Provider
 		add(&prov)
 	}
-	applyVKGovernanceFromWildcards(vk, byKey)
+	applyVKGovernanceFromModelConfigs(vk, byKey)
 }
 
-// vkWildcardIndexFromModelConfigs builds an index of VK-scoped all-models wildcard model
-// configs keyed by vkWildcardIndexKey, from a slice of model-config pointers.
-func vkWildcardIndexFromModelConfigs(mcs []*configstoreTables.TableModelConfig) map[string]*configstoreTables.TableModelConfig {
+// buildVKModelConfigIndex builds a lookup map of VK-scoped model configs keyed by
+// vkModelConfigIndexKey, from a slice of model-config pointers.
+func buildVKModelConfigIndex(mcs []*configstoreTables.TableModelConfig) map[string]*configstoreTables.TableModelConfig {
 	byKey := make(map[string]*configstoreTables.TableModelConfig)
 	for _, mc := range mcs {
 		if mc != nil && mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ModelName == configstoreTables.ModelConfigAllModels && mc.ScopeID != nil {
-			byKey[vkWildcardIndexKey(*mc.ScopeID, mc.Provider)] = mc
+			byKey[vkModelConfigIndexKey(*mc.ScopeID, mc.Provider)] = mc
 		}
 	}
 	return byKey
 }
 
 // hydrateVKListGovernance reverse-maps governance for a list of VKs using a single bulk load
-// of all VK-scoped wildcard model configs (avoids per-VK/per-provider queries).
+// of all VK-scoped model configs (avoids per-VK/per-provider queries).
 func (h *GovernanceHandler) hydrateVKListGovernance(ctx context.Context, vks []configstoreTables.TableVirtualKey) {
 	if len(vks) == 0 {
 		return
@@ -713,11 +761,11 @@ func (h *GovernanceHandler) hydrateVKListGovernance(ctx context.Context, vks []c
 	for i := range allMCs {
 		mc := &allMCs[i]
 		if mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ModelName == configstoreTables.ModelConfigAllModels && mc.ScopeID != nil {
-			byKey[vkWildcardIndexKey(*mc.ScopeID, mc.Provider)] = mc
+			byKey[vkModelConfigIndexKey(*mc.ScopeID, mc.Provider)] = mc
 		}
 	}
 	for i := range vks {
-		applyVKGovernanceFromWildcards(&vks[i], byKey)
+		applyVKGovernanceFromModelConfigs(&vks[i], byKey)
 	}
 }
 
@@ -872,9 +920,15 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 		sort.Slice(virtualKeys, func(i, j int) bool {
 			return virtualKeys[i].CreatedAt.Before(virtualKeys[j].CreatedAt)
 		})
-		byKey := vkWildcardIndexFromModelConfigs(data.ModelConfigs)
-		for _, vk := range virtualKeys {
-			applyVKGovernanceFromWildcards(vk, byKey)
+		byKey := buildVKModelConfigIndex(data.ModelConfigs)
+		hydratedVKs := make([]*configstoreTables.TableVirtualKey, len(virtualKeys))
+		for i, vk := range virtualKeys {
+			clone := *vk
+			pcs := make([]configstoreTables.TableVirtualKeyProviderConfig, len(vk.ProviderConfigs))
+			copy(pcs, vk.ProviderConfigs)
+			clone.ProviderConfigs = pcs
+			applyVKGovernanceFromModelConfigs(&clone, byKey)
+			hydratedVKs[i] = &clone
 		}
 		SendJSON(ctx, map[string]interface{}{
 			"virtual_keys": hydratedVKs,
@@ -943,7 +997,7 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 500, "Failed to retrieve virtual keys")
 			return
 		}
-		// Reverse-map governance from VK-scoped wildcard model configs for display.
+		// Reverse-map governance from VK-scoped model configs for display.
 		h.hydrateVKListGovernance(ctx, virtualKeys)
 		SendJSON(ctx, map[string]interface{}{
 			"virtual_keys": virtualKeys,
@@ -1038,10 +1092,10 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		if err := h.configStore.CreateVirtualKey(ctx, &vk, tx); err != nil {
 			return err
 		}
-		// VK top-level and per-provider budgets/rate-limits are the single-source-of-truth
-		// VK-scoped wildcard model configs, written via syncVKGovernanceToModelConfigs below.
+		// VK top-level and per-provider budgets/rate-limits are stored in VK-scoped model configs,
+		// the single source of truth, written via syncVKGovernanceToModelConfigs below.
 		// The per-provider desired state is accumulated while creating the provider configs.
-		var vkGovProviders []vkWildcardDesired
+		var vkGovProviders []vkModelConfigDesired
 		if req.ProviderConfigs != nil {
 			for _, pc := range req.ProviderConfigs {
 				providerName := schemas.ModelProvider(strings.TrimSpace(pc.Provider))
@@ -1090,14 +1144,14 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 				if err := h.configStore.CreateVirtualKeyProviderConfig(ctx, providerConfig, tx); err != nil {
 					return err
 				}
-				// Provider-config budgets/rate-limit are folded into a VK-scoped wildcard
-				// model config for this provider (written by syncVKGovernanceToModelConfigs).
+				// Provider-config budgets/rate-limit are stored in the VK-scoped model config
+				// for this provider (written by syncVKGovernanceToModelConfigs).
 				providerNameStr := string(providerName)
 				var pcRateLimit *configstoreTables.TableRateLimit
 				if pc.RateLimit != nil {
 					pcRateLimit = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 				}
-				vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+				vkGovProviders = append(vkGovProviders, vkModelConfigDesired{
 					provider:          &providerNameStr,
 					budgetsProvided:   true,
 					budgets:           pc.Budgets,
@@ -1106,12 +1160,12 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 				})
 			}
 		}
-		// Fold VK top-level + per-provider governance into VK-scoped wildcard model configs.
+		// Fold VK top-level + per-provider governance into VK-scoped model configs.
 		var topRateLimit *configstoreTables.TableRateLimit
 		if req.RateLimit != nil {
 			topRateLimit = rateLimitFromRequestFields(req.RateLimit.TokenMaxLimit, req.RateLimit.TokenResetDuration, req.RateLimit.RequestMaxLimit, req.RateLimit.RequestResetDuration)
 		}
-		if err := h.syncVKGovernanceToModelConfigs(ctx, tx, &vk, vkWildcardDesired{
+		if err := h.syncVKGovernanceToModelConfigs(ctx, tx, &vk, vkModelConfigDesired{
 			budgetsProvided:   true,
 			budgets:           req.Budgets,
 			rateLimitProvided: req.RateLimit != nil,
@@ -1161,7 +1215,7 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		logger.Error("failed to reload virtual key: %v", err)
 		preloadedVk = &vk
 	}
-	// Reverse-map governance from the wildcard model configs just written, for display.
+	// Reverse-map governance from the model configs just written, for display.
 	h.hydrateVKGovernance(ctx, preloadedVk)
 
 	SendJSON(ctx, map[string]any{
@@ -1181,10 +1235,14 @@ func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 500, "Governance data is not available")
 			return
 		}
-		byKey := vkWildcardIndexFromModelConfigs(data.ModelConfigs)
+		byKey := buildVKModelConfigIndex(data.ModelConfigs)
 		for _, vk := range data.VirtualKeys {
 			if vk.ID == vkID {
-				applyVKGovernanceFromWildcards(vk, byKey)
+				clone := *vk
+				pcs := make([]configstoreTables.TableVirtualKeyProviderConfig, len(vk.ProviderConfigs))
+				copy(pcs, vk.ProviderConfigs)
+				clone.ProviderConfigs = pcs
+				applyVKGovernanceFromModelConfigs(&clone, byKey)
 				SendJSON(ctx, map[string]interface{}{
 					"virtual_key": &clone,
 				})
@@ -1203,7 +1261,7 @@ func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 500, "Failed to retrieve virtual key")
 		return
 	}
-	// Reverse-map governance from the VK-scoped wildcard model configs for display.
+	// Reverse-map governance from VK-scoped model configs for display.
 	h.hydrateVKGovernance(ctx, vk)
 
 	SendJSON(ctx, map[string]interface{}{
@@ -1283,11 +1341,10 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		if req.CalendarAligned != nil {
 			vk.CalendarAligned = *req.CalendarAligned
 		}
-		// VK top-level and per-provider budgets/rate-limits are folded into VK-scoped
-		// wildcard model configs (the single source of truth), written by
-		// syncVKGovernanceToModelConfigs below. Per-provider desired state is accumulated
-		// while reconciling provider config rows.
-		var vkGovProviders []vkWildcardDesired
+		// VK top-level and per-provider budgets/rate-limits are stored in VK-scoped model
+		// configs (the single source of truth), written by syncVKGovernanceToModelConfigs
+		// below. Per-provider desired state is accumulated while reconciling provider config rows.
+		var vkGovProviders []vkModelConfigDesired
 
 		if err := h.configStore.UpdateVirtualKey(ctx, vk, tx); err != nil {
 			return err
@@ -1368,13 +1425,13 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					if err := h.configStore.CreateVirtualKeyProviderConfig(ctx, providerConfig, tx); err != nil {
 						return err
 					}
-					// Provider-config governance is folded into a VK-scoped wildcard model config.
+					// Provider-config governance is stored in the VK-scoped model config for this provider.
 					pName := string(providerName)
 					var pcRL *configstoreTables.TableRateLimit
 					if pc.RateLimit != nil {
 						pcRL = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 					}
-					vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+					vkGovProviders = append(vkGovProviders, vkModelConfigDesired{
 						provider:          &pName,
 						budgetsProvided:   true,
 						budgets:           pc.Budgets,
@@ -1420,9 +1477,9 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					existing.AllowAllKeys = allowAllKeys
 					existing.Keys = keys
 
-					// Provider-config governance is folded into a VK-scoped wildcard model
-					// config (written by syncVKGovernanceToModelConfigs). pc.Budgets == nil
-					// leaves the wildcard's budgets unchanged; an explicit set reconciles them.
+					// Provider-config governance is stored in the VK-scoped model config for this
+					// provider (written by syncVKGovernanceToModelConfigs). pc.Budgets == nil
+					// leaves existing budgets unchanged; an explicit set reconciles them.
 					pName := string(providerName)
 					rlRemove := false
 					var pcRL *configstoreTables.TableRateLimit
@@ -1433,7 +1490,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 							pcRL = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 						}
 					}
-					vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+					vkGovProviders = append(vkGovProviders, vkModelConfigDesired{
 						provider:          &pName,
 						budgetsProvided:   pc.Budgets != nil,
 						budgets:           pc.Budgets,
@@ -1465,10 +1522,10 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 				}
 			}
 		}
-		// Fold VK governance into VK-scoped wildcard model configs. The top-level is always
-		// reconciled (provided-aware); per-provider wildcards are reconciled only when the
-		// request supplied provider_configs (else they're left untouched).
-		top := vkWildcardDesired{
+		// Fold VK governance into VK-scoped model configs. The top-level is always reconciled
+		// (provided-aware); per-provider configs are reconciled only when the request supplied
+		// provider_configs (else they're left untouched).
+		top := vkModelConfigDesired{
 			budgetsProvided:   req.Budgets != nil,
 			budgets:           req.Budgets,
 			rateLimitProvided: req.RateLimit != nil,
@@ -1598,7 +1655,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		logger.Error("failed to load relationships for updated VK: %v", err)
 		preloadedVk = vk
 	}
-	// Reverse-map governance from the VK-scoped wildcard model configs for display.
+	// Reverse-map governance from VK-scoped model configs for display.
 	h.hydrateVKGovernance(ctx, preloadedVk)
 	if _, err := h.governanceManager.ReloadVirtualKey(ctx, vk.ID); err != nil {
 		// Should never happen but just in case
@@ -2646,22 +2703,64 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 500, "Governance data is not available")
 			return
 		}
-		// Copy into a value slice before enriching: never mutate ScopeName on the
-		// pointers returned here, so we don't risk racing the in-memory store regardless
-		// of whether the manager hands back shared pointers or clones.
-		modelConfigs := make([]configstoreTables.TableModelConfig, 0, len(data.ModelConfigs))
+		search := string(ctx.QueryArgs().Peek("search"))
+		// Deep-copy into a value slice: top-level struct copy + nested pointer/slice fields
+		// so we never alias or mutate live governance state during serialization.
+		all := make([]configstoreTables.TableModelConfig, 0, len(data.ModelConfigs))
 		for _, mc := range data.ModelConfigs {
-			if mc != nil {
-				modelConfigs = append(modelConfigs, *mc)
+			if mc == nil {
+				continue
+			}
+			if search != "" && !strings.Contains(strings.ToLower(mc.ModelName), strings.ToLower(search)) {
+				continue
+			}
+			clone := *mc
+			if len(mc.Budgets) > 0 {
+				bs := make([]configstoreTables.TableBudget, len(mc.Budgets))
+				copy(bs, mc.Budgets)
+				clone.Budgets = bs
+			}
+			if mc.Budget != nil {
+				b := *mc.Budget
+				clone.Budget = &b
+			}
+			if mc.RateLimit != nil {
+				rl := *mc.RateLimit
+				clone.RateLimit = &rl
+			}
+			all = append(all, clone)
+		}
+		totalCount := len(all)
+		// Apply pagination if requested, otherwise return all (consistent with DB path).
+		limitStr := string(ctx.QueryArgs().Peek("limit"))
+		offsetStr := string(ctx.QueryArgs().Peek("offset"))
+		offset := 0
+		limit := totalCount
+		if offsetStr != "" {
+			if n, err := strconv.Atoi(offsetStr); err == nil && n >= 0 {
+				offset = n
 			}
 		}
-		h.enrichModelConfigScopeNames(ctx, modelConfigs)
+		if limitStr != "" {
+			if n, err := strconv.Atoi(limitStr); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		if offset > totalCount {
+			offset = totalCount
+		}
+		end := offset + limit
+		if end > totalCount {
+			end = totalCount
+		}
+		page := all[offset:end]
+		h.enrichModelConfigScopeNames(ctx, page)
 		SendJSON(ctx, map[string]any{
-			"model_configs": modelConfigs,
-			"count":         len(modelConfigs),
-			"total_count":   len(modelConfigs),
-			"limit":         len(modelConfigs),
-			"offset":        0,
+			"model_configs": page,
+			"count":         len(page),
+			"total_count":   totalCount,
+			"limit":         limit,
+			"offset":        offset,
 		})
 		return
 	}
@@ -2755,19 +2854,26 @@ func (h *GovernanceHandler) getModelConfig(ctx *fasthttp.RequestCtx) {
 }
 
 // resolveModelConfigScopeName populates the transient ScopeName for a single non-global
-// model config (currently resolves a virtual_key scope_id to the VK's name). The cache
-// lets callers dedupe lookups across many configs. Resolution failures are non-fatal.
+// model config by dispatching to the resolver registered for mc.Scope. Unknown scopes
+// (no resolver registered) and resolution failures are non-fatal — ScopeName stays empty
+// and the UI falls back to rendering the scope_id. The cache lets callers dedupe lookups
+// across many configs; it is keyed by (scope, scope_id) so distinct scopes never collide.
 func (h *GovernanceHandler) resolveModelConfigScopeName(ctx context.Context, mc *configstoreTables.TableModelConfig, cache map[string]string) {
-	if mc == nil || mc.Scope != configstoreTables.ModelConfigScopeVirtualKey || mc.ScopeID == nil {
+	if mc == nil || mc.Scope == "" || mc.ScopeID == nil {
+		return
+	}
+	resolver, ok := lookupScopeNameResolver(mc.Scope)
+	if !ok {
 		return
 	}
 	id := *mc.ScopeID
-	name, ok := cache[id]
-	if !ok {
-		if vk, err := h.configStore.GetVirtualKey(ctx, id); err == nil && vk != nil {
-			name = vk.Name
+	key := mc.Scope + "|" + id
+	name, cached := cache[key]
+	if !cached {
+		if resolved, found := resolver(ctx, id); found {
+			name = resolved
 		}
-		cache[id] = name
+		cache[key] = name
 	}
 	mc.ScopeName = name
 }
@@ -2856,6 +2962,11 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", req.Budgets[i].ResetDuration))
 			return
 		}
+		if seenDurations[req.Budgets[i].ResetDuration] {
+			SendError(ctx, 400, fmt.Sprintf("Duplicate reset_duration in budgets: %s", req.Budgets[i].ResetDuration))
+			return
+		}
+		seenDurations[req.Budgets[i].ResetDuration] = true
 	}
 	var mc configstoreTables.TableModelConfig
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
@@ -3090,16 +3201,16 @@ type ProviderGovernanceResponse struct {
 	RateLimit *configstoreTables.TableRateLimit `json:"rate_limit,omitempty"`
 }
 
-// providerGovernanceFromWildcard maps an "all models on a provider" model config
-// (scope=global, model_name="*", provider set) to a ProviderGovernanceResponse. Provider
-// governance now lives in governance_model_configs as these wildcard rows,
-// this endpoint is a compatibility facade over them.
-func providerGovernanceFromWildcard(mc *configstoreTables.TableModelConfig) (ProviderGovernanceResponse, bool) {
+// modelConfigToProviderGovernance converts a model config to a ProviderGovernanceResponse.
+// Returns false if the config does not represent provider-level governance
+// (i.e. not scope=global, model_name="*", with a provider set).
+func modelConfigToProviderGovernance(mc *configstoreTables.TableModelConfig) (ProviderGovernanceResponse, bool) {
 	if mc == nil || mc.Scope != configstoreTables.ModelConfigScopeGlobal ||
 		mc.ModelName != configstoreTables.ModelConfigAllModels || mc.Provider == nil {
 		return ProviderGovernanceResponse{}, false
 	}
 	// Provider governance is single-budget by API; surface the first owned budget.
+	// This will be updated with the v2 endpoint, which can surface all budgets
 	var budget *configstoreTables.TableBudget
 	if len(mc.Budgets) > 0 {
 		budget = &mc.Budgets[0]
@@ -3108,7 +3219,7 @@ func providerGovernanceFromWildcard(mc *configstoreTables.TableModelConfig) (Pro
 }
 
 // getProviderGovernance handles GET /api/governance/providers - returns provider-level governance,
-// now backed by the wildcard ("all models on a provider") model configs.
+// now backed by all-models model configs scoped per provider.
 func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
 	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
 	var result []ProviderGovernanceResponse
@@ -3119,7 +3230,7 @@ func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		for _, mc := range data.ModelConfigs {
-			if r, ok := providerGovernanceFromWildcard(mc); ok {
+			if r, ok := modelConfigToProviderGovernance(mc); ok {
 				result = append(result, r)
 			}
 		}
@@ -3131,7 +3242,7 @@ func (h *GovernanceHandler) getProviderGovernance(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		for i := range configs {
-			if r, ok := providerGovernanceFromWildcard(&configs[i]); ok {
+			if r, ok := modelConfigToProviderGovernance(&configs[i]); ok {
 				result = append(result, r)
 			}
 		}
@@ -3260,7 +3371,7 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			// Nothing to persist (removal request on a provider with no governance).
 			return nil
 		case !hasGovernance && !isNew:
-			// All governance removed → delete the wildcard config and its owned/orphaned rows.
+			// All governance removed → delete the model config and its owned/orphaned rows.
 			if existingBudget != nil {
 				budgetIDToDelete = existingBudget.ID
 			}
@@ -3351,7 +3462,7 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 				resp.Budget = &mc.Budgets[0]
 			}
 			resp.RateLimit = mc.RateLimit
-		} else if r, ok := providerGovernanceFromWildcard(reloaded); ok {
+		} else if r, ok := modelConfigToProviderGovernance(reloaded); ok {
 			resp.Budget, resp.RateLimit = r.Budget, r.RateLimit
 		}
 	}
@@ -3362,7 +3473,7 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 }
 
 // deleteProviderGovernance handles DELETE /api/governance/providers/{provider_name} - removes
-// provider-level governance by deleting the wildcard ("all models on this provider") model config.
+// provider-level governance by deleting the all-models model config for that provider.
 func (h *GovernanceHandler) deleteProviderGovernance(ctx *fasthttp.RequestCtx) {
 	providerName := ctx.UserValue("provider_name").(string)
 	mc, err := h.configStore.GetModelConfig(ctx, configstoreTables.ModelConfigScopeGlobal, nil, configstoreTables.ModelConfigAllModels, &providerName)

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -2704,6 +2704,8 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		search := string(ctx.QueryArgs().Peek("search"))
+		scopeFilter := string(ctx.QueryArgs().Peek("scope"))
+		providerFilter := string(ctx.QueryArgs().Peek("provider"))
 		// Deep-copy into a value slice: top-level struct copy + nested pointer/slice fields
 		// so we never alias or mutate live governance state during serialization.
 		all := make([]configstoreTables.TableModelConfig, 0, len(data.ModelConfigs))
@@ -2713,6 +2715,14 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 			}
 			if search != "" && !strings.Contains(strings.ToLower(mc.ModelName), strings.ToLower(search)) {
 				continue
+			}
+			if scopeFilter != "" && mc.Scope != scopeFilter {
+				continue
+			}
+			if providerFilter != "" {
+				if mc.Provider == nil || *mc.Provider != providerFilter {
+					continue
+				}
 			}
 			clone := *mc
 			if len(mc.Budgets) > 0 {
@@ -2769,11 +2779,15 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
 	search := string(ctx.QueryArgs().Peek("search"))
+	scope := string(ctx.QueryArgs().Peek("scope"))
+	provider := string(ctx.QueryArgs().Peek("provider"))
 
-	if limitStr != "" || offsetStr != "" || search != "" {
+	if limitStr != "" || offsetStr != "" || search != "" || scope != "" || provider != "" {
 		// Paginated path
 		params := configstore.ModelConfigsQueryParams{
-			Search: search,
+			Search:   search,
+			Scope:    scope,
+			Provider: provider,
 		}
 		if limitStr != "" {
 			n, err := strconv.Atoi(limitStr)

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -342,6 +342,385 @@ func isRateLimitRemovalRequest(req *UpdateRateLimitRequest) bool {
 		req.TokenResetDuration == nil && req.RequestResetDuration == nil
 }
 
+// reconcileModelConfigBudgets upserts the desired set of budgets owned by a model config
+// (via TableBudget.ModelConfigID), preserving usage on matched rows and deleting removed
+// ones. It mutates mc.Budgets to the reconciled set. The model config row must already
+// exist (callers create it first). Mirrors the VK/team multi-budget reconciliation.
+func (h *GovernanceHandler) reconcileModelConfigBudgets(ctx context.Context, tx *gorm.DB, mc *configstoreTables.TableModelConfig, requests []CreateBudgetRequest) error {
+	seenDurations := make(map[string]bool, len(requests))
+	for _, b := range requests {
+		if b.MaxLimit < 0 {
+			return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
+		}
+		if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
+			return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
+		}
+		if seenDurations[b.ResetDuration] {
+			return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
+		}
+		seenDurations[b.ResetDuration] = true
+	}
+
+	existingByID, existingByDuration := buildBudgetLookup(mc.Budgets, requests)
+	var reconciled []configstoreTables.TableBudget
+	matchedIDs := make(map[string]bool)
+	for _, b := range requests {
+		existing, found, err := findExistingBudget(b, existingByID, existingByDuration)
+		if err != nil {
+			return err
+		}
+		if found {
+			existing.MaxLimit = b.MaxLimit
+			existing.ResetDuration = b.ResetDuration
+			if err := validateBudget(&existing); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateBudget(ctx, &existing, tx); err != nil {
+				return err
+			}
+			reconciled = append(reconciled, existing)
+			matchedIDs[existing.ID] = true
+		} else {
+			budget := configstoreTables.TableBudget{
+				ID:            uuid.NewString(),
+				MaxLimit:      b.MaxLimit,
+				ResetDuration: b.ResetDuration,
+				LastReset:     budgetLastReset(mc.CalendarAligned, b.ResetDuration),
+				CurrentUsage:  0,
+				ModelConfigID: &mc.ID,
+			}
+			inheritUsageFromClosestShorterBudget(&budget, mc.Budgets, false)
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			reconciled = append(reconciled, budget)
+		}
+	}
+	// Delete budgets no longer present.
+	for _, existing := range mc.Budgets {
+		if !matchedIDs[existing.ID] {
+			if err := h.configStore.DeleteBudget(ctx, existing.ID, tx); err != nil {
+				return fmt.Errorf("failed to delete removed model config budget: %w", err)
+			}
+		}
+	}
+	mc.Budgets = reconciled
+	return nil
+}
+
+// vkWildcardDesired is the desired governance state for one VK-scoped all-models wildcard
+// model config (provider=nil for the VK top-level, or a specific provider). The *Provided
+// flags distinguish "leave unchanged" (false, used by partial VK updates) from "set to the
+// given value" (true). The rateLimit carries only the limit/duration fields (no ID/usage).
+type vkWildcardDesired struct {
+	provider          *string
+	budgetsProvided   bool
+	budgets           []CreateBudgetRequest
+	rateLimitProvided bool
+	rateLimitRemove   bool
+	rateLimit         *configstoreTables.TableRateLimit
+}
+
+// syncVKGovernanceToModelConfigs folds a virtual key's governance (top-level + per-provider
+// budgets/rate-limits) into VK-scoped all-models wildcard model configs, the single source of
+// truth. It upserts the top-level and per-provider wildcards and deletes wildcards for
+// providers no longer configured. Must run inside the VK create/update transaction.
+// reconcileProviders controls per-provider handling: true treats perProvider as the full
+// desired set (upserting them and deleting wildcards for absent providers); false leaves all
+// per-provider wildcards untouched (for a partial VK update that omits provider_configs).
+func (h *GovernanceHandler) syncVKGovernanceToModelConfigs(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, top vkWildcardDesired, perProvider []vkWildcardDesired, reconcileProviders bool) error {
+	if err := h.upsertVKWildcard(ctx, tx, vk, top); err != nil {
+		return err
+	}
+	if !reconcileProviders {
+		return nil
+	}
+	keep := make(map[string]bool, len(perProvider))
+	for _, pg := range perProvider {
+		if pg.provider == nil {
+			continue
+		}
+		keep[*pg.provider] = true
+		if err := h.upsertVKWildcard(ctx, tx, vk, pg); err != nil {
+			return err
+		}
+	}
+	// Delete VK-scoped provider wildcards whose provider is no longer configured.
+	var existing []configstoreTables.TableModelConfig
+	if err := tx.Preload("Budgets").
+		Where("scope = ? AND scope_id = ? AND model_name = ? AND provider IS NOT NULL",
+			configstoreTables.ModelConfigScopeVirtualKey, vk.ID, configstoreTables.ModelConfigAllModels).
+		Find(&existing).Error; err != nil {
+		return err
+	}
+	for i := range existing {
+		mc := &existing[i]
+		if mc.Provider != nil && !keep[*mc.Provider] {
+			if err := h.deleteVKWildcardModelConfig(ctx, tx, mc); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// upsertVKWildcard reconciles a single VK-scoped wildcard model config to the desired state.
+func (h *GovernanceHandler) upsertVKWildcard(ctx context.Context, tx *gorm.DB, vk *configstoreTables.TableVirtualKey, d vkWildcardDesired) error {
+	q := tx.Preload("Budgets").Where("scope = ? AND scope_id = ? AND model_name = ?",
+		configstoreTables.ModelConfigScopeVirtualKey, vk.ID, configstoreTables.ModelConfigAllModels)
+	if d.provider == nil {
+		q = q.Where("provider IS NULL")
+	} else {
+		q = q.Where("provider = ?", *d.provider)
+	}
+	var existingList []configstoreTables.TableModelConfig
+	if err := q.Limit(1).Find(&existingList).Error; err != nil {
+		return err
+	}
+	isNew := len(existingList) == 0
+
+	var mc configstoreTables.TableModelConfig
+	if isNew {
+		mc = configstoreTables.TableModelConfig{
+			ID:              uuid.NewString(),
+			ModelName:       configstoreTables.ModelConfigAllModels,
+			Provider:        d.provider,
+			Scope:           configstoreTables.ModelConfigScopeVirtualKey,
+			ScopeID:         &vk.ID,
+			CalendarAligned: vk.CalendarAligned,
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+	} else {
+		mc = existingList[0]
+		mc.CalendarAligned = vk.CalendarAligned // keep in sync with the owning VK
+	}
+
+	// Rate limit (mc references it via RateLimitID, so resolve before persisting the mc).
+	var rateLimitIDToDelete string
+	if d.rateLimitProvided {
+		switch {
+		case d.rateLimitRemove:
+			if mc.RateLimitID != nil {
+				rateLimitIDToDelete = *mc.RateLimitID
+				mc.RateLimitID = nil
+				mc.RateLimit = nil
+			}
+		case mc.RateLimitID != nil:
+			rl := configstoreTables.TableRateLimit{}
+			if err := tx.First(&rl, "id = ?", *mc.RateLimitID).Error; err != nil {
+				return err
+			}
+			rl.TokenMaxLimit = d.rateLimit.TokenMaxLimit
+			rl.TokenResetDuration = d.rateLimit.TokenResetDuration
+			rl.RequestMaxLimit = d.rateLimit.RequestMaxLimit
+			rl.RequestResetDuration = d.rateLimit.RequestResetDuration
+			if err := validateRateLimit(&rl); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateRateLimit(ctx, &rl, tx); err != nil {
+				return err
+			}
+			mc.RateLimit = &rl
+		default:
+			rl := configstoreTables.TableRateLimit{
+				ID:                   uuid.NewString(),
+				TokenMaxLimit:        d.rateLimit.TokenMaxLimit,
+				TokenResetDuration:   d.rateLimit.TokenResetDuration,
+				RequestMaxLimit:      d.rateLimit.RequestMaxLimit,
+				RequestResetDuration: d.rateLimit.RequestResetDuration,
+				TokenLastReset:       time.Now(),
+				RequestLastReset:     time.Now(),
+			}
+			if err := validateRateLimit(&rl); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateRateLimit(ctx, &rl, tx); err != nil {
+				return err
+			}
+			mc.RateLimitID = &rl.ID
+			mc.RateLimit = &rl
+		}
+	}
+
+	// Resulting budget count: the desired set if provided, else the existing set.
+	finalBudgetCount := len(mc.Budgets)
+	if d.budgetsProvided {
+		finalBudgetCount = len(d.budgets)
+	}
+	hasGovernance := mc.RateLimitID != nil || finalBudgetCount > 0
+
+	if !hasGovernance {
+		// No governance left → drop the wildcard (and its budgets) if it existed.
+		if !isNew {
+			for i := range mc.Budgets {
+				if err := h.configStore.DeleteBudget(ctx, mc.Budgets[i].ID, tx); err != nil {
+					return err
+				}
+			}
+			if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
+				return err
+			}
+		}
+		if rateLimitIDToDelete != "" {
+			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Persist the mc (create or update) before touching budgets, which FK to it.
+	if isNew {
+		if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
+			return err
+		}
+	} else {
+		mc.UpdatedAt = time.Now()
+		if err := h.configStore.UpdateModelConfig(ctx, &mc, tx); err != nil {
+			return err
+		}
+	}
+
+	if d.budgetsProvided {
+		if err := h.reconcileModelConfigBudgets(ctx, tx, &mc, d.budgets); err != nil {
+			return err
+		}
+	}
+
+	if rateLimitIDToDelete != "" {
+		if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteVKWildcardModelConfig removes a VK-scoped wildcard model config and its owned
+// budgets/rate-limit (used when a provider config is removed from the VK).
+func (h *GovernanceHandler) deleteVKWildcardModelConfig(ctx context.Context, tx *gorm.DB, mc *configstoreTables.TableModelConfig) error {
+	for i := range mc.Budgets {
+		if err := h.configStore.DeleteBudget(ctx, mc.Budgets[i].ID, tx); err != nil {
+			return err
+		}
+	}
+	rlID := mc.RateLimitID
+	if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
+		return err
+	}
+	if rlID != nil {
+		if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", *rlID).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// rateLimitFromRequestFields builds a transient TableRateLimit (limit/duration fields only)
+// for the VK governance sync, from the shared rate-limit request field shape.
+func rateLimitFromRequestFields(tokenMax *int64, tokenDur *string, reqMax *int64, reqDur *string) *configstoreTables.TableRateLimit {
+	return &configstoreTables.TableRateLimit{
+		TokenMaxLimit:        tokenMax,
+		TokenResetDuration:   tokenDur,
+		RequestMaxLimit:      reqMax,
+		RequestResetDuration: reqDur,
+	}
+}
+
+// vkWildcardIndexKey keys a VK-scoped all-models wildcard by scope target + provider
+func vkWildcardIndexKey(scopeID string, provider *string) string {
+	if provider == nil {
+		return scopeID + "|"
+	}
+	return scopeID + "|" + *provider
+}
+
+// applyVKGovernanceFromWildcards repopulates a VK's (and each provider config's) budgets and
+// rate-limit FROM the VK-scoped wildcard model configs that now own them — for serialization
+// only (so the VK sheet still renders the governance it edits). byKey indexes the wildcards by
+// vkWildcardIndexKey. The reverse of syncVKGovernanceToModelConfigs.
+func applyVKGovernanceFromWildcards(vk *configstoreTables.TableVirtualKey, byKey map[string]*configstoreTables.TableModelConfig) {
+	if mc := byKey[vkWildcardIndexKey(vk.ID, nil)]; mc != nil {
+		vk.Budgets = mc.Budgets
+		vk.RateLimit = mc.RateLimit
+		vk.RateLimitID = mc.RateLimitID
+	} else {
+		vk.Budgets = nil
+		vk.RateLimit = nil
+		vk.RateLimitID = nil
+	}
+	for i := range vk.ProviderConfigs {
+		pc := &vk.ProviderConfigs[i]
+		if mc := byKey[vkWildcardIndexKey(vk.ID, &pc.Provider)]; mc != nil {
+			pc.Budgets = mc.Budgets
+			pc.RateLimit = mc.RateLimit
+			pc.RateLimitID = mc.RateLimitID
+		} else {
+			pc.Budgets = nil
+			pc.RateLimit = nil
+			pc.RateLimitID = nil
+		}
+	}
+}
+
+// hydrateVKGovernance reverse-maps a single VK's governance from its wildcard model configs.
+func (h *GovernanceHandler) hydrateVKGovernance(ctx context.Context, vk *configstoreTables.TableVirtualKey) {
+	if vk == nil {
+		return
+	}
+	byKey := make(map[string]*configstoreTables.TableModelConfig)
+	add := func(provider *string) {
+		mc, err := h.configStore.GetModelConfig(ctx, configstoreTables.ModelConfigScopeVirtualKey, &vk.ID, configstoreTables.ModelConfigAllModels, provider)
+		if err == nil && mc != nil {
+			byKey[vkWildcardIndexKey(vk.ID, provider)] = mc
+		}
+	}
+	add(nil)
+	for i := range vk.ProviderConfigs {
+		prov := vk.ProviderConfigs[i].Provider
+		add(&prov)
+	}
+	applyVKGovernanceFromWildcards(vk, byKey)
+}
+
+// vkWildcardIndexFromModelConfigs builds an index of VK-scoped all-models wildcard model
+// configs keyed by vkWildcardIndexKey, from a slice of model-config pointers.
+func vkWildcardIndexFromModelConfigs(mcs []*configstoreTables.TableModelConfig) map[string]*configstoreTables.TableModelConfig {
+	byKey := make(map[string]*configstoreTables.TableModelConfig)
+	for _, mc := range mcs {
+		if mc != nil && mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ModelName == configstoreTables.ModelConfigAllModels && mc.ScopeID != nil {
+			byKey[vkWildcardIndexKey(*mc.ScopeID, mc.Provider)] = mc
+		}
+	}
+	return byKey
+}
+
+// hydrateVKListGovernance reverse-maps governance for a list of VKs using a single bulk load
+// of all VK-scoped wildcard model configs (avoids per-VK/per-provider queries).
+func (h *GovernanceHandler) hydrateVKListGovernance(ctx context.Context, vks []configstoreTables.TableVirtualKey) {
+	if len(vks) == 0 {
+		return
+	}
+	allMCs, err := h.configStore.GetModelConfigs(ctx)
+	if err != nil {
+		logger.Error("failed to load model configs for VK governance hydration: %v", err)
+		return
+	}
+	byKey := make(map[string]*configstoreTables.TableModelConfig)
+	for i := range allMCs {
+		mc := &allMCs[i]
+		if mc.Scope == configstoreTables.ModelConfigScopeVirtualKey && mc.ModelName == configstoreTables.ModelConfigAllModels && mc.ScopeID != nil {
+			byKey[vkWildcardIndexKey(*mc.ScopeID, mc.Provider)] = mc
+		}
+	}
+	for i := range vks {
+		applyVKGovernanceFromWildcards(&vks[i], byKey)
+	}
+}
+
 func collectProviderConfigDeleteIDs(
 	config configstoreTables.TableVirtualKeyProviderConfig,
 	budgetIDs []string,
@@ -394,7 +773,7 @@ type CreateModelConfigRequest struct {
 	Provider  *string                 `json:"provider,omitempty"` // Optional provider, nil means all providers
 	Scope     string                  `json:"scope,omitempty"`    // Defaults to "global" if not provided
 	ScopeID   *string                 `json:"scope_id,omitempty"` // Required for non-global scopes (e.g. the virtual key ID)
-	Budget    *CreateBudgetRequest    `json:"budget,omitempty"`
+	Budgets   []CreateBudgetRequest   `json:"budgets,omitempty"`  // A model config may carry multiple budgets (distinct reset windows)
 	RateLimit *CreateRateLimitRequest `json:"rate_limit,omitempty"`
 }
 
@@ -404,7 +783,7 @@ type CreateModelConfigRequest struct {
 type UpdateModelConfigRequest struct {
 	ModelName *string                 `json:"model_name,omitempty"`
 	Provider  *string                 `json:"provider,omitempty"` // Optional provider, nil means no change
-	Budget    *UpdateBudgetRequest    `json:"budget,omitempty"`
+	Budgets   []CreateBudgetRequest   `json:"budgets,omitempty"`  // Full desired set of budgets (reconciled against existing)
 	RateLimit *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
 }
 
@@ -477,6 +856,35 @@ func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 
 // getVirtualKeys handles GET /api/governance/virtual-keys - Get all virtual keys with relationships
 func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
+	// Check if "from_memory" query parameter is set to true
+	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
+	if fromMemory {
+		data := h.governanceManager.GetGovernanceData(ctx)
+		if data == nil {
+			SendError(ctx, 500, "Governance data is not available")
+			return
+		}
+		// Convert map to slice to match the non-memory response format (array)
+		virtualKeys := make([]*configstoreTables.TableVirtualKey, 0, len(data.VirtualKeys))
+		for _, vk := range data.VirtualKeys {
+			virtualKeys = append(virtualKeys, vk)
+		}
+		sort.Slice(virtualKeys, func(i, j int) bool {
+			return virtualKeys[i].CreatedAt.Before(virtualKeys[j].CreatedAt)
+		})
+		byKey := vkWildcardIndexFromModelConfigs(data.ModelConfigs)
+		for _, vk := range virtualKeys {
+			applyVKGovernanceFromWildcards(vk, byKey)
+		}
+		SendJSON(ctx, map[string]interface{}{
+			"virtual_keys": hydratedVKs,
+			"count":        len(hydratedVKs),
+			"total_count":  len(hydratedVKs),
+			"limit":        len(hydratedVKs),
+			"offset":       0,
+		})
+		return
+	}
 	// Check for pagination/filter parameters
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
@@ -535,6 +943,8 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 500, "Failed to retrieve virtual keys")
 			return
 		}
+		// Reverse-map governance from VK-scoped wildcard model configs for display.
+		h.hydrateVKListGovernance(ctx, virtualKeys)
 		SendJSON(ctx, map[string]interface{}{
 			"virtual_keys": virtualKeys,
 			"count":        len(virtualKeys),
@@ -552,6 +962,7 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 500, "Failed to retrieve virtual keys")
 		return
 	}
+	h.hydrateVKListGovernance(ctx, virtualKeys)
 	SendJSON(ctx, map[string]interface{}{
 		"virtual_keys": virtualKeys,
 		"count":        len(virtualKeys),
@@ -624,46 +1035,13 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 			IsActive:        isActive,
 			CalendarAligned: req.CalendarAligned,
 		}
-		if req.RateLimit != nil {
-			rateLimit := configstoreTables.TableRateLimit{
-				ID:                   uuid.NewString(),
-				TokenMaxLimit:        req.RateLimit.TokenMaxLimit,
-				TokenResetDuration:   req.RateLimit.TokenResetDuration,
-				RequestMaxLimit:      req.RateLimit.RequestMaxLimit,
-				RequestResetDuration: req.RateLimit.RequestResetDuration,
-				TokenLastReset:       time.Now(),
-				RequestLastReset:     time.Now(),
-			}
-			if err := validateRateLimit(&rateLimit); err != nil {
-				return err
-			}
-			if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-				return err
-			}
-			vk.RateLimitID = &rateLimit.ID
-		}
 		if err := h.configStore.CreateVirtualKey(ctx, &vk, tx); err != nil {
 			return err
 		}
-		// Create multi-budgets for VK
-		if len(req.Budgets) > 0 {
-			for _, b := range req.Budgets {
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      b.MaxLimit,
-					ResetDuration: b.ResetDuration,
-					LastReset:     budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-					CurrentUsage:  0,
-					VirtualKeyID:  &vk.ID,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-			}
-		}
+		// VK top-level and per-provider budgets/rate-limits are the single-source-of-truth
+		// VK-scoped wildcard model configs, written via syncVKGovernanceToModelConfigs below.
+		// The per-provider desired state is accumulated while creating the provider configs.
+		var vkGovProviders []vkWildcardDesired
 		if req.ProviderConfigs != nil {
 			for _, pc := range req.ProviderConfigs {
 				providerName := schemas.ModelProvider(strings.TrimSpace(pc.Provider))
@@ -709,54 +1087,37 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 					Keys:              keys,
 				}
 
-				// Create rate limit for provider config if provided
-				if pc.RateLimit != nil {
-					rateLimit := configstoreTables.TableRateLimit{
-						ID:                   uuid.NewString(),
-						TokenMaxLimit:        pc.RateLimit.TokenMaxLimit,
-						TokenResetDuration:   pc.RateLimit.TokenResetDuration,
-						RequestMaxLimit:      pc.RateLimit.RequestMaxLimit,
-						RequestResetDuration: pc.RateLimit.RequestResetDuration,
-						TokenLastReset:       time.Now(),
-						RequestLastReset:     time.Now(),
-					}
-					if err := validateRateLimit(&rateLimit); err != nil {
-						return err
-					}
-					if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-						return err
-					}
-					providerConfig.RateLimitID = &rateLimit.ID
-				}
-
 				if err := h.configStore.CreateVirtualKeyProviderConfig(ctx, providerConfig, tx); err != nil {
 					return err
 				}
-				// Create multi-budgets for provider config
-				if len(pc.Budgets) > 0 {
-					seenDurations := make(map[string]bool)
-					for _, b := range pc.Budgets {
-						if seenDurations[b.ResetDuration] {
-							return &badRequestError{err: fmt.Errorf("duplicate reset_duration in provider config budgets: %s", b.ResetDuration)}
-						}
-						seenDurations[b.ResetDuration] = true
-						budget := configstoreTables.TableBudget{
-							ID:               uuid.NewString(),
-							MaxLimit:         b.MaxLimit,
-							ResetDuration:    b.ResetDuration,
-							LastReset:        budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-							CurrentUsage:     0,
-							ProviderConfigID: &providerConfig.ID,
-						}
-						if err := validateBudget(&budget); err != nil {
-							return err
-						}
-						if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-							return err
-						}
-					}
+				// Provider-config budgets/rate-limit are folded into a VK-scoped wildcard
+				// model config for this provider (written by syncVKGovernanceToModelConfigs).
+				providerNameStr := string(providerName)
+				var pcRateLimit *configstoreTables.TableRateLimit
+				if pc.RateLimit != nil {
+					pcRateLimit = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 				}
+				vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+					provider:          &providerNameStr,
+					budgetsProvided:   true,
+					budgets:           pc.Budgets,
+					rateLimitProvided: pc.RateLimit != nil,
+					rateLimit:         pcRateLimit,
+				})
 			}
+		}
+		// Fold VK top-level + per-provider governance into VK-scoped wildcard model configs.
+		var topRateLimit *configstoreTables.TableRateLimit
+		if req.RateLimit != nil {
+			topRateLimit = rateLimitFromRequestFields(req.RateLimit.TokenMaxLimit, req.RateLimit.TokenResetDuration, req.RateLimit.RequestMaxLimit, req.RateLimit.RequestResetDuration)
+		}
+		if err := h.syncVKGovernanceToModelConfigs(ctx, tx, &vk, vkWildcardDesired{
+			budgetsProvided:   true,
+			budgets:           req.Budgets,
+			rateLimitProvided: req.RateLimit != nil,
+			rateLimit:         topRateLimit,
+		}, vkGovProviders, true); err != nil {
+			return err
 		}
 		if req.MCPConfigs != nil {
 			// Check for duplicate MCPClientName values before processing
@@ -800,6 +1161,8 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		logger.Error("failed to reload virtual key: %v", err)
 		preloadedVk = &vk
 	}
+	// Reverse-map governance from the wildcard model configs just written, for display.
+	h.hydrateVKGovernance(ctx, preloadedVk)
 
 	SendJSON(ctx, map[string]any{
 		"message":     "Virtual key created successfully",
@@ -810,6 +1173,27 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 // getVirtualKey handles GET /api/governance/virtual-keys/{vk_id} - Get a specific virtual key
 func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 	vkID := ctx.UserValue("vk_id").(string)
+	// Check if "from_memory" query parameter is set to true
+	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
+	if fromMemory {
+		data := h.governanceManager.GetGovernanceData(ctx)
+		if data == nil {
+			SendError(ctx, 500, "Governance data is not available")
+			return
+		}
+		byKey := vkWildcardIndexFromModelConfigs(data.ModelConfigs)
+		for _, vk := range data.VirtualKeys {
+			if vk.ID == vkID {
+				applyVKGovernanceFromWildcards(vk, byKey)
+				SendJSON(ctx, map[string]interface{}{
+					"virtual_key": &clone,
+				})
+				return
+			}
+		}
+		SendError(ctx, 404, "Virtual key not found")
+		return
+	}
 	vk, err := h.configStore.GetVirtualKey(ctx, vkID)
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
@@ -819,6 +1203,8 @@ func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 500, "Failed to retrieve virtual key")
 		return
 	}
+	// Reverse-map governance from the VK-scoped wildcard model configs for display.
+	h.hydrateVKGovernance(ctx, vk)
 
 	SendJSON(ctx, map[string]interface{}{
 		"virtual_key": vk,
@@ -897,130 +1283,11 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		if req.CalendarAligned != nil {
 			vk.CalendarAligned = *req.CalendarAligned
 		}
-		// Handle multi-budget updates
-		if req.Budgets != nil {
-			// Validate multi-budgets
-			seenDurations := make(map[string]bool)
-			requestBudgets := append([]CreateBudgetRequest(nil), req.Budgets...)
-			sort.Slice(requestBudgets, func(i, j int) bool {
-				return compareBudgetRequestDurations(requestBudgets[i], requestBudgets[j])
-			})
-			for _, b := range requestBudgets {
-				if b.MaxLimit < 0 {
-					return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
-				}
-				if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
-					return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
-				}
-				if seenDurations[b.ResetDuration] {
-					return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
-				}
-				seenDurations[b.ResetDuration] = true
-			}
-
-			existingByID, existingByDuration := buildBudgetLookup(vk.Budgets, requestBudgets)
-			resetBudgetUsage := req.ResetBudgetUsage != nil && *req.ResetBudgetUsage
-			var reconciledBudgets []configstoreTables.TableBudget
-			matchedIDs := make(map[string]bool)
-			for _, b := range requestBudgets {
-				existing, found, err := findExistingBudget(b, existingByID, existingByDuration)
-				if err != nil {
-					return err
-				}
-				if found {
-					existing.MaxLimit = b.MaxLimit
-					existing.ResetDuration = b.ResetDuration
-					resetBudgetUsageIfRequested(&existing, resetBudgetUsage, vk.CalendarAligned)
-					if err := validateBudget(&existing); err != nil {
-						return err
-					}
-					if err := h.configStore.UpdateBudget(ctx, &existing, tx); err != nil {
-						return err
-					}
-					reconciledBudgets = append(reconciledBudgets, existing)
-					matchedIDs[existing.ID] = true
-				} else {
-					// New budget duration — create fresh
-					budget := configstoreTables.TableBudget{
-						ID:            uuid.NewString(),
-						MaxLimit:      b.MaxLimit,
-						ResetDuration: b.ResetDuration,
-						LastReset:     budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-						CurrentUsage:  0,
-						VirtualKeyID:  &vk.ID,
-					}
-					inheritUsageFromClosestShorterBudget(&budget, vk.Budgets, resetBudgetUsage)
-					if err := validateBudget(&budget); err != nil {
-						return err
-					}
-					if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-						return err
-					}
-					reconciledBudgets = append(reconciledBudgets, budget)
-				}
-			}
-			// Delete budgets that are no longer present
-			for _, existing := range vk.Budgets {
-				if !matchedIDs[existing.ID] {
-					if err := h.configStore.DeleteBudget(ctx, existing.ID, tx); err != nil {
-						return fmt.Errorf("failed to delete removed VK budget: %w", err)
-					}
-				}
-			}
-			vk.Budgets = reconciledBudgets
-		}
-
-		// Handle rate limit updates
-		if req.RateLimit != nil {
-			if isRateLimitRemovalRequest(req.RateLimit) {
-				if vk.RateLimitID != nil {
-					rateLimitIDToDelete = *vk.RateLimitID
-					vk.RateLimitID = nil
-					vk.RateLimit = nil
-				}
-			} else if vk.RateLimitID != nil {
-				// Update existing rate limit
-				rateLimit := configstoreTables.TableRateLimit{}
-				if err := tx.First(&rateLimit, "id = ?", *vk.RateLimitID).Error; err != nil {
-					return err
-				}
-
-				if req.RateLimit.TokenMaxLimit != nil {
-					rateLimit.TokenMaxLimit = req.RateLimit.TokenMaxLimit
-				}
-				if req.RateLimit.TokenResetDuration != nil {
-					rateLimit.TokenResetDuration = req.RateLimit.TokenResetDuration
-				}
-				if req.RateLimit.RequestMaxLimit != nil {
-					rateLimit.RequestMaxLimit = req.RateLimit.RequestMaxLimit
-				}
-				if req.RateLimit.RequestResetDuration != nil {
-					rateLimit.RequestResetDuration = req.RateLimit.RequestResetDuration
-				}
-
-				if err := h.configStore.UpdateRateLimit(ctx, &rateLimit, tx); err != nil {
-					return err
-				}
-			} else {
-				// Create new rate limit
-				rateLimit := configstoreTables.TableRateLimit{
-					ID:                   uuid.NewString(),
-					TokenMaxLimit:        req.RateLimit.TokenMaxLimit,
-					TokenResetDuration:   req.RateLimit.TokenResetDuration,
-					RequestMaxLimit:      req.RateLimit.RequestMaxLimit,
-					RequestResetDuration: req.RateLimit.RequestResetDuration,
-					TokenLastReset:       time.Now(),
-					RequestLastReset:     time.Now(),
-				}
-				if err := validateRateLimit(&rateLimit); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-					return err
-				}
-				vk.RateLimitID = &rateLimit.ID
-			}
-		}
+		// VK top-level and per-provider budgets/rate-limits are folded into VK-scoped
+		// wildcard model configs (the single source of truth), written by
+		// syncVKGovernanceToModelConfigs below. Per-provider desired state is accumulated
+		// while reconciling provider config rows.
+		var vkGovProviders []vkWildcardDesired
 
 		if err := h.configStore.UpdateVirtualKey(ctx, vk, tx); err != nil {
 			return err
@@ -1098,56 +1365,22 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 						AllowAllKeys:      allowAllKeys,
 						Keys:              keys,
 					}
-					// Create rate limit for provider config if provided
-					if pc.RateLimit != nil {
-						rateLimit := configstoreTables.TableRateLimit{
-							ID:                   uuid.NewString(),
-							TokenMaxLimit:        pc.RateLimit.TokenMaxLimit,
-							TokenResetDuration:   pc.RateLimit.TokenResetDuration,
-							RequestMaxLimit:      pc.RateLimit.RequestMaxLimit,
-							RequestResetDuration: pc.RateLimit.RequestResetDuration,
-							TokenLastReset:       time.Now(),
-							RequestLastReset:     time.Now(),
-						}
-						if err := validateRateLimit(&rateLimit); err != nil {
-							return err
-						}
-						if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-							return err
-						}
-						providerConfig.RateLimitID = &rateLimit.ID
-					}
 					if err := h.configStore.CreateVirtualKeyProviderConfig(ctx, providerConfig, tx); err != nil {
 						return err
 					}
-					// Create multi-budgets for new provider config in update
-					if len(pc.Budgets) > 0 {
-						seenDurations := make(map[string]bool)
-						pcBudgets := append([]CreateBudgetRequest(nil), pc.Budgets...)
-						sort.Slice(pcBudgets, func(i, j int) bool {
-							return compareBudgetRequestDurations(pcBudgets[i], pcBudgets[j])
-						})
-						for _, b := range pcBudgets {
-							if seenDurations[b.ResetDuration] {
-								return &badRequestError{err: fmt.Errorf("duplicate reset_duration in provider config budgets: %s", b.ResetDuration)}
-							}
-							seenDurations[b.ResetDuration] = true
-							budget := configstoreTables.TableBudget{
-								ID:               uuid.NewString(),
-								MaxLimit:         b.MaxLimit,
-								ResetDuration:    b.ResetDuration,
-								LastReset:        budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-								CurrentUsage:     0,
-								ProviderConfigID: &providerConfig.ID,
-							}
-							if err := validateBudget(&budget); err != nil {
-								return err
-							}
-							if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-								return err
-							}
-						}
+					// Provider-config governance is folded into a VK-scoped wildcard model config.
+					pName := string(providerName)
+					var pcRL *configstoreTables.TableRateLimit
+					if pc.RateLimit != nil {
+						pcRL = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 					}
+					vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+						provider:          &pName,
+						budgetsProvided:   true,
+						budgets:           pc.Budgets,
+						rateLimitProvided: pc.RateLimit != nil,
+						rateLimit:         pcRL,
+					})
 				} else {
 					// Update existing provider config
 					existing, ok := existingConfigsMap[*pc.ID]
@@ -1187,134 +1420,27 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					existing.AllowAllKeys = allowAllKeys
 					existing.Keys = keys
 
-					// Handle multi-budget updates for existing provider config
-					if pc.Budgets != nil {
-						// Validate
-						seenDurations := make(map[string]bool)
-						pcBudgets := append([]CreateBudgetRequest(nil), pc.Budgets...)
-						sort.Slice(pcBudgets, func(i, j int) bool {
-							return compareBudgetRequestDurations(pcBudgets[i], pcBudgets[j])
-						})
-						for _, b := range pcBudgets {
-							if b.MaxLimit < 0 {
-								return &badRequestError{err: fmt.Errorf("provider config budget max_limit cannot be negative: %.2f", b.MaxLimit)}
-							}
-							if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
-								return &badRequestError{err: fmt.Errorf("invalid provider config budget reset duration format: %s", b.ResetDuration)}
-							}
-							if seenDurations[b.ResetDuration] {
-								return &badRequestError{err: fmt.Errorf("duplicate reset_duration in provider config budgets: %s", b.ResetDuration)}
-							}
-							seenDurations[b.ResetDuration] = true
-						}
-
-						sort.Slice(existing.Budgets, func(i, j int) bool {
-							if existing.Budgets[i].ResetDuration == existing.Budgets[j].ResetDuration {
-								return existing.Budgets[i].ID < existing.Budgets[j].ID
-							}
-							return existing.Budgets[i].ResetDuration < existing.Budgets[j].ResetDuration
-						})
-
-						pcExistingByID, pcExistingByDuration := buildBudgetLookup(existing.Budgets, pcBudgets)
-						resetBudgetUsage := req.ResetBudgetUsage != nil && *req.ResetBudgetUsage
-						var pcReconciledBudgets []configstoreTables.TableBudget
-						pcMatchedIDs := make(map[string]bool)
-						for _, b := range pcBudgets {
-							eb, found, err := findExistingBudget(b, pcExistingByID, pcExistingByDuration)
-							if err != nil {
-								return err
-							}
-							if found {
-								eb.MaxLimit = b.MaxLimit
-								eb.ResetDuration = b.ResetDuration
-								resetBudgetUsageIfRequested(&eb, resetBudgetUsage, vk.CalendarAligned)
-								if err := validateBudget(&eb); err != nil {
-									return err
-								}
-								if err := h.configStore.UpdateBudget(ctx, &eb, tx); err != nil {
-									return err
-								}
-								pcReconciledBudgets = append(pcReconciledBudgets, eb)
-								pcMatchedIDs[eb.ID] = true
-							} else {
-								// New budget duration — create fresh
-								budget := configstoreTables.TableBudget{
-									ID:               uuid.NewString(),
-									MaxLimit:         b.MaxLimit,
-									ResetDuration:    b.ResetDuration,
-									LastReset:        budgetLastReset(vk.CalendarAligned, b.ResetDuration),
-									CurrentUsage:     0,
-									ProviderConfigID: &existing.ID,
-								}
-								inheritUsageFromClosestShorterBudget(&budget, existing.Budgets, resetBudgetUsage)
-								if err := validateBudget(&budget); err != nil {
-									return err
-								}
-								if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-									return err
-								}
-								pcReconciledBudgets = append(pcReconciledBudgets, budget)
-							}
-						}
-						// Delete budgets that are no longer present
-						for _, eb := range existing.Budgets {
-							if !pcMatchedIDs[eb.ID] {
-								if err := h.configStore.DeleteBudget(ctx, eb.ID, tx); err != nil {
-									return fmt.Errorf("failed to delete removed provider config budget: %w", err)
-								}
-							}
-						}
-						existing.Budgets = pcReconciledBudgets
-					}
-					// Handle rate limit updates for provider config
+					// Provider-config governance is folded into a VK-scoped wildcard model
+					// config (written by syncVKGovernanceToModelConfigs). pc.Budgets == nil
+					// leaves the wildcard's budgets unchanged; an explicit set reconciles them.
+					pName := string(providerName)
+					rlRemove := false
+					var pcRL *configstoreTables.TableRateLimit
 					if pc.RateLimit != nil {
 						if isRateLimitRemovalRequest(pc.RateLimit) {
-							if existing.RateLimitID != nil {
-								providerRateLimitIDsToDelete = append(providerRateLimitIDsToDelete, *existing.RateLimitID)
-								existing.RateLimitID = nil
-								existing.RateLimit = nil
-							}
-						} else if existing.RateLimitID != nil {
-							// Update existing rate limit
-							rateLimit := configstoreTables.TableRateLimit{}
-							if err := tx.First(&rateLimit, "id = ?", *existing.RateLimitID).Error; err != nil {
-								return err
-							}
-							if pc.RateLimit.TokenMaxLimit != nil {
-								rateLimit.TokenMaxLimit = pc.RateLimit.TokenMaxLimit
-							}
-							if pc.RateLimit.TokenResetDuration != nil {
-								rateLimit.TokenResetDuration = pc.RateLimit.TokenResetDuration
-							}
-							if pc.RateLimit.RequestMaxLimit != nil {
-								rateLimit.RequestMaxLimit = pc.RateLimit.RequestMaxLimit
-							}
-							if pc.RateLimit.RequestResetDuration != nil {
-								rateLimit.RequestResetDuration = pc.RateLimit.RequestResetDuration
-							}
-							if err := h.configStore.UpdateRateLimit(ctx, &rateLimit, tx); err != nil {
-								return err
-							}
+							rlRemove = true
 						} else {
-							// Create new rate limit for existing provider config
-							rateLimit := configstoreTables.TableRateLimit{
-								ID:                   uuid.NewString(),
-								TokenMaxLimit:        pc.RateLimit.TokenMaxLimit,
-								TokenResetDuration:   pc.RateLimit.TokenResetDuration,
-								RequestMaxLimit:      pc.RateLimit.RequestMaxLimit,
-								RequestResetDuration: pc.RateLimit.RequestResetDuration,
-								TokenLastReset:       time.Now(),
-								RequestLastReset:     time.Now(),
-							}
-							if err := validateRateLimit(&rateLimit); err != nil {
-								return err
-							}
-							if err := h.configStore.CreateRateLimit(ctx, &rateLimit, tx); err != nil {
-								return err
-							}
-							existing.RateLimitID = &rateLimit.ID
+							pcRL = rateLimitFromRequestFields(pc.RateLimit.TokenMaxLimit, pc.RateLimit.TokenResetDuration, pc.RateLimit.RequestMaxLimit, pc.RateLimit.RequestResetDuration)
 						}
 					}
+					vkGovProviders = append(vkGovProviders, vkWildcardDesired{
+						provider:          &pName,
+						budgetsProvided:   pc.Budgets != nil,
+						budgets:           pc.Budgets,
+						rateLimitProvided: pc.RateLimit != nil,
+						rateLimitRemove:   rlRemove,
+						rateLimit:         pcRL,
+					})
 					if err := h.configStore.UpdateVirtualKeyProviderConfig(ctx, &existing, tx); err != nil {
 						return err
 					}
@@ -1338,6 +1464,24 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					}
 				}
 			}
+		}
+		// Fold VK governance into VK-scoped wildcard model configs. The top-level is always
+		// reconciled (provided-aware); per-provider wildcards are reconciled only when the
+		// request supplied provider_configs (else they're left untouched).
+		top := vkWildcardDesired{
+			budgetsProvided:   req.Budgets != nil,
+			budgets:           req.Budgets,
+			rateLimitProvided: req.RateLimit != nil,
+		}
+		if req.RateLimit != nil {
+			if isRateLimitRemovalRequest(req.RateLimit) {
+				top.rateLimitRemove = true
+			} else {
+				top.rateLimit = rateLimitFromRequestFields(req.RateLimit.TokenMaxLimit, req.RateLimit.TokenResetDuration, req.RateLimit.RequestMaxLimit, req.RateLimit.RequestResetDuration)
+			}
+		}
+		if err := h.syncVKGovernanceToModelConfigs(ctx, tx, vk, top, vkGovProviders, req.ProviderConfigs != nil); err != nil {
+			return err
 		}
 		if req.MCPConfigs != nil {
 			// Check for duplicate MCPClientName values among all configs before processing
@@ -1454,6 +1598,8 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		logger.Error("failed to load relationships for updated VK: %v", err)
 		preloadedVk = vk
 	}
+	// Reverse-map governance from the VK-scoped wildcard model configs for display.
+	h.hydrateVKGovernance(ctx, preloadedVk)
 	if _, err := h.governanceManager.ReloadVirtualKey(ctx, vk.ID); err != nil {
 		// Should never happen but just in case
 		logger.Error("failed to reload virtual key after update: %v", err)
@@ -2648,6 +2794,8 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 	}
 	// Default and validate scope. Global is the implicit default (preserves
 	// pre-scope behavior). Non-global scopes require a scope_id naming the target.
+	// scopeCalendarAligned is inherited from the owning VK for virtual_key scope.
+	scopeCalendarAligned := false
 	if req.Scope == "" {
 		req.Scope = configstoreTables.ModelConfigScopeGlobal
 	}
@@ -2664,7 +2812,8 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 		}
 		// For the virtual_key scope, the scope_id must reference an existing VK.
 		if req.Scope == configstoreTables.ModelConfigScopeVirtualKey {
-			if _, vkErr := h.configStore.GetVirtualKey(ctx, *req.ScopeID); vkErr != nil {
+			vk, vkErr := h.configStore.GetVirtualKey(ctx, *req.ScopeID)
+			if vkErr != nil {
 				if errors.Is(vkErr, configstore.ErrNotFound) {
 					SendError(ctx, 400, fmt.Sprintf("Virtual key '%s' not found", *req.ScopeID))
 				} else {
@@ -2673,6 +2822,8 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 				}
 				return
 			}
+			// Inherit calendar alignment from the owning VK so budgets reset consistently.
+			scopeCalendarAligned = vk.CalendarAligned
 		}
 	}
 	// Check if a model config with the same identity (scope, scope_id, model_name, provider) already exists
@@ -2694,47 +2845,31 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 		}
 		return
 	}
-	// Validate budget if provided
-	if req.Budget != nil {
-		if req.Budget.MaxLimit < 0 {
-			SendError(ctx, 400, fmt.Sprintf("Budget max_limit cannot be negative: %.2f", req.Budget.MaxLimit))
+	// Validate budgets if provided
+	seenDurations := make(map[string]bool, len(req.Budgets))
+	for i := range req.Budgets {
+		if req.Budgets[i].MaxLimit < 0 {
+			SendError(ctx, 400, fmt.Sprintf("Budget max_limit cannot be negative: %.2f", req.Budgets[i].MaxLimit))
 			return
 		}
-		if _, err := configstoreTables.ParseDuration(req.Budget.ResetDuration); err != nil {
-			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", req.Budget.ResetDuration))
+		if _, err := configstoreTables.ParseDuration(req.Budgets[i].ResetDuration); err != nil {
+			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", req.Budgets[i].ResetDuration))
 			return
 		}
 	}
 	var mc configstoreTables.TableModelConfig
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		mc = configstoreTables.TableModelConfig{
-			ID:        uuid.NewString(),
-			ModelName: req.ModelName,
-			Provider:  req.Provider,
-			Scope:     req.Scope,
-			ScopeID:   req.ScopeID,
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
+			ID:              uuid.NewString(),
+			ModelName:       req.ModelName,
+			Provider:        req.Provider,
+			Scope:           req.Scope,
+			ScopeID:         req.ScopeID,
+			CalendarAligned: scopeCalendarAligned,
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
 		}
-		// Create budget if provided
-		if req.Budget != nil {
-			budget := configstoreTables.TableBudget{
-				ID:            uuid.NewString(),
-				MaxLimit:      req.Budget.MaxLimit,
-				ResetDuration: req.Budget.ResetDuration,
-				LastReset:     budgetLastReset(false, req.Budget.ResetDuration),
-				CurrentUsage:  0,
-			}
-			if err := validateBudget(&budget); err != nil {
-				return err
-			}
-			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-				return err
-			}
-			mc.BudgetID = &budget.ID
-			mc.Budget = &budget
-		}
-		// Create rate limit if provided
+		// Create rate limit if provided (mc references it via RateLimitID, so create first).
 		if req.RateLimit != nil {
 			rateLimit := configstoreTables.TableRateLimit{
 				ID:                   uuid.NewString(),
@@ -2754,8 +2889,27 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 			mc.RateLimitID = &rateLimit.ID
 			mc.RateLimit = &rateLimit
 		}
+		// Create the model config row first so its budgets can reference it via ModelConfigID.
 		if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
 			return err
+		}
+		// Create owned budgets (a model config may carry multiple).
+		for _, b := range req.Budgets {
+			budget := configstoreTables.TableBudget{
+				ID:            uuid.NewString(),
+				MaxLimit:      b.MaxLimit,
+				ResetDuration: b.ResetDuration,
+				LastReset:     budgetLastReset(mc.CalendarAligned, b.ResetDuration),
+				CurrentUsage:  0,
+				ModelConfigID: &mc.ID,
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			mc.Budgets = append(mc.Budgets, budget)
 		}
 		return nil
 	}); err != nil {
@@ -2794,8 +2948,8 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		// Track IDs to delete after updating the model config (to avoid FK constraint)
-		var budgetIDToDelete, rateLimitIDToDelete string
+		// Track rate-limit ID to delete after updating the model config (to avoid FK constraint).
+		var rateLimitIDToDelete string
 
 		// Update fields if provided
 		if req.ModelName != nil {
@@ -2805,62 +2959,12 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 		if req.Provider != nil {
 			mc.Provider = req.Provider
 		}
-		// Handle budget updates
-		if req.Budget != nil {
-			// Check if budget removal is requested (all fields nil)
-			budgetIsEmpty := isBudgetRemovalRequest(req.Budget)
-			if budgetIsEmpty {
-				// Mark budget for deletion after FK is removed
-				if mc.BudgetID != nil {
-					budgetIDToDelete = *mc.BudgetID
-					mc.BudgetID = nil
-					mc.Budget = nil
-				}
-			} else if mc.BudgetID != nil {
-				// Update existing budget — all fields are optional (partial update)
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *mc.BudgetID).Error; err != nil {
-					return err
-				}
-				if req.Budget.MaxLimit != nil {
-					budget.MaxLimit = *req.Budget.MaxLimit
-				}
-				if req.Budget.ResetDuration != nil {
-					budget.ResetDuration = *req.Budget.ResetDuration
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.Budget = &budget
-			} else {
-				// Create new budget
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
-				}
-				if *req.Budget.MaxLimit < 0 {
-					return fmt.Errorf("budget max_limit cannot be negative: %.2f", *req.Budget.MaxLimit)
-				}
-				if _, err := configstoreTables.ParseDuration(*req.Budget.ResetDuration); err != nil {
-					return fmt.Errorf("invalid reset duration format: %s", *req.Budget.ResetDuration)
-				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.BudgetID = &budget.ID
-				mc.Budget = &budget
+		// Handle budget updates: req.Budgets is the full desired set. A non-nil empty
+		// slice removes all budgets; omitting the field leaves them unchanged. Budgets
+		// are owned via ModelConfigID, so no model-config FK juggling is needed.
+		if req.Budgets != nil {
+			if err := h.reconcileModelConfigBudgets(ctx, tx, mc, req.Budgets); err != nil {
+				return err
 			}
 		}
 		// Handle rate limit updates
@@ -2918,12 +3022,7 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 			return err
 		}
 
-		// Now that FK references are removed, delete the orphaned budget/rate limit
-		if budgetIDToDelete != "" {
-			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", budgetIDToDelete).Error; err != nil {
-				return err
-			}
-		}
+		// Now that the FK reference is removed, delete the orphaned rate limit.
 		if rateLimitIDToDelete != "" {
 			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
 				return err
@@ -3000,7 +3099,12 @@ func providerGovernanceFromWildcard(mc *configstoreTables.TableModelConfig) (Pro
 		mc.ModelName != configstoreTables.ModelConfigAllModels || mc.Provider == nil {
 		return ProviderGovernanceResponse{}, false
 	}
-	return ProviderGovernanceResponse{Provider: *mc.Provider, Budget: mc.Budget, RateLimit: mc.RateLimit}, true
+	// Provider governance is single-budget by API; surface the first owned budget.
+	var budget *configstoreTables.TableBudget
+	if len(mc.Budgets) > 0 {
+		budget = &mc.Budgets[0]
+	}
+	return ProviderGovernanceResponse{Provider: *mc.Provider, Budget: budget, RateLimit: mc.RateLimit}, true
 }
 
 // getProviderGovernance handles GET /api/governance/providers - returns provider-level governance,
@@ -3083,58 +3187,18 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 		mc = *existing
 	}
 
+	// Existing single owned budget, if any (provider governance is single-budget by API).
+	var existingBudget *configstoreTables.TableBudget
+	if len(mc.Budgets) > 0 {
+		existingBudget = &mc.Budgets[0]
+	}
+
 	deleted := false
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		var budgetIDToDelete, rateLimitIDToDelete string
 
-		// Budget lifecycle (owner is the wildcard model config).
-		if req.Budget != nil {
-			if isBudgetRemovalRequest(req.Budget) {
-				if mc.BudgetID != nil {
-					budgetIDToDelete = *mc.BudgetID
-					mc.BudgetID = nil
-					mc.Budget = nil
-				}
-			} else if mc.BudgetID != nil {
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *mc.BudgetID).Error; err != nil {
-					return err
-				}
-				if req.Budget.MaxLimit != nil {
-					budget.MaxLimit = *req.Budget.MaxLimit
-				}
-				if req.Budget.ResetDuration != nil {
-					budget.ResetDuration = *req.Budget.ResetDuration
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.Budget = &budget
-			} else {
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
-				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.BudgetID = &budget.ID
-				mc.Budget = &budget
-			}
-		}
-		// Rate limit lifecycle (owner is the wildcard model config).
+		// Rate limit lifecycle (mc references it via RateLimitID, so resolve it before
+		// persisting the model config below).
 		if req.RateLimit != nil {
 			if isRateLimitRemovalRequest(req.RateLimit) {
 				if mc.RateLimitID != nil {
@@ -3179,23 +3243,80 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			}
 		}
 
-		hasGovernance := mc.BudgetID != nil || mc.RateLimitID != nil
+		// Determine the budget outcome (without writing yet — budgets reference the mc,
+		// which may not exist yet for a new provider governance row).
+		removeBudget := req.Budget != nil && isBudgetRemovalRequest(req.Budget)
+		willHaveBudget := existingBudget != nil && !removeBudget
+		if req.Budget != nil && !removeBudget && existingBudget == nil {
+			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
+				return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
+			}
+			willHaveBudget = true
+		}
+
+		hasGovernance := mc.RateLimitID != nil || willHaveBudget
 		switch {
 		case !hasGovernance && isNew:
 			// Nothing to persist (removal request on a provider with no governance).
+			return nil
 		case !hasGovernance && !isNew:
-			// All governance removed → delete the wildcard config and its orphaned rows.
+			// All governance removed → delete the wildcard config and its owned/orphaned rows.
+			if existingBudget != nil {
+				budgetIDToDelete = existingBudget.ID
+			}
 			if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
 				return err
 			}
 			deleted = true
 		case isNew:
+			// Create the model config first so its budget can reference it.
 			if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
 				return err
 			}
 		default:
 			if err := h.configStore.UpdateModelConfig(ctx, &mc, tx); err != nil {
 				return err
+			}
+		}
+
+		// Budget lifecycle (owned via ModelConfigID; the mc row now exists for create cases).
+		if !deleted && req.Budget != nil {
+			if removeBudget {
+				if existingBudget != nil {
+					budgetIDToDelete = existingBudget.ID
+					mc.Budgets = nil
+				}
+			} else if existingBudget != nil {
+				budget := *existingBudget
+				if req.Budget.MaxLimit != nil {
+					budget.MaxLimit = *req.Budget.MaxLimit
+				}
+				if req.Budget.ResetDuration != nil {
+					budget.ResetDuration = *req.Budget.ResetDuration
+				}
+				if err := validateBudget(&budget); err != nil {
+					return err
+				}
+				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
+					return err
+				}
+				mc.Budgets = []configstoreTables.TableBudget{budget}
+			} else {
+				budget := configstoreTables.TableBudget{
+					ID:            uuid.NewString(),
+					MaxLimit:      *req.Budget.MaxLimit,
+					ResetDuration: *req.Budget.ResetDuration,
+					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
+					CurrentUsage:  0,
+					ModelConfigID: &mc.ID,
+				}
+				if err := validateBudget(&budget); err != nil {
+					return err
+				}
+				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+					return err
+				}
+				mc.Budgets = []configstoreTables.TableBudget{budget}
 			}
 		}
 
@@ -3223,12 +3344,15 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 		if err := h.governanceManager.RemoveModelConfig(ctx, mc.ID); err != nil {
 			logger.Error("failed to remove provider governance from memory: %v", err)
 		}
-	} else if mc.BudgetID != nil || mc.RateLimitID != nil {
+	} else if len(mc.Budgets) > 0 || mc.RateLimitID != nil {
 		if reloaded, err := h.governanceManager.ReloadModelConfig(ctx, mc.ID); err != nil {
 			logger.Error("failed to reload provider governance in memory: %v", err)
-			resp.Budget, resp.RateLimit = mc.Budget, mc.RateLimit
-		} else {
-			resp.Budget, resp.RateLimit = reloaded.Budget, reloaded.RateLimit
+			if len(mc.Budgets) > 0 {
+				resp.Budget = &mc.Budgets[0]
+			}
+			resp.RateLimit = mc.RateLimit
+		} else if r, ok := providerGovernanceFromWildcard(reloaded); ok {
+			resp.Budget, resp.RateLimit = r.Budget, r.RateLimit
 		}
 	}
 	SendJSON(ctx, map[string]interface{}{

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -385,6 +385,34 @@ func findExistingBudget(request CreateBudgetRequest, byID map[string]configstore
 	return existing, found, nil
 }
 
+// coerceLegacyBudget converts a single UpdateBudgetRequest into a *[]CreateBudgetRequest
+// so it can be handled uniformly via reconcileModelConfigBudgets. Returns nil when the
+// request carries no actionable change (e.g. only one field set but no existing budget to
+// merge with, leaving the budget list unchanged).
+func coerceLegacyBudget(req *UpdateBudgetRequest, existing *configstoreTables.TableBudget) *[]CreateBudgetRequest {
+	if isBudgetRemovalRequest(req) {
+		empty := []CreateBudgetRequest{}
+		return &empty
+	}
+	b := CreateBudgetRequest{}
+	if existing != nil {
+		b.ID = existing.ID
+		b.MaxLimit = existing.MaxLimit
+		b.ResetDuration = existing.ResetDuration
+	}
+	if req.MaxLimit != nil {
+		b.MaxLimit = *req.MaxLimit
+	}
+	if req.ResetDuration != nil {
+		b.ResetDuration = *req.ResetDuration
+	}
+	if b.MaxLimit == 0 || b.ResetDuration == "" {
+		return nil
+	}
+	result := []CreateBudgetRequest{b}
+	return &result
+}
+
 func isRateLimitRemovalRequest(req *UpdateRateLimitRequest) bool {
 	return req != nil && req.TokenMaxLimit == nil && req.RequestMaxLimit == nil &&
 		req.TokenResetDuration == nil && req.RequestResetDuration == nil
@@ -837,8 +865,10 @@ type UpdateModelConfigRequest struct {
 
 // UpdateProviderGovernanceRequest represents the request body for updating provider governance
 type UpdateProviderGovernanceRequest struct {
-	Budget    *UpdateBudgetRequest    `json:"budget,omitempty"`
-	RateLimit *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	Budget          *UpdateBudgetRequest    `json:"budget,omitempty"`          // deprecated; use budgets
+	Budgets         *[]CreateBudgetRequest  `json:"budgets,omitempty"`         // nil=no change, []=remove all
+	RateLimit       *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	CalendarAligned *bool                   `json:"calendar_aligned,omitempty"`
 }
 
 // RegisterRoutes registers all governance-related routes for the new hierarchical system
@@ -3210,9 +3240,11 @@ func (h *GovernanceHandler) deleteModelConfig(ctx *fasthttp.RequestCtx) {
 
 // ProviderGovernanceResponse represents a provider with its governance settings
 type ProviderGovernanceResponse struct {
-	Provider  string                            `json:"provider"`
-	Budget    *configstoreTables.TableBudget    `json:"budget,omitempty"`
-	RateLimit *configstoreTables.TableRateLimit `json:"rate_limit,omitempty"`
+	Provider        string                            `json:"provider"`
+	Budget          *configstoreTables.TableBudget    `json:"budget,omitempty"` // deprecated: use budgets
+	Budgets         []configstoreTables.TableBudget   `json:"budgets,omitempty"`
+	RateLimit       *configstoreTables.TableRateLimit `json:"rate_limit,omitempty"`
+	CalendarAligned bool                              `json:"calendar_aligned"`
 }
 
 // modelConfigToProviderGovernance converts a model config to a ProviderGovernanceResponse.
@@ -3223,13 +3255,19 @@ func modelConfigToProviderGovernance(mc *configstoreTables.TableModelConfig) (Pr
 		mc.ModelName != configstoreTables.ModelConfigAllModels || mc.Provider == nil {
 		return ProviderGovernanceResponse{}, false
 	}
-	// Provider governance is single-budget by API; surface the first owned budget.
-	// This will be updated with the v2 endpoint, which can surface all budgets
 	var budget *configstoreTables.TableBudget
 	if len(mc.Budgets) > 0 {
 		budget = &mc.Budgets[0]
 	}
-	return ProviderGovernanceResponse{Provider: *mc.Provider, Budget: budget, RateLimit: mc.RateLimit}, true
+	budgets := make([]configstoreTables.TableBudget, len(mc.Budgets))
+	copy(budgets, mc.Budgets)
+	return ProviderGovernanceResponse{
+		Provider:        *mc.Provider,
+		Budget:          budget,
+		Budgets:         budgets,
+		RateLimit:       mc.RateLimit,
+		CalendarAligned: mc.CalendarAligned,
+	}, true
 }
 
 // getProviderGovernance handles GET /api/governance/providers - returns provider-level governance,
@@ -3273,6 +3311,10 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 	var req UpdateProviderGovernanceRequest
 	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
 		SendError(ctx, 400, "Invalid JSON")
+		return
+	}
+	if req.Budget != nil && req.Budgets != nil {
+		SendError(ctx, 400, "only one of 'budget' or 'budgets' may be set")
 		return
 	}
 	// Validate the provider exists.
@@ -3320,7 +3362,12 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 
 	deleted := false
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		var budgetIDToDelete, rateLimitIDToDelete string
+		var rateLimitIDToDelete string
+
+		// Apply CalendarAligned if provided.
+		if req.CalendarAligned != nil {
+			mc.CalendarAligned = *req.CalendarAligned
+		}
 
 		// Rate limit lifecycle (mc references it via RateLimitID, so resolve it before
 		// persisting the model config below).
@@ -3368,15 +3415,22 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			}
 		}
 
-		// Determine the budget outcome (without writing yet — budgets reference the mc,
-		// which may not exist yet for a new provider governance row).
-		removeBudget := req.Budget != nil && isBudgetRemovalRequest(req.Budget)
-		willHaveBudget := existingBudget != nil && !removeBudget
-		if req.Budget != nil && !removeBudget && existingBudget == nil {
-			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-				return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
+		// Determine effective budgets: budgets field takes priority; budget field is coerced
+		// into a single-element slice for backward compatibility.
+		effectiveBudgets := req.Budgets
+		if effectiveBudgets == nil && req.Budget != nil {
+			if len(mc.Budgets) > 1 {
+				return &badRequestError{err: fmt.Errorf("deprecated 'budget' field cannot be used when multiple budgets already exist; use 'budgets'")}
 			}
-			willHaveBudget = true
+			effectiveBudgets = coerceLegacyBudget(req.Budget, existingBudget)
+			if effectiveBudgets == nil && !isBudgetRemovalRequest(req.Budget) {
+				return &badRequestError{err: fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")}
+			}
+		}
+
+		willHaveBudget := len(mc.Budgets) > 0
+		if effectiveBudgets != nil {
+			willHaveBudget = len(*effectiveBudgets) > 0
 		}
 
 		hasGovernance := mc.RateLimitID != nil || willHaveBudget
@@ -3385,16 +3439,18 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			// Nothing to persist (removal request on a provider with no governance).
 			return nil
 		case !hasGovernance && !isNew:
-			// All governance removed → delete the model config and its owned/orphaned rows.
-			if existingBudget != nil {
-				budgetIDToDelete = existingBudget.ID
+			// All governance removed → delete the model config and its owned budgets.
+			for _, b := range mc.Budgets {
+				if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", b.ID).Error; err != nil {
+					return err
+				}
 			}
 			if err := tx.Delete(&configstoreTables.TableModelConfig{}, "id = ?", mc.ID).Error; err != nil {
 				return err
 			}
 			deleted = true
 		case isNew:
-			// Create the model config first so its budget can reference it.
+			// Create the model config first so its budgets can reference it.
 			if err := h.configStore.CreateModelConfig(ctx, &mc, tx); err != nil {
 				return err
 			}
@@ -3404,53 +3460,14 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 			}
 		}
 
-		// Budget lifecycle (owned via ModelConfigID; the mc row now exists for create cases).
-		if !deleted && req.Budget != nil {
-			if removeBudget {
-				if existingBudget != nil {
-					budgetIDToDelete = existingBudget.ID
-					mc.Budgets = nil
-				}
-			} else if existingBudget != nil {
-				budget := *existingBudget
-				if req.Budget.MaxLimit != nil {
-					budget.MaxLimit = *req.Budget.MaxLimit
-				}
-				if req.Budget.ResetDuration != nil {
-					budget.ResetDuration = *req.Budget.ResetDuration
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.Budgets = []configstoreTables.TableBudget{budget}
-			} else {
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
-					CurrentUsage:  0,
-					ModelConfigID: &mc.ID,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.Budgets = []configstoreTables.TableBudget{budget}
-			}
-		}
-
-		// Delete orphaned budget/rate-limit rows after the FK references are gone.
-		if budgetIDToDelete != "" {
-			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", budgetIDToDelete).Error; err != nil {
+		// Budget reconciliation (mc row exists at this point for create cases).
+		if !deleted && effectiveBudgets != nil {
+			if err := h.reconcileModelConfigBudgets(ctx, tx, &mc, *effectiveBudgets); err != nil {
 				return err
 			}
 		}
+
+		// Delete orphaned rate-limit row if it was unlinked.
 		if rateLimitIDToDelete != "" {
 			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
 				return err
@@ -3458,6 +3475,11 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 		}
 		return nil
 	}); err != nil {
+		var badReqErr *badRequestError
+		if errors.As(err, &badReqErr) {
+			SendError(ctx, 400, err.Error())
+			return
+		}
 		logger.Error("failed to update provider governance: %v", err)
 		SendError(ctx, 500, fmt.Sprintf("Failed to update provider governance: %v", err))
 		return
@@ -3472,12 +3494,11 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 	} else if len(mc.Budgets) > 0 || mc.RateLimitID != nil {
 		if reloaded, err := h.governanceManager.ReloadModelConfig(ctx, mc.ID); err != nil {
 			logger.Error("failed to reload provider governance in memory: %v", err)
-			if len(mc.Budgets) > 0 {
-				resp.Budget = &mc.Budgets[0]
+			if r, ok := modelConfigToProviderGovernance(&mc); ok {
+				resp = r
 			}
-			resp.RateLimit = mc.RateLimit
 		} else if r, ok := modelConfigToProviderGovernance(reloaded); ok {
-			resp.Budget, resp.RateLimit = r.Budget, r.RateLimit
+			resp = r
 		}
 	}
 	SendJSON(ctx, map[string]interface{}{

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1510,6 +1510,225 @@ func TestCollectProviderConfigDeleteIDs(t *testing.T) {
 	}
 }
 
+func TestCoerceLegacyBudget(t *testing.T) {
+	existing := &configstoreTables.TableBudget{ID: "bud-1", MaxLimit: 50, ResetDuration: "1d"}
+
+	tests := []struct {
+		name     string
+		req      *UpdateBudgetRequest
+		existing *configstoreTables.TableBudget
+		// nil wantResult means coerce returns nil (no actionable change)
+		wantNil    bool
+		wantEmpty  bool // non-nil but empty slice (removal)
+		wantID     string
+		wantLimit  float64
+		wantPeriod string
+	}{
+		{
+			name:      "empty object → removal, returns empty slice",
+			req:       &UpdateBudgetRequest{},
+			existing:  nil,
+			wantEmpty: true,
+		},
+		{
+			name:      "both fields set, no existing → new budget entry, no ID",
+			req:       &UpdateBudgetRequest{MaxLimit: schemas.Ptr(100.0), ResetDuration: schemas.Ptr("1w")},
+			existing:  nil,
+			wantLimit: 100,
+			wantPeriod: "1w",
+		},
+		{
+			name:       "update max_limit only, existing budget → merges ID and reset_duration",
+			req:        &UpdateBudgetRequest{MaxLimit: schemas.Ptr(200.0)},
+			existing:   existing,
+			wantID:     "bud-1",
+			wantLimit:  200,
+			wantPeriod: "1d",
+		},
+		{
+			name:       "update reset_duration only, existing budget → merges ID and max_limit",
+			req:        &UpdateBudgetRequest{ResetDuration: schemas.Ptr("1w")},
+			existing:   existing,
+			wantID:     "bud-1",
+			wantLimit:  50,
+			wantPeriod: "1w",
+		},
+		{
+			name:     "max_limit only, no existing → cannot build valid budget, returns nil",
+			req:      &UpdateBudgetRequest{MaxLimit: schemas.Ptr(100.0)},
+			existing: nil,
+			wantNil:  true,
+		},
+		{
+			name:     "reset_duration only, no existing → cannot build valid budget, returns nil",
+			req:      &UpdateBudgetRequest{ResetDuration: schemas.Ptr("1d")},
+			existing: nil,
+			wantNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := coerceLegacyBudget(tt.req, tt.existing)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if tt.wantEmpty {
+				if len(*got) != 0 {
+					t.Fatalf("expected empty slice, got %+v", *got)
+				}
+				return
+			}
+			if len(*got) != 1 {
+				t.Fatalf("expected 1-element slice, got %d elements", len(*got))
+			}
+			b := (*got)[0]
+			if b.ID != tt.wantID {
+				t.Errorf("ID = %q, want %q", b.ID, tt.wantID)
+			}
+			if b.MaxLimit != tt.wantLimit {
+				t.Errorf("MaxLimit = %v, want %v", b.MaxLimit, tt.wantLimit)
+			}
+			if b.ResetDuration != tt.wantPeriod {
+				t.Errorf("ResetDuration = %q, want %q", b.ResetDuration, tt.wantPeriod)
+			}
+		})
+	}
+}
+
+func TestModelConfigToProviderGovernanceNewFields(t *testing.T) {
+	provider := "openai"
+	base := configstoreTables.TableModelConfig{
+		Scope:     configstoreTables.ModelConfigScopeGlobal,
+		ModelName: configstoreTables.ModelConfigAllModels,
+		Provider:  &provider,
+	}
+
+	t.Run("nil mc returns false", func(t *testing.T) {
+		if _, ok := modelConfigToProviderGovernance(nil); ok {
+			t.Fatal("expected false for nil mc")
+		}
+	})
+
+	t.Run("wrong scope returns false", func(t *testing.T) {
+		mc := base
+		mc.Scope = "virtual_key"
+		if _, ok := modelConfigToProviderGovernance(&mc); ok {
+			t.Fatal("expected false for non-global scope")
+		}
+	})
+
+	t.Run("no budgets: Budget nil, Budgets empty, CalendarAligned false", func(t *testing.T) {
+		mc := base
+		r, ok := modelConfigToProviderGovernance(&mc)
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if r.Budget != nil {
+			t.Errorf("Budget should be nil, got %+v", r.Budget)
+		}
+		if len(r.Budgets) != 0 {
+			t.Errorf("Budgets should be empty, got %+v", r.Budgets)
+		}
+		if r.CalendarAligned {
+			t.Error("CalendarAligned should be false")
+		}
+	})
+
+	t.Run("single budget: Budget points to first, Budgets has one entry", func(t *testing.T) {
+		mc := base
+		mc.Budgets = []configstoreTables.TableBudget{{ID: "b1", MaxLimit: 100, ResetDuration: "1d"}}
+		r, ok := modelConfigToProviderGovernance(&mc)
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if r.Budget == nil || r.Budget.ID != "b1" {
+			t.Errorf("Budget = %+v, want ID=b1", r.Budget)
+		}
+		if len(r.Budgets) != 1 || r.Budgets[0].ID != "b1" {
+			t.Errorf("Budgets = %+v, want 1 entry with ID=b1", r.Budgets)
+		}
+	})
+
+	t.Run("multiple budgets: Budget is first, Budgets contains all", func(t *testing.T) {
+		mc := base
+		mc.Budgets = []configstoreTables.TableBudget{
+			{ID: "b1", MaxLimit: 100, ResetDuration: "1d"},
+			{ID: "b2", MaxLimit: 500, ResetDuration: "1w"},
+		}
+		r, ok := modelConfigToProviderGovernance(&mc)
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if r.Budget == nil || r.Budget.ID != "b1" {
+			t.Errorf("Budget should point to first budget, got %+v", r.Budget)
+		}
+		if len(r.Budgets) != 2 {
+			t.Fatalf("Budgets len = %d, want 2", len(r.Budgets))
+		}
+		if r.Budgets[0].ID != "b1" || r.Budgets[1].ID != "b2" {
+			t.Errorf("Budgets = %+v", r.Budgets)
+		}
+	})
+
+	t.Run("calendar_aligned is propagated", func(t *testing.T) {
+		mc := base
+		mc.CalendarAligned = true
+		r, ok := modelConfigToProviderGovernance(&mc)
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if !r.CalendarAligned {
+			t.Error("CalendarAligned should be true")
+		}
+	})
+
+	t.Run("Budgets slice is a copy, not a reference to mc.Budgets", func(t *testing.T) {
+		mc := base
+		mc.Budgets = []configstoreTables.TableBudget{{ID: "b1", MaxLimit: 100, ResetDuration: "1d"}}
+		r, _ := modelConfigToProviderGovernance(&mc)
+		r.Budgets[0].MaxLimit = 999
+		if mc.Budgets[0].MaxLimit == 999 {
+			t.Error("mutating response Budgets should not affect the original mc")
+		}
+	})
+}
+
+func TestUpdateProviderGovernance_BudgetMutualExclusion(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &GovernanceHandler{}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("provider_name", "openai")
+	ctx.Request.SetBodyString(`{
+		"budget":  {"max_limit": 100, "reset_duration": "1d"},
+		"budgets": [{"max_limit": 100, "reset_duration": "1d"}]
+	}`)
+
+	h.updateProviderGovernance(ctx)
+
+	if ctx.Response.StatusCode() != 400 {
+		t.Fatalf("expected 400, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+	if !strings.Contains(resp.Error.Message, "budget") {
+		t.Errorf("error message should mention 'budget', got: %q", resp.Error.Message)
+	}
+}
+
 func TestValidateRoutingFallbacks(t *testing.T) {
 
 	tests := []struct {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2717,6 +2717,11 @@ func updateGovernanceConfigInStore(
 			if err := config.ConfigStore.CreateModelConfig(ctx, &modelConfig, tx); err != nil {
 				return fmt.Errorf("failed to create model config %s: %w", modelConfig.ID, err)
 			}
+			if len(modelConfig.BudgetIDs) > 0 {
+				if err := linkModelConfigBudgets(tx, modelConfig.ID, modelConfig.BudgetIDs); err != nil {
+					return err
+				}
+			}
 		}
 
 		// Update model configs (config.json changed)
@@ -2726,6 +2731,11 @@ func updateGovernanceConfigInStore(
 			}
 			if err := config.ConfigStore.UpdateModelConfig(ctx, &modelConfig, tx); err != nil {
 				return fmt.Errorf("failed to update model config %s: %w", modelConfig.ID, err)
+			}
+			if len(modelConfig.BudgetIDs) > 0 {
+				if err := linkModelConfigBudgets(tx, modelConfig.ID, modelConfig.BudgetIDs); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -2797,6 +2807,50 @@ func validateModelConfigGovernanceOwnership(tx *gorm.DB, modelConfig configstore
 	}
 	if err := validateRateLimitLinkOwnership(tx, modelConfig.RateLimitID, "model config", modelConfig.ID); err != nil {
 		return err
+	}
+	for _, budgetID := range modelConfig.BudgetIDs {
+		id := budgetID
+		if err := validateBudgetLinkOwnership(tx, &id, "model config", modelConfig.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// linkModelConfigBudgets sets model_config_id on each budget in budgetIDs, and clears it from
+// any budgets previously owned by mcID that are no longer in the list.
+func linkModelConfigBudgets(tx *gorm.DB, mcID string, budgetIDs []string) error {
+	// Normalize: trim whitespace and deduplicate.
+	seen := make(map[string]struct{}, len(budgetIDs))
+	normalized := make([]string, 0, len(budgetIDs))
+	for _, raw := range budgetIDs {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		normalized = append(normalized, id)
+	}
+
+	// Clear ownership from budgets that are no longer referenced.
+	unlinkQ := tx.Model(&configstoreTables.TableBudget{}).
+		Where("model_config_id = ?", mcID)
+	if len(normalized) > 0 {
+		unlinkQ = unlinkQ.Where("id NOT IN ?", normalized)
+	}
+	if err := unlinkQ.Update("model_config_id", nil).Error; err != nil {
+		return fmt.Errorf("failed to unlink stale budgets from model config %q: %w", mcID, err)
+	}
+	// Link the declared budgets.
+	for _, id := range normalized {
+		if err := tx.Model(&configstoreTables.TableBudget{}).
+			Where("id = ?", id).
+			Update("model_config_id", mcID).Error; err != nil {
+			return fmt.Errorf("failed to link budget %q to model config %q: %w", id, mcID, err)
+		}
 	}
 	return nil
 }
@@ -2995,6 +3049,11 @@ func createGovernanceConfigInStore(ctx context.Context, config *Config) {
 			}
 			if err := config.ConfigStore.CreateModelConfig(ctx, modelConfig, tx); err != nil {
 				return fmt.Errorf("failed to create model config %s: %w", modelConfig.ID, err)
+			}
+			if len(modelConfig.BudgetIDs) > 0 {
+				if err := linkModelConfigBudgets(tx, modelConfig.ID, modelConfig.BudgetIDs); err != nil {
+					return err
+				}
 			}
 		}
 		for i := range config.GovernanceConfig.Providers {

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1115,6 +1115,10 @@ func (m *MockConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableMo
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetModelConfigsByScopeAndScopeIDs(ctx context.Context, scope string, scopeIDs []string) ([]tables.TableModelConfig, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) GetProviderGovernanceModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error) {
 	return nil, nil
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -389,6 +389,17 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 		}
 	}
 	governancePlugin.GetGovernanceStore().UpdateVirtualKeyInMemory(ctx, virtualKey, nil, nil, nil)
+	// Also reload any model configs scoped to this VK so governance changes made
+	// via the VK sheet (syncVKGovernanceToModelConfigs) are reflected in memory
+	// immediately — both on the node that handled the update and on peers that
+	// receive this reload via the cluster gossip broadcast.
+	if mcs, err := s.Config.ConfigStore.GetModelConfigsByScopeAndScopeIDs(
+		ctx, tables.ModelConfigScopeVirtualKey, []string{id},
+	); err == nil {
+		for i := range mcs {
+			governancePlugin.GetGovernanceStore().UpdateModelConfigInMemory(ctx, &mcs[i])
+		}
+	}
 	s.MCPServerHandler.SyncVKMCPServer(virtualKey)
 	return virtualKey, nil
 }
@@ -507,10 +518,16 @@ func (s *BifrostHTTPServer) ReloadModelConfig(ctx context.Context, id string) (*
 		return preloadedMC, nil
 	}
 
-	// Sync updated usage values back to database if they changed
-	if updatedMC.Budget != nil && preloadedMC.Budget != nil {
-		if updatedMC.Budget.CurrentUsage != preloadedMC.Budget.CurrentUsage {
-			if err := s.Config.ConfigStore.UpdateBudgetUsage(ctx, updatedMC.Budget.ID, updatedMC.Budget.CurrentUsage); err != nil {
+	// Sync updated budget usage values back to database if they changed (per budget ID,
+	// since a model config may own multiple budgets).
+	preloadedUsage := make(map[string]float64, len(preloadedMC.Budgets))
+	for i := range preloadedMC.Budgets {
+		preloadedUsage[preloadedMC.Budgets[i].ID] = preloadedMC.Budgets[i].CurrentUsage
+	}
+	for i := range updatedMC.Budgets {
+		b := &updatedMC.Budgets[i]
+		if old, ok := preloadedUsage[b.ID]; ok && old != b.CurrentUsage {
+			if err := s.Config.ConfigStore.UpdateBudgetUsage(ctx, b.ID, b.CurrentUsage); err != nil {
 				logger.Error("failed to sync budget usage to database: %v", err)
 			}
 		}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -693,6 +693,15 @@
                 "type": "string",
                 "description": "Optional provider name to scope this config"
               },
+              "scope": {
+                "type": "string",
+                "description": "Scope where this config applies: \"global\" (default) or \"virtual_key\"",
+                "default": "global"
+              },
+              "scope_id": {
+                "type": "string",
+                "description": "Target entity ID for non-global scopes (e.g. virtual key ID). Required when scope != \"global\""
+              },
               "budget_id": {
                 "type": "string",
                 "description": "Budget ID to associate with this model"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -704,7 +704,12 @@
               },
               "budget_id": {
                 "type": "string",
-                "description": "Budget ID to associate with this model"
+                "description": "Deprecated — single budget reference. Use budget_ids instead."
+              },
+              "budget_ids": {
+                "type": "array",
+                "description": "List of budget IDs (from governance.budgets) to associate with this model config. Supports multiple budgets (e.g. daily + monthly). Replaces budget_id.",
+                "items": { "type": "string" }
               },
               "rate_limit_id": {
                 "type": "string",

--- a/ui/app/_fallbacks/enterprise/lib/registrations/modelLimitScopes.ts
+++ b/ui/app/_fallbacks/enterprise/lib/registrations/modelLimitScopes.ts
@@ -1,0 +1,7 @@
+// OSS-build fallback for the enterprise scope registrations.
+//
+// Side-effect imports of this module from OSS code (e.g. from the Model
+// Limits page) compile to a no-op when the @enterprise alias resolves to
+// _fallbacks/. The enterprise build replaces this module with one that
+// registers the "user" scope (and its picker + deep-link).
+export {};

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -3,6 +3,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Label } from "@/components/ui/label";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
+import MultiBudgetLines from "@/components/ui/multibudgets";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -39,8 +40,15 @@ const formSchema = z
 		provider: z.string().optional(),
 		scope: z.string().optional(),
 		scopeId: z.string().optional(),
-		budgetMaxLimit: z.number().nonnegative().optional(),
-		budgetResetDuration: z.string().optional(),
+		budgets: z
+			.array(
+				z.object({
+					id: z.string().optional(),
+					max_limit: z.number().nonnegative().optional(),
+					reset_duration: z.string().optional(),
+				}),
+			)
+			.optional(),
 		tokenMaxLimit: z.number().int().nonnegative().optional(),
 		tokenResetDuration: z.string().optional(),
 		requestMaxLimit: z.number().int().nonnegative().optional(),
@@ -106,8 +114,11 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 			provider: modelConfig?.provider || "",
 			scope: modelConfig?.scope || "global",
 			scopeId: modelConfig?.scope_id || "",
-			budgetMaxLimit: modelConfig?.budget?.max_limit ?? undefined,
-			budgetResetDuration: modelConfig?.budget?.reset_duration || "1M",
+			budgets: (modelConfig?.budgets ?? []).map((b) => ({
+				id: b.id,
+				max_limit: b.max_limit,
+				reset_duration: b.reset_duration,
+			})),
 			tokenMaxLimit: modelConfig?.rate_limit?.token_max_limit ?? undefined,
 			tokenResetDuration: modelConfig?.rate_limit?.token_reset_duration || "1h",
 			requestMaxLimit: modelConfig?.rate_limit?.request_max_limit ?? undefined,
@@ -115,8 +126,9 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 		},
 	});
 
+	const watchedBudgets = form.watch("budgets");
 	const hasAnyLimit =
-		(form.watch("budgetMaxLimit") !== undefined && form.watch("budgetMaxLimit") !== null) ||
+		(watchedBudgets?.some((b) => b.max_limit !== undefined && b.max_limit !== null) ?? false) ||
 		(form.watch("tokenMaxLimit") !== undefined && form.watch("tokenMaxLimit") !== null) ||
 		(form.watch("requestMaxLimit") !== undefined && form.watch("requestMaxLimit") !== null);
 
@@ -135,8 +147,11 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 				provider: modelConfig.provider || "",
 				scope: modelConfig.scope || "global",
 				scopeId: modelConfig.scope_id || "",
-				budgetMaxLimit: modelConfig.budget?.max_limit ?? undefined,
-				budgetResetDuration: modelConfig.budget?.reset_duration || "1M",
+				budgets: (modelConfig.budgets ?? []).map((b) => ({
+					id: b.id,
+					max_limit: b.max_limit,
+					reset_duration: b.reset_duration,
+				})),
 				tokenMaxLimit: modelConfig.rate_limit?.token_max_limit ?? undefined,
 				tokenResetDuration: modelConfig.rate_limit?.token_reset_duration || "1h",
 				requestMaxLimit: modelConfig.rate_limit?.request_max_limit ?? undefined,
@@ -159,23 +174,17 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 		try {
 			const provider = data.provider && data.provider.trim() !== "" ? data.provider : undefined;
 
+			// Full desired set of budgets (kept lines with a max_limit). For updates this is
+			// reconciled server-side; an empty array removes all budgets.
+			const budgetsPayload = (data.budgets ?? [])
+				.filter((b) => b.max_limit !== undefined && b.max_limit !== null)
+				.map((b) => ({ id: b.id, max_limit: b.max_limit as number, reset_duration: b.reset_duration || "1M" }));
+
 			if (isEditing && modelConfig) {
-				const hadBudget = !!modelConfig.budget;
-				const hasBudget = data.budgetMaxLimit !== undefined && data.budgetMaxLimit !== null;
 				const hadRateLimit = !!modelConfig.rate_limit;
 				const hasRateLimit =
 					(data.tokenMaxLimit !== undefined && data.tokenMaxLimit !== null) ||
 					(data.requestMaxLimit !== undefined && data.requestMaxLimit !== null);
-
-				let budgetPayload: { max_limit?: number; reset_duration?: string } | undefined;
-				if (hasBudget) {
-					budgetPayload = {
-						max_limit: data.budgetMaxLimit,
-						reset_duration: data.budgetResetDuration || "1M",
-					};
-				} else if (hadBudget) {
-					budgetPayload = {};
-				}
 
 				let rateLimitPayload:
 					| {
@@ -202,7 +211,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 					data: {
 						model_name: data.modelName,
 						provider: provider,
-						budget: budgetPayload,
+						budgets: budgetsPayload,
 						rate_limit: rateLimitPayload,
 					},
 				}).unwrap();
@@ -213,13 +222,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 					provider,
 					scope: data.scope || "global",
 					scope_id: data.scope === "virtual_key" ? data.scopeId : undefined,
-					budget:
-						data.budgetMaxLimit !== undefined && data.budgetMaxLimit !== null
-							? {
-									max_limit: data.budgetMaxLimit,
-									reset_duration: data.budgetResetDuration || "1M",
-								}
-							: undefined,
+					budgets: budgetsPayload.length > 0 ? budgetsPayload : undefined,
 					rate_limit:
 						(data.tokenMaxLimit !== undefined && data.tokenMaxLimit !== null) ||
 						(data.requestMaxLimit !== undefined && data.requestMaxLimit !== null)
@@ -403,27 +406,17 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 
 							<DottedSeparator />
 
-							{/* Budget Configuration */}
+							{/* Budget Configuration (multi-budget) */}
 							<div className="space-y-4">
-								<Label className="text-sm font-medium">Budget</Label>
-								<FormField
-									control={form.control}
-									name="budgetMaxLimit"
-									render={({ field }) => (
-										<FormItem>
-											<NumberAndSelect
-												id="modelBudgetMaxLimit"
-												labelClassName="font-normal"
-												label="Maximum Spend (USD)"
-												value={field.value}
-												selectValue={form.watch("budgetResetDuration") || "1M"}
-												onChangeNumber={(value) => field.onChange(value)}
-												onChangeSelect={(value) => form.setValue("budgetResetDuration", value, { shouldDirty: true })}
-												options={resetDurationOptions}
-											/>
-											<FormMessage />
-										</FormItem>
-									)}
+								<MultiBudgetLines
+									data-testid="model-limit-budget-lines"
+									label="Budget"
+									lines={(form.watch("budgets") ?? []).map((b) => ({
+										id: b.id,
+										max_limit: b.max_limit,
+										reset_duration: b.reset_duration ?? "1M",
+									}))}
+									onChange={(lines) => form.setValue("budgets", lines, { shouldDirty: true })}
 								/>
 							</div>
 
@@ -476,20 +469,20 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 							</div>
 
 							{/* Current Usage Display (for editing) */}
-							{isEditing && (modelConfig?.budget || modelConfig?.rate_limit) && (
+							{isEditing && ((modelConfig?.budgets?.length ?? 0) > 0 || modelConfig?.rate_limit) && (
 								<>
 									<DottedSeparator />
 									<div className="space-y-3">
 										<Label className="text-sm font-medium">Current Usage</Label>
 										<div className="bg-muted/50 grid grid-cols-2 gap-4 rounded-lg p-4">
-											{modelConfig?.budget && (
-												<div className="space-y-1">
-													<p className="text-muted-foreground text-xs">Budget</p>
+											{(modelConfig?.budgets ?? []).map((b) => (
+												<div key={b.id} className="space-y-1">
+													<p className="text-muted-foreground text-xs">Budget ({b.reset_duration})</p>
 													<p className="text-sm font-medium">
-														${modelConfig.budget.current_usage.toFixed(2)} / ${modelConfig.budget.max_limit.toFixed(2)}
+														${b.current_usage.toFixed(2)} / ${b.max_limit.toFixed(2)}
 													</p>
 												</div>
-											)}
+											))}
 											{modelConfig?.rate_limit?.token_max_limit && (
 												<div className="space-y-1">
 													<p className="text-muted-foreground text-xs">Tokens</p>

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -7,15 +7,17 @@ import MultiBudgetLines from "@/components/ui/multibudgets";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { ComboboxSelect } from "@/components/ui/combobox";
-import { MODEL_LIMIT_SCOPES, resetDurationOptions } from "@/lib/constants/governance";
+import { resetDurationOptions } from "@/lib/constants/governance";
 import { RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import { getModelLimitScope, getModelLimitScopes } from "@/lib/registries/modelLimitScopes";
+// Side-effect import: pulls in downstream scope registrations (e.g. enterprise
+// registers "user" + user picker). The OSS-build fallback is an empty module.
+import "@enterprise/lib/registrations/modelLimitScopes";
 import {
 	getErrorMessage,
 	useCreateModelConfigMutation,
 	useGetProvidersQuery,
-	useGetVirtualKeysQuery,
 	useLazyGetModelsQuery,
 	useUpdateModelConfigMutation,
 } from "@/lib/store";
@@ -77,7 +79,6 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 	};
 
 	const { data: providersData } = useGetProvidersQuery();
-	const { data: vksData = { virtual_keys: [] } } = useGetVirtualKeysQuery();
 	const [createModelConfig, { isLoading: isCreating }] = useCreateModelConfigMutation();
 	const [updateModelConfig, { isLoading: isUpdating }] = useUpdateModelConfigMutation();
 	const [getModels] = useLazyGetModelsQuery();
@@ -221,7 +222,11 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 					model_name: data.modelName,
 					provider,
 					scope: data.scope || "global",
-					scope_id: data.scope === "virtual_key" ? data.scopeId : undefined,
+					// Any scope with a registered PickerComponent carries a target;
+					// global (no picker) sends no scope_id. Mirrors the registry
+					// shape, so adding a new scope (e.g. enterprise's "user")
+					// doesn't need a branch here.
+					scope_id: getModelLimitScope(data.scope || "global")?.PickerComponent ? data.scopeId : undefined,
 					budgets: budgetsPayload.length > 0 ? budgetsPayload : undefined,
 					rate_limit:
 						(data.tokenMaxLimit !== undefined && data.tokenMaxLimit !== null) ||
@@ -357,7 +362,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 												</SelectTrigger>
 											</FormControl>
 											<SelectContent>
-												{MODEL_LIMIT_SCOPES.map((option) => (
+												{getModelLimitScopes().map((option) => (
 													<SelectItem key={option.value} value={option.value}>
 														{option.label}
 													</SelectItem>
@@ -369,40 +374,41 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 								)}
 							/>
 
-							{/* Virtual Key picker (only for the Virtual Key scope) */}
-							{form.watch("scope") === "virtual_key" && (
-								<FormField
-									control={form.control}
-									name="scopeId"
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>Virtual Key</FormLabel>
-											<FormControl>
-												<div data-testid="model-limit-scope-id-select">
-													<ComboboxSelect
-														options={[
-															// Guarantee the currently-selected VK is selectable even if it
-															// falls outside the first page of fetched virtual keys.
-															...(modelConfig?.scope_id && modelConfig?.scope_name
-																? [{ label: modelConfig.scope_name, value: modelConfig.scope_id }]
-																: []),
-															...vksData.virtual_keys
-																.filter((vk) => vk.id !== modelConfig?.scope_id)
-																.map((vk) => ({ label: vk.name, value: vk.id })),
-														]}
-														value={field.value || null}
-														onValueChange={(value) => field.onChange(value ?? "")}
-														placeholder="Select a virtual key..."
-														disabled={isEditing}
-														noPortal
-													/>
-												</div>
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							)}
+							{/* Scope-target picker — driven by the scope registry.
+								Each non-global scope (virtual_key, user, …) registers its
+								own PickerComponent; we render whichever the current scope
+								provides. */}
+							{(() => {
+								const scopeEntry = getModelLimitScope(form.watch("scope") || "global");
+								const Picker = scopeEntry?.PickerComponent;
+								if (!Picker) return null;
+								return (
+									<FormField
+										control={form.control}
+										name="scopeId"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>{scopeEntry.label}</FormLabel>
+												<FormControl>
+													<div data-testid="model-limit-scope-id-select">
+														<Picker
+															value={field.value || ""}
+															onChange={(v) => field.onChange(v ?? "")}
+															disabled={isEditing}
+															fallbackOption={
+																modelConfig?.scope === scopeEntry.value && modelConfig?.scope_id && modelConfig?.scope_name
+																	? { value: modelConfig.scope_id, label: modelConfig.scope_name }
+																	: null
+															}
+														/>
+													</div>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								);
+							})()}
 
 							<DottedSeparator />
 

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -15,7 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { resetDurationLabels } from "@/lib/constants/governance";
+import { resetDurationLabels, supportsCalendarAlignment } from "@/lib/constants/governance";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { getErrorMessage, useDeleteModelConfigMutation } from "@/lib/store";
@@ -23,12 +23,13 @@ import { ModelConfig } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
+import { ArrowUpRight, ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
 import { ModelLimitsEmptyState } from "./modelLimitsEmptyState";
 import { getScopeLabel } from "@/lib/utils/labels";
+import { useNavigate } from "@tanstack/react-router";
 
 // Helper to format reset duration for display
 const formatResetDuration = (duration: string) => {
@@ -123,6 +124,7 @@ export default function ModelLimitsTable({
 	limit,
 	onOffsetChange,
 }: ModelLimitsTableProps) {
+	const navigate = useNavigate();
 	const [showModelLimitSheet, setShowModelLimitSheet] = useState(false);
 	const [editingModelConfigId, setEditingModelConfigId] = useState<string | null>(null);
 	const [deleteModelConfigId, setDeleteModelConfigId] = useState<string | null>(null);
@@ -248,6 +250,7 @@ export default function ModelLimitsTable({
 								<TableHead className="font-medium">Model</TableHead>
 								<TableHead className="font-medium">Provider</TableHead>
 								<TableHead className="font-medium">Scope</TableHead>
+								<TableHead className="font-medium">Scope Target</TableHead>
 								<TableHead className="font-medium">Budget</TableHead>
 								<TableHead className="font-medium">Rate Limit</TableHead>
 								<TableHead className="w-[100px]"></TableHead>
@@ -256,14 +259,15 @@ export default function ModelLimitsTable({
 						<TableBody>
 							{modelConfigs.length === 0 ? (
 								<TableRow>
-									<TableCell colSpan={6} className="h-24 text-center">
+									<TableCell colSpan={7} className="h-24 text-center">
 										<span className="text-muted-foreground text-sm">No matching model limits found.</span>
 									</TableCell>
 								</TableRow>
 							) : (
 								modelConfigs.map((config) => {
-									const isBudgetExhausted =
-										config.budget?.max_limit && config.budget.max_limit > 0 && config.budget.current_usage >= config.budget.max_limit;
+									// Model configs can own multiple budgets; show all (like the VK table).
+									const budgets = config.budgets ?? (config.budget ? [config.budget] : []);
+									const isBudgetExhausted = budgets.some((b) => b.max_limit > 0 && b.current_usage >= b.max_limit);
 									const isRateLimitExhausted =
 										(config.rate_limit?.token_max_limit &&
 											config.rate_limit.token_max_limit > 0 &&
@@ -274,10 +278,6 @@ export default function ModelLimitsTable({
 									const isExhausted = isBudgetExhausted || isRateLimitExhausted;
 
 									// Compute safe percentages to avoid division by zero
-									const budgetPercentage =
-										config.budget?.max_limit && config.budget.max_limit > 0
-											? Math.min((config.budget.current_usage / config.budget.max_limit) * 100, 100)
-											: 0;
 									const tokenPercentage =
 										config.rate_limit?.token_max_limit && config.rate_limit.token_max_limit > 0
 											? Math.min((config.rate_limit.token_current_usage / config.rate_limit.token_max_limit) * 100, 100)
@@ -318,41 +318,45 @@ export default function ModelLimitsTable({
 											<TableCell>
 												<Badge variant="secondary">{getScopeLabel(config.scope ?? "global")}</Badge>
 											</TableCell>
-											<TableCell className="min-w-[180px]">
-												{config.budget ? (
+											<TableCell>
+												{config.scope !== "global" && config.scope_id && config.scope_name ? (
 													<TooltipProvider>
 														<Tooltip>
 															<TooltipTrigger asChild>
-																<div className="space-y-2">
-																	<div className="flex items-center justify-between gap-4">
-																		<span className="font-medium">{formatCurrency(config.budget.max_limit)}</span>
-																		<span className="text-muted-foreground text-xs">
-																			{formatResetDuration(config.budget.reset_duration)}
-																		</span>
-																	</div>
-																	<Progress
-																		value={budgetPercentage}
-																		className={cn(
-																			"bg-muted/70 dark:bg-muted/30 h-1.5",
-																			isBudgetExhausted
-																				? "[&>div]:bg-red-500/70"
-																				: budgetPercentage > 80
-																					? "[&>div]:bg-amber-500/70"
-																					: "[&>div]:bg-emerald-500/70",
-																		)}
-																	/>
-																</div>
+																<Badge
+																	variant="secondary"
+																	className="flex max-w-[160px] cursor-pointer items-center gap-1 hover:opacity-80"
+																	data-testid={`model-limit-scope-target-${config.scope_id}`}
+																	onClick={() => navigate({ to: "/workspace/governance/virtual-keys", search: { vk: config.scope_id } })}
+																>
+																	<span className="truncate">{config.scope_name}</span>
+																	<ArrowUpRight className="h-3 w-3 shrink-0" />
+																</Badge>
 															</TooltipTrigger>
-															<TooltipContent>
-																<p className="font-medium">
-																	{formatCurrency(config.budget.current_usage)} / {formatCurrency(config.budget.max_limit)}
-																</p>
-																<p className="text-primary-foreground/80 text-xs">
-																	Resets {formatResetDuration(config.budget.reset_duration)}
-																</p>
-															</TooltipContent>
+															<TooltipContent className="max-w-[320px] break-all">{config.scope_name}</TooltipContent>
 														</Tooltip>
 													</TooltipProvider>
+												) : (
+													<span className="text-muted-foreground text-sm">—</span>
+												)}
+											</TableCell>
+											<TableCell className="min-w-[180px]">
+												{budgets.length > 0 ? (
+													<div className="flex flex-col gap-1">
+														{budgets.map((b, idx) => (
+															<div key={b.id ?? idx} className="flex flex-col">
+																<span
+																	className={cn("font-mono text-sm", b.max_limit > 0 && b.current_usage >= b.max_limit && "text-red-400")}
+																>
+																	{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
+																</span>
+																<span className="text-muted-foreground text-xs">
+																	Resets {formatResetDuration(b.reset_duration)}
+																	{config.calendar_aligned && supportsCalendarAlignment(b.reset_duration) && " (calendar)"}
+																</span>
+															</div>
+														))}
+													</div>
 												) : (
 													<span className="text-muted-foreground text-sm">-</span>
 												)}

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -29,6 +29,10 @@ import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
 import { ModelLimitsEmptyState } from "./modelLimitsEmptyState";
 import { getScopeLabel } from "@/lib/utils/labels";
+import { getModelLimitScope } from "@/lib/registries/modelLimitScopes";
+// Side-effect import: pull in downstream scope registrations (enterprise
+// "user" deep-link, etc.). No-op for OSS builds.
+import "@enterprise/lib/registrations/modelLimitScopes";
 import { useNavigate } from "@tanstack/react-router";
 
 // Helper to format reset duration for display
@@ -327,7 +331,11 @@ export default function ModelLimitsTable({
 																	variant="secondary"
 																	className="flex max-w-[160px] cursor-pointer items-center gap-1 hover:opacity-80"
 																	data-testid={`model-limit-scope-target-${config.scope_id}`}
-																	onClick={() => navigate({ to: "/workspace/governance/virtual-keys", search: { vk: config.scope_id } })}
+																	onClick={() => {
+																		if (!config.scope_id) return;
+																		const target = getModelLimitScope(config.scope ?? "global")?.buildDeepLink?.(config.scope_id);
+																		if (target) navigate(target as never);
+																	}}
 																>
 																	<span className="truncate">{config.scope_name}</span>
 																	<ArrowUpRight className="h-3 w-3 shrink-0" />

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -20,6 +20,8 @@ import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { getErrorMessage, useDeleteModelConfigMutation } from "@/lib/store";
 import { ModelConfig } from "@/lib/types/governance";
+import { ModelProvider } from "@/lib/types/config";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -29,7 +31,7 @@ import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
 import { ModelLimitsEmptyState } from "./modelLimitsEmptyState";
 import { getScopeLabel } from "@/lib/utils/labels";
-import { getModelLimitScope } from "@/lib/registries/modelLimitScopes";
+import { getModelLimitScope, getModelLimitScopes } from "@/lib/registries/modelLimitScopes";
 // Side-effect import: pull in downstream scope registrations (enterprise
 // "user" deep-link, etc.). No-op for OSS builds.
 import "@enterprise/lib/registrations/modelLimitScopes";
@@ -110,9 +112,14 @@ function ModelLimitActionsMenu({
 interface ModelLimitsTableProps {
 	modelConfigs: ModelConfig[];
 	totalCount: number;
+	providers: ModelProvider[];
 	search: string;
 	debouncedSearch: string;
 	onSearchChange: (value: string) => void;
+	scope: string;
+	onScopeChange: (value: string) => void;
+	provider: string;
+	onProviderChange: (value: string) => void;
 	offset: number;
 	limit: number;
 	onOffsetChange: (offset: number) => void;
@@ -121,9 +128,14 @@ interface ModelLimitsTableProps {
 export default function ModelLimitsTable({
 	modelConfigs,
 	totalCount,
+	providers,
 	search,
 	debouncedSearch,
 	onSearchChange,
+	scope,
+	onScopeChange,
+	provider,
+	onProviderChange,
 	offset,
 	limit,
 	onOffsetChange,
@@ -174,7 +186,7 @@ export default function ModelLimitsTable({
 		setEditingModelConfigId(null);
 	};
 
-	const hasActiveFilters = debouncedSearch;
+	const hasActiveFilters = debouncedSearch || scope || provider;
 
 	// True empty state: no model limits at all (not just filtered to zero)
 	if (totalCount === 0 && !hasActiveFilters) {
@@ -232,9 +244,9 @@ export default function ModelLimitsTable({
 					</Button>
 				</div>
 
-				{/* Toolbar: Search */}
-				<div className="flex items-center gap-3">
-					<div className="relative max-w-sm flex-1">
+				{/* Toolbar: Search + Filters */}
+				<div className="flex flex-wrap items-center gap-3">
+					<div className="relative min-w-[220px] flex-1">
 						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 						<Input
 							aria-label="Search model limits by model name"
@@ -245,6 +257,48 @@ export default function ModelLimitsTable({
 							data-testid="model-limits-search-input"
 						/>
 					</div>
+
+					<Select value={scope || "all"} onValueChange={(v) => onScopeChange(v === "all" ? "" : v)}>
+						<SelectTrigger className="w-[160px]" data-testid="model-limits-filter-scope">
+							<SelectValue placeholder="All Scopes" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">All Scopes</SelectItem>
+							{getModelLimitScopes().map((o) => (
+								<SelectItem key={o.value} value={o.value}>
+									{o.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+
+					<Select value={provider || "all"} onValueChange={(v) => onProviderChange(v === "all" ? "" : v)}>
+						<SelectTrigger className="w-[160px]" data-testid="model-limits-filter-provider">
+							<SelectValue placeholder="All Providers" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">All Providers</SelectItem>
+							{(providers ?? []).map((p) => (
+								<SelectItem key={p.name} value={p.name}>
+									<div className="flex items-center gap-2">
+										<RenderProviderIcon provider={p.name as ProviderIconType} size="sm" className="h-4 w-4" />
+										<span>{ProviderLabels[p.name as ProviderName] || p.name}</span>
+									</div>
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+
+					{hasActiveFilters && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => { onSearchChange(""); onScopeChange(""); onProviderChange(""); }}
+							data-testid="model-limits-filter-clear"
+						>
+							Clear filters
+						</Button>
+					)}
 				</div>
 
 				<div className="rounded-sm border" data-testid="model-limits-table">

--- a/ui/app/workspace/model-limits/views/modelLimitsView.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsView.tsx
@@ -1,4 +1,4 @@
-import { getErrorMessage, useGetModelConfigsQuery } from "@/lib/store";
+import { getErrorMessage, useGetModelConfigsQuery, useGetProvidersQuery } from "@/lib/store";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useEffect, useState } from "react";
@@ -12,20 +12,26 @@ export default function ModelLimitsView() {
 	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
 
 	const [search, setSearch] = useState("");
+	const [scope, setScope] = useState("");
+	const [provider, setProvider] = useState("");
 	const [offset, setOffset] = useState(0);
 
 	const debouncedSearch = useDebouncedValue(search, 300);
 
-	// Reset to first page when search changes
+	// Reset to first page when any filter changes
 	useEffect(() => {
 		setOffset(0);
-	}, [debouncedSearch]);
+	}, [debouncedSearch, scope, provider]);
+
+	const { data: providers } = useGetProvidersQuery();
 
 	const { data: modelConfigsData, error: modelConfigsError } = useGetModelConfigsQuery(
 		{
 			limit: PAGE_SIZE,
 			offset,
 			search: debouncedSearch || undefined,
+			scope: scope || undefined,
+			provider: provider || undefined,
 		},
 		{
 			skip: !hasGovernanceAccess,
@@ -53,9 +59,14 @@ export default function ModelLimitsView() {
 			<ModelLimitsTable
 				modelConfigs={modelConfigsData?.model_configs || []}
 				totalCount={modelConfigsData?.total_count || 0}
+				providers={providers ?? []}
 				search={search}
 				debouncedSearch={debouncedSearch}
 				onSearchChange={setSearch}
+				scope={scope}
+				onScopeChange={setScope}
+				provider={provider}
+				onProviderChange={setProvider}
 				offset={offset}
 				limit={PAGE_SIZE}
 				onOffsetChange={setOffset}

--- a/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
@@ -1,9 +1,10 @@
 import { Button } from "@/components/ui/button";
-import { Form, FormField, FormItem } from "@/components/ui/form";
+import { Form } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
+import MultiBudgetLines, { BudgetLineEntry } from "@/components/ui/multibudgets";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { DottedSeparator } from "@/components/ui/separator";
-import { resetDurationOptions } from "@/lib/constants/governance";
+import { Switch } from "@/components/ui/switch";
 import {
 	getErrorMessage,
 	useDeleteProviderGovernanceMutation,
@@ -11,6 +12,7 @@ import {
 	useUpdateProviderGovernanceMutation,
 } from "@/lib/store";
 import { ModelProvider } from "@/lib/types/config";
+import { CreateBudgetRequest, ProviderGovernance } from "@/lib/types/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
@@ -22,14 +24,17 @@ interface GovernanceFormFragmentProps {
 	provider: ModelProvider;
 }
 
+const budgetLineSchema = z.object({
+	id: z.string().optional(),
+	max_limit: z.number({ error: "Budget limit must be a number" }).nonnegative("Budget limit cannot be negative").optional(),
+	reset_duration: z.string().min(1, "Reset duration is required"),
+});
+
 const formSchema = z.object({
-	// Budget
-	budgetMaxLimit: z.number().nonnegative().optional(),
-	budgetResetDuration: z.string().optional(),
-	// Token limits
+	budgets: z.array(budgetLineSchema),
+	calendarAligned: z.boolean(),
 	tokenMaxLimit: z.number().int().nonnegative().optional(),
 	tokenResetDuration: z.string().optional(),
-	// Request limits
 	requestMaxLimit: z.number().int().nonnegative().optional(),
 	requestResetDuration: z.string().optional(),
 });
@@ -37,13 +42,29 @@ const formSchema = z.object({
 type FormData = z.infer<typeof formSchema>;
 
 const DEFAULT_GOVERNANCE_FORM_VALUES: FormData = {
-	budgetMaxLimit: undefined,
-	budgetResetDuration: "1M",
+	budgets: [],
+	calendarAligned: false,
 	tokenMaxLimit: undefined,
 	tokenResetDuration: "1h",
 	requestMaxLimit: undefined,
 	requestResetDuration: "1h",
 };
+
+function governanceToFormValues(provGov: ProviderGovernance | undefined): FormData {
+	if (!provGov) return DEFAULT_GOVERNANCE_FORM_VALUES;
+	return {
+		budgets: (provGov.budgets ?? []).map((b) => ({
+			id: b.id,
+			max_limit: b.max_limit,
+			reset_duration: b.reset_duration,
+		})),
+		calendarAligned: provGov.calendar_aligned ?? false,
+		tokenMaxLimit: provGov.rate_limit?.token_max_limit ?? undefined,
+		tokenResetDuration: provGov.rate_limit?.token_reset_duration || "1h",
+		requestMaxLimit: provGov.rate_limit?.request_max_limit ?? undefined,
+		requestResetDuration: provGov.rate_limit?.request_reset_duration || "1h",
+	};
+}
 
 export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps) {
 	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
@@ -56,63 +77,45 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 	const [updateProviderGovernance, { isLoading: isUpdating }] = useUpdateProviderGovernanceMutation();
 	const [deleteProviderGovernance, { isLoading: isDeleting }] = useDeleteProviderGovernanceMutation();
 
-	// Find governance data for this provider
 	const providerGovernance = providerGovernanceData?.providers?.find((p) => p.provider === provider.name);
-	const hasExistingGovernance = !!(providerGovernance?.budget || providerGovernance?.rate_limit);
+	const hasExistingGovernance = !!((providerGovernance?.budgets?.length ?? 0) > 0 || providerGovernance?.rate_limit);
 
 	const form = useForm<FormData>({
 		resolver: zodResolver(formSchema),
 		defaultValues: DEFAULT_GOVERNANCE_FORM_VALUES,
 	});
 
-	// Update form values when provider governance data is loaded (polling)
+	const watchedBudgets = form.watch("budgets");
+	const watchedCalendarAligned = form.watch("calendarAligned");
+
 	useEffect(() => {
-		// Never reset form during polling if user is editing
 		if (providerGovernance && !form.formState.isDirty) {
-			form.reset({
-				budgetMaxLimit: providerGovernance.budget?.max_limit ?? undefined,
-				budgetResetDuration: providerGovernance.budget?.reset_duration || "1M",
-				tokenMaxLimit: providerGovernance.rate_limit?.token_max_limit ?? undefined,
-				tokenResetDuration: providerGovernance.rate_limit?.token_reset_duration || "1h",
-				requestMaxLimit: providerGovernance.rate_limit?.request_max_limit ?? undefined,
-				requestResetDuration: providerGovernance.rate_limit?.request_reset_duration || "1h",
-			});
+			form.reset(governanceToFormValues(providerGovernance));
 		}
 	}, [providerGovernance, form]);
 
-	// Reset form when provider changes
 	useEffect(() => {
-		// Never reset form if user is editing - just skip the reset
-		if (form.formState.isDirty) {
-			return;
-		}
+		if (form.formState.isDirty) return;
 		const newProvGov = providerGovernanceData?.providers?.find((p) => p.provider === provider.name);
-		form.reset({
-			budgetMaxLimit: newProvGov?.budget?.max_limit ?? undefined,
-			budgetResetDuration: newProvGov?.budget?.reset_duration || "1M",
-			tokenMaxLimit: newProvGov?.rate_limit?.token_max_limit ?? undefined,
-			tokenResetDuration: newProvGov?.rate_limit?.token_reset_duration || "1h",
-			requestMaxLimit: newProvGov?.rate_limit?.request_max_limit ?? undefined,
-			requestResetDuration: newProvGov?.rate_limit?.request_reset_duration || "1h",
-		});
+		form.reset(governanceToFormValues(newProvGov));
 	}, [provider.name, form]);
 
 	const onSubmit = async (data: FormData) => {
 		try {
-			// Determine if we need to send empty objects to signal removal
-			const hadBudget = !!providerGovernance?.budget;
-			const hasBudget = data.budgetMaxLimit !== undefined;
+			const validBudgets = data.budgets.filter((b) => b.max_limit !== undefined && b.max_limit > 0);
+			const hadBudgets = (providerGovernance?.budgets?.length ?? 0) > 0;
 			const hadRateLimit = !!providerGovernance?.rate_limit;
 			const hasRateLimit = data.tokenMaxLimit !== undefined || data.requestMaxLimit !== undefined;
 
-			let budgetPayload: { max_limit?: number; reset_duration?: string } | undefined;
-			if (hasBudget) {
-				budgetPayload = {
-					max_limit: data.budgetMaxLimit,
-					reset_duration: data.budgetResetDuration || "1M",
-				};
-			} else if (hadBudget) {
-				budgetPayload = {};
+			let budgetsPayload: CreateBudgetRequest[] | undefined;
+			if (validBudgets.length > 0) {
+				budgetsPayload = validBudgets.map((b) => ({
+					id: b.id,
+					max_limit: b.max_limit!,
+					reset_duration: b.reset_duration,
+				}));
+			} else if (hadBudgets) {
+				budgetsPayload = [];
 			}
 
 			let rateLimitPayload:
@@ -137,14 +140,13 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 			await updateProviderGovernance({
 				provider: provider.name,
 				data: {
-					budget: budgetPayload,
+					budgets: budgetsPayload,
+					...(budgetsPayload !== undefined ? { calendar_aligned: data.calendarAligned } : {}),
 					rate_limit: rateLimitPayload,
 				},
 			}).unwrap();
 
 			toast.success("Governance configuration saved successfully");
-
-			// Reset form with the saved values to update the initial state for change detection
 			form.reset(data);
 		} catch (error) {
 			toast.error("Failed to update provider governance", {
@@ -165,93 +167,76 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 		}
 	};
 
-	// Always show the form
 	return (
 		<Form {...form}>
 			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6">
 				{/* Budget Configuration */}
-				<div className="space-y-4">
-					<Label className="text-sm font-medium">Budget Configuration</Label>
-					<FormField
-						control={form.control}
-						name="budgetMaxLimit"
-						render={({ field }) => (
-							<FormItem>
-								<NumberAndSelect
-									id="providerBudgetMaxLimit"
-									labelClassName="font-normal"
-									label="Maximum Spend (USD)"
-									value={field.value}
-									selectValue={form.watch("budgetResetDuration") || "1M"}
-									onChangeNumber={(value) => field.onChange(value)}
-									onChangeSelect={(value) => form.setValue("budgetResetDuration", value, { shouldDirty: true })}
-									options={resetDurationOptions}
-								/>
-							</FormItem>
-						)}
-					/>
-				</div>
+				<MultiBudgetLines
+					data-testid="provider-governance-budgets"
+					lines={watchedBudgets as BudgetLineEntry[]}
+					onChange={(lines) => form.setValue("budgets", lines, { shouldDirty: true })}
+				/>
+
+				{/* Calendar Alignment — only shown when there are budgets */}
+				{watchedBudgets.length > 0 && (
+					<div className="flex items-center justify-between gap-4">
+						<div className="space-y-1">
+							<Label className="text-sm" htmlFor="provider-calendar-aligned">
+								Align to calendar cycle
+							</Label>
+							<p className="text-muted-foreground text-xs">
+								Reset budgets at the start of each period (e.g. 1st of month) instead of rolling from creation date.
+							</p>
+						</div>
+						<Switch
+							id="provider-calendar-aligned"
+							data-testid="provider-governance-calendar-aligned-switch"
+							checked={watchedCalendarAligned}
+							onCheckedChange={(checked) => form.setValue("calendarAligned", checked, { shouldDirty: true })}
+						/>
+					</div>
+				)}
 
 				<DottedSeparator />
 
 				{/* Rate Limiting Configuration */}
 				<div className="space-y-4">
 					<Label className="text-sm font-medium">Rate Limiting Configuration</Label>
-
-					<FormField
-						control={form.control}
-						name="tokenMaxLimit"
-						render={({ field }) => (
-							<FormItem>
-								<NumberAndSelect
-									id="providerTokenMaxLimit"
-									labelClassName="font-normal"
-									label="Maximum Tokens"
-									value={field.value}
-									selectValue={form.watch("tokenResetDuration") || "1h"}
-									onChangeNumber={(value) => field.onChange(value)}
-									onChangeSelect={(value) => form.setValue("tokenResetDuration", value, { shouldDirty: true })}
-									options={resetDurationOptions}
-								/>
-							</FormItem>
-						)}
+					<NumberAndSelect
+						id="providerTokenMaxLimit"
+						labelClassName="font-normal"
+						label="Maximum Tokens"
+						value={form.watch("tokenMaxLimit")}
+						selectValue={form.watch("tokenResetDuration") || "1h"}
+						onChangeNumber={(value) => form.setValue("tokenMaxLimit", value, { shouldDirty: true })}
+						onChangeSelect={(value) => form.setValue("tokenResetDuration", value, { shouldDirty: true })}
 					/>
-
-					<FormField
-						control={form.control}
-						name="requestMaxLimit"
-						render={({ field }) => (
-							<FormItem>
-								<NumberAndSelect
-									id="providerRequestMaxLimit"
-									labelClassName="font-normal"
-									label="Maximum Requests"
-									value={field.value}
-									selectValue={form.watch("requestResetDuration") || "1h"}
-									onChangeNumber={(value) => field.onChange(value)}
-									onChangeSelect={(value) => form.setValue("requestResetDuration", value, { shouldDirty: true })}
-									options={resetDurationOptions}
-								/>
-							</FormItem>
-						)}
+					<NumberAndSelect
+						id="providerRequestMaxLimit"
+						labelClassName="font-normal"
+						label="Maximum Requests"
+						value={form.watch("requestMaxLimit")}
+						selectValue={form.watch("requestResetDuration") || "1h"}
+						onChangeNumber={(value) => form.setValue("requestMaxLimit", value, { shouldDirty: true })}
+						onChangeSelect={(value) => form.setValue("requestResetDuration", value, { shouldDirty: true })}
 					/>
 				</div>
 
-				{/* Current Usage Display - only when editing existing */}
-				{hasExistingGovernance && (providerGovernance?.budget || providerGovernance?.rate_limit) && (
+				{/* Current Usage — only shown when governance exists */}
+				{hasExistingGovernance && (
 					<>
 						<DottedSeparator />
 						<div className="space-y-4">
 							<Label className="text-sm font-medium">Current Usage</Label>
 							<div className="bg-muted/50 grid grid-cols-2 gap-4 rounded-lg p-4">
-								{providerGovernance?.budget && (
-									<div className="space-y-1">
-										<p className="text-muted-foreground text-xs">Budget Usage</p>
+								{providerGovernance?.budgets?.map((b) => (
+									<div key={b.id} className="space-y-1">
+										<p className="text-muted-foreground text-xs">Budget ({b.reset_duration})</p>
 										<p className="text-sm font-medium">
-											${providerGovernance.budget.current_usage.toFixed(2)} / ${providerGovernance.budget.max_limit.toFixed(2)}
+											${b.current_usage.toFixed(2)} / ${b.max_limit.toFixed(2)}
 										</p>
 									</div>
-								)}
+								))}
 								{providerGovernance?.rate_limit?.token_max_limit && (
 									<div className="space-y-1">
 										<p className="text-muted-foreground text-xs">Token Usage</p>

--- a/ui/app/workspace/providers/views/providerGovernanceTable.tsx
+++ b/ui/app/workspace/providers/views/providerGovernanceTable.tsx
@@ -163,7 +163,7 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 	const providerGovernance = providerGovernanceData?.providers?.find((p) => p.provider === provider.name);
 
 	// Check if any governance is configured
-	const hasGovernance = providerGovernance?.budget || providerGovernance?.rate_limit;
+	const hasGovernance = (providerGovernance?.budgets?.length ?? 0) > 0 || providerGovernance?.rate_limit;
 
 	if (isLoading) {
 		return (
@@ -185,10 +185,9 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 		return null;
 	}
 
-	const budget = providerGovernance?.budget;
+	const budgets = providerGovernance?.budgets ?? [];
 	const rateLimit = providerGovernance?.rate_limit;
 
-	const isBudgetExhausted = !!(budget?.max_limit && budget.max_limit > 0 && budget.current_usage >= budget.max_limit);
 	const isTokenExhausted = !!(
 		rateLimit?.token_max_limit &&
 		rateLimit.token_max_limit > 0 &&
@@ -209,17 +208,18 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 			</CardHeader>
 
 			<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-				{/* Budget Card */}
-				{budget && (
+				{/* Budget Cards — one per budget window */}
+				{budgets.map((budget) => (
 					<MetricCard
-						title="Budget"
+						key={budget.id}
+						title={`Budget (${formatResetDuration(budget.reset_duration)})`}
 						value={budget.current_usage}
 						max={budget.max_limit}
 						unit="$"
 						resetDuration={budget.reset_duration}
-						isExhausted={isBudgetExhausted}
+						isExhausted={budget.max_limit > 0 && budget.current_usage >= budget.max_limit}
 					/>
-				)}
+				))}
 
 				{/* Token Rate Limit Card */}
 				{rateLimit?.token_max_limit && (

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -27,6 +27,7 @@ import {
 	getErrorMessage,
 	useBulkRotateVirtualKeysMutation,
 	useDeleteVirtualKeyMutation,
+	useGetVirtualKeyQuery,
 	useLazyGetVirtualKeysQuery,
 	useUpdateVirtualKeyMutation,
 } from "@/lib/store";
@@ -53,6 +54,7 @@ import {
 	ShieldCheck,
 	Trash2,
 } from "lucide-react";
+import { useQueryState } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useVirtualKeyUsage } from "../hooks/useVirtualKeyUsage";
@@ -335,10 +337,22 @@ export default function VirtualKeysTable({
 		() => (editingVirtualKeyId ? (virtualKeys.find((vk) => vk.id === editingVirtualKeyId) ?? null) : null),
 		[editingVirtualKeyId, virtualKeys],
 	);
-	const selectedVirtualKey = useMemo(
+	const selectedVkInList = useMemo(
 		() => (selectedVkId ? (virtualKeys.find((vk) => vk.id === selectedVkId) ?? null) : null),
 		[selectedVkId, virtualKeys],
 	);
+	// Deep-link support: another page (e.g. Model Limits) can open a VK via ?vk=<id>.
+	// The target may not be on the current page/filter, so fetch it by id as a fallback.
+	const [vkParam, setVkParam] = useQueryState("vk");
+	const needsVkFetch = !!selectedVkId && !selectedVkInList;
+	const { data: fetchedVkData } = useGetVirtualKeyQuery(selectedVkId ?? "", { skip: !needsVkFetch });
+	const selectedVirtualKey = selectedVkInList ?? (needsVkFetch ? (fetchedVkData?.virtual_key ?? null) : null);
+
+	useEffect(() => {
+		if (!vkParam) return;
+		onSelectedVkChange(vkParam);
+		setVkParam(null); // consume the param; selection is held in parent state from here
+	}, [vkParam, setVkParam, onSelectedVkChange]);
 
 	const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create);
 	const hasUpdateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Update);

--- a/ui/lib/constants/governance.ts
+++ b/ui/lib/constants/governance.ts
@@ -23,13 +23,6 @@ export const budgetDurationOptions = [
 // Must stay in sync with IsCalendarAlignableDuration in framework/configstore/tables/utils.go.
 export const supportsCalendarAlignment = (duration: string): boolean => duration.length > 0 && /[dwMY]$/.test(duration);
 
-// Scopes available for model limits. "global" applies to all traffic; "virtual_key"
-// applies only when a specific virtual key is used. Extensible (team/customer/user) later.
-export const MODEL_LIMIT_SCOPES = [
-	{ label: "Global", value: "global" },
-	{ label: "Virtual Key", value: "virtual_key" },
-];
-
 // Map of duration values to short labels for display
 export const resetDurationLabels: Record<string, string> = {
 	"1m": "Every Minute",

--- a/ui/lib/registries/modelLimitScopes.tsx
+++ b/ui/lib/registries/modelLimitScopes.tsx
@@ -1,0 +1,105 @@
+// Runtime registry of model_config scopes available to the UI.
+//
+// OSS ships the base set (global + virtual_key) registered at module load.
+// Downstream builds (enterprise) extend the registry by importing their
+// registration module via the @enterprise alias — see
+// ui/app/_fallbacks/enterprise/lib/registrations/modelLimitScopes.ts
+// for the OSS-build fallback.
+//
+// Each entry can supply:
+//   - PickerComponent: the React component used by the Model Limit sheet to
+//     pick the scope target (e.g. a VK picker). Scopes without a target —
+//     e.g. global — omit this.
+//   - buildDeepLink: a function returning the route to navigate to when the
+//     user clicks the Scope Target badge on the Model Limits table.
+
+import type { ComponentType } from "react";
+import { ComboboxSelect } from "@/components/ui/combobox";
+import { useGetVirtualKeysQuery } from "@/lib/store";
+
+export interface ScopePickerProps {
+	value: string;
+	onChange: (value: string) => void;
+	disabled?: boolean;
+	// Optional fallback option to guarantee the currently-selected target is
+	// always selectable, even if it falls outside the first page fetched by
+	// the picker. The Model Limit sheet passes the model_config's own
+	// scope_id/scope_name when editing an existing row.
+	fallbackOption?: { value: string; label: string } | null;
+}
+
+export interface ScopeDeepLink {
+	to: string;
+	search?: Record<string, string>;
+}
+
+export interface ModelLimitScopeEntry {
+	value: string;
+	label: string;
+	// Optional. Scopes without a target (e.g. global) omit this.
+	PickerComponent?: ComponentType<ScopePickerProps>;
+	// Optional. Scopes without a navigable target omit this.
+	buildDeepLink?: (scopeId: string) => ScopeDeepLink;
+}
+
+const registry = new Map<string, ModelLimitScopeEntry>();
+
+/**
+ * Registers (or replaces) a scope entry. Intended to be called at module
+ * load — once, before the first render that reads the registry.
+ */
+export function registerModelLimitScope(entry: ModelLimitScopeEntry): void {
+	if (!entry.value) {
+		return;
+	}
+	registry.set(entry.value, entry);
+}
+
+/** Returns all registered scope entries, in registration order. */
+export function getModelLimitScopes(): ModelLimitScopeEntry[] {
+	return Array.from(registry.values());
+}
+
+export function getModelLimitScope(value: string): ModelLimitScopeEntry | undefined {
+	return registry.get(value);
+}
+
+// ---------------------------------------------------------------------------
+// OSS default registrations.
+// ---------------------------------------------------------------------------
+
+function VirtualKeyPicker({ value, onChange, disabled, fallbackOption }: ScopePickerProps) {
+	const { data: vksData } = useGetVirtualKeysQuery();
+	const virtualKeys = vksData?.virtual_keys ?? [];
+	const options = [
+		...(fallbackOption && !virtualKeys.some((vk) => vk.id === fallbackOption.value) ? [fallbackOption] : []),
+		...virtualKeys
+			.filter((vk) => vk.id !== fallbackOption?.value)
+			.map((vk) => ({ label: vk.name, value: vk.id })),
+	];
+	return (
+		<ComboboxSelect
+			options={options}
+			value={value || null}
+			onValueChange={(v: string | null) => onChange(v ?? "")}
+			placeholder="Select a virtual key..."
+			disabled={disabled}
+			noPortal
+		/>
+	);
+}
+
+registerModelLimitScope({
+	value: "global",
+	label: "Global",
+});
+
+registerModelLimitScope({
+	value: "virtual_key",
+	label: "Virtual Key",
+	PickerComponent: VirtualKeyPicker,
+	buildDeepLink: (scopeId) => ({
+		to: "/workspace/governance/virtual-keys",
+		search: { vk: scopeId },
+	}),
+});

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -501,6 +501,8 @@ export const governanceApi = baseApi.injectEndpoints({
 					...(params?.limit && { limit: params.limit }),
 					...(params?.offset !== undefined && { offset: params.offset }),
 					...(params?.search && { search: params.search }),
+					...(params?.scope && { scope: params.scope }),
+					...(params?.provider && { provider: params.provider }),
 				},
 			}),
 			providesTags: ["ModelConfigs"],
@@ -524,15 +526,18 @@ export const governanceApi = baseApi.injectEndpoints({
 			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
+					const mc = data.model_config;
 					const queries = (getState() as any).api.queries;
 					for (const entry of Object.values(queries) as any[]) {
 						if (entry?.endpointName !== "getModelConfigs" || entry?.status !== "fulfilled") continue;
-						const search = entry.originalArgs?.search as string | undefined;
-						if (search && !data.model_config.model_name.toLowerCase().includes(search.toLowerCase())) continue;
+						const args = entry.originalArgs as GetModelConfigsParams | undefined;
+						if (args?.search && !mc.model_name.toLowerCase().includes(args.search.toLowerCase())) continue;
+						if (args?.scope && mc.scope !== args.scope) continue;
+						if (args?.provider && mc.provider !== args.provider) continue;
 						dispatch(
 							governanceApi.util.updateQueryData("getModelConfigs", entry.originalArgs, (draft) => {
 								if (!draft.model_configs) draft.model_configs = [];
-								draft.model_configs.unshift(data.model_config);
+								draft.model_configs.unshift(mc);
 								draft.count = (draft.count || 0) + 1;
 								draft.total_count = (draft.total_count || 0) + 1;
 							}),

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -517,8 +517,10 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
-			// Wildcard model configs back provider governance; refresh the provider page too.
-			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
+			// Wildcard model configs back provider/VK/user governance; refresh those pages too.
+			// "Users" + "UserGovernance" are no-op tags in OSS builds (no consumer registers them);
+			// enterprise consumers pick them up via the userGovernanceApi / usersApi tag wiring.
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys", "Users", "UserGovernance"],
 			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -548,7 +550,10 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
+			// Wildcard model configs back provider/VK/user governance; refresh those pages too.
+			// "Users" + "UserGovernance" are no-op tags in OSS builds (no consumer registers them);
+			// enterprise consumers pick them up via the userGovernanceApi / usersApi tag wiring.
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys", "Users", "UserGovernance"],
 			async onQueryStarted({ id }, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -581,8 +586,10 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/model-configs/${id}`,
 				method: "DELETE",
 			}),
-			// Wildcard model configs back provider governance; refresh the provider page too.
-			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
+			// Wildcard model configs back provider/VK/user governance; refresh those pages too.
+			// "Users" + "UserGovernance" are no-op tags in OSS builds (no consumer registers them);
+			// enterprise consumers pick them up via the userGovernanceApi / usersApi tag wiring.
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys", "Users", "UserGovernance"],
 			async onQueryStarted(id, { dispatch, getState, queryFulfilled }) {
 				try {
 					await queryFulfilled;

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -85,7 +85,8 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
-			invalidatesTags: ["VirtualKeys"],
+			// VK governance is backed by VK-scoped model configs; refresh Model Limits too.
+			invalidatesTags: ["VirtualKeys", "ModelConfigs"],
 		}),
 
 		updateVirtualKey: builder.mutation<{ message: string; virtual_key: VirtualKey }, { vkId: string; data: UpdateVirtualKeyRequest }>({
@@ -94,7 +95,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			invalidatesTags: ["VirtualKeys"],
+			invalidatesTags: ["VirtualKeys", "ModelConfigs"],
 		}),
 
 		rotateVirtualKey: builder.mutation<{ message: string; virtual_key: VirtualKey }, string>({
@@ -119,7 +120,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/virtual-keys/${vkId}`,
 				method: "DELETE",
 			}),
-			invalidatesTags: ["VirtualKeys"],
+			invalidatesTags: ["VirtualKeys", "ModelConfigs"],
 		}),
 
 		// Teams
@@ -517,7 +518,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				body: data,
 			}),
 			// Wildcard model configs back provider governance; refresh the provider page too.
-			invalidatesTags: ["ProviderGovernance"],
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
 			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -547,7 +548,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			invalidatesTags: ["ProviderGovernance"],
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
 			async onQueryStarted({ id }, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
@@ -581,7 +582,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "DELETE",
 			}),
 			// Wildcard model configs back provider governance; refresh the provider page too.
-			invalidatesTags: ["ProviderGovernance"],
+			invalidatesTags: ["ProviderGovernance", "VirtualKeys"],
 			async onQueryStarted(id, { dispatch, getState, queryFulfilled }) {
 				try {
 					await queryFulfilled;

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -527,15 +527,16 @@ export interface GetPricingOverridesResponse {
 // Provider governance - for extending provider with budget/rate limit
 export interface ProviderGovernance {
 	provider: string;
-	budget_id?: string;
-	rate_limit_id?: string;
-	budget?: Budget;
+	budget?: Budget; // deprecated: use budgets
+	budgets?: Budget[];
 	rate_limit?: RateLimit;
+	calendar_aligned?: boolean;
 }
 
 export interface UpdateProviderGovernanceRequest {
-	budget?: UpdateBudgetRequest;
+	budgets?: CreateBudgetRequest[]; // [] = remove all
 	rate_limit?: UpdateRateLimitRequest;
+	calendar_aligned?: boolean;
 }
 
 export interface GetProviderGovernanceResponse {

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -350,10 +350,11 @@ export interface ModelConfig {
 	scope?: string; // "global" (default) or "virtual_key"
 	scope_id?: string; // Target of a non-global scope (e.g. the virtual key ID)
 	scope_name?: string; // Resolved, human-readable name of the scope target (read-only)
-	budget_id?: string;
+	calendar_aligned?: boolean; // Snap budget resets to calendar boundaries (inherited from VK for vk scope)
 	rate_limit_id?: string;
 	// Populated relationships
-	budget?: Budget;
+	budgets?: Budget[]; // Multi-budget: each with a distinct reset_duration
+	budget?: Budget; // Deprecated: superseded by budgets (kept for back-compat reads)
 	rate_limit?: RateLimit;
 	created_at: string;
 	updated_at: string;
@@ -365,14 +366,14 @@ export interface CreateModelConfigRequest {
 	provider?: string; // Optional provider - if empty/null, applies to all providers
 	scope?: string; // Defaults to "global" if omitted
 	scope_id?: string; // Required for non-global scopes (e.g. the virtual key ID)
-	budget?: CreateBudgetRequest;
+	budgets?: CreateBudgetRequest[];
 	rate_limit?: CreateRateLimitRequest;
 }
 
 export interface UpdateModelConfigRequest {
 	model_name?: string;
 	provider?: string; // Optional provider - if empty/null, applies to all providers
-	budget?: UpdateBudgetRequest;
+	budgets?: CreateBudgetRequest[]; // Full desired set; reconciled against existing
 	rate_limit?: UpdateRateLimitRequest;
 }
 

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -381,6 +381,8 @@ export interface GetModelConfigsParams {
 	limit?: number;
 	offset?: number;
 	search?: string;
+	scope?: string;
+	provider?: string;
 }
 
 // Response types for model configs

--- a/ui/lib/utils/labels.ts
+++ b/ui/lib/utils/labels.ts
@@ -1,14 +1,20 @@
+import { getModelLimitScope } from "@/lib/registries/modelLimitScopes";
+
 /**
- * Gets a friendly display name for a scope
- * @param scope - The scope value (global|team|customer|virtual_key)
- * @returns Friendly display name
+ * Gets a friendly display name for a scope.
+ *
+ * Consults the model_limit scope registry first.
+ * Falls back to a small built-in map of historical labels,
+ * then to the raw scope value.
  */
 export function getScopeLabel(scope: string): string {
-	const labels: Record<string, string> = {
-		global: "Global",
+	const entry = getModelLimitScope(scope);
+	if (entry) {
+		return entry.label;
+	}
+	const legacy: Record<string, string> = {
 		team: "Team",
 		customer: "Customer",
-		virtual_key: "Virtual Key",
 	};
-	return labels[scope] || scope;
+	return legacy[scope] || scope;
 }


### PR DESCRIPTION
## Summary

Adds a new **Model Limits** documentation page and updates related API schemas and access profile docs to expose the unified model-level governance interface in Bifrost. This gives users a single place to understand and configure spending caps and rate limits scoped globally, per virtual key, or per user — keyed on a specific model or all models.

## Changes

- Added `docs/features/governance/model-limits.mdx` — a full reference page covering the scope system, Web UI walkthrough, REST API usage, `config.json` configuration, worked examples, and how limits interact at request time.
- Registered the new page in `docs/docs.json` under the governance navigation group.
- Extended `docs/enterprise/access-profiles.mdx` with a section explaining how to attach per-model limits to individual users without modifying the shared access profile template, including a step-by-step guide and a `curl` example.
- Updated the `listModelConfigs` OpenAPI operation to reflect pagination query parameters (`limit`, `offset`, `search`, `scope`, `provider`, `from_memory`) and renamed the summary to "List model limits".
- Updated `ModelConfig`, `ListModelConfigsResponse`, `CreateModelConfigRequest`, `UpdateModelConfigRequest`, `ProviderGovernanceResponse`, and `UpdateProviderGovernanceRequest` schemas to add `scope`, `scope_id`, `scope_name`, `calendar_aligned`, and `budgets` (array) fields. The singular `budget` field is retained but marked deprecated for backward compatibility. `count` is renamed to `total_count`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Navigate to the Bifrost docs site and confirm **Model Limits** appears under **Budget & Limits** in the governance sidebar.
2. Verify all internal links resolve — particularly the cross-references between `access-profiles.mdx` and `model-limits.mdx`.
3. Confirm the OpenAPI spec renders the new query parameters for `GET /api/governance/model-configs` and that the updated schema fields (`scope`, `budgets`, `total_count`, etc.) appear correctly.

## Breaking changes

- [ ] Yes
- [x] No

The `budget` (singular) field and `count` field are preserved in the schema for backward compatibility. Consumers relying on `count` should migrate to `total_count`.

## Related issues

## Security considerations

None — documentation-only change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Model Limits documentation covering configuration, API usage, and scope management.
  * Added guidance on overriding Access Profiles with per-user model limits for Enterprise users.
  * Updated API documentation for model limits endpoints with pagination and filtering parameters.
  * Updated API schemas to reflect multi-budget support, scoping options, and calendar-aligned reset capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->