### PR TITLE
fix: model extraction for azure passthrough

### DIFF
--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2854,7 +2854,10 @@ func extractModelFromPath(path string) string {
 	path = strings.TrimPrefix(path, "/")
 	parts := strings.Split(path, "/")
 	for i, p := range parts {
-		if p == "models" || p == "tunedModels" {
+		// GenAI uses models/{model} and tunedModels/{model}; Azure OpenAI uses
+		// deployments/{deployment}, where the deployment name is the model identifier
+		// (deployment-based Azure routes usually omit "model" from the request body).
+		if p == "models" || p == "tunedModels" || p == "deployments" {
 			if i+1 < len(parts) {
 				model := parts[i+1]
 				// Strip :suffix for GenAI (e.g. :generateContent, :streamGenerateContent)

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -688,3 +688,53 @@ func TestExtraParamsSetViaInterfaceMutatesOriginalReq(t *testing.T) {
 	assert.Contains(t, bifrostReq.ChatRequest.Params.ExtraParams, "guardrailConfig",
 		"extra params should propagate through RequestConverter to BifrostChatRequest")
 }
+
+// TestExtractModelFromPath covers model extraction across provider path styles: GenAI
+// models/tunedModels (with :action suffixes), Vertex fully-qualified publisher paths, and
+// Azure OpenAI deployments/{deployment} (where the deployment name is the model identifier).
+func TestExtractModelFromPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"azure deployment chat", "/openai/deployments/my-gpt4o/chat/completions", "my-gpt4o"},
+		{"azure deployment leading-stripped", "openai/deployments/prod-embed-3/embeddings", "prod-embed-3"},
+		{"genai models with action", "/v1beta/models/gemini-2.5-pro:generateContent", "gemini-2.5-pro"},
+		{"genai models stream action", "/models/gemini-2.5-flash:streamGenerateContent", "gemini-2.5-flash"},
+		{"genai tunedModels", "/v1beta/tunedModels/my-tuned-1:generateContent", "my-tuned-1"},
+		{"vertex fully-qualified", "/projects/p/locations/us-central1/publishers/google/models/gemini-3-pro:streamGenerateContent", "gemini-3-pro"},
+		{"no model segment", "/v1/chat/completions", ""},
+		{"deployments with no trailing segment", "/openai/deployments", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractModelFromPath(tt.path); got != tt.want {
+				t.Fatalf("extractModelFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractPassthroughModel verifies the path value wins when present, and the body model is
+// used as a fallback — notably for Azure deployment routes where the body usually omits "model".
+func TestExtractPassthroughModel(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		bodyModel string
+		want      string
+	}{
+		{"azure deployment path overrides empty body", "/openai/deployments/my-gpt4o/chat/completions", "", "my-gpt4o"},
+		{"body fallback when path has no model", "/openai/v1/chat/completions", "gpt-4o", "gpt-4o"},
+		{"path wins over body", "/openai/deployments/dep-a/chat/completions", "ignored-body-model", "dep-a"},
+		{"both empty", "/v1/chat/completions", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractPassthroughModel(tt.path, tt.bodyModel); got != tt.want {
+				t.Fatalf("extractPassthroughModel(%q, %q) = %q, want %q", tt.path, tt.bodyModel, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Azure OpenAI deployment-based routes encode the model identifier in the URL path as `deployments/{deployment}` rather than in the request body. Without recognising this path segment, model extraction would fail for Azure passthrough requests, causing the deployment name to be lost.

## Changes

- Added `"deployments"` as a recognised path segment in `extractModelFromPath`, alongside `"models"` and `"tunedModels"`, so that Azure OpenAI routes like `/openai/deployments/my-gpt4o/chat/completions` correctly resolve `my-gpt4o` as the model identifier.
- Added `TestExtractModelFromPath` covering GenAI (`models`/`tunedModels` with `:action` suffixes), Vertex fully-qualified publisher paths, Azure `deployments/{deployment}` paths, and edge cases with no model segment.
- Added `TestExtractPassthroughModel` verifying that the path-extracted value takes precedence over the body model, with the body model used as a fallback when the path contains no model segment — the expected behaviour for Azure deployment routes where the body typically omits `"model"`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/integrations/...
```

The two new test functions `TestExtractModelFromPath` and `TestExtractPassthroughModel` directly exercise the changed logic. Confirm all cases pass, particularly:
- `azure deployment chat`: expects `my-gpt4o` extracted from `/openai/deployments/my-gpt4o/chat/completions`
- `azure deployment path overrides empty body`: expects `my-gpt4o` when body model is empty
- `deployments with no trailing segment`: expects `""` when no deployment name follows the segment

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This change only affects URL path parsing for model name extraction and introduces no new auth, secret handling, or external surface area.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure OpenAI integration support.

* **Tests**
  * Added test coverage for model extraction and routing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->