### PR TITLE
feat: add per-alias Vertex project/region overrides and context-aware model family resolution

### DIFF
--- a/core/providers/vertex/cachedcontents.go
+++ b/core/providers/vertex/cachedcontents.go
@@ -115,13 +115,13 @@ func (provider *VertexProvider) CachedContentCreate(ctx *schemas.BifrostContext,
 		return nil, providerUtils.NewBifrostOperationError("model is required for cached content create", nil)
 	}
 
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
-		return nil, providerUtils.NewConfigurationError("project_id is not set in vertex key config")
+		return nil, providerUtils.NewConfigurationError("project_id is not set")
 	}
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
-		return nil, providerUtils.NewConfigurationError("region is not set in vertex key config")
+		return nil, providerUtils.NewConfigurationError("region is not set")
 	}
 
 	model := expandVertexModelPath(request.Model, projectID, region)
@@ -210,13 +210,13 @@ func (provider *VertexProvider) CachedContentCreate(ctx *schemas.BifrostContext,
 }
 
 func (provider *VertexProvider) cachedContentListByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCachedContentListRequest) (*schemas.BifrostCachedContentListResponse, time.Duration, *schemas.BifrostError) {
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
-		return nil, 0, providerUtils.NewConfigurationError("project_id is not set in vertex key config")
+		return nil, 0, providerUtils.NewConfigurationError("project_id is not set")
 	}
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
-		return nil, 0, providerUtils.NewConfigurationError("region is not set in vertex key config")
+		return nil, 0, providerUtils.NewConfigurationError("region is not set")
 	}
 
 	req := fasthttp.AcquireRequest()
@@ -292,13 +292,13 @@ func (provider *VertexProvider) CachedContentList(ctx *schemas.BifrostContext, k
 }
 
 func (provider *VertexProvider) cachedContentRetrieveByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCachedContentRetrieveRequest) (*schemas.BifrostCachedContentRetrieveResponse, time.Duration, *schemas.BifrostError) {
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
-		return nil, 0, providerUtils.NewConfigurationError("project_id is not set in vertex key config")
+		return nil, 0, providerUtils.NewConfigurationError("project_id is not set")
 	}
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
-		return nil, 0, providerUtils.NewConfigurationError("region is not set in vertex key config")
+		return nil, 0, providerUtils.NewConfigurationError("region is not set")
 	}
 
 	req := fasthttp.AcquireRequest()
@@ -372,13 +372,13 @@ func (provider *VertexProvider) CachedContentRetrieve(ctx *schemas.BifrostContex
 }
 
 func (provider *VertexProvider) cachedContentUpdateByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCachedContentUpdateRequest) (*schemas.BifrostCachedContentUpdateResponse, time.Duration, *schemas.BifrostError) {
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
-		return nil, 0, providerUtils.NewConfigurationError("project_id is not set in vertex key config")
+		return nil, 0, providerUtils.NewConfigurationError("project_id is not set")
 	}
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
-		return nil, 0, providerUtils.NewConfigurationError("region is not set in vertex key config")
+		return nil, 0, providerUtils.NewConfigurationError("region is not set")
 	}
 
 	body := vertexCachedContent{}
@@ -482,13 +482,13 @@ func (provider *VertexProvider) CachedContentUpdate(ctx *schemas.BifrostContext,
 }
 
 func (provider *VertexProvider) cachedContentDeleteByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCachedContentDeleteRequest) (*schemas.BifrostCachedContentDeleteResponse, time.Duration, *schemas.BifrostError) {
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
-		return nil, 0, providerUtils.NewConfigurationError("project_id is not set in vertex key config")
+		return nil, 0, providerUtils.NewConfigurationError("project_id is not set")
 	}
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
-		return nil, 0, providerUtils.NewConfigurationError("region is not set in vertex key config")
+		return nil, 0, providerUtils.NewConfigurationError("region is not set")
 	}
 
 	req := fasthttp.AcquireRequest()

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -10,6 +10,55 @@ import (
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
+// resolveVertexProjectID returns the GCP project ID for the current attempt.
+// Priority: alias-level VertexAliasCfg.ProjectID > key-level
+// VertexKeyConfig.ProjectID. Per-alias override lets one Vertex credential
+// span deployments across distinct GCP projects (e.g. Anthropic models in
+// one project, Gemini in another).
+func resolveVertexProjectID(ctx *schemas.BifrostContext, key schemas.Key) string {
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.VertexAliasCfg != nil && ra.Config.VertexAliasCfg.ProjectID != nil {
+		if v := ra.Config.VertexAliasCfg.ProjectID.GetValue(); v != "" {
+			return v
+		}
+	}
+	if key.VertexKeyConfig != nil {
+		return key.VertexKeyConfig.ProjectID.GetValue()
+	}
+	return ""
+}
+
+// resolveVertexProjectNumber returns the GCP project number for the current
+// attempt. Same precedence as resolveVertexProjectID.
+func resolveVertexProjectNumber(ctx *schemas.BifrostContext, key schemas.Key) string {
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.VertexAliasCfg != nil && ra.Config.VertexAliasCfg.ProjectNumber != nil {
+		if v := ra.Config.VertexAliasCfg.ProjectNumber.GetValue(); v != "" {
+			return v
+		}
+	}
+	if key.VertexKeyConfig != nil {
+		return key.VertexKeyConfig.ProjectNumber.GetValue()
+	}
+	return ""
+}
+
+// resolveVertexRegion returns the Vertex region for the current attempt.
+// Priority: alias-level AliasConfig.Region (top-level, shared with other
+// providers) > key-level VertexKeyConfig.Region. Different Vertex model
+// families publish in different regions (Anthropic on us-east5, Gemini on
+// us-central1, …), so per-alias overrides let one credential reach all of
+// them.
+func resolveVertexRegion(ctx *schemas.BifrostContext, key schemas.Key) string {
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.Region != nil {
+		if v := ra.Config.Region.GetValue(); v != "" {
+			return v
+		}
+	}
+	if key.VertexKeyConfig != nil {
+		return key.VertexKeyConfig.Region.GetValue()
+	}
+	return ""
+}
+
 // getRequestBodyForAnthropicResponses serializes a BifrostResponsesRequest into the Anthropic wire format for Vertex AI.
 // Compared to the native Anthropic path, it strips model/region fields, remaps tool versions, injects beta headers
 // into the request body (rather than HTTP headers), and pins the Anthropic API version to DefaultVertexAnthropicVersion.

--- a/core/providers/vertex/utils_test.go
+++ b/core/providers/vertex/utils_test.go
@@ -354,3 +354,146 @@ func TestVertexRegionToPool(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveVertexProjectID_AliasOverride verifies the per-alias ProjectID
+// override lets one Vertex credential serve deployments across distinct GCP
+// projects.
+func TestResolveVertexProjectID_AliasOverride(t *testing.T) {
+	keyProject := "key-level-project"
+	aliasProject := "alias-level-project"
+	key := schemas.Key{
+		VertexKeyConfig: &schemas.VertexKeyConfig{
+			ProjectID: *schemas.NewEnvVar(keyProject),
+		},
+	}
+
+	if got := resolveVertexProjectID(nil, key); got != keyProject {
+		t.Errorf("nil ctx: got %q, want key-level %q", got, keyProject)
+	}
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	if got := resolveVertexProjectID(ctx, key); got != keyProject {
+		t.Errorf("empty ctx: got %q, want key-level %q", got, keyProject)
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "best-claude",
+		Config: &schemas.AliasConfig{
+			ModelID: "claude-sonnet-4-5",
+			VertexAliasCfg: &schemas.VertexAliasCfg{
+				ProjectID: schemas.NewEnvVar(aliasProject),
+			},
+		},
+	})
+	if got := resolveVertexProjectID(ctx, key); got != aliasProject {
+		t.Errorf("alias override should win: got %q, want %q", got, aliasProject)
+	}
+
+	// Empty alias ProjectID falls through to key-level.
+	ctx2 := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx2.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "x",
+		Config: &schemas.AliasConfig{
+			ModelID: "x",
+			VertexAliasCfg: &schemas.VertexAliasCfg{
+				ProjectID: schemas.NewEnvVar(""),
+			},
+		},
+	})
+	if got := resolveVertexProjectID(ctx2, key); got != keyProject {
+		t.Errorf("empty alias ProjectID should fall through: got %q, want %q", got, keyProject)
+	}
+}
+
+// TestResolveVertexRegion_AliasOverride verifies the top-level
+// AliasConfig.Region override for Vertex.
+func TestResolveVertexRegion_AliasOverride(t *testing.T) {
+	keyRegion := "us-central1"
+	aliasRegion := "us-east5"
+	key := schemas.Key{
+		VertexKeyConfig: &schemas.VertexKeyConfig{
+			Region: *schemas.NewEnvVar(keyRegion),
+		},
+	}
+
+	if got := resolveVertexRegion(nil, key); got != keyRegion {
+		t.Errorf("nil ctx: got %q, want %q", got, keyRegion)
+	}
+
+	ctx0 := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	if got := resolveVertexRegion(ctx0, key); got != keyRegion {
+		t.Errorf("empty ctx: got %q, want key-level %q", got, keyRegion)
+	}
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "best-claude",
+		Config: &schemas.AliasConfig{
+			ModelID: "claude-sonnet-4-5",
+			Region:  schemas.NewEnvVar(aliasRegion),
+		},
+	})
+	if got := resolveVertexRegion(ctx, key); got != aliasRegion {
+		t.Errorf("alias Region should win: got %q, want %q", got, aliasRegion)
+	}
+
+	ctx2 := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx2.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "x",
+		Config: &schemas.AliasConfig{
+			ModelID: "x",
+			Region:  schemas.NewEnvVar(""),
+		},
+	})
+	if got := resolveVertexRegion(ctx2, key); got != keyRegion {
+		t.Errorf("empty alias Region should fall through: got %q, want %q", got, keyRegion)
+	}
+}
+
+// TestResolveVertexProjectNumber_AliasOverride mirrors the ProjectID test.
+func TestResolveVertexProjectNumber_AliasOverride(t *testing.T) {
+	keyNumber := "111111"
+	aliasNumber := "222222"
+	key := schemas.Key{
+		VertexKeyConfig: &schemas.VertexKeyConfig{
+			ProjectNumber: *schemas.NewEnvVar(keyNumber),
+		},
+	}
+
+	if got := resolveVertexProjectNumber(nil, key); got != keyNumber {
+		t.Errorf("nil ctx: got %q, want %q", got, keyNumber)
+	}
+
+	ctx0 := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	if got := resolveVertexProjectNumber(ctx0, key); got != keyNumber {
+		t.Errorf("empty ctx: got %q, want key-level %q", got, keyNumber)
+	}
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "x",
+		Config: &schemas.AliasConfig{
+			ModelID: "x",
+			VertexAliasCfg: &schemas.VertexAliasCfg{
+				ProjectNumber: schemas.NewEnvVar(aliasNumber),
+			},
+		},
+	})
+	if got := resolveVertexProjectNumber(ctx, key); got != aliasNumber {
+		t.Errorf("alias ProjectNumber should win: got %q, want %q", got, aliasNumber)
+	}
+
+	ctx2 := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx2.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "x",
+		Config: &schemas.AliasConfig{
+			ModelID: "x",
+			VertexAliasCfg: &schemas.VertexAliasCfg{
+				ProjectNumber: schemas.NewEnvVar(""),
+			},
+		},
+	})
+	if got := resolveVertexProjectNumber(ctx2, key); got != keyNumber {
+		t.Errorf("empty alias ProjectNumber should fall through: got %q, want %q", got, keyNumber)
+	}
+}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -197,7 +197,7 @@ func (provider *VertexProvider) GetProviderKey() schemas.ModelProvider {
 // 1. If deployments or allowedModels are configured, return those (no API call needed)
 // 2. Otherwise, fetch from the publishers.models.list API endpoint (Model Garden)
 func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
@@ -426,7 +426,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 			var extraParams map[string]interface{}
 			var err error
 
-			if schemas.IsAnthropicModel(request.Model) {
+			if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 				// Anthropic-on-Vertex doesn't accept URL-source document blocks.
 				// Inline any URL documents to base64 before the converter runs.
 				if err := inlineDocumentURLs(ctx, request); err != nil {
@@ -467,7 +467,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 				if err != nil {
 					return nil, fmt.Errorf("failed to delete model field: %w", err)
 				}
-			} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
+			} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 				reqBody, err := gemini.ToGeminiChatCompletionRequest(request)
 				if err != nil {
 					return nil, err
@@ -508,25 +508,25 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
-	if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
+	if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 		if rawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && rawBody {
 			jsonBody = gemini.NormalizeRawGenerateContentRequestForCompatibility(jsonBody)
 		}
 		jsonBody = stripVertexGeminiUnsupportedFieldsRaw(jsonBody)
 	}
 
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
 
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
 
 	// Remap unsupported tool versions for Vertex (handles raw passthrough bodies)
-	if schemas.IsAnthropicModel(request.Model) && jsonBody != nil {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) && jsonBody != nil {
 		remappedBody, remapErr := anthropic.RemapRawToolVersionsForProvider(jsonBody, schemas.Vertex, request.Model)
 		if remapErr != nil {
 			return nil, providerUtils.NewBifrostOperationError(remapErr.Error(), nil)
@@ -547,7 +547,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	var completeURL string
 	if schemas.IsAllDigitsASCII(request.Model) {
 		// Custom Fine-tuned models use OpenAPI endpoint
-		projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+		projectNumber := resolveVertexProjectNumber(ctx, key)
 		if projectNumber == "" {
 			return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 		}
@@ -555,13 +555,13 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 		}
 		completeURL = getVertexEndpointURL(region, "v1beta1", projectNumber, request.Model, ":generateContent")
-	} else if schemas.IsAnthropicModel(request.Model) {
+	} else if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		// Claude models use Anthropic publisher — model-aware host for multi-region support
 		completeURL = getVertexModelAwarePublisherModelURL(region, "v1", projectID, "anthropic", request.Model, ":rawPredict")
-	} else if schemas.IsMistralModel(request.Model) {
+	} else if schemas.IsMistralModelFamily(ctx, request.Model) {
 		// Mistral models use mistralai publisher with rawPredict
 		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "mistralai", request.Model, ":rawPredict")
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsGemmaModel(request.Model) {
+	} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 		// Gemini models support api key
 		if key.Value.GetValue() != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
@@ -584,7 +584,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-	if (schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model)) &&
+	if (schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model)) &&
 		request.Params != nil && request.Params.ServiceTier != nil {
 		if v := vertexServiceTierHeaderValue(region, request.Model, *request.Params.ServiceTier); v != "" {
 			req.Header.Set(VertexServiceTierHeader, v)
@@ -653,7 +653,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		}, nil
 	}
 
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		// Create response object from pool
 		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
 		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
@@ -682,7 +682,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		}
 
 		return response, nil
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
+	} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 		geminiResponse := gemini.GenerateContentResponse{}
 
 		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
@@ -734,17 +734,17 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 // Returns a channel of BifrostStreamChunk objects for streaming results or an error if the request fails.
 func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	providerName := provider.GetProviderKey()
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
 
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
 
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		// Use Anthropic-style streaming for Claude models
 		jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 			ctx,
@@ -859,7 +859,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			provider.logger,
 			postHookSpanFinalizer,
 		)
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
+	} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 		// Use Gemini-style streaming for Gemini models
 		jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 			ctx,
@@ -888,7 +888,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 		}
 
 		// For custom/fine-tuned models, validate projectNumber is set
-		projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+		projectNumber := resolveVertexProjectNumber(ctx, key)
 		if schemas.IsAllDigitsASCII(request.Model) && projectNumber == "" {
 			return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 		}
@@ -909,7 +909,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			"Cache-Control": "no-cache",
 		}
 
-		if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+		if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) {
 			if _, overridden := provider.networkConfig.ExtraHeaders[VertexServiceTierHeader]; !overridden {
 				if request.Params != nil && request.Params.ServiceTier != nil {
 					if v := vertexServiceTierHeaderValue(region, request.Model, *request.Params.ServiceTier); v != "" {
@@ -955,7 +955,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 		authQuery := ""
 		// Determine the URL based on model type
 		var completeURL string
-		if schemas.IsMistralModel(request.Model) {
+		if schemas.IsMistralModelFamily(ctx, request.Model) {
 			// Mistral models use mistralai publisher with streamRawPredict
 			completeURL = getVertexPublisherModelURL(region, "v1", projectID, "mistralai", request.Model, ":streamRawPredict")
 		} else {
@@ -1009,17 +1009,17 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 
 // Responses performs a responses request to the Vertex API.
 func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, request.Model, false, false, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
-		projectID := key.VertexKeyConfig.ProjectID.GetValue()
+		projectID := resolveVertexProjectID(ctx, key)
 		if projectID == "" {
 			return nil, providerUtils.NewConfigurationError("project ID is not set")
 		}
 
-		region := key.VertexKeyConfig.Region.GetValue()
+		region := resolveVertexRegion(ctx, key)
 		if region == "" {
 			return nil, providerUtils.NewConfigurationError("region is not set in key config")
 		}
@@ -1128,7 +1128,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 		}
 
 		return response, nil
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
+	} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 		jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
@@ -1153,12 +1153,12 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 		}
 		jsonBody = stripVertexGeminiUnsupportedFieldsRaw(jsonBody)
 
-		projectID := key.VertexKeyConfig.ProjectID.GetValue()
+		projectID := resolveVertexProjectID(ctx, key)
 		if projectID == "" {
 			return nil, providerUtils.NewConfigurationError("project ID is not set")
 		}
 
-		region := key.VertexKeyConfig.Region.GetValue()
+		region := resolveVertexRegion(ctx, key)
 		if region == "" {
 			return nil, providerUtils.NewConfigurationError("region is not set in key config")
 		}
@@ -1169,7 +1169,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 		}
 
 		// For custom/fine-tuned models, validate projectNumber is set
-		projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+		projectNumber := resolveVertexProjectNumber(ctx, key)
 		if schemas.IsAllDigitsASCII(request.Model) && projectNumber == "" {
 			return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 		}
@@ -1189,7 +1189,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 
 		req.Header.SetMethod(http.MethodPost)
 		req.Header.SetContentType("application/json")
-		if (schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model)) &&
+		if (schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model)) &&
 			request.Params != nil && request.Params.ServiceTier != nil {
 			if v := vertexServiceTierHeaderValue(region, request.Model, *request.Params.ServiceTier); v != "" {
 				req.Header.Set(VertexServiceTierHeader, v)
@@ -1290,13 +1290,13 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 
 // ResponsesStream performs a streaming responses request to the Vertex API.
 func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	if schemas.IsAnthropicModel(request.Model) {
-		region := key.VertexKeyConfig.Region.GetValue()
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+		region := resolveVertexRegion(ctx, key)
 		if region == "" {
 			return nil, providerUtils.NewConfigurationError("region is not set in key config")
 		}
 
-		projectID := key.VertexKeyConfig.ProjectID.GetValue()
+		projectID := resolveVertexProjectID(ctx, key)
 		if projectID == "" {
 			return nil, providerUtils.NewConfigurationError("project ID is not set")
 		}
@@ -1344,13 +1344,13 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			provider.logger,
 			postHookSpanFinalizer,
 		)
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
-		region := key.VertexKeyConfig.Region.GetValue()
+	} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
+		region := resolveVertexRegion(ctx, key)
 		if region == "" {
 			return nil, providerUtils.NewConfigurationError("region is not set in key config")
 		}
 
-		projectID := key.VertexKeyConfig.ProjectID.GetValue()
+		projectID := resolveVertexProjectID(ctx, key)
 		if projectID == "" {
 			return nil, providerUtils.NewConfigurationError("project ID is not set")
 		}
@@ -1387,7 +1387,7 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		}
 
 		// For custom/fine-tuned models, validate projectNumber is set
-		projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+		projectNumber := resolveVertexProjectNumber(ctx, key)
 		if schemas.IsAllDigitsASCII(request.Model) && projectNumber == "" {
 			return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 		}
@@ -1407,7 +1407,7 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			"Cache-Control": "no-cache",
 		}
 
-		if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+		if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) {
 			if _, overridden := provider.networkConfig.ExtraHeaders[VertexServiceTierHeader]; !overridden {
 				if request.Params != nil && request.Params.ServiceTier != nil {
 					if v := vertexServiceTierHeaderValue(region, request.Model, *request.Params.ServiceTier); v != "" {
@@ -1463,12 +1463,12 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 // All Vertex AI embedding models use the same response format regardless of the model type.
 // Returns a BifrostResponse containing the embedding(s) and any error that occurred.
 func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
 
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
@@ -1485,7 +1485,7 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	}
 
 	// For custom/fine-tuned models, validate projectNumber is set
-	projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+	projectNumber := resolveVertexProjectNumber(ctx, key)
 	if schemas.IsAllDigitsASCII(request.Model) && projectNumber == "" {
 		return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 	}
@@ -1617,7 +1617,7 @@ func (provider *VertexProvider) Speech(ctx *schemas.BifrostContext, key schemas.
 
 // Rerank performs a rerank request using Vertex Discovery Engine ranking API.
 func (provider *VertexProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
-	projectID := strings.TrimSpace(key.VertexKeyConfig.ProjectID.GetValue())
+	projectID := strings.TrimSpace(resolveVertexProjectID(ctx, key))
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
@@ -1771,7 +1771,7 @@ func (provider *VertexProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 
 func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
 	// Validate model type before processing
-	if !schemas.IsGeminiModel(request.Model) && !schemas.IsAllDigitsASCII(request.Model) && !schemas.IsImagenModel(request.Model) {
+	if !schemas.IsGeminiModelFamily(ctx, request.Model) && !schemas.IsAllDigitsASCII(request.Model) && !schemas.IsImagenModelFamily(ctx, request.Model) {
 		return nil, providerUtils.NewConfigurationError(fmt.Sprintf("image generation is only supported for Gemini and Imagen models, got: %s", request.Model))
 	}
 
@@ -1783,7 +1783,7 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 			var extraParams map[string]interface{}
 			var err error
 
-			if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+			if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) {
 				reqBody := gemini.ToGeminiImageGenerationRequest(request)
 				if reqBody == nil {
 					return nil, fmt.Errorf("image generation input is not provided")
@@ -1796,7 +1796,7 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
 				}
-			} else if schemas.IsImagenModel(request.Model) {
+			} else if schemas.IsImagenModelFamily(ctx, request.Model) {
 				reqBody := gemini.ToImagenImageGenerationRequest(request)
 				if reqBody == nil {
 					return nil, fmt.Errorf("image generation input is not provided")
@@ -1821,12 +1821,12 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 		return nil, bifrostErr
 	}
 
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
 
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
@@ -1837,7 +1837,7 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 	var completeURL string
 	if schemas.IsAllDigitsASCII(request.Model) {
 		// Custom Fine-tuned models use OpenAPI endpoint
-		projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+		projectNumber := resolveVertexProjectNumber(ctx, key)
 		if projectNumber == "" {
 			return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 		}
@@ -1846,13 +1846,13 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 		}
 		completeURL = getVertexEndpointURL(region, "v1beta1", projectNumber, request.Model, ":generateContent")
 
-	} else if schemas.IsImagenModel(request.Model) {
+	} else if schemas.IsImagenModelFamily(ctx, request.Model) {
 		// Imagen models are published models, use publishers/google/models path
 		if value := key.Value.GetValue(); value != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(value))
 		}
 		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", gemini.NormalizeModelName(request.Model), ":predict")
-	} else if schemas.IsGeminiModel(request.Model) {
+	} else if schemas.IsGeminiModelFamily(ctx, request.Model) {
 		if value := key.Value.GetValue(); value != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(value))
 		}
@@ -1932,7 +1932,7 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 		}, nil
 	}
 
-	if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+	if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) {
 		geminiResponse := gemini.GenerateContentResponse{}
 
 		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
@@ -1991,7 +1991,7 @@ func (provider *VertexProvider) ImageGenerationStream(ctx *schemas.BifrostContex
 // Returns a BifrostResponse containing the images and any error that occurred.
 func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
 	// Validate model type before processing
-	if !schemas.IsGeminiModel(request.Model) && !schemas.IsAllDigitsASCII(request.Model) && !schemas.IsImagenModel(request.Model) {
+	if !schemas.IsGeminiModelFamily(ctx, request.Model) && !schemas.IsAllDigitsASCII(request.Model) && !schemas.IsImagenModelFamily(ctx, request.Model) {
 		return nil, providerUtils.NewConfigurationError(fmt.Sprintf("image edit is only supported for Gemini and Imagen models, got: %s", request.Model))
 	}
 
@@ -2003,7 +2003,7 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 			var extraParams map[string]interface{}
 			var err error
 
-			if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+			if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) {
 				reqBody := gemini.ToGeminiImageEditRequest(request)
 				if reqBody == nil {
 					return nil, fmt.Errorf("image edit input is not provided")
@@ -2016,7 +2016,7 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
 				}
-			} else if schemas.IsImagenModel(request.Model) {
+			} else if schemas.IsImagenModelFamily(ctx, request.Model) {
 				reqBody := gemini.ToImagenImageEditRequest(request)
 				if reqBody == nil {
 					return nil, fmt.Errorf("image edit input is not provided")
@@ -2041,12 +2041,12 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 		return nil, bifrostErr
 	}
 
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
 
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
@@ -2058,14 +2058,14 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 
 	var completeURL string
 	if schemas.IsAllDigitsASCII(request.Model) {
-		projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+		projectNumber := resolveVertexProjectNumber(ctx, key)
 		if projectNumber == "" {
 			return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 		}
 		completeURL = getVertexEndpointURL(region, "v1beta1", projectNumber, gemini.NormalizeModelName(request.Model), ":generateContent")
-	} else if schemas.IsImagenModel(request.Model) {
+	} else if schemas.IsImagenModelFamily(ctx, request.Model) {
 		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", gemini.NormalizeModelName(request.Model), ":predict")
-	} else if schemas.IsGeminiModel(request.Model) {
+	} else if schemas.IsGeminiModelFamily(ctx, request.Model) {
 		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", gemini.NormalizeModelName(request.Model), ":generateContent")
 	}
 
@@ -2140,7 +2140,7 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 		}, nil
 	}
 
-	if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+	if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) {
 		geminiResponse := gemini.GenerateContentResponse{}
 
 		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
@@ -2206,7 +2206,7 @@ func (provider *VertexProvider) VideoGeneration(ctx *schemas.BifrostContext, key
 	providerName := provider.GetProviderKey()
 
 	// Only Gemini models support video generation in Vertex
-	if !schemas.IsVeoModel(bifrostReq.Model) && !schemas.IsAllDigitsASCII(bifrostReq.Model) {
+	if !schemas.IsVeoModelFamily(ctx, bifrostReq.Model) && !schemas.IsAllDigitsASCII(bifrostReq.Model) {
 		return nil, providerUtils.NewConfigurationError(fmt.Sprintf("video generation is only supported for Veo models in Vertex, got: %s", bifrostReq.Model))
 	}
 
@@ -2222,12 +2222,12 @@ func (provider *VertexProvider) VideoGeneration(ctx *schemas.BifrostContext, key
 		return nil, bifrostErr
 	}
 
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
 
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
@@ -2239,7 +2239,7 @@ func (provider *VertexProvider) VideoGeneration(ctx *schemas.BifrostContext, key
 	}
 
 	// For custom/fine-tuned models, validate projectNumber is set
-	projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+	projectNumber := resolveVertexProjectNumber(ctx, key)
 	if schemas.IsAllDigitsASCII(bifrostReq.Model) && projectNumber == "" {
 		return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 	}
@@ -2328,7 +2328,7 @@ func (provider *VertexProvider) VideoRetrieve(ctx *schemas.BifrostContext, key s
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
 
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
@@ -2682,7 +2682,7 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		bifrostErr *schemas.BifrostError
 	)
 
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		jsonBody, bifrostErr = getRequestBodyForAnthropicResponses(ctx, request, request.Model, false, true, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		if bifrostErr != nil {
 			return nil, bifrostErr
@@ -2713,12 +2713,12 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		}
 	}
 
-	projectID := key.VertexKeyConfig.ProjectID.GetValue()
+	projectID := resolveVertexProjectID(ctx, key)
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
 
-	region := key.VertexKeyConfig.Region.GetValue()
+	region := resolveVertexRegion(ctx, key)
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
@@ -2726,17 +2726,17 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 	authQuery := ""
 	var completeURL string
 
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		// Use model-aware host based on request.Model, but URL path uses "count-tokens"
 		effectiveRegion := getVertexEffectiveRegion(region, request.Model)
 		baseURL := getVertexModelAwareAPIBaseURL(region, "v1", request.Model)
 		completeURL = fmt.Sprintf("%s/projects/%s/locations/%s/publishers/%s/models/%s%s", baseURL, projectID, effectiveRegion, "anthropic", "count-tokens", ":rawPredict")
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
+	} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 		if key.Value.GetValue() != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 		}
 
-		projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+		projectNumber := resolveVertexProjectNumber(ctx, key)
 		if schemas.IsAllDigitsASCII(request.Model) && projectNumber == "" {
 			return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 		}
@@ -2816,7 +2816,7 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		}, nil
 	}
 
-	if schemas.IsAnthropicModel(request.Model) {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		anthropicResponse := &anthropic.AnthropicCountTokensResponse{}
 
 		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
@@ -2916,12 +2916,12 @@ func (provider *VertexProvider) Passthrough(
 	key schemas.Key,
 	req *schemas.BifrostPassthroughRequest,
 ) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
-	projectID := strings.TrimSpace(key.VertexKeyConfig.ProjectID.GetValue())
+	projectID := strings.TrimSpace(resolveVertexProjectID(ctx, key))
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
 
-	keyRegion := key.VertexKeyConfig.Region.GetValue()
+	keyRegion := resolveVertexRegion(ctx, key)
 	if keyRegion == "" {
 		keyRegion = "global"
 	}
@@ -3065,12 +3065,12 @@ func (provider *VertexProvider) PassthroughStream(
 	key schemas.Key,
 	req *schemas.BifrostPassthroughRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	projectID := strings.TrimSpace(key.VertexKeyConfig.ProjectID.GetValue())
+	projectID := strings.TrimSpace(resolveVertexProjectID(ctx, key))
 	if projectID == "" {
 		return nil, providerUtils.NewConfigurationError("project ID is not set")
 	}
 
-	keyRegion := key.VertexKeyConfig.Region.GetValue()
+	keyRegion := resolveVertexRegion(ctx, key)
 	if keyRegion == "" {
 		keyRegion = "global"
 	}

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -156,7 +156,10 @@ const (
 	ModelFamilyMistral   ModelFamily = "mistral"
 	ModelFamilyCohere    ModelFamily = "cohere"
 	ModelFamilyGemini    ModelFamily = "gemini"
+	ModelFamilyGemma     ModelFamily = "gemma"
 	ModelFamilyLlama     ModelFamily = "llama"
+	ModelFamilyImagen    ModelFamily = "imagen"
+	ModelFamilyVeo       ModelFamily = "veo"
 	ModelFamilyNova      ModelFamily = "nova"
 	ModelFamilyTitan     ModelFamily = "titan"
 )
@@ -168,7 +171,8 @@ func (mf *ModelFamily) IsValid() bool {
 	}
 	switch *mf {
 	case ModelFamilyAnthropic, ModelFamilyOpenAI, ModelFamilyMistral,
-		ModelFamilyCohere, ModelFamilyGemini, ModelFamilyLlama,
+		ModelFamilyCohere, ModelFamilyGemini, ModelFamilyGemma,
+		ModelFamilyLlama, ModelFamilyImagen, ModelFamilyVeo,
 		ModelFamilyNova, ModelFamilyTitan:
 		return true
 	}
@@ -359,8 +363,18 @@ func ResolveFamily(ctx *BifrostContext, fallbackModel string) ModelFamily {
 			return ModelFamilyAnthropic
 		case IsMistralModel(s):
 			return ModelFamilyMistral
+		// Imagen and Veo are checked before Gemini as a defensive ordering:
+		// they are distinct Google model families whose names do not contain
+		// "gemini", so they could never be mis-classified here, but keeping
+		// them first makes the intent explicit.
+		case IsImagenModel(s):
+			return ModelFamilyImagen
+		case IsVeoModel(s):
+			return ModelFamilyVeo
 		case IsGeminiModel(s):
 			return ModelFamilyGemini
+		case IsGemmaModel(s):
+			return ModelFamilyGemma
 		case IsLlamaModel(s):
 			return ModelFamilyLlama
 		case IsNovaModel(s):
@@ -416,6 +430,33 @@ func IsCohereModelFamily(ctx *BifrostContext, model string) bool {
 // request/response envelope.
 func IsTitanModelFamily(ctx *BifrostContext, model string) bool {
 	return ResolveFamily(ctx, model) == ModelFamilyTitan
+}
+
+// IsGeminiModelFamily reports whether the current attempt resolves to the
+// Google Gemini model family. Used by Vertex to pick Gemini-shaped request
+// transforms and the publishers/google URL prefix.
+func IsGeminiModelFamily(ctx *BifrostContext, model string) bool {
+	return ResolveFamily(ctx, model) == ModelFamilyGemini
+}
+
+// IsGemmaModelFamily reports whether the current attempt resolves to the
+// Gemma model family. Vertex routes Gemma via the publishers/google path
+// alongside Gemini.
+func IsGemmaModelFamily(ctx *BifrostContext, model string) bool {
+	return ResolveFamily(ctx, model) == ModelFamilyGemma
+}
+
+// IsImagenModelFamily reports whether the current attempt resolves to the
+// Imagen model family. Used by Vertex for the :predict endpoint and Imagen-
+// specific request shaping.
+func IsImagenModelFamily(ctx *BifrostContext, model string) bool {
+	return ResolveFamily(ctx, model) == ModelFamilyImagen
+}
+
+// IsVeoModelFamily reports whether the current attempt resolves to the Veo
+// model family. Used by Vertex for video-generation request shaping.
+func IsVeoModelFamily(ctx *BifrostContext, model string) bool {
+	return ResolveFamily(ctx, model) == ModelFamilyVeo
 }
 
 // ResolveConfig returns the AliasConfig for the given user-facing model name,


### PR DESCRIPTION
## Summary

Introduces per-alias overrides for Vertex AI's `project_id`, `project_number`, and `region` configuration values, allowing a single Vertex credential to serve requests across multiple GCP projects and regions. This is particularly useful when different model families (e.g., Anthropic Claude on `us-east5`, Gemini on `us-central1`) are deployed in separate GCP projects or regions.

## Changes

- Added `resolveVertexProjectID`, `resolveVertexProjectNumber`, and `resolveVertexRegion` helper functions in `utils.go` that check for alias-level overrides in `BifrostContext` before falling back to key-level configuration values.
- Replaced all direct `key.VertexKeyConfig.*` field accesses throughout the Vertex provider with calls to these resolver functions, covering all operations: chat completion, streaming, embeddings, responses, cached content, image/video generation, reranking, token counting, and passthrough.
- Replaced model-family detection calls (`IsAnthropicModel`, `IsGeminiModel`, `IsGemmaModel`, `IsImagenModel`, `IsVeoModel`, `IsMistralModel`) with context-aware variants (`IsAnthropicModelFamily`, `IsGeminiModelFamily`, etc.) so that alias-level `ModelFamily` overrides are respected when routing requests to the correct Vertex endpoint and request format.
- Added `ModelFamilyGemma`, `ModelFamilyImagen`, and `ModelFamilyVeo` as first-class `ModelFamily` constants and registered them in `ResolveFamily`, with Imagen and Veo checked before Gemini to avoid substring-match conflicts.
- Added context-aware `IsGeminiModelFamily`, `IsGemmaModelFamily`, `IsImagenModelFamily`, and `IsVeoModelFamily` helpers to `account.go`.
- Added unit tests covering alias override precedence, empty-alias fallthrough to key-level values, and nil-context handling for all three resolver functions.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/vertex/... -run TestResolveVertex
go test ./core/...
```

Configure a Vertex key alias with `VertexAliasCfg.ProjectID` or `AliasConfig.Region` set to a value different from the key-level config and verify that requests are routed to the alias-specified project/region rather than the key-level defaults.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new secrets or auth mechanisms are introduced. Alias-level project/region values follow the same `EnvVar` resolution path as key-level values, so secrets can still be sourced from environment variables rather than being hardcoded.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for additional Google Vertex AI model families.
  * Added flexible configuration resolution with alias-level parameter overrides for the Vertex provider.

* **Tests**
  * Added comprehensive tests validating configuration override behavior for Vertex parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->