### PR TITLE
feat: vertex files api

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2166,7 +2166,8 @@ func (bifrost *Bifrost) FileUploadRequest(ctx *schemas.BifrostContext, req *sche
 			},
 		}
 	}
-	if len(req.File) == 0 {
+
+	if len(req.File) == 0 && req.Provider != schemas.Vertex {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{

--- a/core/providers/vertex/types.go
+++ b/core/providers/vertex/types.go
@@ -246,3 +246,30 @@ type VertexCountTokensResponse struct {
 	TotalTokens             int32 `json:"totalTokens,omitempty"`
 	CachedContentTokenCount int32 `json:"cachedContentTokenCount,omitempty"`
 }
+
+// ================================ GCS File API Types ================================
+
+// gcsObjectMetadata represents GCS object metadata as returned by the JSON API.
+type gcsObjectMetadata struct {
+	Name        string            `json:"name"`
+	Bucket      string            `json:"bucket"`
+	Size        string            `json:"size"`        // int64 serialised as string by GCS
+	ContentType string            `json:"contentType"`
+	TimeCreated string            `json:"timeCreated"` // RFC3339
+	Updated     string            `json:"updated"`     // RFC3339
+	Metadata    map[string]string `json:"metadata"`
+}
+
+// gcsObjectListResponse is the GCS object list response envelope.
+type gcsObjectListResponse struct {
+	NextPageToken string              `json:"nextPageToken"`
+	Items         []gcsObjectMetadata `json:"items"`
+}
+
+// gcsErrorBody is the GCS API error response envelope.
+type gcsErrorBody struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1,13 +1,16 @@
 package vertex
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"regexp"
 	"strings"
@@ -19,6 +22,7 @@ import (
 	"golang.org/x/oauth2/google"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/providers/openai"
@@ -96,13 +100,14 @@ func NewVertexProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	config.CheckAndSetDefaults()
 	requestTimeout := time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds)
 	client := &fasthttp.Client{
-		ReadTimeout:         requestTimeout,
-		WriteTimeout:        requestTimeout,
-		MaxConnsPerHost:     config.NetworkConfig.MaxConnsPerHost,
-		MaxIdleConnDuration: 30 * time.Second,
-		MaxConnWaitTimeout:  requestTimeout,
-		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
-		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadTimeout:            requestTimeout,
+		WriteTimeout:           requestTimeout,
+		MaxConnsPerHost:        config.NetworkConfig.MaxConnsPerHost,
+		MaxIdleConnDuration:    30 * time.Second,
+		MaxConnWaitTimeout:     requestTimeout,
+		MaxConnDuration:        time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
+		ConnPoolStrategy:       fasthttp.FIFO,
+		DisablePathNormalizing: true,
 	}
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
@@ -2648,30 +2653,629 @@ func (provider *VertexProvider) BatchResults(_ *schemas.BifrostContext, _ []sche
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
 }
 
-// FileUpload is not yet implemented for Vertex AI provider.
-// Vertex AI uses Google Cloud Storage (GCS) for batch input/output files.
-func (provider *VertexProvider) FileUpload(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostFileUploadRequest) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileUploadRequest, provider.GetProviderKey())
+const (
+	gcsStorageBase = "https://storage.googleapis.com/storage/v1"
+	gcsUploadBase  = "https://storage.googleapis.com/upload/storage/v1"
+)
+
+// --- GCS helpers ---
+
+func gcsObjectKey(prefix, filename string) string {
+	key := "vertex-files/" + uuid.New().String() + "/" + filename
+	if prefix != "" {
+		key = strings.Trim(prefix, "/") + "/" + key
+	}
+	return key
 }
 
-// FileList is not yet implemented for Vertex AI provider.
-func (provider *VertexProvider) FileList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileListRequest) (*schemas.BifrostFileListResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileListRequest, provider.GetProviderKey())
+// gcsEncodeObjectName percent-encodes a GCS object name for the URL path,
+// encoding slashes as %2F (url.PathEscape preserves them).
+func gcsEncodeObjectName(name string) string {
+	return strings.ReplaceAll(url.PathEscape(name), "/", "%2F")
 }
 
-// FileRetrieve is not yet implemented for Vertex AI provider.
-func (provider *VertexProvider) FileRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileRetrieveRequest) (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileRetrieveRequest, provider.GetProviderKey())
+func parseGCSURI(uri string) (bucket, objectKey string, err error) {
+	if !strings.HasPrefix(uri, "gs://") {
+		return "", "", fmt.Errorf("invalid GCS URI %q: must start with gs://", uri)
+	}
+	rest := strings.TrimPrefix(uri, "gs://")
+	idx := strings.IndexByte(rest, '/')
+	if idx < 0 {
+		return rest, "", nil
+	}
+	return rest[:idx], rest[idx+1:], nil
 }
 
-// FileDelete is not yet implemented for Vertex AI provider.
-func (provider *VertexProvider) FileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileDeleteRequest) (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileDeleteRequest, provider.GetProviderKey())
+func gcsParseTime(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return 0
+	}
+	return t.Unix()
 }
 
-// FileContent is not yet implemented for Vertex AI provider.
-func (provider *VertexProvider) FileContent(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
+func gcsParseSize(s string) int64 {
+	var n int64
+	fmt.Sscanf(s, "%d", &n)
+	return n
+}
+
+func gcsMetadataToFileObject(bucket string, obj gcsObjectMetadata) schemas.FileObject {
+	filename := obj.Metadata["bifrost_filename"]
+	if filename == "" {
+		// Fall back to last path segment of the object key.
+		if idx := strings.LastIndexByte(obj.Name, '/'); idx >= 0 {
+			filename = obj.Name[idx+1:]
+		} else {
+			filename = obj.Name
+		}
+	}
+	return schemas.FileObject{
+		ID:        "gs://" + bucket + "/" + obj.Name,
+		Object:    "file",
+		Bytes:     gcsParseSize(obj.Size),
+		CreatedAt: gcsParseTime(obj.TimeCreated),
+		UpdatedAt: gcsParseTime(obj.Updated),
+		Filename:  filename,
+		Purpose:   schemas.FilePurpose(obj.Metadata["bifrost_purpose"]),
+		Status:    schemas.FileStatusProcessed,
+	}
+}
+
+func gcsGetAuthHeader(key schemas.Key) (string, error) {
+	tokenSrc, err := getAuthTokenSource(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to get GCS auth token source: %w", err)
+	}
+	tok, err := tokenSrc.Token()
+	if err != nil {
+		removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+		return "", fmt.Errorf("failed to acquire GCS access token: %w", err)
+	}
+	return "Bearer " + tok.AccessToken, nil
+}
+
+func parseGCSAPIError(body []byte, statusCode int, op string) *schemas.BifrostError {
+	var gcsErr gcsErrorBody
+	_ = sonic.Unmarshal(body, &gcsErr)
+	msg := gcsErr.Error.Message
+	if msg == "" {
+		msg = fmt.Sprintf("GCS %s failed with HTTP %d", op, statusCode)
+	}
+	return providerUtils.NewProviderAPIError(msg, nil, statusCode, nil, nil)
+}
+
+// FileUpload uploads a file to GCS for use with Vertex AI inference.
+//
+// Two modes based on whether file bytes are provided:
+//   - Direct (request.File non-empty): uploads bytes via GCS multipart upload.
+//   - Resumable (request.File empty): mints a GCS resumable upload session URL.
+//     The client uploads bytes directly to GCS; Bifrost stays out of the data path.
+func (provider *VertexProvider) FileUpload(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostFileUploadRequest) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+	var bucket, prefix string
+	if request.StorageConfig != nil && request.StorageConfig.GCS != nil {
+		bucket = request.StorageConfig.GCS.Bucket
+		prefix = request.StorageConfig.GCS.Prefix
+	}
+	if bucket == "" {
+		return nil, providerUtils.NewBifrostOperationError("gcs_bucket is required for Vertex FileUpload (provide in storage_config.gcs)", nil)
+	}
+
+	filename := request.Filename
+	if filename == "" {
+		filename = "file-" + uuid.New().String()
+	}
+
+	objectKey := gcsObjectKey(prefix, filename)
+	gcsURI := "gs://" + bucket + "/" + objectKey
+
+	contentType := "application/octet-stream"
+	if request.ContentType != nil && *request.ContentType != "" {
+		contentType = *request.ContentType
+	}
+
+	authHeader, authErr := gcsGetAuthHeader(key)
+	if authErr != nil {
+		return nil, providerUtils.NewBifrostOperationError(authErr.Error(), nil)
+	}
+
+	gcsMeta := map[string]string{
+		"bifrost_filename":     filename,
+		"bifrost_purpose":      string(request.Purpose),
+		"bifrost_content_type": contentType,
+	}
+
+	// GCS object metadata JSON, shared by both upload modes (multipart part 1
+	// for direct uploads, session body for resumable uploads).
+	metaJSON, err := sonic.Marshal(map[string]interface{}{
+		"name":        objectKey,
+		"contentType": contentType,
+		"metadata":    gcsMeta,
+	})
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to marshal GCS object metadata", err)
+	}
+
+	startTime := time.Now()
+
+	if len(request.File) == 0 {
+		return provider.gcsFileUploadResumable(ctx, key, authHeader, bucket, contentType, gcsURI, metaJSON, request, filename, startTime)
+	}
+	return provider.gcsFileUploadDirect(ctx, key, authHeader, bucket, contentType, gcsURI, metaJSON, request, filename, startTime)
+}
+
+func (provider *VertexProvider) gcsFileUploadDirect(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	authHeader, bucket, contentType, gcsURI string,
+	metaJSON []byte,
+	request *schemas.BifrostFileUploadRequest,
+	filename string,
+	startTime time.Time,
+) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+	// Build GCS multipart/related body: part 1 = JSON object metadata, part 2 = file bytes.
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	metaPartHeader := textproto.MIMEHeader{}
+	metaPartHeader.Set("Content-Type", "application/json; charset=UTF-8")
+	metaPart, err := mw.CreatePart(metaPartHeader)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to create GCS metadata part", err)
+	}
+	if _, err := metaPart.Write(metaJSON); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to write GCS metadata part", err)
+	}
+
+	filePartHeader := textproto.MIMEHeader{}
+	filePartHeader.Set("Content-Type", contentType)
+	filePart, err := mw.CreatePart(filePartHeader)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to create GCS file part", err)
+	}
+	if _, err := filePart.Write(request.File); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to write file bytes", err)
+	}
+	if err := mw.Close(); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to finalise GCS multipart body", err)
+	}
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI(fmt.Sprintf("%s/b/%s/o?uploadType=multipart", gcsUploadBase, url.PathEscape(bucket)))
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("multipart/related; boundary=" + mw.Boundary())
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	req.Header.Set("Authorization", authHeader)
+	req.SetBody(buf.Bytes())
+
+	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	if resp.StatusCode() != fasthttp.StatusOK && resp.StatusCode() != fasthttp.StatusCreated {
+		if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+		}
+		return nil, parseGCSAPIError(resp.Body(), resp.StatusCode(), "upload")
+	}
+
+	return &schemas.BifrostFileUploadResponse{
+		ID:             gcsURI,
+		Object:         "file",
+		Bytes:          int64(len(request.File)),
+		CreatedAt:      startTime.Unix(),
+		Filename:       filename,
+		Purpose:        request.Purpose,
+		Status:         schemas.FileStatusProcessed,
+		StorageBackend: schemas.FileStorageGCS,
+		StorageURI:     gcsURI,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency: time.Since(startTime).Milliseconds(),
+		},
+	}, nil
+}
+
+func (provider *VertexProvider) gcsFileUploadResumable(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	authHeader, bucket, contentType, gcsURI string,
+	metaJSON []byte,
+	request *schemas.BifrostFileUploadRequest,
+	filename string,
+	startTime time.Time,
+) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI(fmt.Sprintf("%s/b/%s/o?uploadType=resumable", gcsUploadBase, url.PathEscape(bucket)))
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json; charset=UTF-8")
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	req.Header.Set("Authorization", authHeader)
+	req.Header.Set("X-Upload-Content-Type", contentType)
+	req.SetBody(metaJSON)
+
+	// content_length is optional but helps GCS validate the upload size.
+	if request.ExtraParams != nil {
+		if cl, ok := request.ExtraParams["content_length"].(float64); ok && cl > 0 {
+			req.Header.Set("X-Upload-Content-Length", fmt.Sprintf("%d", int64(cl)))
+		}
+	}
+
+	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+		}
+		return nil, parseGCSAPIError(resp.Body(), resp.StatusCode(), "resumable session initiation")
+	}
+
+	sessionURL := string(resp.Header.Peek("Location"))
+	if sessionURL == "" {
+		return nil, providerUtils.NewBifrostOperationError("GCS did not return a Location header for the resumable session", nil)
+	}
+
+	return &schemas.BifrostFileUploadResponse{
+		ID:             gcsURI,
+		Object:         "file",
+		Bytes:          0,
+		CreatedAt:      startTime.Unix(),
+		Filename:       filename,
+		Purpose:        request.Purpose,
+		Status:         schemas.FileStatusPendingUpload,
+		StorageBackend: schemas.FileStorageGCS,
+		StorageURI:     gcsURI,
+		UploadURL:      &sessionURL,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency: time.Since(startTime).Milliseconds(),
+		},
+	}, nil
+}
+
+// FileList lists GCS objects under the configured prefix.
+// Bucket must be provided via storage_config.gcs.
+// Pagination is serial across keys: each key's GCS pages are exhausted (via the
+// native pageToken) before moving to the next key.
+func (provider *VertexProvider) FileList(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostFileListRequest) (*schemas.BifrostFileListResponse, *schemas.BifrostError) {
+	if len(keys) == 0 {
+		return nil, providerUtils.NewBifrostOperationError("no keys provided for Vertex FileList", nil)
+	}
+	var bucket, prefix string
+	if request.StorageConfig != nil && request.StorageConfig.GCS != nil {
+		bucket = request.StorageConfig.GCS.Bucket
+		prefix = request.StorageConfig.GCS.Prefix
+	}
+	if bucket == "" {
+		return nil, providerUtils.NewBifrostOperationError("gcs_bucket is required for Vertex FileList (provide in storage_config.gcs)", nil)
+	}
+
+	// Serial pagination across keys: exhaust one key's pages before moving to the next.
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
+	}
+
+	key, nativeCursor, ok := helper.GetCurrentKey()
+	if !ok {
+		// All keys exhausted
+		return &schemas.BifrostFileListResponse{
+			Object:  "list",
+			Data:    []schemas.FileObject{},
+			HasMore: false,
+		}, nil
+	}
+
+	authHeader, authErr := gcsGetAuthHeader(key)
+	if authErr != nil {
+		return nil, providerUtils.NewBifrostOperationError(authErr.Error(), nil)
+	}
+
+	params := url.Values{}
+	if prefix != "" {
+		params.Set("prefix", prefix)
+	}
+	limit := request.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	params.Set("maxResults", fmt.Sprintf("%d", limit))
+	if nativeCursor != "" {
+		params.Set("pageToken", nativeCursor)
+	}
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI(fmt.Sprintf("%s/b/%s/o?%s", gcsStorageBase, url.PathEscape(bucket), params.Encode()))
+	req.Header.SetMethod(http.MethodGet)
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	req.Header.Set("Authorization", authHeader)
+
+	startTime := time.Now()
+	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+		}
+		return nil, parseGCSAPIError(resp.Body(), resp.StatusCode(), "list")
+	}
+
+	var listResp gcsObjectListResponse
+	if err := sonic.Unmarshal(resp.Body(), &listResp); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to parse GCS list response", err)
+	}
+
+	files := make([]schemas.FileObject, 0, len(listResp.Items))
+	for _, item := range listResp.Items {
+		files = append(files, gcsMetadataToFileObject(bucket, item))
+	}
+
+	// Build cursor for next request: stay on this key while it has more pages,
+	// then advance to the next key.
+	nextCursor, hasMore := helper.BuildNextCursor(listResp.NextPageToken != "", listResp.NextPageToken)
+
+	result := &schemas.BifrostFileListResponse{
+		Object:  "list",
+		Data:    files,
+		HasMore: hasMore,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency: time.Since(startTime).Milliseconds(),
+		},
+	}
+	if nextCursor != "" {
+		result.After = &nextCursor
+	}
+	return result, nil
+}
+
+// FileRetrieve fetches GCS object metadata, trying each key until one succeeds.
+// FileID must be a gs:// URI.
+func (provider *VertexProvider) FileRetrieve(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostFileRetrieveRequest) (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError) {
+	if len(keys) == 0 {
+		return nil, providerUtils.NewBifrostOperationError("no keys provided for Vertex FileRetrieve", nil)
+	}
+
+	var lastErr *schemas.BifrostError
+	for _, key := range keys {
+		resp, err := provider.fileRetrieveByKey(ctx, key, request)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		provider.logger.Debug("Vertex FileRetrieve failed for key %s: %v", key.Name, err.Error)
+	}
+	return nil, lastErr
+}
+
+// fileRetrieveByKey fetches GCS object metadata for a single key.
+func (provider *VertexProvider) fileRetrieveByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostFileRetrieveRequest) (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError) {
+	bucket, objectKey, parseErr := parseGCSURI(request.FileID)
+	if parseErr != nil {
+		return nil, providerUtils.NewBifrostOperationError(parseErr.Error(), nil)
+	}
+
+	authHeader, authErr := gcsGetAuthHeader(key)
+	if authErr != nil {
+		return nil, providerUtils.NewBifrostOperationError(authErr.Error(), nil)
+	}
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI(fmt.Sprintf("%s/b/%s/o/%s", gcsStorageBase, url.PathEscape(bucket), gcsEncodeObjectName(objectKey)))
+	req.Header.SetMethod(http.MethodGet)
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	req.Header.Set("Authorization", authHeader)
+
+	startTime := time.Now()
+	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+		}
+		return nil, parseGCSAPIError(resp.Body(), resp.StatusCode(), "retrieve")
+	}
+
+	var obj gcsObjectMetadata
+	if err := sonic.Unmarshal(resp.Body(), &obj); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to parse GCS object metadata", err)
+	}
+
+	filename := obj.Metadata["bifrost_filename"]
+	if filename == "" {
+		if idx := strings.LastIndexByte(obj.Name, '/'); idx >= 0 {
+			filename = obj.Name[idx+1:]
+		} else {
+			filename = obj.Name
+		}
+	}
+
+	return &schemas.BifrostFileRetrieveResponse{
+		ID:             request.FileID,
+		Object:         "file",
+		Bytes:          gcsParseSize(obj.Size),
+		CreatedAt:      gcsParseTime(obj.TimeCreated),
+		UpdatedAt:      gcsParseTime(obj.Updated),
+		Filename:       filename,
+		Purpose:        schemas.FilePurpose(obj.Metadata["bifrost_purpose"]),
+		Status:         schemas.FileStatusProcessed,
+		StorageBackend: schemas.FileStorageGCS,
+		StorageURI:     request.FileID,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency: time.Since(startTime).Milliseconds(),
+		},
+	}, nil
+}
+
+// FileDelete deletes a GCS object, trying each key until one succeeds.
+// FileID must be a gs:// URI. Deleting a non-existent object is treated as
+// success (idempotent).
+func (provider *VertexProvider) FileDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostFileDeleteRequest) (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError) {
+	if len(keys) == 0 {
+		return nil, providerUtils.NewBifrostOperationError("no keys provided for Vertex FileDelete", nil)
+	}
+
+	var lastErr *schemas.BifrostError
+	for _, key := range keys {
+		resp, err := provider.fileDeleteByKey(ctx, key, request)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		provider.logger.Debug("Vertex FileDelete failed for key %s: %v", key.Name, err.Error)
+	}
+	return nil, lastErr
+}
+
+// fileDeleteByKey deletes a GCS object for a single key.
+func (provider *VertexProvider) fileDeleteByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostFileDeleteRequest) (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError) {
+	bucket, objectKey, parseErr := parseGCSURI(request.FileID)
+	if parseErr != nil {
+		return nil, providerUtils.NewBifrostOperationError(parseErr.Error(), nil)
+	}
+
+	authHeader, authErr := gcsGetAuthHeader(key)
+	if authErr != nil {
+		return nil, providerUtils.NewBifrostOperationError(authErr.Error(), nil)
+	}
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI(fmt.Sprintf("%s/b/%s/o/%s", gcsStorageBase, url.PathEscape(bucket), gcsEncodeObjectName(objectKey)))
+	req.Header.SetMethod(http.MethodDelete)
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	req.Header.Set("Authorization", authHeader)
+
+	startTime := time.Now()
+	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// 204 = deleted; 404 = already gone — both succeed for an idempotent delete.
+	if resp.StatusCode() != fasthttp.StatusNoContent && resp.StatusCode() != fasthttp.StatusNotFound {
+		if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+		}
+		return nil, parseGCSAPIError(resp.Body(), resp.StatusCode(), "delete")
+	}
+
+	return &schemas.BifrostFileDeleteResponse{
+		ID:      request.FileID,
+		Object:  "file",
+		Deleted: true,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency: time.Since(startTime).Milliseconds(),
+		},
+	}, nil
+}
+
+// FileContent downloads the raw bytes of a GCS object, trying each key until one
+// succeeds. FileID must be a gs:// URI.
+func (provider *VertexProvider) FileContent(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
+	if len(keys) == 0 {
+		return nil, providerUtils.NewBifrostOperationError("no keys provided for Vertex FileContent", nil)
+	}
+
+	var lastErr *schemas.BifrostError
+	for _, key := range keys {
+		resp, err := provider.fileContentByKey(ctx, key, request)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		provider.logger.Debug("Vertex FileContent failed for key %s: %v", key.Name, err.Error)
+	}
+	return nil, lastErr
+}
+
+// fileContentByKey downloads the raw bytes of a GCS object for a single key.
+func (provider *VertexProvider) fileContentByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
+	bucket, objectKey, parseErr := parseGCSURI(request.FileID)
+	if parseErr != nil {
+		return nil, providerUtils.NewBifrostOperationError(parseErr.Error(), nil)
+	}
+
+	authHeader, authErr := gcsGetAuthHeader(key)
+	if authErr != nil {
+		return nil, providerUtils.NewBifrostOperationError(authErr.Error(), nil)
+	}
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI(fmt.Sprintf("%s/b/%s/o/%s?alt=media", gcsStorageBase, url.PathEscape(bucket), gcsEncodeObjectName(objectKey)))
+	req.Header.SetMethod(http.MethodGet)
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	req.Header.Set("Authorization", authHeader)
+
+	startTime := time.Now()
+	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+		}
+		return nil, parseGCSAPIError(resp.Body(), resp.StatusCode(), "content download")
+	}
+
+	// Copy body before deferred ReleaseResponse invalidates the buffer.
+	content := make([]byte, len(resp.Body()))
+	copy(content, resp.Body())
+
+	contentType := string(resp.Header.Peek("Content-Type"))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	return &schemas.BifrostFileContentResponse{
+		FileID:      request.FileID,
+		Content:     content,
+		ContentType: contentType,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency: time.Since(startTime).Milliseconds(),
+		},
+	}, nil
 }
 
 // CountTokens counts the number of tokens in the provided content using Vertex AI's countTokens endpoint.

--- a/core/schemas/files.go
+++ b/core/schemas/files.go
@@ -19,11 +19,12 @@ const (
 type FileStatus string
 
 const (
-	FileStatusUploaded   FileStatus = "uploaded"
-	FileStatusProcessed  FileStatus = "processed"
-	FileStatusProcessing FileStatus = "processing"
-	FileStatusError      FileStatus = "error"
-	FileStatusDeleted    FileStatus = "deleted"
+	FileStatusUploaded      FileStatus = "uploaded"
+	FileStatusProcessed     FileStatus = "processed"
+	FileStatusProcessing    FileStatus = "processing"
+	FileStatusPendingUpload FileStatus = "pending_upload" // resumable session minted, bytes not yet received (Vertex)
+	FileStatusError         FileStatus = "error"
+	FileStatusDeleted       FileStatus = "deleted"
 )
 
 // FileStorageBackend represents the storage backend type.
@@ -112,6 +113,10 @@ type BifrostFileUploadResponse struct {
 	// Storage backend info
 	StorageBackend FileStorageBackend `json:"storage_backend,omitempty"`
 	StorageURI     string             `json:"storage_uri,omitempty"` // S3/GCS URI if applicable
+
+	// GCS resumable upload session URL (Vertex only, set when File bytes are not provided).
+	// Client PUTs file bytes directly to this URL; Bifrost stays out of the data path.
+	UploadURL *string `json:"upload_url,omitempty"`
 
 	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
 }

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -3035,36 +3035,71 @@ func (h *CompletionHandler) fileUpload(ctx *fasthttp.RequestCtx) {
 	}
 	purpose := purposeValues[0]
 
-	// Extract file (required)
+	// Extract file (optional for providers that support resumable uploads, e.g. Vertex/GCS;
+	// when omitted, the provider mints an upload session URL instead of receiving bytes)
+	var fileData []byte
+	var filename string
 	fileHeaders := form.File["file"]
-	if len(fileHeaders) == 0 {
-		SendError(ctx, fasthttp.StatusBadRequest, "file is required")
-		return
+	if len(fileHeaders) > 0 {
+		fileHeader := fileHeaders[0]
+		filename = fileHeader.Filename
+
+		// Open and read the file
+		file, err := fileHeader.Open()
+		if err != nil {
+			logger.Warn("Failed to open uploaded file: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "Internal Server Error")
+			return
+		}
+		defer file.Close()
+
+		// Read file data
+		fileData, err = io.ReadAll(file)
+		if err != nil {
+			logger.Warn("Failed to read uploaded file: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "Internal Server Error")
+			return
+		}
+	} else if len(form.Value["filename"]) > 0 {
+		filename = form.Value["filename"][0]
 	}
 
-	fileHeader := fileHeaders[0]
-
-	// Open and read the file
-	file, err := fileHeader.Open()
-	if err != nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, "Internal Server Error")
-		return
+	// Extract content type (used for resumable upload sessions and stored object metadata)
+	var contentType *string
+	if len(form.Value["content_type"]) > 0 && form.Value["content_type"][0] != "" {
+		contentType = &form.Value["content_type"][0]
 	}
-	defer file.Close()
 
-	// Read file data
-	fileData, err := io.ReadAll(file)
-	if err != nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, "Internal Server Error")
-		return
+	// GCS storage location for Vertex uploads: sent as individual multipart fields,
+	// parsed into the typed StorageConfig rather than passed opaquely via extra_params.
+	var storageConfig *schemas.FileStorageConfig
+	if len(form.Value["gcs_bucket"]) > 0 && form.Value["gcs_bucket"][0] != "" {
+		gcs := &schemas.GCSStorageConfig{Bucket: form.Value["gcs_bucket"][0]}
+		if len(form.Value["gcs_prefix"]) > 0 {
+			gcs.Prefix = form.Value["gcs_prefix"][0]
+		}
+		storageConfig = &schemas.FileStorageConfig{GCS: gcs}
+	}
+
+	// Collect unknown form fields as extra params (multipart — cannot use extractExtraParams which expects JSON).
+	// gcs_bucket/gcs_prefix are consumed into StorageConfig above; other providers (e.g. Bedrock s3_bucket) still flow through here.
+	fileUploadKnownFields := map[string]bool{"file": true, "purpose": true, "provider": true, "filename": true, "content_type": true, "gcs_bucket": true, "gcs_prefix": true}
+	extraParams := map[string]interface{}{}
+	for k, vals := range form.Value {
+		if !fileUploadKnownFields[k] && len(vals) > 0 && vals[0] != "" {
+			extraParams[k] = vals[0]
+		}
 	}
 
 	// Build Bifrost file upload request
 	bifrostFileReq := &schemas.BifrostFileUploadRequest{
-		Provider: schemas.ModelProvider(provider),
-		File:     fileData,
-		Filename: fileHeader.Filename,
-		Purpose:  schemas.FilePurpose(purpose),
+		Provider:      schemas.ModelProvider(provider),
+		File:          fileData,
+		Filename:      filename,
+		Purpose:       schemas.FilePurpose(purpose),
+		ContentType:   contentType,
+		StorageConfig: storageConfig,
+		ExtraParams:   extraParams,
 	}
 
 	// Convert context
@@ -3127,13 +3162,35 @@ func (h *CompletionHandler) fileList(ctx *fasthttp.RequestCtx) {
 		order = &s
 	}
 
+	// GCS storage location for Vertex listing: parsed into the typed StorageConfig
+	// rather than passed opaquely via extra_params.
+	var storageConfig *schemas.FileStorageConfig
+	if gcsBucket := string(ctx.QueryArgs().Peek("gcs_bucket")); gcsBucket != "" {
+		storageConfig = &schemas.FileStorageConfig{GCS: &schemas.GCSStorageConfig{
+			Bucket: gcsBucket,
+			Prefix: string(ctx.QueryArgs().Peek("gcs_prefix")),
+		}}
+	}
+
+	// Collect unknown query args as extra params. gcs_bucket/gcs_prefix are consumed into
+	// StorageConfig above; other providers (e.g. Bedrock s3_bucket) still flow through here.
+	fileListKnownArgs := map[string]bool{"provider": true, "x-model-provider": true, "purpose": true, "limit": true, "after": true, "order": true, "gcs_bucket": true, "gcs_prefix": true}
+	extraParams := map[string]interface{}{}
+	ctx.QueryArgs().VisitAll(func(k, v []byte) {
+		if argKey := string(k); !fileListKnownArgs[argKey] && len(v) > 0 {
+			extraParams[argKey] = string(v)
+		}
+	})
+
 	// Build Bifrost file list request
 	bifrostFileReq := &schemas.BifrostFileListRequest{
-		Provider: schemas.ModelProvider(provider),
-		Purpose:  schemas.FilePurpose(purpose),
-		Limit:    limit,
-		After:    after,
-		Order:    order,
+		Provider:      schemas.ModelProvider(provider),
+		Purpose:       schemas.FilePurpose(purpose),
+		Limit:         limit,
+		After:         after,
+		Order:         order,
+		StorageConfig: storageConfig,
+		ExtraParams:   extraParams,
 	}
 
 	// Convert context
@@ -3167,6 +3224,13 @@ func (h *CompletionHandler) fileRetrieve(ctx *fasthttp.RequestCtx) {
 	if fileID == "" {
 		SendError(ctx, fasthttp.StatusBadRequest, "file_id is required")
 		return
+	}
+
+	// Decode URL-encoded file ID (e.g. gs:// / s3:// URIs must be percent-encoded in the path)
+	if decodedID, err := url.PathUnescape(fileID); err == nil {
+		fileID = decodedID
+	} else {
+		logger.Warn("Failed to URL-decode file_id %q: %v; using original", fileID, err)
 	}
 
 	// Get provider from query parameters
@@ -3215,6 +3279,13 @@ func (h *CompletionHandler) fileDelete(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Decode URL-encoded file ID (e.g. gs:// / s3:// URIs must be percent-encoded in the path)
+	if decodedID, err := url.PathUnescape(fileID); err == nil {
+		fileID = decodedID
+	} else {
+		logger.Warn("Failed to URL-decode file_id %q: %v; using original", fileID, err)
+	}
+
 	// Get provider from query parameters
 	provider := string(ctx.QueryArgs().Peek("provider"))
 	if provider == "" {
@@ -3259,6 +3330,13 @@ func (h *CompletionHandler) fileContent(ctx *fasthttp.RequestCtx) {
 	if fileID == "" {
 		SendError(ctx, fasthttp.StatusBadRequest, "file_id is required")
 		return
+	}
+
+	// Decode URL-encoded file ID (e.g. gs:// / s3:// URIs must be percent-encoded in the path)
+	if decodedID, err := url.PathUnescape(fileID); err == nil {
+		fileID = decodedID
+	} else {
+		logger.Warn("Failed to URL-decode file_id %q: %v; using original", fileID, err)
 	}
 
 	// Get provider from query parameters

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -14,7 +14,7 @@ import { Control, UseFormReturn } from "react-hook-form";
 import { DeploymentsTable } from "./deploymentsTable";
 
 // Providers that support batch APIs
-const BATCH_SUPPORTED_PROVIDERS = ["openai", "bedrock", "anthropic", "gemini", "azure"];
+const BATCH_SUPPORTED_PROVIDERS = ["openai", "bedrock", "anthropic", "gemini", "azure", "vertex"];
 
 interface Props {
 	control: Control<any>;
@@ -345,7 +345,7 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 					/>
 				</>
 			)}
-			{supportsBatchAPI && !isBedrock && !isAzure && <BatchAPIFormField control={control} form={form} />}
+			{supportsBatchAPI && !isBedrock && !isAzure && !isVertex && <BatchAPIFormField control={control} form={form} />}
 			{isAzure && (
 				<div className="space-y-4">
 					<Separator className="my-6" />
@@ -624,6 +624,7 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							)}
 						/>
 					)}
+					{supportsBatchAPI && <BatchAPIFormField control={control} form={form} />}
 				</div>
 			)}
 			{isReplicate && (


### PR DESCRIPTION
## Summary

Implements the full GCS-backed File API for the Vertex AI provider, replacing the previous stub implementations that returned `UnsupportedOperation` errors. Vertex AI uses Google Cloud Storage rather than a native file store, so all file operations (upload, list, retrieve, delete, content download) are mapped to GCS JSON API calls authenticated via the existing Vertex credential chain.

## Changes

- **Vertex `FileUpload`**: Supports two modes — direct upload (multipart/related to GCS when file bytes are provided) and resumable session initiation (returns a GCS `Location` URL when no bytes are provided, allowing the client to PUT bytes directly to GCS). A new `UploadURL` field is added to `BifrostFileUploadResponse` to carry the session URL.
- **Vertex `FileList`**: Lists GCS objects under a configurable bucket/prefix. Supports cursor-based pagination via `pageToken`.
- **Vertex `FileRetrieve`**: Fetches GCS object metadata by `gs://` URI.
- **Vertex `FileDelete`**: Deletes a GCS object by `gs://` URI. Treats 404 as success for idempotency.
- **Vertex `FileContent`**: Downloads raw object bytes from GCS by `gs://` URI.
- **GCS helpers**: Added `gcsResolveBucket`, `gcsObjectKey`, `gcsEncodeObjectName`, `parseGCSURI`, `gcsMetadataToFileObject`, `gcsGetAuthHeader`, and `parseGCSAPIError` to support the above operations. Bucket and prefix can be supplied via `StorageConfig.GCS` or `extra_params["gcs_bucket"]`/`extra_params["gcs_prefix"]`.
- **New GCS types**: `gcsObjectMetadata`, `gcsObjectListResponse`, and `gcsErrorBody` added to `vertex/types.go`.
- **`FileStatusPendingUpload`**: New `FileStatus` constant representing a resumable session that has been minted but whose bytes have not yet been received.
- **`bifrost.go` validation**: The empty-file guard is skipped for Vertex, since resumable uploads intentionally omit file bytes.
- **HTTP transport `fileUpload`**: The `file` multipart field is now optional. When absent, a `filename` form field is accepted instead. `content_type` and arbitrary extra form fields (e.g. `gcs_bucket`, `gcs_prefix`) are forwarded to the provider.
- **HTTP transport `fileList`**: Unknown query args are collected and forwarded as `ExtraParams` so storage-backed providers can receive `gcs_bucket` etc.
- **HTTP transport file ID decoding**: `fileRetrieve`, `fileDelete`, and `fileContent` now percent-decode the file ID path segment, allowing `gs://` and `s3://` URIs to be passed safely in URL paths.
- **`DisablePathNormalizing`**: Enabled on the Vertex fasthttp client to prevent path normalization from mangling percent-encoded GCS object names.
- **UI**: Vertex is added to `BATCH_SUPPORTED_PROVIDERS` and the missing `BatchAPIFormField` is rendered for providers that support batch.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./...

# Direct upload (file bytes provided)
curl -X POST http://localhost:8080/v1/files \
  -F "provider=vertex" \
  -F "purpose=batch" \
  -F "gcs_bucket=my-bucket" \
  -F "file=@/path/to/file.jsonl"
# Expected: 200 with status=processed and storage_uri=gs://my-bucket/...

# Resumable upload session (no file bytes)
curl -X POST http://localhost:8080/v1/files \
  -F "provider=vertex" \
  -F "purpose=batch" \
  -F "gcs_bucket=my-bucket" \
  -F "filename=input.jsonl" \
  -F "content_type=application/jsonl"
# Expected: 200 with status=pending_upload and upload_url set

# List files
curl "http://localhost:8080/v1/files?provider=vertex&gcs_bucket=my-bucket"

# Retrieve metadata (gs:// URI must be percent-encoded in path)
curl "http://localhost:8080/v1/files/gs%3A%2F%2Fmy-bucket%2Fvertex-files%2F...?provider=vertex"

# Delete
curl -X DELETE "http://localhost:8080/v1/files/gs%3A%2F%2Fmy-bucket%2Fvertex-files%2F...?provider=vertex"

# Download content
curl "http://localhost:8080/v1/files/gs%3A%2F%2Fmy-bucket%2Fvertex-files%2F.../content?provider=vertex"
```

GCS bucket must be provided either in `StorageConfig.GCS.Bucket` or via the `gcs_bucket` extra param. An optional `gcs_prefix` scopes object keys within the bucket.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- GCS requests are authenticated using the existing Vertex credential chain (`getAuthTokenSource`). Tokens are short-lived and refreshed automatically; stale token sources are evicted on refresh failure.
- File IDs for Vertex are `gs://` URIs. Callers supplying arbitrary file IDs to retrieve/delete/content endpoints should validate that URIs reference expected buckets before forwarding to the API.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vertex provider: full file support — upload (multipart & resumable with returned upload URL), list, retrieve, delete, and download.
  * UI: Vertex keys can be marked for batch API usage.

* **Improvements**
  * File uploads may omit bytes; filename, content_type, and unknown form/query fields are preserved as extra params.
  * File IDs with special characters are percent-decoded.
  * Deletes are idempotent (missing objects treated as success).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->