### PR TITLE
fix: use JS-based theme detection for loading shell instead of `prefers-color-scheme` media query

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -10,47 +10,7 @@
 	</head>
 
 	<body class="font-sans antialiased">
-		<div id="root">
-			<!-- Inline loading shell — shown until React mounts and replaces #root's innerHTML. -->
-			<style>
-				*{box-sizing:border-box;margin:0;padding:0;border:0 solid}
-				#bifrost-shell{display:flex;height:100vh;background:#f4f4f5;color:#71717a;font-family:ui-sans-serif,system-ui,-apple-system,sans-serif}
-				@media(prefers-color-scheme:dark){#bifrost-shell{background:#1a1a1e;color:#a1a1aa}}
-				#bifrost-shell .sidebar{width:240px;border-right:1px solid rgba(0,0,0,.08);padding:16px;display:flex;flex-direction:column;gap:24px}
-				@media(prefers-color-scheme:dark){#bifrost-shell .sidebar{border-color:rgba(255,255,255,.1)}}
-				#bifrost-shell .logo{height:24px;width:auto;opacity:.8}
-				#bifrost-shell .nav-item{height:12px;border-radius:6px;background:currentColor;opacity:.08}
-				#bifrost-shell .main{flex:1;padding:32px;display:flex;flex-direction:column;gap:20px}
-				#bifrost-shell .bar{border-radius:6px;background:currentColor;opacity:.06}
-				@keyframes shell-fade{from{opacity:0}to{opacity:1}}
-				#bifrost-shell{animation:shell-fade .2s ease-out}
-			</style>
-			<div id="bifrost-shell" aria-hidden="true">
-				<div class="sidebar">
-					<picture>
-						<source srcset="/bifrost-logo-dark.webp" media="(prefers-color-scheme:dark)">
-						<img src="/bifrost-logo.webp" class="logo" alt="" width="120" height="24">
-					</picture>
-					<div style="display:flex;flex-direction:column;gap:10px">
-						<div class="nav-item" style="width:70%"></div>
-						<div class="nav-item" style="width:55%"></div>
-						<div class="nav-item" style="width:80%"></div>
-						<div class="nav-item" style="width:45%"></div>
-						<div class="nav-item" style="width:65%"></div>
-					</div>
-				</div>
-				<div class="main">
-					<div class="bar" style="height:32px;width:240px"></div>
-					<div class="bar" style="height:1px;width:100%"></div>
-					<div style="display:flex;gap:16px">
-						<div class="bar" style="height:80px;flex:1"></div>
-						<div class="bar" style="height:80px;flex:1"></div>
-						<div class="bar" style="height:80px;flex:1"></div>
-					</div>
-					<div class="bar" style="height:200px;width:100%"></div>
-				</div>
-			</div>
-		</div>
+		<div id=root><script>!function(){try{var e=localStorage.getItem("theme"),e="dark"===e||"light"!==e&&matchMedia("(prefers-color-scheme:dark)").matches;document.getElementById("root").classList.toggle("shell-dark",e)}catch(t){try{document.getElementById("root").classList.toggle("shell-dark",matchMedia("(prefers-color-scheme:dark)").matches)}catch(t){}}}()</script><style>*{box-sizing:border-box;margin:0;padding:0;border:0 solid}#bifrost-shell{display:flex;height:100vh;background:#f4f4f5;color:#71717a;font-family:ui-sans-serif,system-ui,-apple-system,sans-serif}.shell-dark #bifrost-shell{background:#1a1a1e;color:#a1a1aa}#bifrost-shell .sidebar{width:240px;border-right:1px solid rgba(0,0,0,.08);padding:16px;display:flex;flex-direction:column;gap:24px}.shell-dark #bifrost-shell .sidebar{border-color:rgba(255,255,255,.1)}#bifrost-shell .logo{height:24px;opacity:.8;width:max-content}#bifrost-shell .logo-dark{display:none}.shell-dark #bifrost-shell .logo-light{display:none}.shell-dark #bifrost-shell .logo-dark{display:inline}#bifrost-shell .nav-item{height:12px;border-radius:6px;background:currentColor;opacity:.08}#bifrost-shell .main{flex:1;padding:32px;display:flex;flex-direction:column;gap:20px}#bifrost-shell .bar{border-radius:6px;background:currentColor;opacity:.06}@keyframes shell-fade{from{opacity:0}to{opacity:1}}#bifrost-shell{animation:shell-fade .2s ease-out}</style><div id=bifrost-shell aria-hidden=true><div class=sidebar><img alt=""class="logo logo-light"src=/bifrost-logo.webp> <img alt=""class="logo logo-dark"src=/bifrost-logo-dark.webp><div style=display:flex;flex-direction:column;gap:10px><div class=nav-item style=width:70%></div><div class=nav-item style=width:55%></div><div class=nav-item style=width:80%></div><div class=nav-item style=width:45%></div><div class=nav-item style=width:65%></div></div></div><div class=main><div class=bar style=height:32px;width:240px></div><div class=bar style=height:1px;width:100%></div><div style=display:flex;gap:16px><div class=bar style=height:80px;flex:1></div><div class=bar style=height:80px;flex:1></div><div class=bar style=height:80px;flex:1></div></div><div class=bar style=height:200px;width:100%></div></div></div></div>
 		<script type="module" src="/app/main.tsx"></script>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

The loading shell shown before React mounts was using a CSS `prefers-color-scheme` media query to determine dark/light mode, which caused a flash of the wrong theme for users who have explicitly set a theme preference in the app. This PR fixes that by reading the stored theme from `localStorage` at shell render time and applying the correct dark/light styles immediately.

## Changes

- Replaced `@media (prefers-color-scheme: dark)` CSS rules in the inline loading shell with a `.shell-dark` class-based approach, so dark mode styles are controlled by a class on `#root` rather than the OS-level media query alone.
- Added an inline script that runs synchronously before the shell renders, reads `localStorage` for a saved `"theme"` value, falls back to `matchMedia` if none is set, and toggles the `shell-dark` class on `#root` accordingly.
- Replaced the `<picture>`/`<source>` element used for the logo with two `<img>` tags (`logo-light` and `logo-dark`), toggled via the `.shell-dark` class, since `<picture>` media queries cannot respond to a JS-applied class.
- Minified the inline shell HTML, styles, and script to reduce initial payload size.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Open the app and set the theme to dark via the UI settings.
2. Hard-reload the page and observe that the loading shell renders in dark mode immediately, with no flash of the light theme.
3. Repeat with the theme set to light and with no stored preference (should fall back to OS preference).

## Screenshots/Recordings

Before: The loading shell always used the OS `prefers-color-scheme` setting, ignoring any user-selected theme stored in `localStorage`, causing a visible flash on reload for users whose app theme differed from their OS theme.

After: The shell correctly reflects the user's stored theme preference from the first paint.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The inline script only reads from `localStorage` and calls `matchMedia` — no user input is evaluated or injected into the DOM.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the initial loading shell to reduce markup and minify the placeholder DOM.
  * Improved early theme handling so the site applies dark/light mode immediately on load.
  * Simplified logo handling to switch between dark and light variants faster during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->