### PR TITLE
fix(gemini): accept numeric schema integer constraints

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/internal/llmtests"
 	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/stretchr/testify/assert"
@@ -430,6 +431,105 @@ func TestThoughtSignatureBypassSentinelRoundTripsThroughJSON(t *testing.T) {
 	var decoded gemini.Part
 	require.NoError(t, json.Unmarshal(encoded, &decoded))
 	assert.Equal(t, []byte("skip_thought_signature_validator"), decoded.ThoughtSignature)
+}
+
+func TestGeminiGenerationRequestUnmarshalAcceptsSchemaIntegerConstraints(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "numeric constraints",
+			body: `{
+				"contents": [{"role": "user", "parts": [{"text": "Search docs"}]}],
+				"tools": [{
+					"functionDeclarations": [{
+						"name": "exa_web_search_exa",
+						"description": "Search project docs",
+						"parameters": {
+							"type": "object",
+							"minProperties": 1,
+							"maxProperties": 3,
+							"properties": {
+								"query": {"type": "string", "description": "Search query", "minLength": 1, "maxLength": 100},
+								"tags": {"type": "array", "items": {"type": "string"}, "minItems": 1, "maxItems": 5}
+							},
+							"required": ["query"]
+						}
+					}]
+				}]
+			}`,
+		},
+		{
+			name: "quoted constraints",
+			body: `{
+				"contents": [{"role": "user", "parts": [{"text": "Search docs"}]}],
+				"tools": [{
+					"functionDeclarations": [{
+						"name": "exa_web_search_exa",
+						"description": "Search project docs",
+						"parameters": {
+							"type": "object",
+							"minProperties": "1",
+							"maxProperties": "3",
+							"properties": {
+								"query": {"type": "string", "description": "Search query", "minLength": "1", "maxLength": "100"},
+								"tags": {"type": "array", "items": {"type": "string"}, "minItems": "1", "maxItems": "5"}
+							},
+							"required": ["query"]
+						}
+					}]
+				}]
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req gemini.GeminiGenerationRequest
+			require.NoError(t, sonic.Unmarshal([]byte(tt.body), &req))
+			require.Len(t, req.Tools, 1)
+			require.Len(t, req.Tools[0].FunctionDeclarations, 1)
+
+			params := req.Tools[0].FunctionDeclarations[0].Parameters
+			require.NotNil(t, params)
+			require.NotNil(t, params.MinProperties)
+			require.NotNil(t, params.MaxProperties)
+			assert.Equal(t, int64(1), *params.MinProperties)
+			assert.Equal(t, int64(3), *params.MaxProperties)
+
+			query := params.Properties["query"]
+			require.NotNil(t, query)
+			require.NotNil(t, query.MinLength)
+			require.NotNil(t, query.MaxLength)
+			assert.Equal(t, int64(1), *query.MinLength)
+			assert.Equal(t, int64(100), *query.MaxLength)
+
+			tags := params.Properties["tags"]
+			require.NotNil(t, tags)
+			require.NotNil(t, tags.MinItems)
+			require.NotNil(t, tags.MaxItems)
+			assert.Equal(t, int64(1), *tags.MinItems)
+			assert.Equal(t, int64(5), *tags.MaxItems)
+		})
+	}
+
+	var req gemini.GeminiGenerationRequest
+	err := sonic.Unmarshal([]byte(`{
+		"tools": [{
+			"functionDeclarations": [{
+				"name": "exa_web_search_exa",
+				"parameters": {
+					"type": "object",
+					"properties": {
+						"query": {"type": "string", "minLength": "many"}
+					}
+				}
+			}]
+		}]
+	}`), &req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid schema integer constraint")
 }
 
 // parseToolParams parses fd.ParametersJSONSchema (raw JSON Schema passthrough) into a

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -514,22 +514,24 @@ func TestGeminiGenerationRequestUnmarshalAcceptsSchemaIntegerConstraints(t *test
 		})
 	}
 
-	var req gemini.GeminiGenerationRequest
-	err := sonic.Unmarshal([]byte(`{
-		"tools": [{
-			"functionDeclarations": [{
-				"name": "exa_web_search_exa",
-				"parameters": {
-					"type": "object",
-					"properties": {
-						"query": {"type": "string", "minLength": "many"}
+	t.Run("invalid string constraint", func(t *testing.T) {
+		var req gemini.GeminiGenerationRequest
+		err := sonic.Unmarshal([]byte(`{
+			"tools": [{
+				"functionDeclarations": [{
+					"name": "exa_web_search_exa",
+					"parameters": {
+						"type": "object",
+						"properties": {
+							"query": {"type": "string", "minLength": "many"}
+						}
 					}
-				}
+				}]
 			}]
-		}]
-	}`), &req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid schema integer constraint")
+		}`), &req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid schema integer constraint")
+	})
 }
 
 // parseToolParams parses fd.ParametersJSONSchema (raw JSON Schema passthrough) into a

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -532,6 +532,79 @@ func TestGeminiGenerationRequestUnmarshalAcceptsSchemaIntegerConstraints(t *test
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid schema integer constraint")
 	})
+
+	t.Run("max int64 numeric constraint", func(t *testing.T) {
+		var req gemini.GeminiGenerationRequest
+		require.NoError(t, sonic.Unmarshal([]byte(`{
+			"tools": [{
+				"functionDeclarations": [{
+					"name": "exa_web_search_exa",
+					"parameters": {
+						"type": "object",
+						"properties": {
+							"query": {"type": "string", "maxLength": 9223372036854775807}
+						}
+					}
+				}]
+			}]
+		}`), &req))
+
+		query := req.Tools[0].FunctionDeclarations[0].Parameters.Properties["query"]
+		require.NotNil(t, query.MaxLength)
+		assert.Equal(t, int64(9223372036854775807), *query.MaxLength)
+	})
+
+	t.Run("null constraint remains unset", func(t *testing.T) {
+		var req gemini.GeminiGenerationRequest
+		require.NoError(t, sonic.Unmarshal([]byte(`{
+			"tools": [{
+				"functionDeclarations": [{
+					"name": "exa_web_search_exa",
+					"parameters": {
+						"type": "object",
+						"properties": {
+							"query": {"type": "string", "minLength": null}
+						}
+					}
+				}]
+			}]
+		}`), &req))
+
+		query := req.Tools[0].FunctionDeclarations[0].Parameters.Properties["query"]
+		assert.Nil(t, query.MinLength)
+	})
+
+	invalidConstraints := []struct {
+		name       string
+		constraint string
+	}{
+		{name: "float", constraint: `1.5`},
+		{name: "bool", constraint: `true`},
+		{name: "object", constraint: `{}`},
+		{name: "array", constraint: `[]`},
+		{name: "overflow string", constraint: `"9223372036854775808"`},
+	}
+
+	for _, tt := range invalidConstraints {
+		t.Run("invalid "+tt.name+" constraint", func(t *testing.T) {
+			var req gemini.GeminiGenerationRequest
+			err := sonic.Unmarshal([]byte(`{
+				"tools": [{
+					"functionDeclarations": [{
+						"name": "exa_web_search_exa",
+						"parameters": {
+							"type": "object",
+							"properties": {
+								"query": {"type": "string", "minLength": `+tt.constraint+`}
+							}
+						}
+					}]
+				}]
+			}`), &req)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid schema integer constraint")
+		})
+	}
 }
 
 // parseToolParams parses fd.ParametersJSONSchema (raw JSON Schema passthrough) into a

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -830,10 +830,10 @@ const (
 type TrafficType string
 
 const (
-	TrafficTypeUnspecified          TrafficType = "TRAFFIC_TYPE_UNSPECIFIED"
-	TrafficTypeOnDemand             TrafficType = "ON_DEMAND"
-	TrafficTypeOnDemandPriority     TrafficType = "ON_DEMAND_PRIORITY"
-	TrafficTypeOnDemandFlex         TrafficType = "ON_DEMAND_FLEX"
+	TrafficTypeUnspecified           TrafficType = "TRAFFIC_TYPE_UNSPECIFIED"
+	TrafficTypeOnDemand              TrafficType = "ON_DEMAND"
+	TrafficTypeOnDemandPriority      TrafficType = "ON_DEMAND_PRIORITY"
+	TrafficTypeOnDemandFlex          TrafficType = "ON_DEMAND_FLEX"
 	TrafficTypeProvisionedThroughput TrafficType = "PROVISIONED_THROUGHPUT"
 )
 
@@ -995,6 +995,98 @@ type Schema struct {
 	Title string `json:"title,omitempty"`
 	// Optional. The type of the data.
 	Type Type `json:"type,omitempty"`
+}
+
+type flexibleSchemaInt64 int64
+
+func (i *flexibleSchemaInt64) UnmarshalJSON(data []byte) error {
+	raw := strings.TrimSpace(string(data))
+	if raw == "" || raw == "null" {
+		return nil
+	}
+
+	if strings.HasPrefix(raw, "\"") {
+		var value string
+		if err := sonic.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		raw = strings.TrimSpace(value)
+	}
+
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid schema integer constraint %q: %w", raw, err)
+	}
+
+	*i = flexibleSchemaInt64(value)
+	return nil
+}
+
+func schemaInt64Ptr(value *flexibleSchemaInt64) *int64 {
+	if value == nil {
+		return nil
+	}
+	out := int64(*value)
+	return &out
+}
+
+// UnmarshalJSON accepts both the quoted integer format emitted by this struct's
+// JSON tags and standard numeric JSON Schema constraints used by SDKs.
+func (s *Schema) UnmarshalJSON(data []byte) error {
+	type schemaAlias struct {
+		AnyOf            []*Schema            `json:"anyOf,omitempty"`
+		Default          any                  `json:"default,omitempty"`
+		Description      string               `json:"description,omitempty"`
+		Enum             []string             `json:"enum,omitempty"`
+		Example          any                  `json:"example,omitempty"`
+		Format           string               `json:"format,omitempty"`
+		Items            *Schema              `json:"items,omitempty"`
+		MaxItems         *flexibleSchemaInt64 `json:"maxItems,omitempty"`
+		MaxLength        *flexibleSchemaInt64 `json:"maxLength,omitempty"`
+		MaxProperties    *flexibleSchemaInt64 `json:"maxProperties,omitempty"`
+		Maximum          *float64             `json:"maximum,omitempty"`
+		MinItems         *flexibleSchemaInt64 `json:"minItems,omitempty"`
+		MinLength        *flexibleSchemaInt64 `json:"minLength,omitempty"`
+		MinProperties    *flexibleSchemaInt64 `json:"minProperties,omitempty"`
+		Minimum          *float64             `json:"minimum,omitempty"`
+		Nullable         *bool                `json:"nullable,omitempty"`
+		Pattern          string               `json:"pattern,omitempty"`
+		Properties       map[string]*Schema   `json:"properties,omitempty"`
+		PropertyOrdering []string             `json:"propertyOrdering,omitempty"`
+		Required         []string             `json:"required,omitempty"`
+		Title            string               `json:"title,omitempty"`
+		Type             Type                 `json:"type,omitempty"`
+	}
+
+	var aux schemaAlias
+	if err := sonic.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	s.AnyOf = aux.AnyOf
+	s.Default = aux.Default
+	s.Description = aux.Description
+	s.Enum = aux.Enum
+	s.Example = aux.Example
+	s.Format = aux.Format
+	s.Items = aux.Items
+	s.MaxItems = schemaInt64Ptr(aux.MaxItems)
+	s.MaxLength = schemaInt64Ptr(aux.MaxLength)
+	s.MaxProperties = schemaInt64Ptr(aux.MaxProperties)
+	s.Maximum = aux.Maximum
+	s.MinItems = schemaInt64Ptr(aux.MinItems)
+	s.MinLength = schemaInt64Ptr(aux.MinLength)
+	s.MinProperties = schemaInt64Ptr(aux.MinProperties)
+	s.Minimum = aux.Minimum
+	s.Nullable = aux.Nullable
+	s.Pattern = aux.Pattern
+	s.Properties = aux.Properties
+	s.PropertyOrdering = aux.PropertyOrdering
+	s.Required = aux.Required
+	s.Title = aux.Title
+	s.Type = aux.Type
+
+	return nil
 }
 
 // Type represents the type of the data.

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1033,58 +1033,30 @@ func schemaInt64Ptr(value *flexibleSchemaInt64) *int64 {
 // UnmarshalJSON accepts both the quoted integer format emitted by this struct's
 // JSON tags and standard numeric JSON Schema constraints used by SDKs.
 func (s *Schema) UnmarshalJSON(data []byte) error {
-	type schemaAlias struct {
-		AnyOf            []*Schema            `json:"anyOf,omitempty"`
-		Default          any                  `json:"default,omitempty"`
-		Description      string               `json:"description,omitempty"`
-		Enum             []string             `json:"enum,omitempty"`
-		Example          any                  `json:"example,omitempty"`
-		Format           string               `json:"format,omitempty"`
-		Items            *Schema              `json:"items,omitempty"`
-		MaxItems         *flexibleSchemaInt64 `json:"maxItems,omitempty"`
-		MaxLength        *flexibleSchemaInt64 `json:"maxLength,omitempty"`
-		MaxProperties    *flexibleSchemaInt64 `json:"maxProperties,omitempty"`
-		Maximum          *float64             `json:"maximum,omitempty"`
-		MinItems         *flexibleSchemaInt64 `json:"minItems,omitempty"`
-		MinLength        *flexibleSchemaInt64 `json:"minLength,omitempty"`
-		MinProperties    *flexibleSchemaInt64 `json:"minProperties,omitempty"`
-		Minimum          *float64             `json:"minimum,omitempty"`
-		Nullable         *bool                `json:"nullable,omitempty"`
-		Pattern          string               `json:"pattern,omitempty"`
-		Properties       map[string]*Schema   `json:"properties,omitempty"`
-		PropertyOrdering []string             `json:"propertyOrdering,omitempty"`
-		Required         []string             `json:"required,omitempty"`
-		Title            string               `json:"title,omitempty"`
-		Type             Type                 `json:"type,omitempty"`
+	type schemaAlias Schema
+	type schemaWithFlexibleConstraints struct {
+		*schemaAlias
+		MaxItems      *flexibleSchemaInt64 `json:"maxItems,omitempty"`
+		MaxLength     *flexibleSchemaInt64 `json:"maxLength,omitempty"`
+		MaxProperties *flexibleSchemaInt64 `json:"maxProperties,omitempty"`
+		MinItems      *flexibleSchemaInt64 `json:"minItems,omitempty"`
+		MinLength     *flexibleSchemaInt64 `json:"minLength,omitempty"`
+		MinProperties *flexibleSchemaInt64 `json:"minProperties,omitempty"`
 	}
 
 	var aux schemaAlias
-	if err := sonic.Unmarshal(data, &aux); err != nil {
+	withConstraints := schemaWithFlexibleConstraints{schemaAlias: &aux}
+	if err := sonic.Unmarshal(data, &withConstraints); err != nil {
 		return err
 	}
 
-	s.AnyOf = aux.AnyOf
-	s.Default = aux.Default
-	s.Description = aux.Description
-	s.Enum = aux.Enum
-	s.Example = aux.Example
-	s.Format = aux.Format
-	s.Items = aux.Items
-	s.MaxItems = schemaInt64Ptr(aux.MaxItems)
-	s.MaxLength = schemaInt64Ptr(aux.MaxLength)
-	s.MaxProperties = schemaInt64Ptr(aux.MaxProperties)
-	s.Maximum = aux.Maximum
-	s.MinItems = schemaInt64Ptr(aux.MinItems)
-	s.MinLength = schemaInt64Ptr(aux.MinLength)
-	s.MinProperties = schemaInt64Ptr(aux.MinProperties)
-	s.Minimum = aux.Minimum
-	s.Nullable = aux.Nullable
-	s.Pattern = aux.Pattern
-	s.Properties = aux.Properties
-	s.PropertyOrdering = aux.PropertyOrdering
-	s.Required = aux.Required
-	s.Title = aux.Title
-	s.Type = aux.Type
+	*s = Schema(aux)
+	s.MaxItems = schemaInt64Ptr(withConstraints.MaxItems)
+	s.MaxLength = schemaInt64Ptr(withConstraints.MaxLength)
+	s.MaxProperties = schemaInt64Ptr(withConstraints.MaxProperties)
+	s.MinItems = schemaInt64Ptr(withConstraints.MinItems)
+	s.MinLength = schemaInt64Ptr(withConstraints.MinLength)
+	s.MinProperties = schemaInt64Ptr(withConstraints.MinProperties)
 
 	return nil
 }

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -999,27 +999,30 @@ type Schema struct {
 
 type flexibleSchemaInt64 int64
 
+var schemaIntegerJSON = sonic.Config{UseInt64: true}.Froze()
+
 func (i *flexibleSchemaInt64) UnmarshalJSON(data []byte) error {
-	raw := strings.TrimSpace(string(data))
-	if raw == "" || raw == "null" {
+	var value any
+	if err := schemaIntegerJSON.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("invalid schema integer constraint: %w", err)
+	}
+
+	switch typedValue := value.(type) {
+	case nil:
 		return nil
-	}
-
-	if strings.HasPrefix(raw, "\"") {
-		var value string
-		if err := sonic.Unmarshal(data, &value); err != nil {
-			return err
+	case int64:
+		*i = flexibleSchemaInt64(typedValue)
+		return nil
+	case string:
+		parsed, err := strconv.ParseInt(typedValue, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid schema integer constraint %q: %w", typedValue, err)
 		}
-		raw = strings.TrimSpace(value)
+		*i = flexibleSchemaInt64(parsed)
+		return nil
+	default:
+		return fmt.Errorf("invalid schema integer constraint %v", typedValue)
 	}
-
-	value, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid schema integer constraint %q: %w", raw, err)
-	}
-
-	*i = flexibleSchemaInt64(value)
-	return nil
 }
 
 func schemaInt64Ptr(value *flexibleSchemaInt64) *int64 {


### PR DESCRIPTION
Fixes #3993.

## Summary

- add custom Gemini `Schema` unmarshalling for JSON Schema integer constraint fields
- accept both standard numeric values and quoted int64 strings for `maxItems`, `maxLength`, `maxProperties`, `minItems`, `minLength`, and `minProperties`
- keep invalid string values rejected with an explicit schema integer constraint error
- add regression coverage for numeric constraints, quoted constraints, and invalid strings

## Why

Some Gemini GenAI clients emit tool/function declaration schemas with standard JSON Schema numeric constraints, for example `minLength: 1`. Bifrost previously rejected those requests during request parsing because these fields used Go JSON `,string` tags and only accepted quoted values such as `"1"`.

Google's REST docs document the canonical int64 wire form as a string, but the public Gemini API accepts both quoted and numeric forms in practice. Accepting both keeps Bifrost compatible with the documented form and with common JSON Schema producers.

## Tests

- `go test ./providers/gemini -run TestGeminiGenerationRequestUnmarshalAcceptsSchemaIntegerConstraints -count=1`
- `go test ./providers/gemini -run 'TestGeminiGenerationRequestUnmarshalAcceptsSchemaIntegerConstraints|TestBifrostToGeminiToolConversion' -count=1`

Known unrelated local note: full `go test ./providers/gemini -count=1` currently fails on `TestListModelsByKey_ParsesSingleModelPayload`, which is outside this patch.

## Agent Disclosure

This issue and patch were investigated, drafted, and submitted with AI-agent assistance. Focused local regression tests were run before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schema constraint parsing now accepts integer constraints as numbers or quoted strings, treats null as unset, and correctly handles large integer limits to reduce decoding errors.

* **Tests**
  * Added tests covering numeric and quoted-string constraint formats, null handling, large-value acceptance, and clear failures for non-numeric or invalid constraint inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->