### PR TITLE
fix: preserve cache_control blocks in open router chat request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1718,14 +1718,14 @@ install-newman: ## Install newman + htmlextra reporter if not already installed
 	@$(USE_NODE); npm list -g newman-reporter-htmlextra > /dev/null 2>&1 || ($(ECHO) "$(YELLOW)Installing newman-reporter-htmlextra...$(NC)" && npm install -g newman-reporter-htmlextra)
 	@$(ECHO) "$(GREEN)Newman + htmlextra are ready$(NC)"
 
-run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost provider-harness Postman collection. HELP=1 prints full parameter docs. Filter via PROVIDER=openai|anthropic|bedrock|gemini|vertex|azure|passthrough, FEATURE="<kw>" or FEATURE="<kw1>,<kw2>" (AND across substrings; matches request name/URL/body), RERUN_FAILED=1 (re-run only items that failed last run). INCLUDE_PREVIEW=1 to run [PREVIEW]-tagged account/region-scoped cases. SKIP_STREAM_CANCEL=1 skips stream cancellation probes. USE_INFISICAL=1 to source from Infisical (Usage: make run-provider-harness-test [HELP=1] [PROVIDER=anthropic] [FEATURE="web search"] [FEATURE="cross-cut,structured output"] [RERUN_FAILED=1] [INCLUDE_PREVIEW=1] [BASE_URL=...] [FOLDER="..."] [ENV_FILE=...] [VIEWER_PORT=8090] [CI=1])
+run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost provider-harness Postman collection. HELP=1 prints full parameter docs. Filter via PROVIDER=openai|anthropic|bedrock|gemini|vertex|azure|passthrough|openrouter, FEATURE="<kw>" or FEATURE="<kw1>,<kw2>" (AND across substrings; matches request name/URL/body), RERUN_FAILED=1 (re-run only items that failed last run). INCLUDE_PREVIEW=1 to run [PREVIEW]-tagged account/region-scoped cases. SKIP_STREAM_CANCEL=1 skips stream cancellation probes. USE_INFISICAL=1 to source from Infisical (Usage: make run-provider-harness-test [HELP=1] [PROVIDER=anthropic] [FEATURE="web search"] [FEATURE="cross-cut,structured output"] [RERUN_FAILED=1] [INCLUDE_PREVIEW=1] [BASE_URL=...] [FOLDER="..."] [ENV_FILE=...] [VIEWER_PORT=8090] [CI=1])
 	@if [ -n "$(HELP)" ]; then \
 		printf '\n%s\n' "$(CYAN)run-provider-harness-test - Bifrost provider harness runner$(NC)"; \
 		printf '%s\n\n' "Runs the Bifrost provider-harness Postman collection through newman, with optional filtering."; \
 		printf '%s\n\n' "Includes §8 Criss-Cross: endpoint-shape × model-provider × modality matrix (chat, streaming, embeddings, audio, image gen, tools, vision, JSON, reasoning)."; \
 		printf '%s\n' "$(YELLOW)PARAMETERS$(NC)"; \
 		printf '  %-18s %s\n' "HELP=1"          "Print this help and exit (no Bifrost or network activity)."; \
-		printf '  %-18s %s\n' "PROVIDER=<name>" "Filter requests by provider. One of: openai, anthropic, bedrock, gemini, vertex, azure, passthrough."; \
+		printf '  %-18s %s\n' "PROVIDER=<name>" "Filter requests by provider. One of: openai, anthropic, bedrock, gemini, vertex, azure, passthrough, openrouter."; \
 		printf '  %-18s %s\n' ""                "  Matches via PROVIDER_KEYWORDS in tests/e2e/api/runners/filter-collection.mjs (loose name/body substring)."; \
 		printf '  %-18s %s\n' "FEATURE=\"<kw>\""  "Filter by case-insensitive keyword(s) against the full request JSON (name + URL + body + ancestor folder names)."; \
 		printf '  %-18s %s\n' ""                "  Single: FEATURE=\"web search\". Multi-keyword AND (comma-separated): FEATURE=\"cross-cut,structured output\"."; \
@@ -1872,11 +1872,11 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 	$(USE_NODE); \
 	PARALLEL_VAL="$(or $(PARALLEL),1)"; \
 	if [ "$$PARALLEL_VAL" != "0" ] && [ -n "$$PARALLEL_VAL" ]; then \
-		$(ECHO) "$(CYAN)Parallel mode (default): forking one newman per provider (openai, anthropic, bedrock, gemini, vertex, azure, passthrough). Set PARALLEL=0 to disable.$(NC)"; \
+		$(ECHO) "$(CYAN)Parallel mode (default): forking one newman per provider (openai, anthropic, bedrock, gemini, vertex, azure, passthrough, openrouter). Set PARALLEL=0 to disable.$(NC)"; \
 		rm -f tmp/newman-report-*.json tmp/newman-cli-*.log tmp/parallel-pids tmp/parallel-status; \
 		: > tmp/parallel-pids; \
 		: > tmp/parallel-status; \
-		PROVIDERS="openai anthropic bedrock gemini vertex azure passthrough"; \
+		PROVIDERS="openai anthropic bedrock gemini vertex azure passthrough openrouter"; \
 		if [ -n "$(PROVIDER)" ]; then PROVIDERS="$(PROVIDER)"; fi; \
 		LAUNCHED=0; \
 		for p in $$PROVIDERS; do \
@@ -1959,7 +1959,7 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		NEWMAN_EXIT=$$PFAILED; \
 	else \
 		SEQ_PROVIDERS="$(PROVIDER)"; \
-		if [ -z "$$SEQ_PROVIDERS" ]; then SEQ_PROVIDERS="openai anthropic bedrock gemini vertex azure passthrough"; fi; \
+		if [ -z "$$SEQ_PROVIDERS" ]; then SEQ_PROVIDERS="openai anthropic bedrock gemini vertex azure passthrough openrouter"; fi; \
 		if [ -t 1 ] && [ -z "$$CI" ] && [ -z "$(CI)" ]; then \
 			: > tmp/newman-cli.log; \
 			$(USE_NODE); node tests/e2e/api/runners/harness-monitor.mjs \

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -29,6 +29,7 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 	openaiReq := &OpenAIChatRequest{
 		Model:    bifrostReq.Model,
 		Messages: ConvertBifrostMessagesToOpenAIMessages(bifrostReq.Input),
+		Provider: bifrostReq.Provider,
 	}
 
 	if bifrostReq.Params != nil {

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -894,3 +894,85 @@ func TestApplyXAICompatibility(t *testing.T) {
 		})
 	}
 }
+
+// TestToOpenAIChatRequest_CacheControl_OpenRouterOnly verifies that
+// Anthropic-style cache_control breakpoints on message content blocks and on
+// tools survive marshalling only when the originating provider is OpenRouter
+// (which forwards them to the underlying Claude/Gemini model). For OpenAI and
+// other OpenAI-format providers, cache_control is still stripped.
+func TestToOpenAIChatRequest_CacheControl_OpenRouterOnly(t *testing.T) {
+	makeReq := func(provider schemas.ModelProvider) *schemas.BifrostChatRequest {
+		return &schemas.BifrostChatRequest{
+			Provider: provider,
+			Model:    "anthropic/claude-opus-4",
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleSystem,
+					Content: &schemas.ChatMessageContent{
+						ContentBlocks: []schemas.ChatContentBlock{
+							{
+								Type:         schemas.ChatContentBlockTypeText,
+								Text:         schemas.Ptr("long cacheable system prompt"),
+								CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+							},
+						},
+					},
+				},
+				{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}},
+			},
+			Params: &schemas.ChatParameters{
+				Tools: []schemas.ChatTool{
+					{
+						Type: schemas.ChatToolTypeFunction,
+						Function: &schemas.ChatToolFunction{
+							Name:        "lookup",
+							Description: schemas.Ptr("lookup something"),
+							Parameters: &schemas.ToolFunctionParameters{
+								Type: "object",
+								Properties: schemas.NewOrderedMapFromPairs(
+									schemas.KV("q", map[string]interface{}{"type": "string"}),
+								),
+							},
+						},
+						CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		provider schemas.ModelProvider
+		wantKept bool
+	}{
+		{name: "openrouter preserves cache_control", provider: schemas.OpenRouter, wantKept: true},
+		{name: "openai strips cache_control", provider: schemas.OpenAI, wantKept: false},
+		{name: "gemini strips cache_control", provider: schemas.Gemini, wantKept: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+			defer cancel()
+
+			result := ToOpenAIChatRequest(ctx, makeReq(tt.provider))
+			require.NotNil(t, result)
+
+			wireBody, err := json.Marshal(result)
+			require.NoError(t, err)
+			s := string(wireBody)
+
+			if tt.wantKept {
+				require.Contains(t, s, "cache_control", "cache_control must be preserved for OpenRouter: %s", s)
+				// Both the content-block breakpoint and the tool breakpoint must survive.
+				require.Equal(t, 2, strings.Count(s, "cache_control"), "expected cache_control on both content block and tool: %s", s)
+			} else {
+				require.NotContains(t, s, "cache_control", "cache_control must be stripped for %s: %s", tt.provider, s)
+			}
+
+			// The tool identity must always survive regardless of stripping.
+			require.Contains(t, s, "lookup")
+		})
+	}
+}

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -88,6 +88,10 @@ type OpenAIChatRequest struct {
 	// This Field is populated only for such providers and is NOT to be used externally.
 	MaxTokens *int `json:"max_tokens,omitempty"`
 
+	// Provider is the originating provider, used for provider-specific marshalling
+	// (e.g. preserving cache_control for OpenRouter). Not serialized to wire.
+	Provider schemas.ModelProvider `json:"-"`
+
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
 	Fallbacks   []string               `json:"fallbacks,omitempty"`
 	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
@@ -134,10 +138,17 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 	}
 	type Alias OpenAIChatRequest
 
+	// OpenRouter forwards Anthropic-style cache_control breakpoints to the
+	// underlying model, so we must preserve cache_control (on content blocks
+	// and tools) when targeting OpenRouter. Everything else (citations,
+	// file types, Anthropic server tools, Anthropic-only tool flags) is still
+	// stripped — OpenRouter is otherwise an OpenAI-format endpoint.
+	keepCacheControl := req.Provider == schemas.OpenRouter
+
 	// First pass: check if we need to modify any messages
 	needsCopy := false
 	for _, msg := range req.Messages {
-		if hasFieldsToStripInChatMessage(msg) {
+		if hasFieldsToStripInChatMessage(msg, keepCacheControl) {
 			needsCopy = true
 			break
 		}
@@ -148,7 +159,7 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 	if needsCopy {
 		processedMessages = make([]OpenAIMessage, len(req.Messages))
 		for i, msg := range req.Messages {
-			if !hasFieldsToStripInChatMessage(msg) {
+			if !hasFieldsToStripInChatMessage(msg, keepCacheControl) {
 				// No modification needed, use original
 				processedMessages[i] = msg
 				continue
@@ -162,10 +173,13 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 				contentCopy := *msg.Content
 				contentCopy.ContentBlocks = make([]schemas.ChatContentBlock, len(msg.Content.ContentBlocks))
 				for j, block := range msg.Content.ContentBlocks {
-					needsBlockCopy := block.CacheControl != nil || block.Citations != nil || (block.File != nil && block.File.FileType != nil)
+					stripBlockCacheControl := block.CacheControl != nil && !keepCacheControl
+					needsBlockCopy := stripBlockCacheControl || block.Citations != nil || (block.File != nil && (block.File.FileType != nil || block.File.FileURL != nil))
 					if needsBlockCopy {
 						blockCopy := block
-						blockCopy.CacheControl = nil
+						if stripBlockCacheControl {
+							blockCopy.CacheControl = nil
+						}
 						blockCopy.Citations = nil
 						// Strip FileType and FileURL from file block
 						if blockCopy.File != nil && (blockCopy.File.FileType != nil || blockCopy.File.FileURL != nil) {
@@ -197,7 +211,8 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 	if len(req.Tools) > 0 {
 		needsToolChange := false
 		for _, tool := range req.Tools {
-			if tool.CacheControl != nil || isAnthropicServerToolShape(tool) || hasAnthropicOnlyToolFlags(tool) {
+			stripToolCacheControl := tool.CacheControl != nil && !keepCacheControl
+			if stripToolCacheControl || isAnthropicServerToolShape(tool) || hasAnthropicOnlyToolFlags(tool) {
 				needsToolChange = true
 				break
 			}
@@ -211,12 +226,15 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 				if isAnthropicServerToolShape(tool) {
 					continue
 				}
-				if tool.CacheControl == nil && !hasAnthropicOnlyToolFlags(tool) {
+				stripToolCacheControl := tool.CacheControl != nil && !keepCacheControl
+				if !stripToolCacheControl && !hasAnthropicOnlyToolFlags(tool) {
 					processedTools = append(processedTools, tool)
 					continue
 				}
 				toolCopy := tool
-				toolCopy.CacheControl = nil
+				if stripToolCacheControl {
+					toolCopy.CacheControl = nil
+				}
 				toolCopy.DeferLoading = nil
 				toolCopy.AllowedCallers = nil
 				toolCopy.InputExamples = nil
@@ -575,10 +593,10 @@ func isAnthropicOnlyResponsesToolType(t schemas.ResponsesTool) bool {
 		t.Type == schemas.ResponsesToolTypeMemory
 }
 
-func hasFieldsToStripInChatMessage(msg OpenAIMessage) bool {
+func hasFieldsToStripInChatMessage(msg OpenAIMessage, keepCacheControl bool) bool {
 	if msg.Content != nil && msg.Content.ContentBlocks != nil {
 		for _, block := range msg.Content.ContentBlocks {
-			if block.CacheControl != nil {
+			if block.CacheControl != nil && !keepCacheControl {
 				return true
 			}
 			if block.Citations != nil {

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -2588,6 +2588,316 @@
         }
 
       ]
+    },
+    {
+      "name": "13. OpenRouter Prompt Caching (cache_control)",
+      "description": "Sends OpenAI-format chat requests through the OpenRouter provider with Anthropic-style cache_control breakpoints on content blocks and tools. OpenRouter forwards cache_control to Claude/Gemini (explicit caching) and harmlessly ignores it for implicit-caching models (OpenAI/DeepSeek) \u2014 these must NOT 400. Bifrost preserves cache_control only when the provider is OpenRouter (stripped for native OpenAI).",
+      "item": [
+        {
+          "name": "OpenRouter Anthropic Claude: cache_control on system block",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) { pm.test('cache_control forwarded: response ok + usage present', function () { var j = pm.response.json(); pm.expect(j.usage || {}).to.be.an('object'); }); } pm.test('cache_control not rejected (no 400)', function () { pm.expect(pm.response.code).to.not.equal(400); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/anthropic/claude-sonnet-4\", \"max_tokens\": 64, \"messages\": [{\"role\": \"system\", \"content\": [{\"type\": \"text\", \"text\": \"You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant.\", \"cache_control\": {\"type\": \"ephemeral\"}}]}, {\"role\": \"user\", \"content\": \"Reply with one word.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Anthropic Claude: cache_control on tool",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) { pm.test('cache_control forwarded: response ok + usage present', function () { var j = pm.response.json(); pm.expect(j.usage || {}).to.be.an('object'); }); } pm.test('cache_control not rejected (no 400)', function () { pm.expect(pm.response.code).to.not.equal(400); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/anthropic/claude-sonnet-4\", \"max_tokens\": 64, \"messages\": [{\"role\": \"system\", \"content\": [{\"type\": \"text\", \"text\": \"You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant.\", \"cache_control\": {\"type\": \"ephemeral\"}}]}, {\"role\": \"user\", \"content\": \"Reply with one word.\"}], \"tools\": [{\"type\": \"function\", \"function\": {\"name\": \"get_weather\", \"description\": \"Get weather for a city\", \"parameters\": {\"type\": \"object\", \"properties\": {\"city\": {\"type\": \"string\"}}, \"required\": [\"city\"]}}, \"cache_control\": {\"type\": \"ephemeral\"}}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Anthropic Claude: cache_control 1h ttl",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) { pm.test('cache_control forwarded: response ok + usage present', function () { var j = pm.response.json(); pm.expect(j.usage || {}).to.be.an('object'); }); } pm.test('cache_control not rejected (no 400)', function () { pm.expect(pm.response.code).to.not.equal(400); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/anthropic/claude-sonnet-4\", \"max_tokens\": 64, \"messages\": [{\"role\": \"system\", \"content\": [{\"type\": \"text\", \"text\": \"You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant.\", \"cache_control\": {\"type\": \"ephemeral\", \"ttl\": \"1h\"}}]}, {\"role\": \"user\", \"content\": \"Reply with one word.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Google Gemini Flash: cache_control on system block",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) { pm.test('cache_control forwarded: response ok + usage present', function () { var j = pm.response.json(); pm.expect(j.usage || {}).to.be.an('object'); }); } pm.test('cache_control not rejected (no 400)', function () { pm.expect(pm.response.code).to.not.equal(400); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/google/gemini-2.5-flash\", \"max_tokens\": 64, \"messages\": [{\"role\": \"system\", \"content\": [{\"type\": \"text\", \"text\": \"You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant.\", \"cache_control\": {\"type\": \"ephemeral\"}}]}, {\"role\": \"user\", \"content\": \"Reply with one word.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Google Gemini Pro: cache_control on system block",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) { pm.test('cache_control forwarded: response ok + usage present', function () { var j = pm.response.json(); pm.expect(j.usage || {}).to.be.an('object'); }); } pm.test('cache_control not rejected (no 400)', function () { pm.expect(pm.response.code).to.not.equal(400); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/google/gemini-2.5-pro\", \"max_tokens\": 64, \"messages\": [{\"role\": \"system\", \"content\": [{\"type\": \"text\", \"text\": \"You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant.\", \"cache_control\": {\"type\": \"ephemeral\"}}]}, {\"role\": \"user\", \"content\": \"Reply with one word.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter OpenAI GPT-4o: cache_control ignored (no 400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) { pm.test('cache_control forwarded: response ok + usage present', function () { var j = pm.response.json(); pm.expect(j.usage || {}).to.be.an('object'); }); } pm.test('cache_control not rejected (no 400)', function () { pm.expect(pm.response.code).to.not.equal(400); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/openai/gpt-4o\", \"max_tokens\": 64, \"messages\": [{\"role\": \"system\", \"content\": [{\"type\": \"text\", \"text\": \"You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant.\", \"cache_control\": {\"type\": \"ephemeral\"}}]}, {\"role\": \"user\", \"content\": \"Reply with one word.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter DeepSeek: cache_control ignored (no 400)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) { pm.test('cache_control forwarded: response ok + usage present', function () { var j = pm.response.json(); pm.expect(j.usage || {}).to.be.an('object'); }); } pm.test('cache_control not rejected (no 400)', function () { pm.expect(pm.response.code).to.not.equal(400); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/deepseek/deepseek-chat\", \"max_tokens\": 64, \"messages\": [{\"role\": \"system\", \"content\": [{\"type\": \"text\", \"text\": \"You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant.\", \"cache_control\": {\"type\": \"ephemeral\"}}]}, {\"role\": \"user\", \"content\": \"Reply with one word.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "OpenRouter Qwen: cache_control on system block",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) { pm.test('cache_control forwarded: response ok + usage present', function () { var j = pm.response.json(); pm.expect(j.usage || {}).to.be.an('object'); }); } pm.test('cache_control not rejected (no 400)', function () { pm.expect(pm.response.code).to.not.equal(400); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"openrouter/qwen/qwen-2.5-72b-instruct\", \"max_tokens\": 64, \"messages\": [{\"role\": \"system\", \"content\": [{\"type\": \"text\", \"text\": \"You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant. You are a meticulous assistant.\", \"cache_control\": {\"type\": \"ephemeral\"}}]}, {\"role\": \"user\", \"content\": \"Reply with one word.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/tests/e2e/api/runners/filter-collection.mjs
+++ b/tests/e2e/api/runners/filter-collection.mjs
@@ -52,6 +52,7 @@ const PROVIDER_KEYWORDS = {
   vertex: ["vertex", "/genai/v1beta/models/{{vertexModel}}"],
   azure: ["azure", "deployments"],
   passthrough: ["_passthrough"],
+  openrouter: ["openrouter"],
 };
 
 // Haystack = item JSON + ancestor folder names. Folder names encode the harness
@@ -102,6 +103,12 @@ const itemMatchesProvider = (item, ancestorNames) => {
   if (!PROVIDER) return true;
   const keywords = PROVIDER_KEYWORDS[PROVIDER] || [PROVIDER];
   const haystack = buildHaystack(item, ancestorNames);
+  // OpenRouter rows (model "openrouter/<vendor>/<model>") embed vendor substrings like
+  // gpt-/claude-/gemini, so they'd otherwise be claimed by the openai/anthropic/gemini
+  // partitions too. Route them exclusively to the openrouter partition.
+  const isOpenRouter = haystack.includes("openrouter");
+  if (PROVIDER === "openrouter") return isOpenRouter;
+  if (isOpenRouter) return false;
   return keywords.some((k) => haystack.includes(k));
 };
 


### PR DESCRIPTION
## Summary

OpenRouter acts as an OpenAI-format proxy but forwards Anthropic-style `cache_control` breakpoints to underlying models (e.g. Claude, Gemini). Previously, `cache_control` was unconditionally stripped from all content blocks and tools during OpenAI-format marshalling, which broke prompt caching when routing through OpenRouter. This PR preserves `cache_control` on content blocks and tools when the originating provider is OpenRouter, while continuing to strip it for all other OpenAI-format providers.

## Changes

- `OpenAIChatRequest` now carries a `Provider` field (not serialized to wire) that is populated from the incoming `BifrostChatRequest` during conversion.
- `MarshalJSON` on `OpenAIChatRequest` derives a `keepCacheControl` flag from `req.Provider == schemas.OpenRouter` and uses it to conditionally skip stripping `cache_control` from content blocks and tools.
- `hasFieldsToStripInChatMessage` accepts a `keepCacheControl bool` parameter so the strip-detection logic stays consistent with the strip-execution logic.
- All other OpenRouter-incompatible fields (citations, file types, Anthropic server tools, Anthropic-only tool flags) continue to be stripped regardless of provider.
- Tests cover the three cases: OpenRouter preserves both the content-block and tool `cache_control` breakpoints, while OpenAI and Gemini strip them.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestToOpenAIChatRequest_CacheControl_OpenRouterOnly -v
go test ./...
```

Expected: `TestToOpenAIChatRequest_CacheControl_OpenRouterOnly` passes with all three sub-tests (OpenRouter preserves `cache_control` on both content block and tool; OpenAI and Gemini strip it entirely). Full test suite passes.

## Breaking changes

- [x] No

## Security considerations

None. The `Provider` field is tagged `json:"-"` and is never serialized to the wire payload sent to the upstream provider.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider info is now forwarded in chat requests so provider-specific options are honored.
  * cache_control directives are preserved only for the OpenRouter provider and removed for others where incompatible.

* **Tests**
  * Added unit tests verifying provider-specific cache_control handling and tool identifiers remain intact when cache_control is stripped.
  * Added end-to-end test cases exercising OpenRouter cache_control scenarios.

* **New Features**
  * Test harness and runner updated to recognize and run OpenRouter-backed tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->