### PR TITLE
adds budget count skip for user attribution

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -244,6 +244,7 @@ const (
 	BifrostContextKeyStructuredOutputToolName            BifrostContextKey = "bifrost-structured-output-tool-name"              // string (to store the name of the structured output tool (set by bifrost))
 	BifrostContextKeyUserAgent                           BifrostContextKey = "bifrost-user-agent"                               // string (set by bifrost)
 	BifrostContextKeySkipBudgetAndRateLimits             BifrostContextKey = "bifrost-skip-budget-and-rate-limits"              // bool (set by bifrost for read-only requests like list models that don't consume quota)
+	BifrostContextKeySkipVirtualKeyUsageTracking         BifrostContextKey = "bifrost-skip-virtual-key-usage-tracking"          // bool (set by governance callers to skip VK usage while preserving VK auth/attribution)
 	BifrostContextKeyTraceID                             BifrostContextKey = "bifrost-trace-id"                                 // string (trace ID for distributed tracing - set by tracing middleware)
 	BifrostContextKeySpanID                              BifrostContextKey = "bifrost-span-id"                                  // string (current span ID for child span creation - set by tracer)
 	BifrostContextKeyParentSpanID                        BifrostContextKey = "bifrost-parent-span-id"                           // string (parent span ID from W3C traceparent header - set by tracing middleware)

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1517,10 +1517,11 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	// Build pricing scopes from context using the governance VK ID (not the raw VK token)
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))
 
-	// Always process usage tracking (with or without virtual key)
-	// When user auth is present, skip VK usage tracking to avoid double-counting
+	// Always process usage tracking. When both virtual key and user are present,
+	// track both scopes; callers that intentionally want user-only accounting can
+	// set BifrostContextKeySkipVirtualKeyUsageTracking.
 	effectiveVK := virtualKey
-	if userID != "" {
+	if bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipVirtualKeyUsageTracking) {
 		effectiveVK = ""
 	}
 	// If effectiveVK is empty, it will be passed as empty string to postHookWorker
@@ -1659,10 +1660,8 @@ func (p *GovernancePlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schema
 	// Extract governance information
 	virtualKey := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyVirtualKey)
 	requestID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyRequestID)
-	userID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID)
 
-	// When user auth is present, skip VK usage tracking to avoid double-counting
-	if userID != "" {
+	if bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipVirtualKeyUsageTracking) {
 		virtualKey = ""
 	}
 

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -236,7 +237,7 @@ func buildModelConfigMultiBudget(id, model string, provider *string, budgets []*
 
 func TestStore_CheckModelBudget_MultiBudget_OneExceededBlocks(t *testing.T) {
 	logger := NewMockLogger()
-	within := buildBudget("b-day", 100.0, "1d")             // plenty of headroom
+	within := buildBudget("b-day", 100.0, "1d")                  // plenty of headroom
 	exceeded := buildBudgetWithUsage("b-hour", 10.0, 10.0, "1h") // at limit
 	mc := buildModelConfigMultiBudget("mc-multi", "gpt-4", nil, []*configstoreTables.TableBudget{within, exceeded})
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
@@ -1871,6 +1872,174 @@ func TestPostHook_UpdatesProviderRateLimitUsage_NoVirtualKey(t *testing.T) {
 	assert.Contains(t, shortCircuit2.Error.Error.Message, "token limit exceeded", "Error should indicate token limit exceeded")
 }
 
+// TestPostHook_TracksVirtualKeyUsageWhenUserIDPresent verifies user attribution
+// does not suppress VK usage tracking.
+func TestPostHook_TracksVirtualKeyUsageWhenUserIDPresent(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("vk-rl", 10000, 0, 1000, 0)
+	vk := buildVirtualKeyWithRateLimit("vk1", "sk-bf-test", "Test VK", rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer plugin.Cleanup()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
+	result := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Model: "gpt-4",
+			Usage: &schemas.BifrostLLMUsage{
+				PromptTokens:     600,
+				CompletionTokens: 400,
+				TotalTokens:      1000,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ChatCompletionRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "gpt-4",
+			},
+		},
+	}
+
+	_, _, err = plugin.PostLLMHook(ctx, result, nil)
+	require.NoError(t, err)
+	plugin.wg.Wait()
+
+	updated, exists := store.GetGovernanceData(context.Background()).RateLimits["vk-rl"]
+	require.True(t, exists)
+	assert.Equal(t, int64(1000), updated.TokenCurrentUsage)
+	assert.Equal(t, int64(1), updated.RequestCurrentUsage)
+}
+
+// TestPostHook_SkipVirtualKeyUsageTrackingFlag verifies callers can explicitly
+// suppress VK usage while keeping VK auth and user attribution on the context.
+func TestPostHook_SkipVirtualKeyUsageTrackingFlag(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("vk-rl", 10000, 0, 1000, 0)
+	vk := buildVirtualKeyWithRateLimit("vk1", "sk-bf-test", "Test VK", rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer plugin.Cleanup()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
+	ctx.SetValue(schemas.BifrostContextKeySkipVirtualKeyUsageTracking, true)
+	result := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Model: "gpt-4",
+			Usage: &schemas.BifrostLLMUsage{
+				PromptTokens:     600,
+				CompletionTokens: 400,
+				TotalTokens:      1000,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ChatCompletionRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "gpt-4",
+			},
+		},
+	}
+
+	_, _, err = plugin.PostLLMHook(ctx, result, nil)
+	require.NoError(t, err)
+	plugin.wg.Wait()
+
+	updated, exists := store.GetGovernanceData(context.Background()).RateLimits["vk-rl"]
+	require.True(t, exists)
+	assert.Equal(t, int64(0), updated.TokenCurrentUsage)
+	assert.Equal(t, int64(0), updated.RequestCurrentUsage)
+	assert.Equal(t, "user1", bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID))
+}
+
+// TestPostMCPHook_TracksVirtualKeyUsageWhenUserIDPresent verifies user
+// attribution does not suppress MCP VK request usage tracking.
+func TestPostMCPHook_TracksVirtualKeyUsageWhenUserIDPresent(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("vk-rl", 10000, 0, 1000, 0)
+	vk := buildVirtualKeyWithRateLimit("vk1", "sk-bf-test", "Test VK", rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer plugin.Cleanup()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
+	resp := &schemas.BifrostMCPResponse{
+		ExtraFields: schemas.BifrostMCPResponseExtraFields{
+			MCPRequestType: schemas.MCPRequestTypeExecuteTool,
+			ClientName:     "client",
+			ToolName:       "tool",
+		},
+	}
+
+	_, _, err = plugin.PostMCPHook(ctx, resp, nil)
+	require.NoError(t, err)
+	plugin.wg.Wait()
+
+	updated, exists := store.GetGovernanceData(context.Background()).RateLimits["vk-rl"]
+	require.True(t, exists)
+	assert.Equal(t, int64(0), updated.TokenCurrentUsage)
+	assert.Equal(t, int64(1), updated.RequestCurrentUsage)
+}
+
+// TestPostMCPHook_SkipVirtualKeyUsageTrackingFlag verifies MCP callers can
+// explicitly suppress VK usage while preserving user attribution.
+func TestPostMCPHook_SkipVirtualKeyUsageTrackingFlag(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("vk-rl", 10000, 0, 1000, 0)
+	vk := buildVirtualKeyWithRateLimit("vk1", "sk-bf-test", "Test VK", rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer plugin.Cleanup()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
+	ctx.SetValue(schemas.BifrostContextKeySkipVirtualKeyUsageTracking, true)
+	resp := &schemas.BifrostMCPResponse{
+		ExtraFields: schemas.BifrostMCPResponseExtraFields{
+			MCPRequestType: schemas.MCPRequestTypeExecuteTool,
+			ClientName:     "client",
+			ToolName:       "tool",
+		},
+	}
+
+	_, _, err = plugin.PostMCPHook(ctx, resp, nil)
+	require.NoError(t, err)
+	plugin.wg.Wait()
+
+	updated, exists := store.GetGovernanceData(context.Background()).RateLimits["vk-rl"]
+	require.True(t, exists)
+	assert.Equal(t, int64(0), updated.TokenCurrentUsage)
+	assert.Equal(t, int64(0), updated.RequestCurrentUsage)
+	assert.Equal(t, "user1", bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID))
+}
+
 func TestPostHook_UpdatesModelBudgetUsage_NoVirtualKey(t *testing.T) {
 	logger := NewMockLogger()
 	// Set budget with initial usage close to limit to test the flow
@@ -2476,4 +2645,3 @@ func TestStore_CheckVirtualKeyScopedModelBudget_MultiBudget_OneExceededBlocks(t 
 	_, err = store.CheckScopedModelBudget(context.Background(), configstoreTables.ModelConfigScopeVirtualKey, vk.ID, &EvaluationRequest{Model: "gpt-4", Provider: schemas.OpenAI}, nil)
 	assert.Error(t, err, "an exceeded budget among several on a VK-scoped config must block")
 }
-


### PR DESCRIPTION
## Summary

Previously, virtual key (VK) usage tracking was automatically suppressed whenever a `userID` was present in the context, under the assumption that tracking both would cause double-counting. This was too broad — there are valid cases where both VK and user attribution should be tracked simultaneously. This PR replaces the implicit `userID`-based suppression with an explicit opt-in context flag, `BifrostContextKeySkipVirtualKeyUsageTracking`, giving callers precise control over whether VK usage is recorded.

## Changes

- Added `BifrostContextKeySkipVirtualKeyUsageTracking` context key to the Bifrost schema, allowing callers to explicitly opt out of VK usage tracking while preserving VK-based auth and attribution.
- Replaced the `userID != ""` condition in both `PostLLMHook` and `PostMCPHook` with a check for the new context flag. VK usage is now suppressed only when the flag is explicitly set, not automatically when a user is present.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Set `BifrostContextKeySkipVirtualKeyUsageTracking` to `true` in the context and confirm that VK usage is not recorded while user-level usage still is. Verify that without the flag, both VK and user usage are tracked even when a `userID` is present.

```sh
go test ./...
```

## Breaking changes

- [x] Yes
- [ ] No

Any integration that previously relied on the presence of a `userID` to automatically suppress VK usage tracking will now track both VK and user usage unless `BifrostContextKeySkipVirtualKeyUsageTracking` is explicitly set to `true` in the context.

## Security considerations

No new auth surfaces are introduced. The new flag is set by governance callers and does not affect authentication or authorization logic — only usage accounting.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to optionally skip virtual-key usage tracking during governance operations while maintaining authentication and attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->