### PR TITLE
docs: direct api key

### DIFF
--- a/docs/deployment-guides/config-json/client.mdx
+++ b/docs/deployment-guides/config-json/client.mdx
@@ -101,6 +101,7 @@ This setting is also configurable via the UI (**MCP Gateway → MCP Settings**) 
 | `max_request_body_size_mb` | integer | `100` | Maximum allowed request body size in MB |
 | `whitelisted_routes` | array of strings | `[]` | Routes that bypass auth middleware |
 | `allowed_headers` | array of strings | `[]` | Additional headers permitted for CORS and WebSocket |
+| `allow_direct_keys` | boolean | `false` | Allow callers to bypass the registered key pool by sending `x-bf-direct-key: true` and a raw provider key in `Authorization` / `x-api-key` / `x-goog-api-key`. See [Direct API Key](../../providers/request-options#direct-api-key) |
 
 ```json
 {

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -62,6 +62,7 @@ Controls the worker pool, logging pipeline, security, and SDK shims. All fields 
 | `logging_headers` | array | `[]` | HTTP headers to capture in log metadata |
 | `enforce_auth_on_inference` | boolean | `false` | Require a virtual key on every `/v1/*` request |
 | `allowed_origins` | array | `["*"]` | CORS allowed origins |
+| `allow_direct_keys` | boolean | `false` | Let callers bypass the key pool with `x-bf-direct-key: true` + a raw provider key |
 | `max_request_body_size_mb` | integer | `100` | Maximum request body in MB |
 | `whitelisted_routes` | array | `[]` | Routes that bypass auth middleware |
 | `allowed_headers` | array | `[]` | Additional headers permitted for CORS/WebSocket |

--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -13,6 +13,7 @@ Bifrost provides request options that control behavior, enable features, and pas
 | `BifrostContextKeyVirtualKey`              | `x-bf-vk`                                            | `string`              | Virtual key identifier for governance                                                                                                 |
 | `BifrostContextKeyAPIKeyName`              | `x-bf-api-key`                                       | `string`              | Explicit API key name selection                                                                                                       |
 | `BifrostContextKeyAPIKeyID`                | `x-bf-api-key-id`                                    | `string`              | Explicit API key ID selection (takes priority over name)                                                                              |
+| `BifrostContextKeyDirectKey`               | `x-bf-direct-key` (+ `Authorization` / `x-api-key` / `x-goog-api-key`) | `schemas.Key`         | Use a caller-supplied raw provider key directly, bypassing the registered key pool. On the gateway, requires `allow_direct_keys` server-side |
 | `BifrostContextKeySessionID`               | `x-bf-session-id`                                    | `string`              | Session ID for key stickiness (requires KV store)                                                                                     |
 | `BifrostContextKeySessionTTL`              | `x-bf-session-ttl`                                   | `time.Duration`       | Session-to-key cache TTL (duration string or seconds)                                                                                 |
 | `BifrostContextKeyRequestID`               | `x-request-id`                                       | `string`              | Custom request ID for tracking                                                                                                        |
@@ -158,6 +159,59 @@ Input: messages,
 })
 
 ````
+</Tab>
+</Tabs>
+
+### Direct API Key
+
+**Context Key:** `BifrostContextKeyDirectKey`
+**Header:** `x-bf-direct-key` (plus the raw key in `Authorization`, `x-api-key`, or `x-goog-api-key`)
+**Type:** `schemas.Key`
+**Required:** No
+
+Supply a raw provider API key with the request and have Bifrost use it directly, bypassing the registered key pool entirely. Unlike [API Key Selection](#api-key-selection) (which references a *stored* key by ID or name), this passes the secret itself — useful for multi-tenant setups where each caller brings their own provider credentials.
+
+On the **gateway**, this is double-gated and off by default:
+
+1. The server admin must enable `allow_direct_keys` (see [client config](../deployment-guides/config-json/client)).
+2. The caller must send `x-bf-direct-key: true` on the request **and** the raw provider key in one of `Authorization: Bearer <key>`, `x-api-key`, or `x-goog-api-key`.
+
+Both conditions must hold; neither alone takes effect. Virtual keys (`sk-bf-*`) in those headers are **not** treated as direct keys — they continue to resolve as virtual keys.
+
+In the **Go SDK** there is no flag: set `BifrostContextKeyDirectKey` to a `schemas.Key` and it is used as-is.
+
+<Warning>
+A direct key bypasses Bifrost's key management entirely — **no governance** (virtual key budgets, rate limits, provider/model allow-lists, routing rules), **no weighted selection**, and **no rotation or fallback** across alternate keys. The key is used exactly as supplied. Enable `allow_direct_keys` only when you intend callers to manage their own provider credentials.
+</Warning>
+
+<Tabs>
+<Tab title="Gateway (cURL)">
+```bash
+curl --location 'http://localhost:8080/v1/chat/completions' \
+--header 'x-bf-direct-key: true' \
+--header 'Authorization: Bearer sk-your-real-openai-key' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello!"}]
+}'
+```
+</Tab>
+<Tab title="Go SDK">
+```go
+ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+ctx.SetValue(schemas.BifrostContextKeyDirectKey, schemas.Key{
+    Value:  schemas.EnvVar{Val: "sk-your-real-openai-key"},
+    Models: []string{},
+    Weight: 1.0,
+})
+
+response, err := client.ChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+    Provider: schemas.OpenAI,
+    Model:    "gpt-4o-mini",
+    Input:    messages,
+})
+```
 </Tab>
 </Tabs>
 
@@ -1233,6 +1287,7 @@ Bifrost maintains a security denylist of headers that are **never** forwarded to
 - `x-goog-api-key` (when used via `x-bf-eh-*`)
 - `x-bf-api-key` (when used via `x-bf-eh-*`)
 - `x-bf-vk` (when used via `x-bf-eh-*`)
+- `x-bf-direct-key` (when used via `x-bf-eh-*`)
 
 ## Internal Context Keys
 <Warning>

--- a/docs/quickstart/go-sdk/context-keys.mdx
+++ b/docs/quickstart/go-sdk/context-keys.mdx
@@ -78,6 +78,22 @@ Skip key selection entirely and pass an empty key to the provider. Useful for pr
 bfCtx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
 ```
 
+### Direct Key
+
+Supply a raw provider API key to use directly, bypassing the registered key pool. Set `BifrostContextKeyDirectKey` to a `schemas.Key` and Bifrost uses it as-is — there is no flag to enable in the SDK (the gateway's `allow_direct_keys` setting only gates the HTTP header path that populates this same key).
+
+```go
+bfCtx.SetValue(schemas.BifrostContextKeyDirectKey, schemas.Key{
+    Value:  schemas.EnvVar{Val: "sk-your-real-openai-key"},
+    Models: []string{},
+    Weight: 1.0,
+})
+```
+
+<Warning>
+A direct key bypasses governance, weighted selection, and rotation/fallback — the key is used exactly as supplied. Prefer [API Key Selection](#api-key-selection) when you want to reference a Bifrost-managed key instead of passing the secret.
+</Warning>
+
 ### Session Stickiness (Session ID)
 
 Bind a session to a specific API key so that requests with the same session ID consistently use the same key. Useful for predictable rate-limit buckets, cost attribution per user, and consistent model routing per session.
@@ -344,6 +360,7 @@ func makeRequest(client *bifrost.Bifrost) {
 | `BifrostContextKeyVirtualKey` | `string` | Set | Virtual key identifier for governance |
 | `BifrostContextKeyAPIKeyName` | `string` | Set | Explicit API key name selection |
 | `BifrostContextKeyAPIKeyID` | `string` | Set | Explicit API key ID selection (priority over name) |
+| `BifrostContextKeyDirectKey` | `schemas.Key` | Set | Use a caller-supplied raw provider key directly, bypassing the key pool |
 | `BifrostContextKeyRequestID` | `string` | Set | Custom request ID for tracking |
 | `BifrostContextKeyFallbackRequestID` | `string` | Read | Request ID used for fallback attempt |
 | `BifrostContextKeySkipKeySelection` | `bool` | Set | Skip key selection entirely |

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -198,7 +198,7 @@
         },
         "allow_direct_keys": {
           "type": "boolean",
-          "description": "Allow callers to bypass the registered key pool by supplying x-bf-direct-key: true and an Authorization header carrying the provider's raw API key.",
+          "description": "Allow callers to bypass the registered key pool by supplying x-bf-direct-key: true and the provider's raw API key in an Authorization (Bearer), x-api-key, or x-goog-api-key header.",
           "default": false
         },
         "mcp_agent_depth": {


### PR DESCRIPTION
## Summary

Documents the new `allow_direct_keys` gateway configuration option and the `BifrostContextKeyDirectKey` context key, which together allow callers to supply a raw provider API key directly to Bifrost, bypassing the registered key pool. This is intended for multi-tenant setups where each caller manages their own provider credentials.

## Changes

- Added `allow_direct_keys` boolean field to the client config and schema reference tables, defaulting to `false`
- Added a new **Direct API Key** section to `request-options.mdx` covering gateway usage (via `x-bf-direct-key: true` + a raw key in `Authorization`, `x-api-key`, or `x-goog-api-key`) and Go SDK usage (via `BifrostContextKeyDirectKey`)
- Added `x-bf-direct-key` to the security denylist so it cannot be forwarded to providers via `x-bf-eh-*` extra headers
- Added `BifrostContextKeyDirectKey` to the Go SDK context keys reference and quickstart guide, including a warning that it bypasses governance, weighted selection, and key rotation/fallback
- Documented the double-gate requirement on the gateway: both `allow_direct_keys` must be enabled server-side and the caller must send `x-bf-direct-key: true`; virtual keys in those headers are not treated as direct keys

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Verify the `allow_direct_keys` entry appears correctly in the client config and schema reference pages.
2. Confirm the **Direct API Key** section renders in `request-options.mdx` with the cURL and Go SDK tabs.
3. Confirm `x-bf-direct-key` appears in the security denylist section.
4. Confirm `BifrostContextKeyDirectKey` appears in the Go SDK context keys table and quickstart guide.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

`allow_direct_keys` is off by default and requires explicit opt-in by the server admin. When enabled, raw provider secrets are passed by callers and used directly — bypassing all of Bifrost's key governance, rate limiting, and rotation. The `x-bf-direct-key` header is added to the security denylist to prevent it from being forwarded to upstream providers via the extra-headers mechanism. Operators should enable this only when callers are trusted to manage their own provider credentials.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Direct API Key" request option allowing callers (when enabled) to supply a raw provider API key alongside the x-bf-direct-key header to bypass the managed key pool.
  * Documented new client.allow_direct_keys configuration to enable this behavior.
  * Updated request-option references and Go SDK context-key docs; added warning that direct keys bypass governance/rotation/selection and updated denylist handling so direct-key headers aren’t forwarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->