### PR TITLE
fix: disable entity assignment fields and skip `team_id`/`customer_id` updates when key has assigned users

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -852,21 +852,25 @@ export default function VirtualKeySheet({
           provider_configs: normalizedProviderConfigs,
           mcp_configs: data.mcpConfigs,
           team_id:
-            data.entityType === "team" &&
-              data.teamId &&
-              data.teamId.trim() !== ""
-              ? data.teamId
-              : data.entityType === "none"
-                ? null
-                : undefined,
+            assignedUsers.length > 0
+              ? undefined
+              : data.entityType === "team" &&
+                  data.teamId &&
+                  data.teamId.trim() !== ""
+                ? data.teamId
+                : data.entityType === "none"
+                  ? null
+                  : undefined,
           customer_id:
-            data.entityType === "customer" &&
-              data.customerId &&
-              data.customerId.trim() !== ""
-              ? data.customerId
-              : data.entityType === "none"
-                ? null
-                : undefined,
+            assignedUsers.length > 0
+              ? undefined
+              : data.entityType === "customer" &&
+                  data.customerId &&
+                  data.customerId.trim() !== ""
+                ? data.customerId
+                : data.entityType === "none"
+                  ? null
+                  : undefined,
           is_active: data.isActive,
           calendar_aligned: data.budgetCalendarAligned,
           reset_budget_usage: resetBudgetUsage,
@@ -2412,12 +2416,18 @@ export default function VirtualKeySheet({
                                     ]);
                                   }
                                 }}
-                                disabled={isTeamLocked}
+                                disabled={isTeamLocked || (isEditing && assignedUsers.length > 0)}
                                 disableSearch
                                 hideClear
                                 className="h-9"
                               />
-                              <FormMessage />
+                              {isEditing && assignedUsers.length > 0 ? (
+                                <p className="text-muted-foreground text-xs">
+                                  This key is assigned to a user. Detach the user first to change the assignment type.
+                                </p>
+                              ) : (
+                                <FormMessage />
+                              )}
                             </FormItem>
                           )}
                         />
@@ -2454,7 +2464,7 @@ export default function VirtualKeySheet({
                                       }
                                     }}
                                     placeholder="Select a team"
-                                    disabled={isTeamLocked}
+                                    disabled={isTeamLocked || (isEditing && assignedUsers.length > 0)}
                                     emptyMessage="No teams found."
                                     className="h-9"
                                   />
@@ -2484,6 +2494,7 @@ export default function VirtualKeySheet({
                                       field.onChange(val ?? "")
                                     }
                                     placeholder="Select a customer"
+                                    disabled={isEditing && assignedUsers.length > 0}
                                     emptyMessage="No customers found."
                                     className="h-9"
                                   />


### PR DESCRIPTION
## Summary

When a virtual key has an assigned user, the team/customer assignment fields should be locked to prevent conflicting ownership. Previously, it was possible to change the entity type or team/customer while a user was still attached to the key, leading to inconsistent state.

## Changes

- `team_id` and `customer_id` are now set to `undefined` (omitted from the update payload) when `assignedUsers.length > 0`, preventing accidental overwrite of user-based assignment on save.
- The entity type selector, team selector, and customer selector are all disabled when editing a key that has assigned users.
- A helper message is shown in place of the form validation message when the key is user-assigned, instructing the user to detach the user before changing the assignment type.
- Added `user_id` to the `VirtualKey` type definition.

## Type of change

- [x] Bug fix

## Affected areas

- [x] UI (React)

## How to test

1. Create a virtual key and assign a user to it.
2. Open the key in edit mode.
3. Verify that the entity type selector, team selector, and customer selector are all disabled.
4. Verify the message "This key is assigned to a user. Detach the user first to change the assignment type." is displayed.
5. Detach the user from the key.
6. Verify that the selectors become enabled again and assignment changes can be saved normally.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [x] No

## Related issues

Link related issues and discussions.

## Security considerations

No security implications. This change is purely a UI guard to prevent inconsistent key ownership state.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents changing entity type or reassignment when users are assigned to a virtual key: entity/type selectors and team/customer pickers are disabled and show explanatory messaging requiring user detachment first.
  * When no users are assigned, team/customer selections behave normally; selecting "none" maps both fields to null to avoid unintended assignments.
  * Keys that are team-locked also disable the entity-type control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->