### PR TITLE
feat: wrap TLS/Certificate network config section in collapsible `Accordion`

### DIFF
--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -1,3 +1,4 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { EnvVarInput } from "@/components/ui/envVarInput";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
@@ -442,62 +443,68 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 								</FormItem>
 							)}
 						/>
-						<div className="space-y-4 rounded-lg border p-4">
-							<h4 className="text-sm font-medium">TLS / Certificate</h4>
-							<FormField
-								control={form.control}
-								name="network_config.insecure_skip_verify"
-								render={({ field }) => (
-									<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-										<div className="space-y-0.5">
-											<FormLabel>Skip TLS verification</FormLabel>
-											<FormDescription>
-												Disable TLS certificate verification for provider connections. This bypasses server certificate validation and
-												should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for
-												self-signed or private CA deployments.
-											</FormDescription>
-										</div>
-										<FormControl>
-											<Switch
-												checked={field.value ?? false}
-												onCheckedChange={field.onChange}
-												disabled={!hasUpdateProviderAccess}
-												data-testid="network-config-insecure-skip-verify"
-											/>
-										</FormControl>
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name="network_config.ca_cert_pem"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
-										<FormControl>
-											<EnvVarInput
-												variant="textarea"
-												placeholder={`-----BEGIN CERTIFICATE-----
+						<Accordion type="single" collapsible className="w-full">
+							<AccordionItem value="tls-config" className="border-b-0">
+								<AccordionTrigger className="py-0" data-testid="tls-config-trigger">
+									<span className="text-sm font-medium">TLS / Certificate</span>
+								</AccordionTrigger>
+								<AccordionContent className="space-y-4 pt-4 pb-0">
+									<FormField
+										control={form.control}
+										name="network_config.insecure_skip_verify"
+										render={({ field }) => (
+											<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+												<div className="space-y-0.5">
+													<FormLabel>Skip TLS verification</FormLabel>
+													<FormDescription>
+														Disable TLS certificate verification for provider connections. This bypasses server certificate validation and
+														should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for
+														self-signed or private CA deployments.
+													</FormDescription>
+												</div>
+												<FormControl>
+													<Switch
+														checked={field.value ?? false}
+														onCheckedChange={field.onChange}
+														disabled={!hasUpdateProviderAccess}
+														data-testid="network-config-insecure-skip-verify"
+													/>
+												</FormControl>
+											</FormItem>
+										)}
+									/>
+									<FormField
+										control={form.control}
+										name="network_config.ca_cert_pem"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+												<FormControl>
+													<EnvVarInput
+														variant="textarea"
+														placeholder={`-----BEGIN CERTIFICATE-----
 ...
 -----END CERTIFICATE----- or env.OPENAI_CA_CERT_PEM`}
-												className="font-mono text-xs"
-												rows={6}
-												hideValueWhenEnv
-												redactNonEnvValue
-												{...field}
-												value={field.value}
-												disabled={!hasUpdateProviderAccess}
-												data-testid="network-config-ca-cert-pem"
-											/>
-										</FormControl>
-										<FormDescription>
-											PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA).
-										</FormDescription>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						</div>
+														className="font-mono text-xs"
+														rows={6}
+														hideValueWhenEnv
+														redactNonEnvValue
+														{...field}
+														value={field.value}
+														disabled={!hasUpdateProviderAccess}
+														data-testid="network-config-ca-cert-pem"
+													/>
+												</FormControl>
+												<FormDescription>
+													PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA).
+												</FormDescription>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								</AccordionContent>
+							</AccordionItem>
+						</Accordion>
 					</div>
 				</div>
 


### PR DESCRIPTION
## Summary

The TLS / Certificate section in the network configuration form was always fully expanded, adding visual noise for users who don't need to configure TLS settings. This PR wraps that section in a collapsible accordion so it stays hidden by default and can be expanded on demand.

## Changes

- Replaced the static bordered `div` containing the TLS / Certificate fields with an `Accordion` component, making the section collapsible
- The "TLS / Certificate" heading now serves as the accordion trigger, preserving the same label while adding expand/collapse behavior

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to a provider's network configuration form in the workspace
2. Verify the TLS / Certificate section is collapsed by default
3. Click the "TLS / Certificate" trigger to expand the section
4. Confirm the "Skip TLS verification" toggle and "CA Certificate (PEM)" textarea are visible and functional after expanding
5. Confirm collapsing the section hides the fields again

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Before: TLS / Certificate fields are always visible in a static bordered box.

After: TLS / Certificate section is collapsed by default and expands via an accordion trigger.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The underlying TLS fields and their behavior (redacted values, env var support) are unchanged.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The TLS / Certificate configuration section in the network form is now collapsible via an accordion component, improving interface organization and reducing visual clutter while preserving all existing form fields and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->