### PR TITLE
fix e2e api test

### DIFF
--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -3235,6 +3235,7 @@ var allowedKeyPairColumns = map[string]struct{}{
 	"customer_id":        {},
 	"customer_name":      {},
 	"user_id":            {},
+	"user_name":          {},
 	"business_unit_id":   {},
 	"business_unit_name": {},
 }


### PR DESCRIPTION
## Summary

Adds `user_name` as an allowed column in the key pair column allowlist for log store queries, enabling filtering and lookups by user name alongside the existing `user_id` field.

## Changes

- Added `"user_name"` to `allowedKeyPairColumns` in `framework/logstore/rdb.go` so that `user_name` is recognized as a valid column for key pair operations, consistent with how other name/ID pairs (e.g., `customer_id`/`customer_name`, `business_unit_id`/`business_unit_name`) are handled.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/...
```

Verify that queries using `user_name` as a key pair column are accepted without error, and that queries using unlisted columns are still rejected.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `allowedKeyPairColumns` map acts as an allowlist to prevent arbitrary column injection in log store queries. Adding `user_name` here is consistent with the existing pattern and does not introduce new attack surface beyond what is already permitted for similar fields.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a validation restriction that prevented user names from being properly utilized in data retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->