### PR TITLE
plugin test fixes

### DIFF
--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -1479,17 +1479,69 @@ func (s *RedisStore) DeleteNamespace(ctx context.Context, namespace string) erro
 	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
-	// Drop the index using FT.DROPINDEX
-	if err := s.client.Do(ctx, "FT.DROPINDEX", namespace).Err(); err != nil {
+	// Drop the index AND its documents using FT.DROPINDEX ... DD. Without DD,
+	// only the index definition is removed while the underlying hashes (keyed
+	// by the "<namespace>:" prefix this index owns) survive - so recreating the
+	// namespace re-indexes the stale documents. DD deletes exactly the documents
+	// matching this index's prefix, keeping DeleteNamespace consistent with the
+	// collection-deleting semantics of the other vector store backends.
+	if err := s.client.Do(ctx, "FT.DROPINDEX", namespace, "DD").Err(); err != nil {
 		// Check if error is "Unknown Index name" - that's OK, index doesn't exist
 		if strings.Contains(strings.ToLower(err.Error()), "unknown index name") {
 			s.deleteNamespaceFieldTypes(namespace)
-			return nil // Index doesn't exist, nothing to drop
+			// The index is gone, so FT.DROPINDEX ... DD could not reach any
+			// documents. Hashes written under the "<namespace>:" prefix by a
+			// prior run (e.g. one that dropped the index without DD) may still
+			// linger; sweep them directly so a recreated namespace starts empty.
+			return s.deleteNamespaceKeys(ctx, namespace)
 		}
 		return fmt.Errorf("failed to drop semantic index %s: %w", namespace, err)
 	}
 
 	s.deleteNamespaceFieldTypes(namespace)
+	return nil
+}
+
+// deleteNamespaceKeys removes every hash stored under the "<namespace>:" prefix.
+//
+// It is the fallback path for DeleteNamespace when the search index no longer
+// exists: the normal path relies on FT.DROPINDEX ... DD to delete the indexed
+// documents, but with no index present that command cannot reach them, leaving
+// orphaned hashes that would be re-indexed (and surface as stale cache hits)
+// the next time the namespace is created. On a Redis Cluster the work is fanned
+// out across every master so all hash slots are covered; on a single node it
+// runs directly against the client.
+func (s *RedisStore) deleteNamespaceKeys(ctx context.Context, namespace string) error {
+	if clusterClient, ok := s.client.(*redis.ClusterClient); ok {
+		return clusterClient.ForEachMaster(ctx, func(ctx context.Context, nodeClient *redis.Client) error {
+			return s.deleteNamespaceKeysSingle(ctx, nodeClient, namespace)
+		})
+	}
+	return s.deleteNamespaceKeysSingle(ctx, s.client, namespace)
+}
+
+// deleteNamespaceKeysSingle SCANs a single Redis node for keys matching the
+// "<namespace>:*" pattern and DELs them in cursor-sized batches until the scan
+// cursor wraps to 0. It operates on one node only; callers handle cluster
+// fan-out. A missing key set is not an error - the loop simply deletes nothing.
+func (s *RedisStore) deleteNamespaceKeysSingle(ctx context.Context, client redis.Cmdable, namespace string) error {
+	pattern := buildKey(namespace, "*")
+	var scanCursor uint64
+	for {
+		keys, nextCursor, err := client.Scan(ctx, scanCursor, pattern, BatchLimit).Result()
+		if err != nil {
+			return fmt.Errorf("failed to scan keys for namespace %s: %w", namespace, err)
+		}
+		if len(keys) > 0 {
+			if err := client.Del(ctx, keys...).Err(); err != nil {
+				return fmt.Errorf("failed to delete keys for namespace %s: %w", namespace, err)
+			}
+		}
+		scanCursor = nextCursor
+		if scanCursor == 0 {
+			break
+		}
+	}
 	return nil
 }
 

--- a/plugins/semanticcache/main_test.go
+++ b/plugins/semanticcache/main_test.go
@@ -23,17 +23,34 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// dropSharedTestNamespace removes the shared test namespace from EVERY vector
+// store backend the suite exercises - not just Weaviate. Redis, Qdrant, and
+// Pinecone are persistent external services, so a deterministic per-t.Name()
+// cache_key written by one run is still present on the next run (within TTL)
+// and surfaces as a spurious cache hit on the first request. Sweeping all
+// backends here is the suite's only cleanup, since clearTestKeysWithStore is a
+// no-op. Stores that aren't configured/reachable in this environment are
+// skipped silently.
 func dropSharedTestNamespace() {
-	cfg := getWeaviateConfigFromEnv()
-	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
-		Type:    vectorstore.VectorStoreTypeWeaviate,
-		Config:  cfg,
-		Enabled: true,
-	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
-	if err != nil {
-		return
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	for _, tc := range getVectorStoreTestCases() {
+		storeConfig, ok := storeConfigForType(tc.StoreType)
+		if !ok {
+			continue
+		}
+		func() {
+			store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+				Type:    tc.StoreType,
+				Config:  storeConfig,
+				Enabled: true,
+			}, logger)
+			if err != nil {
+				return // backend not configured/available in this environment
+			}
+			defer store.Close(context.Background(), SharedTestNamespace)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = store.DeleteNamespace(ctx, SharedTestNamespace)
+		}()
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	_ = store.DeleteNamespace(ctx, SharedTestNamespace)
 }

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -15,6 +15,41 @@ import (
 	mocker "github.com/maximhq/bifrost/plugins/mocker"
 )
 
+// embeddingThrottle bounds the number of concurrent live embedding calls
+// across every parallel test in the process. The semantic cache plugin embeds
+// each request against real OpenAI for similarity search; with no cap, the
+// burst from many t.Parallel() tests trips OpenAI's embeddings rate limit
+// (429), and each affected test then self-skips via the "upstream request
+// error" guard - silently hiding dozens of tests. A small cap smooths the
+// burst so the test account's retry/backoff (MaxRetries in GetConfigForProvider)
+// can absorb any residual throttling. Override with
+// SEMCACHE_TEST_EMBED_CONCURRENCY; defaults to 2.
+var embeddingThrottle = make(chan struct{}, embeddingConcurrency())
+
+func embeddingConcurrency() int {
+	if v := os.Getenv("SEMCACHE_TEST_EMBED_CONCURRENCY"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 2
+}
+
+// throttledEmbeddingExecutor wraps an EmbeddingRequestExecutor with the
+// package-level concurrency cap above so embedding bursts stay under the
+// provider's rate limit regardless of the test runner or -parallel setting.
+func throttledEmbeddingExecutor(inner EmbeddingRequestExecutor) EmbeddingRequestExecutor {
+	return func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		select {
+		case embeddingThrottle <- struct{}{}:
+		case <-ctx.Done():
+			return nil, &schemas.BifrostError{Error: &schemas.ErrorField{Message: "embedding throttle wait cancelled: " + ctx.Err().Error()}}
+		}
+		defer func() { <-embeddingThrottle }()
+		return inner(ctx, req)
+	}
+}
+
 // isTransientUpstreamError reports whether a BifrostError reflects a
 // transient upstream condition (timeout, rate-limit, 5xx) where skipping
 // the test is reasonable. All other errors — including missing API keys,
@@ -157,6 +192,25 @@ func getPineconeConfigFromEnv() vectorstore.PineconeConfig {
 	return vectorstore.PineconeConfig{
 		APIKey:    *apiKey,
 		IndexHost: *indexHost,
+	}
+}
+
+// storeConfigForType returns the env-derived connection config for a vector
+// store type. The bool is false for an unrecognized type. Shared by test setup
+// and the TestMain namespace sweep so both stay in lockstep when a new backend
+// is added.
+func storeConfigForType(storeType vectorstore.VectorStoreType) (interface{}, bool) {
+	switch storeType {
+	case vectorstore.VectorStoreTypeWeaviate:
+		return getWeaviateConfigFromEnv(), true
+	case vectorstore.VectorStoreTypeRedis:
+		return getRedisConfigFromEnv(), true
+	case vectorstore.VectorStoreTypeQdrant:
+		return getQdrantConfigFromEnv(), true
+	case vectorstore.VectorStoreTypePinecone:
+		return getPineconeConfigFromEnv(), true
+	default:
+		return nil, false
 	}
 }
 
@@ -463,17 +517,8 @@ func NewTestSetupWithVectorStore(t *testing.T, config *Config, storeType vectors
 	}
 
 	// Get the appropriate config for the vector store type
-	var storeConfig interface{}
-	switch storeType {
-	case vectorstore.VectorStoreTypeWeaviate:
-		storeConfig = getWeaviateConfigFromEnv()
-	case vectorstore.VectorStoreTypeRedis:
-		storeConfig = getRedisConfigFromEnv()
-	case vectorstore.VectorStoreTypeQdrant:
-		storeConfig = getQdrantConfigFromEnv()
-	case vectorstore.VectorStoreTypePinecone:
-		storeConfig = getPineconeConfigFromEnv()
-	default:
+	storeConfig, ok := storeConfigForType(storeType)
+	if !ok {
 		t.Fatalf("Unsupported vector store type: %s", storeType)
 	}
 
@@ -508,7 +553,7 @@ func NewTestSetupWithVectorStore(t *testing.T, config *Config, storeType vectors
 	client := getMockedBifrostClient(t, ctx, logger, plugin)
 
 	// Wire the global client as the embedding executor so semantic search works.
-	pluginImpl.SetEmbeddingRequestExecutor(client.EmbeddingRequest)
+	pluginImpl.SetEmbeddingRequestExecutor(throttledEmbeddingExecutor(client.EmbeddingRequest))
 
 	return &TestSetup{
 		Logger: logger,


### PR DESCRIPTION
## Summary

`DeleteNamespace` on the Redis vector store previously called `FT.DROPINDEX` without the `DD` flag, which removed only the index definition while leaving the underlying hash keys in place. On the next namespace creation those orphaned hashes were re-indexed and surfaced as stale cache hits. This PR fixes that by passing `DD` to `FT.DROPINDEX` so documents are deleted alongside the index, and adds a fallback SCAN/DEL sweep for the case where the index no longer exists but orphaned hashes may still linger from a prior incomplete cleanup.

## Changes

- `FT.DROPINDEX` is now called with the `DD` flag so indexed documents are removed atomically with the index definition.
- When `FT.DROPINDEX` returns "Unknown Index name", a new `deleteNamespaceKeys` / `deleteNamespaceKeysSingle` pair SCANs and DELs all hashes under the `<namespace>:*` prefix directly, with cluster fan-out support via `ForEachMaster`.
- `dropSharedTestNamespace` in the semantic cache test suite now sweeps every configured vector store backend (not just Weaviate) so stale keys from persistent external services don't produce spurious cache hits across test runs.
- A `storeConfigForType` helper centralises the per-backend config lookup, removing duplicated switch blocks in `NewTestSetupWithVectorStore` and `dropSharedTestNamespace`.
- A `throttledEmbeddingExecutor` wrapper and `embeddingThrottle` semaphore (default concurrency 2, overridable via `SEMCACHE_TEST_EMBED_CONCURRENCY`) are introduced to prevent parallel tests from bursting OpenAI's embeddings rate limit and silently self-skipping.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Start a local Redis instance (or point at an existing one) and run the semantic cache integration tests:

```sh
export REDIS_URL=redis://localhost:6379
export OPENAI_API_KEY=<your-key>
export SEMCACHE_TEST_EMBED_CONCURRENCY=2   # optional, defaults to 2

go test ./plugins/semanticcache/... -v -run TestSemanticCache
```

Expected outcome: the test namespace is fully cleared between runs, no stale cache hits appear on the first request of a fresh run, and no tests self-skip due to rate-limit errors.

To verify the `DD` fix specifically, run `DeleteNamespace` on a populated namespace and confirm via `redis-cli KEYS "<namespace>:*"` that no hashes remain after the call.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII changes. The SCAN/DEL sweep is scoped strictly to the `<namespace>:*` key prefix owned by the index being deleted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redis namespace deletion now fully removes associated data and documents, and falls back to scanning/deleting orphaned keys when indexes are missing.

* **Tests**
  * Test cleanup now removes shared namespaces across all configured vector store backends, skipping unavailable backends.
  * Added configurable concurrency throttling for embedding requests in tests and improved per-store cleanup timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->