### PR TITLE
feat: add `disable_content_logging` option to OTel profiles to drop message/tool content from exported spans

### DIFF
--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3450,6 +3450,11 @@
           "description": "Skip TLS verification (ignored if tls_ca_cert is set)",
           "default": true
         },
+        "disable_content_logging": {
+          "type": "boolean",
+          "description": "When true, message content (input/output messages, embeddings, tool definitions, and tool call arguments/results) is dropped from exported spans. Only metadata such as model, tokens, and latency is sent to the collector.",
+          "default": false
+        },
         "plugin_span_filter": {
           "$ref": "#/$defs/otelPluginSpanFilter"
         }
@@ -3551,6 +3556,10 @@
         "insecure": {
           "type": "boolean",
           "description": "Deprecated in the profiles wrapper; configure insecure per profile instead."
+        },
+        "disable_content_logging": {
+          "type": "boolean",
+          "description": "Deprecated in the profiles wrapper; configure disable_content_logging per profile instead."
         }
       },
       "required": ["profiles"],

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -479,6 +479,8 @@ bifrost:
         # TLS configuration
         tls_ca_cert: "" # Path to TLS CA certificate file
         insecure: false # Skip TLS verification (ignored if tls_ca_cert is set)
+        # Drop message content (input/output messages, embeddings, tool defs/args/results) from exported spans
+        disable_content_logging: false
 
     datadog:
       enabled: false

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -130,7 +130,7 @@ func (p *OtelPlugin) buildReparentMap(spans []*schemas.Span) map[string]string {
 // convertTraceToResourceSpan converts a Bifrost trace to OTEL ResourceSpan for the given
 // profile service name. Span filtering and instance attributes are shared across profiles;
 // only the resource service name differs per profile.
-func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace, requestHeaders []string) *ResourceSpan {
+func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace, requestHeaders []string, disableContentLogging bool) *ResourceSpan {
 	reparent := p.buildReparentMap(trace.Spans)
 	filteredHeaders := schemas.FilterHeaders(trace.RequestHeaders, requestHeaders)
 	otelSpans := make([]*Span, 0, len(trace.Spans))
@@ -138,7 +138,7 @@ func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schem
 		if !p.shouldExportSpan(span) {
 			continue
 		}
-		otelSpan := convertSpanToOTELSpan(trace.TraceID, span)
+		otelSpan := convertSpanToOTELSpan(trace.TraceID, span, disableContentLogging)
 		// If the span's direct parent was filtered, rewrite its parent ID to the
 		// nearest exported ancestor so the hierarchy stays connected.
 		if effectiveParent, ok := reparent[span.ParentID]; ok {
@@ -176,7 +176,7 @@ func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schem
 }
 
 // convertSpanToOTELSpan converts a single Bifrost span to OTEL format
-func convertSpanToOTELSpan(traceID string, span *schemas.Span) *Span {
+func convertSpanToOTELSpan(traceID string, span *schemas.Span, disableContentLogging bool) *Span {
 	otelSpan := &Span{
 		TraceId:           hexToBytes(traceID, 16),
 		SpanId:            hexToBytes(span.SpanID, 8),
@@ -184,9 +184,9 @@ func convertSpanToOTELSpan(traceID string, span *schemas.Span) *Span {
 		Kind:              convertSpanKind(span.Kind),
 		StartTimeUnixNano: uint64(span.StartTime.UnixNano()),
 		EndTimeUnixNano:   uint64(span.EndTime.UnixNano()),
-		Attributes:        convertAttributesToKeyValues(span.Attributes),
+		Attributes:        convertAttributesToKeyValues(span.Attributes, disableContentLogging),
 		Status:            convertSpanStatus(span.Status, span.StatusMsg),
-		Events:            convertSpanEvents(span.Events),
+		Events:            convertSpanEvents(span.Events, disableContentLogging),
 	}
 
 	// Set parent span ID if present
@@ -218,19 +218,44 @@ func (p *OtelPlugin) getInstrumentationScope(serviceName string) *commonpb.Instr
 	}
 }
 
-// convertAttributesToKeyValues converts map[string]any to OTEL KeyValue slice
-func convertAttributesToKeyValues(attrs map[string]any) []*KeyValue {
+// convertAttributesToKeyValues converts map[string]any to OTEL KeyValue slice.
+// When disableContentLogging is true, attributes carrying message/input/output content or
+// tool definitions/arguments/results are dropped so only metadata is exported.
+func convertAttributesToKeyValues(attrs map[string]any, disableContentLogging bool) []*KeyValue {
 	if attrs == nil {
 		return nil
 	}
 	kvs := make([]*KeyValue, 0, len(attrs))
 	for k, v := range attrs {
+		if disableContentLogging && isContentAttribute(k) {
+			continue
+		}
 		kv := anyToKeyValue(k, v)
 		if kv != nil {
 			kvs = append(kvs, kv)
 		}
 	}
 	return kvs
+}
+
+// isContentAttribute returns true if the attribute key contains message/input/output content
+// or tool definitions/arguments/results that should be filtered when content logging is disabled.
+func isContentAttribute(key string) bool {
+	switch key {
+	case schemas.AttrInputMessages, schemas.AttrOutputMessages,
+		schemas.AttrInputText, schemas.AttrInputSpeech,
+		schemas.AttrInputEmbedding:
+		return true
+	case schemas.AttrTools, schemas.AttrRespTools,
+		schemas.AttrToolName, schemas.AttrToolCallID,
+		schemas.AttrToolCallArguments, schemas.AttrToolCallResult,
+		schemas.AttrToolType,
+		schemas.AttrToolChoiceType, schemas.AttrToolChoiceName,
+		schemas.AttrRespToolChoiceType, schemas.AttrRespToolChoiceName:
+		return true
+	default:
+		return false
+	}
 }
 
 // anyToKeyValue converts any Go value to OTEL KeyValue
@@ -378,7 +403,7 @@ func convertSpanStatus(status schemas.SpanStatus, msg string) *tracepb.Status {
 }
 
 // convertSpanEvents converts Bifrost span events to OTEL events
-func convertSpanEvents(events []schemas.SpanEvent) []*Event {
+func convertSpanEvents(events []schemas.SpanEvent, disableContentLogging bool) []*Event {
 	if len(events) == 0 {
 		return nil
 	}
@@ -387,7 +412,7 @@ func convertSpanEvents(events []schemas.SpanEvent) []*Event {
 		otelEvents[i] = &Event{
 			TimeUnixNano: uint64(event.Timestamp.UnixNano()),
 			Name:         event.Name,
-			Attributes:   convertAttributesToKeyValues(event.Attributes),
+			Attributes:   convertAttributesToKeyValues(event.Attributes, disableContentLogging),
 		}
 	}
 	return otelEvents

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -83,6 +83,11 @@ type Profile struct {
 	// RequestHeaders lists request-header name patterns (exact or wildcard like "x-custom-*"
 	// or "*") whose captured values are attached to the root span as attributes.
 	RequestHeaders []string `json:"request_headers,omitempty"`
+
+	// DisableContentLogging controls whether message content is exported to the OTEL collector.
+	// When true, only metadata (model, tokens, latency, etc.) is exported; input/output message
+	// content, tool definitions, and tool call arguments/results are dropped from span attributes.
+	DisableContentLogging bool `json:"disable_content_logging,omitempty"`
 }
 
 // UnmarshalJSON applies field defaults that the zero-value wouldn't capture.
@@ -191,18 +196,19 @@ func hoistSpanFilter(data []byte) *PluginSpanFilter {
 // flattened to plain strings ("env.VAR_NAME" or the literal value) for DB/config-file
 // persistence.
 type profileForStorage struct {
-	Enabled             bool              `json:"enabled"`
-	ServiceName         string            `json:"service_name"`
-	CollectorURL        string            `json:"collector_url"`
-	Headers             map[string]string `json:"headers,omitempty"`
-	TraceType           TraceType         `json:"trace_type"`
-	Protocol            Protocol          `json:"protocol"`
-	TLSCACert           string            `json:"tls_ca_cert,omitempty"`
-	Insecure            bool              `json:"insecure"`
-	MetricsEnabled      bool              `json:"metrics_enabled"`
-	MetricsEndpoint     string            `json:"metrics_endpoint,omitempty"`
-	MetricsPushInterval int               `json:"metrics_push_interval,omitempty"`
-	RequestHeaders      []string          `json:"request_headers,omitempty"`
+	Enabled               bool              `json:"enabled"`
+	ServiceName           string            `json:"service_name"`
+	CollectorURL          string            `json:"collector_url"`
+	Headers               map[string]string `json:"headers,omitempty"`
+	TraceType             TraceType         `json:"trace_type"`
+	Protocol              Protocol          `json:"protocol"`
+	TLSCACert             string            `json:"tls_ca_cert,omitempty"`
+	Insecure              bool              `json:"insecure"`
+	MetricsEnabled        bool              `json:"metrics_enabled"`
+	MetricsEndpoint       string            `json:"metrics_endpoint,omitempty"`
+	MetricsPushInterval   int               `json:"metrics_push_interval,omitempty"`
+	RequestHeaders        []string          `json:"request_headers,omitempty"`
+	DisableContentLogging bool              `json:"disable_content_logging,omitempty"`
 }
 
 // configForStorage is the persisted wrapper shape.
@@ -225,18 +231,19 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			continue
 		}
 		out.Profiles = append(out.Profiles, profileForStorage{
-			Enabled:             p.Enabled,
-			ServiceName:         p.ServiceName,
-			CollectorURL:        schemas.EnvVarAsString(p.CollectorURL),
-			Headers:             p.Headers,
-			TraceType:           p.TraceType,
-			Protocol:            p.Protocol,
-			TLSCACert:           p.TLSCACert,
-			Insecure:            p.Insecure,
-			MetricsEnabled:      p.MetricsEnabled,
-			MetricsEndpoint:     schemas.EnvVarAsString(p.MetricsEndpoint),
-			MetricsPushInterval: p.MetricsPushInterval,
-			RequestHeaders:      p.RequestHeaders,
+			Enabled:               p.Enabled,
+			ServiceName:           p.ServiceName,
+			CollectorURL:          schemas.EnvVarAsString(p.CollectorURL),
+			Headers:               p.Headers,
+			TraceType:             p.TraceType,
+			Protocol:              p.Protocol,
+			TLSCACert:             p.TLSCACert,
+			Insecure:              p.Insecure,
+			MetricsEnabled:        p.MetricsEnabled,
+			MetricsEndpoint:       schemas.EnvVarAsString(p.MetricsEndpoint),
+			MetricsPushInterval:   p.MetricsPushInterval,
+			RequestHeaders:        p.RequestHeaders,
+			DisableContentLogging: p.DisableContentLogging,
 		})
 	}
 	return sonic.Marshal(out)
@@ -300,12 +307,13 @@ func hideResolvedEnvValue(v *schemas.EnvVar) *schemas.EnvVar {
 // plus an optional metrics exporter, along with the per-profile identity (service name)
 // used when converting traces for this destination.
 type otelTarget struct {
-	serviceName     string
-	url             string
-	traceType       TraceType
-	client          OtelClient
-	metricsExporter *MetricsExporter
-	requestHeaders  []string
+	serviceName           string
+	url                   string
+	traceType             TraceType
+	client                OtelClient
+	metricsExporter       *MetricsExporter
+	requestHeaders        []string
+	disableContentLogging bool
 }
 
 // OtelPlugin is the plugin for OpenTelemetry.
@@ -428,10 +436,11 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 
 	url := profile.CollectorURL.GetValue()
 	target := &otelTarget{
-		serviceName:    serviceName,
-		url:            url,
-		traceType:      profile.TraceType,
-		requestHeaders: slices.Clone(profile.RequestHeaders),
+		serviceName:           serviceName,
+		url:                   url,
+		traceType:             profile.TraceType,
+		requestHeaders:        slices.Clone(profile.RequestHeaders),
+		disableContentLogging: profile.DisableContentLogging,
 	}
 
 	var err error
@@ -614,7 +623,7 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 		go func(t *otelTarget) {
 			defer wg.Done()
 			if t.client != nil {
-				resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders)
+				resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders, t.disableContentLogging)
 				if err := t.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
 					logger.Error("failed to emit trace %s to %s: %v", trace.TraceID, t.url, err)
 				}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1814,6 +1814,11 @@
           },
           "description": "Request header name patterns (exact or wildcard like x-custom-*) to capture and emit as span attributes. Note: * captures all headers including sensitive ones like Authorization."
         },
+        "disable_content_logging": {
+          "type": "boolean",
+          "description": "When true, message content (input/output messages, embeddings, tool definitions, and tool call arguments/results) is dropped from exported spans. Only metadata such as model, tokens, and latency is sent to the collector.",
+          "default": false
+        },
         "headers": {
           "type": "object",
           "additionalProperties": {

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -35,6 +35,7 @@ interface StoredOtelProfile {
 	metrics_endpoint?: string | EnvVar;
 	metrics_push_interval?: number;
 	request_headers?: string[];
+	disable_content_logging?: boolean;
 }
 
 // StoredOtelConfig is either the canonical { profiles: [...] } wrapper or a legacy single
@@ -96,6 +97,7 @@ const emptyProfile = (): ProfileForm => ({
 	metrics_endpoint: emptyEnvVar(),
 	metrics_push_interval: 15,
 	request_headers: [],
+	disable_content_logging: false,
 });
 
 // toProfileForm normalizes a stored profile into the EnvVar-based form representation.
@@ -112,6 +114,7 @@ const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
 	metrics_endpoint: toEnvVarFormValue(p?.metrics_endpoint),
 	metrics_push_interval: p?.metrics_push_interval ?? 15,
 	request_headers: p?.request_headers ?? [],
+	disable_content_logging: p?.disable_content_logging ?? false,
 });
 
 // buildDefaults handles both stored shapes: the { profiles: [...] } wrapper and the legacy
@@ -435,6 +438,24 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 									/>
 								</FormControl>
 								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={control}
+						name={`${base}.disable_content_logging`}
+						render={({ field }) => (
+							<FormItem className="flex flex-row items-center justify-between">
+								<div className="space-y-0.5">
+									<FormLabel className="text-base">Disable Content Logging</FormLabel>
+									<FormDescription>
+										When enabled, message content (input/output messages, tool definitions, and tool call arguments/results) is dropped
+										from exported spans. Only metadata such as model, tokens, and latency is sent to the collector.
+									</FormDescription>
+								</div>
+								<FormControl>
+									<Switch checked={field.value} onCheckedChange={field.onChange} disabled={!hasOtelAccess} data-testid={`otel-profile-${index}-disable-content-logging-toggle`} />
+								</FormControl>
 							</FormItem>
 						)}
 					/>

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -764,6 +764,7 @@ export const otelConfigSchema = z
 		metrics_endpoint: envVarSchema.optional(),
 		metrics_push_interval: z.number().int().min(1).max(300).default(15),
 		request_headers: z.array(z.string()).default([]),
+		disable_content_logging: z.boolean().default(false),
 	})
 	.superRefine((data, ctx) => {
 		// A disabled profile is not sent anywhere, so skip all validation for it.


### PR DESCRIPTION
## Summary

Adds a `disable_content_logging` option to OTEL profiles that allows operators to strip message content from exported spans before they reach the collector. When enabled, only metadata (model, token counts, latency, etc.) is exported — input/output messages, tool definitions, tool call arguments, and tool call results are dropped from span attributes and events.

## Changes

- Added `DisableContentLogging bool` field to the `Profile` and `otelTarget` structs, and included it in `profileForStorage` serialization/deserialization so the setting persists correctly.
- Propagated `disableContentLogging` through `convertTraceToResourceSpan` → `convertSpanToOTELSpan` → `convertAttributesToKeyValues` and `convertSpanEvents`, so filtering applies to both span attributes and span event attributes.
- Introduced `isContentAttribute(key string) bool` to centralize the list of attribute keys that carry message/tool content (`AttrInputMessages`, `AttrOutputMessages`, `AttrInputText`, `AttrInputSpeech`, `AttrTools`, `AttrRespTools`, `AttrToolName`, `AttrToolCallID`, `AttrToolCallArguments`, `AttrToolCallResult`, `AttrToolType`, `AttrToolChoiceType`, `AttrToolChoiceName`, `AttrRespToolChoiceType`, `AttrRespToolChoiceName`).
- Added a **Disable Content Logging** toggle to the OTEL profile form in the UI, wired to the `disable_content_logging` field with appropriate label and description text.
- Extended the Zod schema (`otelConfigSchema`) and the `StoredOtelProfile` TypeScript interface to include `disable_content_logging`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/otel/...

# UI
cd ui
pnpm i
pnpm build
```

1. Configure an OTEL profile in the UI and enable **Disable Content Logging**.
2. Send a request through Bifrost that produces a trace with input/output messages and tool calls.
3. Inspect the spans received by the OTEL collector and confirm that attributes such as `gen_ai.prompt`, `gen_ai.completion`, tool definitions, and tool call arguments/results are absent, while model, token count, and latency attributes are still present.
4. Disable the toggle and repeat — confirm content attributes reappear in the exported spans.

**New config field:**

| Field | Type | Default | Description |
|---|---|---|---|
| `disable_content_logging` | `bool` | `false` | When `true`, drops message content and tool data from exported OTEL spans. |

## Screenshots/Recordings

A new toggle appears in the OTEL profile configuration section beneath the existing request headers field, labeled **Disable Content Logging** with a description explaining what is suppressed.

## Breaking changes

- [x] No

## Related issues

## Security considerations

This feature directly addresses PII and data-sensitivity concerns. Operators handling regulated data or operating under strict data-minimization requirements can enable `disable_content_logging` to ensure that raw prompt/completion content and tool payloads are never forwarded to the OTEL collector, reducing the risk of sensitive data exposure in observability pipelines.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-profile "Disable Content Logging" toggle for OTEL. When enabled, exported traces omit message content (inputs/outputs, embeddings, tool and tool-call details) while retaining metadata (model, tokens, latency). The option appears in the UI and is persisted per profile (defaults to off).
* **Chores**
  * Configuration schemas and Helm values updated to expose and document the new per-profile setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->