### PR TITLE
Adds 1.5.8 rollback instructions (this will be a standard process)

### DIFF
--- a/docs/changelogs/v1.5.10.mdx
+++ b/docs/changelogs/v1.5.10.mdx
@@ -27,9 +27,12 @@ description: "v1.5.10 changelog - 2026-06-07"
 - **Virtual Key Usage Tracking Under User Attribution** - Usage is no longer silently dropped from virtual-key accounting whenever a user is attributed on a request. Governance now tracks both the virtual-key and user scopes by default; callers that deliberately want user-only accounting can opt in with the new `bifrost-skip-virtual-key-usage-tracking` context flag (#4123)
 - **Wildcard Allow-Lists for Catalog-Opaque Providers** - A wildcard (`*`) allowed-models list now correctly permits any model for providers whose models the catalog cannot enumerate - custom providers without list-models support, and keyless self-hosted vLLM/Ollama/SGL - instead of incorrectly rejecting them (#4124)
 
-## ⏲️Rolling back (to 1.5.8)
+## ⏲️ Rolling back (to 1.5.8)
 
-### Single node setup
+These are the DB queries you would need to fire if you need to rollback to v1.5.8.
+
+<AccordionGroup>
+  <Accordion title="Single node setup">
 
 ```sql
 -- ============================================================
@@ -133,7 +136,9 @@ DELETE FROM migrations WHERE id = 'add_budget_model_config_id_column';
 COMMIT;
 ```
 
-### Multiple nodes
+  </Accordion>
+
+  <Accordion title="Multiple nodes">
 
 ```sql
 -- ============================================================
@@ -231,6 +236,9 @@ DELETE FROM migrations WHERE id = 'migrate_provider_governance_to_model_configs'
 
 COMMIT;
 ```
+
+  </Accordion>
+</AccordionGroup>
 
 </Update>
 <Update label="Core" description="1.5.18">

--- a/docs/changelogs/v1.5.11.mdx
+++ b/docs/changelogs/v1.5.11.mdx
@@ -24,6 +24,8 @@ description: "v1.5.11 changelog - 2026-06-08"
 
 ## ⏲️ Rolling back (to 1.5.8)
 
+These are the DB queries you would need to fire if you need to rollback to v1.5.8.
+
 <AccordionGroup>
   <Accordion title="Single node setup">
 

--- a/docs/changelogs/v1.5.9.mdx
+++ b/docs/changelogs/v1.5.9.mdx
@@ -72,6 +72,220 @@ description: "v1.5.9 changelog - 2026-06-07"
 
 - **Dependency Upgrades** — Bumped transitive `golang.org/x` dependencies (crypto, net, sys, text) for Docker Scout CVE remediation and `recharts` to 3.8.1; cascaded version bumps across all modules (#3900, #4003)
 
+
+## ⏲️ Rolling back (to 1.5.8)
+
+These are the DB queries you would need to fire if you need to rollback to v1.5.8.
+
+<AccordionGroup>
+  <Accordion title="Single node setup">
+
+```sql
+-- ============================================================
+-- STEP 1: Rollback migrate_virtual_key_governance_to_model_configs
+-- ============================================================
+
+BEGIN;
+
+-- 1A. Restore VK top-level governance (provider IS NULL rows)
+
+UPDATE governance_budgets
+SET virtual_key_id = mc.scope_id,
+    model_config_id = NULL
+FROM governance_model_configs mc
+WHERE governance_budgets.model_config_id = mc.id
+  AND mc.scope = 'virtual_key'
+  AND mc.model_name = '*'
+  AND mc.provider IS NULL
+  AND mc.scope_id IS NOT NULL;
+
+UPDATE governance_virtual_keys
+SET rate_limit_id = mc.rate_limit_id
+FROM governance_model_configs mc
+WHERE mc.scope = 'virtual_key'
+  AND mc.scope_id = governance_virtual_keys.id
+  AND mc.model_name = '*'
+  AND mc.provider IS NULL
+  AND mc.rate_limit_id IS NOT NULL;
+
+-- 1B. Restore VK per-provider governance (provider IS NOT NULL rows)
+
+UPDATE governance_budgets
+SET provider_config_id = pc.id,
+    model_config_id = NULL
+FROM governance_model_configs mc
+JOIN governance_virtual_key_provider_configs pc
+  ON pc.virtual_key_id = mc.scope_id AND pc.provider = mc.provider
+WHERE governance_budgets.model_config_id = mc.id
+  AND mc.scope = 'virtual_key'
+  AND mc.model_name = '*'
+  AND mc.provider IS NOT NULL
+  AND mc.scope_id IS NOT NULL;
+
+UPDATE governance_virtual_key_provider_configs
+SET rate_limit_id = mc.rate_limit_id
+FROM governance_model_configs mc
+WHERE mc.scope = 'virtual_key'
+  AND mc.scope_id = governance_virtual_key_provider_configs.virtual_key_id
+  AND mc.provider = governance_virtual_key_provider_configs.provider
+  AND mc.model_name = '*'
+  AND mc.rate_limit_id IS NOT NULL;
+
+-- 1C. Delete the VK-scoped wildcard model config rows
+DELETE FROM governance_model_configs
+WHERE scope = 'virtual_key'
+  AND model_name = '*';
+
+-- 1D. Remove the migration record
+DELETE FROM migrations WHERE id = 'migrate_virtual_key_governance_to_model_configs';
+
+COMMIT;
+
+-- ============================================================
+-- STEP 2: Rollback migrate_provider_governance_to_model_configs
+-- ============================================================
+
+BEGIN;
+
+UPDATE config_providers
+SET budget_id = mc.budget_id,
+    rate_limit_id = mc.rate_limit_id
+FROM governance_model_configs mc
+WHERE mc.scope = 'global'
+  AND mc.scope_id IS NULL
+  AND mc.model_name = '*'
+  AND mc.provider = config_providers.name;
+
+DELETE FROM governance_model_configs
+WHERE scope = 'global'
+  AND scope_id IS NULL
+  AND model_name = '*'
+  AND provider IS NOT NULL;
+
+DELETE FROM migrations WHERE id = 'migrate_provider_governance_to_model_configs';
+
+COMMIT;
+
+-- ============================================================
+-- STEP 3 (if needed): Rollback add_budget_model_config_id_column
+-- Only if downgrading to a version before this column existed
+-- ============================================================
+
+BEGIN;
+
+UPDATE governance_budgets SET model_config_id = NULL WHERE model_config_id IS NOT NULL;
+
+ALTER TABLE governance_budgets DROP COLUMN model_config_id;
+
+DELETE FROM migrations WHERE id = 'add_budget_model_config_id_column';
+
+COMMIT;
+```
+
+  </Accordion>
+
+  <Accordion title="Multiple nodes">
+
+```sql
+-- ============================================================
+-- PHASE 1: DUAL-WRITE — restore old FKs, keep new rows intact
+-- Safe to run while the current (new) version is serving traffic
+-- ============================================================
+
+BEGIN;
+
+-- 1A. Restore provider-level governance back to config_providers
+UPDATE config_providers
+SET budget_id = mc.budget_id,
+    rate_limit_id = mc.rate_limit_id
+FROM governance_model_configs mc
+WHERE mc.scope = 'global'
+  AND mc.scope_id IS NULL
+  AND mc.model_name = '*'
+  AND mc.provider = config_providers.name;
+
+-- 1B. Restore VK top-level budgets back to governance_virtual_keys
+--     (intentionally NOT clearing model_config_id yet — new pods still need it)
+UPDATE governance_budgets
+SET virtual_key_id = mc.scope_id
+FROM governance_model_configs mc
+WHERE governance_budgets.model_config_id = mc.id
+  AND mc.scope = 'virtual_key'
+  AND mc.model_name = '*'
+  AND mc.provider IS NULL
+  AND mc.scope_id IS NOT NULL;
+
+-- Restore VK top-level rate limits
+UPDATE governance_virtual_keys
+SET rate_limit_id = mc.rate_limit_id
+FROM governance_model_configs mc
+WHERE mc.scope = 'virtual_key'
+  AND mc.scope_id = governance_virtual_keys.id
+  AND mc.model_name = '*'
+  AND mc.provider IS NULL
+  AND mc.rate_limit_id IS NOT NULL;
+
+-- 1C. Restore VK per-provider budgets back to provider configs
+UPDATE governance_budgets
+SET provider_config_id = pc.id
+FROM governance_model_configs mc
+JOIN governance_virtual_key_provider_configs pc
+  ON pc.virtual_key_id = mc.scope_id AND pc.provider = mc.provider
+WHERE governance_budgets.model_config_id = mc.id
+  AND mc.scope = 'virtual_key'
+  AND mc.model_name = '*'
+  AND mc.provider IS NOT NULL
+  AND mc.scope_id IS NOT NULL;
+
+-- Restore VK per-provider rate limits
+UPDATE governance_virtual_key_provider_configs
+SET rate_limit_id = mc.rate_limit_id
+FROM governance_model_configs mc
+WHERE mc.scope = 'virtual_key'
+  AND mc.scope_id = governance_virtual_key_provider_configs.virtual_key_id
+  AND mc.provider = governance_virtual_key_provider_configs.provider
+  AND mc.model_name = '*'
+  AND mc.rate_limit_id IS NOT NULL;
+
+COMMIT;
+
+
+-- ============================================================
+-- PHASE 2: CLEANUP — remove new-version-only data
+-- Run ONLY after ALL pods are on the old version
+-- ============================================================
+
+BEGIN;
+
+-- Clear model_config_id from budgets (old version doesn't use it)
+UPDATE governance_budgets SET model_config_id = NULL WHERE model_config_id IS NOT NULL;
+
+-- Delete the VK-scoped wildcard model config rows
+DELETE FROM governance_model_configs
+WHERE scope = 'virtual_key'
+  AND model_name = '*';
+
+-- Delete the provider-level wildcard model config rows
+DELETE FROM governance_model_configs
+WHERE scope = 'global'
+  AND scope_id IS NULL
+  AND model_name = '*'
+  AND provider IS NOT NULL;
+
+-- Remove migration records so a future upgrade re-runs them
+DELETE FROM migrations WHERE id = 'migrate_virtual_key_governance_to_model_configs';
+DELETE FROM migrations WHERE id = 'migrate_provider_governance_to_model_configs';
+
+-- Optional: only if the old version predates the model_config_id column
+-- ALTER TABLE governance_budgets DROP COLUMN model_config_id;
+-- DELETE FROM migrations WHERE id = 'add_budget_model_config_id_column';
+
+COMMIT;
+```
+
+  </Accordion>
+</AccordionGroup>
+
 </Update>
 <Update label="Core" description="1.5.17">
 - feat: OpenAI compaction support (#4053)


### PR DESCRIPTION
## Summary

Improves the rollback documentation across the v1.5.9, v1.5.10, and v1.5.11 changelogs by adding missing rollback SQL scripts and wrapping rollback sections in collapsible accordions for better readability.

## Changes

- Added the full rollback SQL scripts (single node and multiple nodes) to the v1.5.9 changelog, which previously had no rollback section at all
- Wrapped the rollback SQL blocks in `v1.5.10` inside `<AccordionGroup>` / `<Accordion>` components to match the format used in other changelogs, and added the introductory sentence explaining the purpose of the queries
- Added the introductory sentence to the v1.5.11 rollback section for consistency
- Fixed a missing space in the `⏲️ Rolling back` heading in v1.5.10

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered changelog pages for v1.5.9, v1.5.10, and v1.5.11 to confirm:
- The rollback sections display with collapsible accordions for single node and multiple node setups
- The introductory sentence appears above the accordion groups
- SQL blocks render correctly inside each accordion

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable