### PR TITLE
fix: enforce auth on inference in auth middleware

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -68480,7 +68480,9 @@
                 "type": "boolean"
               },
               "disable_auth_on_inference": {
-                "type": "boolean"
+                "type": "boolean",
+                "deprecated": true,
+                "description": "Deprecated and ignored. Use client_config.enforce_auth_on_inference instead."
               }
             }
           },
@@ -68745,7 +68747,9 @@
                 "type": "boolean"
               },
               "disable_auth_on_inference": {
-                "type": "boolean"
+                "type": "boolean",
+                "deprecated": true,
+                "description": "Deprecated and ignored. Use client_config.enforce_auth_on_inference instead."
               }
             }
           }

--- a/docs/openapi/schemas/management/config.yaml
+++ b/docs/openapi/schemas/management/config.yaml
@@ -137,6 +137,8 @@ AuthConfig:
       type: boolean
     disable_auth_on_inference:
       type: boolean
+      deprecated: true
+      description: "Deprecated and ignored. Use client_config.enforce_auth_on_inference instead."
 
 HeaderFilterConfig:
   type: object

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1403,10 +1403,9 @@ func GenerateFrameworkConfigHash(pricingURL *string, modelParametersURL *string,
 
 // AuthConfig represents configured auth config for Bifrost dashboard
 type AuthConfig struct {
-	AdminUserName          *schemas.EnvVar `json:"admin_username"`
-	AdminPassword          *schemas.EnvVar `json:"admin_password"`
-	IsEnabled              bool            `json:"is_enabled"`
-	DisableAuthOnInference bool            `json:"disable_auth_on_inference"`
+	AdminUserName *schemas.EnvVar `json:"admin_username"`
+	AdminPassword *schemas.EnvVar `json:"admin_password"`
+	IsEnabled     bool            `json:"is_enabled"`
 }
 
 // ConfigMap maps provider names to their configurations.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -5013,7 +5013,6 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 		var username *string
 		var password *string
 		var isEnabled bool
-		var disableAuthOnInference bool
 		for _, entry := range governanceConfigs {
 			switch entry.Key {
 			case tables.ConfigAdminUsernameKey:
@@ -5022,8 +5021,6 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 				password = bifrost.Ptr(entry.Value)
 			case tables.ConfigIsAuthEnabledKey:
 				isEnabled = entry.Value == "true"
-			case tables.ConfigDisableAuthOnInferenceKey:
-				disableAuthOnInference = entry.Value == "true"
 			case tables.ConfigComplexityAnalyzerConfigKey:
 				if strings.TrimSpace(entry.Value) == "" {
 					continue
@@ -5040,10 +5037,9 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 		}
 		if username != nil && password != nil {
 			authConfig = &AuthConfig{
-				AdminUserName:          schemas.NewEnvVar(*username),
-				AdminPassword:          schemas.NewEnvVar(*password),
-				IsEnabled:              isEnabled,
-				DisableAuthOnInference: disableAuthOnInference,
+				AdminUserName: schemas.NewEnvVar(*username),
+				AdminPassword: schemas.NewEnvVar(*password),
+				IsEnabled:     isEnabled,
 			}
 		}
 	}
@@ -5104,7 +5100,6 @@ func (s *RDBConfigStore) GetAuthConfig(ctx context.Context) (*AuthConfig, error)
 	var username *string
 	var password *string
 	var isEnabled bool
-	var disableAuthOnInference bool
 	if err := s.DB().WithContext(ctx).First(&tables.TableGovernanceConfig{}, "key = ?", tables.ConfigAdminUsernameKey).Select("value").Scan(&username).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
@@ -5120,23 +5115,13 @@ func (s *RDBConfigStore) GetAuthConfig(ctx context.Context) (*AuthConfig, error)
 			return nil, err
 		}
 	}
-	if err := s.DB().WithContext(ctx).First(&tables.TableGovernanceConfig{}, "key = ?", tables.ConfigDisableAuthOnInferenceKey).Select("value").Scan(&disableAuthOnInference).Error; err != nil {
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, err
-		}
-	}
 	if username == nil || password == nil {
 		return nil, nil
 	}
-	// We are no longer keeping this option in the database
-	if !isEnabled {
-		disableAuthOnInference = true
-	}
 	return &AuthConfig{
-		AdminUserName:          schemas.NewEnvVar(*username),
-		AdminPassword:          schemas.NewEnvVar(*password),
-		IsEnabled:              isEnabled,
-		DisableAuthOnInference: disableAuthOnInference,
+		AdminUserName: schemas.NewEnvVar(*username),
+		AdminPassword: schemas.NewEnvVar(*password),
+		IsEnabled:     isEnabled,
 	}, nil
 }
 
@@ -5158,12 +5143,6 @@ func (s *RDBConfigStore) UpdateAuthConfig(ctx context.Context, config *AuthConfi
 		if err := tx.Save(&tables.TableGovernanceConfig{
 			Key:   tables.ConfigIsAuthEnabledKey,
 			Value: fmt.Sprintf("%t", config.IsEnabled),
-		}).Error; err != nil {
-			return err
-		}
-		if err := tx.Save(&tables.TableGovernanceConfig{
-			Key:   tables.ConfigDisableAuthOnInferenceKey,
-			Value: fmt.Sprintf("%t", config.DisableAuthOnInference),
 		}).Error; err != nil {
 			return err
 		}

--- a/framework/configstore/tables/config.go
+++ b/framework/configstore/tables/config.go
@@ -3,11 +3,10 @@ package tables
 import "github.com/maximhq/bifrost/core/network"
 
 const (
-	ConfigAdminUsernameKey          = "admin_username"
-	ConfigAdminPasswordKey          = "admin_password"
-	ConfigIsAuthEnabledKey          = "is_auth_enabled"
-	ConfigDisableAuthOnInferenceKey = "disable_auth_on_inference"
-	ConfigProxyKey                  = "proxy_config"
+	ConfigAdminUsernameKey = "admin_username"
+	ConfigAdminPasswordKey = "admin_password"
+	ConfigIsAuthEnabledKey = "is_auth_enabled"
+	ConfigProxyKey         = "proxy_config"
 	// ConfigComplexityAnalyzerConfigKey stores the persisted analyzer config JSON.
 	ConfigComplexityAnalyzerConfigKey = "complexity_analyzer_config"
 	ConfigRestartRequiredKey          = "restart_required"

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -505,10 +505,7 @@ false
 {{- if hasKey .Values.bifrost.governance.authConfig "isEnabled" }}
 {{- $_ := set $authConfig "is_enabled" .Values.bifrost.governance.authConfig.isEnabled }}
 {{- end }}
-{{- if hasKey .Values.bifrost.governance.authConfig "disableAuthOnInference" }}
-{{- $_ := set $authConfig "disable_auth_on_inference" .Values.bifrost.governance.authConfig.disableAuthOnInference }}
-{{- end }}
-{{- if or $authConfig.admin_username $authConfig.admin_password $authConfig.is_enabled $authConfig.disable_auth_on_inference }}
+{{- if or $authConfig.admin_username $authConfig.admin_password $authConfig.is_enabled }}
 {{- $_ := set $governance "auth_config" $authConfig }}
 {{- end }}
 {{- end }}
@@ -533,10 +530,7 @@ false
 {{- if hasKey .Values.bifrost.authConfig "isEnabled" }}
 {{- $_ := set $authConfig "is_enabled" .Values.bifrost.authConfig.isEnabled }}
 {{- end }}
-{{- if hasKey .Values.bifrost.authConfig "disableAuthOnInference" }}
-{{- $_ := set $authConfig "disable_auth_on_inference" .Values.bifrost.authConfig.disableAuthOnInference }}
-{{- end }}
-{{- if or $authConfig.admin_username $authConfig.admin_password $authConfig.is_enabled $authConfig.disable_auth_on_inference }}
+{{- if or $authConfig.admin_username $authConfig.admin_password $authConfig.is_enabled }}
 {{- $_ := set $config "auth_config" $authConfig }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3740,7 +3740,8 @@
         },
         "disableAuthOnInference": {
           "type": "boolean",
-          "description": "Whether authentication is disabled on inference"
+          "deprecated": true,
+          "description": "Deprecated and ignored. Use client.enforceAuthOnInference instead."
         },
         "existingSecret": {
           "type": "string"

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -192,7 +192,6 @@ bifrost:
     adminUsername: ""
     adminPassword: ""
     isEnabled: false
-    disableAuthOnInference: false
     # Use existing Kubernetes secret for admin credentials
     existingSecret: ""
     usernameKey: "username"
@@ -230,7 +229,7 @@ bifrost:
     # Deprecated: use enforceAuthOnInference instead.
     enforceGovernanceHeader: false
     # Require auth (VK, API key, or user token) on inference endpoints.
-    # When unset, inference endpoints follow authConfig.disableAuthOnInference behavior.
+    # Open by default in the raw binary; this chart enables enforcement for production.
     enforceAuthOnInference: true
     maxRequestBodySizeMb: 100
     compat:
@@ -674,7 +673,6 @@ bifrost:
       adminUsername: ""
       adminPassword: ""
       isEnabled: false
-      disableAuthOnInference: false
       # Use existing Kubernetes secret for admin credentials
       existingSecret: ""
       usernameKey: "username"

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -150,26 +150,23 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 				}
 			}
 			mapConfig["auth_config"] = map[string]any{
-				"admin_username":            authConfig.AdminUserName,
-				"admin_password":            passwordEnvVar,
-				"is_enabled":                authConfig.IsEnabled,
-				"disable_auth_on_inference": authConfig.DisableAuthOnInference,
+				"admin_username": authConfig.AdminUserName,
+				"admin_password": passwordEnvVar,
+				"is_enabled":     authConfig.IsEnabled,
 			}
 		} else {
 			// No auth config exists yet, return default empty EnvVar values
 			mapConfig["auth_config"] = map[string]any{
-				"admin_username":            &schemas.EnvVar{Val: "", EnvVar: "", FromEnv: false},
-				"admin_password":            &schemas.EnvVar{Val: "", EnvVar: "", FromEnv: false},
-				"is_enabled":                false,
-				"disable_auth_on_inference": true,
+				"admin_username": &schemas.EnvVar{Val: "", EnvVar: "", FromEnv: false},
+				"admin_password": &schemas.EnvVar{Val: "", EnvVar: "", FromEnv: false},
+				"is_enabled":     false,
 			}
 		}
 	} else {
 		mapConfig["auth_config"] = map[string]any{
-			"admin_username":            &schemas.EnvVar{Val: "", EnvVar: "", FromEnv: false},
-			"admin_password":            &schemas.EnvVar{Val: "", EnvVar: "", FromEnv: false},
-			"is_enabled":                false,
-			"disable_auth_on_inference": true,
+			"admin_username": &schemas.EnvVar{Val: "", EnvVar: "", FromEnv: false},
+			"admin_password": &schemas.EnvVar{Val: "", EnvVar: "", FromEnv: false},
+			"is_enabled":     false,
 		}
 	}
 	mapConfig["is_db_connected"] = h.store.ConfigStore != nil

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -722,12 +722,13 @@ func isRealtimeTransportEndpoint(path string) bool {
 
 // AuthMiddleware is a middleware that handles authentication for the API.
 type AuthMiddleware struct {
-	store             configstore.ConfigStore
-	whitelistedRoutes atomic.Pointer[[]string]
-	authConfig        atomic.Pointer[configstore.AuthConfig]
-	wsTicketStore     *WSTicketStore
-	tempTokensService *temptoken.Service // optional; when nil, temp-token fallback is disabled
-	tempTokensEnabled atomic.Bool
+	store                  configstore.ConfigStore
+	whitelistedRoutes      atomic.Pointer[[]string]
+	authConfig             atomic.Pointer[configstore.AuthConfig]
+	wsTicketStore          *WSTicketStore
+	tempTokensService      *temptoken.Service // optional; when nil, temp-token fallback is disabled
+	tempTokensEnabled      atomic.Bool
+	enforceAuthOnInference atomic.Bool
 }
 
 // InitAuthMiddleware initializes the auth middleware. The tempTokens service
@@ -755,10 +756,12 @@ func InitAuthMiddleware(store configstore.ConfigStore, wsTicketStore *WSTicketSt
 	if err == nil && clientConfig != nil {
 		am.whitelistedRoutes.Store(&clientConfig.WhitelistedRoutes)
 		am.tempTokensEnabled.Store(clientConfig.MCPEnableTempTokenAuth)
+		am.enforceAuthOnInference.Store(clientConfig.EnforceAuthOnInference)
 	} else {
 		emptyRoutes := []string{}
 		am.whitelistedRoutes.Store(&emptyRoutes)
 		am.tempTokensEnabled.Store(false)
+		am.enforceAuthOnInference.Store(false)
 	}
 
 	return am, nil
@@ -776,6 +779,11 @@ func (m *AuthMiddleware) UpdateWhitelistedRoutes(routes []string) {
 // UpdateTempTokenAuthEnabled updates whether scoped temp-token fallback auth is accepted.
 func (m *AuthMiddleware) UpdateTempTokenAuthEnabled(enabled bool) {
 	m.tempTokensEnabled.Store(enabled)
+}
+
+// UpdateEnforceAuthOnInference updates whether auth is enforced on inference endpoints.
+func (m *AuthMiddleware) UpdateEnforceAuthOnInference(enforce bool) {
+	m.enforceAuthOnInference.Store(enforce)
 }
 
 // tryTempTokenOrUnauthorized is the last-resort auth path: a request that
@@ -806,10 +814,13 @@ func (m *AuthMiddleware) tryTempTokenOrUnauthorized(ctx *fasthttp.RequestCtx, ne
 	SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
 }
 
-// InferenceMiddleware is for inference requests (including MCP routes) if authConfig is set, it will skip authentication if disableAuthOnInference is true.
+// InferenceMiddleware is for inference requests (including MCP routes). It skips
+// authentication when the ClientConfig.EnforceAuthOnInference switch is disabled.
+// That switch is config/Helm-driven and survives restarts. Inference auth is open
+// by default (raw binary); the Helm chart enables enforcement for production.
 func (m *AuthMiddleware) InferenceMiddleware() schemas.BifrostHTTPMiddleware {
 	return m.middleware(func(authConfig *configstore.AuthConfig, url string) bool {
-		return authConfig.DisableAuthOnInference
+		return !m.enforceAuthOnInference.Load()
 	})
 }
 
@@ -897,7 +908,7 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 				next(ctx)
 				return
 			}
-			if isRealtimeTransportEndpoint(string(ctx.Path())) {
+			if isRealtimeTransportEndpoint(url) {
 				next(ctx)
 				return
 			}

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -738,6 +738,9 @@ func TestAuthMiddleware_InferenceMiddleware_RealtimeTransportBypassesAuth(t *tes
 		AdminPassword: schemas.NewEnvVar("hashedpassword"),
 		IsEnabled:     true,
 	})
+	// Enforce auth on inference; realtime transport endpoints must still bypass it
+	// because browser clients connect with an ephemeral key, not admin credentials.
+	am.UpdateEnforceAuthOnInference(true)
 
 	routes := []string{
 		"/v1/realtime",
@@ -775,6 +778,9 @@ func TestAuthMiddleware_InferenceMiddleware_RealtimeMintingStillRequiresAuth(t *
 		AdminPassword: schemas.NewEnvVar("hashedpassword"),
 		IsEnabled:     true,
 	})
+	// Enforce auth on inference. Minting endpoints follow the inference auth toggle with
+	// no exception (unlike the transport carve-out), so they require auth when enforced.
+	am.UpdateEnforceAuthOnInference(true)
 
 	routes := []string{
 		"/v1/realtime/client_secrets",

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3520,8 +3520,7 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 	// If DB already matches file config, skip hashing and DB write
 	if dbAuthConfig != nil {
 		usernameMatch := dbAuthConfig.AdminUserName.GetValue() == authConfig.AdminUserName.GetValue()
-		boolsMatch := dbAuthConfig.IsEnabled == authConfig.IsEnabled &&
-			dbAuthConfig.DisableAuthOnInference == authConfig.DisableAuthOnInference
+		boolsMatch := dbAuthConfig.IsEnabled == authConfig.IsEnabled
 		var passwordMatch bool
 		if filePassword == "" {
 			passwordMatch = dbAuthConfig.AdminPassword.GetValue() == ""
@@ -3533,10 +3532,9 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 		if usernameMatch && passwordMatch && boolsMatch {
 			// DB matches file -- use DB hash but preserve file env var references
 			config.GovernanceConfig.AuthConfig = &configstore.AuthConfig{
-				AdminUserName:          authConfig.AdminUserName,
-				AdminPassword:          preserveEnvVar(authConfig.AdminPassword, dbAuthConfig.AdminPassword.GetValue()),
-				IsEnabled:              authConfig.IsEnabled,
-				DisableAuthOnInference: authConfig.DisableAuthOnInference,
+				AdminUserName: authConfig.AdminUserName,
+				AdminPassword: preserveEnvVar(authConfig.AdminPassword, dbAuthConfig.AdminPassword.GetValue()),
+				IsEnabled:     authConfig.IsEnabled,
 			}
 			return
 		}
@@ -3563,10 +3561,9 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 	}
 	// Build auth config with hashed password but preserve env var references
 	config.GovernanceConfig.AuthConfig = &configstore.AuthConfig{
-		AdminUserName:          authConfig.AdminUserName,
-		AdminPassword:          preserveEnvVar(authConfig.AdminPassword, hashedPassword),
-		IsEnabled:              authConfig.IsEnabled,
-		DisableAuthOnInference: authConfig.DisableAuthOnInference,
+		AdminUserName: authConfig.AdminUserName,
+		AdminPassword: preserveEnvVar(authConfig.AdminPassword, hashedPassword),
+		IsEnabled:     authConfig.IsEnabled,
 	}
 	// Persist to config store
 	if err := config.ConfigStore.UpdateAuthConfig(ctx, config.GovernanceConfig.AuthConfig); err != nil {

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -16138,6 +16138,12 @@ var excludedSchemaFields = map[string]map[string]bool{
 	"governance": {
 		"business_units": true, // Enterprise feature; not in OSS GovernanceConfig
 	},
+	"auth_config": {
+		"disable_auth_on_inference": true, // Deprecated and ignored; kept in schema for backward-compatible config.json validation. Use enforce_auth_on_inference.
+	},
+	"governance.auth_config": {
+		"disable_auth_on_inference": true, // Deprecated and ignored; kept in schema for backward-compatible config.json validation. Use enforce_auth_on_inference.
+	},
 	"governance.teams": {
 		"budget_id":        true, // Replaced by budgets[] relationship with team_id FK on TableBudget
 		"business_unit_id": true, // Enterprise feature; not in OSS TableTeam
@@ -16938,21 +16944,17 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 		require.NoError(t, err)
 
 		mockStore.authConfig = &configstore.AuthConfig{
-			AdminUserName:          schemas.NewEnvVar("sameadmin"),
-			AdminPassword:          schemas.NewEnvVar(hashedPassword),
-			IsEnabled:              true,
-			DisableAuthOnInference: false,
-		}
+			AdminUserName: schemas.NewEnvVar("sameadmin"),
+			AdminPassword: schemas.NewEnvVar(hashedPassword),
+			IsEnabled:     true}
 		config := &Config{
 			ConfigStore: mockStore,
 		}
 		configData := &ConfigData{
 			AuthConfig: &configstore.AuthConfig{
-				AdminUserName:          schemas.NewEnvVar("sameadmin"),
-				AdminPassword:          schemas.NewEnvVar(plainPassword),
-				IsEnabled:              true,
-				DisableAuthOnInference: false,
-			},
+				AdminUserName: schemas.NewEnvVar("sameadmin"),
+				AdminPassword: schemas.NewEnvVar(plainPassword),
+				IsEnabled:     true},
 		}
 
 		loadAuthConfig(ctx, config, configData)
@@ -17154,21 +17156,17 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 		require.NoError(t, err)
 
 		mockStore.authConfig = &configstore.AuthConfig{
-			AdminUserName:          schemas.NewEnvVar("admin"),
-			AdminPassword:          schemas.NewEnvVar(hashedPassword),
-			IsEnabled:              true,
-			DisableAuthOnInference: false,
-		}
+			AdminUserName: schemas.NewEnvVar("admin"),
+			AdminPassword: schemas.NewEnvVar(hashedPassword),
+			IsEnabled:     true}
 		config := &Config{
 			ConfigStore: mockStore,
 		}
 		configData := &ConfigData{
 			AuthConfig: &configstore.AuthConfig{
-				AdminUserName:          schemas.NewEnvVar("admin"),
-				AdminPassword:          schemas.NewEnvVar(plainPassword),
-				IsEnabled:              true,
-				DisableAuthOnInference: false,
-			},
+				AdminUserName: schemas.NewEnvVar("admin"),
+				AdminPassword: schemas.NewEnvVar(plainPassword),
+				IsEnabled:     true},
 		}
 
 		loadAuthConfig(ctx, config, configData)

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -833,6 +833,7 @@ func (s *BifrostHTTPServer) ReloadClientConfigFromConfigStore(ctx context.Contex
 	if s.AuthMiddleware != nil {
 		s.AuthMiddleware.UpdateWhitelistedRoutes(config.WhitelistedRoutes)
 		s.AuthMiddleware.UpdateTempTokenAuthEnabled(config.MCPEnableTempTokenAuth)
+		s.AuthMiddleware.UpdateEnforceAuthOnInference(config.EnforceAuthOnInference)
 	}
 	// Reloading config in bifrost client
 	if s.Client != nil {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2357,7 +2357,8 @@
         },
         "disable_auth_on_inference": {
           "type": "boolean",
-          "description": "Whether authentication is disabled on inference"
+          "deprecated": true,
+          "description": "Deprecated and ignored. Use client_config.enforce_auth_on_inference instead."
         }
       },
       "additionalProperties": false

--- a/ui/app/_fallbacks/enterprise/components/api-keys/apiKeysIndexView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/api-keys/apiKeysIndexView.tsx
@@ -53,7 +53,7 @@ curl --location 'http://localhost:8080/v1/chat/completions'
 		);
 	}
 
-	const isInferenceAuthDisabled = bifrostConfig?.auth_config?.disable_auth_on_inference ?? false;
+	const isInferenceAuthDisabled = !(bifrostConfig?.client_config?.enforce_auth_on_inference ?? false);
 
 	return (
 		<div className="mx-auto w-full max-w-4xl space-y-4">

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -13,8 +13,7 @@ import { parseArrayFromText } from "@/lib/utils/array";
 import { validateOrigins } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useGetAuthTypeQuery } from "@enterprise/lib/store/apis/scimApi";
-import { Link } from "@tanstack/react-router";
-import { AlertTriangle, Info, Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -43,7 +42,6 @@ export default function SecurityView() {
 		admin_username: { value: "", env_var: "", from_env: false },
 		admin_password: { value: "", env_var: "", from_env: false },
 		is_enabled: false,
-		disable_auth_on_inference: true,
 	});
 
 	useEffect(() => {
@@ -80,10 +78,7 @@ export default function SecurityView() {
 			authConfig.admin_password?.env_var !== bifrostConfig?.auth_config?.admin_password?.env_var ||
 			authConfig.admin_password?.from_env !== bifrostConfig?.auth_config?.admin_password?.from_env;
 		const authChanged = showPasswordSection
-			? authConfig.is_enabled !== bifrostConfig?.auth_config?.is_enabled ||
-				usernameChanged ||
-				passwordChanged ||
-				authConfig.disable_auth_on_inference !== bifrostConfig?.auth_config?.disable_auth_on_inference
+			? authConfig.is_enabled !== bifrostConfig?.auth_config?.is_enabled || usernameChanged || passwordChanged
 			: false;
 
 		const localRequired = localConfig.required_headers?.slice().sort().join(",");
@@ -144,10 +139,6 @@ export default function SecurityView() {
 		setAuthConfig((prev) => ({ ...prev, is_enabled: checked }));
 	}, []);
 
-	const handleDisableAuthOnInferenceToggle = useCallback((checked: boolean) => {
-		setAuthConfig((prev) => ({ ...prev, disable_auth_on_inference: checked }));
-	}, []);
-
 	const handleAuthFieldChange = useCallback((field: "admin_username" | "admin_password", value: EnvVar) => {
 		setAuthConfig((prev) => ({ ...prev, [field]: value }));
 	}, []);
@@ -187,25 +178,6 @@ export default function SecurityView() {
 			</div>
 
 			<div className="space-y-4">
-				{authConfig.is_enabled && !authConfig.disable_auth_on_inference && (
-					<Alert variant="default" className="border-blue-20">
-						<Info className="h-4 w-4 text-blue-600" />
-						<AlertDescription>
-							You will need to use Basic Auth for all your inference calls (including MCP tool execution). You can disable it below. Check{" "}
-							<Link to="/workspace/config/api-keys" className="text-md text-primary underline">
-								API Keys
-							</Link>
-						</AlertDescription>
-					</Alert>
-				)}
-				{authConfig.is_enabled && (authConfig.disable_auth_on_inference ?? true) && (
-					<Alert variant="default" className="border-blue-20">
-						<Info className="h-4 w-4 text-blue-600" />
-						<AlertDescription>
-							Authentication is disabled for inference calls. Only dashboard, admin API and MCP tool execution calls require authentication.
-						</AlertDescription>
-					</Alert>
-				)}
 				{/* Password Protect the Dashboard */}
 				{IS_ENTERPRISE && authTypeLoading ? (
 					<div className="flex items-center justify-center rounded-lg border p-8" data-testid="security-auth-type-loading">
@@ -260,26 +232,6 @@ export default function SecurityView() {
 										onChange={(value) => handleAuthFieldChange("admin_password", value)}
 									/>
 								</div>
-								{authConfig.is_enabled && (
-									<div className="flex items-center justify-between">
-										<div className="space-y-0.5">
-											<Label htmlFor="disable-auth-inference" className="text-sm font-medium">
-												Disable authentication on inference calls <Badge variant="secondary">Deprecating soon</Badge>
-											</Label>
-											<p className="text-muted-foreground text-sm">
-												When enabled, inference API calls (chat completions, embeddings, etc.) will not require authentication. Dashboard
-												and admin API calls will still require authentication.
-											</p>
-										</div>
-										<Switch
-											id="disable-auth-inference"
-											className="ml-5"
-											checked={authConfig.disable_auth_on_inference ?? true}
-											disabled={!authConfig.is_enabled}
-											onCheckedChange={handleDisableAuthOnInferenceToggle}
-										/>
-									</div>
-								)}
 							</div>
 						</div>
 					</div>

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -442,7 +442,6 @@ export interface AuthConfig {
 	admin_username: EnvVar;
 	admin_password: EnvVar;
 	is_enabled: boolean;
-	disable_auth_on_inference?: boolean;
 }
 
 // Global proxy type (for global proxy configuration, not per-provider)


### PR DESCRIPTION
## Summary

Deprecates and removes the `disable_auth_on_inference` field from `AuthConfig` in favor of `client_config.enforce_auth_on_inference`. The old field is now marked deprecated in all schemas and OpenAPI specs, ignored at runtime, and stripped from the Go structs, database queries, and UI. Inference auth enforcement is now driven entirely by `ClientConfig.EnforceAuthOnInference`, which persists across restarts and can be updated live via config reload.

## Changes

- Removed `DisableAuthOnInference` from the `AuthConfig` struct, database read/write paths, and all call sites.
- Removed `ConfigDisableAuthOnInferenceKey` database constant and stopped reading or writing that key.
- Added `enforceAuthOnInference atomic.Bool` to `AuthMiddleware`, initialized from `ClientConfig` on startup and updated on every config reload via a new `UpdateEnforceAuthOnInference` method.
- Updated `InferenceMiddleware` to skip auth when `enforceAuthOnInference` is `false` (open by default in the raw binary; the Helm chart sets it to `true` for production).
- Fixed `isRealtimeTransportEndpoint` check in the middleware to use the pre-parsed `url` variable instead of re-reading `ctx.Path()`.
- Marked `disable_auth_on_inference` as `deprecated` in `config.schema.json`, `openapi.json`, `schemas/management/config.yaml`, and `values.schema.json` with a pointer to the replacement field.
- Removed the `disableAuthOnInference` Helm values and template logic; updated the `enforceAuthOnInference` comment to reflect the new default behavior.
- Removed the `disable_auth_on_inference` toggle, related alerts, and associated state/handlers from the Security settings UI.
- Updated the API Keys fallback view to derive `isInferenceAuthDisabled` from `client_config.enforce_auth_on_inference` instead of `auth_config.disable_auth_on_inference`.
- Added `disable_auth_on_inference` to the schema field exclusion list in config tests so backward-compatible config files continue to validate without errors.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

1. Start the server without setting `enforce_auth_on_inference`; confirm inference requests succeed without credentials (open by default).
2. Set `client_config.enforce_auth_on_inference: true` and confirm unauthenticated inference requests are rejected with `401 Unauthorized`.
3. Trigger a config reload and verify the enforcement state updates without a restart.
4. Confirm that realtime transport endpoints (`/v1/realtime`) still bypass auth even when `enforce_auth_on_inference` is `true`.
5. Confirm that realtime minting endpoints (`/v1/realtime/client_secrets`) require auth when `enforce_auth_on_inference` is `true`.
6. Pass a config file containing `disable_auth_on_inference` and confirm it is accepted (backward-compatible) but has no effect at runtime.

## Breaking changes

- [x] Yes
- [ ] No

`disable_auth_on_inference` is no longer read or persisted. Existing config files that set it will continue to parse without error, but the value is silently ignored. Operators relying on `disable_auth_on_inference: false` to enforce auth on inference must migrate to `client_config.enforce_auth_on_inference: true`.

## Security considerations

Inference endpoints are **open by default** when no `ClientConfig` is present. The Helm chart explicitly sets `enforceAuthOnInference: true` for production deployments. Operators running the raw binary who require auth on inference routes must set `client_config.enforce_auth_on_inference: true` explicitly in their configuration.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable