### PR TITLE
docs: add `PreRequestHook` routing phase to plugin lifecycle and sequencing docs

### DIFF
--- a/docs/architecture/core/plugins.mdx
+++ b/docs/architecture/core/plugins.mdx
@@ -68,8 +68,12 @@ Every plugin goes through a well-defined lifecycle that ensures proper resource 
 stateDiagram-v2
     [*] --> PluginInit: Plugin Creation
     PluginInit --> Registered: Add to BifrostConfig
-    Registered --> PreHookCall: Request Received
+    Registered --> PreRequestHookCall: Request Received (once per request)
 
+    PreRequestHookCall --> RouteDecided: Provider/Model resolved
+    PreRequestHookCall --> RouteDecided: Return Error (logged, non-blocking)
+
+    RouteDecided --> PreHookCall: Per-attempt phase
     PreHookCall --> ModifyRequest: Normal Flow
     PreHookCall --> ShortCircuitResponse: Return Response
     PreHookCall --> ShortCircuitError: Return Error
@@ -87,7 +91,7 @@ stateDiagram-v2
 
     FallbackCheck --> TryFallback: AllowFallbacks=true/nil
     FallbackCheck --> ResponseReady: AllowFallbacks=false
-    TryFallback --> PreHookCall: Next Provider
+    TryFallback --> PreHookCall: Next Provider (PreRequestHook NOT re-run)
 
     ModifyResponse --> ResponseReady: Modified
     RecoverError --> ResponseReady: Recovered
@@ -148,6 +152,12 @@ sequenceDiagram
     participant Provider
 
     Client->>Bifrost: Request
+    Note over Bifrost,Plugin2: PreRequestHook phase (once per request, before any fan-out)
+    Bifrost->>Plugin1: PreRequestHook(request)
+    Plugin1-->>Bifrost: routed request
+    Bifrost->>Plugin2: PreRequestHook(request)
+    Plugin2-->>Bifrost: routed request
+    Note over Bifrost,Plugin2: PreLLMHook phase (per provider attempt)
     Bifrost->>Plugin1: PreLLMHook(request)
     Plugin1-->>Bifrost: modified request
     Bifrost->>Plugin2: PreLLMHook(request)
@@ -163,9 +173,19 @@ sequenceDiagram
 
 **Execution Order:**
 
-1. **PreHooks:** Execute in registration order (1 → 2 → N)
-2. **Provider Call:** If no short-circuit occurred
-3. **PostHooks:** Execute in reverse order (N → 2 → 1)
+1. **PreRequestHooks** (per-request, registration order 1 → 2 → N): the **routing phase**. Plugins decide which provider/model the request goes to. Mutations to `req.Provider`/`req.Model`/`req.Fallbacks` commit to the shared request and are observed by every subsequent phase and every fallback attempt. There is no short-circuit. Plugin errors are non-blocking — logged as warnings and the pipeline continues to the next plugin. After all PreRequestHooks have run, the core validates `req.Provider`: an unresolved provider returns a 400 to the caller.
+2. **PreLLMHooks** (per attempt, registration order 1 → 2 → N): pre-call transforms — caching, validation, content modification. May short-circuit with a synthetic response.
+3. **Provider Call:** if no short-circuit occurred.
+4. **PostLLMHooks** (per attempt, reverse order N → 2 → 1): response transforms — error recovery, logging, observability.
+
+**Per-request vs per-attempt:** `PreRequestHook` runs **exactly once** at the top of `handleRequest` / `handleStreamRequest`, before any provider call. `PreLLMHook` and `PostLLMHook` run **once per provider attempt** — so if the primary call fails and a fallback fires, `PreLLMHook` and `PostLLMHook` run again on the fallback, but `PreRequestHook` does **not**. This is what makes `PreRequestHook` the right place for routing decisions: the decision is committed once and applies uniformly to the primary attempt and every fallback.
+
+<Info>
+**When to use which hook:**
+- **PreRequestHook** → routing decisions (governance rules, load balancing, model-catalog provider resolution). Mutations to `req.Provider`/`req.Model`/`req.Fallbacks` stick.
+- **PreLLMHook** → per-attempt transforms (semantic-cache lookups, request validation, content rewrites). Mutations to provider/model are intentionally no-ops here.
+- **PostLLMHook** → per-attempt response handling (caching writes, logging, error recovery).
+</Info>
 
 #### **Short-Circuit Response Flow (Cache Hit)**
 
@@ -178,6 +198,7 @@ sequenceDiagram
     participant Provider
 
     Client->>Bifrost: Request
+    Note over Bifrost,Cache: PreRequestHook phase (routing decided)
     Bifrost->>Auth: PreLLMHook(request)
     Auth-->>Bifrost: modified request
     Bifrost->>Cache: PreLLMHook(request)
@@ -203,6 +224,7 @@ sequenceDiagram
     participant Provider
 
     Client->>Bifrost: Stream Request
+    Note over Bifrost,Plugin2: PreRequestHook phase (routing decided)
     Bifrost->>Plugin1: PreLLMHook(request)
     Plugin1-->>Bifrost: modified request
     Bifrost->>Plugin2: PreLLMHook(request)

--- a/docs/plugins/getting-started.mdx
+++ b/docs/plugins/getting-started.mdx
@@ -54,8 +54,9 @@ This generates a `.so` file that exports specific functions matching Bifrost's p
     - `GetName() string` - Return the plugin name
     - `HTTPTransportPreHook()` - Intercept HTTP requests before they enter Bifrost core (HTTP transport only)
     - `HTTPTransportPostHook()` - Intercept HTTP responses after they exit Bifrost core (HTTP transport only)
-    - `PreLLMHook()` - Intercept requests before they reach providers
-    - `PostLLMHook()` - Process responses after provider calls
+    - `PreRequestHook()` <sup>v1.6.x+</sup> - Once-per-request routing phase: decide provider/model/fallbacks
+    - `PreLLMHook()` - Intercept requests before they reach providers (runs per provider attempt)
+    - `PostLLMHook()` - Process responses after provider calls (runs per provider attempt)
     - `Cleanup() error` - Clean up resources on shutdown
   </Tab>
   <Tab title="v1.3.x">
@@ -83,7 +84,7 @@ This means if you're running Bifrost on Linux AMD64, you must build your plugin 
 
 1. **Load** - Bifrost loads the `.so` file using Go's `plugin.Open()`
 2. **Initialize** - Calls `Init()` with configuration from `config.json`
-3. **Hook Execution** - Calls `PreLLMHook()` and `PostLLMHook()` for each request
+3. **Hook Execution** - Calls `PreRequestHook()`, `PreLLMHook()` and `PostLLMHook()` for each request
 4. **Cleanup** - Calls `Cleanup()` when Bifrost shuts down
 
 Plugins execute in a specific order:
@@ -91,10 +92,11 @@ Plugins execute in a specific order:
 <Tabs>
   <Tab title="v1.4.x+">
     1. `HTTPTransportPreHook` - Intercept HTTP requests (HTTP transport only)
-    2. `PreLLMHook`/`PreMCPHook` - Executes in registration order, can short-circuit requests
-    3. Provider call (if not short-circuited)
-    4. `PostLLMHook`/`PostMCPHook` - Executes in reverse order of PreHooks
-    5. `HTTPTransportPostHook` - Intercept HTTP responses (HTTP transport only, reverse order)
+    2. `PreRequestHook` <sup>v1.6.x+</sup> - **Once per request**, before any provider call. Routing decisions (provider/model/fallbacks) happen here and propagate to every attempt.
+    3. `PreLLMHook`/`PreMCPHook` - Per provider attempt, registration order, can short-circuit requests
+    4. Provider call (if not short-circuited)
+    5. `PostLLMHook`/`PostMCPHook` - Per provider attempt, reverse order of PreHooks
+    6. `HTTPTransportPostHook` - Intercept HTTP responses (HTTP transport only, reverse order)
   </Tab>
   <Tab title="v1.3.x">
     1. `TransportInterceptor` - Modifies raw HTTP requests (HTTP transport only)

--- a/docs/plugins/sequencing.mdx
+++ b/docs/plugins/sequencing.mdx
@@ -32,6 +32,20 @@ graph LR
 Post-hooks execute in **reverse order** of pre-hooks (LIFO pattern). This means a `pre_builtin` plugin's `PreLLMHook` runs first, but its `PostLLMHook` runs last - ensuring proper cleanup and state unwinding.
 </Info>
 
+### Routing layer order (PreRequestHook)
+
+`PreRequestHook` is the per-request **routing phase**. All routing-capable plugins fire here in registration order, and each one sees the routing decisions of those that ran before it. Built-in routing plugins are sequenced as follows within the `builtin` group:
+
+| Order | Plugin | Role |
+|-------|--------|------|
+| 4 | governance | Routing rules (CEL) + VK-scoped weighted load balancing |
+| Higher | adaptive-loadbalancer (Enterprise) | Performance-based provider selection across the model catalog |
+| 9 (last) | model-catalog-resolver | **Final fallback** — fills in `req.Provider` from the model catalog for unprefixed models when no earlier plugin picked one |
+
+The resolver runs last so CEL routing rules can match on `provider == ""` (the unresolved state) and earlier plugins always get the canonical bare model. After `PreRequestHook` returns, the core validates that `req.Provider` is non-empty — an unresolvable request returns a 400 with a clear error.
+
+Custom routing plugins can slot into this chain via `placement` + `order` like any other plugin. Place them in `pre_builtin` to override governance, or `post_builtin` to act as a custom fallback after all built-ins.
+
 ### Ordering within a group
 
 Within each placement group, plugins are sorted by their `order` value (lower executes earlier). Plugins with the same order preserve their registration order.
@@ -185,6 +199,6 @@ When in doubt, use the default `post_builtin` placement. Most custom plugins - l
 
 ## Next steps
 
-- **[Writing a Go plugin](./writing-go-plugin)** - Build your first custom plugin with `PreLLMHook` and `PostLLMHook`
+- **[Writing a Go plugin](./writing-go-plugin)** - Build your first custom plugin with `PreRequestHook`, `PreLLMHook`, and `PostLLMHook`
 - **[Writing a WASM plugin](./writing-wasm-plugin)** - Build a portable WASM plugin
 - **[Plugin architecture](../architecture/core/plugins)** - Deep dive into the plugin lifecycle and hook execution model

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -152,6 +152,16 @@ func HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTP
 }
 
 
+// PreRequestHook is called once per top-level request (NOT per fallback attempt).
+// This is the routing phase — use it for provider/model/fallback decisions.
+// Mutations to req.Provider/req.Model/req.Fallbacks commit and propagate to every attempt.
+// Errors are non-blocking (logged + skipped).
+func PreRequestHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error {
+	ctx.Log(schemas.LogLevelInfo, "PreRequestHook called")
+	// Plugins that don't participate in routing should just return nil
+	return nil
+}
+
 // PreLLMHook is called before the request is sent to the provider
 // This is where you can modify requests or short-circuit the flow
 func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
@@ -267,6 +277,13 @@ func HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTP
 	// return modifiedChunk, nil
 }
 
+
+// PreRequestHook is called once per top-level request (routing phase)
+// Mutations to req.Provider/req.Model/req.Fallbacks commit across fallbacks
+func PreRequestHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error {
+	fmt.Println("PreRequestHook called")
+	return nil
+}
 
 // PreLLMHook is called before the request is sent to the provider
 // This is where you can modify requests or short-circuit the flow
@@ -546,6 +563,58 @@ This function is **only called** when using `bifrost-http`. It's **not invoked**
 </Warning>
   </Tab>
 </Tabs>
+
+#### `PreRequestHook(...)` <sup>v1.6.x+</sup>
+
+Called **once per top-level request**, before any provider call and before `PreLLMHook`. This is the **routing phase**: it's where plugins decide which provider, model, and fallbacks the request should be sent to.
+
+Use this for:
+- **Routing decisions**: governance rules, virtual-key load balancing, geo/tier routing
+- **Provider resolution**: filling in `req.Provider` for unprefixed model names (the built-in `model-catalog-resolver` does this as the last routing layer)
+- **Fallback chain construction**: populating `req.Fallbacks` based on policy
+
+**Why a separate hook from `PreLLMHook`:**
+
+| Aspect | `PreRequestHook` | `PreLLMHook` |
+|---|---|---|
+| Runs | Once per request | Once per provider attempt (re-runs on each fallback) |
+| Provider/Model mutations | **Commit and propagate** to every attempt | No-op for `Provider`/`Model` (overwritten by core) |
+| Use for | Routing decisions | Request transforms, caching, validation |
+| Short-circuit | No | Yes (can return a synthetic response) |
+| Error semantics | Non-blocking (logged, pipeline continues) | Non-blocking (logged, pipeline continues) |
+
+**Routing Example:**
+
+```go
+func PreRequestHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error {
+	provider, model, _ := req.GetRequestFields()
+
+	// Route premium-tier requests to a faster provider
+	if tier := ctx.Value(schemas.BifrostContextKey("x-tier")); tier == "premium" && provider == "openai" {
+		req.SetProvider(schemas.Anthropic)
+		req.SetModel("claude-3-5-sonnet")
+		// Emit a routing-engine log entry so users can see why this decision was made
+		ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, schemas.LogLevelInfo,
+			fmt.Sprintf("Routed %s to anthropic/claude-3-5-sonnet (tier=premium)", model))
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyRoutingEnginesUsed,
+			schemas.RoutingEngineRoutingRule)
+	}
+	return nil
+}
+```
+
+**Two helpers worth knowing when writing routing logic:**
+
+- `ctx.AppendRoutingEngineLog(engine, level, message)` — emits a structured log entry visible in observability tools. Use it to explain *why* a routing decision was made.
+- `schemas.AppendToContextList(ctx, schemas.BifrostContextKeyRoutingEnginesUsed, engineName)` — records which routing engine(s) participated. Surfaces in telemetry as `routing.engines_used`.
+
+<Info>
+**Plugin order matters for routing.** Built-in routing plugins run in this order within `PreRequestHook`: governance routing rules → governance VK load balancing → enterprise load balancer → model-catalog-resolver (final fallback). Custom plugins can slot in via `placement` + `order` — see [Plugin Sequencing](./sequencing).
+</Info>
+
+<Info>
+**Errors are non-blocking.** Returning a non-nil error from `PreRequestHook` logs a warning but does NOT fail the request — the pipeline continues with the next plugin. The core validates `req.Provider` after all `PreRequestHook` plugins have run; an unresolved provider returns a 400 to the caller.
+</Info>
 
 #### `PreLLMHook(...)`
 

--- a/docs/providers/provider-routing.mdx
+++ b/docs/providers/provider-routing.mdx
@@ -836,20 +836,21 @@ This is how Bifrost achieves **intelligent cross-provider routing** without manu
   v1.5.0-prerelease7 and above**.
 </Info>
 
-When a request includes a bare model name without a `provider/` prefix (e.g., `"model": "gpt-4o"` instead of `"model": "openai/gpt-4o"`), Bifrost automatically resolves the provider using the Model Catalog. Note that this default behavior is applied **after all other routing engines** have run.
+When a request includes a bare model name without a `provider/` prefix (e.g., `"model": "gpt-4o"` instead of `"model": "openai/gpt-4o"`), Bifrost automatically resolves the provider using the Model Catalog. This default behavior is applied **after all other routing engines** have run — the built-in `model-catalog-resolver` PreRequestHook plugin is registered as the last routing layer (order 9 within `builtin`), so governance routing rules, VK load balancing, and enterprise LB all get first crack.
 
 ### How It Works
 
 1. **Request arrives** without a provider prefix (e.g., `"model": "gpt-4o"`)
-2. **Catalog lookup**: Bifrost calls `GetProvidersForModel("gpt-4o")` to find all providers that support the model
-3. **Provider selected**: A provider from the catalog's available list is used (e.g., `openai`)
-4. **Request continues**: The resolved `provider/model` string is used for load balancing and fallback handling
+2. Governance, VK LB, and enterprise LB all run first; if any of them sets `req.Provider`, the resolver no-ops
+3. **Catalog lookup** (if `req.Provider` is still empty): Bifrost calls `GetProvidersForModel("gpt-4o")` to find all providers that support the model
+4. **Provider selected**: If the request came in via an integration route (OpenAI / Anthropic / GenAI / Bedrock / Cohere) and the catalog includes that integration's canonical provider in the candidate list, it is preferred. Otherwise the first candidate is selected.
+5. **Request continues**: The resolved `provider/model` is used for the provider call, fallback handling, and Level 2 key selection.
 
 This is logged as the **`model-catalog`** routing engine in telemetry and routing logs, with a message like:
 
 ```
 No provider specified for model gpt-4o, found 3 options in model catalog:
-[openai, azure, groq], selecting first: openai
+[openai, azure, groq], selected: openai
 ```
 
 ### Example
@@ -1189,60 +1190,67 @@ This means key-level optimization works regardless of how the provider was chose
 flowchart TD
     Start["Request: gpt-4o"]
 
-    subgraph Governance["Governance Plugin (HTTPTransportIntercept)"]
+    subgraph PreReq["PreRequestHook Phase (once per request, registration order)"]
         HasVK{"Has VK with<br/>provider_configs?"}
-        GovRoute["Provider Selection:<br/>Weighted random"]
-        AddPrefix["Add prefix:<br/>azure/gpt-4o"]
+        GovRoute["Governance:<br/>Routing rules + VK weighted random"]
+        AddPrefix["Set req.Provider/Model:<br/>azure/gpt-4o"]
+        PrefixCheck{"req.Provider<br/>already set?"}
+        LBProvider["Enterprise LB:<br/>Performance-based selection"]
+        AddLBPrefix["Set req.Provider/Model:<br/>openai/gpt-4o"]
+        Resolver["model-catalog-resolver:<br/>Fill from catalog (last fallback)"]
     end
 
-    subgraph LB1["Load Balancer Level 1 (Middleware)"]
-        PrefixCheck{"Has provider<br/>prefix?"}
-        LBProvider["Provider Selection:<br/>Performance-based"]
-        AddLBPrefix["Add prefix:<br/>openai/gpt-4o"]
-    end
-
-    subgraph LB2["Load Balancer Level 2 (Key Selector)"]
+    subgraph LB2["Load Balancer Level 2 (Key Selector, in core)"]
         GetKeys["Get available keys<br/>for selected provider"]
         ScoreKeys["Score keys by<br/>performance metrics"]
         SelectKey["Select best key"]
     end
 
     Start --> HasVK
-    HasVK -->|Yes| GovRoute --> AddPrefix
+    HasVK -->|Yes| GovRoute --> AddPrefix --> PrefixCheck
     HasVK -->|No| PrefixCheck
-    AddPrefix --> PrefixCheck
-    PrefixCheck -->|Yes, skip Level 1| GetKeys
-    PrefixCheck -->|No| LBProvider --> AddLBPrefix --> GetKeys
+    PrefixCheck -->|Yes, skip LB Level 1| Resolver
+    PrefixCheck -->|No| LBProvider --> AddLBPrefix --> Resolver
+    Resolver --> GetKeys
     GetKeys --> ScoreKeys --> SelectKey --> Execute["Execute request<br/>with selected provider + key"]
 ```
 
 ### Execution Order
 
-1. **HTTPTransportIntercept** (Governance Plugin - Provider Level)
-   - Runs first in the request pipeline
-   - Checks if Virtual Key has `provider_configs`
-   - If yes: adds provider prefix (e.g., `azure/gpt-4o`)
-   - **Result**: Provider is selected by governance rules
+All three routing layers (governance, enterprise LB Level 1, model-catalog-resolver) now run inside a single **PreRequestHook** phase that fires **once per top-level request**, before any provider call and before per-attempt hooks. Within that phase, plugins execute in placement + order:
 
-2. **Middleware** (Load Balancing Plugin - Provider Level / Direction)
-   - Runs after HTTPTransportIntercept
-   - Checks if model string contains "/"
-   - If yes: **skips provider selection** (already determined by governance or user)
-   - If no: performs performance-based provider selection
-   - **Result**: Provider prefix added if not already present
+1. **Governance Plugin** (PreRequestHook, builtin order 4)
+   - Evaluates routing rules (CEL expressions, scope hierarchy)
+   - If Virtual Key has `provider_configs`: performs weighted random provider selection
+   - **Result**: `req.Provider`/`req.Model` set; `req.Fallbacks` populated
 
-3. **KeySelector** (Load Balancing - Key Level / Route)
-   - **Always runs** during request execution in Bifrost core
-   - Gets all keys for the selected provider
-   - Filters keys based on model restrictions
+2. **Enterprise Load Balancer Level 1** (PreRequestHook, builtin)
+   - Runs after governance
+   - If `req.Provider` is already set (by governance or by an explicit `provider/model` prefix from the user): **skips provider selection**
+   - If not: performs performance-based provider selection across catalog providers
+   - **Result**: `req.Provider`/`req.Model` set if previously empty
+
+3. **model-catalog-resolver** (PreRequestHook, builtin order 9 — final fallback)
+   - Runs last
+   - If `req.Provider` is still empty: looks up the model in the catalog and picks a provider (preferring the integration's canonical provider when the request came in via an integration route)
+   - Emits a `model-catalog` routing-engine log entry
+   - **Result**: Always leaves `req.Provider` populated when the catalog knows about the model
+
+4. **Empty-provider validation** (core, after PreRequestHook)
+   - If `req.Provider` is still empty: returns 400 to the caller with a clear error
+
+5. **Load Balancer Level 2** (Key Selector — core, per provider attempt)
+   - **Always runs** during request execution
+   - Gets all keys for the selected provider, filters by model restrictions
    - Scores each key by performance metrics
    - Selects best key using weighted random + exploration
    - **Result**: Optimal key selected within the provider
 
 <Info>
-  **Important**: Even when governance specifies `azure/gpt-4o`, load balancing
-  **still optimizes which Azure key to use** based on performance metrics. This
-  is the power of the two-level architecture!
+  **Important**: Even when governance specifies `azure/gpt-4o` in PreRequestHook,
+  load balancing Level 2 **still optimizes which Azure key to use** based on
+  performance metrics. The two-level architecture is preserved — only the
+  *layer* where Level 1 runs has moved from a middleware to PreRequestHook.
 </Info>
 
 ### Example Scenarios
@@ -1395,35 +1403,37 @@ Routing Rules provide sophisticated, expression-based control over request routi
 flowchart TD
     Start["Request: model + provider"]
 
-    subgraph Rules["1. Routing Rules Layer (Evaluated First)"]
-        RuleMatch{"CEL Expression<br/>Matches?"}
-        RuleDecision["Override:<br/>New provider/model/fallbacks"]
-        NoMatch["No match:<br/>Continue to Governance"]
+    subgraph PreReq["PreRequestHook Phase (once per request)"]
+        direction TB
+        subgraph Gov["Governance Plugin"]
+            RuleMatch{"CEL Routing Rule<br/>Matches?"}
+            RuleDecision["Override:<br/>provider/model/fallbacks"]
+            VKValidation["Virtual Key Validation"]
+            GovRouting["VK Provider Selection<br/>(weighted random)"]
+        end
+        LB1["Enterprise LB Level 1:<br/>Provider Selection<br/>(skipped if provider already set)"]
+        Resolver["model-catalog-resolver:<br/>Fill provider from catalog<br/>(final fallback)"]
     end
 
-    subgraph Gov["2. Governance Layer (if no routing rule matched)"]
-        VKValidation["Virtual Key Validation"]
-        GovRouting["Provider Governance Routing<br/>(weighted random)"]
-    end
-
-    subgraph LB["3. Load Balancing Layer"]
-        LB1["Level 1: Provider Selection"]
-        LB2["Level 2: Key Selection"]
-    end
+    LB2["LB Level 2: Key Selection<br/>(core, per attempt)"]
 
     Start --> RuleMatch
     RuleMatch -->|Yes| RuleDecision --> LB1
-    RuleMatch -->|No| NoMatch --> VKValidation --> GovRouting --> LB1
-    LB1 --> LB2 --> Execute["Execute with<br/>selected provider + key"]
+    RuleMatch -->|No| VKValidation --> GovRouting --> LB1
+    LB1 --> Resolver --> LB2 --> Execute["Execute with<br/>selected provider + key"]
 ```
 
 ### How It Works
 
+All routing layers below execute inside the **PreRequestHook** phase in registration order; routing rules run first within the governance plugin's hook body, before VK load balancing:
+
 1. **Routing rules evaluate first** in scope precedence order (VirtualKey → Team → Customer → Global)
-2. **If a routing rule matches**: provider/model/fallbacks are overridden, governance provider_configs are skipped
-3. **If no routing rule matches**: governance provider selection runs (weighted random)
-4. **Load balancing Level 1**: skipped if provider already determined (has "/" prefix)
-5. **Load balancing Level 2** (key selection): always runs to select the best key within the determined provider
+2. **If a routing rule matches**: provider/model/fallbacks are overridden, the VK `provider_configs` weighted selection is skipped
+3. **If no routing rule matches**: VK provider selection runs (weighted random)
+4. **Enterprise LB Level 1**: skipped if `req.Provider` is already set; otherwise performs performance-based selection
+5. **model-catalog-resolver**: last fallback — fills `req.Provider` from the catalog if no earlier plugin set it
+6. **Empty-provider validation** (core): returns 400 if `req.Provider` is still empty after the phase
+7. **Load balancing Level 2** (key selection, core, per attempt): always runs to select the best key within the determined provider
 
 ### Available CEL Variables
 


### PR DESCRIPTION
## Summary

Documents the `PreRequestHook` interface introduced in v1.6.x — a new per-request routing phase that fires exactly once before any provider call, distinct from `PreLLMHook` which runs per provider attempt. This clarifies where routing decisions (provider, model, fallbacks) should be made and how they propagate through the fallback chain.

## Changes

- Added `PreRequestHook` to the plugin lifecycle state diagram, sequence diagrams, and execution order descriptions across the architecture and getting-started docs, making clear it runs once per request while `PreLLMHook`/`PostLLMHook` run per attempt
- Added a routing layer order table in `sequencing.mdx` documenting the built-in plugin execution order within `PreRequestHook`: governance (order 4) → enterprise load balancer → model-catalog-resolver (order 9, final fallback)
- Added a full `PreRequestHook` reference section in `writing-go-plugin.mdx` with a comparison table against `PreLLMHook`, a routing example using `SetProvider`/`SetModel`, and notes on the two routing observability helpers (`AppendRoutingEngineLog`, `AppendToContextList`)
- Updated `provider-routing.mdx` to reflect that all three routing layers (governance, enterprise LB Level 1, model-catalog-resolver) now execute inside the `PreRequestHook` phase rather than across separate middleware stages, and updated the flowcharts and execution order lists accordingly
- Clarified that `model-catalog-resolver` now prefers the integration's canonical provider (OpenAI/Anthropic/GenAI/Bedrock/Cohere) when the request arrived via an integration route, rather than always selecting the first catalog candidate
- Updated the log message example from `selecting first:` to `selected:` to match the new resolver behavior

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered docs for accuracy against the v1.6.x plugin interface. Verify that:
- The `PreRequestHook` signature (`func PreRequestHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error`) matches the SDK
- The execution order table in `sequencing.mdx` matches the registered plugin orders in the codebase
- The flowcharts in `provider-routing.mdx` correctly reflect that all Level 1 routing now happens in `PreRequestHook`

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Documents the `PreRequestHook` routing phase introduced alongside the model-catalog-resolver and routing engine changes in v1.6.x.

## Security considerations

None. Documentation-only change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin lifecycle documentation to clarify `PreRequestHook` execution (v1.6.x+) as a once-per-request routing phase separate from per-attempt hook phases.
  * Enhanced plugin sequencing and execution order documentation with clearer per-request vs. per-attempt semantics.
  * Expanded provider routing documentation with updated default resolution order and governance/load-balancing interaction details.
  * Added comprehensive `PreRequestHook` guidance for plugin developers with routing examples and helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->