### PR TITLE
docs: note about allow private network in release notes

### DIFF
--- a/docs/changelogs/ent-v1.4.7.mdx
+++ b/docs/changelogs/ent-v1.4.7.mdx
@@ -15,6 +15,10 @@ description: "Enterprise v1.4.7 changelog - 2026-06-07"
   v1.4.7 has a known issue where <code>/virtua-key/quota</code> was not sending back budgets. This is fixed in v1.4.8.
 </Warning>
 
+<Note>
+  **Private Network Access** — To connect to a provider on a private network (e.g. a local vLLM or Ollama instance), set `allow_private_network: true` in the provider's `network_config`. This allows connections to RFC 1918 ranges (`192.168.x.x`, `10.x.x.x`, `172.16.x.x`). Link-local addresses (`169.254.x.x`) remain blocked regardless of this setting. See [Provider Configuration](/quickstart/gateway/provider-configuration#private-network-access) for details.
+</Note>
+
 ## Changelog
 
 A governance and organizational-hierarchy release on `transports/v1.5.10`. The headline work is a full **customer -> team -> business unit** model with end-to-end usage and budget tracking, a rebuilt **DAC + RBAC** layer backed by a virtual-key mapping table, and a more robust **access profile** lifecycle.

--- a/docs/changelogs/v1.5.9.mdx
+++ b/docs/changelogs/v1.5.9.mdx
@@ -17,6 +17,10 @@ description: "v1.5.9 changelog - 2026-06-07"
 </Tabs>
 
 <Update label="Bifrost(HTTP)" description="1.5.9">
+<Note>
+  **Private Network Access** — To connect to a provider on a private network (e.g. a local vLLM or Ollama instance), set `allow_private_network: true` in the provider's `network_config`. This allows connections to RFC 1918 ranges (`192.168.x.x`, `10.x.x.x`, `172.16.x.x`). Link-local addresses (`169.254.x.x`) remain blocked regardless of this setting. See [Provider Configuration](/quickstart/gateway/provider-configuration#private-network-access) for details.
+</Note>
+
 ## ✨ Features
 
 - **OpenAI Compaction** — Added OpenAI conversation compaction support across core, framework, logging, and the API surface (#4053)

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -405,6 +405,63 @@ curl --location 'http://localhost:8080/api/providers' \
   standard providers, it's optional and overrides the default endpoint.
 </Note>
 
+### Private Network Access
+
+If your provider runs on a private IP address (e.g. a local vLLM or Ollama instance on `192.168.x.x` or `10.x.x.x`), set `allow_private_network: true` in `network_config`. Link-local addresses (`169.254.x.x`) remain blocked regardless of this setting.
+
+<Tabs group="private-network">
+
+<Tab title="Using API">
+
+```bash
+curl --location 'http://localhost:8080/api/providers' \
+--header 'Content-Type: application/json' \
+--data '{
+    "provider": "ollama-local",
+    "keys": [
+        {
+            "name": "ollama-key",
+            "value": "dummy",
+            "models": ["*"],
+            "weight": 1.0
+        }
+    ],
+    "network_config": {
+        "base_url": "http://192.168.1.195:8000",
+        "allow_private_network": true
+    }
+}'
+```
+
+</Tab>
+
+<Tab title="Using config.json">
+
+```json
+{
+  "providers": {
+    "ollama-local": {
+      "keys": [
+        {
+          "name": "ollama-key",
+          "value": "dummy",
+          "models": ["*"],
+          "weight": 1.0
+        }
+      ],
+      "network_config": {
+        "base_url": "http://192.168.1.195:8000",
+        "allow_private_network": true
+      }
+    }
+  }
+}
+```
+
+</Tab>
+
+</Tabs>
+
 ### Managing Retries
 
 Configure retry behavior for handling temporary failures and rate limits. This example sets up exponential backoff with up to 5 retries, starting with 1ms delay and capping at 10 seconds - ideal for handling transient network issues.

--- a/docs/quickstart/go-sdk/provider-configuration.mdx
+++ b/docs/quickstart/go-sdk/provider-configuration.mdx
@@ -148,6 +148,27 @@ func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schem
 <Note>
 For self-hosted providers like Ollama and SGL, `BaseURL` is required. For standard providers, it's optional and overrides the default endpoint.
 </Note>
+
+### Private Network Access
+
+If your provider runs on a private IP address (e.g. a local vLLM or Ollama instance on `192.168.x.x` or `10.x.x.x`), set `AllowPrivateNetwork: true` in `NetworkConfig`. Link-local addresses (`169.254.x.x`) remain blocked regardless of this setting.
+
+```go
+func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schemas.ProviderConfig, error) {
+	switch provider {
+	case schemas.OpenAI:
+		return &schemas.ProviderConfig{
+			NetworkConfig: schemas.NetworkConfig{
+				BaseURL:              "http://192.168.1.195:8000",
+				AllowPrivateNetwork:  true,
+			},
+			ConcurrencyAndBufferSize: schemas.DefaultConcurrencyAndBufferSize,
+		}, nil
+	}
+	return nil, fmt.Errorf("provider %s not supported", provider)
+}
+```
+
 ### Managing Retries
 
 Configure retry behavior for handling temporary failures and rate limits. This example sets up exponential backoff with up to 5 retries, starting with 1ms delay and capping at 10 seconds - ideal for handling transient network issues.


### PR DESCRIPTION
## Summary

Adds a changelog note for the v1.5.9 release documenting the new Private Network Access feature, which allows Bifrost to connect to providers hosted on private/local networks.

## Changes

- Added a `<Note>` block to the v1.5.9 changelog explaining that setting `allow_private_network: true` in a provider's `network_config` enables connections to RFC 1918 address ranges, supporting local deployments such as vLLM or Ollama instances.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the changelog renders correctly in the docs site and that the `<Note>` block displays the Private Network Access guidance as expected.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The documented feature (`allow_private_network: true`) explicitly opts into connections to private RFC 1918 ranges. Users should be aware this setting should only be enabled intentionally, as it bypasses the default restriction on private network access.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for enabling Private Network Access for providers, with examples for API usage, configuration files, and the Go SDK.
  * Clarified that enabling Private Network Access permits connections to RFC1918 private IP ranges while continuing to block link-local addresses (169.254.x.x).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->