### PR TITLE
fix: remove raw request flag from providers which don't support it

### DIFF
--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -824,6 +824,19 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 							"Integration route default provider %s is not found in the available providers list, selecting first: %s",
 							RouteConfigTypeToProvider[config.Type], availableProviders[0],
 						))
+						// For Anthropic-type routes, raw request body passthrough is only valid for
+						// providers that speak the Anthropic Messages API natively. When the model
+						// catalog falls back to a provider that doesn't (e.g. Bedrock), clear the
+						// flag so the provider performs its own format conversion.
+						firstProvider := availableProviders[0]
+						if config.Type == RouteConfigTypeAnthropic &&
+							firstProvider != schemas.Anthropic &&
+							firstProvider != schemas.Vertex &&
+							firstProvider != schemas.Azure {
+							bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
+							bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawResponse, false)
+							bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, false)
+						}
 					}
 					bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, availableProviders)
 				} else if hasExistingProviders {

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -466,6 +466,51 @@ func TestCreateHandler_AnthropicRouteKeepsCatalogProvidersWhenAvailableProviders
 	require.Equal(t, []schemas.ModelProvider{schemas.Bedrock, schemas.Vertex}, capturedProviders)
 }
 
+func TestCreateHandler_AnthropicRouteClears_UseRawRequestBody_WhenCatalogSelectsBedrock(t *testing.T) {
+	handlerStore := &mockHandlerStore{
+		availableProviders: []schemas.ModelProvider{schemas.Bedrock},
+	}
+
+	var capturedUseRaw interface{}
+	var capturedSendRawResponse interface{}
+	var capturedPassthroughOverrides interface{}
+	route := RouteConfig{
+		Type:   RouteConfigTypeAnthropic,
+		Path:   "/v1/messages",
+		Method: fasthttp.MethodPost,
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ResponsesRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &anthropic.AnthropicMessageRequest{}
+		},
+		GetRequestModel: anthropicModelGetter,
+		PreCallback:     checkAnthropicPassthrough,
+		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
+			capturedUseRaw = ctx.Value(schemas.BifrostContextKeyUseRawRequestBody)
+			capturedSendRawResponse = ctx.Value(schemas.BifrostContextKeySendBackRawResponse)
+			capturedPassthroughOverrides = ctx.Value(schemas.BifrostContextKeyPassthroughOverridesPresent)
+			return nil, fmt.Errorf("stop before bifrost execution")
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		},
+	}
+
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.Header.Set("user-agent", "claude-code/1.0")
+	ctx.Request.SetBodyString(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`)
+
+	router.createHandler(route)(ctx)
+
+	require.Equal(t, fasthttp.StatusInternalServerError, ctx.Response.StatusCode())
+	require.Equal(t, false, capturedUseRaw, "UseRawRequestBody should be cleared when catalog selects Bedrock")
+	require.Equal(t, false, capturedSendRawResponse, "SendBackRawResponse should be cleared when catalog selects Bedrock")
+	require.Equal(t, false, capturedPassthroughOverrides, "PassthroughOverridesPresent should be cleared when catalog selects Bedrock")
+}
+
 func TestCreateHandler_CustomParserFailureClosesConnection(t *testing.T) {
 	handlerStore := &mockHandlerStore{}
 	converterCalled := false


### PR DESCRIPTION
## Summary

When an Anthropic-type route's default provider is not found in the available providers list, the router falls back to the first available provider. However, raw request body passthrough is only valid for providers that natively speak the Anthropic Messages API (Anthropic, Vertex, Azure). If the fallback provider is something like Bedrock, leaving the raw passthrough flag enabled causes incorrect behavior since Bedrock requires its own format conversion.

## Changes

- When the router falls back to the first available provider on an Anthropic-type route, the `BifrostContextKeyUseRawRequestBody` flag is explicitly cleared if the fallback provider is not one of the natively Anthropic-compatible providers (Anthropic, Vertex, Azure). This ensures the selected provider performs its own format conversion rather than attempting to pass through an incompatible raw request body.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Configure an Anthropic-type route where the default provider is unavailable and the fallback resolves to a non-native provider such as Bedrock. Send a request and verify that the provider correctly performs format conversion rather than passing through the raw Anthropic-formatted body.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure Anthropic-type routes disable raw request/response passthrough when a fallback provider requires its own request/response formatting, so downstream providers receive data in their expected format.

* **Tests**
  * Added an integration test validating passthrough flags are cleared and handler behavior when such a fallback provider is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->