### PR TITLE
docs: updates dd & otel docs for plugin filtering

### DIFF
--- a/docs/enterprise/datadog-connector.mdx
+++ b/docs/enterprise/datadog-connector.mdx
@@ -412,6 +412,51 @@ Each APM trace includes comprehensive LLM operation metadata:
 
 ---
 
+## Plugin Span Filtering
+
+By default every plugin's pre- and post-hook execution generates a span, which can bloat APM traces when many plugins are active (e.g. 8 built-in plugins × 2 hooks = 16 plugin spans per request). Use `plugin_span_filter` inside the Datadog plugin config to control which plugin spans are exported. This affects only the exported APM trace spans — plugin execution and metrics are unchanged.
+
+**Via config.json** (inside the Datadog plugin config):
+
+```json
+{
+  "plugins": [
+    {
+      "name": "datadog",
+      "enabled": true,
+      "config": {
+        "service_name": "bifrost",
+        "agent_addr": "localhost:8126",
+        "enable_traces": true,
+        "plugin_span_filter": {
+          "mode": "exclude",
+          "plugins": ["logging", "compat", "telemetry"]
+        }
+      }
+    }
+  ]
+}
+```
+
+**Via the UI**: Open the **Observability** page, select the **Datadog** connector, and click **Configure Plugin Tracing**. Toggle individual plugins on or off and save. UI-saved settings persist across restarts unless `plugin_span_filter` is set in config.json with a higher `version` value.
+
+**Filter modes:**
+
+| Mode | Behaviour |
+|------|-----------|
+| `exclude` | Export spans for all plugins **except** those listed |
+| `include` | Export spans **only** for the listed plugins |
+
+**Built-in plugin names** (for reference): `telemetry`, `prompts`, `logging`, `governance`, `otel`, `semantic_cache`, `compat`, `maxim`.
+
+When a plugin span is filtered out, its children are automatically re-parented to the nearest exported ancestor so the trace hierarchy stays connected. The filter applies to APM trace spans only; it does not change DogStatsD metrics, which are never derived from plugin spans.
+
+<Note>
+  Each observability connector has its own independent `plugin_span_filter` — filtering plugin spans for Datadog does not affect OTEL, BigQuery, or any other connector. `plugin_span_filter` follows the standard plugin config precedence rules; to make a config.json value override UI-saved DB settings on restart, set a higher `version` on the Datadog plugin entry (e.g. `"version": 2`). See [Plugin Versioning](/deployment-guides/config-json/plugins) for details.
+</Note>
+
+---
+
 ## Supported Request Types
 
 The Datadog plugin captures all Bifrost request types:

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -1056,7 +1056,7 @@ By default every plugin's pre- and post-hook execution generates a span, which c
 }
 ```
 
-**Via the UI**: Open the Plugins page and click **Configure Plugin Tracing**. Toggle individual plugins on or off and save. UI-saved settings persist across restarts unless `plugin_span_filter` is set in config.json with a higher `version` value.
+**Via the UI**: Open the **Observability** page, select the **Open Telemetry** connector, and click **Configure Plugin Tracing**. Toggle individual plugins on or off and save. UI-saved settings persist across restarts unless `plugin_span_filter` is set in config.json with a higher `version` value.
 
 **Filter modes:**
 


### PR DESCRIPTION
## Summary

Documents the `plugin_span_filter` configuration option for the Datadog connector, and corrects the UI navigation path for the OTEL connector's plugin span filtering instructions.

## Changes

- Added a new **Plugin Span Filtering** section to the Datadog connector docs, covering `exclude`/`include` filter modes, config.json usage, UI configuration, built-in plugin names, child span re-parenting behavior, and a note on per-connector filter independence and config versioning precedence.
- Updated the OTEL connector docs to correct the UI navigation path from the generic "Plugins page" to the specific **Observability** page → **Open Telemetry** connector flow, matching the Datadog connector's updated instructions.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation for:
- The new **Plugin Span Filtering** section appearing correctly in the Datadog connector page, including the config.json example, filter mode table, built-in plugin name list, and the `<Note>` callout.
- The OTEL connector page showing the corrected UI navigation path ("Open the **Observability** page, select the **Open Telemetry** connector...").

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Plugin Span Filtering guide for Datadog APM explaining how to include/exclude plugin execution spans, supported filter modes (include/exclude), built-in plugin names, example configuration, and how filtering re-parents child spans in traces.
  * Clarified OpenTelemetry connector docs to use the Observability page for plugin tracing and that connector config can override UI-saved filters by version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->