### PR TITLE
[fix]: Mistral provider - honor request_path_overrides for all endpoints

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- [fix]: mistral custom providers can override request paths for all endpoints [@georg-wolflein](https://github.com/georg-wolflein)
 [fix]: warn callers not to truncate the `#t=` temp-token fragment on MCP inline-auth links [@MarcusPeng](https://github.com/MarcusPeng)
 [fix]: zero pooled ChannelMessage references on release to avoid pinning request bodies [@citrocat](https://github.com/citrocat)
 - fix: preserve Gemini file upload MIME types for GenAI file URI completions

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -76,6 +76,15 @@ func (provider *MistralProvider) GetProviderKey() schemas.ModelProvider {
 	return providerUtils.GetProviderName(schemas.Mistral, provider.customProviderConfig)
 }
 
+// buildRequestURL constructs the full request URL using the provider's configuration.
+func (provider *MistralProvider) buildRequestURL(ctx *schemas.BifrostContext, defaultPath string, requestType schemas.RequestType) string {
+	path, isCompleteURL := providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType)
+	if isCompleteURL {
+		return path
+	}
+	return provider.networkConfig.BaseURL + path
+}
+
 // listModelsByKey performs a list models request for a single key.
 // Returns the response and latency, or an error if the request fails.
 func (provider *MistralProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
@@ -88,7 +97,7 @@ func (provider *MistralProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/models"))
+	req.SetRequestURI(provider.buildRequestURL(ctx, "/v1/models", schemas.ListModelsRequest))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -178,7 +187,7 @@ func (provider *MistralProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.buildRequestURL(ctx, "/v1/chat/completions", schemas.ChatCompletionRequest),
 		provider.normalizeChatRequestForConversion(request),
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -200,7 +209,7 @@ func (provider *MistralProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.buildRequestURL(ctx, "/v1/chat/completions", schemas.ChatCompletionStreamRequest),
 		provider.normalizeChatRequestForConversion(request),
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -251,7 +260,7 @@ func (provider *MistralProvider) Embedding(ctx *schemas.BifrostContext, key sche
 	return openai.HandleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
+		provider.buildRequestURL(ctx, "/v1/embeddings", schemas.EmbeddingRequest),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -298,7 +307,7 @@ func (provider *MistralProvider) Transcription(ctx *schemas.BifrostContext, key 
 	// Set extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"))
+	req.SetRequestURI(provider.buildRequestURL(ctx, "/v1/audio/transcriptions", schemas.TranscriptionRequest))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType(contentType)
 	if key.Value.GetValue() != "" {
@@ -412,7 +421,7 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.Header.SetMethod(http.MethodPost)
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"))
+	req.SetRequestURI(provider.buildRequestURL(ctx, "/v1/audio/transcriptions", schemas.TranscriptionStreamRequest))
 
 	// Set headers
 	for headerKey, value := range headers {
@@ -645,7 +654,7 @@ func (provider *MistralProvider) OCR(ctx *schemas.BifrostContext, key schemas.Ke
 	// Set extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/ocr"))
+	req.SetRequestURI(provider.buildRequestURL(ctx, "/v1/ocr", schemas.OCRRequest))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {


### PR DESCRIPTION
## Description

The Mistral provider built every request URL inline (`BaseURL + GetPathFromContext(...)`, and a hardcoded path for chat streaming), so unlike the OpenAI/Anthropic/Cohere providers it never consulted `CustomProviderConfig.RequestPathOverrides`. A `base_provider_type: mistral` custom provider therefore could not target a Mistral-compatible endpoint whose path differs from the default.

This surfaced with OCR against Azure AI Foundry's Mistral Document AI, served at `/providers/mistral/azure/ocr` (not `/v1/ocr`). Auth already matches, so the hardcoded path was the only blocker. The root cause is general, so the fix is too.

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Affected Packages

- `core/providers/mistral/`

## Changes Made

- Added a `buildRequestURL` helper mirroring the OpenAI/Anthropic/Cohere providers (resolves paths via `GetRequestPath` → honors context overrides, `request_path_overrides`, and full-URL overrides).
- Routed all Mistral endpoints through it: models, chat, chat-stream, embeddings, transcription, transcription-stream, OCR.
- Added a `core/changelog.md` entry.

Note: the chat-streaming endpoint previously ignored even the context path override (its path was hardcoded); it now honors it like the other endpoints.

## Testing

- [x] Unit tests added/updated — override resolution is covered by `TestGetRequestPath` in `core/providers/utils`.
- [x] Manual testing completed — built the HTTP transport image and validated OCR against Azure AI Foundry Mistral OCR via a custom provider with `request_path_overrides`.

## Checklist

- [x] Code follows the project's code style
- [x] Tests are passing locally
- [x] No breaking changes — default behavior is unchanged with no override configured
- [x] Commit messages follow the format: `[type]: description`
- [x] All affected packages are mentioned in commit messages

## Related Issues

Closes #4219