### PR TITLE
chore: bump Bifrost Helm chart to 2.1.22 with `sourceOfTruth`, `disable_content_logging`, `allow_private_network`, multi-profile OTEL, and governance role/budget enhancements

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.21
-appVersion: "1.5.3"
+version: 2.1.22
+appVersion: "1.5.9"
 keywords:
   - ai
   - gateway

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,23 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.21
+**Latest Version:** 2.1.22
 
 ## Changelog
+
+### 2.1.22
+
+- Added `bifrost.governance.roles` array to `values.yaml`, `values.schema.json`, and `_helpers.tpl`. Each role requires a `name` and accepts optional `description`, `dac` (`own-data` | `team-data` | `all-data`, default `all-data`), `access_profile`, and `permissions[]` (`resource` + `operation`).
+- `bifrost.plugins.otel.config` now accepts either the existing single-profile shape or a new `profiles` wrapper (`otelProfilesConfig`) with an array of profiles. Each profile is independently enabled/disabled. A shared `plugin_span_filter` can be set at the top level in either shape.
+- Added `disable_content_logging` to OTEL config (both single-profile and per-profile). When `true`, message content (input/output messages, embeddings, tool definitions, tool call arguments/results) is dropped from exported spans — only metadata (model, tokens, latency) is sent to the collector.
+- Added `otelPluginSpanFilter` (`mode`: `include`/`exclude`, `plugins` array) to the OTEL config schema, available in both single-profile and multi-profile shapes.
+- Added `calendar_aligned` to `bifrost.governance.modelConfigs[]`. 
+- Added `model_config_id` and `customer_id` as budget owner fields in `governance.budgets[]`, alongside the existing `virtual_key_id`, `provider_config_id`, and `team_id`.
+- Extended `attributeTeamMappings` and `attributeBusinessUnitMappings` in SCIM auth config with optional `attributeType` (`user` | `group`) and `attributeValue` fields to enable SCIM-driven team/business-unit provisioning.
+- Added OAuth MCP client config example to `values.yaml` showing `authType: oauth` with `oauthConfigId`.
+- Added `bifrost.sourceOfTruth` (`split` | `config.json`, optional). When set to `"config.json"`, sections explicitly present in the file become authoritative on startup — database-only rows for those sections are pruned. Omitting the field preserves the default `"split"` merge behavior.
+- Added `allow_private_network` to `networkConfig` in `values.schema.json`. When `true`, allows connections to RFC 1918 private IPs (10.x, 172.16.x, 192.168.x) — useful for providers on a k8s pod network, LAN, or private VPC.
+
 
 ### 2.1.21
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -202,6 +202,9 @@ false
 
 {{- define "bifrost.config" -}}
 {{- $config := dict "$schema" "https://www.getbifrost.ai/schema" }}
+{{- if .Values.bifrost.sourceOfTruth }}
+{{- $_ := set $config "source_of_truth" .Values.bifrost.sourceOfTruth }}
+{{- end }}
 {{- if .Values.bifrost.encryptionKey }}
 {{- $_ := set $config "encryption_key" .Values.bifrost.encryptionKey }}
 {{- end }}
@@ -1162,6 +1165,9 @@ false
 {{- if hasKey $inputConfig "insecure" }}
 {{- $_ := set $otelConfig "insecure" $inputConfig.insecure }}
 {{- end }}
+{{- if hasKey $inputConfig "disable_content_logging" }}
+{{- $_ := set $otelConfig "disable_content_logging" $inputConfig.disable_content_logging }}
+{{- end }}
 {{- if $inputConfig.plugin_span_filter }}
 {{- $_ := set $otelConfig "plugin_span_filter" $inputConfig.plugin_span_filter }}
 {{- end }}
@@ -1302,6 +1308,13 @@ Validation template - validates required fields from config.schema.json
 Call this template at the beginning of deployment/stateful templates
 */}}
 {{- define "bifrost.validate" -}}
+
+{{/* Validate bifrost.sourceOfTruth enum */}}
+{{- if .Values.bifrost.sourceOfTruth }}
+{{- if and (ne .Values.bifrost.sourceOfTruth "split") (ne .Values.bifrost.sourceOfTruth "config.json") }}
+{{- fail (printf "ERROR: bifrost.sourceOfTruth must be 'split' or 'config.json', got: %s" .Values.bifrost.sourceOfTruth) }}
+{{- end }}
+{{- end }}
 
 {{/* Validate semantic cache plugin when enabled */}}
 {{- if and .Values.bifrost.plugins.telemetry.enabled (hasKey .Values.bifrost.plugins.telemetry "version") (lt (int .Values.bifrost.plugins.telemetry.version) 1) }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -232,6 +232,12 @@
           "type": "string",
           "enum": ["json", "text"]
         },
+        "sourceOfTruth": {
+          "type": "string",
+          "enum": ["split", "config.json"],
+          "default": "split",
+          "description": "Controls how config.json is reconciled with the database on startup. \"split\" (default) preserves existing merge behavior. \"config.json\" makes explicitly-present sections in the file authoritative — database-only rows for those sections are pruned on startup."
+        },
         "encryptionKey": {
           "type": "string",
           "description": "Encryption key for sensitive data. If not set, encryption is disabled and data is stored in plaintext."
@@ -3461,7 +3467,7 @@
         "insecure": {
           "type": "boolean",
           "description": "Skip TLS verification (ignored if tls_ca_cert is set)",
-          "default": true
+          "default": false
         },
         "disable_content_logging": {
           "type": "boolean",
@@ -4039,6 +4045,11 @@
             "type": "boolean"
           },
           "description": "Override default Anthropic beta header support per provider. Keys are header prefixes (e.g. 'redact-thinking-'), values are true (supported) or false (unsupported). Headers not listed use the built-in defaults."
+        },
+        "allow_private_network": {
+          "type": "boolean",
+          "description": "Allow connections to RFC 1918 private IPs (10.x, 172.16.x, 192.168.x). Enable for providers on a k8s pod network, LAN, or private VPC. Loopback addresses (localhost, 127.0.0.1, ::1) remain allowed regardless of this setting. Link-local addresses (169.254.x.x) are always blocked.",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -168,6 +168,12 @@ bifrost:
   logLevel: info
   logStyle: json
 
+  # Controls how config.json is reconciled with the database on startup.
+  # "split" (default): existing merge behavior — file and DB rows coexist.
+  # "config.json": sections explicitly present in the file are authoritative;
+  #   database-only rows for those sections are pruned on startup.
+  # sourceOfTruth: "config.json"
+
   # Encryption key for sensitive data
   # Can be set as a secret or environment variable
   encryptionKey: ""
@@ -289,6 +295,10 @@ bifrost:
     #     retry_backoff_max_ms: 5000                    # Max retry backoff in ms
     #     stream_idle_timeout_in_seconds: 60            # Max wait for next stream chunk (default: 60)
     #     max_conns_per_host: 5000                      # Max TCP connections per host (default: 5000)
+    #     enforce_http2: false                           # Force HTTP/2 on provider connections (e.g. Bedrock)
+    #     insecure_skip_verify: false                   # Disable TLS certificate verification (last resort)
+    #     ca_cert_pem: ""                               # PEM-encoded CA cert for self-signed/private CA
+    #     allow_private_network: false                  # Allow connections to RFC 1918 private IPs (k8s pod network, LAN, VPC)
     #     beta_header_overrides:                         # Override Anthropic beta header support (optional)
     #       redact-thinking-: true                       # Enable/disable specific beta headers by prefix
     #   # Concurrency configuration (optional)
@@ -466,22 +476,40 @@ bifrost:
       enabled: false
       version: 1
       config:
+        # plugin_span_filter:         # Optional: filter which plugin hook spans are exported
+        #   mode: "include"           # "include" or "exclude"
+        #   plugins: ["maxim", "otel"]
+        #
+        # Multi-profile shape (use profiles OR the flat single-profile fields below, not both):
+        # profiles:
+        #   - service_name: "bifrost"
+        #     collector_url: ""       # e.g., http://otel-collector:4318 (HTTP) or otel-collector:4317 (gRPC)
+        #     trace_type: "genai_extension" # genai_extension | vercel | open_inference
+        #     protocol: "grpc"        # http | grpc
+        #     metrics_enabled: false
+        #     metrics_endpoint: ""    # e.g., http://otel-collector:4318/v1/metrics (HTTP) or otel-collector:4317 (gRPC)
+        #     metrics_push_interval: 15 # Push interval in seconds (1-300)
+        #     headers: {}
+        #     tls_ca_cert: ""         # Path to TLS CA certificate file
+        #     insecure: true          # Skip TLS verification (ignored if tls_ca_cert is set)
+        #     disable_content_logging: false
+        #
+        # Single-profile shape:
         service_name: "bifrost"
-        collector_url: ""
-        trace_type: "genai_extension"
-        protocol: "grpc"
+        collector_url: ""             # e.g., http://otel-collector:4318 (HTTP) or otel-collector:4317 (gRPC)
+        trace_type: "genai_extension" # genai_extension | vercel | open_inference
+        protocol: "grpc"              # http | grpc
         # Push-based metrics export via OTLP (recommended for multi-node clusters)
         metrics_enabled: false
-        metrics_endpoint: "" # e.g., http://otel-collector:4318/v1/metrics (HTTP) or otel-collector:4317 (gRPC)
-        metrics_push_interval: 15 # Push interval in seconds (1-300)
-        # Custom headers for the collector (supports env.VAR_NAME prefix for env var substitution)
+        metrics_endpoint: ""          # e.g., http://otel-collector:4318/v1/metrics (HTTP) or otel-collector:4317 (gRPC)
+        metrics_push_interval: 15     # Push interval in seconds (1-300)
+        # Custom headers for the collector (supports env.VAR_NAME prefix)
         headers: {}
         # TLS configuration
         tls_ca_cert: "" # Path to TLS CA certificate file
         insecure: false # Skip TLS verification (ignored if tls_ca_cert is set)
         # Drop message content (input/output messages, embeddings, tool defs/args/results) from exported spans
         disable_content_logging: false
-
     datadog:
       enabled: false
       version: 1
@@ -538,7 +566,7 @@ bifrost:
       #   config: {}               # Team configuration data
       #   claims: {}               # Team claims data
     roles: []
-      # - name: "data-analyst"
+      # - name: "dataAnalyst"
       #   description: "Read-only access for data analysts"
       #   dac: "team-data"           # own-data | team-data | all-data (default: all-data)
       #   access_profile: "analyst-profile"  # Optional: name of an access_profile to attach

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,30 @@ apiVersion: v1
 entries:
   bifrost:
   - apiVersion: v2
+    appVersion: 1.5.9
+    created: "2026-06-08T15:13:28.66826+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 4d9dc47dd7933db04a55312868331c0bbe89574934420c83186d143e737c21fa
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://github.com/maximhq/bifrost/releases/download/helm-chart-v2.1.22/bifrost-2.1.22.tgz
+    version: 2.1.22
+  - apiVersion: v2
     appVersion: 1.5.3
     created: "2026-06-03T22:30:14.895665+05:30"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
@@ -1012,4 +1036,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-06-03T22:30:14.891442+05:30"
+generated: "2026-06-08T15:13:28.664133+05:30"


### PR DESCRIPTION
## Summary

Bumps the Bifrost Helm chart to version `2.1.22` (app version `1.5.9`), introducing governance roles, multi-profile OTEL export, content logging controls, extended budget ownership, SCIM attribute mappings, an OAuth MCP client config example, a `sourceOfTruth` reconciliation mode, and private network access control.

## Changes

- Added `bifrost.governance.roles` array supporting `name`, `description`, `dac`, `access_profile`, and `permissions[]` (`resource` + `operation`) fields across `values.yaml`, `values.schema.json`, and `_helpers.tpl`.
- Refactored OTEL plugin config to support both a single-profile shape and a new `profiles` wrapper (`otelProfilesConfig`) with an array of independently enable/disable-able profiles. A shared `plugin_span_filter` can be set at the top level in either shape.
- Added `disable_content_logging` to OTEL config (single-profile and per-profile) to drop message content (input/output messages, embeddings, tool definitions, tool call arguments/results) from exported spans while retaining metadata (model, tokens, latency).
- Added `otelPluginSpanFilter` (`mode`: `include`/`exclude`, `plugins` array) to the OTEL config schema for both single-profile and multi-profile shapes.
- Added `calendar_aligned` to `bifrost.governance.modelConfigs[]`.
- Added `model_config_id` and `customer_id` as budget owner fields in `governance.budgets[]` alongside existing `virtual_key_id`, `provider_config_id`, and `team_id`.
- Extended `attributeTeamMappings` and `attributeBusinessUnitMappings` in SCIM auth config with optional `attributeType` (`user` | `group`) and `attributeValue` fields to enable SCIM-driven team/business-unit provisioning.
- Added an OAuth MCP client config example to `values.yaml` showing `authType: oauth` with `oauthConfigId`.
- Added `bifrost.sourceOfTruth` (`split` | `config.json`) to control how `config.json` is reconciled with the database on startup. When set to `"config.json"`, sections explicitly present in the file become authoritative and database-only rows for those sections are pruned. Omitting the field preserves the default `"split"` merge behavior. Invalid values are rejected at render time via a `helm.sh/hook` validation.
- Added `allow_private_network` to `networkConfig` to permit connections to RFC 1918 private IPs (10.x, 172.16.x, 192.168.x), useful for providers on a k8s pod network, LAN, or private VPC.
- Fixed the `insecure` OTEL field default from `true` to `false` in `values.schema.json`.
- Updated Helm index with the new chart release entry pointing to `bifrost-2.1.22.tgz`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
helm repo update
helm install bifrost bifrost/bifrost --version 2.1.22 -f values.yaml
helm lint helm-charts/bifrost/
helm template helm-charts/bifrost/ | kubectl apply --dry-run=client -f -
```

Validate new fields by supplying a `values.yaml` that exercises:
- A `governance.roles` entry with `permissions`.
- An OTEL config using the `profiles` wrapper with `disable_content_logging: true`.
- A `governance.budgets` entry using `model_config_id` or `customer_id`.
- A SCIM mapping with `attributeType` and `attributeValue`.
- `sourceOfTruth: "config.json"` to verify database pruning behavior on startup.
- A provider config with `allow_private_network: true` targeting a private VPC endpoint.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

- `disable_content_logging` provides a mechanism to prevent PII/sensitive prompt content from being exported to OTEL collectors.
- `allow_private_network` must be explicitly opted into; RFC 1918 addresses remain blocked by default. Link-local addresses (169.254.x.x) are always blocked regardless of this setting.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable