### PR TITLE
removing ptr usages

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1202,8 +1202,8 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 		} else {
 			// VK was provided but does not exist in the store — reject regardless of mandatory setting
 			return nil, &schemas.BifrostError{
-				Type:       bifrost.Ptr("virtual_key_not_found"),
-				StatusCode: bifrost.Ptr(401),
+				Type:       new("virtual_key_not_found"),
+				StatusCode: new(401),
 				Error: &schemas.ErrorField{
 					Message: "virtual key not found. The provided virtual key does not exist or has been revoked.",
 				},

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1171,7 +1171,7 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 	// Set defaults: nil means "use DB default (true)"
 	isActive := req.IsActive
 	if isActive == nil {
-		isActive = bifrost.Ptr(true)
+		isActive = new(true)
 	}
 	// Fetch providers from DB to ensure up-to-date data in cluster mode.
 	providerSet := map[schemas.ModelProvider]struct{}{}


### PR DESCRIPTION
## Summary

Replaces usages of `bifrost.Ptr(...)` with Go's built-in `new(...)` for creating pointers to literal values, simplifying pointer allocation across the governance plugin and HTTP transport handler.

## Changes

- Replaced `bifrost.Ptr("virtual_key_not_found")` and `bifrost.Ptr(401)` with `new("virtual_key_not_found")` and `new(401)` in the governance plugin's error return path
- Replaced `bifrost.Ptr(true)` with `new(true)` in the virtual key creation handler's default `isActive` assignment

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This is a purely mechanical refactor with no behavioral changes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal pointer handling in governance request processing and virtual key creation using standard Go utilities instead of custom helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->