### PR TITLE
feat: add `MCPLibraryURL` and `MCPLibrarySyncInterval` config columns with sync integration

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1386,14 +1386,42 @@ type frameworkConfigHashPayload struct {
 	PricingSyncInterval *int64  `json:"pricing_sync_interval"`
 }
 
+type frameworkConfigHashPayloadWithMCP struct {
+	PricingURL             *string `json:"pricing_url"`
+	ModelParametersURL     *string `json:"model_parameters_url"`
+	PricingSyncInterval    *int64  `json:"pricing_sync_interval"`
+	MCPLibraryURL          *string `json:"mcp_library_url"`
+	MCPLibrarySyncInterval *int64  `json:"mcp_library_sync_interval"`
+}
+
+// FrameworkConfigHashOptions adds optional framework config fields to the
+// config.json change-detection hash while preserving the legacy pricing-only
+// hash when omitted.
+type FrameworkConfigHashOptions struct {
+	MCPLibraryURL          *string
+	MCPLibrarySyncInterval *int64
+}
+
 // GenerateFrameworkConfigHash generates a SHA256 hash for a framework config.
 // This is used to detect changes to framework config between config.json and database.
-func GenerateFrameworkConfigHash(pricingURL *string, modelParametersURL *string, pricingSyncInterval *int64) (string, error) {
-	data, err := sonic.Marshal(frameworkConfigHashPayload{
-		PricingURL:          pricingURL,
-		ModelParametersURL:  modelParametersURL,
-		PricingSyncInterval: pricingSyncInterval,
-	})
+func GenerateFrameworkConfigHash(pricingURL *string, modelParametersURL *string, pricingSyncInterval *int64, opts ...FrameworkConfigHashOptions) (string, error) {
+	var data []byte
+	var err error
+	if len(opts) > 0 {
+		data, err = sonic.Marshal(frameworkConfigHashPayloadWithMCP{
+			PricingURL:             pricingURL,
+			ModelParametersURL:     modelParametersURL,
+			PricingSyncInterval:    pricingSyncInterval,
+			MCPLibraryURL:          opts[0].MCPLibraryURL,
+			MCPLibrarySyncInterval: opts[0].MCPLibrarySyncInterval,
+		})
+	} else {
+		data, err = sonic.Marshal(frameworkConfigHashPayload{
+			PricingURL:          pricingURL,
+			ModelParametersURL:  modelParametersURL,
+			PricingSyncInterval: pricingSyncInterval,
+		})
+	}
 	if err != nil {
 		return "", err
 	}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -869,6 +869,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddMCPLibraryTable(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddMCPLibraryConfigColumns(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -9809,6 +9812,50 @@ func migrationAddMCPLibraryTable(ctx context.Context, db *gorm.DB) error {
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_mcp_library_table migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPLibraryConfigColumns adds the mcp_library_url and
+// mcp_library_sync_interval columns to framework_configs. These store the sync
+// source + interval for the MCP server library catalog, mirroring pricing_url /
+// pricing_sync_interval. Idempotent via HasColumn guards.
+func migrationAddMCPLibraryConfigColumns(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_mcp_library_config_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableFrameworkConfig{}, "mcp_library_url") {
+				if err := mg.AddColumn(&tables.TableFrameworkConfig{}, "MCPLibraryURL"); err != nil {
+					return fmt.Errorf("add mcp_library_url column: %w", err)
+				}
+			}
+			if !mg.HasColumn(&tables.TableFrameworkConfig{}, "mcp_library_sync_interval") {
+				if err := mg.AddColumn(&tables.TableFrameworkConfig{}, "MCPLibrarySyncInterval"); err != nil {
+					return fmt.Errorf("add mcp_library_sync_interval column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TableFrameworkConfig{}, "mcp_library_url") {
+				if err := mg.DropColumn(&tables.TableFrameworkConfig{}, "MCPLibraryURL"); err != nil {
+					return fmt.Errorf("drop mcp_library_url column: %w", err)
+				}
+			}
+			if mg.HasColumn(&tables.TableFrameworkConfig{}, "mcp_library_sync_interval") {
+				if err := mg.DropColumn(&tables.TableFrameworkConfig{}, "MCPLibrarySyncInterval"); err != nil {
+					return fmt.Errorf("drop mcp_library_sync_interval column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_library_config_columns migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -43,6 +43,7 @@ func setupRDBTestStore(t *testing.T) *RDBConfigStore {
 		&tables.TableGovernanceConfig{},
 		&tables.TablePlugin{},
 		&tables.TableMCPClient{},
+		&tables.TableMCPLibrary{},
 		&tables.TableVirtualKeyMCPConfig{},
 		&tables.TableFolder{},
 		&tables.TablePrompt{},
@@ -183,6 +184,30 @@ func TestRDBConfigStore_UpdateComplexityAnalyzerConfigRejectsInvalidConfig(t *te
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestUpsertMCPLibraryEntry(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	entry := &tables.TableMCPLibrary{
+		Slug:           "filesystem",
+		Name:           "Filesystem",
+		Description:    "original",
+		ConnectionType: schemas.MCPConnectionTypeSTDIO,
+		AuthType:       schemas.MCPAuthTypeNone,
+		Source:         "remote",
+	}
+	require.NoError(t, store.UpsertMCPLibraryEntry(ctx, entry))
+
+	entry.Description = "updated"
+	require.NoError(t, store.UpsertMCPLibraryEntry(ctx, entry))
+
+	entries, totalCount, err := store.GetMCPLibraryPaginated(ctx, MCPLibraryQueryParams{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), totalCount)
+	require.Len(t, entries, 1)
+	require.Equal(t, "updated", entries[0].Description)
 }
 
 // =============================================================================

--- a/framework/configstore/tables/framework.go
+++ b/framework/configstore/tables/framework.go
@@ -7,7 +7,12 @@ type TableFrameworkConfig struct {
 	PricingURL          *string `gorm:"type:text" json:"pricing_url"`
 	PricingSyncInterval *int64  `gorm:"" json:"pricing_sync_interval"`
 	ModelParametersURL  *string `gorm:"type:text" json:"model_parameters_url"`
-	ConfigHash          string  `gorm:"type:text" json:"config_hash"`
+	// MCPLibraryURL is the endpoint the MCP server library catalog is synced
+	// from. Empty/nil falls back to modelcatalog.DefaultMCPLibraryURL. Mirrors
+	// PricingURL: the default ships out of the box and the user can override it.
+	MCPLibraryURL          *string `gorm:"type:text" json:"mcp_library_url"`
+	MCPLibrarySyncInterval *int64  `gorm:"" json:"mcp_library_sync_interval"`
+	ConfigHash             string  `gorm:"type:text" json:"config_hash"`
 }
 
 // TableName sets the table name for each model

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -34,6 +34,12 @@ type ModelCatalog struct {
 	live      *live.Store
 	keyconf   *keyconfig.Store
 
+	// MCP library sync configuration (protected by syncMu)
+	mcpLibraryURL          string
+	mcpLibrarySyncInterval time.Duration
+	lastMCPLibrarySyncedAt time.Time
+	syncMu                 sync.RWMutex
+
 	shouldSyncGate func(ctx context.Context) bool
 	afterSyncHook  func(ctx context.Context)
 
@@ -55,6 +61,14 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 	if config != nil && config.ModelParametersURL != nil && *config.ModelParametersURL != "" {
 		modelParametersURL = *config.ModelParametersURL
 	}
+	mcpLibraryURL := DefaultMCPLibraryURL
+	if config != nil && config.MCPLibraryURL != nil && *config.MCPLibraryURL != "" {
+		mcpLibraryURL = *config.MCPLibraryURL
+	}
+	mcpLibrarySyncInterval := DefaultSyncInterval
+	if config != nil && config.MCPLibrarySyncInterval != nil && *config.MCPLibrarySyncInterval > 0 {
+		mcpLibrarySyncInterval = time.Duration(*config.MCPLibrarySyncInterval) * time.Second
+	}
 	syncInterval := DefaultSyncInterval
 	if config != nil && config.PricingSyncInterval != nil {
 		syncInterval = time.Duration(*config.PricingSyncInterval) * time.Second
@@ -65,6 +79,8 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 	logger.Info("pricing sync interval set to %v (scheduler checks every %v)", syncInterval, syncWorkerTickerPeriod)
 
 	mc := &ModelCatalog{
+		mcpLibraryURL:          mcpLibraryURL,
+		mcpLibrarySyncInterval: mcpLibrarySyncInterval,
 		configStore:            configStore,
 		logger:                 logger,
 		distributedLockManager: configstore.NewDistributedLockManager(configStore, logger, configstore.WithDefaultTTL(30*time.Second)),
@@ -182,6 +198,44 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		if paramsErr != nil {
 			return nil, paramsErr
 		}
+
+		// MCP library catalog follows the datasheet bootstrap pattern: if the DB
+		// already has catalog rows, refresh from URL in the background; if it is
+		// empty, block startup until the first remote sync lands so the library page
+		// is populated immediately after boot.
+		hasMCPLibraryData, err := mc.hasMCPLibraryData(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load initial MCP library data: %w", err)
+		}
+		if hasMCPLibraryData {
+			logger.Info("existing MCP library data found in database, syncing from URL in background")
+			mc.wg.Add(1)
+			go func() {
+				defer mc.wg.Done()
+				if err := mc.withDistributedLock(mc.syncCtx, "model_catalog_mcp_library_startup_sync", 10, func() error {
+					return mc.syncMCPLibrary(mc.syncCtx)
+				}); err != nil {
+					mc.logger.Warn("background startup MCP library sync failed: %v", err)
+				} else {
+					mc.syncMu.Lock()
+					mc.lastMCPLibrarySyncedAt = time.Now()
+					mc.syncMu.Unlock()
+				}
+			}()
+		} else {
+			// Empty DB: attempt a blocking sync so the library page is populated
+			// immediately after boot. Unlike pricing, a failure here is non-fatal
+			// — the background worker will retry on the next tick.
+			if err := mc.withDistributedLock(ctx, "model_catalog_mcp_library_startup_sync", 10, func() error {
+				return mc.syncMCPLibrary(ctx)
+			}); err != nil {
+				logger.Warn("initial MCP library sync failed (will retry in background): %v", err)
+			} else {
+				mc.syncMu.Lock()
+				mc.lastMCPLibrarySyncedAt = time.Now()
+				mc.syncMu.Unlock()
+			}
+		}
 	} else {
 		if err := mc.datasheet.LoadFromURLIntoMemory(ctx); err != nil {
 			return nil, fmt.Errorf("failed to load pricing data into memory: %w", err)
@@ -249,6 +303,19 @@ func (mc *ModelCatalog) UpdateSyncConfig(ctx context.Context, config *Config) er
 	if config != nil && config.ModelParametersURL != nil && *config.ModelParametersURL != "" {
 		modelParametersURL = *config.ModelParametersURL
 	}
+	mcpLibraryURL := DefaultMCPLibraryURL
+	if config != nil && config.MCPLibraryURL != nil && *config.MCPLibraryURL != "" {
+		mcpLibraryURL = *config.MCPLibraryURL
+	}
+	mcpLibrarySyncInterval := DefaultSyncInterval
+	if config != nil && config.MCPLibrarySyncInterval != nil && *config.MCPLibrarySyncInterval > 0 {
+		mcpLibrarySyncInterval = time.Duration(*config.MCPLibrarySyncInterval) * time.Second
+	}
+	mc.syncMu.Lock()
+	mc.mcpLibraryURL = mcpLibraryURL
+	mc.mcpLibrarySyncInterval = mcpLibrarySyncInterval
+	mc.syncMu.Unlock()
+
 	syncInterval := DefaultSyncInterval
 	if config != nil && config.PricingSyncInterval != nil {
 		syncInterval = time.Duration(*config.PricingSyncInterval) * time.Second
@@ -299,6 +366,22 @@ func (mc *ModelCatalog) ForceReloadPricing(ctx context.Context) error {
 			paramsErr = fmt.Errorf("failed to sync model parameters: %w", err)
 		}
 	}()
+
+	// MCP library sync runs alongside but is non-fatal: a failure here must not
+	// block a pricing/params force-reload. It is logged and the last-sync
+	// timestamp is only advanced on success.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := mc.syncMCPLibrary(ctx); err != nil {
+			mc.logger.Warn("MCP library sync during force-reload failed: %v", err)
+			return
+		}
+		mc.syncMu.Lock()
+		mc.lastMCPLibrarySyncedAt = time.Now()
+		mc.syncMu.Unlock()
+	}()
+
 	wg.Wait()
 	if pricingErr != nil {
 		return pricingErr
@@ -365,42 +448,73 @@ func (mc *ModelCatalog) syncWorker(ctx context.Context) {
 }
 
 func (mc *ModelCatalog) syncTick(ctx context.Context) {
-	if time.Since(mc.datasheet.LastSyncedAt()) < mc.datasheet.SyncInterval() {
+	pricingDue := time.Since(mc.datasheet.LastSyncedAt()) >= mc.datasheet.SyncInterval()
+	mcpLibraryDue := mc.isMCPLibrarySyncDue()
+	if !pricingDue && !mcpLibraryDue {
 		return
 	}
 	mc.logger.Debug("starting model catalog background sync")
-	if err := mc.withDistributedLock(ctx, "model_catalog_pricing_sync", 10, func() error {
-		var wg sync.WaitGroup
-		var pricingErr, paramsErr error
-		wg.Add(2)
+
+	// Pricing and MCP library use separate distributed locks so their
+	// independent cadences don't block each other.
+	var outerWg sync.WaitGroup
+	if pricingDue {
+		outerWg.Add(1)
 		go func() {
-			defer wg.Done()
-			if err := mc.runPricingSync(ctx); err != nil {
-				mc.logger.Error("background pricing sync failed: %v", err)
-				pricingErr = err
+			defer outerWg.Done()
+			if err := mc.withDistributedLock(ctx, "model_catalog_pricing_sync", 10, func() error {
+				var wg sync.WaitGroup
+				var pricingErr, paramsErr error
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					if err := mc.runPricingSync(ctx); err != nil {
+						mc.logger.Error("background pricing sync failed: %v", err)
+						pricingErr = err
+					}
+				}()
+				go func() {
+					defer wg.Done()
+					if err := mc.runParamsSync(ctx); err != nil {
+						mc.logger.Error("background model parameters sync failed: %v", err)
+						paramsErr = err
+					}
+				}()
+				wg.Wait()
+				if pricingErr == nil && paramsErr == nil {
+					if mc.afterSyncHook != nil {
+						mc.afterSyncHook(ctx)
+					}
+					mc.datasheet.MarkSynced(time.Now())
+				}
+				if pricingErr != nil {
+					return pricingErr
+				}
+				return paramsErr
+			}); err != nil {
+				mc.logger.Error("failed to run pricing sync: %v", err)
 			}
 		}()
-		go func() {
-			defer wg.Done()
-			if err := mc.runParamsSync(ctx); err != nil {
-				mc.logger.Error("background model parameters sync failed: %v", err)
-				paramsErr = err
-			}
-		}()
-		wg.Wait()
-		if pricingErr == nil && paramsErr == nil {
-			if mc.afterSyncHook != nil {
-				mc.afterSyncHook(ctx)
-			}
-			mc.datasheet.MarkSynced(time.Now())
-		}
-		if pricingErr != nil {
-			return pricingErr
-		}
-		return paramsErr
-	}); err != nil {
-		mc.logger.Error("failed to run model catalog sync: %v", err)
 	}
+	if mcpLibraryDue {
+		outerWg.Add(1)
+		go func() {
+			defer outerWg.Done()
+			if err := mc.withDistributedLock(ctx, "model_catalog_mcp_library_sync", 10, func() error {
+				if err := mc.syncMCPLibrary(ctx); err != nil {
+					mc.logger.Error("background MCP library sync failed: %v", err)
+					return err
+				}
+				mc.syncMu.Lock()
+				mc.lastMCPLibrarySyncedAt = time.Now()
+				mc.syncMu.Unlock()
+				return nil
+			}); err != nil {
+				mc.logger.Error("failed to run MCP library sync: %v", err)
+			}
+		}()
+	}
+	outerWg.Wait()
 	mc.logger.Debug("model catalog background sync completed")
 }
 
@@ -452,6 +566,31 @@ func (mc *ModelCatalog) withDistributedLock(ctx context.Context, key string, ret
 // and background sync.
 func (mc *ModelCatalog) hasPricingData() bool {
 	return len(mc.datasheet.DatasheetProviders()) > 0
+}
+
+func (mc *ModelCatalog) hasMCPLibraryData(ctx context.Context) (bool, error) {
+	if mc.configStore == nil {
+		return false, nil
+	}
+	_, totalCount, err := mc.configStore.GetMCPLibraryPaginated(ctx, configstore.MCPLibraryQueryParams{Limit: 1})
+	if err != nil {
+		return false, err
+	}
+	return totalCount > 0, nil
+}
+
+func (mc *ModelCatalog) isMCPLibrarySyncDue() bool {
+	if mc.configStore == nil {
+		return false
+	}
+	mc.syncMu.RLock()
+	lastSyncedAt := mc.lastMCPLibrarySyncedAt
+	syncInterval := mc.mcpLibrarySyncInterval
+	mc.syncMu.RUnlock()
+	if syncInterval <= 0 {
+		syncInterval = DefaultSyncInterval
+	}
+	return lastSyncedAt.IsZero() || time.Since(lastSyncedAt) >= syncInterval
 }
 
 // knownProviders returns the union of providers seen by any store. Used by

--- a/framework/modelcatalog/mcp_library_sync.go
+++ b/framework/modelcatalog/mcp_library_sync.go
@@ -17,6 +17,50 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	urlFetchMaxRetries     = 3                // retries after the first attempt (4 attempts total)
+	urlFetchMaxBackoff     = 10 * time.Second // cap for exponential backoff (steps start at 1s)
+	retryBackoffMin        = time.Second      // initial wait before the first retry
+	maxMCPLibraryBodyBytes = 50 << 20         // 50 MiB — hard cap on the catalog payload to prevent OOM
+)
+
+// withRetries runs op up to maxRetries+1 times, waiting with exponential
+// backoff (starting at retryBackoffMin, capped at maxBackoff) between attempts.
+// It returns the first successful result or the last error. The context is
+// honored during both the operation and the backoff waits.
+func withRetries[T any](ctx context.Context, maxRetries int, maxBackoff time.Duration, op func() (T, error)) (T, error) {
+	var zero T
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		select {
+		case <-ctx.Done():
+			return zero, ctx.Err()
+		default:
+		}
+
+		if attempt > 0 {
+			backoff := retryBackoffMin * time.Duration(1<<uint(attempt-1))
+			if maxBackoff > 0 && backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			select {
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+		v, err := op()
+		if err == nil {
+			return v, nil
+		}
+		lastErr = err
+	}
+	return zero, lastErr
+}
+
 // MCPLibraryEntry is the JSON shape a single server has in the remote MCP
 // library catalog (the payload fetched from DefaultMCPLibraryURL / custom URL).
 // The catalog carries no slug; it is derived from Name at sync time via
@@ -57,7 +101,7 @@ func SyncMCPLibrary(ctx context.Context, url string, store configstore.ConfigSto
 		url = DefaultMCPLibraryURL
 	}
 
-	entries, err := WithRetries(ctx, urlFetchMaxRetries, urlFetchMaxBackoff, func() ([]MCPLibraryEntry, error) {
+	entries, err := withRetries(ctx, urlFetchMaxRetries, urlFetchMaxBackoff, func() ([]MCPLibraryEntry, error) {
 		return fetchMCPLibrary(ctx, url)
 	})
 	if err != nil {

--- a/framework/modelcatalog/mcplibrarysync_test.go
+++ b/framework/modelcatalog/mcplibrarysync_test.go
@@ -1,0 +1,144 @@
+package modelcatalog
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchMCPLibraryFromFileURL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "servers.json")
+	payload := `{"servers":[{"name":"Filesystem","connection_type":"stdio","auth_type":"none"}]}`
+	require.NoError(t, os.WriteFile(path, []byte(payload), 0o600))
+
+	entries, err := fetchMCPLibrary(context.Background(), "file://"+path)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "Filesystem", entries[0].Name)
+	require.Equal(t, schemas.MCPConnectionTypeSTDIO, entries[0].ConnectionType)
+}
+
+func TestWithRetries_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	errTransient := errors.New("transient")
+
+	tests := []struct {
+		name         string
+		maxRetries   int
+		maxBackoff   time.Duration
+		// failCount is how many times op fails before succeeding.
+		// Set to -1 to always fail.
+		failCount    int
+		ctxTimeout   time.Duration // 0 means no timeout
+		wantAttempts int
+		wantVal      string
+		wantErr      error
+	}{
+		{
+			name:         "succeeds after N retries",
+			maxRetries:   3,
+			maxBackoff:   time.Millisecond,
+			failCount:    2,
+			wantAttempts: 3,
+			wantVal:      "ok",
+		},
+		{
+			name:         "succeeds on first attempt",
+			maxRetries:   3,
+			maxBackoff:   time.Millisecond,
+			failCount:    0,
+			wantAttempts: 1,
+			wantVal:      "ok",
+		},
+		{
+			name:         "exhausts all retries",
+			maxRetries:   2,
+			maxBackoff:   time.Millisecond,
+			failCount:    -1,
+			wantAttempts: 3, // 1 initial + 2 retries
+			wantErr:      errTransient,
+		},
+		{
+			// maxBackoff left high so the first retry's backoff wait (1s,
+			// from retryBackoffMin) outlasts the 20ms ctx timeout, forcing
+			// cancellation during the wait rather than after exhausting
+			// retries.
+			name:         "context cancelled before success",
+			maxRetries:   5,
+			maxBackoff:   time.Second,
+			failCount:    -1,
+			ctxTimeout:   20 * time.Millisecond,
+			wantErr:      context.DeadlineExceeded,
+		},
+		{
+			name:         "backoff does not exceed cap",
+			maxRetries:   6,
+			maxBackoff:   2 * time.Millisecond,
+			failCount:    -1,
+			wantAttempts: 7, // 1 initial + 6 retries
+			wantErr:      errTransient,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			var cancel context.CancelFunc
+			if tt.ctxTimeout > 0 {
+				ctx, cancel = context.WithTimeout(ctx, tt.ctxTimeout)
+				defer cancel()
+			}
+
+			attempts := 0
+			start := time.Now()
+
+			op := func() (string, error) {
+				attempts++
+				if tt.failCount < 0 || attempts <= tt.failCount {
+					return "", errTransient
+				}
+				return "ok", nil
+			}
+
+			val, err := withRetries(ctx, tt.maxRetries, tt.maxBackoff, op)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Empty(t, val)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantVal, val)
+			}
+
+			if tt.wantAttempts > 0 {
+				require.Equal(t, tt.wantAttempts, attempts)
+			}
+
+			// For the context-cancellation case, verify that attempts stopped
+			// early (well before maxRetries+1).
+			if tt.ctxTimeout > 0 {
+				require.Less(t, attempts, tt.maxRetries+1,
+					"expected context cancellation to stop retries early")
+			}
+
+			// For the backoff-cap case, verify total elapsed time stays
+			// bounded. With maxBackoff=2ms and 6 retries, uncapped
+			// exponential would be 1+2+4+8+16+32 = 63ms. Capped at 2ms
+			// it's at most 6*2 = 12ms. We allow a generous margin.
+			if tt.name == "backoff does not exceed cap" {
+				elapsed := time.Since(start)
+				require.Less(t, elapsed, 200*time.Millisecond,
+					"total elapsed time suggests backoff was not capped")
+			}
+		})
+	}
+}

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -288,6 +288,21 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Validate MCP library catalog URL override (only when set and non-default)
+	if payload.FrameworkConfig.MCPLibraryURL != nil && *payload.FrameworkConfig.MCPLibraryURL != "" && *payload.FrameworkConfig.MCPLibraryURL != modelcatalog.DefaultMCPLibraryURL {
+		if err := checkURLAccessibility(*payload.FrameworkConfig.MCPLibraryURL); err != nil {
+			logger.Warn("failed to check the accessibility of the MCP library URL: %v", err)
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("failed to check the accessibility of the MCP library URL: %v", err))
+			return
+		}
+	}
+	// Checking the MCP library sync interval
+	if payload.FrameworkConfig.MCPLibrarySyncInterval != nil && *payload.FrameworkConfig.MCPLibrarySyncInterval <= 0 {
+		logger.Warn("MCP library sync interval must be greater than 0")
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP library sync interval must be greater than 0")
+		return
+	}
+
 	// Get current config with proper locking
 	currentConfig := h.store.ClientConfig
 	updatedConfig := currentConfig
@@ -533,10 +548,12 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	// if framework config is nil, we will use the default pricing config
 	if frameworkConfig == nil {
 		frameworkConfig = &configstoreTables.TableFrameworkConfig{
-			ID:                  0,
-			PricingURL:          bifrost.Ptr(modelcatalog.DefaultPricingURL),
-			PricingSyncInterval: bifrost.Ptr(int64(modelcatalog.DefaultSyncInterval.Seconds())),
-			ModelParametersURL:  bifrost.Ptr(modelcatalog.DefaultModelParametersURL),
+			ID:                     0,
+			PricingURL:             bifrost.Ptr(modelcatalog.DefaultPricingURL),
+			PricingSyncInterval:    bifrost.Ptr(int64(modelcatalog.DefaultSyncInterval.Seconds())),
+			ModelParametersURL:     bifrost.Ptr(modelcatalog.DefaultModelParametersURL),
+			MCPLibraryURL:          bifrost.Ptr(modelcatalog.DefaultMCPLibraryURL),
+			MCPLibrarySyncInterval: bifrost.Ptr(int64(modelcatalog.DefaultSyncInterval.Seconds())),
 		}
 	}
 	// Handling individual nil cases
@@ -548,6 +565,12 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	}
 	if frameworkConfig.ModelParametersURL == nil {
 		frameworkConfig.ModelParametersURL = bifrost.Ptr(modelcatalog.DefaultModelParametersURL)
+	}
+	if frameworkConfig.MCPLibraryURL == nil {
+		frameworkConfig.MCPLibraryURL = bifrost.Ptr(modelcatalog.DefaultMCPLibraryURL)
+	}
+	if frameworkConfig.MCPLibrarySyncInterval == nil {
+		frameworkConfig.MCPLibrarySyncInterval = bifrost.Ptr(int64(modelcatalog.DefaultSyncInterval.Seconds()))
 	}
 	// Updating framework config
 	shouldReloadFrameworkConfig := false
@@ -584,6 +607,23 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			shouldReloadFrameworkConfig = true
 		}
 	}
+	if payload.FrameworkConfig.MCPLibraryURL != nil {
+		effectiveMCPLibraryURL := *payload.FrameworkConfig.MCPLibraryURL
+		if effectiveMCPLibraryURL == "" {
+			effectiveMCPLibraryURL = modelcatalog.DefaultMCPLibraryURL
+		}
+		if frameworkConfig.MCPLibraryURL == nil || effectiveMCPLibraryURL != *frameworkConfig.MCPLibraryURL {
+			frameworkConfig.MCPLibraryURL = &effectiveMCPLibraryURL
+			shouldReloadFrameworkConfig = true
+		}
+	}
+	if payload.FrameworkConfig.MCPLibrarySyncInterval != nil {
+		syncInterval := *payload.FrameworkConfig.MCPLibrarySyncInterval
+		if frameworkConfig.MCPLibrarySyncInterval == nil || syncInterval != *frameworkConfig.MCPLibrarySyncInterval {
+			frameworkConfig.MCPLibrarySyncInterval = &syncInterval
+			shouldReloadFrameworkConfig = true
+		}
+	}
 	// Reload config if required
 	if shouldReloadFrameworkConfig {
 		var syncSeconds int64
@@ -594,9 +634,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		}
 		h.store.FrameworkConfig = &framework.FrameworkConfig{
 			Pricing: &modelcatalog.Config{
-				PricingURL:          frameworkConfig.PricingURL,
-				PricingSyncInterval: &syncSeconds,
-				ModelParametersURL:  frameworkConfig.ModelParametersURL,
+				PricingURL:             frameworkConfig.PricingURL,
+				PricingSyncInterval:    &syncSeconds,
+				ModelParametersURL:     frameworkConfig.ModelParametersURL,
+				MCPLibraryURL:          frameworkConfig.MCPLibraryURL,
+				MCPLibrarySyncInterval: frameworkConfig.MCPLibrarySyncInterval,
 			},
 		}
 		// Saving framework config

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3843,8 +3843,11 @@ func ResolveFrameworkPricingConfig(
 	filePricingURL := (*string)(nil)
 	fileModelParametersURL := (*string)(nil)
 	fileSyncSeconds := (*int64)(nil)
+	fileMCPLibraryURL := (*string)(nil)
+	fileMCPLibrarySyncSeconds := (*int64)(nil)
 	skipURLBackfill := false // prevent DB backfill of unresolved env references
 	skipModelParamsURLBackfill := false
+	skipMCPLibraryURLBackfill := false
 	if fileConfig != nil && fileConfig.Pricing != nil {
 		if fileConfig.Pricing.PricingURL != nil {
 			raw := *fileConfig.Pricing.PricingURL
@@ -3894,6 +3897,39 @@ func ResolveFrameworkPricingConfig(
 				fileSyncSeconds = &val
 			}
 		}
+		if fileConfig.Pricing.MCPLibraryURL != nil {
+			raw := strings.TrimSpace(*fileConfig.Pricing.MCPLibraryURL)
+			if raw == "" {
+				// Blank is treated as "not set"; fall back to default.
+			} else if strings.HasPrefix(raw, "env.") {
+				resolvedURL, err := envutils.ProcessEnvValue(raw)
+				if err != nil {
+					logger.Warn("mcp_library_url: env variable not found (%v); keeping original value %q", err, raw)
+					fileMCPLibraryURL = &raw
+					skipMCPLibraryURLBackfill = true
+				} else {
+					resolved := strings.TrimSpace(resolvedURL)
+					if resolved != "" {
+						fileMCPLibraryURL = &resolved
+					}
+				}
+			} else {
+				fileMCPLibraryURL = &raw
+			}
+		}
+		if fileConfig.Pricing.MCPLibrarySyncInterval != nil {
+			val := *fileConfig.Pricing.MCPLibrarySyncInterval
+			switch {
+			case val <= 0:
+				logger.Warn("mcp_library_sync_interval in config.json is invalid (%d seconds), ignoring — using default (%d seconds)", val, defaultSyncSeconds)
+			case val < modelcatalog.MinimumPricingSyncIntervalSec:
+				clamped := modelcatalog.MinimumPricingSyncIntervalSec
+				logger.Warn("mcp_library_sync_interval in config.json is below minimum (%d seconds), clamping to %d seconds", val, clamped)
+				fileMCPLibrarySyncSeconds = &clamped
+			default:
+				fileMCPLibrarySyncSeconds = &val
+			}
+		}
 	}
 
 	// --- Phase 2: apply file config over defaults ---
@@ -3901,6 +3937,11 @@ func ResolveFrameworkPricingConfig(
 	resolvedPricingURL := &defaultPricingURL
 	resolvedModelParametersURL := &defaultModelParametersURL
 	resolvedSyncSeconds := &defaultSyncSeconds
+
+	defaultMCPLibraryURL := modelcatalog.DefaultMCPLibraryURL
+	defaultMCPLibrarySyncSeconds := int64(modelcatalog.DefaultSyncInterval.Seconds())
+	resolvedMCPLibraryURL := &defaultMCPLibraryURL
+	resolvedMCPLibrarySyncInterval := &defaultMCPLibrarySyncSeconds
 
 	if filePricingURL != nil {
 		resolvedPricingURL = filePricingURL
@@ -3915,6 +3956,16 @@ func ResolveFrameworkPricingConfig(
 		logger.Debug("pricing_sync_interval resolved from file: %d seconds", *fileSyncSeconds)
 	}
 
+	// MCP library catalog sync source mirrors the datasheet URL handling for
+	// defaults, env substitution, interval validation, and hash-gated config.json
+	// changes. DB precedence is applied in Phase 3 below.
+	if fileMCPLibraryURL != nil {
+		resolvedMCPLibraryURL = fileMCPLibraryURL
+	}
+	if fileMCPLibrarySyncSeconds != nil {
+		resolvedMCPLibrarySyncInterval = fileMCPLibrarySyncSeconds
+	}
+
 	// --- Phase 3: DB values applied; file wins on hash mismatch (file changed since last write) ---
 
 	needsDBUpdate := false
@@ -3922,8 +3973,22 @@ func ResolveFrameworkPricingConfig(
 
 	// Hash the file-resolved values; skip if nothing valid survived Phase 1.
 	fileHash := ""
-	if fileConfig != nil && fileConfig.Pricing != nil && !skipURLBackfill && (filePricingURL != nil || fileSyncSeconds != nil) {
-		h, err := configstore.GenerateFrameworkConfigHash(filePricingURL, fileModelParametersURL, fileSyncSeconds)
+	fileHasHashableMCPConfig := (fileMCPLibraryURL != nil && !skipMCPLibraryURLBackfill) || fileMCPLibrarySyncSeconds != nil
+	if fileConfig != nil && fileConfig.Pricing != nil && !skipURLBackfill && (filePricingURL != nil || fileSyncSeconds != nil || fileHasHashableMCPConfig) {
+		var h string
+		var err error
+		if fileHasHashableMCPConfig {
+			mcpHashURL := fileMCPLibraryURL
+			if skipMCPLibraryURLBackfill {
+				mcpHashURL = nil
+			}
+			h, err = configstore.GenerateFrameworkConfigHash(filePricingURL, fileModelParametersURL, fileSyncSeconds, configstore.FrameworkConfigHashOptions{
+				MCPLibraryURL:          mcpHashURL,
+				MCPLibrarySyncInterval: fileMCPLibrarySyncSeconds,
+			})
+		} else {
+			h, err = configstore.GenerateFrameworkConfigHash(filePricingURL, fileModelParametersURL, fileSyncSeconds)
+		}
 		if err != nil {
 			logger.Warn("failed to compute framework config hash: %v", err)
 		} else {
@@ -3977,6 +4042,48 @@ func ResolveFrameworkPricingConfig(
 		} else {
 			needsDBUpdate = true
 		}
+
+		// MCP library config follows the same hash-gated config.json precedence as
+		// datasheet config: DB wins while the file is unchanged; file wins and is
+		// backfilled when the file changed since the last persisted hash.
+		if dbConfig.MCPLibraryURL != nil {
+			if trimmed := strings.TrimSpace(*dbConfig.MCPLibraryURL); trimmed != "" {
+				if fileChanged && fileMCPLibraryURL != nil && !skipMCPLibraryURLBackfill {
+					logger.Info("mcp_library_url from config.json overrides DB (file hash changed) — updating DB")
+					needsDBUpdate = true
+				} else {
+					resolvedMCPLibraryURL = &trimmed
+				}
+			} else if !skipMCPLibraryURLBackfill {
+				needsDBUpdate = true
+			}
+		} else if !skipMCPLibraryURLBackfill {
+			needsDBUpdate = true
+		}
+		if dbConfig.MCPLibrarySyncInterval != nil {
+			val := *dbConfig.MCPLibrarySyncInterval
+			switch {
+			case val <= 0:
+				logger.Warn("mcp_library_sync_interval in DB is corrupted (%d seconds), ignoring — backfilling with %d seconds", val, *resolvedMCPLibrarySyncInterval)
+				needsDBUpdate = true
+			case val < modelcatalog.MinimumPricingSyncIntervalSec:
+				logger.Warn("mcp_library_sync_interval in DB is below minimum (%d seconds) — backfilling", val)
+				if !fileChanged || fileMCPLibrarySyncSeconds == nil {
+					clamped := modelcatalog.MinimumPricingSyncIntervalSec
+					resolvedMCPLibrarySyncInterval = &clamped
+				}
+				needsDBUpdate = true
+			default:
+				if fileChanged && fileMCPLibrarySyncSeconds != nil {
+					logger.Info("mcp_library_sync_interval from config.json overrides DB (file hash changed): file=%d db=%d seconds — updating DB", *fileMCPLibrarySyncSeconds, val)
+					needsDBUpdate = true
+				} else {
+					resolvedMCPLibrarySyncInterval = dbConfig.MCPLibrarySyncInterval
+				}
+			}
+		} else {
+			needsDBUpdate = true
+		}
 	}
 
 	// --- Phase 4: nil guard ---
@@ -3992,6 +4099,12 @@ func ResolveFrameworkPricingConfig(
 		logger.Warn("invariant violation: pricing_sync_interval resolved to nil — falling back to default %d seconds", defaultSyncSeconds)
 		resolvedSyncSeconds = &defaultSyncSeconds
 	}
+	if resolvedMCPLibraryURL == nil {
+		resolvedMCPLibraryURL = &defaultMCPLibraryURL
+	}
+	if resolvedMCPLibrarySyncInterval == nil {
+		resolvedMCPLibrarySyncInterval = &defaultMCPLibrarySyncSeconds
+	}
 
 	// Only update the stored hash when the file actually changed; preserve the
 	// existing hash for correction-only DB updates (null backfill, corruption fix).
@@ -4004,15 +4117,19 @@ func ResolveFrameworkPricingConfig(
 	}
 
 	return &configstoreTables.TableFrameworkConfig{
-			ID:                  configID,
-			PricingURL:          resolvedPricingURL,
-			PricingSyncInterval: resolvedSyncSeconds,
-			ModelParametersURL:  resolvedModelParametersURL,
-			ConfigHash:          persistedHash,
+			ID:                     configID,
+			PricingURL:             resolvedPricingURL,
+			PricingSyncInterval:    resolvedSyncSeconds,
+			ModelParametersURL:     resolvedModelParametersURL,
+			MCPLibraryURL:          resolvedMCPLibraryURL,
+			MCPLibrarySyncInterval: resolvedMCPLibrarySyncInterval,
+			ConfigHash:             persistedHash,
 		}, &modelcatalog.Config{
-			PricingURL:          resolvedPricingURL,
-			PricingSyncInterval: resolvedSyncSeconds,
-			ModelParametersURL:  resolvedModelParametersURL,
+			PricingURL:             resolvedPricingURL,
+			PricingSyncInterval:    resolvedSyncSeconds,
+			ModelParametersURL:     resolvedModelParametersURL,
+			MCPLibraryURL:          resolvedMCPLibraryURL,
+			MCPLibrarySyncInterval: resolvedMCPLibrarySyncInterval,
 		}, needsDBUpdate
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -639,6 +639,19 @@ func (m *MockConfigStore) GetMCPLibraryPaginated(ctx context.Context, params con
 	return nil, 0, nil
 }
 
+func (m *MockConfigStore) GetMCPLibraryFilterData(ctx context.Context) (*configstore.MCPLibraryFilterData, error) {
+	return &configstore.MCPLibraryFilterData{
+		Categories:      []string{},
+		ConnectionTypes: []string{},
+		AuthTypes:       []string{},
+		Tags:            []string{},
+	}, nil
+}
+
+func (m *MockConfigStore) UpsertMCPLibraryEntry(ctx context.Context, entry *tables.TableMCPLibrary, tx ...*gorm.DB) error {
+	return nil
+}
+
 func (m *MockConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) error {
 	if m.mcpConfig == nil {
 		return nil


### PR DESCRIPTION
## Summary

Adds `mcp_library_url` and `mcp_library_sync_interval` as configurable fields for the MCP server library catalog, mirroring the existing `pricing_url` / `pricing_sync_interval` pattern. This allows operators to override the default MCP library catalog source and sync cadence via the API or config file, with the DB acting as the authoritative store once set.

## Changes

- Added `MCPLibraryURL` and `MCPLibrarySyncInterval` fields to `TableFrameworkConfig` with a corresponding idempotent DB migration.
- Wired `mcpLibraryURL` into `ModelCatalog` initialization, `UpdateSyncConfig`, `ForceReloadPricing`, and the background `syncTick` loop. MCP library sync runs concurrently with pricing/params syncs but is non-fatal — failures are logged and do not block pricing sync completion or startup.
- Added a background goroutine at startup to perform an initial MCP library sync without blocking the main init path.
- Introduced a generic `withRetries` helper (exponential backoff, context-aware) in `mcp_library_sync.go`, replacing the previously exported `WithRetries`.
- Extended `ResolveFrameworkPricingConfig` to resolve `MCPLibraryURL` and `MCPLibrarySyncInterval` with the same file → DB precedence logic used for other catalog fields (no hash gating, DB is authoritative once set).
- Added validation in the `updateConfig` HTTP handler: the custom MCP library URL is checked for reachability (HTTP 200) before being accepted, and the sync interval must be greater than zero.
- Updated `MockConfigStore` in tests to implement the new `GetMCPLibraryFilterData` and `UpsertMCPLibraryEntry` interface methods.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Set a custom `mcp_library_url` via the config API and confirm the catalog syncs from the override URL.
- Set `mcp_library_url` to an unreachable URL and confirm the API returns a 500 with an appropriate error message.
- Set `mcp_library_sync_interval` to `0` or a negative value and confirm the API returns a 400.
- Restart the service and confirm the MCP library sync runs in the background at startup without blocking other initialization.
- Confirm that a failure in MCP library sync does not prevent pricing or model parameter syncs from completing.

**New config fields (under `framework.pricing`):**

| Field | Default | Description |
|---|---|---|
| `mcp_library_url` | `DefaultMCPLibraryURL` | URL to fetch the MCP server library catalog from |
| `mcp_library_sync_interval` | `DefaultSyncInterval` (seconds) | How often to re-sync the MCP library catalog |

## Breaking changes

- [x] No

## Security considerations

The custom `mcp_library_url` is validated with an outbound HTTP GET before being persisted. Operators should ensure the configured URL is a trusted source, as its contents are written directly into the MCP library catalog store.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP library support: configurable catalog URL and sync interval, integrated sync alongside pricing/params with retries/backoff and non-blocking updates; live validation of URL and interval inputs.
* **Migrations**
  * DB migration adds MCP library columns and table support, idempotent with rollback.
* **Refactor**
  * Config resolution and background sync updated to honor MCP defaults, precedence, and include MCP inputs in config-change detection.
* **Tests**
  * Added tests for MCP upsert and fetching MCP catalogs (including file://).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->