### PR TITLE
chore: bump `recharts` from 3.1.2 to 3.8.1 and remove `optimizeDeps` include

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -62,7 +62,7 @@
 				"react-resizable-panels": "4.5.3",
 				"react-select": "5.10.2",
 				"react-textarea-autosize": "8.5.9",
-				"recharts": "3.1.2",
+				"recharts": "3.8.1",
 				"shiki": "3.23.0",
 				"sonner": "2.0.7",
 				"streamdown": "2.3.0",
@@ -8987,12 +8987,15 @@
 			}
 		},
 		"node_modules/recharts": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.2.tgz",
-			"integrity": "sha512-vhNbYwaxNbk/IATK0Ki29k3qvTkGqwvCgyQAQ9MavvvBwjvKnMTswdbklJpcOAoMPN/qxF3Lyqob0zO+ZXkZ4g==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+			"integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
 			"license": "MIT",
+			"workspaces": [
+				"www"
+			],
 			"dependencies": {
-				"@reduxjs/toolkit": "1.x.x || 2.x.x",
+				"@reduxjs/toolkit": "^1.9.0 || 2.x.x",
 				"clsx": "^2.1.1",
 				"decimal.js-light": "^2.5.1",
 				"es-toolkit": "^1.39.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -68,7 +68,7 @@
 		"react-resizable-panels": "4.5.3",
 		"react-select": "5.10.2",
 		"react-textarea-autosize": "8.5.9",
-		"recharts": "3.1.2",
+		"recharts": "3.8.1",
 		"shiki": "3.23.0",
 		"sonner": "2.0.7",
 		"streamdown": "2.3.0",

--- a/ui/vite.config.mts
+++ b/ui/vite.config.mts
@@ -65,9 +65,6 @@ export default defineConfig({
 			},
 		},
 	},
-	optimizeDeps: {
-		include: ["recharts"],
-	},
 	build: {
 		outDir: "out",
 		emptyOutDir: true,


### PR DESCRIPTION
## Summary

Upgrades the `recharts` dependency from `3.1.2` to `3.8.1` to pick up the latest fixes and improvements in the charting library.

## Changes

- Bumped `recharts` from `3.1.2` to `3.8.1` in `package.json` and `package-lock.json`
- Removed the explicit `optimizeDeps.include: ["recharts"]` workaround from `vite.config.mts`, as it is no longer needed with the updated version

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
npm i
npm run build
```

Verify the UI builds successfully and that any chart components render correctly in the browser.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the charting library (recharts) to v3.8.1.
  * Removed an explicit build-time dependency optimization configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->