### PR TITLE
fixed docs typo

### DIFF
--- a/docs/changelogs/ent-v1.4.7.mdx
+++ b/docs/changelogs/ent-v1.4.7.mdx
@@ -11,8 +11,8 @@ description: "Enterprise v1.4.7 changelog - 2026-06-07"
   details, and a step-by-step checklist before upgrading.
 </Warning>
 
-<Warning>>
-v1.4.7 has a known `/virtua-key/quota` issue which is fixed in v1.4.8.
+<Warning>
+  v1.4.7 has a known <code>/virtua-key/quota</code> issue which is fixed in v1.4.8.
 </Warning>
 
 ## Changelog

--- a/docs/changelogs/v1.5.11.mdx
+++ b/docs/changelogs/v1.5.11.mdx
@@ -17,6 +17,7 @@ description: "v1.5.11 changelog - 2026-06-08"
 </Tabs>
 
 <Update label="Bifrost(HTTP)" description="1.5.11">
+
 <Warning>
 Run the rollback queries below before migrating if you need to preserve compatibility with v1.5.8.
 </Warning>


### PR DESCRIPTION
## Summary

Fixes two minor documentation issues in changelog files: a malformed `<Warning>` tag and a missing blank line that could affect MDX rendering.

## Changes

- Removed an extra `>` from the opening `<Warning>` tag in `ent-v1.4.7.mdx` and wrapped the `/virtua-key/quota` path in a `<code>` element for proper inline code formatting
- Added a blank line after the `<Update>` tag in `v1.5.11.mdx` to ensure correct MDX parsing of the nested `<Warning>` block

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered changelog pages for `ent-v1.4.7` and `v1.5.11` to confirm the warning banners display correctly and the `/virtua-key/quota` path renders as inline code.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable