### PR TITLE
feat: replace flat aliases table with rich `DeploymentsTable` supporting per-deployment model family, canonical name, and provider overrides

### DIFF
--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -1,6 +1,5 @@
 import { EnvVarInput } from "@/components/ui/envVarInput";
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { HeadersTable, type CellRenderParams } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
 import { Separator } from "@/components/ui/separator";
@@ -12,35 +11,10 @@ import { isRedacted } from "@/lib/utils/validation";
 import { Info } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Control, UseFormReturn } from "react-hook-form";
+import { DeploymentsTable } from "./deploymentsTable";
 
 // Providers that support batch APIs
 const BATCH_SUPPORTED_PROVIDERS = ["openai", "bedrock", "anthropic", "gemini", "azure"];
-
-/** Normalize form value (object or legacy JSON string) for the alias map editor. */
-function normalizeAliasesValue(v: Record<string, string> | string | undefined | null): Record<string, string> {
-	if (v == null) {
-		return {};
-	}
-	if (typeof v === "string") {
-		const t = v.trim();
-		if (!t) {
-			return {};
-		}
-		try {
-			const p = JSON.parse(t) as unknown;
-			if (typeof p === "object" && p !== null && !Array.isArray(p)) {
-				return Object.fromEntries(Object.entries(p as Record<string, unknown>).map(([k, val]) => [k, String(val ?? "")]));
-			}
-		} catch {
-			return {};
-		}
-		return {};
-	}
-	if (typeof v === "object" && !Array.isArray(v)) {
-		return Object.fromEntries(Object.entries(v).map(([k, val]) => [k, typeof val === "string" ? val : String(val ?? "")]));
-	}
-	return {};
-}
 
 interface Props {
 	control: Control<any>;
@@ -346,34 +320,22 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 						control={control}
 						name={`key.aliases`}
 						render={({ field }) => (
-							<FormItem data-testid="apikey-aliases-field">
-								<FormLabel>Aliases (Optional)</FormLabel>
+							<FormItem data-testid="apikey-deployments-field">
+								<FormLabel>Deployments (Optional)</FormLabel>
 								<FormDescription>
-									Map each request model name to the provider&apos;s identifier (deployment name, inference profile ID, fine-tuned endpoint
-									ID, etc.) or just a custom name, e.g. &quot;claude-sonnet-4-5&quot; -&gt; &quot;custom-claude-4.5-sonnet&quot;.
+									Map a request model name to the provider&apos;s identifier (deployment name, inference profile ID, fine-tuned endpoint
+									ID, etc.). Expand a row to set the canonical model name, model family, and provider-specific overrides — these power
+									cost/pricing logs and family-based routing.
 								</FormDescription>
 								<FormControl>
-									<div data-testid="apikey-aliases-table">
-										<HeadersTable
-											label=""
-											value={normalizeAliasesValue(field.value)}
+									<div data-testid="apikey-deployments-table">
+										<DeploymentsTable
+											providerName={providerName}
+											value={field.value}
 											onChange={(next) => {
 												form.clearErrors("key.aliases");
 												field.onChange(Object.keys(next).length > 0 ? next : {});
 											}}
-											keyPlaceholder="Request model name"
-											valuePlaceholder="Deployment / profile / resource ID"
-											renderValueInput={({ value: cellValue, onChange, placeholder, disabled }: CellRenderParams) => (
-												<ModelMultiselect
-													isSingleSelect
-													provider={providerName}
-													value={cellValue}
-													onChange={onChange}
-													placeholder={placeholder ?? "Deployment / profile / resource ID"}
-													disabled={disabled}
-													unfiltered={true}
-												/>
-											)}
 										/>
 									</div>
 								</FormControl>

--- a/ui/app/workspace/providers/fragments/deploymentsTable.tsx
+++ b/ui/app/workspace/providers/fragments/deploymentsTable.tsx
@@ -1,0 +1,584 @@
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { EnvVarInput } from "@/components/ui/envVarInput";
+import { Input } from "@/components/ui/input";
+import { ModelMultiselect } from "@/components/ui/modelMultiselect";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { AliasConfig, ModelFamily, ModelFamilyValues } from "@/lib/types/config";
+import { EnvVar } from "@/lib/types/schemas";
+import { cn } from "@/lib/utils";
+import { ChevronDown, ChevronRight, Trash } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+
+type DeploymentsValue = Record<string, AliasConfig> | undefined | null;
+
+interface Props {
+	value: DeploymentsValue;
+	onChange: (next: Record<string, AliasConfig>) => void;
+	providerName: string;
+	disabled?: boolean;
+}
+
+interface Row {
+	name: string;
+	config: AliasConfig;
+}
+
+// Normalize legacy shapes (Record<string, string> from older configs or stringified JSON)
+// into the rich Record<string, AliasConfig> the component operates on.
+function normalize(value: DeploymentsValue): Record<string, AliasConfig> {
+	if (value == null) {
+		return {};
+	}
+	if (typeof value === "string") {
+		try {
+			const parsed = JSON.parse(value);
+			return normalize(parsed);
+		} catch {
+			return {};
+		}
+	}
+	if (typeof value !== "object" || Array.isArray(value)) {
+		return {};
+	}
+	const out: Record<string, AliasConfig> = {};
+	for (const [k, v] of Object.entries(value)) {
+		if (typeof v === "string") {
+			out[k] = { model_id: v };
+		} else if (v && typeof v === "object") {
+			const cfg = v as Partial<AliasConfig>;
+			out[k] = { ...cfg, model_id: typeof cfg.model_id === "string" ? cfg.model_id : "" };
+		}
+	}
+	return out;
+}
+
+const emptyEnvVar: EnvVar = { value: "", env_var: "", from_env: false };
+const isEmptyEnvVar = (v: EnvVar | undefined): boolean => !v || (!v.value && !v.env_var);
+
+function FieldRow({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+	return (
+		<div className="space-y-1.5">
+			<label className="text-sm font-medium">{label}</label>
+			{children}
+			{hint && <p className="text-muted-foreground text-xs">{hint}</p>}
+		</div>
+	);
+}
+
+function SectionHeader({ title, description }: { title: string; description?: string }) {
+	return (
+		<div className="border-b pb-2">
+			<h4 className="text-sm font-semibold">{title}</h4>
+			{description && <p className="text-muted-foreground mt-0.5 text-xs">{description}</p>}
+		</div>
+	);
+}
+
+function EnvVarField({
+	value,
+	onChange,
+	placeholder,
+	disabled,
+}: {
+	value: EnvVar | undefined;
+	onChange: (next: EnvVar | undefined) => void;
+	placeholder?: string;
+	disabled?: boolean;
+}) {
+	return (
+		<EnvVarInput
+			value={value ?? emptyEnvVar}
+			onChange={(next) => onChange(isEmptyEnvVar(next) ? undefined : next)}
+			placeholder={placeholder}
+			disabled={disabled}
+		/>
+	);
+}
+
+function StringField({
+	value,
+	onChange,
+	placeholder,
+	disabled,
+}: {
+	value: string | undefined;
+	onChange: (next: string | undefined) => void;
+	placeholder?: string;
+	disabled?: boolean;
+}) {
+	return (
+		<Input
+			value={value ?? ""}
+			onChange={(e) => onChange(e.target.value === "" ? undefined : e.target.value)}
+			placeholder={placeholder}
+			disabled={disabled}
+		/>
+	);
+}
+
+interface ProviderSectionProps {
+	config: AliasConfig;
+	onChange: (patch: Partial<AliasConfig>) => void;
+	disabled?: boolean;
+}
+
+function AzureSection({ config, onChange, disabled }: ProviderSectionProps) {
+	return (
+		<div className="space-y-4">
+			<SectionHeader
+				title="Azure overrides"
+				description="Override key-level Azure defaults for this deployment. Leave blank to use the key's settings."
+			/>
+			<FieldRow label="API version" hint="Override the Azure OpenAI api-version query parameter.">
+				<StringField
+					value={config.api_version}
+					onChange={(v) => onChange({ api_version: v })}
+					placeholder="2024-10-21"
+					disabled={disabled}
+				/>
+			</FieldRow>
+			<FieldRow label="Anthropic version" hint="Override the anthropic-version header for Claude-on-Azure deployments.">
+				<StringField
+					value={config.anthropic_version}
+					onChange={(v) => onChange({ anthropic_version: v })}
+					placeholder="2023-06-01"
+					disabled={disabled}
+				/>
+			</FieldRow>
+			<FieldRow label="Endpoint" hint="Point this deployment at a different Azure resource than the key default.">
+				<EnvVarField
+					value={config.endpoint}
+					onChange={(v) => onChange({ endpoint: v })}
+					placeholder="https://your-resource.openai.azure.com or env.AZURE_ENDPOINT"
+					disabled={disabled}
+				/>
+			</FieldRow>
+		</div>
+	);
+}
+
+function VertexSection({ config, onChange, disabled }: ProviderSectionProps) {
+	return (
+		<div className="space-y-4">
+			<SectionHeader
+				title="Vertex overrides"
+				description="Override key-level Vertex defaults for this deployment. Leave blank to use the key's settings."
+			/>
+			<FieldRow label="Project ID">
+				<EnvVarField
+					value={config.project_id}
+					onChange={(v) => onChange({ project_id: v })}
+					placeholder="gcp-project-id or env.VERTEX_PROJECT_ID"
+					disabled={disabled}
+				/>
+			</FieldRow>
+			<FieldRow label="Project number" hint="Required for fine-tuned models.">
+				<EnvVarField
+					value={config.project_number}
+					onChange={(v) => onChange({ project_number: v })}
+					placeholder="123456789 or env.VERTEX_PROJECT_NUMBER"
+					disabled={disabled}
+				/>
+			</FieldRow>
+			<FieldRow label="Region">
+				<EnvVarField
+					value={config.region}
+					onChange={(v) => onChange({ region: v })}
+					placeholder="us-central1 or env.VERTEX_REGION"
+					disabled={disabled}
+				/>
+			</FieldRow>
+		</div>
+	);
+}
+
+function BedrockSection({ config, onChange, disabled }: ProviderSectionProps) {
+	return (
+		<div className="space-y-4">
+			<SectionHeader
+				title="Bedrock overrides"
+				description="Override key-level Bedrock defaults for this deployment. Leave blank to use the key's settings."
+			/>
+			<FieldRow label="Region">
+				<EnvVarField
+					value={config.region}
+					onChange={(v) => onChange({ region: v })}
+					placeholder="us-east-1 or env.BEDROCK_REGION"
+					disabled={disabled}
+				/>
+			</FieldRow>
+			<FieldRow label="Inference profile ARN" hint="Cross-region inference profile ARN to invoke instead of the model ID.">
+				<EnvVarField
+					value={config.inference_profile_arn}
+					onChange={(v) => onChange({ inference_profile_arn: v })}
+					placeholder="arn:aws:bedrock:us-east-1:123:inference-profile/... or env.BEDROCK_PROFILE_ARN"
+					disabled={disabled}
+				/>
+			</FieldRow>
+		</div>
+	);
+}
+
+function ReplicateSection({ config, onChange, disabled }: ProviderSectionProps) {
+	return (
+		<div className="space-y-4">
+			<SectionHeader
+				title="Replicate overrides"
+				description="Override key-level Replicate defaults for this deployment."
+			/>
+			<div className="flex items-start justify-between gap-4 rounded-md border p-3">
+				<div className="space-y-0.5">
+					<label className="text-sm font-medium">Use deployments endpoint</label>
+					<p className="text-muted-foreground text-xs">
+						Route through Replicate&apos;s deployments endpoint instead of the models endpoint.
+					</p>
+				</div>
+				<Switch
+					checked={config.use_deployments_endpoint ?? false}
+					onCheckedChange={(checked) => onChange({ use_deployments_endpoint: checked ? true : undefined })}
+					disabled={disabled}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function ProviderSection({ providerName, ...props }: ProviderSectionProps & { providerName: string }) {
+	switch (providerName) {
+		case "azure":
+			return <AzureSection {...props} />;
+		case "vertex":
+			return <VertexSection {...props} />;
+		case "bedrock":
+			return <BedrockSection {...props} />;
+		case "replicate":
+			return <ReplicateSection {...props} />;
+		default:
+			return null;
+	}
+}
+
+function ExpandedConfigPanel({
+	config,
+	onChange,
+	providerName,
+	disabled,
+}: {
+	config: AliasConfig;
+	onChange: (patch: Partial<AliasConfig>) => void;
+	providerName: string;
+	disabled?: boolean;
+}) {
+	return (
+		<div className="space-y-6 border-t p-4">
+			<div className="space-y-4">
+				<FieldRow
+					label="Canonical model name"
+					hint="The canonical name used for routing and pricing. Defaults to the model ID when blank."
+				>
+					<StringField
+						value={config.model_name}
+						onChange={(v) => onChange({ model_name: v })}
+						placeholder="e.g. claude-sonnet-4-5"
+						disabled={disabled}
+					/>
+				</FieldRow>
+				<FieldRow label="Model family" hint="Forces the family used for routing decisions. Derived from model name when left blank.">
+					<Select
+						value={config.model_family ?? "__none__"}
+						onValueChange={(v) => onChange({ model_family: v === "__none__" ? undefined : (v as ModelFamily) })}
+						disabled={disabled}
+					>
+						<SelectTrigger className="w-full">
+							<SelectValue placeholder="Select a model family" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="__none__">None</SelectItem>
+							{ModelFamilyValues.map((f) => (
+								<SelectItem key={f} value={f}>
+									{f}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</FieldRow>
+				<FieldRow label="Description" hint="Note for users. Not used by Bifrost.">
+					<Textarea
+						value={config.description ?? ""}
+						onChange={(e) => {
+							const v = e.target.value;
+							onChange({ description: v === "" ? undefined : v });
+						}}
+						placeholder="What is this deployment used for?"
+						rows={2}
+						disabled={disabled}
+					/>
+				</FieldRow>
+			</div>
+			<ProviderSection providerName={providerName} config={config} onChange={onChange} disabled={disabled} />
+		</div>
+	);
+}
+
+export function DeploymentsTable({ value, onChange, providerName, disabled = false }: Props) {
+	const normalized = useMemo(() => normalize(value), [value]);
+	const rows: Row[] = useMemo(() => Object.entries(normalized).map(([name, config]) => ({ name, config })), [normalized]);
+
+	// Stable per-row id keyed by current deployment name. Survives rename so
+	// expanded/pendingNames state stays attached to the same row, and gives
+	// React a stable list key instead of array index.
+	const rowIdsRef = useRef<Map<string, string>>(new Map());
+	const ensureRowId = (name: string): string => {
+		const existing = rowIdsRef.current.get(name);
+		if (existing) return existing;
+		const id =
+			typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+				? crypto.randomUUID()
+				: `row-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+		rowIdsRef.current.set(name, id);
+		return id;
+	};
+	const rowsWithIds = useMemo(() => rows.map((r) => ({ ...r, rowId: ensureRowId(r.name) })), [rows]);
+
+	const [expanded, setExpanded] = useState<Set<string>>(new Set());
+	const [draftExpanded, setDraftExpanded] = useState(false);
+	const [draftRow, setDraftRow] = useState<Row>({ name: "", config: { model_id: "" } });
+	// Per-row pending rename state, keyed by stable rowId. Keeps the input
+	// controllable while a typed name collides with another committed row or is
+	// empty — without this, we'd either snap the input back (jarring) or emit a
+	// duplicate and silently drop a row.
+	const [pendingNames, setPendingNames] = useState<Record<string, string>>({});
+
+	const emit = (nextRows: Row[]) => {
+		const out: Record<string, AliasConfig> = {};
+		for (const r of nextRows) {
+			if (!r.name.trim()) continue;
+			out[r.name] = r.config;
+		}
+		onChange(out);
+	};
+
+	const updateRowByName = (oldName: string, patch: Partial<Row>) => {
+		const next = rows.map((r) => (r.name === oldName ? { name: patch.name ?? r.name, config: patch.config ?? r.config } : r));
+		emit(next);
+	};
+
+	const patchConfig = (name: string, patch: Partial<AliasConfig>) => {
+		const current = rows.find((r) => r.name === name);
+		if (!current) return;
+		updateRowByName(name, { config: { ...current.config, ...patch } });
+	};
+
+	const removeRow = (rowId: string, name: string) => {
+		emit(rows.filter((r) => r.name !== name));
+		rowIdsRef.current.delete(name);
+		setExpanded((prev) => {
+			if (!prev.has(rowId)) return prev;
+			const next = new Set(prev);
+			next.delete(rowId);
+			return next;
+		});
+		setPendingNames((prev) => {
+			if (!(rowId in prev)) return prev;
+			const { [rowId]: _drop, ...rest } = prev;
+			return rest;
+		});
+	};
+
+	const renameRow = (rowId: string, oldName: string, newName: string) => {
+		const trimmed = newName.trim();
+		const normalizedName = trimmed.toLowerCase();
+		// Backend alias validation is case-insensitive and rejects leading/trailing
+		// whitespace, so collision detection mirrors that to avoid UI-passes /
+		// server-rejects splits.
+		const collides =
+			normalizedName !== "" && rows.some((r) => r.name !== oldName && r.name.trim().toLowerCase() === normalizedName);
+		if (collides || trimmed === "") {
+			setPendingNames((p) => ({ ...p, [rowId]: newName }));
+			return;
+		}
+		setPendingNames((p) => {
+			if (!(rowId in p)) return p;
+			const { [rowId]: _drop, ...rest } = p;
+			return rest;
+		});
+		// Transfer the stable rowId from old name → new name so per-row UI state
+		// (expanded, pendingNames) survives the rename.
+		rowIdsRef.current.delete(oldName);
+		rowIdsRef.current.set(trimmed, rowId);
+		const next = rows.map((r) => (r.name === oldName ? { name: trimmed, config: r.config } : r));
+		emit(next);
+	};
+
+	const patchDraftConfig = (patch: Partial<AliasConfig>) => {
+		setDraftRow((r) => ({ ...r, config: { ...r.config, ...patch } }));
+	};
+
+	// Commit the in-progress draft row into the committed list. Called from
+	// blur / Enter / model-selection. No-op when either field is missing — the
+	// inline hint below the draft row warns the user before submit that a
+	// partial entry will be dropped.
+	const commitDraftIfReady = (override?: Row) => {
+		const candidate = override ?? draftRow;
+		const name = candidate.name.trim();
+		const modelId = candidate.config.model_id.trim();
+		if (!name || !modelId) return;
+		const exists = Object.keys(normalized).some((k) => k.trim().toLowerCase() === name.toLowerCase());
+		if (exists) return;
+		emit([...rows, { name, config: { ...candidate.config, model_id: modelId } }]);
+		setDraftRow({ name: "", config: { model_id: "" } });
+		setDraftExpanded(false);
+	};
+
+	const toggleExpanded = (rowId: string) => {
+		setExpanded((prev) => {
+			const next = new Set(prev);
+			if (next.has(rowId)) next.delete(rowId);
+			else next.add(rowId);
+			return next;
+		});
+	};
+
+	return (
+		<div className="overflow-hidden rounded-md border">
+			<div className="bg-muted/50 text-foreground grid h-10 grid-cols-[28px_1fr_1fr_28px] items-center gap-2 border-b px-4 text-sm font-medium">
+				<div />
+				<div>Deployment name</div>
+				<div>Model ID</div>
+				<span className="sr-only">Actions</span>
+			</div>
+			<div className="divide-y">
+				{rowsWithIds.map((row) => {
+					const isOpen = expanded.has(row.rowId);
+					const pending = pendingNames[row.rowId];
+					return (
+						<Collapsible key={row.rowId} open={isOpen} onOpenChange={() => toggleExpanded(row.rowId)}>
+							<div className={cn(isOpen && "bg-muted/20")}>
+								<div className="grid grid-cols-[28px_1fr_1fr_28px] items-center gap-2 px-2 py-1.5">
+									<CollapsibleTrigger asChild>
+										<Button
+											variant="ghost"
+											size="icon"
+											className="h-7 w-7"
+											disabled={disabled}
+											data-testid={`deployment-expand-${row.name}`}
+										>
+											{isOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+										</Button>
+									</CollapsibleTrigger>
+									<div className="space-y-1">
+										<Input
+											value={pending ?? row.name}
+											onChange={(e) => renameRow(row.rowId, row.name, e.target.value)}
+											placeholder="Request model name"
+											disabled={disabled}
+											data-testid={`deployment-name-${row.name}`}
+										/>
+										{pending !== undefined && (
+											<p className="text-destructive text-xs">
+												{pending.trim() === "" ? "Name cannot be empty." : "A deployment with this name already exists."}
+											</p>
+										)}
+									</div>
+									<ModelMultiselect
+										isSingleSelect
+										provider={providerName}
+										value={row.config.model_id}
+										onChange={(v) => patchConfig(row.name, { model_id: typeof v === "string" ? v : "" })}
+										placeholder="Deployment / profile / resource ID"
+										disabled={disabled}
+										unfiltered={true}
+										data-testid={`deployment-model-${row.name}`}
+									/>
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon"
+										className="text-muted-foreground hover:text-destructive h-7 w-7"
+										onClick={() => removeRow(row.rowId, row.name)}
+										disabled={disabled}
+										data-testid={`deployment-delete-${row.name}`}
+									>
+										<Trash className="h-4 w-4" />
+									</Button>
+								</div>
+								<CollapsibleContent>
+									<ExpandedConfigPanel
+										config={row.config}
+										onChange={(patch) => patchConfig(row.name, patch)}
+										providerName={providerName}
+										disabled={disabled}
+									/>
+								</CollapsibleContent>
+							</div>
+						</Collapsible>
+					);
+				})}
+				<Collapsible open={draftExpanded} onOpenChange={setDraftExpanded}>
+					<div className={cn(draftExpanded && "bg-muted/20")}>
+						<div className="grid grid-cols-[28px_1fr_1fr_28px] items-center gap-2 px-2 py-1.5">
+							<CollapsibleTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="h-7 w-7"
+									disabled={disabled}
+									data-testid="draft-deployment-expand"
+								>
+									{draftExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+								</Button>
+							</CollapsibleTrigger>
+							<Input
+								value={draftRow.name}
+								onChange={(e) => setDraftRow((r) => ({ ...r, name: e.target.value }))}
+								onBlur={() => commitDraftIfReady()}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										commitDraftIfReady();
+									}
+								}}
+								placeholder="Request model name"
+								disabled={disabled}
+								data-testid="draft-deployment-name"
+							/>
+							<ModelMultiselect
+								isSingleSelect
+								provider={providerName}
+								value={draftRow.config.model_id}
+								onChange={(v) => {
+									const modelId = typeof v === "string" ? v : "";
+									const nextDraft = { ...draftRow, config: { ...draftRow.config, model_id: modelId } };
+									setDraftRow(nextDraft);
+									commitDraftIfReady(nextDraft);
+								}}
+								placeholder="Deployment / profile / resource ID"
+								disabled={disabled}
+								unfiltered={true}
+								data-testid="draft-deployment-model"
+							/>
+							<div />
+						</div>
+						{(draftRow.name.trim() !== "" || draftRow.config.model_id.trim() !== "") &&
+							!(draftRow.name.trim() && draftRow.config.model_id.trim()) && (
+								<p className="text-muted-foreground px-4 pb-2 text-xs">
+									Both deployment name and model ID are required — this row will not be saved until both are filled.
+								</p>
+							)}
+						<CollapsibleContent>
+							<ExpandedConfigPanel
+								config={draftRow.config}
+								onChange={patchDraftConfig}
+								providerName={providerName}
+								disabled={disabled}
+							/>
+						</CollapsibleContent>
+					</div>
+				</Collapsible>
+			</div>
+		</div>
+	);
+}

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -1,5 +1,5 @@
 import { KnownProvidersNames } from "@/lib/constants/logs";
-import { envVarSchema } from "@/lib/types/schemas";
+import { aliasConfigSchema, envVarSchema } from "@/lib/types/schemas";
 import { isValidAliases, isValidVertexAuthCredentials } from "@/lib/utils/validation";
 import { z } from "zod";
 
@@ -151,9 +151,9 @@ const KeySchema = z.object({
 	models: z.array(z.string()),
 	weight: z.number().min(0.1, "Key weights must be between 0.1 and 1").max(1, "Key weights must be between 0.1 and 1"),
 	aliases: z
-		.union([z.record(z.string(), z.string()), z.string()])
+		.record(z.string(), aliasConfigSchema)
 		.optional()
-		.refine((value) => !value || isValidAliases(value), { message: "Aliases must be a valid JSON object" }),
+		.refine((value) => !value || isValidAliases(value), { message: "Deployments must have a Model ID set on every row" }),
 	azure_key_config: AzureKeyConfigSchema.optional(),
 	vertex_key_config: VertexKeyConfigSchema.optional(),
 	bedrock_key_config: BedrockKeyConfigSchema.optional(),

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -20,6 +20,57 @@ export const isKnownProvider = (provider: string): provider is KnownProvider => 
 	return KnownProvidersNames.includes(provider.toLowerCase() as KnownProvider);
 };
 
+// ModelFamily matching Go's schemas.ModelFamily — 1st-tier family routing enum
+export type ModelFamily =
+	| "anthropic"
+	| "openai"
+	| "mistral"
+	| "cohere"
+	| "gemini"
+	| "gemma"
+	| "llama"
+	| "imagen"
+	| "veo"
+	| "nova"
+	| "titan";
+
+export const ModelFamilyValues: ModelFamily[] = [
+	"anthropic",
+	"openai",
+	"mistral",
+	"cohere",
+	"gemini",
+	"gemma",
+	"llama",
+	"imagen",
+	"veo",
+	"nova",
+	"titan",
+];
+
+// AliasConfig matching Go's schemas.AliasConfig.
+// Go embeds AzureAliasCfg/VertexAliasCfg/BedrockAliasCfg/ReplicateAliasCfg as
+// pointer structs which flatten on the wire — sub-config fields live at the
+// top level of the JSON object.
+export interface AliasConfig {
+	model_id: string;
+	model_name?: string;
+	model_family?: ModelFamily;
+	description?: string;
+	region?: EnvVar;
+	// Azure overrides
+	api_version?: string;
+	anthropic_version?: string;
+	endpoint?: EnvVar;
+	// Vertex overrides
+	project_id?: EnvVar;
+	project_number?: EnvVar;
+	// Bedrock overrides
+	inference_profile_arn?: EnvVar;
+	// Replicate overrides
+	use_deployments_endpoint?: boolean;
+}
+
 // AzureKeyConfig matching Go's schemas.AzureKeyConfig
 export interface AzureKeyConfig {
 	endpoint: EnvVar;
@@ -134,7 +185,7 @@ export interface ModelProviderKey {
 	weight: number;
 	enabled?: boolean;
 	use_for_batch_api?: boolean;
-	aliases?: Record<string, string>;
+	aliases?: Record<string, AliasConfig>;
 	azure_key_config?: AzureKeyConfig;
 	vertex_key_config?: VertexKeyConfig;
 	bedrock_key_config?: BedrockKeyConfig;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -227,6 +227,51 @@ export const sglKeyConfigSchema = z
 		path: ["url"],
 	});
 
+// Model family enum schema — must mirror schemas.ModelFamily in Go.
+export const modelFamilySchema = z.enum([
+	"anthropic",
+	"openai",
+	"mistral",
+	"cohere",
+	"gemini",
+	"gemma",
+	"llama",
+	"imagen",
+	"veo",
+	"nova",
+	"titan",
+]);
+
+// AliasConfig schema — mirrors schemas.AliasConfig with the embedded
+// provider sub-configs flattened to top-level optional fields (matches Go's
+// embedded-pointer-struct JSON output).
+const aliasConfigObjectSchema = z.object({
+	model_id: z.string().trim().min(1, "Model ID is required"),
+	model_name: z.string().trim().optional(),
+	model_family: modelFamilySchema.optional(),
+	description: z.string().optional(),
+	region: envVarSchema.optional(),
+	// Azure overrides
+	api_version: z.string().optional(),
+	anthropic_version: z.string().optional(),
+	endpoint: envVarSchema.optional(),
+	// Vertex overrides
+	project_id: envVarSchema.optional(),
+	project_number: envVarSchema.optional(),
+	// Bedrock overrides
+	inference_profile_arn: envVarSchema.optional(),
+	// Replicate overrides
+	use_deployments_endpoint: z.boolean().optional(),
+});
+
+// The Go server emits the legacy string wire shape (`{"my-alias": "model-id"}`)
+// for aliases that only carry ModelID — see AliasConfig.MarshalJSON. Accept
+// both shapes here so edit-time validation doesn't reject hydrated state.
+export const aliasConfigSchema = z.preprocess(
+	(value) => (typeof value === "string" ? { model_id: value } : value),
+	aliasConfigObjectSchema,
+);
+
 // Model provider key schema
 export const modelProviderKeySchema = z
 	.object({
@@ -253,7 +298,7 @@ export const modelProviderKeySchema = z
 				return num;
 			})
 			.pipe(z.number().min(0, "Weight must be equal to or greater than 0").max(1, "Weight must be equal to or less than 1")),
-		aliases: z.record(z.string(), z.string()).optional(),
+		aliases: z.record(z.string(), aliasConfigSchema).optional(),
 		azure_key_config: azureKeyConfigSchema.optional(),
 		vertex_key_config: vertexKeyConfigSchema.optional(),
 		bedrock_key_config: bedrockKeyConfigSchema.optional(),

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -230,37 +230,26 @@ export function isValidVertexAuthCredentials(value: string): boolean {
 }
 
 /**
- * Validates aliases configuration
- * @param value - The aliases value (object or string)
- * @returns true if valid (redacted, or valid JSON object)
+ * Validates the deployments (aliases) map: every entry must have a non-empty
+ * trimmed deployment name and a non-empty trimmed model_id. An empty map is
+ * also considered valid (the field is optional at the form level).
  */
-export function isValidAliases(value: Record<string, string> | string | undefined): boolean {
-	if (!value) {
+export function isValidAliases(value: Record<string, { model_id?: string }> | undefined | null): boolean {
+	if (value == null || typeof value !== "object") {
 		return false;
 	}
-
-	// If it's already an object, check if it has entries
-	if (typeof value === "object") {
-		return Object.keys(value).length > 0;
-	}
-
-	// If it's a string, check for redaction or valid JSON
-	if (typeof value === "string") {
-		// If redacted, consider it valid (backend has the real value)
-		if (isRedacted(value)) {
-			return true;
+	for (const [name, cfg] of Object.entries(value)) {
+		if (!name || !name.trim()) {
+			return false;
 		}
-
-		// Try to parse as JSON
-		try {
-			const parsed = JSON.parse(value);
-			return typeof parsed === "object" && parsed !== null && Object.keys(parsed).length > 0;
-		} catch {
+		if (!cfg || typeof cfg !== "object") {
+			return false;
+		}
+		if (!cfg.model_id || !cfg.model_id.trim()) {
 			return false;
 		}
 	}
-
-	return false;
+	return true;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the flat "Aliases" key-value table (mapping request model name → string deployment ID) with a richer "Deployments" table that supports per-deployment metadata and provider-specific overrides. This enables cost/pricing logs and family-based routing to work correctly for custom deployments.

## Changes

- Introduced a new `DeploymentsTable` component that renders each deployment as a collapsible row. Expanding a row exposes fields for canonical model name, model family, description, and provider-specific overrides (Azure API version, endpoint, Anthropic version; Vertex project ID/number/region; Bedrock region and inference profile ARN; Replicate deployments endpoint toggle).
- Replaced the `normalizeAliasesValue` helper and `HeadersTable`-based aliases editor in `apiKeysFormFragment.tsx` with the new `DeploymentsTable`. The form label and description were updated from "Aliases" to "Deployments" to reflect the richer semantics.
- Added `AliasConfig` and `ModelFamily` types to `config.ts`, mirroring the Go `schemas.AliasConfig` struct (with embedded provider sub-configs flattened to top-level fields on the wire).
- Added `aliasConfigSchema` and `modelFamilySchema` Zod schemas to `schemas.ts`. The alias schema uses `z.preprocess` to accept the legacy `string` wire shape emitted by the Go server for simple aliases, coercing it to `{ model_id: string }` so hydrated state passes validation without a migration.
- Updated `KeySchema` in `providerForm.ts` to use `z.record(z.string(), aliasConfigSchema)` and updated the validation error message to reflect the new requirement.
- Rewrote `isValidAliases` in `validation.ts` to validate the rich `Record<string, { model_id?: string }>` shape, checking that every entry has a non-empty deployment name and a non-empty `model_id`.
- Updated `ModelProviderKey` in `config.ts` to type `aliases` as `Record<string, AliasConfig>` instead of `Record<string, string>`.
- The `DeploymentsTable` includes a draft row at the bottom for adding new entries. The draft is committed automatically when both the deployment name and model ID are filled. Rename collision detection is case-insensitive and stable row IDs are used to preserve expanded/pending state across renames.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
```

1. Navigate to a provider key configuration form.
2. Verify the "Deployments" table renders in place of the old "Aliases" table.
3. Add a new deployment by filling in the deployment name and model ID in the draft row — confirm it commits automatically when both fields are populated.
4. Expand a committed row and verify the canonical model name, model family, description, and provider-specific override fields are visible and editable.
5. For Azure, Vertex, Bedrock, and Replicate providers, confirm the correct provider-specific section appears in the expanded panel.
6. Rename a deployment to an existing name and confirm the inline collision error appears and the row is not committed.
7. Load an existing config that uses the legacy `Record<string, string>` alias format and confirm it hydrates correctly into the new table without validation errors.

## Screenshots/Recordings

Before: A simple two-column key/value table labeled "Aliases" with a plain text input for the deployment ID.

After: A collapsible table labeled "Deployments" where each row can be expanded to reveal canonical model name, model family, description, and provider-specific override fields.

## Breaking changes

- [x] Yes
- [ ] No

The `aliases` field type changes from `Record<string, string>` to `Record<string, AliasConfig>` in the UI type system and form schema. Existing configs using the legacy string format are handled transparently via the `aliasConfigSchema` preprocessor and the `normalize` function in `DeploymentsTable`, so no manual migration is required for stored configs. Any code outside this diff that directly constructs or reads `ModelProviderKey.aliases` as `Record<string, string>` will need to be updated.

## Related issues

## Security considerations

No new secrets or auth surfaces introduced. Provider-specific override fields (endpoint, credentials) use the existing `EnvVarInput` component, which supports environment variable references and redaction consistent with the rest of the form.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable