### PR TITLE
fix: private network toggle in custom provider form

### DIFF
--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -23,6 +23,7 @@ const formSchema = z.object({
 	allowed_requests: allowedRequestsSchema,
 	request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
 	is_key_less: z.boolean().optional(),
+	allow_private_network: z.boolean().optional(),
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -79,6 +80,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 			},
 			request_path_overrides: undefined,
 			is_key_less: false,
+			allow_private_network: false,
 		},
 	});
 
@@ -99,6 +101,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 			},
 			network_config: {
 				base_url: data.base_url,
+				allow_private_network: data.allow_private_network ?? false,
 				default_request_timeout_in_seconds: 30,
 				max_retries: 0,
 				retry_backoff_initial: 500,
@@ -190,6 +193,32 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 											/>
 										</FormControl>
 										<FormMessage />
+									</div>
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="allow_private_network"
+							render={({ field }) => (
+								<FormItem>
+									<div className="flex items-center justify-between space-x-2 rounded-lg border p-3">
+										<div className="space-y-0.5">
+											<label htmlFor="allow-private-network" className="text-sm font-medium">
+												Allow Private Network
+											</label>
+											<p className="text-muted-foreground text-sm">
+												Allow connecting to private network IPs (e.g. 192.168.x.x, 10.x.x.x). Link-local addresses remain blocked.
+											</p>
+										</div>
+										<Switch
+											id="allow-private-network"
+											size="md"
+											checked={field.value}
+											onCheckedChange={field.onChange}
+											disabled={!hasProviderCreateAccess}
+											data-testid="custom-provider-allow-private-network-switch"
+										/>
 									</div>
 								</FormItem>
 							)}


### PR DESCRIPTION
## Summary

Adds an "Allow Private Network" toggle to the custom provider creation form, enabling users to configure whether a custom provider can connect to private network IP ranges (e.g., `192.168.x.x`, `10.x.x.x`). Link-local addresses remain blocked regardless of this setting.

## Changes

- Added `allow_private_network` as an optional boolean field to the custom provider form schema, defaulting to `false`
- Wired the field value into `network_config.allow_private_network` when saving the provider
- Added a labeled toggle switch in the form UI with a description clarifying which address ranges are affected and which remain blocked

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the custom provider creation sheet in the workspace providers UI.
2. Verify the "Allow Private Network" toggle is visible and defaults to off.
3. Enable the toggle and save the provider — confirm `allow_private_network: true` is included in the saved `network_config`.
4. Disable the toggle and save — confirm `allow_private_network: false` is sent.
5. Verify the toggle is disabled when the user lacks provider create access.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the custom provider form showing the new toggle._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

This toggle explicitly opts a custom provider into connecting to private network ranges. It defaults to `false` (blocked), preserving the existing secure-by-default behavior. Link-local addresses remain blocked unconditionally to prevent SSRF via metadata endpoints.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Allow Private Network" toggle option in the custom provider creation form, enabling users to control private network access settings when setting up custom providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->