### PR TITLE
feat: scope `ListModels` to single key when `KeyID` is set, add `filterKeysByID` helper

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6057,6 +6057,29 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					}
 					continue
 				}
+				// Scope to a single key when ListModelsRequest.KeyID is set, so
+				// callers (the catalog composer) can cache per-key without an
+				// extra round-trip and without the provider aggregating across
+				// every configured key.
+				if lmr := req.BifrostRequest.ListModelsRequest; lmr != nil && lmr.KeyID != nil {
+					target := *lmr.KeyID
+					keys = filterKeysByID(keys, target)
+					if len(keys) == 0 {
+						req.Err <- schemas.BifrostError{
+							IsBifrostError: false,
+							Error: &schemas.ErrorField{
+								Message: fmt.Sprintf("no key found with id %q for provider %s", target, provider.GetProviderKey()),
+							},
+							ExtraFields: schemas.BifrostErrorExtraFields{
+								Provider:               provider.GetProviderKey(),
+								RequestType:            req.RequestType,
+								OriginalModelRequested: model,
+								ResolvedModelUsed:      model,
+							},
+						}
+						continue
+					}
+				}
 			} else {
 				// Determine if this is a multi-key batch/file/container operation
 				// BatchCreate, FileUpload, ContainerCreate, ContainerFileCreate use single key; other batch/file/container ops use multiple keys
@@ -7523,6 +7546,20 @@ func (bifrost *Bifrost) getBifrostRequest() *schemas.BifrostRequest {
 func (bifrost *Bifrost) releaseBifrostRequest(req *schemas.BifrostRequest) {
 	resetBifrostRequest(req)
 	bifrost.bifrostRequestPool.Put(req)
+}
+
+// filterKeysByID returns the subset of keys whose ID equals target. Used to
+// scope a ListModels request to a single key when ListModelsRequest.KeyID is
+// set. Returns an empty slice when no key matches; the input slice is not
+// mutated.
+func filterKeysByID(keys []schemas.Key, target string) []schemas.Key {
+	out := make([]schemas.Key, 0, len(keys))
+	for _, k := range keys {
+		if k.ID == target {
+			out = append(out, k)
+		}
+	}
+	return out
 }
 
 // getAllSupportedKeys retrieves all valid keys for a ListModels request.

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -2712,3 +2712,47 @@ func TestPluginPipelineStreamingRace(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestFilterKeysByID covers the KeyID scoping path for ListModels requests:
+// a hit returns the single matching key, a miss returns an empty slice
+// (which the caller surfaces as "no key found"), and the input slice must
+// not be mutated.
+func TestFilterKeysByID(t *testing.T) {
+	keys := []schemas.Key{
+		{ID: "k1"},
+		{ID: "k2"},
+		{ID: "k3"},
+	}
+
+	t.Run("match returns single key", func(t *testing.T) {
+		got := filterKeysByID(keys, "k2")
+		if len(got) != 1 || got[0].ID != "k2" {
+			t.Fatalf("filterKeysByID(_, k2) = %+v, want one key with ID=k2", got)
+		}
+	})
+
+	t.Run("no match returns empty slice", func(t *testing.T) {
+		got := filterKeysByID(keys, "does-not-exist")
+		if len(got) != 0 {
+			t.Fatalf("filterKeysByID(_, missing) = %+v, want empty", got)
+		}
+	})
+
+	t.Run("empty target returns empty slice", func(t *testing.T) {
+		got := filterKeysByID(keys, "")
+		if len(got) != 0 {
+			t.Fatalf("filterKeysByID(_, \"\") = %+v, want empty", got)
+		}
+	})
+
+	t.Run("input slice is not mutated", func(t *testing.T) {
+		before := make([]schemas.Key, len(keys))
+		copy(before, keys)
+		_ = filterKeysByID(keys, "k1")
+		for i := range keys {
+			if keys[i].ID != before[i].ID {
+				t.Fatalf("input mutated at index %d: got %q, want %q", i, keys[i].ID, before[i].ID)
+			}
+		}
+	})
+}

--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -51,6 +51,18 @@ type BifrostListModelsRequest struct {
 	// Unfiltered: If true, the response will include all models for the provider, regardless of the allowed models (internal bifrost use only, not sent to the provider)
 	Unfiltered bool `json:"-"`
 
+	// KeyID: If non-nil, scope the call to a single key (matched by Key.ID).
+	// Lets callers cache list-models output per-key for fine-grained
+	// invalidation. Internal bifrost use only; not sent to the provider.
+	//
+	// Matching runs against the already-filtered set of supported keys for the
+	// provider — keys that are disabled (Enabled == false) or fail validation
+	// are excluded before the lookup, so a KeyID referring to such a key
+	// produces the same "no key found" error as a KeyID that does not exist
+	// at all. Callers needing to distinguish those cases must check the raw
+	// account configuration themselves.
+	KeyID *string `json:"-"`
+
 	// ExtraParams: Additional provider-specific query parameters
 	// This allows for flexibility to pass any custom parameters that specific providers might support
 	ExtraParams map[string]interface{} `json:"-"`


### PR DESCRIPTION
## Summary

Adds a `KeyID` field to `BifrostListModelsRequest` that scopes a `ListModels` call to a single key matched by `Key.ID`. This allows callers such as the catalog composer to cache list-models output per-key for fine-grained invalidation without requiring an extra round-trip or having the provider aggregate results across every configured key.

## Changes

- Added `KeyID *string` to `BifrostListModelsRequest` (tagged `json:"-"` so it is never forwarded to providers). When set, the request worker filters the already-validated key set down to the single matching key before dispatching. If no key matches, a `BifrostError` is returned immediately.
- Added `filterKeysByID` helper that returns a new slice containing only keys whose `ID` equals the target, leaving the input slice unmodified.
- Added `TestFilterKeysByID` covering: a successful match, a missing key, an empty target string, and input-slice immutability.

Note: the lookup runs against the already-filtered set of supported keys (disabled or invalid keys are excluded before the match), so a `KeyID` pointing to a disabled key produces the same "no key found" error as a non-existent `KeyID`. Callers that need to distinguish these cases must inspect the raw account configuration directly.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

The new `TestFilterKeysByID` test directly exercises the helper and the key-scoping logic. To validate end-to-end, issue a `ListModels` request with `KeyID` set to a valid key ID and confirm only that key's models are returned. Issue one with an unknown `KeyID` and confirm a "no key found" error is returned.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`KeyID` is tagged `json:"-"` and is never serialised or forwarded to any external provider. No secrets or PII are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable