### PR TITLE
fix: remove usage from responses.created event in openai stream

### DIFF
--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -2634,6 +2634,10 @@ func (resp *BifrostResponsesStreamResponse) WithDefaults() *BifrostResponsesStre
 
 	// Copy nested response (applies defaults)
 	result.Response = resp.Response.WithDefaults()
+	// OpenAI Responses API requires usage=null on response.created; final usage is on response.completed only
+	if resp.Type == ResponsesStreamResponseTypeCreated && result.Response != nil {
+		result.Response.Usage = nil
+	}
 
 	// Copy all streaming-specific fields
 	result.OutputIndex = resp.OutputIndex


### PR DESCRIPTION
## Summary

The OpenAI Responses API expects `usage` to be `null` on `response.created` stream events, with final usage data only appearing on `response.completed`. This PR enforces that contract by nullifying usage on the created event within `WithDefaults()`.

## Changes

- In `BifrostResponsesStreamResponse.WithDefaults()`, when the stream event type is `ResponsesStreamResponseTypeCreated`, the `Usage` field on the nested response is explicitly set to `nil` after defaults are applied, ensuring compliance with the OpenAI Responses API streaming specification.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a streaming request through the Responses API and inspect the individual stream events. The `response.created` event should have `usage: null`, while the `response.completed` event should contain the populated usage object.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected streaming response behavior so usage data is omitted on intermediate stream events and included only on the final completion event, ensuring accurate usage reporting for streamed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->