### PR TITLE
feat: add business unit CRUD, team assignment, and governance endpoints to OpenAPI spec

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -40926,6 +40926,1008 @@
         }
       }
     },
+    "/api/governance/business-units": {
+      "get": {
+        "operationId": "listBusinessUnits",
+        "summary": "List business units",
+        "description": "Returns a paginated list of business units, each with its team count.",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (1-based)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of business units to return (max 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Case-insensitive search by business unit name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Paginated list of business units",
+                  "required": [
+                    "business_units",
+                    "total",
+                    "page",
+                    "limit"
+                  ],
+                  "properties": {
+                    "business_units": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "Business unit summary as returned in list responses",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "team_count": {
+                            "type": "integer"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createBusinessUnit",
+        "summary": "Create business unit",
+        "description": "Creates a new business unit. Names must be unique.",
+        "tags": [
+          "Governance"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Create business unit request",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Business unit created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Response for business unit create/update operations",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A business unit with this name already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/governance/business-units/{id}": {
+      "get": {
+        "operationId": "getBusinessUnit",
+        "summary": "Get business unit",
+        "description": "Returns a specific business unit by ID, including governance and team count.",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Business unit ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Single business unit with governance and team count",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "team_count": {
+                      "type": "integer"
+                    },
+                    "budget": {
+                      "$ref": "#/components/schemas/Budget"
+                    },
+                    "rate_limit": {
+                      "$ref": "#/components/schemas/RateLimit"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Business unit not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteBusinessUnit",
+        "summary": "Delete business unit",
+        "description": "Deletes a business unit. Any teams assigned to it are atomically unassigned\nas part of the deletion.\n",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Business unit ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Business unit deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Business unit not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/governance/business-units/{id}/teams": {
+      "get": {
+        "operationId": "listBusinessUnitTeams",
+        "summary": "List business unit teams",
+        "description": "Returns a paginated list of teams assigned to the business unit.",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Business unit ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (1-based)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of teams to return (max 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Case-insensitive search by team name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Paginated list of teams assigned to a business unit",
+                  "required": [
+                    "teams",
+                    "total",
+                    "page",
+                    "limit"
+                  ],
+                  "properties": {
+                    "teams": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Business unit not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "assignTeamToBusinessUnit",
+        "summary": "Assign team to business unit",
+        "description": "Assigns an existing team to the business unit. Returns 409 if the team is\nalready assigned to a different business unit.\n",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Business unit ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Request to assign a team to a business unit",
+                "required": [
+                  "team_id"
+                ],
+                "properties": {
+                  "team_id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team assigned to business unit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Business unit or team not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Team is already assigned to another business unit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/governance/business-units/{id}/teams/{team_id}": {
+      "delete": {
+        "operationId": "removeTeamFromBusinessUnit",
+        "summary": "Remove team from business unit",
+        "description": "Unassigns a team from the business unit.",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Business unit ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "description": "Team ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team removed from business unit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Business unit or team not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/governance/business-units/{id}/governance": {
+      "post": {
+        "operationId": "createBusinessUnitGovernance",
+        "summary": "Create business unit governance",
+        "description": "Configures budget and/or rate limit governance for a business unit. At least\none of `budget` or `rate_limit` is required. Returns 409 if the business unit\nalready has governance configured (use PUT to update).\n",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Business unit ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Create business unit governance request. The business unit is identified by\nthe {id} path parameter. At least one of budget or rate_limit is required.\n",
+                "anyOf": [
+                  {
+                    "required": [
+                      "budget"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "rate_limit"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "budget": {
+                    "$ref": "#/components/schemas/CreateBudgetRequest"
+                  },
+                  "rate_limit": {
+                    "$ref": "#/components/schemas/CreateRateLimitRequest"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Business unit governance created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Business unit governance operation response",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "business_unit": {
+                      "type": "object",
+                      "description": "Business unit configuration with governance association",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "source_id": {
+                          "type": "string",
+                          "description": "External source identifier (e.g. from SCIM provisioning)"
+                        },
+                        "profile": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "nullable": true
+                        },
+                        "config": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "nullable": true
+                        },
+                        "claims": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "nullable": true
+                        },
+                        "budget_id": {
+                          "type": "string"
+                        },
+                        "rate_limit_id": {
+                          "type": "string"
+                        },
+                        "budget": {
+                          "$ref": "#/components/schemas/Budget"
+                        },
+                        "rate_limit": {
+                          "$ref": "#/components/schemas/RateLimit"
+                        },
+                        "config_hash": {
+                          "type": "string"
+                        },
+                        "created_by_user_id": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Business unit not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Business unit already has governance configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateBusinessUnitGovernance",
+        "summary": "Update business unit governance",
+        "description": "Updates budget and/or rate limit governance for a business unit. Passing an\nempty `budget` or `rate_limit` object removes that governance component.\n",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Business unit ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Update business unit governance request. Passing an empty budget or rate_limit\nobject removes that governance component.\n",
+                "properties": {
+                  "budget": {
+                    "$ref": "#/components/schemas/UpdateBudgetRequest"
+                  },
+                  "rate_limit": {
+                    "$ref": "#/components/schemas/UpdateRateLimitRequest"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Business unit governance updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Business unit governance operation response",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "business_unit": {
+                      "type": "object",
+                      "description": "Business unit configuration with governance association",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "source_id": {
+                          "type": "string",
+                          "description": "External source identifier (e.g. from SCIM provisioning)"
+                        },
+                        "profile": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "nullable": true
+                        },
+                        "config": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "nullable": true
+                        },
+                        "claims": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "nullable": true
+                        },
+                        "budget_id": {
+                          "type": "string"
+                        },
+                        "rate_limit_id": {
+                          "type": "string"
+                        },
+                        "budget": {
+                          "$ref": "#/components/schemas/Budget"
+                        },
+                        "rate_limit": {
+                          "$ref": "#/components/schemas/RateLimit"
+                        },
+                        "config_hash": {
+                          "type": "string"
+                        },
+                        "created_by_user_id": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Business unit not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteBusinessUnitGovernance",
+        "summary": "Delete business unit governance",
+        "description": "Removes all budget and rate limit governance from a business unit.",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Business unit ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Business unit governance deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Business unit not found or has no governance configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/governance/budgets": {
       "get": {
         "operationId": "listBudgets",
@@ -41370,12 +42372,13 @@
           {
             "name": "scope",
             "in": "query",
-            "description": "Filter by scope (`global` or `virtual_key`)",
+            "description": "Filter by scope (`global`, `virtual_key`, or `user`; `user` is Enterprise only)",
             "schema": {
               "type": "string",
               "enum": [
                 "global",
-                "virtual_key"
+                "virtual_key",
+                "user"
               ]
             }
           },

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -824,6 +824,18 @@ paths:
   /api/governance/customers/{customer_id}:
     $ref: './paths/management/governance.yaml#/customers-by-id'
 
+  # Governance - Business Units (Enterprise)
+  /api/governance/business-units:
+    $ref: './paths/management/businessunits.yaml#/business-units'
+  /api/governance/business-units/{id}:
+    $ref: './paths/management/businessunits.yaml#/business-units-by-id'
+  /api/governance/business-units/{id}/teams:
+    $ref: './paths/management/businessunits.yaml#/business-units-teams'
+  /api/governance/business-units/{id}/teams/{team_id}:
+    $ref: './paths/management/businessunits.yaml#/business-units-team-by-id'
+  /api/governance/business-units/{id}/governance:
+    $ref: './paths/management/businessunits.yaml#/business-units-governance'
+
   # Governance - Budgets and Rate Limits
   /api/governance/budgets:
     $ref: './paths/management/governance.yaml#/budgets'

--- a/docs/openapi/paths/management/businessunits.yaml
+++ b/docs/openapi/paths/management/businessunits.yaml
@@ -1,0 +1,410 @@
+# Paths for Business Unit management (Enterprise).
+#
+# Business units are organizational groupings above teams (1:N with teams) with
+# their own governance (budget + rate limit). They live entirely under
+# /api/governance/business-units, mirroring the other governance entities; the
+# budget + rate-limit configuration is nested under /{id}/governance. Implemented
+# in bifrost-enterprise/handlers/businessunits.go.
+
+# ---- Business Unit CRUD ----
+
+business-units:
+  get:
+    operationId: listBusinessUnits
+    summary: List business units
+    description: Returns a paginated list of business units, each with its team count.
+    tags:
+      - Governance
+    parameters:
+      - name: page
+        in: query
+        description: Page number (1-based)
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+      - name: limit
+        in: query
+        description: Maximum number of business units to return (max 100)
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 20
+      - name: search
+        in: query
+        description: Case-insensitive search by business unit name
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/ListBusinessUnitsResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  post:
+    operationId: createBusinessUnit
+    summary: Create business unit
+    description: Creates a new business unit. Names must be unique.
+    tags:
+      - Governance
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/governance.yaml#/CreateBusinessUnitRequest'
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Business unit created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/BusinessUnitMutationResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '409':
+        description: A business unit with this name already exists
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+business-units-by-id:
+  get:
+    operationId: getBusinessUnit
+    summary: Get business unit
+    description: Returns a specific business unit by ID, including governance and team count.
+    tags:
+      - Governance
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Business unit ID
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/BusinessUnitDetailResponse'
+      '404':
+        description: Business unit not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  delete:
+    operationId: deleteBusinessUnit
+    summary: Delete business unit
+    description: |
+      Deletes a business unit. Any teams assigned to it are atomically unassigned
+      as part of the deletion.
+    tags:
+      - Governance
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Business unit ID
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Business unit deleted successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/MessageResponse'
+      '404':
+        description: Business unit not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+# ---- Business Unit - Team Association ----
+
+business-units-teams:
+  get:
+    operationId: listBusinessUnitTeams
+    summary: List business unit teams
+    description: Returns a paginated list of teams assigned to the business unit.
+    tags:
+      - Governance
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Business unit ID
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: Page number (1-based)
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+      - name: limit
+        in: query
+        description: Maximum number of teams to return (max 100)
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 20
+      - name: search
+        in: query
+        description: Case-insensitive search by team name
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/BusinessUnitTeamsResponse'
+      '404':
+        description: Business unit not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  post:
+    operationId: assignTeamToBusinessUnit
+    summary: Assign team to business unit
+    description: |
+      Assigns an existing team to the business unit. Returns 409 if the team is
+      already assigned to a different business unit.
+    tags:
+      - Governance
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Business unit ID
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/governance.yaml#/AssignTeamToBusinessUnitRequest'
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Team assigned to business unit
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/MessageResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Business unit or team not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '409':
+        description: Team is already assigned to another business unit
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+business-units-team-by-id:
+  delete:
+    operationId: removeTeamFromBusinessUnit
+    summary: Remove team from business unit
+    description: Unassigns a team from the business unit.
+    tags:
+      - Governance
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Business unit ID
+        schema:
+          type: string
+      - name: team_id
+        in: path
+        required: true
+        description: Team ID
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Team removed from business unit
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/MessageResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Business unit or team not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+# ---- Business Unit Governance (budget + rate limit) ----
+
+business-units-governance:
+  post:
+    operationId: createBusinessUnitGovernance
+    summary: Create business unit governance
+    description: |
+      Configures budget and/or rate limit governance for a business unit. At least
+      one of `budget` or `rate_limit` is required. Returns 409 if the business unit
+      already has governance configured (use PUT to update).
+    tags:
+      - Governance
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Business unit ID
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/governance.yaml#/CreateBusinessUnitGovernanceRequest'
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Business unit governance created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/BusinessUnitGovernanceResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Business unit not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '409':
+        description: Business unit already has governance configured
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  put:
+    operationId: updateBusinessUnitGovernance
+    summary: Update business unit governance
+    description: |
+      Updates budget and/or rate limit governance for a business unit. Passing an
+      empty `budget` or `rate_limit` object removes that governance component.
+    tags:
+      - Governance
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Business unit ID
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/governance.yaml#/UpdateBusinessUnitGovernanceRequest'
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Business unit governance updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/BusinessUnitGovernanceResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Business unit not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  delete:
+    operationId: deleteBusinessUnitGovernance
+    summary: Delete business unit governance
+    description: Removes all budget and rate limit governance from a business unit.
+    tags:
+      - Governance
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Business unit ID
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Business unit governance deleted successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/MessageResponse'
+      '404':
+        description: Business unit not found or has no governance configured
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'

--- a/docs/openapi/paths/management/governance.yaml
+++ b/docs/openapi/paths/management/governance.yaml
@@ -835,10 +835,10 @@ model-configs:
           type: string
       - name: scope
         in: query
-        description: Filter by scope (`global` or `virtual_key`)
+        description: Filter by scope (`global`, `virtual_key`, or `user`; `user` is Enterprise only)
         schema:
           type: string
-          enum: [global, virtual_key]
+          enum: [global, virtual_key, user]
       - name: provider
         in: query
         description: Filter by provider name

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -685,6 +685,194 @@ CustomerResponse:
     customer:
       $ref: '#/Customer'
 
+# Business Units (Enterprise)
+
+BusinessUnit:
+  type: object
+  description: Business unit configuration with governance association
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    source_id:
+      type: string
+      description: External source identifier (e.g. from SCIM provisioning)
+    profile:
+      type: object
+      additionalProperties: true
+      nullable: true
+    config:
+      type: object
+      additionalProperties: true
+      nullable: true
+    claims:
+      type: object
+      additionalProperties: true
+      nullable: true
+    budget_id:
+      type: string
+    rate_limit_id:
+      type: string
+    budget:
+      $ref: '#/Budget'
+    rate_limit:
+      $ref: '#/RateLimit'
+    config_hash:
+      type: string
+    created_by_user_id:
+      type: string
+    created_at:
+      type: string
+      format: date-time
+    updated_at:
+      type: string
+      format: date-time
+
+BusinessUnitListItem:
+  type: object
+  description: Business unit summary as returned in list responses
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    team_count:
+      type: integer
+    created_at:
+      type: string
+      format: date-time
+    updated_at:
+      type: string
+      format: date-time
+
+ListBusinessUnitsResponse:
+  type: object
+  description: Paginated list of business units
+  required:
+    - business_units
+    - total
+    - page
+    - limit
+  properties:
+    business_units:
+      type: array
+      items:
+        $ref: '#/BusinessUnitListItem'
+    total:
+      type: integer
+    page:
+      type: integer
+    limit:
+      type: integer
+
+BusinessUnitDetailResponse:
+  type: object
+  description: Single business unit with governance and team count
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    team_count:
+      type: integer
+    budget:
+      $ref: '#/Budget'
+    rate_limit:
+      $ref: '#/RateLimit'
+    created_at:
+      type: string
+      format: date-time
+    updated_at:
+      type: string
+      format: date-time
+
+CreateBusinessUnitRequest:
+  type: object
+  description: Create business unit request
+  required:
+    - name
+  properties:
+    name:
+      type: string
+
+BusinessUnitMutationResponse:
+  type: object
+  description: Response for business unit create/update operations
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+
+AssignTeamToBusinessUnitRequest:
+  type: object
+  description: Request to assign a team to a business unit
+  required:
+    - team_id
+  properties:
+    team_id:
+      type: string
+
+BusinessUnitTeamsResponse:
+  type: object
+  description: Paginated list of teams assigned to a business unit
+  required:
+    - teams
+    - total
+    - page
+    - limit
+  properties:
+    teams:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+    total:
+      type: integer
+    page:
+      type: integer
+    limit:
+      type: integer
+
+CreateBusinessUnitGovernanceRequest:
+  type: object
+  description: |
+    Create business unit governance request. The business unit is identified by
+    the {id} path parameter. At least one of budget or rate_limit is required.
+  anyOf:
+    - required: [budget]
+    - required: [rate_limit]
+  properties:
+    budget:
+      $ref: '#/CreateBudgetRequest'
+    rate_limit:
+      $ref: '#/CreateRateLimitRequest'
+
+UpdateBusinessUnitGovernanceRequest:
+  type: object
+  description: |
+    Update business unit governance request. Passing an empty budget or rate_limit
+    object removes that governance component.
+  properties:
+    budget:
+      $ref: '#/UpdateBudgetRequest'
+    rate_limit:
+      $ref: '#/UpdateRateLimitRequest'
+
+BusinessUnitGovernanceResponse:
+  type: object
+  description: Business unit governance operation response
+  properties:
+    message:
+      type: string
+    business_unit:
+      $ref: '#/BusinessUnit'
+
 TableKey:
   type: object
   description: Table key configuration


### PR DESCRIPTION
## Summary

Introduces Business Units as a new Enterprise governance entity — an organizational grouping that sits above teams (one business unit to many teams) and supports its own budget and rate limit governance. Also expands model config limits with multi-budget support, scoping (global/virtual_key/user), and calendar-aligned resets, and adds a `SessionCookieAuth` security scheme for dashboard session endpoints.

## Changes

- Added a full CRUD API for business units under `/api/governance/business-units`, including list (paginated, searchable), create, get, update, and delete operations.
- Added team assignment endpoints (`POST /api/governance/business-units/{id}/teams` and `DELETE /api/governance/business-units/{id}/teams/{teamId}`) to associate and unassociate teams from a business unit. A team can only belong to one business unit at a time (409 on conflict).
- Added governance sub-resource endpoints (`POST/PUT/DELETE /api/governance/business-units/{id}/governance`) to configure, update, and remove budget and rate limit governance on a business unit.
- Replaced the single `budget` field on `ModelConfig`, `CreateModelConfigRequest`, `UpdateModelConfigRequest`, and provider governance schemas with a `budgets` array supporting multiple budget lines per model limit, each with a unique `reset_duration`. The legacy `budget` field is retained for backward compatibility.
- Added `scope` (`global`, `virtual_key`, `user`) and `scope_id` fields to model config schemas to allow per-virtual-key and per-user model limits.
- Added `calendar_aligned` flag to model config and provider governance schemas to enable budget resets at clean calendar boundaries.
- Renamed `count` to `total_count` in `ListModelConfigsResponse` to better reflect its role in pagination.
- Updated `listModelConfigs` to be paginated with `limit`, `offset`, `search`, `scope`, `provider`, and `from_memory` query parameters.
- Removed `ManagementBearerAuth` requirement from the session login, session info, and OAuth callback endpoints (they are now unauthenticated or use other mechanisms).
- Added `SessionCookieAuth` as an accepted security scheme on session logout and WebSocket ticket endpoints, alongside `ManagementBearerAuth`.
- Updated the `/api/keys/virtual` endpoint to accept `VirtualKeyAuth`, `BearerAuth`, and `ApiKeyAuth` instead of `ManagementBearerAuth`.
- Added the `SessionCookieAuth` security scheme definition (HTTPOnly `token` cookie set by the login endpoint).
- Added new OpenAPI source files: `docs/openapi/paths/management/businessunits.yaml` and corresponding schemas in `docs/openapi/schemas/management/governance.yaml`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./...
```

- Create a business unit via `POST /api/governance/business-units` and verify it is returned by `GET /api/governance/business-units`.
- Assign a team to the business unit and confirm a 409 is returned when attempting to assign the same team to a different business unit.
- Configure governance on the business unit via `POST /api/governance/business-units/{id}/governance` and verify budget/rate limit are reflected in `GET /api/governance/business-units/{id}`.
- Delete the business unit and confirm assigned teams are unassigned atomically.
- Create a model config with multiple `budgets` entries and verify the legacy `budget` field still returns the first entry.
- Verify that session login and OAuth callback endpoints no longer require a management bearer token.
- Verify that session logout accepts both `ManagementBearerAuth` and the `token` session cookie.

## Breaking changes

- [x] Yes
- [ ] No

`count` in `ListModelConfigsResponse` has been renamed to `total_count`. Clients reading this field will need to update accordingly. The legacy `budget` field on model config and provider governance responses is deprecated in favour of `budgets` but remains present for backward compatibility.

## Related issues

## Security considerations

The session login and OAuth callback endpoints have had `ManagementBearerAuth` removed, making them publicly accessible as intended for unauthenticated flows. The new `SessionCookieAuth` scheme uses an HTTPOnly cookie, limiting XSS exposure for dashboard session authentication.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Business Units management (CRUD), team assignment/removal, and governance (budget/rate-limit) endpoints.
  * Business Unit governance supports create/update/delete of budget and rate-limit associations.

* **Documentation**
  * API docs updated for new endpoints, paginated responses, and request/response shapes.
  * Expanded scope options for model-configs listing to include "user" (Enterprise-only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->