### PR TITLE
feat: add `request_headers` pattern capture to OTel and Maxim observability plugins with wildcard support

### DIFF
--- a/core/schemas/headers.go
+++ b/core/schemas/headers.go
@@ -1,0 +1,43 @@
+package schemas
+
+import "strings"
+
+// MatchHeaderPattern reports whether a lowercased header name matches a pattern.
+// Supports exact match, "*" (all), and a single trailing-wildcard prefix (e.g. "x-custom-*").
+// The pattern is trimmed and lowercased before comparison; the header name is expected to
+// already be lowercased by the caller.
+func MatchHeaderPattern(headerName, pattern string) bool {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	if pattern == "" {
+		return false
+	}
+	if pattern == "*" {
+		return true
+	}
+	if prefix, ok := strings.CutSuffix(pattern, "*"); ok {
+		return strings.HasPrefix(headerName, prefix)
+	}
+	return headerName == pattern
+}
+
+// FilterHeaders returns the subset of headers whose (lowercased) keys match any of the
+// given patterns (exact name or wildcard like "x-custom-*" or "*"). Header keys are
+// expected to already be lowercased by the capture layer. Returns nil when nothing matches.
+func FilterHeaders(headers map[string]string, patterns []string) map[string]string {
+	if len(headers) == 0 || len(patterns) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	for name, value := range headers {
+		for _, pattern := range patterns {
+			if MatchHeaderPattern(name, pattern) {
+				out[name] = value
+				break
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -9,16 +9,17 @@ import (
 
 // Trace represents a distributed trace that captures the full lifecycle of a request
 type Trace struct {
-	RequestID  string           // Request ID for the trace
-	TraceID    string           // Unique identifier for this trace
-	ParentID   string           // Parent trace ID from incoming W3C traceparent header
-	RootSpan   *Span            // The root span of this trace
-	Spans      []*Span          // All spans in this trace
-	StartTime  time.Time        // When the trace started
-	EndTime    time.Time        // When the trace completed
-	Attributes map[string]any   // Additional attributes for the trace
-	PluginLogs []PluginLogEntry // Plugin log entries accumulated during request processing
-	mu         sync.Mutex       // Mutex for thread-safe span operations
+	RequestID      string            // Request ID for the trace
+	TraceID        string            // Unique identifier for this trace
+	ParentID       string            // Parent trace ID from incoming W3C traceparent header
+	RootSpan       *Span             // The root span of this trace
+	Spans          []*Span           // All spans in this trace
+	StartTime      time.Time         // When the trace started
+	EndTime        time.Time         // When the trace completed
+	Attributes     map[string]any    // Additional attributes for the trace
+	RequestHeaders map[string]string // Lowercased request headers, populated only when a connector opts in
+	PluginLogs     []PluginLogEntry  // Plugin log entries accumulated during request processing
+	mu             sync.Mutex        // Mutex for thread-safe span operations
 }
 
 // AddSpan adds a span to the trace in a thread-safe manner
@@ -54,6 +55,13 @@ func (t *Trace) SetRequestID(requestID string) {
 	t.RequestID = requestID
 }
 
+// SetRequestHeaders sets the captured request headers for the trace.
+func (t *Trace) SetRequestHeaders(headers map[string]string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.RequestHeaders = headers
+}
+
 // Reset clears the trace for reuse from pool
 func (t *Trace) Reset() {
 	t.mu.Lock()
@@ -69,6 +77,7 @@ func (t *Trace) Reset() {
 	t.StartTime = time.Time{}
 	t.EndTime = time.Time{}
 	t.Attributes = nil
+	t.RequestHeaders = nil
 	for i := range t.PluginLogs {
 		t.PluginLogs[i] = PluginLogEntry{}
 	}
@@ -223,20 +232,20 @@ const (
 	// AttrEmbeddingsDimensionCount is the OTel spec key for embedding dimensions
 	// (Bifrost historically emitted AttrDimensions = gen_ai.request.dimensions).
 	AttrEmbeddingsDimensionCount = "gen_ai.embeddings.dimension.count"
-	AttrSeed             = "gen_ai.request.seed"
-	AttrSuffix           = "gen_ai.request.suffix"
-	AttrDimensions       = "gen_ai.request.dimensions"      // legacy: replaced by AttrEmbeddingsDimensionCount
-	AttrEncodingFormat   = "gen_ai.request.encoding_format" // legacy: singular form; replaced by AttrEncodingFormats (string[])
-	AttrEncodingFormats  = "gen_ai.request.encoding_formats"
-	AttrLanguage         = "gen_ai.request.language"
-	AttrPrompt           = "gen_ai.request.prompt"
-	AttrResponseFormat   = "gen_ai.request.response_format"
-	AttrFormat           = "gen_ai.request.format"
-	AttrVoice            = "gen_ai.request.voice"
-	AttrMultiVoiceConfig = "gen_ai.request.multi_voice_config"
-	AttrInstructions     = "gen_ai.request.instructions"
-	AttrSpeed            = "gen_ai.request.speed"
-	AttrMessageCount     = "gen_ai.request.message_count"
+	AttrSeed                     = "gen_ai.request.seed"
+	AttrSuffix                   = "gen_ai.request.suffix"
+	AttrDimensions               = "gen_ai.request.dimensions"      // legacy: replaced by AttrEmbeddingsDimensionCount
+	AttrEncodingFormat           = "gen_ai.request.encoding_format" // legacy: singular form; replaced by AttrEncodingFormats (string[])
+	AttrEncodingFormats          = "gen_ai.request.encoding_formats"
+	AttrLanguage                 = "gen_ai.request.language"
+	AttrPrompt                   = "gen_ai.request.prompt"
+	AttrResponseFormat           = "gen_ai.request.response_format"
+	AttrFormat                   = "gen_ai.request.format"
+	AttrVoice                    = "gen_ai.request.voice"
+	AttrMultiVoiceConfig         = "gen_ai.request.multi_voice_config"
+	AttrInstructions             = "gen_ai.request.instructions"
+	AttrSpeed                    = "gen_ai.request.speed"
+	AttrMessageCount             = "gen_ai.request.message_count"
 
 	// Response Attributes
 	AttrResponseID       = "gen_ai.response.id"
@@ -419,11 +428,11 @@ const (
 	AttrOutputTokenDetailsSearch       = "gen_ai.usage.output_token_details.num_search_queries"
 
 	// Tool execution attributes (OTel GenAI spec) used on MCP tool spans.
-	AttrToolName            = "gen_ai.tool.name"
-	AttrToolCallID          = "gen_ai.tool.call.id"
-	AttrToolCallArguments   = "gen_ai.tool.call.arguments"
-	AttrToolCallResult      = "gen_ai.tool.call.result"
-	AttrToolType            = "gen_ai.tool.type"
+	AttrToolName          = "gen_ai.tool.name"
+	AttrToolCallID        = "gen_ai.tool.call.id"
+	AttrToolCallArguments = "gen_ai.tool.call.arguments"
+	AttrToolCallResult    = "gen_ai.tool.call.result"
+	AttrToolType          = "gen_ai.tool.type"
 
 	// =====================================================================
 	// Bifrost-namespaced attributes (bifrost.*)
@@ -436,20 +445,20 @@ const (
 	// The corresponding legacy gen_ai.* emissions are tagged "// legacy:" at their
 	// call sites and will be removed once dashboards migrate over.
 	// =====================================================================
-	AttrBifrostProviderName       = "bifrost.provider.name"
-	AttrBifrostRequestID          = "bifrost.request.id"
-	AttrBifrostVirtualKeyID       = "bifrost.virtual_key.id"
-	AttrBifrostVirtualKeyName     = "bifrost.virtual_key.name"
-	AttrBifrostSelectedKeyID      = "bifrost.selected_key.id"
-	AttrBifrostSelectedKeyName    = "bifrost.selected_key.name"
-	AttrBifrostRoutingRuleID      = "bifrost.routing_rule.id"
-	AttrBifrostRoutingRuleName    = "bifrost.routing_rule.name"
-	AttrBifrostTeamID             = "bifrost.team.id"
-	AttrBifrostTeamName           = "bifrost.team.name"
-	AttrBifrostCustomerID         = "bifrost.customer.id"
-	AttrBifrostCustomerName       = "bifrost.customer.name"
-	AttrBifrostRetries            = "bifrost.retries"
-	AttrBifrostFallbackIndex      = "bifrost.fallback_index"
+	AttrBifrostProviderName        = "bifrost.provider.name"
+	AttrBifrostRequestID           = "bifrost.request.id"
+	AttrBifrostVirtualKeyID        = "bifrost.virtual_key.id"
+	AttrBifrostVirtualKeyName      = "bifrost.virtual_key.name"
+	AttrBifrostSelectedKeyID       = "bifrost.selected_key.id"
+	AttrBifrostSelectedKeyName     = "bifrost.selected_key.name"
+	AttrBifrostRoutingRuleID       = "bifrost.routing_rule.id"
+	AttrBifrostRoutingRuleName     = "bifrost.routing_rule.name"
+	AttrBifrostTeamID              = "bifrost.team.id"
+	AttrBifrostTeamName            = "bifrost.team.name"
+	AttrBifrostCustomerID          = "bifrost.customer.id"
+	AttrBifrostCustomerName        = "bifrost.customer.name"
+	AttrBifrostRetries             = "bifrost.retries"
+	AttrBifrostFallbackIndex       = "bifrost.fallback_index"
 	AttrBifrostStopSequencesJoined = "bifrost.request.stop_sequences"
 
 	// OTel general semconv (no gen_ai prefix). Emitted alongside the legacy

--- a/framework/tracing/store.go
+++ b/framework/tracing/store.go
@@ -14,12 +14,12 @@ import (
 type DeferredSpanInfo struct {
 	SpanID              string
 	StartTime           time.Time
-	Tracer              schemas.Tracer          // Reference to tracer for completing the span
-	RequestID           string                  // Request ID for accumulator lookup
-	FirstChunkTime      time.Time               // Timestamp of first chunk (for TTFT calculation)
-	ChunkCount          int                     // Count of received streaming chunks (for AttrTotalChunks)
+	Tracer              schemas.Tracer           // Reference to tracer for completing the span
+	RequestID           string                   // Request ID for accumulator lookup
+	FirstChunkTime      time.Time                // Timestamp of first chunk (for TTFT calculation)
+	ChunkCount          int                      // Count of received streaming chunks (for AttrTotalChunks)
 	AccumulatedResponse *schemas.BifrostResponse // Full accumulated response from streaming chunks
-	mu                  sync.Mutex              // Mutex for thread-safe chunk accumulation
+	mu                  sync.Mutex               // Mutex for thread-safe chunk accumulation
 }
 
 // TraceStore manages traces with thread-safe access and object pooling
@@ -106,6 +106,9 @@ func (s *TraceStore) CreateTrace(inheritedTraceID string, requestID ...string) s
 		clear(trace.Attributes)
 	}
 
+	// Reset request headers
+	trace.RequestHeaders = nil
+
 	s.traces.Store(trace.TraceID, trace)
 	return trace.TraceID
 }
@@ -125,6 +128,15 @@ func (s *TraceStore) SetRequestID(traceID string, requestID string) {
 		return
 	}
 	trace.SetRequestID(requestID)
+}
+
+// SetRequestHeaders sets the captured request headers for the trace
+func (s *TraceStore) SetRequestHeaders(traceID string, headers map[string]string) {
+	trace := s.GetTrace(traceID)
+	if trace == nil {
+		return
+	}
+	trace.SetRequestHeaders(headers)
 }
 
 // CompleteTrace marks the trace as complete, removes it from store, and returns it for flushing

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -18,12 +18,13 @@ import (
 // framework's TraceStore implementation.
 // It also embeds a streaming.Accumulator for centralized streaming chunk accumulation.
 type Tracer struct {
-	store          *TraceStore
-	accumulator    *streaming.Accumulator
-	pricingManager *modelcatalog.ModelCatalog
-	logger         schemas.Logger
-	obsPlugins     atomic.Pointer[[]schemas.ObservabilityPlugin]
-	flushWG        sync.WaitGroup
+	store              *TraceStore
+	accumulator        *streaming.Accumulator
+	pricingManager     *modelcatalog.ModelCatalog
+	logger             schemas.Logger
+	obsPlugins         atomic.Pointer[[]schemas.ObservabilityPlugin]
+	cachedHdrPatterns  atomic.Pointer[[]string]
+	flushWG            sync.WaitGroup
 }
 
 // NewTracer creates a new Tracer wrapping the given TraceStore.
@@ -40,11 +41,66 @@ func NewTracer(store *TraceStore, pricingManager *modelcatalog.ModelCatalog, log
 }
 
 // SetObservabilityPlugins updates the plugins that receive completed traces.
+// It also precomputes the deduplicated, normalized union of request-header patterns
+// requested by those plugins so the per-request capture path is a single atomic load.
 func (t *Tracer) SetObservabilityPlugins(obsPlugins []schemas.ObservabilityPlugin) {
 	if t == nil {
 		return
 	}
 	t.obsPlugins.Store(&obsPlugins)
+
+	seen := make(map[string]struct{})
+	var patterns []string
+	for _, plugin := range obsPlugins {
+		if w, ok := plugin.(interface{ RequestHeaderPatterns() []string }); ok {
+			for _, p := range w.RequestHeaderPatterns() {
+				normalized := strings.ToLower(strings.TrimSpace(p))
+				if normalized == "" {
+					continue
+				}
+				if _, exists := seen[normalized]; !exists {
+					seen[normalized] = struct{}{}
+					patterns = append(patterns, normalized)
+				}
+			}
+		}
+	}
+	t.cachedHdrPatterns.Store(&patterns)
+}
+
+// ShouldCaptureRequestHeaders reports whether any observability plugin has opted into
+// request-header capture (by implementing RequestHeaderPatterns). Derived from the cached
+// pattern union computed in SetObservabilityPlugins, so there is no per-request recompute.
+func (t *Tracer) ShouldCaptureRequestHeaders() bool {
+	cached := t.cachedHdrPatterns.Load()
+	return cached != nil && len(*cached) > 0
+}
+
+// CollectRequestHeaderPatterns returns the deduplicated union of header patterns
+// requested by all observability plugins. The middleware uses this to capture only
+// matched headers onto the trace, keeping the trace lean. The union is precomputed in
+// SetObservabilityPlugins; this is a single atomic load.
+func (t *Tracer) CollectRequestHeaderPatterns() []string {
+	cached := t.cachedHdrPatterns.Load()
+	if cached == nil {
+		return nil
+	}
+	return *cached
+}
+
+// SetTraceRequestHeaders filters the given request headers down to the union of
+// patterns requested by observability plugins and stores the matched subset on the
+// trace. Header keys are expected to be lowercased by the caller.
+func (t *Tracer) SetTraceRequestHeaders(traceID string, headers map[string]string) {
+	if len(headers) == 0 {
+		return
+	}
+	patterns := t.CollectRequestHeaderPatterns()
+	matched := schemas.FilterHeaders(headers, patterns)
+	if len(matched) == 0 {
+		return
+	}
+	t.store.SetRequestHeaders(traceID, matched)
 }
 
 // CreateTrace creates a new trace with optional parent ID and returns the trace ID.

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -452,19 +452,6 @@ func (p *LoggerPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext,
 	return chunk, nil
 }
 
-// loggingHeaderMatchesPattern returns true if headerName matches pattern.
-// Supports trailing wildcard ("x-custom-*") and bare wildcard ("*").
-// Both pattern and headerName must be pre-lowercased by the caller.
-func loggingHeaderMatchesPattern(pattern, headerName string) bool {
-	if pattern == "*" {
-		return true
-	}
-	if strings.HasSuffix(pattern, "*") {
-		return strings.HasPrefix(headerName, pattern[:len(pattern)-1])
-	}
-	return pattern == headerName
-}
-
 // captureLoggingHeaders extracts configured logging headers and x-bf-lh-* prefixed headers
 // from the request context. Returns a new metadata map, or nil if no headers were captured.
 // System entries (e.g. isAsyncRequest) should be set AFTER calling this so they take precedence.
@@ -481,7 +468,7 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 		for _, h := range *p.loggingHeaders {
 			pattern := strings.ToLower(strings.TrimSpace(h))
 			for hKey, hVal := range allHeaders {
-				if loggingHeaderMatchesPattern(pattern, hKey) {
+				if schemas.MatchHeaderPattern(hKey, pattern) {
 					if metadata == nil {
 						metadata = make(map[string]any)
 					}

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -29,8 +29,9 @@ const (
 //   - APIKey: API key for Maxim SDK authentication
 //   - LogRepoID: Optional default ID for the Maxim logger instance
 type Config struct {
-	LogRepoID string `json:"log_repo_id,omitempty"` // Optional - can be empty
-	APIKey    string `json:"api_key"`
+	LogRepoID      string   `json:"log_repo_id,omitempty"` // Optional - can be empty
+	APIKey         string   `json:"api_key"`
+	RequestHeaders []string `json:"request_headers,omitempty"` // Optional request-header name patterns (exact or wildcard) to attach as trace tags
 }
 
 // Plugin implements the schemas.LLMPlugin interface for Maxim's logger.
@@ -48,6 +49,7 @@ type Plugin struct {
 	loggers          map[string]*logging.Logger
 	loggerMutex      *sync.RWMutex
 	logger           schemas.Logger
+	requestHeaders   []string
 }
 
 // Init initializes and returns a Plugin instance for Maxim's logger.
@@ -75,6 +77,7 @@ func Init(config *Config, logger schemas.Logger) (schemas.LLMPlugin, error) {
 		loggers:          make(map[string]*logging.Logger),
 		loggerMutex:      &sync.RWMutex{},
 		logger:           logger,
+		requestHeaders:   config.RequestHeaders,
 	}
 
 	// Initialize default logger if LogRepoId is provided
@@ -554,6 +557,13 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 	tags, hasTags := ctx.Value(TagsKey).(map[string]string)
 	// Also capture x-bf-dim-* dimensions to forward as tags
 	dims, hasDims := ctx.Value(schemas.BifrostContextKeyDimensions).(map[string]string)
+	// Capture configured request headers (exact or wildcard patterns) to forward as tags.
+	var reqHeaders map[string]string
+	if len(plugin.requestHeaders) > 0 {
+		allHeaders, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+		reqHeaders = schemas.FilterHeaders(allHeaders, plugin.requestHeaders)
+	}
+	hasReqHeaders := len(reqHeaders) > 0
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
@@ -686,6 +696,18 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 		}
 		if hasTraceID && traceID != "" && modelTag != "" {
 			logger.AddTagToTrace(traceID, "model", string(modelTag))
+		}
+		// add configured request headers as tags (prefixed to avoid colliding with other tags)
+		if hasReqHeaders {
+			for key, value := range reqHeaders {
+				tagKey := "header." + key
+				if generationID != "" {
+					logger.AddTagToGeneration(generationID, tagKey, value)
+				}
+				if traceID != "" {
+					logger.AddTagToTrace(traceID, tagKey, value)
+				}
+			}
 		}
 		// Flush only the effective logger that was used for this request
 		logger.Flush()

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -130,8 +130,9 @@ func (p *OtelPlugin) buildReparentMap(spans []*schemas.Span) map[string]string {
 // convertTraceToResourceSpan converts a Bifrost trace to OTEL ResourceSpan for the given
 // profile service name. Span filtering and instance attributes are shared across profiles;
 // only the resource service name differs per profile.
-func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace) *ResourceSpan {
+func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace, requestHeaders []string) *ResourceSpan {
 	reparent := p.buildReparentMap(trace.Spans)
+	filteredHeaders := schemas.FilterHeaders(trace.RequestHeaders, requestHeaders)
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
 		if !p.shouldExportSpan(span) {
@@ -156,6 +157,9 @@ func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schem
 			}
 			if len(p.instanceAttrs) > 0 {
 				otelSpan.Attributes = append(otelSpan.Attributes, p.instanceAttrs...)
+			}
+			for k, v := range filteredHeaders {
+				otelSpan.Attributes = append(otelSpan.Attributes, kvStr("http.request.header."+k, v))
 			}
 		}
 		otelSpans = append(otelSpans, otelSpan)

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 
@@ -78,6 +79,10 @@ type Profile struct {
 	MetricsEnabled      bool            `json:"metrics_enabled"`
 	MetricsEndpoint     *schemas.EnvVar `json:"metrics_endpoint,omitempty"`
 	MetricsPushInterval int             `json:"metrics_push_interval,omitempty"` // in seconds, default 15
+
+	// RequestHeaders lists request-header name patterns (exact or wildcard like "x-custom-*"
+	// or "*") whose captured values are attached to the root span as attributes.
+	RequestHeaders []string `json:"request_headers,omitempty"`
 }
 
 // UnmarshalJSON applies field defaults that the zero-value wouldn't capture.
@@ -197,6 +202,7 @@ type profileForStorage struct {
 	MetricsEnabled      bool              `json:"metrics_enabled"`
 	MetricsEndpoint     string            `json:"metrics_endpoint,omitempty"`
 	MetricsPushInterval int               `json:"metrics_push_interval,omitempty"`
+	RequestHeaders      []string          `json:"request_headers,omitempty"`
 }
 
 // configForStorage is the persisted wrapper shape.
@@ -230,6 +236,7 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			MetricsEnabled:      p.MetricsEnabled,
 			MetricsEndpoint:     schemas.EnvVarAsString(p.MetricsEndpoint),
 			MetricsPushInterval: p.MetricsPushInterval,
+			RequestHeaders:      p.RequestHeaders,
 		})
 	}
 	return sonic.Marshal(out)
@@ -298,6 +305,7 @@ type otelTarget struct {
 	traceType       TraceType
 	client          OtelClient
 	metricsExporter *MetricsExporter
+	requestHeaders  []string
 }
 
 // OtelPlugin is the plugin for OpenTelemetry.
@@ -420,9 +428,10 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 
 	url := profile.CollectorURL.GetValue()
 	target := &otelTarget{
-		serviceName: serviceName,
-		url:         url,
-		traceType:   profile.TraceType,
+		serviceName:    serviceName,
+		url:            url,
+		traceType:      profile.TraceType,
+		requestHeaders: slices.Clone(profile.RequestHeaders),
 	}
 
 	var err error
@@ -605,7 +614,7 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 		go func(t *otelTarget) {
 			defer wg.Done()
 			if t.client != nil {
-				resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace)
+				resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders)
 				if err := t.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
 					logger.Error("failed to emit trace %s to %s: %v", trace.TraceID, t.url, err)
 				}
@@ -617,6 +626,28 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 	}
 	wg.Wait()
 	return nil
+}
+
+// RequestHeaderPatterns returns the deduplicated union of request-header name patterns
+// across all enabled profiles. The tracing middleware uses this to capture matching
+// headers onto the trace; each profile filters to its own subset at conversion time.
+func (p *OtelPlugin) RequestHeaderPatterns() []string {
+	seen := make(map[string]struct{})
+	var patterns []string
+	for _, t := range p.targets {
+		for _, h := range t.requestHeaders {
+			normalized := strings.ToLower(strings.TrimSpace(h))
+			if normalized == "" {
+				continue
+			}
+			if _, ok := seen[normalized]; ok {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			patterns = append(patterns, normalized)
+		}
+	}
+	return patterns
 }
 
 // Helper functions for type-safe attribute extraction from trace spans

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -1174,6 +1174,16 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 					ctx.SetUserValue(schemas.BifrostContextKeySpanID, spanID)
 				}
 			}
+			// Capture request headers onto the trace when a connector has opted in.
+			// Gated so there is no overhead when no observability plugin wants headers.
+			if tracer.ShouldCaptureRequestHeaders() {
+				headers := make(map[string]string)
+				ctx.Request.Header.All()(func(key, value []byte) bool {
+					headers[strings.ToLower(string(key))] = string(value)
+					return true
+				})
+				tracer.SetTraceRequestHeaders(traceID, headers)
+			}
 			defer func() {
 				deferred, _ := ctx.UserValue(schemas.BifrostContextKeyDeferTraceCompletion).(bool)
 				// Record response status on the root span

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1478,6 +1478,13 @@
                     "log_repo_id": {
                       "type": "string",
                       "description": "Optional default ID for the Maxim logger instance"
+                    },
+                    "request_headers": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Request header name patterns (exact or wildcard like x-custom-*) to capture and attach as trace tags. Note: * captures all headers including sensitive ones like Authorization."
                     }
                   },
                   "required": ["api_key"],
@@ -1799,6 +1806,13 @@
           "default": 15,
           "minimum": 1,
           "maximum": 300
+        },
+        "request_headers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Request header name patterns (exact or wildcard like x-custom-*) to capture and emit as span attributes. Note: * captures all headers including sensitive ones like Authorization."
         },
         "headers": {
           "type": "object",

--- a/ui/app/workspace/observability/fragments/maximFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/maximFormFragment.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@/components/ui/button";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { RequestHeadersTextarea } from "@/components/ui/requestHeadersTextarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { maximFormSchema, type MaximFormSchema } from "@/lib/types/schemas";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -15,6 +16,7 @@ interface MaximFormFragmentProps {
 		enabled?: boolean;
 		api_key?: string;
 		log_repo_id?: string;
+		request_headers?: string[];
 	};
 	onSave: (config: MaximFormSchema) => Promise<void>;
 	onDelete?: () => void;
@@ -36,6 +38,7 @@ export function MaximFormFragment({ initialConfig, onSave, onDelete, isDeleting 
 			maxim_config: {
 				api_key: initialConfig?.api_key ?? "",
 				log_repo_id: initialConfig?.log_repo_id ?? "",
+				request_headers: initialConfig?.request_headers ?? [],
 			},
 		},
 	});
@@ -52,6 +55,7 @@ export function MaximFormFragment({ initialConfig, onSave, onDelete, isDeleting 
 			maxim_config: {
 				api_key: initialConfig?.api_key ?? "",
 				log_repo_id: initialConfig?.log_repo_id ?? "",
+				request_headers: initialConfig?.request_headers ?? [],
 			},
 		});
 	}, [form, initialConfig]);
@@ -106,6 +110,32 @@ export function MaximFormFragment({ initialConfig, onSave, onDelete, isDeleting 
 								</FormItem>
 							)}
 						/>
+
+						<FormField
+							control={form.control}
+							name="maxim_config.request_headers"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Request Headers <span className="text-muted-foreground font-normal">(Optional)</span></FormLabel>
+									<FormDescription>
+										Comma-separated list of request headers to capture and attach as trace tags. Supports exact names and wildcard
+										patterns (e.g. <code className="text-xs">x-custom-*</code> captures all headers with that prefix, <code className="text-xs">*</code> captures
+										all headers — note that <code className="text-xs">*</code> will capture sensitive headers like Authorization).
+									</FormDescription>
+									<FormControl>
+										<RequestHeadersTextarea
+											className="h-24"
+											placeholder="X-Tenant-ID, X-Request-Source, x-custom-*"
+											disabled={!hasMaximAccess}
+											value={field.value ?? []}
+											onChange={field.onChange}
+											data-testid="request-headers-textarea"
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
 					</div>
 				</div>
 
@@ -150,6 +180,7 @@ export function MaximFormFragment({ initialConfig, onSave, onDelete, isDeleting 
 									maxim_config: {
 										api_key: initialConfig?.api_key ?? "",
 										log_repo_id: initialConfig?.log_repo_id ?? "",
+										request_headers: initialConfig?.request_headers ?? [],
 									},
 								});
 							}}

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -7,6 +7,7 @@ import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { RequestHeadersTextarea } from "@/components/ui/requestHeadersTextarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { otelFormSchema, type EnvVar, type OtelFormSchema } from "@/lib/types/schemas";
 import { emptyEnvVar, toEnvVarFormValue, toEnvVarMapFormValue } from "@/lib/utils/envVarForm";
@@ -33,6 +34,7 @@ interface StoredOtelProfile {
 	metrics_enabled?: boolean;
 	metrics_endpoint?: string | EnvVar;
 	metrics_push_interval?: number;
+	request_headers?: string[];
 }
 
 // StoredOtelConfig is either the canonical { profiles: [...] } wrapper or a legacy single
@@ -93,6 +95,7 @@ const emptyProfile = (): ProfileForm => ({
 	metrics_enabled: false,
 	metrics_endpoint: emptyEnvVar(),
 	metrics_push_interval: 15,
+	request_headers: [],
 });
 
 // toProfileForm normalizes a stored profile into the EnvVar-based form representation.
@@ -108,6 +111,7 @@ const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
 	metrics_enabled: p?.metrics_enabled ?? false,
 	metrics_endpoint: toEnvVarFormValue(p?.metrics_endpoint),
 	metrics_push_interval: p?.metrics_push_interval ?? 15,
+	request_headers: p?.request_headers ?? [],
 });
 
 // buildDefaults handles both stored shapes: the { profiles: [...] } wrapper and the legacy
@@ -404,6 +408,31 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 							<FormItem className="w-full">
 								<FormControl>
 									<HeadersTable value={field.value || {}} onChange={field.onChange} disabled={!hasOtelAccess} useEnvVarInput />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={control}
+						name={`${base}.request_headers`}
+						render={({ field }) => (
+							<FormItem className="w-full">
+								<FormLabel>Request Headers <span className="text-muted-foreground font-normal">(Optional)</span></FormLabel>
+								<FormDescription>
+									Comma-separated list of request headers to capture and emit as span attributes. Supports exact names and wildcard
+									patterns (e.g. <code className="text-xs">x-custom-*</code> captures all headers with that prefix, <code className="text-xs">*</code> captures
+									all headers — note that <code className="text-xs">*</code> will capture sensitive headers like Authorization).
+								</FormDescription>
+								<FormControl>
+									<RequestHeadersTextarea
+										className="h-24"
+										placeholder="X-Tenant-ID, X-Request-Source, x-custom-*"
+										disabled={!hasOtelAccess}
+										value={field.value ?? []}
+										onChange={field.onChange}
+										data-testid={`request-headers-textarea-${index}`}
+									/>
 								</FormControl>
 								<FormMessage />
 							</FormItem>

--- a/ui/components/ui/requestHeadersTextarea.tsx
+++ b/ui/components/ui/requestHeadersTextarea.tsx
@@ -1,0 +1,38 @@
+import { Textarea } from "@/components/ui/textarea";
+import { parseArrayFromText } from "@/lib/utils/array";
+import { useEffect, useRef, useState } from "react";
+
+interface RequestHeadersTextareaProps {
+	value: string[];
+	onChange: (value: string[]) => void;
+	disabled?: boolean;
+	className?: string;
+	placeholder?: string;
+	"data-testid"?: string;
+}
+
+export function RequestHeadersTextarea({ value, onChange, disabled, className, placeholder, ...rest }: RequestHeadersTextareaProps) {
+	const [text, setText] = useState(() => (value ?? []).join(", "));
+	const textRef = useRef(text);
+	textRef.current = text;
+
+	useEffect(() => {
+		if (parseArrayFromText(textRef.current).join(",") !== (value ?? []).join(",")) {
+			setText((value ?? []).join(", "));
+		}
+	}, [value]);
+
+	return (
+		<Textarea
+			className={className}
+			placeholder={placeholder}
+			disabled={disabled}
+			value={text}
+			onChange={(e) => {
+				setText(e.target.value);
+				onChange(parseArrayFromText(e.target.value));
+			}}
+			data-testid={rest["data-testid"]}
+		/>
+	);
+}

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -763,6 +763,7 @@ export const otelConfigSchema = z
 		metrics_enabled: z.boolean().default(false),
 		metrics_endpoint: envVarSchema.optional(),
 		metrics_push_interval: z.number().int().min(1).max(300).default(15),
+		request_headers: z.array(z.string()).default([]),
 	})
 	.superRefine((data, ctx) => {
 		// A disabled profile is not sent anywhere, so skip all validation for it.
@@ -862,6 +863,7 @@ export const otelFormSchema = z.object({
 export const maximConfigSchema = z.object({
 	api_key: z.string().default(""),
 	log_repo_id: z.string().optional(),
+	request_headers: z.array(z.string()).default([]),
 });
 
 // Maxim form schema for the MaximFormFragment


### PR DESCRIPTION
## Summary

Observability plugins (OTel and Maxim) can now opt into capturing specific incoming request headers and attaching them to traces/spans as attributes or tags. Header capture is entirely opt-in and gated so there is zero overhead when no plugin requests it.

## Changes

- Added `MatchHeaderPattern` and `FilterHeaders` helpers to `core/schemas/headers.go` supporting exact names, trailing wildcards (`x-custom-*`), and the bare wildcard (`*`). The local duplicate in the logging plugin was removed in favour of the shared implementation.
- Added `RequestHeaders map[string]string` to `schemas.Trace`, with a thread-safe `SetRequestHeaders` setter and proper `Reset` clearing.
- Added `SetRequestHeaders` to `TraceStore` and three new methods to `Tracer`: `ShouldCaptureRequestHeaders`, `CollectRequestHeaderPatterns`, and `SetTraceRequestHeaders`. These derive live state from the stored plugins so no separate flag needs to be kept in sync.
- The HTTP tracing middleware now captures and lowercases all request headers onto the trace when `ShouldCaptureRequestHeaders` returns true, keeping the hot path free of allocation when no plugin opts in.
- The OTel plugin gains a per-profile `request_headers` config field. `RequestHeaderPatterns` satisfies the new interface the tracer checks. At conversion time, `convertTraceToResourceSpan` filters the trace's captured headers to the profile's own patterns and emits them as `http.request.header.<name>` span attributes on the root span.
- The Maxim plugin gains a `request_headers` config field. In `PostLLMHook`, matched headers are forwarded as `header.<name>` tags on both the generation and the trace.
- UI forms for both OTel and Maxim expose a textarea for entering comma-separated header patterns, with inline documentation warning that `*` will capture sensitive headers such as `Authorization`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/schemas/... ./framework/tracing/... ./plugins/otel/... ./plugins/maxim/... ./plugins/logging/...

# UI
cd ui
pnpm i
pnpm build
```

**OTel:** Add `"request_headers": ["x-tenant-id", "x-custom-*"]` to an OTel profile config, send a request with those headers, and verify the root span contains `http.request.header.x-tenant-id` (and any `x-custom-*` matches) as attributes.

**Maxim:** Add `"request_headers": ["x-tenant-id"]` to the Maxim config, send a request, and verify the generation and trace in Maxim carry a `header.x-tenant-id` tag.

**No-op path:** With no `request_headers` configured on any plugin, confirm `ShouldCaptureRequestHeaders` returns false and no header iteration occurs in the middleware.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `*` wildcard pattern will capture all headers, including `Authorization` and other credential-bearing headers. This is documented in the UI form descriptions and in code comments. Users should configure patterns as narrowly as possible. Captured headers are stored in-memory on the trace object and forwarded only to the observability backends the user has explicitly configured.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added request header capture capability with pattern-based filtering (exact match and wildcard support)
- Maxim plugin now supports configuring which request headers to capture and attach as trace tags
- OTEL plugin now supports per-profile configuration for emitting request headers as span attributes
- UI forms now include configurable request header patterns for both Maxim and OTEL observability plugins
- ⚠️ Warning: Wildcard (`*`) pattern includes sensitive headers like Authorization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->