### PR TITLE
feat: add `CreateUserNameInMemory` to `GovernanceStore` interface with no-op local implementation

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -172,6 +172,7 @@ type GovernanceStore interface {
 	CreateUserGovernanceInMemory(ctx context.Context, userID string, budget *configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit)
 	UpdateUserGovernanceInMemory(ctx context.Context, userID string, budget *configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit)
 	DeleteUserGovernanceInMemory(ctx context.Context, userID string)
+	CreateUserNameInMemory(ctx context.Context, userID string, userName string)
 	// User-level governance checks (enterprise-only)
 	CheckUserBudget(ctx context.Context, userID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error)
 	CheckUserRateLimit(ctx context.Context, userID string, request *EvaluationRequest, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
@@ -3296,6 +3297,11 @@ func (gs *LocalGovernanceStore) GetUserGovernance(ctx context.Context, userID st
 
 // CreateUserGovernanceInMemory adds user governance data to the in-memory store (enterprise-only)
 func (gs *LocalGovernanceStore) CreateUserGovernanceInMemory(ctx context.Context, userID string, budget *configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit) {
+	// NoOp
+	// Available in enterprise
+}
+
+func (gs *LocalGovernanceStore) CreateUserNameInMemory(ctx context.Context, userID string, userName string) {
 	// NoOp
 	// Available in enterprise
 }

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -1,3 +1,4 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { EnvVarInput } from "@/components/ui/envVarInput";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
@@ -442,62 +443,68 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 								</FormItem>
 							)}
 						/>
-						<div className="space-y-4 rounded-lg border p-4">
-							<h4 className="text-sm font-medium">TLS / Certificate</h4>
-							<FormField
-								control={form.control}
-								name="network_config.insecure_skip_verify"
-								render={({ field }) => (
-									<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-										<div className="space-y-0.5">
-											<FormLabel>Skip TLS verification</FormLabel>
-											<FormDescription>
-												Disable TLS certificate verification for provider connections. This bypasses server certificate validation and
-												should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for
-												self-signed or private CA deployments.
-											</FormDescription>
-										</div>
-										<FormControl>
-											<Switch
-												checked={field.value ?? false}
-												onCheckedChange={field.onChange}
-												disabled={!hasUpdateProviderAccess}
-												data-testid="network-config-insecure-skip-verify"
-											/>
-										</FormControl>
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name="network_config.ca_cert_pem"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
-										<FormControl>
-											<EnvVarInput
-												variant="textarea"
-												placeholder={`-----BEGIN CERTIFICATE-----
+						<Accordion type="single" collapsible className="w-full">
+							<AccordionItem value="tls-config" className="border-b-0">
+								<AccordionTrigger className="py-0" data-testid="tls-config-trigger">
+									<span className="text-sm font-medium">TLS / Certificate</span>
+								</AccordionTrigger>
+								<AccordionContent className="space-y-4 pt-4 pb-0">
+									<FormField
+										control={form.control}
+										name="network_config.insecure_skip_verify"
+										render={({ field }) => (
+											<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+												<div className="space-y-0.5">
+													<FormLabel>Skip TLS verification</FormLabel>
+													<FormDescription>
+														Disable TLS certificate verification for provider connections. This bypasses server certificate validation and
+														should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for
+														self-signed or private CA deployments.
+													</FormDescription>
+												</div>
+												<FormControl>
+													<Switch
+														checked={field.value ?? false}
+														onCheckedChange={field.onChange}
+														disabled={!hasUpdateProviderAccess}
+														data-testid="network-config-insecure-skip-verify"
+													/>
+												</FormControl>
+											</FormItem>
+										)}
+									/>
+									<FormField
+										control={form.control}
+										name="network_config.ca_cert_pem"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+												<FormControl>
+													<EnvVarInput
+														variant="textarea"
+														placeholder={`-----BEGIN CERTIFICATE-----
 ...
 -----END CERTIFICATE----- or env.OPENAI_CA_CERT_PEM`}
-												className="font-mono text-xs"
-												rows={6}
-												hideValueWhenEnv
-												redactNonEnvValue
-												{...field}
-												value={field.value}
-												disabled={!hasUpdateProviderAccess}
-												data-testid="network-config-ca-cert-pem"
-											/>
-										</FormControl>
-										<FormDescription>
-											PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA).
-										</FormDescription>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						</div>
+														className="font-mono text-xs"
+														rows={6}
+														hideValueWhenEnv
+														redactNonEnvValue
+														{...field}
+														value={field.value}
+														disabled={!hasUpdateProviderAccess}
+														data-testid="network-config-ca-cert-pem"
+													/>
+												</FormControl>
+												<FormDescription>
+													PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA).
+												</FormDescription>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								</AccordionContent>
+							</AccordionItem>
+						</Accordion>
 					</div>
 				</div>
 


### PR DESCRIPTION
## Summary

Adds a `CreateUserNameInMemory` method to the `GovernanceStore` interface and provides a no-op implementation in `LocalGovernanceStore`, with the full implementation reserved for the enterprise version.

## Changes

- Added `CreateUserNameInMemory(ctx context.Context, userID string, userName string)` to the `GovernanceStore` interface
- Added a no-op implementation of `CreateUserNameInMemory` in `LocalGovernanceStore`, consistent with the existing pattern for enterprise-only governance features like `CreateUserGovernanceInMemory`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

Verify that any struct implementing `GovernanceStore` satisfies the updated interface by ensuring the build succeeds.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No direct security implications. The method stores a user name in memory and is a no-op in the open-source version; the enterprise implementation should ensure user name data is handled appropriately and not exposed unintentionally.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added enterprise governance framework components to support future user management enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->