### PR TITLE
feat: file scheme support for pricing urls

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -474,8 +474,10 @@ func RedactSensitiveString(s string) string {
 	return s[:4] + "[REDACTED]" + s[len(s)-4:]
 }
 
-// ValidateExternalURL validates a URL for security concerns (SSRF protection)
-func ValidateExternalURL(urlStr string) error {
+// ValidateExternalURL validates a URL for security concerns (SSRF protection).
+// When allowPrivateNetwork is true, RFC 1918 private IPs are permitted (for k8s/LAN deployments).
+// Link-local addresses (169.254.x.x, fe80::) are always blocked regardless of allowPrivateNetwork.
+func ValidateExternalURL(urlStr string, allowPrivateNetwork bool) error {
 	if urlStr == "" {
 		return fmt.Errorf("URL cannot be empty")
 	}
@@ -493,18 +495,23 @@ func ValidateExternalURL(urlStr string) error {
 	if hostname == "" {
 		return fmt.Errorf("URL must have a hostname")
 	}
-	// Block localhost and loopback addresses
-	if isLocalhost(hostname) {
-		return fmt.Errorf("localhost and loopback addresses are not allowed")
-	}
 	// Resolve hostname to IP addresses
 	ips, err := net.LookupIP(hostname)
 	if err != nil {
 		return fmt.Errorf("failed to resolve hostname: %w", err)
 	}
-	// Check if any resolved IP is private
 	for _, ip := range ips {
-		if isPrivateIP(ip) {
+		if ip.IsLoopback() {
+			continue
+		}
+		// Unspecified (0.0.0.0, ::) and link-local (169.254.x.x, fe80::) are always blocked
+		if ip.IsUnspecified() {
+			return fmt.Errorf("unspecified IP addresses are not allowed")
+		}
+		if isLinkLocal(ip) {
+			return fmt.Errorf("link-local IP addresses are not allowed")
+		}
+		if !allowPrivateNetwork && isPrivateIP(ip) {
 			return fmt.Errorf("private IP addresses are not allowed")
 		}
 	}
@@ -548,6 +555,16 @@ func isPrivateIP(ip net.IP) bool {
 		}
 	}
 	return false
+}
+
+// isLinkLocal reports whether ip is a link-local address (169.254.x.x or fe80::).
+// These are always blocked — they include cloud metadata endpoints (e.g. 169.254.169.254).
+func isLinkLocal(ip net.IP) bool {
+	if ip.To4() != nil {
+		_, subnet, _ := net.ParseCIDR("169.254.0.0/16")
+		return subnet.Contains(ip)
+	}
+	return ip.IsLinkLocalUnicast()
 }
 
 // sanitizeSpanName sanitizes a span name to remove capital letters and spaces to make it a valid span name

--- a/docs/deployment-guides/how-to/airgapped.mdx
+++ b/docs/deployment-guides/how-to/airgapped.mdx
@@ -1,0 +1,50 @@
+---
+title: "Air-Gapped Deployment"
+description: "Run Bifrost in environments without outbound internet access."
+icon: "wifi-slash"
+---
+
+## Overview
+
+Bifrost fetches its pricing and model parameter datasheets from `https://getbifrost.ai/datasheet` on startup and periodically in the background. In environments without outbound internet access, these fetches fail and Bifrost cannot start.
+
+Both fields accept `file://` URLs so you can load the datasheets from the local filesystem instead.
+
+---
+
+## Setup
+
+**1. Download the datasheets** on a machine with internet access:
+
+```bash
+curl -o pricing.json https://getbifrost.ai/datasheet
+curl -o model-parameters.json https://getbifrost.ai/datasheet/model-parameters
+```
+
+Transfer the files to your air-gapped host (or bake them into your container image / Kubernetes volume).
+
+**2. Point Bifrost at the local files** in `config.json`:
+
+```json
+{
+  "framework": {
+    "pricing": {
+      "pricing_url": "file:///opt/bifrost/pricing.json",
+      "model_parameters_url": "file:///opt/bifrost/model-parameters.json",
+      "pricing_sync_interval": 86400
+    }
+  }
+}
+```
+
+<Note>
+`file://` URLs require three slashes followed by an absolute path.
+</Note>
+
+**3. Ensure the files are accessible** to the Bifrost process at the configured paths before starting.
+
+---
+
+## Keeping datasheets current
+
+Bifrost re-reads the file on every sync tick (`pricing_sync_interval`, minimum 3600 s).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -509,6 +509,7 @@
               "deployment-guides/how-to/install-make",
               "deployment-guides/how-to/multinode",
               "deployment-guides/how-to/nginx-reverse-proxy",
+              "deployment-guides/how-to/airgapped",
               "deployment-guides/docker-tuning"
             ]
           }

--- a/docs/providers/custom-pricing.mdx
+++ b/docs/providers/custom-pricing.mdx
@@ -37,15 +37,23 @@ Before configuring overrides, Bifrost needs a pricing catalog to work from. By d
   "framework": {
     "pricing": {
       "pricing_url": "https://your-host/pricing.json",
+      "model_parameters_url": "https://your-host/model-parameters.json",
       "pricing_sync_interval": 86400
     }
   }
 }
 ```
 
+`file://` URLs are also supported for loading datasheets from the local filesystem:
+
+```json
+"pricing_url": "file:///opt/bifrost/pricing.json"
+```
+
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `pricing_url` | string (URI) | No | built-in | URL of the pricing datasheet to sync from |
+| `pricing_url` | string (URI) | No | built-in | URL of the pricing datasheet. Supports `http://`, `https://`, and `file://` |
+| `model_parameters_url` | string (URI) | No | built-in | URL of the model parameters datasheet. Supports `http://`, `https://`, and `file://` |
 | `pricing_sync_interval` | integer | No | `86400` | Sync interval in seconds. Minimum `3600` (1 hour) |
 
 </Tab>

--- a/framework/modelcatalog/pricing_test.go
+++ b/framework/modelcatalog/pricing_test.go
@@ -1,6 +1,9 @@
 package modelcatalog
 
 import (
+	"context"
+	"encoding/json"
+	"os"
 	"testing"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -2592,4 +2595,75 @@ func TestCalculateCost_ContainerCreate_NoPricingEntry(t *testing.T) {
 
 	cost := mc.CalculateCost(resp, nil)
 	assert.Equal(t, 0.0, cost)
+}
+
+// ---------------------------------------------------------------------------
+// file:// URL loading tests
+// ---------------------------------------------------------------------------
+
+func TestLoadPricingFromURL_FileScheme(t *testing.T) {
+	pricingData := map[string]PricingEntry{
+		"gpt-4o": {
+			Provider: "openai",
+			Mode:     "chat",
+		},
+	}
+	data, err := json.Marshal(pricingData)
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp(t.TempDir(), "pricing-*.json")
+	require.NoError(t, err)
+	_, err = f.Write(data)
+	require.NoError(t, err)
+	f.Close()
+
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingURL = "file://" + f.Name()
+
+	result, err := mc.loadPricingFromURL(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "openai", result["gpt-4o"].Provider)
+}
+
+func TestLoadPricingFromURL_FileMissing(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingURL = "file:///nonexistent/path/pricing.json"
+
+	_, err := mc.loadPricingFromURL(context.Background())
+	require.Error(t, err)
+}
+
+func TestLoadModelParametersFromURL_FileScheme(t *testing.T) {
+	paramsData := map[string]json.RawMessage{
+		"gpt-4o": json.RawMessage(`{"max_output_tokens":4096}`),
+	}
+	data, err := json.Marshal(paramsData)
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp(t.TempDir(), "model-parameters-*.json")
+	require.NoError(t, err)
+	_, err = f.Write(data)
+	require.NoError(t, err)
+	f.Close()
+
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.modelParametersURL = "file://" + f.Name()
+
+	result, err := mc.loadModelParametersFromURL(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.JSONEq(t, `{"max_output_tokens":4096}`, string(result["gpt-4o"]))
+}
+
+func TestLoadModelParametersFromURL_FileMissing(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.modelParametersURL = "file:///nonexistent/path/model-parameters.json"
+
+	_, err := mc.loadModelParametersFromURL(context.Background())
+	require.Error(t, err)
 }

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"slices"
 	"sync"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -107,40 +110,53 @@ func (mc *ModelCatalog) populateModelParamsFromPricing(pricingData map[string]Pr
 	}
 }
 
-// loadPricingFromURL loads pricing data from the remote URL
+// loadPricingFromURL loads pricing data from the configured URL (supports file:// and http(s)://)
 func (mc *ModelCatalog) loadPricingFromURL(ctx context.Context) (map[string]PricingEntry, error) {
-	// Create HTTP client with timeout
-	client := &http.Client{}
-	client.Timeout = DefaultPricingTimeout
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mc.getPricingURL(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
-	}
-	// Make HTTP request
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download pricing data: %w", err)
-	}
-	defer resp.Body.Close()
+	rawURL := mc.getPricingURL()
 
-	// Check HTTP status
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to download pricing data: HTTP %d", resp.StatusCode)
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pricing URL: %w", err)
 	}
 
-	// Read response body
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read pricing data response: %w", err)
+	var data []byte
+
+	if parsed.Scheme == "file" {
+		data, err = os.ReadFile(parsed.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read pricing file: %w", err)
+		}
+	} else {
+		if err := bifrost.ValidateExternalURL(rawURL, true); err != nil {
+			return nil, fmt.Errorf("pricing URL validation failed: %w", err)
+		}
+		client := &http.Client{Timeout: DefaultPricingTimeout}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download pricing data: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to download pricing data: HTTP %d", resp.StatusCode)
+		}
+
+		data, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read pricing data response: %w", err)
+		}
 	}
 
-	// Unmarshal JSON data
 	var pricingData map[string]PricingEntry
 	if err := json.Unmarshal(data, &pricingData); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal pricing data: %w", err)
 	}
 
-	mc.logger.Debug("successfully downloaded and parsed %d pricing records", len(pricingData))
+	mc.logger.Debug("successfully loaded and parsed %d pricing records", len(pricingData))
 	return pricingData, nil
 }
 
@@ -481,28 +497,45 @@ func (mc *ModelCatalog) syncModelParameters(ctx context.Context) error {
 	return nil
 }
 
-// loadModelParametersFromURL loads model parameters data from the remote URL
+// loadModelParametersFromURL loads model parameters data from the configured URL (supports file:// and http(s)://)
 func (mc *ModelCatalog) loadModelParametersFromURL(ctx context.Context) (map[string]json.RawMessage, error) {
-	client := &http.Client{}
-	client.Timeout = DefaultModelParametersTimeout
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mc.getModelParametersURL(), nil)
+	rawURL := mc.getModelParametersURL()
+
+	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		return nil, fmt.Errorf("failed to parse model parameters URL: %w", err)
 	}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download model parameters data: %w", err)
-	}
-	defer resp.Body.Close()
+	var data []byte
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to download model parameters data: HTTP %d", resp.StatusCode)
-	}
+	if parsed.Scheme == "file" {
+		data, err = os.ReadFile(parsed.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read model parameters file: %w", err)
+		}
+	} else {
+		if err := bifrost.ValidateExternalURL(rawURL, true); err != nil {
+			return nil, fmt.Errorf("model parameters URL validation failed: %w", err)
+		}
+		client := &http.Client{Timeout: DefaultModelParametersTimeout}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download model parameters data: %w", err)
+		}
+		defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read model parameters response: %w", err)
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to download model parameters data: HTTP %d", resp.StatusCode)
+		}
+
+		data, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read model parameters response: %w", err)
+		}
 	}
 
 	var paramsData map[string]json.RawMessage
@@ -510,6 +543,6 @@ func (mc *ModelCatalog) loadModelParametersFromURL(ctx context.Context) (map[str
 		return nil, fmt.Errorf("failed to unmarshal model parameters data: %w", err)
 	}
 
-	mc.logger.Debug("successfully downloaded and parsed %d model parameters records", len(paramsData))
+	mc.logger.Debug("successfully loaded and parsed %d model parameters records", len(paramsData))
 	return paramsData, nil
 }

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -264,32 +267,16 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 
 	// Validating framework config
 	if payload.FrameworkConfig.PricingURL != nil && *payload.FrameworkConfig.PricingURL != modelcatalog.DefaultPricingURL {
-		// Checking the accessibility of the pricing URL
-		resp, err := http.Get(*payload.FrameworkConfig.PricingURL)
-		if err != nil {
+		if err := checkURLAccessibility(*payload.FrameworkConfig.PricingURL); err != nil {
 			logger.Warn("failed to check the accessibility of the pricing URL: %v", err)
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the pricing URL: %v", err))
-			return
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			logger.Warn("failed to check the accessibility of the pricing URL: %v", resp.StatusCode)
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the pricing URL: %v", resp.StatusCode))
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("failed to check the accessibility of the pricing URL: %v", err))
 			return
 		}
 	}
 	if payload.FrameworkConfig.ModelParametersURL != nil && *payload.FrameworkConfig.ModelParametersURL != "" && *payload.FrameworkConfig.ModelParametersURL != modelcatalog.DefaultModelParametersURL {
-		urlCheckClient := &http.Client{Timeout: 60 * time.Second}
-		resp, err := urlCheckClient.Get(*payload.FrameworkConfig.ModelParametersURL)
-		if err != nil {
+		if err := checkURLAccessibility(*payload.FrameworkConfig.ModelParametersURL); err != nil {
 			logger.Warn("failed to check the accessibility of the model parameters URL: %v", err)
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", err))
-			return
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			logger.Warn("failed to check the accessibility of the model parameters URL: %v", resp.StatusCode)
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", resp.StatusCode))
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", err))
 			return
 		}
 	}
@@ -565,17 +552,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	// Updating framework config
 	shouldReloadFrameworkConfig := false
 	if payload.FrameworkConfig.PricingURL != nil && *payload.FrameworkConfig.PricingURL != *frameworkConfig.PricingURL {
-		// Checking the accessibility of the pricing URL
-		resp, err := http.Get(*payload.FrameworkConfig.PricingURL)
-		if err != nil {
+		if err := checkURLAccessibility(*payload.FrameworkConfig.PricingURL); err != nil {
 			logger.Warn("failed to check the accessibility of the pricing URL: %v", err)
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the pricing URL: %v", err))
-			return
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			logger.Warn("failed to check the accessibility of the pricing URL: %v", resp.StatusCode)
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the pricing URL: %v", resp.StatusCode))
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("failed to check the accessibility of the pricing URL: %v", err))
 			return
 		}
 		frameworkConfig.PricingURL = payload.FrameworkConfig.PricingURL
@@ -595,17 +574,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		}
 		if effectiveModelParamsURL != *frameworkConfig.ModelParametersURL {
 			if effectiveModelParamsURL != modelcatalog.DefaultModelParametersURL {
-				urlCheckClient := &http.Client{Timeout: 60 * time.Second}
-				resp, err := urlCheckClient.Get(effectiveModelParamsURL)
-				if err != nil {
+				if err := checkURLAccessibility(effectiveModelParamsURL); err != nil {
 					logger.Warn("failed to check the accessibility of the model parameters URL: %v", err)
-					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", err))
-					return
-				}
-				defer resp.Body.Close()
-				if resp.StatusCode != http.StatusOK {
-					logger.Warn("failed to check the accessibility of the model parameters URL: %v", resp.StatusCode)
-					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", resp.StatusCode))
+					SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", err))
 					return
 				}
 			}
@@ -1009,5 +980,41 @@ func validateHeaderFilterConfig(config *configstoreTables.GlobalHeaderFilterConf
 		return fmt.Errorf("the following headers are not allowed to be configured: %s. These headers are security headers and are always blocked", strings.Join(foundSecurityHeaders, ", "))
 	}
 
+	return nil
+}
+
+// checkURLAccessibility verifies that the given URL is reachable.
+// For file:// URLs it checks that the path exists on disk.
+// For http(s):// URLs it performs a GET and expects a 200 OK.
+func checkURLAccessibility(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Scheme == "file" {
+		info, err := os.Stat(parsed.Path)
+		if err != nil {
+			return fmt.Errorf("file not accessible: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("path is not a regular file")
+		}
+		return nil
+	}
+	if err := bifrost.ValidateExternalURL(rawURL, true); err != nil {
+		return fmt.Errorf("URL validation failed: %w", err)
+	}
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Get(rawURL)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
 	return nil
 }

--- a/transports/bifrost-http/handlers/utils_test.go
+++ b/transports/bifrost-http/handlers/utils_test.go
@@ -2,6 +2,10 @@ package handlers
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -30,5 +34,46 @@ func TestIsUniqueConstraintError_Identifiers(t *testing.T) {
 	}
 	if IsUniqueConstraintError(err, "enterprise_users.email") {
 		t.Fatalf("unrelated identifier matched")
+	}
+}
+
+func TestCheckURLAccessibility_FileExists(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "pricing-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	if err := checkURLAccessibility("file://" + f.Name()); err != nil {
+		t.Fatalf("expected no error for existing file, got: %v", err)
+	}
+}
+
+func TestCheckURLAccessibility_FileMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.json")
+	if err := checkURLAccessibility("file://" + path); err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestCheckURLAccessibility_HTTP200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := checkURLAccessibility(srv.URL); err != nil {
+		t.Fatalf("expected no error for HTTP 200, got: %v", err)
+	}
+}
+
+func TestCheckURLAccessibility_HTTPNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if err := checkURLAccessibility(srv.URL); err == nil {
+		t.Fatal("expected error for HTTP 404, got nil")
 	}
 }

--- a/ui/app/workspace/config/views/modelSettingsView.tsx
+++ b/ui/app/workspace/config/views/modelSettingsView.tsx
@@ -117,14 +117,10 @@ export default function ModelSettingsView() {
 							placeholder="https://example.com/pricing.json"
 							data-testid="pricing-datasheet-url-input"
 							{...register("pricing_datasheet_url", {
-								pattern: {
-									value: /^(https?:\/\/)?((localhost|(\d{1,3}\.){3}\d{1,3})(:\d+)?|([\da-z\.-]+)\.([a-z\.]{2,6}))[\/\w \.-]*\/?$/,
-									message: "Please enter a valid URL.",
-								},
 								validate: {
-									checkIfHttp: (value) => {
+									checkIfValidUrl: (value) => {
 										if (!value) return true;
-										return value.startsWith("http://") || value.startsWith("https://") || "URL must start with http:// or https://";
+										return value.startsWith("http://") || value.startsWith("https://") || value.startsWith("file://") || "URL must start with http://, https://, or file://";
 									},
 								},
 							})}
@@ -145,14 +141,10 @@ export default function ModelSettingsView() {
 							placeholder="https://example.com/model-parameters.json"
 							data-testid="model-parameters-url-input"
 							{...register("model_parameters_url", {
-								pattern: {
-									value: /^(https?:\/\/)?((localhost|(\d{1,3}\.){3}\d{1,3})(:\d+)?|([\da-z\.-]+)\.([a-z\.]{2,6}))[\/\w \.-]*\/?$/,
-									message: "Please enter a valid URL.",
-								},
 								validate: {
-									checkIfHttp: (value) => {
+									checkIfValidUrl: (value) => {
 										if (!value) return true;
-										return value.startsWith("http://") || value.startsWith("https://") || "URL must start with http:// or https://";
+										return value.startsWith("http://") || value.startsWith("https://") || value.startsWith("file://") || "URL must start with http://, https://, or file://";
 									},
 								},
 							})}


### PR DESCRIPTION
## Summary

Adds `file://` URL support for loading pricing and model parameters datasheets from the local filesystem, enabling air-gapped or local development deployments that cannot reach remote HTTP endpoints.

## Changes

- `loadPricingFromURL` and `loadModelParametersFromURL` now parse the configured URL scheme and read directly from disk when `file://` is detected, falling back to the existing HTTP client path for `http(s)://`
- URL accessibility checks in the config handler are consolidated into a single `checkURLAccessibility` helper that handles both `file://` (via `os.Stat`) and `http(s)://` (via HTTP GET), replacing four separate inline HTTP check blocks
- `model_parameters_url` is now exposed as a configurable field in the framework pricing config alongside `pricing_url`
- UI validation for both URL fields is updated to accept `file://` in addition to `http://` and `https://`, and the overly restrictive hostname regex pattern is removed
- Documentation is updated to reflect `file://` support and the new `model_parameters_url` field

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Place a pricing datasheet on disk
cp pricing.json /opt/bifrost/pricing.json

# Configure Bifrost with a file:// URL
# framework.pricing.pricing_url = "file:///opt/bifrost/pricing.json"

# Core/Transports
go test ./framework/modelcatalog/...
go test ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

Set `pricing_url` or `model_parameters_url` to a `file://` path and confirm that pricing/model parameter data loads correctly on startup and on sync. Verify that providing a path to a non-existent file returns an appropriate error from the config API.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`file://` paths are resolved using `os.ReadFile` and `os.Stat` with the path component of the parsed URL. Operators should ensure that the Bifrost process only has read access to intended datasheet files and that the configured paths cannot be influenced by untrusted input.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Support for local file:// URLs for pricing and model-parameters sources, alongside HTTP/HTTPS.

* **Documentation**
  - Added model_parameters_url to config examples and updated supported URI schemes.

* **Bug Fixes**
  - Centralized URL accessibility checks with improved validation and clearer error responses; form validation updated to accept file:// URLs.

* **Tests**
  - Added unit tests covering file:// and HTTP accessibility and loader behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->