### PR TITLE
fix: add colored tooltip values and subtle cursor highlight to dashboard charts

### DIFF
--- a/ui/app/workspace/dashboard/components/charts/costChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/costChart.tsx
@@ -45,13 +45,13 @@ function CustomTooltip({ active, payload, selectedModel, displayModels }: any) {
 										<span className="h-2 w-2 rounded-full" style={{ backgroundColor: isOther ? OTHER_SERIES_COLOR : getModelColor(idx) }} />
 										<span className="max-w-[120px] truncate text-zinc-600 dark:text-zinc-400">{isOther ? OTHER_SERIES_LABEL : model}</span>
 									</span>
-									<span className="font-medium">{formatCost(cost)}</span>
+									<span className="font-medium" style={{ color: isOther ? OTHER_SERIES_COLOR : getModelColor(idx) }}>{formatCost(cost)}</span>
 								</div>
 							);
 						})}
 						<div className="flex items-center justify-between gap-4 border-t border-zinc-200 pt-1 dark:border-zinc-700">
 							<span className="text-zinc-600 dark:text-zinc-400">Total</span>
-							<span className="font-medium">{formatCost(data.total_cost)}</span>
+							<span className="font-medium text-zinc-900 dark:text-zinc-100">{formatCost(data.total_cost)}</span>
 						</div>
 					</>
 				) : (
@@ -60,7 +60,7 @@ function CustomTooltip({ active, payload, selectedModel, displayModels }: any) {
 							<span className="h-2 w-2 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
 							<span className="text-zinc-600 dark:text-zinc-400">{selectedModel}</span>
 						</span>
-						<span className="font-medium">{formatCost(data.by_model?.[selectedModel] || 0)}</span>
+						<span className="font-medium text-zinc-900 dark:text-zinc-100">{formatCost(data.by_model?.[selectedModel] || 0)}</span>
 					</div>
 				)}
 			</div>
@@ -141,7 +141,7 @@ function CostChartImpl({ data, chartType, startTime, endTime, selectedModel }: C
 							domain={[0, (dataMax: number) => Math.max(dataMax, 0.01)]}
 							allowDataOverflow={false}
 						/>
-						<Tooltip content={<CustomTooltip selectedModel={selectedModel} displayModels={displayModels} />} />
+						<Tooltip content={<CustomTooltip selectedModel={selectedModel} displayModels={displayModels} />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
 						{displayModels.map((model, idx) => (
 							<Bar
 								isAnimationActive={false}
@@ -177,7 +177,7 @@ function CostChartImpl({ data, chartType, startTime, endTime, selectedModel }: C
 							domain={[0, (dataMax: number) => Math.max(dataMax, 0.01)]}
 							allowDataOverflow={false}
 						/>
-						<Tooltip content={<CustomTooltip selectedModel={selectedModel} displayModels={displayModels} />} />
+						<Tooltip content={<CustomTooltip selectedModel={selectedModel} displayModels={displayModels} />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
 						{displayModels.map((model, idx) => {
 							const color = model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx);
 							return (

--- a/ui/app/workspace/dashboard/components/charts/latencyChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/latencyChart.tsx
@@ -162,7 +162,7 @@ function LatencyChartImpl({ data, chartType, startTime, endTime }: LatencyChartP
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
-						<Tooltip content={<CustomTooltip />} />
+						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
 						{/* Render P99 first (behind), then overlay in descending order so Avg is in front */}
 						<Area
 							isAnimationActive={false}

--- a/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
@@ -50,7 +50,7 @@ function CustomTooltip({ active, payload, selectedModel, displayModels }: any) {
 										<span className="h-2 w-2 rounded-full" style={{ backgroundColor: isOther ? OTHER_SERIES_COLOR : getModelColor(idx) }} />
 										<span className="max-w-[120px] truncate text-zinc-600 dark:text-zinc-400">{isOther ? OTHER_SERIES_LABEL : model}</span>
 									</span>
-									<span className="font-medium">{total.toLocaleString()}</span>
+									<span className="font-medium" style={{ color: isOther ? OTHER_SERIES_COLOR : getModelColor(idx) }}>{total.toLocaleString()}</span>
 								</div>
 							);
 						})}
@@ -167,7 +167,7 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
-						<Tooltip content={<CustomTooltip selectedModel={selectedModel} displayModels={displayModels} />} />
+						<Tooltip content={<CustomTooltip selectedModel={selectedModel} displayModels={displayModels} />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
 						{selectedModel === "all" ? (
 							displayModels.map((model, idx) => (
 								<Bar
@@ -226,7 +226,7 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
-						<Tooltip content={<CustomTooltip selectedModel={selectedModel} displayModels={displayModels} />} />
+						<Tooltip content={<CustomTooltip selectedModel={selectedModel} displayModels={displayModels} />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
 						{selectedModel === "all" ? (
 							displayModels.map((model, idx) => {
 								const color = model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx);

--- a/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
@@ -133,21 +133,30 @@ function TopDimensionChart({
 									dataKey="displayName"
 									tick={(props: any) => {
 										const { x, y, payload } = props;
-										const maxChars = 14;
-										const label = payload.value.length > maxChars ? `${payload.value.slice(0, maxChars)}…` : payload.value;
+										const labelWidth = 92;
 										return (
-											<text x={x} y={y} dy={4} textAnchor="end" fontSize={11} className="fill-zinc-500">
-												<title>{payload.value}</title>
-												{label}
-											</text>
+											<foreignObject x={x - labelWidth} y={y - 9} width={labelWidth} height={18} style={{ overflow: "visible" }}>
+												<div
+													title={payload.value}
+													className="truncate text-right text-[11px] leading-[18px] text-zinc-500 dark:text-zinc-400"
+													style={{ width: labelWidth }}
+												>
+													{payload.value}
+												</div>
+											</foreignObject>
 										);
 									}}
 									tickLine={false}
 									axisLine={false}
-									width={92}
+									width={100}
 								/>
-								<Tooltip content={<TopDimensionTooltip />} />
-								<Bar dataKey="total_requests" isAnimationActive={false} barSize={24} radius={[0, 4, 4, 0]}>
+								<Tooltip content={<TopDimensionTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+								<Bar
+									dataKey="total_requests"
+									isAnimationActive={false}
+									barSize={24}
+									radius={[0, 4, 4, 0]}
+								>
 									{chartData.map((entry, idx) => (
 										<Cell key={entry.id} fill={getModelColor(idx)} />
 									))}

--- a/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
@@ -190,7 +190,7 @@ function TopModelsChart({
 									domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 									allowDataOverflow={false}
 								/>
-								<Tooltip content={<UsageShareTooltip models={displayModels} />} />
+								<Tooltip content={<UsageShareTooltip models={displayModels} />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
 								{displayModels.map((model, idx) => (
 									<Bar
 										key={model}


### PR DESCRIPTION
## Summary

Improves the visual consistency and interactivity of dashboard charts by adding hover cursor highlights and applying model-specific colors to tooltip values.

## Changes

- Added a semi-transparent cursor highlight (`fillOpacity: 0.15`) on hover for all bar and area charts across the cost, latency, model usage, dimension rankings, and model rankings charts
- Per-model cost and usage values in tooltips now render in their corresponding model color instead of the default text color, making it easier to associate values with their series
- Total cost and single-model cost values in tooltips now use explicit light/dark mode text colors for better contrast
- Slightly widened the Y-axis label area in the dimension rankings chart from 92px to 100px

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the workspace dashboard and hover over bars in the cost, model usage, latency, dimension rankings, and model rankings charts. Verify that:
1. A subtle gray highlight appears behind the hovered bar column
2. Per-model values in the tooltip are colored to match their corresponding chart series
3. Total and single-model cost values are clearly readable in both light and dark mode

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before/after screenshots showing tooltip color changes and cursor highlight on chart hover recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tooltip text styling improved for contrast and emphasis across cost, model-usage, and latency charts (per-model values use stronger weight and explicit light/dark text colors).
  * Tooltip cursor appearance standardized with custom fill and opacity for bar/area charts and ranking tooltips.
  * Top-dimensions chart category column width increased from 92 to 100 for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->