### PR TITLE
feat: allow private network config with link-local blocking

### DIFF
--- a/core/network/utils.go
+++ b/core/network/utils.go
@@ -12,6 +12,7 @@ func IsLocalhost(hostname string) bool {
 }
 
 var privateSubnets []*net.IPNet
+var linkLocalSubnet *net.IPNet
 
 func init() {
 	for _, cidr := range []string{
@@ -24,6 +25,18 @@ func init() {
 		_, subnet, _ := net.ParseCIDR(cidr)
 		privateSubnets = append(privateSubnets, subnet)
 	}
+	_, linkLocalSubnet, _ = net.ParseCIDR("169.254.0.0/16")
+}
+
+// IsLinkLocal reports whether ip is a link-local address.
+// These are always blocked regardless of AllowPrivateNetwork — they include
+// cloud instance metadata endpoints (169.254.169.254, fe80::) that must
+// never be reachable even in private-network deployments.
+func IsLinkLocal(ip net.IP) bool {
+	if ip.To4() != nil {
+		return linkLocalSubnet.Contains(ip)
+	}
+	return ip.IsLinkLocalUnicast()
 }
 
 // IsPrivateIP reports whether ip falls in a private, loopback, or link-local range.

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -100,7 +100,7 @@ func NewAnthropicProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -186,7 +186,7 @@ func NewAzureProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*A
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	return &AzureProvider{

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -135,7 +135,7 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 		ConnPoolStrategy:    fasthttp.FIFO,
 	}
 	mantleFasthttpClient = providerUtils.ConfigureProxy(mantleFasthttpClient, config.ProxyConfig, logger)
-	mantleFasthttpClient = providerUtils.ConfigureDialer(mantleFasthttpClient)
+	mantleFasthttpClient = providerUtils.ConfigureDialer(mantleFasthttpClient, config.NetworkConfig.AllowPrivateNetwork)
 	mantleFasthttpClient = providerUtils.ConfigureTLS(mantleFasthttpClient, config.NetworkConfig, logger)
 	mantleStreamingFasthttpClient := providerUtils.BuildStreamingClient(mantleFasthttpClient)
 

--- a/core/providers/cerebras/cerebras.go
+++ b/core/providers/cerebras/cerebras.go
@@ -41,7 +41,7 @@ func NewCerebrasProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -114,7 +114,7 @@ func NewCohereProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 
 	// Setting proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Pre-warm response pools
 	for i := 0; i < config.ConcurrencyAndBufferSize.Concurrency; i++ {

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -48,7 +48,7 @@ func NewElevenlabsProvider(config *schemas.ProviderConfig, logger schemas.Logger
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/fireworks/fireworks.go
+++ b/core/providers/fireworks/fireworks.go
@@ -41,7 +41,7 @@ func NewFireworksProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -75,7 +75,7 @@ func NewGeminiProvider(config *schemas.ProviderConfig, logger schemas.Logger) *G
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 

--- a/core/providers/groq/groq.go
+++ b/core/providers/groq/groq.go
@@ -46,7 +46,7 @@ func NewGroqProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*Gr
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -88,7 +88,7 @@ func NewHuggingFaceProvider(config *schemas.ProviderConfig, logger schemas.Logge
 	}
 
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	if config.NetworkConfig.BaseURL == "" {

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -51,7 +51,7 @@ func NewMistralProvider(config *schemas.ProviderConfig, logger schemas.Logger) *
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/nebius/nebius.go
+++ b/core/providers/nebius/nebius.go
@@ -44,7 +44,7 @@ func NewNebiusProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -47,7 +47,7 @@ func NewOllamaProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -58,7 +58,7 @@ func NewOpenAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) *O
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -43,7 +43,7 @@ func NewOpenRouterProvider(config *schemas.ProviderConfig, logger schemas.Logger
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/parasail/parasail.go
+++ b/core/providers/parasail/parasail.go
@@ -42,7 +42,7 @@ func NewParasailProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -44,7 +44,7 @@ func NewPerplexityProvider(config *schemas.ProviderConfig, logger schemas.Logger
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -51,7 +51,7 @@ func NewReplicateProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")

--- a/core/providers/runway/runway.go
+++ b/core/providers/runway/runway.go
@@ -42,7 +42,7 @@ func NewRunwayProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 
 	// Configure proxy if provided
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 
 	// Set default BaseURL if not provided

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -47,7 +47,7 @@ func NewSGLProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*SGL
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")

--- a/core/providers/utils/dialer_test.go
+++ b/core/providers/utils/dialer_test.go
@@ -22,7 +22,7 @@ func TestConfigureDialer_SetsRetryIfErr(t *testing.T) {
 		t.Fatal("precondition: RetryIfErr should be nil on a new client")
 	}
 
-	ConfigureDialer(client)
+	ConfigureDialer(client, false)
 
 	if client.RetryIfErr == nil {
 		t.Fatal("ConfigureDialer should set RetryIfErr")
@@ -47,7 +47,7 @@ func TestConfigureDialer_SetsDial(t *testing.T) {
 		t.Fatal("precondition: Dial should be nil on a new client")
 	}
 
-	ConfigureDialer(client)
+	ConfigureDialer(client, false)
 
 	if client.Dial == nil {
 		t.Fatal("ConfigureDialer should set a Dial function")
@@ -67,7 +67,7 @@ func TestConfigureDialer_ComposesWithExistingDial(t *testing.T) {
 		return net.Dial("tcp", addr)
 	}
 
-	ConfigureDialer(client)
+	ConfigureDialer(client, false)
 
 	// Start a test server to connect to
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -104,11 +104,26 @@ func TestConfigureDialer_TCPKeepAliveEnabled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// The default (no-proxy) path enforces SSRF protection and blocks loopback,
-	// so test servers on 127.0.0.1 are unreachable via that path. Keepalive is
-	// verified through the existingDial path below, which also applies it.
+	// Test without existing dial (direct connection path)
+	t.Run("without_existing_dial", func(t *testing.T) {
+		client := &fasthttp.Client{}
+		ConfigureDialer(client, false)
 
-	// Test with existing dial (proxy composition path)
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(req)
+		defer fasthttp.ReleaseResponse(resp)
+
+		req.SetRequestURI(server.URL)
+		req.Header.SetMethod(http.MethodGet)
+
+		if err := client.Do(req, resp); err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		if resp.StatusCode() != 200 {
+			t.Fatalf("expected 200, got %d", resp.StatusCode())
+		}
+	})
 
 	// Test with existing dial (proxy composition path)
 	t.Run("with_existing_dial", func(t *testing.T) {
@@ -119,7 +134,7 @@ func TestConfigureDialer_TCPKeepAliveEnabled(t *testing.T) {
 			connFromProxy = conn
 			return conn, err
 		}
-		ConfigureDialer(client)
+		ConfigureDialer(client, false)
 
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
@@ -148,7 +163,7 @@ func TestConfigureDialer_TCPKeepAliveEnabled(t *testing.T) {
 // same client pointer it received (for chaining).
 func TestConfigureDialer_ReturnValue(t *testing.T) {
 	client := &fasthttp.Client{}
-	result := ConfigureDialer(client)
+	result := ConfigureDialer(client, false)
 	if result != client {
 		t.Error("ConfigureDialer should return the same client pointer")
 	}
@@ -163,12 +178,9 @@ func TestConfigureDialer_Idempotent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Pre-set existingDial so the proxy path is used — httptest binds to
-	// 127.0.0.1, which the default SSRF-safe path blocks.
 	client := &fasthttp.Client{}
-	client.Dial = func(addr string) (net.Conn, error) { return net.Dial("tcp", addr) }
-	ConfigureDialer(client)
-	ConfigureDialer(client) // called again
+	ConfigureDialer(client, false)
+	ConfigureDialer(client, false) // called again
 
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -217,11 +229,8 @@ func TestConfigureDialer_WithRetryOnStaleConnection(t *testing.T) {
 		MaxIdleConnDuration: clientIdleTimeout,
 		MaxConnsPerHost:     10,
 	}
-	// Pre-set existingDial so the proxy path is used — httptest binds to
-	// 127.0.0.1, which the default SSRF-safe path blocks.
-	client.Dial = func(addr string) (net.Conn, error) { return net.Dial("tcp", addr) }
-	// Use ConfigureDialer (the function under test) to install RetryIfErr + keepalive
-	ConfigureDialer(client)
+	// Use ConfigureDialer (the function under test) instead of manually setting RetryIfErr
+	ConfigureDialer(client, false)
 
 	// First request: establish connection in pool
 	req := fasthttp.AcquireRequest()
@@ -292,12 +301,8 @@ func TestConfigureDialer_SSRFProtection(t *testing.T) {
 		addr    string
 		wantErr string
 	}{
-		// Localhost / loopback — rejected by IsLocalhost before DNS is touched
-		{"localhost name", "localhost:80", "not allowed"},
-		{"127.0.0.1 literal", "127.0.0.1:80", "not allowed"},
-		{"[::1] loopback", "[::1]:80", "not allowed"},
-		{"0.0.0.0 all-zeros", "0.0.0.0:80", "not allowed"},
-		{"[::] unspecified short", "[::]:80", "not allowed"},
+		// Unspecified addresses — IsPrivateIP rejects them via IsUnspecified()
+		{"0.0.0.0 all-zeros", "0.0.0.0:80", "unspecified IP"},
 
 		// RFC 1918 private ranges — LookupIP returns the literal IP, IsPrivateIP rejects it
 		{"10.x.x.x", "10.0.0.1:80", "private IP"},
@@ -305,21 +310,21 @@ func TestConfigureDialer_SSRFProtection(t *testing.T) {
 		{"192.168.x.x", "192.168.1.1:80", "private IP"},
 
 		// Link-local / cloud metadata
-		{"169.254.169.254 AWS metadata", "169.254.169.254:80", "private IP"},
-		{"169.254.x.x link-local", "169.254.1.1:80", "private IP"},
+		{"169.254.169.254 AWS metadata", "169.254.169.254:80", "link-local IP"},
+		{"169.254.x.x link-local", "169.254.1.1:80", "link-local IP"},
 
 		// IPv6 private
 		{"[fc00::1] unique-local", "[fc00::1]:80", "private IP"},
 		{"[fd00::1] unique-local", "[fd00::1]:80", "private IP"},
 
 		// Unspecified IPv6 long form — regression for bypass via 0:0:0:0:0:0:0:0
-		{"[0:0:0:0:0:0:0:0] unspecified long form", "[0:0:0:0:0:0:0:0]:80", "private IP"},
+		{"[0:0:0:0:0:0:0:0] unspecified long form", "[0:0:0:0:0:0:0:0]:80", "unspecified IP"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := &fasthttp.Client{ReadTimeout: time.Second}
-			ConfigureDialer(client)
+			ConfigureDialer(client, false)
 			_, err := client.Dial(tt.addr)
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
@@ -340,7 +345,7 @@ func TestConfigureDialer_SSRFProxyBypass(t *testing.T) {
 		proxyCalled = true
 		return nil, fmt.Errorf("proxy handled: %s", addr)
 	}
-	ConfigureDialer(client)
+	ConfigureDialer(client, false)
 
 	_, err := client.Dial("10.0.0.1:80")
 	if !proxyCalled {
@@ -355,14 +360,14 @@ func TestConfigureDialer_SSRFProxyBypass(t *testing.T) {
 // even when ReadTimeout is 0 (context.Background() is used instead of WithTimeout).
 func TestConfigureDialer_SSRFZeroTimeout(t *testing.T) {
 	client := &fasthttp.Client{ReadTimeout: 0}
-	ConfigureDialer(client)
+	ConfigureDialer(client, false)
 
 	_, err := client.Dial("169.254.169.254:80")
 	if err == nil {
 		t.Fatal("expected SSRF rejection with zero ReadTimeout, got nil")
 	}
-	if !strings.Contains(err.Error(), "private IP") {
-		t.Errorf("expected 'private IP' error, got %q", err.Error())
+	if !strings.Contains(err.Error(), "link-local IP") {
+		t.Errorf("expected 'link-local IP' error, got %q", err.Error())
 	}
 }
 
@@ -373,7 +378,7 @@ func TestConfigureDialer_SSRFMultiIPAllFail(t *testing.T) {
 	// A connection attempt to it will fail (refused or timeout) without any
 	// private-IP rejection, letting us exercise the lastErr return path.
 	client := &fasthttp.Client{ReadTimeout: 200 * time.Millisecond}
-	ConfigureDialer(client)
+	ConfigureDialer(client, false)
 
 	_, err := client.Dial("192.0.2.1:9")
 	if err == nil {
@@ -395,7 +400,7 @@ func TestConfigureDialer_DialError(t *testing.T) {
 		return nil, expectedErr
 	}
 
-	ConfigureDialer(client)
+	ConfigureDialer(client, false)
 
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()

--- a/core/providers/utils/streamingclient_test.go
+++ b/core/providers/utils/streamingclient_test.go
@@ -24,7 +24,7 @@ func TestBuildStreamingClient_ZerosReadWriteTimeout(t *testing.T) {
 		MaxConnWaitTimeout: 15 * time.Second,
 		MaxConnsPerHost:    123,
 	}
-	ConfigureDialer(base)
+	ConfigureDialer(base, false)
 
 	stream := BuildStreamingClient(base)
 
@@ -94,7 +94,7 @@ func TestBuildStreamingClient_LongStreamSurvives(t *testing.T) {
 		ReadTimeout:  1 * time.Second, // would abort the stream without the fix
 		WriteTimeout: 1 * time.Second,
 	}
-	ConfigureDialer(base)
+	ConfigureDialer(base, false)
 	stream := BuildStreamingClient(base)
 
 	req := fasthttp.AcquireRequest()

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -253,7 +253,7 @@ func ConfigureRetry(client *fasthttp.Client) *fasthttp.Client {
 //
 // Dead connections are detected within ~25s (10 + 5*3), before the 30s
 // MaxIdleConnDuration expires and the connection is reused.
-func ConfigureDialer(client *fasthttp.Client) *fasthttp.Client {
+func ConfigureDialer(client *fasthttp.Client, allowPrivateNetwork bool) *fasthttp.Client {
 	// Configure stale-connection retry policy
 	client.RetryIfErr = network.StaleConnectionRetryIfErr
 
@@ -286,9 +286,6 @@ func ConfigureDialer(client *fasthttp.Client) *fasthttp.Client {
 			if splitErr != nil {
 				return nil, splitErr
 			}
-			if network.IsLocalhost(host) {
-				return nil, fmt.Errorf("connection to %s is not allowed", host)
-			}
 			// Bound DNS resolution with the same timeout that governs the TCP
 			resolveCtx := context.Background()
 			if client.ReadTimeout > 0 {
@@ -306,7 +303,15 @@ func ConfigureDialer(client *fasthttp.Client) *fasthttp.Client {
 			}
 			var lastErr error
 			for _, ip := range ips {
-				if network.IsPrivateIP(ip) {
+				// Unspecified (0.0.0.0, ::) and link-local (169.254.x.x, fe80::) are always blocked
+				if ip.IsUnspecified() {
+					return nil, fmt.Errorf("connection to unspecified IP %s is not allowed", ip)
+				}
+				if network.IsLinkLocal(ip) {
+					return nil, fmt.Errorf("connection to link-local IP %s is not allowed", ip)
+				}
+				// RFC 1918 blocked unless operator explicitly opted in; loopback always allowed
+				if !ip.IsLoopback() && !allowPrivateNetwork && network.IsPrivateIP(ip) {
 					return nil, fmt.Errorf("connection to private IP %s is not allowed", ip)
 				}
 				conn, err = dialer.Dial("tcp", net.JoinHostPort(ip.String(), port))

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -105,7 +105,7 @@ func NewVertexProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 		ConnPoolStrategy:    fasthttp.FIFO,
 	}
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	return &VertexProvider{

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -43,7 +43,7 @@ func NewVLLMProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*VL
 	}
 
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")

--- a/core/providers/xai/xai.go
+++ b/core/providers/xai/xai.go
@@ -42,7 +42,7 @@ func NewXAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*XAI
 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
-	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -63,6 +63,7 @@ type NetworkConfig struct {
 	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`             // Max TCP connections per provider host (default: 5000)
 	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                  // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
 	BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`          // Override default beta header support per provider (keys are prefixes like "redact-thinking-")
+	AllowPrivateNetwork            bool              `json:"allow_private_network,omitempty"`          // Allow connections to RFC 1918 private IPs (for k8s pods, LAN deployments). Link-local (169.254.x.x) is always blocked.
 }
 
 // UnmarshalJSON customizes JSON unmarshaling for NetworkConfig.
@@ -86,6 +87,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 		MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`
 		EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`
 		BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`
+		AllowPrivateNetwork            bool              `json:"allow_private_network,omitempty"`
 	}
 
 	var alias NetworkConfigAlias
@@ -104,6 +106,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 	nc.MaxConnsPerHost = alias.MaxConnsPerHost
 	nc.EnforceHTTP2 = alias.EnforceHTTP2
 	nc.BetaHeaderOverrides = alias.BetaHeaderOverrides
+	nc.AllowPrivateNetwork = alias.AllowPrivateNetwork
 
 	// Parse RetryBackoffInitial: string → ParseDuration, integer → milliseconds (legacy)
 	if len(alias.RetryBackoffInitial) > 0 && string(alias.RetryBackoffInitial) != "null" {
@@ -175,6 +178,7 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`
 		EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`
 		BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`
+		AllowPrivateNetwork            bool              `json:"allow_private_network,omitempty"`
 	}
 
 	alias := NetworkConfigAlias{
@@ -190,6 +194,7 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		MaxConnsPerHost:            nc.MaxConnsPerHost,
 		EnforceHTTP2:               nc.EnforceHTTP2,
 		BetaHeaderOverrides:        nc.BetaHeaderOverrides,
+		AllowPrivateNetwork:        nc.AllowPrivateNetwork,
 	}
 	if nc.CACertPEM != nil {
 		alias.CACertPEM = EnvVarAsString(nc.CACertPEM)

--- a/core/utils.go
+++ b/core/utils.go
@@ -475,8 +475,10 @@ func RedactSensitiveString(s string) string {
 	return s[:4] + "[REDACTED]" + s[len(s)-4:]
 }
 
-// ValidateExternalURL validates a URL for security concerns (SSRF protection)
-func ValidateExternalURL(urlStr string) error {
+// ValidateExternalURL validates a URL for security concerns (SSRF protection).
+// When allowPrivateNetwork is true, RFC 1918 private IPs are permitted (for k8s/LAN deployments).
+// Link-local addresses (169.254.x.x, fe80::) are always blocked regardless of allowPrivateNetwork.
+func ValidateExternalURL(urlStr string, allowPrivateNetwork bool) error {
 	if urlStr == "" {
 		return fmt.Errorf("URL cannot be empty")
 	}
@@ -494,18 +496,23 @@ func ValidateExternalURL(urlStr string) error {
 	if hostname == "" {
 		return fmt.Errorf("URL must have a hostname")
 	}
-	// Block localhost and loopback addresses
-	if network.IsLocalhost(hostname) {
-		return fmt.Errorf("localhost and loopback addresses are not allowed")
-	}
 	// Resolve hostname to IP addresses
 	ips, err := net.LookupIP(hostname)
 	if err != nil {
 		return fmt.Errorf("failed to resolve hostname: %w", err)
 	}
-	// Check if any resolved IP is private
 	for _, ip := range ips {
-		if network.IsPrivateIP(ip) {
+		if ip.IsLoopback() {
+			continue
+		}
+		// Unspecified (0.0.0.0, ::) and link-local (169.254.x.x, fe80::) are always blocked
+		if ip.IsUnspecified() {
+			return fmt.Errorf("unspecified IP addresses are not allowed")
+		}
+		if network.IsLinkLocal(ip) {
+			return fmt.Errorf("link-local IP addresses are not allowed")
+		}
+		if !allowPrivateNetwork && network.IsPrivateIP(ip) {
 			return fmt.Errorf("private IP addresses are not allowed")
 		}
 	}

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -10,10 +10,11 @@ import (
 
 func TestValidateExternalURL(t *testing.T) {
 	tests := []struct {
-		name    string
-		url     string
-		wantErr bool
-		errMsg  string
+		name                string
+		url                 string
+		allowPrivateNetwork bool
+		wantErr             bool
+		errMsg              string
 	}{
 		// Valid URLs
 		{
@@ -69,36 +70,32 @@ func TestValidateExternalURL(t *testing.T) {
 			errMsg:  "URL must have a hostname",
 		},
 
-		// Localhost / loopback by name
+		// Localhost / loopback — allowed for local deployments (Ollama, vLLM, SGL)
 		{
 			name:    "localhost",
 			url:     "http://localhost",
-			wantErr: true,
-			errMsg:  "localhost and loopback addresses are not allowed",
+			wantErr: false,
 		},
 		{
 			name:    "localhost with port",
 			url:     "http://localhost:8080",
-			wantErr: true,
-			errMsg:  "localhost and loopback addresses are not allowed",
+			wantErr: false,
 		},
 		{
 			name:    "loopback 127.0.0.1",
 			url:     "http://127.0.0.1",
-			wantErr: true,
-			errMsg:  "localhost and loopback addresses are not allowed",
+			wantErr: false,
 		},
 		{
 			name:    "loopback ::1",
 			url:     "http://[::1]",
-			wantErr: true,
-			errMsg:  "localhost and loopback addresses are not allowed",
+			wantErr: false,
 		},
 		{
 			name:    "all-zeros 0.0.0.0",
 			url:     "http://0.0.0.0",
 			wantErr: true,
-			errMsg:  "localhost and loopback addresses are not allowed",
+			errMsg:  "unspecified IP addresses are not allowed",
 		},
 
 		// Private IP ranges (RFC 1918)
@@ -121,24 +118,24 @@ func TestValidateExternalURL(t *testing.T) {
 			errMsg:  "private IP addresses are not allowed",
 		},
 
-		// Link-local / cloud metadata
+		// Link-local / cloud metadata — always blocked even with AllowPrivateNetwork
 		{
 			name:    "AWS metadata service",
 			url:     "http://169.254.169.254",
 			wantErr: true,
-			errMsg:  "private IP addresses are not allowed",
+			errMsg:  "link-local IP addresses are not allowed",
 		},
 		{
 			name:    "AWS metadata with path",
 			url:     "http://169.254.169.254/latest/meta-data/",
 			wantErr: true,
-			errMsg:  "private IP addresses are not allowed",
+			errMsg:  "link-local IP addresses are not allowed",
 		},
 		{
 			name:    "link-local 169.254.x.x",
 			url:     "http://169.254.1.1",
 			wantErr: true,
-			errMsg:  "private IP addresses are not allowed",
+			errMsg:  "link-local IP addresses are not allowed",
 		},
 
 		// Query-parameter injection (the PoC vector from the advisory)
@@ -146,7 +143,7 @@ func TestValidateExternalURL(t *testing.T) {
 			name:    "query param injection targeting metadata service",
 			url:     "http://169.254.169.254/latest/meta-data/iam/security-credentials/role?x=",
 			wantErr: true,
-			errMsg:  "private IP addresses are not allowed",
+			errMsg:  "link-local IP addresses are not allowed",
 		},
 		{
 			name:    "query param injection targeting internal host",
@@ -154,11 +151,39 @@ func TestValidateExternalURL(t *testing.T) {
 			wantErr: true,
 			errMsg:  "private IP addresses are not allowed",
 		},
+
+		// AllowPrivateNetwork=true: RFC 1918 allowed, link-local still blocked
+		{
+			name:                "allow_private_network permits 10.x.x.x",
+			url:                 "http://10.0.0.5:8000",
+			allowPrivateNetwork: true,
+			wantErr:             false,
+		},
+		{
+			name:                "allow_private_network permits 192.168.x.x",
+			url:                 "http://192.168.1.50:11434",
+			allowPrivateNetwork: true,
+			wantErr:             false,
+		},
+		{
+			name:                "allow_private_network still blocks 169.254.169.254",
+			url:                 "http://169.254.169.254",
+			allowPrivateNetwork: true,
+			wantErr:             true,
+			errMsg:              "link-local IP addresses are not allowed",
+		},
+		{
+			name:                "allow_private_network still blocks 0.0.0.0",
+			url:                 "http://0.0.0.0",
+			allowPrivateNetwork: true,
+			wantErr:             true,
+			errMsg:              "unspecified IP addresses are not allowed",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateExternalURL(tt.url)
+			err := ValidateExternalURL(tt.url, tt.allowPrivateNetwork)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error containing %q, got nil", tt.errMsg)

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -65837,6 +65837,11 @@
           "ca_cert_pem": {
             "type": "string",
             "description": "PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA)"
+          },
+          "allow_private_network": {
+            "type": "boolean",
+            "default": false,
+            "description": "Allow connections to RFC 1918 private IPs (10.x, 172.16.x, 192.168.x). Enable for providers on a k8s pod network, LAN, or private VPC. Loopback addresses (localhost, 127.0.0.1, ::1) remain allowed regardless of this setting. Link-local addresses (169.254.x.x) are always blocked."
           }
         }
       },

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -37,6 +37,10 @@ NetworkConfig:
     ca_cert_pem:
       type: string
       description: PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA)
+    allow_private_network:
+      type: boolean
+      default: false
+      description: Allow connections to RFC 1918 private IPs (10.x, 172.16.x, 192.168.x). Enable for providers on a k8s pod network, LAN, or private VPC. Loopback addresses (localhost, 127.0.0.1, ::1) remain allowed regardless of this setting. Link-local addresses (169.254.x.x) are always blocked.
 
 ConcurrencyAndBufferSize:
   type: object

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -282,7 +282,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		if payload.NetworkConfig.BaseURL != "" {
-			if err := bifrost.ValidateExternalURL(payload.NetworkConfig.BaseURL); err != nil {
+			if err := bifrost.ValidateExternalURL(payload.NetworkConfig.BaseURL, payload.NetworkConfig.AllowPrivateNetwork); err != nil {
 				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid base URL: %v", err))
 				return
 			}
@@ -456,7 +456,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	if nc.BaseURL != "" {
-		if err := bifrost.ValidateExternalURL(nc.BaseURL); err != nil {
+		if err := bifrost.ValidateExternalURL(nc.BaseURL, nc.AllowPrivateNetwork); err != nil {
 			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid base URL: %v", err))
 			return
 		}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2088,6 +2088,11 @@
             "type": "boolean"
           },
           "description": "Override default Anthropic beta header support per provider. Keys are header prefixes (e.g. 'redact-thinking-'), values are true (supported) or false (unsupported). Headers not listed use the built-in defaults."
+        },
+        "allow_private_network": {
+          "type": "boolean",
+          "description": "Allow connections to RFC 1918 private IPs (10.x, 172.16.x, 192.168.x). Enable for providers on a k8s pod network, LAN, or private VPC. Loopback addresses (localhost, 127.0.0.1, ::1) remain allowed regardless of this setting. Link-local addresses (169.254.x.x) are always blocked.",
+          "default": false
         }
       },
       "additionalProperties": false
@@ -2152,6 +2157,11 @@
             "type": "boolean"
           },
           "description": "Override default Anthropic beta header support per provider. Keys are header prefixes (e.g. 'redact-thinking-'), values are true (supported) or false (unsupported). Headers not listed use the built-in defaults."
+        },
+        "allow_private_network": {
+          "type": "boolean",
+          "description": "Allow connections to RFC 1918 private IPs (10.x, 172.16.x, 192.168.x). Enable for providers on a k8s pod network, LAN, or private VPC. Loopback addresses (localhost, 127.0.0.1, ::1) remain allowed regardless of this setting. Link-local addresses (169.254.x.x) are always blocked.",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -78,6 +78,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 					provider.network_config?.stream_idle_timeout_in_seconds ?? DefaultNetworkConfig.stream_idle_timeout_in_seconds,
 				max_conns_per_host: provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
 				enforce_http2: provider.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
+				allow_private_network: provider.network_config?.allow_private_network ?? DefaultNetworkConfig.allow_private_network,
 			},
 		},
 	});
@@ -112,6 +113,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 					data.network_config?.stream_idle_timeout_in_seconds ?? DefaultNetworkConfig.stream_idle_timeout_in_seconds,
 				max_conns_per_host: data.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
 				enforce_http2: data.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
+				allow_private_network: data.network_config?.allow_private_network ?? DefaultNetworkConfig.allow_private_network,
 			},
 		});
 		updateProvider(updatedProvider)
@@ -144,6 +146,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 					provider.network_config?.stream_idle_timeout_in_seconds ?? DefaultNetworkConfig.stream_idle_timeout_in_seconds,
 				max_conns_per_host: provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
 				enforce_http2: provider.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
+				allow_private_network: provider.network_config?.allow_private_network ?? DefaultNetworkConfig.allow_private_network,
 			},
 		});
 	}, [form, provider.name, provider.network_config]);
@@ -392,6 +395,29 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 											onCheckedChange={field.onChange}
 											disabled={!hasUpdateProviderAccess}
 											data-testid="network-config-enforce-http2"
+										/>
+									</FormControl>
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="network_config.allow_private_network"
+							render={({ field }) => (
+								<FormItem className="flex flex-row items-center justify-between">
+									<div className="space-y-0.5">
+										<FormLabel>Allow Private Network</FormLabel>
+										<FormDescription>
+											Allow connections to private IPs (e.g. <code>10.x</code>, <code>192.168.x</code>). Required for providers on a
+											LAN, k8s pod network, or private VPC. Cloud metadata addresses (169.254.x.x) are always blocked.
+										</FormDescription>
+									</div>
+									<FormControl>
+										<Switch
+											checked={field.value ?? false}
+											onCheckedChange={field.onChange}
+											disabled={!hasUpdateProviderAccess}
+											data-testid="network-config-allow-private-network"
 										/>
 									</FormControl>
 								</FormItem>

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -88,6 +88,7 @@ export const DefaultNetworkConfig = {
 	stream_idle_timeout_in_seconds: 60,
 	max_conns_per_host: 5000,
 	enforce_http2: false,
+	allow_private_network: false,
 } satisfies NetworkConfig;
 
 export const DefaultPerformanceConfig = {

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -177,6 +177,7 @@ export interface NetworkConfig {
 	max_conns_per_host?: number;
 	enforce_http2?: boolean;
 	beta_header_overrides?: Record<string, boolean>;
+	allow_private_network?: boolean;
 }
 
 // ConcurrencyAndBufferSize matching Go's schemas.ConcurrencyAndBufferSize

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -327,6 +327,7 @@ export const networkConfigSchema = z
 			.max(10000, "Max connections must be at most 10000")
 			.optional(),
 		enforce_http2: z.boolean().optional(),
+		allow_private_network: z.boolean().optional(),
 	})
 	.refine((d) => d.retry_backoff_initial <= d.retry_backoff_max, {
 		message: "retry_backoff_initial must be <= retry_backoff_max",
@@ -379,6 +380,7 @@ export const networkFormConfigSchema = z
 			.max(10000, "Max connections must be at most 10000")
 			.optional(),
 		enforce_http2: z.boolean().optional(),
+		allow_private_network: z.boolean().optional(),
 	})
 	.refine((d) => d.retry_backoff_initial <= d.retry_backoff_max, {
 		message: "Initial backoff must be less than or equal to max backoff",


### PR DESCRIPTION
## Summary

A new `allow_private_network` configuration option has been added to `NetworkConfig`, giving operators explicit control over whether provider connections may target RFC 1918 private IP ranges (e.g. `10.x`, `172.16.x`, `192.168.x`). This is required for deployments where providers run on a Kubernetes pod network, LAN, or private VPC. Loopback addresses (`localhost`, `127.0.0.1`, `::1`) are now unconditionally permitted. Link-local addresses (`169.254.x.x`, `fe80::`) and unspecified addresses (`0.0.0.0`, `::`) are always blocked regardless of this setting, protecting cloud instance metadata endpoints.

## Changes

- Added `AllowPrivateNetwork bool` to `NetworkConfig` in `core/schemas/provider.go`, with full JSON marshal/unmarshal support.
- Added `IsLinkLocal` to `core/network/utils.go` with a dedicated `169.254.0.0/16` subnet check for IPv4 and `IsLinkLocalUnicast()` for IPv6, separating link-local blocking from the general private-IP check.
- Updated `ConfigureDialer` in `core/providers/utils/utils.go` to accept `allowPrivateNetwork bool`. Unspecified and link-local IPs are always rejected; loopback is always allowed; RFC 1918 ranges are only rejected when `allowPrivateNetwork` is `false`.
- Removed the `IsLocalhost` pre-check from `ValidateExternalURL` in `core/utils.go`. Loopback addresses now pass validation. Unspecified and link-local addresses are checked explicitly with distinct error messages.
- Updated `ValidateExternalURL` signature to accept `allowPrivateNetwork bool` and propagated the flag through all call sites in the HTTP transport handlers.
- Passed `config.NetworkConfig.AllowPrivateNetwork` to `ConfigureDialer` across all provider constructors (Anthropic, Azure, Bedrock, Cerebras, Cohere, ElevenLabs, Fireworks, Gemini, Groq, HuggingFace, Mistral, Nebius, Ollama, OpenAI, OpenRouter, Parasail, Perplexity, Replicate, Runway, SGL, Vertex, vLLM, xAI).
- Added `allow_private_network` to `transports/config.schema.json` in both provider definition locations.
- Added an "Allow Private Network" toggle to the provider network configuration form in the UI (`networkFormFragment.tsx`), with updated type definitions and Zod schemas.
- Removed workarounds in dialer tests that pre-set `client.Dial` to bypass SSRF protection for `httptest` servers on `127.0.0.1`. Tests now exercise the direct connection path. Added a `without_existing_dial` sub-test to `TestConfigureDialer_TCPKeepAliveEnabled`. Updated SSRF test cases to reflect new error message strings (`link-local IP`, `unspecified IP`) and removed loopback cases that are no longer blocked.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/... ./core/providers/utils/...
```

Configure a provider with `"allow_private_network": true` and a `base_url` pointing to a private IP (e.g. `http://10.0.0.5:8000`). Verify the URL passes `ValidateExternalURL` and connections succeed. Verify that `http://169.254.169.254` is still rejected with a `link-local IP addresses are not allowed` error even when `allow_private_network` is `true`. Verify that `http://localhost:11434` passes validation regardless of the setting.

## Breaking changes

- [x] Yes
- [ ] No

`ValidateExternalURL` now takes a second `allowPrivateNetwork bool` argument. Any direct callers outside this repository must be updated. Additionally, loopback addresses (`localhost`, `127.0.0.1`, `::1`) are no longer rejected by `ValidateExternalURL` or `ConfigureDialer`. Deployments that relied on loopback blocking as a security boundary should note this change.

## Security considerations

Link-local addresses (`169.254.x.x`, `fe80::`) are split out into a dedicated `IsLinkLocal` check and are **always** blocked, even when `allow_private_network` is `true`. This ensures cloud instance metadata endpoints (AWS `169.254.169.254`, Azure IMDS, GCP metadata) cannot be reached under any operator configuration. Unspecified addresses (`0.0.0.0`, `::`) are also always blocked. RFC 1918 private ranges are only reachable when an operator explicitly sets `allow_private_network: true`, making the security trade-off an intentional, visible configuration decision rather than a silent bypass.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `allow_private_network` configuration option to network settings, enabling providers to connect to RFC1918 private IP ranges when explicitly enabled.
  * Loopback addresses (localhost, 127.0.0.1, ::1) are now always permitted, regardless of settings.

* **Bug Fixes**
  * Improved SSRF protection: link-local and unspecified IPs remain unconditionally blocked for security, while private IP blocking is now configurable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->