### PR TITLE
feat: remove the `slug` field from the MCP server schema and add 100+ initial servers to the library

### DIFF
--- a/community/mcp-library/schema.json
+++ b/community/mcp-library/schema.json
@@ -24,16 +24,9 @@
   "definitions": {
     "server": {
       "type": "object",
-      "required": ["slug", "name", "connection_type"],
+      "required": ["name", "connection_type"],
       "additionalProperties": false,
       "properties": {
-        "slug": {
-          "type": "string",
-          "description": "Unique, stable, URL-safe identifier. Used as the primary key for syncing. Never change it once merged.",
-          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
-          "minLength": 2,
-          "maxLength": 100
-        },
         "name": {
           "type": "string",
           "description": "Human-readable display name.",

--- a/community/mcp-library/servers.json
+++ b/community/mcp-library/servers.json
@@ -1,9 +1,8 @@
 {
   "$schema": "./schema.json",
-  "lastUpdatedAt": "2026-06-02T00:00:00Z",
+  "lastUpdatedAt": "2026-06-09T00:00:00Z",
   "servers": [
     {
-      "slug": "filesystem",
       "name": "Filesystem",
       "description": "Read and write files on the local filesystem within configured directories.",
       "category": "Developer Tools",
@@ -27,25 +26,3374 @@
       ]
     },
     {
-      "slug": "github",
-      "name": "GitHub",
-      "description": "Access GitHub repositories, issues, and pull requests through the official GitHub MCP server.",
+      "name": "GitHub (Remote)",
+      "description": "Connect AI tools directly to GitHub's platform to read repositories and code, manage issues and pull requests, analyze code, monitor GitHub Actions, and automate workflows. Hosted remotely by GitHub.",
       "category": "Developer Tools",
       "connection_type": "http",
       "connection_url": "https://api.githubcopilot.com/mcp/",
-      "auth_type": "headers",
-      "required_header_keys": [
-        "Authorization"
-      ],
-      "icon_url": "https://github.githubassets.com/favicons/favicon.png",
+      "auth_type": "oauth",
       "docs_url": "https://github.com/github/github-mcp-server",
       "publisher": "GitHub",
-      "version": "1.0.0",
       "tags": [
+        "github",
         "git",
-        "repository",
+        "repositories",
         "issues",
-        "pull-requests"
+        "pull-requests",
+        "ci-cd",
+        "code"
+      ]
+    },
+    {
+      "name": "GitHub (Local)",
+      "description": "Run the GitHub MCP Server locally via Docker to read repositories and code, manage issues and pull requests, analyze code, monitor GitHub Actions, and automate workflows. Requires a GitHub Personal Access Token.",
+      "category": "Developer Tools",
+      "connection_type": "stdio",
+      "stdio_config": {
+        "command": "docker",
+        "args": [
+          "run",
+          "-i",
+          "--rm",
+          "-e",
+          "GITHUB_PERSONAL_ACCESS_TOKEN",
+          "ghcr.io/github/github-mcp-server"
+        ],
+        "envs": [
+          "GITHUB_PERSONAL_ACCESS_TOKEN"
+        ]
+      },
+      "auth_type": "none",
+      "docs_url": "https://github.com/github/github-mcp-server",
+      "publisher": "GitHub",
+      "tags": [
+        "github",
+        "git",
+        "repositories",
+        "issues",
+        "pull-requests",
+        "ci-cd",
+        "code",
+        "docker"
+      ]
+    },
+    {
+      "name": "Linear",
+      "description": "Connect AI tools to Linear to find, create, and update issues, projects, and comments. Hosted remotely by Linear.",
+      "category": "Project Management",
+      "connection_type": "http",
+      "connection_url": "https://mcp.linear.app/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://linear.app/docs/mcp",
+      "publisher": "Linear",
+      "tags": [
+        "linear",
+        "issues",
+        "projects",
+        "comments",
+        "project-management"
+      ]
+    },
+    {
+      "name": "Notion",
+      "description": "Connect AI tools to your Notion workspace to search, read, create, and update pages and databases. Hosted remotely by Notion.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.notion.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.notion.com/docs/mcp",
+      "publisher": "Notion",
+      "tags": [
+        "notion",
+        "docs",
+        "wiki",
+        "knowledge-base",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Atlassian",
+      "description": "Connect AI tools to your Atlassian Cloud site to interact with Jira, Confluence, and Compass data in real time. Hosted remotely by Atlassian.",
+      "category": "Project Management",
+      "connection_type": "http",
+      "connection_url": "https://mcp.atlassian.com/v1/mcp/authv2",
+      "auth_type": "oauth",
+      "docs_url": "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/",
+      "publisher": "Atlassian",
+      "tags": [
+        "atlassian",
+        "jira",
+        "confluence",
+        "compass",
+        "project-management"
+      ]
+    },
+    {
+      "name": "Maxim",
+      "description": "Run the Maxim AI MCP server locally to manage log repositories, datasets, and evaluators, and analyze logs of sessions and traces. Requires a Maxim API key.",
+      "category": "AI Tools",
+      "connection_type": "stdio",
+      "stdio_config": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@maximai/mcp-server@latest"
+        ],
+        "envs": [
+          "MAXIM_API_KEY"
+        ]
+      },
+      "auth_type": "none",
+      "docs_url": "https://www.npmjs.com/package/@maximai/mcp-server",
+      "publisher": "Maxim AI",
+      "tags": [
+        "maxim",
+        "observability",
+        "evaluation",
+        "datasets",
+        "logs",
+        "ai"
+      ]
+    },
+    {
+      "name": "Ahrefs",
+      "description": "Connect AI tools to the Ahrefs API to enrich answers with SEO metrics, backlink data, keyword research, and site analysis. Hosted remotely by Ahrefs.",
+      "category": "Marketing",
+      "connection_type": "http",
+      "connection_url": "https://api.ahrefs.com/mcp/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.ahrefs.com/en/mcp/docs/introduction",
+      "publisher": "Ahrefs",
+      "tags": [
+        "ahrefs",
+        "seo",
+        "backlinks",
+        "keywords",
+        "marketing"
+      ]
+    },
+    {
+      "name": "Calendly",
+      "description": "Connect AI tools to Calendly to list event types, find available slots, book and cancel events, manage availability, and generate scheduling links. Hosted remotely by Calendly.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.calendly.com",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.calendly.com/calendly-mcp-server",
+      "publisher": "Calendly",
+      "tags": [
+        "calendly",
+        "scheduling",
+        "calendar",
+        "meetings",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Stripe",
+      "description": "Connect AI tools to the Stripe API to manage customers, invoices, products, prices, subscriptions, payment links, refunds, and disputes, and to search Stripe documentation. Hosted remotely by Stripe.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.stripe.com",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.stripe.com/mcp",
+      "publisher": "Stripe",
+      "tags": [
+        "stripe",
+        "payments",
+        "billing",
+        "invoices",
+        "subscriptions",
+        "finance"
+      ]
+    },
+    {
+      "name": "Vercel",
+      "description": "Connect AI tools to Vercel to search documentation, manage projects and deployments, and analyze deployment logs. Hosted remotely by Vercel.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.vercel.com",
+      "auth_type": "oauth",
+      "docs_url": "https://vercel.com/docs/agent-resources/vercel-mcp",
+      "publisher": "Vercel",
+      "tags": [
+        "vercel",
+        "deployments",
+        "projects",
+        "logs",
+        "hosting",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Netlify",
+      "description": "Run the Netlify MCP server locally to create, manage, and deploy projects, manage access controls and extensions, handle form submissions, and set environment variables via the Netlify API and CLI. Requires Node.js 22+ and a Netlify account.",
+      "category": "Developer Tools",
+      "connection_type": "stdio",
+      "stdio_config": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@netlify/mcp"
+        ],
+        "envs": [
+          "NETLIFY_PERSONAL_ACCESS_TOKEN"
+        ]
+      },
+      "auth_type": "none",
+      "docs_url": "https://docs.netlify.com/welcome/build-with-ai/netlify-mcp-server/",
+      "publisher": "Netlify",
+      "tags": [
+        "netlify",
+        "deployments",
+        "projects",
+        "hosting",
+        "cli",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Vanta",
+      "description": "Run the Vanta MCP server locally to retrieve compliance test results, manage security findings, review framework requirements, track vulnerabilities, and access controls, documents, integrations, and risk scenarios. Requires Vanta OAuth credentials.",
+      "category": "Security",
+      "connection_type": "stdio",
+      "stdio_config": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@vantasdk/vanta-mcp-server"
+        ],
+        "envs": [
+          "VANTA_ENV_FILE"
+        ]
+      },
+      "auth_type": "none",
+      "docs_url": "https://github.com/VantaInc/vanta-mcp-server",
+      "publisher": "Vanta",
+      "tags": [
+        "vanta",
+        "compliance",
+        "security",
+        "soc2",
+        "iso27001",
+        "vulnerabilities"
+      ]
+    },
+    {
+      "name": "Airtable",
+      "description": "Connect AI tools to your Airtable bases to search, analyze, create, and update records, manage tables and fields, and explore schemas and interfaces. Hosted remotely by Airtable.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.airtable.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://support.airtable.com/docs/using-the-airtable-mcp-server",
+      "publisher": "Airtable",
+      "tags": [
+        "airtable",
+        "database",
+        "records",
+        "spreadsheet",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Cal.com",
+      "description": "Connect AI tools to Cal.com to manage bookings, event types, schedules, availability, and organization memberships through natural language. Hosted remotely by Cal.com.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.cal.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://cal.com/docs/platform/mcp-server",
+      "publisher": "Cal.com",
+      "tags": [
+        "cal.com",
+        "scheduling",
+        "calendar",
+        "bookings",
+        "meetings",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Asana",
+      "description": "Connect AI tools to Asana to access tasks, projects, and workspaces, track status and ownership, and work across workspace activity. Hosted remotely by Asana.",
+      "category": "Project Management",
+      "connection_type": "http",
+      "connection_url": "https://mcp.asana.com/v2/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.asana.com/docs/using-asanas-model-control-protocol-mcp-server",
+      "publisher": "Asana",
+      "tags": [
+        "asana",
+        "tasks",
+        "projects",
+        "workspaces",
+        "project-management"
+      ]
+    },
+    {
+      "name": "Canva",
+      "description": "Connect AI tools to Canva to find and discuss designs, assets, exports, and comments, and iterate on creative work conversationally. Hosted remotely by Canva.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://mcp.canva.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.canva.dev/docs/connect/canva-mcp-server-setup/",
+      "publisher": "Canva",
+      "tags": [
+        "canva",
+        "design",
+        "assets",
+        "exports",
+        "comments"
+      ]
+    },
+    {
+      "name": "Cloudflare",
+      "description": "Connect AI tools to Cloudflare to inspect resources, plan infrastructure changes, and work across Workers, D1, R2, DNS, and account APIs. Hosted remotely by Cloudflare.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.cloudflare.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.cloudflare.com/agents/model-context-protocol/",
+      "publisher": "Cloudflare",
+      "tags": [
+        "cloudflare",
+        "workers",
+        "dns",
+        "d1",
+        "r2",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Figma",
+      "description": "Connect AI tools to Figma to bring files, designs, and Dev Mode context into workflows so agents can understand and act on visual work. Hosted remotely by Figma.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://mcp.figma.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://help.figma.com/hc/en-us/articles/32132100833559-Guide-to-the-Dev-Mode-MCP-Server",
+      "publisher": "Figma",
+      "tags": [
+        "figma",
+        "design",
+        "dev-mode",
+        "files",
+        "prototyping"
+      ]
+    },
+    {
+      "name": "HubSpot",
+      "description": "Connect AI tools to HubSpot to read and act on CRM objects, records, and account data, and understand customer workflows. Hosted remotely by HubSpot.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://mcp.hubspot.com",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.hubspot.com/mcp",
+      "publisher": "HubSpot",
+      "tags": [
+        "hubspot",
+        "crm",
+        "sales",
+        "marketing",
+        "contacts"
+      ]
+    },
+    {
+      "name": "Neon",
+      "description": "Connect AI tools to Neon to manage Postgres projects and branches, run SQL, and search documentation. Hosted remotely by Neon.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.neon.tech/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://neon.com/docs/ai/neon-mcp-server",
+      "publisher": "Neon",
+      "tags": [
+        "neon",
+        "postgres",
+        "database",
+        "sql",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Railway",
+      "description": "Connect AI tools to Railway to access project and deployment context, investigate app state, plan changes, and work across environments. Hosted remotely by Railway.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.railway.com",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.railway.com/reference/mcp-server",
+      "publisher": "Railway",
+      "tags": [
+        "railway",
+        "deployments",
+        "projects",
+        "environments",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Parallel",
+      "description": "Connect AI tools to Parallel for real-time web search and content extraction in search-grounded AI workflows. Hosted remotely by Parallel.",
+      "category": "Search",
+      "connection_type": "http",
+      "connection_url": "https://search.parallel.ai/mcp",
+      "auth_type": "none",
+      "docs_url": "https://docs.parallel.ai/integrations/mcp-server",
+      "publisher": "Parallel",
+      "tags": [
+        "parallel",
+        "search",
+        "web",
+        "content-extraction",
+        "research"
+      ]
+    },
+    {
+      "name": "Sentry",
+      "description": "Connect AI tools to Sentry to retrieve, analyze, and debug application issues and errors, and bring project, issue, and reliability context into incident workflows. Hosted remotely by Sentry.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.sentry.dev/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.sentry.io/product/sentry-mcp/",
+      "publisher": "Sentry",
+      "tags": [
+        "sentry",
+        "errors",
+        "debugging",
+        "observability",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Slack",
+      "description": "Connect AI tools to Slack to find decisions, summarize discussions, and understand channel activity across messages, channels, users, and canvases. Hosted remotely by Slack.",
+      "category": "Communication",
+      "connection_type": "http",
+      "connection_url": "https://mcp.slack.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.slack.dev/mcp",
+      "publisher": "Slack",
+      "tags": [
+        "slack",
+        "messages",
+        "channels",
+        "communication",
+        "collaboration"
+      ]
+    },
+    {
+      "name": "Supabase",
+      "description": "Connect AI tools to Supabase to work with project, database, and documentation context across Postgres, auth, storage, and edge functions. Hosted remotely by Supabase.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.supabase.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://supabase.com/docs/guides/getting-started/mcp",
+      "publisher": "Supabase",
+      "tags": [
+        "supabase",
+        "postgres",
+        "database",
+        "auth",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "GitLab",
+      "description": "Connect AI tools securely to your GitLab data to work with projects, issues, merge requests, and CI/CD. Hosted remotely by GitLab.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://gitlab.com/api/v4/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.gitlab.com/user/gitlab_duo/model_context_protocol/mcp_server/",
+      "publisher": "GitLab",
+      "tags": [
+        "gitlab",
+        "git",
+        "repositories",
+        "merge-requests",
+        "ci-cd",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Todoist",
+      "description": "Connect AI tools to Todoist to search, create, complete, and manage your tasks and projects. Hosted remotely by Todoist.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://ai.todoist.net/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.todoist.com/help/articles/connect-todoist-to-ai-tools-with-mcp",
+      "publisher": "Todoist",
+      "tags": [
+        "todoist",
+        "tasks",
+        "projects",
+        "to-do",
+        "productivity"
+      ]
+    },
+    {
+      "name": "PayPal",
+      "description": "Connect AI tools to the PayPal platform to access payments, invoicing, subscriptions, and transaction data. Hosted remotely by PayPal.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.paypal.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.paypal.ai/docs/tools/mcp-quickstart",
+      "publisher": "PayPal",
+      "tags": [
+        "paypal",
+        "payments",
+        "invoicing",
+        "subscriptions",
+        "finance"
+      ]
+    },
+    {
+      "name": "Monday",
+      "description": "Connect AI tools to monday.com to manage projects, boards, items, and workflows. Hosted remotely by monday.com.",
+      "category": "Project Management",
+      "connection_type": "http",
+      "connection_url": "https://mcp.monday.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.monday.com/apps/docs/mcp",
+      "publisher": "monday.com",
+      "tags": [
+        "monday",
+        "boards",
+        "projects",
+        "workflows",
+        "project-management"
+      ]
+    },
+    {
+      "name": "Honeycomb",
+      "description": "Connect AI tools to Honeycomb to query and explore observability data, traces, and SLOs. Hosted remotely by Honeycomb.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.honeycomb.io/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.honeycomb.io/integrations/mcp/",
+      "publisher": "Honeycomb",
+      "tags": [
+        "honeycomb",
+        "observability",
+        "tracing",
+        "slo",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Square",
+      "description": "Connect AI tools to Square to search and manage transaction, merchant, and payment data. Hosted remotely by Square.",
+      "category": "Finance",
+      "connection_type": "sse",
+      "connection_url": "https://mcp.squareup.com/sse",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.squareup.com/docs/mcp",
+      "publisher": "Square",
+      "tags": [
+        "square",
+        "payments",
+        "merchants",
+        "transactions",
+        "finance"
+      ]
+    },
+    {
+      "name": "ClickUp",
+      "description": "Connect AI tools to ClickUp to manage tasks, docs, and projects with real-time workspace context. Hosted remotely by ClickUp.",
+      "category": "Project Management",
+      "connection_type": "http",
+      "connection_url": "https://mcp.clickup.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://clickup.com/blog/clickup-mcp-server/",
+      "publisher": "ClickUp",
+      "tags": [
+        "clickup",
+        "tasks",
+        "docs",
+        "projects",
+        "project-management"
+      ]
+    },
+    {
+      "name": "Intercom",
+      "description": "Connect AI tools to Intercom to access conversations, contacts, and support data for better customer insights. Hosted remotely by Intercom.",
+      "category": "Customer Support",
+      "connection_type": "http",
+      "connection_url": "https://mcp.intercom.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.intercom.com/docs/guides/mcp",
+      "publisher": "Intercom",
+      "tags": [
+        "intercom",
+        "support",
+        "conversations",
+        "contacts",
+        "customer-support"
+      ]
+    },
+    {
+      "name": "Miro",
+      "description": "Connect AI tools to Miro to access and create content on boards for visual collaboration. Hosted remotely by Miro.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://mcp.miro.com/",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.miro.com/docs/mcp-server",
+      "publisher": "Miro",
+      "tags": [
+        "miro",
+        "whiteboard",
+        "boards",
+        "collaboration",
+        "design"
+      ]
+    },
+    {
+      "name": "Mixpanel",
+      "description": "Connect AI tools to Mixpanel to analyze, query, and manage your product analytics data. Hosted remotely by Mixpanel.",
+      "category": "Analytics",
+      "connection_type": "http",
+      "connection_url": "https://mcp.mixpanel.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.mixpanel.com/docs/mcp-server",
+      "publisher": "Mixpanel",
+      "tags": [
+        "mixpanel",
+        "analytics",
+        "product-analytics",
+        "events",
+        "data"
+      ]
+    },
+    {
+      "name": "Cloudinary",
+      "description": "Connect AI tools to Cloudinary to manage, transform, and deliver images and videos across your media assets. Hosted remotely by Cloudinary.",
+      "category": "Developer Tools",
+      "connection_type": "sse",
+      "connection_url": "https://asset-management.mcp.cloudinary.com/sse",
+      "auth_type": "oauth",
+      "docs_url": "https://cloudinary.com/documentation/cloudinary_llm_mcp",
+      "publisher": "Cloudinary",
+      "tags": [
+        "cloudinary",
+        "media",
+        "images",
+        "video",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "PlanetScale",
+      "description": "Connect AI tools to PlanetScale for authenticated access to your Postgres and MySQL databases. Hosted remotely by PlanetScale.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.pscale.dev/mcp/planetscale",
+      "auth_type": "oauth",
+      "docs_url": "https://planetscale.com/docs/concepts/planetscale-mcp-server",
+      "publisher": "PlanetScale",
+      "tags": [
+        "planetscale",
+        "mysql",
+        "postgres",
+        "database",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Box",
+      "description": "Connect AI tools to Box for governed access to file and folder context, search, and Box AI within your existing permissions. Hosted remotely by Box.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.box.com",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.box.com/guides/box-mcp/remote/",
+      "publisher": "Box",
+      "tags": [
+        "box",
+        "files",
+        "storage",
+        "documents",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Sanity",
+      "description": "Connect AI tools to Sanity to create, query, and manage structured content. Hosted remotely by Sanity.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.sanity.io",
+      "auth_type": "oauth",
+      "docs_url": "https://www.sanity.io/docs/mcp-agent-actions",
+      "publisher": "Sanity",
+      "tags": [
+        "sanity",
+        "cms",
+        "content",
+        "structured-content",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Make",
+      "description": "Connect AI tools to Make to run scenarios and manage your Make account and automations. Hosted remotely by Make.",
+      "category": "Automation",
+      "connection_type": "http",
+      "connection_url": "https://mcp.make.com",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.make.com/mcp-server",
+      "publisher": "Make",
+      "tags": [
+        "make",
+        "automation",
+        "scenarios",
+        "workflows",
+        "integrations"
+      ]
+    },
+    {
+      "name": "Postman",
+      "description": "Connect AI tools to Postman to give API context to your coding agents across collections, requests, and workspaces. Hosted remotely by Postman.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.postman.com/minimal",
+      "auth_type": "oauth",
+      "docs_url": "https://learning.postman.com/docs/developer/postman-api/mcp-server/",
+      "publisher": "Postman",
+      "tags": [
+        "postman",
+        "api",
+        "collections",
+        "testing",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Mintlify",
+      "description": "Connect AI tools to Mintlify to search, read, and edit your documentation. Hosted remotely by Mintlify.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.mintlify.com",
+      "auth_type": "oauth",
+      "docs_url": "https://mintlify.com/docs/ai/model-context-protocol",
+      "publisher": "Mintlify",
+      "tags": [
+        "mintlify",
+        "documentation",
+        "docs",
+        "search",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Hugging Face",
+      "description": "Connect AI tools to the Hugging Face Hub to access models, datasets, Spaces, and thousands of Gradio apps. Hosted remotely by Hugging Face.",
+      "category": "AI Tools",
+      "connection_type": "http",
+      "connection_url": "https://huggingface.co/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://huggingface.co/settings/mcp",
+      "publisher": "Hugging Face",
+      "tags": [
+        "hugging-face",
+        "models",
+        "datasets",
+        "spaces",
+        "ai"
+      ]
+    },
+    {
+      "name": "Microsoft Learn",
+      "description": "Connect AI tools to Microsoft Learn to search trusted Microsoft documentation and power your development. Hosted remotely by Microsoft.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://learn.microsoft.com/api/mcp",
+      "auth_type": "none",
+      "docs_url": "https://learn.microsoft.com/en-us/training/support/mcp",
+      "publisher": "Microsoft",
+      "tags": [
+        "microsoft",
+        "documentation",
+        "docs",
+        "search",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Context7",
+      "description": "Connect AI tools to Context7 to fetch up-to-date, version-specific documentation and code examples for libraries and frameworks. Hosted remotely by Context7.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.context7.com/mcp",
+      "auth_type": "none",
+      "docs_url": "https://context7.com/",
+      "publisher": "Context7",
+      "tags": [
+        "context7",
+        "documentation",
+        "libraries",
+        "code-examples",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Exa",
+      "description": "Connect AI tools to Exa for web search and code documentation search to ground answers in real-time results. Hosted remotely by Exa.",
+      "category": "Search",
+      "connection_type": "http",
+      "connection_url": "https://mcp.exa.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.exa.ai/reference/exa-mcp",
+      "publisher": "Exa",
+      "tags": [
+        "exa",
+        "search",
+        "web",
+        "research",
+        "documentation"
+      ]
+    },
+    {
+      "name": "Tavily",
+      "description": "Connect AI tools to Tavily to search the web and extract content for agentic, search-grounded workflows. Hosted remotely by Tavily.",
+      "category": "Search",
+      "connection_type": "http",
+      "connection_url": "https://mcp.tavily.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.tavily.com/documentation/mcp",
+      "publisher": "Tavily",
+      "tags": [
+        "tavily",
+        "search",
+        "web",
+        "research",
+        "content-extraction"
+      ]
+    },
+    {
+      "name": "Semrush",
+      "description": "Connect AI tools to Semrush to access SEO, market data, and brand visibility insights. Hosted remotely by Semrush.",
+      "category": "Marketing",
+      "connection_type": "http",
+      "connection_url": "https://mcp.semrush.com/claude/v1/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.semrush.com/apps/",
+      "publisher": "Semrush",
+      "tags": [
+        "semrush",
+        "seo",
+        "marketing",
+        "keywords",
+        "analytics"
+      ]
+    },
+    {
+      "name": "Xero",
+      "description": "Connect AI tools to Xero to access your accounting and financial data from any conversation. Hosted remotely by Xero.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.xero.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.xero.com/documentation/guides/oauth2/mcp/",
+      "publisher": "Xero",
+      "tags": [
+        "xero",
+        "accounting",
+        "finance",
+        "invoicing",
+        "bookkeeping"
+      ]
+    },
+    {
+      "name": "Clerk",
+      "description": "Connect AI tools to Clerk to manage authentication, organizations, users, and billing. Hosted remotely by Clerk.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.clerk.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://clerk.com/docs/integrations/mcp",
+      "publisher": "Clerk",
+      "tags": [
+        "clerk",
+        "authentication",
+        "users",
+        "billing",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Amplitude",
+      "description": "Connect AI tools to Amplitude to give teams powerful behavioral and product analytics insights. Hosted remotely by Amplitude.",
+      "category": "Analytics",
+      "connection_type": "http",
+      "connection_url": "https://mcp.amplitude.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://amplitude.com/docs/get-started/mcp",
+      "publisher": "Amplitude",
+      "tags": [
+        "amplitude",
+        "analytics",
+        "product-analytics",
+        "behavioral",
+        "data"
+      ]
+    },
+    {
+      "name": "Hex",
+      "description": "Connect AI tools to Hex to answer questions with the Hex agent across your data and notebooks. Hosted remotely by Hex.",
+      "category": "Analytics",
+      "connection_type": "http",
+      "connection_url": "https://app.hex.tech/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://learn.hex.tech/docs/explore-data/hex-mcp",
+      "publisher": "Hex",
+      "tags": [
+        "hex",
+        "analytics",
+        "data-science",
+        "notebooks",
+        "data"
+      ]
+    },
+    {
+      "name": "Dovetail",
+      "description": "Connect AI tools to Dovetail to turn customer feedback and research into decisions. Hosted remotely by Dovetail.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://dovetail.com/api/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://dovetail.com/help/mcp-server/",
+      "publisher": "Dovetail",
+      "tags": [
+        "dovetail",
+        "research",
+        "feedback",
+        "insights",
+        "productivity"
+      ]
+    },
+    {
+      "name": "WordPress.com",
+      "description": "Connect AI tools to WordPress.com for secure, permission-scoped access to manage your sites and content. Hosted remotely by WordPress.com.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://public-api.wordpress.com/wpcom/v2/mcp/v1",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.wordpress.com/docs/mcp/",
+      "publisher": "Automattic",
+      "tags": [
+        "wordpress",
+        "cms",
+        "websites",
+        "content",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "SurveyMonkey",
+      "description": "Connect AI tools to SurveyMonkey to design surveys, collect responses, and analyze results. Hosted remotely by SurveyMonkey.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.surveymonkey.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.surveymonkey.com/api/v3/",
+      "publisher": "SurveyMonkey",
+      "tags": [
+        "surveymonkey",
+        "surveys",
+        "forms",
+        "feedback",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Jotform",
+      "description": "Connect AI tools to Jotform to create forms and analyze submissions. Hosted remotely by Jotform.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.jotform.com/mcp-app",
+      "auth_type": "oauth",
+      "docs_url": "https://www.jotform.com/ai/mcp-server/",
+      "publisher": "Jotform",
+      "tags": [
+        "jotform",
+        "forms",
+        "submissions",
+        "surveys",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Lucid",
+      "description": "Connect AI tools to Lucid to ideate, diagram, and align teams across Lucidchart and Lucidspark. Hosted remotely by Lucid.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://mcp.lucid.app/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://lucid.co/resources/mcp",
+      "publisher": "Lucid Software",
+      "tags": [
+        "lucid",
+        "diagrams",
+        "whiteboard",
+        "collaboration",
+        "design"
+      ]
+    },
+    {
+      "name": "Eraser",
+      "description": "Connect AI tools to Eraser to generate, manage, and update diagrams and files. Hosted remotely by Eraser.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://app.eraser.io/api/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.eraser.io/docs/mcp-server",
+      "publisher": "Eraser",
+      "tags": [
+        "eraser",
+        "diagrams",
+        "documentation",
+        "architecture",
+        "design"
+      ]
+    },
+    {
+      "name": "GoCardless",
+      "description": "Connect AI tools to GoCardless to build and manage bank payment and direct debit integrations. Hosted remotely by GoCardless.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.gocardless.com",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.gocardless.com/docs/mcp-server",
+      "publisher": "GoCardless",
+      "tags": [
+        "gocardless",
+        "payments",
+        "direct-debit",
+        "billing",
+        "finance"
+      ]
+    },
+    {
+      "name": "IFTTT",
+      "description": "Connect AI tools to IFTTT to connect, control, and automate over 1,000 apps and services. Hosted remotely by IFTTT.",
+      "category": "Automation",
+      "connection_type": "http",
+      "connection_url": "https://ifttt.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://ifttt.com/explore/mcp",
+      "publisher": "IFTTT",
+      "tags": [
+        "ifttt",
+        "automation",
+        "integrations",
+        "workflows",
+        "no-code"
+      ]
+    },
+    {
+      "name": "Twilio",
+      "description": "Connect AI tools to Twilio to search and explore Twilio documentation for building communications and customer engagement. Hosted remotely by Twilio.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.twilio.com/docs",
+      "auth_type": "none",
+      "docs_url": "https://www.twilio.com/docs/alpha/mcp-server",
+      "publisher": "Twilio",
+      "tags": [
+        "twilio",
+        "documentation",
+        "communications",
+        "sms",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Financial Modeling Prep",
+      "description": "Connect AI tools to Financial Modeling Prep for comprehensive financial datasets covering market and company analysis. Hosted remotely by FMP.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://financialmodelingprep.com/mcp",
+      "auth_type": "none",
+      "docs_url": "https://site.financialmodelingprep.com/developer/docs",
+      "publisher": "Financial Modeling Prep",
+      "tags": [
+        "fmp",
+        "financial-data",
+        "markets",
+        "stocks",
+        "finance"
+      ]
+    },
+    {
+      "name": "Daloopa",
+      "description": "Connect AI tools to Daloopa for financial fundamentals and KPI data sourced from SEC filings, investor presentations, and public financial documents. Hosted remotely by Daloopa.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.daloopa.com/server/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://daloopa.com/developers",
+      "publisher": "Daloopa",
+      "tags": [
+        "daloopa",
+        "financial-data",
+        "fundamentals",
+        "kpi",
+        "finance"
+      ]
+    },
+    {
+      "name": "Quartr",
+      "description": "Connect AI tools to Quartr for financial data and AI infrastructure for company research. Hosted remotely by Quartr.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.quartr.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://quartr.com/solutions/api",
+      "publisher": "Quartr",
+      "tags": [
+        "quartr",
+        "financial-data",
+        "research",
+        "earnings",
+        "finance"
+      ]
+    },
+    {
+      "name": "Bigdata.com",
+      "description": "Connect AI tools to Bigdata.com for institutional-grade financial data covering global news, transcripts, and regulatory filings. Hosted remotely by Bigdata.com.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.bigdata.com/",
+      "auth_type": "headers",
+      "required_header_keys": [
+        "x-api-key"
+      ],
+      "docs_url": "https://docs.bigdata.com/mcp-reference/introduction",
+      "publisher": "Bigdata.com",
+      "tags": [
+        "bigdata",
+        "financial-data",
+        "news",
+        "filings",
+        "finance"
+      ]
+    },
+    {
+      "name": "Fiscal.ai",
+      "description": "Connect AI tools to Fiscal.ai for clean public-equity fundamental data and structured company and market context. Hosted remotely by Fiscal.ai.",
+      "category": "Finance",
+      "connection_type": "sse",
+      "connection_url": "https://api.fiscal.ai/mcp/sse",
+      "auth_type": "none",
+      "docs_url": "https://fiscal.ai/",
+      "publisher": "Fiscal.ai",
+      "tags": [
+        "fiscal-ai",
+        "financial-data",
+        "equities",
+        "fundamentals",
+        "finance"
+      ]
+    },
+    {
+      "name": "Ramp",
+      "description": "Connect AI tools to Ramp to search, access, and analyze your Ramp financial data and spending patterns. Hosted remotely by Ramp.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://ramp-mcp-remote.ramp.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.ramp.com/developer-api/v1/mcp",
+      "publisher": "Ramp",
+      "tags": [
+        "ramp",
+        "spend",
+        "expenses",
+        "finance",
+        "procurement"
+      ]
+    },
+    {
+      "name": "Ramp Data",
+      "description": "Connect AI tools to Ramp Data for spend analysis and benchmarking across a large network of business transaction data. Hosted remotely by Ramp.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.ramp.com/ramp-data/anthropic/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.ramp.com/developer-api/v1/mcp",
+      "publisher": "Ramp",
+      "tags": [
+        "ramp",
+        "spend",
+        "benchmarking",
+        "finance",
+        "data"
+      ]
+    },
+    {
+      "name": "CoinDesk",
+      "description": "Connect AI tools to CoinDesk for real-time and historical digital asset market data and indices. Hosted remotely by CoinDesk.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.coindesk.com/mcp",
+      "auth_type": "none",
+      "docs_url": "https://developers.coindesk.com/",
+      "publisher": "CoinDesk",
+      "tags": [
+        "coindesk",
+        "crypto",
+        "market-data",
+        "indices",
+        "finance"
+      ]
+    },
+    {
+      "name": "Crypto.com",
+      "description": "Connect AI tools to Crypto.com for real-time prices, order books, conversions, candlestick charts, and token-market information. Hosted remotely by Crypto.com.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.crypto.com/market-data/mcp",
+      "auth_type": "none",
+      "docs_url": "https://crypto.com/",
+      "publisher": "Crypto.com",
+      "tags": [
+        "crypto-com",
+        "crypto",
+        "market-data",
+        "trading",
+        "finance"
+      ]
+    },
+    {
+      "name": "Rillet",
+      "description": "Connect AI tools to Rillet to query your live general ledger and financials in plain English. Hosted remotely by Rillet.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://api.rillet.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.rillet.com/",
+      "publisher": "Rillet",
+      "tags": [
+        "rillet",
+        "accounting",
+        "general-ledger",
+        "erp",
+        "finance"
+      ]
+    },
+    {
+      "name": "Digits",
+      "description": "Connect AI tools to Digits to track and analyze your business finances through connected accounting context. Hosted remotely by Digits.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://api.digits.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://digits.com/",
+      "publisher": "Digits",
+      "tags": [
+        "digits",
+        "accounting",
+        "bookkeeping",
+        "finance",
+        "analytics"
+      ]
+    },
+    {
+      "name": "Carta",
+      "description": "Connect AI tools to Carta to work with cap table, investor, fund, accounting, and company financial data for private-capital workflows. Hosted remotely by Carta.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.app.carta.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://carta.com/",
+      "publisher": "Carta",
+      "tags": [
+        "carta",
+        "cap-table",
+        "equity",
+        "fund-administration",
+        "finance"
+      ]
+    },
+    {
+      "name": "Privacy.com",
+      "description": "Connect AI tools to Privacy.com to manage virtual cards and track spending patterns. Hosted remotely by Privacy.com.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.privacy.com",
+      "auth_type": "oauth",
+      "docs_url": "https://privacy.com/",
+      "publisher": "Privacy.com",
+      "tags": [
+        "privacy",
+        "virtual-cards",
+        "payments",
+        "spend",
+        "finance"
+      ]
+    },
+    {
+      "name": "Airwallex",
+      "description": "Connect AI tools to Airwallex to access documentation, API references, and sandbox testing context for building payment integrations. Hosted remotely by Airwallex.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp-demo.airwallex.com/developer",
+      "auth_type": "none",
+      "docs_url": "https://www.airwallex.com/docs",
+      "publisher": "Airwallex",
+      "tags": [
+        "airwallex",
+        "payments",
+        "documentation",
+        "fintech",
+        "finance"
+      ]
+    },
+    {
+      "name": "Yahoo Finance",
+      "description": "Connect AI tools to Yahoo Finance for stock data, market news, financials, and price history. Hosted remotely.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://gateway.mcpservers.org/yahoo-finance/mcp",
+      "auth_type": "none",
+      "docs_url": "https://finance.yahoo.com/",
+      "publisher": "mcpservers.org",
+      "tags": [
+        "yahoo-finance",
+        "stocks",
+        "market-data",
+        "news",
+        "finance"
+      ]
+    },
+    {
+      "name": "Expedia",
+      "description": "Connect AI tools to Expedia to plan trips and search flights and hotels. Hosted remotely by Expedia.",
+      "category": "Travel",
+      "connection_type": "http",
+      "connection_url": "https://www.expedia.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.expedia.com/",
+      "publisher": "Expedia",
+      "tags": [
+        "expedia",
+        "travel",
+        "flights",
+        "hotels",
+        "booking"
+      ]
+    },
+    {
+      "name": "Uber",
+      "description": "Connect AI tools to Uber to get price and time estimates for any ride option. Hosted remotely by Uber.",
+      "category": "Travel",
+      "connection_type": "http",
+      "connection_url": "https://mcp.uber.com/claude/rides-3p/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.uber.com/",
+      "publisher": "Uber",
+      "tags": [
+        "uber",
+        "rides",
+        "transportation",
+        "travel",
+        "mobility"
+      ]
+    },
+    {
+      "name": "Uber Eats",
+      "description": "Connect AI tools to Uber Eats to explore restaurants and dishes for local food delivery. Hosted remotely by Uber.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://mcp.ubereats.com/eats-claude/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.ubereats.com/",
+      "publisher": "Uber",
+      "tags": [
+        "uber-eats",
+        "food-delivery",
+        "restaurants",
+        "lifestyle",
+        "ordering"
+      ]
+    },
+    {
+      "name": "Resy",
+      "description": "Connect AI tools to Resy to find and book restaurants instantly. Hosted remotely by Resy.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://apigw.americanexpress.com/dining/v1/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://resy.com/",
+      "publisher": "Resy",
+      "tags": [
+        "resy",
+        "restaurants",
+        "reservations",
+        "dining",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "DoorDash",
+      "description": "Connect AI tools to DoorDash for food delivery and restaurant reservation workflows. Hosted remotely by DoorDash.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://openapi.doordash.com/mcp/consumer",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.doordash.com/",
+      "publisher": "DoorDash",
+      "tags": [
+        "doordash",
+        "food-delivery",
+        "restaurants",
+        "lifestyle",
+        "ordering"
+      ]
+    },
+    {
+      "name": "Instacart",
+      "description": "Connect AI tools to Instacart to shop for groceries with fast delivery across stores and products. Hosted remotely by Instacart.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://fig-mcp.instacart.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.instacart.com/",
+      "publisher": "Instacart",
+      "tags": [
+        "instacart",
+        "groceries",
+        "delivery",
+        "shopping",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Tripadvisor",
+      "description": "Connect AI tools to Tripadvisor to research accommodations with reviews, ratings, photos, availability, and nearby points of interest. Hosted remotely by Tripadvisor.",
+      "category": "Travel",
+      "connection_type": "http",
+      "connection_url": "https://production.ai-mcp-extensibility-prd.tamg.cloud/ogMvjY4De1G7CiHanMOAgddl/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.tripadvisor.com/",
+      "publisher": "Tripadvisor",
+      "tags": [
+        "tripadvisor",
+        "travel",
+        "hotels",
+        "reviews",
+        "booking"
+      ]
+    },
+    {
+      "name": "Trivago",
+      "description": "Connect AI tools to Trivago to search hotels and accommodations by location, dates, and travel context. Hosted remotely by Trivago.",
+      "category": "Travel",
+      "connection_type": "http",
+      "connection_url": "https://mcp.trivago.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.trivago.com/",
+      "publisher": "Trivago",
+      "tags": [
+        "trivago",
+        "travel",
+        "hotels",
+        "accommodation",
+        "booking"
+      ]
+    },
+    {
+      "name": "Viator",
+      "description": "Connect AI tools to Viator to discover and book travel experiences around the world. Hosted remotely by Viator.",
+      "category": "Travel",
+      "connection_type": "http",
+      "connection_url": "https://exp-app-mcp.prod.ep.viator.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.viator.com/",
+      "publisher": "Viator",
+      "tags": [
+        "viator",
+        "travel",
+        "experiences",
+        "tours",
+        "booking"
+      ]
+    },
+    {
+      "name": "StubHub",
+      "description": "Connect AI tools to StubHub to find tickets for concerts, sports, theater, comedy, festivals, and other live events. Hosted remotely by StubHub.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://open-ai-app.stubhub.net/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.stubhub.com/",
+      "publisher": "StubHub",
+      "tags": [
+        "stubhub",
+        "tickets",
+        "events",
+        "concerts",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "AllTrails",
+      "description": "Connect AI tools to AllTrails to discover hikes, walks, and outdoor routes with curated trail info, reviews, and photos. Hosted remotely by AllTrails.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://www.alltrails.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.alltrails.com/",
+      "publisher": "AllTrails",
+      "tags": [
+        "alltrails",
+        "hiking",
+        "outdoors",
+        "trails",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Strava",
+      "description": "Connect AI tools to Strava to access activities, fitness trends, training load, and goals. Hosted remotely by Strava.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://mcp.strava.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.strava.com/",
+      "publisher": "Strava",
+      "tags": [
+        "strava",
+        "fitness",
+        "activities",
+        "training",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Fever",
+      "description": "Connect AI tools to Fever to discover live entertainment events, concerts, and cultural experiences worldwide. Hosted remotely by Fever.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://data-search.apigw.feverup.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://feverup.com/",
+      "publisher": "Fever",
+      "tags": [
+        "fever",
+        "events",
+        "entertainment",
+        "tickets",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Taskrabbit",
+      "description": "Connect AI tools to Taskrabbit to check local service availability and pricing and scope home-service needs. Hosted remotely by Taskrabbit.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://mcp.taskrabbit.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.taskrabbit.com/",
+      "publisher": "Taskrabbit",
+      "tags": [
+        "taskrabbit",
+        "services",
+        "home",
+        "tasks",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Thumbtack",
+      "description": "Connect AI tools to Thumbtack to plan home projects and connect with local professionals for repairs and improvements. Hosted remotely by Thumbtack.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://mcp.thumbtack.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.thumbtack.com/",
+      "publisher": "Thumbtack",
+      "tags": [
+        "thumbtack",
+        "services",
+        "home",
+        "professionals",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Fathom",
+      "description": "Connect AI tools to Fathom to access meeting recordings, transcripts, and summaries. Hosted remotely by Fathom.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://api.fathom.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.fathom.video/",
+      "publisher": "Fathom",
+      "tags": [
+        "fathom",
+        "meetings",
+        "transcripts",
+        "notes",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Granola",
+      "description": "Connect AI tools to Granola to capture meeting notes and context with AI-powered summaries and follow-ups. Hosted remotely by Granola.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.granola.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.granola.ai/",
+      "publisher": "Granola",
+      "tags": [
+        "granola",
+        "meetings",
+        "notes",
+        "transcripts",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Otter.ai",
+      "description": "Connect AI tools to Otter.ai to access meeting transcripts, summaries, and conversation records and extract decisions and action items. Hosted remotely by Otter.ai.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.otter.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://otter.ai/",
+      "publisher": "Otter.ai",
+      "tags": [
+        "otter",
+        "meetings",
+        "transcripts",
+        "notes",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Grain",
+      "description": "Connect AI tools to Grain to turn meetings into insights, summaries, and next steps. Hosted remotely by Grain.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://api.grain.com/_/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://grain.com/",
+      "publisher": "Grain",
+      "tags": [
+        "grain",
+        "meetings",
+        "transcripts",
+        "insights",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Krisp",
+      "description": "Connect AI tools to Krisp to bring meeting transcripts and notes into workflows for summaries, follow-ups, and decisions. Hosted remotely by Krisp.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.krisp.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://krisp.ai/",
+      "publisher": "Krisp",
+      "tags": [
+        "krisp",
+        "meetings",
+        "transcripts",
+        "notes",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Superhuman Mail",
+      "description": "Connect AI tools to Superhuman to search inboxes, draft replies, schedule meetings, and manage email and calendar. Hosted remotely by Superhuman.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.mail.superhuman.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://superhuman.com/",
+      "publisher": "Superhuman",
+      "tags": [
+        "superhuman",
+        "email",
+        "calendar",
+        "inbox",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Mem",
+      "description": "Connect AI tools to Mem, the AI notebook for notes, thoughts, and personal knowledge. Hosted remotely by Mem.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.mem.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://get.mem.ai/",
+      "publisher": "Mem",
+      "tags": [
+        "mem",
+        "notes",
+        "knowledge-base",
+        "personal",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Craft",
+      "description": "Connect AI tools to Craft to create structured documents, manage tasks, and organize a personal knowledge base. Hosted remotely by Craft.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.craft.do/my/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.craft.do/",
+      "publisher": "Craft",
+      "tags": [
+        "craft",
+        "notes",
+        "documents",
+        "knowledge-base",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Workable",
+      "description": "Connect AI tools to Workable for hiring and HR workflows across candidates, jobs, and pipelines. Hosted remotely by Workable.",
+      "category": "Human Resources",
+      "connection_type": "http",
+      "connection_url": "https://mcp.workable.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://workable.readme.io/",
+      "publisher": "Workable",
+      "tags": [
+        "workable",
+        "hiring",
+        "recruiting",
+        "hr",
+        "ats"
+      ]
+    },
+    {
+      "name": "Metaview",
+      "description": "Connect AI tools to Metaview for interview, hiring, and recruiting context. Hosted remotely by Metaview.",
+      "category": "Human Resources",
+      "connection_type": "http",
+      "connection_url": "https://mcp.metaview.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.metaview.ai/",
+      "publisher": "Metaview",
+      "tags": [
+        "metaview",
+        "recruiting",
+        "interviews",
+        "hiring",
+        "hr"
+      ]
+    },
+    {
+      "name": "ZipRecruiter",
+      "description": "Connect AI tools to ZipRecruiter to search live jobs by title, company, location, salary, work style, and more. Hosted remotely by ZipRecruiter.",
+      "category": "Human Resources",
+      "connection_type": "http",
+      "connection_url": "https://api.ziprecruiter.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.ziprecruiter.com/",
+      "publisher": "ZipRecruiter",
+      "tags": [
+        "ziprecruiter",
+        "jobs",
+        "recruiting",
+        "hiring",
+        "hr"
+      ]
+    },
+    {
+      "name": "Harmonic",
+      "description": "Connect AI tools to Harmonic to discover, research, and enrich companies and people for market mapping and prospect research. Hosted remotely by Harmonic.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://mcp.api.harmonic.ai",
+      "auth_type": "oauth",
+      "docs_url": "https://harmonic.ai/",
+      "publisher": "Harmonic",
+      "tags": [
+        "harmonic",
+        "prospecting",
+        "enrichment",
+        "companies",
+        "sales"
+      ]
+    },
+    {
+      "name": "Lusha",
+      "description": "Connect AI tools to Lusha to find and enrich B2B contacts and companies for sales intelligence and prospecting. Hosted remotely by Lusha.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://mcp.lusha.com/mcp/claude",
+      "auth_type": "oauth",
+      "docs_url": "https://www.lusha.com/",
+      "publisher": "Lusha",
+      "tags": [
+        "lusha",
+        "prospecting",
+        "enrichment",
+        "contacts",
+        "sales"
+      ]
+    },
+    {
+      "name": "ZoomInfo",
+      "description": "Connect AI tools to ZoomInfo for verified B2B company and contact data to search companies, identify stakeholders, and build account lists. Hosted remotely by ZoomInfo.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://mcp.zoominfo.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.zoominfo.com/",
+      "publisher": "ZoomInfo",
+      "tags": [
+        "zoominfo",
+        "prospecting",
+        "enrichment",
+        "contacts",
+        "sales"
+      ]
+    },
+    {
+      "name": "Outreach",
+      "description": "Connect AI tools to Outreach for sales engagement and revenue-team workflows with account, prospect, and outreach context. Hosted remotely by Outreach.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://api.outreach.io/mcp/",
+      "auth_type": "oauth",
+      "docs_url": "https://www.outreach.io/",
+      "publisher": "Outreach",
+      "tags": [
+        "outreach",
+        "sales-engagement",
+        "prospecting",
+        "crm",
+        "sales"
+      ]
+    },
+    {
+      "name": "Sprouts",
+      "description": "Connect AI tools to Sprouts.ai for natural-language access to a B2B prospect database with role, industry, and lead-qualification signals. Hosted remotely by Sprouts.ai.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://sprouts-mcp-server.kartikay-dhar.workers.dev",
+      "auth_type": "oauth",
+      "docs_url": "https://sprouts.ai/",
+      "publisher": "Sprouts.ai",
+      "tags": [
+        "sprouts",
+        "prospecting",
+        "lead-generation",
+        "contacts",
+        "sales"
+      ]
+    },
+    {
+      "name": "Scite",
+      "description": "Connect AI tools to Scite for evidence-based answers grounded in peer-reviewed research and citation context. Hosted remotely by Scite.",
+      "category": "Research",
+      "connection_type": "http",
+      "connection_url": "https://api.scite.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://scite.ai/",
+      "publisher": "Scite",
+      "tags": [
+        "scite",
+        "research",
+        "citations",
+        "academic",
+        "science"
+      ]
+    },
+    {
+      "name": "Synthesize Bio",
+      "description": "Connect AI tools to Synthesize Bio to generate and analyze gene-expression data from a virtual human using natural-language experiment descriptions. Hosted remotely by Synthesize Bio.",
+      "category": "Research",
+      "connection_type": "http",
+      "connection_url": "https://app.synthesize.bio/api/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://synthesize.bio/",
+      "publisher": "Synthesize Bio",
+      "tags": [
+        "synthesize-bio",
+        "biology",
+        "gene-expression",
+        "biotech",
+        "research"
+      ]
+    },
+    {
+      "name": "CourtListener",
+      "description": "Connect AI tools to CourtListener for legal research across millions of U.S. court opinions, PACER dockets, judge profiles, and citation data. Hosted remotely by Free Law Project.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://mcp.courtlistener.com/",
+      "auth_type": "none",
+      "docs_url": "https://www.courtlistener.com/",
+      "publisher": "Free Law Project",
+      "tags": [
+        "courtlistener",
+        "legal",
+        "court-opinions",
+        "dockets",
+        "research"
+      ]
+    },
+    {
+      "name": "Everlaw",
+      "description": "Connect AI tools to Everlaw to search and explore case data, review evidence, and find documents. Hosted remotely by Everlaw.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://api.everlaw.com/v1/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.everlaw.com/",
+      "publisher": "Everlaw",
+      "tags": [
+        "everlaw",
+        "legal",
+        "ediscovery",
+        "documents",
+        "litigation"
+      ]
+    },
+    {
+      "name": "Midpage",
+      "description": "Connect AI tools to Midpage to conduct legal research and create legal work product. Hosted remotely by Midpage.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://app.midpage.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://midpage.ai/",
+      "publisher": "Midpage",
+      "tags": [
+        "midpage",
+        "legal",
+        "research",
+        "documents",
+        "litigation"
+      ]
+    },
+    {
+      "name": "Ironclad",
+      "description": "Connect AI tools to Ironclad for plain-language search across contracts to find agreement terms, obligations, and related records. Hosted remotely by Ironclad.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://mcp.na1.ironcladapp.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.ironcladapp.com/",
+      "publisher": "Ironclad",
+      "tags": [
+        "ironclad",
+        "contracts",
+        "legal",
+        "clm",
+        "agreements"
+      ]
+    },
+    {
+      "name": "Definely",
+      "description": "Connect AI tools to Definely for structured contract review tools for clause analysis and agreement review. Hosted remotely by Definely.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://mcp.eu.definely.com/api/proxy/core-mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://definely.com/",
+      "publisher": "Definely",
+      "tags": [
+        "definely",
+        "contracts",
+        "legal",
+        "review",
+        "documents"
+      ]
+    },
+    {
+      "name": "Legal Data Hunter",
+      "description": "Connect AI tools to Legal Data Hunter to search 23M+ legal documents across 160+ jurisdictions for research and document comparison. Hosted remotely by Legal Data Hunter.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://legaldatahunter.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://legaldatahunter.com/",
+      "publisher": "Legal Data Hunter",
+      "tags": [
+        "legal-data-hunter",
+        "legal",
+        "research",
+        "documents",
+        "jurisdictions"
+      ]
+    },
+    {
+      "name": "Descrybe",
+      "description": "Connect AI tools to Descrybe for structured U.S. primary-law context to ground legal research in source material. Hosted remotely by Descrybe.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://mcp.descrybe.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://descrybe.ai/",
+      "publisher": "Descrybe",
+      "tags": [
+        "descrybe",
+        "legal",
+        "us-law",
+        "research",
+        "primary-law"
+      ]
+    },
+    {
+      "name": "Lawve AI",
+      "description": "Connect AI tools to Lawve AI for expert-written skills for legal work. Hosted remotely by Lawve AI.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://mcp.lawve.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://lawve.ai/",
+      "publisher": "Lawve AI",
+      "tags": [
+        "lawve",
+        "legal",
+        "skills",
+        "documents",
+        "research"
+      ]
+    },
+    {
+      "name": "Courtroom5",
+      "description": "Connect AI tools to Courtroom5 for jurisdiction-aware civil legal guidance for self-represented litigants across U.S. states. Hosted remotely by Courtroom5.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://mcp.courtroom5.com/v1",
+      "auth_type": "oauth",
+      "docs_url": "https://courtroom5.com/",
+      "publisher": "Courtroom5",
+      "tags": [
+        "courtroom5",
+        "legal",
+        "litigation",
+        "self-represented",
+        "guidance"
+      ]
+    },
+    {
+      "name": "Shopify",
+      "description": "Connect AI tools to Shopify to build, manage, and analyze online stores across products, inventory, orders, customers, and analytics. Hosted remotely by Shopify.",
+      "category": "E-Commerce",
+      "connection_type": "http",
+      "connection_url": "https://setup.shopify.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://shopify.dev/docs/apps/build/model-context-protocol",
+      "publisher": "Shopify",
+      "tags": [
+        "shopify",
+        "ecommerce",
+        "products",
+        "orders",
+        "inventory"
+      ]
+    },
+    {
+      "name": "GoDaddy",
+      "description": "Connect AI tools to GoDaddy to search domains, check availability, and explore naming ideas. Hosted remotely by GoDaddy.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://api.godaddy.com/v1/domains/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developer.godaddy.com/",
+      "publisher": "GoDaddy",
+      "tags": [
+        "godaddy",
+        "domains",
+        "dns",
+        "hosting",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Goodnotes",
+      "description": "Connect AI tools to Goodnotes to turn AI insights into documents and notes. Hosted remotely by Goodnotes.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://claude-mcp-api.ml.goodnotes.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.goodnotes.com/",
+      "publisher": "Goodnotes",
+      "tags": [
+        "goodnotes",
+        "notes",
+        "documents",
+        "handwriting",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Mermaid Chart",
+      "description": "Connect AI tools to Mermaid Chart to validate Mermaid syntax and render diagrams as high-quality SVGs with interactive previews. Hosted remotely by Mermaid Chart.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://mcp.mermaid.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.mermaidchart.com/",
+      "publisher": "Mermaid Chart",
+      "tags": [
+        "mermaid",
+        "diagrams",
+        "svg",
+        "charts",
+        "design"
+      ]
+    },
+    {
+      "name": "Magic Patterns",
+      "description": "Connect AI tools to Magic Patterns to discuss and iterate on product interface designs, explore UI ideas, and revise concepts. Hosted remotely by Magic Patterns.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://mcp.magicpatterns.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.magicpatterns.com/",
+      "publisher": "Magic Patterns",
+      "tags": [
+        "magic-patterns",
+        "design",
+        "ui",
+        "prototyping",
+        "components"
+      ]
+    },
+    {
+      "name": "Excalidraw",
+      "description": "Connect AI tools to Excalidraw to create interactive hand-drawn diagrams from conversations. Hosted remotely.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://excalidraw-mcp-app.vercel.app/mcp",
+      "auth_type": "none",
+      "docs_url": "https://excalidraw.com/",
+      "publisher": "Excalidraw",
+      "tags": [
+        "excalidraw",
+        "diagrams",
+        "whiteboard",
+        "sketching",
+        "design"
+      ]
+    },
+    {
+      "name": "Trimble SketchUp",
+      "description": "Connect AI tools to SketchUp to generate, refine, and share 3D model concepts from conversational descriptions. Hosted remotely by Trimble.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://api.sketchup.com/mcp/v1/sketchup/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.sketchup.com/",
+      "publisher": "Trimble",
+      "tags": [
+        "sketchup",
+        "3d-modeling",
+        "architecture",
+        "design",
+        "cad"
+      ]
+    },
+    {
+      "name": "Netlify (Remote)",
+      "description": "Connect AI tools to Netlify to create, deploy, manage, and secure websites. Hosted remotely by Netlify.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://netlify-mcp.netlify.app/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.netlify.com/welcome/build-with-ai/netlify-mcp-server/",
+      "publisher": "Netlify",
+      "tags": [
+        "netlify",
+        "deployments",
+        "hosting",
+        "websites",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "MailerLite",
+      "description": "Connect AI tools to MailerLite for drafting, reviewing, and planning email marketing work. Hosted remotely by MailerLite.",
+      "category": "Marketing",
+      "connection_type": "http",
+      "connection_url": "https://mcp.mailerlite.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.mailerlite.com/",
+      "publisher": "MailerLite",
+      "tags": [
+        "mailerlite",
+        "email-marketing",
+        "campaigns",
+        "newsletters",
+        "marketing"
+      ]
+    },
+    {
+      "name": "Coupler.io",
+      "description": "Connect AI tools to Coupler.io to access business data from hundreds of marketing, sales, finance, and ecommerce sources. Hosted remotely by Coupler.io.",
+      "category": "Analytics",
+      "connection_type": "http",
+      "connection_url": "https://mcp.coupler.io/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.coupler.io/",
+      "publisher": "Coupler.io",
+      "tags": [
+        "coupler",
+        "data-integration",
+        "analytics",
+        "reporting",
+        "data"
+      ]
+    },
+    {
+      "name": "Lumin",
+      "description": "Connect AI tools to Lumin to manage documents, send signature requests, and convert Markdown to PDF. Hosted remotely by Lumin.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp.luminpdf.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.luminpdf.com/",
+      "publisher": "Lumin",
+      "tags": [
+        "lumin",
+        "documents",
+        "signatures",
+        "pdf",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Clarify",
+      "description": "Connect AI tools to Clarify to query, create, and update CRM records conversationally. Hosted remotely by Clarify.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://api.clarify.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://clarify.ai/",
+      "publisher": "Clarify",
+      "tags": [
+        "clarify",
+        "crm",
+        "sales",
+        "records",
+        "contacts"
+      ]
+    },
+    {
+      "name": "Day AI",
+      "description": "Connect AI tools to Day AI to know everything about your prospects and customers with CRMx, providing account and relationship data. Hosted remotely by Day AI.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://day.ai/api/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://day.ai/",
+      "publisher": "Day AI",
+      "tags": [
+        "day-ai",
+        "crm",
+        "sales",
+        "accounts",
+        "relationships"
+      ]
+    },
+    {
+      "name": "Crossbeam",
+      "description": "Connect AI tools to Crossbeam to surface partner overlaps, warm paths, and co-sell opportunities with real-time partnership context. Hosted remotely by Crossbeam.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://mcp.crossbeam.com",
+      "auth_type": "oauth",
+      "docs_url": "https://www.crossbeam.com/",
+      "publisher": "Crossbeam",
+      "tags": [
+        "crossbeam",
+        "partnerships",
+        "co-sell",
+        "ecosystem",
+        "sales"
+      ]
+    },
+    {
+      "name": "Pylon",
+      "description": "Connect AI tools to Pylon to search and manage support issues, track customer status, and coordinate responses. Hosted remotely by Pylon.",
+      "category": "Customer Support",
+      "connection_type": "http",
+      "connection_url": "https://mcp.usepylon.com/",
+      "auth_type": "oauth",
+      "docs_url": "https://usepylon.com/",
+      "publisher": "Pylon",
+      "tags": [
+        "pylon",
+        "support",
+        "tickets",
+        "customer-support",
+        "helpdesk"
+      ]
+    },
+    {
+      "name": "Unthread",
+      "description": "Connect AI tools to Unthread to search conversations, monitor SLAs, analyze support metrics, and manage support tickets. Hosted remotely by Unthread.",
+      "category": "Customer Support",
+      "connection_type": "http",
+      "connection_url": "https://app.unthread.io/api/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://unthread.io/",
+      "publisher": "Unthread",
+      "tags": [
+        "unthread",
+        "support",
+        "tickets",
+        "sla",
+        "customer-support"
+      ]
+    },
+    {
+      "name": "Jam",
+      "description": "Connect AI tools to Jam to capture screen recordings and automatic context for issue reports and bug tracking. Hosted remotely by Jam.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.jam.dev/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://jam.dev/",
+      "publisher": "Jam",
+      "tags": [
+        "jam",
+        "bug-reports",
+        "screen-recording",
+        "debugging",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Monte Carlo",
+      "description": "Connect AI tools to Monte Carlo for data and AI observability, monitoring data reliability, and investigating data quality incidents. Hosted remotely by Monte Carlo.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://integrations.getmontecarlo.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.getmontecarlo.com/",
+      "publisher": "Monte Carlo",
+      "tags": [
+        "monte-carlo",
+        "data-observability",
+        "data-quality",
+        "monitoring",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Polar Analytics",
+      "description": "Connect AI tools to Polar Analytics to bring ecommerce and business data into one analytics workspace. Hosted remotely by Polar Analytics.",
+      "category": "Analytics",
+      "connection_type": "http",
+      "connection_url": "https://api.polaranalytics.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://polaranalytics.com/",
+      "publisher": "Polar Analytics",
+      "tags": [
+        "polar-analytics",
+        "ecommerce",
+        "analytics",
+        "reporting",
+        "data"
+      ]
+    },
+    {
+      "name": "Omni Analytics",
+      "description": "Connect AI tools to Omni to query data through a semantic model with natural language for governed analytics. Hosted remotely by Omni.",
+      "category": "Analytics",
+      "connection_type": "http",
+      "connection_url": "https://callbacks.omniapp.co/callback/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://omni.co/",
+      "publisher": "Omni",
+      "tags": [
+        "omni",
+        "analytics",
+        "semantic-model",
+        "data",
+        "bi"
+      ]
+    },
+    {
+      "name": "Local Falcon",
+      "description": "Connect AI tools to Local Falcon for AI visibility and local search intelligence including map rankings and regional SEO performance. Hosted remotely by Local Falcon.",
+      "category": "Marketing",
+      "connection_type": "sse",
+      "connection_url": "https://mcp.localfalcon.com",
+      "auth_type": "oauth",
+      "docs_url": "https://www.localfalcon.com/",
+      "publisher": "Local Falcon",
+      "tags": [
+        "local-falcon",
+        "local-seo",
+        "map-rankings",
+        "visibility",
+        "marketing"
+      ]
+    },
+    {
+      "name": "Similarweb",
+      "description": "Connect AI tools to Similarweb for real-time web, mobile app, and market intelligence data on traffic, keywords, and benchmarking. Hosted remotely by Similarweb.",
+      "category": "Marketing",
+      "connection_type": "http",
+      "connection_url": "https://mcp.similarweb.com",
+      "auth_type": "oauth",
+      "docs_url": "https://developers.similarweb.com/",
+      "publisher": "Similarweb",
+      "tags": [
+        "similarweb",
+        "traffic",
+        "market-data",
+        "competitive-intelligence",
+        "marketing"
+      ]
+    },
+    {
+      "name": "Peec AI",
+      "description": "Connect AI tools to Peec AI to analyze brand visibility across LLMs with AI-search and brand-monitoring context. Hosted remotely by Peec AI.",
+      "category": "Marketing",
+      "connection_type": "http",
+      "connection_url": "https://api.peec.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://peec.ai/",
+      "publisher": "Peec AI",
+      "tags": [
+        "peec-ai",
+        "brand-monitoring",
+        "ai-search",
+        "visibility",
+        "marketing"
+      ]
+    },
+    {
+      "name": "Motion",
+      "description": "Connect AI tools to Motion to analyze Meta ad creative and competitor ad libraries for creative-performance context and paid-social strategy. Hosted remotely by Motion.",
+      "category": "Marketing",
+      "connection_type": "http",
+      "connection_url": "https://projects.motionapp.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://motionapp.com/",
+      "publisher": "Motion",
+      "tags": [
+        "motion",
+        "ads",
+        "creative",
+        "meta",
+        "marketing"
+      ]
+    },
+    {
+      "name": "Apollo GraphOS",
+      "description": "Connect AI tools to Apollo GraphOS to search Apollo docs, specs, and best practices for GraphQL development. Hosted remotely by Apollo.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.apollographql.com",
+      "auth_type": "none",
+      "docs_url": "https://www.apollographql.com/docs/",
+      "publisher": "Apollo GraphQL",
+      "tags": [
+        "apollo",
+        "graphql",
+        "documentation",
+        "api",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "AdisInsight",
+      "description": "Connect AI tools to AdisInsight for pharmaceutical drug and clinical trial intelligence across pipelines, trials, and regulatory milestones. Hosted remotely by Springer.",
+      "category": "Research",
+      "connection_type": "http",
+      "connection_url": "https://adisinsight-mcp.springer.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://adisinsight.springer.com/",
+      "publisher": "Springer Nature",
+      "tags": [
+        "adisinsight",
+        "pharma",
+        "clinical-trials",
+        "drugs",
+        "research"
+      ]
+    },
+    {
+      "name": "LILT",
+      "description": "Connect AI tools to LILT for high-quality translation with human verification. Hosted remotely by LILT.",
+      "category": "AI Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.lilt.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://lilt.com/",
+      "publisher": "LILT",
+      "tags": [
+        "lilt",
+        "translation",
+        "localization",
+        "language",
+        "ai"
+      ]
+    },
+    {
+      "name": "Splice",
+      "description": "Connect AI tools to Splice to search the sounds catalog, build stacks, and explore samples. Hosted remotely by Splice.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://mcp.splice.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://splice.com/",
+      "publisher": "Splice",
+      "tags": [
+        "splice",
+        "music",
+        "samples",
+        "audio",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Ticket Tailor",
+      "description": "Connect AI tools to Ticket Tailor to manage events, tickets, and orders. Hosted remotely by Ticket Tailor.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://mcp.tickettailor.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.tickettailor.com/",
+      "publisher": "Ticket Tailor",
+      "tags": [
+        "ticket-tailor",
+        "events",
+        "tickets",
+        "ticketing",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Wyndham Hotels",
+      "description": "Connect AI tools to Wyndham Hotels to search and compare hotels by city, dates, amenities, and trip needs. Hosted remotely by Wyndham.",
+      "category": "Travel",
+      "connection_type": "http",
+      "connection_url": "https://mcp.wyndhamhotels.com/claude/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.wyndhamhotels.com/",
+      "publisher": "Wyndham Hotels & Resorts",
+      "tags": [
+        "wyndham",
+        "travel",
+        "hotels",
+        "accommodation",
+        "booking"
+      ]
+    },
+    {
+      "name": "DirectBooker",
+      "description": "Connect AI tools to DirectBooker to compare hotels and book directly with properties. Hosted remotely by DirectBooker.",
+      "category": "Travel",
+      "connection_type": "http",
+      "connection_url": "https://www.directbooker.ai/claude",
+      "auth_type": "none",
+      "docs_url": "https://www.directbooker.com/",
+      "publisher": "DirectBooker",
+      "tags": [
+        "directbooker",
+        "travel",
+        "hotels",
+        "booking",
+        "accommodation"
+      ]
+    },
+    {
+      "name": "Melon",
+      "description": "Connect AI tools to Melon to browse music charts and personalized music picks. Hosted remotely by Melon.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://mcp.melon.com/mcp/",
+      "auth_type": "oauth",
+      "docs_url": "https://www.melon.com/",
+      "publisher": "Melon",
+      "tags": [
+        "melon",
+        "music",
+        "charts",
+        "streaming",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Audible",
+      "description": "Connect AI tools to Audible to discover audiobook recommendations by genre, mood, topic, or natural-language preference. Hosted remotely by Audible.",
+      "category": "Lifestyle",
+      "connection_type": "http",
+      "connection_url": "https://mcp.audible.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.audible.com/",
+      "publisher": "Audible",
+      "tags": [
+        "audible",
+        "audiobooks",
+        "books",
+        "recommendations",
+        "lifestyle"
+      ]
+    },
+    {
+      "name": "Egnyte",
+      "description": "Connect AI tools to Egnyte for governed content collaboration to securely access files and business documents. Hosted remotely by Egnyte.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://mcp-server.egnyte.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.egnyte.com/",
+      "publisher": "Egnyte",
+      "tags": [
+        "egnyte",
+        "files",
+        "documents",
+        "storage",
+        "productivity"
+      ]
+    },
+    {
+      "name": "iManage Work",
+      "description": "Connect AI tools to iManage Work for governed access to knowledge, documents, and matter context for professional teams. Hosted remotely by iManage.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://cloudimanage.com/mcp/work",
+      "auth_type": "oauth",
+      "docs_url": "https://imanage.com/",
+      "publisher": "iManage",
+      "tags": [
+        "imanage",
+        "documents",
+        "knowledge-management",
+        "legal",
+        "matters"
+      ]
+    },
+    {
+      "name": "NetDocuments",
+      "description": "Connect AI tools to NetDocuments for governed document context to search, review, and run matter-aware analysis within existing permissions. Hosted remotely by NetDocuments.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://web-api.us.netdocuments.app/connect/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.netdocuments.com/",
+      "publisher": "NetDocuments",
+      "tags": [
+        "netdocuments",
+        "documents",
+        "legal",
+        "matters",
+        "dms"
+      ]
+    },
+    {
+      "name": "Google Cloud BigQuery",
+      "description": "Connect AI tools to Google Cloud BigQuery for advanced analytical insights for data agents. Hosted remotely by Google Cloud.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://bigquery.googleapis.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://cloud.google.com/bigquery/docs",
+      "publisher": "Google Cloud",
+      "tags": [
+        "bigquery",
+        "data-warehouse",
+        "analytics",
+        "sql",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Enterpret",
+      "description": "Connect AI tools to Enterpret to unify customer feedback and understand themes across sources. Hosted remotely by Enterpret.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://wisdom-api.enterpret.com/server/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.enterpret.com/",
+      "publisher": "Enterpret",
+      "tags": [
+        "enterpret",
+        "feedback",
+        "customer-insights",
+        "themes",
+        "productivity"
+      ]
+    },
+    {
+      "name": "aws",
+      "description": "Connect AI tools to AWS to securely access all AWS services through a small, fixed set of tools, with current documentation and authenticated API access. Hosted remotely by AWS.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://aws-mcp.us-east-1.api.aws/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://docs.aws.amazon.com/agent-toolkit/latest/userguide/mcp-server.html",
+      "publisher": "Amazon Web Services",
+      "tags": [
+        "aws",
+        "cloud",
+        "infrastructure",
+        "documentation",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "pg-aiguide",
+      "description": "Connect AI tools to pg-aiguide to search Postgres and Tiger documentation and learn database skills. Hosted remotely by TigerData.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://mcp.tigerdata.com/docs",
+      "auth_type": "none",
+      "docs_url": "https://www.tigerdata.com/",
+      "publisher": "TigerData",
+      "tags": [
+        "pg-aiguide",
+        "postgres",
+        "documentation",
+        "database",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Send",
+      "description": "Connect AI tools to Send to create shareable documents, one-pagers, decks, and presentations. Hosted remotely by Send.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://www.send.co/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.send.co/",
+      "publisher": "Send",
+      "tags": [
+        "send",
+        "documents",
+        "presentations",
+        "decks",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Malwarebytes",
+      "description": "Connect AI tools to Malwarebytes to check links, phone numbers, and emails for scams with security-screening context. Hosted remotely by Malwarebytes.",
+      "category": "Security",
+      "connection_type": "http",
+      "connection_url": "https://scamguard.malwarebytes.com/claude/mcp",
+      "auth_type": "none",
+      "docs_url": "https://www.malwarebytes.com/",
+      "publisher": "Malwarebytes",
+      "tags": [
+        "malwarebytes",
+        "security",
+        "scam-detection",
+        "phishing",
+        "safety"
+      ]
+    },
+    {
+      "name": "Era Context",
+      "description": "Connect AI tools to Era Context to bring personal-finance context into workflows. Hosted remotely by Era.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://context.era.app",
+      "auth_type": "oauth",
+      "docs_url": "https://era.app/",
+      "publisher": "Era",
+      "tags": [
+        "era",
+        "personal-finance",
+        "budgeting",
+        "money",
+        "finance"
+      ]
+    },
+    {
+      "name": "Solve Intelligence",
+      "description": "Connect AI tools to Solve Intelligence to search, draft, and chart patents across patent and non-patent literature. Hosted remotely by Solve Intelligence.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://api.solveintelligence.com/mcp/",
+      "auth_type": "oauth",
+      "docs_url": "https://www.solveintelligence.com/",
+      "publisher": "Solve Intelligence",
+      "tags": [
+        "solve-intelligence",
+        "patents",
+        "ip",
+        "legal",
+        "research"
+      ]
+    },
+    {
+      "name": "Lorikeet",
+      "description": "Connect AI tools to Lorikeet for a concierge-style AI layer supporting complex customer-service workflows. Hosted remotely by Lorikeet.",
+      "category": "Customer Support",
+      "connection_type": "http",
+      "connection_url": "https://api.lorikeetcx.ai/v1/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.lorikeetcx.ai/",
+      "publisher": "Lorikeet",
+      "tags": [
+        "lorikeet",
+        "support",
+        "concierge",
+        "customer-support",
+        "automation"
+      ]
+    },
+    {
+      "name": "Granted",
+      "description": "Connect AI tools to Granted to discover grant opportunities, compare funding options, and plan applications. Hosted remotely by Granted.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://grantedai.com/api/mcp/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://grantedai.com/",
+      "publisher": "Granted",
+      "tags": [
+        "granted",
+        "grants",
+        "funding",
+        "applications",
+        "productivity"
+      ]
+    },
+    {
+      "name": "IBISWorld",
+      "description": "Connect AI tools to IBISWorld for financials, risk data, and analysis across tens of thousands of industries for market sizing and benchmarking. Hosted remotely by IBISWorld.",
+      "category": "Research",
+      "connection_type": "http",
+      "connection_url": "https://mcp.ibisworld.com",
+      "auth_type": "oauth",
+      "docs_url": "https://www.ibisworld.com/",
+      "publisher": "IBISWorld",
+      "tags": [
+        "ibisworld",
+        "industry-research",
+        "market-data",
+        "benchmarking",
+        "research"
+      ]
+    },
+    {
+      "name": "Guidepoint",
+      "description": "Connect AI tools to Guidepoint for access to trusted expert knowledge for research, market, and diligence analysis. Hosted remotely by Guidepoint.",
+      "category": "Research",
+      "connection_type": "http",
+      "connection_url": "https://clapi.guidepoint.io/mcp-server/v1/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.guidepoint.com/",
+      "publisher": "Guidepoint",
+      "tags": [
+        "guidepoint",
+        "expert-network",
+        "research",
+        "diligence",
+        "insights"
+      ]
+    },
+    {
+      "name": "Third Bridge",
+      "description": "Connect AI tools to Third Bridge for expert-led enhanced insights for financial and business analysis. Hosted remotely by Third Bridge.",
+      "category": "Research",
+      "connection_type": "sse",
+      "connection_url": "https://ai.thirdbridge.com/mcp/sse",
+      "auth_type": "oauth",
+      "docs_url": "https://thirdbridge.com/",
+      "publisher": "Third Bridge",
+      "tags": [
+        "third-bridge",
+        "expert-network",
+        "research",
+        "insights",
+        "finance"
+      ]
+    },
+    {
+      "name": "Datasite",
+      "description": "Connect AI tools to Datasite for M&A data-room workflows, diligence content, and transaction collaboration. Hosted remotely by Datasite.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.global.datasite.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.datasite.com/",
+      "publisher": "Datasite",
+      "tags": [
+        "datasite",
+        "ma",
+        "data-room",
+        "diligence",
+        "finance"
+      ]
+    },
+    {
+      "name": "GovTribe",
+      "description": "Connect AI tools to GovTribe for government procurement and spending data across opportunities, contracts, agencies, and vendors. Hosted remotely by GovTribe.",
+      "category": "Research",
+      "connection_type": "http",
+      "connection_url": "https://govtribe.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://govtribe.com/",
+      "publisher": "GovTribe",
+      "tags": [
+        "govtribe",
+        "government",
+        "procurement",
+        "contracts",
+        "research"
+      ]
+    },
+    {
+      "name": "D&B Risk Analytics",
+      "description": "Connect AI tools to Dun & Bradstreet Risk Analytics to execute risk workflows powered by the D&B Commercial Graph for KYC, KYB, and entity resolution. Hosted remotely by Dun & Bradstreet.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://agents.riskanalytics.dnb.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.dnb.com/",
+      "publisher": "Dun & Bradstreet",
+      "tags": [
+        "dnb",
+        "risk",
+        "kyc",
+        "kyb",
+        "finance"
+      ]
+    },
+    {
+      "name": "ICE Data Services",
+      "description": "Connect AI tools to ICE Data Services for U.S. fixed-income trade and reference data analysis. Hosted remotely by ICE.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://fids-mcp.ice.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.ice.com/data-services",
+      "publisher": "Intercontinental Exchange",
+      "tags": [
+        "ice",
+        "fixed-income",
+        "market-data",
+        "bonds",
+        "finance"
+      ]
+    },
+    {
+      "name": "Verisk Underwriting Intelligence",
+      "description": "Connect AI tools to Verisk for conversational access to ISO Loss Cost insights for underwriters, actuaries, and product teams. Hosted remotely by Verisk.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://gatewaymcp.verisk.com/underwriting/intelligencemcp/v1",
+      "auth_type": "oauth",
+      "docs_url": "https://www.verisk.com/",
+      "publisher": "Verisk",
+      "tags": [
+        "verisk",
+        "insurance",
+        "underwriting",
+        "actuarial",
+        "finance"
+      ]
+    },
+    {
+      "name": "Verisk XactRestore",
+      "description": "Connect AI tools to Verisk XactRestore for natural-language estimating to create rooms, adjust line items, and surface pricing for restoration professionals. Hosted remotely by Verisk.",
+      "category": "Finance",
+      "connection_type": "sse",
+      "connection_url": "https://xactrestore-xactremodelserver-usw2-prod.propsol.io/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.verisk.com/",
+      "publisher": "Verisk",
+      "tags": [
+        "verisk",
+        "insurance",
+        "estimating",
+        "restoration",
+        "finance"
+      ]
+    },
+    {
+      "name": "Aura",
+      "description": "Connect AI tools to Aura for company intelligence and workforce analytics across headcount, hiring, and corporate structure. Hosted remotely by Aura.",
+      "category": "Research",
+      "connection_type": "http",
+      "connection_url": "https://mcp.auraintelligence.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.auraintelligence.com/",
+      "publisher": "Aura",
+      "tags": [
+        "aura",
+        "company-intelligence",
+        "workforce",
+        "analytics",
+        "research"
+      ]
+    },
+    {
+      "name": "Ketryx",
+      "description": "Connect AI tools to Ketryx to search and explore regulated software lifecycle, quality, and compliance data. Hosted remotely by Ketryx.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://app.ketryx.com/api/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.ketryx.com/",
+      "publisher": "Ketryx",
+      "tags": [
+        "ketryx",
+        "compliance",
+        "quality",
+        "regulated",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Gainsight",
+      "description": "Connect AI tools to Gainsight (Staircase AI) to bring customer context into workflows for customer-success teams. Hosted remotely by Gainsight.",
+      "category": "Customer Support",
+      "connection_type": "http",
+      "connection_url": "https://mcp.staircase.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.gainsight.com/",
+      "publisher": "Gainsight",
+      "tags": [
+        "gainsight",
+        "customer-success",
+        "customer-data",
+        "retention",
+        "customer-support"
+      ]
+    },
+    {
+      "name": "Quo",
+      "description": "Connect AI tools to Quo to surface call insights and missed opportunities through conversation intelligence. Hosted remotely by Quo.",
+      "category": "Sales",
+      "connection_type": "http",
+      "connection_url": "https://mcp.quo.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://quo.com/",
+      "publisher": "Quo",
+      "tags": [
+        "quo",
+        "conversation-intelligence",
+        "calls",
+        "sales",
+        "insights"
+      ]
+    },
+    {
+      "name": "Zocks",
+      "description": "Connect AI tools to Zocks for client conversation intelligence for financial advisors, including meeting insights, goals, and planning opportunities. Hosted remotely by Zocks.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.zocks.io/v1/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.zocks.io/",
+      "publisher": "Zocks",
+      "tags": [
+        "zocks",
+        "financial-advisors",
+        "conversation-intelligence",
+        "wealth",
+        "finance"
+      ]
+    },
+    {
+      "name": "Shapes",
+      "description": "Connect AI tools to Shapes for live HR and people data, including headcount, attrition risk, compensation gaps, and time off. Hosted remotely by Shapes.",
+      "category": "Human Resources",
+      "connection_type": "http",
+      "connection_url": "https://mcp.shapes.co/",
+      "auth_type": "oauth",
+      "docs_url": "https://www.shapes.co/",
+      "publisher": "Shapes",
+      "tags": [
+        "shapes",
+        "hr",
+        "people-analytics",
+        "headcount",
+        "workforce"
+      ]
+    },
+    {
+      "name": "Adobe Experience Manager",
+      "description": "Connect AI tools to Adobe Experience Manager to create, edit, search, and publish pages and content fragments in natural language. Hosted remotely by Adobe.",
+      "category": "Marketing",
+      "connection_type": "http",
+      "connection_url": "https://mcp.adobeaemcloud.com/adobe/mcp/aem",
+      "auth_type": "oauth",
+      "docs_url": "https://business.adobe.com/products/experience-manager/adobe-experience-manager.html",
+      "publisher": "Adobe",
+      "tags": [
+        "adobe",
+        "aem",
+        "cms",
+        "content",
+        "marketing"
+      ]
+    },
+    {
+      "name": "Adobe Journey Optimizer",
+      "description": "Connect AI tools to Adobe Journey Optimizer to review statuses, find draft issues, and understand orchestration portfolios. Hosted remotely by Adobe.",
+      "category": "Marketing",
+      "connection_type": "http",
+      "connection_url": "https://ajo-mcp.adobe.io/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://business.adobe.com/products/journey-optimizer/adobe-journey-optimizer.html",
+      "publisher": "Adobe",
+      "tags": [
+        "adobe",
+        "journey-optimizer",
+        "campaigns",
+        "orchestration",
+        "marketing"
+      ]
+    },
+    {
+      "name": "Adobe Marketing Agent",
+      "description": "Connect AI tools to Adobe for marketing campaign and audience insights. Hosted remotely by Adobe.",
+      "category": "Marketing",
+      "connection_type": "http",
+      "connection_url": "https://aep-ai-ama.adobe.io/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://business.adobe.com/products/experience-platform/adobe-experience-platform.html",
+      "publisher": "Adobe",
+      "tags": [
+        "adobe",
+        "marketing",
+        "campaigns",
+        "audiences",
+        "analytics"
+      ]
+    },
+    {
+      "name": "Adobe for Creativity",
+      "description": "Connect AI tools to Adobe creative tools including Photoshop, Lightroom, Illustrator, Firefly, Premiere, Express, InDesign, and Stock through natural language. Hosted remotely by Adobe.",
+      "category": "Design",
+      "connection_type": "http",
+      "connection_url": "https://adobe-creativity.adobe.io/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.adobe.com/",
+      "publisher": "Adobe",
+      "tags": [
+        "adobe",
+        "creative",
+        "photoshop",
+        "firefly",
+        "design"
+      ]
+    },
+    {
+      "name": "Autodesk Product Help",
+      "description": "Connect AI tools to Autodesk Product Help to search and retrieve official product documentation across more than 110 products. Hosted remotely by Autodesk.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://developer.api.autodesk.com/knowledge/public/v1/mcp",
+      "auth_type": "none",
+      "docs_url": "https://www.autodesk.com/",
+      "publisher": "Autodesk",
+      "tags": [
+        "autodesk",
+        "documentation",
+        "cad",
+        "product-help",
+        "developer-tools"
+      ]
+    },
+    {
+      "name": "Orion by Gravity",
+      "description": "Connect AI tools to Orion for business insights and data-backed recommendations from an autonomous AI analyst. Hosted remotely by Gravity.",
+      "category": "Analytics",
+      "connection_type": "http",
+      "connection_url": "https://g.runorion.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.runorion.com/",
+      "publisher": "Gravity",
+      "tags": [
+        "orion",
+        "analytics",
+        "ai-analyst",
+        "insights",
+        "data"
+      ]
+    },
+    {
+      "name": "Aiwyn Tax",
+      "description": "Connect AI tools to Aiwyn to estimate federal and state taxes from user-provided tax documents. Hosted remotely by Aiwyn.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://mcp.columnapi.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.aiwyn.ai/",
+      "publisher": "Aiwyn",
+      "tags": [
+        "aiwyn",
+        "tax",
+        "accounting",
+        "estimation",
+        "finance"
+      ]
+    },
+    {
+      "name": "Clarity AI",
+      "description": "Connect AI tools to Clarity AI to simulate fund classifications under the proposed SFDR 2.0 framework for ESG workflows. Hosted remotely by Clarity AI.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://clarity-sfdr20-mcp.pro.clarity.ai/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://clarity.ai/",
+      "publisher": "Clarity AI",
+      "tags": [
+        "clarity-ai",
+        "esg",
+        "sfdr",
+        "compliance",
+        "finance"
+      ]
+    },
+    {
+      "name": "Chronograph",
+      "description": "Connect AI tools to Chronograph to interact with private-investment portfolio data. Hosted remotely by Chronograph.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://ai.chronograph.pe/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.chronograph.pe/",
+      "publisher": "Chronograph",
+      "tags": [
+        "chronograph",
+        "private-equity",
+        "portfolio",
+        "investments",
+        "finance"
+      ]
+    },
+    {
+      "name": "Aurora by Consilio",
+      "description": "Connect AI tools to Aurora, a read-only Consilio connector for engagement, document, matter, and workspace data. Hosted remotely by Consilio.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://mcp.ai.consilio.com",
+      "auth_type": "oauth",
+      "docs_url": "https://www.consilio.com/",
+      "publisher": "Consilio",
+      "tags": [
+        "aurora",
+        "consilio",
+        "legal",
+        "ediscovery",
+        "documents"
+      ]
+    },
+    {
+      "name": "BoardWise",
+      "description": "Connect AI tools to BoardWise for read-only educational guidance for licensed professionals facing state licensing-board matters. Hosted remotely by BoardWise.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://uakozrqrztgrgwoywxkx.supabase.co/functions/v1/mcp-server",
+      "auth_type": "none",
+      "docs_url": "https://www.boardwise.ai/",
+      "publisher": "BoardWise",
+      "tags": [
+        "boardwise",
+        "legal",
+        "licensing",
+        "professionals",
+        "guidance"
+      ]
+    },
+    {
+      "name": "TopCounsel",
+      "description": "Connect AI tools to TopCounsel to find outside counsel recommendations based on insights from a large in-house counsel community. Hosted remotely by TopCounsel.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://api.techgc.co/api/mcp/topcounsel",
+      "auth_type": "oauth",
+      "docs_url": "https://www.techgc.co/",
+      "publisher": "TechGC",
+      "tags": [
+        "topcounsel",
+        "legal",
+        "outside-counsel",
+        "recommendations",
+        "community"
+      ]
+    },
+    {
+      "name": "Trellis",
+      "description": "Connect AI tools to Trellis to access state trial-court data including dockets, rulings, verdicts, and filings for legal research and case strategy. Hosted remotely by Trellis.",
+      "category": "Legal",
+      "connection_type": "http",
+      "connection_url": "https://mcp.trellis.law/anthropic",
+      "auth_type": "oauth",
+      "docs_url": "https://trellis.law/",
+      "publisher": "Trellis",
+      "tags": [
+        "trellis",
+        "legal",
+        "trial-court",
+        "dockets",
+        "litigation"
+      ]
+    },
+    {
+      "name": "Kindora",
+      "description": "Connect AI tools to Kindora to find funders who support causes like yours for prospect research and funding strategy. Hosted remotely by Kindora.",
+      "category": "Productivity",
+      "connection_type": "http",
+      "connection_url": "https://kindora-mcp.azurewebsites.net/mcp/",
+      "auth_type": "oauth",
+      "docs_url": "https://www.kindora.org/",
+      "publisher": "Kindora",
+      "tags": [
+        "kindora",
+        "funders",
+        "grants",
+        "nonprofit",
+        "productivity"
+      ]
+    },
+    {
+      "name": "Tropic",
+      "description": "Connect AI tools to Tropic to benchmark software and AI contract pricing against verified technology transactions and prepare negotiations. Hosted remotely by Tropic.",
+      "category": "Finance",
+      "connection_type": "http",
+      "connection_url": "https://app.tropicapp.io/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://www.tropicapp.io/",
+      "publisher": "Tropic",
+      "tags": [
+        "tropic",
+        "procurement",
+        "contracts",
+        "spend",
+        "finance"
+      ]
+    },
+    {
+      "name": "PostHog",
+      "description": "Connect AI tools to PostHog to manage feature flags, query product analytics, investigate errors, and explore your PostHog data. Hosted remotely by PostHog.",
+      "category": "Analytics",
+      "connection_type": "http",
+      "connection_url": "https://mcp.posthog.com/mcp",
+      "auth_type": "oauth",
+      "docs_url": "https://posthog.com/docs/model-context-protocol",
+      "publisher": "PostHog",
+      "tags": [
+        "posthog",
+        "analytics",
+        "product-analytics",
+        "feature-flags",
+        "data"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Expands the MCP server library from 2 entries to over 150 servers across a wide range of categories, and removes the `slug` field from the schema and all server entries.

## Changes

- Removed the `slug` field from the schema definition and dropped it as a required property on server objects
- Removed `slug` values from the existing Filesystem and GitHub server entries
- Split the single GitHub entry into two: `GitHub (Remote)` using OAuth over HTTP, and `GitHub (Local)` using stdio via Docker with a personal access token
- Added 150+ new MCP server entries spanning categories including Developer Tools, Finance, Legal, Marketing, Analytics, Sales, Design, Productivity, Travel, Lifestyle, Human Resources, Customer Support, Security, Research, Automation, E-Commerce, and more
- Updated `lastUpdatedAt` to `2026-06-09T00:00:00Z`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate the updated `servers.json` against the updated `schema.json` to confirm all entries are valid and no server object includes a `slug` field.

```sh
# Validate JSON schema
npx ajv validate -s community/mcp-library/schema.json -d community/mcp-library/servers.json
```

Spot-check a sample of new entries to confirm required fields (`name`, `connection_type`) are present and `connection_url` is populated for HTTP/SSE entries, and `stdio_config` is populated for stdio entries.

## Breaking changes

- [x] Yes
- [ ] No

The `slug` field has been removed from the schema. Any downstream system that relied on `slug` as a primary key for syncing server records will need to migrate to an alternative identifier (e.g., `name` or `connection_url`).

## Related issues

## Security considerations

Several new servers use `auth_type: none`, meaning they expose publicly accessible endpoints without authentication. Consumers of this library should be aware that connecting to these servers does not require credentials. OAuth-based servers delegate authentication to the respective provider. No secrets or PII are stored in this file.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Server configuration simplified: server entries now require only name and connection type; the slug field is no longer required or validated, making configuration and validation more flexible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->