### PR TITLE
feat: add custom MCP library entries with soft-delete and sync protection

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -872,6 +872,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddMCPLibraryConfigColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddMCPLibrarySourceColumns(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -9856,6 +9859,56 @@ func migrationAddMCPLibraryConfigColumns(ctx context.Context, db *gorm.DB) error
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_mcp_library_config_columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPLibrarySourceColumns adds the source and deleted_at columns to
+// mcp_library. `source` marks a row as remote-synced or org-internal ("custom")
+// so the sync can protect custom rows; `deleted_at` is a soft-delete tombstone
+// so a user-hidden row (remote or custom) is never resurrected by the next sync.
+// Idempotent via HasColumn guards.
+func migrationAddMCPLibrarySourceColumns(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_mcp_library_source_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableMCPLibrary{}, "source") {
+				if err := mg.AddColumn(&tables.TableMCPLibrary{}, "Source"); err != nil {
+					return fmt.Errorf("add source column: %w", err)
+				}
+			}
+			if !mg.HasColumn(&tables.TableMCPLibrary{}, "deleted_at") {
+				if err := mg.AddColumn(&tables.TableMCPLibrary{}, "DeletedAt"); err != nil {
+					return fmt.Errorf("add deleted_at column: %w", err)
+				}
+			}
+			// Create indexes on the new columns (AddColumn doesn't create indexes
+			// from struct tags). `deleted_at IS NULL` is the leading predicate on
+			// every paginated library query, so the index avoids a full table scan.
+			if !mg.HasIndex(&tables.TableMCPLibrary{}, "idx_mcp_library_source") {
+				if err := mg.CreateIndex(&tables.TableMCPLibrary{}, "Source"); err != nil {
+					return fmt.Errorf("create index on mcp_library.source: %w", err)
+				}
+			}
+			if !mg.HasIndex(&tables.TableMCPLibrary{}, "idx_mcp_library_deleted_at") {
+				if err := mg.CreateIndex(&tables.TableMCPLibrary{}, "DeletedAt"); err != nil {
+					return fmt.Errorf("create index on mcp_library.deleted_at: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// Rollback is intentionally a no-op: dropping `source` and
+			// `deleted_at` would destroy custom-row protection markers and
+			// soft-delete tombstones, letting the next sync resurrect rows the
+			// user hid. This migration is one-way.
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_library_source_columns migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1624,7 +1624,7 @@ var mcpLibrarySortColumns = map[string]string{
 // search, filtering, sorting, and pagination. Returns the page of rows and the
 // total count matching the filters (before pagination).
 func (s *RDBConfigStore) GetMCPLibraryPaginated(ctx context.Context, params MCPLibraryQueryParams) ([]tables.TableMCPLibrary, int64, error) {
-	baseQuery := s.DB().WithContext(ctx).Model(&tables.TableMCPLibrary{})
+	baseQuery := s.DB().WithContext(ctx).Model(&tables.TableMCPLibrary{}).Where("deleted_at IS NULL")
 
 	if params.Search != "" {
 		search := "%" + strings.ToLower(params.Search) + "%"
@@ -1712,6 +1712,7 @@ func (s *RDBConfigStore) GetMCPLibraryFilterData(ctx context.Context) (*MCPLibra
 		var values []string
 		if err := db.Model(&tables.TableMCPLibrary{}).
 			Distinct(column).
+			Where("deleted_at IS NULL").
 			Where(column+" IS NOT NULL AND "+column+" != ?", "").
 			Order(column+" ASC").
 			Pluck(column, &values).Error; err != nil {
@@ -1735,6 +1736,7 @@ func (s *RDBConfigStore) GetMCPLibraryFilterData(ctx context.Context) (*MCPLibra
 	var tagBlobs []string
 	if err := db.Model(&tables.TableMCPLibrary{}).
 		Distinct("tags").
+		Where("deleted_at IS NULL").
 		Where("tags IS NOT NULL AND tags != ?", "").
 		Pluck("tags", &tagBlobs).Error; err != nil {
 		return nil, err
@@ -1806,6 +1808,47 @@ func (s *RDBConfigStore) UpsertMCPLibraryEntry(ctx context.Context, entry *table
 		return s.parseGormError(err)
 	}
 	return nil
+}
+
+// CreateCustomMCPLibraryEntry inserts an org-internal ("custom") library row.
+// Source is forced to "custom" regardless of what the caller passed. The unique
+// slug index prevents duplicates; parseGormError maps that to ErrAlreadyExists.
+func (s *RDBConfigStore) CreateCustomMCPLibraryEntry(ctx context.Context, entry *tables.TableMCPLibrary) error {
+	entry.Source = "custom"
+	if err := s.DB().WithContext(ctx).Create(entry).Error; err != nil {
+		return s.parseGormError(err)
+	}
+	return nil
+}
+
+// SoftDeleteMCPLibraryEntry tombstones a library row by ID (sets deleted_at to
+// now) so it no longer appears in listings and the remote sync respects the
+// tombstone. Works on both "remote" and "custom" rows.
+func (s *RDBConfigStore) SoftDeleteMCPLibraryEntry(ctx context.Context, id uint) error {
+	result := s.DB().WithContext(ctx).
+		Model(&tables.TableMCPLibrary{}).
+		Where("id = ? AND deleted_at IS NULL", id).
+		Update("deleted_at", time.Now())
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// GetProtectedMCPLibrarySlugs returns the slugs the remote sync must skip:
+// custom rows (any source != "remote") and soft-deleted rows (deleted_at set).
+func (s *RDBConfigStore) GetProtectedMCPLibrarySlugs(ctx context.Context) ([]string, error) {
+	var slugs []string
+	if err := s.DB().WithContext(ctx).
+		Model(&tables.TableMCPLibrary{}).
+		Where("source != 'remote' OR deleted_at IS NOT NULL").
+		Pluck("slug", &slugs).Error; err != nil {
+		return nil, err
+	}
+	return slugs, nil
 }
 func (s *RDBConfigStore) GetMCPClientByID(ctx context.Context, id string) (*tables.TableMCPClient, error) {
 	var mcpClient tables.TableMCPClient

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -190,10 +190,19 @@ type ConfigStore interface {
 	UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient) error
 	DeleteMCPClientConfig(ctx context.Context, id string) error
 
-	// MCP library catalog (synced, read-only)
+	// MCP library catalog (synced + org-custom)
 	GetMCPLibraryPaginated(ctx context.Context, params MCPLibraryQueryParams) ([]tables.TableMCPLibrary, int64, error)
 	GetMCPLibraryFilterData(ctx context.Context) (*MCPLibraryFilterData, error)
 	UpsertMCPLibraryEntry(ctx context.Context, entry *tables.TableMCPLibrary, tx ...*gorm.DB) error
+	// CreateCustomMCPLibraryEntry inserts an org-internal ("custom") library row.
+	// Returns ErrAlreadyExists when the slug collides with an existing entry.
+	CreateCustomMCPLibraryEntry(ctx context.Context, entry *tables.TableMCPLibrary) error
+	// SoftDeleteMCPLibraryEntry tombstones a library row by ID (sets deleted_at)
+	// so it is hidden from listings and never resurrected by the remote sync.
+	SoftDeleteMCPLibraryEntry(ctx context.Context, id uint) error
+	// GetProtectedMCPLibrarySlugs returns the slugs the remote sync must not
+	// overwrite or recreate: custom rows and soft-deleted (tombstoned) rows.
+	GetProtectedMCPLibrarySlugs(ctx context.Context) ([]string, error)
 
 	// Vector store config CRUD
 	UpdateVectorStoreConfig(ctx context.Context, config *vectorstore.Config) error

--- a/framework/configstore/tables/mcp_library.go
+++ b/framework/configstore/tables/mcp_library.go
@@ -7,10 +7,11 @@ import (
 )
 
 // TableMCPLibrary represents a single discoverable MCP server in the MCP
-// library catalog. Rows are synced from the external MCP library datasheet
-// (see modelcatalog.DefaultMCPLibraryURL) on a configurable interval — this is
-// a read-only, synced-only catalog that users browse and install from,
-// mirroring the governance_model_pricing / governance_model_parameters tables.
+// library catalog. Most rows are synced from the external MCP library datasheet
+// (see modelcatalog.DefaultMCPLibraryURL) on a configurable interval, mirroring
+// the governance_model_pricing / governance_model_parameters tables. Orgs may
+// also publish their own internal servers as "custom" rows (see Source), which
+// are protected from being overwritten or resurrected by the remote sync.
 //
 // A row is a *template* for an schemas.MCPClientConfig: it carries the
 // connection details a user needs to install the server, shaped the same way
@@ -56,6 +57,21 @@ type TableMCPLibrary struct {
 	Publisher string         `gorm:"type:varchar(255)" json:"publisher,omitempty"`
 	Tags      []string       `gorm:"type:text;serializer:json;default:null" json:"tags,omitempty"`
 	Metadata  map[string]any `gorm:"type:text;serializer:json;default:null" json:"metadata,omitempty"`
+
+	// Source distinguishes remote-synced rows ("remote") from org-internal rows
+	// a user published through the API ("custom"). Custom rows are protected from
+	// the remote sync: a slug clash in the remote payload is skipped, never
+	// overwritten. Defaults to "remote" so existing rows and the sync upsert keep
+	// their old behavior.
+	Source string `gorm:"type:varchar(20);not null;default:'remote';index:idx_mcp_library_source" json:"source"`
+
+	// DeletedAt is a soft-delete tombstone (nil = visible). A user may hide any
+	// entry — including a remote-seeded one — and the tombstone must survive the
+	// next sync so the row is never resurrected. This is a plain nullable
+	// timestamp rather than gorm.DeletedAt on purpose: the sync upsert keys off
+	// slug and must still see tombstoned rows by slug to skip them; gorm's
+	// soft-delete would hide them from that lookup and let duplicates reinsert.
+	DeletedAt *time.Time `gorm:"index:idx_mcp_library_deleted_at;default:null" json:"-"`
 
 	CreatedAt time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`

--- a/framework/modelcatalog/mcp_library_sync.go
+++ b/framework/modelcatalog/mcp_library_sync.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -112,6 +113,18 @@ func SyncMCPLibrary(ctx context.Context, url string, store configstore.ConfigSto
 		return 0, nil
 	}
 
+	// Load the slugs the sync must not touch: org-internal ("custom") rows and
+	// soft-deleted ("tombstoned") rows. A remote payload entry whose slug is in
+	// this set is skipped silently so the rest of the payload still seeds.
+	protected, err := store.GetProtectedMCPLibrarySlugs(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load protected MCP library slugs: %w", err)
+	}
+	protectedSet := make(map[string]bool, len(protected))
+	for _, slug := range protected {
+		protectedSet[slug] = true
+	}
+
 	// Upsert all entries in a single transaction.
 	count := 0
 	err = store.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
@@ -120,6 +133,15 @@ func SyncMCPLibrary(ctx context.Context, url string, store configstore.ConfigSto
 			e := &entries[i]
 			if e.Name == "" {
 				continue // skip malformed entries
+			}
+			// The catalog payload carries no slug; derive it from the name,
+			// matching the slug generation used for custom library entries.
+			slug := Slugify(e.Name)
+			if slug == "" {
+				continue // name had no slug-able content
+			}
+			if protectedSet[slug] {
+				continue // never overwrite custom or tombstoned rows
 			}
 			if seen[slug] {
 				continue // deduplicate within the payload
@@ -142,6 +164,7 @@ func SyncMCPLibrary(ctx context.Context, url string, store configstore.ConfigSto
 				Publisher:          e.Publisher,
 				Tags:               e.Tags,
 				Metadata:           e.Metadata,
+				Source:             "remote",
 				CreatedAt:          now,
 				UpdatedAt:          now,
 			}
@@ -264,4 +287,32 @@ func fetchMCPLibrary(ctx context.Context, rawURL string) ([]MCPLibraryEntry, err
 	}
 
 	return payload.Servers, nil
+}
+
+// Slugify derives a URL/identifier-safe slug from a display name: lowercase,
+// non-alphanumeric runs collapsed to a single "-", and leading/trailing "-"
+// trimmed. Used to key custom library entries off their name so the existing
+// unique slug index detects duplicates. Returns "" for names with no
+// alphanumeric content (the caller rejects an empty slug).
+//
+// NOTE: only ASCII letters and digits are retained — accented/unicode characters
+// (e.g. "données") are stripped, which may produce unexpected slugs for non-ASCII
+// names. This is intentional to keep slugs URL-safe without a transliteration
+// dependency; callers should be aware of this limitation.
+func Slugify(name string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash && b.Len() > 0 {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -73,6 +73,8 @@ func (h *MCPHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.Bif
 	r.GET("/api/mcp/library", lib.ChainMiddlewares(h.getMCPLibrary, middlewares...))
 	r.GET("/api/mcp/library/filterdata", lib.ChainMiddlewares(h.getMCPLibraryFilterData, middlewares...))
 	r.POST("/api/mcp/library/force-sync", lib.ChainMiddlewares(h.forceSyncMCPLibrary, middlewares...))
+	r.POST("/api/mcp/library", lib.ChainMiddlewares(h.createMCPLibraryEntry, middlewares...))
+	r.DELETE("/api/mcp/library/{id}", lib.ChainMiddlewares(h.deleteMCPLibraryEntry, middlewares...))
 	r.POST("/api/mcp/client", lib.ChainMiddlewares(h.addMCPClient, middlewares...))
 	r.PUT("/api/mcp/client/{id}", lib.ChainMiddlewares(h.updateMCPClient, middlewares...))
 	r.DELETE("/api/mcp/client/{id}", lib.ChainMiddlewares(h.deleteMCPClient, middlewares...))
@@ -1875,4 +1877,153 @@ func perUserHeaderKeysAdded(oldKeys, newKeys []string) bool {
 		}
 	}
 	return false
+}
+
+// CreateMCPLibraryEntryRequest is the body for POST /api/mcp/library. It carries
+// the user-supplied fields of a custom library entry; DB-managed fields (id,
+// slug, source, timestamps) are derived server-side. The slug is generated from
+// Name, and the unique slug index enforces no-duplicate-name.
+type CreateMCPLibraryEntryRequest struct {
+	Name               string                    `json:"name"`
+	Description        string                    `json:"description,omitempty"`
+	Category           string                    `json:"category,omitempty"`
+	ConnectionType     schemas.MCPConnectionType `json:"connection_type"`
+	ConnectionURL      string                    `json:"connection_url,omitempty"`
+	StdioConfig        *schemas.MCPStdioConfig   `json:"stdio_config,omitempty"`
+	AuthType           schemas.MCPAuthType       `json:"auth_type,omitempty"`
+	RequiredHeaderKeys []string                  `json:"required_header_keys,omitempty"`
+	IconURL            string                    `json:"icon_url,omitempty"`
+	DocsURL            string                    `json:"docs_url,omitempty"`
+	Publisher          string                    `json:"publisher,omitempty"`
+	Tags               []string                  `json:"tags,omitempty"`
+}
+
+// createMCPLibraryEntry handles POST /api/mcp/library — publishes an org-internal
+// ("custom") MCP server into the library so other members can discover and
+// install it. The entry is protected from the remote sync (see Source/skip-set
+// in SyncMCPLibrary). A duplicate name (same generated slug) returns 409.
+func (h *MCPHandler) createMCPLibraryEntry(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
+		return
+	}
+
+	var req CreateMCPLibraryEntryRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err))
+		return
+	}
+
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "name is required")
+		return
+	}
+
+	// Validate connection type and the matching connection field.
+	switch req.ConnectionType {
+	case schemas.MCPConnectionTypeHTTP, schemas.MCPConnectionTypeSSE:
+		if strings.TrimSpace(req.ConnectionURL) == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "connection_url is required for http/sse connection types")
+			return
+		}
+	case schemas.MCPConnectionTypeSTDIO:
+		if req.StdioConfig == nil || strings.TrimSpace(req.StdioConfig.Command) == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "stdio_config.command is required for stdio connection type")
+			return
+		}
+	default:
+		SendError(ctx, fasthttp.StatusBadRequest, "connection_type must be one of: http, stdio, sse")
+		return
+	}
+
+	// Default and validate auth type.
+	if req.AuthType == "" {
+		req.AuthType = schemas.MCPAuthTypeNone
+	}
+	switch req.AuthType {
+	case schemas.MCPAuthTypeNone, schemas.MCPAuthTypeHeaders, schemas.MCPAuthTypeOauth,
+		schemas.MCPAuthTypePerUserOauth, schemas.MCPAuthTypePerUserHeaders:
+	default:
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid auth_type")
+		return
+	}
+
+	slug := modelcatalog.Slugify(req.Name)
+	if slug == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "name must contain at least one alphanumeric character")
+		return
+	}
+
+	now := time.Now()
+	entry := &configstoreTables.TableMCPLibrary{
+		Slug:               slug,
+		Name:               req.Name,
+		Description:        req.Description,
+		Category:           req.Category,
+		ConnectionType:     req.ConnectionType,
+		ConnectionURL:      req.ConnectionURL,
+		StdioConfig:        req.StdioConfig,
+		AuthType:           req.AuthType,
+		RequiredHeaderKeys: req.RequiredHeaderKeys,
+		IconURL:            req.IconURL,
+		DocsURL:            req.DocsURL,
+		Publisher:          req.Publisher,
+		Tags:               req.Tags,
+		Source:             "custom",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	if err := h.store.ConfigStore.CreateCustomMCPLibraryEntry(ctx, entry); err != nil {
+		if errors.Is(err, configstore.ErrAlreadyExists) {
+			SendError(ctx, fasthttp.StatusConflict, "an MCP library server with this name already exists")
+			return
+		}
+		logger.Error("failed to create custom MCP library entry: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to create MCP library entry")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"status":  "success",
+		"message": "MCP library server published successfully",
+		"entry":   entry,
+	})
+}
+
+// deleteMCPLibraryEntry handles DELETE /api/mcp/library/{id} — soft-deletes a
+// library entry (remote or custom) by numeric ID. The row is hidden from
+// listings and the remote sync respects the tombstone, so a hidden remote entry
+// is never resurrected. Also the escape hatch for a duplicate-name lockout.
+func (h *MCPHandler) deleteMCPLibraryEntry(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
+		return
+	}
+	idStr, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid id: %v", err))
+		return
+	}
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "id must be a positive integer")
+		return
+	}
+
+	if err := h.store.ConfigStore.SoftDeleteMCPLibraryEntry(ctx, uint(id)); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "MCP library entry not found")
+			return
+		}
+		logger.Error("failed to soft-delete MCP library entry %d: %v", id, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to delete MCP library entry")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"status":  "success",
+		"message": "MCP library server removed successfully",
+	})
 }

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -652,6 +652,18 @@ func (m *MockConfigStore) UpsertMCPLibraryEntry(ctx context.Context, entry *tabl
 	return nil
 }
 
+func (m *MockConfigStore) CreateCustomMCPLibraryEntry(ctx context.Context, entry *tables.TableMCPLibrary) error {
+	return nil
+}
+
+func (m *MockConfigStore) SoftDeleteMCPLibraryEntry(ctx context.Context, id uint) error {
+	return nil
+}
+
+func (m *MockConfigStore) GetProtectedMCPLibrarySlugs(ctx context.Context) ([]string, error) {
+	return []string{}, nil
+}
+
 func (m *MockConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) error {
 	if m.mcpConfig == nil {
 		return nil
@@ -16476,6 +16488,7 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 	defaultURL := modelcatalog.DefaultPricingURL
 	defaultSyncSeconds := int64(modelcatalog.DefaultSyncInterval.Seconds())
 	defaultModelParamsURL := modelcatalog.DefaultModelParametersURL
+	defaultMCPLibraryURL := modelcatalog.DefaultMCPLibraryURL
 	fileURL := "https://example.com/pricing.json"
 	fileSyncSeconds := int64((12 * time.Hour).Seconds())
 	dbURL := "https://db.example.com/pricing.json"
@@ -16516,11 +16529,13 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 		uiEditedURL := "https://ui-edited.example.com/pricing.json"
 		uiEditedSync := int64((24 * time.Hour).Seconds())
 		dbConfig := &tables.TableFrameworkConfig{
-			ID:                  8,
-			PricingURL:          &uiEditedURL,
-			PricingSyncInterval: &uiEditedSync,
-			ModelParametersURL:  &defaultModelParamsURL,
-			ConfigHash:          storedHash, // hash of last file-applied values
+			ID:                     8,
+			PricingURL:             &uiEditedURL,
+			PricingSyncInterval:    &uiEditedSync,
+			ModelParametersURL:     &defaultModelParamsURL,
+			MCPLibraryURL:          &defaultMCPLibraryURL,
+			MCPLibrarySyncInterval: &defaultSyncSeconds,
+			ConfigHash:             storedHash, // hash of last file-applied values
 		}
 		fileConfig := &framework.FrameworkConfig{
 			Pricing: &modelcatalog.Config{
@@ -16602,8 +16617,118 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 		require.False(t, needsDBUpdate)
 		require.Equal(t, defaultURL, *normalizedTable.PricingURL)
 		require.Equal(t, defaultSyncSeconds, *normalizedTable.PricingSyncInterval)
+		require.Equal(t, defaultMCPLibraryURL, *normalizedTable.MCPLibraryURL)
+		require.Equal(t, defaultSyncSeconds, *normalizedTable.MCPLibrarySyncInterval)
 		require.Equal(t, defaultURL, *normalizedModelCatalog.PricingURL)
 		require.Equal(t, defaultSyncSeconds, *normalizedModelCatalog.PricingSyncInterval)
+		require.Equal(t, defaultMCPLibraryURL, *normalizedModelCatalog.MCPLibraryURL)
+		require.Equal(t, defaultSyncSeconds, *normalizedModelCatalog.MCPLibrarySyncInterval)
+	})
+
+	t.Run("mcp library file values override defaults", func(t *testing.T) {
+		mcpURL := "https://example.com/mcp-library.json"
+		mcpSyncSeconds := int64((2 * time.Hour).Seconds())
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{
+				MCPLibraryURL:          &mcpURL,
+				MCPLibrarySyncInterval: &mcpSyncSeconds,
+			},
+		}
+
+		normalizedTable, normalizedModelCatalog, needsDBUpdate := ResolveFrameworkPricingConfig(nil, fileConfig)
+		require.False(t, needsDBUpdate)
+		require.Equal(t, mcpURL, *normalizedTable.MCPLibraryURL)
+		require.Equal(t, mcpSyncSeconds, *normalizedTable.MCPLibrarySyncInterval)
+		require.Equal(t, mcpURL, *normalizedModelCatalog.MCPLibraryURL)
+		require.Equal(t, mcpSyncSeconds, *normalizedModelCatalog.MCPLibrarySyncInterval)
+	})
+
+	t.Run("mcp library file values override db when file hash changed", func(t *testing.T) {
+		mcpURL := "https://file.example.com/mcp-library.json"
+		mcpSyncSeconds := int64((2 * time.Hour).Seconds())
+		dbMCPURL := modelcatalog.DefaultMCPLibraryURL
+		dbMCPSyncSeconds := int64((24 * time.Hour).Seconds())
+		dbConfig := &tables.TableFrameworkConfig{
+			ID:                     11,
+			MCPLibraryURL:          &dbMCPURL,
+			MCPLibrarySyncInterval: &dbMCPSyncSeconds,
+			ConfigHash:             "old-hash",
+		}
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{
+				MCPLibraryURL:          &mcpURL,
+				MCPLibrarySyncInterval: &mcpSyncSeconds,
+			},
+		}
+
+		normalizedTable, normalizedModelCatalog, needsDBUpdate := ResolveFrameworkPricingConfig(dbConfig, fileConfig)
+		require.True(t, needsDBUpdate)
+		require.Equal(t, mcpURL, *normalizedTable.MCPLibraryURL)
+		require.Equal(t, mcpSyncSeconds, *normalizedTable.MCPLibrarySyncInterval)
+		require.Equal(t, mcpURL, *normalizedModelCatalog.MCPLibraryURL)
+		require.Equal(t, mcpSyncSeconds, *normalizedModelCatalog.MCPLibrarySyncInterval)
+	})
+
+	t.Run("mcp library db wins when file hash matches stored hash", func(t *testing.T) {
+		fileMCPURL := "https://file.example.com/mcp-library.json"
+		fileMCPSyncSeconds := int64((2 * time.Hour).Seconds())
+		storedHash, err := configstore.GenerateFrameworkConfigHash(nil, nil, nil, configstore.FrameworkConfigHashOptions{
+			MCPLibraryURL:          &fileMCPURL,
+			MCPLibrarySyncInterval: &fileMCPSyncSeconds,
+		})
+		require.NoError(t, err)
+		uiEditedMCPURL := "https://ui.example.com/mcp-library.json"
+		uiEditedMCPSyncSeconds := int64((3 * time.Hour).Seconds())
+		dbConfig := &tables.TableFrameworkConfig{
+			ID:                     12,
+			PricingURL:             &defaultURL,
+			PricingSyncInterval:    &defaultSyncSeconds,
+			ModelParametersURL:     &defaultModelParamsURL,
+			MCPLibraryURL:          &uiEditedMCPURL,
+			MCPLibrarySyncInterval: &uiEditedMCPSyncSeconds,
+			ConfigHash:             storedHash,
+		}
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{
+				MCPLibraryURL:          &fileMCPURL,
+				MCPLibrarySyncInterval: &fileMCPSyncSeconds,
+			},
+		}
+
+		normalizedTable, normalizedModelCatalog, needsDBUpdate := ResolveFrameworkPricingConfig(dbConfig, fileConfig)
+		require.False(t, needsDBUpdate)
+		require.Equal(t, uiEditedMCPURL, *normalizedTable.MCPLibraryURL)
+		require.Equal(t, uiEditedMCPSyncSeconds, *normalizedTable.MCPLibrarySyncInterval)
+		require.Equal(t, uiEditedMCPURL, *normalizedModelCatalog.MCPLibraryURL)
+		require.Equal(t, uiEditedMCPSyncSeconds, *normalizedModelCatalog.MCPLibrarySyncInterval)
+	})
+
+	t.Run("mcp library file interval below minimum is clamped", func(t *testing.T) {
+		tooLow := int64(1800)
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{
+				MCPLibrarySyncInterval: &tooLow,
+			},
+		}
+
+		normalizedTable, normalizedModelCatalog, needsDBUpdate := ResolveFrameworkPricingConfig(nil, fileConfig)
+		require.False(t, needsDBUpdate)
+		require.Equal(t, modelcatalog.MinimumPricingSyncIntervalSec, *normalizedTable.MCPLibrarySyncInterval)
+		require.Equal(t, modelcatalog.MinimumPricingSyncIntervalSec, *normalizedModelCatalog.MCPLibrarySyncInterval)
+	})
+
+	t.Run("mcp library invalid db interval falls back and requests db update", func(t *testing.T) {
+		invalidDBSync := int64(0)
+		dbConfig := &tables.TableFrameworkConfig{
+			ID:                     10,
+			MCPLibraryURL:          &defaultMCPLibraryURL,
+			MCPLibrarySyncInterval: &invalidDBSync,
+		}
+
+		normalizedTable, normalizedModelCatalog, needsDBUpdate := ResolveFrameworkPricingConfig(dbConfig, nil)
+		require.True(t, needsDBUpdate)
+		require.Equal(t, defaultSyncSeconds, *normalizedTable.MCPLibrarySyncInterval)
+		require.Equal(t, defaultSyncSeconds, *normalizedModelCatalog.MCPLibrarySyncInterval)
 	})
 
 	t.Run("invalid db interval (zero) falls back and requests db update", func(t *testing.T) {
@@ -16748,10 +16873,14 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 			require.NotNil(t, tableOut.PricingURL, "PricingURL must never be nil")
 			require.NotNil(t, tableOut.PricingSyncInterval, "PricingSyncInterval must never be nil")
 			require.NotNil(t, tableOut.ModelParametersURL, "ModelParametersURL must never be nil")
+			require.NotNil(t, tableOut.MCPLibraryURL, "MCPLibraryURL must never be nil")
+			require.NotNil(t, tableOut.MCPLibrarySyncInterval, "MCPLibrarySyncInterval must never be nil")
 			require.NotNil(t, catalogOut, "modelcatalog.Config must never be nil")
 			require.NotNil(t, catalogOut.PricingURL, "Config.PricingURL must never be nil")
 			require.NotNil(t, catalogOut.PricingSyncInterval, "Config.PricingSyncInterval must never be nil")
 			require.NotNil(t, catalogOut.ModelParametersURL, "Config.ModelParametersURL must never be nil")
+			require.NotNil(t, catalogOut.MCPLibraryURL, "Config.MCPLibraryURL must never be nil")
+			require.NotNil(t, catalogOut.MCPLibrarySyncInterval, "Config.MCPLibrarySyncInterval must never be nil")
 		}
 	})
 

--- a/ui/app/workspace/mcp-registry/library/page.tsx
+++ b/ui/app/workspace/mcp-registry/library/page.tsx
@@ -8,9 +8,10 @@ import { getErrorMessage, useGetMCPClientsQuery, useGetMCPLibraryQuery } from "@
 import type { MCPLibraryEntry } from "@/lib/types/mcp";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ChevronLeft, ChevronRight, LayoutGrid, Library, List, Search, Settings } from "lucide-react";
+import { ChevronLeft, ChevronRight, LayoutGrid, Library, List, Plus, Search, Settings } from "lucide-react";
 import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { MCPLibraryAddServerSheet } from "./views/mcpLibraryAddServerSheet";
 import { MCPLibraryFilterSidebar, type MCPLibraryFilters } from "./views/mcpLibraryFilterSidebar";
 import { MCPLibraryInstallSheet, sanitizeServerName } from "./views/mcpLibraryInstallSheet";
 import { MCPLibraryServerCard } from "./views/mcpLibraryServerCard";
@@ -37,6 +38,7 @@ export default function MCPLibraryPage() {
 	const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.Update);
 	const [selectedServer, setSelectedServer] = useState<MCPLibraryEntry | null>(null);
 	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [addServerOpen, setAddServerOpen] = useState(false);
 	const [viewMode, setViewMode] = useState<MCPLibraryViewMode>(getInitialViewMode);
 	const { toast } = useToast();
 
@@ -166,6 +168,12 @@ export default function MCPLibraryPage() {
 								<p className="text-muted-foreground max-w-2xl text-sm">Browse and install MCP servers from the synced catalog.</p>
 							</div>
 							<div className="flex items-center gap-2">
+								{hasCreateMCPClientAccess && (
+									<Button variant="outline" size="sm" onClick={() => setAddServerOpen(true)} data-testid="mcp-library-add-server-btn">
+										<Plus className="h-4 w-4" />
+										Add Server
+									</Button>
+								)}
 								{hasSettingsAccess && (
 									<Button variant="outline" size="sm" onClick={() => setSettingsOpen(true)} data-testid="mcp-library-settings-btn">
 										<Settings className="h-4 w-4" />
@@ -268,6 +276,7 @@ export default function MCPLibraryPage() {
 													server={server}
 													isInstalled={isInstalled}
 													canCreateMCPClient={hasCreateMCPClientAccess}
+													canDelete={hasDeleteMCPLibraryAccess}
 													onInstall={setSelectedServer}
 												/>
 											);
@@ -278,6 +287,7 @@ export default function MCPLibraryPage() {
 										servers={servers}
 										installedServerSlugs={installedServerSlugs}
 										canCreateMCPClient={hasCreateMCPClientAccess}
+										canDelete={hasDeleteMCPLibraryAccess}
 										onInstall={setSelectedServer}
 									/>
 								)}
@@ -339,6 +349,9 @@ export default function MCPLibraryPage() {
 
 			{/* Settings sheet */}
 			<MCPLibrarySettingsSheet open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+
+			{/* Add Server sheet */}
+			<MCPLibraryAddServerSheet open={addServerOpen} onClose={() => setAddServerOpen(false)} />
 		</div>
 	);
 }

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryAddServerSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryAddServerSheet.tsx
@@ -1,0 +1,293 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { getErrorMessage, useCreateMCPLibraryEntryMutation } from "@/lib/store";
+import type { CreateMCPLibraryEntryRequest, MCPAuthType, MCPConnectionType } from "@/lib/types/mcp";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+interface MCPLibraryAddServerFormData {
+	name: string;
+	description: string;
+	category: string;
+	connection_type: MCPConnectionType;
+	connection_url: string;
+	command: string;
+	args: string;
+	envs: string;
+	auth_type: MCPAuthType;
+	required_header_keys: string;
+	icon_url: string;
+	docs_url: string;
+	tags: string;
+}
+
+interface MCPLibraryAddServerSheetProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+const DEFAULTS: MCPLibraryAddServerFormData = {
+	name: "",
+	description: "",
+	category: "",
+	connection_type: "http",
+	connection_url: "",
+	command: "",
+	args: "",
+	envs: "",
+	auth_type: "none",
+	required_header_keys: "",
+	icon_url: "",
+	docs_url: "",
+	tags: "",
+};
+
+// Split a comma/newline-separated string into a trimmed, non-empty list.
+function parseList(text: string): string[] {
+	return text
+		.split(/[\n,]/)
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+export function MCPLibraryAddServerSheet({ open, onClose }: MCPLibraryAddServerSheetProps) {
+	const [createEntry, { isLoading }] = useCreateMCPLibraryEntryMutation();
+
+	const {
+		register,
+		handleSubmit,
+		watch,
+		setValue,
+		reset,
+		formState: { errors },
+	} = useForm<MCPLibraryAddServerFormData>({ defaultValues: DEFAULTS });
+
+	useEffect(() => {
+		if (open) reset(DEFAULTS);
+	}, [open, reset]);
+
+	const connectionType = watch("connection_type");
+	const authType = watch("auth_type");
+	const isStdio = connectionType === "stdio";
+	const needsHeaderKeys = authType === "headers" || authType === "per_user_headers";
+
+	const onSubmit = async (data: MCPLibraryAddServerFormData) => {
+		const tags = parseList(data.tags);
+		const payload: CreateMCPLibraryEntryRequest = {
+			name: data.name.trim(),
+			description: data.description.trim() || undefined,
+			category: data.category.trim() || undefined,
+			connection_type: data.connection_type,
+			auth_type: data.auth_type,
+			icon_url: data.icon_url.trim() || undefined,
+			docs_url: data.docs_url.trim() || undefined,
+			tags: tags.length ? tags : undefined,
+		};
+
+		if (isStdio) {
+			payload.stdio_config = {
+				command: data.command.trim(),
+				args: parseList(data.args),
+				envs: parseList(data.envs),
+			};
+		} else {
+			payload.connection_url = data.connection_url.trim();
+		}
+
+		if (needsHeaderKeys) {
+			payload.required_header_keys = parseList(data.required_header_keys);
+		}
+
+		try {
+			await createEntry(payload).unwrap();
+			toast.success("MCP server published to the library.");
+			onClose();
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+		}
+	};
+
+	return (
+		<Sheet open={open} onOpenChange={(sheetOpen) => !sheetOpen && onClose()}>
+			<SheetContent className="flex w-full flex-col overflow-x-hidden p-0 pt-4">
+				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky px-8 -top-4 bg-card z-10">
+					<SheetTitle>Add MCP Server</SheetTitle>
+					<SheetDescription>This MCP server will be available org-wide for members to discover, install, and use.</SheetDescription>
+				</SheetHeader>
+
+				<form onSubmit={handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
+					<div className="flex-1 space-y-4 px-8 py-4">
+						{/* Name */}
+						<div className="space-y-2">
+							<Label htmlFor="mcp-add-name">Name</Label>
+							<Input
+								id="mcp-add-name"
+								placeholder="My Internal Server"
+								data-testid="mcp-add-name-input"
+								className={errors.name ? "border-destructive" : ""}
+								{...register("name", {
+									required: "Name is required",
+									validate: (v) => v.trim().length > 0 || "Name is required",
+								})}
+							/>
+							{errors.name && <p className="text-destructive text-sm">{errors.name.message}</p>}
+						</div>
+
+						{/* Description */}
+						<div className="space-y-2">
+							<Label htmlFor="mcp-add-description">Description</Label>
+							<Textarea
+								id="mcp-add-description"
+								placeholder="What this server does..."
+								data-testid="mcp-add-description-input"
+								{...register("description")}
+							/>
+						</div>
+
+						{/* Connection details */}
+						<div className="flex gap-3">
+							<div className="w-32 shrink-0 space-y-2">
+								<Label>Connection Type</Label>
+								<Select value={connectionType} onValueChange={(v) => setValue("connection_type", v as MCPConnectionType)}>
+									<SelectTrigger className="w-full" data-testid="mcp-add-connection-type">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="http">HTTP</SelectItem>
+										<SelectItem value="sse">SSE</SelectItem>
+										<SelectItem value="stdio">STDIO</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							{!isStdio && (
+								<div className="min-w-0 flex-1 space-y-2">
+									<Label htmlFor="mcp-add-url">Connection URL</Label>
+									<Input
+										id="mcp-add-url"
+										placeholder="https://my-server.internal/mcp"
+										data-testid="mcp-add-url-input"
+										className={errors.connection_url ? "border-destructive" : ""}
+										{...register("connection_url", {
+											validate: (v) => (!isStdio ? v.trim().length > 0 || "Connection URL is required" : true),
+										})}
+									/>
+									{errors.connection_url && <p className="text-destructive text-sm">{errors.connection_url.message}</p>}
+								</div>
+							)}
+						</div>
+
+						{isStdio && (
+							<div className="space-y-4 rounded-sm border p-4">
+								<div className="space-y-2">
+									<Label htmlFor="mcp-add-command">Command</Label>
+									<Input
+										id="mcp-add-command"
+										placeholder="npx"
+										data-testid="mcp-add-command-input"
+										className={errors.command ? "border-destructive" : ""}
+										{...register("command", {
+											validate: (v) => (isStdio ? v.trim().length > 0 || "Command is required for stdio" : true),
+										})}
+									/>
+									{errors.command && <p className="text-destructive text-sm">{errors.command.message}</p>}
+								</div>
+								<div className="space-y-2">
+									<Label htmlFor="mcp-add-args">Arguments</Label>
+									<Input
+										id="mcp-add-args"
+										placeholder="comma separated, e.g. -y, my-package"
+										data-testid="mcp-add-args-input"
+										{...register("args")}
+									/>
+								</div>
+								<div className="space-y-2">
+									<Label htmlFor="mcp-add-envs">Environment Variable Names</Label>
+									<Input
+										id="mcp-add-envs"
+										placeholder="comma separated, e.g. API_KEY, DB_URL"
+										data-testid="mcp-add-envs-input"
+										{...register("envs")}
+									/>
+									<p className="text-muted-foreground text-xs">Only names — users supply values at install time.</p>
+								</div>
+							</div>
+						)}
+
+						{/* Auth + category */}
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-2 w-full">
+								<Label>Authentication</Label>
+								<Select value={authType} onValueChange={(v) => setValue("auth_type", v as MCPAuthType)}>
+									<SelectTrigger data-testid="mcp-add-auth-type" className="w-full">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="none">None</SelectItem>
+										<SelectItem value="headers">Headers</SelectItem>
+										<SelectItem value="oauth">OAuth</SelectItem>
+										<SelectItem value="per_user_headers">Per-user Headers</SelectItem>
+										<SelectItem value="per_user_oauth">Per-user OAuth</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="mcp-add-category">Category</Label>
+								<Input id="mcp-add-category" placeholder="e.g. Database" data-testid="mcp-add-category-input" {...register("category")} />
+							</div>
+						</div>
+
+						{needsHeaderKeys && (
+							<div className="space-y-2">
+								<Label htmlFor="mcp-add-header-keys">Required Header Names</Label>
+								<Input
+									id="mcp-add-header-keys"
+									placeholder="comma separated, e.g. X-Api-Key"
+									data-testid="mcp-add-header-keys-input"
+									{...register("required_header_keys")}
+								/>
+								<p className="text-muted-foreground text-xs">Only names — users supply values at install time.</p>
+							</div>
+						)}
+
+						{/* Optional metadata */}
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-2">
+								<Label htmlFor="mcp-add-icon">Icon URL</Label>
+								<Input id="mcp-add-icon" placeholder="https://..." data-testid="mcp-add-icon-input" {...register("icon_url")} />
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="mcp-add-docs">Docs URL</Label>
+								<Input id="mcp-add-docs" placeholder="https://..." data-testid="mcp-add-docs-input" {...register("docs_url")} />
+							</div>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="mcp-add-tags">Tags</Label>
+							<Input
+								id="mcp-add-tags"
+								placeholder="comma separated, e.g. internal, database"
+								data-testid="mcp-add-tags-input"
+								{...register("tags")}
+							/>
+						</div>
+					</div>
+
+					<div className="border-border bg-card sticky bottom-0 z-10 border-t px-8 py-4">
+						<div className="flex justify-end gap-2">
+							<Button type="button" variant="outline" onClick={onClose} disabled={isLoading} data-testid="mcp-add-cancel-btn">
+								Cancel
+							</Button>
+							<Button type="submit" disabled={isLoading} data-testid="mcp-add-submit-btn">
+								{isLoading ? "Publishing..." : "Publish to Library"}
+							</Button>
+						</div>
+					</div>
+				</form>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryDeleteDialog.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryDeleteDialog.tsx
@@ -1,0 +1,57 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import type { MCPLibraryEntry } from "@/lib/types/mcp";
+
+interface MCPLibraryDeleteDialogProps {
+	/** The entry being removed; when null the dialog is closed. */
+	server: MCPLibraryEntry | null;
+	open: boolean;
+	isDeleting: boolean;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+	confirmTestId: string;
+}
+
+// Shared confirmation dialog for soft-deleting a library entry, used by both the
+// card and table views. Copy is sync-aware: custom entries simply disappear,
+// while remote entries are tombstoned so they don't reappear on the next sync.
+export function MCPLibraryDeleteDialog({ server, open, isDeleting, onOpenChange, onConfirm, confirmTestId }: MCPLibraryDeleteDialogProps) {
+	const isCustom = server?.source === "custom";
+
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Remove "{server?.name}" from library?</AlertDialogTitle>
+					<AlertDialogDescription>
+						{isCustom
+							? "This custom server will no longer be available for members to install."
+							: "This server will be hidden from the library and will not reappear on the next catalog sync."}{" "}
+						Existing installations are not affected.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={(event) => {
+							event.preventDefault();
+							onConfirm();
+						}}
+						disabled={isDeleting}
+						data-testid={confirmTestId}
+					>
+						{isDeleting ? "Removing..." : "Remove"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryServerCard.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryServerCard.tsx
@@ -2,9 +2,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { getErrorMessage, useDeleteMCPLibraryEntryMutation } from "@/lib/store";
 import type { MCPLibraryEntry } from "@/lib/types/mcp";
 import { Link } from "@tanstack/react-router";
-import { BookIcon, Globe, Library, Radio, Terminal } from "lucide-react";
+import { BookIcon, Globe, Radio, Terminal, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 import { MCPLibraryDeleteDialog } from "./mcpLibraryDeleteDialog";
 
 const MAX_VISIBLE_TAGS = 3;
@@ -53,10 +56,24 @@ interface MCPLibraryServerCardProps {
 	server: MCPLibraryEntry;
 	isInstalled: boolean;
 	canCreateMCPClient: boolean;
+	canDelete: boolean;
 	onInstall: (server: MCPLibraryEntry) => void;
 }
 
-export function MCPLibraryServerCard({ server, isInstalled, canCreateMCPClient, onInstall }: MCPLibraryServerCardProps) {
+export function MCPLibraryServerCard({ server, isInstalled, canCreateMCPClient, canDelete, onInstall }: MCPLibraryServerCardProps) {
+	const [deleteEntry, { isLoading: isDeleting }] = useDeleteMCPLibraryEntryMutation();
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const isCustom = server.source === "custom";
+
+	const handleDelete = async () => {
+		try {
+			await deleteEntry(server.id).unwrap();
+			toast.success(`"${server.name}" removed from the library.`);
+			setConfirmOpen(false);
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+		}
+	};
 	return (
 		<Card
 			key={server.slug}
@@ -90,7 +107,10 @@ export function MCPLibraryServerCard({ server, isInstalled, canCreateMCPClient, 
 							<CardTitle className="min-w-0 pt-0.5 text-sm leading-5">
 								<span className="block truncate">{server.name}</span>
 							</CardTitle>
-							{isInstalled && <Badge variant="success">Installed</Badge>}
+							<div className="flex shrink-0 items-center gap-1.5">
+								{isCustom && <Badge variant="outline">Custom</Badge>}
+								{isInstalled && <Badge variant="success">Installed</Badge>}
+							</div>
 						</div>
 						<div className="flex min-w-0 flex-wrap items-center gap-1.5">
 							{server.category && (
@@ -141,6 +161,24 @@ export function MCPLibraryServerCard({ server, isInstalled, canCreateMCPClient, 
 					<span className="truncate">{authLabel(server.auth_type)}</span>
 				</div>
 				<div className="flex shrink-0 items-center gap-2">
+					{canDelete && (
+						<div className="hidden group-hover:block fade-in">
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={() => setConfirmOpen(true)}
+										aria-label={`Remove ${server.name} from library`}
+										data-testid={`mcp-library-delete-${server.slug}`}
+									>
+										<Trash2 className="h-4 w-4" />
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent>Remove from library</TooltipContent>
+							</Tooltip>
+						</div>
+					)}
 					{server.docs_url && (
 						<Tooltip>
 							<TooltipTrigger asChild>
@@ -175,6 +213,15 @@ export function MCPLibraryServerCard({ server, isInstalled, canCreateMCPClient, 
 					)}
 				</div>
 			</CardFooter>
+
+			<MCPLibraryDeleteDialog
+				server={server}
+				open={confirmOpen}
+				isDeleting={isDeleting}
+				onOpenChange={(open) => !open && setConfirmOpen(false)}
+				onConfirm={handleDelete}
+				confirmTestId={`mcp-library-delete-confirm-${server.slug}`}
+			/>
 		</Card>
 	);
 }

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx
@@ -2,9 +2,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { getErrorMessage, useDeleteMCPLibraryEntryMutation } from "@/lib/store";
 import type { MCPLibraryEntry } from "@/lib/types/mcp";
 import { Link } from "@tanstack/react-router";
-import { BookIcon, Check, Download, Library, LogIn } from "lucide-react";
+import { BookIcon, Check, Download, LogIn, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 import { MCPLibraryDeleteDialog } from "./mcpLibraryDeleteDialog";
 import { authLabel, MCP_ICON_FALLBACK, transportIcon, transportLabel } from "./mcpLibraryServerCard";
 
@@ -12,10 +15,25 @@ interface MCPLibraryServersTableProps {
 	servers: MCPLibraryEntry[];
 	installedServerSlugs: Set<string>;
 	canCreateMCPClient: boolean;
+	canDelete: boolean;
 	onInstall: (server: MCPLibraryEntry) => void;
 }
 
-export function MCPLibraryServersTable({ servers, installedServerSlugs, canCreateMCPClient, onInstall }: MCPLibraryServersTableProps) {
+export function MCPLibraryServersTable({ servers, installedServerSlugs, canCreateMCPClient, canDelete, onInstall }: MCPLibraryServersTableProps) {
+	const [deleteEntry, { isLoading: isDeleting }] = useDeleteMCPLibraryEntryMutation();
+	const [serverToDelete, setServerToDelete] = useState<MCPLibraryEntry | null>(null);
+
+	const handleDelete = async () => {
+		if (!serverToDelete) return;
+		try {
+			await deleteEntry(serverToDelete.id).unwrap();
+			toast.success(`"${serverToDelete.name}" removed from the library.`);
+			setServerToDelete(null);
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+		}
+	};
+
 	return (
 		<div className="overflow-hidden rounded-md border" data-testid="mcp-library-table-view">
 			<Table>
@@ -63,6 +81,7 @@ export function MCPLibraryServersTable({ servers, installedServerSlugs, canCreat
 													Installed
 												</Badge>
 											)}
+											{server.source === "custom" && <Badge variant="outline">Custom</Badge>}
 
 										</div>
 										<p className="text-muted-foreground line-clamp-1 max-w-4xl text-sm leading-5">
@@ -152,6 +171,15 @@ export function MCPLibraryServersTable({ servers, installedServerSlugs, canCreat
 					})}
 				</TableBody>
 			</Table>
+
+			<MCPLibraryDeleteDialog
+				server={serverToDelete}
+				open={!!serverToDelete}
+				isDeleting={isDeleting}
+				onOpenChange={(open) => !open && setServerToDelete(null)}
+				onConfirm={handleDelete}
+				confirmTestId="mcp-library-table-delete-confirm"
+			/>
 		</div>
 	);
 }

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -1,9 +1,11 @@
 import {
 	CreateMCPClientRequest,
+	CreateMCPLibraryEntryRequest,
 	GetMCPClientsParams,
 	GetMCPClientsResponse,
 	GetMCPLibraryParams,
 	GetMCPLibraryResponse,
+	MCPLibraryEntry,
 	MCPLibraryFilterData,
 	OAuthFlowResponse,
 	OAuthStatusResponse,
@@ -21,7 +23,7 @@ export const mcpApi = baseApi.injectEndpoints({
 			query: (params) => ({
 				url: "/mcp/clients",
 				params: {
-					...(params?.limit && { limit: params.limit }),
+					...(params?.limit !== undefined && { limit: params.limit }),
 					...(params?.offset !== undefined && { offset: params.offset }),
 					...(params?.search && { search: params.search }),
 				},
@@ -60,6 +62,56 @@ export const mcpApi = baseApi.injectEndpoints({
 				url: "/mcp/library/force-sync",
 				method: "POST",
 			}),
+			invalidatesTags: ["MCPLibrary"],
+		}),
+
+		// Publish a custom (org-internal) MCP server into the library
+		createMCPLibraryEntry: builder.mutation<
+			{ status: string; message: string; entry: MCPLibraryEntry },
+			CreateMCPLibraryEntryRequest
+		>({
+			query: (data) => ({
+				url: "/mcp/library",
+				method: "POST",
+				body: data,
+			}),
+			invalidatesTags: ["MCPLibrary"],
+		}),
+
+		// Soft-delete (hide) a library entry — remote or custom — by numeric id
+		deleteMCPLibraryEntry: builder.mutation<{ status: string; message: string }, number>({
+			query: (id) => ({
+				url: `/mcp/library/${id}`,
+				method: "DELETE",
+			}),
+			async onQueryStarted(id, { dispatch, getState, queryFulfilled }) {
+				// Optimistically remove the row from every cached getMCPLibrary page
+				// so it disappears immediately; roll back the patches if the request fails.
+				const patches: { undo: () => void }[] = [];
+				const queries = (getState() as any).api.queries;
+				for (const entry of Object.values(queries) as any[]) {
+					if (entry?.endpointName !== "getMCPLibrary" || entry?.status !== "fulfilled") continue;
+					patches.push(
+						dispatch(
+							mcpApi.util.updateQueryData("getMCPLibrary", entry.originalArgs, (draft) => {
+								if (!draft.servers) return;
+								const before = draft.servers.length;
+								draft.servers = draft.servers.filter((s) => s.id !== id);
+								if (draft.servers.length < before) {
+									draft.count = Math.max(0, (draft.count || 0) - 1);
+									draft.total_count = Math.max(0, (draft.total_count || 0) - 1);
+								}
+							}),
+						),
+					);
+				}
+				try {
+					await queryFulfilled;
+				} catch {
+					patches.forEach((p) => p.undo());
+				}
+			},
+			// Keep tag invalidation as a fallback to reconcile with the server.
 			invalidatesTags: ["MCPLibrary"],
 		}),
 		// Create new MCP client
@@ -190,6 +242,8 @@ export const {
 	useGetMCPLibraryQuery,
 	useGetMCPLibraryFilterDataQuery,
 	useForceSyncMCPLibraryMutation,
+	useCreateMCPLibraryEntryMutation,
+	useDeleteMCPLibraryEntryMutation,
 	useCreateMCPClientMutation,
 	useUpdateMCPClientMutation,
 	useDeleteMCPClientMutation,

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -204,8 +204,26 @@ export interface MCPLibraryEntry {
 	publisher?: string;
 	tags?: string[];
 	metadata?: Record<string, unknown>;
+	/** "remote" for synced rows, "custom" for org-published entries. */
+	source?: "remote" | "custom";
 	created_at: string;
 	updated_at: string;
+}
+
+/** Body for POST /api/mcp/library — publish a custom (org-internal) library entry. */
+export interface CreateMCPLibraryEntryRequest {
+	name: string;
+	description?: string;
+	category?: string;
+	connection_type: MCPConnectionType;
+	connection_url?: string;
+	stdio_config?: MCPStdioConfig;
+	auth_type?: MCPAuthType;
+	required_header_keys?: string[];
+	icon_url?: string;
+	docs_url?: string;
+	publisher?: string;
+	tags?: string[];
 }
 
 export interface GetMCPLibraryParams {


### PR DESCRIPTION
## Summary

Extends the MCP library catalog to support org-internal ("custom") servers alongside the remotely-synced entries. Previously the library was a read-only, sync-only catalog. This PR adds the ability for org members with the appropriate permissions to publish their own internal MCP servers into the library, and to soft-delete any entry (remote or custom) so it is hidden from listings and never resurrected by the next remote sync.

## Changes

- Added `source` (`varchar(20)`, default `"remote"`) and `deleted_at` (nullable timestamp) columns to `mcp_library` via a new idempotent migration (`migrationAddMCPLibrarySourceColumns`). `source` distinguishes remote-synced rows from org-published ones; `deleted_at` is a plain nullable tombstone rather than GORM's `DeletedAt` so the sync upsert can still find tombstoned rows by slug and skip them rather than reinserting.
- All paginated listing and filter-data queries now filter `WHERE deleted_at IS NULL` so soft-deleted rows are invisible to users.
- Added `CreateCustomMCPLibraryEntry` (forces `source = "custom"`, maps slug collisions to `ErrAlreadyExists`), `SoftDeleteMCPLibraryEntry` (sets `deleted_at = now()` by ID, returns `ErrNotFound` if already gone or missing), and `GetProtectedMCPLibrarySlugs` (returns slugs of custom and tombstoned rows the sync must skip) to the `ConfigStore` interface and RDB implementation.
- The remote sync (`SyncMCPLibrary`) now loads the protected slug set before upserting and silently skips any payload entry whose slug is in that set. Remote rows are explicitly stamped `source = "remote"` on upsert.
- Added `POST /api/mcp/library` and `DELETE /api/mcp/library/{id}` HTTP endpoints with full validation (connection type, auth type, required fields) and appropriate error mapping (409 for duplicate slug, 404 for missing entry).
- Added a `Slugify` helper in `modelcatalog` that derives a URL-safe slug from a display name; used by the create handler to key custom entries off their name.
- Added `POST /api/mcp/library` and `DELETE /api/mcp/library/{id}` RTK Query mutations (`useCreateMCPLibraryEntryMutation`, `useDeleteMCPLibraryEntryMutation`) and the `CreateMCPLibraryEntryRequest` type on the frontend.
- Added an "Add Server" sheet (`MCPLibraryAddServerSheet`) accessible to users with create-MCP-client permission, with fields for all connection types (HTTP/SSE/STDIO), auth types, and optional metadata.
- Added a delete (trash) button with a confirmation dialog to both the card and table views. Custom entries are badged "Custom". Remote entries show a sync-aware warning in the confirmation dialog.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./framework/modelcatalog/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Start the server and navigate to the MCP Library page.
2. Click **Add Server**, fill in a name and HTTP connection URL, and click **Publish to Library**. Verify the entry appears with a "Custom" badge.
3. Trigger a force-sync and confirm the custom entry is not overwritten or removed.
4. Click the trash icon on the custom entry, confirm removal, and verify it disappears from the listing.
5. Click the trash icon on a remote-synced entry, confirm removal, trigger a force-sync, and verify the entry does not reappear.
6. Attempt to create a second entry with the same name and verify a 409 conflict response is returned.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `source` field is forced server-side to `"custom"` on creation regardless of caller input, preventing callers from spoofing remote entries. The delete endpoint operates by numeric ID and checks `deleted_at IS NULL` before updating, preventing double-tombstone races. No secrets or PII are introduced; header key names (not values) are stored.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publish org-specific MCP servers (POST) and soft-delete them (DELETE); RBAC‑gated “Add Server” button, Add Server sheet, and delete confirmation dialog.
  * UI shows “Custom” badges; table/grid delete controls and client-side create/delete mutations/hooks.

* **Bug Fixes / Improvements**
  * Soft-deleted entries excluded from listings, filters, and pagination; custom and deleted slugs protected from remote sync.
  * Deterministic slug generation for imports and optimistic client cache updates on delete for immediate UI responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->