### PR TITLE
Accept Cohere-spec string-array documents on /v1/rerank

### DIFF
--- a/core/schemas/rerank.go
+++ b/core/schemas/rerank.go
@@ -7,6 +7,33 @@ type RerankDocument struct {
 	Meta map[string]interface{} `json:"meta,omitempty"`
 }
 
+// UnmarshalJSON accepts both Cohere/vLLM-compatible shapes for a rerank
+// document: a bare JSON string ("hello") or a JSON object ({"text":"hello"}).
+//
+// The Cohere Rerank API and vLLM both accept either form, and many OpenAI-
+// compatible clients (including Open WebUI) send documents as a string array
+// (e.g. `"documents": ["a", "b"]`). Without this method, requests of that
+// shape are rejected at JSON-decode time with a 400 from /v1/rerank.
+func (d *RerankDocument) UnmarshalJSON(data []byte) error {
+	// Try a bare string first.
+	var s string
+	if err := Unmarshal(data, &s); err == nil {
+		d.Text = s
+		d.ID = nil
+		d.Meta = nil
+		return nil
+	}
+	// Fall back to the object form. The alias trick avoids recursion
+	// into this UnmarshalJSON while preserving the full field set.
+	type alias RerankDocument
+	var a alias
+	if err := Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*d = RerankDocument(a)
+	return nil
+}
+
 // RerankParameters contains optional parameters for a rerank request.
 type RerankParameters struct {
 	TopN            *int                   `json:"top_n,omitempty"`

--- a/core/schemas/rerank_test.go
+++ b/core/schemas/rerank_test.go
@@ -1,0 +1,79 @@
+package schemas
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Cohere's Rerank API and vLLM both accept either a bare string or an object
+// with a "text" field for each document. These tests pin the dual-shape
+// behaviour added in RerankDocument.UnmarshalJSON.
+
+func TestRerankDocument_UnmarshalString(t *testing.T) {
+	var d RerankDocument
+	if err := json.Unmarshal([]byte(`"hello"`), &d); err != nil {
+		t.Fatalf("unmarshal bare string: %v", err)
+	}
+	if d.Text != "hello" {
+		t.Fatalf("Text = %q, want %q", d.Text, "hello")
+	}
+	if d.ID != nil {
+		t.Fatalf("ID = %v, want nil", d.ID)
+	}
+	if d.Meta != nil {
+		t.Fatalf("Meta = %v, want nil", d.Meta)
+	}
+}
+
+func TestRerankDocument_UnmarshalObject(t *testing.T) {
+	var d RerankDocument
+	if err := json.Unmarshal([]byte(`{"text":"hello"}`), &d); err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+	if d.Text != "hello" {
+		t.Fatalf("Text = %q, want %q", d.Text, "hello")
+	}
+}
+
+func TestRerankDocument_UnmarshalObjectWithIDAndMeta(t *testing.T) {
+	var d RerankDocument
+	body := `{"text":"hello","id":"doc-1","meta":{"source":"unit-test"}}`
+	if err := json.Unmarshal([]byte(body), &d); err != nil {
+		t.Fatalf("unmarshal object with id/meta: %v", err)
+	}
+	if d.Text != "hello" {
+		t.Fatalf("Text = %q, want %q", d.Text, "hello")
+	}
+	if d.ID == nil || *d.ID != "doc-1" {
+		t.Fatalf("ID = %v, want doc-1", d.ID)
+	}
+	if got, ok := d.Meta["source"].(string); !ok || got != "unit-test" {
+		t.Fatalf("Meta[source] = %v, want unit-test", d.Meta["source"])
+	}
+}
+
+func TestRerankDocuments_UnmarshalStringSlice(t *testing.T) {
+	var docs []RerankDocument
+	if err := json.Unmarshal([]byte(`["a","b"]`), &docs); err != nil {
+		t.Fatalf("unmarshal string slice: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("len = %d, want 2", len(docs))
+	}
+	if docs[0].Text != "a" || docs[1].Text != "b" {
+		t.Fatalf("docs = %+v, want [{Text:a} {Text:b}]", docs)
+	}
+}
+
+func TestRerankDocuments_UnmarshalMixedSlice(t *testing.T) {
+	// Belt-and-suspenders: a slice with both shapes interleaved is something
+	// no real client sends, but the decoder should still tolerate it.
+	var docs []RerankDocument
+	body := `["a",{"text":"b"}]`
+	if err := json.Unmarshal([]byte(body), &docs); err != nil {
+		t.Fatalf("unmarshal mixed slice: %v", err)
+	}
+	if len(docs) != 2 || docs[0].Text != "a" || docs[1].Text != "b" {
+		t.Fatalf("docs = %+v", docs)
+	}
+}


### PR DESCRIPTION
## Why

The Cohere Rerank API and vLLM both accept either a bare string or an object with a `text` field for each document. Many OpenAI-compatible clients — notably **Open WebUI** — send documents as a JSON string array:

```json
{"model": "...", "query": "q", "documents": ["a", "b"]}
```

Today Bifrost's `/v1/rerank` handler decodes into `[]schemas.RerankDocument`, which only accepts the object form, so those requests fail at JSON-decode time with a 400. This blocks Open WebUI's rerank flow against Bifrost entirely.

Reference: [Cohere Rerank API docs](https://docs.cohere.com/reference/rerank) — the `documents` field is documented as accepting either `list of strings` or `list of objects`.

## Reproduction

```bash
# Before this change — 400 Bad Request:
curl -X POST <bifrost>/v1/rerank \
  -d '{"model":"...","query":"q","documents":["a","b"]}'

# Object form already works — 200 OK:
curl -X POST <bifrost>/v1/rerank \
  -d '{"model":"...","query":"q","documents":[{"text":"a"},{"text":"b"}]}'
```

After this change, both shapes return 200.

## What

Add a custom `UnmarshalJSON` on `schemas.RerankDocument` that tries a bare string first and falls back to the existing object form via the standard alias trick (so `Text` / `ID` / `Meta` are preserved without recursing back into the custom unmarshaler).

Both downstream provider converters (`core/providers/cohere/rerank.go`, `core/providers/vllm/rerank.go`) already read `.Text` from each document, so they keep working unchanged. The `/v2/rerank` Cohere integration was already fine — its `CohereRerankRequest.Documents` is a `[]string` decoded directly, then converted to `[]RerankDocument` server-side.

The existing `prepareRerankRequest` validation that requires non-empty `document text` continues to apply, since the bare-string form populates `Text`.

## Test plan

5 unit tests added in `core/schemas/rerank_test.go`:

- [x] `TestRerankDocument_UnmarshalString` — `"hello"` → `{Text:"hello"}`
- [x] `TestRerankDocument_UnmarshalObject` — `{"text":"hello"}` → `{Text:"hello"}`
- [x] `TestRerankDocument_UnmarshalObjectWithIDAndMeta` — full object form preserves `id` and `meta`
- [x] `TestRerankDocuments_UnmarshalStringSlice` — `["a","b"]` → `[{Text:"a"},{Text:"b"}]` (the Open WebUI shape)
- [x] `TestRerankDocuments_UnmarshalMixedSlice` — interleaved shapes still decode

Files are gofmt-clean. Local `go test` could not run in my sandboxed environment (Go module proxy blocked from fetching the toolchain required by `go.mod`); CI on this branch will validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rerank document requests now accept flexible input formats—simplified string entries or full object entries with text, ID, and metadata.

* **Tests**
  * Added comprehensive test coverage for rerank document JSON decoding across multiple input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->