### PR TITLE
fix(anthropic): rewrite manual thinking to adaptive on raw path for Opus 4.7+

### DIFF
--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -478,6 +478,27 @@ func StripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelPr
 		}
 	}
 
+	// thinking — Opus 4.7+ (incl. 4.8) only support adaptive thinking; the
+	// deprecated manual form (thinking.type:"enabled" with budget_tokens) is
+	// rejected by Anthropic with a 400. Rewrite it to adaptive for parity with
+	// the typed conversion path (chat/responses), which maps enabled→adaptive
+	// via IsOpus47Plus. Raw passthrough clients (e.g. the Claude Agent SDK)
+	// frequently default to the manual form for Opus models.
+	if IsOpus47Plus(model) {
+		if t := providerUtils.GetJSONField(jsonBody, "thinking.type"); t.Exists() && t.String() == "enabled" {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "thinking.type", "adaptive")
+			if err != nil {
+				return nil, fmt.Errorf("rewrite raw thinking.type to adaptive: %w", err)
+			}
+			if providerUtils.JSONFieldExists(jsonBody, "thinking.budget_tokens") {
+				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "thinking.budget_tokens")
+				if err != nil {
+					return nil, fmt.Errorf("strip raw thinking.budget_tokens: %w", err)
+				}
+			}
+		}
+	}
+
 	// top-level cache_control.scope
 	if !features.PromptCachingScope && providerUtils.JSONFieldExists(jsonBody, "cache_control.scope") {
 		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "cache_control.scope")

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -2524,6 +2524,88 @@ func TestStripUnsupportedFieldsFromRawBody_EffortGating(t *testing.T) {
 	}
 }
 
+// TestStripUnsupportedFieldsFromRawBody_ThinkingRewrite exercises the raw-bytes
+// path parity with the typed conversion path: on Opus 4.7+ (incl. 4.8) the
+// deprecated manual thinking form (type:"enabled" with budget_tokens) is
+// rewritten to adaptive (and budget_tokens dropped); other models pass through
+// unchanged.
+func TestStripUnsupportedFieldsFromRawBody_ThinkingRewrite(t *testing.T) {
+	tests := []struct {
+		name          string
+		model         string
+		body          string
+		wantType      string
+		wantHasBudget bool
+	}{
+		{
+			name:          "opus 4.8 rewrites enabled to adaptive and drops budget_tokens",
+			model:         "claude-opus-4-8",
+			body:          `{"model":"claude-opus-4-8","thinking":{"type":"enabled","budget_tokens":10000}}`,
+			wantType:      "adaptive",
+			wantHasBudget: false,
+		},
+		{
+			name:          "opus 4.8 dotted variant rewrites enabled to adaptive",
+			model:         "claude-opus-4.8",
+			body:          `{"model":"claude-opus-4.8","thinking":{"type":"enabled","budget_tokens":4096}}`,
+			wantType:      "adaptive",
+			wantHasBudget: false,
+		},
+		{
+			name:          "opus 4.7 rewrites enabled to adaptive and drops budget_tokens",
+			model:         "claude-opus-4-7",
+			body:          `{"model":"claude-opus-4-7","thinking":{"type":"enabled","budget_tokens":8000}}`,
+			wantType:      "adaptive",
+			wantHasBudget: false,
+		},
+		{
+			name:          "opus 4.8 already adaptive is left untouched",
+			model:         "claude-opus-4-8",
+			body:          `{"model":"claude-opus-4-8","thinking":{"type":"adaptive"}}`,
+			wantType:      "adaptive",
+			wantHasBudget: false,
+		},
+		{
+			name:          "model fallback - opus 4.8 inferred from body when arg empty",
+			model:         "",
+			body:          `{"model":"claude-opus-4-8-20260601","thinking":{"type":"enabled","budget_tokens":2048}}`,
+			wantType:      "adaptive",
+			wantHasBudget: false,
+		},
+		{
+			name:          "opus 4.6 keeps deprecated-but-functional manual thinking",
+			model:         "claude-opus-4-6",
+			body:          `{"model":"claude-opus-4-6","thinking":{"type":"enabled","budget_tokens":10000}}`,
+			wantType:      "enabled",
+			wantHasBudget: true,
+		},
+		{
+			name:          "sonnet 4.6 keeps manual thinking",
+			model:         "claude-sonnet-4-6",
+			body:          `{"model":"claude-sonnet-4-6","thinking":{"type":"enabled","budget_tokens":6000}}`,
+			wantType:      "enabled",
+			wantHasBudget: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := StripUnsupportedFieldsFromRawBody([]byte(tt.body), schemas.Anthropic, tt.model)
+			if err != nil {
+				t.Fatalf("StripUnsupportedFieldsFromRawBody: %v", err)
+			}
+			gotType := providerUtils.GetJSONField(out, "thinking.type").String()
+			if gotType != tt.wantType {
+				t.Errorf("thinking.type=%q, want %q; body=%s", gotType, tt.wantType, string(out))
+			}
+			haveBudget := providerUtils.JSONFieldExists(out, "thinking.budget_tokens")
+			if haveBudget != tt.wantHasBudget {
+				t.Errorf("thinking.budget_tokens present=%v, want %v; body=%s", haveBudget, tt.wantHasBudget, string(out))
+			}
+		})
+	}
+}
+
 func TestAddMissingBetaHeadersToContext_TaskBudgets(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -2952,8 +3034,8 @@ func TestBudgetTokensMaxEffortCapsBelowMaxTokens(t *testing.T) {
 	const minBudget = MinimumReasoningMaxTokens
 
 	cases := []struct {
-		maxTokens    int
-		wantBudget   int
+		maxTokens  int
+		wantBudget int
 	}{
 		{maxTokens: 16000, wantBudget: 15999},
 		{maxTokens: 32000, wantBudget: 31999},


### PR DESCRIPTION
## Summary

Claude Opus 4.7 and 4.8 only support **adaptive** thinking. The deprecated manual form (`thinking.type: "enabled"` with `budget_tokens`) is rejected by the Anthropic API with a 400:

> `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

This is consistent with Anthropic's docs ([extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking), [adaptive thinking](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking)): on Opus 4.7/4.8, manual `type: "enabled"` is rejected and you must use `type: "adaptive"` + `output_config.effort`.

PR #3868 extended the Opus 4.7+ capability gating (`IsOpus47Plus`) across the **typed** conversion path (`chat.go` / `responses.go`), which already maps `enabled`→`adaptive`. However, the **raw passthrough** path (`StripUnsupportedFieldsFromRawBody`, used when `UseRawRequestBody` is set — e.g. the native Anthropic integration that the Claude Agent SDK / Claude Code uses) only *deletes* unsupported fields and never rewrites `thinking`. As a result, a native Anthropic client sending `thinking: {type: "enabled", budget_tokens: N}` to `claude-opus-4-8` had its body passed through unmodified and hit the 400.

This was reproduced via Asteroid's astro-agent, which routes the Claude Agent SDK through Bifrost via `ANTHROPIC_BASE_URL` and never sets `thinking`/`effort`, so the SDK's default manual thinking config reached Anthropic and failed for Opus 4.8.

## Changes

- `StripUnsupportedFieldsFromRawBody`: when `IsOpus47Plus(model)`, rewrite `thinking.type` `"enabled"` → `"adaptive"` and drop `thinking.budget_tokens`, giving the raw path parity with the typed conversion path. Other models (e.g. Opus 4.6, Sonnet 4.6, where manual thinking is still functional) are untouched.
- Added `TestStripUnsupportedFieldsFromRawBody_ThinkingRewrite` covering Opus 4.8 (`4-8` and `4.8` variants), Opus 4.7, already-adaptive bodies, the body-embedded model fallback, and pass-through for Opus 4.6 / Sonnet 4.6.

## Test plan

- [x] `GOWORK=off go test ./providers/anthropic/... -run 'TestStripUnsupportedFieldsFromRawBody|TestSupportsAdaptiveThinking|TestSupportsEffortParameter'` passes
- [x] `go vet ./providers/anthropic/` clean
- [ ] E2E: send a native Anthropic `/v1/messages` request to `claude-opus-4-8` with `thinking: {type: "enabled", budget_tokens: N}` and confirm no 400 (thinking rewritten to adaptive)

Made with [Cursor](https://cursor.com)