### PR TITLE
fix: bedrock outputAssessments type correction

### DIFF
--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -509,31 +509,88 @@ type BedrockConverseTrace struct {
 	Guardrail *BedrockGuardrailTrace `json:"guardrail,omitempty"` // Guardrail trace details
 }
 
-// BedrockGuardrailTrace represents detailed guardrail trace information.
-// Bedrock uses two different shapes depending on the call path:
-//   - Converse (non-streaming): actionReason + inputAssessment (map keyed by guardrail ID)
-//   - ConverseStream: action (enum) + inputAssessments / outputAssessments (arrays)
-//
-// Both shapes are captured here so the struct round-trips faithfully in both cases.
+// BedrockGuardrailTrace represents guardrail trace information returned by Bedrock Converse / ConverseStream.
+// Both paths use the same shape: inputAssessment is map[guardrailId]Assessment,
+// outputAssessments is map[guardrailId][]Assessment.
 type BedrockGuardrailTrace struct {
-	// Converse (non-streaming) fields
-	ActionReason    *string                        `json:"actionReason,omitempty"`    // Human-readable reason the guardrail acted
-	InputAssessment map[string]interface{}         `json:"inputAssessment,omitempty"` // Map of guardrail ID → assessment detail
-	ModelOutput     []interface{}                  `json:"modelOutput,omitempty"`     // Model output after guardrail evaluation
-
-	// ConverseStream fields
-	Action            *string                      `json:"action,omitempty"`            // Action taken by guardrail (NONE | INTERVENED)
-	InputAssessments  []BedrockGuardrailAssessment `json:"inputAssessments,omitempty"`  // Input assessments (streaming)
-	OutputAssessments []BedrockGuardrailAssessment `json:"outputAssessments,omitempty"` // Output assessments (streaming)
-	Trace             *BedrockGuardrailTraceDetail `json:"trace,omitempty"`             // Detailed trace information
+	ActionReason      *string                                 `json:"actionReason,omitempty"`      // Human-readable reason the guardrail acted
+	InputAssessment   map[string]BedrockGuardrailAssessment   `json:"inputAssessment,omitempty"`   // Map of guardrail ID → single assessment
+	OutputAssessments map[string][]BedrockGuardrailAssessment `json:"outputAssessments,omitempty"` // Map of guardrail ID → array of assessments
+	ModelOutput       []interface{}                           `json:"modelOutput,omitempty"`       // Model output after guardrail evaluation
+	Action            *string                                 `json:"action,omitempty"`            // Action taken by guardrail (NONE | INTERVENED)
+	Trace             *BedrockGuardrailTraceDetail            `json:"trace,omitempty"`             // Detailed trace information
 }
 
 // BedrockGuardrailAssessment represents a guardrail assessment
 type BedrockGuardrailAssessment struct {
-	TopicPolicy         *BedrockGuardrailTopicPolicy         `json:"topicPolicy,omitempty"`         // Topic policy assessment
-	ContentPolicy       *BedrockGuardrailContentPolicy       `json:"contentPolicy,omitempty"`       // Content policy assessment
-	WordPolicy          *BedrockGuardrailWordPolicy          `json:"wordPolicy,omitempty"`          // Word policy assessment
-	SensitiveInfoPolicy *BedrockGuardrailSensitiveInfoPolicy `json:"sensitiveInfoPolicy,omitempty"` // Sensitive information policy assessment
+	AppliedGuardrailDetails   *BedrockGuardrailAppliedDetails           `json:"appliedGuardrailDetails,omitempty"`
+	AutomatedReasoningPolicy  *BedrockGuardrailAutomatedReasoningPolicy  `json:"automatedReasoningPolicy,omitempty"`
+	ContentPolicy             *BedrockGuardrailContentPolicy             `json:"contentPolicy,omitempty"`
+	ContextualGroundingPolicy *BedrockGuardrailContextualGroundingPolicy `json:"contextualGroundingPolicy,omitempty"`
+	InvocationMetrics         *BedrockGuardrailInvocationMetrics         `json:"invocationMetrics,omitempty"`
+	SensitiveInfoPolicy       *BedrockGuardrailSensitiveInfoPolicy       `json:"sensitiveInformationPolicy,omitempty"`
+	TopicPolicy               *BedrockGuardrailTopicPolicy               `json:"topicPolicy,omitempty"`
+	WordPolicy                *BedrockGuardrailWordPolicy                `json:"wordPolicy,omitempty"`
+}
+
+// BedrockGuardrailAppliedDetails holds metadata about the specific guardrail that was applied
+type BedrockGuardrailAppliedDetails struct {
+	GuardrailArn       *string  `json:"guardrailArn,omitempty"`
+	GuardrailID        *string  `json:"guardrailId,omitempty"`
+	GuardrailOrigin    []string `json:"guardrailOrigin,omitempty"`
+	GuardrailOwnership *string  `json:"guardrailOwnership,omitempty"`
+	GuardrailVersion   *string  `json:"guardrailVersion,omitempty"`
+}
+
+// BedrockGuardrailAutomatedReasoningPolicy represents an automated reasoning policy assessment
+type BedrockGuardrailAutomatedReasoningPolicy struct {
+	Findings []interface{} `json:"findings,omitempty"`
+}
+
+// BedrockGuardrailContextualGroundingPolicy represents a contextual grounding policy assessment
+type BedrockGuardrailContextualGroundingPolicy struct {
+	Filters []BedrockGuardrailContextualGroundingFilter `json:"filters,omitempty"`
+}
+
+// BedrockGuardrailContextualGroundingFilter represents a single contextual grounding filter result
+type BedrockGuardrailContextualGroundingFilter struct {
+	Type      *string  `json:"type,omitempty"`
+	Action    *string  `json:"action,omitempty"`
+	Score     *float64 `json:"score,omitempty"`
+	Threshold *float64 `json:"threshold,omitempty"`
+	Detected  *bool    `json:"detected,omitempty"`
+}
+
+// BedrockGuardrailInvocationMetrics holds latency and usage metrics for a guardrail invocation
+type BedrockGuardrailInvocationMetrics struct {
+	GuardrailCoverage          *BedrockGuardrailCoverage `json:"guardrailCoverage,omitempty"`
+	GuardrailProcessingLatency *int64                    `json:"guardrailProcessingLatency,omitempty"`
+	Usage                      *BedrockGuardrailUsage    `json:"usage,omitempty"`
+}
+
+// BedrockGuardrailCoverage holds coverage statistics for a guardrail invocation
+type BedrockGuardrailCoverage struct {
+	Images         *BedrockGuardrailCoverageCount `json:"images,omitempty"`
+	TextCharacters *BedrockGuardrailCoverageCount `json:"textCharacters,omitempty"`
+}
+
+// BedrockGuardrailCoverageCount holds guarded/total counts for a coverage dimension
+type BedrockGuardrailCoverageCount struct {
+	Guarded *int64 `json:"guarded,omitempty"`
+	Total   *int64 `json:"total,omitempty"`
+}
+
+// BedrockGuardrailUsage holds token/unit consumption for a guardrail invocation
+type BedrockGuardrailUsage struct {
+	AutomatedReasoningPolicies          *int64 `json:"automatedReasoningPolicies,omitempty"`
+	AutomatedReasoningPolicyUnits       *int64 `json:"automatedReasoningPolicyUnits,omitempty"`
+	ContentPolicyImageUnits             *int64 `json:"contentPolicyImageUnits,omitempty"`
+	ContentPolicyUnits                  *int64 `json:"contentPolicyUnits,omitempty"`
+	ContextualGroundingPolicyUnits      *int64 `json:"contextualGroundingPolicyUnits,omitempty"`
+	SensitiveInformationPolicyFreeUnits *int64 `json:"sensitiveInformationPolicyFreeUnits,omitempty"`
+	SensitiveInformationPolicyUnits     *int64 `json:"sensitiveInformationPolicyUnits,omitempty"`
+	TopicPolicyUnits                    *int64 `json:"topicPolicyUnits,omitempty"`
+	WordPolicyUnits                     *int64 `json:"wordPolicyUnits,omitempty"`
 }
 
 // BedrockGuardrailTopicPolicy represents topic policy assessment

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -290,6 +290,47 @@
               "path": ["bedrock", "model", "{{bedrockModel}}", "converse"]
             }
           }
+        },
+        {
+          "name": "POST /bedrock/model/{modelId}/converse — guardrailConfig + trace (outputAssessments regression)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Regression: Bifrost 1.4.6 crashed with mismatch type []bedrock.BedrockGuardrailAssessment",
+                  "// when trace:enabled caused Bedrock to return outputAssessments as a map keyed by guardrail ID.",
+                  "if (pm.response.code >= 400) { return; }",
+                  "pm.test('trace.guardrail.outputAssessments is a map not an array', function () {",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.trace, 'expected trace in response').to.exist;",
+                  "  pm.expect(j.trace.guardrail, 'expected trace.guardrail').to.exist;",
+                  "  var oa = j.trace.guardrail.outputAssessments;",
+                  "  if (oa !== undefined) {",
+                  "    pm.expect(typeof oa).to.equal('object');",
+                  "    pm.expect(Array.isArray(oa), 'outputAssessments must not be an array').to.be.false;",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [{ \"text\": \"What is the capital of France?\" }]\n    }\n  ],\n  \"inferenceConfig\": { \"maxTokens\": 256 },\n  \"guardrailConfig\": {\n    \"guardrailIdentifier\": \"{{bedrockGuardrailIdentifier}}\",\n    \"guardrailVersion\": \"{{bedrockGuardrailVersion}}\",\n    \"trace\": \"enabled\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/model/{{bedrockModel}}/converse",
+              "host": ["{{baseUrl}}"],
+              "path": ["bedrock", "model", "{{bedrockModel}}", "converse"]
+            }
+          }
         }
       ]
     },

--- a/tests/integrations/python/tests/test_bedrock.py
+++ b/tests/integrations/python/tests/test_bedrock.py
@@ -3427,3 +3427,67 @@ class TestBedrockGuardrail:
             f"  ✓ guardrail trace present — action={action_val!r}, "
             f"keys={list(guardrail_trace.keys())}"
         )
+
+    @skip_if_no_api_key("bedrock")
+    def test_56_outputAssessments_is_map(self, bedrock_client):
+        """Test Case 56: outputAssessments is a map keyed by guardrail ID, not a list.
+
+        Regression for Bifrost 1.4.6: BedrockGuardrailTrace.OutputAssessments was
+        typed as []BedrockGuardrailAssessment.  Bedrock Converse (non-streaming) returns
+        outputAssessments as map[guardrailId][]Assessment, so unmarshalling crashed with:
+            mismatch type []bedrock.BedrockGuardrailAssessment with value object
+        This surfaced as InternalServerError on every guardrailed Converse call with
+        trace:enabled, regardless of whether the guardrail actually intervened.
+
+        Uses a benign prompt so the model actually produces output and Bedrock populates
+        outputAssessments in the trace.  A blocked prompt (guardrail_intervened on input)
+        never reaches the model, so outputAssessments would be absent — masking the bug.
+        """
+        identifier, version = self._get_guardrail_config()
+        model_id = get_model("bedrock", "chat")
+
+        # Benign prompt: model generates output → Bedrock includes outputAssessments in trace.
+        # A blocked prompt never reaches the model, so outputAssessments would be absent
+        # and the type-mismatch regression would go undetected.
+        response = bedrock_client.converse(
+            modelId=model_id,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"text": "What is the capital of France?"}],
+                }
+            ],
+            guardrailConfig={
+                "guardrailIdentifier": identifier,
+                "guardrailVersion": version,
+                "trace": "enabled",
+            },
+            inferenceConfig={"maxTokens": 256},
+        )
+
+        assert response is not None, "Response must not be None (was 500 pre-fix)"
+        assert "stopReason" in response, "Response must contain stopReason"
+
+        trace = response.get("trace") or {}
+        guardrail_trace = trace.get("guardrail") or {}
+        output_assessments = guardrail_trace.get("outputAssessments")
+        
+        assert output_assessments is not None, (
+            "trace.guardrail.outputAssessments must be present when trace:enabled and the "
+            "model generates output — its absence means the trace was dropped or the prompt "
+            "was blocked before the model ran"
+        )
+        assert isinstance(output_assessments, dict), (
+            f"outputAssessments must be map[guardrailId][]Assessment, "
+            f"got {type(output_assessments).__name__}"
+        )
+        for key, val in output_assessments.items():
+            assert isinstance(key, str), f"outputAssessments key must be a string, got {type(key)}"
+            assert isinstance(val, list), (
+                f"outputAssessments[{key!r}] must be a list of assessments, got {type(val)}"
+            )
+
+        print(
+            f"  ✓ outputAssessments type correct — stopReason={response['stopReason']}, "
+            f"outputAssessments keys={list(output_assessments.keys())}"
+        )

--- a/tests/integrations/python/tests/test_langchain.py
+++ b/tests/integrations/python/tests/test_langchain.py
@@ -1539,6 +1539,149 @@ class TestLangChainIntegration:
         except Exception as e:
             pytest.skip(f"Bedrock guardrail test not available: {e}")
 
+    def test_31_bedrock_guardrail_outputAssessments_is_map(self, test_config):
+        """Test Case 31: outputAssessments round-trips as a map, not a list (1.4.6 regression).
+
+        Bifrost 1.4.6 crashed with mismatch type []bedrock.BedrockGuardrailAssessment
+        when Bedrock returned outputAssessments as a map keyed by guardrail ID.
+        With trace:enabled Bedrock includes outputAssessments on every response, so
+        every guardrailed call via ChatBedrockConverse would fail with InternalServerError.
+
+        Requires BEDROCK_GUARDRAIL_IDENTIFIER; skipped automatically otherwise.
+        """
+        if not BEDROCK_CONVERSE_AVAILABLE:
+            pytest.skip("langchain-aws not installed")
+
+        identifier = os.environ.get("BEDROCK_GUARDRAIL_IDENTIFIER")
+        version = os.environ.get("BEDROCK_GUARDRAIL_VERSION", "DRAFT")
+        if not identifier:
+            pytest.skip(
+                "Guardrail not configured — set BEDROCK_GUARDRAIL_IDENTIFIER env var"
+            )
+
+        base_url = get_integration_url("bedrock")
+        config = get_config()
+        integration_settings = config.get_integration_settings("bedrock")
+        region = integration_settings.get("region", "us-west-2")
+
+        bedrock_boto3_client = boto3.client(
+            "bedrock-runtime",
+            region_name=region,
+            endpoint_url=base_url,
+        )
+
+        try:
+            llm = ChatBedrockConverse(
+                model=get_model("bedrock", "chat"),
+                client=bedrock_boto3_client,
+                guardrails={
+                    "guardrailIdentifier": identifier,
+                    "guardrailVersion": version,
+                    "trace": "enabled",
+                },
+                max_tokens=256,
+            )
+
+            # Benign prompt so the model generates output and Bedrock populates outputAssessments.
+            # A blocked prompt never reaches the model, leaving outputAssessments absent.
+            response = llm.invoke([HumanMessage(content="What is the capital of France?")])
+
+            # Must not raise InternalServerError (the pre-fix failure mode)
+            metadata = getattr(response, "response_metadata", {}) or {}
+            assert "stopReason" in metadata, (
+                "response_metadata must contain stopReason"
+            )
+
+            # If the raw trace is surfaced in additional_kwargs, verify the shape
+            raw_trace = metadata.get("trace") or {}
+            guardrail_trace = raw_trace.get("guardrail") or {}
+            output_assessments = guardrail_trace.get("outputAssessments")
+            if output_assessments is not None:
+                assert isinstance(output_assessments, dict), (
+                    f"outputAssessments must be map[guardrailId][]Assessment, "
+                    f"got {type(output_assessments).__name__}"
+                )
+
+            print(
+                f"  ✓ outputAssessments regression: no parse crash, "
+                f"stopReason={metadata.get('stopReason')!r}"
+            )
+
+        except Exception as e:
+            pytest.skip(f"Bedrock guardrail outputAssessments regression test not available: {e}")
+
+    def test_32_bedrock_guardrail_streaming_outputAssessments_is_map(self, test_config):
+        """Test Case 32: outputAssessments is a map in the ConverseStream metadata event.
+
+        Same regression as test_31 but via the streaming path. ChatBedrockConverse with
+        streaming=True uses ConverseStream; the guardrail trace arrives in the metadata
+        event and must parse without crashing.
+        """
+        if not BEDROCK_CONVERSE_AVAILABLE:
+            pytest.skip("langchain-aws not installed")
+
+        identifier = os.environ.get("BEDROCK_GUARDRAIL_IDENTIFIER")
+        version = os.environ.get("BEDROCK_GUARDRAIL_VERSION", "DRAFT")
+        if not identifier:
+            pytest.skip(
+                "Guardrail not configured — set BEDROCK_GUARDRAIL_IDENTIFIER env var"
+            )
+
+        base_url = get_integration_url("bedrock")
+        config = get_config()
+        integration_settings = config.get_integration_settings("bedrock")
+        region = integration_settings.get("region", "us-west-2")
+
+        bedrock_boto3_client = boto3.client(
+            "bedrock-runtime",
+            region_name=region,
+            endpoint_url=base_url,
+        )
+
+        try:
+            llm = ChatBedrockConverse(
+                model=get_model("bedrock", "chat"),
+                client=bedrock_boto3_client,
+                guardrails={
+                    "guardrailIdentifier": identifier,
+                    "guardrailVersion": version,
+                    "trace": "enabled",
+                },
+                max_tokens=256,
+            )
+
+            # Benign prompt — model generates output so Bedrock populates outputAssessments.
+            # Accumulate via stream() — the final chunk carries response_metadata with the trace.
+            stream = llm.stream([HumanMessage(content="What is the capital of France?")])
+            full = next(stream)
+            for chunk in stream:
+                full += chunk
+
+            assert full.content, "Streaming response should have content"
+
+            metadata = getattr(full, "response_metadata", {}) or {}
+            raw_trace = metadata.get("trace") or {}
+            guardrail_trace = raw_trace.get("guardrail") or {}
+            output_assessments = guardrail_trace.get("outputAssessments")
+
+            if output_assessments is not None:
+                assert isinstance(output_assessments, dict), (
+                    f"outputAssessments must be map[guardrailId][]Assessment, "
+                    f"got {type(output_assessments).__name__}"
+                )
+                for key, val in output_assessments.items():
+                    assert isinstance(val, list), (
+                        f"outputAssessments[{key!r}] must be a list, got {type(val).__name__}"
+                    )
+
+            print(
+                f"  ✓ streaming outputAssessments regression: no parse crash, "
+                f"outputAssessments={'present' if output_assessments is not None else 'absent'}"
+            )
+
+        except Exception as e:
+            pytest.skip(f"Bedrock guardrail streaming test not available: {e}")
+
 
 # Skip standard tests if langchain-tests is not available
 @pytest.mark.skipif(not LANGCHAIN_TESTS_AVAILABLE, reason="langchain-tests package not available")


### PR DESCRIPTION
## Summary

Fixes a crash introduced in Bifrost 1.4.6 where Bedrock Converse calls with `trace: enabled` would always return an `InternalServerError`. The root cause was a type mismatch: `BedrockGuardrailTrace.OutputAssessments` was typed as `[]BedrockGuardrailAssessment` (a slice), but Bedrock returns `outputAssessments` as `map[guardrailId][]Assessment` (a map keyed by guardrail ID). This caused JSON unmarshalling to crash on every guardrailed Converse call that reached the model and produced output.

## Changes

- Corrected `BedrockGuardrailTrace.OutputAssessments` from `[]BedrockGuardrailAssessment` to `map[string][]BedrockGuardrailAssessment` to match the actual Bedrock API shape
- Corrected `BedrockGuardrailTrace.InputAssessment` from `map[string]interface{}` to `map[string]BedrockGuardrailAssessment` for type safety
- Unified the struct to a single shape covering both Converse and ConverseStream paths, removing the previously incorrect split between "streaming" and "non-streaming" field sets
- Expanded `BedrockGuardrailAssessment` with the full set of fields returned by Bedrock, including `AppliedGuardrailDetails`, `AutomatedReasoningPolicy`, `ContextualGroundingPolicy`, and `InvocationMetrics`
- Added supporting types: `BedrockGuardrailAppliedDetails`, `BedrockGuardrailAutomatedReasoningPolicy`, `BedrockGuardrailContextualGroundingPolicy`, `BedrockGuardrailContextualGroundingFilter`, `BedrockGuardrailInvocationMetrics`, `BedrockGuardrailCoverage`, `BedrockGuardrailCoverageCount`, and `BedrockGuardrailUsage`
- Added a regression test (`test_56`) to the Bedrock integration suite asserting `outputAssessments` is a map, not a list
- Added regression tests (`test_31`, `test_32`) to the LangChain integration suite covering both non-streaming and streaming paths
- Added a Postman/Newman e2e collection test case for the `guardrailConfig` + `trace` path that validates `outputAssessments` shape

> **Note:** A benign prompt is intentionally used in all regression tests. A blocked prompt never reaches the model, so `outputAssessments` would be absent in the trace — masking the type-mismatch bug entirely.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Core
go test ./core/providers/bedrock/...

# Integration tests (requires AWS credentials and a configured guardrail)
export BEDROCK_GUARDRAIL_IDENTIFIER=<your-guardrail-id>
export BEDROCK_GUARDRAIL_VERSION=DRAFT  # or a pinned version

cd tests/integrations/python
pytest tests/test_bedrock.py::TestBedrockConverse::test_56_outputAssessments_is_map -v
pytest tests/test_langchain.py::TestLangChainBedrock::test_31_bedrock_guardrail_outputAssessments_is_map -v
pytest tests/test_langchain.py::TestLangChainBedrock::test_32_bedrock_guardrail_streaming_outputAssessments_is_map -v
```

Set the following environment variables to enable guardrail tests:

| Variable | Description |
|---|---|
| `BEDROCK_GUARDRAIL_IDENTIFIER` | The guardrail ID to use for trace regression tests |
| `BEDROCK_GUARDRAIL_VERSION` | Guardrail version (defaults to `DRAFT`) |

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No new auth, secrets, or PII handling introduced. The fix only corrects the Go type used to deserialise guardrail trace data returned by AWS Bedrock.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable