### PR TITLE
helm releases

### DIFF
--- a/docs/changelogs/helm-v2.1.21.mdx
+++ b/docs/changelogs/helm-v2.1.21.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.1.21"
+description: "Helm v2.1.21 changelog - 2026-06-04"
+---
+
+<Update label="Bifrost Helm" description="v2.1.21">
+
+## Changelog
+
+- Added `per_user_oauth` and `per_user_headers` to the MCP connection `authType` enum in `values.schema.json` (`bifrost.mcp.clientConfigs[].authType`). These per-user auth modes were already supported by the application but were previously rejected at chart validation time.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -825,6 +825,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.21",
               "changelogs/helm-v2.1.20",
               "changelogs/helm-v2.1.19",
               "changelogs/helm-v2.1.18",


### PR DESCRIPTION
## Summary

Adds the Helm v2.1.21 changelog entry, documenting the addition of `per_user_oauth` and `per_user_headers` to the MCP connection `authType` enum in `values.schema.json`.

## Changes

- Added changelog for Helm v2.1.21, noting that `per_user_oauth` and `per_user_headers` are now included in the `bifrost.mcp.clientConfigs[].authType` enum in `values.schema.json`. These auth modes were already supported by the application but were previously rejected during Helm chart validation due to the missing enum entries.
- Registered the new changelog page in `docs.json`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the new changelog page renders correctly in the documentation site under the Helm changelogs section and that `helm-v2.1.21` appears in the navigation.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm v2.1.21 changelog to document per-user OAuth and per-user headers authentication options for MCP connections, now validated at Helm chart deployment time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->