### PR TITLE
fix(helm): add missing azure_key_config fields to schema

### DIFF
--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3667,6 +3667,25 @@
               "type": "string",
               "description": "Azure endpoint (can use env. prefix)"
             },
+            "client_id": {
+              "type": "string",
+              "description": "Azure client ID for authentication (can use env. prefix)"
+            },
+            "client_secret": {
+              "type": "string",
+              "description": "Azure client secret for authentication (can use env. prefix)"
+            },
+            "tenant_id": {
+              "type": "string",
+              "description": "Azure tenant ID for authentication (can use env. prefix)"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Azure scopes for authentication"
+            },
             "deployments": {
               "type": "object",
               "additionalProperties": {
@@ -3680,6 +3699,11 @@
             }
           },
           "required": ["endpoint"],
+          "dependentRequired": {
+            "client_id": ["client_secret", "tenant_id"],
+            "client_secret": ["client_id", "tenant_id"],
+            "tenant_id": ["client_id", "client_secret"]
+          },
           "additionalProperties": false
         },
         "vertex_key_config": {
@@ -4394,6 +4418,25 @@
                     "type": "string",
                     "description": "Azure endpoint (can use env. prefix)"
                   },
+                  "client_id": {
+                    "type": "string",
+                    "description": "Azure client ID for authentication (can use env. prefix)"
+                  },
+                  "client_secret": {
+                    "type": "string",
+                    "description": "Azure client secret for authentication (can use env. prefix)"
+                  },
+                  "tenant_id": {
+                    "type": "string",
+                    "description": "Azure tenant ID for authentication (can use env. prefix)"
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Azure scopes for authentication"
+                  },
                   "deployments": {
                     "type": "object",
                     "additionalProperties": {
@@ -4405,6 +4448,12 @@
                     "type": "string",
                     "description": "Azure API version"
                   }
+                },
+                "required": ["endpoint"],
+                "dependentRequired": {
+                  "client_id": ["client_secret", "tenant_id"],
+                  "client_secret": ["client_id", "tenant_id"],
+                  "tenant_id": ["client_id", "client_secret"]
                 },
                 "additionalProperties": false
               },


### PR DESCRIPTION
## Summary

The Helm chart's `values.schema.json` is missing four fields in the `azure_key_config` object that exist in the Go `AzureKeyConfig` struct. This causes Helm schema validation to reject valid Azure configurations that include `client_id`, `client_secret`, `tenant_id`, or `scopes`.

## Changes

Added the following fields to `azure_key_config` in `helm-charts/bifrost/values.schema.json` (both `$defs.providerKey` and `$defs.virtualKeyProviderConfig` paths):

- `client_id` (string) - Azure client ID for authentication
- `client_secret` (string) - Azure client secret for authentication
- `tenant_id` (string) - Azure tenant ID for authentication
- `scopes` (array of strings) - Azure scopes for authentication

These match the Go struct in `core/schemas/account.go`:

```go
type AzureKeyConfig struct {
    Endpoint     EnvVar   `json:"endpoint"`
    ClientID     *EnvVar  `json:"client_id,omitempty"`
    ClientSecret *EnvVar  `json:"client_secret,omitempty"`
    TenantID     *EnvVar  `json:"tenant_id,omitempty"`
    Scopes       []string `json:"scopes,omitempty"`
}
```

## How to test

1. Validate the JSON schema is well-formed:
   ```sh
   python3 -c "import json; json.load(open('helm-charts/bifrost/values.schema.json'))"
   ```

2. Verify the new fields appear in both `azure_key_config` locations:
   ```sh
   python3 -c "
   import json
   data = json.load(open('helm-charts/bifrost/values.schema.json'))
   akc1 = data['\$defs']['providerKey']['properties']['azure_key_config']['properties']
   akc2 = data['\$defs']['virtualKeyProviderConfig']['properties']['keys']['items']['properties']['azure_key_config']['properties']
   for f in ['client_id', 'client_secret', 'tenant_id', 'scopes']:
       assert f in akc1, f'Missing {f} in providerKey'
       assert f in akc2, f'Missing {f} in virtualKeyProviderConfig'
   print('All fields present in both locations')
   "
   ```

3. Test Helm chart rendering with an azure_key_config that includes the new fields:
   ```sh
   helm template bifrost helm-charts/bifrost --set 'azure.keys[0].azure_key_config.client_id=test'
   ```

## Type of change

- [x] Bug fix

## Affected areas

- [x] Docs (Helm chart schema)

## Breaking changes

- [x] No

## Related issues

Fixes #3990


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended Helm chart configuration schema to support Azure OAuth credentials (client_id, client_secret, tenant_id, scopes) for provider-level and per-key configurations. Validation now enforces that endpoint stays required and that the three credential fields must be supplied together if any is provided, ensuring consistent Azure auth validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->