### PR TITLE
feat: add adaptive routing settings sub-route with sidebar nav and enterprise fallback

### DIFF
--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"math"
 	"slices"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -265,7 +266,10 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	} else {
 		s.markPluginDisabled(modelcatalogresolver.PluginName)
 	}
-	s.Config.SetPluginOrderInfo(modelcatalogresolver.PluginName, builtinPlacement, schemas.Ptr(9))
+	// Place it in post_builtin with a max order so it runs after every other routing plugin,
+	// including post_builtin ones like the enterprise load balancer (which would otherwise run
+	// after this builtin and never get a chance to pick the provider first).
+	s.Config.SetPluginOrderInfo(modelcatalogresolver.PluginName, schemas.Ptr(schemas.PluginPlacementPostBuiltin), schemas.Ptr(math.MaxInt))
 
 	return nil
 }

--- a/ui/app/_fallbacks/enterprise/components/load-balancer/loadBalancerSettingsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/load-balancer/loadBalancerSettingsView.tsx
@@ -1,0 +1,3 @@
+// On OSS, the adaptive routing settings page shows the same enterprise upsell as the
+// adaptive routing dashboard — reuse that fallback rather than duplicating it.
+export { default } from "../adaptive-routing/adaptiveRoutingView";

--- a/ui/app/workspace/adaptive-routing/layout.tsx
+++ b/ui/app/workspace/adaptive-routing/layout.tsx
@@ -1,14 +1,16 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useChildMatches } from "@tanstack/react-router";
 import { NoPermissionView } from "@/components/noPermissionView";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import AdaptiveRoutingPage from "./page";
 
 function RouteComponent() {
 	const hasAdaptiveRouterAccess = useRbac(RbacResource.AdaptiveRouter, RbacOperation.View);
+	const childMatches = useChildMatches();
 	if (!hasAdaptiveRouterAccess) {
 		return <NoPermissionView entity="adaptive routing" />;
 	}
-	return <AdaptiveRoutingPage />;
+	// Render the dashboard at the base path; defer to child routes (e.g. /settings).
+	return childMatches.length === 0 ? <AdaptiveRoutingPage /> : <Outlet />;
 }
 
 export const Route = createFileRoute("/workspace/adaptive-routing")({

--- a/ui/app/workspace/adaptive-routing/settings/layout.tsx
+++ b/ui/app/workspace/adaptive-routing/settings/layout.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import AdaptiveRoutingSettingsPage from "./page";
+
+export const Route = createFileRoute("/workspace/adaptive-routing/settings")({
+	component: AdaptiveRoutingSettingsPage,
+});

--- a/ui/app/workspace/adaptive-routing/settings/page.tsx
+++ b/ui/app/workspace/adaptive-routing/settings/page.tsx
@@ -1,0 +1,9 @@
+import LoadBalancerSettingsView from "@enterprise/components/load-balancer/loadBalancerSettingsView";
+
+export default function AdaptiveRoutingSettingsPage() {
+	return (
+		<div className="mx-auto flex w-full max-w-7xl">
+			<LoadBalancerSettingsView />
+		</div>
+	);
+}

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -257,7 +257,9 @@ const SidebarItemView = ({
   const hasSubItems =
     "subItems" in item && item.subItems && item.subItems.length > 0;
   const isRouteMatch = (url: string) => {
-    if (url === "/workspace/custom-pricing") return pathname === url;
+    // Exact-match base paths that have sibling tab routes nested under them, so the base
+    // tab isn't also highlighted when a child tab (e.g. /settings) is active.
+    if (url === "/workspace/custom-pricing" || url === "/workspace/adaptive-routing") return pathname === url;
     return pathname.startsWith(url);
   };
   const isAnySubItemActive =
@@ -963,8 +965,24 @@ export default function AppSidebar() {
         title: "Adaptive Routing",
         url: "/workspace/adaptive-routing",
         icon: Shuffle,
-        description: "Manage adaptive load balancer",
+        description: "Manage adaptive routing",
         hasAccess: isAdaptiveRoutingAllowed,
+        subItems: [
+          {
+            title: "Dashboard",
+            url: "/workspace/adaptive-routing",
+            icon: ChartColumnBig,
+            description: "Adaptive routing metrics",
+            hasAccess: isAdaptiveRoutingAllowed,
+          },
+          {
+            title: "Settings",
+            url: "/workspace/adaptive-routing/settings",
+            icon: Settings,
+            description: "Adaptive routing settings",
+            hasAccess: isAdaptiveRoutingAllowed,
+          },
+        ],
       },
       ...(isDbConnected
         ? [
@@ -1158,7 +1176,7 @@ export default function AppSidebar() {
   useEffect(() => {
     const newExpandedItems = new Set<string>();
     const isRouteMatch = (url: string) => {
-      if (url === "/workspace/custom-pricing") return pathname === url;
+      if (url === "/workspace/custom-pricing" || url === "/workspace/adaptive-routing") return pathname === url;
       return pathname.startsWith(url);
     };
     items.forEach((item) => {

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -180,6 +180,7 @@ export const baseApi = createApi({
     "AuditLogs",
     "UserGovernance",
     "LargePayloadConfig",
+    "LoadBalancerConfig",
     "Folders",
     "Prompts",
     "Versions",


### PR DESCRIPTION
## Summary

Adds a dedicated **Settings** sub-route (`/workspace/adaptive-routing/settings`) to the Adaptive Routing section, giving it a tabbed sidebar structure similar to other sections like Custom Pricing. On OSS builds, the settings page reuses the existing enterprise upsell fallback from the adaptive routing dashboard rather than introducing a duplicate.

## Changes

- Added `/workspace/adaptive-routing/settings` as a child route with its own layout and page component, rendering `LoadBalancerSettingsView` from the enterprise layer.
- Updated the adaptive routing layout to use `useChildMatches` and `<Outlet />` so the dashboard renders at the base path while child routes (e.g. `/settings`) render independently.
- Added `Dashboard` and `Settings` sub-items to the Adaptive Routing sidebar entry, mirroring the tab pattern used elsewhere.
- Extended the `isRouteMatch` exact-match logic in the sidebar to include `/workspace/adaptive-routing`, preventing the Dashboard tab from remaining highlighted when the Settings tab is active.
- Added an OSS fallback for `loadBalancerSettingsView` that re-exports the existing `adaptiveRoutingView` upsell component.
- Registered `LoadBalancerConfig` as a tag in the base API for cache invalidation.
- Updated the sidebar description from "Manage adaptive load balancer" to "Manage adaptive routing".

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Adaptive Routing section in the sidebar.
2. Confirm the sidebar now shows **Dashboard** and **Settings** sub-items.
3. Click **Dashboard** — verify it renders the adaptive routing dashboard and the Dashboard tab is highlighted.
4. Click **Settings** — verify it renders the settings view and the Settings tab is highlighted (Dashboard tab should not remain highlighted).
5. On an OSS build, verify the Settings page displays the same enterprise upsell as the Dashboard page.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots showing the new sidebar sub-items and the settings page._

## Breaking changes

- [x] No

## Related issues

## Security considerations

No new auth surfaces introduced. The existing RBAC check (`RbacResource.AdaptiveRouter`) in the layout guards both the dashboard and the new settings route.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Adaptive Routing Settings page with dedicated navigation and dashboard access.
  * Enhanced sidebar navigation with sub-items for Adaptive Routing Dashboard and Settings.
  * Integrated load balancer settings into the Adaptive Routing interface with enterprise fallback support.
  * Improved plugin execution order to ensure provider selection occurs after routing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->