### PR TITLE
feat: add config-based skills registry

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,19 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: en-US
 
+early_access: true
+
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+
 reviews:
-  profile: assertive
-  request_changes_workflow: false
+  high_level_summary_in_walkthrough: true
+  fail_commit_status: true
+  suggested_labels: false
+  auto_assign_reviewers: true
+  profile: chill
+  request_changes_workflow: true
   high_level_summary: true
   review_status: true
   changed_files_summary: true
@@ -13,9 +23,41 @@ reviews:
     enabled: true
     drafts: false
     auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
     base_branches:
       - ".*"
   path_instructions:
+    - path: package.json
+      instructions: |
+        do not allow any carats in package.json, we never want any auto updates for any patch versions of any
+        packages in package.json
+    - path: "**"
+      instructions: |
+        always check the stack if there is one for the current PR. do not give localized reviews for the PR,
+        always see all changes in the light of the whole stack of PRs (if there is a stack, if there is no stack you can
+        continue to make localized suggestions/reviews)
+    - path: "**/*.go"
+      instructions: |
+        Rule: No raw context keys in Go.
+
+        When reviewing code, ALWAYS check for incorrect usage of context values.
+
+        Reject or flag the change if you find ANY of the following:
+        - context.WithValue(ctx, "someKey", value)         // string literal key
+        - context.WithValue(ctx, someStringVar, value)   // key is type string
+        - context.WithValue(ctx, fmt.Sprintf(...), value)    // computed/dynamic string key
+        - ctx.Value("someKey") or ctx.Value(someStringVar)        // same problem on retrieval
+
+        Required pattern:
+        - Context keys MUST be a dedicated named type (NOT plain string), e.g.
+          - type contextKey string
+            const userIDKey contextKey = "userId"
+          OR
+          - type userIDKeyType struct{}
+            var userIDKey userIDKeyType
+
+        - The key passed to WithValue/Value MUST be that typed identifier, e.g.
+          - ctx = context.WithValue(ctx, userIDKey, userID)
     - path: "core/**"
       instructions: |
         Review Go core changes for concurrency safety, provider isolation, pooled object reset discipline, and plugin hook ordering.

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -637,6 +637,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPromptRepoTables(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddSkillsRepoTables(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddPluginOrderColumns(ctx, db); err != nil {
 		return err
 	}
@@ -6571,6 +6574,73 @@ func migrationAddMCPClientAllowedExtraHeadersJSONColumn(ctx context.Context, db 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running add_mcp_client_allowed_extra_headers_json_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddSkillsRepoTables adds the skills repository tables.
+// Files belong to skill_versions (not directly to skills); blobs are reused
+// across versions via shared blob_id/storage_key references.
+//
+// Idempotent: guards each table create so retrying after a partially applied
+// migration does not fail when some tables were already created.
+func migrationAddSkillsRepoTables(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_skills_repo_tables",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// --- skills table ---
+			if !mg.HasTable(&tables.TableSkill{}) {
+				if err := mg.CreateTable(&tables.TableSkill{}); err != nil {
+					return fmt.Errorf("create skills table: %w", err)
+				}
+			}
+
+			// --- skill_versions table ---
+			if !mg.HasTable(&tables.TableSkillVersion{}) {
+				if err := mg.CreateTable(&tables.TableSkillVersion{}); err != nil {
+					return fmt.Errorf("create skill_versions table: %w", err)
+				}
+			}
+
+			// --- skill_file_blobs table ---
+			if !mg.HasTable(&tables.TableSkillFileBlob{}) {
+				if err := mg.CreateTable(&tables.TableSkillFileBlob{}); err != nil {
+					return fmt.Errorf("create skill_file_blobs table: %w", err)
+				}
+			}
+
+			// --- skill_files table ---
+			if !mg.HasTable(&tables.TableSkillFile{}) {
+				if err := mg.CreateTable(&tables.TableSkillFile{}); err != nil {
+					return fmt.Errorf("create skill_files table: %w", err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if err := mg.DropTable(&tables.TableSkillFile{}); err != nil {
+				return err
+			}
+			if err := mg.DropTable(&tables.TableSkillVersion{}); err != nil {
+				return err
+			}
+			if err := mg.DropTable(&tables.TableSkill{}); err != nil {
+				return err
+			}
+			if err := mg.DropTable(&tables.TableSkillFileBlob{}); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running skills repo tables migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -333,6 +333,83 @@ func TestUpsertMCPLibraryEntry(t *testing.T) {
 	require.Equal(t, "updated", entries[0].Description)
 }
 
+func TestValidateSkillVersionIncrementRequiresGreaterVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		latest  string
+		next    string
+		wantErr bool
+	}{
+		{name: "rejects lower prerelease core", latest: "1.0.3", next: "1.0.2-1", wantErr: true},
+		{name: "accepts same core with suffix after release", latest: "1.0.3", next: "1.0.3-1", wantErr: false},
+		{name: "accepts release after same core suffix", latest: "1.0.3-beta1", next: "1.0.3", wantErr: false},
+		{name: "accepts higher patch", latest: "1.0.3", next: "1.0.4", wantErr: false},
+		{name: "accepts higher minor", latest: "1.0.3", next: "1.1.0", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSkillVersionIncrement(tt.latest, tt.next)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestLatestCreatedSkillVersionUsesCreationOrder(t *testing.T) {
+	store := setupRDBTestStore(t)
+	err := store.DB().AutoMigrate(
+		&tables.TableSkill{},
+		&tables.TableSkillVersion{},
+		&tables.TableSkillFile{},
+		&tables.TableSkillFileBlob{},
+	)
+	require.NoError(t, err)
+	ctx := context.Background()
+	baseTime := time.Now()
+
+	skillID := "skill-latest-created"
+	err = store.DB().Create(&tables.TableSkill{
+		ID:            skillID,
+		Name:          "latest-created",
+		Description:   "Latest created version test",
+		SkillMDBody:   "body",
+		LatestVersion: "1.0.3",
+		CreatedAt:     baseTime,
+		UpdatedAt:     baseTime,
+	}).Error
+	require.NoError(t, err)
+	err = store.DB().Create(&tables.TableSkillVersion{
+		ID:                  "skill-version-old",
+		SkillID:             skillID,
+		Version:             "1.0.3",
+		SkillMDBody:         "body",
+		FrontmatterSnapshot: tables.SkillJSONMap{"name": "latest-created", "description": "Latest created version test"},
+		CreatedAt:           baseTime,
+	}).Error
+	require.NoError(t, err)
+	err = store.DB().Create(&tables.TableSkillVersion{
+		ID:                  "skill-version-new",
+		SkillID:             skillID,
+		Version:             "1.0.2-1",
+		SkillMDBody:         "body",
+		FrontmatterSnapshot: tables.SkillJSONMap{"name": "latest-created", "description": "Latest created version test"},
+		CreatedAt:           baseTime.Add(time.Minute),
+	}).Error
+	require.NoError(t, err)
+
+	latest, err := latestCreatedSkillVersion(store.DB(), skillID)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.2-1", latest)
+
+	skill, err := store.GetSkillLean(ctx, skillID)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.2-1", skill.HighestVersion)
+}
+
 // =============================================================================
 // Provider and Key Tests
 // =============================================================================

--- a/framework/configstore/skills.go
+++ b/framework/configstore/skills.go
@@ -1,0 +1,1216 @@
+package configstore
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const allSkillsVersionConfigKey = "skills_repository.all_skills_version"
+
+type allSkillsVersionBump string
+
+type pendingSkillObjectWrite struct {
+	key      string
+	data     []byte
+	metadata map[string]string
+}
+
+// runPendingSkillObjectWrites uploads pending objects to the store after the DB
+// transaction has committed. If any upload fails it performs a compensating DB
+// delete so the committed rows don't reference missing objects:
+//   - isCreate=true  → deletes the entire skill (cascades to versions/files)
+//   - isCreate=false → deletes only the newly created version row
+//
+// Already-written objects from earlier iterations are best-effort cleaned up
+// to avoid orphans. Any stragglers are caught by the startup orphan cleanup.
+func runPendingSkillObjectWrites(ctx context.Context, db *gorm.DB, objectStore objectstore.ObjectStore, writes []pendingSkillObjectWrite, isCreate bool, skillID, versionID string) error {
+	if objectStore == nil || len(writes) == 0 {
+		return nil
+	}
+	for i, write := range writes {
+		if err := objectStore.Put(ctx, write.key, write.data, write.metadata); err != nil {
+			writeErr := fmt.Errorf("failed to write skill file object %s: %w", write.key, err)
+
+			// Use a bounded detached context: request cancellation often causes the
+			// Put failure, but compensation must still get a chance to repair DB rows.
+			compensationCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			compensationDB := db.WithContext(compensationCtx)
+
+			// Compensating delete: remove the DB rows that reference the missing objects.
+			var compensationErr error
+			if isCreate {
+				compensationErr = compensationDB.Where("id = ?", skillID).Delete(&tables.TableSkill{}).Error
+			} else {
+				compensationErr = compensationDB.Where("id = ?", versionID).Delete(&tables.TableSkillVersion{}).Error
+			}
+			if compensationErr != nil {
+				return fmt.Errorf("%w; failed to compensate committed skill rows: %v", writeErr, compensationErr)
+			}
+
+			// Best-effort cleanup of objects written in earlier iterations.
+			if i > 0 {
+				written := make([]string, i)
+				for j := range i {
+					written[j] = writes[j].key
+				}
+				_ = objectStore.DeleteBatch(compensationCtx, written)
+			}
+			return writeErr
+		}
+	}
+	return nil
+}
+
+func runSkillObjectCleanup(ctx context.Context, logger schemas.Logger, objectStore objectstore.ObjectStore, keys []string) {
+	if objectStore == nil || len(keys) == 0 {
+		return
+	}
+	if err := objectStore.DeleteBatch(ctx, keys); err != nil && logger != nil {
+		logger.Warn("failed to cleanup skill file objects, will be cleanedup in the restart automatically: %v", err)
+	}
+}
+
+const (
+	allSkillsVersionBumpPatch allSkillsVersionBump = "patch"
+	allSkillsVersionBumpMinor allSkillsVersionBump = "minor"
+	allSkillsVersionBumpMajor allSkillsVersionBump = "major"
+
+	// MaxSkillFileContentSize is the maximum allowed size for any single skill
+	// file, regardless of source type.
+	MaxSkillFileContentSize = 50 * 1024 * 1024
+
+	// SkillObjectPrefix is the object-store prefix for all skill files.
+	SkillObjectPrefix = "skills/"
+)
+
+// SkillHarnessNames lists the supported agent harness identifiers
+// (e.g. "claude-code", "codex"). Used for Git smart HTTP route
+// registration and reserved-name validation.
+var SkillHarnessNames = []string{"claude-code", "codex"}
+
+// SkillReservedNames lists skill names that are reserved by the serving
+// layer (static routes that would shadow dynamic skill-name routes).
+// Built from SkillHarnessNames plus additional synthetic names.
+var SkillReservedNames = append([]string{"all-skills", "all"}, SkillHarnessNames...)
+
+var (
+	skillNamePattern   = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	skillSemverPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z][0-9A-Za-z.-]*))?$`)
+	// skillReservedFrontmatterFields contains frontmatter keys that are managed
+	// as first-class DB columns and must not appear in extra_frontmatter.
+	skillReservedFrontmatterFields = map[string]struct{}{
+		"name":          {},
+		"description":   {},
+		"license":       {},
+		"compatibility": {},
+		"metadata":      {},
+		"allowed-tools": {},
+	}
+)
+
+// IsSkillReservedFrontmatterField returns true if the given key is a reserved
+// frontmatter field managed as a first-class DB column.
+func IsSkillReservedFrontmatterField(key string) bool {
+	_, reserved := skillReservedFrontmatterFields[key]
+	return reserved
+}
+
+type skillVersionParts struct {
+	major  int
+	minor  int
+	patch  int
+	suffix string
+}
+
+// ValidateSkill validates the skill-level fields required by the Agent Skills spec.
+func ValidateSkill(skill *tables.TableSkill, version string) error {
+	if skill == nil {
+		return fmt.Errorf("skill is required")
+	}
+	if err := ValidateSkillName(skill.Name); err != nil {
+		return err
+	}
+	if strings.TrimSpace(skill.Description) == "" {
+		return fmt.Errorf("skill description is required")
+	}
+	if len(skill.Description) > 1024 {
+		return fmt.Errorf("skill description must be 1024 characters or fewer")
+	}
+	if skill.Compatibility != nil && len(*skill.Compatibility) > 500 {
+		return fmt.Errorf("skill compatibility must be 500 characters or fewer")
+	}
+	if strings.TrimSpace(skill.SkillMDBody) == "" {
+		return fmt.Errorf("skill_md_body is required")
+	}
+	if !utf8.ValidString(skill.SkillMDBody) {
+		return fmt.Errorf("skill_md_body must be valid UTF-8")
+	}
+	if err := ValidateSkillVersion(version); err != nil {
+		return err
+	}
+	for key, value := range skill.Metadata {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("metadata keys must be non-empty")
+		}
+		if !utf8.ValidString(value) {
+			return fmt.Errorf("metadata value for %q must be valid UTF-8", key)
+		}
+	}
+	for key := range skill.ExtraFrontmatter {
+		if IsSkillReservedFrontmatterField(key) {
+			return fmt.Errorf("extra_frontmatter key %q conflicts with a reserved frontmatter field", key)
+		}
+	}
+	return nil
+}
+
+// ValidateSkillName validates lowercase alphanumeric + hyphen skill names.
+func ValidateSkillName(name string) error {
+	if name == "" {
+		return fmt.Errorf("skill name is required")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("skill name must be 64 characters or fewer")
+	}
+	if !skillNamePattern.MatchString(name) {
+		return fmt.Errorf("skill name must contain only lowercase letters, numbers, and single hyphens with no leading, trailing, or consecutive hyphens")
+	}
+	if slices.Contains(SkillReservedNames, name) {
+		return fmt.Errorf("%q is a reserved name used by the skills serving layer", name)
+	}
+	return nil
+}
+
+// ValidateSkillFile validates a skill file definition before storage writes.
+func ValidateSkillFile(file *tables.TableSkillFile) error {
+	if file == nil {
+		return fmt.Errorf("skill file is required")
+	}
+	if err := ValidateSkillFilePath(file.Path); err != nil {
+		return err
+	}
+	if err := validateSkillSourceType(file.SourceType); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateSkillFilePath validates safe relative file paths within a skill.
+func ValidateSkillFilePath(filePath string) error {
+	p := strings.TrimSpace(filePath)
+	if p == "" {
+		return fmt.Errorf("skill file path is required")
+	}
+	if strings.HasPrefix(p, "/") || filepath.IsAbs(p) {
+		return fmt.Errorf("skill file path must be relative")
+	}
+	if strings.HasSuffix(p, "/") {
+		return fmt.Errorf("skill file path must not have a trailing slash")
+	}
+	if strings.Contains(p, "\\") {
+		return fmt.Errorf("skill file path must use forward slashes")
+	}
+	for segment := range strings.SplitSeq(p, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return fmt.Errorf("skill file path must not contain empty, current, or parent directory segments")
+		}
+	}
+	return nil
+}
+
+func validateSkillSourceType(sourceType string) error {
+	switch sourceType {
+	case tables.SkillSourceTypeURL, tables.SkillSourceTypeDataURL, tables.SkillSourceTypeText, tables.SkillSourceTypeUpload:
+		return nil
+	default:
+		return fmt.Errorf("skill file source_type must be one of url, dataurl, text, or upload")
+	}
+}
+
+// ValidateSkillVersion validates skill versions as MAJOR.MINOR.PATCH with an optional -suffix.
+func ValidateSkillVersion(version string) error {
+	_, err := parseSkillSemver(version)
+	return err
+}
+
+func parseSkillSemver(version string) (skillVersionParts, error) {
+	if version != strings.TrimSpace(version) {
+		return skillVersionParts{}, fmt.Errorf("skill version must not have leading or trailing whitespace")
+	}
+	matches := skillSemverPattern.FindStringSubmatch(version)
+	if matches == nil {
+		return skillVersionParts{}, fmt.Errorf("skill version must be semver MAJOR.MINOR.PATCH with optional -suffix")
+	}
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return skillVersionParts{}, fmt.Errorf("skill version major component overflows: %w", err)
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return skillVersionParts{}, fmt.Errorf("skill version minor component overflows: %w", err)
+	}
+	patch, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return skillVersionParts{}, fmt.Errorf("skill version patch component overflows: %w", err)
+	}
+	return skillVersionParts{major: major, minor: minor, patch: patch, suffix: matches[4]}, nil
+}
+
+func validateSkillVersionIncrement(previousVersion, nextVersion string) error {
+	if previousVersion == "" {
+		_, err := parseSkillSemver(nextVersion)
+		return err
+	}
+	prev, err := parseSkillSemver(previousVersion)
+	if err != nil {
+		return fmt.Errorf("stored latest skill version is invalid: %w", err)
+	}
+	next, err := parseSkillSemver(nextVersion)
+	if err != nil {
+		return err
+	}
+	if next.major < prev.major || (next.major == prev.major && next.minor < prev.minor) || (next.major == prev.major && next.minor == prev.minor && next.patch < prev.patch) {
+		return fmt.Errorf("skill version %q must not go below latest version %q", nextVersion, previousVersion)
+	}
+	if next.major == prev.major && next.minor == prev.minor && next.patch == prev.patch && next.suffix == prev.suffix {
+		return fmt.Errorf("skill version %q already matches the latest version; choose a new version", nextVersion)
+	}
+	return nil
+}
+
+func latestCreatedSkillVersion(tx *gorm.DB, skillID string) (string, error) {
+	var latest string
+	err := tx.Model(&tables.TableSkillVersion{}).
+		Where("skill_id = ?", skillID).
+		Select("version").
+		Order("created_at DESC").
+		Limit(1).
+		Scan(&latest).Error
+	return latest, err
+}
+
+func allSkillsBumpForVersionChange(previousVersion, nextVersion string) (allSkillsVersionBump, error) {
+	prev, err := parseSkillSemver(previousVersion)
+	if err != nil {
+		return "", fmt.Errorf("stored latest skill version is invalid: %w", err)
+	}
+	next, err := parseSkillSemver(nextVersion)
+	if err != nil {
+		return "", err
+	}
+	if next.major > prev.major {
+		return allSkillsVersionBumpMajor, nil
+	}
+	if next.minor > prev.minor {
+		return allSkillsVersionBumpMinor, nil
+	}
+	return allSkillsVersionBumpPatch, nil
+}
+
+func nextAllSkillsVersion(current string, bump allSkillsVersionBump, firstSkill bool) (string, error) {
+	if current == "" {
+		current = "0.0.0"
+	}
+	if firstSkill && current == "0.0.0" {
+		return "1.0.0", nil
+	}
+	parts, err := parseSkillSemver(current)
+	if err != nil {
+		return "", fmt.Errorf("stored all-skills version is invalid: %w", err)
+	}
+	switch bump {
+	case allSkillsVersionBumpMajor:
+		return fmt.Sprintf("%d.0.0", parts.major+1), nil
+	case allSkillsVersionBumpMinor:
+		return fmt.Sprintf("%d.%d.0", parts.major, parts.minor+1), nil
+	case allSkillsVersionBumpPatch:
+		return fmt.Sprintf("%d.%d.%d", parts.major, parts.minor, parts.patch+1), nil
+	default:
+		return "", fmt.Errorf("unsupported all-skills version bump %q", bump)
+	}
+}
+
+func bumpAllSkillsVersionTx(ctx context.Context, tx *gorm.DB, bump allSkillsVersionBump, firstSkill bool) error {
+	var config tables.TableGovernanceConfig
+	err := tx.WithContext(ctx).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		First(&config, "key = ?", allSkillsVersionConfigKey).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		config = tables.TableGovernanceConfig{Key: allSkillsVersionConfigKey, Value: "0.0.0"}
+		if err := tx.WithContext(ctx).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			Create(&config).Error; err != nil {
+			return err
+		}
+		if err := tx.WithContext(ctx).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			First(&config, "key = ?", allSkillsVersionConfigKey).Error; err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	next, err := nextAllSkillsVersion(config.Value, bump, firstSkill)
+	if err != nil {
+		return err
+	}
+	config.Value = next
+	return tx.WithContext(ctx).Save(&config).Error
+}
+
+// GetAllSkillsVersion returns the repository-level version for the bundled all-skills plugin.
+func (s *RDBConfigStore) GetAllSkillsVersion(ctx context.Context) (string, error) {
+	config, err := s.GetConfig(ctx, allSkillsVersionConfigKey)
+	if errors.Is(err, ErrNotFound) {
+		return "0.0.0", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(config.Value) == "" {
+		return "0.0.0", nil
+	}
+	return config.Value, nil
+}
+
+// BumpAllSkillsVersion manually advances the repository-level all-skills version.
+func (s *RDBConfigStore) BumpAllSkillsVersion(ctx context.Context, bump string) (string, error) {
+	bumpType := allSkillsVersionBump(bump)
+	switch bumpType {
+	case allSkillsVersionBumpPatch, allSkillsVersionBumpMinor, allSkillsVersionBumpMajor:
+	default:
+		return "", fmt.Errorf("unsupported all-skills version bump %q", bump)
+	}
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return bumpAllSkillsVersionTx(ctx, tx, bumpType, false)
+	}); err != nil {
+		return "", err
+	}
+	return s.GetAllSkillsVersion(ctx)
+}
+
+// StoreSkillFileContent stores inline file content in the DB blob fallback, or
+// prepares an object-storage write for the caller to run after DB commit.
+func StoreSkillFileContent(ctx context.Context, tx *gorm.DB, objectStore objectstore.ObjectStore, skillID string, file *tables.TableSkillFile, data []byte) (*pendingSkillObjectWrite, error) {
+	if file == nil {
+		return nil, fmt.Errorf("skill file is required")
+	}
+	if objectStore != nil {
+		key := file.StorageKey
+		if key == nil || strings.TrimSpace(*key) == "" {
+			generated := fmt.Sprintf(SkillObjectPrefix+"%s/%s/%s", skillID, file.ID, path.Base(file.Path))
+			key = &generated
+		}
+		file.StorageKey = key
+		file.BlobID = nil
+		return &pendingSkillObjectWrite{
+			key:      *key,
+			data:     data,
+			metadata: map[string]string{"skill_id": skillID, "file_id": file.ID},
+		}, nil
+	}
+
+	blobID := uuid.NewString()
+	blob := tables.TableSkillFileBlob{
+		ID:   blobID,
+		Data: data,
+	}
+	if err := tx.Create(&blob).Error; err != nil {
+		return nil, err
+	}
+	file.BlobID = &blobID
+	file.StorageKey = nil
+	return nil, nil
+}
+
+func validateSkillStorageKeyScope(skillID string, file *tables.TableSkillFile, key string) error {
+	if !strings.HasPrefix(key, SkillObjectPrefix) {
+		return fmt.Errorf("storage_key %q is not under the skills object prefix", key)
+	}
+
+	uploadPrefix := SkillObjectPrefix + "uploads/"
+	skillPrefix := SkillObjectPrefix + skillID + "/"
+
+	switch file.SourceType {
+	case tables.SkillSourceTypeUpload:
+		if file.UploadID != nil && strings.TrimSpace(*file.UploadID) != "" {
+			expectedPrefix := uploadPrefix + strings.TrimSpace(*file.UploadID) + "/"
+			if !strings.HasPrefix(key, expectedPrefix) {
+				return fmt.Errorf("storage_key %q does not belong to upload_id %q", key, strings.TrimSpace(*file.UploadID))
+			}
+			return nil
+		}
+		if !strings.HasPrefix(key, uploadPrefix) {
+			return fmt.Errorf("storage_key %q is not under the staged upload prefix", key)
+		}
+	case tables.SkillSourceTypeText, tables.SkillSourceTypeDataURL:
+		if !strings.HasPrefix(key, skillPrefix) {
+			return fmt.Errorf("storage_key %q is not scoped to skill %q", key, skillID)
+		}
+	}
+	return nil
+}
+
+func validateSkillFileReference(tx *gorm.DB, skillID string, file *tables.TableSkillFile) error {
+	if file.BlobID != nil && strings.TrimSpace(*file.BlobID) != "" {
+		var blobCount int64
+		if err := tx.Model(&tables.TableSkillFileBlob{}).Where("id = ?", *file.BlobID).Count(&blobCount).Error; err != nil {
+			return err
+		}
+		if blobCount == 0 {
+			return fmt.Errorf("blob_id %q does not exist", *file.BlobID)
+		}
+
+		var foreignCount int64
+		if err := tx.Model(&tables.TableSkillFile{}).
+			Joins("JOIN skill_versions ON skill_versions.id = skill_files.skill_version_id").
+			Where("skill_files.blob_id = ? AND skill_versions.skill_id <> ?", *file.BlobID, skillID).
+			Count(&foreignCount).Error; err != nil {
+			return err
+		}
+		if foreignCount > 0 {
+			return fmt.Errorf("blob_id %q is already bound to another skill", *file.BlobID)
+		}
+	}
+
+	if file.StorageKey != nil && strings.TrimSpace(*file.StorageKey) != "" {
+		key := strings.TrimSpace(*file.StorageKey)
+		if err := validateSkillStorageKeyScope(skillID, file, key); err != nil {
+			return err
+		}
+
+		var foreignCount int64
+		if err := tx.Model(&tables.TableSkillFile{}).
+			Joins("JOIN skill_versions ON skill_versions.id = skill_files.skill_version_id").
+			Where("skill_files.storage_key = ? AND skill_versions.skill_id <> ?", key, skillID).
+			Count(&foreignCount).Error; err != nil {
+			return err
+		}
+		if foreignCount > 0 {
+			return fmt.Errorf("storage_key %q is already bound to another skill", key)
+		}
+		file.StorageKey = &key
+	}
+	return nil
+}
+
+func decodeSkillDataURL(dataURL string) ([]byte, string, error) {
+	parsed, err := url.Parse(dataURL)
+	if err != nil || parsed.Scheme != "data" {
+		return nil, "", fmt.Errorf("dataurl must be a valid data: URL")
+	}
+	parts := strings.SplitN(dataURL, ",", 2)
+	if len(parts) != 2 || !strings.Contains(parts[0], ";base64") {
+		return nil, "", fmt.Errorf("dataurl must contain ;base64,")
+	}
+	// Reject oversized payloads before materializing the full decode in memory.
+	if base64.StdEncoding.DecodedLen(len(parts[1])) > MaxSkillFileContentSize {
+		return nil, "", fmt.Errorf("dataurl payload exceeds maximum size of %d bytes", MaxSkillFileContentSize)
+	}
+	mimeType := strings.TrimPrefix(strings.Split(parts[0], ";")[0], "data:")
+	data, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, "", fmt.Errorf("dataurl base64 decode failed: %w", err)
+	}
+	return data, mimeType, nil
+}
+
+func validateSkillFileSource(file *tables.TableSkillFile) ([]byte, error) {
+	// Reject files with both blob_id and storage_key — exactly one backing store is allowed.
+	hasBlobID := file.BlobID != nil && strings.TrimSpace(*file.BlobID) != ""
+	hasStorageKey := file.StorageKey != nil && strings.TrimSpace(*file.StorageKey) != ""
+	if hasBlobID && hasStorageKey {
+		return nil, fmt.Errorf("file %q must have either blob_id or storage_key, not both", file.Path)
+	}
+	switch file.SourceType {
+	case tables.SkillSourceTypeURL:
+		if file.SourceURL == nil || strings.TrimSpace(*file.SourceURL) == "" {
+			return nil, fmt.Errorf("url source_type requires source_url")
+		}
+		u, err := url.Parse(*file.SourceURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return nil, fmt.Errorf("source_url must be an http or https URL")
+		}
+		file.StorageKey = nil
+		file.BlobID = nil
+		return nil, nil
+	case tables.SkillSourceTypeText:
+		if file.InlineContent == nil || *file.InlineContent == "" {
+			if hasStorageKey || hasBlobID {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("text source_type requires content or an existing file reference")
+		}
+		data := []byte(*file.InlineContent)
+		if len(data) > MaxSkillFileContentSize {
+			return nil, fmt.Errorf("text file content exceeds maximum size of %d bytes", MaxSkillFileContentSize)
+		}
+		file.StorageKey = nil
+		file.BlobID = nil
+		return data, nil
+	case tables.SkillSourceTypeDataURL:
+		if file.DataURL == nil || strings.TrimSpace(*file.DataURL) == "" {
+			if hasStorageKey || hasBlobID {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("dataurl source_type requires dataurl or an existing file reference")
+		}
+		data, mimeType, err := decodeSkillDataURL(*file.DataURL)
+		if err != nil {
+			return nil, err
+		}
+		if len(data) > MaxSkillFileContentSize {
+			return nil, fmt.Errorf("dataurl file content exceeds maximum size of %d bytes", MaxSkillFileContentSize)
+		}
+		if file.MimeType == "" {
+			file.MimeType = mimeType
+		}
+		file.StorageKey = nil
+		file.BlobID = nil
+		return data, nil
+	case tables.SkillSourceTypeUpload:
+		if !hasStorageKey && !hasBlobID {
+			return nil, fmt.Errorf("upload source_type requires storage_key or blob_id")
+		}
+		return nil, nil
+	default:
+		return nil, validateSkillSourceType(file.SourceType)
+	}
+}
+
+// CreateSkill creates a skill with an initial version and its files.
+func (s *RDBConfigStore) CreateSkill(ctx context.Context, skill *tables.TableSkill, version string, objectStore objectstore.ObjectStore) error {
+	if err := ValidateSkill(skill, version); err != nil {
+		return err
+	}
+	var objectWrites []pendingSkillObjectWrite
+	var firstSkill bool
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing tables.TableSkill
+		if err := tx.First(&existing, "name = ?", skill.Name).Error; err == nil {
+			return fmt.Errorf("skill name %q already exists", skill.Name)
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		var existingSkillCount int64
+		if err := tx.Model(&tables.TableSkill{}).Count(&existingSkillCount).Error; err != nil {
+			return err
+		}
+		firstSkill = existingSkillCount == 0
+		if skill.ID == "" {
+			skill.ID = uuid.NewString()
+		}
+		skill.LatestVersion = version
+		files := skill.Files
+		skill.Files = nil
+		skill.Versions = nil
+		if err := tx.Create(skill).Error; err != nil {
+			return err
+		}
+		// Create the version row, then create files under it.
+		versionRow, err := createSkillVersion(tx, skill, version)
+		if err != nil {
+			return err
+		}
+		writes, err := createVersionFiles(ctx, tx, objectStore, skill.ID, versionRow.ID, files)
+		if err != nil {
+			return err
+		}
+		objectWrites = append(objectWrites, writes...)
+		// Populate transient Files for the response.
+		return populateSkillFiles(tx, skill)
+	}); err != nil {
+		return err
+	}
+	if err := runPendingSkillObjectWrites(ctx, s.DB().WithContext(ctx), objectStore, objectWrites, true, skill.ID, ""); err != nil {
+		return err
+	}
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return bumpAllSkillsVersionTx(ctx, tx, allSkillsVersionBumpMinor, firstSkill)
+	}); err != nil {
+		return fmt.Errorf("skill %q was created successfully but all-skills version could not be bumped; manually bump all-skills version with a minor bump to publish this create: %w", skill.Name, err)
+	}
+	return nil
+}
+
+// GetSkill returns a skill with lean version summaries (id, version, created_at) and serving files.
+func (s *RDBConfigStore) GetSkill(ctx context.Context, id string) (*tables.TableSkill, error) {
+	var skill tables.TableSkill
+	if err := s.ScopedDB(ctx).
+		Preload("Versions", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "skill_id", "version", "created_at").Order("created_at DESC")
+		}).
+		First(&skill, "skills.id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
+		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	return &skill, nil
+}
+
+// GetSkillLean returns a skill without versions preloaded (only serving files).
+func (s *RDBConfigStore) GetSkillLean(ctx context.Context, id string) (*tables.TableSkill, error) {
+	var skill tables.TableSkill
+	if err := s.ScopedDB(ctx).
+		First(&skill, "skills.id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
+		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	// Populate the most recently created version for bump validation.
+	latest, err := latestCreatedSkillVersion(s.ScopedDB(ctx), skill.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load latest created skill version: %w", err)
+	}
+	if latest != "" {
+		skill.HighestVersion = latest
+	}
+	return &skill, nil
+}
+
+// GetSkillByName returns a skill by name with lean version summaries and serving files.
+func (s *RDBConfigStore) GetSkillByName(ctx context.Context, name string) (*tables.TableSkill, error) {
+	var skill tables.TableSkill
+	if err := s.ScopedDB(ctx).
+		Preload("Versions", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "skill_id", "version", "created_at").Order("created_at DESC")
+		}).
+		First(&skill, "skills.name = ?", name).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
+		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	return &skill, nil
+}
+
+// ListSkillVersions returns paginated versions for a skill.
+func (s *RDBConfigStore) ListSkillVersions(ctx context.Context, skillID string, params SkillVersionListQueryParams) ([]tables.TableSkillVersion, int64, error) {
+	var total int64
+	db := s.ScopedDB(ctx).Model(&tables.TableSkillVersion{}).Where("skill_id = ?", skillID)
+	if err := db.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var versions []tables.TableSkillVersion
+	query := db.
+		Select("id", "skill_id", "version", "created_by", "created_at").
+		Order(skillVersionListOrder(params))
+	if params.Limit > 0 {
+		query = query.Limit(params.Limit)
+	}
+	if params.Offset > 0 {
+		query = query.Offset(params.Offset)
+	}
+	if err := query.Find(&versions).Error; err != nil {
+		return nil, 0, err
+	}
+	return versions, total, nil
+}
+
+// GetSkillVersion returns a specific version by skill ID and version string.
+func (s *RDBConfigStore) GetSkillVersion(ctx context.Context, skillID, version string) (*tables.TableSkillVersion, error) {
+	var v tables.TableSkillVersion
+	if err := s.ScopedDB(ctx).
+		Preload("Files").
+		Preload("Files.Blob").
+		First(&v, "skill_id = ? AND version = ?", skillID, version).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &v, nil
+}
+
+// UpdateSkill saves skill fields, creates a new version, and creates files under it.
+// When serve=true, the skill row is updated to serve this new version.
+// When serve=false, only the version and files are created; the skill continues serving its current version.
+//
+// The serve switch is deferred until after object-store writes succeed so the
+// skill never points at a version whose files failed to upload.
+func (s *RDBConfigStore) UpdateSkill(ctx context.Context, skill *tables.TableSkill, version string, serve bool, objectStore objectstore.ObjectStore) error {
+	if err := ValidateSkill(skill, version); err != nil {
+		return err
+	}
+
+	// Phase 1: Create the version and files inside a transaction, but do NOT
+	// update the skill's serving state yet. This keeps the skill pointing at
+	// the old version until uploads are confirmed.
+	var objectWrites []pendingSkillObjectWrite
+	var versionID string
+	var existingLatestVersion string
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing tables.TableSkill
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&existing, "id = ?", skill.ID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+		existingLatestVersion = existing.LatestVersion
+		latestCreatedVersion, err := latestCreatedSkillVersion(tx, skill.ID)
+		if err != nil {
+			return err
+		}
+		if latestCreatedVersion == "" {
+			latestCreatedVersion = existing.LatestVersion
+		}
+		if err := validateSkillVersionIncrement(latestCreatedVersion, version); err != nil {
+			return err
+		}
+		// Also check that this version doesn't already exist (handles shift-back scenarios
+		// where LatestVersion is older but higher versions exist in history).
+		var existingVersion tables.TableSkillVersion
+		if err := tx.First(&existingVersion, "skill_id = ? AND version = ?", skill.ID, version).Error; err == nil {
+			return fmt.Errorf("skill version %q already exists in version history", version)
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		files := skill.Files
+
+		versionRow, err := createSkillVersion(tx, skill, version)
+		if err != nil {
+			return err
+		}
+		versionID = versionRow.ID
+		writes, err := createVersionFiles(ctx, tx, objectStore, skill.ID, versionRow.ID, files)
+		if err != nil {
+			return err
+		}
+		objectWrites = append(objectWrites, writes...)
+
+		if !serve {
+			// Restore the existing serving data for the response.
+			skill.LatestVersion = existing.LatestVersion
+			skill.SkillMDBody = existing.SkillMDBody
+			skill.Description = existing.Description
+			skill.License = existing.License
+			skill.Compatibility = existing.Compatibility
+			skill.AllowedTools = existing.AllowedTools
+			skill.Metadata = existing.Metadata
+			skill.ExtraFrontmatter = existing.ExtraFrontmatter
+		}
+		return populateSkillFiles(tx, skill)
+	}); err != nil {
+		return err
+	}
+
+	// Phase 2: Upload objects to the store. On failure, delete the version row
+	// as compensation — the skill still serves its previous version safely.
+	if err := runPendingSkillObjectWrites(ctx, s.DB().WithContext(ctx), objectStore, objectWrites, false, skill.ID, versionID); err != nil {
+		return err
+	}
+
+	if !serve {
+		return nil
+	}
+
+	// Phase 3: Object writes succeeded — now atomically flip the skill to
+	// serve the new version and bump the all-skills governance version.
+	// If this fails, the skill continues serving its previous version safely.
+	// The new version row and its objects remain intact so the caller can
+	// retry serving (e.g. via shift-version) without re-uploading.
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		skill.LatestVersion = version
+		result := tx.Model(&tables.TableSkill{}).
+			Where("id = ?", skill.ID).
+			Select("Description", "License", "Compatibility", "Metadata", "ExtraFrontmatter", "AllowedTools", "SkillMDBody", "LatestVersion", "UpdatedAt").
+			Updates(skill)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		bump, err := allSkillsBumpForVersionChange(existingLatestVersion, version)
+		if err != nil {
+			return err
+		}
+		return bumpAllSkillsVersionTx(ctx, tx, bump, false)
+	}); err != nil {
+		return fmt.Errorf("version %s was created successfully but could not be served — use shift-version to retry: %w", version, err)
+	}
+	return nil
+}
+
+// DeleteSkill deletes a skill, cleaning up object-store files across ALL versions.
+func (s *RDBConfigStore) DeleteSkill(ctx context.Context, id string, objectStore objectstore.ObjectStore) error {
+	var keys []string
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var skill tables.TableSkill
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&skill, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+		// Collect ALL distinct storage keys across all versions' files for this skill.
+		if objectStore != nil {
+			if err := tx.Model(&tables.TableSkillFile{}).
+				Where("skill_version_id IN (?)",
+					tx.Model(&tables.TableSkillVersion{}).Select("id").Where("skill_id = ?", id),
+				).
+				Where("storage_key IS NOT NULL AND storage_key != ''").
+				Distinct("storage_key").
+				Pluck("storage_key", &keys).Error; err != nil {
+				return err
+			}
+		}
+		// DB cascade handles: skill → versions → files, files → blobs
+		if err := tx.Delete(&skill).Error; err != nil {
+			return err
+		}
+		return bumpAllSkillsVersionTx(ctx, tx, allSkillsVersionBumpMajor, false)
+	}); err != nil {
+		return err
+	}
+	runSkillObjectCleanup(ctx, s.logger, objectStore, keys)
+	return nil
+}
+
+// ListSkills returns paginated skills with the serving version's file count and total count.
+func (s *RDBConfigStore) ListSkills(ctx context.Context, params SkillListQueryParams) ([]tables.TableSkill, int64, error) {
+	var skills []tables.TableSkill
+	query := s.ScopedDB(ctx).Model(&tables.TableSkill{})
+	if params.Search != "" {
+		like := "%" + strings.ToLower(params.Search) + "%"
+		query = query.Where("LOWER(name) LIKE ? OR LOWER(description) LIKE ?", like, like)
+	}
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	query = query.Omit("skill_md_body").Order(skillListOrder(params))
+	if params.Limit > 0 {
+		query = query.Limit(params.Limit)
+	}
+	if params.Offset > 0 {
+		query = query.Offset(params.Offset)
+	}
+	if err := query.Find(&skills).Error; err != nil {
+		return nil, 0, err
+	}
+	if len(skills) > 0 {
+		type fileCountRow struct {
+			SkillID   string
+			FileCount int64
+		}
+		var rows []fileCountRow
+		if err := s.ScopedDB(ctx).
+			Table("skill_versions").
+			Select("skill_versions.skill_id AS skill_id, COUNT(skill_files.id) AS file_count").
+			Joins("JOIN skills ON skills.id = skill_versions.skill_id AND skills.latest_version = skill_versions.version").
+			Joins("LEFT JOIN skill_files ON skill_files.skill_version_id = skill_versions.id").
+			Where("skill_versions.skill_id IN ?", skillIDs(skills)).
+			Group("skill_versions.skill_id").
+			Scan(&rows).Error; err != nil {
+			return nil, 0, err
+		}
+		fileCounts := make(map[string]int64, len(rows))
+		for _, row := range rows {
+			fileCounts[row.SkillID] = row.FileCount
+		}
+		for i := range skills {
+			skills[i].FileCount = fileCounts[skills[i].ID]
+		}
+	}
+	return skills, total, nil
+}
+
+func skillListOrder(params SkillListQueryParams) string {
+	column := "created_at"
+	switch params.SortBy {
+	case "name":
+		column = "name"
+	case "updated_at":
+		column = "updated_at"
+	case "created_at", "":
+		column = "created_at"
+	}
+	return column + " " + normalizedSortOrder(params.Order) + ", id ASC"
+}
+
+func skillVersionListOrder(params SkillVersionListQueryParams) string {
+	column := "created_at"
+	switch params.SortBy {
+	case "version":
+		column = "version"
+	case "created_at", "":
+		column = "created_at"
+	}
+	return column + " " + normalizedSortOrder(params.Order) + ", id ASC"
+}
+
+func normalizedSortOrder(order string) string {
+	if strings.EqualFold(order, "asc") {
+		return "ASC"
+	}
+	return "DESC"
+}
+
+func skillIDs(skills []tables.TableSkill) []string {
+	ids := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		ids = append(ids, skill.ID)
+	}
+	return ids
+}
+
+// createVersionFiles creates file rows under a version, reusing blob/storage references
+// for existing files that already carry a blob_id or storage_key.
+func createVersionFiles(ctx context.Context, tx *gorm.DB, objectStore objectstore.ObjectStore, skillID, versionID string, files []tables.TableSkillFile) ([]pendingSkillObjectWrite, error) {
+	objectWrites := make([]pendingSkillObjectWrite, 0)
+	for i := range files {
+		file := &files[i]
+		file.ID = uuid.NewString()
+		file.SkillVersionID = versionID
+		data, err := validateSkillFileSource(file)
+		if err != nil {
+			return nil, err
+		}
+		if data != nil {
+			file.FileSizeBytes = int64(len(data))
+		}
+		if err := validateSkillFileReference(tx, skillID, file); err != nil {
+			return nil, err
+		}
+		if err := ValidateSkillFile(file); err != nil {
+			return nil, err
+		}
+		if err := tx.Create(file).Error; err != nil {
+			return nil, err
+		}
+		if data != nil {
+			write, err := StoreSkillFileContent(ctx, tx, objectStore, skillID, file, data)
+			if err != nil {
+				return nil, err
+			}
+			if write != nil {
+				objectWrites = append(objectWrites, *write)
+			}
+			if err := tx.Model(&tables.TableSkillFile{}).Where("id = ?", file.ID).Updates(map[string]any{
+				"storage_key":     file.StorageKey,
+				"blob_id":         file.BlobID,
+				"file_size_bytes": file.FileSizeBytes,
+				"mime_type":       file.MimeType,
+			}).Error; err != nil {
+				return nil, err
+			}
+		}
+	}
+	return objectWrites, nil
+}
+
+// createSkillVersion creates a version row with a frontmatter snapshot (no file snapshot needed;
+// files belong to the version via FK).
+func createSkillVersion(tx *gorm.DB, skill *tables.TableSkill, version string) (*tables.TableSkillVersion, error) {
+	frontmatter := tables.SkillJSONMap{
+		"description": skill.Description,
+	}
+	if skill.License != nil {
+		frontmatter["license"] = *skill.License
+	}
+	if skill.Compatibility != nil {
+		frontmatter["compatibility"] = *skill.Compatibility
+	}
+	if skill.AllowedTools != nil {
+		frontmatter["allowed-tools"] = *skill.AllowedTools
+	}
+	for key, value := range skill.ExtraFrontmatter {
+		if !IsSkillReservedFrontmatterField(key) {
+			frontmatter[key] = value
+		}
+	}
+	if len(skill.Metadata) > 0 {
+		frontmatter["metadata"] = skill.Metadata
+	}
+
+	versionRow := tables.TableSkillVersion{
+		ID:                  uuid.NewString(),
+		SkillID:             skill.ID,
+		Version:             version,
+		SkillMDBody:         skill.SkillMDBody,
+		FrontmatterSnapshot: frontmatter,
+		CreatedBy:           skill.CreatedBy,
+	}
+	if err := tx.Create(&versionRow).Error; err != nil {
+		return nil, err
+	}
+	return &versionRow, nil
+}
+
+// populateSkillFiles reloads the serving version's files into the transient skill.Files.
+func populateSkillFiles(tx *gorm.DB, skill *tables.TableSkill) error {
+	var version tables.TableSkillVersion
+	if err := tx.Preload("Files").
+		Preload("Files.Blob").
+		First(&version, "skill_id = ? AND version = ?", skill.ID, skill.LatestVersion).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("serving version %q for skill %q has no version row; data may be inconsistent", skill.LatestVersion, skill.ID)
+		}
+		return err
+	}
+	skill.Files = version.Files
+	return nil
+}
+
+// SkillFrontmatterFields contains skill fields reconstructed from a version frontmatter snapshot.
+// Name is not included because it is immutable after creation.
+type SkillFrontmatterFields struct {
+	Description      string
+	License          *string
+	Compatibility    *string
+	AllowedTools     *string
+	Metadata         tables.SkillStringMap
+	ExtraFrontmatter tables.SkillJSONMap
+}
+
+// ExtractSkillFieldsFromFrontmatter reconstructs skill fields from a version's frontmatter snapshot.
+func ExtractSkillFieldsFromFrontmatter(frontmatter tables.SkillJSONMap) SkillFrontmatterFields {
+	fields := SkillFrontmatterFields{ExtraFrontmatter: make(tables.SkillJSONMap)}
+	if v, ok := frontmatter["description"].(string); ok {
+		fields.Description = v
+	}
+	if v, ok := frontmatter["license"].(string); ok {
+		fields.License = &v
+	}
+	if v, ok := frontmatter["compatibility"].(string); ok {
+		fields.Compatibility = &v
+	}
+	if v, ok := frontmatter["allowed-tools"].(string); ok {
+		fields.AllowedTools = &v
+	}
+	if m, ok := frontmatter["metadata"].(map[string]any); ok {
+		fields.Metadata = make(tables.SkillStringMap, len(m))
+		for k, v := range m {
+			if s, ok := v.(string); ok {
+				fields.Metadata[k] = s
+			}
+		}
+	}
+	for k, v := range frontmatter {
+		if !IsSkillReservedFrontmatterField(k) {
+			fields.ExtraFrontmatter[k] = v
+		}
+	}
+	return fields
+}
+
+// ShiftSkillVersion shifts a skill to serve a previously-saved version.
+// Files already exist on the target version; only the skill row fields and latest_version pointer change.
+func (s *RDBConfigStore) ShiftSkillVersion(ctx context.Context, skillID string, targetVersion string, objectStore objectstore.ObjectStore) error {
+	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var skill tables.TableSkill
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&skill, "id = ?", skillID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+
+		var version tables.TableSkillVersion
+		if err := tx.First(&version, "skill_id = ? AND version = ?", skillID, targetVersion).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("version %q not found for this skill", targetVersion)
+			}
+			return err
+		}
+
+		if skill.LatestVersion == targetVersion {
+			return fmt.Errorf("skill is already serving version %q", targetVersion)
+		}
+
+		// Snapshot current state if not already versioned.
+		var existingSnapshot tables.TableSkillVersion
+		if err := tx.First(&existingSnapshot, "skill_id = ? AND version = ?", skillID, skill.LatestVersion).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				if _, err := createSkillVersion(tx, &skill, skill.LatestVersion); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+
+		// Extract fields from target version frontmatter and update skill row (name is immutable).
+		fields := ExtractSkillFieldsFromFrontmatter(version.FrontmatterSnapshot)
+		if err := tx.Model(&tables.TableSkill{}).Where("id = ?", skillID).Updates(map[string]any{
+			"description":       fields.Description,
+			"license":           fields.License,
+			"compatibility":     fields.Compatibility,
+			"allowed_tools":     fields.AllowedTools,
+			"metadata":          fields.Metadata,
+			"extra_frontmatter": fields.ExtraFrontmatter,
+			"skill_md_body":     version.SkillMDBody,
+			"latest_version":    targetVersion,
+		}).Error; err != nil {
+			return err
+		}
+		return bumpAllSkillsVersionTx(ctx, tx, allSkillsVersionBumpPatch, false)
+	})
+}
+
+// CreateSkillFileBlob creates an orphan blob record (e.g. for the upload endpoint's DB fallback).
+func (s *RDBConfigStore) CreateSkillFileBlob(ctx context.Context, blob *tables.TableSkillFileBlob) error {
+	if blob.ID == "" {
+		blob.ID = uuid.NewString()
+	}
+	return s.DB().WithContext(ctx).Create(blob).Error
+}
+
+// UpdateSkillConfigHash sets the config_hash on a skill row so config reconciliation
+// can detect subsequent no-change restarts without re-running UpdateSkill.
+func (s *RDBConfigStore) UpdateSkillConfigHash(ctx context.Context, skillID string, configHash string) error {
+	return s.DB().WithContext(ctx).
+		Model(&tables.TableSkill{}).
+		Where("id = ?", skillID).
+		Update("config_hash", configHash).Error
+}
+
+// CleanupOrphanSkillFileBlobs deletes DB fallback blobs not referenced by any skill file.
+// When force is false, a 30-minute grace period protects freshly uploaded pending blobs.
+func (s *RDBConfigStore) CleanupOrphanSkillFileBlobs(ctx context.Context, force bool) (int64, error) {
+	query := s.DB().WithContext(ctx)
+	if !force {
+		cutoff := time.Now().Add(-30 * time.Minute)
+		query = query.Where("created_at < ?", cutoff)
+	}
+	result := query.
+		Where("NOT EXISTS (?)",
+			s.DB().Model(&tables.TableSkillFile{}).
+				Select("1").
+				Where("skill_files.blob_id = skill_file_blobs.id"),
+		).
+		Delete(&tables.TableSkillFileBlob{})
+	return result.RowsAffected, result.Error
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/objectstore"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"gorm.io/gorm"
 )
@@ -35,6 +36,22 @@ type ModelConfigsQueryParams struct {
 	Search   string
 	Scope    string // optional; filters to an exact scope value (e.g. "global", "virtual_key")
 	Provider string // optional; filters to an exact provider value (e.g. "openai")
+}
+
+// SkillListQueryParams holds pagination, filtering, and search parameters for skill repository queries.
+type SkillListQueryParams struct {
+	Limit  int
+	Offset int
+	Search string
+	SortBy string // name, updated_at, created_at (default: created_at)
+	Order  string // asc, desc (default: desc)
+}
+
+type SkillVersionListQueryParams struct {
+	Limit  int
+	Offset int
+	SortBy string // version, created_at (default: created_at)
+	Order  string // asc, desc (default: desc)
 }
 
 // RoutingRulesQueryParams holds pagination, filtering, and search parameters for routing rules queries.
@@ -578,6 +595,23 @@ type ConfigStore interface {
 	GetLatestPromptVersion(ctx context.Context, promptID string) (*tables.TablePromptVersion, error)
 	CreatePromptVersion(ctx context.Context, version *tables.TablePromptVersion) error
 	DeletePromptVersion(ctx context.Context, id uint) error
+
+	// Skills Repository
+	CreateSkill(ctx context.Context, skill *tables.TableSkill, version string, objectStore objectstore.ObjectStore) error
+	GetSkill(ctx context.Context, id string) (*tables.TableSkill, error)
+	GetSkillLean(ctx context.Context, id string) (*tables.TableSkill, error)
+	GetSkillByName(ctx context.Context, name string) (*tables.TableSkill, error)
+	GetSkillVersion(ctx context.Context, skillID, version string) (*tables.TableSkillVersion, error)
+	ListSkillVersions(ctx context.Context, skillID string, params SkillVersionListQueryParams) ([]tables.TableSkillVersion, int64, error)
+	UpdateSkill(ctx context.Context, skill *tables.TableSkill, version string, serve bool, objectStore objectstore.ObjectStore) error
+	DeleteSkill(ctx context.Context, id string, objectStore objectstore.ObjectStore) error
+	ListSkills(ctx context.Context, params SkillListQueryParams) ([]tables.TableSkill, int64, error)
+	ShiftSkillVersion(ctx context.Context, skillID string, targetVersion string, objectStore objectstore.ObjectStore) error
+	GetAllSkillsVersion(ctx context.Context) (string, error)
+	BumpAllSkillsVersion(ctx context.Context, bump string) (string, error)
+	CreateSkillFileBlob(ctx context.Context, blob *tables.TableSkillFileBlob) error
+	CleanupOrphanSkillFileBlobs(ctx context.Context, force bool) (int64, error)
+	UpdateSkillConfigHash(ctx context.Context, skillID string, configHash string) error
 
 	// Prompt Repository - Sessions
 	GetPromptSessions(ctx context.Context, promptID string) ([]tables.TablePromptSession, error)

--- a/framework/configstore/tables/skills.go
+++ b/framework/configstore/tables/skills.go
@@ -1,0 +1,212 @@
+// Package tables provides tables for the configstore
+package tables
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	SkillSourceTypeURL     = "url"
+	SkillSourceTypeDataURL = "dataurl"
+	SkillSourceTypeText    = "text"
+	SkillSourceTypeUpload  = "upload"
+)
+
+// SkillStringMap is stored as JSON and represents spec metadata string pairs.
+type SkillStringMap map[string]string
+
+// SkillJSONMap is stored as JSON and represents arbitrary extra frontmatter.
+type SkillJSONMap map[string]any
+
+// Value implements driver.Valuer for SkillStringMap.
+func (m SkillStringMap) Value() (driver.Value, error) {
+	if m == nil {
+		return "{}", nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return string(data), nil
+}
+
+// Scan implements sql.Scanner for SkillStringMap.
+func (m *SkillStringMap) Scan(value any) error {
+	return scanSkillJSON(value, m)
+}
+
+// Value implements driver.Valuer for SkillJSONMap.
+func (m SkillJSONMap) Value() (driver.Value, error) {
+	if m == nil {
+		return "{}", nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return string(data), nil
+}
+
+// Scan implements sql.Scanner for SkillJSONMap.
+func (m *SkillJSONMap) Scan(value any) error {
+	return scanSkillJSON(value, m)
+}
+
+func scanSkillJSON(value any, dest any) error {
+	if value == nil {
+		return nil
+	}
+
+	var data []byte
+	switch v := value.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return fmt.Errorf("unsupported skill JSON value type %T", value)
+	}
+
+	if len(data) == 0 {
+		return nil
+	}
+	return json.Unmarshal(data, dest)
+}
+
+// TableSkill represents a skill in the repository. Every save creates a version snapshot.
+type TableSkill struct {
+	ID               string         `gorm:"type:varchar(36);primaryKey" json:"id"`
+	Name             string         `gorm:"type:varchar(64);not null;uniqueIndex" json:"name"`
+	Description      string         `gorm:"type:varchar(1024);not null" json:"description"`
+	License          *string        `gorm:"type:text" json:"license,omitempty"`
+	Compatibility    *string        `gorm:"type:varchar(500)" json:"compatibility,omitempty"`
+	Metadata         SkillStringMap `gorm:"type:json" json:"metadata,omitempty"`
+	ExtraFrontmatter SkillJSONMap   `gorm:"type:json;column:extra_frontmatter" json:"extra_frontmatter,omitempty"`
+	AllowedTools     *string        `gorm:"type:text;column:allowed_tools" json:"allowed_tools,omitempty"`
+	SkillMDBody      string         `gorm:"type:text;not null;column:skill_md_body" json:"skill_md_body"`
+	LatestVersion    string         `gorm:"type:varchar(100);not null;column:latest_version" json:"latest_version"`
+	CreatedBy        *string        `gorm:"type:varchar(255);column:created_by" json:"created_by,omitempty"`
+	ConfigHash       string         `gorm:"type:varchar(64)" json:"-"`
+	CreatedAt        time.Time      `gorm:"not null" json:"created_at"`
+	UpdatedAt        time.Time      `gorm:"not null" json:"updated_at"`
+
+	Versions []TableSkillVersion `gorm:"foreignKey:SkillID;constraint:OnDelete:CASCADE" json:"versions,omitempty"`
+
+	// Transient: populated from the serving version's files for API convenience.
+	// Not stored in the skills table; filled by the store layer on read.
+	Files []TableSkillFile `gorm:"-" json:"files,omitempty"`
+
+	// Transient: serving version file count for list responses.
+	// Not stored in the skills table; filled by the store layer on list reads.
+	FileCount int64 `gorm:"-" json:"file_count"`
+
+	// Transient: most recently created version string across all versions of this skill.
+	// Filled by the store layer; used by the frontend for version bump validation.
+	HighestVersion string `gorm:"-" json:"highest_version,omitempty"`
+}
+
+// TableName for TableSkill.
+func (TableSkill) TableName() string { return "skills" }
+
+// TableSkillVersion represents an immutable snapshot of a skill save.
+// Files belong to versions, not directly to skills.
+type TableSkillVersion struct {
+	ID                  string       `gorm:"type:varchar(36);primaryKey" json:"id"`
+	SkillID             string       `gorm:"type:varchar(36);not null;index;uniqueIndex:idx_skill_version" json:"skill_id"`
+	Version             string       `gorm:"type:varchar(100);not null;uniqueIndex:idx_skill_version" json:"version"`
+	SkillMDBody         string       `gorm:"type:text;not null;column:skill_md_body" json:"skill_md_body,omitempty"`
+	FrontmatterSnapshot SkillJSONMap `gorm:"type:json;column:frontmatter_snapshot" json:"frontmatter_snapshot,omitempty"`
+	CreatedBy           *string      `gorm:"type:varchar(255);column:created_by" json:"created_by,omitempty"`
+	CreatedAt           time.Time    `gorm:"not null" json:"created_at"`
+
+	Skill *TableSkill `gorm:"foreignKey:SkillID" json:"skill,omitempty"`
+
+	Files []TableSkillFile `gorm:"foreignKey:SkillVersionID;constraint:OnDelete:CASCADE" json:"files,omitempty"`
+}
+
+// TableName for TableSkillVersion.
+func (TableSkillVersion) TableName() string { return "skill_versions" }
+
+// TableSkillFile represents a file associated with a skill version.
+// The file row is a pointer to the underlying blob/storage; blobs are reused
+// across versions when the file content hasn't changed.
+type TableSkillFile struct {
+	ID             string    `gorm:"type:varchar(36);primaryKey" json:"id"`
+	SkillVersionID string    `gorm:"type:varchar(36);not null;index;uniqueIndex:idx_skill_file_path;column:skill_version_id" json:"skill_version_id"`
+	Path           string    `gorm:"type:varchar(1024);not null;uniqueIndex:idx_skill_file_path" json:"path"`
+	SourceType     string    `gorm:"type:varchar(32);not null;column:source_type" json:"source_type"`
+	SourceURL      *string   `gorm:"type:text;column:source_url" json:"source_url,omitempty"`
+	StorageKey     *string   `gorm:"type:text;column:storage_key" json:"storage_key,omitempty"`
+	BlobID         *string   `gorm:"type:varchar(36);index;column:blob_id" json:"blob_id,omitempty"`
+	MimeType       string    `gorm:"type:varchar(255);column:mime_type" json:"mime_type"`
+	FileSizeBytes  int64     `gorm:"not null;default:0;column:file_size_bytes" json:"file_size_bytes"`
+	CreatedAt      time.Time `gorm:"not null" json:"created_at"`
+	UpdatedAt      time.Time `gorm:"not null" json:"updated_at"`
+
+	SkillVersion *TableSkillVersion  `gorm:"foreignKey:SkillVersionID" json:"skill_version,omitempty"`
+	Blob         *TableSkillFileBlob `gorm:"foreignKey:BlobID;constraint:OnDelete:SET NULL" json:"blob,omitempty"`
+
+	InlineContent *string `gorm:"-" json:"content,omitempty"`
+	DataURL       *string `gorm:"-" json:"dataurl,omitempty"`
+	UploadID      *string `gorm:"-" json:"upload_id,omitempty"`
+}
+
+// TableName for TableSkillFile.
+func (TableSkillFile) TableName() string { return "skill_files" }
+
+// BeforeSave normalizes the path before persisting so the unique index enforces the canonical form.
+func (f *TableSkillFile) BeforeSave(tx *gorm.DB) error {
+	f.Path = strings.TrimSpace(f.Path)
+	return nil
+}
+
+// NormalizedPath returns a trimmed relative path so uniqueness logic is stable.
+func (f TableSkillFile) NormalizedPath() string {
+	return strings.TrimSpace(f.Path)
+}
+
+// TableSkillFileBlob stores fallback file bytes when object storage is unavailable.
+type TableSkillFileBlob struct {
+	ID        string    `gorm:"type:varchar(36);primaryKey" json:"id"`
+	Data      []byte    `gorm:"not null" json:"-"`
+	CreatedAt time.Time `gorm:"not null" json:"created_at"`
+}
+
+// TableName for TableSkillFileBlob.
+func (TableSkillFileBlob) TableName() string { return "skill_file_blobs" }
+
+// BeforeCreate ensures map fields are initialized before insertion.
+func (s *TableSkill) BeforeCreate(tx *gorm.DB) error {
+	if s.Metadata == nil {
+		s.Metadata = SkillStringMap{}
+	}
+	if s.ExtraFrontmatter == nil {
+		s.ExtraFrontmatter = SkillJSONMap{}
+	}
+	return nil
+}
+
+// BeforeSave ensures map fields are initialized before update.
+func (s *TableSkill) BeforeSave(tx *gorm.DB) error {
+	if s.Metadata == nil {
+		s.Metadata = SkillStringMap{}
+	}
+	if s.ExtraFrontmatter == nil {
+		s.ExtraFrontmatter = SkillJSONMap{}
+	}
+	return nil
+}
+
+// BeforeCreate ensures snapshot fields are initialized before insertion.
+func (v *TableSkillVersion) BeforeCreate(tx *gorm.DB) error {
+	if v.FrontmatterSnapshot == nil {
+		v.FrontmatterSnapshot = SkillJSONMap{}
+	}
+	return nil
+}

--- a/framework/objectstore/gcs.go
+++ b/framework/objectstore/gcs.go
@@ -12,6 +12,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/maximhq/bifrost/core/schemas"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
 
@@ -117,6 +118,23 @@ func (g *GCSObjectStore) Get(ctx context.Context, key string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+// ListByPrefix returns object keys matching the given prefix.
+func (g *GCSObjectStore) ListByPrefix(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	it := g.client.Bucket(g.bucket).Objects(ctx, &storage.Query{Prefix: prefix})
+	objects := make([]ObjectInfo, 0)
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("objectstore: gcs list prefix %s: %w", prefix, err)
+		}
+		objects = append(objects, ObjectInfo{Key: attrs.Name, LastModified: attrs.Updated})
+	}
+	return objects, nil
 }
 
 // Delete removes a single object by key.

--- a/framework/objectstore/mock.go
+++ b/framework/objectstore/mock.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strings"
 	"sync"
+	"time"
 )
 
 // InMemoryObjectStore is an in-memory ObjectStore implementation for testing.
 type InMemoryObjectStore struct {
-	mu      sync.RWMutex
-	objects map[string][]byte
-	tags    map[string]map[string]string
+	mu        sync.RWMutex
+	objects   map[string][]byte
+	tags      map[string]map[string]string
+	createdAt map[string]time.Time
 
 	// PutErr, if set, is returned by Put for simulating failures.
 	PutErr error
@@ -22,8 +25,9 @@ type InMemoryObjectStore struct {
 // NewInMemoryObjectStore creates a new in-memory object store.
 func NewInMemoryObjectStore() *InMemoryObjectStore {
 	return &InMemoryObjectStore{
-		objects: make(map[string][]byte),
-		tags:    make(map[string]map[string]string),
+		objects:   make(map[string][]byte),
+		tags:      make(map[string]map[string]string),
+		createdAt: make(map[string]time.Time),
 	}
 }
 
@@ -37,6 +41,9 @@ func (m *InMemoryObjectStore) Put(_ context.Context, key string, data []byte, ta
 	cp := make([]byte, len(data))
 	copy(cp, data)
 	m.objects[key] = cp
+	if _, exists := m.createdAt[key]; !exists {
+		m.createdAt[key] = time.Now()
+	}
 	if len(tags) > 0 {
 		tagsCp := make(map[string]string, len(tags))
 		maps.Copy(tagsCp, tags)
@@ -62,11 +69,24 @@ func (m *InMemoryObjectStore) Get(_ context.Context, key string) ([]byte, error)
 	return cp, nil
 }
 
+func (m *InMemoryObjectStore) ListByPrefix(_ context.Context, prefix string) ([]ObjectInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	objects := make([]ObjectInfo, 0)
+	for key := range m.objects {
+		if key != "" && strings.HasPrefix(key, prefix) {
+			objects = append(objects, ObjectInfo{Key: key, LastModified: m.createdAt[key]})
+		}
+	}
+	return objects, nil
+}
+
 func (m *InMemoryObjectStore) Delete(_ context.Context, key string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.objects, key)
 	delete(m.tags, key)
+	delete(m.createdAt, key)
 	return nil
 }
 
@@ -76,6 +96,7 @@ func (m *InMemoryObjectStore) DeleteBatch(_ context.Context, keys []string) erro
 	for _, key := range keys {
 		delete(m.objects, key)
 		delete(m.tags, key)
+		delete(m.createdAt, key)
 	}
 	return nil
 }
@@ -117,4 +138,11 @@ func (m *InMemoryObjectStore) Keys() []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// SetCreatedAt overrides the creation time for the given key. For testing assertions.
+func (m *InMemoryObjectStore) SetCreatedAt(key string, t time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createdAt[key] = t
 }

--- a/framework/objectstore/objectstore.go
+++ b/framework/objectstore/objectstore.go
@@ -3,7 +3,16 @@
 // objects from S3, GCS (via S3 interop), MinIO, R2, or other S3-compatible stores.
 package objectstore
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// ObjectInfo describes a stored object returned by listing operations.
+type ObjectInfo struct {
+	Key          string
+	LastModified time.Time
+}
 
 // ObjectStore abstracts S3-compatible blob storage operations.
 type ObjectStore interface {
@@ -13,6 +22,9 @@ type ObjectStore interface {
 
 	// Get retrieves and decompresses data for the given key.
 	Get(ctx context.Context, key string) ([]byte, error)
+
+	// ListByPrefix returns objects matching the given prefix with metadata.
+	ListByPrefix(ctx context.Context, prefix string) ([]ObjectInfo, error)
 
 	// Delete removes an object by key.
 	Delete(ctx context.Context, key string) error

--- a/framework/objectstore/objectstore_test.go
+++ b/framework/objectstore/objectstore_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 )
 
@@ -103,6 +104,24 @@ func TestInMemoryObjectStore(t *testing.T) {
 	}
 	if store.Len() != 1 {
 		t.Fatalf("Len after batch delete: got %d, want 1", store.Len())
+	}
+
+	// ListByPrefix
+	_ = store.Put(ctx, "prefix/one", []byte("1"), nil)
+	_ = store.Put(ctx, "prefix/two", []byte("2"), nil)
+	_ = store.Put(ctx, "other/three", []byte("3"), nil)
+	objects, err := store.ListByPrefix(ctx, "prefix/")
+	if err != nil {
+		t.Fatalf("ListByPrefix: %v", err)
+	}
+	if len(objects) != 2 {
+		t.Fatalf("ListByPrefix got %d objects, want 2: %v", len(objects), objects)
+	}
+	gotKeys := []string{objects[0].Key, objects[1].Key}
+	sort.Strings(gotKeys)
+	wantKeys := []string{"prefix/one", "prefix/two"}
+	if gotKeys[0] != wantKeys[0] || gotKeys[1] != wantKeys[1] {
+		t.Fatalf("ListByPrefix keys: got %v, want %v", gotKeys, wantKeys)
 	}
 
 	// Ping and Close

--- a/framework/objectstore/s3.go
+++ b/framework/objectstore/s3.go
@@ -218,6 +218,34 @@ func (s *S3ObjectStore) DeleteBatch(ctx context.Context, keys []string) error {
 	return nil
 }
 
+// ListByPrefix returns all non-empty object keys matching the given prefix.
+func (s *S3ObjectStore) ListByPrefix(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(prefix),
+	})
+
+	objects := make([]ObjectInfo, 0)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("objectstore: list objects with prefix %s: %w", prefix, err)
+		}
+		for _, object := range page.Contents {
+			key := aws.ToString(object.Key)
+			if key != "" {
+				info := ObjectInfo{Key: key}
+				if object.LastModified != nil {
+					info.LastModified = *object.LastModified
+				}
+				objects = append(objects, info)
+			}
+		}
+	}
+
+	return objects, nil
+}
+
 // Ping checks connectivity by performing a HeadBucket call.
 // Note: HeadBucket requires the s3:ListBucket IAM permission on the bucket resource.
 func (s *S3ObjectStore) Ping(ctx context.Context) error {

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -170,6 +170,7 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 		}
 	}
 	mapConfig["is_db_connected"] = h.store.ConfigStore != nil
+	mapConfig["is_git_available"] = CheckGitAvailability()
 	mapConfig["is_cache_connected"] = h.store.VectorStore != nil
 	mapConfig["is_logs_connected"] = h.store.LogsStore != nil
 	// Fetching proxy config

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -858,6 +858,10 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 		// /api/oauth/config/* (admin-only) and bypass the temp-token fallback
 		// in tryTempTokenOrUnauthorized.
 		"/api/dev",
+		// Skills serving endpoints are public — marketplace URLs cannot carry
+		// credentials securely. Management endpoints under /api/skills (without
+		// /serve/) remain authenticated.
+		"/api/skills/serve/",
 	}
 	return m.middleware(func(authConfig *configstore.AuthConfig, url string) bool {
 		if slices.Contains(systemWhitelistedRoutes, url) ||
@@ -869,8 +873,8 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 		// Check user-configured whitelisted routes
 		if configuredRoutes := m.whitelistedRoutes.Load(); configuredRoutes != nil {
 			if slices.Contains(*configuredRoutes, url) || slices.IndexFunc(*configuredRoutes, func(route string) bool {
-				if strings.HasSuffix(route, "*") {
-					return strings.HasPrefix(url, strings.TrimSuffix(route, "*"))
+				if before, ok := strings.CutSuffix(route, "*"); ok {
+					return strings.HasPrefix(url, before)
 				}
 				return false
 			}) != -1 {

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -690,6 +690,50 @@ func TestAuthMiddleware_EnabledAuthConfig_NoAuth(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_SkillsPublicServeManagementSplit(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	am := &AuthMiddleware{}
+	am.UpdateAuthConfig(&configstore.AuthConfig{
+		AdminUserName: schemas.NewEnvVar("admin"),
+		AdminPassword: schemas.NewEnvVar("hashedpassword"),
+		IsEnabled:     true,
+	})
+
+	t.Run("serve routes bypass auth", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.SetRequestURI("/api/skills/serve/my-skill.git/info/refs?service=git-upload-pack")
+
+		nextCalled := false
+		handler := am.APIMiddleware()(func(ctx *fasthttp.RequestCtx) {
+			nextCalled = true
+		})
+		handler(ctx)
+
+		if !nextCalled {
+			t.Fatal("expected public skills serving route to bypass auth")
+		}
+	})
+
+	t.Run("management routes require auth", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.SetRequestURI("/api/skills")
+
+		nextCalled := false
+		handler := am.APIMiddleware()(func(ctx *fasthttp.RequestCtx) {
+			nextCalled = true
+		})
+		handler(ctx)
+
+		if nextCalled {
+			t.Fatal("expected skills management route to require auth")
+		}
+		if ctx.Response.StatusCode() != fasthttp.StatusUnauthorized {
+			t.Fatalf("expected %d, got %d", fasthttp.StatusUnauthorized, ctx.Response.StatusCode())
+		}
+	})
+}
+
 // TestAuthMiddleware_WhitelistedRoutes tests that whitelisted routes bypass auth
 func TestAuthMiddleware_WhitelistedRoutes(t *testing.T) {
 	SetLogger(&mockLogger{})

--- a/transports/bifrost-http/handlers/skills.go
+++ b/transports/bifrost-http/handlers/skills.go
@@ -1,0 +1,908 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fasthttp/router"
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// ============================================================================
+// Validation constants
+// ============================================================================
+
+// skillUploadObjectPrefix references the canonical prefix from configstore.
+var skillUploadObjectPrefix = configstore.SkillObjectPrefix + "uploads/"
+
+// Reserved frontmatter keys that cannot appear in extra_frontmatter.
+var reservedFrontmatterKeys = map[string]struct{}{
+	"name":          {},
+	"description":   {},
+	"license":       {},
+	"compatibility": {},
+	"metadata":      {},
+	"allowed-tools": {},
+}
+
+// ============================================================================
+// SkillsHandler
+// ============================================================================
+
+// SkillsHandler handles skill repository management endpoints.
+type SkillsHandler struct {
+	store       configstore.ConfigStore
+	objectStore objectstore.ObjectStore // nullable — object storage may not be configured
+}
+
+type SkillOrphanCleanupResult struct {
+	DeletedDBBlobs        int64 `json:"deleted_db_blobs"`
+	DeletedStorageObjects int   `json:"deleted_storage_objects"`
+}
+
+type AllSkillsVersionResponse struct {
+	Version string `json:"version"`
+}
+
+type BumpAllSkillsVersionRequest struct {
+	Bump string `json:"bump"`
+}
+
+// NewSkillsHandler creates a new SkillsHandler.
+// objectStore may be nil; when nil, file uploads fall back to DB blobs.
+func NewSkillsHandler(store configstore.ConfigStore, objectStore objectstore.ObjectStore) *SkillsHandler {
+	if store == nil {
+		return nil
+	}
+	return &SkillsHandler{store: store, objectStore: objectStore}
+}
+
+// RegisterRoutes registers the routes for the SkillsHandler.
+func (h *SkillsHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	// File uploads (before skill CRUD so /files/ prefix matches first)
+	r.POST("/api/skills/files/upload", lib.ChainMiddlewares(h.uploadFile, middlewares...))
+	r.DELETE("/api/skills/files/orphans", lib.ChainMiddlewares(h.cleanupOrphanFiles, middlewares...))
+	r.GET("/api/skills/all/version", lib.ChainMiddlewares(h.getAllSkillsVersion, middlewares...))
+	r.PUT("/api/skills/all/version", lib.ChainMiddlewares(h.bumpAllSkillsVersion, middlewares...))
+
+	// Skill CRUD
+	r.POST("/api/skills", lib.ChainMiddlewares(h.createSkill, middlewares...))
+	r.GET("/api/skills", lib.ChainMiddlewares(h.listSkills, middlewares...))
+	r.GET("/api/skills/{id}", lib.ChainMiddlewares(h.getSkill, middlewares...))
+	r.GET("/api/skills/{id}/versions", lib.ChainMiddlewares(h.listSkillVersions, middlewares...))
+	r.PUT("/api/skills/{id}", lib.ChainMiddlewares(h.updateSkill, middlewares...))
+	r.DELETE("/api/skills/{id}", lib.ChainMiddlewares(h.deleteSkill, middlewares...))
+	r.POST("/api/skills/{id}/shift-version", lib.ChainMiddlewares(h.shiftVersion, middlewares...))
+}
+
+// ============================================================================
+// Request/Response Types
+// ============================================================================
+
+// CreateSkillRequest is the JSON payload for creating a skill.
+type CreateSkillRequest struct {
+	Name             string            `json:"name"`
+	Description      string            `json:"description"`
+	License          *string           `json:"license,omitempty"`
+	Compatibility    *string           `json:"compatibility,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	ExtraFrontmatter map[string]any    `json:"extra_frontmatter,omitempty"`
+	AllowedTools     *string           `json:"allowed_tools,omitempty"`
+	SkillMDBody      string            `json:"skill_md_body"`
+	Version          string            `json:"version"`
+	Files            []SkillFileEntry  `json:"files,omitempty"`
+}
+
+// UpdateSkillRequest is the JSON payload for updating a skill.
+type UpdateSkillRequest struct {
+	Description      string            `json:"description"`
+	License          *string           `json:"license,omitempty"`
+	Compatibility    *string           `json:"compatibility,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	ExtraFrontmatter map[string]any    `json:"extra_frontmatter,omitempty"`
+	AllowedTools     *string           `json:"allowed_tools,omitempty"`
+	SkillMDBody      string            `json:"skill_md_body"`
+	Version          string            `json:"version"`
+	Files            []SkillFileEntry  `json:"files,omitempty"`
+	Serve            *bool             `json:"serve,omitempty"` // when false, creates a new version without switching serving
+}
+
+// SkillFileEntry represents a single file in the create/update request.
+type SkillFileEntry struct {
+	Path       string  `json:"path"`
+	SourceType string  `json:"source_type"`
+	Content    *string `json:"content,omitempty"`     // for source_type "text"
+	SourceURL  *string `json:"source_url,omitempty"`  // for source_type "url"
+	DataURL    *string `json:"dataurl,omitempty"`     // for source_type "dataurl"
+	UploadID   *string `json:"upload_id,omitempty"`   // for source_type "upload"
+	StorageKey *string `json:"storage_key,omitempty"` // existing stored file reference
+	BlobID     *string `json:"blob_id,omitempty"`     // existing DB fallback blob reference
+	MimeType   string  `json:"mime_type"`
+}
+
+// ============================================================================
+// File Upload Handlers
+// ============================================================================
+
+// uploadFile handles POST /api/skills/files/upload — multipart file upload.
+func (h *SkillsHandler) uploadFile(ctx *fasthttp.RequestCtx) {
+	form, err := ctx.MultipartForm()
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid multipart form data")
+		return
+	}
+
+	filePath := ""
+	if paths, ok := form.Value["path"]; ok && len(paths) > 0 {
+		filePath = paths[0]
+	}
+
+	files := form.File["file"]
+	if len(files) == 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, "file is required")
+		return
+	}
+	if len(files) > 1 {
+		SendError(ctx, fasthttp.StatusBadRequest, "only one file is allowed per upload request")
+		return
+	}
+	fileHeader := files[0]
+	filename := fileHeader.Filename
+	if filePath == "" {
+		filePath = filename
+	}
+	if errMsg := validateSkillFilePath(filePath); errMsg != "" {
+		SendError(ctx, fasthttp.StatusBadRequest, errMsg)
+		return
+	}
+
+	// Read file bytes.
+	if fileHeader.Size > configstore.MaxSkillFileContentSize {
+		SendError(ctx, fasthttp.StatusRequestEntityTooLarge, "file exceeds 50 MB upload limit")
+		return
+	}
+	f, err := fileHeader.Open()
+	if err != nil {
+		logger.Error("failed to open uploaded file: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to read uploaded file")
+		return
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, configstore.MaxSkillFileContentSize+1))
+	if err != nil {
+		logger.Error("failed to read uploaded file: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to read uploaded file")
+		return
+	}
+	if len(data) > configstore.MaxSkillFileContentSize {
+		SendError(ctx, fasthttp.StatusRequestEntityTooLarge, "file exceeds 50 MB upload limit")
+		return
+	}
+
+	uploadID := uuid.New().String()
+	mimeType := fileHeader.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
+	// Store in object storage if available, else create a DB blob.
+	if h.objectStore != nil {
+		storageKey := fmt.Sprintf("%s%s/%s", skillUploadObjectPrefix, uploadID, path.Base(filePath))
+		if err := h.objectStore.Put(ctx, storageKey, data, map[string]string{
+			"upload_id": uploadID,
+			"path":      filePath,
+		}); err != nil {
+			logger.Error("failed to store file in object storage: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to store uploaded file")
+			return
+		}
+
+		SendJSON(ctx, map[string]any{
+			"upload_id":       uploadID,
+			"storage_key":     storageKey,
+			"path":            filePath,
+			"filename":        filename,
+			"mime_type":       mimeType,
+			"file_size_bytes": int64(len(data)),
+		})
+		return
+	}
+
+	// Fallback: store as a DB blob.
+	blobID := uuid.New().String()
+	blob := &tables.TableSkillFileBlob{
+		ID:   blobID,
+		Data: data,
+	}
+	if err := h.store.CreateSkillFileBlob(ctx, blob); err != nil {
+		logger.Error("failed to store file blob: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to store uploaded file")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"upload_id":       uploadID,
+		"blob_id":         blobID,
+		"path":            filePath,
+		"filename":        filename,
+		"mime_type":       mimeType,
+		"file_size_bytes": int64(len(data)),
+	})
+}
+
+// cleanupOrphanFiles handles DELETE /api/skills/files/orphans.
+func (h *SkillsHandler) cleanupOrphanFiles(ctx *fasthttp.RequestCtx) {
+	force := string(ctx.QueryArgs().Peek("force")) == "true"
+	result, err := CleanupOrphanSkillFiles(ctx, h.store, h.objectStore, force)
+	if err != nil {
+		logger.Error("failed to cleanup orphan skill files: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to cleanup orphan files")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"deleted_db_blobs":          result.DeletedDBBlobs,
+		"deleted_storage_objects":   result.DeletedStorageObjects,
+		"object_storage_configured": h.objectStore != nil,
+		"message":                   "orphan skill files cleaned up successfully",
+	})
+}
+
+// CleanupOrphanSkillFiles removes DB fallback blobs and unreferenced upload objects.
+// When force is false, a 30-minute grace period protects freshly uploaded pending files.
+func CleanupOrphanSkillFiles(ctx context.Context, store configstore.ConfigStore, objectStore objectstore.ObjectStore, force bool) (SkillOrphanCleanupResult, error) {
+	var result SkillOrphanCleanupResult
+	if store == nil {
+		return result, fmt.Errorf("config store is required")
+	}
+
+	deletedDBBlobs, err := store.CleanupOrphanSkillFileBlobs(ctx, force)
+	if err != nil {
+		return result, fmt.Errorf("cleanup orphan skill file blobs: %w", err)
+	}
+	result.DeletedDBBlobs = deletedDBBlobs
+
+	if objectStore == nil {
+		return result, nil
+	}
+
+	uploadObjects, err := objectStore.ListByPrefix(ctx, configstore.SkillObjectPrefix)
+	if err != nil {
+		return result, fmt.Errorf("list skill upload objects: %w", err)
+	}
+	if len(uploadObjects) == 0 {
+		return result, nil
+	}
+
+	var referencedKeys []string
+	if err := store.DB().WithContext(ctx).
+		Model(&tables.TableSkillFile{}).
+		Where("storage_key IS NOT NULL AND storage_key != ''").
+		Distinct("storage_key").
+		Pluck("storage_key", &referencedKeys).Error; err != nil {
+		return result, fmt.Errorf("list referenced skill file storage keys: %w", err)
+	}
+
+	referenced := make(map[string]struct{}, len(referencedKeys))
+	for _, key := range referencedKeys {
+		referenced[key] = struct{}{}
+	}
+
+	// Only reap unreferenced objects older than 30 minutes unless force is set.
+	orphanKeys := make([]string, 0)
+	if force {
+		for _, obj := range uploadObjects {
+			if _, ok := referenced[obj.Key]; !ok {
+				orphanKeys = append(orphanKeys, obj.Key)
+			}
+		}
+	} else {
+		cutoff := time.Now().Add(-30 * time.Minute)
+		for _, obj := range uploadObjects {
+			if _, ok := referenced[obj.Key]; !ok && obj.LastModified.Before(cutoff) {
+				orphanKeys = append(orphanKeys, obj.Key)
+			}
+		}
+	}
+	if len(orphanKeys) == 0 {
+		return result, nil
+	}
+	if err := objectStore.DeleteBatch(ctx, orphanKeys); err != nil {
+		return result, fmt.Errorf("delete orphan skill upload objects: %w", err)
+	}
+	result.DeletedStorageObjects = len(orphanKeys)
+	return result, nil
+}
+
+func (h *SkillsHandler) getAllSkillsVersion(ctx *fasthttp.RequestCtx) {
+	version, err := h.store.GetAllSkillsVersion(ctx)
+	if err != nil {
+		logger.Error("failed to get all-skills version: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to get all-skills version")
+		return
+	}
+	SendJSON(ctx, AllSkillsVersionResponse{Version: version})
+}
+
+func (h *SkillsHandler) bumpAllSkillsVersion(ctx *fasthttp.RequestCtx) {
+	var req BumpAllSkillsVersionRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	version, err := h.store.BumpAllSkillsVersion(ctx, strings.ToLower(strings.TrimSpace(req.Bump)))
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	SendJSON(ctx, AllSkillsVersionResponse{Version: version})
+}
+
+// ============================================================================
+// Skill CRUD Handlers
+// ============================================================================
+
+// createSkill handles POST /api/skills.
+func (h *SkillsHandler) createSkill(ctx *fasthttp.RequestCtx) {
+	var req CreateSkillRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if errs := validateSkillRequest(req.Name, req.Description, req.SkillMDBody, req.Version, req.ExtraFrontmatter, req.Files, true); len(errs) > 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, strings.Join(errs, "; "))
+		return
+	}
+
+	if err := inferLiveFileMimeTypes(ctx, req.Files, "skills api create"); err != nil {
+		logger.Warn("%v", err)
+	}
+
+	skill := &tables.TableSkill{
+		ID:               uuid.New().String(),
+		Name:             req.Name,
+		Description:      req.Description,
+		License:          req.License,
+		Compatibility:    req.Compatibility,
+		Metadata:         tables.SkillStringMap(req.Metadata),
+		ExtraFrontmatter: tables.SkillJSONMap(req.ExtraFrontmatter),
+		AllowedTools:     req.AllowedTools,
+		SkillMDBody:      req.SkillMDBody,
+		LatestVersion:    req.Version,
+	}
+
+	// Build file records (SkillVersionID is set by the store).
+	for _, fe := range req.Files {
+		skill.Files = append(skill.Files, fileEntryToTableSkillFile(fe))
+	}
+
+	if err := h.store.CreateSkill(ctx, skill, req.Version, h.objectStore); err != nil {
+		if errors.Is(err, configstore.ErrAlreadyExists) {
+			SendError(ctx, fasthttp.StatusConflict, "a skill with this name already exists")
+			return
+		}
+		logger.Error("failed to create skill: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skill": skill,
+	})
+}
+
+func parseSkillSortParams(ctx *fasthttp.RequestCtx, allowed map[string]struct{}, defaultSortBy, defaultOrder string) (string, string) {
+	sortBy := string(ctx.QueryArgs().Peek("sort_by"))
+	if _, ok := allowed[sortBy]; !ok {
+		sortBy = defaultSortBy
+	}
+	order := strings.ToLower(string(ctx.QueryArgs().Peek("order")))
+	if order != "asc" && order != "desc" {
+		order = defaultOrder
+	}
+	return sortBy, order
+}
+
+// listSkills handles GET /api/skills.
+func (h *SkillsHandler) listSkills(ctx *fasthttp.RequestCtx) {
+	sortBy, order := parseSkillSortParams(ctx, map[string]struct{}{
+		"name":       {},
+		"updated_at": {},
+		"created_at": {},
+	}, "created_at", "desc")
+	params := configstore.SkillListQueryParams{
+		Search: string(ctx.QueryArgs().Peek("search")),
+		SortBy: sortBy,
+		Order:  order,
+	}
+
+	if limitStr := string(ctx.QueryArgs().Peek("limit")); limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil && v > 0 {
+			params.Limit = min(v, 100)
+		}
+	}
+	if params.Limit == 0 {
+		params.Limit = 50 // sensible default
+	}
+
+	if offsetStr := string(ctx.QueryArgs().Peek("offset")); offsetStr != "" {
+		if v, err := strconv.Atoi(offsetStr); err == nil && v >= 0 {
+			params.Offset = v
+		}
+	}
+
+	skills, total, err := h.store.ListSkills(ctx, params)
+	if err != nil {
+		logger.Error("failed to list skills: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skills": skills,
+		"total":  total,
+		"limit":  params.Limit,
+		"offset": params.Offset,
+	})
+}
+
+// getSkill handles GET /api/skills/{id}.
+func (h *SkillsHandler) getSkill(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	// Check for ?version=X.Y.Z query param to return a specific version's data.
+	if versionParam := string(ctx.QueryArgs().Peek("version")); versionParam != "" {
+		skill, err := h.store.GetSkillLean(ctx, id)
+		if err != nil {
+			if errors.Is(err, configstore.ErrNotFound) {
+				SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+				return
+			}
+			logger.Error("failed to get skill: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+			return
+		}
+		found, err := h.store.GetSkillVersion(ctx, id, versionParam)
+		if err != nil {
+			if errors.Is(err, configstore.ErrNotFound) {
+				SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("version %q not found", versionParam))
+				return
+			}
+			logger.Error("failed to get skill version: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+			return
+		}
+		// Overlay version data onto skill response (name is immutable, stays as current).
+		skill.SkillMDBody = found.SkillMDBody
+		skill.LatestVersion = found.Version
+		fields := configstore.ExtractSkillFieldsFromFrontmatter(found.FrontmatterSnapshot)
+		skill.Description = fields.Description
+		skill.License = fields.License
+		skill.Compatibility = fields.Compatibility
+		skill.AllowedTools = fields.AllowedTools
+		skill.Metadata = fields.Metadata
+		skill.ExtraFrontmatter = fields.ExtraFrontmatter
+		skill.Files = found.Files
+		SendJSON(ctx, map[string]any{
+			"skill": skill,
+		})
+		return
+	}
+
+	skill, err := h.store.GetSkillLean(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+			return
+		}
+		logger.Error("failed to get skill: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skill": skill,
+	})
+}
+
+// listSkillVersions handles GET /api/skills/{id}/versions.
+func (h *SkillsHandler) listSkillVersions(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	limit := 25
+	offset := 0
+	sortBy, order := parseSkillSortParams(ctx, map[string]struct{}{
+		"version":    {},
+		"created_at": {},
+	}, "created_at", "desc")
+	if n, err := strconv.Atoi(string(ctx.QueryArgs().Peek("limit"))); err == nil && n > 0 {
+		limit = min(n, 100)
+	}
+	if n, err := strconv.Atoi(string(ctx.QueryArgs().Peek("offset"))); err == nil && n >= 0 {
+		offset = n
+	}
+
+	versions, total, err := h.store.ListSkillVersions(ctx, id, configstore.SkillVersionListQueryParams{
+		Limit:  limit,
+		Offset: offset,
+		SortBy: sortBy,
+		Order:  order,
+	})
+	if err != nil {
+		logger.Error("failed to list skill versions: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"versions": versions,
+		"total":    total,
+		"limit":    limit,
+		"offset":   offset,
+	})
+}
+
+// shiftVersion handles POST /api/skills/{id}/shift-version.
+func (h *SkillsHandler) shiftVersion(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Version == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "version is required")
+		return
+	}
+
+	if err := h.store.ShiftSkillVersion(ctx, id, req.Version, h.objectStore); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+			return
+		}
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "already serving") {
+			SendError(ctx, fasthttp.StatusBadRequest, errMsg)
+			return
+		}
+		logger.Error("failed to shift skill version: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, errMsg)
+		return
+	}
+
+	skill, err := h.store.GetSkill(ctx, id)
+	if err != nil {
+		logger.Error("failed to reload skill after version shift: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "version shifted but failed to reload skill")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skill": skill,
+	})
+}
+
+// updateSkill handles PUT /api/skills/{id}.
+func (h *SkillsHandler) updateSkill(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	var req UpdateSkillRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if errs := validateSkillRequest("", req.Description, req.SkillMDBody, req.Version, req.ExtraFrontmatter, req.Files, false); len(errs) > 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, strings.Join(errs, "; "))
+		return
+	}
+
+	if err := inferLiveFileMimeTypes(ctx, req.Files, "skills api update"); err != nil {
+		logger.Warn("%v", err)
+	}
+
+	skill, err := h.store.GetSkill(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+			return
+		}
+		logger.Error("failed to get skill for update: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Apply updates (name is immutable after creation).
+	skill.Description = req.Description
+	skill.License = req.License
+	skill.Compatibility = req.Compatibility
+	skill.Metadata = tables.SkillStringMap(req.Metadata)
+	skill.ExtraFrontmatter = tables.SkillJSONMap(req.ExtraFrontmatter)
+	skill.AllowedTools = req.AllowedTools
+	skill.SkillMDBody = req.SkillMDBody
+
+	// Rebuild files from the request (SkillVersionID is set by the store).
+	var files []tables.TableSkillFile
+	for _, fe := range req.Files {
+		files = append(files, fileEntryToTableSkillFile(fe))
+	}
+	skill.Files = files
+
+	serve := req.Serve == nil || *req.Serve // default true for backward compat
+	if err := h.store.UpdateSkill(ctx, skill, req.Version, serve, h.objectStore); err != nil {
+		if errors.Is(err, configstore.ErrAlreadyExists) {
+			SendError(ctx, fasthttp.StatusConflict, fmt.Sprintf("version %s already exists for this skill; provide a new version", req.Version))
+			return
+		}
+		logger.Error("failed to update skill: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	reloadedSkill, err := h.store.GetSkill(ctx, id)
+	if err != nil {
+		logger.Error("failed to reload skill after update: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "skill updated but failed to reload skill")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skill": reloadedSkill,
+	})
+}
+
+// deleteSkill handles DELETE /api/skills/{id}.
+func (h *SkillsHandler) deleteSkill(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.store.DeleteSkill(ctx, id, h.objectStore); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+			return
+		}
+		logger.Error("failed to delete skill: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"message": "skill deleted successfully",
+	})
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// extractStringParam extracts a path param and sends an error if missing.
+func extractStringParam(ctx *fasthttp.RequestCtx, name string) (string, bool) {
+	val := ctx.UserValue(name)
+	if val == nil {
+		SendError(ctx, fasthttp.StatusBadRequest, name+" is required")
+		return "", false
+	}
+	s, ok := val.(string)
+	if !ok || s == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid "+name)
+		return "", false
+	}
+	return s, true
+}
+
+// inferLiveFileMimeTypes infers MIME for live URL references before validation/storage.
+// Uses the SSRF-protected skillURLClient for outbound HEAD requests to avoid
+// hitting private/loopback IPs or non-HTTP(S) schemes.
+// Failures are warnings only: live sources may become reachable later, so we
+// fall back to octet-stream instead of blocking registration.
+func inferLiveFileMimeTypes(ctx context.Context, files []SkillFileEntry, source string) error {
+	var warnings []string
+	for i := range files {
+		f := &files[i]
+		if f.SourceType != tables.SkillSourceTypeURL || f.SourceURL == nil || *f.SourceURL == "" {
+			continue
+		}
+		mimeType, err := inferMimeTypeFromURL(ctx, *f.SourceURL)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("file %q: could not infer MIME from URL %q: %v", f.Path, *f.SourceURL, err))
+			f.MimeType = "application/octet-stream"
+			continue
+		}
+		f.MimeType = mimeType
+	}
+	if len(warnings) > 0 {
+		return fmt.Errorf("%s MIME inference warnings: %s", source, strings.Join(warnings, "; "))
+	}
+	return nil
+}
+
+// inferMimeTypeFromURL performs a HEAD request using the SSRF-protected client
+// to infer the MIME type from the server's Content-Type header.
+func inferMimeTypeFromURL(ctx context.Context, rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("blocked non-HTTP(S) scheme: %s", parsed.Scheme)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := skillURLClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("HEAD returned status %d", resp.StatusCode)
+	}
+	mimeType := strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])
+	if mimeType == "" {
+		return "", fmt.Errorf("HEAD response did not include Content-Type")
+	}
+	return mimeType, nil
+}
+
+// fileEntryToTableSkillFile converts a request file entry to a TableSkillFile record.
+// SkillVersionID is set by the store layer during create/update.
+func fileEntryToTableSkillFile(fe SkillFileEntry) tables.TableSkillFile {
+	sf := tables.TableSkillFile{
+		Path:       fe.Path,
+		SourceType: fe.SourceType,
+		MimeType:   fe.MimeType,
+	}
+
+	switch fe.SourceType {
+	case tables.SkillSourceTypeURL:
+		sf.SourceURL = fe.SourceURL
+	case tables.SkillSourceTypeText:
+		sf.InlineContent = fe.Content
+		sf.StorageKey = fe.StorageKey
+		sf.BlobID = fe.BlobID
+	case tables.SkillSourceTypeDataURL:
+		sf.DataURL = fe.DataURL
+		sf.StorageKey = fe.StorageKey
+		sf.BlobID = fe.BlobID
+	case tables.SkillSourceTypeUpload:
+		sf.UploadID = fe.UploadID
+		sf.StorageKey = fe.StorageKey
+		sf.BlobID = fe.BlobID
+	}
+
+	return sf
+}
+
+// validateSkillRequest performs backend validation on skill fields.
+// When validateName is true, the name field is validated (used for create).
+// Returns a slice of error messages (empty if valid).
+func validateSkillRequest(name, description, body, version string, extraFM map[string]any, files []SkillFileEntry, validateName bool) []string {
+	var errs []string
+
+	// Name: 1-64 chars, lowercase alphanum + hyphens, no leading/trailing/consecutive hyphens.
+	if validateName {
+		if err := configstore.ValidateSkillName(name); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if description == "" {
+		errs = append(errs, "description is required")
+	} else if len(description) > 1024 {
+		errs = append(errs, "description must be at most 1024 characters")
+	}
+
+	// Body: non-empty.
+	if strings.TrimSpace(body) == "" {
+		errs = append(errs, "skill_md_body is required and must not be empty")
+	}
+
+	// Version: required.
+	if err := configstore.ValidateSkillVersion(version); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	// Extra frontmatter: no reserved keys.
+	for key := range extraFM {
+		if _, reserved := reservedFrontmatterKeys[key]; reserved {
+			errs = append(errs, fmt.Sprintf("extra_frontmatter key %q is reserved and cannot be used", key))
+		}
+	}
+
+	// Files: validate each entry.
+	seenPaths := make(map[string]bool, len(files))
+	for i, f := range files {
+		prefix := fmt.Sprintf("files[%d]", i)
+		if f.Path == "" {
+			errs = append(errs, prefix+": path is required")
+		}
+		if f.SourceType == "" {
+			errs = append(errs, prefix+": source_type is required")
+		}
+		if f.Path != "" {
+			normalized := path.Clean(f.Path)
+			if seenPaths[normalized] {
+				errs = append(errs, prefix+": duplicate file path "+f.Path)
+			}
+			seenPaths[normalized] = true
+			if errMsg := validateSkillFilePath(f.Path); errMsg != "" {
+				errs = append(errs, prefix+": "+errMsg)
+			}
+		}
+		// Source-type-specific checks.
+		switch f.SourceType {
+		case tables.SkillSourceTypeURL:
+			if f.SourceURL == nil || *f.SourceURL == "" {
+				errs = append(errs, prefix+": source_url is required for url source type")
+			} else if !strings.HasPrefix(*f.SourceURL, "http://") && !strings.HasPrefix(*f.SourceURL, "https://") {
+				errs = append(errs, prefix+": source_url must start with http:// or https://")
+			}
+		case tables.SkillSourceTypeText:
+			if (f.Content == nil || *f.Content == "") && f.StorageKey == nil && f.BlobID == nil {
+				errs = append(errs, prefix+": content or an existing file reference is required for text source type")
+			}
+		case tables.SkillSourceTypeDataURL:
+			if (f.DataURL == nil || *f.DataURL == "") && f.StorageKey == nil && f.BlobID == nil {
+				errs = append(errs, prefix+": dataurl or an existing file reference is required for dataurl source type")
+			} else if f.DataURL != nil && *f.DataURL != "" && (!strings.HasPrefix(*f.DataURL, "data:") || !strings.Contains(*f.DataURL, ";base64,")) {
+				errs = append(errs, prefix+": dataurl must be a valid data URL (data:...;base64,...)")
+			}
+		case tables.SkillSourceTypeUpload:
+			if f.StorageKey == nil && f.BlobID == nil {
+				errs = append(errs, prefix+": storage_key or blob_id is required for upload source type")
+			} else if f.StorageKey != nil && !strings.HasPrefix(*f.StorageKey, configstore.SkillObjectPrefix) {
+				errs = append(errs, prefix+": storage_key must be under the skills/ object prefix")
+			}
+		default:
+			if f.SourceType != "" {
+				errs = append(errs, prefix+": unknown source_type "+f.SourceType)
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateSkillFilePath checks that a relative file path is safe (no traversal).
+func validateSkillFilePath(p string) string {
+	if err := configstore.ValidateSkillFilePath(p); err != nil {
+		return err.Error()
+	}
+	return ""
+}

--- a/transports/bifrost-http/handlers/skills_cleanup_test.go
+++ b/transports/bifrost-http/handlers/skills_cleanup_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+)
+
+type testLogger struct{}
+
+func (testLogger) Debug(string, ...any) {}
+func (testLogger) Info(string, ...any)  {}
+func (testLogger) Warn(string, ...any)  {}
+func (testLogger) Error(string, ...any) {}
+func (testLogger) Fatal(msg string, args ...any) {
+	panic("fatal called")
+}
+func (testLogger) SetLevel(schemas.LogLevel)              {}
+func (testLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (testLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func newTestConfigStore(t *testing.T) configstore.ConfigStore {
+	t.Helper()
+	store, err := configstore.NewConfigStore(context.Background(), &configstore.Config{
+		Enabled: true,
+		Type:    configstore.ConfigStoreTypeSQLite,
+		Config: &configstore.SQLiteConfig{
+			Path: filepath.Join(t.TempDir(), "config.db"),
+		},
+	}, testLogger{})
+	if err != nil {
+		t.Fatalf("new config store: %v", err)
+	}
+	t.Cleanup(func() { store.Close(context.Background()) })
+	return store
+}
+
+func TestCleanupOrphanSkillFilesDeletesDBFallbackBlobs(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+	referencedBlobID := "referenced-blob"
+	orphanBlobID := "orphan-blob"
+
+	if err := store.CreateSkillFileBlob(ctx, &tables.TableSkillFileBlob{ID: referencedBlobID, Data: []byte("referenced")}); err != nil {
+		t.Fatalf("create referenced blob: %v", err)
+	}
+	if err := store.CreateSkillFileBlob(ctx, &tables.TableSkillFileBlob{ID: orphanBlobID, Data: []byte("orphan")}); err != nil {
+		t.Fatalf("create orphan blob: %v", err)
+	}
+	// Backdate the orphan blob so it exceeds the 30-minute grace period.
+	if err := store.DB().WithContext(ctx).Model(&tables.TableSkillFileBlob{}).Where("id = ?", orphanBlobID).Update("created_at", time.Now().Add(-1*time.Hour)).Error; err != nil {
+		t.Fatalf("backdate orphan blob: %v", err)
+	}
+	if err := store.CreateSkill(ctx, &tables.TableSkill{
+		Name:        "cleanup-db-test",
+		Description: "cleanup db test",
+		SkillMDBody: "body",
+		Files: []tables.TableSkillFile{{
+			Path:          "reference.txt",
+			SourceType:    tables.SkillSourceTypeUpload,
+			BlobID:        &referencedBlobID,
+			MimeType:      "text/plain",
+			FileSizeBytes: 10,
+		}},
+	}, "1.0.0", nil); err != nil {
+		t.Fatalf("create skill: %v", err)
+	}
+
+	result, err := CleanupOrphanSkillFiles(ctx, store, nil, false)
+	if err != nil {
+		t.Fatalf("cleanup orphan files: %v", err)
+	}
+	if result.DeletedDBBlobs != 1 {
+		t.Fatalf("DeletedDBBlobs got %d, want 1", result.DeletedDBBlobs)
+	}
+	if result.DeletedStorageObjects != 0 {
+		t.Fatalf("DeletedStorageObjects got %d, want 0", result.DeletedStorageObjects)
+	}
+
+	if err := store.DB().WithContext(ctx).First(&tables.TableSkillFileBlob{}, "id = ?", referencedBlobID).Error; err != nil {
+		t.Fatalf("referenced blob should remain: %v", err)
+	}
+	var remaining int64
+	if err := store.DB().WithContext(ctx).Model(&tables.TableSkillFileBlob{}).Where("id = ?", orphanBlobID).Count(&remaining).Error; err != nil {
+		t.Fatalf("count orphan blob: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("orphan blob remained")
+	}
+}
+
+func TestCleanupOrphanSkillFilesDeletesOnlyUnreferencedUploadObjects(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+	objStore := objectstore.NewInMemoryObjectStore()
+	referencedKey := configstore.SkillObjectPrefix + "uploads/referenced/file.txt"
+	orphanKey := configstore.SkillObjectPrefix + "uploads/orphan/file.txt"
+	outsidePrefixKey := "other/file.txt"
+
+	for key := range map[string]struct{}{referencedKey: {}, orphanKey: {}, outsidePrefixKey: {}} {
+		if err := objStore.Put(ctx, key, []byte(key), nil); err != nil {
+			t.Fatalf("put %s: %v", key, err)
+		}
+	}
+	// Backdate orphan object so it exceeds the 30-minute grace period.
+	objStore.SetCreatedAt(orphanKey, time.Now().Add(-1*time.Hour))
+	uploadID := "referenced"
+	if err := store.CreateSkill(ctx, &tables.TableSkill{
+		Name:        "cleanup-object-test",
+		Description: "cleanup object test",
+		SkillMDBody: "body",
+		Files: []tables.TableSkillFile{{
+			Path:          "file.txt",
+			SourceType:    tables.SkillSourceTypeUpload,
+			StorageKey:    &referencedKey,
+			UploadID:      &uploadID,
+			MimeType:      "text/plain",
+			FileSizeBytes: 10,
+		}},
+	}, "1.0.0", objStore); err != nil {
+		t.Fatalf("create skill: %v", err)
+	}
+
+	result, err := CleanupOrphanSkillFiles(ctx, store, objStore, false)
+	if err != nil {
+		t.Fatalf("cleanup orphan files: %v", err)
+	}
+	if result.DeletedStorageObjects != 1 {
+		t.Fatalf("DeletedStorageObjects got %d, want 1", result.DeletedStorageObjects)
+	}
+	if _, err := objStore.Get(ctx, referencedKey); err != nil {
+		t.Fatalf("referenced object should remain: %v", err)
+	}
+	if _, err := objStore.Get(ctx, outsidePrefixKey); err != nil {
+		t.Fatalf("outside-prefix object should remain: %v", err)
+	}
+	if _, err := objStore.Get(ctx, orphanKey); err == nil {
+		t.Fatalf("orphan object remained")
+	}
+}

--- a/transports/bifrost-http/handlers/skills_serving.go
+++ b/transports/bifrost-http/handlers/skills_serving.go
@@ -1,0 +1,1413 @@
+package handlers
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fasthttp/router"
+	billy "github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-billy/v5/osfs"
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+	"github.com/valyala/fasthttp"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// ============================================================================
+// Git binary availability check
+// ============================================================================
+
+// gitBinaryPath holds the resolved path to the git binary, or empty if unavailable.
+var gitBinaryPath string
+
+func init() {
+	gitBinaryPath, _ = exec.LookPath("git")
+}
+
+// CheckGitAvailability returns true if the git binary is available on PATH.
+func CheckGitAvailability() bool {
+	return gitBinaryPath != ""
+}
+
+// maxSkillGitRepoSize caps assembled git repo payloads before they are materialized into memfs.
+const maxSkillGitRepoSize = 500 * 1024 * 1024 // 500 MB
+
+// skillURLClient is a dedicated HTTP client for fetching URL-sourced skill content.
+// Uses a custom transport that blocks connections to private/loopback IPs to prevent SSRF.
+var skillURLClient = &http.Client{
+	Timeout: 15 * time.Second,
+	Transport: &http.Transport{
+		DialContext: ssrfSafeDialContext,
+	},
+}
+
+// ssrfSafeDialContext wraps the default dialer to reject connections to private,
+// loopback, and link-local IP addresses. This prevents SSRF attacks where an
+// admin-configured source_url points to internal infrastructure.
+func ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address %s: %w", addr, err)
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("DNS lookup failed for %s: %w", host, err)
+	}
+
+	for _, ip := range ips {
+		if isPrivateIP(ip.IP) {
+			return nil, fmt.Errorf("blocked connection to private/loopback IP %s (host: %s)", ip.IP, host)
+		}
+	}
+
+	// All IPs are public; dial one of the already-resolved IPs directly to
+	// prevent DNS rebinding attacks where a second resolution returns a
+	// different (private) IP.
+	return (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+}
+
+// isPrivateIP returns true for loopback, private, link-local, unspecified, and multicast addresses.
+func isPrivateIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast()
+}
+
+// fetchURLSafe fetches content from a URL with SSRF protection, timeout, and size cap.
+// Used by both serveSkillFile and fetchFileContentForArchive.
+func fetchURLSafe(ctx context.Context, rawURL string) ([]byte, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("blocked non-HTTP(S) scheme: %s", parsed.Scheme)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	resp, err := skillURLClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("URL returned status %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, configstore.MaxSkillFileContentSize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if int64(len(data)) > configstore.MaxSkillFileContentSize {
+		return nil, fmt.Errorf("response exceeds %d MB size limit", configstore.MaxSkillFileContentSize/(1024*1024))
+	}
+	return data, nil
+}
+
+// ============================================================================
+// SkillsServingHandler — public (no auth) marketplace and download endpoints
+// ============================================================================
+
+// SkillsServingHandler serves skill marketplace catalogs, plugin manifests,
+// composed SKILL.md files, individual file content, and zip archives.
+// All routes are public — intentionally NOT wrapped with auth middlewares.
+type SkillsServingHandler struct {
+	store        configstore.ConfigStore
+	objectStore  objectstore.ObjectStore // nullable — may not be configured
+	gitAvailable bool
+}
+
+// NewSkillsServingHandler creates a new SkillsServingHandler.
+// Returns nil if store is nil.
+func NewSkillsServingHandler(store configstore.ConfigStore, objectStore objectstore.ObjectStore) *SkillsServingHandler {
+	if store == nil {
+		return nil
+	}
+	return &SkillsServingHandler{store: store, objectStore: objectStore, gitAvailable: CheckGitAvailability()}
+}
+
+// RegisterRoutes registers public serving endpoints.
+// These routes are intentionally NOT wrapped with auth middlewares — marketplace
+// URLs cannot carry credentials securely.
+func (h *SkillsServingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	// Git-based marketplace routes only registered when git binary is available,
+	// since Claude Code and Codex require git clone support.
+	if h.gitAvailable {
+		// Claude Code marketplace
+		r.GET("/api/skills/serve/claude-code/.claude-plugin/marketplace.json", h.claudeCodeMarketplace)
+
+		// Codex marketplace — Codex expects .agents/plugins/marketplace.json
+		r.GET("/api/skills/serve/codex/.agents/plugins/marketplace.json", h.codexMarketplace)
+		// Codex marketplace git routes (Codex clones the marketplace URL itself)
+		codexMktBase := "/api/skills/serve/codex"
+		r.GET(codexMktBase+"/info/refs", h.codexMarketplaceGit())
+		r.POST(codexMktBase+"/git-upload-pack", h.codexMarketplaceGit())
+
+		// Git smart HTTP serving (shared by both Claude Code and Codex)
+		for _, harness := range configstore.SkillHarnessNames {
+			h.registerGitRoutes(r, harness)
+		}
+	} else {
+		logger.Warn("git binary not found — Claude Code / Codex marketplace routes disabled")
+	}
+
+	// Generic download (always available, no git required)
+	r.GET("/api/skills/serve/all/download.zip", h.allSkillsZipDownload)
+	r.GET("/api/skills/serve/{skill-name}/download.zip", h.genericZipDownload)
+	r.GET("/api/skills/serve/{skill-name}/files/{filepath:*}", h.genericFileDownload)
+}
+
+// pluginNamePrefix is prepended to all skill names when exposed as marketplace plugins.
+const pluginNamePrefix = "bifrost-"
+
+// allSkillsPluginName is the name of the bundled "all skills" plugin.
+const allSkillsPluginName = pluginNamePrefix + "all-skills"
+
+// ============================================================================
+// Marketplace JSON generation
+// ============================================================================
+
+// claudeCodeMarketplace generates GET /api/skills/serve/claude-code/.claude-plugin/marketplace.json
+func (h *SkillsServingHandler) claudeCodeMarketplace(ctx *fasthttp.RequestCtx) {
+	skills, err := h.listAllSkills(ctx)
+	if err != nil {
+		return
+	}
+
+	allSkillsVersion := "0.0.0"
+	if len(skills) > 0 {
+		allSkillsVersion, err = h.store.GetAllSkillsVersion(ctx)
+		if err != nil {
+			logger.Error("all-skills: failed to get version: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to get all-skills version")
+			return
+		}
+	}
+
+	baseURL := h.resolveBaseURL(ctx)
+	plugins := make([]map[string]any, 0, len(skills)+1)
+	for _, skillSummary := range skills {
+		plugins = append(plugins, map[string]any{
+			"name":        pluginNamePrefix + skillSummary.Name,
+			"description": skillSummary.Description,
+			"version":     skillSummary.LatestVersion,
+			"source": map[string]any{
+				"source": "url",
+				"url":    baseURL + "/api/skills/serve/claude-code/plugins/" + pluginNamePrefix + skillSummary.Name,
+			},
+		})
+	}
+	// Bundled "all skills" plugin
+	if len(skills) > 0 {
+		plugins = append(plugins, map[string]any{
+			"name":        allSkillsPluginName,
+			"description": "All Bifrost skills bundled in a single plugin.",
+			"version":     allSkillsVersion,
+			"source": map[string]any{
+				"source": "url",
+				"url":    baseURL + "/api/skills/serve/claude-code/plugins/" + allSkillsPluginName,
+			},
+		})
+	}
+
+	result := map[string]any{
+		"name": "bifrost-skills",
+		"owner": map[string]any{
+			"name": "Bifrost Gateway",
+		},
+		"plugins": plugins,
+	}
+
+	SendJSON(ctx, result)
+}
+
+// codexMarketplace generates GET /api/skills/serve/codex/.codex-plugin/marketplace.json
+func (h *SkillsServingHandler) codexMarketplace(ctx *fasthttp.RequestCtx) {
+	marketplaceJSON, err := h.buildCodexMarketplaceJSON(ctx)
+	if err != nil {
+		return // error already sent
+	}
+	ctx.SetContentType("application/json")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetBody(marketplaceJSON)
+}
+
+// buildCodexMarketplaceJSON builds the Codex marketplace JSON bytes.
+// Shared by both the plain HTTP endpoint and the git-clone endpoint.
+func (h *SkillsServingHandler) buildCodexMarketplaceJSON(ctx *fasthttp.RequestCtx) ([]byte, error) {
+	skills, err := h.listAllSkills(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	allSkillsVersion := "0.0.0"
+	if len(skills) > 0 {
+		allSkillsVersion, err = h.store.GetAllSkillsVersion(ctx)
+		if err != nil {
+			logger.Error("all-skills: failed to get version: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to get all-skills version")
+			return nil, err
+		}
+	}
+
+	baseURL := h.resolveBaseURL(ctx)
+	plugins := make([]map[string]any, 0, len(skills)+1)
+	for _, skillSummary := range skills {
+		plugins = append(plugins, map[string]any{
+			"name":        pluginNamePrefix + skillSummary.Name,
+			"description": skillSummary.Description,
+			"version":     skillSummary.LatestVersion,
+			"source": map[string]any{
+				"source": "url",
+				"url":    baseURL + "/api/skills/serve/codex/plugins/" + pluginNamePrefix + skillSummary.Name,
+			},
+			"policy": map[string]any{
+				"installation":   "AVAILABLE",
+				"authentication": "ON_INSTALL",
+			},
+			"category": "Productivity",
+		})
+	}
+	// Bundled "all skills" plugin
+	if len(skills) > 0 {
+		plugins = append(plugins, map[string]any{
+			"name":        allSkillsPluginName,
+			"description": "All Bifrost skills bundled in a single plugin.",
+			"version":     allSkillsVersion,
+			"source": map[string]any{
+				"source": "url",
+				"url":    baseURL + "/api/skills/serve/codex/plugins/" + allSkillsPluginName,
+			},
+			"policy": map[string]any{
+				"installation":   "AVAILABLE",
+				"authentication": "ON_INSTALL",
+			},
+			"category": "Productivity",
+		})
+	}
+
+	result := map[string]any{
+		"name": "bifrost-skills",
+		"interface": map[string]any{
+			"displayName": "Bifrost Skills",
+		},
+		"plugins": plugins,
+	}
+
+	return json.MarshalIndent(result, "", "  ")
+}
+
+// ============================================================================
+// Git repository abstraction
+// ============================================================================
+
+// GitRepoFile represents a single file to include in a generated git repository.
+type GitRepoFile struct {
+	Path    string // relative path within the repo (e.g. ".claude-plugin/plugin.json")
+	Content []byte
+}
+
+// GitRepoSpec describes the full contents of a git repository to be built.
+// All git serving paths (plugin install, marketplace clone) produce a
+// GitRepoSpec and then feed it through the same buildGitRepo → serveGitRepo
+// pipeline.
+type GitRepoSpec struct {
+	Files []GitRepoFile
+	Label string // human-readable label for error logs (e.g. skill name)
+}
+
+// buildGitRepo creates an in-memory bare git repository from a GitRepoSpec.
+func buildGitRepo(spec *GitRepoSpec) (*memory.Storage, error) {
+	storage := memory.NewStorage()
+	wt := memfs.New()
+	repo, err := git.Init(storage, wt)
+	if err != nil {
+		return nil, fmt.Errorf("git init: %w", err)
+	}
+
+	headRef := plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))
+	err = storage.SetReference(headRef)
+	if err != nil {
+		return nil, fmt.Errorf("set HEAD: %w", err)
+	}
+
+	for _, f := range spec.Files {
+		if err := writeBillyFile(wt, f.Path, f.Content); err != nil {
+			return nil, fmt.Errorf("write %s: %w", f.Path, err)
+		}
+	}
+
+	w, err := repo.Worktree()
+	if err != nil {
+		return nil, fmt.Errorf("get worktree: %w", err)
+	}
+	if _, err := w.Add("."); err != nil {
+		return nil, fmt.Errorf("stage files: %w", err)
+	}
+	// Use a fixed epoch so the same skill data always produces the same commit
+	// hash. Git clone does GET /info/refs then POST /git-upload-pack as two
+	// independent requests — if the commit hash changes between them (e.g. from
+	// time.Now()), the client's "want" hash won't exist in the second repo and
+	// git upload-pack fails with "not our ref".
+	_, err = w.Commit("serve "+spec.Label, &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Bifrost Gateway",
+			Email: "bifrost@getbifrost.ai",
+			When:  time.Unix(0, 0),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+	return storage, nil
+}
+
+// ============================================================================
+// Git repo spec assemblers
+// ============================================================================
+
+// assemblePluginRepoSpec builds a GitRepoSpec for a single skill plugin.
+// Layout:
+//
+//	.<harness>-plugin/plugin.json
+//	skills/<skill-name>/SKILL.md
+//	skills/<skill-name>/<file-path>...
+func (h *SkillsServingHandler) assemblePluginRepoSpec(ctx context.Context, skill *tables.TableSkill, harness string) (*GitRepoSpec, error) {
+	var files []GitRepoFile
+	var totalSize int64
+	addRepoFile := func(repoFile GitRepoFile) error {
+		totalSize += int64(len(repoFile.Content))
+		if totalSize > maxSkillGitRepoSize {
+			return fmt.Errorf("skill repo exceeds %d MB size limit", maxSkillGitRepoSize/(1024*1024))
+		}
+		files = append(files, repoFile)
+		return nil
+	}
+
+	// Plugin manifest
+	manifestDir := manifestDirName(harness)
+	manifestJSON, err := json.MarshalIndent(buildPluginManifest(skill, harness), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal plugin.json: %w", err)
+	}
+	if err := addRepoFile(GitRepoFile{Path: path.Join(manifestDir, "plugin.json"), Content: manifestJSON}); err != nil {
+		return nil, err
+	}
+
+	// SKILL.md
+	if err := addRepoFile(GitRepoFile{
+		Path:    path.Join("skills", skill.Name, "SKILL.md"),
+		Content: []byte(composeSkillMD(skill)),
+	}); err != nil {
+		return nil, err
+	}
+
+	// Attached files
+	for i := range skill.Files {
+		file := &skill.Files[i]
+		data, err := fetchFileContentForArchive(ctx, file, h.objectStore)
+		if err != nil {
+			logger.Error("skill %s: repo spec: failed to fetch file %s: %v", skill.Name, file.Path, err)
+			continue
+		}
+		if err := addRepoFile(GitRepoFile{
+			Path:    path.Join("skills", buildSkillFilePath(skill.Name, file)),
+			Content: data,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return &GitRepoSpec{Files: files, Label: skill.Name + " " + skill.LatestVersion}, nil
+}
+
+// assembleAllSkillsRepoSpec builds a GitRepoSpec bundling every skill into one plugin.
+// Layout:
+//
+//	.<harness>-plugin/plugin.json
+//	skills/<skill-name>/SKILL.md   (for each skill)
+//	skills/<skill-name>/<files>... (for each skill)
+func (h *SkillsServingHandler) assembleAllSkillsRepoSpec(ctx context.Context, harness string) (*GitRepoSpec, error) {
+	skills, _, err := h.store.ListSkills(ctx, configstore.SkillListQueryParams{Limit: 10000, SortBy: "name", Order: "asc"})
+	if err != nil {
+		return nil, fmt.Errorf("list skills: %w", err)
+	}
+	version, err := h.store.GetAllSkillsVersion(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get all-skills version: %w", err)
+	}
+
+	var repoFiles []GitRepoFile
+	var totalSize int64
+	addRepoFile := func(repoFile GitRepoFile) error {
+		totalSize += int64(len(repoFile.Content))
+		if totalSize > maxSkillGitRepoSize {
+			return fmt.Errorf("all-skills repo exceeds %d MB size limit", maxSkillGitRepoSize/(1024*1024))
+		}
+		repoFiles = append(repoFiles, repoFile)
+		return nil
+	}
+
+	// Plugin manifest — reuse buildPluginManifest with a synthetic skill record
+	allSkillsSkill := &tables.TableSkill{
+		Name:          strings.TrimPrefix(allSkillsPluginName, pluginNamePrefix),
+		Description:   "All Bifrost skills bundled in a single plugin.",
+		LatestVersion: version,
+	}
+	manifestDir := manifestDirName(harness)
+	manifestJSON, _ := json.MarshalIndent(buildPluginManifest(allSkillsSkill, harness), "", "  ")
+	if err := addRepoFile(GitRepoFile{Path: path.Join(manifestDir, "plugin.json"), Content: manifestJSON}); err != nil {
+		return nil, err
+	}
+
+	// Each skill's SKILL.md + files
+	for i := range skills {
+		// Fetch full skill with blob data
+		full, err := h.store.GetSkillByName(ctx, skills[i].Name)
+		if err != nil {
+			logger.Error("all-skills: failed to get skill %s: %v", skills[i].Name, err)
+			continue
+		}
+		if err := addRepoFile(GitRepoFile{
+			Path:    path.Join("skills", full.Name, "SKILL.md"),
+			Content: []byte(composeSkillMD(full)),
+		}); err != nil {
+			return nil, err
+		}
+		for j := range full.Files {
+			file := &full.Files[j]
+			data, err := fetchFileContentForArchive(ctx, file, h.objectStore)
+			if err != nil {
+				logger.Error("all-skills: failed to fetch file %s/%s: %v", full.Name, file.Path, err)
+				continue
+			}
+			if err := addRepoFile(GitRepoFile{
+				Path:    path.Join("skills", buildSkillFilePath(full.Name, file)),
+				Content: data,
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &GitRepoSpec{Files: repoFiles, Label: "all-skills"}, nil
+}
+
+// assembleMarketplaceRepoSpec builds a GitRepoSpec for a marketplace git repo.
+// Claude Code: .claude-plugin/marketplace.json
+// Codex:       .agents/plugins/marketplace.json
+func assembleMarketplaceRepoSpec(marketplaceJSON []byte, harness string) *GitRepoSpec {
+	var manifestPath string
+	switch harness {
+	case "codex":
+		manifestPath = ".agents/plugins/marketplace.json"
+	default:
+		manifestPath = path.Join(manifestDirName(harness), "marketplace.json")
+	}
+	return &GitRepoSpec{
+		Files: []GitRepoFile{
+			{Path: manifestPath, Content: marketplaceJSON},
+		},
+		Label: harness + "-marketplace",
+	}
+}
+
+// ============================================================================
+// Git smart HTTP serving via direct git upload-pack
+// ============================================================================
+
+// registerGitRoutes registers Git smart HTTP routes for a given harness.
+func (h *SkillsServingHandler) registerGitRoutes(r *router.Router, harness string) {
+	base := "/api/skills/serve/" + harness + "/plugins/{skill-name}"
+	r.GET(base+"/info/refs", h.servePluginGit(harness))
+	r.POST(base+"/git-upload-pack", h.servePluginGit(harness))
+}
+
+// servePluginGit handles git smart HTTP for per-plugin repos.
+// Plugin names in the URL are prefixed with "bifrost-". The special name
+// "bifrost-all-skills" serves a bundled repo containing every skill.
+func (h *SkillsServingHandler) servePluginGit(harness string) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		rawName := ""
+		if val := ctx.UserValue("skill-name"); val != nil {
+			rawName, _ = val.(string)
+		}
+		if rawName == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "skill name is required")
+			return
+		}
+
+		repoBase := "/api/skills/serve/" + harness + "/plugins/" + rawName
+
+		// Handle the bundled "all skills" plugin.
+		if rawName == allSkillsPluginName {
+			spec, err := h.assembleAllSkillsRepoSpec(ctx, harness)
+			if err != nil {
+				logger.Error("all-skills: failed to assemble repo spec: %v", err)
+				SendError(ctx, fasthttp.StatusInternalServerError, "failed to prepare all-skills plugin")
+				return
+			}
+			serveGitRepo(ctx, spec, repoBase)
+			return
+		}
+
+		// Strip the "bifrost-" prefix to look up the actual skill name.
+		skillName := strings.TrimPrefix(rawName, pluginNamePrefix)
+		skill, err := h.store.GetSkillByName(ctx, skillName)
+		if err != nil {
+			if errors.Is(err, configstore.ErrNotFound) {
+				SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("skill %q not found", skillName))
+				return
+			}
+			logger.Error("failed to get skill %s: %v", skillName, err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to retrieve skill")
+			return
+		}
+
+		spec, err := h.assemblePluginRepoSpec(ctx, skill, harness)
+		if err != nil {
+			logger.Error("skill %s: failed to assemble repo spec: %v", skill.Name, err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to prepare plugin git repository")
+			return
+		}
+
+		serveGitRepo(ctx, spec, repoBase)
+	}
+}
+
+// codexMarketplaceGit returns a handler that serves the Codex marketplace as a
+// git repo. Codex clones the marketplace URL itself (unlike Claude Code which
+// fetches marketplace.json as plain HTTP).
+func (h *SkillsServingHandler) codexMarketplaceGit() fasthttp.RequestHandler {
+	repoBase := "/api/skills/serve/codex"
+	return func(ctx *fasthttp.RequestCtx) {
+		marketplaceJSON, err := h.buildCodexMarketplaceJSON(ctx)
+		if err != nil {
+			return // error already sent
+		}
+
+		spec := assembleMarketplaceRepoSpec(marketplaceJSON, "codex")
+		serveGitRepo(ctx, spec, repoBase)
+	}
+}
+
+// serveGitRepo builds a git repo from a spec and serves it via direct git
+// upload-pack calls (inspired by go-git-http pattern). No CGI layer needed.
+func serveGitRepo(ctx *fasthttp.RequestCtx, spec *GitRepoSpec, repoBase string) {
+	storage, err := buildGitRepo(spec)
+	if err != nil {
+		logger.Error("%s: failed to build git repo: %v", spec.Label, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to build git repository")
+		return
+	}
+
+	tempDir, err := exportToTempBareRepo(storage)
+	if err != nil {
+		logger.Error("%s: failed to export bare repo: %v", spec.Label, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to prepare git repository")
+		return
+	}
+	defer os.RemoveAll(tempDir)
+
+	pathInfo := strings.TrimPrefix(string(ctx.Path()), repoBase)
+	if strings.HasSuffix(pathInfo, "/info/refs") {
+		serveInfoRefs(ctx, tempDir, spec.Label)
+	} else if strings.HasSuffix(pathInfo, "/git-upload-pack") {
+		serveUploadPack(ctx, tempDir, spec.Label)
+	} else {
+		SendError(ctx, fasthttp.StatusNotFound, "unknown git endpoint")
+	}
+}
+
+// serveInfoRefs handles GET /info/refs?service=git-upload-pack by running
+// `git upload-pack --stateless-rpc --advertise-refs` and wrapping the output
+// in the git smart HTTP advertisement format.
+func serveInfoRefs(ctx *fasthttp.RequestCtx, repoDir, label string) {
+	serviceName := string(ctx.QueryArgs().Peek("service"))
+	if serviceName == "" {
+		serviceName = "git-upload-pack"
+	}
+
+	// Only upload-pack is supported (read-only serving).
+	if serviceName != "git-upload-pack" {
+		SendError(ctx, fasthttp.StatusForbidden, "service not available")
+		return
+	}
+
+	// Bind to request context with a timeout so stalled git processes
+	// don't outlive a client disconnect or server shutdown. 30s is generous —
+	// upload-pack on these in-memory repos completes in <1s normally, but we
+	// allow headroom for large all-skills repos under load.
+	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cmdCtx, gitBinaryPath, "upload-pack", "--stateless-rpc", "--advertise-refs", ".") //nolint:gosec // gitBinaryPath is from exec.LookPath
+	cmd.Dir = repoDir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		logger.Error("%s: git upload-pack --advertise-refs failed: %v, stderr: %s", label, err, stderr.String())
+		SendError(ctx, fasthttp.StatusInternalServerError, "git info/refs failed")
+		return
+	}
+
+	ctx.Response.Header.Set("Cache-Control", "no-cache")
+	ctx.SetContentType(fmt.Sprintf("application/x-%s-advertisement", serviceName))
+	ctx.SetStatusCode(fasthttp.StatusOK)
+
+	// Write pkt-line service announcement header, then the advertised refs.
+	ctx.Write(pktLine("# service=" + serviceName + "\n")) //nolint:errcheck
+	ctx.Write(pktFlush())                                 //nolint:errcheck
+	ctx.Write(stdout.Bytes())                             //nolint:errcheck
+}
+
+// serveUploadPack handles POST /git-upload-pack by piping the request body
+// into `git upload-pack --stateless-rpc` and streaming the output back.
+func serveUploadPack(ctx *fasthttp.RequestCtx, repoDir, label string) {
+	// Bind to request context with a timeout so stalled git processes
+	// don't outlive a client disconnect or server shutdown. 30s is generous —
+	// upload-pack on these in-memory repos completes in <1s normally, but we
+	// allow headroom for large all-skills repos under load.
+	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cmdCtx, gitBinaryPath, "upload-pack", "--stateless-rpc", ".") //nolint:gosec // gitBinaryPath is from exec.LookPath
+	cmd.Dir = repoDir
+	cmd.Stdin = bytes.NewReader(ctx.PostBody())
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		logger.Error("%s: git upload-pack failed: %v, stderr: %s", label, err, stderr.String())
+		SendError(ctx, fasthttp.StatusInternalServerError, "git upload-pack failed")
+		return
+	}
+
+	ctx.Response.Header.Set("Cache-Control", "no-cache")
+	ctx.SetContentType("application/x-git-upload-pack-result")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetBody(stdout.Bytes())
+}
+
+// pktLine encodes a string as a git pkt-line (4-hex-digit length prefix + data).
+func pktLine(s string) []byte {
+	return []byte(fmt.Sprintf("%04x%s", len(s)+4, s))
+}
+
+// pktFlush returns the git pkt-line flush packet.
+func pktFlush() []byte {
+	return []byte("0000")
+}
+
+// exportToTempBareRepo exports an in-memory go-git storage to a temporary bare
+// git repository on disk, suitable for use with `git http-backend`.
+func exportToTempBareRepo(memStorage *memory.Storage) (string, error) {
+	tempDir, err := os.MkdirTemp("", "bifrost-skill-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+
+	// Create a bare repo on disk.
+	fs := osfs.New(tempDir)
+	dot, err := fs.Chroot(".")
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return "", fmt.Errorf("chroot: %w", err)
+	}
+	diskStorage := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+
+	if err := diskStorage.Init(); err != nil {
+		os.RemoveAll(tempDir)
+		return "", fmt.Errorf("init bare repo: %w", err)
+	}
+
+	// Copy all objects from memory to disk storage.
+	for _, objType := range []plumbing.ObjectType{plumbing.CommitObject, plumbing.TreeObject, plumbing.BlobObject, plumbing.TagObject} {
+		iter, err := memStorage.IterEncodedObjects(objType)
+		if err != nil {
+			continue
+		}
+		if err := iter.ForEach(func(obj plumbing.EncodedObject) error {
+			_, err := diskStorage.SetEncodedObject(obj)
+			return err
+		}); err != nil {
+			os.RemoveAll(tempDir)
+			return "", fmt.Errorf("copy %s objects: %w", objType, err)
+		}
+	}
+
+	// Copy all references from memory to disk storage.
+	refIter, err := memStorage.IterReferences()
+	if err == nil {
+		if err := refIter.ForEach(func(ref *plumbing.Reference) error {
+			return diskStorage.SetReference(ref)
+		}); err != nil {
+			os.RemoveAll(tempDir)
+			return "", fmt.Errorf("copy references: %w", err)
+		}
+	}
+
+	// Also copy HEAD.
+	head, err := memStorage.Reference(plumbing.HEAD)
+	if err == nil {
+		if err := diskStorage.SetReference(head); err != nil {
+			os.RemoveAll(tempDir)
+			return "", fmt.Errorf("copy HEAD: %w", err)
+		}
+	}
+
+	return tempDir, nil
+}
+
+// writeBillyFile writes data to a file in a billy in-memory filesystem,
+// creating parent directories as needed.
+func writeBillyFile(fs billy.Filesystem, filePath string, data []byte) error {
+	dir := path.Dir(filePath)
+	if dir != "." && dir != "/" {
+		if err := fs.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+	f, err := fs.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", filePath, err)
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	if err != nil {
+		return fmt.Errorf("write %s: %w", filePath, err)
+	}
+	return nil
+}
+
+// ============================================================================
+// Plugin manifest generation
+// ============================================================================
+
+// manifestDirName returns the plugin manifest directory name for a harness.
+// Claude Code uses ".claude-plugin", Codex uses ".codex-plugin".
+func manifestDirName(harness string) string {
+	switch harness {
+	case "claude-code":
+		return ".claude-plugin"
+	case "codex":
+		return ".codex-plugin"
+	default:
+		return "." + harness + "-plugin"
+	}
+}
+
+// buildPluginManifest creates the plugin.json for a given harness.
+func buildPluginManifest(skill *tables.TableSkill, harness string) map[string]any {
+	manifest := map[string]any{
+		"name":        pluginNamePrefix + skill.Name,
+		"description": skill.Description,
+		"version":     skill.LatestVersion,
+	}
+	if harness == "codex" {
+		// Format name for display: replace hyphens with spaces, title case
+		displayName := strings.ReplaceAll(skill.Name, "-", " ")
+		displayName = cases.Title(language.English).String(displayName) // simple title case is fine here
+		manifest["interface"] = map[string]any{
+			"displayName":      displayName,
+			"shortDescription": skill.Description,
+			"category":         "Productivity",
+		}
+	}
+	return manifest
+}
+
+// ============================================================================
+// SKILL.md composition
+// ============================================================================
+
+// composeSkillMD builds the full SKILL.md from DB fields:
+// YAML frontmatter (standard fields → extra_frontmatter → metadata) + body.
+func composeSkillMD(skill *tables.TableSkill) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+
+	// Standard fields first
+	b.WriteString("name: ")
+	b.WriteString(yamlScalar(skill.Name))
+	b.WriteString("\n")
+
+	b.WriteString("description: ")
+	b.WriteString(yamlScalar(skill.Description))
+	b.WriteString("\n")
+
+	if skill.License != nil && *skill.License != "" {
+		b.WriteString("license: ")
+		b.WriteString(yamlScalar(*skill.License))
+		b.WriteString("\n")
+	}
+	if skill.Compatibility != nil && *skill.Compatibility != "" {
+		b.WriteString("compatibility: ")
+		b.WriteString(yamlScalar(*skill.Compatibility))
+		b.WriteString("\n")
+	}
+	if skill.AllowedTools != nil && *skill.AllowedTools != "" {
+		b.WriteString("allowed-tools: ")
+		b.WriteString(yamlScalar(*skill.AllowedTools))
+		b.WriteString("\n")
+	}
+
+	// Extra frontmatter fields spread as top-level YAML keys
+	// Sort keys for deterministic output
+	if len(skill.ExtraFrontmatter) > 0 {
+		extraKeys := make([]string, 0, len(skill.ExtraFrontmatter))
+		for k := range skill.ExtraFrontmatter {
+			if !configstore.IsSkillReservedFrontmatterField(k) {
+				extraKeys = append(extraKeys, k)
+			}
+		}
+		sort.Strings(extraKeys)
+		for _, k := range extraKeys {
+			writeYAMLKeyValue(&b, k, skill.ExtraFrontmatter[k], 0)
+		}
+	}
+
+	// Metadata as nested block
+	if len(skill.Metadata) > 0 {
+		b.WriteString("metadata:\n")
+		metaKeys := make([]string, 0, len(skill.Metadata))
+		for k := range skill.Metadata {
+			metaKeys = append(metaKeys, k)
+		}
+		sort.Strings(metaKeys)
+		for _, k := range metaKeys {
+			b.WriteString("  ")
+			b.WriteString(k)
+			b.WriteString(": ")
+			b.WriteString(yamlMetadataScalar(skill.Metadata[k]))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("---\n")
+	b.WriteString(skill.SkillMDBody)
+
+	return b.String()
+}
+
+// yamlScalar returns a YAML-safe representation of a string value.
+// Always quotes the value to prevent YAML parsers from reinterpreting
+// strings that look like booleans, numbers, dates, or other scalars.
+func yamlScalar(s string) string {
+	if s == "" {
+		return `""`
+	}
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+	escaped = strings.ReplaceAll(escaped, "\r", `\r`)
+	return `"` + escaped + `"`
+}
+
+func yamlMetadataScalar(s string) string {
+	return s
+}
+
+// writeYAMLKeyValue writes a key-value pair to a YAML builder.
+// Handles nested maps and slices with indentation.
+func writeYAMLKeyValue(b *strings.Builder, key string, value any, indent int) {
+	prefix := strings.Repeat("  ", indent)
+	switch v := value.(type) {
+	case map[string]any:
+		b.WriteString(prefix)
+		b.WriteString(key)
+		b.WriteString(":\n")
+		writeYAMLMapEntries(b, v, indent+1)
+	case []any:
+		b.WriteString(prefix)
+		b.WriteString(key)
+		b.WriteString(":\n")
+		writeYAMLListItems(b, v, indent+1)
+	default:
+		b.WriteString(prefix)
+		b.WriteString(key)
+		b.WriteString(": ")
+		switch val := value.(type) {
+		case bool:
+			if val {
+				b.WriteString("true")
+			} else {
+				b.WriteString("false")
+			}
+		case float64:
+			// JSON numbers unmarshal as float64
+			if val == float64(int64(val)) {
+				fmt.Fprintf(b, "%d", int64(val))
+			} else {
+				fmt.Fprintf(b, "%g", val)
+			}
+		case string:
+			b.WriteString(yamlScalar(val))
+		default:
+			b.WriteString(yamlScalar(fmt.Sprintf("%v", value)))
+		}
+		b.WriteString("\n")
+	}
+}
+
+func writeYAMLMapEntries(b *strings.Builder, values map[string]any, indent int) {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeYAMLKeyValue(b, k, values[k], indent)
+	}
+}
+
+func writeYAMLListItems(b *strings.Builder, values []any, indent int) {
+	prefix := strings.Repeat("  ", indent)
+	for _, item := range values {
+		switch elem := item.(type) {
+		case map[string]any:
+			b.WriteString(prefix)
+			b.WriteString("-\n")
+			writeYAMLMapEntries(b, elem, indent+1)
+		case []any:
+			b.WriteString(prefix)
+			b.WriteString("-\n")
+			writeYAMLListItems(b, elem, indent+1)
+		default:
+			b.WriteString(prefix)
+			b.WriteString("- ")
+			writeYAMLInlineValue(b, elem)
+			b.WriteString("\n")
+		}
+	}
+}
+
+// writeYAMLInlineValue writes a scalar value inline (no key prefix, no newline).
+// Used for scalar values inside arrays.
+func writeYAMLInlineValue(b *strings.Builder, value any) {
+	switch v := value.(type) {
+	case bool:
+		if v {
+			b.WriteString("true")
+		} else {
+			b.WriteString("false")
+		}
+	case float64:
+		if v == float64(int64(v)) {
+			fmt.Fprintf(b, "%d", int64(v))
+		} else {
+			fmt.Fprintf(b, "%g", v)
+		}
+	case string:
+		b.WriteString(yamlScalar(v))
+	default:
+		b.WriteString(yamlScalar(fmt.Sprintf("%v", value)))
+	}
+}
+
+// ============================================================================
+// Individual file serving
+// ============================================================================
+
+// genericFileDownload serves GET /api/skills/serve/{skill-name}/files/{filepath:*}
+func (h *SkillsServingHandler) genericFileDownload(ctx *fasthttp.RequestCtx) {
+	h.doServeFileContent(ctx)
+}
+
+func (h *SkillsServingHandler) doServeFileContent(ctx *fasthttp.RequestCtx) {
+	skill, ok := h.lookupSkillByPathParam(ctx)
+	if !ok {
+		return
+	}
+
+	filePath := ""
+	if val := ctx.UserValue("filepath"); val != nil {
+		filePath, _ = val.(string)
+	}
+	if filePath == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "file path is required")
+		return
+	}
+
+	// Find matching file
+	var matchedFile *tables.TableSkillFile
+	for i := range skill.Files {
+		f := &skill.Files[i]
+		if f.NormalizedPath() == filePath {
+			matchedFile = f
+			break
+		}
+	}
+
+	if matchedFile == nil {
+		SendError(ctx, fasthttp.StatusNotFound, "file not found")
+		return
+	}
+
+	serveSkillFile(ctx, matchedFile, h.objectStore, skill.Name)
+}
+
+// serveSkillFile streams file content based on source type.
+func serveSkillFile(ctx *fasthttp.RequestCtx, file *tables.TableSkillFile, objStore objectstore.ObjectStore, skillName string) {
+	if file.MimeType != "" {
+		ctx.SetContentType(file.MimeType)
+	} else {
+		ctx.SetContentType("application/octet-stream")
+	}
+	ctx.Response.Header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, path.Base(file.Path)))
+
+	switch file.SourceType {
+	case tables.SkillSourceTypeURL:
+		if file.SourceURL == nil || *file.SourceURL == "" {
+			logger.Error("skill %s file %s: url source has no source_url", skillName, file.Path)
+			SendError(ctx, fasthttp.StatusInternalServerError, "file source URL not configured")
+			return
+		}
+		data, err := fetchURLSafe(ctx, *file.SourceURL)
+		if err != nil {
+			logger.Error("skill %s file %s: failed to fetch from URL %s: %v", skillName, file.Path, redactURLForLog(*file.SourceURL), err)
+			SendError(ctx, fasthttp.StatusBadGateway, "failed to fetch file from source URL")
+			return
+		}
+		ctx.SetStatusCode(fasthttp.StatusOK)
+		ctx.SetBody(data)
+
+	case tables.SkillSourceTypeText, tables.SkillSourceTypeDataURL, tables.SkillSourceTypeUpload:
+		data, err := fetchStoredFileContent(ctx, file, objStore)
+		if err != nil {
+			logger.Error("skill %s file %s: failed to retrieve stored content: %v", skillName, file.Path, err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to retrieve file content")
+			return
+		}
+		ctx.SetStatusCode(fasthttp.StatusOK)
+		ctx.SetBody(data)
+
+	default:
+		SendError(ctx, fasthttp.StatusInternalServerError, "unsupported file source type")
+	}
+}
+
+func redactURLForLog(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+// fetchStoredFileContent retrieves file bytes from object storage or DB blob.
+func fetchStoredFileContent(ctx context.Context, file *tables.TableSkillFile, objStore objectstore.ObjectStore) ([]byte, error) {
+	// Try object storage first; fall back to DB blob if object store
+	// fails (e.g. files created before object store was configured still
+	// have their data in the blob table).
+	if objStore != nil && file.StorageKey != nil && *file.StorageKey != "" {
+		data, err := objStore.Get(ctx, *file.StorageKey)
+		if err == nil {
+			return data, nil
+		}
+		logger.Warn("object store get failed for key %s, falling back to blob: %v", *file.StorageKey, err)
+	}
+	// Fall back to DB blob
+	if file.Blob != nil {
+		return file.Blob.Data, nil
+	}
+	if file.BlobID != nil && *file.BlobID != "" {
+		return nil, fmt.Errorf("blob_id set but blob data not preloaded (blob_id=%s)", *file.BlobID)
+	}
+	return nil, fmt.Errorf("no storage_key or blob_id available for file %s", file.Path)
+}
+
+// fetchFileContentForArchive retrieves file bytes for archive generation.
+// Same logic as serveSkillFile but returns bytes instead of writing to response.
+func fetchFileContentForArchive(ctx context.Context, file *tables.TableSkillFile, objStore objectstore.ObjectStore) ([]byte, error) {
+	switch file.SourceType {
+	case tables.SkillSourceTypeURL:
+		if file.SourceURL == nil || *file.SourceURL == "" {
+			return nil, fmt.Errorf("url source has no source_url")
+		}
+		return fetchURLSafe(ctx, *file.SourceURL)
+
+	case tables.SkillSourceTypeText, tables.SkillSourceTypeDataURL, tables.SkillSourceTypeUpload:
+		// Handle transient pre-storage content (available at create/update time
+		// before files are persisted to blob/object storage).
+		if file.InlineContent != nil && *file.InlineContent != "" {
+			return []byte(*file.InlineContent), nil
+		}
+		if file.DataURL != nil && *file.DataURL != "" {
+			parts := strings.SplitN(*file.DataURL, ",", 2)
+			if len(parts) == 2 {
+				if strings.Contains(parts[0], ";base64") {
+					data, err := base64.StdEncoding.DecodeString(parts[1])
+					if err == nil {
+						return data, nil
+					}
+				} else {
+					// Plain data URL payloads are percent-encoded; '+' remains literal here.
+					data, err := url.PathUnescape(parts[1])
+					if err != nil {
+						return nil, fmt.Errorf("dataurl percent decode failed: %w", err)
+					}
+					return []byte(data), nil
+				}
+			}
+		}
+		return fetchStoredFileContent(ctx, file, objStore)
+
+	default:
+		return nil, fmt.Errorf("unsupported source type %s", file.SourceType)
+	}
+}
+
+// ============================================================================
+// Generic zip download
+// ============================================================================
+
+// allSkillsZipDownload serves GET /api/skills/serve/all/download.zip
+// Returns a zip archive containing all skills.
+func (h *SkillsServingHandler) allSkillsZipDownload(ctx *fasthttp.RequestCtx) {
+	skills, err := h.listAllSkills(ctx)
+	if err != nil {
+		logger.Error("all-skills zip: failed to list skills: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to list skills")
+		return
+	}
+
+	ctx.SetContentType("application/zip")
+	ctx.Response.Header.Set("Content-Disposition", `attachment; filename="all-skills.zip"`)
+	ctx.SetStatusCode(fasthttp.StatusOK)
+
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	requestDone := ctx.Done()
+	go func() {
+		select {
+		case <-requestDone:
+			cancelStream()
+		case <-streamCtx.Done():
+		}
+	}()
+
+	// Stream the zip directly to the response -- no full in-memory buffer.
+	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+		defer cancelStream()
+		zw := zip.NewWriter(w)
+
+		for _, s := range skills {
+			full, err := h.store.GetSkillByName(streamCtx, s.Name)
+			if err != nil {
+				logger.Error("all-skills zip: failed to get skill %s: %v", s.Name, err)
+				continue
+			}
+			composed := composeSkillMD(full)
+			if err := writeZipEntry(zw, path.Join(full.Name, "SKILL.md"), []byte(composed)); err != nil {
+				logger.Error("all-skills zip: failed to write skill %s manifest: %v", full.Name, err)
+				return
+			}
+
+			for i := range full.Files {
+				file := &full.Files[i]
+				data, err := fetchFileContentForArchive(streamCtx, file, h.objectStore)
+				if err != nil {
+					continue
+				}
+				filePath := buildSkillFilePath(full.Name, file)
+				if err := writeZipEntry(zw, filePath, data); err != nil {
+					logger.Error("all-skills zip: failed to write file %s/%s: %v", full.Name, file.Path, err)
+					return
+				}
+			}
+			// Flush after each skill so data trickles to the client
+			// instead of buffering the entire archive.
+			if err := w.Flush(); err != nil {
+				logger.Error("all-skills zip: failed to flush response: %v", err)
+				return
+			}
+		}
+
+		if err := zw.Close(); err != nil {
+			logger.Error("all-skills zip: failed to close zip: %v", err)
+			return
+		}
+		if err := w.Flush(); err != nil {
+			logger.Error("all-skills zip: failed to flush response: %v", err)
+		}
+	})
+}
+
+// genericZipDownload serves GET /api/skills/serve/{skill-name}/download.zip
+// Returns a raw Agent Skills directory zip without the plugin wrapper.
+func (h *SkillsServingHandler) genericZipDownload(ctx *fasthttp.RequestCtx) {
+	skill, ok := h.lookupSkillByPathParam(ctx)
+	if !ok {
+		return
+	}
+
+	ctx.SetContentType("application/zip")
+	ctx.Response.Header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.zip"`, skill.Name))
+	ctx.SetStatusCode(fasthttp.StatusOK)
+
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	requestDone := ctx.Done()
+	go func() {
+		select {
+		case <-requestDone:
+			cancelStream()
+		case <-streamCtx.Done():
+		}
+	}()
+
+	// Stream the zip directly to the response -- no full in-memory buffer.
+	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+		defer cancelStream()
+		zw := zip.NewWriter(w)
+
+		// Write SKILL.md
+		composed := composeSkillMD(skill)
+		if err := writeZipEntry(zw, path.Join(skill.Name, "SKILL.md"), []byte(composed)); err != nil {
+			logger.Error("skill %s: zip: failed to write manifest: %v", skill.Name, err)
+			return
+		}
+
+		// Write files
+		for i := range skill.Files {
+			file := &skill.Files[i]
+			data, err := fetchFileContentForArchive(streamCtx, file, h.objectStore)
+			if err != nil {
+				logger.Error("skill %s: zip: failed to fetch file %s: %v", skill.Name, file.Path, err)
+				continue
+			}
+
+			filePath := buildSkillFilePath(skill.Name, file)
+			if err := writeZipEntry(zw, filePath, data); err != nil {
+				logger.Error("skill %s: zip: failed to write file %s: %v", skill.Name, file.Path, err)
+				return
+			}
+			// Flush after each file so data trickles to the client.
+			if err := w.Flush(); err != nil {
+				logger.Error("skill %s: zip: failed to flush response: %v", skill.Name, err)
+				return
+			}
+		}
+
+		if err := zw.Close(); err != nil {
+			logger.Error("skill %s: failed to close zip: %v", skill.Name, err)
+			return
+		}
+		if err := w.Flush(); err != nil {
+			logger.Error("skill %s: zip: failed to flush response: %v", skill.Name, err)
+		}
+	})
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+func writeZipEntry(zw *zip.Writer, name string, data []byte) error {
+	fw, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	if _, err := fw.Write(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+// buildSkillFilePath computes the relative file path within the skill directory.
+// e.g., <skill-name>/nested/path/file.py
+func buildSkillFilePath(skillName string, file *tables.TableSkillFile) string {
+	return path.Join(skillName, file.Path)
+}
+
+// lookupSkillByPathParam extracts the skill-name path parameter and fetches the skill.
+func (h *SkillsServingHandler) lookupSkillByPathParam(ctx *fasthttp.RequestCtx) (*tables.TableSkill, bool) {
+	val := ctx.UserValue("skill-name")
+	if val == nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "skill name is required")
+		return nil, false
+	}
+	name, ok := val.(string)
+	if !ok || name == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid skill name")
+		return nil, false
+	}
+
+	skill, err := h.store.GetSkillByName(ctx, name)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("skill %q not found", name))
+			return nil, false
+		}
+		logger.Error("failed to get skill %s: %v", name, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to retrieve skill")
+		return nil, false
+	}
+	return skill, true
+}
+
+// listAllSkills fetches all skills for marketplace generation.
+func (h *SkillsServingHandler) listAllSkills(ctx *fasthttp.RequestCtx) ([]tables.TableSkill, error) {
+	// Use a large limit to get all skills for the marketplace catalog
+	skills, _, err := h.store.ListSkills(ctx, configstore.SkillListQueryParams{Limit: 10000, SortBy: "name", Order: "asc"})
+	if err != nil {
+		logger.Error("failed to list skills for marketplace: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to list skills")
+		return nil, err
+	}
+	return skills, nil
+}
+
+// resolveBaseURL derives the base URL from the request's Host header and scheme.
+func (h *SkillsServingHandler) resolveBaseURL(ctx *fasthttp.RequestCtx) string {
+	scheme := string(ctx.Request.Header.Peek("X-Forwarded-Proto"))
+	if scheme == "" {
+		if ctx.IsTLS() {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	host := string(ctx.Request.Header.Peek("X-Forwarded-Host"))
+	if host == "" {
+		host = string(ctx.Host())
+	}
+
+	return scheme + "://" + host
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -37,6 +37,7 @@ import (
 	"github.com/maximhq/bifrost/framework/mcpcatalog"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/framework/oauth2"
+	"github.com/maximhq/bifrost/framework/objectstore"
 	plugins "github.com/maximhq/bifrost/framework/plugins"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"github.com/maximhq/bifrost/plugins/compat"
@@ -178,6 +179,37 @@ type ConfigData struct {
 
 	presentSections           map[string]bool
 	presentGovernanceSections map[string]bool
+	SkillsRegistry            *SkillsRegistryConfig `json:"skills_registry,omitempty"`
+}
+
+// SkillsRegistryConfig defines declarative skill definitions in config.json.
+type SkillsRegistryConfig struct {
+	Enabled *bool                 `json:"enabled,omitempty"`
+	Skills  []SkillsRegistryEntry `json:"skills,omitempty"`
+}
+
+// SkillsRegistryEntry describes a single skill to reconcile from config.json.
+type SkillsRegistryEntry struct {
+	Name             string                 `json:"name"`
+	Description      string                 `json:"description"`
+	License          string                 `json:"license,omitempty"`
+	Compatibility    string                 `json:"compatibility,omitempty"`
+	AllowedTools     string                 `json:"allowed_tools,omitempty"`
+	ExtraFrontmatter map[string]interface{} `json:"extra_frontmatter,omitempty"`
+	Metadata         map[string]string      `json:"metadata,omitempty"`
+	SkillMDBody      string                 `json:"skill_md_body"`
+	Version          string                 `json:"version"`
+	Files            []SkillsRegistryFile   `json:"files,omitempty"`
+}
+
+// SkillsRegistryFile describes a file attached to a config-defined skill.
+type SkillsRegistryFile struct {
+	Path       string `json:"path"`
+	SourceType string `json:"source_type"`
+	// Source-type-specific fields
+	URL     string `json:"url,omitempty"` // for source_type "url"
+	Content  string `json:"content,omitempty"`  // for source_type "text"
+	DataURL  string `json:"dataurl,omitempty"`  // for source_type "dataurl"
 }
 
 // FeatureFlagsFileConfig is the config.json / Helm shape for feature flag
@@ -355,6 +387,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 		Plugins           []*schemas.PluginConfig               `json:"plugins,omitempty"`
 		WebSocket         *schemas.WebSocketConfig              `json:"websocket,omitempty"`
 		FeatureFlags      *FeatureFlagsFileConfig               `json:"feature_flags,omitempty"`
+		SkillsRegistry    *SkillsRegistryConfig                 `json:"skills_registry,omitempty"`
 	}
 
 	var temp TempConfigData
@@ -385,6 +418,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 			}
 		}
 	}
+	cd.SkillsRegistry = temp.SkillsRegistry
 	// Initialize providers map if nil
 	if cd.Providers == nil {
 		cd.Providers = make(map[string]configstore.ProviderConfig)
@@ -450,6 +484,7 @@ type Config struct {
 	ConfigStore configstore.ConfigStore
 	VectorStore vectorstore.VectorStore
 	LogsStore   logstore.LogStore
+	ObjectStore objectstore.ObjectStore
 
 	// In-memory storage
 	ServerConfig     *ServerConfig
@@ -837,11 +872,13 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 	loadAuthConfig(ctx, config, &configData)
 	// 9. Plugins
 	loadPlugins(ctx, config, &configData)
-	// 10. Framework config and pricing manager
+	// 10. Skills registry (after plugins, before framework)
+	loadSkillsRegistry(ctx, config, &configData)
+	// 11. Framework config and pricing manager
 	initFrameworkConfig(ctx, config, &configData)
-	// 11. Encryption sync
+	// 12. Encryption sync
 	syncEncryption(ctx, config)
-	// 12. WebSocket defaults
+	// 13. WebSocket defaults
 	if configData.WebSocket != nil {
 		configData.WebSocket.CheckAndSetDefaults()
 		config.WebSocketConfig = configData.WebSocket
@@ -903,6 +940,9 @@ func initStores(ctx context.Context, config *Config, configData *ConfigData, con
 		if err != nil {
 			return err
 		}
+		if err := initSkillsObjectStore(ctx, config, configData.LogsStoreConfig); err != nil {
+			return err
+		}
 		logger.Info("logs store initialized")
 	} else if configData.LogsStoreConfig == nil {
 		// No logs store section — check DB for stored config (if available), then fall back to default SQLite
@@ -952,6 +992,9 @@ func initStores(ctx context.Context, config *Config, configData *ConfigData, con
 			}
 		}
 		logger.Info("logs store initialized")
+		if err := initSkillsObjectStore(ctx, config, logStoreConfig); err != nil {
+			return err
+		}
 		if config.ConfigStore != nil {
 			if err = config.ConfigStore.UpdateLogsStoreConfig(ctx, logStoreConfig); err != nil {
 				return fmt.Errorf("failed to update logs store config: %w", err)
@@ -4779,9 +4822,33 @@ func (c *Config) Close(ctx context.Context) {
 	if c.LogsStore != nil {
 		c.LogsStore.Close(ctx)
 	}
+	if c.ObjectStore != nil {
+		if err := c.ObjectStore.Close(); err != nil {
+			logger.Warn("failed to close object store: %v", err)
+		}
+	}
 	if c.VectorStore != nil {
 		c.VectorStore.Close(ctx, "")
 	}
+}
+
+func initSkillsObjectStore(ctx context.Context, config *Config, logStoreConfig *logstore.Config) error {
+	if config == nil || config.ObjectStore != nil || logStoreConfig == nil || logStoreConfig.ObjectStorage == nil {
+		return nil
+	}
+	objStore, err := objectstore.NewObjectStore(ctx, logStoreConfig.ObjectStorage, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create skills object store: %w", err)
+	}
+	pingCtx, pingCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer pingCancel()
+	if err := objStore.Ping(pingCtx); err != nil {
+		_ = objStore.Close()
+		return fmt.Errorf("failed to ping skills object store: %w", err)
+	}
+	config.ObjectStore = objStore
+	logger.Info("skills object store initialized")
+	return nil
 }
 
 // initFeatureFlags constructs the feature flag store and applies overrides

--- a/transports/bifrost-http/lib/config_skills.go
+++ b/transports/bifrost-http/lib/config_skills.go
@@ -1,0 +1,232 @@
+package lib
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+)
+
+// loadSkillsRegistry reconciles config-defined skills with the database on startup.
+func loadSkillsRegistry(ctx context.Context, config *Config, configData *ConfigData) {
+	if config.ConfigStore == nil {
+		return
+	}
+	if configData.SkillsRegistry == nil || len(configData.SkillsRegistry.Skills) == 0 {
+		return
+	}
+	// If enabled is explicitly set to false, skip
+	if configData.SkillsRegistry.Enabled != nil && !*configData.SkillsRegistry.Enabled {
+		return
+	}
+	reconcileSkillsRegistry(ctx, config.ConfigStore, configData.SkillsRegistry.Skills, config.ObjectStore)
+}
+
+// reconcileSkillsRegistry processes each config-defined skill entry: creates missing skills
+// or appends a new version if the definition changed and the provided version is valid.
+func reconcileSkillsRegistry(ctx context.Context, store configstore.ConfigStore, entries []SkillsRegistryEntry, objStore objectstore.ObjectStore) {
+	// Preflight: reject duplicate skill names before any writes.
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if _, dup := seen[entry.Name]; dup {
+			logger.Error("skills_registry: duplicate skill name %q in config — skipping entire skills_registry reconciliation", entry.Name)
+			return
+		}
+		seen[entry.Name] = struct{}{}
+	}
+
+	for i := range entries {
+		entry := &entries[i]
+		if err := reconcileOneSkill(ctx, store, entry, objStore); err != nil {
+			logger.Error("skills_registry: skill %q: %v", entry.Name, err)
+		}
+	}
+}
+
+func reconcileOneSkill(ctx context.Context, store configstore.ConfigStore, entry *SkillsRegistryEntry, objStore objectstore.ObjectStore) error {
+	// Reject upload source type in config — it requires the interactive/API upload flow
+	for _, f := range entry.Files {
+		if f.SourceType == configstoreTables.SkillSourceTypeUpload {
+			return fmt.Errorf("source_type \"upload\" is not supported in config.json; use dataurl, text, or url instead (file %q)", f.Path)
+		}
+	}
+
+	// Compute config hash first (cheap, in-memory) so we can skip unchanged
+	// entries before doing any network I/O (e.g. HEAD requests for URL files).
+	configHash, err := generateSkillRegistryEntryHash(entry)
+	if err != nil {
+		return fmt.Errorf("failed to generate config hash: %w", err)
+	}
+
+	// Check if skill already exists
+	existing, err := store.GetSkillByName(ctx, entry.Name)
+	if err != nil && err != configstore.ErrNotFound {
+		return fmt.Errorf("failed to look up existing skill: %w", err)
+	}
+
+	// Early exit on hash match — avoids file conversion, validation, and
+	// network I/O (URL MIME inference) when the config entry hasn't changed.
+	if existing != nil {
+		switch existing.ConfigHash {
+		case "":
+			// Skill was created via API/dashboard and is now appearing in config.json.
+			// Config takes ownership — warn so operators know the API-managed content
+			// is being superseded.
+			logger.Warn("skills_registry: skill %q was created via API/dashboard; config.json is now managing it", entry.Name)
+		case configHash:
+			logger.Debug("skills_registry: skill %q unchanged (hash match), skipping", entry.Name)
+			return nil
+		}
+	}
+
+	// Config changed, new skill, or claiming an API-created skill —
+	// now resolve files (may issue HEAD requests for URL sources).
+	skill := configEntryToTableSkill(entry)
+	files := configEntryToTableFiles(ctx, entry)
+
+	// Validate using the same pipeline as the management API
+	if err := configstore.ValidateSkill(&skill, entry.Version); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+	seenPaths := make(map[string]struct{}, len(files))
+	for i := range files {
+		if err := configstore.ValidateSkillFile(&files[i]); err != nil {
+			return fmt.Errorf("file %q validation failed: %w", files[i].Path, err)
+		}
+		if _, dup := seenPaths[files[i].Path]; dup {
+			return fmt.Errorf("duplicate file path %q", files[i].Path)
+		}
+		seenPaths[files[i].Path] = struct{}{}
+	}
+
+	if existing == nil {
+		// Skill does not exist — create with the provided version
+		skill.ConfigHash = configHash
+		skill.Files = files
+		if err := store.CreateSkill(ctx, &skill, entry.Version, objStore); err != nil {
+			return fmt.Errorf("failed to create skill: %w", err)
+		}
+		logger.Info("skills_registry: created skill %q version %s", entry.Name, entry.Version)
+		return nil
+	}
+
+	// Publish a new version and serve it directly.
+	skill.ID = existing.ID
+	skill.Files = files
+	if err := store.UpdateSkill(ctx, &skill, entry.Version, true, objStore); err != nil {
+		// If the version already exists or is behind, the config entry cannot be applied.
+		// Persist the config hash so subsequent restarts see a match and skip cleanly,
+		// avoiding noisy errors on every boot.
+		if strings.Contains(err.Error(), "already matches the latest version") ||
+			strings.Contains(err.Error(), "already exists in version history") {
+			if hashErr := store.UpdateSkillConfigHash(ctx, existing.ID, configHash); hashErr != nil {
+				logger.Warn("skills_registry: skill %q: version %q already exists but failed to update config hash: %v", entry.Name, entry.Version, hashErr)
+			} else {
+				logger.Info("skills_registry: skill %q: version %q already exists, adopted by config", entry.Name, entry.Version)
+			}
+			return nil
+		}
+		// Validation failure (e.g. version goes backwards) — do nothing, log and move on.
+		return fmt.Errorf("failed to update skill (check version %q against latest): %w", entry.Version, err)
+	}
+
+	// Version created successfully — update config hash.
+	if hashErr := store.UpdateSkillConfigHash(ctx, existing.ID, configHash); hashErr != nil {
+		logger.Warn("skills_registry: skill %q: version %s created but failed to update config hash: %v", entry.Name, entry.Version, hashErr)
+	}
+
+	logger.Info("skills_registry: updated skill %q to version %s", entry.Name, entry.Version)
+	return nil
+}
+
+// configEntryToTableSkill converts a SkillsRegistryEntry to a TableSkill.
+func configEntryToTableSkill(entry *SkillsRegistryEntry) configstoreTables.TableSkill {
+	skill := configstoreTables.TableSkill{
+		Name:             entry.Name,
+		Description:      entry.Description,
+		SkillMDBody:      entry.SkillMDBody,
+		Metadata:         configstoreTables.SkillStringMap(entry.Metadata),
+		ExtraFrontmatter: configstoreTables.SkillJSONMap(entry.ExtraFrontmatter),
+	}
+	if entry.License != "" {
+		skill.License = &entry.License
+	}
+	if entry.Compatibility != "" {
+		skill.Compatibility = &entry.Compatibility
+	}
+	if entry.AllowedTools != "" {
+		skill.AllowedTools = &entry.AllowedTools
+	}
+	return skill
+}
+
+// configEntryToTableFiles converts config file entries to TableSkillFile entries.
+func configEntryToTableFiles(ctx context.Context, entry *SkillsRegistryEntry) []configstoreTables.TableSkillFile {
+	files := make([]configstoreTables.TableSkillFile, 0, len(entry.Files))
+	for _, cf := range entry.Files {
+		file := configstoreTables.TableSkillFile{
+			Path:       cf.Path,
+			SourceType: cf.SourceType,
+		}
+		switch cf.SourceType {
+		case configstoreTables.SkillSourceTypeURL:
+			file.SourceURL = &cf.URL
+			if mimeType, err := inferConfigLiveURLMimeType(ctx, cf.URL); err != nil {
+				logger.Warn("skills_registry: skill %q file %q: could not infer MIME from URL %q: %v; using application/octet-stream", entry.Name, cf.Path, cf.URL, err)
+				file.MimeType = "application/octet-stream"
+			} else {
+				file.MimeType = mimeType
+			}
+		case configstoreTables.SkillSourceTypeText:
+			file.InlineContent = &cf.Content
+			file.MimeType = "text/plain"
+		case configstoreTables.SkillSourceTypeDataURL:
+			file.DataURL = &cf.DataURL
+		}
+		files = append(files, file)
+	}
+	return files
+}
+
+func inferConfigLiveURLMimeType(ctx context.Context, rawURL string) (string, error) {
+	client := http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("HEAD returned status %d", resp.StatusCode)
+	}
+	mimeType := strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])
+	if mimeType == "" {
+		return "", fmt.Errorf("HEAD response did not include Content-Type")
+	}
+	return mimeType, nil
+}
+
+// generateSkillRegistryEntryHash produces a deterministic SHA-256 hash of a config
+// entry so that unchanged entries are not re-applied on every restart.
+func generateSkillRegistryEntryHash(entry *SkillsRegistryEntry) (string, error) {
+	// Marshal the entire entry to JSON for a deterministic content hash.
+	// json.Marshal sorts map keys alphabetically (since Go 1.12), so the
+	// output is stable across restarts for the same Go values.
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:]), nil
+}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -373,6 +373,7 @@ import (
 	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/objectstore"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"github.com/maximhq/bifrost/plugins/governance/complexity"
 	otelPlugin "github.com/maximhq/bifrost/plugins/otel"
@@ -1846,6 +1847,66 @@ func (m *MockConfigStore) CreatePromptVersion(ctx context.Context, version *tabl
 	return nil
 }
 func (m *MockConfigStore) DeletePromptVersion(ctx context.Context, id uint) error { return nil }
+
+// Skills Repository
+func (m *MockConfigStore) CreateSkill(ctx context.Context, skill *tables.TableSkill, version string, objectStore objectstore.ObjectStore) error {
+	return nil
+}
+
+func (m *MockConfigStore) GetSkill(ctx context.Context, id string) (*tables.TableSkill, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) GetSkillLean(ctx context.Context, id string) (*tables.TableSkill, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) GetSkillByName(ctx context.Context, name string) (*tables.TableSkill, error) {
+	return nil, configstore.ErrNotFound
+}
+
+func (m *MockConfigStore) GetSkillVersion(ctx context.Context, skillID, version string) (*tables.TableSkillVersion, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) ListSkillVersions(ctx context.Context, skillID string, params configstore.SkillVersionListQueryParams) ([]tables.TableSkillVersion, int64, error) {
+	return nil, 0, nil
+}
+
+func (m *MockConfigStore) UpdateSkill(ctx context.Context, skill *tables.TableSkill, version string, serve bool, objectStore objectstore.ObjectStore) error {
+	return nil
+}
+
+func (m *MockConfigStore) DeleteSkill(ctx context.Context, id string, objectStore objectstore.ObjectStore) error {
+	return nil
+}
+
+func (m *MockConfigStore) ListSkills(ctx context.Context, params configstore.SkillListQueryParams) ([]tables.TableSkill, int64, error) {
+	return nil, 0, nil
+}
+
+func (m *MockConfigStore) ShiftSkillVersion(ctx context.Context, skillID string, targetVersion string, objectStore objectstore.ObjectStore) error {
+	return nil
+}
+
+func (m *MockConfigStore) GetAllSkillsVersion(ctx context.Context) (string, error) {
+	return "1.0.0", nil
+}
+
+func (m *MockConfigStore) BumpAllSkillsVersion(ctx context.Context, bump string) (string, error) {
+	return "1.0.1", nil
+}
+
+func (m *MockConfigStore) CreateSkillFileBlob(ctx context.Context, blob *tables.TableSkillFileBlob) error {
+	return nil
+}
+
+func (m *MockConfigStore) CleanupOrphanSkillFileBlobs(ctx context.Context, force bool) (int64, error) {
+	return 0, nil
+}
+func (m *MockConfigStore) UpdateSkillConfigHash(ctx context.Context, skillID string, configHash string) error {
+	return nil
+}
 
 // Prompt Repository - Sessions
 func (m *MockConfigStore) GetPromptSessions(ctx context.Context, promptID string) ([]tables.TablePromptSession, error) {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1411,6 +1411,14 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	if promptsHandler != nil {
 		promptsHandler.RegisterRoutes(s.Router, middlewares...)
 	}
+	skillsHandler := handlers.NewSkillsHandler(s.Config.ConfigStore, s.Config.ObjectStore)
+	if skillsHandler != nil {
+		skillsHandler.RegisterRoutes(s.Router, middlewares...)
+	}
+	skillsServingHandler := handlers.NewSkillsServingHandler(s.Config.ConfigStore, s.Config.ObjectStore)
+	if skillsServingHandler != nil {
+		skillsServingHandler.RegisterRoutes(s.Router, middlewares...)
+	}
 	cacheHandler.RegisterRoutes(s.Router, middlewares...)
 	if featureFlagsHandler != nil {
 		featureFlagsHandler.RegisterRoutes(s.Router, middlewares...)
@@ -1534,6 +1542,25 @@ func (s *BifrostHTTPServer) PrepareCommonMiddlewares() []schemas.BifrostHTTPMidd
 		}
 	})
 	return commonMiddlewares
+}
+
+func startSkillsOrphanCleanupWorker(ctx context.Context, config *lib.Config) {
+	if config == nil || config.ConfigStore == nil {
+		return
+	}
+
+	// Run once on startup asynchronously with a 10-minute timeout so a stalled
+	// DB or object-store call does not leave the goroutine hanging indefinitely.
+	go func() {
+		cleanupCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
+		result, err := handlers.CleanupOrphanSkillFiles(cleanupCtx, config.ConfigStore, config.ObjectStore, false)
+		if err != nil {
+			logger.Warn("skills orphan cleanup failed during startup: %v", err)
+		} else {
+			logger.Info("skills orphan cleanup completed during startup: deleted_db_blobs=%d deleted_storage_objects=%d", result.DeletedDBBlobs, result.DeletedStorageObjects)
+		}
+	}()
 }
 
 // Bootstrap initializes the Bifrost HTTP server with all necessary components.
@@ -1782,6 +1809,12 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		}
 		return fmt.Errorf("failed to initialize inference routes: %v", err)
 	}
+	// Serve a minimal robots.txt so crawlers/CLI tools (e.g. Claude Code) don't
+	// trigger 404 warnings when probing the host before marketplace fetches.
+	s.Router.GET("/robots.txt", func(ctx *fasthttp.RequestCtx) {
+		ctx.SetContentType("text/plain; charset=utf-8")
+		ctx.SetBodyString("User-agent: *\nAllow: /\n")
+	})
 	// Register UI handler
 	s.RegisterUIRoutes()
 	// Checking if config has server config and use it to set read buffer size
@@ -1792,6 +1825,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		MaxRequestBodySize: s.Config.ClientConfig.MaxRequestBodySizeMB * 1024 * 1024,
 		ReadBufferSize:     s.Config.ServerConfig.ReadBufferSize,
 	}
+	startSkillsOrphanCleanupWorker(s.Ctx, s.Config)
 	return nil
 }
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1287,6 +1287,75 @@
       },
       "additionalProperties": false
     },
+    "skills_registry": {
+      "type": "object",
+      "description": "Declarative Skills Repository definitions reconciled from config.json",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether config-defined skills should be reconciled at startup"
+        },
+        "skills": {
+          "type": "array",
+          "description": "Skills to create or update from config.json",
+          "items": {
+            "type": "object",
+            "required": ["name", "description", "skill_md_body", "version"],
+            "properties": {
+              "name": { "type": "string" },
+              "description": { "type": "string" },
+              "license": { "type": "string" },
+              "compatibility": { "type": "string" },
+              "allowed_tools": { "type": "string" },
+              "extra_frontmatter": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+              },
+              "skill_md_body": { "type": "string" },
+              "version": { "type": "string" },
+              "files": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["path", "source_type"],
+                  "properties": {
+                    "path": { "type": "string" },
+                    "source_type": {
+                      "type": "string",
+                      "enum": ["text", "url", "dataurl"]
+                    },
+                    "url": { "type": "string" },
+                    "content": { "type": "string" },
+                    "dataurl": { "type": "string" }
+                  },
+                  "additionalProperties": false,
+                  "oneOf": [
+                    {
+                      "properties": { "source_type": { "const": "url" } },
+                      "required": ["url"]
+                    },
+                    {
+                      "properties": { "source_type": { "const": "text" } },
+                      "required": ["content"]
+                    },
+                    {
+                      "properties": { "source_type": { "const": "dataurl" } },
+                      "required": ["dataurl"]
+                    }
+                  ]
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "plugins": {
       "type": "array",
       "description": "Plugins configuration",


### PR DESCRIPTION
## Summary

Adds declarative Skills Repository support through Bifrost configuration. Skills
can now be defined in config, reconciled on startup, and kept in sync through
config-hash change detection.

## Changes

- Added `skills_registry` config structures.
- Added startup reconciliation for config-defined skills.
- Added hash-based change detection to avoid unnecessary rewrites.
- Added config schema coverage for Skills Repository config.
- Updated config test mock support for the expanded config store interface.
- Reused shared configstore validation helpers for names, versions, file paths,
  and frontmatter.
- Preserved URL/filepath MIME inference behavior for config-defined files.
- Explicitly rejects `upload` source type from config; supported config file
  source types are `text`, `url`, `filepath`, and `dataurl`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate this change with the following command:

```sh
# From bifrost/
direnv exec . go test ./transports/bifrost-http/lib
```

Expected result: config loading tests pass, including config-store mock coverage
for the expanded Skills Repository interface. The `skills_registry` schema is
covered by the checked-in JSON schema.

New config surface: `skills_registry` in Bifrost config.

## Screenshots/Recordings

N/A — backend config support only.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Config-defined skills are reconciled through the same backend validation and
persistence path as API-created skills. URL and filepath sources are
operator-controlled live references; filepath sources can read local files
during startup and serving, so they should only be used with trusted
configuration. The interactive `upload` source type is not accepted from config.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative skills registry configuration for listing skills in config files.
  * Automatic reconciliation of configured skills at startup with per-skill validation and change detection.
  * Persistent storage and version tracking for skill metadata and associated files.
  * Support for multiple file source types (text, URL, filepath, data URL) with MIME inference and sensible fallbacks.
  * Stricter schema validation for the skills registry and safe handling when registry is absent or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->