### PR TITLE
feat: adds calendar_aligned support to customers

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -843,6 +843,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationMigrateVirtualKeyGovernanceToModelConfigs(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddCustomerCalendarAlignedColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -9459,6 +9462,39 @@ func migrationAddAdditionalAttributesToPricing(ctx context.Context, db *gorm.DB)
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_additional_attributes_to_pricing migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddCustomerCalendarAlignedColumn adds calendar_aligned to governance_customers
+// so customer-level calendar alignment can be persisted. No backfill is needed: the
+// legacy per-budget/per-rate-limit calendar_aligned columns were dropped by
+// drop_legacy_calendar_aligned_columns before this migration runs, and calendar_aligned
+// never worked for customers, so there is no prior behavior to preserve.
+func migrationAddCustomerCalendarAlignedColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_customer_calendar_aligned_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if !mig.HasColumn(&tables.TableCustomer{}, "calendar_aligned") {
+				if err := mig.AddColumn(&tables.TableCustomer{}, "CalendarAligned"); err != nil {
+					return fmt.Errorf("failed to add calendar_aligned column to governance_customers: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if mig.HasColumn(&tables.TableCustomer{}, "calendar_aligned") {
+				return mig.DropColumn(&tables.TableCustomer{}, "calendar_aligned")
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_customer_calendar_aligned_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/customer.go
+++ b/framework/configstore/tables/customer.go
@@ -1,6 +1,10 @@
 package tables
 
-import "time"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // TableCustomer represents a customer entity with budget and rate limit
 type TableCustomer struct {
@@ -15,6 +19,8 @@ type TableCustomer struct {
 	Teams       []TableTeam       `gorm:"foreignKey:CustomerID" json:"teams"`
 	VirtualKeys []TableVirtualKey `gorm:"foreignKey:CustomerID" json:"virtual_keys"`
 
+	CalendarAligned bool `gorm:"default:false" json:"calendar_aligned"`
+
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
 	ConfigHash string `gorm:"type:varchar(255);null" json:"config_hash"`
@@ -25,3 +31,15 @@ type TableCustomer struct {
 
 // TableName sets the table name for each model
 func (TableCustomer) TableName() string { return "governance_customers" }
+
+// AfterFind stamps IsCalendarAligned on the owned budget and rate limit so the
+// reset path (which reads the derived field off those objects) sees the correct value.
+func (c *TableCustomer) AfterFind(tx *gorm.DB) error {
+	if c.Budget != nil {
+		c.Budget.IsCalendarAligned = c.CalendarAligned
+	}
+	if c.RateLimit != nil {
+		c.RateLimit.IsCalendarAligned = c.CalendarAligned
+	}
+	return nil
+}

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -2954,10 +2954,12 @@ func (gs *LocalGovernanceStore) CreateCustomerInMemory(ctx context.Context, cust
 	}
 	// Create associated budget if exists
 	if customer.Budget != nil {
+		customer.Budget.IsCalendarAligned = customer.CalendarAligned
 		gs.budgets.Store(customer.Budget.ID, customer.Budget)
 	}
 	// Create associated rate limit if exists
 	if customer.RateLimit != nil {
+		customer.RateLimit.IsCalendarAligned = customer.CalendarAligned
 		gs.rateLimits.Store(customer.RateLimit.ID, customer.RateLimit)
 	}
 	gs.customers.Store(customer.ID, customer)
@@ -2979,6 +2981,7 @@ func (gs *LocalGovernanceStore) UpdateCustomerInMemory(ctx context.Context, cust
 
 		// Handle budget updates with consistent logic
 		if clone.Budget != nil {
+			clone.Budget.IsCalendarAligned = clone.CalendarAligned
 			// Preserve existing usage from memory when updating customer budget config
 			if existingBudgetValue, exists := gs.budgets.Load(clone.Budget.ID); exists && existingBudgetValue != nil {
 				if existingBudget, ok := existingBudgetValue.(*configstoreTables.TableBudget); ok && existingBudget != nil {
@@ -2999,6 +3002,7 @@ func (gs *LocalGovernanceStore) UpdateCustomerInMemory(ctx context.Context, cust
 
 		// Handle rate limit updates with consistent logic
 		if clone.RateLimit != nil {
+			clone.RateLimit.IsCalendarAligned = clone.CalendarAligned
 			// Preserve existing usage from memory when updating customer rate limit config
 			if existingRateLimitValue, exists := gs.rateLimits.Load(clone.RateLimit.ID); exists && existingRateLimitValue != nil {
 				if existingRateLimit, ok := existingRateLimitValue.(*configstoreTables.TableRateLimit); ok && existingRateLimit != nil {

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -1190,6 +1190,122 @@ func TestCompileAndCacheProgram_EmptyExpression(t *testing.T) {
 	assert.Equal(t, program, program2)
 }
 
+// TestGovernanceStore_Customer_CalendarAligned_CreateInMemory verifies that
+// CreateCustomerInMemory stamps IsCalendarAligned on the in-memory budget and
+// rate limit so ResetExpiredBudgetsInMemory uses the calendar-aligned reset path.
+func TestGovernanceStore_Customer_CalendarAligned_CreateInMemory(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	budgetID := "cust-bud-1"
+	rlID := "cust-rl-1"
+	budget := &configstoreTables.TableBudget{
+		ID:            budgetID,
+		MaxLimit:      100.0,
+		ResetDuration: "1M",
+		LastReset:     time.Now(),
+	}
+	rl := &configstoreTables.TableRateLimit{
+		ID:              rlID,
+		TokenMaxLimit:   ptrInt64(1000),
+		TokenLastReset:  time.Now(),
+		RequestLastReset: time.Now(),
+	}
+	customer := buildCustomer("cust-1", "ACME", budget)
+	customer.CalendarAligned = true
+	customer.RateLimit = rl
+	customer.RateLimitID = &rlID
+
+	store.CreateCustomerInMemory(context.Background(), customer)
+
+	rawBudget, ok := store.budgets.Load(budgetID)
+	require.True(t, ok, "budget should be in memory after create")
+	storedBudget, ok := rawBudget.(*configstoreTables.TableBudget)
+	require.True(t, ok)
+	assert.True(t, storedBudget.IsCalendarAligned, "budget.IsCalendarAligned should be true when customer.CalendarAligned=true")
+
+	rawRL, ok := store.rateLimits.Load(rlID)
+	require.True(t, ok, "rate limit should be in memory after create")
+	storedRL, ok := rawRL.(*configstoreTables.TableRateLimit)
+	require.True(t, ok)
+	assert.True(t, storedRL.IsCalendarAligned, "rate_limit.IsCalendarAligned should be true when customer.CalendarAligned=true")
+}
+
+// TestGovernanceStore_Customer_CalendarAligned_CreateInMemory_False verifies that
+// IsCalendarAligned is false when the customer does not have calendar alignment enabled.
+func TestGovernanceStore_Customer_CalendarAligned_CreateInMemory_False(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	budgetID := "cust-bud-2"
+	budget := &configstoreTables.TableBudget{
+		ID:            budgetID,
+		MaxLimit:      50.0,
+		ResetDuration: "1d",
+		LastReset:     time.Now(),
+	}
+	customer := buildCustomer("cust-2", "Globex", budget)
+	customer.CalendarAligned = false
+
+	store.CreateCustomerInMemory(context.Background(), customer)
+
+	rawBudget, ok := store.budgets.Load(budgetID)
+	require.True(t, ok)
+	storedBudget, ok := rawBudget.(*configstoreTables.TableBudget)
+	require.True(t, ok)
+	assert.False(t, storedBudget.IsCalendarAligned, "budget.IsCalendarAligned should be false when customer.CalendarAligned=false")
+}
+
+// TestGovernanceStore_Customer_CalendarAligned_UpdateInMemory verifies that
+// UpdateCustomerInMemory re-stamps IsCalendarAligned on the budget and rate limit
+// so an in-flight toggle (false→true) takes effect immediately in memory.
+func TestGovernanceStore_Customer_CalendarAligned_UpdateInMemory(t *testing.T) {
+	logger := NewMockLogger()
+
+	budgetID := "cust-bud-3"
+	rlID := "cust-rl-3"
+	budget := &configstoreTables.TableBudget{
+		ID:            budgetID,
+		MaxLimit:      200.0,
+		ResetDuration: "1M",
+		LastReset:     time.Now(),
+	}
+	rl := &configstoreTables.TableRateLimit{
+		ID:              rlID,
+		TokenMaxLimit:   ptrInt64(500),
+		TokenLastReset:  time.Now(),
+		RequestLastReset: time.Now(),
+	}
+	customer := buildCustomer("cust-3", "Initech", budget)
+	customer.CalendarAligned = false
+	customer.RateLimit = rl
+	customer.RateLimitID = &rlID
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Customers: []configstoreTables.TableCustomer{*customer},
+		Budgets:   []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	// Budget and rate limit should start as non-calendar-aligned
+	rawBudget, _ := store.budgets.Load(budgetID)
+	assert.False(t, rawBudget.(*configstoreTables.TableBudget).IsCalendarAligned)
+
+	// Toggle calendar_aligned to true and update in memory
+	customer.CalendarAligned = true
+	store.UpdateCustomerInMemory(context.Background(), customer, nil)
+
+	rawBudget, ok := store.budgets.Load(budgetID)
+	require.True(t, ok)
+	assert.True(t, rawBudget.(*configstoreTables.TableBudget).IsCalendarAligned, "budget.IsCalendarAligned should be true after update with CalendarAligned=true")
+
+	rawRL, ok := store.rateLimits.Load(rlID)
+	require.True(t, ok)
+	assert.True(t, rawRL.(*configstoreTables.TableRateLimit).IsCalendarAligned, "rate_limit.IsCalendarAligned should be true after update with CalendarAligned=true")
+}
+
 // Utility functions for tests
 func ptrInt64(i int64) *int64 {
 	return &i

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -831,16 +831,18 @@ type UpdateTeamRequest struct {
 
 // CreateCustomerRequest represents the request body for creating a customer
 type CreateCustomerRequest struct {
-	Name      string                  `json:"name" validate:"required"`
-	Budget    *CreateBudgetRequest    `json:"budget,omitempty"`
-	RateLimit *CreateRateLimitRequest `json:"rate_limit,omitempty"` // Customer can have its own rate limit
+	Name            string                  `json:"name" validate:"required"`
+	Budget          *CreateBudgetRequest    `json:"budget,omitempty"`
+	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`
+	CalendarAligned bool                    `json:"calendar_aligned,omitempty"`
 }
 
 // UpdateCustomerRequest represents the request body for updating a customer
 type UpdateCustomerRequest struct {
-	Name      *string                 `json:"name,omitempty"`
-	Budget    *UpdateBudgetRequest    `json:"budget,omitempty"`
-	RateLimit *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	Name            *string                 `json:"name,omitempty"`
+	Budget          *UpdateBudgetRequest    `json:"budget,omitempty"`
+	RateLimit       *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	CalendarAligned *bool                   `json:"calendar_aligned,omitempty"`
 }
 
 // CreateModelConfigRequest represents the request body for creating a model config
@@ -865,8 +867,8 @@ type UpdateModelConfigRequest struct {
 
 // UpdateProviderGovernanceRequest represents the request body for updating provider governance
 type UpdateProviderGovernanceRequest struct {
-	Budget          *UpdateBudgetRequest    `json:"budget,omitempty"`          // deprecated; use budgets
-	Budgets         *[]CreateBudgetRequest  `json:"budgets,omitempty"`         // nil=no change, []=remove all
+	Budget          *UpdateBudgetRequest    `json:"budget,omitempty"`  // deprecated; use budgets
+	Budgets         *[]CreateBudgetRequest  `json:"budgets,omitempty"` // nil=no change, []=remove all
 	RateLimit       *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
 	CalendarAligned *bool                   `json:"calendar_aligned,omitempty"`
 }
@@ -2363,8 +2365,9 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 	var customer configstoreTables.TableCustomer
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		customer = configstoreTables.TableCustomer{
-			ID:   uuid.NewString(),
-			Name: req.Name,
+			ID:              uuid.NewString(),
+			Name:            req.Name,
+			CalendarAligned: req.CalendarAligned,
 		}
 
 		if req.Budget != nil {
@@ -2372,7 +2375,7 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 				ID:            uuid.NewString(),
 				MaxLimit:      req.Budget.MaxLimit,
 				ResetDuration: req.Budget.ResetDuration,
-				LastReset:     budgetLastReset(false, req.Budget.ResetDuration),
+				LastReset:     budgetLastReset(req.CalendarAligned, req.Budget.ResetDuration),
 				CurrentUsage:  0,
 			}
 			if err := validateBudget(&budget); err != nil {
@@ -2461,6 +2464,11 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 		if req.Name != nil {
 			customer.Name = *req.Name
 		}
+		wasCalendarAligned := customer.CalendarAligned
+		if req.CalendarAligned != nil {
+			customer.CalendarAligned = *req.CalendarAligned
+		}
+		calendarAlignmentJustEnabled := !wasCalendarAligned && customer.CalendarAligned
 		// Handle budget updates
 		if req.Budget != nil {
 			// Check if budget removal is requested (all fields nil)
@@ -2506,7 +2514,7 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 					ID:            uuid.NewString(),
 					MaxLimit:      *req.Budget.MaxLimit,
 					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
+					LastReset:     budgetLastReset(customer.CalendarAligned, *req.Budget.ResetDuration),
 					CurrentUsage:  0,
 				}
 				if err := validateBudget(&budget); err != nil {
@@ -2566,6 +2574,37 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 				}
 				customer.RateLimitID = &rateLimit.ID
 				customer.RateLimit = &rateLimit
+			}
+		}
+		// Snap budget and rate limit to the current calendar period when calendar
+		// alignment transitions false -> true in this request.
+		if calendarAlignmentJustEnabled {
+			now := time.Now()
+			if customer.Budget != nil && configstoreTables.IsCalendarAlignableDuration(customer.Budget.ResetDuration) {
+				customer.Budget.LastReset = configstoreTables.GetCalendarPeriodStart(customer.Budget.ResetDuration, now)
+				customer.Budget.CurrentUsage = 0
+				if err := h.configStore.UpdateBudget(ctx, customer.Budget, tx); err != nil {
+					return fmt.Errorf("failed to snap customer budget on calendar-align enable: %w", err)
+				}
+			}
+			if customer.RateLimit != nil {
+				rl := customer.RateLimit
+				snapped := false
+				if rl.TokenResetDuration != nil && configstoreTables.IsCalendarAlignableDuration(*rl.TokenResetDuration) {
+					rl.TokenLastReset = configstoreTables.GetCalendarPeriodStart(*rl.TokenResetDuration, now)
+					rl.TokenCurrentUsage = 0
+					snapped = true
+				}
+				if rl.RequestResetDuration != nil && configstoreTables.IsCalendarAlignableDuration(*rl.RequestResetDuration) {
+					rl.RequestLastReset = configstoreTables.GetCalendarPeriodStart(*rl.RequestResetDuration, now)
+					rl.RequestCurrentUsage = 0
+					snapped = true
+				}
+				if snapped {
+					if err := h.configStore.UpdateRateLimit(ctx, rl, tx); err != nil {
+						return fmt.Errorf("failed to snap customer rate limit on calendar-align enable: %w", err)
+					}
+				}
 			}
 		}
 		if err := h.configStore.UpdateCustomer(ctx, customer, tx); err != nil {
@@ -3365,9 +3404,11 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 		var rateLimitIDToDelete string
 
 		// Apply CalendarAligned if provided.
+		wasCalendarAligned := mc.CalendarAligned
 		if req.CalendarAligned != nil {
 			mc.CalendarAligned = *req.CalendarAligned
 		}
+		calendarAlignmentJustEnabled := !wasCalendarAligned && mc.CalendarAligned
 
 		// Rate limit lifecycle (mc references it via RateLimitID, so resolve it before
 		// persisting the model config below).
@@ -3464,6 +3505,43 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 		if !deleted && effectiveBudgets != nil {
 			if err := h.reconcileModelConfigBudgets(ctx, tx, &mc, *effectiveBudgets); err != nil {
 				return err
+			}
+		}
+
+		// Snap budgets and rate limit to the current calendar period when calendar
+		// alignment transitions false → true. Runs after reconciliation so combined
+		// "toggle + budgets" requests see the final reconciled state.
+		if !deleted && calendarAlignmentJustEnabled {
+			now := time.Now()
+			for i := range mc.Budgets {
+				b := &mc.Budgets[i]
+				if !configstoreTables.IsCalendarAlignableDuration(b.ResetDuration) {
+					continue
+				}
+				b.LastReset = configstoreTables.GetCalendarPeriodStart(b.ResetDuration, now)
+				b.CurrentUsage = 0
+				if err := h.configStore.UpdateBudget(ctx, b, tx); err != nil {
+					return fmt.Errorf("failed to snap provider budget %s on calendar-align enable: %w", b.ID, err)
+				}
+			}
+			if mc.RateLimit != nil {
+				rl := mc.RateLimit
+				snapped := false
+				if rl.TokenResetDuration != nil && configstoreTables.IsCalendarAlignableDuration(*rl.TokenResetDuration) {
+					rl.TokenLastReset = configstoreTables.GetCalendarPeriodStart(*rl.TokenResetDuration, now)
+					rl.TokenCurrentUsage = 0
+					snapped = true
+				}
+				if rl.RequestResetDuration != nil && configstoreTables.IsCalendarAlignableDuration(*rl.RequestResetDuration) {
+					rl.RequestLastReset = configstoreTables.GetCalendarPeriodStart(*rl.RequestResetDuration, now)
+					rl.RequestCurrentUsage = 0
+					snapped = true
+				}
+				if snapped {
+					if err := h.configStore.UpdateRateLimit(ctx, rl, tx); err != nil {
+						return fmt.Errorf("failed to snap provider rate limit on calendar-align enable: %w", err)
+					}
+				}
 			}
 		}
 

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1757,3 +1757,236 @@ func TestValidateRoutingFallbacks(t *testing.T) {
 		})
 	}
 }
+
+// --- customer calendar_aligned handler tests ---
+
+type mockCustomerStore struct {
+	configstore.ConfigStore
+	customers      map[string]*configstoreTables.TableCustomer
+	createdBudgets []*configstoreTables.TableBudget
+	updatedBudgets []*configstoreTables.TableBudget
+	updatedRLs     []*configstoreTables.TableRateLimit
+}
+
+func newMockCustomerStore() *mockCustomerStore {
+	return &mockCustomerStore{customers: make(map[string]*configstoreTables.TableCustomer)}
+}
+
+func (m *mockCustomerStore) ExecuteTransaction(_ context.Context, fn func(*gorm.DB) error) error {
+	return fn(nil)
+}
+func (m *mockCustomerStore) GetCustomer(_ context.Context, id string) (*configstoreTables.TableCustomer, error) {
+	c, ok := m.customers[id]
+	if !ok {
+		return nil, configstore.ErrNotFound
+	}
+	clone := *c
+	if c.Budget != nil {
+		b := *c.Budget
+		clone.Budget = &b
+	}
+	if c.RateLimit != nil {
+		rl := *c.RateLimit
+		clone.RateLimit = &rl
+	}
+	return &clone, nil
+}
+func (m *mockCustomerStore) CreateCustomer(_ context.Context, customer *configstoreTables.TableCustomer, _ ...*gorm.DB) error {
+	m.customers[customer.ID] = customer
+	return nil
+}
+func (m *mockCustomerStore) UpdateCustomer(_ context.Context, customer *configstoreTables.TableCustomer, _ ...*gorm.DB) error {
+	m.customers[customer.ID] = customer
+	return nil
+}
+func (m *mockCustomerStore) CreateBudget(_ context.Context, budget *configstoreTables.TableBudget, _ ...*gorm.DB) error {
+	m.createdBudgets = append(m.createdBudgets, budget)
+	return nil
+}
+func (m *mockCustomerStore) UpdateBudget(_ context.Context, budget *configstoreTables.TableBudget, _ ...*gorm.DB) error {
+	m.updatedBudgets = append(m.updatedBudgets, budget)
+	return nil
+}
+func (m *mockCustomerStore) CreateRateLimit(_ context.Context, rl *configstoreTables.TableRateLimit, _ ...*gorm.DB) error {
+	return nil
+}
+func (m *mockCustomerStore) UpdateRateLimit(_ context.Context, rl *configstoreTables.TableRateLimit, _ ...*gorm.DB) error {
+	m.updatedRLs = append(m.updatedRLs, rl)
+	return nil
+}
+func (m *mockCustomerStore) DeleteBudget(_ context.Context, _ string, _ ...*gorm.DB) error { return nil }
+
+type mockCustomerGovernanceManager struct {
+	GovernanceManager
+}
+
+func (m *mockCustomerGovernanceManager) ReloadCustomer(_ context.Context, _ string) (*configstoreTables.TableCustomer, error) {
+	return nil, nil
+}
+
+// TestCreateCustomer_CalendarAligned_SnapsBudgetLastReset verifies that when
+// calendar_aligned=true is set on create, the budget's LastReset is snapped to
+// the calendar period start rather than time.Now().
+func TestCreateCustomer_CalendarAligned_SnapsBudgetLastReset(t *testing.T) {
+	SetLogger(&mockLogger{})
+	store := newMockCustomerStore()
+	h := &GovernanceHandler{configStore: store, governanceManager: &mockCustomerGovernanceManager{}}
+
+	body, _ := json.Marshal(map[string]any{
+		"name":             "ACME",
+		"calendar_aligned": true,
+		"budget": map[string]any{
+			"max_limit":      100.0,
+			"reset_duration": "1M",
+		},
+	})
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetBody(body)
+
+	before := time.Now()
+	h.createCustomer(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if len(store.createdBudgets) != 1 {
+		t.Fatalf("expected 1 created budget, got %d", len(store.createdBudgets))
+	}
+	b := store.createdBudgets[0]
+	// Calendar-aligned LastReset must be at the start of the calendar period,
+	// which is always <= the beginning of the test, never a rolling time.Now().
+	if b.LastReset.After(before) {
+		t.Errorf("calendar-aligned budget LastReset %v should not be after test start %v (expected period start)", b.LastReset, before)
+	}
+	// Confirm the stored customer has CalendarAligned=true.
+	var created *configstoreTables.TableCustomer
+	for _, c := range store.customers {
+		created = c
+	}
+	if created == nil || !created.CalendarAligned {
+		t.Errorf("stored customer should have CalendarAligned=true")
+	}
+}
+
+// TestCreateCustomer_CalendarAligned_False verifies that when calendar_aligned is
+// not set, budget LastReset is a rolling time.Now() (not at a period boundary).
+func TestCreateCustomer_CalendarAligned_False(t *testing.T) {
+	SetLogger(&mockLogger{})
+	store := newMockCustomerStore()
+	h := &GovernanceHandler{configStore: store, governanceManager: &mockCustomerGovernanceManager{}}
+
+	body, _ := json.Marshal(map[string]any{
+		"name": "Globex",
+		"budget": map[string]any{
+			"max_limit":      50.0,
+			"reset_duration": "1M",
+		},
+	})
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetBody(body)
+
+	before := time.Now()
+	h.createCustomer(ctx)
+	after := time.Now()
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if len(store.createdBudgets) != 1 {
+		t.Fatalf("expected 1 created budget, got %d", len(store.createdBudgets))
+	}
+	b := store.createdBudgets[0]
+	// Rolling LastReset should be within the test window.
+	if b.LastReset.Before(before) || b.LastReset.After(after) {
+		t.Errorf("non-calendar-aligned budget LastReset %v should be between %v and %v", b.LastReset, before, after)
+	}
+}
+
+// TestUpdateCustomer_CalendarAligned_SnapsExistingBudget verifies that toggling
+// calendar_aligned from false to true snaps the existing budget's LastReset to the
+// start of the current calendar period and resets CurrentUsage.
+func TestUpdateCustomer_CalendarAligned_SnapsExistingBudget(t *testing.T) {
+	SetLogger(&mockLogger{})
+	store := newMockCustomerStore()
+
+	budgetID := "bud-snap"
+	oldLastReset := time.Now().AddDate(0, -1, 0) // 1 month ago
+	store.customers["cust-snap"] = &configstoreTables.TableCustomer{
+		ID:              "cust-snap",
+		Name:            "Initech",
+		CalendarAligned: false,
+		BudgetID:        &budgetID,
+		Budget: &configstoreTables.TableBudget{
+			ID:            budgetID,
+			MaxLimit:      200.0,
+			ResetDuration: "1M",
+			LastReset:     oldLastReset,
+			CurrentUsage:  99.0,
+		},
+	}
+	h := &GovernanceHandler{configStore: store, governanceManager: &mockCustomerGovernanceManager{}}
+
+	body, _ := json.Marshal(map[string]any{"calendar_aligned": true})
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetBody(body)
+	ctx.SetUserValue("customer_id", "cust-snap")
+
+	snapBefore := time.Now()
+	h.updateCustomer(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	// UpdateBudget must have been called once (for the snap).
+	if len(store.updatedBudgets) != 1 {
+		t.Fatalf("expected 1 UpdateBudget call for snap, got %d", len(store.updatedBudgets))
+	}
+	snapped := store.updatedBudgets[0]
+	// LastReset must be at the calendar period start, not the old value.
+	if snapped.LastReset.Equal(oldLastReset) {
+		t.Error("budget LastReset was not snapped: still equals old value")
+	}
+	if snapped.LastReset.After(snapBefore) {
+		t.Errorf("snapped LastReset %v should be at the period start, not time.Now() (%v)", snapped.LastReset, snapBefore)
+	}
+	if snapped.CurrentUsage != 0 {
+		t.Errorf("expected CurrentUsage reset to 0, got %v", snapped.CurrentUsage)
+	}
+}
+
+// TestUpdateCustomer_CalendarAligned_NoSnapWhenAlreadyEnabled verifies that if
+// calendar_aligned is already true, no snap/UpdateBudget call occurs on update.
+func TestUpdateCustomer_CalendarAligned_NoSnapWhenAlreadyEnabled(t *testing.T) {
+	SetLogger(&mockLogger{})
+	store := newMockCustomerStore()
+
+	budgetID := "bud-already"
+	store.customers["cust-already"] = &configstoreTables.TableCustomer{
+		ID:              "cust-already",
+		Name:            "Umbrella",
+		CalendarAligned: true, // already enabled
+		BudgetID:        &budgetID,
+		Budget: &configstoreTables.TableBudget{
+			ID:            budgetID,
+			MaxLimit:      300.0,
+			ResetDuration: "1M",
+			LastReset:     time.Now().AddDate(0, -1, 0),
+			CurrentUsage:  42.0,
+		},
+	}
+	h := &GovernanceHandler{configStore: store, governanceManager: &mockCustomerGovernanceManager{}}
+
+	body, _ := json.Marshal(map[string]any{"calendar_aligned": true})
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetBody(body)
+	ctx.SetUserValue("customer_id", "cust-already")
+
+	h.updateCustomer(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if len(store.updatedBudgets) != 0 {
+		t.Errorf("expected no UpdateBudget call when calendar_aligned was already true, got %d", len(store.updatedBudgets))
+	}
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -636,6 +636,24 @@ func promoteDeprecatedCalendarAligned(configData *ConfigData) {
 		team := &configData.Governance.Teams[i]
 		promoteCalendarAligned(&team.CalendarAligned, team.Budgets, team.RateLimit)
 	}
+	for i := range configData.Governance.Customers {
+		customer := &configData.Governance.Customers[i]
+		// Customers reference budget/rate-limit by ID in config.json (no inline objects),
+		// so Budget and RateLimit are normally nil here. Handle the singular pointer
+		// directly rather than wrapping in a slice to avoid copy-and-clear issues.
+		if customer.Budget != nil {
+			if customer.Budget.CalendarAlignedInput != nil && *customer.Budget.CalendarAlignedInput {
+				customer.CalendarAligned = true
+			}
+			customer.Budget.CalendarAlignedInput = nil
+		}
+		if customer.RateLimit != nil && customer.RateLimit.CalendarAlignedInput != nil {
+			if *customer.RateLimit.CalendarAlignedInput {
+				customer.CalendarAligned = true
+			}
+			customer.RateLimit.CalendarAlignedInput = nil
+		}
+	}
 }
 
 // promoteCalendarAligned ORs each child's legacy calendar_aligned input into

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -476,6 +476,11 @@
               "rate_limit_id": {
                 "type": "string",
                 "description": "Associated rate limit ID"
+              },
+              "calendar_aligned": {
+                "type": "boolean",
+                "description": "Snap the customer's budget and rate-limit reset windows to clean calendar boundaries (day, week, month, year)",
+                "default": false
               }
             },
             "required": ["id", "name"],

--- a/ui/app/workspace/governance/views/customerSheet.tsx
+++ b/ui/app/workspace/governance/views/customerSheet.tsx
@@ -1,11 +1,22 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { resetDurationOptions } from "@/lib/constants/governance";
+import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
 import { getErrorMessage, useCreateCustomerMutation, useUpdateCustomerMutation } from "@/lib/store";
 import { CreateCustomerRequest, Customer, UpdateCustomerRequest } from "@/lib/types/governance";
 import { formatCurrency } from "@/lib/utils/governance";
@@ -31,6 +42,7 @@ interface CustomerFormData {
 	tokenResetDuration: string;
 	requestMaxLimit: number | undefined;
 	requestResetDuration: string;
+	calendarAligned: boolean;
 	isDirty: boolean;
 }
 
@@ -43,6 +55,7 @@ const createInitialState = (customer?: Customer | null): Omit<CustomerFormData, 
 		tokenResetDuration: customer?.rate_limit?.token_reset_duration || "1h",
 		requestMaxLimit: customer?.rate_limit?.request_max_limit ?? undefined,
 		requestResetDuration: customer?.rate_limit?.request_reset_duration || "1h",
+		calendarAligned: customer?.calendar_aligned ?? false,
 	};
 };
 
@@ -53,6 +66,8 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		...createInitialState(customer),
 		isDirty: false,
 	});
+
+	const [showCalendarAlignWarning, setShowCalendarAlignWarning] = useState(false);
 
 	const hasCreateAccess = useRbac(RbacResource.Customers, RbacOperation.Create);
 	const hasUpdateAccess = useRbac(RbacResource.Customers, RbacOperation.Update);
@@ -70,6 +85,14 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		}
 	}, [open, customer]);
 
+	const handleCalendarAlignedChange = (checked: boolean) => {
+		if (checked && isEditing && !initialState.calendarAligned) {
+			setShowCalendarAlignWarning(true);
+		} else {
+			updateField("calendarAligned", checked);
+		}
+	};
+
 	useEffect(() => {
 		const currentData = {
 			name: formData.name,
@@ -79,6 +102,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 			tokenResetDuration: formData.tokenResetDuration,
 			requestMaxLimit: formData.requestMaxLimit,
 			requestResetDuration: formData.requestResetDuration,
+			calendarAligned: formData.calendarAligned,
 		};
 		setFormData((prev) => ({
 			...prev,
@@ -92,6 +116,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		formData.tokenResetDuration,
 		formData.requestMaxLimit,
 		formData.requestResetDuration,
+		formData.calendarAligned,
 		initialState,
 	]);
 
@@ -142,6 +167,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 			if (isEditing && customer) {
 				const updateData: UpdateCustomerRequest = {
 					name: formData.name,
+					calendar_aligned: formData.calendarAligned,
 				};
 
 				const hadBudget = !!customer.budget;
@@ -176,6 +202,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 			} else {
 				const createData: CreateCustomerRequest = {
 					name: formData.name,
+					calendar_aligned: formData.calendarAligned,
 				};
 
 				if (budgetMaxLimitNum !== undefined && budgetMaxLimitNum !== null) {
@@ -277,6 +304,68 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 								onChangeSelect={(value) => updateField("requestResetDuration", value)}
 								options={resetDurationOptions}
 							/>
+
+							{/* Calendar alignment toggle — only shown when there's an alignable budget or rate limit */}
+							{(() => {
+								const hasAlignableBudget =
+									formData.budgetMaxLimit !== undefined &&
+									formData.budgetMaxLimit !== null &&
+									supportsCalendarAlignment(formData.budgetResetDuration);
+								const hasAlignableRateLimit =
+									(formData.tokenMaxLimit !== undefined &&
+										formData.tokenMaxLimit !== null &&
+										supportsCalendarAlignment(formData.tokenResetDuration)) ||
+									(formData.requestMaxLimit !== undefined &&
+										formData.requestMaxLimit !== null &&
+										supportsCalendarAlignment(formData.requestResetDuration));
+								if (!hasAlignableBudget && !hasAlignableRateLimit) return null;
+								return (
+									<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+										<div className="space-y-0.5">
+											<Label htmlFor="customer-calendar-aligned-toggle" className="text-sm font-normal">
+												Align to calendar cycle
+											</Label>
+											<p className="text-muted-foreground text-xs">
+												Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from
+												creation date. Applies to durations of a day or longer.
+											</p>
+										</div>
+										<Switch
+											id="customer-calendar-aligned-toggle"
+											checked={formData.calendarAligned}
+											onCheckedChange={handleCalendarAlignedChange}
+											data-testid="customer-calendar-aligned-toggle"
+										/>
+									</div>
+								);
+							})()}
+
+							{/* Warning dialog shown when enabling calendar alignment on an existing customer */}
+							<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
+								<AlertDialogContent>
+									<AlertDialogHeader>
+										<AlertDialogTitle>Reset budget and rate-limit usage?</AlertDialogTitle>
+										<AlertDialogDescription>
+											Enabling calendar alignment will reset budget usage to <span className="font-semibold">$0.00</span> and
+											token/request rate-limit counters to <span className="font-semibold">0</span> for this customer, then snap
+											each reset date to the start of its current period (e.g. start of day, week, month, or year). The usage
+											reset cannot be undone, but calendar alignment can be turned off later. This will take effect when you save.
+										</AlertDialogDescription>
+									</AlertDialogHeader>
+									<AlertDialogFooter>
+										<AlertDialogCancel data-testid="customer-calendar-align-cancel-btn">Cancel</AlertDialogCancel>
+										<AlertDialogAction
+											data-testid="customer-calendar-align-enable-btn"
+											onClick={() => {
+												updateField("calendarAligned", true);
+												setShowCalendarAlignWarning(false);
+											}}
+										>
+											Enable Calendar Alignment
+										</AlertDialogAction>
+									</AlertDialogFooter>
+								</AlertDialogContent>
+							</AlertDialog>
 
 							{isEditing && (customer?.budget || customer?.rate_limit) && (
 								<div className="bg-muted/50 space-y-4 rounded-lg border p-4">

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -42,6 +42,7 @@ export interface Customer {
 	name: string;
 	budget_id?: string;
 	rate_limit_id?: string;
+	calendar_aligned?: boolean;
 	// Populated relationships
 	teams?: Team[];
 	budget?: Budget;
@@ -210,12 +211,14 @@ export interface CreateCustomerRequest {
 	name: string;
 	budget?: CreateBudgetRequest;
 	rate_limit?: CreateRateLimitRequest;
+	calendar_aligned?: boolean;
 }
 
 export interface UpdateCustomerRequest {
 	name?: string;
 	budget?: UpdateBudgetRequest;
 	rate_limit?: UpdateRateLimitRequest;
+	calendar_aligned?: boolean;
 }
 
 export interface CreateBudgetRequest {


### PR DESCRIPTION
## Summary

Adds `calendar_aligned` support at the customer level, allowing customer budgets and rate limits to reset at clean calendar boundaries (start of day, week, month, or year) rather than rolling from the creation date. Previously, calendar alignment was only available for providers and teams.

## Changes

- Added `CalendarAligned bool` column to `governance_customers` via a new database migration (`add_customer_calendar_aligned_column`). No backfill is needed since calendar alignment never functioned at the customer level previously.
- Added a GORM `AfterFind` hook on `TableCustomer` that stamps `IsCalendarAligned` onto the associated `Budget` and `RateLimit` so the reset path sees the correct value after a database load.
- Propagated `IsCalendarAligned` from the customer onto its in-memory budget and rate limit in `CreateCustomerInMemory` and `UpdateCustomerInMemory` so in-flight toggles take effect immediately without requiring a reload.
- Updated `createCustomer` to pass `CalendarAligned` into the new customer record and use it when computing the initial `LastReset` for the budget (calendar period start vs. rolling `time.Now()`).
- Updated `updateCustomer` to detect a `false → true` transition and snap the existing budget's `LastReset` to the current calendar period start while zeroing `CurrentUsage`. The same snap logic is applied to the rate limit's token and request windows.
- Applied the same `false → true` snap logic to `updateProviderGovernance` so provider-level budgets and rate limits are also snapped atomically after reconciliation when calendar alignment is first enabled.
- Extended `promoteDeprecatedCalendarAligned` in the config loader to handle customers, promoting any legacy per-budget or per-rate-limit `calendar_aligned` input up to the customer-level field.
- Added `calendar_aligned` to the JSON schema for the customer governance config block.
- Exposed `calendar_aligned` on `CreateCustomerRequest` and `UpdateCustomerRequest` in both the Go handler types and the TypeScript API types.
- Added a calendar alignment toggle to the customer sheet UI, conditionally rendered only when the customer has at least one alignable budget or rate limit duration. Enabling the toggle on an existing customer shows a confirmation dialog warning that usage counters will be reset.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/... ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

**Manual verification:**

1. Create a customer with `calendar_aligned: true` and a monthly budget via the API or UI. Confirm `last_reset` is set to the first of the current month, not `time.Now()`.
2. Create a customer with `calendar_aligned: false`. Confirm `last_reset` is a rolling timestamp within the request window.
3. Update an existing customer from `calendar_aligned: false` to `true`. Confirm `UpdateBudget` is called with `last_reset` snapped to the period start and `current_usage` zeroed.
4. Update a customer that already has `calendar_aligned: true` to `true` again. Confirm no extra `UpdateBudget` call is made.
5. In the UI, open a customer with a monthly budget and toggle "Align to calendar cycle" on. Confirm the warning dialog appears and, after confirming, the toggle is enabled and saved correctly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth surfaces or secrets are introduced. The snap-on-enable path resets usage counters, which is intentional and gated behind the existing customer update permission.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar alignment setting for customers that snaps budget and rate-limit reset windows to calendar boundaries (day/week/month/year).
  * When enabling calendar alignment on existing customers, budgets are automatically snapped to the current calendar period.
  * UI support for toggling calendar alignment with confirmation dialog for existing customers.

* **Tests**
  * Added unit tests for calendar alignment propagation and budget snapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->