### PR TITLE
refactor: extract `publishRoutingAllowlist` and filter by model when publishing VK provider allowlist

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -595,6 +595,32 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	return nil
 }
 
+// publishRoutingAllowlist records, for downstream routing layers, which of the VK's configured
+// providers permit modelStr according to the VK's own allowed_models / blocked_models. It is a
+// coarse provider gate (BifrostContextKeyRoutingAllowedProviders) layered on top of the model
+// catalog checks those layers already run — its purpose is to stop a later routing layer (load
+// balancing, model-catalog resolution) from selecting a provider the VK forbids for this model,
+// even when governance itself couldn't pick one. An empty slice means "no provider is permitted"
+// (fail-closed via the empty-provider validation in handleRequest); a nil VK publishes nothing.
+//
+// Provider prefixes on the request model are already split into req.Provider + bare model at the
+// HTTP layer (resolveModelAndProvider), so VK allowed_models / blocked_models are matched against
+// bare names and plain membership checks are sufficient here.
+func (p *GovernancePlugin) publishRoutingAllowlist(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey, modelStr string) {
+	if virtualKey == nil {
+		return
+	}
+	allowed := make([]schemas.ModelProvider, 0, len(virtualKey.ProviderConfigs))
+	for _, pc := range virtualKey.ProviderConfigs {
+		// No model to filter on → keep the provider so we don't over-restrict.
+		if modelStr == "" ||
+			(pc.AllowedModels.IsAllowed(modelStr) && !pc.BlacklistedModels.IsBlocked(modelStr)) {
+			allowed = append(allowed, schemas.ModelProvider(pc.Provider))
+		}
+	}
+	ctx.SetValue(schemas.BifrostContextKeyRoutingAllowedProviders, allowed)
+}
+
 // applyRoutingRules evaluates routing rules against req and mutates
 // req.Provider/req.Model/req.Fallbacks when a rule matches. Returns the matched RoutingDecision
 // (nil if no rule matched). Integrations normalize req.Model (and Provider when applicable) before
@@ -1013,20 +1039,6 @@ func (p *GovernancePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *sche
 
 	stampGovernanceCtxFromVK(ctx, virtualKey)
 
-	// Publish the VK's allowed-provider set so downstream routing layers (enterprise LB,
-	// model-catalog-resolver) intersect their candidates with it. This guards against the case
-	// where governance fails to pick a provider (every VK entry rejected by allowed_models /
-	// budget / rate limit) and a downstream layer would otherwise pick a provider the VK does
-	// not permit. Empty slice means "no provider is permitted" → fail-closed via the empty-
-	// provider validation in handleRequest.
-	if virtualKey != nil {
-		allowed := make([]schemas.ModelProvider, 0, len(virtualKey.ProviderConfigs))
-		for _, pc := range virtualKey.ProviderConfigs {
-			allowed = append(allowed, schemas.ModelProvider(pc.Provider))
-		}
-		ctx.SetValue(schemas.BifrostContextKeyRoutingAllowedProviders, allowed)
-	}
-
 	// Large-payload mode: the body streams to the provider unparsed, so req.Model is
 	// empty for routes where the model lives in the body (OpenAI/Anthropic chat,
 	// responses, etc.). Route on LargePayloadMetadata.Model — the provider's
@@ -1041,6 +1053,8 @@ func (p *GovernancePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *sche
 		if newModel != "" && newModel != metadata.Model {
 			metadata.Model = newModel
 		}
+		_, routedModel := schemas.ParseModelString(metadata.Model, "")
+		p.publishRoutingAllowlist(ctx, virtualKey, routedModel)
 		return nil
 	}
 
@@ -1049,6 +1063,12 @@ func (p *GovernancePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *sche
 			return err
 		}
 	}
+
+	// Publish the VK provider allowlist for the (post routing-rules) model so downstream routing
+	// layers (load balancing, model-catalog resolution) and core enforcement intersect their
+	// candidates with it — a later layer must not select a provider the VK forbids for this model.
+	_, routedModel, _ := req.GetRequestFields()
+	p.publishRoutingAllowlist(ctx, virtualKey, routedModel)
 
 	if virtualKey != nil {
 		if err := p.loadBalanceProvider(ctx, req, virtualKey); err != nil {


### PR DESCRIPTION
## Summary

The routing allowlist published to `BifrostContextKeyRoutingAllowedProviders` previously included all providers on a virtual key regardless of their `allowed_models` / `blocked_models` configuration. This meant a downstream routing layer (load balancing, model-catalog resolution) could select a provider that the VK explicitly forbids for the requested model. This PR fixes that by filtering the allowlist against the model being routed before publishing it.

## Changes

- Extracted the allowlist-publishing logic into a dedicated `publishRoutingAllowlist` method that filters each provider config against the resolved model using `AllowedModels.IsAllowed` / `BlacklistedModels.IsBlocked` before adding it to the allowed set.
- Removed the previous inline allowlist construction in `PreRequestHook`, which unconditionally included every provider on the VK without any model-level filtering.
- `publishRoutingAllowlist` is now called after routing rules have been applied (so the model is in its final post-routing state) for both the large-payload path (using `ParseModelString` on `LargePayloadMetadata.Model`) and the standard path (using `req.GetRequestFields()`).
- An empty allowed slice continues to mean "no provider is permitted," preserving the existing fail-closed behaviour enforced by the empty-provider validation in `handleRequest`.
- A `nil` virtual key is a no-op, so unauthenticated or VK-less requests are unaffected.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Plugins

## How to test

```sh
go test ./...
```

1. Configure a virtual key with two providers where one provider has `allowed_models` that excludes the requested model.
2. Send a request for that model and confirm the excluded provider is never selected by the load balancer or model-catalog resolver.
3. Confirm that a request for a model permitted by both providers can still be routed to either.
4. Confirm that a request where no provider permits the model fails closed rather than falling through to a forbidden provider.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This tightens provider selection enforcement on virtual keys. Previously, a model-level restriction on a VK provider config could be bypassed by a downstream routing layer picking that provider after governance failed to select one. That bypass path is now closed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency between routing rule application and provider allowlist enforcement for virtual keys with model restrictions, ensuring correct provider filtering is applied after routing decisions are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->