### PR TITLE
chore: pin `recharts` dependency to use scoped `es-toolkit` and add `optimizeDeps` include

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6033,16 +6033,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/es-toolkit": {
-			"version": "1.47.0",
-			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
-			"integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
-			"license": "MIT",
-			"workspaces": [
-				"docs",
-				"benchmarks"
-			]
-		},
 		"node_modules/esbuild": {
 			"version": "0.28.0",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
@@ -9023,6 +9013,16 @@
 				"react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
+		"node_modules/recharts/node_modules/es-toolkit": {
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+			"integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
+		},
 		"node_modules/recharts/node_modules/reselect": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -10690,24 +10690,6 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
 		},
 		"node_modules/zod": {
 			"version": "4.2.1",

--- a/ui/vite.config.mts
+++ b/ui/vite.config.mts
@@ -65,6 +65,9 @@ export default defineConfig({
 			},
 		},
 	},
+	optimizeDeps: {
+		include: ["recharts"],
+	},
 	build: {
 		outDir: "out",
 		emptyOutDir: true,


### PR DESCRIPTION
## Summary

Fixes a dependency resolution issue with `recharts` by explicitly including it in Vite's `optimizeDeps`. This resolves a conflict where the top-level `es-toolkit` version (`1.47.0`) was being used instead of the version required by `recharts` (`1.45.1`), which could cause runtime errors or unexpected behavior.

## Changes

- Added `recharts` to `optimizeDeps.include` in `vite.config.mts` so Vite pre-bundles it correctly, ensuring it uses its own pinned `es-toolkit` dependency rather than the hoisted version.
- Removed the top-level `es-toolkit` (`1.47.0`) from `package-lock.json`, replacing it with a scoped entry under `recharts` using `1.45.1`.
- Removed the unused `yaml` package from `package-lock.json`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
npm i
npm run build
```

Verify the build completes without errors and that charts render correctly in the UI.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved dependency handling.

---

**Note:** This release contains only internal optimization improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->