### PR TITLE
feat: add `live` model catalog cache store with filtered/unfiltered entry support

### DIFF
--- a/framework/modelcatalog/live/store.go
+++ b/framework/modelcatalog/live/store.go
@@ -1,0 +1,125 @@
+// Package live caches the response of provider /v1/models calls per
+// (provider, keyID, unfiltered). Filtered entries are pre-gated by the
+// provider's ListModelsPipeline against the key's allowed/blacklisted/aliases;
+// callers reading filtered entries MUST NOT reapply that gate elsewhere or
+// alias-backfill rows will be dropped.
+//
+// The store is passive — it never calls the network. Callers (the HTTP server
+// after key add/update, or a future background refresher) decide when to
+// fetch and push results in via Upsert.
+package live
+
+import (
+	"slices"
+	"sync"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Key identifies one cached response. KeyID is "" for keyless providers
+// (Vertex workload identity, Bedrock IAM, etc).
+type Key struct {
+	Provider   schemas.ModelProvider
+	KeyID      string
+	Unfiltered bool
+}
+
+// Entry is a single cached response.
+type Entry struct {
+	Models []string
+}
+
+type Store struct {
+	mu      sync.RWMutex
+	entries map[Key]Entry
+	logger  schemas.Logger
+}
+
+func New(logger schemas.Logger) *Store {
+	if logger == nil {
+		logger = bifrost.NewNoOpLogger()
+	}
+	return &Store{entries: make(map[Key]Entry), logger: logger}
+}
+
+// Upsert stores a successful fetch.
+func (s *Store) Upsert(provider schemas.ModelProvider, keyID string, unfiltered bool, models []string) {
+	cp := make([]string, len(models))
+	copy(cp, models)
+	k := Key{Provider: provider, KeyID: keyID, Unfiltered: unfiltered}
+	s.mu.Lock()
+	s.entries[k] = Entry{Models: cp}
+	s.mu.Unlock()
+}
+
+// Invalidate drops both filtered and unfiltered entries for one key. Called
+// when the key's credential value changes (cached models were computed
+// against the old credential) or when the key is deleted.
+func (s *Store) Invalidate(provider schemas.ModelProvider, keyID string) {
+	s.mu.Lock()
+	delete(s.entries, Key{Provider: provider, KeyID: keyID, Unfiltered: false})
+	delete(s.entries, Key{Provider: provider, KeyID: keyID, Unfiltered: true})
+	s.mu.Unlock()
+}
+
+// InvalidateProvider drops every entry for the provider across all keys and
+// modes. Called on provider delete.
+func (s *Store) InvalidateProvider(provider schemas.ModelProvider) {
+	s.mu.Lock()
+	for k := range s.entries {
+		if k.Provider == provider {
+			delete(s.entries, k)
+		}
+	}
+	s.mu.Unlock()
+}
+
+// ModelsForProvider returns the union of filtered entries for the provider,
+// sorted. Filtered entries are pre-gated so this is the effective allowed set
+// across the provider's keys.
+func (s *Store) ModelsForProvider(provider schemas.ModelProvider) []string {
+	return s.unionForProvider(provider, false)
+}
+
+// UnfilteredModelsForProvider returns the union of unfiltered entries — the
+// raw provider catalog with no key-level gating applied.
+func (s *Store) UnfilteredModelsForProvider(provider schemas.ModelProvider) []string {
+	return s.unionForProvider(provider, true)
+}
+
+// Snapshot returns a defensive copy of every entry for diagnostics. Slices
+// are copied; the returned map is independent of store state.
+func (s *Store) Snapshot() map[Key]Entry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[Key]Entry, len(s.entries))
+	for k, e := range s.entries {
+		cp := make([]string, len(e.Models))
+		copy(cp, e.Models)
+		out[k] = Entry{Models: cp}
+	}
+	return out
+}
+
+// unionForProvider returns the sorted, deduplicated set of models across all
+// entries matching the given provider and unfiltered flag.
+func (s *Store) unionForProvider(provider schemas.ModelProvider, unfiltered bool) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	seen := make(map[string]struct{})
+	for k, e := range s.entries {
+		if k.Provider != provider || k.Unfiltered != unfiltered {
+			continue
+		}
+		for _, m := range e.Models {
+			seen[m] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for m := range seen {
+		out = append(out, m)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/framework/modelcatalog/live/store_test.go
+++ b/framework/modelcatalog/live/store_test.go
@@ -1,0 +1,141 @@
+package live
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const (
+	openai    = schemas.OpenAI
+	anthropic = schemas.Anthropic
+)
+
+func upsertFiltered(s *Store, p schemas.ModelProvider, keyID string, models []string) {
+	s.Upsert(p, keyID, false, models)
+}
+
+func upsertUnfiltered(s *Store, p schemas.ModelProvider, keyID string, models []string) {
+	s.Upsert(p, keyID, true, models)
+}
+
+func TestUpsertAndReadFiltered(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o", "gpt-4o-mini"})
+
+	got := s.ModelsForProvider(openai)
+	want := []string{"gpt-4o", "gpt-4o-mini"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ModelsForProvider = %v, want %v", got, want)
+	}
+}
+
+func TestFilteredAndUnfilteredDoNotMix(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertUnfiltered(s, openai, "k1", []string{"gpt-4o", "gpt-4o-mini", "o1"})
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("filtered read = %v, want [gpt-4o]", got)
+	}
+	if got := s.UnfilteredModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o", "gpt-4o-mini", "o1"}) {
+		t.Errorf("unfiltered read = %v, want [gpt-4o gpt-4o-mini o1]", got)
+	}
+}
+
+func TestUnionAcrossKeys(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o", "gpt-4o-mini"})
+	upsertFiltered(s, openai, "k2", []string{"gpt-4o-mini", "o1"})
+
+	got := s.ModelsForProvider(openai)
+	want := []string{"gpt-4o", "gpt-4o-mini", "o1"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("ModelsForProvider = %v, want %v", got, want)
+	}
+}
+
+func TestInvalidateOneKeyPreservesOthers(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertFiltered(s, openai, "k2", []string{"o1"})
+	upsertUnfiltered(s, openai, "k1", []string{"gpt-4o", "extra"})
+
+	s.Invalidate(openai, "k1")
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"o1"}) {
+		t.Errorf("after Invalidate, filtered = %v, want [o1]", got)
+	}
+	if got := s.UnfilteredModelsForProvider(openai); len(got) != 0 {
+		t.Errorf("after Invalidate, unfiltered = %v, want empty (k1's unfiltered should also drop)", got)
+	}
+}
+
+func TestInvalidateProviderDropsEverything(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertFiltered(s, openai, "k2", []string{"o1"})
+	upsertFiltered(s, anthropic, "k3", []string{"claude-3-5-sonnet"})
+
+	s.InvalidateProvider(openai)
+
+	if got := s.ModelsForProvider(openai); len(got) != 0 {
+		t.Errorf("openai after InvalidateProvider = %v, want empty", got)
+	}
+	if got := s.ModelsForProvider(anthropic); !slices.Equal(got, []string{"claude-3-5-sonnet"}) {
+		t.Errorf("anthropic untouched = %v, want [claude-3-5-sonnet]", got)
+	}
+}
+
+func TestKeylessProviderUsesEmptyKeyID(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, schemas.Vertex, "", []string{"gemini-2.0-flash"})
+
+	if got := s.ModelsForProvider(schemas.Vertex); !slices.Equal(got, []string{"gemini-2.0-flash"}) {
+		t.Errorf("keyless read = %v, want [gemini-2.0-flash]", got)
+	}
+}
+
+func TestSnapshotIsDefensiveCopy(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+
+	snap := s.Snapshot()
+	k := Key{Provider: openai, KeyID: "k1", Unfiltered: false}
+	snap[k].Models[0] = "MUTATED"
+
+	got := s.ModelsForProvider(openai)
+	if !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("store mutated through Snapshot: %v", got)
+	}
+}
+
+func TestUpsertCopiesInputSlice(t *testing.T) {
+	s := New(nil)
+	input := []string{"gpt-4o"}
+	s.Upsert(openai, "k1", false, input)
+
+	input[0] = "MUTATED"
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("store mutated through input slice: %v", got)
+	}
+}
+
+func TestModelsForProviderUnknownProviderReturnsEmpty(t *testing.T) {
+	s := New(nil)
+	if got := s.ModelsForProvider(openai); len(got) != 0 {
+		t.Errorf("unknown provider = %v, want empty", got)
+	}
+}
+
+func TestUpsertOverwritesSameKey(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertFiltered(s, openai, "k1", []string{"o1"})
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"o1"}) {
+		t.Errorf("after re-Upsert = %v, want [o1] (overwrite, not append)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a thread-safe, in-memory cache (`live.Store`) for provider model catalog responses. The store holds per-`(provider, keyID, unfiltered)` entries and is intentionally passive — it never initiates network calls. Callers are responsible for fetching and pushing results via `Upsert`, keeping the cache decoupled from transport concerns.

## Changes

- Added `framework/modelcatalog/live/store.go` with a `Store` type that caches `/v1/models` responses keyed by provider, key ID, and a filtered/unfiltered flag.
- Filtered entries are pre-gated by the provider's `ListModelsPipeline` at write time; callers reading filtered entries must not reapply that gate to avoid dropping alias-backfill rows.
- `ModelsForProvider` and `UnfilteredModelsForProvider` return the sorted, deduplicated union across all matching keys for a provider.
- `Invalidate` drops both filtered and unfiltered entries for a single key (e.g., on credential rotation or key deletion). `InvalidateProvider` drops all entries for a provider (e.g., on provider deletion).
- `Snapshot` returns a full defensive copy of the store for diagnostics.
- Both `Upsert` and `Snapshot` copy slices to prevent external mutation of cached state.
- Keyless providers (Vertex workload identity, Bedrock IAM, etc.) are supported via an empty `KeyID`.
- Added `framework/modelcatalog/live/store_test.go` covering union across keys, filtered/unfiltered isolation, invalidation behavior, defensive copying, overwrite semantics, and keyless provider handling.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/live/...
```

All tests should pass. Key scenarios covered:

- Filtered and unfiltered entries for the same key do not bleed into each other.
- Union across multiple keys for the same provider is deduplicated and sorted.
- `Invalidate` removes both filtered and unfiltered entries for the target key while leaving other keys intact.
- `InvalidateProvider` removes all entries for the target provider while leaving other providers intact.
- Mutating the input slice after `Upsert`, or mutating a `Snapshot`, does not affect store state.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Cached model lists may include key IDs as cache discriminators. The store holds no credential values — only the key ID string used as a lookup discriminator. No PII or secrets are stored.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable