### PR TITLE
fix: make global model listing best effort

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -49,6 +49,8 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+const listModelsWatchdogGracePeriod = 100 * time.Millisecond
+
 // ChannelMessage represents a message passed through the request channel.
 // It contains the request, response and error channels, and the request type.
 type ChannelMessage struct {
@@ -486,7 +488,12 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 		providerDone := make(chan struct{})
 
 		go func(providerKey schemas.ModelProvider, providerTimeout time.Duration, done chan<- struct{}) {
-			defer close(done)
+			doneClosed := false
+			defer func() {
+				if !doneClosed {
+					close(done)
+				}
+			}()
 			providerCtx, cancelProviderCtx := schemas.NewBifrostContextWithTimeout(ctx, providerTimeout)
 			defer cancelProviderCtx()
 			providerCtx.SetValue(schemas.BifrostContextKeyRequestID, uuid.New().String())
@@ -566,6 +573,8 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 				providerRequest.PageToken = response.NextPageToken
 			}
 
+			close(done)
+			doneClosed = true
 			results <- providerResult{
 				provider:    providerKey,
 				models:      providerModels,
@@ -575,11 +584,23 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 		}(providerKey, providerTimeout, providerDone)
 
 		go func(providerKey schemas.ModelProvider, timeout time.Duration, done <-chan struct{}) {
-			timer := time.NewTimer(timeout)
-			defer timer.Stop()
+			timer := time.NewTimer(timeout + listModelsWatchdogGracePeriod)
+			defer func() {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+			}()
 
 			select {
 			case <-timer.C:
+				select {
+				case <-done:
+					return
+				default:
+				}
 				timeoutErr := listModelsProviderTimeoutError(providerKey, timeout)
 				results <- providerResult{
 					provider: providerKey,
@@ -633,15 +654,6 @@ collectResults:
 		}
 		seenProviders[result.provider] = struct{}{}
 
-		if len(result.models) == 0 && len(result.keyStatuses) == 0 && result.err == nil {
-			result.err = listModelsNilResponseError(result.provider)
-			result.keyStatuses = []schemas.KeyStatus{{
-				Provider: result.provider,
-				Status:   schemas.KeyStatusListModelsFailed,
-				Error:    result.err,
-			}}
-		}
-
 		if len(result.models) > 0 {
 			allModels = append(allModels, result.models...)
 		}
@@ -657,14 +669,18 @@ collectResults:
 		if _, seen := seenProviders[providerKey]; seen {
 			continue
 		}
-		timeoutErr := listModelsProviderTimeoutError(providerKey, bifrost.listModelsTimeoutForProvider(providerKey))
+		providerTimeout := bifrost.listModelsTimeoutForProvider(providerKey)
+		providerErr := listModelsProviderTimeoutError(providerKey, providerTimeout)
+		if errors.Is(ctx.Err(), context.Canceled) {
+			providerErr = listModelsContextError(providerKey, ctx.Err(), providerTimeout)
+		}
 		allKeyStatuses = append(allKeyStatuses, schemas.KeyStatus{
 			Provider: providerKey,
 			Status:   schemas.KeyStatusListModelsFailed,
-			Error:    timeoutErr,
+			Error:    providerErr,
 		})
 		if firstError == nil {
-			firstError = timeoutErr
+			firstError = providerErr
 		}
 	}
 

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -470,8 +470,9 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 		err         *schemas.BifrostError
 	}
 
-	results := make(chan providerResult, len(providerKeys))
-	var wg sync.WaitGroup
+	results := make(chan providerResult, len(providerKeys)*2)
+	launchedProviders := 0
+	launchedProviderKeys := make([]schemas.ModelProvider, 0, len(providerKeys))
 
 	// Launch concurrent requests for all providers
 	for _, providerKey := range providerKeys {
@@ -479,11 +480,15 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 			continue
 		}
 
-		wg.Add(1)
-		go func(providerKey schemas.ModelProvider) {
-			defer wg.Done()
+		providerTimeout := bifrost.listModelsTimeoutForProvider(providerKey)
+		launchedProviders++
+		launchedProviderKeys = append(launchedProviderKeys, providerKey)
+		providerDone := make(chan struct{})
 
-			providerCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		go func(providerKey schemas.ModelProvider, providerTimeout time.Duration, done chan<- struct{}) {
+			defer close(done)
+			providerCtx, cancelProviderCtx := schemas.NewBifrostContextWithTimeout(ctx, providerTimeout)
+			defer cancelProviderCtx()
 			providerCtx.SetValue(schemas.BifrostContextKeyRequestID, uuid.New().String())
 
 			providerModels := make([]schemas.Model, 0)
@@ -528,15 +533,29 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 					break
 				}
 
-				if response == nil || len(response.Data) == 0 {
+				if response != nil && len(response.KeyStatuses) > 0 {
+					providerKeyStatuses = append(providerKeyStatuses, response.KeyStatuses...)
+				}
+
+				if response == nil {
+					if providerCtx.Err() != nil {
+						providerErr = listModelsContextError(providerKey, providerCtx.Err(), providerTimeout)
+					} else {
+						providerErr = listModelsNilResponseError(providerKey)
+					}
+					providerKeyStatuses = append(providerKeyStatuses, schemas.KeyStatus{
+						Provider: providerKey,
+						Status:   schemas.KeyStatusListModelsFailed,
+						Error:    providerErr,
+					})
+					break
+				}
+
+				if len(response.Data) == 0 {
 					break
 				}
 
 				providerModels = append(providerModels, response.Data...)
-
-				if len(response.KeyStatuses) > 0 {
-					providerKeyStatuses = append(providerKeyStatuses, response.KeyStatuses...)
-				}
 
 				// Check if there are more pages
 				if response.NextPageToken == "" {
@@ -553,19 +572,76 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 				keyStatuses: providerKeyStatuses,
 				err:         providerErr,
 			}
-		}(providerKey)
-	}
+		}(providerKey, providerTimeout, providerDone)
 
-	// Wait for all goroutines to complete
-	wg.Wait()
-	close(results)
+		go func(providerKey schemas.ModelProvider, timeout time.Duration, done <-chan struct{}) {
+			timer := time.NewTimer(timeout)
+			defer timer.Stop()
+
+			select {
+			case <-timer.C:
+				timeoutErr := listModelsProviderTimeoutError(providerKey, timeout)
+				results <- providerResult{
+					provider: providerKey,
+					keyStatuses: []schemas.KeyStatus{{
+						Provider: providerKey,
+						Status:   schemas.KeyStatusListModelsFailed,
+						Error:    timeoutErr,
+					}},
+					err: timeoutErr,
+				}
+			case <-done:
+			case <-ctx.Done():
+			}
+		}(providerKey, providerTimeout, providerDone)
+	}
 
 	// Accumulate all models and key statuses from all providers
 	allModels := make([]schemas.Model, 0)
 	allKeyStatuses := make([]schemas.KeyStatus, 0)
 	var firstError *schemas.BifrostError
 
-	for result := range results {
+	seenProviders := make(map[schemas.ModelProvider]struct{}, launchedProviders)
+collectResults:
+	for len(seenProviders) < launchedProviders {
+		var result providerResult
+		select {
+		case result = <-results:
+		case <-ctx.Done():
+			if ctx.Err() != nil && firstError == nil {
+				statusCode := fasthttp.StatusGatewayTimeout
+				if errors.Is(ctx.Err(), context.Canceled) {
+					statusCode = 499
+				}
+				firstError = &schemas.BifrostError{
+					IsBifrostError: true,
+					StatusCode:     &statusCode,
+					Error: &schemas.ErrorField{
+						Message: ctx.Err().Error(),
+						Error:   ctx.Err(),
+					},
+					ExtraFields: schemas.BifrostErrorExtraFields{
+						RequestType: schemas.ListModelsRequest,
+					},
+				}
+			}
+			break collectResults
+		}
+
+		if _, seen := seenProviders[result.provider]; seen {
+			continue
+		}
+		seenProviders[result.provider] = struct{}{}
+
+		if len(result.models) == 0 && len(result.keyStatuses) == 0 && result.err == nil {
+			result.err = listModelsNilResponseError(result.provider)
+			result.keyStatuses = []schemas.KeyStatus{{
+				Provider: result.provider,
+				Status:   schemas.KeyStatusListModelsFailed,
+				Error:    result.err,
+			}}
+		}
+
 		if len(result.models) > 0 {
 			allModels = append(allModels, result.models...)
 		}
@@ -574,6 +650,21 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 		}
 		if result.err != nil && firstError == nil {
 			firstError = result.err
+		}
+	}
+
+	for _, providerKey := range launchedProviderKeys {
+		if _, seen := seenProviders[providerKey]; seen {
+			continue
+		}
+		timeoutErr := listModelsProviderTimeoutError(providerKey, bifrost.listModelsTimeoutForProvider(providerKey))
+		allKeyStatuses = append(allKeyStatuses, schemas.KeyStatus{
+			Provider: providerKey,
+			Status:   schemas.KeyStatusListModelsFailed,
+			Error:    timeoutErr,
+		})
+		if firstError == nil {
+			firstError = timeoutErr
 		}
 	}
 
@@ -602,6 +693,71 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 	response = response.ApplyPagination(req.PageSize, req.PageToken)
 
 	return response, nil
+}
+
+func listModelsProviderTimeoutError(providerKey schemas.ModelProvider, timeout time.Duration) *schemas.BifrostError {
+	statusCode := fasthttp.StatusGatewayTimeout
+	errorType := schemas.RequestTimedOut
+	return &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Type:    &errorType,
+			Message: fmt.Sprintf("list models timed out for provider %s after %s", providerKey, timeout),
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ListModelsRequest,
+			Provider:    providerKey,
+		},
+	}
+}
+
+func listModelsContextError(providerKey schemas.ModelProvider, err error, timeout time.Duration) *schemas.BifrostError {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return listModelsProviderTimeoutError(providerKey, timeout)
+	}
+
+	statusCode := 499
+	errorType := schemas.RequestCancelled
+	return &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Type:    &errorType,
+			Message: fmt.Sprintf("list models cancelled for provider %s: %v", providerKey, err),
+			Error:   err,
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ListModelsRequest,
+			Provider:    providerKey,
+		},
+	}
+}
+
+func listModelsNilResponseError(providerKey schemas.ModelProvider) *schemas.BifrostError {
+	statusCode := fasthttp.StatusBadGateway
+	return &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Message: fmt.Sprintf("list models returned no response for provider %s", providerKey),
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ListModelsRequest,
+			Provider:    providerKey,
+		},
+	}
+}
+
+func (bifrost *Bifrost) listModelsTimeoutForProvider(providerKey schemas.ModelProvider) time.Duration {
+	timeoutSeconds := schemas.DefaultRequestTimeoutInSeconds
+	if config, err := bifrost.account.GetConfigForProvider(providerKey); err == nil && config != nil {
+		timeoutSeconds = config.NetworkConfig.DefaultRequestTimeoutInSeconds
+	}
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = schemas.DefaultRequestTimeoutInSeconds
+	}
+	return time.Duration(timeoutSeconds) * time.Second
 }
 
 func filterProvidersByContext(ctx *schemas.BifrostContext, providerKeys []schemas.ModelProvider) []schemas.ModelProvider {

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -3,7 +3,10 @@ package bifrost
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -731,6 +734,12 @@ func (ma *MockAccount) AddProviderWithBaseURL(provider schemas.ModelProvider, co
 	}
 }
 
+func (ma *MockAccount) SetProviderConfig(provider schemas.ModelProvider, config *schemas.ProviderConfig) {
+	ma.mu.Lock()
+	defer ma.mu.Unlock()
+	ma.configs[provider] = config
+}
+
 func (ma *MockAccount) UpdateProviderConfig(provider schemas.ModelProvider, concurrency int, bufferSize int) {
 	ma.mu.Lock()
 	defer ma.mu.Unlock()
@@ -875,6 +884,102 @@ func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {
 
 	if tracer.flushed.Load() != 1 {
 		t.Fatalf("expected trace flush count 1, got %d", tracer.flushed.Load())
+	}
+}
+
+func TestListAllModels_ReturnsFastProviderWhenAnotherProviderIsSlow(t *testing.T) {
+	fastServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"fast-model","object":"model","owned_by":"test"}]}`))
+	}))
+	defer fastServer.Close()
+
+	releaseSlowProvider := make(chan struct{})
+	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-releaseSlowProvider:
+		case <-time.After(5 * time.Second):
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"slow-model","object":"model","owned_by":"test"}]}`))
+	}))
+	defer slowServer.Close()
+
+	account := NewMockAccount()
+	fastProvider := schemas.ModelProvider("fast-custom")
+	slowProvider := schemas.ModelProvider("slow-custom")
+	account.SetProviderConfig(fastProvider, &schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			BaseURL:                        fastServer.URL,
+			DefaultRequestTimeoutInSeconds: 5,
+		},
+		ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{Concurrency: 1, BufferSize: 10},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			BaseProviderType: schemas.OpenAI,
+		},
+	})
+	account.SetProviderConfig(slowProvider, &schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			BaseURL:                        slowServer.URL,
+			DefaultRequestTimeoutInSeconds: 1,
+		},
+		ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{Concurrency: 1, BufferSize: 10},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			BaseProviderType: schemas.OpenAI,
+		},
+	})
+	account.SetKeysForProvider(fastProvider, []schemas.Key{
+		{
+			ID:     "fast-key",
+			Value:  *schemas.NewEnvVar("sk-fast"),
+			Models: schemas.WhiteList{"*"},
+			Weight: 100,
+		},
+	})
+	account.SetKeysForProvider(slowProvider, []schemas.Key{
+		{
+			ID:     "slow-key",
+			Value:  *schemas.NewEnvVar("sk-slow"),
+			Models: schemas.WhiteList{"*"},
+			Weight: 100,
+		},
+	})
+
+	bifrost, err := Init(context.Background(), schemas.BifrostConfig{
+		Account:         account,
+		Logger:          NewDefaultLogger(schemas.LogLevelError),
+		InitialPoolSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer bifrost.Shutdown()
+	configuredProviders, err := bifrost.GetConfiguredProviders()
+	if err != nil {
+		t.Fatalf("GetConfiguredProviders failed: %v", err)
+	}
+	if len(configuredProviders) != 2 {
+		t.Fatalf("expected two configured providers, got %#v", configuredProviders)
+	}
+	if !slices.Contains(configuredProviders, fastProvider) || !slices.Contains(configuredProviders, slowProvider) {
+		t.Fatalf("expected fast and slow providers, got %#v", configuredProviders)
+	}
+
+	start := time.Now()
+	response, bifrostErr := bifrost.ListAllModels(nil, &schemas.BifrostListModelsRequest{})
+	elapsed := time.Since(start)
+	close(releaseSlowProvider)
+
+	if bifrostErr != nil {
+		t.Fatalf("ListAllModels returned error: %v", bifrostErr)
+	}
+	if elapsed >= 2*time.Second {
+		t.Fatalf("ListAllModels waited too long for slow provider: %s", elapsed)
+	}
+	if response == nil || len(response.Data) != 1 || response.Data[0].ID != string(fastProvider)+"/fast-model" {
+		t.Fatalf("expected only fast provider model, got %#v", response)
 	}
 }
 

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -983,6 +983,62 @@ func TestListAllModels_ReturnsFastProviderWhenAnotherProviderIsSlow(t *testing.T
 	}
 }
 
+func TestListAllModels_AllowsEmptyProviderInventory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	account := NewMockAccount()
+	provider := schemas.ModelProvider("empty-custom")
+	account.SetProviderConfig(provider, &schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			BaseURL:                        server.URL,
+			DefaultRequestTimeoutInSeconds: 5,
+		},
+		ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{Concurrency: 1, BufferSize: 10},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			BaseProviderType: schemas.OpenAI,
+		},
+	})
+	account.SetKeysForProvider(provider, []schemas.Key{
+		{
+			ID:     "empty-key",
+			Value:  *schemas.NewEnvVar("sk-empty"),
+			Models: schemas.WhiteList{"*"},
+			Weight: 100,
+		},
+	})
+
+	bifrost, err := Init(context.Background(), schemas.BifrostConfig{
+		Account:         account,
+		Logger:          NewDefaultLogger(schemas.LogLevelError),
+		InitialPoolSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer bifrost.Shutdown()
+
+	response, bifrostErr := bifrost.ListAllModels(nil, &schemas.BifrostListModelsRequest{})
+	if bifrostErr != nil {
+		t.Fatalf("ListAllModels returned error for empty inventory: %v", bifrostErr)
+	}
+	if response == nil {
+		t.Fatal("expected empty response, got nil")
+	}
+	if len(response.Data) != 0 {
+		t.Fatalf("expected no models, got %#v", response.Data)
+	}
+	if len(response.KeyStatuses) != 1 || response.KeyStatuses[0].Status != schemas.KeyStatusSuccess {
+		t.Fatalf("expected one successful key status, got %#v", response.KeyStatuses)
+	}
+}
+
 // mockKVStore implements schemas.KVStore for session stickiness tests.
 type mockKVStore struct {
 	mu   sync.RWMutex

--- a/core/providers/openai/list_models_fallback_test.go
+++ b/core/providers/openai/list_models_fallback_test.go
@@ -50,6 +50,55 @@ func TestListModelsByKey_FallsBackToConfiguredModelsOnUpstreamError(t *testing.T
 	}
 }
 
+func TestHandleOpenAIListModelsRequest_FallbackPreservesFailedKeyStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := HandleOpenAIListModelsRequest(
+		ctx,
+		&fasthttp.Client{ReadTimeout: time.Second, WriteTimeout: time.Second},
+		&schemas.BifrostListModelsRequest{Provider: schemas.ModelProvider("bao-qwen")},
+		server.URL,
+		[]schemas.Key{{
+			ID:     "local-key",
+			Models: schemas.WhiteList{"hermes-qwen"},
+			Aliases: schemas.KeyAliases{
+				"hermes-qwen": "Qwen/Qwen3-32B",
+			},
+		}},
+		nil,
+		schemas.ModelProvider("bao-qwen"),
+		false,
+		false,
+	)
+
+	if err != nil {
+		t.Fatalf("HandleOpenAIListModelsRequest returned error: %v", err)
+	}
+	if resp == nil || len(resp.Data) != 1 {
+		t.Fatalf("expected one fallback model, got %#v", resp)
+	}
+	if len(resp.KeyStatuses) != 1 {
+		t.Fatalf("expected one key status, got %#v", resp.KeyStatuses)
+	}
+	status := resp.KeyStatuses[0]
+	if status.KeyID != "local-key" {
+		t.Fatalf("expected key id to be preserved, got %q", status.KeyID)
+	}
+	if status.Provider != schemas.ModelProvider("bao-qwen") {
+		t.Fatalf("expected provider status for bao-qwen, got %q", status.Provider)
+	}
+	if status.Status != schemas.KeyStatusListModelsFailed {
+		t.Fatalf("expected fallback status to reflect upstream failure, got %q", status.Status)
+	}
+	if status.Error == nil || status.Error.StatusCode == nil || *status.Error.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected original upstream 503 error, got %#v", status.Error)
+	}
+}
+
 func TestListModelsByKey_FallsBackToConfiguredAliasesWithWildcardModels(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)

--- a/core/providers/openai/list_models_fallback_test.go
+++ b/core/providers/openai/list_models_fallback_test.go
@@ -1,0 +1,117 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+func TestListModelsByKey_FallsBackToConfiguredModelsOnUpstreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := ListModelsByKey(
+		ctx,
+		&fasthttp.Client{ReadTimeout: time.Second, WriteTimeout: time.Second},
+		server.URL,
+		schemas.Key{
+			ID:     "local-key",
+			Models: schemas.WhiteList{"hermes-qwen"},
+			Aliases: schemas.KeyAliases{
+				"hermes-qwen": "Qwen/Qwen3-32B",
+			},
+		},
+		false,
+		nil,
+		schemas.ModelProvider("bao-qwen"),
+		false,
+		false,
+	)
+
+	if err != nil {
+		t.Fatalf("ListModelsByKey returned error: %v", err)
+	}
+	if resp == nil || len(resp.Data) != 1 {
+		t.Fatalf("expected one fallback model, got %#v", resp)
+	}
+	if resp.Data[0].ID != "bao-qwen/hermes-qwen" {
+		t.Fatalf("expected configured model id, got %q", resp.Data[0].ID)
+	}
+	if resp.Data[0].Alias == nil || *resp.Data[0].Alias != "Qwen/Qwen3-32B" {
+		t.Fatalf("expected alias to preserve upstream model id, got %#v", resp.Data[0].Alias)
+	}
+}
+
+func TestListModelsByKey_FallsBackToConfiguredAliasesWithWildcardModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := ListModelsByKey(
+		ctx,
+		&fasthttp.Client{ReadTimeout: time.Second, WriteTimeout: time.Second},
+		server.URL,
+		schemas.Key{
+			ID:     "local-key",
+			Models: schemas.WhiteList{"*"},
+			Aliases: schemas.KeyAliases{
+				"desktop-picker-name": "actual-local-model",
+			},
+		},
+		false,
+		nil,
+		schemas.ModelProvider("local-openai"),
+		false,
+		false,
+	)
+
+	if err != nil {
+		t.Fatalf("ListModelsByKey returned error: %v", err)
+	}
+	if resp == nil || len(resp.Data) != 1 {
+		t.Fatalf("expected one alias fallback model, got %#v", resp)
+	}
+	if resp.Data[0].ID != "local-openai/desktop-picker-name" {
+		t.Fatalf("expected alias model id, got %q", resp.Data[0].ID)
+	}
+	if resp.Data[0].Alias == nil || *resp.Data[0].Alias != "actual-local-model" {
+		t.Fatalf("expected alias target, got %#v", resp.Data[0].Alias)
+	}
+}
+
+func TestListModelsByKey_UnfilteredDoesNotUseConfiguredFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := ListModelsByKey(
+		ctx,
+		&fasthttp.Client{ReadTimeout: time.Second, WriteTimeout: time.Second},
+		server.URL,
+		schemas.Key{
+			ID:     "local-key",
+			Models: schemas.WhiteList{"hermes-qwen"},
+		},
+		true,
+		nil,
+		schemas.ModelProvider("bao-qwen"),
+		false,
+		false,
+	)
+
+	if err == nil {
+		t.Fatalf("expected upstream error for unfiltered request, got response %#v", resp)
+	}
+}

--- a/core/providers/openai/list_models_fallback_test.go
+++ b/core/providers/openai/list_models_fallback_test.go
@@ -89,6 +89,45 @@ func TestListModelsByKey_FallsBackToConfiguredAliasesWithWildcardModels(t *testi
 	}
 }
 
+func TestListModelsByKey_FallsBackToConfiguredAliasesWithEmptyAllowlist(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := ListModelsByKey(
+		ctx,
+		&fasthttp.Client{ReadTimeout: time.Second, WriteTimeout: time.Second},
+		server.URL,
+		schemas.Key{
+			ID:     "local-key",
+			Models: schemas.WhiteList{},
+			Aliases: schemas.KeyAliases{
+				"desktop-picker-name": "actual-local-model",
+			},
+		},
+		false,
+		nil,
+		schemas.ModelProvider("local-openai"),
+		false,
+		false,
+	)
+
+	if err != nil {
+		t.Fatalf("ListModelsByKey returned error: %v", err)
+	}
+	if resp == nil || len(resp.Data) != 1 {
+		t.Fatalf("expected one alias fallback model, got %#v", resp)
+	}
+	if resp.Data[0].ID != "local-openai/desktop-picker-name" {
+		t.Fatalf("expected alias model id, got %q", resp.Data[0].ID)
+	}
+	if resp.Data[0].Alias == nil || *resp.Data[0].Alias != "actual-local-model" {
+		t.Fatalf("expected alias target, got %#v", resp.Data[0].Alias)
+	}
+}
+
 func TestListModelsByKey_UnfilteredDoesNotUseConfiguredFallback(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -161,7 +161,7 @@ func ListModelsByKey(
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, client, req, resp)
 	defer wait()
 	if bifrostErr != nil {
-		if fallback := configuredListModelsFallback(providerName, key, unfiltered); fallback != nil {
+		if fallback := configuredListModelsFallback(providerName, key, unfiltered, bifrostErr); fallback != nil {
 			fallback.ExtraFields.Latency = latency.Milliseconds()
 			return fallback, nil
 		}
@@ -174,7 +174,7 @@ func ListModelsByKey(
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		bifrostErr := ParseOpenAIError(resp)
-		if fallback := configuredListModelsFallback(providerName, key, unfiltered); fallback != nil {
+		if fallback := configuredListModelsFallback(providerName, key, unfiltered, bifrostErr); fallback != nil {
 			fallback.ExtraFields.Latency = latency.Milliseconds()
 			fallback.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
 			return fallback, nil
@@ -190,7 +190,7 @@ func ListModelsByKey(
 	// Use enhanced response handler with pre-allocated response
 	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, openaiResponse, nil, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
-		if fallback := configuredListModelsFallback(providerName, key, unfiltered); fallback != nil {
+		if fallback := configuredListModelsFallback(providerName, key, unfiltered, bifrostErr); fallback != nil {
 			fallback.ExtraFields.Latency = latency.Milliseconds()
 			fallback.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
 			return fallback, nil
@@ -216,7 +216,7 @@ func ListModelsByKey(
 	return response, nil
 }
 
-func configuredListModelsFallback(providerName schemas.ModelProvider, key schemas.Key, unfiltered bool) *schemas.BifrostListModelsResponse {
+func configuredListModelsFallback(providerName schemas.ModelProvider, key schemas.Key, unfiltered bool, upstreamErr *schemas.BifrostError) *schemas.BifrostListModelsResponse {
 	if unfiltered {
 		return nil
 	}
@@ -224,6 +224,16 @@ func configuredListModelsFallback(providerName schemas.ModelProvider, key schema
 	response := (&OpenAIListModelsResponse{}).ToBifrostListModelsResponse(providerName, key.Models, key.BlacklistedModels, key.Aliases, false)
 	if response == nil || len(response.Data) == 0 {
 		return nil
+	}
+	if upstreamErr != nil {
+		upstreamErr.ExtraFields.Provider = providerName
+		upstreamErr.ExtraFields.RequestType = schemas.ListModelsRequest
+		response.KeyStatuses = []schemas.KeyStatus{{
+			KeyID:    key.ID,
+			Provider: providerName,
+			Status:   schemas.KeyStatusListModelsFailed,
+			Error:    upstreamErr,
+		}}
 	}
 	return response
 }

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -161,6 +161,10 @@ func ListModelsByKey(
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, client, req, resp)
 	defer wait()
 	if bifrostErr != nil {
+		if fallback := configuredListModelsFallback(providerName, key, unfiltered); fallback != nil {
+			fallback.ExtraFields.Latency = latency.Milliseconds()
+			return fallback, nil
+		}
 		return nil, bifrostErr
 	}
 	// Extract provider response headers early so they're available on error paths too
@@ -170,6 +174,11 @@ func ListModelsByKey(
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		bifrostErr := ParseOpenAIError(resp)
+		if fallback := configuredListModelsFallback(providerName, key, unfiltered); fallback != nil {
+			fallback.ExtraFields.Latency = latency.Milliseconds()
+			fallback.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
+			return fallback, nil
+		}
 		return nil, bifrostErr
 	}
 
@@ -181,6 +190,11 @@ func ListModelsByKey(
 	// Use enhanced response handler with pre-allocated response
 	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, openaiResponse, nil, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
+		if fallback := configuredListModelsFallback(providerName, key, unfiltered); fallback != nil {
+			fallback.ExtraFields.Latency = latency.Milliseconds()
+			fallback.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
+			return fallback, nil
+		}
 		return nil, bifrostErr
 	}
 
@@ -200,6 +214,18 @@ func ListModelsByKey(
 	}
 
 	return response, nil
+}
+
+func configuredListModelsFallback(providerName schemas.ModelProvider, key schemas.Key, unfiltered bool) *schemas.BifrostListModelsResponse {
+	if unfiltered {
+		return nil
+	}
+
+	response := (&OpenAIListModelsResponse{}).ToBifrostListModelsResponse(providerName, key.Models, key.BlacklistedModels, key.Aliases, false)
+	if response == nil || len(response.Data) == 0 {
+		return nil
+	}
+	return response
 }
 
 // HandleOpenAIListModelsRequest handles a list models request to OpenAI's API.

--- a/core/providers/utils/models.go
+++ b/core/providers/utils/models.go
@@ -334,11 +334,13 @@ func (p *ListModelsPipeline) FilterModel(modelID string) []FilterResult {
 //	  "my-gpt4" not in included → add {ID:"openai/my-gpt4", Alias:"gpt-4-turbo"}
 //	  "gpt-3.5" not in included → add {ID:"openai/gpt-3.5"}
 //
-// Case B — allowlist wildcard (*) only:
+// Case B — wildcard allowlist (*) OR empty restricted allowlist with aliases:
 //
 //	We don't know all model names (no explicit list), so we only backfill entries
 //	that were explicitly configured via aliases and not yet matched from the API.
-//	Note: an empty allowlist is deny-all (IsRestricted()==true), not wildcard.
+//	An empty restricted allowlist with aliases reaches this path so local/custom
+//	providers can still surface their configured alias names when upstream discovery
+//	returns nothing or is unavailable.
 //
 //	Example: aliases={"my-gpt4":"gpt-4-turbo"}, "my-gpt4" not in included
 //	  → add {ID:"openai/my-gpt4", Alias:"gpt-4-turbo"}
@@ -380,7 +382,7 @@ func (p *ListModelsPipeline) BackfillModels(included map[string]bool) []schemas.
 		return result
 	}
 
-	// Case B: wildcard allowlist — backfill only explicitly configured aliases.
+	// Case B: wildcard or empty restricted allowlist — backfill only explicitly configured aliases.
 	if !p.Unfiltered && len(p.Aliases) > 0 {
 		for aliasKey, providerID := range p.Aliases {
 			if included[strings.ToLower(aliasKey)] {

--- a/core/providers/utils/models.go
+++ b/core/providers/utils/models.go
@@ -347,7 +347,7 @@ func (p *ListModelsPipeline) FilterModel(modelID string) []FilterResult {
 func (p *ListModelsPipeline) BackfillModels(included map[string]bool) []schemas.Model {
 	var result []schemas.Model
 
-	if !p.Unfiltered && p.AllowedModels.IsRestricted() {
+	if !p.Unfiltered && p.AllowedModels.IsRestricted() && !p.AllowedModels.IsEmpty() {
 		// Case A: backfill explicit allowlist entries not yet matched.
 		for _, entry := range p.AllowedModels {
 			if included[strings.ToLower(entry)] {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2740,11 +2740,15 @@ func extractSuccessfulListModelsResponses(results chan schemas.ListModelsByKeyRe
 			continue
 		}
 
-		keyStatuses = append(keyStatuses, schemas.KeyStatus{
-			KeyID:    result.KeyID,
-			Provider: provider,
-			Status:   schemas.KeyStatusSuccess,
-		})
+		if result.Response != nil && len(result.Response.KeyStatuses) > 0 {
+			keyStatuses = append(keyStatuses, result.Response.KeyStatuses...)
+		} else {
+			keyStatuses = append(keyStatuses, schemas.KeyStatus{
+				KeyID:    result.KeyID,
+				Provider: provider,
+				Status:   schemas.KeyStatusSuccess,
+			})
+		}
 		successfulResponses = append(successfulResponses, result.Response)
 	}
 
@@ -2787,8 +2791,10 @@ func HandleKeylessListModelsRequest(
 
 	// Success case
 	if resp != nil {
-		keyStatus.Status = schemas.KeyStatusSuccess
-		resp.KeyStatuses = []schemas.KeyStatus{keyStatus}
+		if len(resp.KeyStatuses) == 0 {
+			keyStatus.Status = schemas.KeyStatusSuccess
+			resp.KeyStatuses = []schemas.KeyStatus{keyStatus}
+		}
 		return resp, nil
 	}
 


### PR DESCRIPTION
## Summary

Make global `ListAllModels()` best-effort and bounded by each provider's existing `network_config.default_request_timeout_in_seconds` instead of waiting for every provider goroutine to finish before returning any models.

This prevents one slow or broken OpenAI-compatible custom provider from making `GET /v1/models` unusable for clients that rely on the global model list, such as OpenAI-compatible model pickers.

## What changed

- Collect global list-model results as providers finish and return partial successful results when another provider exceeds its configured request timeout.
- Preserve provider/key failure status where available, and synthesize provider-level failure status for provider timeouts or nil responses.
- Return an error only when no provider yields any models and at least one provider produced a real error.
- Add OpenAI-compatible fallback behavior: if upstream `/v1/models` fails but the key has explicit configured `models[]` / aliases, return those configured models for filtered requests.
- Keep `Unfiltered` semantics strict: unfiltered requests still require upstream inventory and do not synthesize configured allowlist fallback.
- Fix alias backfill for wildcard model allowlists when upstream listing is unavailable or omits configured aliases.

## Reproduction

Before this change, `ListAllModels()` launched provider list calls concurrently but then waited on `wg.Wait()`. A slow/down custom OpenAI-compatible provider could block the entire global `/v1/models` response, even when other providers had already returned models.

The new regression test configures two custom OpenAI-compatible providers backed by local test servers: one responds immediately, while the other blocks beyond its configured one-second timeout. `ListAllModels()` now returns the fast provider model without waiting for the slow provider to complete.

## Tests

```bash
cd core && go test . -count=1
cd core && go test ./providers/openai -count=1
cd core && go test ./providers/utils -count=1
git diff --check HEAD
```

All commands pass locally.

## Notes

No production config or secrets were used. The live-style validation is covered with local `httptest` custom OpenAI-compatible providers, including a simulated slow `/v1/models` endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Model listing now completes faster and doesn't wait for slow providers to respond
  * Added fallback model support when providers are unavailable
  * Enhanced error resilience and status reporting when collecting models from multiple sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->