### PR TITLE
fix: fixes create virtual key double usage counting

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -2605,34 +2605,42 @@ func (gs *LocalGovernanceStore) CreateVirtualKeyInMemory(ctx context.Context, vk
 		return // Nothing to create
 	}
 
+	clone := *vk
+
+	// Clone provider configs
+	if vk.ProviderConfigs != nil {
+		clone.ProviderConfigs = make([]configstoreTables.TableVirtualKeyProviderConfig, len(vk.ProviderConfigs))
+		copy(clone.ProviderConfigs, vk.ProviderConfigs)
+	}
+
 	// Store budgets
-	for i := range vk.Budgets {
-		vk.Budgets[i].IsCalendarAligned = vk.CalendarAligned
-		gs.budgets.Store(vk.Budgets[i].ID, &vk.Budgets[i])
+	for i := range clone.Budgets {
+		clone.Budgets[i].IsCalendarAligned = clone.CalendarAligned
+		gs.budgets.Store(clone.Budgets[i].ID, &clone.Budgets[i])
 	}
 
 	// Create associated rate limit if exists
-	if vk.RateLimit != nil {
-		vk.RateLimit.IsCalendarAligned = vk.CalendarAligned
-		gs.rateLimits.Store(vk.RateLimit.ID, vk.RateLimit)
+	if clone.RateLimit != nil {
+		clone.RateLimit.IsCalendarAligned = clone.CalendarAligned
+		gs.rateLimits.Store(clone.RateLimit.ID, clone.RateLimit)
 	}
 
 	// Create provider config budgets and rate limits if they exist
-	if vk.ProviderConfigs != nil {
-		for i := range vk.ProviderConfigs {
-			pc := &vk.ProviderConfigs[i]
+	if clone.ProviderConfigs != nil {
+		for i := range clone.ProviderConfigs {
+			pc := &clone.ProviderConfigs[i]
 			for j := range pc.Budgets {
-				pc.Budgets[j].IsCalendarAligned = vk.CalendarAligned
+				pc.Budgets[j].IsCalendarAligned = clone.CalendarAligned
 				gs.budgets.Store(pc.Budgets[j].ID, &pc.Budgets[j])
 			}
 			if pc.RateLimit != nil {
-				pc.RateLimit.IsCalendarAligned = vk.CalendarAligned
+				pc.RateLimit.IsCalendarAligned = clone.CalendarAligned
 				gs.rateLimits.Store(pc.RateLimit.ID, pc.RateLimit)
 			}
 		}
 	}
 
-	gs.virtualKeys.Store(vk.Value, vk)
+	gs.virtualKeys.Store(clone.Value, &clone)
 }
 
 // UpdateVirtualKeyInMemory updates an existing virtual key in the in-memory store (lock-free)
@@ -2886,20 +2894,22 @@ func (gs *LocalGovernanceStore) CreateTeamInMemory(ctx context.Context, team *co
 		return // Nothing to create
 	}
 
+	clone := *team
+
 	// Create associated budgets if they exist
-	for i := range team.Budgets {
-		team.Budgets[i].IsCalendarAligned = team.CalendarAligned
-		b := team.Budgets[i]
+	for i := range clone.Budgets {
+		clone.Budgets[i].IsCalendarAligned = clone.CalendarAligned
+		b := clone.Budgets[i]
 		gs.budgets.Store(b.ID, &b)
 	}
 
 	// Create associated rate limit if exists
-	if team.RateLimit != nil {
-		team.RateLimit.IsCalendarAligned = team.CalendarAligned
-		gs.rateLimits.Store(team.RateLimit.ID, team.RateLimit)
+	if clone.RateLimit != nil {
+		clone.RateLimit.IsCalendarAligned = clone.CalendarAligned
+		gs.rateLimits.Store(clone.RateLimit.ID, clone.RateLimit)
 	}
 
-	gs.teams.Store(team.ID, team)
+	gs.teams.Store(clone.ID, &clone)
 }
 
 // UpdateTeamInMemory updates an existing team in the in-memory store (lock-free)
@@ -3018,15 +3028,16 @@ func (gs *LocalGovernanceStore) CreateCustomerInMemory(ctx context.Context, cust
 	if customer == nil {
 		return // Nothing to create
 	}
-	for i := range customer.Budgets {
-		customer.Budgets[i].IsCalendarAligned = customer.CalendarAligned
-		gs.budgets.Store(customer.Budgets[i].ID, &customer.Budgets[i])
+	clone := *customer
+	for i := range clone.Budgets {
+		clone.Budgets[i].IsCalendarAligned = clone.CalendarAligned
+		gs.budgets.Store(clone.Budgets[i].ID, &clone.Budgets[i])
 	}
-	if customer.RateLimit != nil {
-		customer.RateLimit.IsCalendarAligned = customer.CalendarAligned
-		gs.rateLimits.Store(customer.RateLimit.ID, customer.RateLimit)
+	if clone.RateLimit != nil {
+		clone.RateLimit.IsCalendarAligned = clone.CalendarAligned
+		gs.rateLimits.Store(clone.RateLimit.ID, clone.RateLimit)
 	}
-	gs.customers.Store(customer.ID, customer)
+	gs.customers.Store(clone.ID, &clone)
 }
 
 // UpdateCustomerInMemory updates an existing customer in the in-memory store (lock-free)

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -591,6 +591,59 @@ func TestGovernanceStore_MultiBudget_InMemoryCreateAndDelete(t *testing.T) {
 	assert.False(t, found, "VK should not be found after delete")
 }
 
+// TestGovernanceStore_CreateVirtualKeyInMemory_DecouplesFromCallerPointer is a regression test
+// for a double-counting bug on new VKs: the create handler keeps mutating the caller's
+// TableVirtualKey after the store call (hydrateVKGovernance reassigns Budgets/RateLimit/RateLimitID
+// from VK-scoped model configs for serialization), so if the store kept that pointer the
+// model-config-owned IDs would leak onto the tracked VK's hierarchy fields and the usage tracker
+// would count each request twice (VK-scoped-model + VK-hierarchy). The stored VK must be a
+// decoupled clone.
+func TestGovernanceStore_CreateVirtualKeyInMemory_DecouplesFromCallerPointer(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	// A freshly-created VK loaded from DB carries no legacy rate-limit/budget — its
+	// governance lives in a VK-scoped model config, so RateLimitID is nil and Budgets empty.
+	// It does carry a provider config (with no per-provider governance of its own yet).
+	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", true)
+	vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"*"}),
+	}
+	store.CreateVirtualKeyInMemory(context.Background(), vk)
+
+	// Simulate hydrateVKGovernance mutating the caller's pointer after the store call: it
+	// reassigns the top-level fields AND mutates the provider-config element IN PLACE
+	// (pc := &vk.ProviderConfigs[i]; pc.Budgets = ...), injecting the model-config-owned
+	// rate-limit/budget identity. The in-place element write is the case greptile flagged:
+	// a shallow clone shares the ProviderConfigs backing array and would leak it.
+	hydratedRL := buildRateLimit("mc-rl", 6, 6)
+	vk.RateLimit = hydratedRL
+	vk.RateLimitID = &hydratedRL.ID
+	vk.Budgets = []configstoreTables.TableBudget{*buildBudget("mc-b", 200.0, "1h")}
+
+	pcRL := buildRateLimit("mc-pc-rl", 10, 10)
+	vk.ProviderConfigs[0].RateLimit = pcRL
+	vk.ProviderConfigs[0].RateLimitID = &pcRL.ID
+	vk.ProviderConfigs[0].Budgets = []configstoreTables.TableBudget{*buildBudget("mc-pc-b", 50.0, "1h")}
+
+	// The tracked VK must NOT reflect those post-create mutations, otherwise the
+	// VK-hierarchy usage path would double-count alongside the VK-scoped-model path.
+	tracked, found := store.GetVirtualKey(context.Background(), "sk-bf-test")
+	require.True(t, found)
+	require.NotNil(t, tracked)
+	assert.Nil(t, tracked.RateLimit, "tracked VK rate limit must stay decoupled from caller mutation")
+	assert.Nil(t, tracked.RateLimitID, "tracked VK rate limit ID must stay decoupled from caller mutation")
+	assert.Empty(t, tracked.Budgets, "tracked VK budgets must stay decoupled from caller mutation")
+
+	// Per-provider entries must stay decoupled too — this is the ProviderConfigs slice
+	// aliasing greptile flagged (in-place element mutation through the shared backing array).
+	require.Len(t, tracked.ProviderConfigs, 1)
+	assert.Nil(t, tracked.ProviderConfigs[0].RateLimit, "tracked provider-config rate limit must stay decoupled")
+	assert.Nil(t, tracked.ProviderConfigs[0].RateLimitID, "tracked provider-config rate limit ID must stay decoupled")
+	assert.Empty(t, tracked.ProviderConfigs[0].Budgets, "tracked provider-config budgets must stay decoupled")
+}
+
 func TestGovernanceStore_UpdateVirtualKeyInMemory_RotatedValueRemovesOldLookup(t *testing.T) {
 	logger := NewMockLogger()
 	budget := buildBudgetWithUsage("budget1", 100.0, 25.0, "1d")
@@ -1207,9 +1260,9 @@ func TestGovernanceStore_Customer_CalendarAligned_CreateInMemory(t *testing.T) {
 		LastReset:     time.Now(),
 	}
 	rl := &configstoreTables.TableRateLimit{
-		ID:              rlID,
-		TokenMaxLimit:   ptrInt64(1000),
-		TokenLastReset:  time.Now(),
+		ID:               rlID,
+		TokenMaxLimit:    ptrInt64(1000),
+		TokenLastReset:   time.Now(),
 		RequestLastReset: time.Now(),
 	}
 	customer := buildCustomer("cust-1", "ACME", budget)
@@ -1273,9 +1326,9 @@ func TestGovernanceStore_Customer_CalendarAligned_UpdateInMemory(t *testing.T) {
 		LastReset:     time.Now(),
 	}
 	rl := &configstoreTables.TableRateLimit{
-		ID:              rlID,
-		TokenMaxLimit:   ptrInt64(500),
-		TokenLastReset:  time.Now(),
+		ID:               rlID,
+		TokenMaxLimit:    ptrInt64(500),
+		TokenLastReset:   time.Now(),
 		RequestLastReset: time.Now(),
 	}
 	customer := buildCustomer("cust-3", "Initech", budget)


### PR DESCRIPTION
## Summary

Fixes a double-counting bug on newly created virtual keys where the in-memory store retained a direct pointer to the caller's `TableVirtualKey`. After `CreateVirtualKeyInMemory` returned, `hydrateVKGovernance` would mutate that same pointer — injecting model-config-owned rate-limit and budget identities onto the VK's fields — causing the usage tracker to count each request twice (once via the VK-scoped model path and again via the VK-hierarchy path).

## Changes

- `CreateVirtualKeyInMemory` now works on a shallow clone of the incoming `*TableVirtualKey` before storing it, ensuring post-create mutations by the caller do not affect the tracked VK's hierarchy fields.
- Added a regression test (`TestGovernanceStore_CreateVirtualKeyInMemory_DecouplesFromCallerPointer`) that simulates the `hydrateVKGovernance` mutation pattern and asserts the stored VK remains unaffected.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -run TestGovernanceStore_CreateVirtualKeyInMemory_DecouplesFromCallerPointer -v
go test ./plugins/governance/...
```

The new regression test will fail on the previous code and pass with the clone fix in place. Verify no other virtual key store tests regress.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Regression introduced by the `hydrateVKGovernance` post-store mutation pattern on newly created virtual keys.

## Security considerations

No auth, secrets, or PII implications. The fix prevents incorrect usage accounting that could allow rate limits and budgets to be bypassed or incorrectly enforced on new virtual keys.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stored isolated copies of virtual keys, teams, and customers so external mutations no longer affect tracked governance records; calendar-aligned flags are correctly applied to associated budgets and rate limits.

* **Tests**
  * Added a regression test ensuring in-memory governance records remain decoupled from caller-provided data after creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->