### PR TITLE
feat: add optional `tx` variadic param to `UpdateBudgetUsage` for transaction support

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3971,8 +3971,12 @@ func (s *RDBConfigStore) DeleteBudget(ctx context.Context, id string, tx ...*gor
 
 // UpdateBudgetUsage updates only the current_usage field of a budget.
 // Uses SkipHooks to avoid triggering BeforeSave validation since we're only updating usage.
-func (s *RDBConfigStore) UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64) error {
-	result := s.DB().WithContext(ctx).
+func (s *RDBConfigStore) UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64, tx ...*gorm.DB) error {
+	db := s.DB()
+	if len(tx) > 0 && tx[0] != nil {
+		db = tx[0]
+	}
+	result := db.WithContext(ctx).
 		Session(&gorm.Session{SkipHooks: true}).
 		Model(&tables.TableBudget{}).
 		Where("id = ?", id).

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -243,7 +243,7 @@ type ConfigStore interface {
 	UpdateBudget(ctx context.Context, budget *tables.TableBudget, tx ...*gorm.DB) error
 	UpdateBudgets(ctx context.Context, budgets []*tables.TableBudget, tx ...*gorm.DB) error
 	DeleteBudget(ctx context.Context, id string, tx ...*gorm.DB) error
-	UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64) error
+	UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64, tx ...*gorm.DB) error
 	UpdateRateLimitUsage(ctx context.Context, id string, tokenCurrentUsage int64, requestCurrentUsage int64) error
 
 	// Routing Rules CRUD

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1152,7 +1152,7 @@ func (m *MockConfigStore) DeleteModelConfig(ctx context.Context, id string, tx .
 }
 
 // Budget/Rate limit usage
-func (m *MockConfigStore) UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64) error {
+func (m *MockConfigStore) UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64, tx ...*gorm.DB) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`UpdateBudgetUsage` did not support transactional execution, making it impossible to include budget usage updates as part of a larger atomic database operation. This PR adds optional transaction support to bring it in line with other store methods.

## Changes

- Added an optional variadic `tx ...*gorm.DB` parameter to `UpdateBudgetUsage` in the `ConfigStore` interface, the `RDBConfigStore` implementation, and the `MockConfigStore` in tests.
- When a transaction is provided, the method uses it instead of the default DB connection.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

Any code calling `UpdateBudgetUsage` through the `ConfigStore` interface will need to be recompiled. The method signature has changed, though existing call sites that pass no transaction argument will continue to work without modification.

## Related issues

N/A

## Security considerations

No security implications. This change only affects how the database operation is scoped within a transaction.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved transaction handling in the configuration storage layer to support optional transactional updates for budget usage.
  * Aligned test mocks with the updated storage interface to ensure consistent behavior during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->