### PR TITLE
fix: gate models for passthrough in vk if present

### DIFF
--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -261,8 +261,10 @@ func (r *BudgetResolver) EvaluateVirtualKeyRequest(ctx *schemas.BifrostContext, 
 			VirtualKey: vk,
 		}
 	}
-	// 3. Check model filtering
-	if IsModelRequiredForRequest(requestType) && !r.isModelAllowed(vk, provider, model) {
+	// 3. Check model filtering. Most request types always carry a model and are always checked.
+	// Passthrough forwards raw provider routes where a model may or may not be resolvable for some request types.
+	isPassthrough := requestType == schemas.PassthroughRequest || requestType == schemas.PassthroughStreamRequest
+	if (IsModelRequiredForRequest(requestType) || (isPassthrough && model != "")) && !r.isModelAllowed(vk, provider, model) {
 		return &EvaluationResult{
 			Decision:   DecisionModelBlocked,
 			Reason:     fmt.Sprintf("Model '%s' is not allowed for this virtual key", model),

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -504,3 +504,47 @@ func TestBudgetResolver_ContextPopulation(t *testing.T) {
 	assert.Equal(t, "team1", teamID)
 	assert.Equal(t, "cust1", customerID)
 }
+
+// TestBudgetResolver_EvaluateRequest_PassthroughModelFiltering verifies that passthrough requests
+// enforce the VK's model allowlist only when a model is resolved: a disallowed model is blocked, an
+// allowed model passes, and an absent model imposes no model restriction. Non-passthrough
+// model-not-required types (e.g. batch) remain unfiltered, confirming the change is scoped.
+func TestBudgetResolver_EvaluateRequest_PassthroughModelFiltering(t *testing.T) {
+	tests := []struct {
+		name        string
+		model       string
+		requestType schemas.RequestType
+		want        Decision
+	}{
+		{"passthrough disallowed model is blocked", "gpt-4o-mini", schemas.PassthroughRequest, DecisionModelBlocked},
+		{"passthrough allowed model passes", "gpt-4", schemas.PassthroughRequest, DecisionAllow},
+		{"passthrough without model has no restriction", "", schemas.PassthroughRequest, DecisionAllow},
+		{"passthrough stream disallowed model is blocked", "gpt-4o-mini", schemas.PassthroughStreamRequest, DecisionModelBlocked},
+		{"passthrough stream allowed model passes", "gpt-4", schemas.PassthroughStreamRequest, DecisionAllow},
+		{"passthrough stream without model has no restriction", "", schemas.PassthroughStreamRequest, DecisionAllow},
+		// Scoping guard: batch is model-not-required and not passthrough, so its model is never
+		// filtered even when set to a disallowed value (behavior unchanged by the passthrough fix).
+		{"batch with disallowed model is not filtered", "gpt-4o-mini", schemas.BatchCreateRequest, DecisionAllow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := NewMockLogger()
+			providerConfigs := []configstoreTables.TableVirtualKeyProviderConfig{
+				buildProviderConfig("openai", []string{"gpt-4", "gpt-4-turbo"}),
+			}
+			vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", providerConfigs)
+
+			store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+				VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+			}, nil)
+			require.NoError(t, err)
+
+			resolver := NewBudgetResolver(store, nil, logger, nil)
+			ctx := &schemas.BifrostContext{}
+
+			result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, tt.model, tt.requestType, false)
+			assertDecision(t, tt.want, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Passthrough requests (`PassthroughRequest` and `PassthroughStreamRequest`) forward raw provider routes where a model may or may not be resolvable. Previously, model filtering was only applied when `IsModelRequiredForRequest` returned true, meaning passthrough requests with a resolved model were never checked against a virtual key's model allowlist. This PR fixes that gap by enforcing model filtering on passthrough requests when a model is present, while still allowing passthrough requests with no resolvable model to proceed unrestricted.

## Changes

- Updated `EvaluateVirtualKeyRequest` in `resolver.go` to additionally apply model filtering for passthrough request types when a model is resolved (non-empty), without affecting other request types where a model is not required (e.g. batch).
- Added `TestBudgetResolver_EvaluateRequest_PassthroughModelFiltering` covering: disallowed model blocked, allowed model passed, absent model unrestricted (for both passthrough and passthrough stream), and a scoping guard confirming batch requests remain unaffected.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

Expected: all tests pass, including the new `TestBudgetResolver_EvaluateRequest_PassthroughModelFiltering` test cases.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This tightens model allowlist enforcement for passthrough requests. Virtual keys with a model allowlist configured will now correctly block disallowed models on passthrough routes when the model is resolvable, closing a bypass path that previously existed for passthrough request types.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened model allowlist enforcement for virtual keys: passthrough requests now enforce model restrictions when a model is explicitly provided or when the request type requires a model, preventing disallowed models from being used while preserving behavior for requests without a model.
* **Tests**
  * Added comprehensive tests validating passthrough request model filtering and overall request scoping to ensure correct allowlist behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->