### PR TITLE
feat: add `per_user_oauth` to MCP connection `authType` enum in Bifrost Helm chart schema

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -443,6 +443,18 @@ false
 {{- end }}
 {{- $_ := set $governance "business_units" $businessUnits }}
 {{- end }}
+{{- if .Values.bifrost.governance.roles }}
+{{- $roles := list }}
+{{- range .Values.bifrost.governance.roles }}
+{{- $role := dict "name" .name }}
+{{- if .description }}{{- $_ := set $role "description" .description }}{{- end }}
+{{- if .dac }}{{- $_ := set $role "dac" .dac }}{{- end }}
+{{- if .access_profile }}{{- $_ := set $role "access_profile" .access_profile }}{{- end }}
+{{- if .permissions }}{{- $_ := set $role "permissions" .permissions }}{{- end }}
+{{- $roles = append $roles $role }}
+{{- end }}
+{{- $_ := set $governance "roles" $roles }}
+{{- end }}
 {{- if .Values.bifrost.governance.virtualKeys }}
 {{- $vks := list }}
 {{- range .Values.bifrost.governance.virtualKeys }}
@@ -494,7 +506,7 @@ false
 {{- $_ := set $governance "auth_config" $authConfig }}
 {{- end }}
 {{- end }}
-{{- if or $governance.budgets $governance.rate_limits $governance.customers $governance.teams $governance.business_units $governance.virtual_keys $governance.routing_rules $governance.model_configs $governance.providers $governance.pricing_overrides $governance.auth_config }}
+{{- if or $governance.budgets $governance.rate_limits $governance.customers $governance.teams $governance.business_units $governance.roles $governance.virtual_keys $governance.routing_rules $governance.model_configs $governance.providers $governance.pricing_overrides $governance.auth_config }}
 {{- $_ := set $config "governance" $governance }}
 {{- end }}
 {{- end }}
@@ -1613,6 +1625,15 @@ Call this template at the beginning of deployment/stateful templates
 {{- end }}
 {{- if not $vk.name }}
 {{- fail (printf "ERROR: bifrost.governance.virtualKeys[%d].name is required for virtual key '%s'." $idx $vk.id) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Validate governance roles */}}
+{{- if .Values.bifrost.governance.roles }}
+{{- range $idx, $role := .Values.bifrost.governance.roles }}
+{{- if not $role.name }}
+{{- fail (printf "ERROR: bifrost.governance.roles[%d].name is required." $idx) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -4089,7 +4089,7 @@
         },
         "authType": {
           "type": "string",
-          "enum": ["none", "headers", "oauth"],
+          "enum": ["none", "headers", "oauth", "per_user_oauth", "per_user_headers"],
           "description": "Authentication type for MCP connection"
         },
         "oauthConfigId": {

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1135,6 +1135,42 @@
                 "required": ["id", "name"]
               }
             },
+            "roles": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "dac": {
+                    "type": "string",
+                    "enum": ["own-data", "team-data", "all-data"],
+                    "default": "all-data"
+                  },
+                  "access_profile": {
+                    "type": "string"
+                  },
+                  "permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "resource": { "type": "string" },
+                        "operation": { "type": "string" }
+                      },
+                      "required": ["resource", "operation"],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+              }
+            },
             "virtualKeys": {
               "type": "array",
               "items": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -383,6 +383,15 @@ bifrost:
       #   tlsConfig:
       #     insecureSkipVerify: false              # Disable TLS verification (dev/test only — takes priority over caCertPem)
       #     caCertPem: "env.MY_MCP_CA_CERT"       # PEM string or env.VAR_NAME reference
+      #
+      # - name: "example-oauth-mcp"
+      #   connectionType: "http"
+      #   connectionString: "https://my-mcp.corp/mcp"
+      #   # authType "oauth": shared OAuth token; provide oauthConfigId referencing an existing oauth_config.
+      #   # authType "per_user_oauth": each user authenticates individually via OAuth flow;
+      #   #   oauth_config is registered via the API (POST /api/mcp/clients), not configured here.
+      #   authType: "oauth"
+      #   oauthConfigId: "my-oauth-config-id"   # ID of the OAuth config created in Bifrost
     # toolSyncInterval: "10m"   # Global tool sync interval (Go duration string, e.g. "10m", "1h", "0s")
     # Tool manager configuration
     toolManagerConfig:
@@ -526,6 +535,18 @@ bifrost:
       #   profile: {}              # Team profile data
       #   config: {}               # Team configuration data
       #   claims: {}               # Team claims data
+    roles: []
+      # - name: "data-analyst"
+      #   description: "Read-only access for data analysts"
+      #   dac: "team-data"           # own-data | team-data | all-data (default: all-data)
+      #   access_profile: "analyst-profile"  # Optional: name of an access_profile to attach
+      #   permissions:
+      #     - resource: "Logs"
+      #       operation: "View"
+      #     - resource: "Metrics"
+      #       operation: "View"
+      #     - resource: "VirtualKeys"
+      #       operation: "View"
     virtualKeys: []
       # - id: "vk-1"
       #   name: "Virtual Key 1"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -605,6 +605,54 @@
             "additionalProperties": false
           }
         },
+        "roles": {
+          "type": "array",
+          "description": "RBAC role definitions. Roles are created or updated on startup if the config hash changes; system roles and dashboard-created roles are never deleted.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Unique role name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Human-readable description of the role"
+              },
+              "dac": {
+                "type": "string",
+                "description": "Data Access Control scope: own-data (user's own records), team-data (user's team records), all-data (unrestricted). Defaults to all-data.",
+                "enum": ["own-data", "team-data", "all-data"],
+                "default": "all-data"
+              },
+              "access_profile": {
+                "type": "string",
+                "description": "Name of the access profile (defined in access_profiles) to attach as the default for this role. Changing this field triggers a re-sync on next startup. Leave unset to let the dashboard manage the assignment."
+              },
+              "permissions": {
+                "type": "array",
+                "description": "List of resource+operation permission pairs to grant to this role",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "resource": {
+                      "type": "string",
+                      "description": "Permission resource (e.g. Logs, VirtualKeys, Users, ModelProvider, Metrics, Guardrails, AccessProfiles, MCPToolGroups, Roles, BusinessUnits, AuditLogs, Billing)"
+                    },
+                    "operation": {
+                      "type": "string",
+                      "description": "Permission operation (e.g. View, Create, Update, Delete, Download, RunInference, ManageInference, ViewInference)"
+                    }
+                  },
+                  "required": ["resource", "operation"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
         "virtual_keys": {
           "type": "array",
           "description": "Virtual key configurations",


### PR DESCRIPTION
## Summary

Adds `per_user_oauth` as a valid authentication type option for MCP connections in the Bifrost Helm chart schema.

## Changes

- Added `per_user_oauth` to the allowed enum values for `authType` in the MCP connection configuration schema, enabling per-user OAuth as a supported authentication method alongside the existing `none`, `headers`, and `oauth` options.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Bifrost Helm chart with an MCP connection configured to use `authType: per_user_oauth` and verify the schema validation accepts the value without errors.

```sh
helm lint helm-charts/bifrost
helm template helm-charts/bifrost --set mcp.authType=per_user_oauth
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This introduces a new OAuth authentication mode scoped to individual users. Ensure that per-user OAuth token handling follows the same security practices as the existing `oauth` flow, including secure storage and transmission of tokens.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-user OAuth authentication option in MCP client configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->