### PR TITLE
feat: add object store prefix listing for skill cleanup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,19 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: en-US
 
+early_access: true
+
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+
 reviews:
-  profile: assertive
-  request_changes_workflow: false
+  high_level_summary_in_walkthrough: true
+  fail_commit_status: true
+  suggested_labels: false
+  auto_assign_reviewers: true
+  profile: chill
+  request_changes_workflow: true
   high_level_summary: true
   review_status: true
   changed_files_summary: true
@@ -13,9 +23,41 @@ reviews:
     enabled: true
     drafts: false
     auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
     base_branches:
       - ".*"
   path_instructions:
+    - path: package.json
+      instructions: |
+        do not allow any carats in package.json, we never want any auto updates for any patch versions of any
+        packages in package.json
+    - path: "**"
+      instructions: |
+        always check the stack if there is one for the current PR. do not give localized reviews for the PR,
+        always see all changes in the light of the whole stack of PRs (if there is a stack, if there is no stack you can
+        continue to make localized suggestions/reviews)
+    - path: "**/*.go"
+      instructions: |
+        Rule: No raw context keys in Go.
+
+        When reviewing code, ALWAYS check for incorrect usage of context values.
+
+        Reject or flag the change if you find ANY of the following:
+        - context.WithValue(ctx, "someKey", value)         // string literal key
+        - context.WithValue(ctx, someStringVar, value)   // key is type string
+        - context.WithValue(ctx, fmt.Sprintf(...), value)    // computed/dynamic string key
+        - ctx.Value("someKey") or ctx.Value(someStringVar)        // same problem on retrieval
+
+        Required pattern:
+        - Context keys MUST be a dedicated named type (NOT plain string), e.g.
+          - type contextKey string
+            const userIDKey contextKey = "userId"
+          OR
+          - type userIDKeyType struct{}
+            var userIDKey userIDKeyType
+
+        - The key passed to WithValue/Value MUST be that typed identifier, e.g.
+          - ctx = context.WithValue(ctx, userIDKey, userID)
     - path: "core/**"
       instructions: |
         Review Go core changes for concurrency safety, provider isolation, pooled object reset discipline, and plugin hook ordering.

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -637,6 +637,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPromptRepoTables(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddSkillsRepoTables(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddPluginOrderColumns(ctx, db); err != nil {
 		return err
 	}
@@ -6571,6 +6574,73 @@ func migrationAddMCPClientAllowedExtraHeadersJSONColumn(ctx context.Context, db 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running add_mcp_client_allowed_extra_headers_json_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddSkillsRepoTables adds the skills repository tables.
+// Files belong to skill_versions (not directly to skills); blobs are reused
+// across versions via shared blob_id/storage_key references.
+//
+// Idempotent: guards each table create so retrying after a partially applied
+// migration does not fail when some tables were already created.
+func migrationAddSkillsRepoTables(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_skills_repo_tables",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// --- skills table ---
+			if !mg.HasTable(&tables.TableSkill{}) {
+				if err := mg.CreateTable(&tables.TableSkill{}); err != nil {
+					return fmt.Errorf("create skills table: %w", err)
+				}
+			}
+
+			// --- skill_versions table ---
+			if !mg.HasTable(&tables.TableSkillVersion{}) {
+				if err := mg.CreateTable(&tables.TableSkillVersion{}); err != nil {
+					return fmt.Errorf("create skill_versions table: %w", err)
+				}
+			}
+
+			// --- skill_file_blobs table ---
+			if !mg.HasTable(&tables.TableSkillFileBlob{}) {
+				if err := mg.CreateTable(&tables.TableSkillFileBlob{}); err != nil {
+					return fmt.Errorf("create skill_file_blobs table: %w", err)
+				}
+			}
+
+			// --- skill_files table ---
+			if !mg.HasTable(&tables.TableSkillFile{}) {
+				if err := mg.CreateTable(&tables.TableSkillFile{}); err != nil {
+					return fmt.Errorf("create skill_files table: %w", err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if err := mg.DropTable(&tables.TableSkillFile{}); err != nil {
+				return err
+			}
+			if err := mg.DropTable(&tables.TableSkillVersion{}); err != nil {
+				return err
+			}
+			if err := mg.DropTable(&tables.TableSkill{}); err != nil {
+				return err
+			}
+			if err := mg.DropTable(&tables.TableSkillFileBlob{}); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running skills repo tables migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -333,6 +333,83 @@ func TestUpsertMCPLibraryEntry(t *testing.T) {
 	require.Equal(t, "updated", entries[0].Description)
 }
 
+func TestValidateSkillVersionIncrementRequiresGreaterVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		latest  string
+		next    string
+		wantErr bool
+	}{
+		{name: "rejects lower prerelease core", latest: "1.0.3", next: "1.0.2-1", wantErr: true},
+		{name: "accepts same core with suffix after release", latest: "1.0.3", next: "1.0.3-1", wantErr: false},
+		{name: "accepts release after same core suffix", latest: "1.0.3-beta1", next: "1.0.3", wantErr: false},
+		{name: "accepts higher patch", latest: "1.0.3", next: "1.0.4", wantErr: false},
+		{name: "accepts higher minor", latest: "1.0.3", next: "1.1.0", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSkillVersionIncrement(tt.latest, tt.next)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestLatestCreatedSkillVersionUsesCreationOrder(t *testing.T) {
+	store := setupRDBTestStore(t)
+	err := store.DB().AutoMigrate(
+		&tables.TableSkill{},
+		&tables.TableSkillVersion{},
+		&tables.TableSkillFile{},
+		&tables.TableSkillFileBlob{},
+	)
+	require.NoError(t, err)
+	ctx := context.Background()
+	baseTime := time.Now()
+
+	skillID := "skill-latest-created"
+	err = store.DB().Create(&tables.TableSkill{
+		ID:            skillID,
+		Name:          "latest-created",
+		Description:   "Latest created version test",
+		SkillMDBody:   "body",
+		LatestVersion: "1.0.3",
+		CreatedAt:     baseTime,
+		UpdatedAt:     baseTime,
+	}).Error
+	require.NoError(t, err)
+	err = store.DB().Create(&tables.TableSkillVersion{
+		ID:                  "skill-version-old",
+		SkillID:             skillID,
+		Version:             "1.0.3",
+		SkillMDBody:         "body",
+		FrontmatterSnapshot: tables.SkillJSONMap{"name": "latest-created", "description": "Latest created version test"},
+		CreatedAt:           baseTime,
+	}).Error
+	require.NoError(t, err)
+	err = store.DB().Create(&tables.TableSkillVersion{
+		ID:                  "skill-version-new",
+		SkillID:             skillID,
+		Version:             "1.0.2-1",
+		SkillMDBody:         "body",
+		FrontmatterSnapshot: tables.SkillJSONMap{"name": "latest-created", "description": "Latest created version test"},
+		CreatedAt:           baseTime.Add(time.Minute),
+	}).Error
+	require.NoError(t, err)
+
+	latest, err := latestCreatedSkillVersion(store.DB(), skillID)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.2-1", latest)
+
+	skill, err := store.GetSkillLean(ctx, skillID)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.2-1", skill.HighestVersion)
+}
+
 // =============================================================================
 // Provider and Key Tests
 // =============================================================================

--- a/framework/configstore/skills.go
+++ b/framework/configstore/skills.go
@@ -1,0 +1,1216 @@
+package configstore
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const allSkillsVersionConfigKey = "skills_repository.all_skills_version"
+
+type allSkillsVersionBump string
+
+type pendingSkillObjectWrite struct {
+	key      string
+	data     []byte
+	metadata map[string]string
+}
+
+// runPendingSkillObjectWrites uploads pending objects to the store after the DB
+// transaction has committed. If any upload fails it performs a compensating DB
+// delete so the committed rows don't reference missing objects:
+//   - isCreate=true  → deletes the entire skill (cascades to versions/files)
+//   - isCreate=false → deletes only the newly created version row
+//
+// Already-written objects from earlier iterations are best-effort cleaned up
+// to avoid orphans. Any stragglers are caught by the startup orphan cleanup.
+func runPendingSkillObjectWrites(ctx context.Context, db *gorm.DB, objectStore objectstore.ObjectStore, writes []pendingSkillObjectWrite, isCreate bool, skillID, versionID string) error {
+	if objectStore == nil || len(writes) == 0 {
+		return nil
+	}
+	for i, write := range writes {
+		if err := objectStore.Put(ctx, write.key, write.data, write.metadata); err != nil {
+			writeErr := fmt.Errorf("failed to write skill file object %s: %w", write.key, err)
+
+			// Use a bounded detached context: request cancellation often causes the
+			// Put failure, but compensation must still get a chance to repair DB rows.
+			compensationCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			compensationDB := db.WithContext(compensationCtx)
+
+			// Compensating delete: remove the DB rows that reference the missing objects.
+			var compensationErr error
+			if isCreate {
+				compensationErr = compensationDB.Where("id = ?", skillID).Delete(&tables.TableSkill{}).Error
+			} else {
+				compensationErr = compensationDB.Where("id = ?", versionID).Delete(&tables.TableSkillVersion{}).Error
+			}
+			if compensationErr != nil {
+				return fmt.Errorf("%w; failed to compensate committed skill rows: %v", writeErr, compensationErr)
+			}
+
+			// Best-effort cleanup of objects written in earlier iterations.
+			if i > 0 {
+				written := make([]string, i)
+				for j := range i {
+					written[j] = writes[j].key
+				}
+				_ = objectStore.DeleteBatch(compensationCtx, written)
+			}
+			return writeErr
+		}
+	}
+	return nil
+}
+
+func runSkillObjectCleanup(ctx context.Context, logger schemas.Logger, objectStore objectstore.ObjectStore, keys []string) {
+	if objectStore == nil || len(keys) == 0 {
+		return
+	}
+	if err := objectStore.DeleteBatch(ctx, keys); err != nil && logger != nil {
+		logger.Warn("failed to cleanup skill file objects, will be cleanedup in the restart automatically: %v", err)
+	}
+}
+
+const (
+	allSkillsVersionBumpPatch allSkillsVersionBump = "patch"
+	allSkillsVersionBumpMinor allSkillsVersionBump = "minor"
+	allSkillsVersionBumpMajor allSkillsVersionBump = "major"
+
+	// MaxSkillFileContentSize is the maximum allowed size for any single skill
+	// file, regardless of source type.
+	MaxSkillFileContentSize = 50 * 1024 * 1024
+
+	// SkillObjectPrefix is the object-store prefix for all skill files.
+	SkillObjectPrefix = "skills/"
+)
+
+// SkillHarnessNames lists the supported agent harness identifiers
+// (e.g. "claude-code", "codex"). Used for Git smart HTTP route
+// registration and reserved-name validation.
+var SkillHarnessNames = []string{"claude-code", "codex"}
+
+// SkillReservedNames lists skill names that are reserved by the serving
+// layer (static routes that would shadow dynamic skill-name routes).
+// Built from SkillHarnessNames plus additional synthetic names.
+var SkillReservedNames = append([]string{"all-skills", "all"}, SkillHarnessNames...)
+
+var (
+	skillNamePattern   = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	skillSemverPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z][0-9A-Za-z.-]*))?$`)
+	// skillReservedFrontmatterFields contains frontmatter keys that are managed
+	// as first-class DB columns and must not appear in extra_frontmatter.
+	skillReservedFrontmatterFields = map[string]struct{}{
+		"name":          {},
+		"description":   {},
+		"license":       {},
+		"compatibility": {},
+		"metadata":      {},
+		"allowed-tools": {},
+	}
+)
+
+// IsSkillReservedFrontmatterField returns true if the given key is a reserved
+// frontmatter field managed as a first-class DB column.
+func IsSkillReservedFrontmatterField(key string) bool {
+	_, reserved := skillReservedFrontmatterFields[key]
+	return reserved
+}
+
+type skillVersionParts struct {
+	major  int
+	minor  int
+	patch  int
+	suffix string
+}
+
+// ValidateSkill validates the skill-level fields required by the Agent Skills spec.
+func ValidateSkill(skill *tables.TableSkill, version string) error {
+	if skill == nil {
+		return fmt.Errorf("skill is required")
+	}
+	if err := ValidateSkillName(skill.Name); err != nil {
+		return err
+	}
+	if strings.TrimSpace(skill.Description) == "" {
+		return fmt.Errorf("skill description is required")
+	}
+	if len(skill.Description) > 1024 {
+		return fmt.Errorf("skill description must be 1024 characters or fewer")
+	}
+	if skill.Compatibility != nil && len(*skill.Compatibility) > 500 {
+		return fmt.Errorf("skill compatibility must be 500 characters or fewer")
+	}
+	if strings.TrimSpace(skill.SkillMDBody) == "" {
+		return fmt.Errorf("skill_md_body is required")
+	}
+	if !utf8.ValidString(skill.SkillMDBody) {
+		return fmt.Errorf("skill_md_body must be valid UTF-8")
+	}
+	if err := ValidateSkillVersion(version); err != nil {
+		return err
+	}
+	for key, value := range skill.Metadata {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("metadata keys must be non-empty")
+		}
+		if !utf8.ValidString(value) {
+			return fmt.Errorf("metadata value for %q must be valid UTF-8", key)
+		}
+	}
+	for key := range skill.ExtraFrontmatter {
+		if IsSkillReservedFrontmatterField(key) {
+			return fmt.Errorf("extra_frontmatter key %q conflicts with a reserved frontmatter field", key)
+		}
+	}
+	return nil
+}
+
+// ValidateSkillName validates lowercase alphanumeric + hyphen skill names.
+func ValidateSkillName(name string) error {
+	if name == "" {
+		return fmt.Errorf("skill name is required")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("skill name must be 64 characters or fewer")
+	}
+	if !skillNamePattern.MatchString(name) {
+		return fmt.Errorf("skill name must contain only lowercase letters, numbers, and single hyphens with no leading, trailing, or consecutive hyphens")
+	}
+	if slices.Contains(SkillReservedNames, name) {
+		return fmt.Errorf("%q is a reserved name used by the skills serving layer", name)
+	}
+	return nil
+}
+
+// ValidateSkillFile validates a skill file definition before storage writes.
+func ValidateSkillFile(file *tables.TableSkillFile) error {
+	if file == nil {
+		return fmt.Errorf("skill file is required")
+	}
+	if err := ValidateSkillFilePath(file.Path); err != nil {
+		return err
+	}
+	if err := validateSkillSourceType(file.SourceType); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateSkillFilePath validates safe relative file paths within a skill.
+func ValidateSkillFilePath(filePath string) error {
+	p := strings.TrimSpace(filePath)
+	if p == "" {
+		return fmt.Errorf("skill file path is required")
+	}
+	if strings.HasPrefix(p, "/") || filepath.IsAbs(p) {
+		return fmt.Errorf("skill file path must be relative")
+	}
+	if strings.HasSuffix(p, "/") {
+		return fmt.Errorf("skill file path must not have a trailing slash")
+	}
+	if strings.Contains(p, "\\") {
+		return fmt.Errorf("skill file path must use forward slashes")
+	}
+	for segment := range strings.SplitSeq(p, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return fmt.Errorf("skill file path must not contain empty, current, or parent directory segments")
+		}
+	}
+	return nil
+}
+
+func validateSkillSourceType(sourceType string) error {
+	switch sourceType {
+	case tables.SkillSourceTypeURL, tables.SkillSourceTypeDataURL, tables.SkillSourceTypeText, tables.SkillSourceTypeUpload:
+		return nil
+	default:
+		return fmt.Errorf("skill file source_type must be one of url, dataurl, text, or upload")
+	}
+}
+
+// ValidateSkillVersion validates skill versions as MAJOR.MINOR.PATCH with an optional -suffix.
+func ValidateSkillVersion(version string) error {
+	_, err := parseSkillSemver(version)
+	return err
+}
+
+func parseSkillSemver(version string) (skillVersionParts, error) {
+	if version != strings.TrimSpace(version) {
+		return skillVersionParts{}, fmt.Errorf("skill version must not have leading or trailing whitespace")
+	}
+	matches := skillSemverPattern.FindStringSubmatch(version)
+	if matches == nil {
+		return skillVersionParts{}, fmt.Errorf("skill version must be semver MAJOR.MINOR.PATCH with optional -suffix")
+	}
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return skillVersionParts{}, fmt.Errorf("skill version major component overflows: %w", err)
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return skillVersionParts{}, fmt.Errorf("skill version minor component overflows: %w", err)
+	}
+	patch, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return skillVersionParts{}, fmt.Errorf("skill version patch component overflows: %w", err)
+	}
+	return skillVersionParts{major: major, minor: minor, patch: patch, suffix: matches[4]}, nil
+}
+
+func validateSkillVersionIncrement(previousVersion, nextVersion string) error {
+	if previousVersion == "" {
+		_, err := parseSkillSemver(nextVersion)
+		return err
+	}
+	prev, err := parseSkillSemver(previousVersion)
+	if err != nil {
+		return fmt.Errorf("stored latest skill version is invalid: %w", err)
+	}
+	next, err := parseSkillSemver(nextVersion)
+	if err != nil {
+		return err
+	}
+	if next.major < prev.major || (next.major == prev.major && next.minor < prev.minor) || (next.major == prev.major && next.minor == prev.minor && next.patch < prev.patch) {
+		return fmt.Errorf("skill version %q must not go below latest version %q", nextVersion, previousVersion)
+	}
+	if next.major == prev.major && next.minor == prev.minor && next.patch == prev.patch && next.suffix == prev.suffix {
+		return fmt.Errorf("skill version %q already matches the latest version; choose a new version", nextVersion)
+	}
+	return nil
+}
+
+func latestCreatedSkillVersion(tx *gorm.DB, skillID string) (string, error) {
+	var latest string
+	err := tx.Model(&tables.TableSkillVersion{}).
+		Where("skill_id = ?", skillID).
+		Select("version").
+		Order("created_at DESC").
+		Limit(1).
+		Scan(&latest).Error
+	return latest, err
+}
+
+func allSkillsBumpForVersionChange(previousVersion, nextVersion string) (allSkillsVersionBump, error) {
+	prev, err := parseSkillSemver(previousVersion)
+	if err != nil {
+		return "", fmt.Errorf("stored latest skill version is invalid: %w", err)
+	}
+	next, err := parseSkillSemver(nextVersion)
+	if err != nil {
+		return "", err
+	}
+	if next.major > prev.major {
+		return allSkillsVersionBumpMajor, nil
+	}
+	if next.minor > prev.minor {
+		return allSkillsVersionBumpMinor, nil
+	}
+	return allSkillsVersionBumpPatch, nil
+}
+
+func nextAllSkillsVersion(current string, bump allSkillsVersionBump, firstSkill bool) (string, error) {
+	if current == "" {
+		current = "0.0.0"
+	}
+	if firstSkill && current == "0.0.0" {
+		return "1.0.0", nil
+	}
+	parts, err := parseSkillSemver(current)
+	if err != nil {
+		return "", fmt.Errorf("stored all-skills version is invalid: %w", err)
+	}
+	switch bump {
+	case allSkillsVersionBumpMajor:
+		return fmt.Sprintf("%d.0.0", parts.major+1), nil
+	case allSkillsVersionBumpMinor:
+		return fmt.Sprintf("%d.%d.0", parts.major, parts.minor+1), nil
+	case allSkillsVersionBumpPatch:
+		return fmt.Sprintf("%d.%d.%d", parts.major, parts.minor, parts.patch+1), nil
+	default:
+		return "", fmt.Errorf("unsupported all-skills version bump %q", bump)
+	}
+}
+
+func bumpAllSkillsVersionTx(ctx context.Context, tx *gorm.DB, bump allSkillsVersionBump, firstSkill bool) error {
+	var config tables.TableGovernanceConfig
+	err := tx.WithContext(ctx).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		First(&config, "key = ?", allSkillsVersionConfigKey).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		config = tables.TableGovernanceConfig{Key: allSkillsVersionConfigKey, Value: "0.0.0"}
+		if err := tx.WithContext(ctx).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			Create(&config).Error; err != nil {
+			return err
+		}
+		if err := tx.WithContext(ctx).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			First(&config, "key = ?", allSkillsVersionConfigKey).Error; err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	next, err := nextAllSkillsVersion(config.Value, bump, firstSkill)
+	if err != nil {
+		return err
+	}
+	config.Value = next
+	return tx.WithContext(ctx).Save(&config).Error
+}
+
+// GetAllSkillsVersion returns the repository-level version for the bundled all-skills plugin.
+func (s *RDBConfigStore) GetAllSkillsVersion(ctx context.Context) (string, error) {
+	config, err := s.GetConfig(ctx, allSkillsVersionConfigKey)
+	if errors.Is(err, ErrNotFound) {
+		return "0.0.0", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(config.Value) == "" {
+		return "0.0.0", nil
+	}
+	return config.Value, nil
+}
+
+// BumpAllSkillsVersion manually advances the repository-level all-skills version.
+func (s *RDBConfigStore) BumpAllSkillsVersion(ctx context.Context, bump string) (string, error) {
+	bumpType := allSkillsVersionBump(bump)
+	switch bumpType {
+	case allSkillsVersionBumpPatch, allSkillsVersionBumpMinor, allSkillsVersionBumpMajor:
+	default:
+		return "", fmt.Errorf("unsupported all-skills version bump %q", bump)
+	}
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return bumpAllSkillsVersionTx(ctx, tx, bumpType, false)
+	}); err != nil {
+		return "", err
+	}
+	return s.GetAllSkillsVersion(ctx)
+}
+
+// StoreSkillFileContent stores inline file content in the DB blob fallback, or
+// prepares an object-storage write for the caller to run after DB commit.
+func StoreSkillFileContent(ctx context.Context, tx *gorm.DB, objectStore objectstore.ObjectStore, skillID string, file *tables.TableSkillFile, data []byte) (*pendingSkillObjectWrite, error) {
+	if file == nil {
+		return nil, fmt.Errorf("skill file is required")
+	}
+	if objectStore != nil {
+		key := file.StorageKey
+		if key == nil || strings.TrimSpace(*key) == "" {
+			generated := fmt.Sprintf(SkillObjectPrefix+"%s/%s/%s", skillID, file.ID, path.Base(file.Path))
+			key = &generated
+		}
+		file.StorageKey = key
+		file.BlobID = nil
+		return &pendingSkillObjectWrite{
+			key:      *key,
+			data:     data,
+			metadata: map[string]string{"skill_id": skillID, "file_id": file.ID},
+		}, nil
+	}
+
+	blobID := uuid.NewString()
+	blob := tables.TableSkillFileBlob{
+		ID:   blobID,
+		Data: data,
+	}
+	if err := tx.Create(&blob).Error; err != nil {
+		return nil, err
+	}
+	file.BlobID = &blobID
+	file.StorageKey = nil
+	return nil, nil
+}
+
+func validateSkillStorageKeyScope(skillID string, file *tables.TableSkillFile, key string) error {
+	if !strings.HasPrefix(key, SkillObjectPrefix) {
+		return fmt.Errorf("storage_key %q is not under the skills object prefix", key)
+	}
+
+	uploadPrefix := SkillObjectPrefix + "uploads/"
+	skillPrefix := SkillObjectPrefix + skillID + "/"
+
+	switch file.SourceType {
+	case tables.SkillSourceTypeUpload:
+		if file.UploadID != nil && strings.TrimSpace(*file.UploadID) != "" {
+			expectedPrefix := uploadPrefix + strings.TrimSpace(*file.UploadID) + "/"
+			if !strings.HasPrefix(key, expectedPrefix) {
+				return fmt.Errorf("storage_key %q does not belong to upload_id %q", key, strings.TrimSpace(*file.UploadID))
+			}
+			return nil
+		}
+		if !strings.HasPrefix(key, uploadPrefix) {
+			return fmt.Errorf("storage_key %q is not under the staged upload prefix", key)
+		}
+	case tables.SkillSourceTypeText, tables.SkillSourceTypeDataURL:
+		if !strings.HasPrefix(key, skillPrefix) {
+			return fmt.Errorf("storage_key %q is not scoped to skill %q", key, skillID)
+		}
+	}
+	return nil
+}
+
+func validateSkillFileReference(tx *gorm.DB, skillID string, file *tables.TableSkillFile) error {
+	if file.BlobID != nil && strings.TrimSpace(*file.BlobID) != "" {
+		var blobCount int64
+		if err := tx.Model(&tables.TableSkillFileBlob{}).Where("id = ?", *file.BlobID).Count(&blobCount).Error; err != nil {
+			return err
+		}
+		if blobCount == 0 {
+			return fmt.Errorf("blob_id %q does not exist", *file.BlobID)
+		}
+
+		var foreignCount int64
+		if err := tx.Model(&tables.TableSkillFile{}).
+			Joins("JOIN skill_versions ON skill_versions.id = skill_files.skill_version_id").
+			Where("skill_files.blob_id = ? AND skill_versions.skill_id <> ?", *file.BlobID, skillID).
+			Count(&foreignCount).Error; err != nil {
+			return err
+		}
+		if foreignCount > 0 {
+			return fmt.Errorf("blob_id %q is already bound to another skill", *file.BlobID)
+		}
+	}
+
+	if file.StorageKey != nil && strings.TrimSpace(*file.StorageKey) != "" {
+		key := strings.TrimSpace(*file.StorageKey)
+		if err := validateSkillStorageKeyScope(skillID, file, key); err != nil {
+			return err
+		}
+
+		var foreignCount int64
+		if err := tx.Model(&tables.TableSkillFile{}).
+			Joins("JOIN skill_versions ON skill_versions.id = skill_files.skill_version_id").
+			Where("skill_files.storage_key = ? AND skill_versions.skill_id <> ?", key, skillID).
+			Count(&foreignCount).Error; err != nil {
+			return err
+		}
+		if foreignCount > 0 {
+			return fmt.Errorf("storage_key %q is already bound to another skill", key)
+		}
+		file.StorageKey = &key
+	}
+	return nil
+}
+
+func decodeSkillDataURL(dataURL string) ([]byte, string, error) {
+	parsed, err := url.Parse(dataURL)
+	if err != nil || parsed.Scheme != "data" {
+		return nil, "", fmt.Errorf("dataurl must be a valid data: URL")
+	}
+	parts := strings.SplitN(dataURL, ",", 2)
+	if len(parts) != 2 || !strings.Contains(parts[0], ";base64") {
+		return nil, "", fmt.Errorf("dataurl must contain ;base64,")
+	}
+	// Reject oversized payloads before materializing the full decode in memory.
+	if base64.StdEncoding.DecodedLen(len(parts[1])) > MaxSkillFileContentSize {
+		return nil, "", fmt.Errorf("dataurl payload exceeds maximum size of %d bytes", MaxSkillFileContentSize)
+	}
+	mimeType := strings.TrimPrefix(strings.Split(parts[0], ";")[0], "data:")
+	data, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, "", fmt.Errorf("dataurl base64 decode failed: %w", err)
+	}
+	return data, mimeType, nil
+}
+
+func validateSkillFileSource(file *tables.TableSkillFile) ([]byte, error) {
+	// Reject files with both blob_id and storage_key — exactly one backing store is allowed.
+	hasBlobID := file.BlobID != nil && strings.TrimSpace(*file.BlobID) != ""
+	hasStorageKey := file.StorageKey != nil && strings.TrimSpace(*file.StorageKey) != ""
+	if hasBlobID && hasStorageKey {
+		return nil, fmt.Errorf("file %q must have either blob_id or storage_key, not both", file.Path)
+	}
+	switch file.SourceType {
+	case tables.SkillSourceTypeURL:
+		if file.SourceURL == nil || strings.TrimSpace(*file.SourceURL) == "" {
+			return nil, fmt.Errorf("url source_type requires source_url")
+		}
+		u, err := url.Parse(*file.SourceURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return nil, fmt.Errorf("source_url must be an http or https URL")
+		}
+		file.StorageKey = nil
+		file.BlobID = nil
+		return nil, nil
+	case tables.SkillSourceTypeText:
+		if file.InlineContent == nil || *file.InlineContent == "" {
+			if hasStorageKey || hasBlobID {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("text source_type requires content or an existing file reference")
+		}
+		data := []byte(*file.InlineContent)
+		if len(data) > MaxSkillFileContentSize {
+			return nil, fmt.Errorf("text file content exceeds maximum size of %d bytes", MaxSkillFileContentSize)
+		}
+		file.StorageKey = nil
+		file.BlobID = nil
+		return data, nil
+	case tables.SkillSourceTypeDataURL:
+		if file.DataURL == nil || strings.TrimSpace(*file.DataURL) == "" {
+			if hasStorageKey || hasBlobID {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("dataurl source_type requires dataurl or an existing file reference")
+		}
+		data, mimeType, err := decodeSkillDataURL(*file.DataURL)
+		if err != nil {
+			return nil, err
+		}
+		if len(data) > MaxSkillFileContentSize {
+			return nil, fmt.Errorf("dataurl file content exceeds maximum size of %d bytes", MaxSkillFileContentSize)
+		}
+		if file.MimeType == "" {
+			file.MimeType = mimeType
+		}
+		file.StorageKey = nil
+		file.BlobID = nil
+		return data, nil
+	case tables.SkillSourceTypeUpload:
+		if !hasStorageKey && !hasBlobID {
+			return nil, fmt.Errorf("upload source_type requires storage_key or blob_id")
+		}
+		return nil, nil
+	default:
+		return nil, validateSkillSourceType(file.SourceType)
+	}
+}
+
+// CreateSkill creates a skill with an initial version and its files.
+func (s *RDBConfigStore) CreateSkill(ctx context.Context, skill *tables.TableSkill, version string, objectStore objectstore.ObjectStore) error {
+	if err := ValidateSkill(skill, version); err != nil {
+		return err
+	}
+	var objectWrites []pendingSkillObjectWrite
+	var firstSkill bool
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing tables.TableSkill
+		if err := tx.First(&existing, "name = ?", skill.Name).Error; err == nil {
+			return fmt.Errorf("skill name %q already exists", skill.Name)
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		var existingSkillCount int64
+		if err := tx.Model(&tables.TableSkill{}).Count(&existingSkillCount).Error; err != nil {
+			return err
+		}
+		firstSkill = existingSkillCount == 0
+		if skill.ID == "" {
+			skill.ID = uuid.NewString()
+		}
+		skill.LatestVersion = version
+		files := skill.Files
+		skill.Files = nil
+		skill.Versions = nil
+		if err := tx.Create(skill).Error; err != nil {
+			return err
+		}
+		// Create the version row, then create files under it.
+		versionRow, err := createSkillVersion(tx, skill, version)
+		if err != nil {
+			return err
+		}
+		writes, err := createVersionFiles(ctx, tx, objectStore, skill.ID, versionRow.ID, files)
+		if err != nil {
+			return err
+		}
+		objectWrites = append(objectWrites, writes...)
+		// Populate transient Files for the response.
+		return populateSkillFiles(tx, skill)
+	}); err != nil {
+		return err
+	}
+	if err := runPendingSkillObjectWrites(ctx, s.DB().WithContext(ctx), objectStore, objectWrites, true, skill.ID, ""); err != nil {
+		return err
+	}
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return bumpAllSkillsVersionTx(ctx, tx, allSkillsVersionBumpMinor, firstSkill)
+	}); err != nil {
+		return fmt.Errorf("skill %q was created successfully but all-skills version could not be bumped; manually bump all-skills version with a minor bump to publish this create: %w", skill.Name, err)
+	}
+	return nil
+}
+
+// GetSkill returns a skill with lean version summaries (id, version, created_at) and serving files.
+func (s *RDBConfigStore) GetSkill(ctx context.Context, id string) (*tables.TableSkill, error) {
+	var skill tables.TableSkill
+	if err := s.ScopedDB(ctx).
+		Preload("Versions", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "skill_id", "version", "created_at").Order("created_at DESC")
+		}).
+		First(&skill, "skills.id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
+		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	return &skill, nil
+}
+
+// GetSkillLean returns a skill without versions preloaded (only serving files).
+func (s *RDBConfigStore) GetSkillLean(ctx context.Context, id string) (*tables.TableSkill, error) {
+	var skill tables.TableSkill
+	if err := s.ScopedDB(ctx).
+		First(&skill, "skills.id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
+		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	// Populate the most recently created version for bump validation.
+	latest, err := latestCreatedSkillVersion(s.ScopedDB(ctx), skill.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load latest created skill version: %w", err)
+	}
+	if latest != "" {
+		skill.HighestVersion = latest
+	}
+	return &skill, nil
+}
+
+// GetSkillByName returns a skill by name with lean version summaries and serving files.
+func (s *RDBConfigStore) GetSkillByName(ctx context.Context, name string) (*tables.TableSkill, error) {
+	var skill tables.TableSkill
+	if err := s.ScopedDB(ctx).
+		Preload("Versions", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "skill_id", "version", "created_at").Order("created_at DESC")
+		}).
+		First(&skill, "skills.name = ?", name).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
+		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	return &skill, nil
+}
+
+// ListSkillVersions returns paginated versions for a skill.
+func (s *RDBConfigStore) ListSkillVersions(ctx context.Context, skillID string, params SkillVersionListQueryParams) ([]tables.TableSkillVersion, int64, error) {
+	var total int64
+	db := s.ScopedDB(ctx).Model(&tables.TableSkillVersion{}).Where("skill_id = ?", skillID)
+	if err := db.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var versions []tables.TableSkillVersion
+	query := db.
+		Select("id", "skill_id", "version", "created_by", "created_at").
+		Order(skillVersionListOrder(params))
+	if params.Limit > 0 {
+		query = query.Limit(params.Limit)
+	}
+	if params.Offset > 0 {
+		query = query.Offset(params.Offset)
+	}
+	if err := query.Find(&versions).Error; err != nil {
+		return nil, 0, err
+	}
+	return versions, total, nil
+}
+
+// GetSkillVersion returns a specific version by skill ID and version string.
+func (s *RDBConfigStore) GetSkillVersion(ctx context.Context, skillID, version string) (*tables.TableSkillVersion, error) {
+	var v tables.TableSkillVersion
+	if err := s.ScopedDB(ctx).
+		Preload("Files").
+		Preload("Files.Blob").
+		First(&v, "skill_id = ? AND version = ?", skillID, version).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &v, nil
+}
+
+// UpdateSkill saves skill fields, creates a new version, and creates files under it.
+// When serve=true, the skill row is updated to serve this new version.
+// When serve=false, only the version and files are created; the skill continues serving its current version.
+//
+// The serve switch is deferred until after object-store writes succeed so the
+// skill never points at a version whose files failed to upload.
+func (s *RDBConfigStore) UpdateSkill(ctx context.Context, skill *tables.TableSkill, version string, serve bool, objectStore objectstore.ObjectStore) error {
+	if err := ValidateSkill(skill, version); err != nil {
+		return err
+	}
+
+	// Phase 1: Create the version and files inside a transaction, but do NOT
+	// update the skill's serving state yet. This keeps the skill pointing at
+	// the old version until uploads are confirmed.
+	var objectWrites []pendingSkillObjectWrite
+	var versionID string
+	var existingLatestVersion string
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing tables.TableSkill
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&existing, "id = ?", skill.ID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+		existingLatestVersion = existing.LatestVersion
+		latestCreatedVersion, err := latestCreatedSkillVersion(tx, skill.ID)
+		if err != nil {
+			return err
+		}
+		if latestCreatedVersion == "" {
+			latestCreatedVersion = existing.LatestVersion
+		}
+		if err := validateSkillVersionIncrement(latestCreatedVersion, version); err != nil {
+			return err
+		}
+		// Also check that this version doesn't already exist (handles shift-back scenarios
+		// where LatestVersion is older but higher versions exist in history).
+		var existingVersion tables.TableSkillVersion
+		if err := tx.First(&existingVersion, "skill_id = ? AND version = ?", skill.ID, version).Error; err == nil {
+			return fmt.Errorf("skill version %q already exists in version history", version)
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		files := skill.Files
+
+		versionRow, err := createSkillVersion(tx, skill, version)
+		if err != nil {
+			return err
+		}
+		versionID = versionRow.ID
+		writes, err := createVersionFiles(ctx, tx, objectStore, skill.ID, versionRow.ID, files)
+		if err != nil {
+			return err
+		}
+		objectWrites = append(objectWrites, writes...)
+
+		if !serve {
+			// Restore the existing serving data for the response.
+			skill.LatestVersion = existing.LatestVersion
+			skill.SkillMDBody = existing.SkillMDBody
+			skill.Description = existing.Description
+			skill.License = existing.License
+			skill.Compatibility = existing.Compatibility
+			skill.AllowedTools = existing.AllowedTools
+			skill.Metadata = existing.Metadata
+			skill.ExtraFrontmatter = existing.ExtraFrontmatter
+		}
+		return populateSkillFiles(tx, skill)
+	}); err != nil {
+		return err
+	}
+
+	// Phase 2: Upload objects to the store. On failure, delete the version row
+	// as compensation — the skill still serves its previous version safely.
+	if err := runPendingSkillObjectWrites(ctx, s.DB().WithContext(ctx), objectStore, objectWrites, false, skill.ID, versionID); err != nil {
+		return err
+	}
+
+	if !serve {
+		return nil
+	}
+
+	// Phase 3: Object writes succeeded — now atomically flip the skill to
+	// serve the new version and bump the all-skills governance version.
+	// If this fails, the skill continues serving its previous version safely.
+	// The new version row and its objects remain intact so the caller can
+	// retry serving (e.g. via shift-version) without re-uploading.
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		skill.LatestVersion = version
+		result := tx.Model(&tables.TableSkill{}).
+			Where("id = ?", skill.ID).
+			Select("Description", "License", "Compatibility", "Metadata", "ExtraFrontmatter", "AllowedTools", "SkillMDBody", "LatestVersion", "UpdatedAt").
+			Updates(skill)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		bump, err := allSkillsBumpForVersionChange(existingLatestVersion, version)
+		if err != nil {
+			return err
+		}
+		return bumpAllSkillsVersionTx(ctx, tx, bump, false)
+	}); err != nil {
+		return fmt.Errorf("version %s was created successfully but could not be served — use shift-version to retry: %w", version, err)
+	}
+	return nil
+}
+
+// DeleteSkill deletes a skill, cleaning up object-store files across ALL versions.
+func (s *RDBConfigStore) DeleteSkill(ctx context.Context, id string, objectStore objectstore.ObjectStore) error {
+	var keys []string
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var skill tables.TableSkill
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&skill, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+		// Collect ALL distinct storage keys across all versions' files for this skill.
+		if objectStore != nil {
+			if err := tx.Model(&tables.TableSkillFile{}).
+				Where("skill_version_id IN (?)",
+					tx.Model(&tables.TableSkillVersion{}).Select("id").Where("skill_id = ?", id),
+				).
+				Where("storage_key IS NOT NULL AND storage_key != ''").
+				Distinct("storage_key").
+				Pluck("storage_key", &keys).Error; err != nil {
+				return err
+			}
+		}
+		// DB cascade handles: skill → versions → files, files → blobs
+		if err := tx.Delete(&skill).Error; err != nil {
+			return err
+		}
+		return bumpAllSkillsVersionTx(ctx, tx, allSkillsVersionBumpMajor, false)
+	}); err != nil {
+		return err
+	}
+	runSkillObjectCleanup(ctx, s.logger, objectStore, keys)
+	return nil
+}
+
+// ListSkills returns paginated skills with the serving version's file count and total count.
+func (s *RDBConfigStore) ListSkills(ctx context.Context, params SkillListQueryParams) ([]tables.TableSkill, int64, error) {
+	var skills []tables.TableSkill
+	query := s.ScopedDB(ctx).Model(&tables.TableSkill{})
+	if params.Search != "" {
+		like := "%" + strings.ToLower(params.Search) + "%"
+		query = query.Where("LOWER(name) LIKE ? OR LOWER(description) LIKE ?", like, like)
+	}
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	query = query.Omit("skill_md_body").Order(skillListOrder(params))
+	if params.Limit > 0 {
+		query = query.Limit(params.Limit)
+	}
+	if params.Offset > 0 {
+		query = query.Offset(params.Offset)
+	}
+	if err := query.Find(&skills).Error; err != nil {
+		return nil, 0, err
+	}
+	if len(skills) > 0 {
+		type fileCountRow struct {
+			SkillID   string
+			FileCount int64
+		}
+		var rows []fileCountRow
+		if err := s.ScopedDB(ctx).
+			Table("skill_versions").
+			Select("skill_versions.skill_id AS skill_id, COUNT(skill_files.id) AS file_count").
+			Joins("JOIN skills ON skills.id = skill_versions.skill_id AND skills.latest_version = skill_versions.version").
+			Joins("LEFT JOIN skill_files ON skill_files.skill_version_id = skill_versions.id").
+			Where("skill_versions.skill_id IN ?", skillIDs(skills)).
+			Group("skill_versions.skill_id").
+			Scan(&rows).Error; err != nil {
+			return nil, 0, err
+		}
+		fileCounts := make(map[string]int64, len(rows))
+		for _, row := range rows {
+			fileCounts[row.SkillID] = row.FileCount
+		}
+		for i := range skills {
+			skills[i].FileCount = fileCounts[skills[i].ID]
+		}
+	}
+	return skills, total, nil
+}
+
+func skillListOrder(params SkillListQueryParams) string {
+	column := "created_at"
+	switch params.SortBy {
+	case "name":
+		column = "name"
+	case "updated_at":
+		column = "updated_at"
+	case "created_at", "":
+		column = "created_at"
+	}
+	return column + " " + normalizedSortOrder(params.Order) + ", id ASC"
+}
+
+func skillVersionListOrder(params SkillVersionListQueryParams) string {
+	column := "created_at"
+	switch params.SortBy {
+	case "version":
+		column = "version"
+	case "created_at", "":
+		column = "created_at"
+	}
+	return column + " " + normalizedSortOrder(params.Order) + ", id ASC"
+}
+
+func normalizedSortOrder(order string) string {
+	if strings.EqualFold(order, "asc") {
+		return "ASC"
+	}
+	return "DESC"
+}
+
+func skillIDs(skills []tables.TableSkill) []string {
+	ids := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		ids = append(ids, skill.ID)
+	}
+	return ids
+}
+
+// createVersionFiles creates file rows under a version, reusing blob/storage references
+// for existing files that already carry a blob_id or storage_key.
+func createVersionFiles(ctx context.Context, tx *gorm.DB, objectStore objectstore.ObjectStore, skillID, versionID string, files []tables.TableSkillFile) ([]pendingSkillObjectWrite, error) {
+	objectWrites := make([]pendingSkillObjectWrite, 0)
+	for i := range files {
+		file := &files[i]
+		file.ID = uuid.NewString()
+		file.SkillVersionID = versionID
+		data, err := validateSkillFileSource(file)
+		if err != nil {
+			return nil, err
+		}
+		if data != nil {
+			file.FileSizeBytes = int64(len(data))
+		}
+		if err := validateSkillFileReference(tx, skillID, file); err != nil {
+			return nil, err
+		}
+		if err := ValidateSkillFile(file); err != nil {
+			return nil, err
+		}
+		if err := tx.Create(file).Error; err != nil {
+			return nil, err
+		}
+		if data != nil {
+			write, err := StoreSkillFileContent(ctx, tx, objectStore, skillID, file, data)
+			if err != nil {
+				return nil, err
+			}
+			if write != nil {
+				objectWrites = append(objectWrites, *write)
+			}
+			if err := tx.Model(&tables.TableSkillFile{}).Where("id = ?", file.ID).Updates(map[string]any{
+				"storage_key":     file.StorageKey,
+				"blob_id":         file.BlobID,
+				"file_size_bytes": file.FileSizeBytes,
+				"mime_type":       file.MimeType,
+			}).Error; err != nil {
+				return nil, err
+			}
+		}
+	}
+	return objectWrites, nil
+}
+
+// createSkillVersion creates a version row with a frontmatter snapshot (no file snapshot needed;
+// files belong to the version via FK).
+func createSkillVersion(tx *gorm.DB, skill *tables.TableSkill, version string) (*tables.TableSkillVersion, error) {
+	frontmatter := tables.SkillJSONMap{
+		"description": skill.Description,
+	}
+	if skill.License != nil {
+		frontmatter["license"] = *skill.License
+	}
+	if skill.Compatibility != nil {
+		frontmatter["compatibility"] = *skill.Compatibility
+	}
+	if skill.AllowedTools != nil {
+		frontmatter["allowed-tools"] = *skill.AllowedTools
+	}
+	for key, value := range skill.ExtraFrontmatter {
+		if !IsSkillReservedFrontmatterField(key) {
+			frontmatter[key] = value
+		}
+	}
+	if len(skill.Metadata) > 0 {
+		frontmatter["metadata"] = skill.Metadata
+	}
+
+	versionRow := tables.TableSkillVersion{
+		ID:                  uuid.NewString(),
+		SkillID:             skill.ID,
+		Version:             version,
+		SkillMDBody:         skill.SkillMDBody,
+		FrontmatterSnapshot: frontmatter,
+		CreatedBy:           skill.CreatedBy,
+	}
+	if err := tx.Create(&versionRow).Error; err != nil {
+		return nil, err
+	}
+	return &versionRow, nil
+}
+
+// populateSkillFiles reloads the serving version's files into the transient skill.Files.
+func populateSkillFiles(tx *gorm.DB, skill *tables.TableSkill) error {
+	var version tables.TableSkillVersion
+	if err := tx.Preload("Files").
+		Preload("Files.Blob").
+		First(&version, "skill_id = ? AND version = ?", skill.ID, skill.LatestVersion).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("serving version %q for skill %q has no version row; data may be inconsistent", skill.LatestVersion, skill.ID)
+		}
+		return err
+	}
+	skill.Files = version.Files
+	return nil
+}
+
+// SkillFrontmatterFields contains skill fields reconstructed from a version frontmatter snapshot.
+// Name is not included because it is immutable after creation.
+type SkillFrontmatterFields struct {
+	Description      string
+	License          *string
+	Compatibility    *string
+	AllowedTools     *string
+	Metadata         tables.SkillStringMap
+	ExtraFrontmatter tables.SkillJSONMap
+}
+
+// ExtractSkillFieldsFromFrontmatter reconstructs skill fields from a version's frontmatter snapshot.
+func ExtractSkillFieldsFromFrontmatter(frontmatter tables.SkillJSONMap) SkillFrontmatterFields {
+	fields := SkillFrontmatterFields{ExtraFrontmatter: make(tables.SkillJSONMap)}
+	if v, ok := frontmatter["description"].(string); ok {
+		fields.Description = v
+	}
+	if v, ok := frontmatter["license"].(string); ok {
+		fields.License = &v
+	}
+	if v, ok := frontmatter["compatibility"].(string); ok {
+		fields.Compatibility = &v
+	}
+	if v, ok := frontmatter["allowed-tools"].(string); ok {
+		fields.AllowedTools = &v
+	}
+	if m, ok := frontmatter["metadata"].(map[string]any); ok {
+		fields.Metadata = make(tables.SkillStringMap, len(m))
+		for k, v := range m {
+			if s, ok := v.(string); ok {
+				fields.Metadata[k] = s
+			}
+		}
+	}
+	for k, v := range frontmatter {
+		if !IsSkillReservedFrontmatterField(k) {
+			fields.ExtraFrontmatter[k] = v
+		}
+	}
+	return fields
+}
+
+// ShiftSkillVersion shifts a skill to serve a previously-saved version.
+// Files already exist on the target version; only the skill row fields and latest_version pointer change.
+func (s *RDBConfigStore) ShiftSkillVersion(ctx context.Context, skillID string, targetVersion string, objectStore objectstore.ObjectStore) error {
+	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var skill tables.TableSkill
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&skill, "id = ?", skillID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+
+		var version tables.TableSkillVersion
+		if err := tx.First(&version, "skill_id = ? AND version = ?", skillID, targetVersion).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("version %q not found for this skill", targetVersion)
+			}
+			return err
+		}
+
+		if skill.LatestVersion == targetVersion {
+			return fmt.Errorf("skill is already serving version %q", targetVersion)
+		}
+
+		// Snapshot current state if not already versioned.
+		var existingSnapshot tables.TableSkillVersion
+		if err := tx.First(&existingSnapshot, "skill_id = ? AND version = ?", skillID, skill.LatestVersion).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				if _, err := createSkillVersion(tx, &skill, skill.LatestVersion); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+
+		// Extract fields from target version frontmatter and update skill row (name is immutable).
+		fields := ExtractSkillFieldsFromFrontmatter(version.FrontmatterSnapshot)
+		if err := tx.Model(&tables.TableSkill{}).Where("id = ?", skillID).Updates(map[string]any{
+			"description":       fields.Description,
+			"license":           fields.License,
+			"compatibility":     fields.Compatibility,
+			"allowed_tools":     fields.AllowedTools,
+			"metadata":          fields.Metadata,
+			"extra_frontmatter": fields.ExtraFrontmatter,
+			"skill_md_body":     version.SkillMDBody,
+			"latest_version":    targetVersion,
+		}).Error; err != nil {
+			return err
+		}
+		return bumpAllSkillsVersionTx(ctx, tx, allSkillsVersionBumpPatch, false)
+	})
+}
+
+// CreateSkillFileBlob creates an orphan blob record (e.g. for the upload endpoint's DB fallback).
+func (s *RDBConfigStore) CreateSkillFileBlob(ctx context.Context, blob *tables.TableSkillFileBlob) error {
+	if blob.ID == "" {
+		blob.ID = uuid.NewString()
+	}
+	return s.DB().WithContext(ctx).Create(blob).Error
+}
+
+// UpdateSkillConfigHash sets the config_hash on a skill row so config reconciliation
+// can detect subsequent no-change restarts without re-running UpdateSkill.
+func (s *RDBConfigStore) UpdateSkillConfigHash(ctx context.Context, skillID string, configHash string) error {
+	return s.DB().WithContext(ctx).
+		Model(&tables.TableSkill{}).
+		Where("id = ?", skillID).
+		Update("config_hash", configHash).Error
+}
+
+// CleanupOrphanSkillFileBlobs deletes DB fallback blobs not referenced by any skill file.
+// When force is false, a 30-minute grace period protects freshly uploaded pending blobs.
+func (s *RDBConfigStore) CleanupOrphanSkillFileBlobs(ctx context.Context, force bool) (int64, error) {
+	query := s.DB().WithContext(ctx)
+	if !force {
+		cutoff := time.Now().Add(-30 * time.Minute)
+		query = query.Where("created_at < ?", cutoff)
+	}
+	result := query.
+		Where("NOT EXISTS (?)",
+			s.DB().Model(&tables.TableSkillFile{}).
+				Select("1").
+				Where("skill_files.blob_id = skill_file_blobs.id"),
+		).
+		Delete(&tables.TableSkillFileBlob{})
+	return result.RowsAffected, result.Error
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/objectstore"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"gorm.io/gorm"
 )
@@ -35,6 +36,22 @@ type ModelConfigsQueryParams struct {
 	Search   string
 	Scope    string // optional; filters to an exact scope value (e.g. "global", "virtual_key")
 	Provider string // optional; filters to an exact provider value (e.g. "openai")
+}
+
+// SkillListQueryParams holds pagination, filtering, and search parameters for skill repository queries.
+type SkillListQueryParams struct {
+	Limit  int
+	Offset int
+	Search string
+	SortBy string // name, updated_at, created_at (default: created_at)
+	Order  string // asc, desc (default: desc)
+}
+
+type SkillVersionListQueryParams struct {
+	Limit  int
+	Offset int
+	SortBy string // version, created_at (default: created_at)
+	Order  string // asc, desc (default: desc)
 }
 
 // RoutingRulesQueryParams holds pagination, filtering, and search parameters for routing rules queries.
@@ -578,6 +595,23 @@ type ConfigStore interface {
 	GetLatestPromptVersion(ctx context.Context, promptID string) (*tables.TablePromptVersion, error)
 	CreatePromptVersion(ctx context.Context, version *tables.TablePromptVersion) error
 	DeletePromptVersion(ctx context.Context, id uint) error
+
+	// Skills Repository
+	CreateSkill(ctx context.Context, skill *tables.TableSkill, version string, objectStore objectstore.ObjectStore) error
+	GetSkill(ctx context.Context, id string) (*tables.TableSkill, error)
+	GetSkillLean(ctx context.Context, id string) (*tables.TableSkill, error)
+	GetSkillByName(ctx context.Context, name string) (*tables.TableSkill, error)
+	GetSkillVersion(ctx context.Context, skillID, version string) (*tables.TableSkillVersion, error)
+	ListSkillVersions(ctx context.Context, skillID string, params SkillVersionListQueryParams) ([]tables.TableSkillVersion, int64, error)
+	UpdateSkill(ctx context.Context, skill *tables.TableSkill, version string, serve bool, objectStore objectstore.ObjectStore) error
+	DeleteSkill(ctx context.Context, id string, objectStore objectstore.ObjectStore) error
+	ListSkills(ctx context.Context, params SkillListQueryParams) ([]tables.TableSkill, int64, error)
+	ShiftSkillVersion(ctx context.Context, skillID string, targetVersion string, objectStore objectstore.ObjectStore) error
+	GetAllSkillsVersion(ctx context.Context) (string, error)
+	BumpAllSkillsVersion(ctx context.Context, bump string) (string, error)
+	CreateSkillFileBlob(ctx context.Context, blob *tables.TableSkillFileBlob) error
+	CleanupOrphanSkillFileBlobs(ctx context.Context, force bool) (int64, error)
+	UpdateSkillConfigHash(ctx context.Context, skillID string, configHash string) error
 
 	// Prompt Repository - Sessions
 	GetPromptSessions(ctx context.Context, promptID string) ([]tables.TablePromptSession, error)

--- a/framework/configstore/tables/skills.go
+++ b/framework/configstore/tables/skills.go
@@ -1,0 +1,212 @@
+// Package tables provides tables for the configstore
+package tables
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	SkillSourceTypeURL     = "url"
+	SkillSourceTypeDataURL = "dataurl"
+	SkillSourceTypeText    = "text"
+	SkillSourceTypeUpload  = "upload"
+)
+
+// SkillStringMap is stored as JSON and represents spec metadata string pairs.
+type SkillStringMap map[string]string
+
+// SkillJSONMap is stored as JSON and represents arbitrary extra frontmatter.
+type SkillJSONMap map[string]any
+
+// Value implements driver.Valuer for SkillStringMap.
+func (m SkillStringMap) Value() (driver.Value, error) {
+	if m == nil {
+		return "{}", nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return string(data), nil
+}
+
+// Scan implements sql.Scanner for SkillStringMap.
+func (m *SkillStringMap) Scan(value any) error {
+	return scanSkillJSON(value, m)
+}
+
+// Value implements driver.Valuer for SkillJSONMap.
+func (m SkillJSONMap) Value() (driver.Value, error) {
+	if m == nil {
+		return "{}", nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return string(data), nil
+}
+
+// Scan implements sql.Scanner for SkillJSONMap.
+func (m *SkillJSONMap) Scan(value any) error {
+	return scanSkillJSON(value, m)
+}
+
+func scanSkillJSON(value any, dest any) error {
+	if value == nil {
+		return nil
+	}
+
+	var data []byte
+	switch v := value.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return fmt.Errorf("unsupported skill JSON value type %T", value)
+	}
+
+	if len(data) == 0 {
+		return nil
+	}
+	return json.Unmarshal(data, dest)
+}
+
+// TableSkill represents a skill in the repository. Every save creates a version snapshot.
+type TableSkill struct {
+	ID               string         `gorm:"type:varchar(36);primaryKey" json:"id"`
+	Name             string         `gorm:"type:varchar(64);not null;uniqueIndex" json:"name"`
+	Description      string         `gorm:"type:varchar(1024);not null" json:"description"`
+	License          *string        `gorm:"type:text" json:"license,omitempty"`
+	Compatibility    *string        `gorm:"type:varchar(500)" json:"compatibility,omitempty"`
+	Metadata         SkillStringMap `gorm:"type:json" json:"metadata,omitempty"`
+	ExtraFrontmatter SkillJSONMap   `gorm:"type:json;column:extra_frontmatter" json:"extra_frontmatter,omitempty"`
+	AllowedTools     *string        `gorm:"type:text;column:allowed_tools" json:"allowed_tools,omitempty"`
+	SkillMDBody      string         `gorm:"type:text;not null;column:skill_md_body" json:"skill_md_body"`
+	LatestVersion    string         `gorm:"type:varchar(100);not null;column:latest_version" json:"latest_version"`
+	CreatedBy        *string        `gorm:"type:varchar(255);column:created_by" json:"created_by,omitempty"`
+	ConfigHash       string         `gorm:"type:varchar(64)" json:"-"`
+	CreatedAt        time.Time      `gorm:"not null" json:"created_at"`
+	UpdatedAt        time.Time      `gorm:"not null" json:"updated_at"`
+
+	Versions []TableSkillVersion `gorm:"foreignKey:SkillID;constraint:OnDelete:CASCADE" json:"versions,omitempty"`
+
+	// Transient: populated from the serving version's files for API convenience.
+	// Not stored in the skills table; filled by the store layer on read.
+	Files []TableSkillFile `gorm:"-" json:"files,omitempty"`
+
+	// Transient: serving version file count for list responses.
+	// Not stored in the skills table; filled by the store layer on list reads.
+	FileCount int64 `gorm:"-" json:"file_count"`
+
+	// Transient: most recently created version string across all versions of this skill.
+	// Filled by the store layer; used by the frontend for version bump validation.
+	HighestVersion string `gorm:"-" json:"highest_version,omitempty"`
+}
+
+// TableName for TableSkill.
+func (TableSkill) TableName() string { return "skills" }
+
+// TableSkillVersion represents an immutable snapshot of a skill save.
+// Files belong to versions, not directly to skills.
+type TableSkillVersion struct {
+	ID                  string       `gorm:"type:varchar(36);primaryKey" json:"id"`
+	SkillID             string       `gorm:"type:varchar(36);not null;index;uniqueIndex:idx_skill_version" json:"skill_id"`
+	Version             string       `gorm:"type:varchar(100);not null;uniqueIndex:idx_skill_version" json:"version"`
+	SkillMDBody         string       `gorm:"type:text;not null;column:skill_md_body" json:"skill_md_body,omitempty"`
+	FrontmatterSnapshot SkillJSONMap `gorm:"type:json;column:frontmatter_snapshot" json:"frontmatter_snapshot,omitempty"`
+	CreatedBy           *string      `gorm:"type:varchar(255);column:created_by" json:"created_by,omitempty"`
+	CreatedAt           time.Time    `gorm:"not null" json:"created_at"`
+
+	Skill *TableSkill `gorm:"foreignKey:SkillID" json:"skill,omitempty"`
+
+	Files []TableSkillFile `gorm:"foreignKey:SkillVersionID;constraint:OnDelete:CASCADE" json:"files,omitempty"`
+}
+
+// TableName for TableSkillVersion.
+func (TableSkillVersion) TableName() string { return "skill_versions" }
+
+// TableSkillFile represents a file associated with a skill version.
+// The file row is a pointer to the underlying blob/storage; blobs are reused
+// across versions when the file content hasn't changed.
+type TableSkillFile struct {
+	ID             string    `gorm:"type:varchar(36);primaryKey" json:"id"`
+	SkillVersionID string    `gorm:"type:varchar(36);not null;index;uniqueIndex:idx_skill_file_path;column:skill_version_id" json:"skill_version_id"`
+	Path           string    `gorm:"type:varchar(1024);not null;uniqueIndex:idx_skill_file_path" json:"path"`
+	SourceType     string    `gorm:"type:varchar(32);not null;column:source_type" json:"source_type"`
+	SourceURL      *string   `gorm:"type:text;column:source_url" json:"source_url,omitempty"`
+	StorageKey     *string   `gorm:"type:text;column:storage_key" json:"storage_key,omitempty"`
+	BlobID         *string   `gorm:"type:varchar(36);index;column:blob_id" json:"blob_id,omitempty"`
+	MimeType       string    `gorm:"type:varchar(255);column:mime_type" json:"mime_type"`
+	FileSizeBytes  int64     `gorm:"not null;default:0;column:file_size_bytes" json:"file_size_bytes"`
+	CreatedAt      time.Time `gorm:"not null" json:"created_at"`
+	UpdatedAt      time.Time `gorm:"not null" json:"updated_at"`
+
+	SkillVersion *TableSkillVersion  `gorm:"foreignKey:SkillVersionID" json:"skill_version,omitempty"`
+	Blob         *TableSkillFileBlob `gorm:"foreignKey:BlobID;constraint:OnDelete:SET NULL" json:"blob,omitempty"`
+
+	InlineContent *string `gorm:"-" json:"content,omitempty"`
+	DataURL       *string `gorm:"-" json:"dataurl,omitempty"`
+	UploadID      *string `gorm:"-" json:"upload_id,omitempty"`
+}
+
+// TableName for TableSkillFile.
+func (TableSkillFile) TableName() string { return "skill_files" }
+
+// BeforeSave normalizes the path before persisting so the unique index enforces the canonical form.
+func (f *TableSkillFile) BeforeSave(tx *gorm.DB) error {
+	f.Path = strings.TrimSpace(f.Path)
+	return nil
+}
+
+// NormalizedPath returns a trimmed relative path so uniqueness logic is stable.
+func (f TableSkillFile) NormalizedPath() string {
+	return strings.TrimSpace(f.Path)
+}
+
+// TableSkillFileBlob stores fallback file bytes when object storage is unavailable.
+type TableSkillFileBlob struct {
+	ID        string    `gorm:"type:varchar(36);primaryKey" json:"id"`
+	Data      []byte    `gorm:"not null" json:"-"`
+	CreatedAt time.Time `gorm:"not null" json:"created_at"`
+}
+
+// TableName for TableSkillFileBlob.
+func (TableSkillFileBlob) TableName() string { return "skill_file_blobs" }
+
+// BeforeCreate ensures map fields are initialized before insertion.
+func (s *TableSkill) BeforeCreate(tx *gorm.DB) error {
+	if s.Metadata == nil {
+		s.Metadata = SkillStringMap{}
+	}
+	if s.ExtraFrontmatter == nil {
+		s.ExtraFrontmatter = SkillJSONMap{}
+	}
+	return nil
+}
+
+// BeforeSave ensures map fields are initialized before update.
+func (s *TableSkill) BeforeSave(tx *gorm.DB) error {
+	if s.Metadata == nil {
+		s.Metadata = SkillStringMap{}
+	}
+	if s.ExtraFrontmatter == nil {
+		s.ExtraFrontmatter = SkillJSONMap{}
+	}
+	return nil
+}
+
+// BeforeCreate ensures snapshot fields are initialized before insertion.
+func (v *TableSkillVersion) BeforeCreate(tx *gorm.DB) error {
+	if v.FrontmatterSnapshot == nil {
+		v.FrontmatterSnapshot = SkillJSONMap{}
+	}
+	return nil
+}

--- a/framework/objectstore/gcs.go
+++ b/framework/objectstore/gcs.go
@@ -12,6 +12,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/maximhq/bifrost/core/schemas"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
 
@@ -117,6 +118,23 @@ func (g *GCSObjectStore) Get(ctx context.Context, key string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+// ListByPrefix returns object keys matching the given prefix.
+func (g *GCSObjectStore) ListByPrefix(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	it := g.client.Bucket(g.bucket).Objects(ctx, &storage.Query{Prefix: prefix})
+	objects := make([]ObjectInfo, 0)
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("objectstore: gcs list prefix %s: %w", prefix, err)
+		}
+		objects = append(objects, ObjectInfo{Key: attrs.Name, LastModified: attrs.Updated})
+	}
+	return objects, nil
 }
 
 // Delete removes a single object by key.

--- a/framework/objectstore/mock.go
+++ b/framework/objectstore/mock.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strings"
 	"sync"
+	"time"
 )
 
 // InMemoryObjectStore is an in-memory ObjectStore implementation for testing.
 type InMemoryObjectStore struct {
-	mu      sync.RWMutex
-	objects map[string][]byte
-	tags    map[string]map[string]string
+	mu        sync.RWMutex
+	objects   map[string][]byte
+	tags      map[string]map[string]string
+	createdAt map[string]time.Time
 
 	// PutErr, if set, is returned by Put for simulating failures.
 	PutErr error
@@ -22,8 +25,9 @@ type InMemoryObjectStore struct {
 // NewInMemoryObjectStore creates a new in-memory object store.
 func NewInMemoryObjectStore() *InMemoryObjectStore {
 	return &InMemoryObjectStore{
-		objects: make(map[string][]byte),
-		tags:    make(map[string]map[string]string),
+		objects:   make(map[string][]byte),
+		tags:      make(map[string]map[string]string),
+		createdAt: make(map[string]time.Time),
 	}
 }
 
@@ -37,6 +41,9 @@ func (m *InMemoryObjectStore) Put(_ context.Context, key string, data []byte, ta
 	cp := make([]byte, len(data))
 	copy(cp, data)
 	m.objects[key] = cp
+	if _, exists := m.createdAt[key]; !exists {
+		m.createdAt[key] = time.Now()
+	}
 	if len(tags) > 0 {
 		tagsCp := make(map[string]string, len(tags))
 		maps.Copy(tagsCp, tags)
@@ -62,11 +69,24 @@ func (m *InMemoryObjectStore) Get(_ context.Context, key string) ([]byte, error)
 	return cp, nil
 }
 
+func (m *InMemoryObjectStore) ListByPrefix(_ context.Context, prefix string) ([]ObjectInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	objects := make([]ObjectInfo, 0)
+	for key := range m.objects {
+		if key != "" && strings.HasPrefix(key, prefix) {
+			objects = append(objects, ObjectInfo{Key: key, LastModified: m.createdAt[key]})
+		}
+	}
+	return objects, nil
+}
+
 func (m *InMemoryObjectStore) Delete(_ context.Context, key string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.objects, key)
 	delete(m.tags, key)
+	delete(m.createdAt, key)
 	return nil
 }
 
@@ -76,6 +96,7 @@ func (m *InMemoryObjectStore) DeleteBatch(_ context.Context, keys []string) erro
 	for _, key := range keys {
 		delete(m.objects, key)
 		delete(m.tags, key)
+		delete(m.createdAt, key)
 	}
 	return nil
 }
@@ -117,4 +138,11 @@ func (m *InMemoryObjectStore) Keys() []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// SetCreatedAt overrides the creation time for the given key. For testing assertions.
+func (m *InMemoryObjectStore) SetCreatedAt(key string, t time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createdAt[key] = t
 }

--- a/framework/objectstore/objectstore.go
+++ b/framework/objectstore/objectstore.go
@@ -3,7 +3,16 @@
 // objects from S3, GCS (via S3 interop), MinIO, R2, or other S3-compatible stores.
 package objectstore
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// ObjectInfo describes a stored object returned by listing operations.
+type ObjectInfo struct {
+	Key          string
+	LastModified time.Time
+}
 
 // ObjectStore abstracts S3-compatible blob storage operations.
 type ObjectStore interface {
@@ -13,6 +22,9 @@ type ObjectStore interface {
 
 	// Get retrieves and decompresses data for the given key.
 	Get(ctx context.Context, key string) ([]byte, error)
+
+	// ListByPrefix returns objects matching the given prefix with metadata.
+	ListByPrefix(ctx context.Context, prefix string) ([]ObjectInfo, error)
 
 	// Delete removes an object by key.
 	Delete(ctx context.Context, key string) error

--- a/framework/objectstore/objectstore_test.go
+++ b/framework/objectstore/objectstore_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 )
 
@@ -103,6 +104,24 @@ func TestInMemoryObjectStore(t *testing.T) {
 	}
 	if store.Len() != 1 {
 		t.Fatalf("Len after batch delete: got %d, want 1", store.Len())
+	}
+
+	// ListByPrefix
+	_ = store.Put(ctx, "prefix/one", []byte("1"), nil)
+	_ = store.Put(ctx, "prefix/two", []byte("2"), nil)
+	_ = store.Put(ctx, "other/three", []byte("3"), nil)
+	objects, err := store.ListByPrefix(ctx, "prefix/")
+	if err != nil {
+		t.Fatalf("ListByPrefix: %v", err)
+	}
+	if len(objects) != 2 {
+		t.Fatalf("ListByPrefix got %d objects, want 2: %v", len(objects), objects)
+	}
+	gotKeys := []string{objects[0].Key, objects[1].Key}
+	sort.Strings(gotKeys)
+	wantKeys := []string{"prefix/one", "prefix/two"}
+	if gotKeys[0] != wantKeys[0] || gotKeys[1] != wantKeys[1] {
+		t.Fatalf("ListByPrefix keys: got %v, want %v", gotKeys, wantKeys)
 	}
 
 	// Ping and Close

--- a/framework/objectstore/s3.go
+++ b/framework/objectstore/s3.go
@@ -218,6 +218,34 @@ func (s *S3ObjectStore) DeleteBatch(ctx context.Context, keys []string) error {
 	return nil
 }
 
+// ListByPrefix returns all non-empty object keys matching the given prefix.
+func (s *S3ObjectStore) ListByPrefix(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(prefix),
+	})
+
+	objects := make([]ObjectInfo, 0)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("objectstore: list objects with prefix %s: %w", prefix, err)
+		}
+		for _, object := range page.Contents {
+			key := aws.ToString(object.Key)
+			if key != "" {
+				info := ObjectInfo{Key: key}
+				if object.LastModified != nil {
+					info.LastModified = *object.LastModified
+				}
+				objects = append(objects, info)
+			}
+		}
+	}
+
+	return objects, nil
+}
+
 // Ping checks connectivity by performing a HeadBucket call.
 // Note: HeadBucket requires the s3:ListBucket IAM permission on the bucket resource.
 func (s *S3ObjectStore) Ping(ctx context.Context) error {


### PR DESCRIPTION
## Summary

Adds prefix-based object listing to the shared object store interface and
implements it for S3, GCS, and the in-memory object store. This supports safe
cleanup of orphaned Skills Repository uploads.

## Changes

- Updated the shared framework objectstore abstraction used by Skills Repository
  cleanup.
- Added `ListByPrefix` to the object store interface.
- Implemented prefix listing for S3 using object listing pagination.
- Implemented prefix listing for GCS using bucket object queries.
- Implemented prefix listing for the in-memory mock object store.
- Added test coverage for in-memory prefix listing behavior and validated the
  Skills orphan cleanup path that deletes only unreferenced upload objects.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate this change with the following command:

```sh
# From bifrost/
direnv exec . go test ./framework/objectstore
direnv exec . go test ./transports/bifrost-http/handlers -run 'TestCleanupOrphanSkillFiles'
```

Expected result: object store tests pass, including in-memory prefix listing;
Skills cleanup tests pass, preserving referenced upload objects and
outside-prefix objects while deleting only unreferenced `skills/uploads/`
objects.

No new configs or environment variables are added in this PR.

## Screenshots/Recordings

N/A — backend object-store capability only.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Prefix listing is used for cleanup workflows. Cleanup callers should only delete
objects after comparing listed upload keys against persisted skill file
references.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable