### PR TITLE
feat: adds multiple budget support to customers

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -982,9 +982,22 @@ func GenerateCustomerHash(c tables.TableCustomer) (string, error) {
 	// Hash Name
 	hash.Write([]byte(c.Name))
 
-	// Hash BudgetID
+	// Collect budget IDs from both sources so config-file context (BudgetID) and
+	// DB context (Budgets) produce the same hash for the same logical state.
+	seen := make(map[string]bool, len(c.Budgets)+1)
 	if c.BudgetID != nil {
-		hash.Write([]byte("budgetID:" + *c.BudgetID))
+		seen[*c.BudgetID] = true
+	}
+	for _, b := range c.Budgets {
+		seen[b.ID] = true
+	}
+	budgetIDs := make([]string, 0, len(seen))
+	for id := range seen {
+		budgetIDs = append(budgetIDs, id)
+	}
+	sort.Strings(budgetIDs)
+	for _, id := range budgetIDs {
+		hash.Write([]byte("budgetID:" + id))
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), nil

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -188,6 +188,7 @@ type legacyBudgetTeam struct {
 // TableName returns the governance_teams table name for legacyBudgetTeam.
 func (legacyBudgetTeam) TableName() string { return "governance_teams" }
 
+
 // sqliteColumnInfo holds the information about a SQLite column.
 type sqliteColumnInfo struct {
 	Name string `gorm:"column:name"`
@@ -844,6 +845,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 		return err
 	}
 	if err := migrationAddCustomerCalendarAlignedColumn(ctx, db); err != nil {
+		return err
+	}
+	if err := migrationAddCustomerBudgetsToBudgetsTable(ctx, db); err != nil {
 		return err
 	}
 	return nil
@@ -9495,6 +9499,112 @@ func migrationAddCustomerCalendarAlignedColumn(ctx context.Context, db *gorm.DB)
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_customer_calendar_aligned_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddCustomerBudgetsToBudgetsTable pivots customer budgets from a single-FK on
+// governance_customers.budget_id to multi-budget ownership via governance_budgets.customer_id,
+// mirroring how team budgets were restructured in migrationAddTeamBudgetsToBudgetsTable.
+func migrationAddCustomerBudgetsToBudgetsTable(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_customer_budgets_to_budgets_table",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// Add customer_id FK column on governance_budgets.
+			if !mg.HasColumn(&tables.TableBudget{}, "customer_id") {
+				if err := mg.AddColumn(&tables.TableBudget{}, "CustomerID"); err != nil {
+					return fmt.Errorf("failed to add customer_id column to governance_budgets: %w", err)
+				}
+			}
+
+			// Create index on the new FK column (AddColumn doesn't create indexes from struct tags).
+			if !mg.HasIndex(&tables.TableBudget{}, "idx_governance_budgets_customer_id") {
+				if err := mg.CreateIndex(&tables.TableBudget{}, "CustomerID"); err != nil {
+					return fmt.Errorf("failed to create index on governance_budgets.customer_id: %w", err)
+				}
+			}
+
+			// Backfill: set customer_id from legacy governance_customers.budget_id (if column still exists).
+			// The column is intentionally kept; a future migration can drop it once all instances
+			// have migrated and the column is confirmed unused.
+			legacyExists, err := hasColumn(tx, "governance_customers", "budget_id")
+			if err != nil {
+				return fmt.Errorf("failed to introspect governance_customers for budget_id: %w", err)
+			}
+			if legacyExists {
+				// Preflight: fail if any customer-referenced budget is already owned by another entity.
+				var conflictCount int64
+				if err := tx.Raw(`
+					SELECT COUNT(*) FROM governance_budgets b
+					WHERE (b.virtual_key_id IS NOT NULL OR b.provider_config_id IS NOT NULL OR b.team_id IS NOT NULL OR b.model_config_id IS NOT NULL)
+					  AND EXISTS (SELECT 1 FROM governance_customers c WHERE c.budget_id = b.id)
+				`).Scan(&conflictCount).Error; err != nil {
+					return fmt.Errorf("failed to check for multi-owner customer budget conflicts: %w", err)
+				}
+				if conflictCount > 0 {
+					return fmt.Errorf(
+						"cannot migrate customer budgets: %d budget row(s) referenced by a customer are already owned by another entity; resolve manually before re-running",
+						conflictCount,
+					)
+				}
+
+				if err := tx.Exec(`
+					UPDATE governance_budgets SET customer_id = (
+						SELECT id FROM governance_customers
+						WHERE governance_customers.budget_id = governance_budgets.id
+					) WHERE customer_id IS NULL AND EXISTS (
+						SELECT 1 FROM governance_customers
+						WHERE governance_customers.budget_id = governance_budgets.id
+					)
+				`).Error; err != nil {
+					return fmt.Errorf("failed to backfill customer budget customer_id: %w", err)
+				}
+			}
+
+			// Create FK constraint with CASCADE delete (defined on TableCustomer.Budgets).
+			if !mg.HasConstraint(&tables.TableCustomer{}, "Budgets") {
+				if err := mg.CreateConstraint(&tables.TableCustomer{}, "Budgets"); err != nil {
+					return fmt.Errorf("failed to create FK constraint for Customer -> Budgets: %w", err)
+				}
+			}
+
+			// Refresh config_hash for customers whose budgets just got linked. GenerateCustomerHash
+			// now includes sorted budget IDs, so hashes written before multi-budget support are stale.
+			var customersToRehash []tables.TableCustomer
+			if err := tx.Preload("Budgets").Find(&customersToRehash).Error; err != nil {
+				return fmt.Errorf("failed to fetch customers for hash refresh: %w", err)
+			}
+			for _, c := range customersToRehash {
+				if len(c.Budgets) == 0 {
+					continue
+				}
+				hash, err := GenerateCustomerHash(c)
+				if err != nil {
+					return fmt.Errorf("failed to generate hash for customer %s: %w", c.ID, err)
+				}
+				if err := tx.Model(&tables.TableCustomer{}).Where("id = ?", c.ID).Update("config_hash", hash).Error; err != nil {
+					return fmt.Errorf("failed to update hash for customer %s: %w", c.ID, err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TableBudget{}, "customer_id") {
+				if err := mg.DropColumn(&tables.TableBudget{}, "customer_id"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_customer_budgets_to_budgets_table migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -109,6 +109,14 @@ func lockBudgetOwner(ctx context.Context, txDB *gorm.DB, budget tables.TableBudg
 			}
 			return err
 		}
+	case budget.CustomerID != nil && *budget.CustomerID != "":
+		var customer tables.TableCustomer
+		if err := dbForUpdate(txDB.WithContext(ctx)).First(&customer, "id = ?", *budget.CustomerID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
 	}
 	return nil
 }
@@ -2576,7 +2584,7 @@ func preloadCustomerRelations(db *gorm.DB, prefix string) *gorm.DB {
 	return db.
 		Preload(relation("Teams")).
 		Preload(relation("Teams.Budgets")).
-		Preload(relation("Budget")).
+		Preload(relation("Budgets")).
 		Preload(relation("RateLimit")).
 		Preload(relation("VirtualKeys"))
 }
@@ -3684,13 +3692,13 @@ func (s *RDBConfigStore) DeleteCustomer(ctx context.Context, id string, tx ...*g
 
 	txDB := tx[0]
 	var customer tables.TableCustomer
-	if err := dbForUpdate(txDB.WithContext(ctx)).Preload("Budget").Preload("RateLimit").First(&customer, "id = ?", id).Error; err != nil {
+	if err := dbForUpdate(txDB.WithContext(ctx)).Preload("RateLimit").First(&customer, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ErrNotFound
 		}
 		return err
 	}
-	// Set customer_id to null for all virtual keys associated with the customer
+	// Null out customer_id on associated VKs and teams before deleting the customer row.
 	if err := txDB.WithContext(ctx).Model(&tables.TableVirtualKey{}).Where("customer_id = ?", id).Update("customer_id", nil).Error; err != nil {
 		return err
 	}
@@ -3698,23 +3706,18 @@ func (s *RDBConfigStore) DeleteCustomer(ctx context.Context, id string, tx ...*g
 	if err := txDB.WithContext(ctx).Model(&tables.TableTeam{}).Where("customer_id = ?", id).Update("customer_id", nil).Error; err != nil {
 		return err
 	}
-	// Store the budget and rate limit IDs before deleting the customer
-	budgetID := customer.BudgetID
 	rateLimitID := customer.RateLimitID
-	// Delete the customer first
+	// Explicitly delete owned budgets before the customer row. FK cascades cannot
+	// be relied on across all dialects for constraints added to pre-existing tables.
+	if err := txDB.WithContext(ctx).Where("customer_id = ?", id).Delete(&tables.TableBudget{}).Error; err != nil {
+		return err
+	}
 	if err := txDB.WithContext(ctx).Delete(&tables.TableCustomer{}, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ErrNotFound
 		}
 		return err
 	}
-	// Delete the customer's budget if it exists
-	if budgetID != nil {
-		if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *budgetID).Error; err != nil {
-			return err
-		}
-	}
-	// Delete the customer's rate limit if it exists
 	if rateLimitID != nil {
 		if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", *rateLimitID).Error; err != nil {
 			return err
@@ -3915,6 +3918,9 @@ func (s *RDBConfigStore) UpdateBudget(ctx context.Context, budget *tables.TableB
 		}
 		if ownerBudget.TeamID == nil {
 			ownerBudget.TeamID = existing.TeamID
+		}
+		if ownerBudget.CustomerID == nil {
+			ownerBudget.CustomerID = existing.CustomerID
 		}
 		if err := lockBudgetOwner(ctx, txDB, ownerBudget); err != nil {
 			return err

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -15,11 +15,12 @@ type TableBudget struct {
 	LastReset     time.Time `gorm:"index" json:"last_reset"`                         // Last time budget was reset
 	CurrentUsage  float64   `gorm:"default:0" json:"current_usage"`                  // Current usage in dollars
 
-	// Owner FKs: a budget belongs to at most one Team, one VK, one ProviderConfig, or one ModelConfig
+	// Owner FKs: a budget belongs to at most one Team, VK, ProviderConfig, ModelConfig, or Customer
 	TeamID           *string `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
 	VirtualKeyID     *string `gorm:"type:varchar(255);index" json:"virtual_key_id,omitempty"`
 	ProviderConfigID *uint   `gorm:"index" json:"provider_config_id,omitempty"`
 	ModelConfigID    *string `gorm:"type:varchar(255);index" json:"model_config_id,omitempty"`
+	CustomerID       *string `gorm:"type:varchar(255);index" json:"customer_id,omitempty"`
 
 	// Deprecated: set calendar_aligned on the parent access profile / VK / team
 	// instead. Kept for backward compatibility with older config.json files;
@@ -61,8 +62,11 @@ func (b *TableBudget) BeforeSave(tx *gorm.DB) error {
 	if b.ModelConfigID != nil {
 		owners++
 	}
+	if b.CustomerID != nil {
+		owners++
+	}
 	if owners > 1 {
-		return fmt.Errorf("budget cannot have more than one owner (team/virtual key/provider config/model config)")
+		return fmt.Errorf("budget cannot have more than one owner (team/virtual key/provider config/model config/customer)")
 	}
 	// Validate that ResetDuration is in correct format (e.g., "30s", "5m", "1h", "1d", "1w", "1M", "1Y")
 	if d, err := ParseDuration(b.ResetDuration); err != nil {

--- a/framework/configstore/tables/customer.go
+++ b/framework/configstore/tables/customer.go
@@ -6,15 +6,17 @@ import (
 	"gorm.io/gorm"
 )
 
-// TableCustomer represents a customer entity with budget and rate limit
+// TableCustomer represents a customer entity with budgets, rate limit and team/VK association
 type TableCustomer struct {
 	ID          string  `gorm:"primaryKey;type:varchar(255)" json:"id"`
 	Name        string  `gorm:"type:varchar(255);not null" json:"name"`
-	BudgetID    *string `gorm:"type:varchar(255);index" json:"budget_id,omitempty"`
 	RateLimitID *string `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
 
+	// BudgetID is a config-file-only field referencing a pre-declared budget (from governance.budgets) to link to this customer. Not persisted; used by the config sync path to set customer_id on the referenced budget row.
+	BudgetID *string `gorm:"-" json:"budget_id,omitempty"`
+
 	// Relationships
-	Budget      *TableBudget      `gorm:"foreignKey:BudgetID" json:"budget,omitempty"`
+	Budgets []TableBudget `gorm:"foreignKey:CustomerID;constraint:OnDelete:CASCADE" json:"budgets,omitempty"`
 	RateLimit   *TableRateLimit   `gorm:"foreignKey:RateLimitID" json:"rate_limit,omitempty"`
 	Teams       []TableTeam       `gorm:"foreignKey:CustomerID" json:"teams"`
 	VirtualKeys []TableVirtualKey `gorm:"foreignKey:CustomerID" json:"virtual_keys"`
@@ -32,11 +34,11 @@ type TableCustomer struct {
 // TableName sets the table name for each model
 func (TableCustomer) TableName() string { return "governance_customers" }
 
-// AfterFind stamps IsCalendarAligned on the owned budget and rate limit so the
+// AfterFind stamps IsCalendarAligned on owned budgets and rate limit so the
 // reset path (which reads the derived field off those objects) sees the correct value.
 func (c *TableCustomer) AfterFind(tx *gorm.DB) error {
-	if c.Budget != nil {
-		c.Budget.IsCalendarAligned = c.CalendarAligned
+	for i := range c.Budgets {
+		c.Budgets[i].IsCalendarAligned = c.CalendarAligned
 	}
 	if c.RateLimit != nil {
 		c.RateLimit.IsCalendarAligned = c.CalendarAligned

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -506,8 +506,17 @@ bifrost:
     customers: []
       # - id: "customer-1"
       #   name: "Customer Name"
-      #   budget_id: "budget-1"
       #   rate_limit_id: "rate-limit-1"
+      #   # Option A: inline multi-budget (each must have a unique reset_duration)
+      #   budgets:
+      #     - id: "budget-monthly"
+      #       max_limit: 500
+      #       reset_duration: "1M"
+      #     - id: "budget-yearly"
+      #       max_limit: 5000
+      #       reset_duration: "1Y"
+      #   # Option B: single budget reference (pre-declared in governance.budgets)
+      #   budget_id: "budget-1"
     teams: []
       # - id: "team-1"
       #   name: "Team Name"

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -639,13 +639,18 @@ func (gs *LocalGovernanceStore) GetGovernanceData(ctx context.Context) *Governan
 		clone := *customer
 		clone.Teams = make([]configstoreTables.TableTeam, 0)
 		clone.VirtualKeys = make([]configstoreTables.TableVirtualKey, 0)
-		if clone.BudgetID != nil {
-			if liveBudget, exists := gs.budgets.Load(*clone.BudgetID); exists && liveBudget != nil {
-				if b, ok := liveBudget.(*configstoreTables.TableBudget); ok {
-					clone.Budget = b
+		// Refresh each owned budget from the live budget map.
+		refreshedBudgets := make([]configstoreTables.TableBudget, 0, len(clone.Budgets))
+		for _, b := range clone.Budgets {
+			if liveBudget, exists := gs.budgets.Load(b.ID); exists && liveBudget != nil {
+				if lb, ok := liveBudget.(*configstoreTables.TableBudget); ok {
+					refreshedBudgets = append(refreshedBudgets, *lb)
+					continue
 				}
 			}
+			refreshedBudgets = append(refreshedBudgets, b)
 		}
+		clone.Budgets = refreshedBudgets
 		if clone.RateLimitID != nil {
 			if liveRL, exists := gs.rateLimits.Load(*clone.RateLimitID); exists && liveRL != nil {
 				if rl, ok := liveRL.(*configstoreTables.TableRateLimit); ok {
@@ -1245,15 +1250,20 @@ func (gs *LocalGovernanceStore) CheckCustomerBudget(ctx context.Context, custome
 		return DecisionAllow, nil
 	}
 	customer, ok := customerValue.(*configstoreTables.TableCustomer)
-	if !ok || customer.BudgetID == nil {
-		return DecisionAllow, nil
-	}
-	customerBudget := gs.LoadBudget(ctx, *customer.BudgetID)
-	if customerBudget == nil {
+	if !ok || len(customer.Budgets) == 0 {
 		return DecisionAllow, nil
 	}
 	key := fmt.Sprintf("Customer:%s", customerID)
-	entityWiseBudgets := EntityWiseBudgets{key: {customerBudget}}
+	var customerBudgets []*configstoreTables.TableBudget
+	for i := range customer.Budgets {
+		if b := gs.LoadBudget(ctx, customer.Budgets[i].ID); b != nil {
+			customerBudgets = append(customerBudgets, b)
+		}
+	}
+	if len(customerBudgets) == 0 {
+		return DecisionAllow, nil
+	}
+	entityWiseBudgets := EntityWiseBudgets{key: customerBudgets}
 	return gs.CheckBudget(ctx, entityWiseBudgets, baselines)
 }
 
@@ -2159,6 +2169,24 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 		}
 	}
 
+	// Stamp customer-owned budget and rate-limit entries in the flat caches so
+	// calendar-aligned resets survive restarts and reloads. Mirrors the model-config
+	// stamping above.
+	for i := range customers {
+		customer := &customers[i]
+		for j := range customer.Budgets {
+			customer.Budgets[j].IsCalendarAligned = customer.CalendarAligned
+			gs.budgets.Store(customer.Budgets[j].ID, &customer.Budgets[j])
+		}
+		if customer.RateLimitID != nil {
+			if raw, ok := gs.rateLimits.Load(*customer.RateLimitID); ok {
+				if rl, ok := raw.(*configstoreTables.TableRateLimit); ok && rl != nil {
+					rl.IsCalendarAligned = customer.CalendarAligned
+				}
+			}
+		}
+	}
+
 	// Build providers map
 	// Key format: provider name (e.g., "openai", "anthropic")
 	for i := range providers {
@@ -2388,10 +2416,10 @@ func (gs *LocalGovernanceStore) collectBudgetsFromHierarchy(_ context.Context, v
 					teamCustomerID = *team.CustomerID
 					if customerValue, exists := gs.customers.Load(*team.CustomerID); exists && customerValue != nil {
 						if customer, ok := customerValue.(*configstoreTables.TableCustomer); ok && customer != nil {
-							if customer.BudgetID != nil {
-								if budgetValue, exists := gs.budgets.Load(*customer.BudgetID); exists && budgetValue != nil {
+							for _, cb := range customer.Budgets {
+								if budgetValue, exists := gs.budgets.Load(cb.ID); exists && budgetValue != nil {
 									if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-										if categoryBudgets := entityWiseBudgets["Customer"]; categoryBudgets == nil {
+										if entityWiseBudgets["Customer"] == nil {
 											entityWiseBudgets["Customer"] = []*configstoreTables.TableBudget{}
 										}
 										entityWiseBudgets["Customer"] = append(entityWiseBudgets["Customer"], budget)
@@ -2409,10 +2437,10 @@ func (gs *LocalGovernanceStore) collectBudgetsFromHierarchy(_ context.Context, v
 	if vk.CustomerID != nil && (teamCustomerID == "" || *vk.CustomerID != teamCustomerID) {
 		if customerValue, exists := gs.customers.Load(*vk.CustomerID); exists && customerValue != nil {
 			if customer, ok := customerValue.(*configstoreTables.TableCustomer); ok && customer != nil {
-				if customer.BudgetID != nil {
-					if budgetValue, exists := gs.budgets.Load(*customer.BudgetID); exists && budgetValue != nil {
+				for _, cb := range customer.Budgets {
+					if budgetValue, exists := gs.budgets.Load(cb.ID); exists && budgetValue != nil {
 						if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-							if categoryBudgets := entityWiseBudgets["Customer"]; categoryBudgets == nil {
+							if entityWiseBudgets["Customer"] == nil {
 								entityWiseBudgets["Customer"] = []*configstoreTables.TableBudget{}
 							}
 							entityWiseBudgets["Customer"] = append(entityWiseBudgets["Customer"], budget)
@@ -2952,12 +2980,10 @@ func (gs *LocalGovernanceStore) CreateCustomerInMemory(ctx context.Context, cust
 	if customer == nil {
 		return // Nothing to create
 	}
-	// Create associated budget if exists
-	if customer.Budget != nil {
-		customer.Budget.IsCalendarAligned = customer.CalendarAligned
-		gs.budgets.Store(customer.Budget.ID, customer.Budget)
+	for i := range customer.Budgets {
+		customer.Budgets[i].IsCalendarAligned = customer.CalendarAligned
+		gs.budgets.Store(customer.Budgets[i].ID, &customer.Budgets[i])
 	}
-	// Create associated rate limit if exists
 	if customer.RateLimit != nil {
 		customer.RateLimit.IsCalendarAligned = customer.CalendarAligned
 		gs.rateLimits.Store(customer.RateLimit.ID, customer.RateLimit)
@@ -2979,25 +3005,24 @@ func (gs *LocalGovernanceStore) UpdateCustomerInMemory(ctx context.Context, cust
 		// Create clone to avoid modifying the original
 		clone := *customer
 
-		// Handle budget updates with consistent logic
-		if clone.Budget != nil {
-			clone.Budget.IsCalendarAligned = clone.CalendarAligned
-			// Preserve existing usage from memory when updating customer budget config
-			if existingBudgetValue, exists := gs.budgets.Load(clone.Budget.ID); exists && existingBudgetValue != nil {
+		// Reconcile budgets: upsert new set, delete any that were removed.
+		newBudgetIDs := make(map[string]bool, len(clone.Budgets))
+		for i := range clone.Budgets {
+			b := &clone.Budgets[i]
+			b.IsCalendarAligned = clone.CalendarAligned
+			if existingBudgetValue, exists := gs.budgets.Load(b.ID); exists && existingBudgetValue != nil {
 				if existingBudget, ok := existingBudgetValue.(*configstoreTables.TableBudget); ok && existingBudget != nil {
-					// Preserve current usage and last reset time from existing in-memory budget
-					clone.Budget.CurrentUsage = existingBudget.CurrentUsage
-					clone.Budget.LastReset = existingBudget.LastReset
+					b.CurrentUsage = existingBudget.CurrentUsage
+					b.LastReset = existingBudget.LastReset
 				}
 			}
-			gs.budgets.Store(clone.Budget.ID, clone.Budget)
-			// Clean up old budget if ID changed (e.g., UUID rotation on propagation)
-			if existingCustomer.Budget != nil && existingCustomer.Budget.ID != clone.Budget.ID {
-				gs.DeleteBudget(ctx, existingCustomer.Budget.ID)
+			gs.budgets.Store(b.ID, b)
+			newBudgetIDs[b.ID] = true
+		}
+		for _, existing := range existingCustomer.Budgets {
+			if !newBudgetIDs[existing.ID] {
+				gs.DeleteBudget(ctx, existing.ID)
 			}
-		} else if existingCustomer.Budget != nil {
-			// Budget was removed from the customer, delete it from memory
-			gs.DeleteBudget(ctx, existingCustomer.Budget.ID)
 		}
 
 		// Handle rate limit updates with consistent logic
@@ -3037,9 +3062,8 @@ func (gs *LocalGovernanceStore) DeleteCustomerInMemory(ctx context.Context, cust
 	// Get customer to check for associated budget and rate limit
 	if customerValue, exists := gs.customers.Load(customerID); exists && customerValue != nil {
 		if customer, ok := customerValue.(*configstoreTables.TableCustomer); ok && customer != nil {
-			// Delete associated budget if exists
-			if customer.BudgetID != nil {
-				gs.DeleteBudget(ctx, *customer.BudgetID)
+			for _, b := range customer.Budgets {
+				gs.DeleteBudget(ctx, b.ID)
 			}
 			// Delete associated rate limit if exists
 			if customer.RateLimitID != nil {
@@ -3309,16 +3333,21 @@ func (gs *LocalGovernanceStore) updateBudgetReferences(ctx context.Context, rese
 		}
 		return true // continue
 	})
-	// Update customers that reference this budget
+	// Update customers that own this budget
 	gs.customers.Range(func(key, value interface{}) bool {
 		customer, ok := value.(*configstoreTables.TableCustomer)
 		if !ok || customer == nil {
 			return true // continue
 		}
-		if customer.BudgetID != nil && *customer.BudgetID == budgetID {
-			clone := *customer
-			clone.Budget = resetBudget
-			gs.customers.Store(key, &clone)
+		for i, b := range customer.Budgets {
+			if b.ID == budgetID {
+				clone := *customer
+				clone.Budgets = make([]configstoreTables.TableBudget, len(customer.Budgets))
+				copy(clone.Budgets, customer.Budgets)
+				clone.Budgets[i] = *resetBudget
+				gs.customers.Store(key, &clone)
+				break
+			}
 		}
 		return true // continue
 	})

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -184,8 +184,8 @@ func buildCustomer(id, name string, budget *configstoreTables.TableBudget) *conf
 		Name: name,
 	}
 	if budget != nil {
-		customer.Budget = budget
-		customer.BudgetID = &budget.ID
+		budget.CustomerID = &customer.ID
+		customer.Budgets = []configstoreTables.TableBudget{*budget}
 	}
 	return customer
 }

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -487,6 +487,74 @@ func (h *GovernanceHandler) reconcileModelConfigBudgets(ctx context.Context, tx 
 	return nil
 }
 
+// reconcileCustomerBudgets upserts the desired set of budgets owned by a customer
+// (via TableBudget.CustomerID), preserving usage on matched rows and deleting removed ones.
+// It mutates customer.Budgets to the reconciled set. Mirrors reconcileModelConfigBudgets.
+func (h *GovernanceHandler) reconcileCustomerBudgets(ctx context.Context, tx *gorm.DB, customer *configstoreTables.TableCustomer, requests []CreateBudgetRequest) error {
+	seenDurations := make(map[string]bool, len(requests))
+	for _, b := range requests {
+		if b.MaxLimit < 0 {
+			return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
+		}
+		if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
+			return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
+		}
+		if seenDurations[b.ResetDuration] {
+			return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
+		}
+		seenDurations[b.ResetDuration] = true
+	}
+
+	existingByID, existingByDuration := buildBudgetLookup(customer.Budgets, requests)
+	var reconciled []configstoreTables.TableBudget
+	matchedIDs := make(map[string]bool)
+	for _, b := range requests {
+		existing, found, err := findExistingBudget(b, existingByID, existingByDuration)
+		if err != nil {
+			return err
+		}
+		if found {
+			existing.MaxLimit = b.MaxLimit
+			existing.ResetDuration = b.ResetDuration
+			if err := validateBudget(&existing); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateBudget(ctx, &existing, tx); err != nil {
+				return err
+			}
+			reconciled = append(reconciled, existing)
+			matchedIDs[existing.ID] = true
+		} else {
+			cid := customer.ID
+			budget := configstoreTables.TableBudget{
+				ID:            uuid.NewString(),
+				MaxLimit:      b.MaxLimit,
+				ResetDuration: b.ResetDuration,
+				LastReset:     budgetLastReset(customer.CalendarAligned, b.ResetDuration),
+				CurrentUsage:  0,
+				CustomerID:    &cid,
+			}
+			inheritUsageFromClosestShorterBudget(&budget, customer.Budgets, false)
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			reconciled = append(reconciled, budget)
+		}
+	}
+	for _, existing := range customer.Budgets {
+		if !matchedIDs[existing.ID] {
+			if err := h.configStore.DeleteBudget(ctx, existing.ID, tx); err != nil {
+				return fmt.Errorf("failed to delete removed customer budget: %w", err)
+			}
+		}
+	}
+	customer.Budgets = reconciled
+	return nil
+}
+
 // vkModelConfigDesired is the desired governance state for one VK-scoped model config tier
 // (provider=nil for the VK top-level, or a specific provider). The *Provided flags distinguish
 // "leave unchanged" (false, used by partial VK updates) from "set to the given value" (true).
@@ -832,7 +900,8 @@ type UpdateTeamRequest struct {
 // CreateCustomerRequest represents the request body for creating a customer
 type CreateCustomerRequest struct {
 	Name            string                  `json:"name" validate:"required"`
-	Budget          *CreateBudgetRequest    `json:"budget,omitempty"`
+	Budgets         []CreateBudgetRequest   `json:"budgets,omitempty"`          // Multi-budget: each must have a unique reset_duration
+	Budget          *CreateBudgetRequest    `json:"budget,omitempty"`           // Deprecated: use budgets
 	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`
 	CalendarAligned bool                    `json:"calendar_aligned,omitempty"`
 }
@@ -840,7 +909,8 @@ type CreateCustomerRequest struct {
 // UpdateCustomerRequest represents the request body for updating a customer
 type UpdateCustomerRequest struct {
 	Name            *string                 `json:"name,omitempty"`
-	Budget          *UpdateBudgetRequest    `json:"budget,omitempty"`
+	Budgets         *[]CreateBudgetRequest  `json:"budgets,omitempty"`          // nil=no change, []=remove all
+	Budget          *UpdateBudgetRequest    `json:"budget,omitempty"`           // Deprecated: use budgets
 	RateLimit       *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
 	CalendarAligned *bool                   `json:"calendar_aligned,omitempty"`
 }
@@ -2344,6 +2414,10 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, "Invalid JSON")
 		return
 	}
+	if len(req.Budgets) > 0 && req.Budget != nil {
+		SendError(ctx, 400, "only one of 'budget' or 'budgets' may be set")
+		return
+	}
 	// Validate required fields
 	if req.Name == "" {
 		SendError(ctx, 400, "Customer name is required")
@@ -2362,6 +2436,14 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 			return
 		}
 	}
+	// Coerce legacy singular budget into the multi-budget slice.
+	budgetRequests := req.Budgets
+	if len(budgetRequests) == 0 && req.Budget != nil {
+		budgetRequests = []CreateBudgetRequest{{
+			MaxLimit:      req.Budget.MaxLimit,
+			ResetDuration: req.Budget.ResetDuration,
+		}}
+	}
 	var customer configstoreTables.TableCustomer
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		customer = configstoreTables.TableCustomer{
@@ -2369,22 +2451,13 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 			Name:            req.Name,
 			CalendarAligned: req.CalendarAligned,
 		}
-
-		if req.Budget != nil {
-			budget := configstoreTables.TableBudget{
-				ID:            uuid.NewString(),
-				MaxLimit:      req.Budget.MaxLimit,
-				ResetDuration: req.Budget.ResetDuration,
-				LastReset:     budgetLastReset(req.CalendarAligned, req.Budget.ResetDuration),
-				CurrentUsage:  0,
-			}
-			if err := validateBudget(&budget); err != nil {
+		if err := h.configStore.CreateCustomer(ctx, &customer, tx); err != nil {
+			return err
+		}
+		if len(budgetRequests) > 0 {
+			if err := h.reconcileCustomerBudgets(ctx, tx, &customer, budgetRequests); err != nil {
 				return err
 			}
-			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-				return err
-			}
-			customer.BudgetID = &budget.ID
 		}
 		if req.RateLimit != nil {
 			rateLimit := configstoreTables.TableRateLimit{
@@ -2400,12 +2473,17 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 				return err
 			}
 			customer.RateLimitID = &rateLimit.ID
-		}
-		if err := h.configStore.CreateCustomer(ctx, &customer, tx); err != nil {
-			return err
+			if err := h.configStore.UpdateCustomer(ctx, &customer, tx); err != nil {
+				return err
+			}
 		}
 		return nil
 	}); err != nil {
+		var badReqErr *badRequestError
+		if errors.As(err, &badReqErr) {
+			SendError(ctx, 400, err.Error())
+			return
+		}
 		SendError(ctx, 500, "failed to create customer")
 		return
 	}
@@ -2445,6 +2523,10 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, "Invalid JSON")
 		return
 	}
+	if req.Budgets != nil && req.Budget != nil {
+		SendError(ctx, 400, "only one of 'budget' or 'budgets' may be set")
+		return
+	}
 	// Fetching customer from database
 	customer, err := h.configStore.GetCustomer(ctx, customerID)
 	if err != nil {
@@ -2457,8 +2539,7 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 	}
 	// Updating customer in database
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		// Track IDs to delete after updating the customer (to avoid FK constraint)
-		var budgetIDToDelete, rateLimitIDToDelete string
+		var rateLimitIDToDelete string
 
 		// Update fields if provided
 		if req.Name != nil {
@@ -2469,62 +2550,24 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 			customer.CalendarAligned = *req.CalendarAligned
 		}
 		calendarAlignmentJustEnabled := !wasCalendarAligned && customer.CalendarAligned
-		// Handle budget updates
-		if req.Budget != nil {
-			// Check if budget removal is requested (all fields nil)
-			budgetIsEmpty := isBudgetRemovalRequest(req.Budget)
-			if budgetIsEmpty {
-				// Mark budget for deletion after FK is removed
-				if customer.BudgetID != nil {
-					budgetIDToDelete = *customer.BudgetID
-					customer.BudgetID = nil
-					customer.Budget = nil
-				}
-			} else if customer.BudgetID != nil {
-				// Update existing budget — all fields are optional (partial update)
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *customer.BudgetID).Error; err != nil {
-					return err
-				}
-				if req.Budget.MaxLimit != nil {
-					budget.MaxLimit = *req.Budget.MaxLimit
-				}
-				if req.Budget.ResetDuration != nil {
-					budget.ResetDuration = *req.Budget.ResetDuration
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				customer.Budget = &budget
-			} else {
-				// Create new budget
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
-				}
-				if *req.Budget.MaxLimit < 0 {
-					return fmt.Errorf("budget max_limit cannot be negative: %.2f", *req.Budget.MaxLimit)
-				}
-				if _, err := configstoreTables.ParseDuration(*req.Budget.ResetDuration); err != nil {
-					return fmt.Errorf("invalid reset duration format: %s", *req.Budget.ResetDuration)
-				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     budgetLastReset(customer.CalendarAligned, *req.Budget.ResetDuration),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				customer.BudgetID = &budget.ID
-				customer.Budget = &budget
+		// Handle budget updates: prefer Budgets slice; coerce legacy Budget if needed.
+		effectiveBudgets := req.Budgets
+		if effectiveBudgets == nil && req.Budget != nil {
+			if len(customer.Budgets) > 1 {
+				return &badRequestError{err: fmt.Errorf("deprecated 'budget' field cannot be used when multiple budgets already exist; use 'budgets'")}
+			}
+			var existingBudget *configstoreTables.TableBudget
+			if len(customer.Budgets) == 1 {
+				existingBudget = &customer.Budgets[0]
+			}
+			effectiveBudgets = coerceLegacyBudget(req.Budget, existingBudget)
+			if effectiveBudgets == nil && !isBudgetRemovalRequest(req.Budget) {
+				return &badRequestError{err: fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")}
+			}
+		}
+		if effectiveBudgets != nil {
+			if err := h.reconcileCustomerBudgets(ctx, tx, customer, *effectiveBudgets); err != nil {
+				return err
 			}
 		}
 		// Handle rate limit updates
@@ -2576,15 +2619,20 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 				customer.RateLimit = &rateLimit
 			}
 		}
-		// Snap budget and rate limit to the current calendar period when calendar
-		// alignment transitions false -> true in this request.
+		// Snap budgets and rate limit to the current calendar period when calendar
+		// alignment transitions false → true. Runs after reconciliation so combined
+		// "toggle + budgets" requests see the final reconciled state.
 		if calendarAlignmentJustEnabled {
 			now := time.Now()
-			if customer.Budget != nil && configstoreTables.IsCalendarAlignableDuration(customer.Budget.ResetDuration) {
-				customer.Budget.LastReset = configstoreTables.GetCalendarPeriodStart(customer.Budget.ResetDuration, now)
-				customer.Budget.CurrentUsage = 0
-				if err := h.configStore.UpdateBudget(ctx, customer.Budget, tx); err != nil {
-					return fmt.Errorf("failed to snap customer budget on calendar-align enable: %w", err)
+			for i := range customer.Budgets {
+				b := &customer.Budgets[i]
+				if !configstoreTables.IsCalendarAlignableDuration(b.ResetDuration) {
+					continue
+				}
+				b.LastReset = configstoreTables.GetCalendarPeriodStart(b.ResetDuration, now)
+				b.CurrentUsage = 0
+				if err := h.configStore.UpdateBudget(ctx, b, tx); err != nil {
+					return fmt.Errorf("failed to snap customer budget %s on calendar-align enable: %w", b.ID, err)
 				}
 			}
 			if customer.RateLimit != nil {
@@ -2611,12 +2659,6 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 			return err
 		}
 
-		// Now that FK references are removed, delete the orphaned budget/rate limit
-		if budgetIDToDelete != "" {
-			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", budgetIDToDelete).Error; err != nil {
-				return err
-			}
-		}
 		if rateLimitIDToDelete != "" {
 			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
 				return err
@@ -2625,6 +2667,11 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 
 		return nil
 	}); err != nil {
+		var badReqErr *badRequestError
+		if errors.As(err, &badReqErr) {
+			SendError(ctx, 400, err.Error())
+			return
+		}
 		SendError(ctx, 500, "Failed to update customer")
 		return
 	}

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1781,9 +1781,10 @@ func (m *mockCustomerStore) GetCustomer(_ context.Context, id string) (*configst
 		return nil, configstore.ErrNotFound
 	}
 	clone := *c
-	if c.Budget != nil {
-		b := *c.Budget
-		clone.Budget = &b
+	if len(c.Budgets) > 0 {
+		clonedBudgets := make([]configstoreTables.TableBudget, len(c.Budgets))
+		copy(clonedBudgets, c.Budgets)
+		clone.Budgets = clonedBudgets
 	}
 	if c.RateLimit != nil {
 		rl := *c.RateLimit
@@ -1910,18 +1911,27 @@ func TestUpdateCustomer_CalendarAligned_SnapsExistingBudget(t *testing.T) {
 	store := newMockCustomerStore()
 
 	budgetID := "bud-snap"
+	budgetID2 := "bud-snap-2"
 	oldLastReset := time.Now().AddDate(0, -1, 0) // 1 month ago
 	store.customers["cust-snap"] = &configstoreTables.TableCustomer{
 		ID:              "cust-snap",
 		Name:            "Initech",
 		CalendarAligned: false,
-		BudgetID:        &budgetID,
-		Budget: &configstoreTables.TableBudget{
-			ID:            budgetID,
-			MaxLimit:      200.0,
-			ResetDuration: "1M",
-			LastReset:     oldLastReset,
-			CurrentUsage:  99.0,
+		Budgets: []configstoreTables.TableBudget{
+			{
+				ID:            budgetID,
+				MaxLimit:      200.0,
+				ResetDuration: "1M",
+				LastReset:     oldLastReset,
+				CurrentUsage:  99.0,
+			},
+			{
+				ID:            budgetID2,
+				MaxLimit:      500.0,
+				ResetDuration: "1Y",
+				LastReset:     oldLastReset,
+				CurrentUsage:  150.0,
+			},
 		},
 	}
 	h := &GovernanceHandler{configStore: store, governanceManager: &mockCustomerGovernanceManager{}}
@@ -1937,20 +1947,25 @@ func TestUpdateCustomer_CalendarAligned_SnapsExistingBudget(t *testing.T) {
 	if ctx.Response.StatusCode() != 200 {
 		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
 	}
-	// UpdateBudget must have been called once (for the snap).
-	if len(store.updatedBudgets) != 1 {
-		t.Fatalf("expected 1 UpdateBudget call for snap, got %d", len(store.updatedBudgets))
+	// UpdateBudget must have been called once per budget (both snap).
+	if len(store.updatedBudgets) != 2 {
+		t.Fatalf("expected 2 UpdateBudget calls for snap, got %d", len(store.updatedBudgets))
 	}
-	snapped := store.updatedBudgets[0]
-	// LastReset must be at the calendar period start, not the old value.
-	if snapped.LastReset.Equal(oldLastReset) {
-		t.Error("budget LastReset was not snapped: still equals old value")
+	snappedIDs := make(map[string]bool, 2)
+	for _, snapped := range store.updatedBudgets {
+		snappedIDs[snapped.ID] = true
+		if snapped.LastReset.Equal(oldLastReset) {
+			t.Errorf("budget %s LastReset was not snapped: still equals old value", snapped.ID)
+		}
+		if snapped.LastReset.After(snapBefore) {
+			t.Errorf("budget %s snapped LastReset %v should be at the period start, not time.Now()", snapped.ID, snapped.LastReset)
+		}
+		if snapped.CurrentUsage != 0 {
+			t.Errorf("budget %s expected CurrentUsage reset to 0, got %v", snapped.ID, snapped.CurrentUsage)
+		}
 	}
-	if snapped.LastReset.After(snapBefore) {
-		t.Errorf("snapped LastReset %v should be at the period start, not time.Now() (%v)", snapped.LastReset, snapBefore)
-	}
-	if snapped.CurrentUsage != 0 {
-		t.Errorf("expected CurrentUsage reset to 0, got %v", snapped.CurrentUsage)
+	if !snappedIDs[budgetID] || !snappedIDs[budgetID2] {
+		t.Errorf("expected both %q and %q to be snapped, got IDs: %v", budgetID, budgetID2, snappedIDs)
 	}
 }
 
@@ -1960,18 +1975,25 @@ func TestUpdateCustomer_CalendarAligned_NoSnapWhenAlreadyEnabled(t *testing.T) {
 	SetLogger(&mockLogger{})
 	store := newMockCustomerStore()
 
-	budgetID := "bud-already"
 	store.customers["cust-already"] = &configstoreTables.TableCustomer{
 		ID:              "cust-already",
 		Name:            "Umbrella",
 		CalendarAligned: true, // already enabled
-		BudgetID:        &budgetID,
-		Budget: &configstoreTables.TableBudget{
-			ID:            budgetID,
-			MaxLimit:      300.0,
-			ResetDuration: "1M",
-			LastReset:     time.Now().AddDate(0, -1, 0),
-			CurrentUsage:  42.0,
+		Budgets: []configstoreTables.TableBudget{
+			{
+				ID:            "bud-already-1",
+				MaxLimit:      300.0,
+				ResetDuration: "1M",
+				LastReset:     time.Now().AddDate(0, -1, 0),
+				CurrentUsage:  42.0,
+			},
+			{
+				ID:            "bud-already-2",
+				MaxLimit:      800.0,
+				ResetDuration: "1Y",
+				LastReset:     time.Now().AddDate(-1, 0, 0),
+				CurrentUsage:  10.0,
+			},
 		},
 	}
 	h := &GovernanceHandler{configStore: store, governanceManager: &mockCustomerGovernanceManager{}}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -624,6 +624,19 @@ func promoteDeprecatedCalendarAligned(configData *ConfigData) {
 	if configData == nil || configData.Governance == nil {
 		return
 	}
+	// Build ID-keyed lookup maps for the global budget/rate-limit sections so
+	// customer entries (which reference by ID, not inline) can promote legacy
+	// calendar_aligned flags from the referenced rows.
+	budgetsByID := make(map[string]*configstoreTables.TableBudget, len(configData.Governance.Budgets))
+	for i := range configData.Governance.Budgets {
+		b := &configData.Governance.Budgets[i]
+		budgetsByID[b.ID] = b
+	}
+	rateLimitsByID := make(map[string]*configstoreTables.TableRateLimit, len(configData.Governance.RateLimits))
+	for i := range configData.Governance.RateLimits {
+		rl := &configData.Governance.RateLimits[i]
+		rateLimitsByID[rl.ID] = rl
+	}
 	for i := range configData.Governance.VirtualKeys {
 		vk := &configData.Governance.VirtualKeys[i]
 		promoteCalendarAligned(&vk.CalendarAligned, vk.Budgets, vk.RateLimit)
@@ -638,20 +651,24 @@ func promoteDeprecatedCalendarAligned(configData *ConfigData) {
 	}
 	for i := range configData.Governance.Customers {
 		customer := &configData.Governance.Customers[i]
-		// Customers reference budget/rate-limit by ID in config.json (no inline objects),
-		// so Budget and RateLimit are normally nil here. Handle the singular pointer
-		// directly rather than wrapping in a slice to avoid copy-and-clear issues.
-		if customer.Budget != nil {
-			if customer.Budget.CalendarAlignedInput != nil && *customer.Budget.CalendarAlignedInput {
-				customer.CalendarAligned = true
+		// Inline budgets (new multi-budget format): promote directly.
+		promoteCalendarAligned(&customer.CalendarAligned, customer.Budgets, nil)
+		// Legacy budget_id reference: look up the referenced row.
+		if customer.BudgetID != nil {
+			if b := budgetsByID[*customer.BudgetID]; b != nil {
+				if b.CalendarAlignedInput != nil && *b.CalendarAlignedInput {
+					customer.CalendarAligned = true
+				}
+				b.CalendarAlignedInput = nil
 			}
-			customer.Budget.CalendarAlignedInput = nil
 		}
-		if customer.RateLimit != nil && customer.RateLimit.CalendarAlignedInput != nil {
-			if *customer.RateLimit.CalendarAlignedInput {
-				customer.CalendarAligned = true
+		if customer.RateLimitID != nil {
+			if rl := rateLimitsByID[*customer.RateLimitID]; rl != nil {
+				if rl.CalendarAlignedInput != nil && *rl.CalendarAlignedInput {
+					customer.CalendarAligned = true
+				}
+				rl.CalendarAlignedInput = nil
 			}
-			customer.RateLimit.CalendarAlignedInput = nil
 		}
 	}
 }
@@ -2533,12 +2550,15 @@ func updateGovernanceConfigInStore(
 		// - team_id -> governance_teams
 		// - virtual_key_id -> governance_virtual_keys
 		// - provider_config_id -> governance_virtual_key_provider_configs
+		// - customer_id -> governance_customers
 		pendingTeamBudgetsToAdd := make([]configstoreTables.TableBudget, 0)
 		pendingVirtualKeyBudgetsToAdd := make([]configstoreTables.TableBudget, 0)
 		pendingProviderConfigBudgetsToAdd := make([]configstoreTables.TableBudget, 0)
+		pendingCustomerBudgetsToAdd := make([]configstoreTables.TableBudget, 0)
 		pendingTeamBudgetsToUpdate := make([]configstoreTables.TableBudget, 0)
 		pendingVirtualKeyBudgetsToUpdate := make([]configstoreTables.TableBudget, 0)
 		pendingProviderConfigBudgetsToUpdate := make([]configstoreTables.TableBudget, 0)
+		pendingCustomerBudgetsToUpdate := make([]configstoreTables.TableBudget, 0)
 
 		// Create budgets
 		for _, budget := range budgetsToAdd {
@@ -2552,6 +2572,10 @@ func updateGovernanceConfigInStore(
 			}
 			if budget.ProviderConfigID != nil {
 				pendingProviderConfigBudgetsToAdd = append(pendingProviderConfigBudgetsToAdd, budget)
+				continue
+			}
+			if budget.CustomerID != nil {
+				pendingCustomerBudgetsToAdd = append(pendingCustomerBudgetsToAdd, budget)
 				continue
 			}
 			if err := config.ConfigStore.CreateBudget(ctx, &budget, tx); err != nil {
@@ -2573,6 +2597,10 @@ func updateGovernanceConfigInStore(
 				pendingProviderConfigBudgetsToUpdate = append(pendingProviderConfigBudgetsToUpdate, budget)
 				continue
 			}
+			if budget.CustomerID != nil {
+				pendingCustomerBudgetsToUpdate = append(pendingCustomerBudgetsToUpdate, budget)
+				continue
+			}
 			if err := config.ConfigStore.UpdateBudget(ctx, &budget, tx); err != nil {
 				return fmt.Errorf("failed to update budget %s: %w", budget.ID, err)
 			}
@@ -2592,17 +2620,85 @@ func updateGovernanceConfigInStore(
 			}
 		}
 
-		// Create customers
-		for _, customer := range customersToAdd {
-			if err := config.ConfigStore.CreateCustomer(ctx, &customer, tx); err != nil {
+		// Create customers — strip inline Budgets first; created explicitly after the row exists.
+		for i := range customersToAdd {
+			customer := &customersToAdd[i]
+			for j := range customer.Budgets {
+				cid := customer.ID
+				customer.Budgets[j].CustomerID = &cid
+				pendingCustomerBudgetsToAdd = append(pendingCustomerBudgetsToAdd, customer.Budgets[j])
+			}
+			customer.Budgets = nil
+			if err := config.ConfigStore.CreateCustomer(ctx, customer, tx); err != nil {
 				return fmt.Errorf("failed to create customer %s: %w", customer.ID, err)
 			}
 		}
 
 		// Update customers (config.json changed)
-		for _, customer := range customersToUpdate {
-			if err := config.ConfigStore.UpdateCustomer(ctx, &customer, tx); err != nil {
+		for i := range customersToUpdate {
+			customer := &customersToUpdate[i]
+			if customer.Budgets != nil {
+				// Fetch existing budget IDs for this customer so we can route
+				// to add vs update — avoids INSERT conflicts on second sync.
+				var existingIDs []string
+				if err := tx.Model(&configstoreTables.TableBudget{}).
+					Where("customer_id = ?", customer.ID).
+					Pluck("id", &existingIDs).Error; err != nil {
+					return fmt.Errorf("failed to query existing budgets for customer %s: %w", customer.ID, err)
+				}
+				existingSet := make(map[string]bool, len(existingIDs))
+				for _, id := range existingIDs {
+					existingSet[id] = true
+				}
+				desiredSet := make(map[string]bool, len(customer.Budgets))
+				for j := range customer.Budgets {
+					cid := customer.ID
+					customer.Budgets[j].CustomerID = &cid
+					desiredSet[customer.Budgets[j].ID] = true
+					if existingSet[customer.Budgets[j].ID] {
+						pendingCustomerBudgetsToUpdate = append(pendingCustomerBudgetsToUpdate, customer.Budgets[j])
+					} else {
+						pendingCustomerBudgetsToAdd = append(pendingCustomerBudgetsToAdd, customer.Budgets[j])
+					}
+				}
+				// Delete stale budgets one by one — mirrors the team/VK reconcile pattern.
+				for _, existingID := range existingIDs {
+					if !desiredSet[existingID] {
+						if err := config.ConfigStore.DeleteBudget(ctx, existingID, tx); err != nil {
+							return fmt.Errorf("failed to delete stale budget %s for customer %s: %w", existingID, customer.ID, err)
+						}
+					}
+				}
+			}
+			customer.Budgets = nil
+			if err := config.ConfigStore.UpdateCustomer(ctx, customer, tx); err != nil {
 				return fmt.Errorf("failed to update customer %s: %w", customer.ID, err)
+			}
+		}
+
+		// Link budget_id references: validate ownership and set customer_id.
+		// For adds: verify the budget is unowned before taking it.
+		// For updates: also clear any stale link from the old budget_id.
+		for _, customer := range customersToAdd {
+			if customer.BudgetID == nil {
+				continue
+			}
+			if err := linkCustomerBudgetID(tx, customer.ID, *customer.BudgetID, false); err != nil {
+				return fmt.Errorf("failed to link budget %s to customer %s: %w", *customer.BudgetID, customer.ID, err)
+			}
+		}
+		for _, customer := range customersToUpdate {
+			if customer.BudgetID == nil {
+				// budget_id removed — unlink any budget previously owned via this path.
+				if err := tx.Model(&configstoreTables.TableBudget{}).
+					Where("customer_id = ?", customer.ID).
+					Update("customer_id", nil).Error; err != nil {
+					return fmt.Errorf("failed to unlink stale budgets from customer %s: %w", customer.ID, err)
+				}
+				continue
+			}
+			if err := linkCustomerBudgetID(tx, customer.ID, *customer.BudgetID, true); err != nil {
+				return fmt.Errorf("failed to link budget %s to customer %s: %w", *customer.BudgetID, customer.ID, err)
 			}
 		}
 
@@ -2629,6 +2725,20 @@ func updateGovernanceConfigInStore(
 
 		// Update team-owned budgets after teams exist.
 		for _, budget := range pendingTeamBudgetsToUpdate {
+			if err := config.ConfigStore.UpdateBudget(ctx, &budget, tx); err != nil {
+				return fmt.Errorf("failed to update budget %s: %w", budget.ID, err)
+			}
+		}
+
+		// Create customer-owned budgets after customers exist (inline budgets + top-level with customer_id).
+		for _, budget := range pendingCustomerBudgetsToAdd {
+			if err := config.ConfigStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return fmt.Errorf("failed to create budget %s: %w", budget.ID, err)
+			}
+		}
+
+		// Update customer-owned budgets declared in top-level governance.budgets.
+		for _, budget := range pendingCustomerBudgetsToUpdate {
 			if err := config.ConfigStore.UpdateBudget(ctx, &budget, tx); err != nil {
 				return fmt.Errorf("failed to update budget %s: %w", budget.ID, err)
 			}
@@ -2831,6 +2941,42 @@ func validateModelConfigGovernanceOwnership(tx *gorm.DB, modelConfig configstore
 		if err := validateBudgetLinkOwnership(tx, &id, "model config", modelConfig.ID); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// linkCustomerBudgetID sets customer_id on the referenced budget row, verifying that the budget
+// is either unowned or already owned by this customer. When clearStale is true it also
+// unlinks any other budget previously owned by the customer (handles budget_id changes).
+func linkCustomerBudgetID(tx *gorm.DB, customerID, budgetID string, clearStale bool) error {
+	var existing configstoreTables.TableBudget
+	if err := tx.Select("id", "customer_id", "team_id", "virtual_key_id", "provider_config_id", "model_config_id").
+		First(&existing, "id = ?", budgetID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("budget %s not found", budgetID)
+		}
+		return fmt.Errorf("failed to check budget ownership: %w", err)
+	}
+	if (existing.CustomerID != nil && *existing.CustomerID != customerID) ||
+		existing.TeamID != nil || existing.VirtualKeyID != nil ||
+		existing.ProviderConfigID != nil || existing.ModelConfigID != nil {
+		return fmt.Errorf("budget %s is already owned by another entity", budgetID)
+	}
+	if clearStale {
+		if err := tx.Model(&configstoreTables.TableBudget{}).
+			Where("customer_id = ? AND id != ?", customerID, budgetID).
+			Update("customer_id", nil).Error; err != nil {
+			return fmt.Errorf("failed to unlink stale budget from customer %s: %w", customerID, err)
+		}
+	}
+	result := tx.Model(&configstoreTables.TableBudget{}).
+		Where("id = ?", budgetID).
+		Update("customer_id", customerID)
+	if result.Error != nil {
+		return fmt.Errorf("failed to link budget %s to customer %s: %w", budgetID, customerID, result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("failed to link budget %s to customer %s: no row updated", budgetID, customerID)
 	}
 	return nil
 }
@@ -3106,8 +3252,25 @@ func createGovernanceConfigInStore(ctx context.Context, config *Config) {
 			} else {
 				customer.ConfigHash = customerHash
 			}
-			if err := config.ConfigStore.CreateCustomer(ctx, customer, tx); err != nil {
+			// Work on a copy so the live GovernanceConfig entry keeps its Budgets
+			// slice — in-memory reads after boot must not see a nil slice.
+			inlineBudgets := customer.Budgets
+			customerRow := *customer
+			customerRow.Budgets = nil
+			if err := config.ConfigStore.CreateCustomer(ctx, &customerRow, tx); err != nil {
 				return fmt.Errorf("failed to create customer %s: %w", customer.ID, err)
+			}
+			for j := range inlineBudgets {
+				cid := customer.ID
+				inlineBudgets[j].CustomerID = &cid
+				if err := config.ConfigStore.CreateBudget(ctx, &inlineBudgets[j], tx); err != nil {
+					return fmt.Errorf("failed to create budget %s for customer %s: %w", inlineBudgets[j].ID, customer.ID, err)
+				}
+			}
+			if customer.BudgetID != nil {
+				if err := linkCustomerBudgetID(tx, customer.ID, *customer.BudgetID, false); err != nil {
+					return fmt.Errorf("failed to link budget %s to customer %s: %w", *customer.BudgetID, customer.ID, err)
+				}
 			}
 		}
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -11699,11 +11699,12 @@ func TestSQLite_RateLimit_HashMismatch_FileSync(t *testing.T) {
 func TestGenerateCustomerHash(t *testing.T) {
 	initTestLogger()
 
-	budgetID := "budget-1"
 	customer1 := tables.TableCustomer{
-		ID:       "customer-1",
-		Name:     "Test Customer",
-		BudgetID: &budgetID,
+		ID:   "customer-1",
+		Name: "Test Customer",
+		Budgets: []tables.TableBudget{
+			{ID: "budget-1", MaxLimit: 100, ResetDuration: "1M"},
+		},
 	}
 
 	hash1, err := configstore.GenerateCustomerHash(customer1)
@@ -11736,21 +11737,55 @@ func TestGenerateCustomerHash(t *testing.T) {
 		t.Error("Different Name should produce different hash")
 	}
 
-	// Different BudgetID should produce different hash
-	newBudgetID := "budget-2"
+	// Different budget ID should produce different hash
 	customer4 := customer1
-	customer4.BudgetID = &newBudgetID
-	hash4, _ := configstore.GenerateCustomerHash(customer4)
+	customer4.Budgets = []tables.TableBudget{{ID: "budget-2", MaxLimit: 100, ResetDuration: "1M"}}
+	hash4, err := configstore.GenerateCustomerHash(customer4)
+	if err != nil {
+		t.Fatalf("failed to generate customer4 hash: %v", err)
+	}
 	if hash1 == hash4 {
-		t.Error("Different BudgetID should produce different hash")
+		t.Error("Different budget ID should produce different hash")
 	}
 
-	// Nil BudgetID should produce different hash
+	// No budgets should produce different hash
 	customer5 := customer1
-	customer5.BudgetID = nil
-	hash5, _ := configstore.GenerateCustomerHash(customer5)
+	customer5.Budgets = nil
+	hash5, err := configstore.GenerateCustomerHash(customer5)
+	if err != nil {
+		t.Fatalf("failed to generate customer5 hash: %v", err)
+	}
 	if hash1 == hash5 {
-		t.Error("Nil BudgetID should produce different hash")
+		t.Error("No budgets should produce different hash")
+	}
+
+	// Multi-budget hash must be order-independent
+	customerA := tables.TableCustomer{
+		ID:   "customer-order",
+		Name: "Order Test",
+		Budgets: []tables.TableBudget{
+			{ID: "budget-x", MaxLimit: 100, ResetDuration: "1M"},
+			{ID: "budget-y", MaxLimit: 200, ResetDuration: "1Y"},
+		},
+	}
+	customerB := tables.TableCustomer{
+		ID:   "customer-order",
+		Name: "Order Test",
+		Budgets: []tables.TableBudget{
+			{ID: "budget-y", MaxLimit: 200, ResetDuration: "1Y"},
+			{ID: "budget-x", MaxLimit: 100, ResetDuration: "1M"},
+		},
+	}
+	hashA, err := configstore.GenerateCustomerHash(customerA)
+	if err != nil {
+		t.Fatalf("failed to generate hashA: %v", err)
+	}
+	hashB, err := configstore.GenerateCustomerHash(customerB)
+	if err != nil {
+		t.Fatalf("failed to generate hashB: %v", err)
+	}
+	if hashA != hashB {
+		t.Error("multi-budget hash should be order-independent")
 	}
 
 	t.Log("✓ Customer hash generation works correctly for all fields")

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -469,9 +469,16 @@
                 "type": "string",
                 "description": "Customer name"
               },
+              "budgets": {
+                "type": "array",
+                "description": "Inline budget configurations for this customer. Each entry must have a unique reset_duration. Mutually exclusive with budget_id.",
+                "items": {
+                  "$ref": "#/$defs/budget_line"
+                }
+              },
               "budget_id": {
                 "type": "string",
-                "description": "Associated budget ID"
+                "description": "Single budget reference (pre-declared in governance.budgets). Deprecated in favour of inline budgets."
               },
               "rate_limit_id": {
                 "type": "string",
@@ -484,6 +491,9 @@
               }
             },
             "required": ["id", "name"],
+            "not": {
+              "required": ["budgets", "budget_id"]
+            },
             "additionalProperties": false
           }
         },
@@ -2931,7 +2941,13 @@
         },
         "auth_type": {
           "type": "string",
-          "enum": ["none", "headers", "oauth", "per_user_oauth", "per_user_headers"],
+          "enum": [
+            "none",
+            "headers",
+            "oauth",
+            "per_user_oauth",
+            "per_user_headers"
+          ],
           "description": "Authentication type for MCP connection"
         },
         "oauth_config_id": {
@@ -3775,9 +3791,18 @@
           "items": {
             "type": "object",
             "properties": {
-              "attribute": { "type": "string", "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')" },
-              "value": { "type": "string", "description": "Claim value to match (case-insensitive)" },
-              "role": { "type": "string", "description": "Bifrost role to assign on match" }
+              "attribute": {
+                "type": "string",
+                "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')"
+              },
+              "value": {
+                "type": "string",
+                "description": "Claim value to match (case-insensitive)"
+              },
+              "role": {
+                "type": "string",
+                "description": "Bifrost role to assign on match"
+              }
             },
             "required": ["attribute", "value", "role"],
             "additionalProperties": false
@@ -3789,9 +3814,18 @@
           "items": {
             "type": "object",
             "properties": {
-              "attribute": { "type": "string", "description": "JWT claim name" },
-              "value": { "type": "string", "description": "Claim value to match, or '*' for pass-through" },
-              "team": { "type": "string", "description": "Bifrost team slug to assign" },
+              "attribute": {
+                "type": "string",
+                "description": "JWT claim name"
+              },
+              "value": {
+                "type": "string",
+                "description": "Claim value to match, or '*' for pass-through"
+              },
+              "team": {
+                "type": "string",
+                "description": "Bifrost team slug to assign"
+              },
               "attributeType": {
                 "type": "string",
                 "enum": ["user", "group"],
@@ -3812,9 +3846,18 @@
           "items": {
             "type": "object",
             "properties": {
-              "attribute": { "type": "string", "description": "JWT claim name" },
-              "value": { "type": "string", "description": "Claim value to match" },
-              "business_unit": { "type": "string", "description": "Bifrost business unit slug to assign" },
+              "attribute": {
+                "type": "string",
+                "description": "JWT claim name"
+              },
+              "value": {
+                "type": "string",
+                "description": "Claim value to match"
+              },
+              "business_unit": {
+                "type": "string",
+                "description": "Bifrost business unit slug to assign"
+              },
               "attributeType": {
                 "type": "string",
                 "enum": ["user", "group"],

--- a/ui/app/workspace/governance/views/customerSheet.tsx
+++ b/ui/app/workspace/governance/views/customerSheet.tsx
@@ -12,13 +12,14 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import MultiBudgetLines, { BudgetLineEntry } from "@/components/ui/multibudgets";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
 import { getErrorMessage, useCreateCustomerMutation, useUpdateCustomerMutation } from "@/lib/store";
-import { CreateCustomerRequest, Customer, UpdateCustomerRequest } from "@/lib/types/governance";
+import { CreateBudgetRequest, CreateCustomerRequest, Customer, UpdateCustomerRequest } from "@/lib/types/governance";
 import { formatCurrency } from "@/lib/utils/governance";
 import { Validator } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -36,8 +37,7 @@ interface CustomerSheetProps {
 
 interface CustomerFormData {
 	name: string;
-	budgetMaxLimit: number | undefined;
-	budgetResetDuration: string;
+	budgets: BudgetLineEntry[];
 	tokenMaxLimit: number | undefined;
 	tokenResetDuration: string;
 	requestMaxLimit: number | undefined;
@@ -49,8 +49,11 @@ interface CustomerFormData {
 const createInitialState = (customer?: Customer | null): Omit<CustomerFormData, "isDirty"> => {
 	return {
 		name: customer?.name || "",
-		budgetMaxLimit: customer?.budget?.max_limit ?? undefined,
-		budgetResetDuration: customer?.budget?.reset_duration || "1M",
+		budgets: (customer?.budgets ?? []).map((b) => ({
+			id: b.id,
+			max_limit: b.max_limit,
+			reset_duration: b.reset_duration,
+		})),
 		tokenMaxLimit: customer?.rate_limit?.token_max_limit ?? undefined,
 		tokenResetDuration: customer?.rate_limit?.token_reset_duration || "1h",
 		requestMaxLimit: customer?.rate_limit?.request_max_limit ?? undefined,
@@ -96,8 +99,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 	useEffect(() => {
 		const currentData = {
 			name: formData.name,
-			budgetMaxLimit: formData.budgetMaxLimit,
-			budgetResetDuration: formData.budgetResetDuration,
+			budgets: formData.budgets,
 			tokenMaxLimit: formData.tokenMaxLimit,
 			tokenResetDuration: formData.tokenResetDuration,
 			requestMaxLimit: formData.requestMaxLimit,
@@ -110,8 +112,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		}));
 	}, [
 		formData.name,
-		formData.budgetMaxLimit,
-		formData.budgetResetDuration,
+		formData.budgets,
 		formData.tokenMaxLimit,
 		formData.tokenResetDuration,
 		formData.requestMaxLimit,
@@ -120,20 +121,47 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		initialState,
 	]);
 
-	const budgetMaxLimitNum = formData.budgetMaxLimit;
+	const canCalendarAlign = useMemo(() => {
+		const hasAlignableBudget = formData.budgets.some(
+			(b) => b.max_limit !== undefined && b.max_limit !== null && supportsCalendarAlignment(b.reset_duration),
+		);
+		const hasAlignableRateLimit =
+			(formData.tokenMaxLimit !== undefined && formData.tokenMaxLimit !== null && supportsCalendarAlignment(formData.tokenResetDuration)) ||
+			(formData.requestMaxLimit !== undefined && formData.requestMaxLimit !== null && supportsCalendarAlignment(formData.requestResetDuration));
+		return hasAlignableBudget || hasAlignableRateLimit;
+	}, [formData.budgets, formData.tokenMaxLimit, formData.tokenResetDuration, formData.requestMaxLimit, formData.requestResetDuration]);
+
+	// Reset calendarAligned when no duration supports alignment,
+	// so a hidden toggle doesn't silently submit calendar_aligned: true.
+	useEffect(() => {
+		if (!formData.calendarAligned) return;
+		if (!canCalendarAlign) {
+			updateField("calendarAligned", false);
+		}
+	}, [canCalendarAlign, formData.calendarAligned]);
+
 	const tokenMaxLimitNum = formData.tokenMaxLimit;
 	const requestMaxLimitNum = formData.requestMaxLimit;
+
+	const hasDuplicateDuration = useMemo(() => {
+		const seen = new Set<string>();
+		return formData.budgets
+			.filter((b) => b.max_limit !== undefined && b.max_limit !== null)
+			.some((b) => {
+				if (seen.has(b.reset_duration)) return true;
+				seen.add(b.reset_duration);
+				return false;
+			});
+	}, [formData.budgets]);
 
 	const validator = useMemo(
 		() =>
 			new Validator([
 				Validator.required(formData.name.trim(), "Customer name is required"),
 				Validator.custom(formData.isDirty, "No changes to save"),
-				...(formData.budgetMaxLimit !== undefined && formData.budgetMaxLimit !== null
-					? [
-						Validator.minValue(budgetMaxLimitNum ?? 0, 0.01, "Budget max limit must be greater than $0.01"),
-						Validator.required(formData.budgetResetDuration, "Budget reset duration is required"),
-					]
+				Validator.custom(!hasDuplicateDuration, "Each budget must have a unique reset period"),
+				...(formData.budgets.some((b) => b.max_limit !== undefined && b.max_limit !== null && b.max_limit < 0.01)
+					? [Validator.custom(false, "Budget max limit must be greater than $0.01")]
 					: []),
 				...(formData.tokenMaxLimit !== undefined && formData.tokenMaxLimit !== null
 					? [
@@ -148,7 +176,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 					]
 					: []),
 			]),
-		[formData, budgetMaxLimitNum, tokenMaxLimitNum, requestMaxLimitNum],
+		[formData, hasDuplicateDuration, tokenMaxLimitNum, requestMaxLimitNum],
 	);
 
 	const updateField = <K extends keyof CustomerFormData>(field: K, value: CustomerFormData[K]) => {
@@ -163,23 +191,17 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 			return;
 		}
 
+		const budgetRequests: CreateBudgetRequest[] = formData.budgets
+			.filter((b) => b.max_limit !== undefined && b.max_limit !== null)
+			.map((b) => ({ id: b.id, max_limit: b.max_limit!, reset_duration: b.reset_duration }));
+
 		try {
 			if (isEditing && customer) {
 				const updateData: UpdateCustomerRequest = {
 					name: formData.name,
 					calendar_aligned: formData.calendarAligned,
+					budgets: budgetRequests,
 				};
-
-				const hadBudget = !!customer.budget;
-				const hasBudget = budgetMaxLimitNum !== undefined && budgetMaxLimitNum !== null;
-				if (hasBudget) {
-					updateData.budget = {
-						max_limit: budgetMaxLimitNum,
-						reset_duration: formData.budgetResetDuration,
-					};
-				} else if (hadBudget) {
-					updateData.budget = {} as UpdateCustomerRequest["budget"];
-				}
 
 				const hadRateLimit = !!customer.rate_limit;
 				const hasRateLimit =
@@ -203,14 +225,8 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 				const createData: CreateCustomerRequest = {
 					name: formData.name,
 					calendar_aligned: formData.calendarAligned,
+					budgets: budgetRequests,
 				};
-
-				if (budgetMaxLimitNum !== undefined && budgetMaxLimitNum !== null) {
-					createData.budget = {
-						max_limit: budgetMaxLimitNum,
-						reset_duration: formData.budgetResetDuration,
-					};
-				}
 
 				if (
 					(tokenMaxLimitNum !== undefined && tokenMaxLimitNum !== null) ||
@@ -244,6 +260,8 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		return validator.getFirstError() || "Please fix validation errors";
 	};
 
+	const showCalendarAlignToggle = canCalendarAlign;
+
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="sm:max-w-2xl max-w-[900px]" data-testid="customer-dialog-content">
@@ -274,15 +292,12 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 								</div>
 							</div>
 
-							<NumberAndSelect
-								id="budgetMaxLimit"
-								label="Maximum Spend (USD)"
-								value={formData.budgetMaxLimit}
-								selectValue={formData.budgetResetDuration}
-								onChangeNumber={(value) => updateField("budgetMaxLimit", value)}
-								onChangeSelect={(value) => updateField("budgetResetDuration", value)}
+							<MultiBudgetLines
+								data-testid="customer-budgets"
+								label="Budget Limits"
+								lines={formData.budgets}
+								onChange={(lines) => updateField("budgets", lines)}
 								options={resetDurationOptions}
-								dataTestId="budget-max-limit-input"
 							/>
 
 							<NumberAndSelect
@@ -305,42 +320,26 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 								options={resetDurationOptions}
 							/>
 
-							{/* Calendar alignment toggle — only shown when there's an alignable budget or rate limit */}
-							{(() => {
-								const hasAlignableBudget =
-									formData.budgetMaxLimit !== undefined &&
-									formData.budgetMaxLimit !== null &&
-									supportsCalendarAlignment(formData.budgetResetDuration);
-								const hasAlignableRateLimit =
-									(formData.tokenMaxLimit !== undefined &&
-										formData.tokenMaxLimit !== null &&
-										supportsCalendarAlignment(formData.tokenResetDuration)) ||
-									(formData.requestMaxLimit !== undefined &&
-										formData.requestMaxLimit !== null &&
-										supportsCalendarAlignment(formData.requestResetDuration));
-								if (!hasAlignableBudget && !hasAlignableRateLimit) return null;
-								return (
-									<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
-										<div className="space-y-0.5">
-											<Label htmlFor="customer-calendar-aligned-toggle" className="text-sm font-normal">
-												Align to calendar cycle
-											</Label>
-											<p className="text-muted-foreground text-xs">
-												Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from
-												creation date. Applies to durations of a day or longer.
-											</p>
-										</div>
-										<Switch
-											id="customer-calendar-aligned-toggle"
-											checked={formData.calendarAligned}
-											onCheckedChange={handleCalendarAlignedChange}
-											data-testid="customer-calendar-aligned-toggle"
-										/>
+							{showCalendarAlignToggle && (
+								<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+									<div className="space-y-0.5">
+										<Label htmlFor="customer-calendar-aligned-toggle" className="text-sm font-normal">
+											Align to calendar cycle
+										</Label>
+										<p className="text-muted-foreground text-xs">
+											Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from
+											creation date. Applies to durations of a day or longer.
+										</p>
 									</div>
-								);
-							})()}
+									<Switch
+										id="customer-calendar-aligned-toggle"
+										checked={formData.calendarAligned}
+										onCheckedChange={handleCalendarAlignedChange}
+										data-testid="customer-calendar-aligned-toggle"
+									/>
+								</div>
+							)}
 
-							{/* Warning dialog shown when enabling calendar alignment on an existing customer */}
 							<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
 								<AlertDialogContent>
 									<AlertDialogHeader>
@@ -367,29 +366,29 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 								</AlertDialogContent>
 							</AlertDialog>
 
-							{isEditing && (customer?.budget || customer?.rate_limit) && (
+							{isEditing && ((customer?.budgets?.length ?? 0) > 0 || customer?.rate_limit) && (
 								<div className="bg-muted/50 space-y-4 rounded-lg border p-4">
 									<p className="text-sm font-medium">Current Usage</p>
 									<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-										{customer?.budget && (
-											<div className="space-y-1">
-												<p className="text-muted-foreground text-xs">Budget</p>
+										{customer?.budgets?.map((budget) => (
+											<div key={budget.id} className="space-y-1">
+												<p className="text-muted-foreground text-xs">Budget ({budget.reset_duration})</p>
 												<div className="flex items-center gap-2">
 													<span className="font-mono text-sm">
-														{formatCurrency(customer.budget.current_usage)} / {formatCurrency(customer.budget.max_limit)}
+														{formatCurrency(budget.current_usage)} / {formatCurrency(budget.max_limit)}
 													</span>
 													<Badge
-														variant={customer.budget.current_usage >= customer.budget.max_limit ? "destructive" : "default"}
+														variant={budget.current_usage >= budget.max_limit ? "destructive" : "default"}
 														className="text-xs"
 													>
-														{Math.round((customer.budget.current_usage / customer.budget.max_limit) * 100)}%
+														{Math.round((budget.current_usage / budget.max_limit) * 100)}%
 													</Badge>
 												</div>
 												<p className="text-muted-foreground text-xs">
-													Last Reset: {formatDistanceToNow(new Date(customer.budget.last_reset), { addSuffix: true })}
+													Last Reset: {formatDistanceToNow(new Date(budget.last_reset), { addSuffix: true })}
 												</p>
 											</div>
-										)}
+										))}
 										{customer?.rate_limit?.token_max_limit && (
 											<div className="space-y-1">
 												<p className="text-muted-foreground text-xs">Tokens</p>

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -248,15 +248,11 @@ export default function CustomersTable({
 										const customerTeams = getTeamsForCustomer(customer.id);
 										const vks = getVirtualKeysForCustomer(customer.id);
 
-										// Budget calculations
-										const isBudgetExhausted =
-											customer.budget?.max_limit &&
-											customer.budget.max_limit > 0 &&
-											customer.budget.current_usage >= customer.budget.max_limit;
-										const budgetPercentage =
-											customer.budget?.max_limit && customer.budget.max_limit > 0
-												? Math.min((customer.budget.current_usage / customer.budget.max_limit) * 100, 100)
-												: 0;
+										// Budget calculations (most-exhausted budget drives the row highlight)
+										const budgets = customer.budgets ?? [];
+										const isBudgetExhausted = budgets.some(
+											(b) => b.max_limit > 0 && b.current_usage >= b.max_limit,
+										);
 
 										// Rate limit calculations
 										const isTokenLimitExhausted =
@@ -312,38 +308,48 @@ export default function CustomersTable({
 													)}
 												</TableCell>
 												<TableCell className="min-w-[180px]">
-													{customer.budget ? (
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<div className="space-y-2">
-																	<div className="flex items-center justify-between gap-4">
-																		<span className="font-medium">{formatCurrency(customer.budget.max_limit)}</span>
-																		<span className="text-muted-foreground text-xs">
-																			{formatResetDuration(customer.budget.reset_duration)}
-																		</span>
-																	</div>
-																	<Progress
-																		value={budgetPercentage}
-																		className={cn(
-																			"bg-muted/70 dark:bg-muted/30 h-1.5",
-																			isBudgetExhausted
-																				? "[&>div]:bg-red-500/70"
-																				: budgetPercentage > 80
-																					? "[&>div]:bg-amber-500/70"
-																					: "[&>div]:bg-emerald-500/70",
-																		)}
-																	/>
-																</div>
-															</TooltipTrigger>
-															<TooltipContent>
-																<p className="font-medium">
-																	{formatCurrency(customer.budget.current_usage)} / {formatCurrency(customer.budget.max_limit)}
-																</p>
-																<p className="text-primary-foreground/80 text-xs">
-																	Resets {formatResetDuration(customer.budget.reset_duration)}
-																</p>
-															</TooltipContent>
-														</Tooltip>
+													{budgets.length > 0 ? (
+														<div className="space-y-2">
+															{budgets.map((budget) => {
+																const pct = budget.max_limit > 0
+																	? Math.min((budget.current_usage / budget.max_limit) * 100, 100)
+																	: 0;
+																const exhausted = budget.max_limit > 0 && budget.current_usage >= budget.max_limit;
+																return (
+																	<Tooltip key={budget.id}>
+																		<TooltipTrigger asChild>
+																			<div className="space-y-1">
+																				<div className="flex items-center justify-between gap-4">
+																					<span className="text-sm font-medium">{formatCurrency(budget.max_limit)}</span>
+																					<span className="text-muted-foreground text-xs">
+																						{formatResetDuration(budget.reset_duration)}
+																					</span>
+																				</div>
+																				<Progress
+																					value={pct}
+																					className={cn(
+																						"bg-muted/70 dark:bg-muted/30 h-1.5",
+																						exhausted
+																							? "[&>div]:bg-red-500/70"
+																							: pct > 80
+																								? "[&>div]:bg-amber-500/70"
+																								: "[&>div]:bg-emerald-500/70",
+																					)}
+																				/>
+																			</div>
+																		</TooltipTrigger>
+																		<TooltipContent>
+																			<p className="font-medium">
+																				{formatCurrency(budget.current_usage)} / {formatCurrency(budget.max_limit)}
+																			</p>
+																			<p className="text-primary-foreground/80 text-xs">
+																				Resets {formatResetDuration(budget.reset_duration)}
+																			</p>
+																		</TooltipContent>
+																	</Tooltip>
+																);
+															})}
+														</div>
 													) : (
 														<span className="text-muted-foreground text-sm">-</span>
 													)}

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -40,12 +40,11 @@ export interface Team {
 export interface Customer {
 	id: string;
 	name: string;
-	budget_id?: string;
 	rate_limit_id?: string;
 	calendar_aligned?: boolean;
 	// Populated relationships
 	teams?: Team[];
-	budget?: Budget;
+	budgets?: Budget[];
 	rate_limit?: RateLimit;
 }
 
@@ -209,14 +208,16 @@ export interface UpdateTeamRequest {
 
 export interface CreateCustomerRequest {
 	name: string;
-	budget?: CreateBudgetRequest;
+	budgets?: CreateBudgetRequest[];
+	budget?: CreateBudgetRequest; // deprecated: use budgets
 	rate_limit?: CreateRateLimitRequest;
 	calendar_aligned?: boolean;
 }
 
 export interface UpdateCustomerRequest {
 	name?: string;
-	budget?: UpdateBudgetRequest;
+	budgets?: CreateBudgetRequest[]; // nil=no change, []=remove all
+	budget?: UpdateBudgetRequest;   // deprecated: use budgets
 	rate_limit?: UpdateRateLimitRequest;
 	calendar_aligned?: boolean;
 }


### PR DESCRIPTION
## Summary

Customers previously supported a single budget via a `budget_id` foreign key on `governance_customers`. This PR migrates customer budget ownership to a `customer_id` FK on `governance_budgets`, matching the existing pattern used by teams. Customers can now have multiple budgets, each with a distinct reset duration.

## Changes

- **Schema**: Removed `BudgetID` from `TableCustomer` and replaced the singular `Budget` relation with a `Budgets []TableBudget` slice backed by `TableBudget.CustomerID`. The `OnDelete:CASCADE` constraint means customer deletion automatically removes owned budgets.
- **Migration** (`migrationAddCustomerBudgetsToBudgetsTable`): Adds `customer_id` column and index to `governance_budgets`, backfills from the legacy `governance_customers.budget_id` column (with a preflight conflict check), creates the FK constraint, and refreshes `config_hash` for any customers whose budgets were just linked.
- **Customer hash**: `GenerateCustomerHash` now iterates sorted budget IDs so hash output is order-independent and covers all owned budgets.
- **Governance store**: All in-memory customer budget operations (`CreateCustomerInMemory`, `UpdateCustomerInMemory`, `DeleteCustomerInMemory`, `collectBudgetsFromHierarchy`, `CheckCustomerBudget`, `updateBudgetReferences`) updated to iterate `Budgets` slices instead of dereferencing a single pointer.
- **HTTP handlers**: `createCustomer` and `updateCustomer` now use a new `reconcileCustomerBudgets` helper (mirroring `reconcileModelConfigBudgets`) that upserts the desired budget set, preserves usage on matched rows, and deletes removed budgets. The legacy singular `budget` field is coerced into the new `budgets` slice for backward compatibility.
- **API types**: `CreateCustomerRequest` and `UpdateCustomerRequest` gain a `budgets []CreateBudgetRequest` field. The old `budget` field is retained but marked deprecated.
- **Calendar alignment snapping**: Updated to iterate all budgets when snapping to a calendar period on `false → true` transitions.
- **UI**: Customer sheet replaced the single `NumberAndSelect` budget input with a `MultiBudgetLines` component supporting multiple budget rows. The customer table now renders one progress bar per budget. The `Customer` type drops `budget_id`/`budget` in favour of `budgets[]`.
- **Config promotion**: `promoteDeprecatedCalendarAligned` for customers now delegates to the shared `promoteCalendarAligned` helper used by other entity types.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

1. Create a customer with multiple budgets via `POST /governance/customers` using the `budgets` array.
2. Verify each budget row in `governance_budgets` has the correct `customer_id`.
3. Delete the customer and confirm all owned budget rows are removed via cascade.
4. Run the migration against an existing database with `budget_id` populated and confirm `customer_id` is backfilled and `config_hash` is refreshed.
5. Use the legacy `budget` field on create/update and confirm it is coerced correctly.

## Breaking changes

- [x] Yes
- [ ] No

The `Customer` API response no longer includes `budget_id` or a singular `budget` object; it returns a `budgets` array. Clients consuming the singular `budget` field must migrate to `budgets`. The legacy `budget` request field continues to work for writes but is deprecated.

The database migration is additive and non-destructive — `governance_customers.budget_id` is intentionally preserved and can be dropped in a future migration once all instances have migrated.

## Related issues

## Security considerations

No new auth surfaces. The cascade delete ensures orphaned budget rows cannot accumulate when customers are removed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customers now support multiple budgets end-to-end (UI, API, in-memory and governance logic): create, edit, display, reconcile, and enforce per-customer budget slices.

* **Migrations**
  * Added a migration to migrate/backfill customers from single- to multi-budget ownership and maintain referential integrity.

* **Deprecations**
  * Legacy single-budget fields deprecated; use the new multi-budget fields.

* **Bug Fixes**
  * Customer hash generation is now deterministic for multi-budget customers.

* **Documentation**
  * Config schema and Helm comments updated to document inline multi-budget configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->