### PR TITLE
feat: add `PreRequestHook` to `LLMPlugin` interface for once-per-request provider/model routing

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -458,8 +458,6 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 			},
 		}
 	}
-	providerKeys = filterProvidersByContext(ctx, providerKeys)
-
 	startTime := time.Now()
 
 	// Result structure for collecting provider responses
@@ -602,35 +600,6 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 	response = response.ApplyPagination(req.PageSize, req.PageToken)
 
 	return response, nil
-}
-
-func filterProvidersByContext(ctx *schemas.BifrostContext, providerKeys []schemas.ModelProvider) []schemas.ModelProvider {
-	if ctx == nil {
-		return providerKeys
-	}
-
-	rawAvailableProviders := ctx.Value(schemas.BifrostContextKeyAvailableProviders)
-	if rawAvailableProviders == nil {
-		return providerKeys
-	}
-
-	availableProviders, ok := rawAvailableProviders.([]schemas.ModelProvider)
-	if !ok {
-		return []schemas.ModelProvider{}
-	}
-
-	if len(availableProviders) == 0 || len(providerKeys) == 0 {
-		return []schemas.ModelProvider{}
-	}
-
-	filteredProviders := make([]schemas.ModelProvider, 0, len(providerKeys))
-	for _, providerKey := range providerKeys {
-		if slices.Contains(availableProviders, providerKey) {
-			filteredProviders = append(filteredProviders, providerKey)
-		}
-	}
-
-	return filteredProviders
 }
 
 // TextCompletionRequest sends a text completion request to the specified provider.
@@ -4197,6 +4166,33 @@ type RealtimeTurnHooks struct {
 	Cleanup        func()
 }
 
+// RunPreRequestHooks acquires a plugin pipeline and runs PreRequestHook on each LLM plugin
+// for callers that do not flow through handleRequest/handleStreamRequest — primarily realtime
+// WebSocket upgrades, where the upgrade itself is the routing decision (once per WS connection)
+// but the per-turn pipeline handles PreLLMHook/PostLLMHook separately.
+//
+// Mutations to req.Provider/req.Model/req.Fallbacks made by PreRequestHook plugins are committed
+// to the shared *BifrostRequest. Plugin errors are non-blocking — they are logged as warnings
+// and the pipeline continues to the next plugin (same semantics as RunLLMPreHooks). Callers
+// should validate req.Provider after this returns if a provider is required.
+func (bifrost *Bifrost) RunPreRequestHooks(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) {
+	if ctx == nil {
+		ctx = bifrost.ctx
+	}
+
+	if _, ok := ctx.Value(schemas.BifrostContextKeyRequestID).(string); !ok {
+		ctx.SetValue(schemas.BifrostContextKeyRequestID, uuid.New().String())
+	}
+
+	pipeline := bifrost.getPluginPipeline()
+	defer bifrost.releasePluginPipeline(pipeline)
+	pipeline.RunPreRequestHooks(ctx, req)
+	// This path has no downstream post-hook cleanup, so drain any plugin logs
+	// emitted by PreRequestHook here to avoid them bleeding into a later request
+	// on a reused/long-lived context (e.g. realtime WS connections).
+	flushPluginLogs(ctx)
+}
+
 // RunStreamPreHooks acquires a plugin pipeline, sets up tracing context, runs PreLLMHooks,
 // and returns a PostHookRunner for per-chunk post-processing.
 // Used by WebSocket handlers that bypass the normal inference path but still need plugin hooks.
@@ -4636,17 +4632,11 @@ func (bifrost *Bifrost) shouldContinueWithFallbacks(fallback schemas.Fallback, f
 func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	defer bifrost.releaseBifrostRequest(req)
 	provider, model, fallbacks := req.GetRequestFields()
-	if err := validateRequest(req); err != nil {
-		err.PopulateExtraFields(req.RequestType, provider, model, model)
-		return nil, err
-	}
 
 	// Handle nil context early to prevent blocking
 	if ctx == nil {
 		ctx = bifrost.ctx
 	}
-
-	bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))
 
 	// Try the primary provider first
 	ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, 0)
@@ -4655,6 +4645,27 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		requestID := uuid.New().String()
 		ctx.SetValue(schemas.BifrostContextKeyRequestID, requestID)
 	}
+
+	// PreRequestHook: once-per-request phase where plugins decide provider/model/fallbacks
+	// (and may mutate other request fields). Mutations commit to req and are observed by
+	// all downstream phases and fallbacks. Plugin errors are non-blocking (logged + skipped).
+	preReqPipeline := bifrost.getPluginPipeline()
+	preReqPipeline.RunPreRequestHooks(ctx, req)
+	bifrost.releasePluginPipeline(preReqPipeline)
+	// Re-read after PreRequestHook — provider/model/fallbacks may have changed.
+	provider, model, fallbacks = req.GetRequestFields()
+	// Empty provider/model after PreRequestHook means no plugin
+	// could pick a provider for this model — the caller's input is unresolvable.
+	if err := validateRequestAfterPreRequestHooks(req); err != nil {
+		// Returning before tryRequest skips the downstream log drain, so flush
+		// any PreRequestHook-emitted plugin logs here.
+		flushPluginLogs(ctx)
+		err.PopulateExtraFields(req.RequestType, provider, model, model)
+		return nil, err
+	}
+
+	bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))
+
 	primaryResult, primaryErr := bifrost.tryRequest(ctx, req)
 	if primaryErr != nil {
 		if primaryErr.Error != nil {
@@ -4727,14 +4738,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 // It is the wrapper for all streaming public API methods.
 func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	defer bifrost.releaseBifrostRequest(req)
-
 	provider, model, fallbacks := req.GetRequestFields()
-
-	if err := validateRequest(req); err != nil {
-		err.PopulateExtraFields(req.RequestType, provider, model, model)
-		err.StatusCode = schemas.Ptr(fasthttp.StatusBadRequest)
-		return nil, err
-	}
 
 	// Handle nil context early to prevent blocking
 	if ctx == nil {
@@ -4748,7 +4752,36 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 		requestID := uuid.New().String()
 		ctx.SetValue(schemas.BifrostContextKeyRequestID, requestID)
 	}
+
+	// PreRequestHook: once-per-request phase. See handleRequest for semantics.
+	preReqPipeline := bifrost.getPluginPipeline()
+	preReqPipeline.RunPreRequestHooks(ctx, req)
+	bifrost.releasePluginPipeline(preReqPipeline)
+	// Re-read after PreRequestHook — provider/model/fallbacks may have changed.
+	provider, model, fallbacks = req.GetRequestFields()
+	// Empty provider after PreRequestHook means no plugin
+	// could pick a provider for this model — the caller's input is unresolvable.
+	if err := validateRequestAfterPreRequestHooks(req); err != nil {
+		// Returning before tryStreamRequest skips the downstream log drain, so
+		// flush any PreRequestHook-emitted plugin logs here.
+		flushPluginLogs(ctx)
+		err.PopulateExtraFields(req.RequestType, provider, model, model)
+		return nil, err
+	}
+
+	bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))
+
 	primaryResult, primaryErr := bifrost.tryStreamRequest(ctx, req)
+	if primaryErr != nil {
+		if primaryErr.Error != nil {
+			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %s", provider, model, primaryErr.Error.Message))
+		} else {
+			bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s returned error: %v", provider, model, primaryErr))
+		}
+		if len(fallbacks) > 0 {
+			bifrost.logger.Debug(fmt.Sprintf("check if we should try %d fallbacks", len(fallbacks)))
+		}
+	}
 
 	// Check if we should proceed with fallbacks
 	shouldTryFallbacks := bifrost.shouldTryFallbacks(req, primaryErr)
@@ -6653,6 +6686,49 @@ func (p *PluginPipeline) RunLLMPreHooks(ctx *schemas.BifrostContext, req *schema
 	return req, nil, p.executedPreHooks
 }
 
+// RunPreRequestHooks executes PreRequestHook on each LLM plugin in registration order, once per
+// top-level request. Plugins mutate req.Provider, req.Model, req.Fallbacks (and any other field
+// they choose); mutations are committed to the shared *BifrostRequest and observed by every
+// subsequent plugin, the provider call, and every fallback attempt. There is no short-circuit
+// and errors are non-blocking — same semantics as RunLLMPreHooks: errors are logged as warnings
+// and accumulated in p.preHookErrors, then the pipeline continues to the next plugin. The empty-
+// provider validation in handleRequest/handleStreamRequest catches the case where no plugin
+// successfully resolved a provider.
+//
+// Per-request semantics: unlike PreLLMHook (which runs again on every fallback), PreRequestHook
+// runs exactly once at the top of handleRequest/handleStreamRequest, before any fan-out.
+func (p *PluginPipeline) RunPreRequestHooks(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) {
+	// If the skip plugin pipeline flag is set, skip the plugin pipeline
+	if skipPluginPipeline, ok := ctx.Value(schemas.BifrostContextKeySkipPluginPipeline).(bool); ok && skipPluginPipeline {
+		return
+	}
+	ctx.BlockRestrictedWrites()
+	defer ctx.UnblockRestrictedWrites()
+	for _, plugin := range p.llmPlugins {
+		pluginName := plugin.GetName()
+		p.logger.Debug("running pre-request hook for plugin %s", pluginName)
+		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.prerequesthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
+		if spanCtx != nil {
+			if spanID, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok {
+				ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
+			}
+		}
+
+		pluginCtx := ctx.WithPluginScope(&pluginName)
+		err := plugin.PreRequestHook(pluginCtx, req)
+		pluginCtx.ReleasePluginScope()
+
+		if err != nil {
+			p.tracer.SetAttribute(handle, "error", err.Error())
+			p.tracer.EndSpan(handle, schemas.SpanStatusError, err.Error())
+			p.preHookErrors = append(p.preHookErrors, err)
+			p.logger.Warn("error in PreRequestHook for plugin %s: %s", pluginName, err.Error())
+			continue
+		}
+		p.tracer.EndSpan(handle, schemas.SpanStatusOk, "")
+	}
+}
+
 // RunPostLLMHooks executes PostHooks in reverse order for the plugins whose PreLLMHook ran.
 // Accepts the response and error, and allows plugins to transform either (e.g., recover from error, or invalidate a response).
 // Returns the final response and error after all hooks. If both are set, error takes precedence unless error is nil.
@@ -7011,6 +7087,22 @@ func (p *PluginPipeline) resetPluginPipeline() {
 	}
 	p.streamScopedCtxs = nil
 	p.streamingMu.Unlock()
+}
+
+// flushPluginLogs drains accumulated plugin logs from the BifrostContext and
+// attaches them to the active trace when one exists. Unlike drainAndAttachPluginLogs,
+// it always drains the buffer first, so logs emitted before any trace is established
+// (e.g. by PreRequestHook) are not carried over to a later request on a reused context.
+func flushPluginLogs(ctx *schemas.BifrostContext) {
+	logs := ctx.DrainPluginLogs()
+	if len(logs) == 0 {
+		return
+	}
+	tracer, traceID, err := GetTracerFromContext(ctx)
+	if err != nil || tracer == nil || traceID == "" {
+		return
+	}
+	tracer.AttachPluginLogs(traceID, logs)
 }
 
 // drainAndAttachPluginLogs drains accumulated plugin logs from the BifrostContext

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -789,51 +789,6 @@ func (t *countingTracer) CompleteAndFlushTrace(_ string) {
 	t.flushed.Add(1)
 }
 
-func TestFilterProvidersByContext(t *testing.T) {
-	providers := []schemas.ModelProvider{
-		schemas.OpenAI,
-		schemas.Anthropic,
-		schemas.Mistral,
-	}
-
-	t.Run("no context filter keeps all providers", func(t *testing.T) {
-		filtered := filterProvidersByContext(nil, providers)
-		if len(filtered) != len(providers) {
-			t.Fatalf("expected all providers, got %v", filtered)
-		}
-	})
-
-	t.Run("available providers restrict list models fanout", func(t *testing.T) {
-		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{schemas.Anthropic})
-
-		filtered := filterProvidersByContext(ctx, providers)
-		if len(filtered) != 1 || filtered[0] != schemas.Anthropic {
-			t.Fatalf("expected only anthropic, got %v", filtered)
-		}
-	})
-
-	t.Run("empty available providers denies all providers", func(t *testing.T) {
-		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{})
-
-		filtered := filterProvidersByContext(ctx, providers)
-		if len(filtered) != 0 {
-			t.Fatalf("expected no providers, got %v", filtered)
-		}
-	})
-
-	t.Run("malformed available providers fails closed", func(t *testing.T) {
-		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, "openai")
-
-		filtered := filterProvidersByContext(ctx, providers)
-		if len(filtered) != 0 {
-			t.Fatalf("expected no providers for malformed context value, got %v", filtered)
-		}
-	})
-}
-
 func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	account := NewMockAccount()

--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -170,12 +170,22 @@ func ReleaseHTTPResponse(resp *HTTPResponse) {
 // PostHooks are executed in the reverse order of PreHooks.
 //
 // Execution order:
-// 1. HTTPTransportPreHook (HTTP transport only, executed in registration order)
-// 2. PreLLMHook (executed in registration order)
-// 3. Provider call
-// 4. PostLLMHook (executed in reverse order of PreHooks)
-// 5. HTTPTransportPostHook (HTTP transport only, executed in reverse order)
-// 5a. HTTPTransportStreamChunkHook (for streaming responses, called per-chunk in reverse order)
+// 1. HTTPTransportPreHook (HTTP transport only, once per request, executed in registration order)
+// 2. PreRequestHook (once per request, executed in registration order)
+// 3. PreLLMHook (executed in registration order, runs again on each fallback attempt)
+// 4. Provider call
+// 5. PostLLMHook (executed in reverse order of PreHooks, runs on each fallback attempt)
+// 6. HTTPTransportPostHook (HTTP transport only, once per request, executed in reverse order)
+// 6a. HTTPTransportStreamChunkHook (for streaming responses, called per-chunk in reverse order)
+//
+// Per-request vs per-attempt phases:
+// - HTTPTransportPreHook, PreRequestHook, HTTPTransportPostHook run ONCE per top-level request.
+// - PreLLMHook, PostLLMHook run ONCE PER ATTEMPT: the primary provider call, plus once per
+//   fallback attempt. Mutations a PreLLMHook makes to the request only carry to later
+//   fallbacks where prepareFallbackRequest happens to share pointers (shallow copy) —
+//   visibility across fallbacks is incidental. PreRequestHook is the explicit phase whose
+//   mutations are committed to the request before any fan-out and are observed by every
+//   subsequent plugin, every PreLLMHook invocation, the provider call, and every fallback.
 //
 // Common use cases: rate limiting, caching, logging, monitoring, request transformation, governance.
 //
@@ -256,6 +266,22 @@ type HTTPTransportPlugin interface {
 
 type LLMPlugin interface {
 	BasePlugin
+
+	// PreRequestHook is called once per top-level request, after HTTPTransportPreHook and before
+	// PreLLMHook. It is the canonical phase for deciding which provider/model/fallbacks the
+	// request should be sent to. Plugins are free to mutate any field on req (Provider, Model,
+	// Fallbacks, Input, Params, Tools, ...) — unlike PreLLMHook, mutations made here are
+	// committed to the request and are observed by all subsequent plugins, the provider call,
+	// and every fallback attempt.
+	//
+	// Error semantics match PreLLMHook: a non-nil error is non-blocking — it is logged as a
+	// warning, the request continues, and the pipeline moves on to the next plugin. PreRequestHook
+	// CANNOT abort the request via error return. Plugins that need to gate or reject a request
+	// (e.g., authorization, content policy) must do so in HTTPTransportPreHook or via a
+	// short-circuit response in PreLLMHook — not by returning an error here.
+	//
+	// Plugins that don't participate in routing should return nil.
+	PreRequestHook(ctx *BifrostContext, req *BifrostRequest) error
 
 	PreLLMHook(ctx *BifrostContext, req *BifrostRequest) (*BifrostRequest, *LLMPluginShortCircuit, error)
 	PostLLMHook(ctx *BifrostContext, resp *BifrostResponse, bifrostErr *BifrostError) (*BifrostResponse, *BifrostError, error)

--- a/core/utils.go
+++ b/core/utils.go
@@ -135,17 +135,17 @@ func calculateBackoff(attempt int, config *schemas.ProviderConfig) time.Duration
 	return min(result, config.NetworkConfig.RetryBackoffMax)
 }
 
-// validateRequest validates the given request.
-func validateRequest(req *schemas.BifrostRequest) *schemas.BifrostError {
+// validateRequestAfterPreRequestHooks validates the provider and model fields of the given request.
+func validateRequestAfterPreRequestHooks(req *schemas.BifrostRequest) *schemas.BifrostError {
 	if req == nil {
 		return newBifrostErrorFromMsg("bifrost request cannot be nil")
 	}
 	provider, model, _ := req.GetRequestFields()
 	if provider == "" {
-		return newBifrostErrorFromMsg("provider is required")
+		return newBifrostErrorFromMsg("could not auto resolve a provider for the request, please specify a provider explicitly")
 	}
 	if isModelRequired(req.RequestType) && model == "" {
-		return newBifrostErrorFromMsg("model is required")
+		return newBifrostErrorFromMsg("could not auto resolve a model for the request, please specify a model explicitly")
 	}
 	return nil
 }

--- a/examples/plugins/hello-world/main.go
+++ b/examples/plugins/hello-world/main.go
@@ -57,6 +57,10 @@ func HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTP
 	return chunk, nil
 }
 
+func PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	value1 := ctx.Value(transportPreHookKey)
 	fmt.Println("value1:", value1)

--- a/examples/plugins/llm-only/main.go
+++ b/examples/plugins/llm-only/main.go
@@ -67,6 +67,11 @@ func GetName() string {
 	return "llm-only"
 }
 
+// PreRequestHook is the per-request routing phase. This example plugin doesn't route.
+func PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook is called before the LLM provider is invoked
 // This example demonstrates request modification and logging
 func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {

--- a/examples/plugins/multi-interface/main.go
+++ b/examples/plugins/multi-interface/main.go
@@ -155,6 +155,11 @@ func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest
 // LLMPlugin Interface
 // ============================================================================
 
+// PreRequestHook is the per-request routing phase. This example plugin doesn't route.
+func PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook is called before the LLM provider is invoked
 func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	if !pluginConfig.EnableLLMHooks {

--- a/framework/plugins/main.go
+++ b/framework/plugins/main.go
@@ -27,7 +27,7 @@ func AsLLMPlugin(plugin schemas.BasePlugin) schemas.LLMPlugin {
 	// Check if it's a DynamicPlugin first
 	if dp, ok := plugin.(*DynamicPlugin); ok {
 		// Only return as LLMPlugin if it actually has LLM hooks
-		if dp.preLLMHook != nil || dp.postLLMHook != nil {
+		if dp.preRequestHook != nil || dp.preLLMHook != nil || dp.postLLMHook != nil {
 			return dp
 		}
 		return nil

--- a/framework/plugins/soloader.go
+++ b/framework/plugins/soloader.go
@@ -94,6 +94,15 @@ func (l *SharedObjectPluginLoader) LoadPlugin(path string, config any) (schemas.
 		}
 	}
 
+	// Optional: PreRequestHook — new .so plugins built against LLMPlugin can export this
+	// to participate in routing. Legacy plugins predating PreRequestHook keep working;
+	// DynamicPlugin's default PreRequestHook is a no-op passthrough.
+	if sym, err := pluginObj.Lookup("PreRequestHook"); err == nil {
+		if dp.preRequestHook, ok = sym.(func(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error); !ok {
+			return nil, fmt.Errorf("failed to cast PreRequestHook to expected signature")
+		}
+	}
+
 	// Optional: PreLLMHook (with backward compatibility for legacy PreHook)
 	if sym, err := pluginObj.Lookup("PreLLMHook"); err == nil {
 		if dp.preLLMHook, ok = sym.(func(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error)); !ok {

--- a/framework/plugins/soplugin.go
+++ b/framework/plugins/soplugin.go
@@ -27,8 +27,12 @@ type DynamicPlugin struct {
 	httpTransportStreamChunkHook func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, stream *schemas.BifrostStreamChunk) (*schemas.BifrostStreamChunk, error)
 
 	// LLMPlugin (optional)
-	preLLMHook  func(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error)
-	postLLMHook func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error)
+	// preRequestHook is forward-compat: new .so plugins built against LLMPlugin can export
+	// PreRequestHook to participate in the per-request routing phase. Legacy plugins predating
+	// PreRequestHook leave it nil and silently no-op for routing.
+	preRequestHook func(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error
+	preLLMHook     func(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error)
+	postLLMHook    func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error)
 
 	// MCPPlugin (optional)
 	preMCPHook  func(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest) (*schemas.BifrostMCPRequest, *schemas.MCPPluginShortCircuit, error)
@@ -77,6 +81,16 @@ func (dp *DynamicPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContex
 		return stream, nil // No-op if not implemented
 	}
 	return dp.httpTransportStreamChunkHook(ctx, req, stream)
+}
+
+// PreRequestHook is invoked once per top-level request to decide provider/model/fallbacks
+// (LLMPlugin interface). Defaults to a no-op passthrough for legacy plugins that don't
+// export PreRequestHook.
+func (dp *DynamicPlugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error {
+	if dp.preRequestHook == nil {
+		return nil
+	}
+	return dp.preRequestHook(ctx, req)
 }
 
 // PreLLMHook is invoked before LLM provider calls (LLMPlugin interface)

--- a/framework/tracing/tracer_test.go
+++ b/framework/tracing/tracer_test.go
@@ -14,6 +14,9 @@ type testRealtimeObservabilityPlugin struct {
 
 func (p *testRealtimeObservabilityPlugin) GetName() string { return "test-observability" }
 func (p *testRealtimeObservabilityPlugin) Cleanup() error  { return nil }
+func (p *testRealtimeObservabilityPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
 func (p *testRealtimeObservabilityPlugin) PreLLMHook(_ *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	return req, nil, nil
 }

--- a/plugins/compat/main.go
+++ b/plugins/compat/main.go
@@ -89,6 +89,11 @@ func (p *CompatPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext,
 	return chunk, nil
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (p *CompatPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook intercepts requests and applies LiteLLM-compatible request normalization.
 func (p *CompatPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	if ctx == nil || req == nil {

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1440,6 +1440,11 @@ func (p *GovernancePlugin) isMCPToolAllowedByVKWith(vk *configstoreTables.TableV
 	return false
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (p *GovernancePlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook intercepts requests before they are processed (governance decision point)
 // Parameters:
 //   - ctx: The Bifrost context

--- a/plugins/jsonparser/main.go
+++ b/plugins/jsonparser/main.go
@@ -98,6 +98,11 @@ func (p *JsonParserPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostCont
 	return chunk, nil
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (p *JsonParserPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook is not used for this plugin as we only process responses
 // Parameters:
 //   - ctx: The Bifrost context

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -503,6 +503,11 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 	return metadata
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (p *LoggerPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook is called before a request is processed - FULLY ASYNC, NO DATABASE I/O
 // Parameters:
 //   - ctx: The Bifrost context

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -229,6 +229,11 @@ func (plugin *Plugin) getOrCreateLogger(logRepoID string) (*logging.Logger, erro
 	return logger, nil
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (plugin *Plugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook is called before a request is processed by Bifrost.
 // It manages trace and generation tracking for incoming requests by either:
 // - Creating a new trace if none exists

--- a/plugins/mocker/main.go
+++ b/plugins/mocker/main.go
@@ -495,6 +495,11 @@ func (p *MockerPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext,
 	return chunk, nil
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (p *MockerPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook intercepts requests and applies mocking rules based on configuration
 // This is called before the actual provider request and can short-circuit the flow
 func (p *MockerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
@@ -853,10 +858,10 @@ func (p *MockerPlugin) generateSuccessShortCircuit(req *schemas.BifrostRequest, 
 				},
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:    req.RequestType,
-				Provider:       provider,
+				RequestType:            req.RequestType,
+				Provider:               provider,
 				OriginalModelRequested: model,
-				Latency:        int64(time.Since(startTime).Milliseconds()),
+				Latency:                int64(time.Since(startTime).Milliseconds()),
 			},
 		}
 	} else if req.RequestType == schemas.ResponsesRequest {
@@ -877,10 +882,10 @@ func (p *MockerPlugin) generateSuccessShortCircuit(req *schemas.BifrostRequest, 
 				TotalTokens:  usage.TotalTokens,
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:    schemas.ResponsesRequest,
-				Provider:       provider,
+				RequestType:            schemas.ResponsesRequest,
+				Provider:               provider,
 				OriginalModelRequested: model,
-				Latency:        int64(time.Since(startTime).Milliseconds()),
+				Latency:                int64(time.Since(startTime).Milliseconds()),
 			},
 		}
 	} else if req.RequestType == schemas.ResponsesStreamRequest {
@@ -905,10 +910,10 @@ func (p *MockerPlugin) generateSuccessShortCircuit(req *schemas.BifrostRequest, 
 				},
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:    schemas.ResponsesStreamRequest,
-				Provider:       provider,
+				RequestType:            schemas.ResponsesStreamRequest,
+				Provider:               provider,
 				OriginalModelRequested: model,
-				Latency:        int64(time.Since(startTime).Milliseconds()),
+				Latency:                int64(time.Since(startTime).Milliseconds()),
 			},
 		}
 	}
@@ -959,8 +964,8 @@ func (p *MockerPlugin) generateErrorShortCircuit(req *schemas.BifrostRequest, re
 		},
 		AllowFallbacks: allowFallbacks,
 		ExtraFields: schemas.BifrostErrorExtraFields{
-			RequestType:    req.RequestType,
-			Provider:       provider,
+			RequestType:            req.RequestType,
+			Provider:               provider,
 			OriginalModelRequested: model,
 		},
 	}
@@ -1083,8 +1088,8 @@ func (p *MockerPlugin) handleDefaultBehavior(req *schemas.BifrostRequest) (*sche
 						},
 					},
 					ExtraFields: schemas.BifrostResponseExtraFields{
-						RequestType:    schemas.ChatCompletionRequest,
-						Provider:       provider,
+						RequestType:            schemas.ChatCompletionRequest,
+						Provider:               provider,
 						OriginalModelRequested: model,
 					},
 				},

--- a/plugins/prompts/main.go
+++ b/plugins/prompts/main.go
@@ -203,6 +203,11 @@ func (p *Plugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *
 	return chunk, nil
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (p *Plugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook resolves the prompt via PromptResolver, loads the version from the in-memory
 // cache, sets governance/observability context (selected prompt name and version), merges
 // version ModelParams with the request (request overrides), converts stored messages to

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -330,6 +330,11 @@ func (plugin *Plugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, 
 	return chunk, nil
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (plugin *Plugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook performs the cache lookup before the request reaches the
 // provider. It runs the direct hash path first (cheapest), falls back to
 // semantic similarity search when configured, and short-circuits the

--- a/plugins/semanticcache/plugin_no_mutation_test.go
+++ b/plugins/semanticcache/plugin_no_mutation_test.go
@@ -30,6 +30,10 @@ type requestCapturer struct {
 func (p *requestCapturer) GetName() string { return "test-request-capturer" }
 func (p *requestCapturer) Cleanup() error  { return nil }
 
+func (p *requestCapturer) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 func (p *requestCapturer) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	p.mu.Lock()
 	// Snapshot the request via JSON round-trip so any later mutation by the

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -613,6 +613,11 @@ func (p *PrometheusPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostCont
 	return chunk, nil
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (p *PrometheusPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook records the start time of the request in the context.
 // This time is used later in PostLLMHook to calculate request duration.
 func (p *PrometheusPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {

--- a/transports/bifrost-http/handlers/realtime_client_secrets_test.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets_test.go
@@ -311,6 +311,10 @@ func (m *mockRealtimeMintingGovernancePlugin) HTTPTransportPostHook(_ *schemas.B
 	return nil
 }
 
+func (m *mockRealtimeMintingGovernancePlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 func (m *mockRealtimeMintingGovernancePlugin) PreLLMHook(_ *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	return req, nil, nil
 }

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -12243,6 +12243,10 @@ type mockLLMPlugin struct {
 	mockPlugin
 }
 
+func (p *mockLLMPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 func (p *mockLLMPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	return req, nil, nil
 }


### PR DESCRIPTION
## Summary

Introduces a new `PreRequestHook` phase to the `LLMPlugin` interface. This hook runs exactly once per top-level request — after `HTTPTransportPreHook` and before `PreLLMHook` — and is the canonical place for plugins to resolve provider, model, and fallback routing decisions. Previously, routing logic had to be shoehorned into `PreLLMHook`, which runs on every fallback attempt and whose mutations have incidental cross-fallback visibility. `PreRequestHook` mutations are committed to the shared `*BifrostRequest` before any fan-out and are observed by every subsequent plugin, every `PreLLMHook` invocation, the provider call, and every fallback.

As part of this change, the `filterProvidersByContext` helper (used in `ListAllModels`) is removed, and request validation is moved to after `PreRequestHook` runs so that plugins have the opportunity to populate provider/model before the empty-field check fires. Error messages for missing provider/model are updated to reflect that auto-resolution was attempted.

## Changes

- Added `PreRequestHook(ctx *BifrostContext, req *BifrostRequest) error` to the `LLMPlugin` interface with non-blocking error semantics (logged as warning, pipeline continues).
- Added `RunPreRequestHooks` to `PluginPipeline`, executing the hook in registration order once per request with tracing and plugin-scope isolation.
- Added `RunPreRequestHooks` as a public method on `Bifrost` for callers (e.g., realtime WebSocket handlers) that bypass the normal inference path.
- Moved `validateRequest` to after `PreRequestHook` execution in both `handleRequest` and `handleStreamRequest`, renamed to `validateRequestAfterPreRequestHooks` with updated error messages.
- Added primary-provider error logging to `handleStreamRequest` to match `handleRequest` behavior.
- Removed `filterProvidersByContext` and its tests from `ListAllModels`.
- Updated `DynamicPlugin` (shared-object loader) to optionally load `PreRequestHook` from `.so` plugins; legacy plugins without the export get a no-op passthrough, preserving backward compatibility.
- Updated `AsLLMPlugin` to recognize `preRequestHook` as sufficient to qualify a `DynamicPlugin` as an `LLMPlugin`.
- Added no-op `PreRequestHook` implementations to all existing plugins (`compat`, `governance`, `jsonparser`, `logging`, `maxim`, `mocker`, `prompts`, `semanticcache`, `telemetry`) and all example/test plugins to satisfy the updated interface.
- Updated plugin execution-order documentation in `plugin.go` to describe per-request vs. per-attempt semantics.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Validate that:
- A plugin implementing `PreRequestHook` can mutate `req.Provider` and `req.Model` before the provider call, and those mutations are visible to subsequent plugins and fallback attempts.
- A plugin that returns a non-nil error from `PreRequestHook` does not abort the request; the pipeline continues to the next plugin and a warning is logged.
- Existing plugins with no-op `PreRequestHook` implementations behave identically to before.
- Legacy `.so` plugins that do not export `PreRequestHook` load and function correctly with the no-op passthrough.
- Requests with no provider set (and no plugin resolving one) return the updated error message: `"could not auto resolve a provider for the request, please specify a provider explicitly"`.

## Breaking changes

- [x] Yes
- [ ] No

The `LLMPlugin` interface gains a new required method `PreRequestHook`. Any external plugin implementing `LLMPlugin` must add a `PreRequestHook` method. Plugins that do not participate in routing should return `nil`. Shared-object (`.so`) plugins are exempt — the loader treats `PreRequestHook` as optional and provides a no-op default.

## Security considerations

`PreRequestHook` runs with `BlockRestrictedWrites` active on the context (same as `RunLLMPreHooks`), preventing plugins from writing to restricted context keys during the hook. Plugins cannot abort or gate requests via error return from this hook; authorization and content-policy enforcement must remain in `HTTPTransportPreHook` or via a short-circuit in `PreLLMHook`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `PreRequestHook` plugin phase enabling plugins to perform per-request routing decisions before provider and model validation.

* **Refactor**
  * Request validation now occurs after plugin hooks execute, allowing automatic resolution of routing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->