### PR TITLE
fix: strip invalid reasoning blocks from anthropic

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -1482,6 +1482,18 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 	return nil, nil, false
 }
 
+// isAnthropicNativeThinking returns true when the upstream response carries
+// genuine Anthropic-signed thinking blocks that are safe to forward as-is.
+func isAnthropicNativeThinking(provider schemas.ModelProvider, model string) bool {
+	if provider == schemas.Anthropic {
+		return true
+	}
+	if (provider == schemas.Vertex || provider == schemas.Azure || provider == schemas.Bedrock) && schemas.IsAnthropicModel(model) {
+		return true
+	}
+	return false
+}
+
 // ToAnthropicResponsesStreamResponse converts a Bifrost Responses stream response to Anthropic SSE string format
 func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp *schemas.BifrostResponsesStreamResponse) []*AnthropicStreamEvent {
 	if bifrostResp == nil {
@@ -1615,29 +1627,39 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 						contentBlock.Type = AnthropicContentBlockTypeText
 						contentBlock.Text = schemas.Ptr("")
 					case schemas.ResponsesMessageTypeReasoning:
-						contentBlock.Type = AnthropicContentBlockTypeThinking
-						contentBlock.Thinking = schemas.Ptr("")
-						contentBlock.Signature = schemas.Ptr("")
-						// Preserve signature if present
-						if bifrostResp.Item.ResponsesReasoning != nil && bifrostResp.Item.ResponsesReasoning.EncryptedContent != nil && *bifrostResp.Item.ResponsesReasoning.EncryptedContent != "" {
-							contentBlock.Data = bifrostResp.Item.ResponsesReasoning.EncryptedContent
-							// When signature is present but thinking content is empty, use redacted_thinking
-							if contentBlock.Thinking != nil && *contentBlock.Thinking == "" {
-								contentBlock.Type = AnthropicContentBlockTypeRedactedThinking
+						if isAnthropicNativeThinking(bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.ResolvedModelUsed) {
+							contentBlock.Type = AnthropicContentBlockTypeThinking
+							contentBlock.Thinking = schemas.Ptr("")
+							contentBlock.Signature = schemas.Ptr("")
+							// Preserve encrypted content for redacted_thinking
+							if bifrostResp.Item.ResponsesReasoning != nil && bifrostResp.Item.ResponsesReasoning.EncryptedContent != nil && *bifrostResp.Item.ResponsesReasoning.EncryptedContent != "" {
+								contentBlock.Data = bifrostResp.Item.ResponsesReasoning.EncryptedContent
+								if contentBlock.Thinking != nil && *contentBlock.Thinking == "" {
+									contentBlock.Type = AnthropicContentBlockTypeRedactedThinking
+								}
 							}
+						} else {
+							// Non-Anthropic reasoning has no valid Anthropic signature.
+							// Emit as text so the block is safe to replay in cross-provider sessions.
+							contentBlock.Type = AnthropicContentBlockTypeText
+							contentBlock.Text = schemas.Ptr("")
 						}
 					case schemas.ResponsesMessageTypeFunctionCall:
 						// Check if this item actually has reasoning content (misclassified)
 						// When thinking is enabled, reasoning content might be incorrectly classified as FunctionCall
 						if bifrostResp.Item.ResponsesReasoning != nil {
 							// This is actually reasoning content, not a function call
-							contentBlock.Type = AnthropicContentBlockTypeThinking
-							contentBlock.Thinking = schemas.Ptr("")
-							contentBlock.Signature = schemas.Ptr("")
-							// Check if there's encrypted content for redacted_thinking
-							if bifrostResp.Item.ResponsesReasoning.EncryptedContent != nil && *bifrostResp.Item.ResponsesReasoning.EncryptedContent != "" {
-								contentBlock.Type = AnthropicContentBlockTypeRedactedThinking
-								contentBlock.Data = bifrostResp.Item.ResponsesReasoning.EncryptedContent
+							if isAnthropicNativeThinking(bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.ResolvedModelUsed) {
+								contentBlock.Type = AnthropicContentBlockTypeThinking
+								contentBlock.Thinking = schemas.Ptr("")
+								contentBlock.Signature = schemas.Ptr("")
+								if bifrostResp.Item.ResponsesReasoning.EncryptedContent != nil && *bifrostResp.Item.ResponsesReasoning.EncryptedContent != "" {
+									contentBlock.Type = AnthropicContentBlockTypeRedactedThinking
+									contentBlock.Data = bifrostResp.Item.ResponsesReasoning.EncryptedContent
+								}
+							} else {
+								contentBlock.Type = AnthropicContentBlockTypeText
+								contentBlock.Text = schemas.Ptr("")
 							}
 						} else {
 							// Regular function call - check if ContentIndex is 0 and thinking might be enabled
@@ -1659,11 +1681,17 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 								}
 							}
 
-							// When thinking is enabled and this is the first block, use thinking/redacted_thinking
+							// When thinking is enabled and this is the first block, only emit
+							// native Anthropic thinking for Anthropic-native providers.
 							if isFirstBlock && hasReasoningInResponse {
-								contentBlock.Type = AnthropicContentBlockTypeThinking
-								contentBlock.Thinking = schemas.Ptr("")
-								contentBlock.Signature = schemas.Ptr("")
+								if isAnthropicNativeThinking(bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.ResolvedModelUsed) {
+									contentBlock.Type = AnthropicContentBlockTypeThinking
+									contentBlock.Thinking = schemas.Ptr("")
+									contentBlock.Signature = schemas.Ptr("")
+								} else {
+									contentBlock.Type = AnthropicContentBlockTypeText
+									contentBlock.Text = schemas.Ptr("")
+								}
 							} else {
 								contentBlock.Type = AnthropicContentBlockTypeToolUse
 								if bifrostResp.Item.ResponsesToolMessage != nil {
@@ -1826,18 +1854,24 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			streamResp.Index = bifrostResp.ContentIndex
 		}
 
-		// Check if this is a signature delta or text delta
-		if bifrostResp.Signature != nil {
-			// This is a signature_delta
-			streamResp.Delta = &AnthropicStreamDelta{
-				Type:      AnthropicStreamDeltaTypeSignature,
-				Signature: bifrostResp.Signature,
+		// For non-Anthropic providers, reasoning was emitted as a text block so
+		// deltas must be text_delta; signature_delta is dropped (no valid signature).
+		if isAnthropicNativeThinking(bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.ResolvedModelUsed) {
+			if bifrostResp.Signature != nil {
+				streamResp.Delta = &AnthropicStreamDelta{
+					Type:      AnthropicStreamDeltaTypeSignature,
+					Signature: bifrostResp.Signature,
+				}
+			} else if bifrostResp.Delta != nil {
+				streamResp.Delta = &AnthropicStreamDelta{
+					Type:     AnthropicStreamDeltaTypeThinking,
+					Thinking: bifrostResp.Delta,
+				}
 			}
 		} else if bifrostResp.Delta != nil {
-			// This is a thinking_delta
 			streamResp.Delta = &AnthropicStreamDelta{
-				Type:     AnthropicStreamDeltaTypeThinking,
-				Thinking: bifrostResp.Delta,
+				Type: AnthropicStreamDeltaTypeText,
+				Text: bifrostResp.Delta,
 			}
 		}
 
@@ -2874,6 +2908,30 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 					Type: AnthropicContentBlockTypeText,
 					Text: msg.Content.ContentStr,
 				})
+			}
+		}
+	}
+
+	// Non-Anthropic reasoning has no valid Anthropic signature. Convert any
+	// thinking/redacted_thinking blocks to text so they are safe to replay in
+	// cross-provider sessions.
+	if !isAnthropicNativeThinking(bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.ResolvedModelUsed) {
+		for i, block := range contentBlocks {
+			switch block.Type {
+			case AnthropicContentBlockTypeThinking:
+				text := ""
+				if block.Thinking != nil {
+					text = *block.Thinking
+				}
+				contentBlocks[i] = AnthropicContentBlock{
+					Type: AnthropicContentBlockTypeText,
+					Text: &text,
+				}
+			case AnthropicContentBlockTypeRedactedThinking:
+				contentBlocks[i] = AnthropicContentBlock{
+					Type: AnthropicContentBlockTypeText,
+					Text: schemas.Ptr(""),
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Reasoning/thinking blocks returned by non-Anthropic providers (e.g. OpenAI, Gemini) lack a valid Anthropic cryptographic signature. Forwarding them as `thinking` or `redacted_thinking` blocks causes downstream failures when those blocks are replayed in subsequent Anthropic API calls. This PR detects whether the upstream response originates from a genuine Anthropic-backed provider and, if not, downgrades thinking blocks to plain `text` blocks so they are safe to use across provider boundaries.

## Changes

- Introduced `isAnthropicNativeThinking(provider, model)` helper that returns `true` only for Anthropic, Vertex+Anthropic model, and Azure+Anthropic model responses — the only cases where thinking blocks carry a valid Anthropic signature.
- In the streaming response converter (`ToAnthropicResponsesStreamResponse`), reasoning items and misclassified function-call items are now emitted as `text` content blocks (with `text_delta` deltas) instead of `thinking`/`redacted_thinking` when the provider is not Anthropic-native. `signature_delta` events are also suppressed in that path.
- In the non-streaming response converter (`ToAnthropicResponsesResponse`), a post-processing pass converts any remaining `thinking` blocks to `text` blocks for non-Anthropic-native responses.
- Extended `StripEmptyThinkingBlocks` to also strip thinking blocks that have an empty `signature` field, preventing unsigned blocks from leaking into request bodies.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

1. Send a request through a non-Anthropic provider (e.g. OpenAI `o1`/`o3`) with reasoning enabled via the Anthropic-compatible responses endpoint.
2. Confirm the returned content blocks have `type: text` rather than `type: thinking` or `type: redacted_thinking`.
3. Replay the returned content as input in a follow-up Anthropic API call and confirm no signature validation error is returned.
4. Send the same request through a native Anthropic provider and confirm `thinking`/`redacted_thinking` blocks are still returned as-is.

## Breaking changes

- [x] No

## Related issues

## Security considerations

Unsigned thinking blocks from third-party providers could previously be forwarded to Anthropic as `thinking` blocks, potentially triggering unexpected behaviour or signature validation errors. Downgrading them to `text` removes that risk.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved handling of AI reasoning blocks when converting responses across different providers, ensuring native thinking blocks are properly emitted for Anthropic models while safely converting to text format for other providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->