### PR TITLE
docs: compaction api

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -4330,6 +4330,750 @@
         ]
       }
     },
+    "/v1/responses/compact": {
+      "post": {
+        "operationId": "createCompaction",
+        "summary": "Compact context",
+        "description": "Compresses a conversation into an opaque encrypted compaction item using the\nOpenAI-compatible context compaction API.\n\nThe response `output` array contains the original user messages plus a final item\nwith `type: \"response.compaction\"` and an `encrypted_content` field. Pass the\nfull `output` array as `input` to future Responses API requests to continue the\nconversation without retransmitting the full history.\n\n**Supported providers:** OpenAI, Azure OpenAI, xAI. Requests to unsupported\nproviders return a 400 error.\n",
+        "tags": [
+          "Compaction"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model in provider/model format (e.g., \"openai/gpt-4o\")"
+                  },
+                  "input": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "message",
+                                "file_search_call",
+                                "computer_call",
+                                "computer_call_output",
+                                "web_search_call",
+                                "web_fetch_call",
+                                "function_call",
+                                "function_call_output",
+                                "code_interpreter_call",
+                                "local_shell_call",
+                                "local_shell_call_output",
+                                "mcp_call",
+                                "custom_tool_call",
+                                "custom_tool_call_output",
+                                "image_generation_call",
+                                "mcp_list_tools",
+                                "mcp_approval_request",
+                                "mcp_approval_responses",
+                                "reasoning",
+                                "item_reference",
+                                "refusal"
+                              ]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "in_progress",
+                                "completed",
+                                "incomplete",
+                                "interpreting",
+                                "failed"
+                              ]
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "assistant",
+                                "user",
+                                "system",
+                                "developer"
+                              ]
+                            },
+                            "content": {
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "input_text",
+                                          "input_image",
+                                          "input_file",
+                                          "input_audio",
+                                          "output_text",
+                                          "refusal",
+                                          "reasoning_text"
+                                        ]
+                                      },
+                                      "file_id": {
+                                        "type": "string"
+                                      },
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "signature": {
+                                        "type": "string"
+                                      },
+                                      "image_url": {
+                                        "type": "string"
+                                      },
+                                      "detail": {
+                                        "type": "string"
+                                      },
+                                      "file_data": {
+                                        "type": "string"
+                                      },
+                                      "file_url": {
+                                        "type": "string"
+                                      },
+                                      "filename": {
+                                        "type": "string"
+                                      },
+                                      "file_type": {
+                                        "type": "string"
+                                      },
+                                      "input_audio": {
+                                        "type": "object",
+                                        "required": [
+                                          "format",
+                                          "data"
+                                        ],
+                                        "properties": {
+                                          "format": {
+                                            "type": "string",
+                                            "enum": [
+                                              "mp3",
+                                              "wav"
+                                            ]
+                                          },
+                                          "data": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "annotations": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "file_citation",
+                                                "url_citation",
+                                                "container_file_citation",
+                                                "file_path"
+                                              ]
+                                            },
+                                            "index": {
+                                              "type": "integer"
+                                            },
+                                            "file_id": {
+                                              "type": "string"
+                                            },
+                                            "text": {
+                                              "type": "string"
+                                            },
+                                            "start_index": {
+                                              "type": "integer"
+                                            },
+                                            "end_index": {
+                                              "type": "integer"
+                                            },
+                                            "filename": {
+                                              "type": "string"
+                                            },
+                                            "title": {
+                                              "type": "string"
+                                            },
+                                            "url": {
+                                              "type": "string"
+                                            },
+                                            "container_id": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "logprobs": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "bytes": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "logprob": {
+                                              "type": "number"
+                                            },
+                                            "token": {
+                                              "type": "string"
+                                            },
+                                            "top_logprobs": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "bytes": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "integer"
+                                                    }
+                                                  },
+                                                  "logprob": {
+                                                    "type": "number"
+                                                  },
+                                                  "token": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "refusal": {
+                                        "type": "string"
+                                      },
+                                      "cache_control": {
+                                        "$ref": "#/components/schemas/CacheControl"
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            "call_id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "arguments": {
+                              "type": "string"
+                            },
+                            "output": {
+                              "type": "object"
+                            },
+                            "action": {
+                              "type": "object"
+                            },
+                            "error": {
+                              "type": "string"
+                            },
+                            "queries": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "results": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "summary": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type",
+                                  "text"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "summary_text"
+                                    ]
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "encrypted_content": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "description": "Conversation to compact. Required unless previous_response_id is provided. Can be a string or array of ResponsesMessage objects. Compaction items from prior responses (type \"response.compaction\") may be included in the array.\n"
+                  },
+                  "instructions": {
+                    "type": "string",
+                    "description": "System instructions that persist across the compacted context."
+                  },
+                  "previous_response_id": {
+                    "type": "string",
+                    "description": "ID of a previous response to extend rather than sending full input."
+                  },
+                  "prompt_cache_key": {
+                    "type": "string"
+                  },
+                  "prompt_cache_retention": {
+                    "type": "string"
+                  },
+                  "service_tier": {
+                    "type": "string"
+                  },
+                  "fallbacks": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Fallback model list in provider/model format."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful compaction response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "object": {
+                      "type": "string",
+                      "description": "Always \"response.compaction\"",
+                      "example": "response.compaction"
+                    },
+                    "model": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "integer"
+                    },
+                    "output": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "message",
+                              "file_search_call",
+                              "computer_call",
+                              "computer_call_output",
+                              "web_search_call",
+                              "web_fetch_call",
+                              "function_call",
+                              "function_call_output",
+                              "code_interpreter_call",
+                              "local_shell_call",
+                              "local_shell_call_output",
+                              "mcp_call",
+                              "custom_tool_call",
+                              "custom_tool_call_output",
+                              "image_generation_call",
+                              "mcp_list_tools",
+                              "mcp_approval_request",
+                              "mcp_approval_responses",
+                              "reasoning",
+                              "item_reference",
+                              "refusal"
+                            ]
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "in_progress",
+                              "completed",
+                              "incomplete",
+                              "interpreting",
+                              "failed"
+                            ]
+                          },
+                          "role": {
+                            "type": "string",
+                            "enum": [
+                              "assistant",
+                              "user",
+                              "system",
+                              "developer"
+                            ]
+                          },
+                          "content": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "input_text",
+                                        "input_image",
+                                        "input_file",
+                                        "input_audio",
+                                        "output_text",
+                                        "refusal",
+                                        "reasoning_text"
+                                      ]
+                                    },
+                                    "file_id": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "signature": {
+                                      "type": "string"
+                                    },
+                                    "image_url": {
+                                      "type": "string"
+                                    },
+                                    "detail": {
+                                      "type": "string"
+                                    },
+                                    "file_data": {
+                                      "type": "string"
+                                    },
+                                    "file_url": {
+                                      "type": "string"
+                                    },
+                                    "filename": {
+                                      "type": "string"
+                                    },
+                                    "file_type": {
+                                      "type": "string"
+                                    },
+                                    "input_audio": {
+                                      "type": "object",
+                                      "required": [
+                                        "format",
+                                        "data"
+                                      ],
+                                      "properties": {
+                                        "format": {
+                                          "type": "string",
+                                          "enum": [
+                                            "mp3",
+                                            "wav"
+                                          ]
+                                        },
+                                        "data": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "annotations": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": [
+                                              "file_citation",
+                                              "url_citation",
+                                              "container_file_citation",
+                                              "file_path"
+                                            ]
+                                          },
+                                          "index": {
+                                            "type": "integer"
+                                          },
+                                          "file_id": {
+                                            "type": "string"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "start_index": {
+                                            "type": "integer"
+                                          },
+                                          "end_index": {
+                                            "type": "integer"
+                                          },
+                                          "filename": {
+                                            "type": "string"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "container_id": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "logprobs": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "bytes": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "logprob": {
+                                            "type": "number"
+                                          },
+                                          "token": {
+                                            "type": "string"
+                                          },
+                                          "top_logprobs": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "bytes": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "logprob": {
+                                                  "type": "number"
+                                                },
+                                                "token": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "refusal": {
+                                      "type": "string"
+                                    },
+                                    "cache_control": {
+                                      "$ref": "#/components/schemas/CacheControl"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          "call_id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "arguments": {
+                            "type": "string"
+                          },
+                          "output": {
+                            "type": "object"
+                          },
+                          "action": {
+                            "type": "object"
+                          },
+                          "error": {
+                            "type": "string"
+                          },
+                          "queries": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "results": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          },
+                          "summary": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "type",
+                                "text"
+                              ],
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "summary_text"
+                                  ]
+                                },
+                                "text": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "encrypted_content": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "description": "The compacted output — the original user messages plus a final item of type \"response.compaction\" whose encrypted_content holds the opaque compacted state. Pass the full output array as input to a future Responses API request.\n"
+                    },
+                    "usage": {
+                      "type": "object",
+                      "properties": {
+                        "input_tokens": {
+                          "type": "integer"
+                        },
+                        "input_tokens_details": {
+                          "type": "object",
+                          "properties": {
+                            "text_tokens": {
+                              "type": "integer"
+                            },
+                            "audio_tokens": {
+                              "type": "integer"
+                            },
+                            "image_tokens": {
+                              "type": "integer"
+                            },
+                            "cached_read_tokens": {
+                              "type": "integer",
+                              "description": "Tokens served from the prompt cache (cache hit), billed at the reduced cache-read rate. Already included in the parent input_tokens total.\n"
+                            },
+                            "cached_write_tokens": {
+                              "type": "integer",
+                              "description": "Tokens written to the prompt cache on this request, billed at the cache-creation rate. Already included in the parent input_tokens total. Populated for providers that separately report cache write tokens (Anthropic, Bedrock).\n"
+                            }
+                          }
+                        },
+                        "output_tokens": {
+                          "type": "integer"
+                        },
+                        "output_tokens_details": {
+                          "type": "object",
+                          "properties": {
+                            "text_tokens": {
+                              "type": "integer"
+                            },
+                            "accepted_prediction_tokens": {
+                              "type": "integer"
+                            },
+                            "audio_tokens": {
+                              "type": "integer"
+                            },
+                            "reasoning_tokens": {
+                              "type": "integer"
+                            },
+                            "rejected_prediction_tokens": {
+                              "type": "integer"
+                            },
+                            "citation_tokens": {
+                              "type": "integer"
+                            },
+                            "num_search_queries": {
+                              "type": "integer"
+                            }
+                          }
+                        },
+                        "total_tokens": {
+                          "type": "integer"
+                        },
+                        "cost": {
+                          "$ref": "#/components/schemas/BifrostCost"
+                        }
+                      }
+                    },
+                    "extra_fields": {
+                      "$ref": "#/components/schemas/BifrostResponseExtraFields"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
     "/v1/batches": {
       "post": {
         "operationId": "createBatch",
@@ -11408,6 +12152,750 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CountTokensResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/openai/v1/responses/compact": {
+      "post": {
+        "operationId": "openaiCreateCompaction",
+        "summary": "Compact context (OpenAI)",
+        "description": "Compresses a conversation into an opaque compaction item using the OpenAI-compatible\n`/v1/responses/compact` endpoint. Drop-in compatible with the OpenAI SDK.\n\nThe response `output` contains the user messages plus a final item with\n`type: \"response.compaction\"` and `encrypted_content`. Pass this output as `input`\nto future Responses API calls to continue the conversation using the compacted context.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/compact`).\n",
+        "tags": [
+          "OpenAI Integration"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model identifier (e.g., \"gpt-4o\"). When routing through Bifrost's provider-prefixed path, use \"provider/model\" format.\n"
+                  },
+                  "input": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "message",
+                                "file_search_call",
+                                "computer_call",
+                                "computer_call_output",
+                                "web_search_call",
+                                "web_fetch_call",
+                                "function_call",
+                                "function_call_output",
+                                "code_interpreter_call",
+                                "local_shell_call",
+                                "local_shell_call_output",
+                                "mcp_call",
+                                "custom_tool_call",
+                                "custom_tool_call_output",
+                                "image_generation_call",
+                                "mcp_list_tools",
+                                "mcp_approval_request",
+                                "mcp_approval_responses",
+                                "reasoning",
+                                "item_reference",
+                                "refusal"
+                              ]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "in_progress",
+                                "completed",
+                                "incomplete",
+                                "interpreting",
+                                "failed"
+                              ]
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "assistant",
+                                "user",
+                                "system",
+                                "developer"
+                              ]
+                            },
+                            "content": {
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "input_text",
+                                          "input_image",
+                                          "input_file",
+                                          "input_audio",
+                                          "output_text",
+                                          "refusal",
+                                          "reasoning_text"
+                                        ]
+                                      },
+                                      "file_id": {
+                                        "type": "string"
+                                      },
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "signature": {
+                                        "type": "string"
+                                      },
+                                      "image_url": {
+                                        "type": "string"
+                                      },
+                                      "detail": {
+                                        "type": "string"
+                                      },
+                                      "file_data": {
+                                        "type": "string"
+                                      },
+                                      "file_url": {
+                                        "type": "string"
+                                      },
+                                      "filename": {
+                                        "type": "string"
+                                      },
+                                      "file_type": {
+                                        "type": "string"
+                                      },
+                                      "input_audio": {
+                                        "type": "object",
+                                        "required": [
+                                          "format",
+                                          "data"
+                                        ],
+                                        "properties": {
+                                          "format": {
+                                            "type": "string",
+                                            "enum": [
+                                              "mp3",
+                                              "wav"
+                                            ]
+                                          },
+                                          "data": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "annotations": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "file_citation",
+                                                "url_citation",
+                                                "container_file_citation",
+                                                "file_path"
+                                              ]
+                                            },
+                                            "index": {
+                                              "type": "integer"
+                                            },
+                                            "file_id": {
+                                              "type": "string"
+                                            },
+                                            "text": {
+                                              "type": "string"
+                                            },
+                                            "start_index": {
+                                              "type": "integer"
+                                            },
+                                            "end_index": {
+                                              "type": "integer"
+                                            },
+                                            "filename": {
+                                              "type": "string"
+                                            },
+                                            "title": {
+                                              "type": "string"
+                                            },
+                                            "url": {
+                                              "type": "string"
+                                            },
+                                            "container_id": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "logprobs": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "bytes": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "logprob": {
+                                              "type": "number"
+                                            },
+                                            "token": {
+                                              "type": "string"
+                                            },
+                                            "top_logprobs": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "bytes": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "integer"
+                                                    }
+                                                  },
+                                                  "logprob": {
+                                                    "type": "number"
+                                                  },
+                                                  "token": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "refusal": {
+                                        "type": "string"
+                                      },
+                                      "cache_control": {
+                                        "$ref": "#/components/schemas/CacheControl"
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            "call_id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "arguments": {
+                              "type": "string"
+                            },
+                            "output": {
+                              "type": "object"
+                            },
+                            "action": {
+                              "type": "object"
+                            },
+                            "error": {
+                              "type": "string"
+                            },
+                            "queries": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "results": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "summary": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type",
+                                  "text"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "summary_text"
+                                    ]
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "encrypted_content": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "description": "Conversation to compact. Required unless previous_response_id is set. Compaction items (type \"response.compaction\") from prior responses may be included.\n"
+                  },
+                  "instructions": {
+                    "type": "string",
+                    "description": "System instructions that persist across the compacted context."
+                  },
+                  "previous_response_id": {
+                    "type": "string",
+                    "description": "ID of a previous response to extend rather than sending full input."
+                  },
+                  "prompt_cache_key": {
+                    "type": "string"
+                  },
+                  "prompt_cache_retention": {
+                    "type": "string"
+                  },
+                  "service_tier": {
+                    "type": "string"
+                  },
+                  "fallbacks": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Bifrost-specific — fallback model list in provider/model format."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful compaction response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "object": {
+                      "type": "string",
+                      "description": "Always \"response.compaction\"",
+                      "example": "response.compaction"
+                    },
+                    "model": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "integer"
+                    },
+                    "output": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "message",
+                              "file_search_call",
+                              "computer_call",
+                              "computer_call_output",
+                              "web_search_call",
+                              "web_fetch_call",
+                              "function_call",
+                              "function_call_output",
+                              "code_interpreter_call",
+                              "local_shell_call",
+                              "local_shell_call_output",
+                              "mcp_call",
+                              "custom_tool_call",
+                              "custom_tool_call_output",
+                              "image_generation_call",
+                              "mcp_list_tools",
+                              "mcp_approval_request",
+                              "mcp_approval_responses",
+                              "reasoning",
+                              "item_reference",
+                              "refusal"
+                            ]
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "in_progress",
+                              "completed",
+                              "incomplete",
+                              "interpreting",
+                              "failed"
+                            ]
+                          },
+                          "role": {
+                            "type": "string",
+                            "enum": [
+                              "assistant",
+                              "user",
+                              "system",
+                              "developer"
+                            ]
+                          },
+                          "content": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "input_text",
+                                        "input_image",
+                                        "input_file",
+                                        "input_audio",
+                                        "output_text",
+                                        "refusal",
+                                        "reasoning_text"
+                                      ]
+                                    },
+                                    "file_id": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "signature": {
+                                      "type": "string"
+                                    },
+                                    "image_url": {
+                                      "type": "string"
+                                    },
+                                    "detail": {
+                                      "type": "string"
+                                    },
+                                    "file_data": {
+                                      "type": "string"
+                                    },
+                                    "file_url": {
+                                      "type": "string"
+                                    },
+                                    "filename": {
+                                      "type": "string"
+                                    },
+                                    "file_type": {
+                                      "type": "string"
+                                    },
+                                    "input_audio": {
+                                      "type": "object",
+                                      "required": [
+                                        "format",
+                                        "data"
+                                      ],
+                                      "properties": {
+                                        "format": {
+                                          "type": "string",
+                                          "enum": [
+                                            "mp3",
+                                            "wav"
+                                          ]
+                                        },
+                                        "data": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "annotations": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": [
+                                              "file_citation",
+                                              "url_citation",
+                                              "container_file_citation",
+                                              "file_path"
+                                            ]
+                                          },
+                                          "index": {
+                                            "type": "integer"
+                                          },
+                                          "file_id": {
+                                            "type": "string"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "start_index": {
+                                            "type": "integer"
+                                          },
+                                          "end_index": {
+                                            "type": "integer"
+                                          },
+                                          "filename": {
+                                            "type": "string"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "container_id": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "logprobs": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "bytes": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "logprob": {
+                                            "type": "number"
+                                          },
+                                          "token": {
+                                            "type": "string"
+                                          },
+                                          "top_logprobs": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "bytes": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "logprob": {
+                                                  "type": "number"
+                                                },
+                                                "token": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "refusal": {
+                                      "type": "string"
+                                    },
+                                    "cache_control": {
+                                      "$ref": "#/components/schemas/CacheControl"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          "call_id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "arguments": {
+                            "type": "string"
+                          },
+                          "output": {
+                            "type": "object"
+                          },
+                          "action": {
+                            "type": "object"
+                          },
+                          "error": {
+                            "type": "string"
+                          },
+                          "queries": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "results": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          },
+                          "summary": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "type",
+                                "text"
+                              ],
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "summary_text"
+                                  ]
+                                },
+                                "text": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "encrypted_content": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "description": "The compacted output — the original user messages plus a final item of type \"response.compaction\" whose encrypted_content holds the opaque compacted state. Pass the full output array as input to a future Responses API request.\n"
+                    },
+                    "usage": {
+                      "type": "object",
+                      "properties": {
+                        "input_tokens": {
+                          "type": "integer"
+                        },
+                        "input_tokens_details": {
+                          "type": "object",
+                          "properties": {
+                            "text_tokens": {
+                              "type": "integer"
+                            },
+                            "audio_tokens": {
+                              "type": "integer"
+                            },
+                            "image_tokens": {
+                              "type": "integer"
+                            },
+                            "cached_read_tokens": {
+                              "type": "integer",
+                              "description": "Tokens served from the prompt cache (cache hit), billed at the reduced cache-read rate. Already included in the parent input_tokens total.\n"
+                            },
+                            "cached_write_tokens": {
+                              "type": "integer",
+                              "description": "Tokens written to the prompt cache on this request, billed at the cache-creation rate. Already included in the parent input_tokens total. Populated for providers that separately report cache write tokens (Anthropic, Bedrock).\n"
+                            }
+                          }
+                        },
+                        "output_tokens": {
+                          "type": "integer"
+                        },
+                        "output_tokens_details": {
+                          "type": "object",
+                          "properties": {
+                            "text_tokens": {
+                              "type": "integer"
+                            },
+                            "accepted_prediction_tokens": {
+                              "type": "integer"
+                            },
+                            "audio_tokens": {
+                              "type": "integer"
+                            },
+                            "reasoning_tokens": {
+                              "type": "integer"
+                            },
+                            "rejected_prediction_tokens": {
+                              "type": "integer"
+                            },
+                            "citation_tokens": {
+                              "type": "integer"
+                            },
+                            "num_search_queries": {
+                              "type": "integer"
+                            }
+                          }
+                        },
+                        "total_tokens": {
+                          "type": "integer"
+                        },
+                        "cost": {
+                          "$ref": "#/components/schemas/BifrostCost"
+                        }
+                      }
+                    },
+                    "extra_fields": {
+                      "$ref": "#/components/schemas/BifrostResponseExtraFields"
+                    }
+                  }
                 }
               }
             }
@@ -34498,11 +35986,7 @@
             }
           }
         },
-        "security": [
-          {
-            "ManagementBearerAuth": []
-          }
-        ],
+        "security": [],
         "responses": {
           "200": {
             "description": "Login successful",
@@ -34568,6 +36052,9 @@
         "security": [
           {
             "ManagementBearerAuth": []
+          },
+          {
+            "SessionCookieAuth": []
           }
         ],
         "responses": {
@@ -34609,11 +36096,7 @@
         "tags": [
           "Session"
         ],
-        "security": [
-          {
-            "ManagementBearerAuth": []
-          }
-        ],
+        "security": [],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -34649,6 +36132,9 @@
         "security": [
           {
             "ManagementBearerAuth": []
+          },
+          {
+            "SessionCookieAuth": []
           }
         ],
         "responses": {
@@ -38223,11 +39709,7 @@
             }
           }
         ],
-        "security": [
-          {
-            "ManagementBearerAuth": []
-          }
-        ],
+        "security": [],
         "responses": {
           "200": {
             "description": "OAuth authorization successful. Returns HTML page that closes the authorization window.",
@@ -38567,7 +40049,13 @@
         ],
         "security": [
           {
-            "ManagementBearerAuth": []
+            "VirtualKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
           }
         ],
         "responses": {
@@ -39842,14 +41330,71 @@
     "/api/governance/model-configs": {
       "get": {
         "operationId": "listModelConfigs",
-        "summary": "List model configs",
-        "description": "Returns a list of all model configurations with their budget and rate limit settings.",
+        "summary": "List model limits",
+        "description": "Returns a paginated list of model limits with their budget and rate limit settings.",
         "tags": [
           "Governance"
         ],
         "security": [
           {
             "ManagementBearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Number of results to skip (for pagination)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Case-insensitive filter by model name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "description": "Filter by scope (`global` or `virtual_key`)",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "global",
+                "virtual_key"
+              ]
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "description": "Filter by provider name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "from_memory",
+            "in": "query",
+            "description": "If true, returns data from in-memory cache (faster, may lag DB by one poll cycle)",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -54883,6 +56428,12 @@
         "in": "header",
         "name": "x-api-key",
         "description": "API key authentication via the `x-api-key` header.\nVirtual keys (prefixed with `sk-bf-`) can also be passed here.\n"
+      },
+      "SessionCookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "token",
+        "description": "Dashboard session authentication via the HTTPOnly `token` cookie that is\nset by `POST /api/session/login`. Used by the Bifrost UI for same-origin\nrequests in place of an `Authorization` header. Accepted on session\nendpoints (`logout`, `ws-ticket`) as an alternative to the management API key.\n"
       }
     },
     "parameters": {
@@ -69506,15 +71057,47 @@
           },
           "model_name": {
             "type": "string",
-            "description": "Name of the model"
+            "description": "Name of the model. Use `*` to match all models."
           },
           "provider": {
             "type": "string",
             "description": "Provider name (optional - applies to all providers if not specified)"
           },
+          "scope": {
+            "type": "string",
+            "description": "Scope where this limit applies. `global` covers all traffic; `virtual_key` scopes to a single virtual key; `user` scopes to a single user (Enterprise only).",
+            "enum": [
+              "global",
+              "virtual_key",
+              "user"
+            ],
+            "default": "global"
+          },
+          "scope_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the scope target (e.g. virtual key ID or user ID). Required when scope is not `global`."
+          },
+          "scope_name": {
+            "type": "string",
+            "nullable": true,
+            "description": "Resolved human-readable name of the scope target (read-only, set by server)."
+          },
+          "calendar_aligned": {
+            "type": "boolean",
+            "description": "When true, all budgets reset at clean calendar boundaries (midnight UTC for day, Monday for week, 1st for month, Jan 1 for year).",
+            "default": false
+          },
+          "budgets": {
+            "type": "array",
+            "description": "Budget configurations for this model limit. Each entry must have a unique reset_duration.",
+            "items": {
+              "$ref": "#/components/schemas/Budget"
+            }
+          },
           "budget": {
             "$ref": "#/components/schemas/Budget",
-            "description": "Budget configuration for this model"
+            "description": "Deprecated: use `budgets`. Returns the first budget for backward compatibility."
           },
           "rate_limit": {
             "$ref": "#/components/schemas/RateLimit",
@@ -69554,9 +71137,9 @@
               "$ref": "#/components/schemas/ModelConfig"
             }
           },
-          "count": {
+          "total_count": {
             "type": "integer",
-            "description": "Number of model configs returned"
+            "description": "Total number of model configs matching the filter (used for pagination)"
           }
         }
       },
@@ -69569,15 +71152,32 @@
         "properties": {
           "model_name": {
             "type": "string",
-            "description": "Name of the model (required)"
+            "description": "Name of the model (required). Use `*` to match all models."
           },
           "provider": {
             "type": "string",
             "description": "Provider name (optional - applies to all providers if not specified)"
           },
-          "budget": {
-            "$ref": "#/components/schemas/CreateBudgetRequest",
-            "description": "Budget configuration"
+          "scope": {
+            "type": "string",
+            "description": "Scope where this limit applies. Defaults to `global`.",
+            "enum": [
+              "global",
+              "virtual_key",
+              "user"
+            ],
+            "default": "global"
+          },
+          "scope_id": {
+            "type": "string",
+            "description": "ID of the scope target (e.g. virtual key ID or user ID). Required when scope is not `global`."
+          },
+          "budgets": {
+            "type": "array",
+            "description": "Budget lines for this limit. Each entry must have a unique reset_duration.",
+            "items": {
+              "$ref": "#/components/schemas/CreateBudgetRequest"
+            }
           },
           "rate_limit": {
             "$ref": "#/components/schemas/CreateRateLimitRequest",
@@ -69587,7 +71187,7 @@
       },
       "UpdateModelConfigRequest": {
         "type": "object",
-        "description": "Request to update an existing model config",
+        "description": "Request to update an existing model config. Scope and scope_id are identity fields and cannot be changed.",
         "properties": {
           "model_name": {
             "type": "string",
@@ -69597,9 +71197,12 @@
             "type": "string",
             "description": "Provider name"
           },
-          "budget": {
-            "$ref": "#/components/schemas/UpdateBudgetRequest",
-            "description": "Budget configuration"
+          "budgets": {
+            "type": "array",
+            "description": "Full desired set of budgets (reconciled server-side). Send an empty array to remove all budgets.",
+            "items": {
+              "$ref": "#/components/schemas/CreateBudgetRequest"
+            }
           },
           "rate_limit": {
             "$ref": "#/components/schemas/UpdateRateLimitRequest",
@@ -69633,13 +71236,25 @@
             "type": "string",
             "description": "Provider name"
           },
+          "budgets": {
+            "type": "array",
+            "description": "Budget configurations for this provider. Each entry has a unique reset_duration.",
+            "items": {
+              "$ref": "#/components/schemas/Budget"
+            }
+          },
           "budget": {
             "$ref": "#/components/schemas/Budget",
-            "description": "Budget configuration"
+            "description": "Deprecated: use `budgets`. Returns the first budget for backward compatibility."
           },
           "rate_limit": {
             "$ref": "#/components/schemas/RateLimit",
             "description": "Rate limit configuration"
+          },
+          "calendar_aligned": {
+            "type": "boolean",
+            "description": "When true, all budgets reset at clean calendar boundaries (midnight UTC for day, Monday for week, 1st for month, Jan 1 for year).",
+            "default": false
           }
         }
       },
@@ -69663,13 +71278,26 @@
         "type": "object",
         "description": "Request to update provider governance settings",
         "properties": {
+          "budgets": {
+            "type": "array",
+            "nullable": true,
+            "description": "Full desired set of budgets. Pointer-to-slice semantics apply: omitting the field leaves budgets unchanged; sending an empty array `[]` removes all budgets; sending a non-empty array replaces all existing budgets with the provided set.\n",
+            "items": {
+              "$ref": "#/components/schemas/CreateBudgetRequest"
+            }
+          },
           "budget": {
             "$ref": "#/components/schemas/UpdateBudgetRequest",
-            "description": "Budget configuration"
+            "description": "Deprecated: use `budgets`."
           },
           "rate_limit": {
             "$ref": "#/components/schemas/UpdateRateLimitRequest",
             "description": "Rate limit configuration"
+          },
+          "calendar_aligned": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "When true, all budgets reset at clean calendar boundaries. Omit to leave unchanged."
           }
         }
       },

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -177,6 +177,8 @@ paths:
     $ref: './paths/inference/videos.yaml#/video-remix'
   /v1/responses/input_tokens:
     $ref: './paths/inference/count-tokens.yaml#/count-tokens'
+  /v1/responses/compact:
+    $ref: './paths/inference/compaction.yaml#/compact'
   /v1/batches:
     $ref: './paths/inference/batches.yaml#/batches'
   /v1/batches/{batch_id}:
@@ -278,6 +280,10 @@ paths:
     $ref: './paths/integrations/openai/responses.yaml#/azure-responses'
   /openai/v1/responses/input_tokens:
     $ref: './paths/integrations/openai/responses.yaml#/responses-input-tokens'
+
+  # Context Compaction
+  /openai/v1/responses/compact:
+    $ref: './paths/integrations/openai/compaction.yaml#/compact'
 
   # Embeddings
   /openai/v1/embeddings:

--- a/docs/openapi/paths/inference/compaction.yaml
+++ b/docs/openapi/paths/inference/compaction.yaml
@@ -1,0 +1,40 @@
+compact:
+  post:
+    operationId: createCompaction
+    summary: Compact context
+    description: |
+      Compresses a conversation into an opaque encrypted compaction item using the
+      OpenAI-compatible context compaction API.
+
+      The response `output` array contains the original user messages plus a final item
+      with `type: "response.compaction"` and an `encrypted_content` field. Pass the
+      full `output` array as `input` to future Responses API requests to continue the
+      conversation without retransmitting the full history.
+
+      **Supported providers:** OpenAI, Azure OpenAI, xAI. Requests to unsupported
+      providers return a 400 error.
+
+    tags:
+    - Compaction
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/compaction.yaml#/CompactionRequest'
+    responses:
+      '200':
+        description: Successful compaction response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/compaction.yaml#/CompactionResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []

--- a/docs/openapi/paths/integrations/openai/compaction.yaml
+++ b/docs/openapi/paths/integrations/openai/compaction.yaml
@@ -1,0 +1,39 @@
+# OpenAI Integration - Context Compaction Endpoints
+
+compact:
+  post:
+    operationId: openaiCreateCompaction
+    summary: Compact context (OpenAI)
+    description: |
+      Compresses a conversation into an opaque compaction item using the OpenAI-compatible
+      `/v1/responses/compact` endpoint. Drop-in compatible with the OpenAI SDK.
+
+      The response `output` contains the user messages plus a final item with
+      `type: "response.compaction"` and `encrypted_content`. Pass this output as `input`
+      to future Responses API calls to continue the conversation using the compacted context.
+
+      **Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/compact`).
+    tags:
+    - OpenAI Integration
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../../schemas/integrations/openai/compaction.yaml#/OpenAICompactionRequest'
+    responses:
+      '200':
+        description: Successful compaction response
+        content:
+          application/json:
+            schema:
+              $ref: '../../../schemas/integrations/openai/compaction.yaml#/OpenAICompactionResponse'
+      '400':
+        $ref: '../../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []

--- a/docs/openapi/schemas/inference/compaction.yaml
+++ b/docs/openapi/schemas/inference/compaction.yaml
@@ -1,0 +1,59 @@
+# Context Compaction API schemas
+
+CompactionRequest:
+  type: object
+  required:
+    - model
+  properties:
+    model:
+      type: string
+      description: Model in provider/model format (e.g., "openai/gpt-4o")
+    input:
+      $ref: './responses.yaml#/ResponsesRequestInput'
+      description: >
+        Conversation to compact. Required unless previous_response_id is provided.
+        Can be a string or array of ResponsesMessage objects. Compaction items from
+        prior responses (type "response.compaction") may be included in the array.
+    instructions:
+      type: string
+      description: System instructions that persist across the compacted context.
+    previous_response_id:
+      type: string
+      description: ID of a previous response to extend rather than sending full input.
+    prompt_cache_key:
+      type: string
+    prompt_cache_retention:
+      type: string
+    service_tier:
+      type: string
+    fallbacks:
+      type: array
+      items:
+        type: string
+      description: Fallback model list in provider/model format.
+
+CompactionResponse:
+  type: object
+  properties:
+    id:
+      type: string
+    object:
+      type: string
+      description: Always "response.compaction"
+      example: response.compaction
+    model:
+      type: string
+    created_at:
+      type: integer
+    output:
+      type: array
+      items:
+        $ref: './responses.yaml#/ResponsesMessage'
+      description: >
+        The compacted output — the original user messages plus a final item of
+        type "response.compaction" whose encrypted_content holds the opaque compacted
+        state. Pass the full output array as input to a future Responses API request.
+    usage:
+      $ref: './responses.yaml#/ResponsesResponseUsage'
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'

--- a/docs/openapi/schemas/integrations/openai/compaction.yaml
+++ b/docs/openapi/schemas/integrations/openai/compaction.yaml
@@ -1,0 +1,46 @@
+# OpenAI Integration - Context Compaction Schemas
+
+OpenAICompactionRequest:
+  type: object
+  required:
+    - model
+  properties:
+    model:
+      type: string
+      description: >
+        Model identifier (e.g., "gpt-4o"). When routing through Bifrost's provider-prefixed
+        path, use "provider/model" format.
+    input:
+      $ref: '#/OpenAICompactionInput'
+    instructions:
+      type: string
+      description: System instructions that persist across the compacted context.
+    previous_response_id:
+      type: string
+      description: ID of a previous response to extend rather than sending full input.
+    prompt_cache_key:
+      type: string
+    prompt_cache_retention:
+      type: string
+    service_tier:
+      type: string
+    # Bifrost-specific
+    fallbacks:
+      type: array
+      items:
+        type: string
+      description: Bifrost-specific — fallback model list in provider/model format.
+
+OpenAICompactionInput:
+  oneOf:
+    - type: string
+    - type: array
+      items:
+        $ref: '../../inference/responses.yaml#/ResponsesMessage'
+  description: >
+    Conversation to compact. Required unless previous_response_id is set.
+    Compaction items (type "response.compaction") from prior responses may be included.
+
+# Response reuses the inference compaction schema
+OpenAICompactionResponse:
+  $ref: '../../inference/compaction.yaml#/CompactionResponse'

--- a/docs/providers/supported-providers/azure.mdx
+++ b/docs/providers/supported-providers/azure.mdx
@@ -29,6 +29,7 @@ Azure is a cloud provider offering access to OpenAI and Anthropic models through
 | Image Generation | ✅            | ✅        | `/openai/v1/images/generations` |
 | Image Edit       | ✅            | ✅        | `/openai/v1/images/edits`       |
 | Video Generation | ✅            | -         | `/openai/v1/videos`             |
+| Context Compaction | ✅          | -         | `/openai/v1/responses/compact`  |
 | Image Variation  | ❌            | ❌        | -                               |
 | Batch            | ❌            | ❌        | -                               |
 | Text Completions | ❌            | ❌        | -                               |
@@ -993,6 +994,16 @@ Azure routes video generation to OpenAI's Sora models via the Azure OpenAI-compa
 | Delete    | ✅        | `DELETE /v1/videos/{id}`      |
 | List      | ✅        | `GET /v1/videos`              |
 | Remix     | ❌        | Not supported                 |
+
+---
+
+# 9. Context Compaction
+
+Context compaction is supported for OpenAI models on Azure. It follows the same request and response format as [OpenAI Context Compaction](/providers/supported-providers/openai#14-context-compaction).
+
+**Endpoint**: `POST /openai/v1/responses/compact`
+
+Bifrost routes the request to `{endpoint}/openai/v1/responses/compact` using the configured Azure deployment. Deployment mapping and authentication (API key, Entra ID, or managed identity) are applied automatically, identical to the Responses API.
 
 ---
 

--- a/docs/providers/supported-providers/openai.mdx
+++ b/docs/providers/supported-providers/openai.mdx
@@ -24,6 +24,7 @@ OpenAI is the **baseline schema** for Bifrost. When using OpenAI directly, param
 | Files | ✅ | - | `/v1/files` |
 | Batch | ✅ | - | `/v1/batches` |
 | Video Generation | ✅ | - | `/v1/videos` |
+| Context Compaction | ✅ | - | `/v1/responses/compact` |
 | List Models | ✅ | - | `/v1/models` |
 
 ## Setup & Configuration
@@ -552,6 +553,27 @@ GET `/v1/models` - Lists available models with metadata. Model IDs in Bifrost re
 | Delete | `DELETE /v1/videos/{id}` | Removes video job |
 | List jobs | `GET /v1/videos` | Query params: `after`, `limit`, `order` |
 | Remix | `POST /v1/videos/{id}/remix` | Body: `{"prompt": "..."}` |
+
+---
+
+# 14. Context Compaction
+
+Compresses a conversation into an opaque encrypted item that can be reused in future Responses API calls, reducing token costs for long-running conversations.
+
+**Request Parameters**
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `model` | string | ✅ | Model identifier |
+| `input` | string/array | ✅* | Conversation to compact. Required unless `previous_response_id` is set. Accepts the same format as the Responses API `input` field, including prior compaction items (`type: "response.compaction"`). |
+| `previous_response_id` | string | ✅* | ID of a previously stored response to compact instead of sending full input. |
+| `instructions` | string | ❌ | System instructions preserved across the compacted context. |
+| `prompt_cache_key` | string | ❌ | Prompt caching key. |
+| `prompt_cache_retention` | string | ❌ | Cache retention duration. |
+| `service_tier` | string | ❌ | Service tier preference. |
+| `fallbacks` | array | ❌ | Bifrost fallback model list. |
+
+**Endpoint**: `POST /v1/responses/compact`
 
 ---
 

--- a/docs/providers/supported-providers/xai.mdx
+++ b/docs/providers/supported-providers/xai.mdx
@@ -22,6 +22,7 @@ xAI is an **OpenAI-compatible provider** powering the Grok family of models. Bif
 | Responses API | ✅ | ✅ | `/v1/responses` |
 | Text Completions | ✅ | ✅ | `/v1/completions` |
 | Image Generation | ✅ | - | `/v1/images/generations` |
+| Context Compaction | ✅ | - | `/v1/responses/compact` |
 | List Models | ✅ | - | `/v1/models` |
 | Embeddings | ❌ | ❌ | - |
 | Speech (TTS) | ❌ | ❌ | - |
@@ -205,6 +206,16 @@ Responses are unmarshaled directly into `BifrostImageGenerationResponse`.
 # 5. List Models
 
 Lists available xAI models with their capabilities and context lengths.
+
+---
+
+# 6. Context Compaction
+
+xAI supports context compaction via its OpenAI-compatible `/v1/responses/compact` endpoint. Bifrost forwards the request to `https://api.x.ai/v1/responses/compact`.
+
+Request and response format is identical to [OpenAI Context Compaction](/providers/supported-providers/openai#14-context-compaction). The response `output` contains the original user messages plus a final item with `type: "response.compaction"` and `encrypted_content`. Pass this output as `input` to future xAI Responses API calls.
+
+**Endpoint**: `POST /v1/responses/compact`
 
 ---
 


### PR DESCRIPTION
## Summary

Adds OpenAPI documentation for the context compaction API (`POST /v1/responses/compact` and `POST /openai/v1/responses/compact`), which compresses a conversation into an opaque encrypted item that can be reused in future Responses API calls to reduce token costs for long-running conversations. Also documents provider support for OpenAI, Azure OpenAI, and xAI, and includes several governance API schema improvements and auth fixes.

## Changes

- Added `POST /v1/responses/compact` (Compaction tag) and `POST /openai/v1/responses/compact` (OpenAI Integration tag) endpoint definitions to the OpenAPI spec, including full request/response schemas for `CompactionRequest`, `CompactionResponse`, `OpenAICompactionRequest`, and `OpenAICompactionResponse`
- Added new YAML path and schema files for compaction under `paths/inference/compaction.yaml`, `paths/integrations/openai/compaction.yaml`, `schemas/inference/compaction.yaml`, and `schemas/integrations/openai/compaction.yaml`
- Documented context compaction support in the OpenAI, Azure, and xAI provider pages, including request parameters, endpoint paths, and routing behavior
- Added `SessionCookieAuth` security scheme (HTTPOnly `token` cookie set by `POST /api/session/login`) and applied it to `logout` and `ws-ticket` endpoints as an alternative to the management API key
- Removed `ManagementBearerAuth` requirement from the login, session check, and OAuth callback endpoints (which are unauthenticated by design)
- Updated the model limits (`/api/governance/model-configs`) list endpoint to support pagination (`limit`, `offset`), filtering (`search`, `scope`, `provider`, `from_memory`), and renamed `count` to `total_count`
- Extended `ModelConfig`, `CreateModelConfigRequest`, `UpdateModelConfigRequest`, and provider governance schemas to support `scope`, `scope_id`, `scope_name`, `calendar_aligned`, and a `budgets` array (replacing the single `budget` field, which is retained as a deprecated backward-compatibility alias)
- Updated the `model_name` field description to note that `*` matches all models
- Corrected the security definition on the model usage endpoint to use `VirtualKeyAuth`, `BearerAuth`, and `ApiKeyAuth` instead of `ManagementBearerAuth`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Validate the compiled OpenAPI spec renders correctly and all `$ref` paths resolve without errors:

```sh
# Lint/validate the OpenAPI spec
npx @redocly/cli lint docs/openapi/openapi.yaml

# Confirm the compiled openapi.json matches the YAML sources
npx @redocly/cli bundle docs/openapi/openapi.yaml -o /tmp/compiled.json
diff /tmp/compiled.json docs/openapi/openapi.json
```

Verify the new compaction endpoints appear in the rendered docs under the **Compaction** and **OpenAI Integration** tags, and that the Azure and xAI provider pages show the context compaction section.

## Screenshots/Recordings

N/A — documentation-only change.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The `SessionCookieAuth` scheme uses an HTTPOnly cookie (`token`) set at login, scoped to same-origin dashboard requests. It is accepted only on session management endpoints (`logout`, `ws-ticket`) as an alternative to the management bearer token. No new secrets or PII handling is introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Context Compaction endpoints for the Responses API (standard and OpenAI-compatible POST /responses/compact)
  * Added SessionCookieAuth (HTTP-only cookie) session auth scheme

* **API Updates**
  * Expanded governance routing rule endpoints with updated auth requirements
  * Refined model governance/config schemas: added total_count, introduced budgets array (deprecated single budget kept), and clarified calendar_aligned/budget reconciliation semantics

* **Documentation**
  * Added Context Compaction guides for OpenAI, Azure, and xAI providers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->