### PR TITLE
refactor: replace `resolvePricing` positional model args with `RoutingInfo` and add backward-compat fallback for legacy `ExtraFields`

### DIFF
--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -272,7 +272,13 @@ func (mc *ModelCatalog) computeCacheEmbeddingCost(cacheDebug *schemas.BifrostCac
 	if scopes.Provider == "" {
 		scopes.Provider = *cacheDebug.ProviderUsed
 	}
-	pricing := mc.resolvePricing(*cacheDebug.ProviderUsed, *cacheDebug.ModelUsed, "", schemas.EmbeddingRequest, scopes)
+	// Cache-debug pricing has only a single model identifier (whatever the
+	// cache recorded). Maps to RoutingInfo.Model — no alias resolution
+	// context exists for the cache-replayed request.
+	pricing := mc.resolvePricing(schemas.RoutingInfo{
+		Provider: schemas.ModelProvider(*cacheDebug.ProviderUsed),
+		Model:    *cacheDebug.ModelUsed,
+	}, schemas.EmbeddingRequest, scopes)
 	if pricing == nil {
 		return 0
 	}
@@ -294,9 +300,22 @@ func (mc *ModelCatalog) calculateBaseCost(result *schemas.BifrostResponse, scope
 		return 0
 	}
 
-	provider := string(extraFields.Provider)
-	originalModelRequested := extraFields.OriginalModelRequested
-	resolvedModelUsed := extraFields.ResolvedModelUsed
+	// Read routing info populated by core.bifrost at request time.
+	//
+	// Backward-compat fallback: when the caller (e.g. LoggerPlugin's
+	// RecalculateCosts replaying logs written before RoutingInfo existed,
+	// or third-party plugins still on the legacy ExtraFields shape) leaves
+	// RoutingInfo empty, synthesise one from the deprecated triplet so
+	// pricing keeps working. Triggered only when RoutingInfo is fully
+	// unset — partial population is trusted as-is.
+	routingInfo := extraFields.RoutingInfo
+	if routingInfo.Provider == "" && routingInfo.Model == "" && routingInfo.ResolvedKeyAlias == nil {
+		routingInfo.Provider = extraFields.Provider
+		routingInfo.Model = extraFields.OriginalModelRequested
+		if r := extraFields.ResolvedModelUsed; r != "" && r != extraFields.OriginalModelRequested {
+			routingInfo.ResolvedKeyAlias = &schemas.ResolvedKeyAlias{ModelID: r}
+		}
+	}
 	requestType := extraFields.RequestType
 
 	// Extract usage data from the response (passthrough and native paths unified)
@@ -314,22 +333,26 @@ func (mc *ModelCatalog) calculateBaseCost(result *schemas.BifrostResponse, scope
 
 	if result.PassthroughResponse != nil {
 		// Infer request type from usage fields + path; passthrough bypasses stream normalization.
-		requestType = inferPassthroughRequestType(extraFields.Provider, extraFields.PassthroughPath, result.PassthroughResponse.PassthroughUsage)
+		requestType = inferPassthroughRequestType(routingInfo.Provider, extraFields.PassthroughPath, result.PassthroughResponse.PassthroughUsage)
 	} else {
 		// Normalize stream request types to their base type for pricing lookup
 		requestType = normalizeStreamRequestType(requestType)
 	}
 
-	// When a pricing model override is set, use it in place of the actual requested/resolved
-	// model names during pricing lookup (e.g. container creates always look up "container").
-	lookupModel, lookupResolved := originalModelRequested, resolvedModelUsed
+	// When a pricing model override is set (e.g. container creates always look
+	// up "container"), it replaces the lookup hierarchy entirely. Build a
+	// synthetic RoutingInfo that reuses Provider but pins the model fields to
+	// the container identifier — the lookup tries it as ModelName, the
+	// override key is the container identifier so per-container overrides
+	// stay addressable.
 	if input.containerIdentifierString != "" {
-		lookupModel = input.containerIdentifierString
-		lookupResolved = input.containerIdentifierString
+		routingInfo = schemas.RoutingInfo{
+			Provider: routingInfo.Provider,
+			Model:    input.containerIdentifierString,
+		}
 	}
 
-	// Resolve pricing entry with deployment fallback
-	pricing := mc.resolvePricing(provider, lookupModel, lookupResolved, requestType, scopes)
+	pricing := mc.resolvePricing(routingInfo, requestType, scopes)
 	if pricing == nil {
 		return 0
 	}
@@ -1159,39 +1182,64 @@ func populateOutputImageCount(imageUsage *schemas.ImageUsage, dataLen int) {
 // Pricing resolution
 // ---------------------------------------------------------------------------
 
-// resolvePricing resolves the pricing entry for a model, trying deployment as fallback.
-func (mc *ModelCatalog) resolvePricing(provider, originalModelRequested, resolvedModelUsed string, requestType schemas.RequestType, scopes PricingLookupScopes) *configstoreTables.TableModelPricing {
-	if resolvedModelUsed == "" {
-		resolvedModelUsed = originalModelRequested
+// resolvePricing resolves the pricing entry for a request directly from the
+// RoutingInfo populated on the response/error by core.bifrost at request time.
+//
+// Lookup precedence — AliasModelName → AliasModelID → ModelName. Each
+// non-empty candidate is tried against the base catalog in order; the first
+// hit wins.
+//
+//   - AliasModelName (RoutingInfo.ResolvedKeyAlias.ModelName) is the canonical
+//     model name the admin tagged on the matched alias. Catches the
+//     opaque-deployment-ID case where the wire model wouldn't hit the catalog
+//     on its own.
+//   - AliasModelID (RoutingInfo.ResolvedKeyAlias.ModelID) is the wire model
+//     when an alias matched. nil/empty otherwise.
+//   - ModelName (RoutingInfo.Model) is the model string the caller sent — the
+//     alias key when an alias matched, or the raw user input when none did.
+//
+// Overrides are applied keyed by the wire model (AliasModelID when an alias
+// matched, otherwise ModelName) so per-deployment override pricing stays
+// addressable in either flow.
+func (mc *ModelCatalog) resolvePricing(routingInfo schemas.RoutingInfo, requestType schemas.RequestType, scopes PricingLookupScopes) *configstoreTables.TableModelPricing {
+	provider := string(routingInfo.Provider)
+	var aliasModelID, aliasModelName string
+	if rka := routingInfo.ResolvedKeyAlias; rka != nil {
+		aliasModelID = rka.ModelID
+		if rka.ModelName != nil {
+			aliasModelName = *rka.ModelName
+		}
 	}
-	mc.logger.Debug("looking up pricing for resolved model %s and provider %s of request type %s", resolvedModelUsed, provider, normalizeRequestType(requestType))
+	overrideKey := aliasModelID
+	if overrideKey == "" {
+		overrideKey = routingInfo.Model
+	}
+	mc.logger.Debug("looking up pricing for wire model %s and provider %s of request type %s", overrideKey, provider, normalizeRequestType(requestType))
 
 	if scopes.Provider == "" {
 		scopes.Provider = provider
 	}
 
-	base, exists := mc.getBasePricing(resolvedModelUsed, provider, requestType)
-	if exists && base != nil {
-		result, _ := mc.applyPricingOverrides(resolvedModelUsed, requestType, *base, scopes)
-		return &result
-	}
-
-	mc.logger.Debug("pricing not found for resolved model %s, trying alias %s", resolvedModelUsed, originalModelRequested)
-	base, exists = mc.getBasePricing(originalModelRequested, provider, requestType)
-	if exists && base != nil {
-		// Apply overrides using the resolved model name, not the alias
-		result, _ := mc.applyPricingOverrides(resolvedModelUsed, requestType, *base, scopes)
-		return &result
+	for _, candidate := range []string{aliasModelName, aliasModelID, routingInfo.Model} {
+		if candidate == "" {
+			continue
+		}
+		base, exists := mc.getBasePricing(candidate, provider, requestType)
+		if exists && base != nil {
+			result, _ := mc.applyPricingOverrides(overrideKey, requestType, *base, scopes)
+			return &result
+		}
+		mc.logger.Debug("pricing not found for %s, trying next candidate", candidate)
 	}
 
 	// No base catalog entry found; still try overrides in case the user defined
 	// override-only pricing for a model not in the built-in catalog.
-	mc.logger.Debug("pricing not found for resolved model %s and provider %s, trying override-only pricing", resolvedModelUsed, provider)
-	result, applied := mc.applyPricingOverrides(resolvedModelUsed, requestType, configstoreTables.TableModelPricing{}, scopes)
+	mc.logger.Debug("pricing not found for any candidate (provider %s), trying override-only pricing keyed by %s", provider, overrideKey)
+	result, applied := mc.applyPricingOverrides(overrideKey, requestType, configstoreTables.TableModelPricing{}, scopes)
 	if applied {
 		return &result
 	}
-	mc.logger.Debug("no pricing found for resolved model %s and provider %s, skipping cost calculation", resolvedModelUsed, provider)
+	mc.logger.Debug("no pricing found for wire model %s and provider %s, skipping cost calculation", overrideKey, provider)
 	return nil
 }
 

--- a/framework/modelcatalog/pricing_overrides_test.go
+++ b/framework/modelcatalog/pricing_overrides_test.go
@@ -56,7 +56,7 @@ func TestGetPricing_OverridePrecedenceExactWildcard(t *testing.T) {
 		},
 	}))
 
-	pricing := mc.resolvePricing("openai", "gpt-4o", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	require.NotNil(t, pricing)
 	require.NotNil(t, pricing.InputCostPerToken)
 	assert.Equal(t, 20.0, *pricing.InputCostPerToken)
@@ -95,7 +95,7 @@ func TestGetPricing_RequestTypeSpecificOverrideBeatsGeneric(t *testing.T) {
 		},
 	}))
 
-	pricing := mc.resolvePricing("openai", "gpt-4o", "", schemas.ResponsesRequest, PricingLookupScopes{Provider: "openai"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ResponsesRequest, PricingLookupScopes{Provider: "openai"})
 	require.NotNil(t, pricing)
 	assert.Equal(t, 15.0, pricing.InputCostPerToken)
 }
@@ -124,7 +124,7 @@ func TestGetPricing_AppliesOverrideAfterFallbackResolution(t *testing.T) {
 		},
 	}))
 
-	pricing := mc.resolvePricing("gemini", "gpt-4o", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "gemini"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "gemini", Model: "gpt-4o"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "gemini"})
 	require.NotNil(t, pricing)
 	assert.Equal(t, 7.0, pricing.InputCostPerToken)
 }
@@ -155,7 +155,7 @@ func TestGetPricing_DeploymentLookupUsesResolvedModelForOverrideMatching(t *test
 
 	// Override pattern matches the resolved model name ("dep-gpt4o"), not the
 	// originally requested name ("gpt-4o"), because resolved model has priority.
-	pricing := mc.resolvePricing("openai", "gpt-4o", "dep-gpt4o", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o", ResolvedKeyAlias: &schemas.ResolvedKeyAlias{ModelID: "dep-gpt4o"}}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	require.NotNil(t, pricing)
 	require.NotNil(t, pricing.InputCostPerToken)
 	assert.Equal(t, 7.0, *pricing.InputCostPerToken)
@@ -195,7 +195,7 @@ func TestGetPricing_FallbackUsesRequestedProviderForScopeMatching(t *testing.T) 
 		},
 	}))
 
-	pricing := mc.resolvePricing("gemini", "gpt-4o", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "gemini"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "gemini", Model: "gpt-4o"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "gemini"})
 	require.NotNil(t, pricing)
 	require.NotNil(t, pricing.InputCostPerToken)
 	assert.Equal(t, 5.0, *pricing.InputCostPerToken)
@@ -225,7 +225,7 @@ func TestGetPricing_ExactOverrideDoesNotMatchProviderPrefixedModel(t *testing.T)
 		},
 	}))
 
-	pricing := mc.resolvePricing("openai", "openai/gpt-4o", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "openai/gpt-4o"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	require.NotNil(t, pricing)
 	assert.Equal(t, 1.0, pricing.InputCostPerToken)
 }
@@ -256,7 +256,7 @@ func TestGetPricing_NoMatchingOverrideLeavesPricingUnchanged(t *testing.T) {
 		},
 	}))
 
-	pricing := mc.resolvePricing("openai", "gpt-4o", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	require.NotNil(t, pricing)
 	assert.Equal(t, 1.0, pricing.InputCostPerToken)
 	assert.Equal(t, 2.0, pricing.OutputCostPerToken)
@@ -288,13 +288,13 @@ func TestDeleteProviderPricingOverrides_StopsApplying(t *testing.T) {
 		},
 	}))
 
-	pricing := mc.resolvePricing("openai", "gpt-4o", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	require.NotNil(t, pricing)
 	assert.Equal(t, 11.0, pricing.InputCostPerToken)
 
 	require.NoError(t, mc.SetPricingOverrides(nil))
 
-	pricing = mc.resolvePricing("openai", "gpt-4o", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	pricing = mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	require.NotNil(t, pricing)
 	assert.Equal(t, 1.0, pricing.InputCostPerToken)
 }
@@ -331,7 +331,7 @@ func TestGetPricing_WildcardSpecificityLongerLiteralWins(t *testing.T) {
 		},
 	}))
 
-	pricing := mc.resolvePricing("openai", "gpt-4o-mini", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o-mini"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	require.NotNil(t, pricing)
 	assert.Equal(t, 6.0, pricing.InputCostPerToken)
 }
@@ -371,7 +371,7 @@ func TestGetPricing_FirstInsertionWinsOnTie(t *testing.T) {
 		},
 	}))
 
-	pricing := mc.resolvePricing("openai", "gpt-4o-mini", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	pricing := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o-mini"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	require.NotNil(t, pricing)
 	require.NotNil(t, pricing.InputCostPerToken)
 	assert.Equal(t, 8.0, *pricing.InputCostPerToken)

--- a/framework/modelcatalog/pricing_test.go
+++ b/framework/modelcatalog/pricing_test.go
@@ -38,15 +38,20 @@ func testCatalogWithPricing(entries map[string]configstoreTables.TableModelPrici
 	return mc
 }
 
+// routingInfoFor builds a minimal RoutingInfo populated by core.bifrost for a
+// non-aliased request — the form pricing reads from.
+func routingInfoFor(provider schemas.ModelProvider, model string) schemas.RoutingInfo {
+	return schemas.RoutingInfo{Provider: provider, Model: model}
+}
+
 // makeChatResponse builds a minimal BifrostResponse for a chat completion.
 func makeChatResponse(provider schemas.ModelProvider, model string, usage *schemas.BifrostLLMUsage) *schemas.BifrostResponse {
 	return &schemas.BifrostResponse{
 		ChatResponse: &schemas.BifrostChatResponse{
 			Usage: usage,
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ChatCompletionRequest,
-				Provider:               provider,
-				OriginalModelRequested: model,
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: routingInfoFor(provider, model),
 			},
 		},
 	}
@@ -58,9 +63,8 @@ func makeEmbeddingResponse(provider schemas.ModelProvider, model string, usage *
 		EmbeddingResponse: &schemas.BifrostEmbeddingResponse{
 			Usage: usage,
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.EmbeddingRequest,
-				Provider:               provider,
-				OriginalModelRequested: model,
+				RequestType: schemas.EmbeddingRequest,
+				RoutingInfo: routingInfoFor(provider, model),
 			},
 		},
 	}
@@ -72,9 +76,8 @@ func makeRerankResponse(provider schemas.ModelProvider, model string, usage *sch
 		RerankResponse: &schemas.BifrostRerankResponse{
 			Usage: usage,
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.RerankRequest,
-				Provider:               provider,
-				OriginalModelRequested: model,
+				RequestType: schemas.RerankRequest,
+				RoutingInfo: routingInfoFor(provider, model),
 			},
 		},
 	}
@@ -86,9 +89,8 @@ func makeImageResponse(provider schemas.ModelProvider, model string, usage *sche
 		ImageGenerationResponse: &schemas.BifrostImageGenerationResponse{
 			Usage: usage,
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ImageGenerationRequest,
-				Provider:               provider,
-				OriginalModelRequested: model,
+				RequestType: schemas.ImageGenerationRequest,
+				RoutingInfo: routingInfoFor(provider, model),
 			},
 		},
 	}
@@ -1158,9 +1160,8 @@ func TestCalculateCost_SemanticCacheDirectHit(t *testing.T) {
 		ChatResponse: &schemas.BifrostChatResponse{
 			Usage: &schemas.BifrostLLMUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ChatCompletionRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4o",
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 				CacheDebug: &schemas.BifrostCacheDebug{
 					CacheHit: true,
 					HitType:  &hitType,
@@ -1194,9 +1195,8 @@ func TestCalculateCost_SemanticCacheSemanticHit(t *testing.T) {
 		ChatResponse: &schemas.BifrostChatResponse{
 			Usage: &schemas.BifrostLLMUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ChatCompletionRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4o",
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 				CacheDebug: &schemas.BifrostCacheDebug{
 					CacheHit:     true,
 					HitType:      &hitType,
@@ -1233,9 +1233,8 @@ func TestCalculateCost_SemanticCacheMiss(t *testing.T) {
 		ChatResponse: &schemas.BifrostChatResponse{
 			Usage: &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ChatCompletionRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4o",
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 				CacheDebug: &schemas.BifrostCacheDebug{
 					CacheHit:     false,
 					ProviderUsed: &embProvider,
@@ -1428,9 +1427,8 @@ func TestCalculateCost_StreamRequestTypeNormalized(t *testing.T) {
 		ChatResponse: &schemas.BifrostChatResponse{
 			Usage: &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ChatCompletionStreamRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4o",
+				RequestType: schemas.ChatCompletionStreamRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
 	}
@@ -1450,10 +1448,8 @@ func TestCalculateCost_WebSocketResponsesFallsBackToChatPricing(t *testing.T) {
 				Usage: &schemas.ResponsesResponseUsage{InputTokens: 1000, OutputTokens: 500, TotalTokens: 1500},
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.WebSocketResponsesRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4o",
-				ResolvedModelUsed:      "gpt-4o",
+				RequestType: schemas.WebSocketResponsesRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
 	}
@@ -1479,7 +1475,7 @@ func TestGetPricing_DirectLookup(t *testing.T) {
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
 	})
-	p := mc.resolvePricing("openai", "gpt-4o", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	assert.Equal(t, 0.000005, derefF(p.InputCostPerToken))
 }
 
@@ -1490,7 +1486,7 @@ func TestGetPricing_GeminiFallsBackToVertex(t *testing.T) {
 			InputCostPerToken: bifrost.Ptr(0.0000001), OutputCostPerToken: bifrost.Ptr(0.0000004),
 		},
 	})
-	p := mc.resolvePricing("gemini", "gemini-2.0-flash", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "gemini"})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "gemini", Model: "gemini-2.0-flash"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "gemini"})
 	assert.Equal(t, 0.0000001, derefF(p.InputCostPerToken))
 }
 
@@ -1498,7 +1494,7 @@ func TestGetPricing_VertexStripsProviderPrefix(t *testing.T) {
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gemini-2.0-flash", "vertex", "chat"): chatPricing(0.0000001, 0.0000004),
 	})
-	p := mc.resolvePricing("vertex", "google/gemini-2.0-flash", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "vertex"})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "vertex", Model: "google/gemini-2.0-flash"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "vertex"})
 	assert.Equal(t, 0.0000001, derefF(p.InputCostPerToken))
 }
 
@@ -1506,7 +1502,7 @@ func TestGetPricing_BedrockAddsAnthropicPrefix(t *testing.T) {
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("anthropic.claude-3-5-sonnet-20241022-v2:0", "bedrock", "chat"): chatPricing(0.000003, 0.000015),
 	})
-	p := mc.resolvePricing("bedrock", "claude-3-5-sonnet-20241022-v2:0", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "bedrock"})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "bedrock", Model: "claude-3-5-sonnet-20241022-v2:0"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "bedrock"})
 	assert.Equal(t, 0.000003, derefF(p.InputCostPerToken))
 }
 
@@ -1514,7 +1510,7 @@ func TestGetPricing_ResponsesFallsBackToChat(t *testing.T) {
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
 	})
-	p := mc.resolvePricing("openai", "gpt-4o", "", schemas.ResponsesRequest, PricingLookupScopes{Provider: "openai"})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ResponsesRequest, PricingLookupScopes{Provider: "openai"})
 	assert.Equal(t, 0.000005, derefF(p.InputCostPerToken))
 }
 
@@ -1522,7 +1518,7 @@ func TestGetPricing_ResponsesStreamFallsBackToChat(t *testing.T) {
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
 	})
-	p := mc.resolvePricing("openai", "gpt-4o", "", schemas.ResponsesStreamRequest, PricingLookupScopes{Provider: "openai"})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ResponsesStreamRequest, PricingLookupScopes{Provider: "openai"})
 	assert.Equal(t, 0.000005, derefF(p.InputCostPerToken))
 }
 
@@ -1530,7 +1526,7 @@ func TestGetPricing_RealtimeFallsBackToChat(t *testing.T) {
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
 	})
-	p := mc.resolvePricing("openai", "gpt-4o", "", schemas.RealtimeRequest, PricingLookupScopes{Provider: "openai"})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.RealtimeRequest, PricingLookupScopes{Provider: "openai"})
 	assert.Equal(t, 0.000005, derefF(p.InputCostPerToken))
 }
 
@@ -1539,13 +1535,13 @@ func TestGetPricing_GeminiResponsesFallsBackToVertexChat(t *testing.T) {
 		makeKey("gemini-2.0-flash", "vertex", "chat"): chatPricing(0.0000001, 0.0000004),
 	})
 	// gemini provider + responses request → try vertex + responses → try vertex + chat
-	p := mc.resolvePricing("gemini", "gemini-2.0-flash", "", schemas.ResponsesRequest, PricingLookupScopes{Provider: "gemini"})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "gemini", Model: "gemini-2.0-flash"}, schemas.ResponsesRequest, PricingLookupScopes{Provider: "gemini"})
 	assert.Equal(t, 0.0000001, derefF(p.InputCostPerToken))
 }
 
 func TestGetPricing_NotFound(t *testing.T) {
 	mc := testCatalogWithPricing(nil)
-	p := mc.resolvePricing("openai", "nonexistent", "", schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "nonexistent"}, schemas.ChatCompletionRequest, PricingLookupScopes{Provider: "openai"})
 	assert.Nil(t, p)
 }
 
@@ -1559,7 +1555,7 @@ func TestResolvePricing_DeploymentFallback(t *testing.T) {
 	})
 
 	// Model not found directly, but deployment matches
-	p := mc.resolvePricing("openai", "gpt-4o-custom", "my-deployment", schemas.ChatCompletionRequest, PricingLookupScopes{})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o-custom", ResolvedKeyAlias: &schemas.ResolvedKeyAlias{ModelID: "my-deployment"}}, schemas.ChatCompletionRequest, PricingLookupScopes{})
 	require.NotNil(t, p)
 	assert.Equal(t, 0.000005, derefF(p.InputCostPerToken))
 }
@@ -1572,14 +1568,14 @@ func TestResolvePricing_ResolvedModelHasPriority(t *testing.T) {
 
 	// Resolved model ("my-deployment") is looked up first and has priority
 	// over the originally requested model ("gpt-4o").
-	p := mc.resolvePricing("openai", "gpt-4o", "my-deployment", schemas.ChatCompletionRequest, PricingLookupScopes{})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o", ResolvedKeyAlias: &schemas.ResolvedKeyAlias{ModelID: "my-deployment"}}, schemas.ChatCompletionRequest, PricingLookupScopes{})
 	require.NotNil(t, p)
 	assert.Equal(t, 0.000001, derefF(p.InputCostPerToken))
 }
 
 func TestResolvePricing_NothingFound(t *testing.T) {
 	mc := testCatalogWithPricing(nil)
-	p := mc.resolvePricing("openai", "unknown", "", schemas.ChatCompletionRequest, PricingLookupScopes{})
+	p := mc.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "unknown"}, schemas.ChatCompletionRequest, PricingLookupScopes{})
 	assert.Nil(t, p)
 }
 
@@ -1882,9 +1878,7 @@ func TestCalculateCost_PriorityTier_EndToEnd(t *testing.T) {
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType:            schemas.ChatCompletionRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4o",
-				ResolvedModelUsed:      "gpt-4o",
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
 	}
@@ -1918,9 +1912,7 @@ func TestCalculateCost_NonPriorityServiceTier_UsesBaseRate(t *testing.T) {
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType:            schemas.ChatCompletionRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4o",
-				ResolvedModelUsed:      "gpt-4o",
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
 	}
@@ -2163,9 +2155,7 @@ func TestCalculateCost_FlexTier_EndToEnd(t *testing.T) {
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType:            schemas.ChatCompletionRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4o",
-				ResolvedModelUsed:      "gpt-4o",
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
 	}
@@ -2191,9 +2181,7 @@ func TestCalculateCost_FlexTier_FallsBackToBaseWhenNoFlexRate(t *testing.T) {
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType:            schemas.ChatCompletionRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4o",
-				ResolvedModelUsed:      "gpt-4o",
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
 	}
@@ -2329,9 +2317,8 @@ func TestCalculateCost_ImageGeneration_OutputCountFromData(t *testing.T) {
 				{URL: "https://example.com/img3.png", Index: 2},
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ImageGenerationRequest,
-				Provider:               "openai",
-				OriginalModelRequested: "dall-e-3",
+				RequestType: schemas.ImageGenerationRequest,
+				RoutingInfo: routingInfoFor("openai", "dall-e-3"),
 			},
 		},
 	}
@@ -2451,9 +2438,7 @@ func TestCalculateCost_ResponsesWithCodeInterpreter(t *testing.T) {
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType:            schemas.ResponsesRequest,
-				Provider:               schemas.OpenAI,
-				OriginalModelRequested: "gpt-4.1",
-				ResolvedModelUsed:      "gpt-4.1",
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4.1"),
 			},
 		},
 	}
@@ -2511,7 +2496,7 @@ func TestCalculateCost_ContainerCreate_NoMemoryLimit(t *testing.T) {
 			Name: "test-container",
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType: schemas.ContainerCreateRequest,
-				Provider:    schemas.OpenAI,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI},
 			},
 		},
 	}
@@ -2543,7 +2528,7 @@ func TestCalculateCost_ContainerCreate_MemorySpecificEntry(t *testing.T) {
 			MemoryLimit: "4g",
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType: schemas.ContainerCreateRequest,
-				Provider:    schemas.OpenAI,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI},
 			},
 		},
 	}
@@ -2569,7 +2554,7 @@ func TestCalculateCost_ContainerCreate_FallsBackToBaseEntry(t *testing.T) {
 			MemoryLimit: "4g",
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType: schemas.ContainerCreateRequest,
-				Provider:    schemas.OpenAI,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI},
 			},
 		},
 	}
@@ -2588,6 +2573,143 @@ func TestCalculateCost_ContainerCreate_NoPricingEntry(t *testing.T) {
 			Name: "test-container",
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType: schemas.ContainerCreateRequest,
+				RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI},
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	assert.Equal(t, 0.0, cost)
+}
+
+// ---------------------------------------------------------------------------
+// Backward-compat: RoutingInfo missing → synthesize from deprecated triplet
+//
+// Covers callers stuck on the legacy ExtraFields shape:
+//   - LoggerPlugin.RecalculateCosts replaying logs written before RoutingInfo existed
+//   - Third-party plugins / SDK users that haven't migrated to RoutingInfo
+//
+// The fallback only fires when RoutingInfo is fully empty (zero Provider,
+// zero Model, nil ResolvedKeyAlias). Any partial population is trusted.
+// ---------------------------------------------------------------------------
+
+func TestCalculateCost_BackCompat_LegacyFieldsOnly_NoAlias(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
+	})
+
+	// Caller populates only the deprecated triplet — no RoutingInfo.
+	// Pricing should fall back to Provider + OriginalModelRequested.
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ChatCompletionRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "gpt-4o",
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	// 1000 * 0.000005 + 500 * 0.000015 = 0.005 + 0.0075 = 0.0125
+	assert.InDelta(t, 0.0125, cost, 1e-12)
+}
+
+func TestCalculateCost_BackCompat_LegacyFieldsOnly_WithAlias(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("my-deployment", "openai", "chat"): chatPricing(0.000005, 0.000015),
+	})
+
+	// Caller populates only the deprecated triplet with a distinct
+	// ResolvedModelUsed (i.e. an alias was matched at original request time
+	// and the wire model differs from the caller-facing name). The fallback
+	// should route ResolvedModelUsed into ResolvedKeyAlias.ModelID so the
+	// catalog lookup hits the deployment-keyed entry.
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ChatCompletionRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "my-alias-name",
+				ResolvedModelUsed:      "my-deployment",
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	// 1000 * 0.000005 + 500 * 0.000015 = 0.0125, charged via the deployment-keyed entry
+	assert.InDelta(t, 0.0125, cost, 1e-12)
+}
+
+func TestCalculateCost_BackCompat_RoutingInfoWinsOverLegacyFields(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
+		makeKey("gemini-2.0-flash", "gemini", "chat"): {
+			Model:              "gemini-2.0-flash",
+			Provider:           "gemini",
+			Mode:               "chat",
+			InputCostPerToken:  bifrost.Ptr(0.0000001),
+			OutputCostPerToken: bifrost.Ptr(0.0000004),
+		},
+	})
+
+	// Both populated. The modern fields (RoutingInfo) must win — the
+	// fallback only fires when RoutingInfo is fully unset.
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ChatCompletionRequest,
+				RoutingInfo:            routingInfoFor(schemas.OpenAI, "gpt-4o"),
+				Provider:               schemas.Gemini,
+				OriginalModelRequested: "gemini-2.0-flash",
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	// Priced via RoutingInfo → openai/gpt-4o → 0.0125 (not the gemini rate).
+	assert.InDelta(t, 0.0125, cost, 1e-12)
+}
+
+func TestCalculateCost_BackCompat_BothEmpty_ReturnsZero(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
+	})
+
+	// Neither RoutingInfo nor the deprecated triplet are populated.
+	// Pricing has no way to identify the model; cost is 0.
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	assert.Equal(t, 0.0, cost)
+}
+
+func TestCalculateCost_BackCompat_PartialRoutingInfo_NoFallback(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
+	})
+
+	// RoutingInfo has Model but no Provider. The legacy Provider field is
+	// also set. The fallback MUST NOT fire — partial RoutingInfo means the
+	// caller intended to use RoutingInfo. With Provider unset on RoutingInfo,
+	// the catalog lookup fails and cost is 0. (This guards the trigger
+	// against false positives.)
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: schemas.RoutingInfo{Model: "gpt-4o"},
 				Provider:    schemas.OpenAI,
 			},
 		},


### PR DESCRIPTION
## Summary

Refactors the pricing resolution path to consume a `schemas.RoutingInfo` struct directly instead of a loose `(provider, originalModelRequested, resolvedModelUsed string)` triplet. This aligns pricing lookups with the routing context that `core.bifrost` already populates at request time, and introduces a structured lookup precedence: `AliasModelName → AliasModelID → ModelName`.

## Changes

- `resolvePricing` now accepts a `schemas.RoutingInfo` instead of three separate string parameters. The lookup order tries `ResolvedKeyAlias.ModelName`, then `ResolvedKeyAlias.ModelID`, then `RoutingInfo.Model`, stopping at the first catalog hit. Override keys are always derived from the wire model (`AliasModelID` when an alias matched, otherwise `Model`).
- `calculateBaseCost` reads `RoutingInfo` from `ExtraFields` directly. A backward-compatibility fallback synthesises a `RoutingInfo` from the deprecated `Provider`/`OriginalModelRequested`/`ResolvedModelUsed` triplet when `RoutingInfo` is fully unset — covering `LoggerPlugin.RecalculateCosts` replaying pre-`RoutingInfo` logs and third-party plugins on the legacy shape. Partial `RoutingInfo` population is trusted as-is and does not trigger the fallback.
- `computeCacheEmbeddingCost` similarly constructs a `RoutingInfo` from the cache-debug fields when calling `resolvePricing`.
- Container pricing overrides now build a synthetic `RoutingInfo` that pins the model fields to the container identifier while preserving the provider, replacing the previous dual `lookupModel`/`lookupResolved` override.
- All call sites in tests are updated to pass `schemas.RoutingInfo` structs. New backward-compat tests cover: legacy-fields-only (no alias), legacy-fields-only (with alias/deployment), `RoutingInfo` winning over legacy fields when both are set, both empty returning zero cost, and partial `RoutingInfo` not triggering the fallback.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/...
```

Key scenarios to verify:
- Pricing resolves correctly for a non-aliased request via `RoutingInfo.Model`.
- Pricing resolves via `ResolvedKeyAlias.ModelID` when an alias is matched and the deployment ID differs from the caller-facing model name.
- `AliasModelName` takes precedence over `AliasModelID` when both are present.
- Legacy `ExtraFields` triplet (no `RoutingInfo`) still produces correct costs.
- When both `RoutingInfo` and the legacy triplet are populated, `RoutingInfo` wins.
- Partial `RoutingInfo` (e.g. `Model` set but `Provider` empty) does not fall back to legacy fields.

## Breaking changes

- [x] Yes
- [ ] No

`resolvePricing` is an internal method, but any code calling it directly with the old `(provider, originalModelRequested, resolvedModelUsed string, ...)` signature must be updated to pass a `schemas.RoutingInfo`. External callers populating only the deprecated `Provider`/`OriginalModelRequested`/`ResolvedModelUsed` fields on `BifrostResponseExtraFields` continue to work via the backward-compat fallback, but should migrate to `RoutingInfo`.

## Related issues

N/A

## Security considerations

No auth, secrets, PII, or sandboxing implications. Pricing resolution is internal cost accounting only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cost routing now uses a unified routing-info model with legacy fallbacks, applies container-create model overrides, and ensures semantic-cache embedding billing reflects actual provider/model routing and new lookup precedence.

* **Tests**
  * Updated and expanded pricing tests to validate routing-info-based resolution, override precedence, request-type fallbacks, legacy compatibility, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->