### PR TITLE
feat(telemetry): configure latency histogram buckets via config.json

### DIFF
--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -86,6 +86,11 @@ type Profile struct {
 	// When true, only metadata (model, tokens, latency, etc.) is exported; input/output message
 	// content, tool definitions, and tool call arguments/results are dropped from span attributes.
 	DisableContentLogging bool `json:"disable_content_logging,omitempty"`
+
+	// Custom histogram bucket boundaries. When nil, compiled-in defaults are used.
+	LatencyBuckets           []float64 `json:"latency_buckets,omitempty"`
+	FirstTokenLatencyBuckets []float64 `json:"first_token_latency_buckets,omitempty"`
+	InterTokenLatencyBuckets []float64 `json:"inter_token_latency_buckets,omitempty"`
 }
 
 // UnmarshalJSON applies field defaults that the zero-value wouldn't capture.
@@ -207,6 +212,9 @@ type profileForStorage struct {
 	MetricsPushInterval   int               `json:"metrics_push_interval,omitempty"`
 	RequestHeaders        []string          `json:"request_headers,omitempty"`
 	DisableContentLogging bool              `json:"disable_content_logging,omitempty"`
+	LatencyBuckets           []float64      `json:"latency_buckets,omitempty"`
+	FirstTokenLatencyBuckets []float64      `json:"first_token_latency_buckets,omitempty"`
+	InterTokenLatencyBuckets []float64      `json:"inter_token_latency_buckets,omitempty"`
 }
 
 // configForStorage is the persisted wrapper shape.
@@ -242,6 +250,9 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			MetricsPushInterval:   p.MetricsPushInterval,
 			RequestHeaders:        p.RequestHeaders,
 			DisableContentLogging: p.DisableContentLogging,
+			LatencyBuckets:           p.LatencyBuckets,
+			FirstTokenLatencyBuckets: p.FirstTokenLatencyBuckets,
+			InterTokenLatencyBuckets: p.InterTokenLatencyBuckets,
 		})
 	}
 	return sonic.Marshal(out)
@@ -470,6 +481,9 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 			TLSCACert:    profile.TLSCACert,
 			Insecure:     profile.Insecure,
 			PushInterval: pushInterval,
+			LatencyBuckets:           profile.LatencyBuckets,
+			FirstTokenLatencyBuckets: profile.FirstTokenLatencyBuckets,
+			InterTokenLatencyBuckets: profile.InterTokenLatencyBuckets,
 		}
 		target.metricsExporter, err = NewMetricsExporter(p.ctx, metricsConfig)
 		if err != nil {

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -301,16 +301,16 @@ func createGRPCExporter(ctx context.Context, config *MetricsConfig) (sdkmetric.E
 }
 
 // validateBuckets checks that buckets are strictly increasing and positive.
-// Returns false and logs a warning if invalid so callers can fall back to defaults.
+// Logs a warning and returns false if invalid so callers can fall back to defaults.
 func validateBuckets(name string, buckets []float64) bool {
 	prev := 0.0
-	for _, v := range buckets {
+	for i, v := range buckets {
 		if v <= 0 {
-			logger.Warn("otel: %s contains non-positive bucket value %v — ignoring custom buckets, using defaults", name, v)
+			logger.Warn("otel: %s[%d] must be > 0, got %v — ignoring custom buckets, using defaults", name, i, v)
 			return false
 		}
-		if v <= prev {
-			logger.Warn("otel: %s bucket values must be strictly increasing (got %v after %v) — ignoring custom buckets, using defaults", name, v, prev)
+		if i > 0 && v <= prev {
+			logger.Warn("otel: %s must be strictly increasing — ignoring custom buckets, using defaults", name)
 			return false
 		}
 		prev = v
@@ -323,13 +323,13 @@ func (m *MetricsExporter) initMetrics(config *MetricsConfig) {
 	firstTokenLatencyBuckets := firstTokenLatencyBuckets
 	interTokenLatencyBuckets := interTokenLatencyBuckets
 	if len(config.LatencyBuckets) > 0 && validateBuckets("latency_buckets", config.LatencyBuckets) {
-		upstreamLatencyBuckets = config.LatencyBuckets
+		upstreamLatencyBuckets = append([]float64(nil), config.LatencyBuckets...)
 	}
 	if len(config.FirstTokenLatencyBuckets) > 0 && validateBuckets("first_token_latency_buckets", config.FirstTokenLatencyBuckets) {
-		firstTokenLatencyBuckets = config.FirstTokenLatencyBuckets
+		firstTokenLatencyBuckets = append([]float64(nil), config.FirstTokenLatencyBuckets...)
 	}
 	if len(config.InterTokenLatencyBuckets) > 0 && validateBuckets("inter_token_latency_buckets", config.InterTokenLatencyBuckets) {
-		interTokenLatencyBuckets = config.InterTokenLatencyBuckets
+		interTokenLatencyBuckets = append([]float64(nil), config.InterTokenLatencyBuckets...)
 	}
 
 	// Bifrost upstream metrics

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -28,6 +28,10 @@ type MetricsConfig struct {
 	TLSCACert    string
 	Insecure     bool // Skip TLS when true; ignored if TLSCACert is set
 	PushInterval int  // in seconds
+	// Custom histogram bucket boundaries. When nil, compiled-in defaults are used.
+	LatencyBuckets           []float64
+	FirstTokenLatencyBuckets []float64
+	InterTokenLatencyBuckets []float64
 }
 
 // MetricsExporter handles OTEL metrics export
@@ -244,7 +248,7 @@ func NewMetricsExporter(ctx context.Context, config *MetricsConfig) (*MetricsExp
 	}
 
 	// Initialize metrics with lazy loading wrappers
-	m.initMetrics()
+	m.initMetrics(config)
 
 	return m, nil
 }
@@ -296,7 +300,20 @@ func createGRPCExporter(ctx context.Context, config *MetricsConfig) (sdkmetric.E
 	return otlpmetricgrpc.New(ctx, opts...)
 }
 
-func (m *MetricsExporter) initMetrics() {
+func (m *MetricsExporter) initMetrics(config *MetricsConfig) {
+	upstreamLatencyBuckets := upstreamLatencyBuckets
+	firstTokenLatencyBuckets := firstTokenLatencyBuckets
+	interTokenLatencyBuckets := interTokenLatencyBuckets
+	if len(config.LatencyBuckets) > 0 {
+		upstreamLatencyBuckets = config.LatencyBuckets
+	}
+	if len(config.FirstTokenLatencyBuckets) > 0 {
+		firstTokenLatencyBuckets = config.FirstTokenLatencyBuckets
+	}
+	if len(config.InterTokenLatencyBuckets) > 0 {
+		interTokenLatencyBuckets = config.InterTokenLatencyBuckets
+	}
+
 	// Bifrost upstream metrics
 	m.upstreamRequestsTotal = &syncInt64Counter{
 		name:  "bifrost_upstream_requests_total",

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -300,17 +300,35 @@ func createGRPCExporter(ctx context.Context, config *MetricsConfig) (sdkmetric.E
 	return otlpmetricgrpc.New(ctx, opts...)
 }
 
+// validateBuckets checks that buckets are strictly increasing and positive.
+// Returns false and logs a warning if invalid so callers can fall back to defaults.
+func validateBuckets(name string, buckets []float64) bool {
+	prev := 0.0
+	for _, v := range buckets {
+		if v <= 0 {
+			logger.Warn("otel: %s contains non-positive bucket value %v — ignoring custom buckets, using defaults", name, v)
+			return false
+		}
+		if v <= prev {
+			logger.Warn("otel: %s bucket values must be strictly increasing (got %v after %v) — ignoring custom buckets, using defaults", name, v, prev)
+			return false
+		}
+		prev = v
+	}
+	return true
+}
+
 func (m *MetricsExporter) initMetrics(config *MetricsConfig) {
 	upstreamLatencyBuckets := upstreamLatencyBuckets
 	firstTokenLatencyBuckets := firstTokenLatencyBuckets
 	interTokenLatencyBuckets := interTokenLatencyBuckets
-	if len(config.LatencyBuckets) > 0 {
+	if len(config.LatencyBuckets) > 0 && validateBuckets("latency_buckets", config.LatencyBuckets) {
 		upstreamLatencyBuckets = config.LatencyBuckets
 	}
-	if len(config.FirstTokenLatencyBuckets) > 0 {
+	if len(config.FirstTokenLatencyBuckets) > 0 && validateBuckets("first_token_latency_buckets", config.FirstTokenLatencyBuckets) {
 		firstTokenLatencyBuckets = config.FirstTokenLatencyBuckets
 	}
-	if len(config.InterTokenLatencyBuckets) > 0 {
+	if len(config.InterTokenLatencyBuckets) > 0 && validateBuckets("inter_token_latency_buckets", config.InterTokenLatencyBuckets) {
 		interTokenLatencyBuckets = config.InterTokenLatencyBuckets
 	}
 

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -77,10 +77,16 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 		CustomLabels   []string            `json:"custom_labels,omitempty"`
 		MetricsEnabled *bool               `json:"metrics_enabled,omitempty"`
 		PushGateway    *pushGatewayStorage `json:"push_gateway,omitempty"`
+		LatencyBuckets           []float64 `json:"latency_buckets,omitempty"`
+		FirstTokenLatencyBuckets []float64 `json:"first_token_latency_buckets,omitempty"`
+		InterTokenLatencyBuckets []float64 `json:"inter_token_latency_buckets,omitempty"`
 	}
 	storage := configStorage{
-		CustomLabels:   c.CustomLabels,
-		MetricsEnabled: c.MetricsEnabled,
+		CustomLabels:             c.CustomLabels,
+		MetricsEnabled:           c.MetricsEnabled,
+		LatencyBuckets:           c.LatencyBuckets,
+		FirstTokenLatencyBuckets: c.FirstTokenLatencyBuckets,
+		InterTokenLatencyBuckets: c.InterTokenLatencyBuckets,
 	}
 	if c.PushGateway != nil {
 		pgw := &pushGatewayStorage{
@@ -197,6 +203,10 @@ type Config struct {
 	PushGateway  *PushGatewayConfig `json:"push_gateway"`
 	// MetricsEnabled controls whether the /metrics scrape endpoint is served.
 	MetricsEnabled *bool `json:"metrics_enabled,omitempty"`
+	// Custom histogram bucket boundaries. When nil, compiled-in defaults are used.
+	LatencyBuckets           []float64 `json:"latency_buckets,omitempty"`
+	FirstTokenLatencyBuckets []float64 `json:"first_token_latency_buckets,omitempty"`
+	InterTokenLatencyBuckets []float64 `json:"inter_token_latency_buckets,omitempty"`
 }
 
 // Keep in sync with plugins/otel/metrics.go's identical arrays so the Prometheus
@@ -234,6 +244,19 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 
 	if pricingManager == nil {
 		logger.Warn("telemetry plugin requires model catalog to calculate cost, all cost calculations will be skipped.")
+	}
+
+	upstreamLatencyBuckets := upstreamLatencyBuckets
+	firstTokenLatencyBuckets := firstTokenLatencyBuckets
+	interTokenLatencyBuckets := interTokenLatencyBuckets
+	if len(config.LatencyBuckets) > 0 {
+		upstreamLatencyBuckets = config.LatencyBuckets
+	}
+	if len(config.FirstTokenLatencyBuckets) > 0 {
+		firstTokenLatencyBuckets = config.FirstTokenLatencyBuckets
+	}
+	if len(config.InterTokenLatencyBuckets) > 0 {
+		interTokenLatencyBuckets = config.InterTokenLatencyBuckets
 	}
 
 	registry := config.Registry

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -237,21 +237,19 @@ var (
 )
 
 // validateBuckets checks that buckets are strictly increasing and positive.
-// Returns false and logs a warning if invalid so callers can fall back to defaults.
-func validateBuckets(name string, buckets []float64, logger schemas.Logger) bool {
+// Returns an error so Init can fail fast before Prometheus panics on invalid input.
+func validateBuckets(name string, buckets []float64) error {
 	prev := 0.0
-	for _, v := range buckets {
+	for i, v := range buckets {
 		if v <= 0 {
-			logger.Warn("telemetry: %s contains non-positive bucket value %v — ignoring custom buckets, using defaults", name, v)
-			return false
+			return fmt.Errorf("%s[%d] must be > 0, got %v", name, i, v)
 		}
-		if v <= prev {
-			logger.Warn("telemetry: %s bucket values must be strictly increasing (got %v after %v) — ignoring custom buckets, using defaults", name, v, prev)
-			return false
+		if i > 0 && v <= prev {
+			return fmt.Errorf("%s must be strictly increasing", name)
 		}
 		prev = v
 	}
-	return true
+	return nil
 }
 
 // Init creates a new PrometheusPlugin with initialized metrics.
@@ -267,14 +265,23 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 	upstreamLatencyBuckets := upstreamLatencyBuckets
 	firstTokenLatencyBuckets := firstTokenLatencyBuckets
 	interTokenLatencyBuckets := interTokenLatencyBuckets
-	if len(config.LatencyBuckets) > 0 && validateBuckets("latency_buckets", config.LatencyBuckets, logger) {
-		upstreamLatencyBuckets = config.LatencyBuckets
+	if len(config.LatencyBuckets) > 0 {
+		if err := validateBuckets("latency_buckets", config.LatencyBuckets); err != nil {
+			return nil, err
+		}
+		upstreamLatencyBuckets = append([]float64(nil), config.LatencyBuckets...)
 	}
-	if len(config.FirstTokenLatencyBuckets) > 0 && validateBuckets("first_token_latency_buckets", config.FirstTokenLatencyBuckets, logger) {
-		firstTokenLatencyBuckets = config.FirstTokenLatencyBuckets
+	if len(config.FirstTokenLatencyBuckets) > 0 {
+		if err := validateBuckets("first_token_latency_buckets", config.FirstTokenLatencyBuckets); err != nil {
+			return nil, err
+		}
+		firstTokenLatencyBuckets = append([]float64(nil), config.FirstTokenLatencyBuckets...)
 	}
-	if len(config.InterTokenLatencyBuckets) > 0 && validateBuckets("inter_token_latency_buckets", config.InterTokenLatencyBuckets, logger) {
-		interTokenLatencyBuckets = config.InterTokenLatencyBuckets
+	if len(config.InterTokenLatencyBuckets) > 0 {
+		if err := validateBuckets("inter_token_latency_buckets", config.InterTokenLatencyBuckets); err != nil {
+			return nil, err
+		}
+		interTokenLatencyBuckets = append([]float64(nil), config.InterTokenLatencyBuckets...)
 	}
 
 	registry := config.Registry

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -236,6 +236,24 @@ var (
 	}
 )
 
+// validateBuckets checks that buckets are strictly increasing and positive.
+// Returns false and logs a warning if invalid so callers can fall back to defaults.
+func validateBuckets(name string, buckets []float64, logger schemas.Logger) bool {
+	prev := 0.0
+	for _, v := range buckets {
+		if v <= 0 {
+			logger.Warn("telemetry: %s contains non-positive bucket value %v — ignoring custom buckets, using defaults", name, v)
+			return false
+		}
+		if v <= prev {
+			logger.Warn("telemetry: %s bucket values must be strictly increasing (got %v after %v) — ignoring custom buckets, using defaults", name, v, prev)
+			return false
+		}
+		prev = v
+	}
+	return true
+}
+
 // Init creates a new PrometheusPlugin with initialized metrics.
 func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger schemas.Logger) (*PrometheusPlugin, error) {
 	if config == nil {
@@ -249,13 +267,13 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 	upstreamLatencyBuckets := upstreamLatencyBuckets
 	firstTokenLatencyBuckets := firstTokenLatencyBuckets
 	interTokenLatencyBuckets := interTokenLatencyBuckets
-	if len(config.LatencyBuckets) > 0 {
+	if len(config.LatencyBuckets) > 0 && validateBuckets("latency_buckets", config.LatencyBuckets, logger) {
 		upstreamLatencyBuckets = config.LatencyBuckets
 	}
-	if len(config.FirstTokenLatencyBuckets) > 0 {
+	if len(config.FirstTokenLatencyBuckets) > 0 && validateBuckets("first_token_latency_buckets", config.FirstTokenLatencyBuckets, logger) {
 		firstTokenLatencyBuckets = config.FirstTokenLatencyBuckets
 	}
-	if len(config.InterTokenLatencyBuckets) > 0 {
+	if len(config.InterTokenLatencyBuckets) > 0 && validateBuckets("inter_token_latency_buckets", config.InterTokenLatencyBuckets, logger) {
 		interTokenLatencyBuckets = config.InterTokenLatencyBuckets
 	}
 

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -69,6 +69,15 @@ func loadBuiltinPlugin(ctx context.Context, name string, pluginConfig any, bifro
 				if extraConfig.MetricsEnabled != nil {
 					telConfig.MetricsEnabled = extraConfig.MetricsEnabled
 				}
+				if len(extraConfig.LatencyBuckets) > 0 {
+					telConfig.LatencyBuckets = extraConfig.LatencyBuckets
+				}
+				if len(extraConfig.FirstTokenLatencyBuckets) > 0 {
+					telConfig.FirstTokenLatencyBuckets = extraConfig.FirstTokenLatencyBuckets
+				}
+				if len(extraConfig.InterTokenLatencyBuckets) > 0 {
+					telConfig.InterTokenLatencyBuckets = extraConfig.InterTokenLatencyBuckets
+				}
 			}
 		}
 		return telemetry.Init(telConfig, bifrostConfig.ModelCatalog, logger)

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1563,6 +1563,21 @@
                         }
                       },
                       "required": ["push_gateway_url"]
+                    },
+                    "latency_buckets": {
+                      "type": "array",
+                      "items": { "type": "number", "exclusiveMinimum": 0 },
+                      "description": "Custom bucket boundaries for end-to-end HTTP and upstream latency histograms. Must be strictly increasing positive values. Defaults to compiled-in LLM-optimised boundaries when omitted."
+                    },
+                    "first_token_latency_buckets": {
+                      "type": "array",
+                      "items": { "type": "number", "exclusiveMinimum": 0 },
+                      "description": "Custom bucket boundaries for time-to-first-token (TTFT) histograms. Must be strictly increasing positive values."
+                    },
+                    "inter_token_latency_buckets": {
+                      "type": "array",
+                      "items": { "type": "number", "exclusiveMinimum": 0 },
+                      "description": "Custom bucket boundaries for inter-token latency histograms. Must be strictly increasing positive values."
                     }
                   },
                   "additionalProperties": false

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2417,6 +2417,21 @@
         },
         "plugin_span_filter": {
           "$ref": "#/$defs/plugin_span_filter"
+        },
+        "latency_buckets": {
+          "type": "array",
+          "items": { "type": "number", "exclusiveMinimum": 0 },
+          "description": "Custom bucket boundaries for end-to-end HTTP and upstream latency histograms. Must be strictly increasing positive values. Defaults to compiled-in LLM-optimised boundaries when omitted."
+        },
+        "first_token_latency_buckets": {
+          "type": "array",
+          "items": { "type": "number", "exclusiveMinimum": 0 },
+          "description": "Custom bucket boundaries for time-to-first-token (TTFT) histograms. Must be strictly increasing positive values."
+        },
+        "inter_token_latency_buckets": {
+          "type": "array",
+          "items": { "type": "number", "exclusiveMinimum": 0 },
+          "description": "Custom bucket boundaries for inter-token latency histograms. Must be strictly increasing positive values."
         }
       },
       "allOf": [


### PR DESCRIPTION
## Summary

Adds configurable latency histogram bucket boundaries for both the Prometheus (`telemetry`) and OTel plugins via `config.json`. Operators running LLM workloads can now customize bucket boundaries per deployment without forking. 

## Changes

- Added `latency_buckets`, `first_token_latency_buckets`, and `inter_token_latency_buckets` fields to `telemetry.Config` and OTel `Profile`
- `plugins/telemetry/main.go`: reads bucket config in `Init()` using local variable shadowing to avoid data races; persists fields in `MarshalForStorage`
- `plugins/otel/metrics.go`: added fields to `MetricsConfig`; `initMetrics` accepts config and applies overrides before histogram registration
- `plugins/otel/main.go`: added fields to `Profile` and `profileForStorage`; passes them through `MetricsConfig` to `initMetrics`
- `transports/bifrost-http/server/plugins.go`: explicitly merges bucket fields when loading telemetry plugin config from persisted store
- `transports/config.schema.json`: documents the three new fields with descriptions and item-level validation

When fields are omitted, compiled-in defaults are used unchanged — no impact on existing deployments.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd plugins/telemetry && go build ./...
cd plugins/otel && go build ./...
cd transports && go build ./...
```

Add to `config.json`:
```json
{
  "plugins": [
    {
      "name": "telemetry",
      "enabled": true,
      "config": {
        "latency_buckets": [0.005, 0.1, 1, 10, 60, 300, 900]
      }
    }
  ]
}
```
Start Bifrost and scrape `/metrics` — bucket boundaries should reflect the configured values. When fields are omitted, existing compiled-in defaults are used.

## Breaking changes

- [x] No

## Related issues

Closes #3969

## Security considerations

None — config fields are read at startup from `config.json` or the persisted config store.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified builds succeed (Go and UI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry and OTEL plugins support configurable histogram bucket boundaries for latency, first-token latency, and inter-token latency.
  * Per-profile/plugin bucket settings can be supplied for finer-grained latency tracking.

* **Bug Fixes / Reliability**
  * Custom bucket arrays are validated (positive, strictly increasing). Invalid inputs: telemetry initialization returns an error; OTEL falls back to defaults and logs a warning.

* **Chores**
  * Configuration schema updated to constrain bucket values (non-negative).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->