### PR TITLE
chore: bump Bifrost Helm chart to 2.1.21 with `per_user_oauth`/`per_user_headers` authType support and helm-index Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ define EXPOSE_ENV
 	fi
 endef
 
-.PHONY: all help dev dev-pulse build-ui build build-cli run run-cli install-air install-pulse clean test test-cli install-ui setup-workspace work-init work-clean docs docker-image docker-run cleanup-enterprise mod-tidy test-integrations-py test-integrations-ts install-playwright run-e2e run-e2e-ui run-e2e-headed run-e2e-api format ui install-newman run-provider-harness-test run-cli-harness-test test-semantic-cache test-semantic-cache-complete _test-semantic-cache-complete-inner
+.PHONY: all help dev dev-pulse build-ui build build-cli run run-cli install-air install-pulse clean test test-cli install-ui setup-workspace work-init work-clean docs docker-image docker-run cleanup-enterprise mod-tidy test-integrations-py test-integrations-ts install-playwright run-e2e run-e2e-ui run-e2e-headed run-e2e-api format ui install-newman run-provider-harness-test run-cli-harness-test test-semantic-cache test-semantic-cache-complete _test-semantic-cache-complete-inner helm-index
 
 all: help
 
@@ -471,6 +471,25 @@ clean-test-reports: ## Clean test reports only
 	@$(ECHO) "$(YELLOW)Cleaning test reports...$(NC)"
 	@rm -rf $(TEST_REPORTS_DIR)/
 	@$(ECHO) "$(GREEN)Test reports cleaned$(NC)"
+
+helm-index: ## Repackage helm chart, regenerate index.yaml digest, then remove the .tgz
+	@if ! which helm > /dev/null 2>&1; then \
+		$(ECHO) "$(RED)Error: helm not installed$(NC)"; \
+		exit 1; \
+	fi
+	@CHART_VERSION=$$(grep '^version:' helm-charts/bifrost/Chart.yaml | awk '{print $$2}'); \
+	$(ECHO) "$(YELLOW)Packaging helm chart v$$CHART_VERSION...$(NC)"; \
+	cd helm-charts && \
+	helm package bifrost && \
+	$(ECHO) "$(YELLOW)Regenerating index.yaml digest...$(NC)" && \
+	if [ -f index.yaml ]; then \
+		helm repo index . --url https://github.com/maximhq/bifrost/releases/download/helm-chart-v$$CHART_VERSION --merge index.yaml; \
+	else \
+		helm repo index . --url https://github.com/maximhq/bifrost/releases/download/helm-chart-v$$CHART_VERSION; \
+	fi && \
+	$(ECHO) "$(YELLOW)Removing bifrost-$$CHART_VERSION.tgz...$(NC)" && \
+	rm -f bifrost-$$CHART_VERSION.tgz && \
+	$(ECHO) "$(GREEN)Helm index updated$(NC)"
 
 generate-html-reports: ## Convert existing XML reports to HTML
 	@if ! which junit-viewer > /dev/null 2>&1; then \

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.20
+version: 2.1.21
 appVersion: "1.5.3"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,12 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.20
+**Latest Version:** 2.1.21
 
 ## Changelog
+
+### 2.1.21
+- Add `per_user_oauth`/`per_user_headers` to `authType` enum in mcpClientConfig
 
 ### 2.1.20
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1779,9 +1779,18 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "attribute": { "type": "string", "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')" },
-                            "value": { "type": "string", "description": "Claim value to match (case-insensitive)" },
-                            "role": { "type": "string", "description": "Bifrost role to assign on match" }
+                            "attribute": {
+                              "type": "string",
+                              "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')"
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "Claim value to match (case-insensitive)"
+                            },
+                            "role": {
+                              "type": "string",
+                              "description": "Bifrost role to assign on match"
+                            }
                           },
                           "required": ["attribute", "value", "role"],
                           "additionalProperties": false
@@ -1893,9 +1902,18 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "attribute": { "type": "string", "description": "JWT claim name (supports dot paths)" },
-                            "value": { "type": "string", "description": "Claim value to match (case-insensitive)" },
-                            "role": { "type": "string", "description": "Bifrost role to assign on match" }
+                            "attribute": {
+                              "type": "string",
+                              "description": "JWT claim name (supports dot paths)"
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "Claim value to match (case-insensitive)"
+                            },
+                            "role": {
+                              "type": "string",
+                              "description": "Bifrost role to assign on match"
+                            }
                           },
                           "required": ["attribute", "value", "role"],
                           "additionalProperties": false
@@ -1996,9 +2014,18 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "attribute": { "type": "string", "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')" },
-                            "value": { "type": "string", "description": "Claim value to match (case-insensitive)" },
-                            "role": { "type": "string", "description": "Bifrost role to assign on match" }
+                            "attribute": {
+                              "type": "string",
+                              "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')"
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "Claim value to match (case-insensitive)"
+                            },
+                            "role": {
+                              "type": "string",
+                              "description": "Bifrost role to assign on match"
+                            }
                           },
                           "required": ["attribute", "value", "role"],
                           "additionalProperties": false
@@ -2257,7 +2284,9 @@
                     "allOf": [
                       {
                         "if": {
-                          "properties": { "credentialMode": { "const": "env" } },
+                          "properties": {
+                            "credentialMode": { "const": "env" }
+                          },
                           "required": ["credentialMode"]
                         },
                         "then": {
@@ -2266,7 +2295,9 @@
                       },
                       {
                         "if": {
-                          "properties": { "credentialMode": { "const": "file" } },
+                          "properties": {
+                            "credentialMode": { "const": "file" }
+                          },
                           "required": ["credentialMode"]
                         },
                         "then": {
@@ -2275,7 +2306,11 @@
                       },
                       {
                         "if": {
-                          "properties": { "credentialMode": { "enum": ["inherit", "env", "file"] } },
+                          "properties": {
+                            "credentialMode": {
+                              "enum": ["inherit", "env", "file"]
+                            }
+                          },
                           "required": ["credentialMode"]
                         },
                         "then": {
@@ -3877,7 +3912,13 @@
         },
         "authType": {
           "type": "string",
-          "enum": ["none", "headers", "oauth"],
+          "enum": [
+            "none",
+            "headers",
+            "oauth",
+            "per_user_oauth",
+            "per_user_headers"
+          ],
           "description": "Authentication type for MCP connection"
         },
         "oauthConfigId": {

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -1,991 +1,1015 @@
 apiVersion: v1
 entries:
   bifrost:
-    - apiVersion: v2
-      appVersion: 1.5.3
-      created: "2026-05-28T22:00:26.010588+05:30"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      digest: 7213e43fd8370d6b97a16b50ee8d2fa2089579ede9b6056a1041e0f11ce4316f
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-        - openai
-        - anthropic
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.20.tgz
-      version: 2.1.20
-    - apiVersion: v2
-      appVersion: 1.5.3
-      created: "2026-05-26T14:33:57.417916+05:30"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      digest: 8e0d91b5fd3a095abfa2c5034149709cbd0c3ea62f3fcf3ca6ca46b223175c42
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-        - openai
-        - anthropic
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.19.tgz
-      version: 2.1.19
-    - apiVersion: v2
-      appVersion: 1.5.3
-      created: "2026-05-22T17:10:47.506843+05:30"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      digest: 8c4063c1297f451e147b0696aa51fe6830896b63e725f24ace86c39f108ea03c
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-        - openai
-        - anthropic
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.18.tgz
-      version: 2.1.18
-    - apiVersion: v2
-      appVersion: 1.5.0
-      created: "2026-05-17T14:30:00+05:30"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      digest: 8e887afbbc89f079595200570b40267c18dcc50f0ac188cff2116358555a8c15
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-        - openai
-        - anthropic
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.17.tgz
-      version: 2.1.17
-    - apiVersion: v2
-      appVersion: 1.5.0
-      created: "2026-05-12T19:31:15.185424+05:30"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      digest: 5bca59decc109f5a57d8a6c739bacd2108a8dc7ce70d66721c9f734fa8ac8645
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-        - openai
-        - anthropic
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.16.tgz
-      version: 2.1.16
-    - apiVersion: v2
-      appVersion: 1.5.0
-      created: "2026-05-11T19:50:28.71576+05:30"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      digest: bfd0e62ef9c284678739c514668fac900257c736336afe677d5e797e08839416
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-        - openai
-        - anthropic
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.15.tgz
-      version: 2.1.15
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease7
-      created: "2026-05-07T00:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.14.tgz
-      version: 2.1.14
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease7
-      created: "2026-05-02T00:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.13.tgz
-      version: 2.1.13
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease7
-      created: "2026-04-30T12:30:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.12.tgz
-      version: 2.1.12
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease7
-      created: "2026-04-29T18:30:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.11.tgz
-      version: 2.1.11
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease4
-      created: "2026-04-29T18:30:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.10.tgz
-      version: 2.1.10
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease4
-      created: "2026-04-28T18:30:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.9.tgz
-      version: 2.1.9
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease5
-      created: "2026-04-26T12:40:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.8.tgz
-      version: 2.1.8
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease4
-      created: "2026-04-24T15:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.7.tgz
-      version: 2.1.7
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease4
-      created: "2026-04-24T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.6.tgz
-      version: 2.1.6
-    - apiVersion: v2
-      appVersion: 1.5.0-prerelease4
-      created: "2026-04-21T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getbifrost.ai/favicon.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: support@getbifrost.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.2.tgz
-      version: 2.1.2
-    - apiVersion: v2
-      appVersion: 1.4.11
-      created: "2026-04-15T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.0-prerelease1.tgz
-      version: 2.1.0-prerelease1
-    - apiVersion: v2
-      appVersion: 1.4.11
-      created: "2026-04-13T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.18-rc.1.tgz
-      version: 2.0.18-rc.1
-    - apiVersion: v2
-      appVersion: 1.4.11
-      created: "2026-04-08T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.17.tgz
-      version: 2.0.17
-    - apiVersion: v2
-      appVersion: 1.4.11
-      created: "2026-04-08T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.16.tgz
-      version: 2.0.16
-    - apiVersion: v2
-      appVersion: 1.4.11
-      created: "2026-04-07T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.15.tgz
-      version: 2.0.15
-    - apiVersion: v2
-      appVersion: 1.4.11
-      created: "2026-03-20T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.14.tgz
-      version: 2.0.14
-    - apiVersion: v2
-      appVersion: 1.4.11
-      created: "2026-03-11T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.13.tgz
-      version: 2.0.13
-    - apiVersion: v2
-      appVersion: 1.4.11
-      created: "2026-03-06T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.12.tgz
-      version: 2.0.12
-    - apiVersion: v2
-      appVersion: 1.4.11
-      created: "2026-03-05T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.11.tgz
-      version: 2.0.11
-    - apiVersion: v2
-      appVersion: 1.4.8
-      created: "2026-03-03T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.10.tgz
-      version: 2.0.10
-    - apiVersion: v2
-      appVersion: 1.4.8
-      created: "2026-02-26T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.9.tgz
-      version: 2.0.9
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2026-02-19T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.8.tgz
-      version: 2.0.8
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2026-02-17T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.7.tgz
-      version: 2.0.7
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2026-02-17T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.6.tgz
-      version: 2.0.6
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2026-02-13T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.5.tgz
-      version: 2.0.5
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2026-02-10T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.4.tgz
-      version: 2.0.4
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2026-02-05T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.3.tgz
-      version: 2.0.3
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2026-01-31T21:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.2.tgz
-      version: 2.0.2
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2026-01-31T20:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.1.tgz
-      version: 2.0.1
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2026-01-31T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.0.tgz
-      version: 2.0.0
-    - apiVersion: v2
-      appVersion: 1.5.2
-      created: "2026-01-28T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.7.0.tgz
-      version: 1.7.0
-    - apiVersion: v2
-      appVersion: 1.4.2
-      created: "2026-01-23T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.6.0.tgz
-      version: 1.6.0
-    - apiVersion: v2
-      appVersion: 1.5.3
-      created: "2026-01-16T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.3.tgz
-      version: 1.5.3
-    - apiVersion: v2
-      appVersion: 1.5.2
-      created: "2026-01-05T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.2.tgz
-      version: 1.5.2
-    - apiVersion: v2
-      appVersion: 1.5.1
-      created: "2025-12-12T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.1.tgz
-      version: 1.5.1
-    - apiVersion: v2
-      appVersion: 1.5.0
-      created: "2025-12-11T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.0.tgz
-      version: 1.5.0
-    - apiVersion: v2
-      appVersion: 1.4.3
-      created: "2025-12-10T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.4.3.tgz
-      version: 1.4.3
-    - apiVersion: v2
-      appVersion: 1.4.2
-      created: "2025-12-08T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.4.2.tgz
-      version: 1.4.2
-    - apiVersion: v2
-      appVersion: 1.4.1
-      created: "2025-11-28T12:00:00Z"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.4.1.tgz
-      version: 1.4.1
-    - apiVersion: v2
-      appVersion: 1.3.36
-      created: "2025-11-26T09:56:49.837282+03:00"
-      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
-        for multiple providers
-      digest: 6e5b4339411070149533006533529840664282c0e40897b589189841c6580331
-      home: https://www.getmaxim.ai/bifrost
-      icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
-      keywords:
-        - ai
-        - gateway
-        - llm
-        - openai
-        - anthropic
-      maintainers:
-        - email: akshay@getmaxim.ai
-          name: Bifrost Team
-      name: bifrost
-      sources:
-        - https://github.com/maximhq/bifrost
-      type: application
-      urls:
-        - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
-      version: 1.3.36
-generated: "2026-05-28T22:00:26.010588+05:30"
+  - apiVersion: v2
+    appVersion: 1.5.3
+    created: "2026-06-03T22:30:14.895665+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: e9999c994ae1dc165e2dcb7aefb669a5e26deef066c225d83aaab1734ed161d1
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://github.com/maximhq/bifrost/releases/download/helm-chart-v2.1.21/bifrost-2.1.21.tgz
+    version: 2.1.21
+  - apiVersion: v2
+    appVersion: 1.5.3
+    created: "2026-05-28T22:00:26.010588+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 7213e43fd8370d6b97a16b50ee8d2fa2089579ede9b6056a1041e0f11ce4316f
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.20.tgz
+    version: 2.1.20
+  - apiVersion: v2
+    appVersion: 1.5.3
+    created: "2026-05-26T14:33:57.417916+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 8e0d91b5fd3a095abfa2c5034149709cbd0c3ea62f3fcf3ca6ca46b223175c42
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.19.tgz
+    version: 2.1.19
+  - apiVersion: v2
+    appVersion: 1.5.3
+    created: "2026-05-22T17:10:47.506843+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 8c4063c1297f451e147b0696aa51fe6830896b63e725f24ace86c39f108ea03c
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.18.tgz
+    version: 2.1.18
+  - apiVersion: v2
+    appVersion: 1.5.0
+    created: "2026-05-17T14:30:00+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 8e887afbbc89f079595200570b40267c18dcc50f0ac188cff2116358555a8c15
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.17.tgz
+    version: 2.1.17
+  - apiVersion: v2
+    appVersion: 1.5.0
+    created: "2026-05-12T19:31:15.185424+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 5bca59decc109f5a57d8a6c739bacd2108a8dc7ce70d66721c9f734fa8ac8645
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.16.tgz
+    version: 2.1.16
+  - apiVersion: v2
+    appVersion: 1.5.0
+    created: "2026-05-11T19:50:28.71576+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: bfd0e62ef9c284678739c514668fac900257c736336afe677d5e797e08839416
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.15.tgz
+    version: 2.1.15
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease7
+    created: "2026-05-07T00:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.14.tgz
+    version: 2.1.14
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease7
+    created: "2026-05-02T00:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.13.tgz
+    version: 2.1.13
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease7
+    created: "2026-04-30T12:30:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.12.tgz
+    version: 2.1.12
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease7
+    created: "2026-04-29T18:30:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.11.tgz
+    version: 2.1.11
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease4
+    created: "2026-04-29T18:30:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.10.tgz
+    version: 2.1.10
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease4
+    created: "2026-04-28T18:30:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.9.tgz
+    version: 2.1.9
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease5
+    created: "2026-04-26T12:40:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.8.tgz
+    version: 2.1.8
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease4
+    created: "2026-04-24T15:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.7.tgz
+    version: 2.1.7
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease4
+    created: "2026-04-24T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.6.tgz
+    version: 2.1.6
+  - apiVersion: v2
+    appVersion: 1.5.0-prerelease4
+    created: "2026-04-21T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.2.tgz
+    version: 2.1.2
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-04-15T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.0-prerelease1.tgz
+    version: 2.1.0-prerelease1
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-04-13T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.18-rc.1.tgz
+    version: 2.0.18-rc.1
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-04-08T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.17.tgz
+    version: 2.0.17
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-04-08T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.16.tgz
+    version: 2.0.16
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-04-07T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.15.tgz
+    version: 2.0.15
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-03-20T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.14.tgz
+    version: 2.0.14
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-03-11T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.13.tgz
+    version: 2.0.13
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-03-06T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.12.tgz
+    version: 2.0.12
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-03-05T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.11.tgz
+    version: 2.0.11
+  - apiVersion: v2
+    appVersion: 1.4.8
+    created: "2026-03-03T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.10.tgz
+    version: 2.0.10
+  - apiVersion: v2
+    appVersion: 1.4.8
+    created: "2026-02-26T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.9.tgz
+    version: 2.0.9
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2026-02-19T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.8.tgz
+    version: 2.0.8
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2026-02-17T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.7.tgz
+    version: 2.0.7
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2026-02-17T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.6.tgz
+    version: 2.0.6
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2026-02-13T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.5.tgz
+    version: 2.0.5
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2026-02-10T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.4.tgz
+    version: 2.0.4
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2026-02-05T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.3.tgz
+    version: 2.0.3
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2026-01-31T21:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.2.tgz
+    version: 2.0.2
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2026-01-31T20:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.1.tgz
+    version: 2.0.1
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2026-01-31T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.0.tgz
+    version: 2.0.0
+  - apiVersion: v2
+    appVersion: 1.5.2
+    created: "2026-01-28T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.7.0.tgz
+    version: 1.7.0
+  - apiVersion: v2
+    appVersion: 1.4.2
+    created: "2026-01-23T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.6.0.tgz
+    version: 1.6.0
+  - apiVersion: v2
+    appVersion: 1.5.3
+    created: "2026-01-16T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.3.tgz
+    version: 1.5.3
+  - apiVersion: v2
+    appVersion: 1.5.2
+    created: "2026-01-05T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.2.tgz
+    version: 1.5.2
+  - apiVersion: v2
+    appVersion: 1.5.1
+    created: "2025-12-12T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.1.tgz
+    version: 1.5.1
+  - apiVersion: v2
+    appVersion: 1.5.0
+    created: "2025-12-11T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.0.tgz
+    version: 1.5.0
+  - apiVersion: v2
+    appVersion: 1.4.3
+    created: "2025-12-10T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.4.3.tgz
+    version: 1.4.3
+  - apiVersion: v2
+    appVersion: 1.4.2
+    created: "2025-12-08T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.4.2.tgz
+    version: 1.4.2
+  - apiVersion: v2
+    appVersion: 1.4.1
+    created: "2025-11-28T12:00:00Z"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.4.1.tgz
+    version: 1.4.1
+  - apiVersion: v2
+    appVersion: 1.3.36
+    created: "2025-11-26T09:56:49.837282+03:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 6e5b4339411070149533006533529840664282c0e40897b589189841c6580331
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
+    version: 1.3.36
+generated: "2026-06-03T22:30:14.891442+05:30"


### PR DESCRIPTION
## Summary

Releases Helm chart version 2.1.21, which adds `per_user_oauth` and `per_user_headers` as valid `authType` values in `mcpClientConfig`. A new `helm-index` Makefile target is also introduced to automate the process of repackaging the chart, regenerating `index.yaml`, and cleaning up the resulting `.tgz`.

## Changes

- Bumped `Chart.yaml` version from `2.1.20` to `2.1.21`
- Added `per_user_oauth` and `per_user_headers` to the `authType` enum in `values.schema.json` for MCP client configs
- Added a `helm-index` Makefile target that packages the Bifrost Helm chart, regenerates `index.yaml` with the correct digest and GitHub Releases download URL, then removes the intermediate `.tgz`
- Updated `index.yaml` with the new `2.1.21` entry pointing to `https://github.com/maximhq/bifrost/releases/download/helm-chart-v2.1.21/bifrost-2.1.21.tgz`
- Updated `README.md` changelog to document the 2.1.21 release

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
# Verify the helm-index target works correctly
make helm-index

# Confirm index.yaml contains the 2.1.21 entry with the correct digest and URL
grep -A5 "version: 2.1.21" helm-charts/index.yaml

# Validate the schema accepts per_user_oauth and per_user_headers as authType values
helm lint helm-charts/bifrost
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The new `per_user_oauth` and `per_user_headers` auth types follow the same patterns as the existing `oauth` and `headers` types.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable