### PR TITLE
fix(transcription): populate fallbacks from multipart form

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -1423,11 +1423,16 @@ func prepareTranscriptionRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (
 	if streamValues := form.Value["stream"]; len(streamValues) > 0 && streamValues[0] == "true" {
 		stream = true
 	}
+	fallbacks, err := parseFallbacks(form.Value["fallbacks"])
+	if err != nil {
+		return nil, false, err
+	}
 	bifrostTranscriptionReq := &schemas.BifrostTranscriptionRequest{
-		Model:    modelName,
-		Provider: schemas.ModelProvider(provider),
-		Input:    transcriptionInput,
-		Params:   transcriptionParams,
+		Model:     modelName,
+		Provider:  schemas.ModelProvider(provider),
+		Input:     transcriptionInput,
+		Params:    transcriptionParams,
+		Fallbacks: fallbacks,
 	}
 	return bifrostTranscriptionReq, stream, nil
 }


### PR DESCRIPTION
## Summary

`/v1/audio/transcriptions` ignored the governance plugin's routing-rule
fallback decision. The governance plugin wrote `fallbacks` back into the
multipart form (`core/network/multipart.go`), but
`prepareTranscriptionRequest` never read `form.Value["fallbacks"]`, so
`BifrostTranscriptionRequest.Fallbacks` was always empty and the core
short-circuited with `no fallbacks configured, we should not try fallbacks`.

The sibling multipart handlers `prepareImageEditRequest` (#L2069-L2086)
and `prepareImageVariationRequest` (#L2210-L2222) already read this
field. This PR closes the asymmetry.

## Changes

- `transports/bifrost-http/handlers/inference.go`:
  `prepareTranscriptionRequest` reads `form.Value["fallbacks"]` and
  passes it through `parseFallbacks` into
  `BifrostTranscriptionRequest.Fallbacks`.

`transcriptionParamsKnownFields` already marks `"fallbacks": true`, so
the value was being skipped from `ExtraParams` but never consumed for
its real purpose.

`prepareSpeechRequest` is a JSON-body endpoint and already sets
`Fallbacks: base.Fallbacks` via the generic `prepareRequest` helper, so
it isn't affected.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)

## How to test

Reproduce per #4005 — set up two providers with a routing rule whose
primary is provider A and fallback is provider B; stop provider A and
hit `/v1/audio/transcriptions`. Before this change Bifrost returns 403
with `no fallbacks configured` in the debug log. After this change the
fallback is honored.

The matching unit-test surface is `prepareTranscriptionRequest`-level
form parsing; the existing image-edit/image-variation tests cover the
same `form.Value["fallbacks"]` → `parseFallbacks` → struct-field path.
I held off on adding a transcription-specific test because the existing
handler tests don't appear to exercise `prepareTranscriptionRequest`
directly; happy to add one if the maintainers prefer.

## Breaking changes

- [x] No

## Related issues

Closes #4005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fallback options in transcription requests, allowing users to specify alternative configurations when submitting transcription jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->