### PR TITLE
fix: gemini parts in tool response

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -2498,6 +2498,192 @@ func TestResponsesAPIParallelFunctionCalling(t *testing.T) {
 				assert.Contains(t, responseStr, "Google", "Response should contain tab content")
 			},
 		},
+		{
+			name: "ResponsesAPI_FunctionCallOutput_MultimodalBlocks_ImagePreserved",
+			input: &schemas.BifrostResponsesRequest{
+				Provider: schemas.Gemini,
+				Model:    "gemini-3-pro-preview",
+				Input: []schemas.ResponsesMessage{
+					{
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("What color is the image the tool returned?"),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+						ResponsesToolMessage: &schemas.ResponsesToolMessage{
+							CallID:    schemas.Ptr("c1"),
+							Name:      schemas.Ptr("read_file"),
+							Arguments: schemas.Ptr(`{}`),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+						ResponsesToolMessage: &schemas.ResponsesToolMessage{
+							CallID: schemas.Ptr("c1"),
+							Output: &schemas.ResponsesToolMessageOutputStruct{
+								// Mixed text + image blocks (OpenAI Responses API format)
+								ResponsesFunctionToolCallOutputBlocks: []schemas.ResponsesMessageContentBlock{
+									{
+										Type: schemas.ResponsesInputMessageContentBlockTypeText,
+										Text: schemas.Ptr("result:"),
+									},
+									{
+										Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+										ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+											// 1x1 red PNG
+											ImageURL: schemas.Ptr("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				var fr *gemini.FunctionResponse
+				for i := range result.Contents {
+					for _, p := range result.Contents[i].Parts {
+						if p.FunctionResponse != nil {
+							fr = p.FunctionResponse
+							break
+						}
+					}
+				}
+				require.NotNil(t, fr, "Should have a functionResponse")
+				assert.Equal(t, "read_file", fr.Name)
+
+				// Text block preserved in the structured response
+				responseStr := string(fr.Response)
+				assert.Contains(t, responseStr, "result:", "Text output should be preserved")
+
+				// Image block preserved as a nested inlineData part (NOT dropped) on Gemini 3+
+				require.Len(t, fr.Parts, 1, "Image block should be attached as a functionResponse part")
+				require.NotNil(t, fr.Parts[0].InlineData, "Media part must carry inlineData")
+				assert.Equal(t, "image/png", fr.Parts[0].InlineData.MIMEType)
+				assert.NotEmpty(t, fr.Parts[0].InlineData.Data, "Image base64 data must be present")
+				assert.NotEmpty(t, fr.Parts[0].InlineData.DisplayName, "Blob should have a displayName")
+
+				// No $ref must be emitted: the Gemini Developer API rejects the $ref form
+				// ("does not match to a display_name"); Gemini 3 reads media directly from parts.
+				assert.NotContains(t, responseStr, "$ref", "Response must NOT contain a $ref placeholder")
+			},
+		},
+		{
+			name: "ResponsesAPI_FunctionCallOutput_MultimodalBlocks_DroppedForOlderModel",
+			input: &schemas.BifrostResponsesRequest{
+				Provider: schemas.Gemini,
+				Model:    "gemini-2.5-flash", // not Gemini 3 → multimodal tool output unsupported
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+						ResponsesToolMessage: &schemas.ResponsesToolMessage{
+							CallID:    schemas.Ptr("c1"),
+							Name:      schemas.Ptr("read_file"),
+							Arguments: schemas.Ptr(`{}`),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+						ResponsesToolMessage: &schemas.ResponsesToolMessage{
+							CallID: schemas.Ptr("c1"),
+							Output: &schemas.ResponsesToolMessageOutputStruct{
+								ResponsesFunctionToolCallOutputBlocks: []schemas.ResponsesMessageContentBlock{
+									{
+										Type: schemas.ResponsesInputMessageContentBlockTypeText,
+										Text: schemas.Ptr("result:"),
+									},
+									{
+										Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+										ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+											ImageURL: schemas.Ptr("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				var fr *gemini.FunctionResponse
+				for i := range result.Contents {
+					for _, p := range result.Contents[i].Parts {
+						if p.FunctionResponse != nil {
+							fr = p.FunctionResponse
+							break
+						}
+					}
+				}
+				require.NotNil(t, fr, "Should have a functionResponse")
+				// Text is still preserved, but the image is dropped (older models reject
+				// multimodal function responses with a hard 400), so no parts are emitted.
+				assert.Contains(t, string(fr.Response), "result:", "Text output should be preserved")
+				assert.Empty(t, fr.Parts, "Media must be dropped for non-Gemini-3 models (no 400)")
+			},
+		},
+		{
+			name: "ResponsesAPI_FunctionCallOutput_MultimodalBlocks_VertexEmitsRef",
+			input: &schemas.BifrostResponsesRequest{
+				Provider: schemas.Vertex, // Vertex AI supports (and requires) the $ref form
+				Model:    "gemini-3-pro-preview",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+						ResponsesToolMessage: &schemas.ResponsesToolMessage{
+							CallID:    schemas.Ptr("c1"),
+							Name:      schemas.Ptr("read_file"),
+							Arguments: schemas.Ptr(`{}`),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+						ResponsesToolMessage: &schemas.ResponsesToolMessage{
+							CallID: schemas.Ptr("c1"),
+							Output: &schemas.ResponsesToolMessageOutputStruct{
+								ResponsesFunctionToolCallOutputBlocks: []schemas.ResponsesMessageContentBlock{
+									{
+										Type: schemas.ResponsesInputMessageContentBlockTypeText,
+										Text: schemas.Ptr("result:"),
+									},
+									{
+										Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+										ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+											ImageURL: schemas.Ptr("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				var fr *gemini.FunctionResponse
+				for i := range result.Contents {
+					for _, p := range result.Contents[i].Parts {
+						if p.FunctionResponse != nil {
+							fr = p.FunctionResponse
+							break
+						}
+					}
+				}
+				require.NotNil(t, fr, "Should have a functionResponse")
+				require.Len(t, fr.Parts, 1, "Image must be attached as a functionResponse part on Vertex")
+				require.NotNil(t, fr.Parts[0].InlineData)
+				dn := fr.Parts[0].InlineData.DisplayName
+				require.NotEmpty(t, dn, "Blob must have a displayName")
+
+				// Vertex DOES emit the $ref, pointing at the blob's displayName.
+				responseStr := string(fr.Response)
+				assert.Contains(t, responseStr, "result:", "Text output should be preserved")
+				assert.Contains(t, responseStr, "$ref", "Vertex must emit a $ref into the response")
+				assert.Contains(t, responseStr, dn, "The $ref must point at the blob displayName")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3811,6 +3997,148 @@ func TestFunctionCallingConfigModeAny_RoundTrip(t *testing.T) {
 			assert.Equal(t, tt.wantAllowedNames, got.AllowedFunctionNames, "AllowedFunctionNames must survive round-trip")
 		})
 	}
+}
+
+// TestMultimodalFunctionResponse_RoundTrip verifies that an image returned by a tool
+// inside functionResponse.parts survives the full
+// GeminiGenerationRequest → BifrostResponsesRequest → GeminiGenerationRequest round-trip
+// (Gemini 3 multimodal function responses), instead of being dropped or collapsed to text.
+func TestMultimodalFunctionResponse_RoundTrip(t *testing.T) {
+	const redPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+	geminiReq := &gemini.GeminiGenerationRequest{
+		Model: "gemini-3-flash-preview",
+		Contents: []gemini.Content{
+			{Role: "user", Parts: []*gemini.Part{{Text: "What color is the tool image?"}}},
+			{Role: "model", Parts: []*gemini.Part{{
+				FunctionCall: &gemini.FunctionCall{ID: "c1", Name: "read_file", Args: json.RawMessage(`{}`)},
+			}}},
+			{Role: "user", Parts: []*gemini.Part{{
+				FunctionResponse: &gemini.FunctionResponse{
+					ID:       "c1",
+					Name:     "read_file",
+					Response: json.RawMessage(`{"media_0":{"$ref":"media_0"},"output":"result:"}`),
+					Parts: []*gemini.Part{{
+						InlineData: &gemini.Blob{MIMEType: "image/png", DisplayName: "media_0", Data: redPNG},
+					}},
+				},
+			}}},
+		},
+	}
+
+	// --- Gemini -> Bifrost: image must be reconstructed as content blocks ---
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostReq := geminiReq.ToBifrostResponsesRequest(bifrostCtx)
+	require.NotNil(t, bifrostReq)
+
+	var outputMsg *schemas.ResponsesMessage
+	for i := range bifrostReq.Input {
+		m := &bifrostReq.Input[i]
+		if m.Type != nil && *m.Type == schemas.ResponsesMessageTypeFunctionCallOutput {
+			outputMsg = m
+			break
+		}
+	}
+	require.NotNil(t, outputMsg, "Should have a function_call_output message")
+	require.NotNil(t, outputMsg.ResponsesToolMessage.Output)
+	blocks := outputMsg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks
+	require.NotEmpty(t, blocks, "Output must be reconstructed as content blocks (not collapsed to a string)")
+
+	var hasText, hasImage bool
+	for _, b := range blocks {
+		if b.Type == schemas.ResponsesInputMessageContentBlockTypeText && b.Text != nil {
+			assert.Equal(t, "result:", *b.Text)
+			hasText = true
+		}
+		if b.Type == schemas.ResponsesInputMessageContentBlockTypeImage &&
+			b.ResponsesInputMessageContentBlockImage != nil &&
+			b.ResponsesInputMessageContentBlockImage.ImageURL != nil {
+			assert.Contains(t, *b.ResponsesInputMessageContentBlockImage.ImageURL, redPNG, "Image base64 must be preserved")
+			hasImage = true
+		}
+	}
+	assert.True(t, hasText, "Text block must be preserved")
+	assert.True(t, hasImage, "Image block must be preserved")
+
+	// --- Bifrost -> Gemini: image must land back in functionResponse.parts ---
+	roundTrip, err := gemini.ToGeminiResponsesRequest(bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, roundTrip)
+
+	var fr *gemini.FunctionResponse
+	for i := range roundTrip.Contents {
+		for _, p := range roundTrip.Contents[i].Parts {
+			if p.FunctionResponse != nil {
+				fr = p.FunctionResponse
+				break
+			}
+		}
+	}
+	require.NotNil(t, fr, "Round-trip must still have a functionResponse")
+	require.Len(t, fr.Parts, 1, "Image must round-trip back into functionResponse.parts")
+	require.NotNil(t, fr.Parts[0].InlineData)
+	assert.Equal(t, "image/png", fr.Parts[0].InlineData.MIMEType)
+	assert.NotEmpty(t, fr.Parts[0].InlineData.Data, "Image data must survive the full round-trip")
+	assert.Contains(t, string(fr.Response), "result:", "Text output must survive the full round-trip")
+}
+
+// TestMultimodalFunctionResponse_PreservesNonRefFields verifies that non-$ref fields in a
+// multimodal functionResponse.response (the Gemini spec allows any keys, not just "output")
+// survive the Gemini -> Bifrost -> Gemini round-trip instead of being dropped, while the
+// $ref placeholders (which point at the media parts) are not re-emitted.
+func TestMultimodalFunctionResponse_PreservesNonRefFields(t *testing.T) {
+	const redPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+	geminiReq := &gemini.GeminiGenerationRequest{
+		Model: "gemini-3-flash-preview",
+		Contents: []gemini.Content{
+			{Role: "user", Parts: []*gemini.Part{{Text: "weather?"}}},
+			{Role: "model", Parts: []*gemini.Part{{
+				FunctionCall: &gemini.FunctionCall{ID: "c1", Name: "get_weather", Args: json.RawMessage(`{}`)},
+			}}},
+			{Role: "user", Parts: []*gemini.Part{{
+				FunctionResponse: &gemini.FunctionResponse{
+					ID:   "c1",
+					Name: "get_weather",
+					// Tool returns real data fields (temp, unit) plus an image reference.
+					Response: json.RawMessage(`{"temp":72,"unit":"F","chart_ref":{"$ref":"chart.png"}}`),
+					Parts: []*gemini.Part{{
+						InlineData: &gemini.Blob{MIMEType: "image/png", DisplayName: "chart.png", Data: redPNG},
+					}},
+				},
+			}}},
+		},
+	}
+
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostReq := geminiReq.ToBifrostResponsesRequest(bifrostCtx)
+	require.NotNil(t, bifrostReq)
+
+	roundTrip, err := gemini.ToGeminiResponsesRequest(bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, roundTrip)
+
+	var fr *gemini.FunctionResponse
+	for i := range roundTrip.Contents {
+		for _, p := range roundTrip.Contents[i].Parts {
+			if p.FunctionResponse != nil {
+				fr = p.FunctionResponse
+				break
+			}
+		}
+	}
+	require.NotNil(t, fr, "Round-trip must still have a functionResponse")
+
+	// Image survives as a part.
+	require.Len(t, fr.Parts, 1, "Image must round-trip into functionResponse.parts")
+	require.NotNil(t, fr.Parts[0].InlineData)
+
+	// Non-$ref data fields survive; the $ref placeholder is not re-emitted.
+	responseStr := string(fr.Response)
+	assert.Contains(t, responseStr, "72", "temp must survive the round-trip")
+	assert.Contains(t, responseStr, `"F"`, "unit must survive the round-trip")
+	assert.NotContains(t, responseStr, "$ref", "the $ref placeholder must not be re-emitted (Gemini provider)")
+	assert.NotContains(t, responseStr, "chart_ref", "the media-ref key must not leak into the response")
 }
 
 // TestImageSizeRoundtrip verifies that imageSize and aspectRatio survive the

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -116,7 +116,7 @@ func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Gem
 
 	// Convert ResponsesInput messages to Gemini contents
 	if bifrostReq.Input != nil {
-		contents, systemInstruction, err := convertResponsesMessagesToGeminiContents(bifrostReq.Input)
+		contents, systemInstruction, err := convertResponsesMessagesToGeminiContents(bifrostReq.Input, bifrostReq.Model, bifrostReq.Provider)
 		if err != nil {
 			return nil, err
 		}
@@ -1942,6 +1942,45 @@ func convertGeminiSystemInstructionToResponsesMessage(systemInstruction *Content
 	}
 }
 
+// stripFunctionResponseMediaRefs returns the textual payload of a Gemini functionResponse.Response
+// to carry alongside reconstructed media blocks. It drops top-level keys whose value is a
+// {"$ref": ...} placeholder — those reference the media we materialize as content blocks, and
+// re-emitting them would re-trigger the Gemini Developer API "$ref" bug — while preserving every
+// other field so multimodal tool results are not lossy. The Gemini spec lets callers use any keys
+// (output, result, error, ...), not just "output". When only the conventional "output" field
+// remains it is unwrapped to keep the common round-trip shape; a media-only response yields "".
+func stripFunctionResponseMediaRefs(response json.RawMessage) string {
+	if len(response) == 0 {
+		return ""
+	}
+	root := providerUtils.GetJSONField(response, "@this")
+	if !root.IsObject() {
+		return string(response)
+	}
+
+	cleaned := []byte(response)
+	remaining := 0
+	for key, value := range root.Map() {
+		if value.IsObject() && value.Get("$ref").Exists() {
+			if updated, err := providerUtils.DeleteJSONField(cleaned, key); err == nil {
+				cleaned = updated
+			}
+			continue
+		}
+		remaining++
+	}
+
+	if remaining == 0 {
+		return "" // media-only result; the forward path emits an empty "output" placeholder
+	}
+	if remaining == 1 {
+		if out := providerUtils.GetJSONField(cleaned, "output"); out.Exists() {
+			return out.String()
+		}
+	}
+	return string(cleaned)
+}
+
 func convertGeminiContentsToResponsesMessages(contents []Content) []schemas.ResponsesMessage {
 	var messages []schemas.ResponsesMessage
 	// Track function call IDs by name to match with responses
@@ -2025,13 +2064,48 @@ func convertGeminiContentsToResponsesMessages(contents []Content) []schemas.Resp
 					}
 				}
 
+				output := &schemas.ResponsesToolMessageOutputStruct{}
+				if len(part.FunctionResponse.Parts) > 0 {
+					// Multimodal function response (Gemini 3 series): the tool returned images/files
+					// nested in functionResponse.parts. Reconstruct them as content blocks so the media
+					// is preserved on the way in, instead of being collapsed to the text "output" field.
+					// Mirrors the forward conversion in convertResponsesMessagesToGeminiContents.
+					var blocks []schemas.ResponsesMessageContentBlock
+					// Preserve the structured response text alongside the media. The Gemini spec allows
+					// any keys (output, result, error, ...), so keep the whole response object minus the
+					// {"$ref": ...} placeholders (those point at the media we materialize as blocks below).
+					if textPayload := stripFunctionResponseMediaRefs(part.FunctionResponse.Response); textPayload != "" {
+						blocks = append(blocks, schemas.ResponsesMessageContentBlock{
+							Type: schemas.ResponsesInputMessageContentBlockTypeText,
+							Text: &textPayload,
+						})
+					}
+					for _, p := range part.FunctionResponse.Parts {
+						var block *schemas.ResponsesMessageContentBlock
+						switch {
+						case p.InlineData != nil:
+							block = convertGeminiInlineDataToContentBlock(p.InlineData)
+						case p.FileData != nil:
+							block = convertGeminiFileDataToContentBlock(p.FileData)
+						}
+						if block != nil {
+							blocks = append(blocks, *block)
+						}
+					}
+					if len(blocks) > 0 {
+						output.ResponsesFunctionToolCallOutputBlocks = blocks
+					} else {
+						output.ResponsesToolCallOutputStr = &responseStr
+					}
+				} else {
+					output.ResponsesToolCallOutputStr = &responseStr
+				}
+
 				msg := schemas.ResponsesMessage{
 					Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
 					ResponsesToolMessage: &schemas.ResponsesToolMessage{
 						CallID: &responseID,
-						Output: &schemas.ResponsesToolMessageOutputStruct{
-							ResponsesToolCallOutputStr: &responseStr,
-						},
+						Output: output,
 					},
 				}
 
@@ -2967,8 +3041,13 @@ func convertResponsesToolChoiceToGemini(toolChoice *schemas.ResponsesToolChoice)
 	return config
 }
 
-// convertResponsesMessagesToGeminiContents converts Responses messages to Gemini contents
-func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessage) ([]Content, *Content, error) {
+// convertResponsesMessagesToGeminiContents converts Responses messages to Gemini contents.
+// model is used to gate features that are only valid on Gemini 3+ (e.g. multimodal function
+// responses, where a tool returns images/files nested in functionResponse.parts). provider
+// distinguishes Vertex AI from the Gemini Developer API, which differ in how multimodal
+// function responses must be referenced (see the FunctionCallOutput handling below).
+func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessage, model string, provider schemas.ModelProvider) ([]Content, *Content, error) {
+	isVertex := provider == schemas.Vertex
 	// if only system / developer message is there, convert it to user message (since openai allows it)
 	if len(messages) == 1 && messages[0].Role != nil && (*messages[0].Role == schemas.ResponsesInputMessageRoleSystem || *messages[0].Role == schemas.ResponsesInputMessageRoleDeveloper) {
 		content := Content{Role: "user"}
@@ -3150,6 +3229,9 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 				// must be sent in a single message with only functionResponse parts (no text/content parts)
 				if msg.ResponsesToolMessage.CallID != nil {
 					responseMap := make(map[string]any)
+					// Multimodal blocks (images, files) returned by the function are collected here
+					// and attached to FunctionResponse.Parts (Gemini 3+ only).
+					var funcMediaParts []*Part
 
 					// Extract output from ResponsesToolMessage.Output
 					if msg.ResponsesToolMessage.Output != nil && msg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr != nil {
@@ -3160,12 +3242,48 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 							responseMap["output"] = output
 						}
 					} else if msg.ResponsesToolMessage.Output != nil && msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks != nil {
-						// Handle structured output blocks (e.g. from Anthropic Responses API format
-						// where output is an array of content blocks like [{"type":"input_text","text":"..."}])
+						// Handle structured output blocks (e.g. from the OpenAI/Anthropic Responses API
+						// format where output is an array of content blocks like
+						// [{"type":"input_text","text":"..."}, {"type":"input_image","image_url":"..."}]).
+						//
+						// Text blocks go into responseMap["output"]. Multimodal blocks (images, files)
+						// cannot live inside the structured response; per the Gemini docs they must be
+						// nested as sibling FunctionResponse.Parts (inlineData/fileData). This is a
+						// Gemini 3+ feature, so for older models we drop the media and keep text only
+						// (sending parts to e.g. gemini-2.5 returns a hard "not supported" 400).
+						//
+						// Referencing the media from the structured response differs by provider:
+						//   - Vertex AI: emit a "<displayName>_ref": {"$ref": "<displayName>"} entry into
+						//     the response (the documented format; Vertex resolves the ref to the part).
+						//   - Gemini Developer API: do NOT emit $ref — the API rejects it
+						//     ("does not match to a display_name", a known upstream bug). The model
+						//     still reads the media directly from parts.
+						supportsMultimodalToolOutput := isGemini3Plus(model)
 						var textParts []string
 						for _, block := range msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks {
 							if block.Text != nil && *block.Text != "" {
 								textParts = append(textParts, *block.Text)
+								continue
+							}
+							if !supportsMultimodalToolOutput {
+								continue // older models can't accept media in a function response
+							}
+							mediaPart, err := convertContentBlockToGeminiPart(block)
+							if err != nil {
+								return nil, nil, fmt.Errorf("failed to convert function output content block: %w", err)
+							}
+							if mediaPart == nil {
+								continue
+							}
+							displayName := fmt.Sprintf("media_%d", len(funcMediaParts))
+							if mediaPart.InlineData != nil {
+								mediaPart.InlineData.DisplayName = displayName
+							} else if mediaPart.FileData != nil {
+								mediaPart.FileData.DisplayName = displayName
+							}
+							funcMediaParts = append(funcMediaParts, mediaPart)
+							if isVertex {
+								responseMap[displayName+"_ref"] = map[string]string{"$ref": displayName}
 							}
 						}
 						if len(textParts) > 0 {
@@ -3175,13 +3293,13 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 							} else {
 								responseMap["output"] = combined
 							}
-						} else {
-							// Fallback for non-text blocks (e.g. images, files): marshal the raw blocks
-							// so responseMap["output"] is never left empty when blocks are present
-							rawBlocks, err := providerUtils.MarshalSorted(msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks)
-							if err == nil && len(rawBlocks) > 0 {
-								responseMap["output"] = json.RawMessage(rawBlocks)
-							}
+						} else if len(funcMediaParts) > 0 {
+							// Media-only result: the content lives in parts. We intentionally emit
+							// {"output": ""} rather than leaving response as {} — an empty object would
+							// be treated by Gemini as the full (empty) function output. The reverse
+							// converter's stripFunctionResponseMediaRefs reads this "" back as no text
+							// block, so the media-only round-trip stays clean.
+							responseMap["output"] = ""
 						}
 					} else if msg.Content != nil && msg.Content.ContentStr != nil {
 						// Fallback to Content.ContentStr for backward compatibility
@@ -3209,6 +3327,7 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 							Name:     funcName,
 							Response: json.RawMessage(responseBytes),
 							ID:       *msg.ResponsesToolMessage.CallID,
+							Parts:    funcMediaParts,
 						},
 					}
 					pendingFunctionResponseParts = append(pendingFunctionResponseParts, part)

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1363,6 +1363,10 @@ func (p *Part) UnmarshalJSON(data []byte) error {
 		FunctionCall        *FunctionCall        `json:"functionCall,omitempty"`
 		FunctionResponse    *FunctionResponse    `json:"functionResponse,omitempty"`
 		Text                string               `json:"text,omitempty"`
+		// snake_case fallbacks: the google-genai SDK serializes FunctionResponsePart
+		// (nested inside functionResponse.parts) with snake_case keys, unlike top-level parts.
+		InlineDataSnake *Blob     `json:"inline_data,omitempty"`
+		FileDataSnake   *FileData `json:"file_data,omitempty"`
 	}
 
 	var aux PartAlias
@@ -1373,7 +1377,13 @@ func (p *Part) UnmarshalJSON(data []byte) error {
 	p.VideoMetadata = aux.VideoMetadata
 	p.Thought = aux.Thought
 	p.InlineData = aux.InlineData
+	if p.InlineData == nil {
+		p.InlineData = aux.InlineDataSnake
+	}
 	p.FileData = aux.FileData
+	if p.FileData == nil {
+		p.FileData = aux.FileDataSnake
+	}
 	p.CodeExecutionResult = aux.CodeExecutionResult
 	p.ExecutableCode = aux.ExecutableCode
 	p.FunctionCall = aux.FunctionCall
@@ -1415,12 +1425,16 @@ type Blob struct {
 	MIMEType string `json:"mimeType,omitempty"`
 }
 
-// UnmarshalJSON custom unmarshaler for Blob to handle URL-safe base64
+// UnmarshalJSON custom unmarshaler for Blob to handle URL-safe base64.
+// Also accepts the snake_case keys (mime_type, display_name) the google-genai SDK
+// emits inside functionResponse.parts (FunctionResponseBlob), preferring camelCase.
 func (b *Blob) UnmarshalJSON(data []byte) error {
 	type BlobAlias struct {
-		DisplayName string `json:"displayName,omitempty"`
-		Data        string `json:"data,omitempty"`
-		MIMEType    string `json:"mimeType,omitempty"`
+		DisplayName      string `json:"displayName,omitempty"`
+		DisplayNameSnake string `json:"display_name,omitempty"`
+		Data             string `json:"data,omitempty"`
+		MIMEType         string `json:"mimeType,omitempty"`
+		MIMETypeSnake    string `json:"mime_type,omitempty"`
 	}
 
 	var aux BlobAlias
@@ -1429,7 +1443,13 @@ func (b *Blob) UnmarshalJSON(data []byte) error {
 	}
 
 	b.DisplayName = aux.DisplayName
+	if b.DisplayName == "" {
+		b.DisplayName = aux.DisplayNameSnake
+	}
 	b.MIMEType = aux.MIMEType
+	if b.MIMEType == "" {
+		b.MIMEType = aux.MIMETypeSnake
+	}
 
 	if aux.Data != "" {
 		// Convert URL-safe base64 to standard base64
@@ -1507,6 +1527,40 @@ type FileData struct {
 	MIMEType string `json:"mimeType,omitempty"`
 }
 
+// UnmarshalJSON custom unmarshaler for FileData. Also accepts the snake_case keys
+// (mime_type, file_uri, display_name) the google-genai SDK emits inside
+// functionResponse.parts (FunctionResponseFileData), preferring camelCase.
+func (f *FileData) UnmarshalJSON(data []byte) error {
+	type FileDataAlias struct {
+		DisplayName      string `json:"displayName,omitempty"`
+		DisplayNameSnake string `json:"display_name,omitempty"`
+		FileURI          string `json:"fileUri,omitempty"`
+		FileURISnake     string `json:"file_uri,omitempty"`
+		MIMEType         string `json:"mimeType,omitempty"`
+		MIMETypeSnake    string `json:"mime_type,omitempty"`
+	}
+
+	var aux FileDataAlias
+	if err := sonic.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	f.DisplayName = aux.DisplayName
+	if f.DisplayName == "" {
+		f.DisplayName = aux.DisplayNameSnake
+	}
+	f.FileURI = aux.FileURI
+	if f.FileURI == "" {
+		f.FileURI = aux.FileURISnake
+	}
+	f.MIMEType = aux.MIMEType
+	if f.MIMEType == "" {
+		f.MIMEType = aux.MIMETypeSnake
+	}
+
+	return nil
+}
+
 // FunctionCall represents a function call.
 type FunctionCall struct {
 	// Optional. The unique ID of the function call. If populated, the client to execute
@@ -1543,6 +1597,10 @@ type FunctionResponse struct {
 	// function output and "error" key to specify error details (if any). If "output" and
 	// "error" keys are not specified, then whole "response" is treated as function output.
 	Response json.RawMessage `json:"response,omitempty"`
+	// Optional. Multimodal content (images, files) returned by the function. Each part must
+	// contain inlineData or fileData with a displayName, referenced from `response` via
+	// {"$ref": "<displayName>"}. Supported on Gemini 3 series models.
+	Parts []*Part `json:"parts,omitempty"`
 }
 
 // ==================== RESPONSE TYPES ====================

--- a/tests/integrations/python/tests/test_google.py
+++ b/tests/integrations/python/tests/test_google.py
@@ -1660,6 +1660,211 @@ Joe: Pretty good, thanks for asking."""
         
         print("\n✓ Gemini 3 Pro Preview thought signature handling test completed successfully!")
 
+    @skip_if_no_api_key("gemini")
+    @pytest.mark.parametrize("model,expect_image_understood", [
+        ("gemini-3-flash-preview", True),
+    ])
+    def test_30_multimodal_function_response_image(self, test_config, model, expect_image_understood):
+        """Test Case 30: Image returned inside a function response (functionResponse.parts).
+
+        A tool returns a solid red image as multimodal content nested in the function response.
+        The image must survive Bifrost's Gemini<->Bifrost translation instead of being dropped.
+        Regression guard for multimodal function_call_output (text + image), and for the
+        model-version gating Bifrost applies:
+
+          - gemini-3-flash-preview: Bifrost forwards the image as functionResponse.parts (no $ref;
+            the $ref form is rejected by the Gemini Developer API), so the model sees it -> "red".
+          - gemini-2.5-flash: multimodal function responses are unsupported (a hard 400 upstream),
+            so Bifrost drops the image and sends text only. The request must still SUCCEED; the
+            model just can't see the image. This proves gating prevents a regression.
+
+        Notes:
+          - No real first turn is needed: we inject the `skip_thought_signature_validator` sentinel
+            as the function call's thought signature (Gemini 3 requires a signature on tool calls).
+          - We deliberately do NOT put a {"$ref": ...} in `response` (Developer API rejects it).
+        """
+        from google.genai import types
+        import base64
+
+        client = get_provider_google_client(provider="gemini")
+
+        read_image_tool = types.Tool(
+            function_declarations=[
+                {
+                    "name": "read_image",
+                    "description": "Reads an image file from disk and returns it.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string", "description": "Path to the image file"}
+                        },
+                        "required": ["path"],
+                    },
+                }
+            ]
+        )
+
+        # BASE64_IMAGE is a 64x64 solid red PNG. FunctionResponseBlob.data takes raw bytes;
+        # the SDK base64-encodes it on the wire (what Bifrost receives).
+        image_bytes = base64.b64decode(BASE64_IMAGE)
+
+        # Bypass Gemini 3's thought-signature validation for this fabricated multi-turn history.
+        # The SDK base64-encodes these bytes on the wire; Gemini decodes and matches the sentinel.
+        skip_sig = b"skip_thought_signature_validator"
+
+        conversation = [
+            types.Content(
+                role="user",
+                parts=[types.Part(text=(
+                    "Call read_image to read 'photo.png', then tell me the single dominant "
+                    "color of the image it returns. Reply with only the color word."
+                ))],
+            ),
+            types.Content(
+                role="model",
+                parts=[types.Part(
+                    function_call=types.FunctionCall(
+                        id="call_1", name="read_image", args={"path": "photo.png"}
+                    ),
+                    thought_signature=skip_sig,
+                )],
+            ),
+            types.Content(
+                role="user",
+                parts=[types.Part(function_response=types.FunctionResponse(
+                    id="call_1",
+                    name="read_image",
+                    response={"output": "Here is the image."},
+                    parts=[types.FunctionResponsePart(
+                        inline_data=types.FunctionResponseBlob(
+                            mime_type="image/png",
+                            display_name="photo.png",
+                            data=image_bytes,
+                        )
+                    )],
+                ))],
+            ),
+        ]
+
+        response = client.models.generate_content(
+            model=model,
+            contents=conversation,
+            config=types.GenerateContentConfig(tools=[read_image_tool]),
+        )
+
+        assert response.candidates, "Response should have candidates"
+        text = (response.text or "").strip().lower()
+        print(f"\n[{model}] reply: {text!r}")
+        assert text, "Model should produce a text reply after the multimodal tool result"
+
+        if expect_image_understood:
+            assert "red" in text, (
+                f"[{model}] model did not identify the tool-returned image color (got: {text!r}). "
+                "The image was likely dropped during functionResponse translation."
+            )
+
+    @skip_if_no_api_key("gemini")
+    @pytest.mark.parametrize("model,expect_image_understood", [
+        ("gemini-2.5-flash", False),
+        ("gemini-3-flash-preview", True),
+    ])
+    def test_30b_multimodal_function_response_full_workflow(self, test_config, model, expect_image_understood):
+        """Test Case 30b: Full two-turn multimodal function-calling workflow (mirrors the
+        Gemini docs example) through Bifrost.
+
+        Unlike test_30 (which fabricates the history), this drives a real round trip:
+          1. Send a prompt that triggers the tool -> the model returns a genuine functionCall
+             (carrying its own thought signature, required by Gemini 3).
+          2. Send the tool result back as a multimodal functionResponse: the response references
+             the image via {"image_ref": {"$ref": "<displayName>"}} and the bytes live in parts,
+             exactly like the docs/Vertex example.
+          3. The model produces a final answer describing the returned image.
+
+        Bifrost adapts the $ref per provider: it keeps it for Vertex and strips it for the Gemini
+        Developer API (where the $ref form is an upstream 400 bug), so this works on both.
+          - gemini-3-flash-preview: image reaches the model -> final answer says "red".
+          - gemini-2.5-flash: multimodal tool output is unsupported, so Bifrost drops the image and
+            the request still succeeds (gating prevents a hard 400); we only assert a text reply.
+        """
+        from google.genai import types
+        import base64
+
+        client = get_provider_google_client(provider="gemini")
+
+        get_image_declaration = types.FunctionDeclaration(
+            name="get_image",
+            description="Retrieves the image file for a specific item.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "item_name": {
+                        "type": "string",
+                        "description": "The name or description of the item (e.g., 'red shirt').",
+                    }
+                },
+                "required": ["item_name"],
+            },
+        )
+        tool_config = types.Tool(function_declarations=[get_image_declaration])
+
+        # Turn 1: a prompt that should make the model call get_image
+        prompt = (
+            "Use get_image to retrieve the shirt I ordered, then tell me its single dominant "
+            "color. Reply with only the color word."
+        )
+        response_1 = client.models.generate_content(
+            model=format_provider_model("vertex", model),
+            contents=[prompt],
+            config=types.GenerateContentConfig(tools=[tool_config]),
+        )
+
+        if not getattr(response_1, "function_calls", None):
+            pytest.skip(f"[{model}] model did not call the tool on turn 1; cannot drive the workflow")
+        function_call = response_1.function_calls[0]
+        print(f"\n[{model}] turn 1 called: {function_call.name}({dict(function_call.args)})")
+
+        # BASE64_IMAGE is a 64x64 solid red PNG; the tool "returns" it as multimodal content.
+        image_bytes = base64.b64decode(BASE64_IMAGE)
+        function_response_data = {"image_ref": {"$ref": "shirt.png"}}
+        function_response_multimodal_data = types.FunctionResponsePart(
+            inline_data=types.FunctionResponseBlob(
+                mime_type="image/png",
+                display_name="shirt.png",
+                data=image_bytes,
+            )
+        )
+
+        # Turn 2: append the real model turn + the tool result, then ask for the final answer.
+        history = [
+            types.Content(role="user", parts=[types.Part(text=prompt)]),
+            response_1.candidates[0].content,
+            types.Content(
+                role="tool",
+                parts=[types.Part.from_function_response(
+                    name=function_call.name,
+                    response=function_response_data,
+                    parts=[function_response_multimodal_data],
+                )],
+            ),
+        ]
+
+        response_2 = client.models.generate_content(
+            model=format_provider_model("vertex", model),
+            contents=history,
+            config=types.GenerateContentConfig(tools=[tool_config]),
+        )
+
+        assert response_2.candidates, "Turn 2 should have candidates"
+        text = (response_2.text or "").strip().lower()
+        print(f"[{model}] final reply: {text!r}")
+        assert text, "Model should produce a final text reply after the multimodal tool result"
+
+        if expect_image_understood:
+            assert "red" in text, (
+                f"[{model}] model did not identify the tool-returned image color (got: {text!r}). "
+                "The image was likely dropped during functionResponse translation."
+            )
+
     @skip_if_no_api_key("google")
     @pytest.mark.parametrize("provider,model", get_cross_provider_params_for_scenario("thinking"))
     def test_29_structured_output_with_thinking(self, google_client, test_config, provider, model):


### PR DESCRIPTION
## Summary

Adds support for multimodal function responses (images and files returned by tools) in the Gemini provider. Previously, when a tool returned image or file content alongside text, the media was either dropped or serialized as a raw JSON fallback. This PR preserves those media blocks by routing them through `FunctionResponse.Parts` (a Gemini 3+ feature), with correct provider-specific behavior for the Gemini Developer API vs. Vertex AI.

## Changes

- **`FunctionResponse.Parts` field added** to the `FunctionResponse` type so images/files returned by tools can be attached as sibling parts alongside the structured response object.
- **Forward conversion (`convertResponsesMessagesToGeminiContents`)** now accepts `model` and `provider` arguments. For Gemini 3+ models, image/file content blocks from `ResponsesFunctionToolCallOutputBlocks` are converted to `inlineData`/`fileData` parts and attached to `FunctionResponse.Parts`. For older models (e.g. `gemini-2.5-flash`), media is silently dropped to avoid a hard upstream 400. Vertex AI emits a `{"$ref": "<displayName>"}` entry in the response object (as documented); the Gemini Developer API does not (the `$ref` form triggers an upstream bug).
- **Reverse conversion (`convertGeminiContentsToResponsesMessages`)** reconstructs multimodal function responses back into `ResponsesFunctionToolCallOutputBlocks` (text + image blocks), preserving media on the Bifrost side instead of collapsing everything to a plain string.
- **`Part.UnmarshalJSON`** now handles snake_case fallbacks (`inline_data`, `file_data`) emitted by the google-genai SDK inside `functionResponse.parts`.
- **`Blob.UnmarshalJSON`** now handles snake_case fallbacks (`mime_type`, `display_name`) from `FunctionResponseBlob`.
- **`FileData.UnmarshalJSON`** added with snake_case fallbacks (`mime_type`, `file_uri`, `display_name`) from `FunctionResponseFileData`.
- **Unit tests** added for: image preserved on Gemini 3 (Developer API, no `$ref`), image dropped on older models, Vertex emitting `$ref`, and a full round-trip (`GeminiGenerationRequest` → `BifrostResponsesRequest` → `GeminiGenerationRequest`).
- **Integration tests** added (`test_30`, `test_30b`) covering a fabricated multimodal tool history and a real two-turn workflow, parameterized across `gemini-3-flash-preview` (image understood) and `gemini-2.5-flash` (image dropped, request still succeeds).

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
# Unit tests
go test ./core/providers/gemini/... -run TestResponsesAPIParallelFunctionCalling
go test ./core/providers/gemini/... -run TestMultimodalFunctionResponse_RoundTrip

# Integration tests (requires GEMINI_API_KEY)
cd tests/integrations/python
pytest tests/test_google.py::TestGoogleProvider::test_30_multimodal_function_response_image
pytest tests/test_google.py::TestGoogleProvider::test_30b_multimodal_function_response_full_workflow
```

Expected outcomes:
- `gemini-3-flash-preview`: model identifies the tool-returned image color as "red".
- `gemini-2.5-flash`: request succeeds without a 400; model produces a text reply (image was dropped by gating).

## Breaking changes

- [x] No

## Security considerations

No new auth, secrets, or PII surface. Base64 image data passes through in-memory only and is not logged or persisted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved multimodal function-response support: tools can return images alongside text for Gemini 3 models; other model types gracefully fall back to text-only or reference-style handling.

* **Compatibility**
  * Better handling of provider/model variations so image-containing tool outputs are preserved where supported and safely downgraded otherwise.

* **Tests**
  * Added end-to-end and regression tests validating multimodal function-response round‑trips and field preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->