### PR TITLE
fix(vertex): add API key auth support to Embedding method

### DIFF
--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1491,7 +1491,11 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	}
 
 	// Build the native Vertex embedding API endpoint
-	url := getCompleteURLForGeminiEndpoint(request.Model, region, projectID, projectNumber, ":predict")
+	authQuery := ""
+	if key.Value.GetValue() != "" {
+		authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
+	}
+	completeURL := getCompleteURLForGeminiEndpoint(request.Model, region, projectID, projectNumber, ":predict")
 
 	// Create HTTP request for streaming
 	req := fasthttp.AcquireRequest()
@@ -1505,22 +1509,28 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	}()
 
 	req.Header.SetMethod(http.MethodPost)
-	req.SetRequestURI(url)
 	req.Header.SetContentType("application/json")
 
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	// Getting oauth2 token
-	tokenSource, err := getAuthTokenSource(key)
-	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError("error creating auth token source", err)
+	// If auth query is set, add it to the URL
+	// Otherwise, get the oauth2 token and set the Authorization header
+	if authQuery != "" {
+		completeURL = fmt.Sprintf("%s?%s", completeURL, authQuery)
+	} else {
+		tokenSource, err := getAuthTokenSource(key)
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError("error creating auth token source", err)
+		}
+		token, err := tokenSource.Token()
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError("error getting token", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token.AccessToken)
 	}
-	token, err := tokenSource.Token()
-	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError("error getting token", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	req.SetRequestURI(completeURL)
 
 	usedLargePayloadBody := providerUtils.ApplyLargePayloadRequestBody(ctx, req)
 	if !usedLargePayloadBody {


### PR DESCRIPTION
## Summary

The Vertex provider's `Embedding()` method unconditionally calls `getAuthTokenSource(key)`, which attempts `google.FindDefaultCredentials()`. This fails in environments where GCP auth is provided externally via context headers (e.g. Workload Identity Federation) rather than Application Default Credentials.

Other methods (`ChatCompletion`, `Responses`, `ResponsesStream`) already handle this correctly by checking `key.Value` first and skipping the internal auth when set — allowing auth provided via `BifrostContextKeyExtraHeaders` to take effect. This PR applies the same pattern to `Embedding()`.

## Changes

- Added `authQuery` check to `Embedding()` in `core/providers/vertex/vertex.go`, matching the pattern used by `ChatCompletion()`, `Responses()`, and `ResponsesStream()`
- When `key.Value` is set, the value is appended as a `?key=...` query parameter and `getAuthTokenSource()` is skipped
- When `key.Value` is empty, the existing OAuth2 flow via `getAuthTokenSource()` is preserved unchanged
- Renamed local `url` variable to `completeURL` to avoid shadowing the `net/url` import (needed for `url.QueryEscape`)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Additionally, to validate the fix end-to-end:

1. Configure a Vertex key with a non-empty `Value` and set `Authorization` header via `BifrostContextKeyExtraHeaders`
2. Send an embedding request to the Vertex provider
3. Verify the request succeeds (previously failed with "error creating auth token source")
4. Verify that embedding requests with empty `key.Value` and valid `AuthCredentials` still work via the OAuth2 path

## Screenshots/Recordings

Thats difficult to provide. We are using bifrost as the interal layer of a ai-gateway service we are building. With this change in play we can successfully route to vertex using our auth header in the same way we do for `Responses` etc.

here is an example of a successful call:
```
rpc POST /service.ai-gateway/service/embeddings {"model":"text-embedding-005","input_text":"Hello world","provider":"vertex","virtual_key":"service.ai-gateway:image-test", "dimensions":4}
{
    "data": [
        {
            "embedding": [
                -0.03997058793902397,
                0.043299295008182526,
                -0.00944140087813139,
                -0.04618649184703827
            ],
            "object": "embedding"
        }
    ],
    "object": "list",
    "provider": "vertex",
    "usage": {
        "prompt_tokens": 2,
        "total_tokens": 2
    }
}
```

Without this patch we always receive a key error instead:

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No new auth mechanisms introduced. The change reuses the existing `authQuery` pattern already present in `ChatCompletion()`, `Responses()`, and `ResponsesStream()`. The API key is URL-encoded via `url.QueryEscape` consistent with all other call sites.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vertex provider now supports API key authentication, giving users an alternative method to authenticate with embedding services. This provides greater flexibility for different use cases and deployment scenarios.

* **Improvements**
  * Refined request handling and configuration for Vertex provider embeddings to ensure proper setup of authentication and network parameters, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->