### PR TITLE
feat: replace stdio env vars text input with key-value table supporting optional host-env passthrough

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -61,7 +61,9 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 
 	const [isLoading, setIsLoading] = useState(false);
 	const [argsText, setArgsText] = useState("");
-	const [envsText, setEnvsText] = useState("");
+	// STDIO env vars as a name→value map. Empty value = pass the bare name so the
+	// stdio process reads it from Bifrost's host environment.
+	const [envVars, setEnvVars] = useState<Record<string, string>>({});
 	const [scopesText, setScopesText] = useState("");
 	const [oauthFlow, setOauthFlow] = useState<{
 		authorizeUrl: string;
@@ -149,7 +151,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		if (open) {
 			reset(emptyForm);
 			setArgsText("");
-			setEnvsText("");
+			setEnvVars({});
 			setScopesText("");
 			setOauthFlow(null);
 			setHeadersFlow(null);
@@ -224,7 +226,14 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					? {
 						command: data.stdio_config?.command || "",
 						args: parseArrayFromText(argsText),
-						envs: parseArrayFromText(envsText),
+						// Each row becomes KEY=value, or a bare KEY when no value is given
+						// (read from Bifrost's host environment). Rows without a name are skipped.
+						envs: Object.entries(envVars)
+							.filter(([name]) => name.trim() !== "")
+							.map(([name, value]) => {
+								const v = value.trim();
+								return v ? `${name}=${v}` : name;
+							}),
 					}
 					: undefined,
 			tls_config:
@@ -842,12 +851,25 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 
 									{/* Envs (local state) */}
 									<div className="space-y-2">
-										<Label>Environment Variables (comma-separated)</Label>
-										<Input
-											value={envsText}
-											onChange={(e) => setEnvsText(e.target.value)}
-											placeholder="API_KEY, DATABASE_URL"
-											data-testid="stdio-envs-input"
+										<div className="flex items-center gap-2">
+											<Label>Environment Variables</Label>
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+													</TooltipTrigger>
+													<TooltipContent className="max-w-xs">
+														<p>Add a value for each variable, or leave it blank to read the value from the environment where Bifrost runs.</p>
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
+										</div>
+										<HeadersTable
+											value={envVars}
+											onChange={setEnvVars}
+											keyPlaceholder="API_KEY"
+											valuePlaceholder="Value (or leave blank to use host env)"
+											label=""
 										/>
 									</div>
 								</>

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -504,6 +504,26 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess, on
 										</span>
 									</div>
 								</div>
+								{mcpClient.config.connection_type === "stdio" &&
+									mcpClient.config.stdio_config?.envs &&
+									mcpClient.config.stdio_config.envs.length > 0 && (
+									<div className="space-y-2">
+										<div className="text-sm font-medium">Environment Variables</div>
+										<HeadersTable
+											value={Object.fromEntries(
+												mcpClient.config.stdio_config.envs.map((env) => {
+													const [name, ...valueParts] = env.split("=");
+													return [name, valueParts.join("=")];
+												}),
+											)}
+											onChange={noop}
+											fixedKeys={mcpClient.config.stdio_config.envs.map((env) => env.split("=")[0])}
+											valuePlaceholder="—"
+											label=""
+											disabled
+										/>
+									</div>
+								)}
 								<FormField
 									control={form.control}
 									name="is_code_mode_client"

--- a/ui/components/ui/headersTable.tsx
+++ b/ui/components/ui/headersTable.tsx
@@ -26,6 +26,13 @@ interface HeadersTableProps<T extends HeaderValue> {
 	label?: string;
 	disabled?: boolean;
 	useEnvVarInput?: boolean;
+	/**
+	 * When provided, the table renders exactly these keys as read-only,
+	 * non-deletable rows (no trailing "add" row). Values stay editable unless
+	 * `disabled` is set. Use this for fixed-schema key sets like a stdio
+	 * server's required environment variables.
+	 */
+	fixedKeys?: string[];
 	/** Optional custom renderer for the key (name) cell input */
 	renderKeyInput?: (params: CellRenderParams) => React.ReactNode;
 	/** Optional custom renderer for the value cell input */
@@ -64,6 +71,7 @@ export function HeadersTable<T extends HeaderValue>({
 	label = "Headers",
 	disabled = false,
 	useEnvVarInput,
+	fixedKeys,
 	renderKeyInput,
 	renderValueInput,
 }: HeadersTableProps<T>) {
@@ -85,11 +93,16 @@ export function HeadersTable<T extends HeaderValue>({
 		return "" as T;
 	};
 
+	const isFixedKeys = Array.isArray(fixedKeys);
+
 	// Convert headers object to array format for table display
 	// Filter out any empty string keys from stored headers
 	const headerEntries = Object.entries(value || {});
-	// Always show at least one empty row at the bottom
-	const rows: [string, T][] = [...headerEntries, ["", getEmptyValue()]];
+	// In fixed-keys mode the rows are exactly the supplied keys (read-only,
+	// no trailing add-row). Otherwise always show one empty row at the bottom.
+	const rows: [string, T][] = fixedKeys
+		? fixedKeys.map((key) => [key, (value?.[key] ?? getEmptyValue())] as [string, T])
+		: [...headerEntries, ["", getEmptyValue()]];
 
 	const handleKeyChange = (oldKey: string, newKey: string, currentValue: T, rowIndex: number) => {
 		// Check if newKey already exists (and it's not the current row's original key)
@@ -203,9 +216,11 @@ export function HeadersTable<T extends HeaderValue>({
 						<TableRow>
 							<TableHead className="w-[40%] px-4 py-2">Name</TableHead>
 							<TableHead className="px-4 py-2">Value</TableHead>
-							<TableHead className="w-10 p-0">
-								<span className="sr-only">Actions</span>
-							</TableHead>
+							{!isFixedKeys && (
+								<TableHead className="w-10 p-0">
+									<span className="sr-only">Actions</span>
+								</TableHead>
+							)}
 						</TableRow>
 					</TableHeader>
 					<TableBody>
@@ -237,6 +252,14 @@ export function HeadersTable<T extends HeaderValue>({
 													disabled,
 													rowKey: key,
 												})
+											) : isFixedKeys ? (
+												<Input
+													value={key}
+													readOnly
+													data-row={index}
+													data-column="key"
+													className="border-0 font-mono text-xs focus-visible:ring-0 focus-visible:ring-offset-0"
+												/>
 											) : (
 												<Input
 													placeholder={keyPlaceholder}
@@ -285,13 +308,15 @@ export function HeadersTable<T extends HeaderValue>({
 											/>
 										)}
 									</TableCell>
-									<TableCell className="p-0">
-										{!disabled && !isEmptyTrailingRow && (
-											<Button type="button" variant="ghost" size="icon" onClick={() => handleDelete(key, index)} className="h-8 w-8">
-												<Trash className="h-4 w-4" />
-											</Button>
-										)}
-									</TableCell>
+									{!isFixedKeys && (
+										<TableCell className="p-0">
+											{!disabled && !isEmptyTrailingRow && (
+												<Button type="button" variant="ghost" size="icon" onClick={() => handleDelete(key, index)} className="h-8 w-8">
+													<Trash className="h-4 w-4" />
+												</Button>
+											)}
+										</TableCell>
+									)}
 								</TableRow>
 							);
 						})}


### PR DESCRIPTION
## Summary

Replaces the free-text comma-separated environment variables input for STDIO MCP clients with a structured key/value table, allowing users to either supply an explicit value for each variable or leave the value blank to inherit it from Bifrost's host environment.

## Changes

- Replaced the single `envsText` string state with an `envVars` record (`Record<string, string>`) in `mcpClientForm.tsx`. On submit, entries are serialized as `KEY=value` or a bare `KEY` when no value is provided.
- Swapped the plain `<Input>` for a `<HeadersTable>` component in the STDIO env vars section, with a tooltip explaining the blank-value behavior.
- Added a read-only `<HeadersTable>` display of environment variables in `mcpClientSheet.tsx` so existing STDIO client configs render the env vars in the same structured format.
- Extended `HeadersTable` with a `fixedKeys` prop. When set, the table renders exactly those keys as non-deletable, read-only name cells with no trailing add-row, enabling fixed-schema display (e.g., the detail sheet view).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the MCP Registry and create a new STDIO client.
2. In the Environment Variables section, add a row with both a name and a value — confirm it serializes as `KEY=value`.
3. Add a row with only a name and no value — confirm it serializes as a bare `KEY`.
4. Add a row with no name — confirm it is excluded from the submitted payload.
5. Open an existing STDIO client's detail sheet and verify environment variables are displayed in the structured table in a read-only state.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: a single comma-separated text input labeled "Environment Variables (comma-separated)".

After: a structured key/value table with an info tooltip, where leaving the value blank passes the variable name through to the host environment.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Environment variable values entered in the form are stored as part of the MCP client configuration. Leaving a value blank causes the variable to be read from Bifrost's host environment at runtime, which should be considered when auditing what secrets are accessible to STDIO child processes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * STDIO environment input replaced with a structured name→value editor and inline help clarifying blank values are read from the host.
  * STDIO connection details now show environment variables in a read-only table when present.
  * Table component gains a fixed-key display mode for stable, read-only key columns while keeping values editable or disabled as appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->