### PR TITLE
feat: add `keyconfig.Store` for per-key config aggregation with allow/block/alias views

### DIFF
--- a/framework/modelcatalog/keyconfig/store.go
+++ b/framework/modelcatalog/keyconfig/store.go
@@ -1,0 +1,333 @@
+// Package keyconfig caches per-key configuration (allowed/blacklisted
+// models, aliases) for every configured provider. It is a pure
+// transformation: callers push raw schemas.Key slices in via SetProvider /
+// Replace, and the store exposes derived views (aggregated allow/block
+// lists, alias-owner index, per-key entries) for routing-time queries.
+//
+// The store performs no I/O — it does not know about configstore, the
+// network, or persistence. The composer (ModelCatalog) owns fetching keys
+// from the config store and pushing them in.
+//
+// Aggregation semantics — provider-level blacklist as the intersection across
+// enabled keys, last-enabled-key-wins on alias collisions — are ported from
+// bifrost-enterprise/core/loadbalancing/plugin.go and extended with per-key
+// alias retention so routing can resolve (provider, model) → (keyID, AliasConfig).
+package keyconfig
+
+import (
+	"slices"
+	"strings"
+	"sync"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// KeyEntry is the per-key configuration snapshot the store maintains. Slice
+// and map fields are owned by the store; callers must not mutate.
+type KeyEntry struct {
+	KeyID       string
+	Enabled     bool
+	Allowed     schemas.WhiteList
+	Blacklisted schemas.BlackList
+	Aliases     schemas.KeyAliases
+}
+
+// AliasOwner identifies which key owns an alias and carries its AliasConfig.
+// Routing uses KeyID to pick credentials; Config carries the deployment /
+// region overrides that must be applied alongside.
+type AliasOwner struct {
+	KeyID  string
+	Config schemas.AliasConfig
+}
+
+// providerState is the immutable snapshot stored per provider. Writers
+// build a fresh providerState off-lock and slot it into the entries map
+// under the write lock, so readers always see a consistent set of derived
+// views — never a torn mix of pre- and post-refresh state.
+type providerState struct {
+	entries     []KeyEntry
+	allowed     schemas.WhiteList
+	blacklisted schemas.BlackList
+	aliasIndex  map[string]AliasOwner
+}
+
+type Store struct {
+	// mu serializes writers (Replace / SetProvider / RemoveProvider) and
+	// gates concurrent readers. Replace holds the write lock for its full
+	// build-and-swap so readers see either the full old snapshot or the
+	// full new one — never an interleaving.
+	mu      sync.RWMutex
+	entries map[schemas.ModelProvider]*providerState
+	logger  schemas.Logger
+}
+
+// New constructs an empty Store.
+func New(logger schemas.Logger) *Store {
+	if logger == nil {
+		logger = bifrost.NewNoOpLogger()
+	}
+	return &Store{
+		entries: make(map[schemas.ModelProvider]*providerState),
+		logger:  logger,
+	}
+}
+
+// Replace resets the store to reflect the snapshot. Providers present in the
+// previous state but absent from snapshot are dropped. The new map is
+// swapped in atomically under the write lock: readers see either the full
+// old snapshot or the full new one, never an interleaving. Use on initial
+// load and on full cross-pod resyncs.
+func (s *Store) Replace(snapshot map[schemas.ModelProvider][]schemas.Key) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	next := make(map[schemas.ModelProvider]*providerState, len(snapshot))
+	for p, keys := range snapshot {
+		if st := s.buildState(p, keys); st != nil {
+			next[p] = st
+		}
+	}
+	s.entries = next
+}
+
+// SetProvider replaces the cached state for one provider. Call after a
+// successful key add / update / delete for that provider.
+func (s *Store) SetProvider(provider schemas.ModelProvider, keys []schemas.Key) {
+	st := s.buildState(provider, keys)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if st == nil {
+		delete(s.entries, provider)
+		return
+	}
+	s.entries[provider] = st
+}
+
+// RemoveProvider drops all state for the provider. Call on provider delete.
+func (s *Store) RemoveProvider(provider schemas.ModelProvider) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, provider)
+}
+
+// EntriesFor returns all per-key entries for the provider (including
+// individually-disabled keys), or nil when the provider has no routable
+// keys at all and was dropped from the store. Returns a defensive slice
+// copy; KeyEntry fields share underlying memory with the store and must
+// not be mutated.
+func (s *Store) EntriesFor(provider schemas.ModelProvider) []KeyEntry {
+	st := s.load(provider)
+	if st == nil {
+		return nil
+	}
+	out := make([]KeyEntry, len(st.entries))
+	copy(out, st.entries)
+	return out
+}
+
+// EntryFor returns the entry for one (provider, keyID), or false if absent.
+func (s *Store) EntryFor(provider schemas.ModelProvider, keyID string) (KeyEntry, bool) {
+	st := s.load(provider)
+	if st == nil {
+		return KeyEntry{}, false
+	}
+	for _, e := range st.entries {
+		if e.KeyID == keyID {
+			return e, true
+		}
+	}
+	return KeyEntry{}, false
+}
+
+// AllowedFor returns the aggregated whitelist: union of enabled keys' Models
+// minus per-key Blacklisted, or ["*"] when any enabled key is unrestricted or
+// the provider is keyless non-standard.
+func (s *Store) AllowedFor(provider schemas.ModelProvider) schemas.WhiteList {
+	st := s.load(provider)
+	if st == nil {
+		return nil
+	}
+	return slices.Clone(st.allowed)
+}
+
+// BlacklistedFor returns the intersection of enabled keys' BlacklistedModels.
+// A model is provider-wide blocked only when *every* enabled key blacklists
+// it — matching the LB semantics that a model is only fully unavailable when
+// no key can serve it.
+func (s *Store) BlacklistedFor(provider schemas.ModelProvider) schemas.BlackList {
+	st := s.load(provider)
+	if st == nil {
+		return nil
+	}
+	return slices.Clone(st.blacklisted)
+}
+
+// IsAllowed composes the aggregated allow/block without copying. Returns
+// false for unknown providers (no state ⇒ no allowance).
+func (s *Store) IsAllowed(provider schemas.ModelProvider, model string) bool {
+	st := s.load(provider)
+	if st == nil {
+		return false
+	}
+	if st.blacklisted.IsBlocked(model) {
+		return false
+	}
+	return st.allowed.IsAllowed(model)
+}
+
+// ResolveAlias returns which key owns the alias on this provider and its
+// AliasConfig. AliasConfig is a value copy — safe to mutate without
+// affecting store state (though inner pointer fields like Region remain
+// shared; treat the returned Config as read-only).
+func (s *Store) ResolveAlias(provider schemas.ModelProvider, model string) (AliasOwner, bool) {
+	st := s.load(provider)
+	if st == nil {
+		return AliasOwner{}, false
+	}
+	// aliasIndex is keyed lowercase; match the case-insensitive contract
+	// of schemas.KeyAliases.ResolveConfig.
+	owner, ok := st.aliasIndex[strings.ToLower(model)]
+	return owner, ok
+}
+
+// Providers returns every provider with cached state. Used by callers
+// (notably the load balancer) that need to enumerate the routing-eligible
+// provider set.
+func (s *Store) Providers() []schemas.ModelProvider {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]schemas.ModelProvider, 0, len(s.entries))
+	for p := range s.entries {
+		out = append(out, p)
+	}
+	return out
+}
+
+// KeysAllowingModel returns the IDs of enabled keys whose Allowed list
+// includes the model and whose Blacklisted list does not block it. Used by
+// routing to skip keys that cannot serve the request without scanning each
+// key's Models slice itself.
+func (s *Store) KeysAllowingModel(provider schemas.ModelProvider, model string) []string {
+	st := s.load(provider)
+	if st == nil {
+		return nil
+	}
+	var out []string
+	for _, e := range st.entries {
+		if !e.Enabled || e.Blacklisted.IsBlockAll() || e.Blacklisted.IsBlocked(model) {
+			continue
+		}
+		if e.Allowed.IsAllowed(model) {
+			out = append(out, e.KeyID)
+		}
+	}
+	return out
+}
+
+// load returns the providerState for one provider under an RLock. Returns
+// nil when the provider isn't in the store. The returned *providerState is
+// immutable once published — safe to read without holding the lock.
+func (s *Store) load(provider schemas.ModelProvider) *providerState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.entries[provider]
+}
+
+// buildState applies the aggregation rules: skip disabled keys and full
+// blacklists, union allowed minus per-key blacklisted, intersect blacklists
+// across enabled keys for the provider-level set, last-enabled-key-wins on
+// alias collisions with a warning. Returns nil when the provider has no
+// routable keys (all disabled or fully block-all) and isn't a keyless
+// non-standard provider — such providers are dropped from the store
+// entirely, since this cache exists for routing-time queries, not
+// inspection. The configstore remains the source of truth for the full
+// configured-key set.
+//
+// Safe to call without holding s.mu — it only reads its parameters and
+// s.logger, and writes only to local variables.
+func (s *Store) buildState(provider schemas.ModelProvider, keys []schemas.Key) *providerState {
+	var (
+		allModelsAllowed bool
+		enabledKeysCount int
+		allowed          schemas.WhiteList
+		blacklistCounts  = make(map[string]int)
+		aliasIndex       = make(map[string]AliasOwner)
+		entries          = make([]KeyEntry, 0, len(keys))
+	)
+
+	// Keyless non-standard providers (custom providers configured without keys)
+	// are unrestricted — there's no allow-list to derive from.
+	if len(keys) == 0 && !bifrost.IsStandardProvider(provider) {
+		allModelsAllowed = true
+	}
+
+	for _, key := range keys {
+		enabled := key.Enabled == nil || *key.Enabled
+		entries = append(entries, KeyEntry{
+			KeyID:       key.ID,
+			Enabled:     enabled,
+			Allowed:     key.Models,
+			Blacklisted: key.BlacklistedModels,
+			Aliases:     key.Aliases,
+		})
+
+		if !enabled || key.BlacklistedModels.IsBlockAll() {
+			continue
+		}
+		enabledKeysCount++
+
+		for _, m := range key.BlacklistedModels {
+			blacklistCounts[strings.ToLower(m)]++
+		}
+
+		if key.Models.IsUnrestricted() {
+			allModelsAllowed = true
+		} else {
+			for _, m := range key.Models {
+				if key.BlacklistedModels.IsBlocked(m) {
+					continue
+				}
+				if !allowed.Contains(m) {
+					allowed = append(allowed, m)
+				}
+			}
+		}
+
+		for aliasName, cfg := range key.Aliases {
+			// Normalize to lowercase so the cross-key alias index matches the
+			// case-insensitive semantic of schemas.KeyAliases.ResolveConfig
+			// and schemas.KeyAliases.Validate's intra-key uniqueness check.
+			// Without this, two keys that differ only in alias casing would
+			// silently both land in the index and the collision warning
+			// would never fire.
+			normalizedAlias := strings.ToLower(aliasName)
+			if prev, exists := aliasIndex[normalizedAlias]; exists && prev.KeyID != key.ID {
+				s.logger.Debug("keyconfig: alias %q on provider %s defined by both key %s and key %s; last enabled key wins",
+					aliasName, provider, prev.KeyID, key.ID)
+			}
+			aliasIndex[normalizedAlias] = AliasOwner{KeyID: key.ID, Config: cfg}
+		}
+	}
+
+	if enabledKeysCount == 0 && !allModelsAllowed {
+		return nil
+	}
+
+	if allModelsAllowed {
+		allowed = schemas.WhiteList{"*"}
+	}
+
+	var blacklisted schemas.BlackList
+	for m, count := range blacklistCounts {
+		if count == enabledKeysCount {
+			blacklisted = append(blacklisted, m)
+		}
+	}
+
+	return &providerState{
+		entries:     entries,
+		allowed:     allowed,
+		blacklisted: blacklisted,
+		aliasIndex:  aliasIndex,
+	}
+}

--- a/framework/modelcatalog/keyconfig/store_test.go
+++ b/framework/modelcatalog/keyconfig/store_test.go
@@ -1,0 +1,680 @@
+package keyconfig
+
+import (
+	"slices"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// --- test logger ---
+
+type recordingLogger struct {
+	mu     sync.Mutex
+	debugs []string
+}
+
+func (l *recordingLogger) Debug(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.debugs = append(l.debugs, format)
+}
+func (l *recordingLogger) Info(format string, args ...any)                   {}
+func (l *recordingLogger) Warn(format string, args ...any)                   {}
+func (l *recordingLogger) Error(format string, args ...any)                  {}
+func (l *recordingLogger) Fatal(format string, args ...any)                  {}
+func (l *recordingLogger) SetLevel(level schemas.LogLevel)                   {}
+func (l *recordingLogger) SetOutputType(outputType schemas.LoggerOutputType) {}
+func (l *recordingLogger) LogHTTPRequest(level schemas.LogLevel, msg string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func (l *recordingLogger) DebugCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.debugs)
+}
+
+func ptrBool(b bool) *bool { return &b }
+
+func newStoreFromFixture(fixture map[schemas.ModelProvider][]schemas.Key) (*Store, *recordingLogger) {
+	log := &recordingLogger{}
+	s := New(log)
+	s.Replace(fixture)
+	return s, log
+}
+
+// --- behavioral tests ---
+
+func TestEmptyKeysAndStandardProviderRemoves(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: nil,
+	})
+	if got := s.AllowedFor(schemas.OpenAI); got != nil {
+		t.Errorf("standard provider with no keys: AllowedFor = %v, want nil", got)
+	}
+	if s.IsAllowed(schemas.OpenAI, "gpt-4o") {
+		t.Error("IsAllowed = true for standard provider with no keys")
+	}
+}
+
+func TestKeylessNonStandardProviderUnrestricted(t *testing.T) {
+	custom := schemas.ModelProvider("my-custom")
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		custom: nil,
+	})
+	allowed := s.AllowedFor(custom)
+	if !slices.Equal(allowed, schemas.WhiteList{"*"}) {
+		t.Errorf("keyless custom: AllowedFor = %v, want [*]", allowed)
+	}
+	if !s.IsAllowed(custom, "anything") {
+		t.Error("keyless custom: IsAllowed = false for arbitrary model")
+	}
+}
+
+func TestUnrestrictedKeyImpliesWildcard(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}},
+		},
+	})
+	if got := s.AllowedFor(schemas.OpenAI); !slices.Equal(got, schemas.WhiteList{"*"}) {
+		t.Errorf("AllowedFor = %v, want [*]", got)
+	}
+	if !s.IsAllowed(schemas.OpenAI, "gpt-4o") {
+		t.Error("IsAllowed = false on wildcard key")
+	}
+}
+
+func TestExplicitAllowFiltersBlacklistedPerKey(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{
+				ID:                "k1",
+				Enabled:           ptrBool(true),
+				Models:            schemas.WhiteList{"gpt-4o", "o1"},
+				BlacklistedModels: schemas.BlackList{"o1"},
+			},
+		},
+	})
+	allowed := s.AllowedFor(schemas.OpenAI)
+	sort.Strings(allowed)
+	if !slices.Equal(allowed, schemas.WhiteList{"gpt-4o"}) {
+		t.Errorf("AllowedFor = %v, want [gpt-4o] (o1 filtered by key blacklist)", allowed)
+	}
+}
+
+func TestBlacklistIntersectionAcrossKeys(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o", "o1"},
+				BlacklistedModels: schemas.BlackList{"o1", "gpt-3.5"}},
+			{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"},
+				BlacklistedModels: schemas.BlackList{"o1"}},
+		},
+	})
+	// o1 is blacklisted by both → provider-level blocked. gpt-3.5 only by one → not.
+	bl := s.BlacklistedFor(schemas.OpenAI)
+	sort.Strings(bl)
+	if !slices.Equal(bl, schemas.BlackList{"o1"}) {
+		t.Errorf("BlacklistedFor = %v, want [o1] (intersection)", bl)
+	}
+	if s.IsAllowed(schemas.OpenAI, "o1") {
+		t.Error("IsAllowed o1 = true, want false (provider-blocked)")
+	}
+}
+
+func TestDisabledKeyDoesNotAffectAggregates(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}},
+			{ID: "k2", Enabled: ptrBool(false), Models: schemas.WhiteList{"o1"}, BlacklistedModels: schemas.BlackList{"gpt-4o"}},
+		},
+	})
+	allowed := s.AllowedFor(schemas.OpenAI)
+	if !slices.Equal(allowed, schemas.WhiteList{"gpt-4o"}) {
+		t.Errorf("AllowedFor = %v, want [gpt-4o] (k2 disabled)", allowed)
+	}
+	if !s.IsAllowed(schemas.OpenAI, "gpt-4o") {
+		t.Error("IsAllowed gpt-4o = false: disabled key's blacklist should not affect")
+	}
+}
+
+func TestBlockAllKeySkipped(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}},
+			{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"o1"}, BlacklistedModels: schemas.BlackList{"*"}},
+		},
+	})
+	allowed := s.AllowedFor(schemas.OpenAI)
+	if !slices.Equal(allowed, schemas.WhiteList{"gpt-4o"}) {
+		t.Errorf("AllowedFor = %v, want [gpt-4o]; block-all key should be skipped", allowed)
+	}
+}
+
+func TestEntriesForIncludesDisabled(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}},
+			{ID: "k2", Enabled: ptrBool(false), Models: schemas.WhiteList{"o1"}},
+		},
+	})
+	entries := s.EntriesFor(schemas.OpenAI)
+	if len(entries) != 2 {
+		t.Fatalf("EntriesFor returned %d entries, want 2 (including disabled)", len(entries))
+	}
+	hasDisabled := false
+	for _, e := range entries {
+		if e.KeyID == "k2" && !e.Enabled {
+			hasDisabled = true
+		}
+	}
+	if !hasDisabled {
+		t.Error("disabled entry missing from EntriesFor")
+	}
+}
+
+func TestEntryForLookup(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}},
+		},
+	})
+	e, ok := s.EntryFor(schemas.OpenAI, "k1")
+	if !ok {
+		t.Fatal("EntryFor returned !ok for existing key")
+	}
+	if e.KeyID != "k1" {
+		t.Errorf("KeyID = %q, want k1", e.KeyID)
+	}
+	if _, ok := s.EntryFor(schemas.OpenAI, "missing"); ok {
+		t.Error("EntryFor returned ok for missing key")
+	}
+}
+
+func TestResolveAliasReturnsOwner(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{
+				ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"},
+				Aliases: schemas.KeyAliases{
+					"my-prod": schemas.AliasConfig{ModelID: "gpt-4o-2024-08-06"},
+				},
+			},
+		},
+	})
+	owner, ok := s.ResolveAlias(schemas.OpenAI, "my-prod")
+	if !ok {
+		t.Fatal("ResolveAlias !ok for known alias")
+	}
+	if owner.KeyID != "k1" {
+		t.Errorf("owner.KeyID = %q, want k1", owner.KeyID)
+	}
+	if owner.Config.ModelID != "gpt-4o-2024-08-06" {
+		t.Errorf("owner.Config.ModelID = %q, want gpt-4o-2024-08-06", owner.Config.ModelID)
+	}
+}
+
+func TestResolveAliasMissing(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}}},
+	})
+	if _, ok := s.ResolveAlias(schemas.OpenAI, "nope"); ok {
+		t.Error("ResolveAlias ok for missing alias")
+	}
+	if _, ok := s.ResolveAlias(schemas.ModelProvider("absent"), "anything"); ok {
+		t.Error("ResolveAlias ok for absent provider")
+	}
+}
+
+func TestAliasCollisionLastEnabledWinsAndLogs(t *testing.T) {
+	s, log := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{
+				ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"},
+				Aliases: schemas.KeyAliases{"my-prod": schemas.AliasConfig{ModelID: "from-k1"}},
+			},
+			{
+				ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"},
+				Aliases: schemas.KeyAliases{"my-prod": schemas.AliasConfig{ModelID: "from-k2"}},
+			},
+		},
+	})
+	owner, _ := s.ResolveAlias(schemas.OpenAI, "my-prod")
+	if owner.KeyID != "k2" {
+		t.Errorf("owner.KeyID = %q, want k2 (last key in slice wins)", owner.KeyID)
+	}
+	if log.DebugCount() == 0 {
+		t.Error("expected collision debug log, got none")
+	}
+}
+
+func TestKeysAllowingModel(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o", "o1"}},
+			{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}, BlacklistedModels: schemas.BlackList{"o1"}},
+			{ID: "k3", Enabled: ptrBool(false), Models: schemas.WhiteList{"gpt-4o"}},
+			{ID: "k4", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}},
+		},
+	})
+	got := s.KeysAllowingModel(schemas.OpenAI, "gpt-4o")
+	sort.Strings(got)
+	if !slices.Equal(got, []string{"k1", "k2", "k4"}) {
+		t.Errorf("KeysAllowingModel gpt-4o = %v, want [k1 k2 k4]", got)
+	}
+	got = s.KeysAllowingModel(schemas.OpenAI, "o1")
+	sort.Strings(got)
+	if !slices.Equal(got, []string{"k1", "k4"}) {
+		t.Errorf("KeysAllowingModel o1 = %v, want [k1 k4] (k2 blacklists, k3 disabled)", got)
+	}
+}
+
+func TestSetProviderIsolated(t *testing.T) {
+	s := New(nil)
+	s.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI:    {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+		schemas.Anthropic: {{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"claude-3-5-sonnet"}}},
+	})
+
+	s.SetProvider(schemas.OpenAI, []schemas.Key{
+		{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o-new"}},
+	})
+
+	if got := s.AllowedFor(schemas.OpenAI); !slices.Equal(got, schemas.WhiteList{"gpt-4o-new"}) {
+		t.Errorf("openai after SetProvider = %v, want [gpt-4o-new]", got)
+	}
+	if got := s.AllowedFor(schemas.Anthropic); !slices.Equal(got, schemas.WhiteList{"claude-3-5-sonnet"}) {
+		t.Errorf("anthropic perturbed by openai SetProvider: %v", got)
+	}
+}
+
+func TestReplaceDropsDisappearedProviders(t *testing.T) {
+	s := New(nil)
+	s.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI:    {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+		schemas.Anthropic: {{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"claude-3-5-sonnet"}}},
+	})
+
+	s.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+
+	if got := s.AllowedFor(schemas.Anthropic); got != nil {
+		t.Errorf("anthropic still present after Replace dropped it: %v", got)
+	}
+}
+
+func TestSetProviderToEmptyDropsStandard(t *testing.T) {
+	s := New(nil)
+	s.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+
+	s.SetProvider(schemas.OpenAI, nil)
+
+	if got := s.AllowedFor(schemas.OpenAI); got != nil {
+		t.Errorf("after SetProvider(empty), AllowedFor = %v, want nil", got)
+	}
+}
+
+func TestRemoveProvider(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	s.RemoveProvider(schemas.OpenAI)
+	if got := s.AllowedFor(schemas.OpenAI); got != nil {
+		t.Errorf("after RemoveProvider, AllowedFor = %v, want nil", got)
+	}
+}
+
+func TestEntriesForReturnsDefensiveCopy(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}}},
+	})
+	entries := s.EntriesFor(schemas.OpenAI)
+	entries[0].KeyID = "MUTATED"
+	again := s.EntriesFor(schemas.OpenAI)
+	if again[0].KeyID != "k1" {
+		t.Errorf("store mutated through EntriesFor: KeyID = %q", again[0].KeyID)
+	}
+}
+
+// These lock down behaviors that the LB plugin used to maintain locally and
+// that the keyconfig store now owns. The "aliases don't leak into allowed"
+// suite documents the structural isolation: Aliases write to aliasIndex,
+// Models write to allowed — they never mix.
+
+func TestAliases_WildcardModels_AllowedStaysWildcard(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.Bedrock: {
+			{
+				ID:      "bk1",
+				Enabled: ptrBool(true),
+				Models:  schemas.WhiteList{"*"},
+				Aliases: schemas.KeyAliases{
+					"my-claude-alias": schemas.AliasConfig{ModelID: "anthropic.claude-3-5-sonnet-20241022-v2:0"},
+				},
+			},
+		},
+	})
+	if got := s.AllowedFor(schemas.Bedrock); !slices.Equal(got, schemas.WhiteList{"*"}) {
+		t.Errorf("AllowedFor = %v, want [*] (Models field wins; aliases do not leak)", got)
+	}
+	if _, ok := s.ResolveAlias(schemas.Bedrock, "my-claude-alias"); !ok {
+		t.Error("alias missing from aliasIndex; should be present alongside ['*']")
+	}
+}
+
+func TestAliases_SpecificModels_AllowedDoesNotIncludeAliasName(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.Azure: {
+			{
+				ID:      "az1",
+				Enabled: ptrBool(true),
+				Models:  schemas.WhiteList{"gpt-4o"},
+				Aliases: schemas.KeyAliases{
+					"gpt4o-prod": schemas.AliasConfig{ModelID: "gpt-4o"},
+				},
+			},
+		},
+	})
+	got := s.AllowedFor(schemas.Azure)
+	sort.Strings(got)
+	if !slices.Equal(got, schemas.WhiteList{"gpt-4o"}) {
+		t.Errorf("AllowedFor = %v, want [gpt-4o] only — alias name 'gpt4o-prod' must NOT appear in allowed", got)
+	}
+	if _, ok := s.ResolveAlias(schemas.Azure, "gpt4o-prod"); !ok {
+		t.Error("alias missing from aliasIndex")
+	}
+}
+
+func TestAliases_EmptyModels_ProviderAbsent(t *testing.T) {
+	// Models=[] with aliases present: aliases are name swappers, not implicit
+	// model grants. Operators must explicitly list models in Models field.
+	// Provider should be absent from aggregates (no enabled allow path).
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.Bedrock: {
+			{
+				ID:      "bk1",
+				Enabled: ptrBool(true),
+				Models:  schemas.WhiteList{},
+				Aliases: schemas.KeyAliases{
+					"prod": schemas.AliasConfig{ModelID: "anthropic.claude-3-5-sonnet-20241022-v2:0"},
+				},
+			},
+		},
+	})
+	if got := s.AllowedFor(schemas.Bedrock); got != nil {
+		t.Errorf("AllowedFor = %v, want nil — aliases alone must not produce an allowed entry", got)
+	}
+}
+
+func TestAllKeysBlockAll_ProviderAbsent(t *testing.T) {
+	// Every key has BlacklistedModels=["*"]. All are skipped by the aggregator,
+	// enabledKeysCount stays 0, provider is dropped from the store.
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}, BlacklistedModels: schemas.BlackList{"*"}},
+			{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"o1"}, BlacklistedModels: schemas.BlackList{"*"}},
+		},
+	})
+	if got := s.AllowedFor(schemas.OpenAI); got != nil {
+		t.Errorf("AllowedFor = %v, want nil — every key is block-all", got)
+	}
+	if s.IsAllowed(schemas.OpenAI, "gpt-4o") {
+		t.Error("IsAllowed = true for provider with all-block-all keys")
+	}
+}
+
+func TestExplicitModels_UnionAcrossEnabledKeys(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o", "o1"}},
+			{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o", "gpt-4.5"}},
+			{ID: "k3", Enabled: ptrBool(false), Models: schemas.WhiteList{"sekret-model"}},
+		},
+	})
+	got := s.AllowedFor(schemas.OpenAI)
+	sort.Strings(got)
+	// AllowedFor returns the deduped union of enabled keys' Models, minus
+	// per-key blacklisted entries. The same model appearing in multiple keys
+	// is collapsed to a single entry.
+	want := schemas.WhiteList{"gpt-4.5", "gpt-4o", "o1"}
+	sort.Strings(want)
+	if !slices.Equal(got, want) {
+		t.Errorf("AllowedFor = %v, want union of enabled keys' Models = %v (k3 disabled, excluded)", got, want)
+	}
+	// Cross-check via IsAllowed (the actual consumer path).
+	for _, m := range []string{"gpt-4o", "o1", "gpt-4.5"} {
+		if !s.IsAllowed(schemas.OpenAI, m) {
+			t.Errorf("IsAllowed(%s) = false, want true (model is in union of enabled keys)", m)
+		}
+	}
+	if s.IsAllowed(schemas.OpenAI, "sekret-model") {
+		t.Error("IsAllowed(sekret-model) = true, want false (only on disabled key k3)")
+	}
+}
+
+// TestIsAllowed_ProviderAbsent ensures IsAllowed returns false
+// (deny-by-default) for a provider that has no cached state.
+func TestIsAllowed_ProviderAbsent(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{})
+	if s.IsAllowed(schemas.OpenAI, "gpt-4o") {
+		t.Error("IsAllowed on empty store = true, want false")
+	}
+}
+
+// TestIsAllowed_BlacklistWinsOverAllow asserts blacklist takes precedence even
+// when the model is also in the allowed set — the per-key gating uses both,
+// but the aggregated view must respect the cross-key intersection blacklist.
+func TestIsAllowed_BlacklistWinsOverAllow(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}, BlacklistedModels: schemas.BlackList{"gpt-4o"}},
+			{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"gpt-4o"}, BlacklistedModels: schemas.BlackList{"gpt-4o"}},
+		},
+	})
+	if s.IsAllowed(schemas.OpenAI, "gpt-4o") {
+		t.Error("IsAllowed = true; want false (every enabled key blacklists gpt-4o)")
+	}
+}
+
+// TestProviders_EmptyStore exercises the no-state baseline.
+func TestProviders_EmptyStore(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{})
+	if got := s.Providers(); len(got) != 0 {
+		t.Errorf("Providers() on empty store = %v, want []", got)
+	}
+}
+
+// TestProviders_StandardWithKeys ensures a standard provider with at least
+// one enabled non-block-all key is enumerated.
+func TestProviders_StandardWithKeys(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI:    {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}}},
+		schemas.Anthropic: {{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}}},
+	})
+	got := s.Providers()
+	sort.Slice(got, func(i, j int) bool { return string(got[i]) < string(got[j]) })
+	want := []schemas.ModelProvider{schemas.Anthropic, schemas.OpenAI}
+	if !slices.Equal(got, want) {
+		t.Errorf("Providers() = %v, want %v", got, want)
+	}
+}
+
+// TestProviders_StandardWithoutKeys verifies a standard provider with no
+// enabled keys is dropped from the enumeration.
+func TestProviders_StandardWithoutKeys(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {{ID: "k1", Enabled: ptrBool(false), Models: schemas.WhiteList{"*"}}},
+	})
+	if got := s.Providers(); len(got) != 0 {
+		t.Errorf("Providers() = %v, want [] (all keys disabled)", got)
+	}
+}
+
+// TestProviders_KeylessNonStandardIncluded covers the keyless custom-provider
+// branch: a non-standard provider with zero keys is still routable
+// (ambient/IAM auth) and must appear in Providers(). buildState marks it
+// unrestricted via the allModelsAllowed branch.
+func TestProviders_KeylessNonStandardIncluded(t *testing.T) {
+	custom := schemas.ModelProvider("my-custom-bedrock")
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{custom: nil})
+	got := s.Providers()
+	if !slices.Contains(got, custom) {
+		t.Errorf("Providers() = %v, want to include %q (keyless non-standard provider)", got, custom)
+	}
+	if !s.IsAllowed(custom, "anything") {
+		t.Error("IsAllowed on keyless non-standard provider = false, want true (allModelsAllowed)")
+	}
+}
+
+// TestBlacklistIntersection_CaseInsensitive verifies the count-bucket
+// normalisation: two keys blocking the same model under different casing
+// must aggregate as one entry so the cross-key intersection reaches
+// enabledKeysCount and the model gets promoted to the provider-wide blacklist.
+// Without strings.ToLower in the count map, this would silently fail.
+func TestBlacklistIntersection_CaseInsensitive(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}, BlacklistedModels: schemas.BlackList{"gpt-4o"}},
+			{ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}, BlacklistedModels: schemas.BlackList{"GPT-4o"}},
+		},
+	})
+	if s.IsAllowed(schemas.OpenAI, "gpt-4o") {
+		t.Error("IsAllowed(gpt-4o) = true; want false (both keys block under different casing, intersection should still fire)")
+	}
+	if s.IsAllowed(schemas.OpenAI, "GpT-4O") {
+		t.Error("IsAllowed(GpT-4O) = true; want false (BlackList.IsBlocked is case-insensitive)")
+	}
+}
+
+// TestAliasIndex_CaseInsensitive_CollisionDetected verifies the alias-name
+// normalisation: two keys defining the same alias under different casing
+// must collide so the last-wins warning fires AND only one entry lands in
+// the index. Without strings.ToLower, both would persist as separate entries
+// and the collision warning would never fire.
+func TestAliasIndex_CaseInsensitive_CollisionDetected(t *testing.T) {
+	s, log := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{
+				ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"},
+				Aliases: schemas.KeyAliases{"My-Prod": schemas.AliasConfig{ModelID: "from-k1"}},
+			},
+			{
+				ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"},
+				Aliases: schemas.KeyAliases{"my-prod": schemas.AliasConfig{ModelID: "from-k2"}},
+			},
+		},
+	})
+	if log.DebugCount() == 0 {
+		t.Error("expected collision debug log on case-different aliases across keys, got none")
+	}
+	owner, ok := s.ResolveAlias(schemas.OpenAI, "MY-PROD")
+	if !ok {
+		t.Fatal("ResolveAlias(MY-PROD) = (_, false); want a match (lookup is case-insensitive)")
+	}
+	if owner.KeyID != "k2" {
+		t.Errorf("owner.KeyID = %q, want k2 (last key in slice wins after case-normalisation)", owner.KeyID)
+	}
+}
+
+// TestResolveAlias_CaseInsensitiveLookup verifies the lookup side of the
+// case-normalisation contract — an alias defined as "best-claude" must
+// resolve regardless of the case used at the call site.
+func TestResolveAlias_CaseInsensitiveLookup(t *testing.T) {
+	s, _ := newStoreFromFixture(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{
+				ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"},
+				Aliases: schemas.KeyAliases{"best-claude": schemas.AliasConfig{ModelID: "claude-sonnet"}},
+			},
+		},
+	})
+	for _, q := range []string{"best-claude", "BEST-CLAUDE", "Best-Claude"} {
+		owner, ok := s.ResolveAlias(schemas.OpenAI, q)
+		if !ok || owner.KeyID != "k1" {
+			t.Errorf("ResolveAlias(%q) = (%+v, %v); want owner k1, true", q, owner, ok)
+		}
+	}
+}
+
+// TestNewNilLogger_DoesNotPanic exercises the NoOpLogger default path. If
+// New(nil) left logger as nil, the alias-collision Debug call would deref
+// nil and crash the test.
+func TestNewNilLogger_DoesNotPanic(t *testing.T) {
+	s := New(nil)
+	s.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI: {
+			{
+				ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"},
+				Aliases: schemas.KeyAliases{"my-prod": schemas.AliasConfig{ModelID: "a"}},
+			},
+			{
+				ID: "k2", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"},
+				Aliases: schemas.KeyAliases{"my-prod": schemas.AliasConfig{ModelID: "b"}},
+			},
+		},
+	})
+	if _, ok := s.ResolveAlias(schemas.OpenAI, "my-prod"); !ok {
+		t.Error("ResolveAlias = false; want true (Replace completed without panic)")
+	}
+}
+
+// TestReplace_AtomicSnapshot verifies that concurrent readers during a
+// Replace never observe a mid-resync provider count. Without atomic
+// publish (e.g. the prior sync.Map mutate-in-place design) readers could
+// see a count between len(old) and len(new). With the build-then-swap
+// design every snapshot read returns either the old or the new size.
+func TestReplace_AtomicSnapshot(t *testing.T) {
+	old := map[schemas.ModelProvider][]schemas.Key{
+		schemas.OpenAI:    {{ID: "k", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}}},
+		schemas.Anthropic: {{ID: "k", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}}},
+		schemas.Cohere:    {{ID: "k", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}}},
+		schemas.Gemini:    {{ID: "k", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}}},
+	}
+	next := map[schemas.ModelProvider][]schemas.Key{
+		schemas.Bedrock: {{ID: "k", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}}},
+	}
+	s, _ := newStoreFromFixture(old)
+	oldSize, nextSize := len(old), len(next)
+
+	stop := make(chan struct{})
+	var reader sync.WaitGroup
+	reader.Add(1)
+	bad := make(chan int, 1)
+	go func() {
+		defer reader.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				n := len(s.Providers())
+				if n != oldSize && n != nextSize {
+					select {
+					case bad <- n:
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		s.Replace(next)
+		s.Replace(old)
+	}
+	close(stop)
+	reader.Wait()
+	select {
+	case n := <-bad:
+		t.Errorf("reader observed torn snapshot size %d (want %d or %d)", n, oldSize, nextSize)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a new `keyconfig` package under `framework/modelcatalog` that provides a thread-safe, in-memory store for per-key configuration (allowed models, blacklisted models, and aliases) across all configured providers. This decouples the aggregation logic for routing-time model access decisions from I/O concerns, giving the `ModelCatalog` a clean interface to push key snapshots into and query derived views from.

## Changes

- Added `framework/modelcatalog/keyconfig/store.go` implementing a `Store` backed by a `sync.Map` that maintains immutable `providerState` snapshots per provider. Each snapshot holds:
  - A flat list of `KeyEntry` values (including disabled keys) for per-key inspection.
  - An aggregated `WhiteList` (union of enabled keys' allowed models, minus per-key blacklisted models; collapses to `["*"]` when any enabled key is unrestricted or the provider is keyless non-standard).
  - An aggregated `BlackList` computed as the intersection across enabled keys — a model is provider-wide blocked only when every enabled key blacklists it.
  - An alias index mapping alias names to the owning key ID and `AliasConfig`, with a last-enabled-key-wins collision policy and a warning logged on conflict.
- `Replace` performs a full atomic swap, dropping providers absent from the new snapshot. `SetProvider` and `RemoveProvider` handle incremental updates.
- Query methods (`IsAllowed`, `AllowedFor`, `BlacklistedFor`, `ResolveAlias`, `KeysAllowingModel`, `EntriesFor`, `EntryFor`, `Providers`) expose derived views without copying internal state unnecessarily; `EntriesFor` and list accessors return defensive copies to prevent external mutation.
- Added `framework/modelcatalog/keyconfig/store_test.go` with behavioral coverage for: keyless standard vs. non-standard providers, wildcard keys, per-key blacklist filtering from the allow list, blacklist intersection semantics, disabled key exclusion, block-all key skipping, alias resolution and collision warnings, `KeysAllowingModel` filtering, `SetProvider` isolation, `Replace` dropping disappeared providers, `RemoveProvider`, and defensive copy guarantees.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/keyconfig/...
```

All tests should pass. The test suite covers aggregation semantics, alias collision warnings, defensive copy guarantees, and atomic replace/remove behavior.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The store holds API key IDs and model access configuration in memory. No secrets (key values) are stored — only key IDs and routing metadata. The `sync.Map`-backed design ensures safe concurrent reads and writes without exposing internal state to callers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an internal key-configuration cache to track per-provider key state, compute aggregated allow/blacklists, resolve aliases with collision handling/logging, drop empty providers, and provide defensive, atomic snapshots for readers.
* **Tests**
  * Added comprehensive tests for aggregation rules, wildcard/unrestricted behavior, disabled-key handling, alias lookup and case-insensitive collisions, provider lifecycle, and snapshot/defensive-copy guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->