### PR TITLE
feat: add `core` routing engine audit trail for retry and fallback transitions

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4740,10 +4740,22 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		return primaryResult, primaryErr
 	}
 
+	// Core is about to make routing decisions of its own (fallback transitions)
+	// — record it on the request's used-engines list so the audit trail closes
+	// the loop on whatever plugin-level engine selected the primary upstream.
+	schemas.AppendToContextList(ctx, schemas.BifrostContextKeyRoutingEnginesUsed, schemas.RoutingEngineCore)
+	ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Primary %s/%s failed (%s); evaluating %d configured fallback(s)", provider, model, routingErrorSummary(primaryErr), len(fallbacks)))
+
+	// Tracks the most recent failure so each fallback transition log carries
+	// the error that triggered it (primary error for the first iteration, the
+	// prior fallback's error for subsequent iterations).
+	lastErr := primaryErr
+
 	// Try fallbacks in order
 	for i, fallback := range fallbacks {
 		ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, i+1)
 		bifrost.logger.Debug(fmt.Sprintf("trying fallback provider %s with model %s", fallback.Provider, fallback.Model))
+		ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Trying fallback %d/%d: %s/%s (previous attempt failed: %s)", i+1, len(fallbacks), fallback.Provider, fallback.Model, routingErrorSummary(lastErr)))
 		ctx.SetValue(schemas.BifrostContextKeyFallbackRequestID, uuid.New().String())
 		clearCtxForFallback(ctx)
 
@@ -4759,6 +4771,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		fallbackReq := bifrost.prepareFallbackRequest(req, fallback)
 		if fallbackReq == nil {
 			bifrost.logger.Debug(fmt.Sprintf("fallback provider %s with model %s is nil", fallback.Provider, fallback.Model))
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelWarn, fmt.Sprintf("Fallback %s/%s skipped: missing provider config", fallback.Provider, fallback.Model))
 			tracer.SetAttribute(handle, "error", "fallback request preparation failed")
 			tracer.EndSpan(handle, schemas.SpanStatusError, "fallback request preparation failed")
 			continue
@@ -4773,6 +4786,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		fallbackErr.SetFallbackRoutingInfo(provider, model)
 		if fallbackErr == nil {
 			bifrost.logger.Debug(fmt.Sprintf("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Request served by fallback %s/%s (attempt %d/%d)", fallback.Provider, fallback.Model, i+1, len(fallbacks)))
 			tracer.EndSpan(handle, schemas.SpanStatusOk, "")
 			return result, nil
 		}
@@ -4785,10 +4799,14 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 
 		// Check if we should continue with more fallbacks
 		if !bifrost.shouldContinueWithFallbacks(fallback, fallbackErr) {
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelError, fmt.Sprintf("Fallback %s/%s failed (%s); halting further fallbacks", fallback.Provider, fallback.Model, routingErrorSummary(fallbackErr)))
 			return nil, fallbackErr
 		}
+
+		lastErr = fallbackErr
 	}
 
+	ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelError, fmt.Sprintf("All %d fallback(s) exhausted; returning primary error (%s)", len(fallbacks), routingErrorSummary(primaryErr)))
 	// All providers failed, return the original error
 	return nil, primaryErr
 }
@@ -4855,9 +4873,18 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 		return primaryResult, primaryErr
 	}
 
+	// Mirror handleRequest: register core on the engines-used list and post
+	// the primary-failure entry to the routing engine log trail before
+	// iterating fallbacks. See handleRequest for the rationale.
+	schemas.AppendToContextList(ctx, schemas.BifrostContextKeyRoutingEnginesUsed, schemas.RoutingEngineCore)
+	ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Primary %s/%s failed (%s); evaluating %d configured fallback(s)", provider, model, routingErrorSummary(primaryErr), len(fallbacks)))
+
+	lastErr := primaryErr
+
 	// Try fallbacks in order
 	for i, fallback := range fallbacks {
 		ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, i+1)
+		ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Trying fallback %d/%d: %s/%s (previous attempt failed: %s)", i+1, len(fallbacks), fallback.Provider, fallback.Model, routingErrorSummary(lastErr)))
 		ctx.SetValue(schemas.BifrostContextKeyFallbackRequestID, uuid.New().String())
 		clearCtxForFallback(ctx)
 
@@ -4872,6 +4899,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 
 		fallbackReq := bifrost.prepareFallbackRequest(req, fallback)
 		if fallbackReq == nil {
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelWarn, fmt.Sprintf("Fallback %s/%s skipped: missing provider config", fallback.Provider, fallback.Model))
 			tracer.SetAttribute(handle, "error", "fallback request preparation failed")
 			tracer.EndSpan(handle, schemas.SpanStatusError, "fallback request preparation failed")
 			continue
@@ -4887,6 +4915,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 		fallbackErr.SetFallbackRoutingInfo(provider, model)
 		if fallbackErr == nil {
 			bifrost.logger.Debug(fmt.Sprintf("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Request served by fallback %s/%s (attempt %d/%d)", fallback.Provider, fallback.Model, i+1, len(fallbacks)))
 			tracer.EndSpan(handle, schemas.SpanStatusOk, "")
 			return result, nil
 		}
@@ -4899,10 +4928,14 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 
 		// Check if we should continue with more fallbacks
 		if !bifrost.shouldContinueWithFallbacks(fallback, fallbackErr) {
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelError, fmt.Sprintf("Fallback %s/%s failed (%s); halting further fallbacks", fallback.Provider, fallback.Model, routingErrorSummary(fallbackErr)))
 			return nil, fallbackErr
 		}
+
+		lastErr = fallbackErr
 	}
 
+	ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelError, fmt.Sprintf("All %d fallback(s) exhausted; returning primary error (%s)", len(fallbacks), routingErrorSummary(primaryErr)))
 	// All providers failed, return the original error
 	return nil, primaryErr
 }
@@ -5464,10 +5497,31 @@ func executeRequestWithRetries[T any](
 	model string,
 	req *schemas.BifrostRequest,
 	logger schemas.Logger,
-) (T, *schemas.BifrostError) {
-	var result T
-	var bifrostError *schemas.BifrostError
+) (result T, bifrostError *schemas.BifrostError) {
 	var attempts int
+
+	// Emit the terminal routing-engine entry on every return path — including
+	// early returns from key-selection failures and tracer-missing — so the
+	// audit trail isn't truncated when execution exits before reaching the
+	// natural end of the function. Skipped when attempts == 0: the request
+	// never crossed core's retry-orchestration boundary, so there's nothing
+	// to record.
+	defer func() {
+		if attempts <= 0 {
+			return
+		}
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyRoutingEnginesUsed, schemas.RoutingEngineCore)
+		switch {
+		case bifrostError == nil:
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Request to %s/%s succeeded after %d retry attempt(s)", providerKey, model, attempts))
+		case bifrostError.IsBifrostError:
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelError, fmt.Sprintf("Retries halted for %s/%s after %d attempt(s): internal Bifrost error (%s)", providerKey, model, attempts, routingErrorSummary(bifrostError)))
+		case bifrostError.Error != nil && bifrostError.Error.Type != nil && *bifrostError.Error.Type == schemas.RequestCancelled:
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelError, fmt.Sprintf("Request to %s/%s cancelled after %d attempt(s)", providerKey, model, attempts))
+		default:
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelError, fmt.Sprintf("Retries exhausted for %s/%s after %d attempt(s); last error: %s", providerKey, model, attempts, routingErrorSummary(bifrostError)))
+		}
+	}()
 
 	var currentKey schemas.Key
 	var usedKeyIDs map[string]bool
@@ -5616,6 +5670,25 @@ func executeRequestWithRetries[T any](
 			//   - 429 pool reset that re-picks the same key — no rotation actually happened.
 			//   - keyless providers — currentKey.ID stays empty, so keyChanged is false.
 			keyChanged := keyProvider != nil && currentKey.ID != previousKeyID
+
+			// Emit a routing-engine log entry for this retry transition so the
+			// per-request audit trail records *why* core decided to retry and
+			// whether it rotated the credential. routingErrorSummary() omits
+			// the upstream message so keys/PII don't leak into the log row.
+			// Key.Name is a user-set label (not the secret value) and is safe.
+			schemas.AppendToContextList(ctx, schemas.BifrostContextKeyRoutingEnginesUsed, schemas.RoutingEngineCore)
+			// Omit the key=... segment for keyless providers, where currentKey is
+			// the zero value and the trailing token would render as "same key=".
+			keyNote := ""
+			if keyProvider != nil {
+				rotationNote := "same key"
+				if keyChanged {
+					rotationNote = "rotated key"
+				}
+				keyNote = fmt.Sprintf("; %s=%s", rotationNote, currentKey.Name)
+			}
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Retry %d/%d for %s/%s (previous attempt failed: %s%s)", attempts, config.NetworkConfig.MaxRetries, providerKey, model, routingErrorSummary(bifrostError), keyNote))
+
 			if !(lastWasPermanentKeyFailure && keyChanged) {
 				backoff := calculateBackoff(attempts-1, config)
 				logger.Debug("sleeping for %s before retry", backoff)
@@ -5905,6 +5978,10 @@ func executeRequestWithRetries[T any](
 	if attempts > 0 {
 		logger.Debug("request failed after %d %s", attempts, map[bool]string{true: "attempts", false: "attempt"}[attempts > 1])
 	}
+
+	// Terminal routing-engine log entry is emitted by the defer at the top of
+	// the function so it runs on every return path, including the early
+	// returns from key-selection or tracer-missing.
 
 	// On final error, clear selected_key so it only reflects a key that actually served a successful response.
 	// The attempt trail is the authoritative record of which keys were tried.

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -356,6 +356,12 @@ const (
 	RoutingEngineRoutingRule   = "routing-rule"
 	RoutingEngineLoadbalancing = "loadbalancing"
 	RoutingEngineModelCatalog  = "model-catalog"
+	// RoutingEngineCore represents the Bifrost core orchestrator's own
+	// routing decisions — primarily fallback transitions. Emitted when the
+	// primary attempt fails and core advances through the fallback chain so
+	// the per-request audit trail closes the loop on what plugin-level
+	// engines (governance, loadbalancing, etc.) selected upstream.
+	RoutingEngineCore = "core"
 )
 
 // KeyAttemptRecord captures the outcome of a single request attempt within executeRequestWithRetries.

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -450,18 +450,20 @@ func (bc *BifrostContext) GetRoutingEngineLogs() []RoutingEngineLogEntry {
 	return nil
 }
 
-// AppendToContextList appends a value to the context list value.
-// Parameters:
-//   - ctx: The Bifrost context
-//   - key: The key to append the value to
-//   - value: The value to append
-func AppendToContextList[T any](ctx *BifrostContext, key BifrostContextKey, value T) {
+// AppendToContextList appends value to the context list at key, skipping the
+// append when value already exists in the list. Downstream consumers of these
+// lists (notably `routing_engines_used` → Prometheus labels) treat duplicate
+// entries as bugs, so set semantics are enforced at the write site.
+func AppendToContextList[T comparable](ctx *BifrostContext, key BifrostContextKey, value T) {
 	if ctx == nil {
 		return
 	}
 	existingValues, ok := ctx.Value(key).([]T)
 	if !ok {
 		existingValues = []T{}
+	}
+	if slices.Contains(existingValues, value) {
+		return
 	}
 	ctx.SetValue(key, append(existingValues, value))
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -214,6 +214,32 @@ func IsRateLimitErrorMessage(errorMessage string) bool {
 	return false
 }
 
+// routingErrorSummary produces a sanitized, audit-safe one-line summary of a
+// BifrostError for emission to the per-request routing engine log trail.
+// It deliberately omits the upstream provider message — which can echo back
+// API keys, tokens, or user input — and surfaces only the error type and HTTP
+// status code. Used by the core fallback orchestrator so the routing log
+// records *why* a fallback was triggered without leaking secrets into log
+// storage or the UI.
+func routingErrorSummary(e *schemas.BifrostError) string {
+	if e == nil {
+		return "unknown error"
+	}
+	parts := make([]string, 0, 2)
+	if e.Error != nil && e.Error.Type != nil && *e.Error.Type != "" {
+		parts = append(parts, *e.Error.Type)
+	} else if e.Type != nil && *e.Type != "" {
+		parts = append(parts, *e.Type)
+	}
+	if e.StatusCode != nil {
+		parts = append(parts, fmt.Sprintf("HTTP %d", *e.StatusCode))
+	}
+	if len(parts) == 0 {
+		return "request failed"
+	}
+	return strings.Join(parts, " ")
+}
+
 // newBifrostError wraps a standard error into a BifrostError with IsBifrostError set to false.
 // This helper function reduces code duplication when handling non-Bifrost errors.
 func newBifrostError(err error) *schemas.BifrostError {

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -220,7 +220,7 @@ Most request-level Bifrost LLM metrics include these labels (the `bifrost_key_ro
 - `alias` - Alias resolved to this model (empty if none)
 - `method` - Request type (chat, completion, embedding, etc.)
 - `virtual_key_id` / `virtual_key_name` - Virtual key identifiers
-- `routing_engine_used` - Comma-separated list of routing engines that contributed to the decision (e.g. `governance`, `routing-rule`, `loadbalancing`, `model-catalog`)
+- `routing_engine_used` - Comma-separated list of routing engines that contributed to the decision (e.g. `governance`, `routing-rule`, `loadbalancing`, `model-catalog`, `core`). `core` is emitted when the Bifrost orchestrator itself makes a routing decision — fallback transitions or retry transitions.
 - `routing_rule_id` / `routing_rule_name` - Routing rule that matched the request
 - `selected_key_id` / `selected_key_name` - API key that successfully served the request (`""` when all attempts failed)
 - `fallback_index` - Fallback position

--- a/docs/features/retries-and-fallbacks.mdx
+++ b/docs/features/retries-and-fallbacks.mdx
@@ -367,6 +367,32 @@ The retry budget is set per-provider in `network_config`. If your fallback provi
 
 ---
 
+## Auditing retry and fallback decisions
+
+Every retry transition and every fallback transition is recorded on the request's **routing engine log trail** under the engine name `core`. This is the same per-request trail that plugins like `governance`, `loadbalancing`, `routing-rule`, and `model-catalog` write to when they make routing decisions — so the chain reads end-to-end: which engine picked the primary, what the primary failed with, what core retried with, and which fallback ultimately served the response.
+
+Entries core emits:
+
+| Phase | Level | Shape |
+|---|---|---|
+| Primary failed, entering fallback loop | Info | `Primary <p>/<m> failed (<type> HTTP <code>); evaluating N configured fallback(s)` |
+| Each fallback iteration | Info | `Trying fallback i/N: <p>/<m> (previous attempt failed: <type> HTTP <code>)` |
+| Fallback skipped (no provider config) | Warn | `Fallback <p>/<m> skipped: missing provider config` |
+| Fallback succeeded | Info | `Request served by fallback <p>/<m> (attempt i/N)` |
+| Fallback halted by short-circuit | Error | `Fallback <p>/<m> failed (<type> HTTP <code>); halting further fallbacks` |
+| All fallbacks exhausted | Error | `All N fallback(s) exhausted; returning primary error (<type> HTTP <code>)` |
+| Retry transition (rotated key) | Info | `Retry n/N for <p>/<m> (previous attempt failed: <type> HTTP <code>; rotated key=<name>)` |
+| Retry transition (same key) | Info | `Retry n/N for <p>/<m> (previous attempt failed: <type> HTTP <code>; same key=<name>)` |
+| Retry transition (keyless provider) | Info | `Retry n/N for <p>/<m> (previous attempt failed: <type> HTTP <code>)` |
+| Retries succeeded | Info | `Request to <p>/<m> succeeded after N retry attempt(s)` |
+| Retries exhausted | Error | `Retries exhausted for <p>/<m> after N attempt(s); last error: <type> HTTP <code>` |
+
+The failure context attached to each entry is intentionally categorical — only the error type (e.g. `rate_limit_error`) and HTTP status code. The upstream provider message is *never* included, since providers can echo back API keys, tokens, or user input. The key identifier surfaced in retry rotation notes is the user-set key **name**, not the secret value.
+
+When core emits at least one entry on a request, it also adds itself to the request log's `routing_engines_used` field (deduped — `core` appears at most once per request even if both the retry and fallback orchestrators were involved).
+
+---
+
 ## Real-world scenarios
 
 **Scenario 1: Rate limiting with key rotation**

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -70,7 +70,7 @@ Base Labels:
 - `method`: Request type (`chat`, `text`, `embedding`, `speech`, `transcription`)
 - `virtual_key_id`: Virtual key ID
 - `virtual_key_name`: Virtual key name
-- `routing_engine_used`: Comma-separated routing engines used (`routing-rule`, `governance`, `loadbalancing`, `model-catalog`)
+- `routing_engine_used`: Comma-separated routing engines used (`routing-rule`, `governance`, `loadbalancing`, `model-catalog`, `core`). `core` is emitted when the Bifrost orchestrator itself makes a routing decision — i.e. a fallback transition or a retry transition.
 - `routing_rule_id`: Routing rule ID that matched the request
 - `routing_rule_name`: Routing rule name that matched the request
 - `selected_key_id`: ID of the key that successfully served the request (empty string `""` on final errors)

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -418,9 +418,11 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 		// assume the prefixed model should be left unchanged.
 		if p.inMemoryStore != nil {
 			if _, ok := p.inMemoryStore.GetConfiguredProviders()[provider]; ok {
+				ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("Skipping load balancing for model %s: already prefixed with configured provider %s", modelStr, provider))
 				return nil
 			}
 		} else {
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelWarn, fmt.Sprintf("Skipping load balancing for model %s: provider-prefixed and no in-memory store to validate against", modelStr))
 			return nil
 		}
 	}
@@ -579,6 +581,7 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 				refined, err := p.modelCatalog.RefineModelForProvider(fbProvider, modelStr)
 				if err != nil {
 					p.logger.Warn("failed to refine model for fallback, skipping fallback in governance plugin: %v", err)
+					ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelWarn, fmt.Sprintf("Fallback provider %s skipped: failed to refine model %s for this provider", fbProvider, modelStr))
 					continue
 				}
 				fbModel = refined

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1092,10 +1092,10 @@ export function LogDetailView({
 											{log.routing_engines_used.map((engine) => (
 												<Badge
 													key={engine}
-													className={RoutingEngineUsedColors[engine as keyof typeof RoutingEngineUsedColors] ?? "bg-gray-100 text-gray-800"}
+													className={cn("border-0 py-1 uppercase", RoutingEngineUsedColors[engine as keyof typeof RoutingEngineUsedColors] ?? "bg-gray-100 text-gray-800")}
 												>
 													<div className="flex items-center gap-2">
-														{RoutingEngineUsedIcons[engine as keyof typeof RoutingEngineUsedIcons]?.()}
+														{RoutingEngineUsedIcons[engine as keyof typeof RoutingEngineUsedIcons]?.({ className: "h-3.5 w-3.5" })}
 														<span>{RoutingEngineUsedLabels[engine as keyof typeof RoutingEngineUsedLabels] ?? engine}</span>
 													</div>
 												</Badge>

--- a/ui/lib/constants/icons.tsx
+++ b/ui/lib/constants/icons.tsx
@@ -1,4 +1,4 @@
-import { Database, Landmark, Network, Shuffle } from "lucide-react";
+import { Database, Landmark, Network, Shuffle, Workflow } from "lucide-react";
 import { useTheme } from "next-themes";
 import { cn } from "../utils";
 
@@ -667,8 +667,9 @@ export const ProviderIcons = {
 export const RoutingEngineUsedIcons = {
 	"routing-rule": ({ className = "h-5 w-5 text-blue-800" }: { className?: string } = {}) => <Network className={className} />,
 	governance: ({ className = "h-5 w-5 text-green-800" }: { className?: string } = {}) => <Landmark className={className} />,
-	loadbalancing: ({ className = "h-5 w-5 text-red-800" }: { className?: string } = {}) => <Shuffle className={className} />,
+	loadbalancing: ({ className = "h-5 w-5 text-orange-800" }: { className?: string } = {}) => <Shuffle className={className} />,
 	"model-catalog": ({ className = "h-5 w-5 text-purple-800" }: { className?: string } = {}) => <Database className={className} />,
+	core: ({ className = "h-5 w-5 text-sky-800" }: { className?: string } = {}) => <Workflow className={className} />,
 } as const;
 
 export type RoutingEngineType = keyof typeof RoutingEngineUsedIcons;

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -320,13 +320,15 @@ export const RoutingEngineUsedLabels = {
 	governance: "Governance",
 	loadbalancing: "Loadbalancing",
 	"model-catalog": "Model Catalog",
+	core: "Core",
 } as const;
 
 export const RoutingEngineUsedColors = {
 	"routing-rule": "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
 	governance: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
-	loadbalancing: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
+	loadbalancing: "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300",
 	"model-catalog": "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300",
+	core: "bg-sky-100 text-sky-800 dark:bg-sky-900 dark:text-sky-300",
 } as const;
 
 export type Status = (typeof Statuses)[number];


### PR DESCRIPTION
## Summary

Adds a `core` routing engine to the per-request audit trail so that fallback transitions and retry transitions made by the Bifrost orchestrator itself are visible alongside decisions made by plugins like `governance`, `loadbalancing`, `routing-rule`, and `model-catalog`. Previously, the routing engine log trail went silent after a plugin selected the primary upstream — there was no record of why core advanced through the fallback chain or how many retries were attempted before succeeding or giving up.

## Changes

- Introduces `RoutingEngineCore = "core"` as a named routing engine constant, emitted by `handleRequest`, `handleStreamRequest`, and `executeRequestWithRetries` at each fallback and retry transition.
- `handleRequest` and `handleStreamRequest` now log: primary failure entering the fallback loop, each fallback attempt (with the triggering error), skipped fallbacks (missing provider config), successful fallback, short-circuit halts, and full fallback exhaustion.
- `executeRequestWithRetries` uses a named return + `defer` to guarantee a terminal log entry on every return path (including early exits from key-selection failures). Each retry transition records whether the key was rotated or reused, and keyless providers omit the key segment entirely.
- Adds `routingErrorSummary()` — a sanitized formatter that surfaces only the error type and HTTP status code, deliberately excluding the upstream provider message to prevent API keys, tokens, or user input from leaking into log storage or the UI.
- `AppendToContextList` is tightened from `any` to `comparable` and gains a deduplication check, so `core` (and any other engine) appears at most once in `routing_engines_used` even when both the retry and fallback orchestrators fire on the same request.
- Governance plugin gains two additional log entries: one when load balancing is skipped because the model is already provider-prefixed, and one when a fallback provider is skipped due to model refinement failure.
- UI adds `core` as a recognized routing engine with a sky-blue color scheme and a `Workflow` icon. The `loadbalancing` engine color is changed from red to orange. Badge rendering is updated to pass icon size props correctly.
- Prometheus and telemetry documentation updated to include `core` in the `routing_engine_used` label description.
- Retries and fallbacks documentation gains a new "Auditing retry and fallback decisions" section with a full table of log entry shapes and a note on the intentional omission of upstream provider messages.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Configure a provider with retries and a fallback chain. Trigger a primary failure (e.g. an invalid API key or a rate-limited endpoint) and inspect the routing engine log trail on the resulting request log. Verify:

1. `core` appears in `routing_engines_used` exactly once.
2. The log trail contains entries for the primary failure, each fallback attempt, and the terminal outcome (success or exhaustion).
3. No upstream provider error message text appears in any `core` log entry — only error type and HTTP status code.
4. For retry scenarios, each retry entry notes whether the key was rotated or reused.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

In the log detail view, confirm that requests involving fallbacks or retries show a `Core` badge in sky-blue alongside any plugin engine badges, and that the `Loadbalancing` badge now renders in orange rather than red.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

`routingErrorSummary()` is specifically designed to exclude upstream provider messages from the routing log trail, since providers can echo back API keys, tokens, or user-supplied content. Only the error type (e.g. `rate_limit_error`) and HTTP status code are recorded. Key rotation notes surface the user-set key **name**, not the secret value.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable