### PR TITLE
feat: add per-alias Azure endpoint, API version, and Anthropic version overrides with context-aware `ResolveFamily`

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6177,7 +6177,13 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		// returned to the pool via its deferred finalizer.
 		if IsStreamRequestType(req.RequestType) {
 			stream, bifrostError = executeRequestWithRetries(req.Context, config, func(k schemas.Key) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-				resolvedModel = k.Aliases.Resolve(originalModelRequested)
+				if aliasConfig := k.Aliases.ResolveConfig(originalModelRequested); aliasConfig != nil {
+					resolvedModel = aliasConfig.ModelID
+					req.Context.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{Key: originalModelRequested, Config: aliasConfig})
+				} else {
+					resolvedModel = originalModelRequested
+					req.Context.SetValue(schemas.BifrostContextKeyResolvedAlias, nil)
+				}
 				req.SetModel(resolvedModel)
 				// Snapshot per-attempt so postHookRunner doesn't observe a later retry's
 				// alias while this attempt's provider goroutine is still emitting chunks.
@@ -6236,7 +6242,13 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			}, keyProvider, req.RequestType, provider.GetProviderKey(), model, &req.BifrostRequest, bifrost.logger)
 		} else {
 			result, bifrostError = executeRequestWithRetries(req.Context, config, func(k schemas.Key) (*schemas.BifrostResponse, *schemas.BifrostError) {
-				resolvedModel = k.Aliases.Resolve(originalModelRequested)
+				if aliasConfig := k.Aliases.ResolveConfig(originalModelRequested); aliasConfig != nil {
+					resolvedModel = aliasConfig.ModelID
+					req.Context.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{Key: originalModelRequested, Config: aliasConfig})
+				} else {
+					resolvedModel = originalModelRequested
+					req.Context.SetValue(schemas.BifrostContextKeyResolvedAlias, nil)
+				}
 				req.SetModel(resolvedModel)
 				return bifrost.handleProviderRequest(provider, config, req, k, keys)
 			}, keyProvider, req.RequestType, provider.GetProviderKey(), model, &req.BifrostRequest, bifrost.logger)

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -226,11 +226,10 @@ func (provider *AzureProvider) completeRequest(
 	}()
 
 	var url string
-	isAnthropicModel := schemas.IsAnthropicModel(model)
 
 	// Set any extra headers from network config.
 	// For Anthropic models, exclude anthropic-beta — it is merged and filtered explicitly below.
-	if isAnthropicModel {
+	if schemas.IsAnthropicModelFamily(ctx, model) {
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, []string{anthropic.AnthropicBetaHeader})
 	} else {
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -239,7 +238,7 @@ func (provider *AzureProvider) completeRequest(
 	req.Header.SetContentType("application/json")
 
 	// Get authentication headers
-	authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, isAnthropicModel)
+	authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, schemas.IsAnthropicModelFamily(ctx, model))
 	if bifrostErr != nil {
 		return nil, 0, nil, bifrostErr
 	}
@@ -249,13 +248,13 @@ func (provider *AzureProvider) completeRequest(
 		req.Header.Set(k, v)
 	}
 
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, 0, nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
 
-	if isAnthropicModel {
-		req.Header.Set("anthropic-version", AzureAnthropicAPIVersionDefault)
+	if schemas.IsAnthropicModelFamily(ctx, model) {
+		req.Header.Set("anthropic-version", resolveAnthropicVersion(ctx))
 		url = fmt.Sprintf("%s/%s", endpoint, path)
 
 		// Merge ExtraHeaders + context anthropic-beta, filter for Azure, then set as HTTP header
@@ -307,6 +306,11 @@ func (provider *AzureProvider) completeRequest(
 // listModelsByKey performs a list models request for a single key.
 // Returns the response and latency, or an error if the request fails.
 func (provider *AzureProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
+
 	// Create the request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -316,7 +320,7 @@ func (provider *AzureProvider) listModelsByKey(ctx *schemas.BifrostContext, key 
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(key.AzureKeyConfig.Endpoint.GetValue() + providerUtils.GetPathFromContext(ctx, "/openai/v1/models"))
+	req.SetRequestURI(endpoint + providerUtils.GetPathFromContext(ctx, "/openai/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 
@@ -460,7 +464,11 @@ func (provider *AzureProvider) TextCompletion(ctx *schemas.BifrostContext, key s
 // It formats the request, sends it to Azure, and processes the response.
 // Returns a channel of BifrostStreamChunk objects or an error if the request fails.
 func (provider *AzureProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	url := fmt.Sprintf("%s/openai/v1/completions", key.AzureKeyConfig.Endpoint.GetValue())
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
+	url := fmt.Sprintf("%s/openai/v1/completions", endpoint)
 
 	// Get Azure authentication headers
 	authHeader, err := provider.getAzureAuthHeaders(ctx, key, false)
@@ -496,7 +504,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			if schemas.IsAnthropicModel(request.Model) {
+			if schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic {
 				reqBody, err := anthropic.ToAnthropicChatRequest(ctx, request)
 				if err != nil {
 					return nil, err
@@ -515,7 +523,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 	}
 
 	var path string
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic {
 		path = "anthropic/v1/messages"
 	} else {
 		path = "openai/v1/chat/completions"
@@ -550,7 +558,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 	var rawRequest interface{}
 	var rawResponse interface{}
 
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic {
 		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
 		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
 		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
@@ -586,14 +594,18 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 // Uses Azure-specific URL construction with deployments and supports both api-key and Bearer token authentication.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *AzureProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
 	var url string
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic {
 		authHeader, err := provider.getAzureAuthHeaders(ctx, key, true)
 		if err != nil {
 			return nil, err
 		}
-		authHeader["anthropic-version"] = AzureAnthropicAPIVersionDefault
-		url = fmt.Sprintf("%s/anthropic/v1/messages", key.AzureKeyConfig.Endpoint.GetValue())
+		authHeader["anthropic-version"] = resolveAnthropicVersion(ctx)
+		url = fmt.Sprintf("%s/anthropic/v1/messages", endpoint)
 
 		jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 			ctx,
@@ -637,7 +649,7 @@ func (provider *AzureProvider) ChatCompletionStream(ctx *schemas.BifrostContext,
 		if err != nil {
 			return nil, err
 		}
-		url = fmt.Sprintf("%s/openai/v1/chat/completions", key.AzureKeyConfig.Endpoint.GetValue())
+		url = fmt.Sprintf("%s/openai/v1/chat/completions", endpoint)
 
 		// Use shared streaming logic from OpenAI
 		return openai.HandleOpenAIChatCompletionStreaming(
@@ -669,7 +681,7 @@ func (provider *AzureProvider) ChatCompletionStream(ctx *schemas.BifrostContext,
 func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	var jsonData []byte
 	var bifrostErr *schemas.BifrostError
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		jsonData, bifrostErr = getRequestBodyForAnthropicResponses(ctx, request, request.Model, false, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	} else {
 		jsonData, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
@@ -685,10 +697,10 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 	}
 
 	var path string
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		path = "anthropic/v1/messages"
 	} else {
-		path = fmt.Sprintf("openai/v1/responses?api-version=%s", AzureAPIVersionPreview)
+		path = fmt.Sprintf("openai/v1/responses?api-version=%s", resolveAPIVersion(ctx, AzureAPIVersionPreview))
 	}
 
 	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(
@@ -720,7 +732,7 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 	var rawRequest interface{}
 	var rawResponse interface{}
 
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
 		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
 		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
@@ -753,14 +765,18 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 
 // ResponsesStream performs a streaming responses request to Azure's API.
 func (provider *AzureProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
 	var url string
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		authHeader, err := provider.getAzureAuthHeaders(ctx, key, true)
 		if err != nil {
 			return nil, err
 		}
-		authHeader["anthropic-version"] = AzureAnthropicAPIVersionDefault
-		url = fmt.Sprintf("%s/anthropic/v1/messages", key.AzureKeyConfig.Endpoint.GetValue())
+		authHeader["anthropic-version"] = resolveAnthropicVersion(ctx)
+		url = fmt.Sprintf("%s/anthropic/v1/messages", endpoint)
 
 		jsonData, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, request.Model, true, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		if bifrostErr != nil {
@@ -790,7 +806,7 @@ func (provider *AzureProvider) ResponsesStream(ctx *schemas.BifrostContext, post
 		if err != nil {
 			return nil, err
 		}
-		url = fmt.Sprintf("%s/openai/v1/responses?api-version=%s", key.AzureKeyConfig.Endpoint.GetValue(), AzureAPIVersionPreview)
+		url = fmt.Sprintf("%s/openai/v1/responses?api-version=%s", endpoint, resolveAPIVersion(ctx, AzureAPIVersionPreview))
 
 		// Use shared streaming logic from OpenAI
 		return openai.HandleOpenAIResponsesStreaming(
@@ -881,7 +897,7 @@ func (provider *AzureProvider) Embedding(ctx *schemas.BifrostContext, key schema
 
 // Speech is not supported by the Azure provider.
 func (provider *AzureProvider) Speech(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -922,13 +938,18 @@ func (provider *AzureProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key,
 // SpeechStream handles streaming for speech synthesis with Azure.
 // Azure sends raw binary audio bytes in SSE format, unlike OpenAI which sends JSON.
 func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
+
 	// Get Azure authentication headers
 	authHeader, err := provider.getAzureAuthHeaders(ctx, key, false)
 	if err != nil {
 		return nil, err
 	}
 
-	url := fmt.Sprintf("%s/openai/v1/audio/speech", key.AzureKeyConfig.Endpoint.GetValue())
+	url := fmt.Sprintf("%s/openai/v1/audio/speech", endpoint)
 
 	// Create HTTP request for streaming
 	req := fasthttp.AcquireRequest()
@@ -1209,7 +1230,11 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 
 // Transcription is not supported by the Azure provider.
 func (provider *AzureProvider) Transcription(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	url := fmt.Sprintf("%s/openai/deployments/%s/audio/transcriptions?api-version=%s", key.AzureKeyConfig.Endpoint.GetValue(), request.Model, DefaultAzureAPIVersion)
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
+	url := fmt.Sprintf("%s/openai/deployments/%s/audio/transcriptions?api-version=%s", endpoint, request.Model, resolveAPIVersion(ctx, DefaultAzureAPIVersion))
 
 	response, err := openai.HandleOpenAITranscriptionRequest(
 		ctx,
@@ -1241,7 +1266,7 @@ func (provider *AzureProvider) TranscriptionStream(ctx *schemas.BifrostContext, 
 // Returns a BifrostResponse containing the bifrost response or an error if the request fails.
 func (provider *AzureProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key,
 	request *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -1275,7 +1300,7 @@ func (provider *AzureProvider) ImageGenerationStream(
 	key schemas.Key,
 	request *schemas.BifrostImageGenerationRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -1311,7 +1336,7 @@ func (provider *AzureProvider) ImageGenerationStream(
 
 // ImageEdit performs an image edit request to Azure's API.
 func (provider *AzureProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -1338,7 +1363,7 @@ func (provider *AzureProvider) ImageEdit(ctx *schemas.BifrostContext, key schema
 
 // ImageEditStream performs a streaming image edit request to Azure's API.
 func (provider *AzureProvider) ImageEditStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostImageEditRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -1380,7 +1405,7 @@ func (provider *AzureProvider) ImageVariation(ctx *schemas.BifrostContext, key s
 // VideoGeneration creates a video using Azure's OpenAI-compatible Sora API.
 // This delegates to the OpenAI handler with Azure-specific URL and authentication.
 func (provider *AzureProvider) VideoGeneration(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostVideoGenerationRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -1415,7 +1440,7 @@ func (provider *AzureProvider) VideoRetrieve(ctx *schemas.BifrostContext, key sc
 	}
 	videoID := providerUtils.StripVideoIDProviderSuffix(request.ID, providerName)
 
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -1450,7 +1475,7 @@ func (provider *AzureProvider) VideoDownload(ctx *schemas.BifrostContext, key sc
 	}
 	videoID := providerUtils.StripVideoIDProviderSuffix(request.ID, providerName)
 
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -1525,7 +1550,7 @@ func (provider *AzureProvider) VideoDelete(ctx *schemas.BifrostContext, key sche
 	}
 	videoID := providerUtils.StripVideoIDProviderSuffix(request.ID, providerName)
 
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -1554,7 +1579,7 @@ func (provider *AzureProvider) VideoDelete(ctx *schemas.BifrostContext, key sche
 
 // VideoList lists videos from Azure's OpenAI-compatible API.
 func (provider *AzureProvider) VideoList(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostVideoListRequest) (*schemas.BifrostVideoListResponse, *schemas.BifrostError) {
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	endpoint := resolveAzureEndpoint(ctx, key)
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
@@ -1588,6 +1613,10 @@ func (provider *AzureProvider) VideoRemix(_ *schemas.BifrostContext, _ schemas.K
 
 // FileUpload uploads a file to Azure OpenAI.
 func (provider *AzureProvider) FileUpload(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostFileUploadRequest) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
 	if len(request.File) == 0 {
 		return nil, providerUtils.NewBifrostOperationError("file content is required", nil)
 	}
@@ -1629,7 +1658,7 @@ func (provider *AzureProvider) FileUpload(ctx *schemas.BifrostContext, key schem
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL
-	requestURL := fmt.Sprintf("%s/openai/v1/files", key.AzureKeyConfig.Endpoint.GetValue())
+	requestURL := fmt.Sprintf("%s/openai/v1/files", endpoint)
 
 	// Set headers
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -1700,6 +1729,11 @@ func (provider *AzureProvider) FileList(ctx *schemas.BifrostContext, keys []sche
 		}, nil
 	}
 
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
+
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -1707,7 +1741,7 @@ func (provider *AzureProvider) FileList(ctx *schemas.BifrostContext, keys []sche
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL with query params
-	requestURL := fmt.Sprintf("%s/openai/v1/files", key.AzureKeyConfig.Endpoint.GetValue())
+	requestURL := fmt.Sprintf("%s/openai/v1/files", endpoint)
 	values := url.Values{}
 	if request.Purpose != "" {
 		values.Set("purpose", string(request.Purpose))
@@ -1803,12 +1837,17 @@ func (provider *AzureProvider) FileRetrieve(ctx *schemas.BifrostContext, keys []
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
+		endpoint := resolveAzureEndpoint(ctx, key)
+		if endpoint == "" {
+			lastErr = providerUtils.NewConfigurationError("endpoint not set")
+			continue
+		}
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
 		// Build URL
-		requestURL := fmt.Sprintf("%s/openai/v1/files/%s", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.FileID))
+		requestURL := fmt.Sprintf("%s/openai/v1/files/%s", endpoint, url.PathEscape(request.FileID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -1887,12 +1926,17 @@ func (provider *AzureProvider) FileDelete(ctx *schemas.BifrostContext, keys []sc
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
+		endpoint := resolveAzureEndpoint(ctx, key)
+		if endpoint == "" {
+			lastErr = providerUtils.NewConfigurationError("endpoint not set")
+			continue
+		}
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
 		// Build URL
-		requestURL := fmt.Sprintf("%s/openai/v1/files/%s", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.FileID))
+		requestURL := fmt.Sprintf("%s/openai/v1/files/%s", endpoint, url.PathEscape(request.FileID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2000,12 +2044,17 @@ func (provider *AzureProvider) FileContent(ctx *schemas.BifrostContext, keys []s
 	var lastErr *schemas.BifrostError
 
 	for _, key := range keys {
+		endpoint := resolveAzureEndpoint(ctx, key)
+		if endpoint == "" {
+			lastErr = providerUtils.NewConfigurationError("endpoint not set")
+			continue
+		}
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
 		// Build URL
-		requestURL := fmt.Sprintf("%s/openai/v1/files/%s/content", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.FileID))
+		requestURL := fmt.Sprintf("%s/openai/v1/files/%s/content", endpoint, url.PathEscape(request.FileID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2075,6 +2124,10 @@ func (provider *AzureProvider) FileContent(ctx *schemas.BifrostContext, keys []s
 // BatchCreate creates a new batch job on Azure OpenAI.
 // Azure Batch API uses the same format as OpenAI but with Azure-specific URL patterns.
 func (provider *AzureProvider) BatchCreate(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostBatchCreateRequest) (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
 	inputFileID := request.InputFileID
 
 	// If no file_id provided but inline requests are available, upload them first
@@ -2110,7 +2163,7 @@ func (provider *AzureProvider) BatchCreate(ctx *schemas.BifrostContext, key sche
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL
-	requestURL := fmt.Sprintf("%s/openai/v1/batches", key.AzureKeyConfig.Endpoint.GetValue())
+	requestURL := fmt.Sprintf("%s/openai/v1/batches", endpoint)
 
 	// Set headers
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2209,6 +2262,11 @@ func (provider *AzureProvider) BatchList(ctx *schemas.BifrostContext, keys []sch
 		}, nil
 	}
 
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
+	}
+
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -2216,7 +2274,7 @@ func (provider *AzureProvider) BatchList(ctx *schemas.BifrostContext, keys []sch
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL with query params
-	baseURL := fmt.Sprintf("%s/openai/v1/batches", key.AzureKeyConfig.Endpoint.GetValue())
+	baseURL := fmt.Sprintf("%s/openai/v1/batches", endpoint)
 	values := url.Values{}
 	if request.Limit > 0 {
 		values.Set("limit", fmt.Sprintf("%d", request.Limit))
@@ -2303,12 +2361,17 @@ func (provider *AzureProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys [
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
+		endpoint := resolveAzureEndpoint(ctx, key)
+		if endpoint == "" {
+			lastErr = providerUtils.NewConfigurationError("endpoint not set")
+			continue
+		}
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
 		// Build URL
-		requestURL := fmt.Sprintf("%s/openai/v1/batches/%s", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.BatchID))
+		requestURL := fmt.Sprintf("%s/openai/v1/batches/%s", endpoint, url.PathEscape(request.BatchID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2388,12 +2451,17 @@ func (provider *AzureProvider) BatchCancel(ctx *schemas.BifrostContext, keys []s
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
+		endpoint := resolveAzureEndpoint(ctx, key)
+		if endpoint == "" {
+			lastErr = providerUtils.NewConfigurationError("endpoint not set")
+			continue
+		}
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
 		// Build URL
-		requestURL := fmt.Sprintf("%s/openai/v1/batches/%s/cancel", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.BatchID))
+		requestURL := fmt.Sprintf("%s/openai/v1/batches/%s/cancel", endpoint, url.PathEscape(request.BatchID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2729,8 +2797,9 @@ func (provider *AzureProvider) Compaction(ctx *schemas.BifrostContext, key schem
 
 // buildContainerURL constructs the Azure container API URL.
 // Container endpoints are not per-deployment, so they use the openai/v1 prefix directly.
-func (provider *AzureProvider) buildContainerURL(key schemas.Key, path string) string {
-	endpoint := strings.TrimRight(key.AzureKeyConfig.Endpoint.GetValue(), "/")
+// ctx carries the resolved alias so per-alias Endpoint overrides are honored.
+func (provider *AzureProvider) buildContainerURL(ctx *schemas.BifrostContext, key schemas.Key, path string) string {
+	endpoint := strings.TrimRight(resolveAzureEndpoint(ctx, key), "/")
 	return fmt.Sprintf("%s/openai/v1%s", endpoint, path)
 }
 
@@ -2742,7 +2811,7 @@ func (provider *AzureProvider) ContainerCreate(ctx *schemas.BifrostContext, key 
 	if request.Name == "" {
 		return nil, providerUtils.NewBifrostOperationError("invalid request: name is required", nil)
 	}
-	if key.AzureKeyConfig == nil || key.AzureKeyConfig.Endpoint.GetValue() == "" {
+	if resolveAzureEndpoint(ctx, key) == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
 
@@ -2779,7 +2848,7 @@ func (provider *AzureProvider) ContainerCreate(ctx *schemas.BifrostContext, key 
 	defer fasthttp.ReleaseResponse(resp)
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-	req.SetRequestURI(provider.buildContainerURL(key, "/containers"))
+	req.SetRequestURI(provider.buildContainerURL(ctx, key, "/containers"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	req.SetBody(jsonBody)
@@ -2863,7 +2932,7 @@ func (provider *AzureProvider) ContainerRetrieve(ctx *schemas.BifrostContext, ke
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
-		if key.AzureKeyConfig == nil || key.AzureKeyConfig.Endpoint.GetValue() == "" {
+		if resolveAzureEndpoint(ctx, key) == "" {
 			lastErr = providerUtils.NewConfigurationError("endpoint not set")
 			continue
 		}
@@ -2872,7 +2941,7 @@ func (provider *AzureProvider) ContainerRetrieve(ctx *schemas.BifrostContext, ke
 		resp := fasthttp.AcquireResponse()
 
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.buildContainerURL(key, "/containers/"+url.PathEscape(request.ContainerID)))
+		req.SetRequestURI(provider.buildContainerURL(ctx, key, "/containers/"+url.PathEscape(request.ContainerID)))
 		req.Header.SetMethod(http.MethodGet)
 
 		authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, false)
@@ -2969,7 +3038,7 @@ func (provider *AzureProvider) ContainerDelete(ctx *schemas.BifrostContext, keys
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
-		if key.AzureKeyConfig == nil || key.AzureKeyConfig.Endpoint.GetValue() == "" {
+		if resolveAzureEndpoint(ctx, key) == "" {
 			lastErr = providerUtils.NewConfigurationError("endpoint not set")
 			continue
 		}
@@ -2978,7 +3047,7 @@ func (provider *AzureProvider) ContainerDelete(ctx *schemas.BifrostContext, keys
 		resp := fasthttp.AcquireResponse()
 
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.buildContainerURL(key, "/containers/"+url.PathEscape(request.ContainerID)))
+		req.SetRequestURI(provider.buildContainerURL(ctx, key, "/containers/"+url.PathEscape(request.ContainerID)))
 		req.Header.SetMethod(http.MethodDelete)
 		req.Header.SetContentType("application/json")
 
@@ -3061,7 +3130,7 @@ func (provider *AzureProvider) ContainerFileCreate(ctx *schemas.BifrostContext, 
 	if len(request.File) == 0 {
 		return nil, providerUtils.NewBifrostOperationError("invalid request: file is required", nil)
 	}
-	if key.AzureKeyConfig == nil || key.AzureKeyConfig.Endpoint.GetValue() == "" {
+	if resolveAzureEndpoint(ctx, key) == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
 
@@ -3084,7 +3153,7 @@ func (provider *AzureProvider) ContainerFileCreate(ctx *schemas.BifrostContext, 
 	defer fasthttp.ReleaseResponse(resp)
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-	req.SetRequestURI(provider.buildContainerURL(key, fmt.Sprintf("/containers/%s/files", url.PathEscape(request.ContainerID))))
+	req.SetRequestURI(provider.buildContainerURL(ctx, key, fmt.Sprintf("/containers/%s/files", url.PathEscape(request.ContainerID))))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.SetBody(body.Bytes())
@@ -3169,11 +3238,11 @@ func (provider *AzureProvider) ContainerFileList(ctx *schemas.BifrostContext, ke
 	if !ok {
 		return &schemas.BifrostContainerFileListResponse{Object: "list", Data: []schemas.ContainerFileObject{}, HasMore: false}, nil
 	}
-	if key.AzureKeyConfig == nil || key.AzureKeyConfig.Endpoint.GetValue() == "" {
+	if resolveAzureEndpoint(ctx, key) == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
 
-	requestURL := provider.buildContainerURL(key, fmt.Sprintf("/containers/%s/files", url.PathEscape(request.ContainerID)))
+	requestURL := provider.buildContainerURL(ctx, key, fmt.Sprintf("/containers/%s/files", url.PathEscape(request.ContainerID)))
 	queryParams := url.Values{}
 	if request.Limit > 0 {
 		queryParams.Set("limit", fmt.Sprintf("%d", request.Limit))
@@ -3275,7 +3344,7 @@ func (provider *AzureProvider) ContainerFileRetrieve(ctx *schemas.BifrostContext
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
-		if key.AzureKeyConfig == nil || key.AzureKeyConfig.Endpoint.GetValue() == "" {
+		if resolveAzureEndpoint(ctx, key) == "" {
 			lastErr = providerUtils.NewConfigurationError("endpoint not set")
 			continue
 		}
@@ -3284,7 +3353,7 @@ func (provider *AzureProvider) ContainerFileRetrieve(ctx *schemas.BifrostContext
 		resp := fasthttp.AcquireResponse()
 
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.buildContainerURL(key, fmt.Sprintf("/containers/%s/files/%s", url.PathEscape(request.ContainerID), url.PathEscape(request.FileID))))
+		req.SetRequestURI(provider.buildContainerURL(ctx, key, fmt.Sprintf("/containers/%s/files/%s", url.PathEscape(request.ContainerID), url.PathEscape(request.FileID))))
 		req.Header.SetMethod(http.MethodGet)
 
 		authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, false)
@@ -3380,7 +3449,7 @@ func (provider *AzureProvider) ContainerFileContent(ctx *schemas.BifrostContext,
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
-		if key.AzureKeyConfig == nil || key.AzureKeyConfig.Endpoint.GetValue() == "" {
+		if resolveAzureEndpoint(ctx, key) == "" {
 			lastErr = providerUtils.NewConfigurationError("endpoint not set")
 			continue
 		}
@@ -3389,7 +3458,7 @@ func (provider *AzureProvider) ContainerFileContent(ctx *schemas.BifrostContext,
 		resp := fasthttp.AcquireResponse()
 
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.buildContainerURL(key, fmt.Sprintf("/containers/%s/files/%s/content", url.PathEscape(request.ContainerID), url.PathEscape(request.FileID))))
+		req.SetRequestURI(provider.buildContainerURL(ctx, key, fmt.Sprintf("/containers/%s/files/%s/content", url.PathEscape(request.ContainerID), url.PathEscape(request.FileID))))
 		req.Header.SetMethod(http.MethodGet)
 
 		authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, false)
@@ -3470,7 +3539,7 @@ func (provider *AzureProvider) ContainerFileDelete(ctx *schemas.BifrostContext, 
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
-		if key.AzureKeyConfig == nil || key.AzureKeyConfig.Endpoint.GetValue() == "" {
+		if resolveAzureEndpoint(ctx, key) == "" {
 			lastErr = providerUtils.NewConfigurationError("endpoint not set")
 			continue
 		}
@@ -3479,7 +3548,7 @@ func (provider *AzureProvider) ContainerFileDelete(ctx *schemas.BifrostContext, 
 		resp := fasthttp.AcquireResponse()
 
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.buildContainerURL(key, fmt.Sprintf("/containers/%s/files/%s", url.PathEscape(request.ContainerID), url.PathEscape(request.FileID))))
+		req.SetRequestURI(provider.buildContainerURL(ctx, key, fmt.Sprintf("/containers/%s/files/%s", url.PathEscape(request.ContainerID), url.PathEscape(request.FileID))))
 		req.Header.SetMethod(http.MethodDelete)
 
 		authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, false)
@@ -3556,7 +3625,10 @@ func (provider *AzureProvider) Passthrough(
 	key schemas.Key,
 	req *schemas.BifrostPassthroughRequest,
 ) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
-	url := provider.buildPassthroughURL(key, req.Path, req.RawQuery)
+	url, err := provider.buildPassthroughURL(ctx, key, req.Path, req.RawQuery)
+	if err != nil {
+		return nil, providerUtils.NewConfigurationError(fmt.Sprintf("failed to build passthrough URL: %s", err.Error()))
+	}
 
 	fasthttpReq := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -3572,7 +3644,7 @@ func (provider *AzureProvider) Passthrough(
 		fasthttpReq.Header.Set(k, v)
 	}
 
-	authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, schemas.IsAnthropicModel(req.Model))
+	authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, schemas.IsAnthropicModelFamily(ctx, req.Model))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -3625,7 +3697,10 @@ func (provider *AzureProvider) PassthroughStream(
 	key schemas.Key,
 	req *schemas.BifrostPassthroughRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	url := provider.buildPassthroughURL(key, req.Path, req.RawQuery)
+	url, err := provider.buildPassthroughURL(ctx, key, req.Path, req.RawQuery)
+	if err != nil {
+		return nil, providerUtils.NewConfigurationError(fmt.Sprintf("failed to build passthrough URL: %s", err.Error()))
+	}
 
 	fasthttpReq := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -3643,7 +3718,7 @@ func (provider *AzureProvider) PassthroughStream(
 
 	fasthttpReq.Header.Set("Connection", "close")
 
-	authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, schemas.IsAnthropicModel(req.Model))
+	authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, schemas.IsAnthropicModelFamily(ctx, req.Model))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -3686,7 +3761,7 @@ func (provider *AzureProvider) PassthroughStream(
 	}
 
 	var anthropicUsage *anthropic.AnthropicPassthroughStreamUsage
-	if schemas.IsAnthropicModel(req.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, req.Model) {
 		anthropicUsage = &anthropic.AnthropicPassthroughStreamUsage{}
 	}
 	return providerUtils.StreamPassthrough(
@@ -3716,8 +3791,13 @@ func (provider *AzureProvider) PassthroughStream(
 }
 
 // buildPassthroughURL constructs the full Azure URL for a passthrough request.
-func (provider *AzureProvider) buildPassthroughURL(key schemas.Key, path, rawQuery string) string {
-	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+// ctx carries the resolved alias used to pick a per-alias api-version override
+// when the caller did not supply one in rawQuery.
+func (provider *AzureProvider) buildPassthroughURL(ctx *schemas.BifrostContext, key schemas.Key, path, rawQuery string) (string, error) {
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return "", fmt.Errorf("endpoint not set")
+	}
 
 	// Normalise paths emitted by the Azure SDK.
 	path = strings.Replace(path, "/openai/responses", "/openai/v1/responses", 1)
@@ -3734,14 +3814,14 @@ func (provider *AzureProvider) buildPassthroughURL(key schemas.Key, path, rawQue
 		// Responses API requires api-version=preview.
 		values, _ := url.ParseQuery(rawQuery)
 		if values.Get("api-version") == "" {
-			values.Set("api-version", AzureAPIVersionPreview)
+			values.Set("api-version", resolveAPIVersion(ctx, AzureAPIVersionPreview))
 			rawQuery = values.Encode()
 		}
 	case strings.Contains(path, "/openai/deployments/"):
 		// Classic /deployments/ routes require api-version. Inject a default if absent.
 		values, _ := url.ParseQuery(rawQuery)
 		if values.Get("api-version") == "" {
-			values.Set("api-version", DefaultAzureAPIVersion)
+			values.Set("api-version", resolveAPIVersion(ctx, DefaultAzureAPIVersion))
 			rawQuery = values.Encode()
 		}
 	}
@@ -3750,7 +3830,7 @@ func (provider *AzureProvider) buildPassthroughURL(key schemas.Key, path, rawQue
 	if rawQuery != "" {
 		fullURL += "?" + rawQuery
 	}
-	return fullURL
+	return fullURL, nil
 }
 
 // extractAzurePassthroughUsage dispatches usage extraction by the upstream API the

--- a/core/providers/azure/azure_passthrough_test.go
+++ b/core/providers/azure/azure_passthrough_test.go
@@ -119,10 +119,153 @@ func TestBuildPassthroughURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := provider.buildPassthroughURL(makeKey(endpoint), tt.path, tt.rawQuery)
+			got, _ := provider.buildPassthroughURL(nil, makeKey(endpoint), tt.path, tt.rawQuery)
 			if got != tt.want {
 				t.Errorf("\ngot:  %s\nwant: %s", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBuildPassthroughURL_AliasAPIVersionOverride verifies that when the
+// resolved alias carries an AzureAliasCfg.APIVersion override, it takes
+// precedence over the route default (DefaultAzureAPIVersion for /deployments/,
+// AzureAPIVersionPreview for /openai/v1/responses) — only in the path where
+// the caller did NOT supply api-version themselves. Caller-supplied wins over
+// alias override; alias override wins over route default.
+func TestBuildPassthroughURL_AliasAPIVersionOverride(t *testing.T) {
+	t.Parallel()
+
+	provider := &AzureProvider{}
+	endpoint := "https://my-resource.openai.azure.com"
+	makeKey := schemas.Key{
+		AzureKeyConfig: &schemas.AzureKeyConfig{
+			Endpoint: *schemas.NewEnvVar(endpoint),
+		},
+	}
+
+	// Build a ctx carrying an alias with APIVersion override.
+	overrideVer := "2024-10-21"
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "best-model",
+		Config: &schemas.AliasConfig{
+			ModelID: "gpt-4o-deployment",
+			AzureAliasCfg: &schemas.AzureAliasCfg{
+				APIVersion: &overrideVer,
+			},
+		},
+	})
+
+	t.Run("deployments route: alias APIVersion overrides default", func(t *testing.T) {
+		got, _ := provider.buildPassthroughURL(ctx, makeKey, "/openai/deployments/gpt-4o/chat/completions", "")
+		want := endpoint + "/openai/deployments/gpt-4o/chat/completions?api-version=" + overrideVer
+		if got != want {
+			t.Errorf("\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("responses route: alias APIVersion overrides preview default", func(t *testing.T) {
+		got, _ := provider.buildPassthroughURL(ctx, makeKey, "/openai/v1/responses", "")
+		want := endpoint + "/openai/v1/responses?api-version=" + overrideVer
+		if got != want {
+			t.Errorf("\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("caller-supplied api-version wins over alias override", func(t *testing.T) {
+		got, _ := provider.buildPassthroughURL(ctx, makeKey, "/openai/deployments/gpt-4o/chat/completions", "api-version=2023-01-01")
+		want := endpoint + "/openai/deployments/gpt-4o/chat/completions?api-version=2023-01-01"
+		if got != want {
+			t.Errorf("\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+}
+
+// TestResolveAPIVersion_NoAlias verifies the helper returns the route default
+// when no resolved alias is in ctx (covers the legacy code path).
+func TestResolveAPIVersion_NoAlias(t *testing.T) {
+	if got := resolveAPIVersion(nil, DefaultAzureAPIVersion); got != DefaultAzureAPIVersion {
+		t.Errorf("got %q, want %q", got, DefaultAzureAPIVersion)
+	}
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	if got := resolveAPIVersion(ctx, AzureAPIVersionPreview); got != AzureAPIVersionPreview {
+		t.Errorf("got %q, want %q", got, AzureAPIVersionPreview)
+	}
+}
+
+// TestResolveAzureEndpoint_AliasOverride verifies the Endpoint override path.
+// Lets one Azure credential cover deployments hosted on multiple cognitive-
+// services resources.
+func TestResolveAzureEndpoint_AliasOverride(t *testing.T) {
+	keyEndpoint := "https://primary.openai.azure.com"
+	aliasEndpoint := "https://anthropic-resource.openai.azure.com"
+	key := schemas.Key{
+		AzureKeyConfig: &schemas.AzureKeyConfig{
+			Endpoint: *schemas.NewEnvVar(keyEndpoint),
+		},
+	}
+
+	// No alias: falls back to key-level endpoint.
+	if got := resolveAzureEndpoint(nil, key); got != keyEndpoint {
+		t.Errorf("nil ctx: got %q, want key-level %q", got, keyEndpoint)
+	}
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	if got := resolveAzureEndpoint(ctx, key); got != keyEndpoint {
+		t.Errorf("empty ctx: got %q, want key-level %q", got, keyEndpoint)
+	}
+
+	// With alias-level Endpoint override, alias wins.
+	override := schemas.NewEnvVar(aliasEndpoint)
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "best-claude",
+		Config: &schemas.AliasConfig{
+			ModelID: "claude-deployment",
+			AzureAliasCfg: &schemas.AzureAliasCfg{
+				Endpoint: override,
+			},
+		},
+	})
+	if got := resolveAzureEndpoint(ctx, key); got != aliasEndpoint {
+		t.Errorf("alias override: got %q, want %q", got, aliasEndpoint)
+	}
+
+	// Alias with empty Endpoint value falls through to key-level — guards against
+	// a misconfigured alias accidentally erasing the endpoint.
+	emptyOverride := schemas.NewEnvVar("")
+	ctx2 := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx2.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "x",
+		Config: &schemas.AliasConfig{
+			ModelID: "x",
+			AzureAliasCfg: &schemas.AzureAliasCfg{
+				Endpoint: emptyOverride,
+			},
+		},
+	})
+	if got := resolveAzureEndpoint(ctx2, key); got != keyEndpoint {
+		t.Errorf("empty alias endpoint should fall through: got %q, want %q", got, keyEndpoint)
+	}
+}
+
+// TestResolveAnthropicVersion_AliasOverride verifies the AnthropicVersion
+// override path mirrors the APIVersion behavior.
+func TestResolveAnthropicVersion_AliasOverride(t *testing.T) {
+	if got := resolveAnthropicVersion(nil); got != AzureAnthropicAPIVersionDefault {
+		t.Errorf("nil ctx: got %q, want default", got)
+	}
+	override := "2024-10-22"
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "best-claude",
+		Config: &schemas.AliasConfig{
+			ModelID: "claude-deployment",
+			AzureAliasCfg: &schemas.AzureAliasCfg{
+				AnthropicVersion: &override,
+			},
+		},
+	})
+	if got := resolveAnthropicVersion(ctx); got != override {
+		t.Errorf("got %q, want %q", got, override)
 	}
 }

--- a/core/providers/azure/utils.go
+++ b/core/providers/azure/utils.go
@@ -37,3 +37,45 @@ func getAzureScopes(configuredScopes []string) []string {
 	}
 	return scopes
 }
+
+// resolveAnthropicVersion returns the anthropic-version header value for the
+// current attempt. Uses the AzureAliasCfg.AnthropicVersion override from the
+// resolved alias when present, otherwise the Azure default.
+func resolveAnthropicVersion(ctx *schemas.BifrostContext) string {
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.AzureAliasCfg != nil && ra.Config.AzureAliasCfg.AnthropicVersion != nil && *ra.Config.AzureAliasCfg.AnthropicVersion != "" {
+		return *ra.Config.AzureAliasCfg.AnthropicVersion
+	}
+	return AzureAnthropicAPIVersionDefault
+}
+
+// resolveAPIVersion returns the Azure api-version query parameter value for
+// the current attempt. Uses the AzureAliasCfg.APIVersion override from the
+// resolved alias when present, otherwise the provided default. Different
+// Azure routes have different defaults (DefaultAzureAPIVersion for classic
+// /openai/deployments/, AzureAPIVersionPreview for /openai/v1/responses);
+// callers pass the route's default so the override can take precedence
+// without losing the route-specific fallback.
+func resolveAPIVersion(ctx *schemas.BifrostContext, defaultVersion string) string {
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.AzureAliasCfg != nil && ra.Config.AzureAliasCfg.APIVersion != nil && *ra.Config.AzureAliasCfg.APIVersion != "" {
+		return *ra.Config.AzureAliasCfg.APIVersion
+	}
+	return defaultVersion
+}
+
+// resolveAzureEndpoint returns the Azure cognitive-services endpoint URL for
+// the current attempt. Uses the AzureAliasCfg.Endpoint override from the
+// resolved alias when present, otherwise the key-level endpoint. Lets one
+// Azure credential (ClientID/Secret/TenantID or API key) span deployments
+// hosted on different Azure resources (e.g. OpenAI on east-us, Anthropic on
+// west-us2).
+func resolveAzureEndpoint(ctx *schemas.BifrostContext, key schemas.Key) string {
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.AzureAliasCfg != nil && ra.Config.AzureAliasCfg.Endpoint != nil {
+		if v := ra.Config.AzureAliasCfg.Endpoint.GetValue(); v != "" {
+			return v
+		}
+	}
+	if key.AzureKeyConfig != nil {
+		return key.AzureKeyConfig.Endpoint.GetValue()
+	}
+	return ""
+}

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/bytedance/sonic"
 )
 
 type KeyStatusType string
@@ -176,7 +178,7 @@ func (mf *ModelFamily) IsValid() bool {
 type AzureAliasCfg struct {
 	APIVersion       *string `json:"api_version,omitempty"`       // overrides the Azure OpenAI api-version query param for this alias
 	AnthropicVersion *string `json:"anthropic_version,omitempty"` // overrides the anthropic-version header for Claude-on-Azure deployments
-	Endpoint         *EnvVar `json:"endpoint,omitempty"`          // overrides AzureKeyConfig.Endpoint for this alias (allows one credential to span multiple Azure resources)
+	Endpoint         *EnvVar `json:"endpoint,omitempty"`          // overrides AzureKeyConfig.Endpoint for this alias — lets one credential span deployments on multiple Azure resources
 }
 
 // VertexAliasCfg holds Vertex-specific overrides that apply to a single alias.
@@ -297,6 +299,83 @@ func (ka KeyAliases) Resolve(model string) string {
 	return model
 }
 
+// ResolvedAlias is what core stashes in BifrostContext after key-level alias
+// resolution. Key is the user-facing model name the client sent (LHS of the
+// alias map). Config is the matched AliasConfig.
+//
+// Carrying the alias key alongside the config lets providers consult it as
+// the lowest-precedence tier for family detection — common case: an admin
+// names their alias "best-claude" but the wire ModelID is an opaque Azure
+// deployment ID, so neither the config fields nor request.Model carry the
+// "claude" substring; the alias key does.
+type ResolvedAlias struct {
+	Key    string
+	Config *AliasConfig
+}
+
+// GetResolvedAlias returns the ResolvedAlias that core stashed in ctx after
+// key-level alias resolution, or nil if no alias matched or ctx is nil.
+//
+// This is set by bifrost.go alongside req.SetModel(resolved). Plugins must
+// not write to this key directly.
+func GetResolvedAlias(ctx *BifrostContext) *ResolvedAlias {
+	if ctx == nil {
+		return nil
+	}
+	v := ctx.Value(BifrostContextKeyResolvedAlias)
+	if v == nil {
+		return nil
+	}
+	ra, _ := v.(*ResolvedAlias)
+	return ra
+}
+
+// ResolveFamily returns the model family for the current attempt, walking
+// the precedence: explicit alias ModelFamily → alias ModelName → alias
+// ModelID → alias Key. When no alias matched, falls back to substring
+// matching against fallbackModel (typically request.Model), preserving
+// pre-refactor behavior.
+//
+// Returns an empty ModelFamily if nothing matches.
+func ResolveFamily(ctx *BifrostContext, fallbackModel string) ModelFamily {
+	ra := GetResolvedAlias(ctx)
+	var candidates []string
+	if ra != nil && ra.Config != nil {
+		if ra.Config.ModelFamily != nil && *ra.Config.ModelFamily != "" {
+			return *ra.Config.ModelFamily
+		}
+		if ra.Config.ModelName != nil {
+			candidates = append(candidates, *ra.Config.ModelName)
+		}
+		candidates = append(candidates, ra.Config.ModelID, ra.Key)
+	} else {
+		candidates = append(candidates, fallbackModel)
+	}
+	for _, s := range candidates {
+		switch {
+		case IsAnthropicModel(s):
+			return ModelFamilyAnthropic
+		case IsMistralModel(s):
+			return ModelFamilyMistral
+		case IsGeminiModel(s):
+			return ModelFamilyGemini
+		case IsNovaModel(s):
+			return ModelFamilyNova
+		}
+	}
+	return ""
+}
+
+// IsAnthropicModelFamily reports whether the current attempt resolves to the
+// Anthropic model family. Thin wrapper over ResolveFamily so provider code
+// reads uniformly at the many call sites that branch on Anthropic vs
+// non-Anthropic (request shape, response parsing, anthropic-version header,
+// URL path construction). model is passed as the substring-match fallback
+// used when no alias is resolved in ctx — typically request.Model.
+func IsAnthropicModelFamily(ctx *BifrostContext, model string) bool {
+	return ResolveFamily(ctx, model) == ModelFamilyAnthropic
+}
+
 // ResolveConfig returns the AliasConfig for the given user-facing model name,
 // or nil if no alias matches. Case-insensitive fallback matches Resolve.
 func (ka KeyAliases) ResolveConfig(model string) *AliasConfig {
@@ -324,7 +403,7 @@ func (ka *KeyAliases) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
+	if err := sonic.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 	result := make(KeyAliases, len(raw))
@@ -337,13 +416,13 @@ func (ka *KeyAliases) UnmarshalJSON(data []byte) error {
 		case '"':
 			// Legacy string value — promote to AliasConfig{ModelID: ...}.
 			var modelID string
-			if err := json.Unmarshal(entry, &modelID); err != nil {
+			if err := sonic.Unmarshal(entry, &modelID); err != nil {
 				return fmt.Errorf("alias %q: %w", k, err)
 			}
 			result[k] = AliasConfig{ModelID: modelID}
 		case '{':
 			var ac AliasConfig
-			if err := json.Unmarshal(entry, &ac); err != nil {
+			if err := sonic.Unmarshal(entry, &ac); err != nil {
 				return fmt.Errorf("alias %q: %w", k, err)
 			}
 			result[k] = ac

--- a/core/schemas/account_test.go
+++ b/core/schemas/account_test.go
@@ -283,6 +283,126 @@ func TestKeyAliasesValidate(t *testing.T) {
 	}
 }
 
+func TestResolveFamilyPrecedence(t *testing.T) {
+	familyOpenAI := ModelFamilyOpenAI
+
+	// Helper to build a BifrostContext carrying a ResolvedAlias.
+	withAlias := func(ra *ResolvedAlias) *BifrostContext {
+		bc := NewBifrostContext(nil, NoDeadline)
+		if ra != nil {
+			bc.SetValue(BifrostContextKeyResolvedAlias, ra)
+		}
+		return bc
+	}
+
+	cases := []struct {
+		name     string
+		ra       *ResolvedAlias
+		fallback string
+		want     ModelFamily
+	}{
+		{
+			name: "tier 1: explicit ModelFamily wins over everything",
+			ra: &ResolvedAlias{
+				Key: "some-claude-name",
+				Config: &AliasConfig{
+					ModelID:     "opaque-id",
+					ModelFamily: &familyOpenAI, // wins despite name/key smelling like Claude
+				},
+			},
+			fallback: "claude-3-5-sonnet",
+			want:     ModelFamilyOpenAI,
+		},
+		{
+			name: "tier 2: ModelName substring when no explicit family",
+			ra: &ResolvedAlias{
+				Key: "best-model",
+				Config: &AliasConfig{
+					ModelID:   "opaque-id",
+					ModelName: Ptr("claude-3-5-sonnet"),
+				},
+			},
+			fallback: "opaque-id",
+			want:     ModelFamilyAnthropic,
+		},
+		{
+			name: "tier 3: ModelID substring when name absent",
+			ra: &ResolvedAlias{
+				Key: "best-model",
+				Config: &AliasConfig{
+					ModelID: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+				},
+			},
+			fallback: "best-model",
+			want:     ModelFamilyAnthropic,
+		},
+		{
+			name: "tier 4: alias key substring when nothing else hits — the legacy 'best-claude→opaque-deployment-id' case the refactor is specifically meant to fix",
+			ra: &ResolvedAlias{
+				Key: "best-claude",
+				Config: &AliasConfig{
+					ModelID: "12345-azure-deployment",
+				},
+			},
+			fallback: "12345-azure-deployment",
+			want:     ModelFamilyAnthropic,
+		},
+		{
+			name:     "no alias matched: fall back to substring on fallbackModel — preserves pre-refactor behavior",
+			ra:       nil,
+			fallback: "claude-3-5-sonnet",
+			want:     ModelFamilyAnthropic,
+		},
+		{
+			name:     "no alias and no substring hit anywhere",
+			ra:       nil,
+			fallback: "totally-unknown-model",
+			want:     "",
+		},
+		{
+			name: "explicit empty ModelFamily pointer is treated as absent (falls through to name)",
+			ra: &ResolvedAlias{
+				Key: "x",
+				Config: &AliasConfig{
+					ModelID:     "opaque-id",
+					ModelName:   Ptr("claude-3-5-sonnet"),
+					ModelFamily: Ptr(ModelFamily("")),
+				},
+			},
+			fallback: "x",
+			want:     ModelFamilyAnthropic,
+		},
+		{
+			name: "first matching candidate wins (ModelName matches Anthropic before ModelID could match anything else)",
+			ra: &ResolvedAlias{
+				Key: "x",
+				Config: &AliasConfig{
+					ModelID:   "mistral-large-2407", // would match Mistral but ModelName is checked first
+					ModelName: Ptr("claude-3-5-sonnet"),
+				},
+			},
+			fallback: "x",
+			want:     ModelFamilyAnthropic,
+		},
+		{
+			name: "uses fallback when ResolvedAlias.Config is nil (defensive)",
+			ra:   &ResolvedAlias{Key: "x", Config: nil},
+			// With Config==nil the candidates list is empty for the alias branch,
+			// so we drop to fallback substring matching.
+			fallback: "claude-3-haiku",
+			want:     ModelFamilyAnthropic,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ResolveFamily(withAlias(c.ra), c.fallback)
+			if got != c.want {
+				t.Fatalf("ResolveFamily: got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
 func TestModelFamilyIsValid(t *testing.T) {
 	valid := []ModelFamily{
 		ModelFamilyAnthropic, ModelFamilyOpenAI, ModelFamilyMistral,

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -228,6 +228,7 @@ const (
 	BifrostContextKeyGovernanceIncludeOnlyKeys           BifrostContextKey = "bf-governance-include-only-keys"        // []string (to store the include-only key IDs for provider config routing (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyNumberOfRetries                     BifrostContextKey = "bifrost-number-of-retries"              // int (to store the number of retries (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"                 // int (to store the fallback index (set by bifrost - DO NOT SET THIS MANUALLY)) 0 for primary, 1 for first fallback, etc.
+	BifrostContextKeyResolvedAlias                       BifrostContextKey = "bifrost-resolved-alias"                 // *ResolvedAlias (set by bifrost after key-level alias resolution — providers read this for model_family routing and provider-specific overrides; nil/absent when no alias matched)
 	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator"           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyStreamIdleTimeout                   BifrostContextKey = "bifrost-stream-idle-timeout"            // time.Duration (per-chunk idle timeout for streaming)
 	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"             // bool (will pass an empty key to the provider)


### PR DESCRIPTION
## Summary

This PR introduces per-alias Azure overrides for endpoint, API version, and Anthropic version, and adds a `ResolvedAlias` context value that providers can read to determine model family routing. Previously, model family detection relied solely on substring matching against the wire model ID, which broke when Azure deployment IDs were opaque strings (e.g., `12345-azure-deployment`) even if the alias key or config clearly indicated the model family (e.g., `best-claude`). This change fixes that by walking a precedence chain — explicit `ModelFamily` field → `ModelName` → `ModelID` → alias key — before falling back to substring matching.

## Changes

- Introduced `ResolvedAlias` struct and `BifrostContextKeyResolvedAlias` context key; `bifrost.go` now stashes the full `AliasConfig` (and the user-facing alias key) into context after each key-level alias resolution, for both streaming and non-streaming paths.
- Added `ResolveFamily`, `IsAnthropicModelFamily`, and `GetResolvedAlias` helpers in `schemas/account.go` that walk the alias precedence chain for model family detection. All Azure provider call sites that previously called `schemas.IsAnthropicModel(model)` now call `schemas.IsAnthropicModelFamily(ctx, model)` or `schemas.ResolveFamily(ctx, model)`.
- Added `AzureAliasCfg` fields (`APIVersion`, `AnthropicVersion`, `Endpoint`) and three resolver helpers (`resolveAzureEndpoint`, `resolveAPIVersion`, `resolveAnthropicVersion`) in `core/providers/azure/utils.go`. All Azure provider methods now use these helpers instead of reading `key.AzureKeyConfig.Endpoint.GetValue()` directly, enabling per-alias endpoint and version overrides.
- `buildPassthroughURL` now returns an error when the endpoint is empty and accepts a `*BifrostContext` to apply alias-level `api-version` overrides on passthrough routes.
- `buildContainerURL` now accepts a `*BifrostContext` for the same reason.
- `KeyAliases.UnmarshalJSON` switched from `encoding/json` to `sonic` for consistency with the rest of the codebase.
- Added `KeyAliases.ResolveConfig` (returns `*AliasConfig`) used by `bifrost.go` to populate `ResolvedAlias`; the existing `Resolve` (returns string) is preserved for backward compatibility.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/... ./core/providers/azure/... ./core/schemas/...
```

Key scenarios to validate:

1. **Opaque Azure deployment alias** — configure an alias like `best-claude → { model_id: "12345-deployment", azure_alias_cfg: {} }` with alias key containing "claude"; verify the request is routed through the Anthropic path (correct URL, `anthropic-version` header set).
2. **Alias-level endpoint override** — configure two aliases pointing to different Azure cognitive-services resources under the same key; verify each request hits the correct endpoint.
3. **Alias-level `api_version` override** — configure an alias with `azure_alias_cfg.api_version: "2024-10-21"`; verify the `api-version` query parameter on `/openai/deployments/` and `/openai/v1/responses` routes uses the override rather than the route default.
4. **Caller-supplied `api-version` wins** — pass `api-version` explicitly in a passthrough `rawQuery`; verify the alias override does not overwrite it.
5. **No alias matched** — verify existing substring-based family detection is unchanged.

## Breaking changes

- [ ] Yes
- [x] No

`buildPassthroughURL` now returns `(string, error)` instead of `string`. This is an internal method on `AzureProvider` and is not part of any exported interface.

## Related issues

## Security considerations

The `ResolvedAlias` value stored in `BifrostContext` is set exclusively by the core request worker and is documented as read-only for plugins. Alias-level endpoint overrides are resolved from `EnvVar` (supporting environment variable indirection), consistent with how key-level endpoints are handled, so secrets are not inlined in config.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable