### PR TITLE
chore: fix radius of otel form to rounded-sm

### DIFF
--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -314,7 +314,7 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 	const collectorPreview = collectorUrl?.from_env ? collectorUrl.env_var : collectorUrl?.value;
 
 	return (
-		<Collapsible open={open} onOpenChange={onOpenChange} className="rounded-lg border" data-testid={`otel-profile-${index}`}>
+		<Collapsible open={open} onOpenChange={onOpenChange} className="rounded-sm border" data-testid={`otel-profile-${index}`}>
 			<div className="flex flex-row items-center gap-2 px-4 py-3">
 				<CollapsibleTrigger asChild>
 					<button type="button" className="flex min-w-0 flex-1 items-center gap-2 text-left">


### PR DESCRIPTION
## Summary

Updates the border radius styling on the OTel profile collapsible section from `rounded-lg` to `rounded-sm` for a more subtle, consistent appearance.

## Changes

- Changed the border radius of the `OtelProfileSection` collapsible container from `rounded-lg` to `rounded-sm`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Navigate to the Observability settings page and verify the OTel profile section displays with a smaller border radius.

## Screenshots/Recordings

Before/after screenshots of the OTel profile collapsible section showing the border radius difference.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined corner styling in observability interface components for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->