### PR TITLE
feat: add `live` model cache store and port keyconfig regression tests for alias/model isolation

### DIFF
--- a/framework/modelcatalog/live/store.go
+++ b/framework/modelcatalog/live/store.go
@@ -1,0 +1,125 @@
+// Package live caches the response of provider /v1/models calls per
+// (provider, keyID, unfiltered). Filtered entries are pre-gated by the
+// provider's ListModelsPipeline against the key's allowed/blacklisted/aliases;
+// callers reading filtered entries MUST NOT reapply that gate elsewhere or
+// alias-backfill rows will be dropped.
+//
+// The store is passive — it never calls the network. Callers (the HTTP server
+// after key add/update, or a future background refresher) decide when to
+// fetch and push results in via Upsert.
+package live
+
+import (
+	"slices"
+	"sync"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Key identifies one cached response. KeyID is "" for keyless providers
+// (Vertex workload identity, Bedrock IAM, etc).
+type Key struct {
+	Provider   schemas.ModelProvider
+	KeyID      string
+	Unfiltered bool
+}
+
+// Entry is a single cached response.
+type Entry struct {
+	Models []string
+}
+
+type Store struct {
+	mu      sync.RWMutex
+	entries map[Key]Entry
+	logger  schemas.Logger
+}
+
+func New(logger schemas.Logger) *Store {
+	if logger == nil {
+		logger = bifrost.NewNoOpLogger()
+	}
+	return &Store{entries: make(map[Key]Entry), logger: logger}
+}
+
+// Upsert stores a successful fetch.
+func (s *Store) Upsert(provider schemas.ModelProvider, keyID string, unfiltered bool, models []string) {
+	cp := make([]string, len(models))
+	copy(cp, models)
+	k := Key{Provider: provider, KeyID: keyID, Unfiltered: unfiltered}
+	s.mu.Lock()
+	s.entries[k] = Entry{Models: cp}
+	s.mu.Unlock()
+}
+
+// Invalidate drops both filtered and unfiltered entries for one key. Called
+// when the key's credential value changes (cached models were computed
+// against the old credential) or when the key is deleted.
+func (s *Store) Invalidate(provider schemas.ModelProvider, keyID string) {
+	s.mu.Lock()
+	delete(s.entries, Key{Provider: provider, KeyID: keyID, Unfiltered: false})
+	delete(s.entries, Key{Provider: provider, KeyID: keyID, Unfiltered: true})
+	s.mu.Unlock()
+}
+
+// InvalidateProvider drops every entry for the provider across all keys and
+// modes. Called on provider delete.
+func (s *Store) InvalidateProvider(provider schemas.ModelProvider) {
+	s.mu.Lock()
+	for k := range s.entries {
+		if k.Provider == provider {
+			delete(s.entries, k)
+		}
+	}
+	s.mu.Unlock()
+}
+
+// ModelsForProvider returns the union of filtered entries for the provider,
+// sorted. Filtered entries are pre-gated so this is the effective allowed set
+// across the provider's keys.
+func (s *Store) ModelsForProvider(provider schemas.ModelProvider) []string {
+	return s.unionForProvider(provider, false)
+}
+
+// UnfilteredModelsForProvider returns the union of unfiltered entries — the
+// raw provider catalog with no key-level gating applied.
+func (s *Store) UnfilteredModelsForProvider(provider schemas.ModelProvider) []string {
+	return s.unionForProvider(provider, true)
+}
+
+// Snapshot returns a defensive copy of every entry for diagnostics. Slices
+// are copied; the returned map is independent of store state.
+func (s *Store) Snapshot() map[Key]Entry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[Key]Entry, len(s.entries))
+	for k, e := range s.entries {
+		cp := make([]string, len(e.Models))
+		copy(cp, e.Models)
+		out[k] = Entry{Models: cp}
+	}
+	return out
+}
+
+// unionForProvider returns the sorted, deduplicated set of models across all
+// entries matching the given provider and unfiltered flag.
+func (s *Store) unionForProvider(provider schemas.ModelProvider, unfiltered bool) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	seen := make(map[string]struct{})
+	for k, e := range s.entries {
+		if k.Provider != provider || k.Unfiltered != unfiltered {
+			continue
+		}
+		for _, m := range e.Models {
+			seen[m] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for m := range seen {
+		out = append(out, m)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/framework/modelcatalog/live/store_test.go
+++ b/framework/modelcatalog/live/store_test.go
@@ -1,0 +1,141 @@
+package live
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const (
+	openai    = schemas.OpenAI
+	anthropic = schemas.Anthropic
+)
+
+func upsertFiltered(s *Store, p schemas.ModelProvider, keyID string, models []string) {
+	s.Upsert(p, keyID, false, models)
+}
+
+func upsertUnfiltered(s *Store, p schemas.ModelProvider, keyID string, models []string) {
+	s.Upsert(p, keyID, true, models)
+}
+
+func TestUpsertAndReadFiltered(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o", "gpt-4o-mini"})
+
+	got := s.ModelsForProvider(openai)
+	want := []string{"gpt-4o", "gpt-4o-mini"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ModelsForProvider = %v, want %v", got, want)
+	}
+}
+
+func TestFilteredAndUnfilteredDoNotMix(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertUnfiltered(s, openai, "k1", []string{"gpt-4o", "gpt-4o-mini", "o1"})
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("filtered read = %v, want [gpt-4o]", got)
+	}
+	if got := s.UnfilteredModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o", "gpt-4o-mini", "o1"}) {
+		t.Errorf("unfiltered read = %v, want [gpt-4o gpt-4o-mini o1]", got)
+	}
+}
+
+func TestUnionAcrossKeys(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o", "gpt-4o-mini"})
+	upsertFiltered(s, openai, "k2", []string{"gpt-4o-mini", "o1"})
+
+	got := s.ModelsForProvider(openai)
+	want := []string{"gpt-4o", "gpt-4o-mini", "o1"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ModelsForProvider = %v, want %v", got, want)
+	}
+}
+
+func TestInvalidateOneKeyPreservesOthers(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertFiltered(s, openai, "k2", []string{"o1"})
+	upsertUnfiltered(s, openai, "k1", []string{"gpt-4o", "extra"})
+
+	s.Invalidate(openai, "k1")
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"o1"}) {
+		t.Errorf("after Invalidate, filtered = %v, want [o1]", got)
+	}
+	if got := s.UnfilteredModelsForProvider(openai); len(got) != 0 {
+		t.Errorf("after Invalidate, unfiltered = %v, want empty (k1's unfiltered should also drop)", got)
+	}
+}
+
+func TestInvalidateProviderDropsEverything(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertFiltered(s, openai, "k2", []string{"o1"})
+	upsertFiltered(s, anthropic, "k3", []string{"claude-3-5-sonnet"})
+
+	s.InvalidateProvider(openai)
+
+	if got := s.ModelsForProvider(openai); len(got) != 0 {
+		t.Errorf("openai after InvalidateProvider = %v, want empty", got)
+	}
+	if got := s.ModelsForProvider(anthropic); !slices.Equal(got, []string{"claude-3-5-sonnet"}) {
+		t.Errorf("anthropic untouched = %v, want [claude-3-5-sonnet]", got)
+	}
+}
+
+func TestKeylessProviderUsesEmptyKeyID(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, schemas.Vertex, "", []string{"gemini-2.0-flash"})
+
+	if got := s.ModelsForProvider(schemas.Vertex); !slices.Equal(got, []string{"gemini-2.0-flash"}) {
+		t.Errorf("keyless read = %v, want [gemini-2.0-flash]", got)
+	}
+}
+
+func TestSnapshotIsDefensiveCopy(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+
+	snap := s.Snapshot()
+	k := Key{Provider: openai, KeyID: "k1", Unfiltered: false}
+	snap[k].Models[0] = "MUTATED"
+
+	got := s.ModelsForProvider(openai)
+	if !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("store mutated through Snapshot: %v", got)
+	}
+}
+
+func TestUpsertCopiesInputSlice(t *testing.T) {
+	s := New(nil)
+	input := []string{"gpt-4o"}
+	s.Upsert(openai, "k1", false, input)
+
+	input[0] = "MUTATED"
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("store mutated through input slice: %v", got)
+	}
+}
+
+func TestModelsForProviderUnknownProviderReturnsEmpty(t *testing.T) {
+	s := New(nil)
+	if got := s.ModelsForProvider(openai); len(got) != 0 {
+		t.Errorf("unknown provider = %v, want empty", got)
+	}
+}
+
+func TestUpsertOverwritesSameKey(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertFiltered(s, openai, "k1", []string{"o1"})
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"o1"}) {
+		t.Errorf("after re-Upsert = %v, want [o1] (overwrite, not append)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a new `live` package that caches provider `/v1/models` responses per `(provider, keyID, unfiltered)` tuple, and adds regression tests to the `keyconfig` store that lock down the structural isolation between `Models` (allowed list) and `Aliases` (alias index).

## Changes

- Added `framework/modelcatalog/live/store.go`: a passive, concurrency-safe cache for live model listings. It supports filtered (key-gated) and unfiltered (raw catalog) entries, exposes union queries across keys for a given provider, and provides targeted invalidation by key or by provider. The store never initiates network calls — callers are responsible for fetching and pushing results via `Upsert`.
- Added `framework/modelcatalog/live/store_test.go`: full test coverage for the live store, including filtered/unfiltered isolation, union across keys, invalidation behavior, keyless provider support (empty `KeyID`), defensive copy guarantees on `Snapshot` and `Upsert`, and overwrite semantics.
- Added regression tests to `framework/modelcatalog/keyconfig/store_test.go` ported from `bifrost-enterprise/core/loadbalancing/lballowedmodels_test.go`. These lock down that aliases write only to `aliasIndex` and never appear in the `allowed` aggregate, that empty `Models` with aliases present produces no allowed entry, that keys with a block-all blacklist cause the provider to be absent from the store, and that `AllowedFor` returns the union of enabled keys' `Models` fields only.

Notable design decisions:
- Filtered and unfiltered entries share the same map keyed by `(Provider, KeyID, Unfiltered)`, keeping the implementation simple while enforcing strict separation at read time.
- Callers reading filtered entries must not reapply the allow/blacklist/alias gate, since filtered entries are already pre-gated by the provider's `ListModelsPipeline`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/...
```

Expected: all tests pass, including the new `live` store tests and the ported `keyconfig` regression tests.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Ported regression tests from `bifrost-enterprise/core/loadbalancing/lballowedmodels_test.go`.

## Security considerations

The live store holds cached model listings. No credentials or secrets are stored. Invalidation on key deletion or credential rotation ensures stale entries do not persist beyond their valid lifetime.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-memory cache for model provider query results with thread-safe concurrent access
  * Supports filtered and unfiltered model retrieval with automatic deduplication across keys
  * Provides cache invalidation by individual key or entire provider

* **Tests**
  * Added comprehensive test coverage for cache operations, edge cases, and data isolation guarantees
<!-- end of auto-generated comment: release notes by coderabbit.ai -->