### PR TITLE
feat: add skills repository dashboard

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,19 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: en-US
 
+early_access: true
+
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+
 reviews:
-  profile: assertive
-  request_changes_workflow: false
+  high_level_summary_in_walkthrough: true
+  fail_commit_status: true
+  suggested_labels: false
+  auto_assign_reviewers: true
+  profile: chill
+  request_changes_workflow: true
   high_level_summary: true
   review_status: true
   changed_files_summary: true
@@ -13,9 +23,41 @@ reviews:
     enabled: true
     drafts: false
     auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
     base_branches:
       - ".*"
   path_instructions:
+    - path: package.json
+      instructions: |
+        do not allow any carats in package.json, we never want any auto updates for any patch versions of any
+        packages in package.json
+    - path: "**"
+      instructions: |
+        always check the stack if there is one for the current PR. do not give localized reviews for the PR,
+        always see all changes in the light of the whole stack of PRs (if there is a stack, if there is no stack you can
+        continue to make localized suggestions/reviews)
+    - path: "**/*.go"
+      instructions: |
+        Rule: No raw context keys in Go.
+
+        When reviewing code, ALWAYS check for incorrect usage of context values.
+
+        Reject or flag the change if you find ANY of the following:
+        - context.WithValue(ctx, "someKey", value)         // string literal key
+        - context.WithValue(ctx, someStringVar, value)   // key is type string
+        - context.WithValue(ctx, fmt.Sprintf(...), value)    // computed/dynamic string key
+        - ctx.Value("someKey") or ctx.Value(someStringVar)        // same problem on retrieval
+
+        Required pattern:
+        - Context keys MUST be a dedicated named type (NOT plain string), e.g.
+          - type contextKey string
+            const userIDKey contextKey = "userId"
+          OR
+          - type userIDKeyType struct{}
+            var userIDKey userIDKeyType
+
+        - The key passed to WithValue/Value MUST be that typed identifier, e.g.
+          - ctx = context.WithValue(ctx, userIDKey, userID)
     - path: "core/**"
       instructions: |
         Review Go core changes for concurrency safety, provider isolation, pooled object reset discipline, and plugin hook ordering.

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -637,6 +637,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPromptRepoTables(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddSkillsRepoTables(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddPluginOrderColumns(ctx, db); err != nil {
 		return err
 	}
@@ -6571,6 +6574,73 @@ func migrationAddMCPClientAllowedExtraHeadersJSONColumn(ctx context.Context, db 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running add_mcp_client_allowed_extra_headers_json_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddSkillsRepoTables adds the skills repository tables.
+// Files belong to skill_versions (not directly to skills); blobs are reused
+// across versions via shared blob_id/storage_key references.
+//
+// Idempotent: guards each table create so retrying after a partially applied
+// migration does not fail when some tables were already created.
+func migrationAddSkillsRepoTables(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_skills_repo_tables",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// --- skills table ---
+			if !mg.HasTable(&tables.TableSkill{}) {
+				if err := mg.CreateTable(&tables.TableSkill{}); err != nil {
+					return fmt.Errorf("create skills table: %w", err)
+				}
+			}
+
+			// --- skill_versions table ---
+			if !mg.HasTable(&tables.TableSkillVersion{}) {
+				if err := mg.CreateTable(&tables.TableSkillVersion{}); err != nil {
+					return fmt.Errorf("create skill_versions table: %w", err)
+				}
+			}
+
+			// --- skill_file_blobs table ---
+			if !mg.HasTable(&tables.TableSkillFileBlob{}) {
+				if err := mg.CreateTable(&tables.TableSkillFileBlob{}); err != nil {
+					return fmt.Errorf("create skill_file_blobs table: %w", err)
+				}
+			}
+
+			// --- skill_files table ---
+			if !mg.HasTable(&tables.TableSkillFile{}) {
+				if err := mg.CreateTable(&tables.TableSkillFile{}); err != nil {
+					return fmt.Errorf("create skill_files table: %w", err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if err := mg.DropTable(&tables.TableSkillFile{}); err != nil {
+				return err
+			}
+			if err := mg.DropTable(&tables.TableSkillVersion{}); err != nil {
+				return err
+			}
+			if err := mg.DropTable(&tables.TableSkill{}); err != nil {
+				return err
+			}
+			if err := mg.DropTable(&tables.TableSkillFileBlob{}); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running skills repo tables migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -333,6 +333,83 @@ func TestUpsertMCPLibraryEntry(t *testing.T) {
 	require.Equal(t, "updated", entries[0].Description)
 }
 
+func TestValidateSkillVersionIncrementRequiresGreaterVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		latest  string
+		next    string
+		wantErr bool
+	}{
+		{name: "rejects lower prerelease core", latest: "1.0.3", next: "1.0.2-1", wantErr: true},
+		{name: "accepts same core with suffix after release", latest: "1.0.3", next: "1.0.3-1", wantErr: false},
+		{name: "accepts release after same core suffix", latest: "1.0.3-beta1", next: "1.0.3", wantErr: false},
+		{name: "accepts higher patch", latest: "1.0.3", next: "1.0.4", wantErr: false},
+		{name: "accepts higher minor", latest: "1.0.3", next: "1.1.0", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSkillVersionIncrement(tt.latest, tt.next)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestLatestCreatedSkillVersionUsesCreationOrder(t *testing.T) {
+	store := setupRDBTestStore(t)
+	err := store.DB().AutoMigrate(
+		&tables.TableSkill{},
+		&tables.TableSkillVersion{},
+		&tables.TableSkillFile{},
+		&tables.TableSkillFileBlob{},
+	)
+	require.NoError(t, err)
+	ctx := context.Background()
+	baseTime := time.Now()
+
+	skillID := "skill-latest-created"
+	err = store.DB().Create(&tables.TableSkill{
+		ID:            skillID,
+		Name:          "latest-created",
+		Description:   "Latest created version test",
+		SkillMDBody:   "body",
+		LatestVersion: "1.0.3",
+		CreatedAt:     baseTime,
+		UpdatedAt:     baseTime,
+	}).Error
+	require.NoError(t, err)
+	err = store.DB().Create(&tables.TableSkillVersion{
+		ID:                  "skill-version-old",
+		SkillID:             skillID,
+		Version:             "1.0.3",
+		SkillMDBody:         "body",
+		FrontmatterSnapshot: tables.SkillJSONMap{"name": "latest-created", "description": "Latest created version test"},
+		CreatedAt:           baseTime,
+	}).Error
+	require.NoError(t, err)
+	err = store.DB().Create(&tables.TableSkillVersion{
+		ID:                  "skill-version-new",
+		SkillID:             skillID,
+		Version:             "1.0.2-1",
+		SkillMDBody:         "body",
+		FrontmatterSnapshot: tables.SkillJSONMap{"name": "latest-created", "description": "Latest created version test"},
+		CreatedAt:           baseTime.Add(time.Minute),
+	}).Error
+	require.NoError(t, err)
+
+	latest, err := latestCreatedSkillVersion(store.DB(), skillID)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.2-1", latest)
+
+	skill, err := store.GetSkillLean(ctx, skillID)
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.2-1", skill.HighestVersion)
+}
+
 // =============================================================================
 // Provider and Key Tests
 // =============================================================================

--- a/framework/configstore/skills.go
+++ b/framework/configstore/skills.go
@@ -1,0 +1,1216 @@
+package configstore
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const allSkillsVersionConfigKey = "skills_repository.all_skills_version"
+
+type allSkillsVersionBump string
+
+type pendingSkillObjectWrite struct {
+	key      string
+	data     []byte
+	metadata map[string]string
+}
+
+// runPendingSkillObjectWrites uploads pending objects to the store after the DB
+// transaction has committed. If any upload fails it performs a compensating DB
+// delete so the committed rows don't reference missing objects:
+//   - isCreate=true  → deletes the entire skill (cascades to versions/files)
+//   - isCreate=false → deletes only the newly created version row
+//
+// Already-written objects from earlier iterations are best-effort cleaned up
+// to avoid orphans. Any stragglers are caught by the startup orphan cleanup.
+func runPendingSkillObjectWrites(ctx context.Context, db *gorm.DB, objectStore objectstore.ObjectStore, writes []pendingSkillObjectWrite, isCreate bool, skillID, versionID string) error {
+	if objectStore == nil || len(writes) == 0 {
+		return nil
+	}
+	for i, write := range writes {
+		if err := objectStore.Put(ctx, write.key, write.data, write.metadata); err != nil {
+			writeErr := fmt.Errorf("failed to write skill file object %s: %w", write.key, err)
+
+			// Use a bounded detached context: request cancellation often causes the
+			// Put failure, but compensation must still get a chance to repair DB rows.
+			compensationCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			compensationDB := db.WithContext(compensationCtx)
+
+			// Compensating delete: remove the DB rows that reference the missing objects.
+			var compensationErr error
+			if isCreate {
+				compensationErr = compensationDB.Where("id = ?", skillID).Delete(&tables.TableSkill{}).Error
+			} else {
+				compensationErr = compensationDB.Where("id = ?", versionID).Delete(&tables.TableSkillVersion{}).Error
+			}
+			if compensationErr != nil {
+				return fmt.Errorf("%w; failed to compensate committed skill rows: %v", writeErr, compensationErr)
+			}
+
+			// Best-effort cleanup of objects written in earlier iterations.
+			if i > 0 {
+				written := make([]string, i)
+				for j := range i {
+					written[j] = writes[j].key
+				}
+				_ = objectStore.DeleteBatch(compensationCtx, written)
+			}
+			return writeErr
+		}
+	}
+	return nil
+}
+
+func runSkillObjectCleanup(ctx context.Context, logger schemas.Logger, objectStore objectstore.ObjectStore, keys []string) {
+	if objectStore == nil || len(keys) == 0 {
+		return
+	}
+	if err := objectStore.DeleteBatch(ctx, keys); err != nil && logger != nil {
+		logger.Warn("failed to cleanup skill file objects, will be cleanedup in the restart automatically: %v", err)
+	}
+}
+
+const (
+	allSkillsVersionBumpPatch allSkillsVersionBump = "patch"
+	allSkillsVersionBumpMinor allSkillsVersionBump = "minor"
+	allSkillsVersionBumpMajor allSkillsVersionBump = "major"
+
+	// MaxSkillFileContentSize is the maximum allowed size for any single skill
+	// file, regardless of source type.
+	MaxSkillFileContentSize = 50 * 1024 * 1024
+
+	// SkillObjectPrefix is the object-store prefix for all skill files.
+	SkillObjectPrefix = "skills/"
+)
+
+// SkillHarnessNames lists the supported agent harness identifiers
+// (e.g. "claude-code", "codex"). Used for Git smart HTTP route
+// registration and reserved-name validation.
+var SkillHarnessNames = []string{"claude-code", "codex"}
+
+// SkillReservedNames lists skill names that are reserved by the serving
+// layer (static routes that would shadow dynamic skill-name routes).
+// Built from SkillHarnessNames plus additional synthetic names.
+var SkillReservedNames = append([]string{"all-skills", "all"}, SkillHarnessNames...)
+
+var (
+	skillNamePattern   = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	skillSemverPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z][0-9A-Za-z.-]*))?$`)
+	// skillReservedFrontmatterFields contains frontmatter keys that are managed
+	// as first-class DB columns and must not appear in extra_frontmatter.
+	skillReservedFrontmatterFields = map[string]struct{}{
+		"name":          {},
+		"description":   {},
+		"license":       {},
+		"compatibility": {},
+		"metadata":      {},
+		"allowed-tools": {},
+	}
+)
+
+// IsSkillReservedFrontmatterField returns true if the given key is a reserved
+// frontmatter field managed as a first-class DB column.
+func IsSkillReservedFrontmatterField(key string) bool {
+	_, reserved := skillReservedFrontmatterFields[key]
+	return reserved
+}
+
+type skillVersionParts struct {
+	major  int
+	minor  int
+	patch  int
+	suffix string
+}
+
+// ValidateSkill validates the skill-level fields required by the Agent Skills spec.
+func ValidateSkill(skill *tables.TableSkill, version string) error {
+	if skill == nil {
+		return fmt.Errorf("skill is required")
+	}
+	if err := ValidateSkillName(skill.Name); err != nil {
+		return err
+	}
+	if strings.TrimSpace(skill.Description) == "" {
+		return fmt.Errorf("skill description is required")
+	}
+	if len(skill.Description) > 1024 {
+		return fmt.Errorf("skill description must be 1024 characters or fewer")
+	}
+	if skill.Compatibility != nil && len(*skill.Compatibility) > 500 {
+		return fmt.Errorf("skill compatibility must be 500 characters or fewer")
+	}
+	if strings.TrimSpace(skill.SkillMDBody) == "" {
+		return fmt.Errorf("skill_md_body is required")
+	}
+	if !utf8.ValidString(skill.SkillMDBody) {
+		return fmt.Errorf("skill_md_body must be valid UTF-8")
+	}
+	if err := ValidateSkillVersion(version); err != nil {
+		return err
+	}
+	for key, value := range skill.Metadata {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("metadata keys must be non-empty")
+		}
+		if !utf8.ValidString(value) {
+			return fmt.Errorf("metadata value for %q must be valid UTF-8", key)
+		}
+	}
+	for key := range skill.ExtraFrontmatter {
+		if IsSkillReservedFrontmatterField(key) {
+			return fmt.Errorf("extra_frontmatter key %q conflicts with a reserved frontmatter field", key)
+		}
+	}
+	return nil
+}
+
+// ValidateSkillName validates lowercase alphanumeric + hyphen skill names.
+func ValidateSkillName(name string) error {
+	if name == "" {
+		return fmt.Errorf("skill name is required")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("skill name must be 64 characters or fewer")
+	}
+	if !skillNamePattern.MatchString(name) {
+		return fmt.Errorf("skill name must contain only lowercase letters, numbers, and single hyphens with no leading, trailing, or consecutive hyphens")
+	}
+	if slices.Contains(SkillReservedNames, name) {
+		return fmt.Errorf("%q is a reserved name used by the skills serving layer", name)
+	}
+	return nil
+}
+
+// ValidateSkillFile validates a skill file definition before storage writes.
+func ValidateSkillFile(file *tables.TableSkillFile) error {
+	if file == nil {
+		return fmt.Errorf("skill file is required")
+	}
+	if err := ValidateSkillFilePath(file.Path); err != nil {
+		return err
+	}
+	if err := validateSkillSourceType(file.SourceType); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateSkillFilePath validates safe relative file paths within a skill.
+func ValidateSkillFilePath(filePath string) error {
+	p := strings.TrimSpace(filePath)
+	if p == "" {
+		return fmt.Errorf("skill file path is required")
+	}
+	if strings.HasPrefix(p, "/") || filepath.IsAbs(p) {
+		return fmt.Errorf("skill file path must be relative")
+	}
+	if strings.HasSuffix(p, "/") {
+		return fmt.Errorf("skill file path must not have a trailing slash")
+	}
+	if strings.Contains(p, "\\") {
+		return fmt.Errorf("skill file path must use forward slashes")
+	}
+	for segment := range strings.SplitSeq(p, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return fmt.Errorf("skill file path must not contain empty, current, or parent directory segments")
+		}
+	}
+	return nil
+}
+
+func validateSkillSourceType(sourceType string) error {
+	switch sourceType {
+	case tables.SkillSourceTypeURL, tables.SkillSourceTypeDataURL, tables.SkillSourceTypeText, tables.SkillSourceTypeUpload:
+		return nil
+	default:
+		return fmt.Errorf("skill file source_type must be one of url, dataurl, text, or upload")
+	}
+}
+
+// ValidateSkillVersion validates skill versions as MAJOR.MINOR.PATCH with an optional -suffix.
+func ValidateSkillVersion(version string) error {
+	_, err := parseSkillSemver(version)
+	return err
+}
+
+func parseSkillSemver(version string) (skillVersionParts, error) {
+	if version != strings.TrimSpace(version) {
+		return skillVersionParts{}, fmt.Errorf("skill version must not have leading or trailing whitespace")
+	}
+	matches := skillSemverPattern.FindStringSubmatch(version)
+	if matches == nil {
+		return skillVersionParts{}, fmt.Errorf("skill version must be semver MAJOR.MINOR.PATCH with optional -suffix")
+	}
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return skillVersionParts{}, fmt.Errorf("skill version major component overflows: %w", err)
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return skillVersionParts{}, fmt.Errorf("skill version minor component overflows: %w", err)
+	}
+	patch, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return skillVersionParts{}, fmt.Errorf("skill version patch component overflows: %w", err)
+	}
+	return skillVersionParts{major: major, minor: minor, patch: patch, suffix: matches[4]}, nil
+}
+
+func validateSkillVersionIncrement(previousVersion, nextVersion string) error {
+	if previousVersion == "" {
+		_, err := parseSkillSemver(nextVersion)
+		return err
+	}
+	prev, err := parseSkillSemver(previousVersion)
+	if err != nil {
+		return fmt.Errorf("stored latest skill version is invalid: %w", err)
+	}
+	next, err := parseSkillSemver(nextVersion)
+	if err != nil {
+		return err
+	}
+	if next.major < prev.major || (next.major == prev.major && next.minor < prev.minor) || (next.major == prev.major && next.minor == prev.minor && next.patch < prev.patch) {
+		return fmt.Errorf("skill version %q must not go below latest version %q", nextVersion, previousVersion)
+	}
+	if next.major == prev.major && next.minor == prev.minor && next.patch == prev.patch && next.suffix == prev.suffix {
+		return fmt.Errorf("skill version %q already matches the latest version; choose a new version", nextVersion)
+	}
+	return nil
+}
+
+func latestCreatedSkillVersion(tx *gorm.DB, skillID string) (string, error) {
+	var latest string
+	err := tx.Model(&tables.TableSkillVersion{}).
+		Where("skill_id = ?", skillID).
+		Select("version").
+		Order("created_at DESC").
+		Limit(1).
+		Scan(&latest).Error
+	return latest, err
+}
+
+func allSkillsBumpForVersionChange(previousVersion, nextVersion string) (allSkillsVersionBump, error) {
+	prev, err := parseSkillSemver(previousVersion)
+	if err != nil {
+		return "", fmt.Errorf("stored latest skill version is invalid: %w", err)
+	}
+	next, err := parseSkillSemver(nextVersion)
+	if err != nil {
+		return "", err
+	}
+	if next.major > prev.major {
+		return allSkillsVersionBumpMajor, nil
+	}
+	if next.minor > prev.minor {
+		return allSkillsVersionBumpMinor, nil
+	}
+	return allSkillsVersionBumpPatch, nil
+}
+
+func nextAllSkillsVersion(current string, bump allSkillsVersionBump, firstSkill bool) (string, error) {
+	if current == "" {
+		current = "0.0.0"
+	}
+	if firstSkill && current == "0.0.0" {
+		return "1.0.0", nil
+	}
+	parts, err := parseSkillSemver(current)
+	if err != nil {
+		return "", fmt.Errorf("stored all-skills version is invalid: %w", err)
+	}
+	switch bump {
+	case allSkillsVersionBumpMajor:
+		return fmt.Sprintf("%d.0.0", parts.major+1), nil
+	case allSkillsVersionBumpMinor:
+		return fmt.Sprintf("%d.%d.0", parts.major, parts.minor+1), nil
+	case allSkillsVersionBumpPatch:
+		return fmt.Sprintf("%d.%d.%d", parts.major, parts.minor, parts.patch+1), nil
+	default:
+		return "", fmt.Errorf("unsupported all-skills version bump %q", bump)
+	}
+}
+
+func bumpAllSkillsVersionTx(ctx context.Context, tx *gorm.DB, bump allSkillsVersionBump, firstSkill bool) error {
+	var config tables.TableGovernanceConfig
+	err := tx.WithContext(ctx).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		First(&config, "key = ?", allSkillsVersionConfigKey).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		config = tables.TableGovernanceConfig{Key: allSkillsVersionConfigKey, Value: "0.0.0"}
+		if err := tx.WithContext(ctx).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			Create(&config).Error; err != nil {
+			return err
+		}
+		if err := tx.WithContext(ctx).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			First(&config, "key = ?", allSkillsVersionConfigKey).Error; err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	next, err := nextAllSkillsVersion(config.Value, bump, firstSkill)
+	if err != nil {
+		return err
+	}
+	config.Value = next
+	return tx.WithContext(ctx).Save(&config).Error
+}
+
+// GetAllSkillsVersion returns the repository-level version for the bundled all-skills plugin.
+func (s *RDBConfigStore) GetAllSkillsVersion(ctx context.Context) (string, error) {
+	config, err := s.GetConfig(ctx, allSkillsVersionConfigKey)
+	if errors.Is(err, ErrNotFound) {
+		return "0.0.0", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(config.Value) == "" {
+		return "0.0.0", nil
+	}
+	return config.Value, nil
+}
+
+// BumpAllSkillsVersion manually advances the repository-level all-skills version.
+func (s *RDBConfigStore) BumpAllSkillsVersion(ctx context.Context, bump string) (string, error) {
+	bumpType := allSkillsVersionBump(bump)
+	switch bumpType {
+	case allSkillsVersionBumpPatch, allSkillsVersionBumpMinor, allSkillsVersionBumpMajor:
+	default:
+		return "", fmt.Errorf("unsupported all-skills version bump %q", bump)
+	}
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return bumpAllSkillsVersionTx(ctx, tx, bumpType, false)
+	}); err != nil {
+		return "", err
+	}
+	return s.GetAllSkillsVersion(ctx)
+}
+
+// StoreSkillFileContent stores inline file content in the DB blob fallback, or
+// prepares an object-storage write for the caller to run after DB commit.
+func StoreSkillFileContent(ctx context.Context, tx *gorm.DB, objectStore objectstore.ObjectStore, skillID string, file *tables.TableSkillFile, data []byte) (*pendingSkillObjectWrite, error) {
+	if file == nil {
+		return nil, fmt.Errorf("skill file is required")
+	}
+	if objectStore != nil {
+		key := file.StorageKey
+		if key == nil || strings.TrimSpace(*key) == "" {
+			generated := fmt.Sprintf(SkillObjectPrefix+"%s/%s/%s", skillID, file.ID, path.Base(file.Path))
+			key = &generated
+		}
+		file.StorageKey = key
+		file.BlobID = nil
+		return &pendingSkillObjectWrite{
+			key:      *key,
+			data:     data,
+			metadata: map[string]string{"skill_id": skillID, "file_id": file.ID},
+		}, nil
+	}
+
+	blobID := uuid.NewString()
+	blob := tables.TableSkillFileBlob{
+		ID:   blobID,
+		Data: data,
+	}
+	if err := tx.Create(&blob).Error; err != nil {
+		return nil, err
+	}
+	file.BlobID = &blobID
+	file.StorageKey = nil
+	return nil, nil
+}
+
+func validateSkillStorageKeyScope(skillID string, file *tables.TableSkillFile, key string) error {
+	if !strings.HasPrefix(key, SkillObjectPrefix) {
+		return fmt.Errorf("storage_key %q is not under the skills object prefix", key)
+	}
+
+	uploadPrefix := SkillObjectPrefix + "uploads/"
+	skillPrefix := SkillObjectPrefix + skillID + "/"
+
+	switch file.SourceType {
+	case tables.SkillSourceTypeUpload:
+		if file.UploadID != nil && strings.TrimSpace(*file.UploadID) != "" {
+			expectedPrefix := uploadPrefix + strings.TrimSpace(*file.UploadID) + "/"
+			if !strings.HasPrefix(key, expectedPrefix) {
+				return fmt.Errorf("storage_key %q does not belong to upload_id %q", key, strings.TrimSpace(*file.UploadID))
+			}
+			return nil
+		}
+		if !strings.HasPrefix(key, uploadPrefix) {
+			return fmt.Errorf("storage_key %q is not under the staged upload prefix", key)
+		}
+	case tables.SkillSourceTypeText, tables.SkillSourceTypeDataURL:
+		if !strings.HasPrefix(key, skillPrefix) {
+			return fmt.Errorf("storage_key %q is not scoped to skill %q", key, skillID)
+		}
+	}
+	return nil
+}
+
+func validateSkillFileReference(tx *gorm.DB, skillID string, file *tables.TableSkillFile) error {
+	if file.BlobID != nil && strings.TrimSpace(*file.BlobID) != "" {
+		var blobCount int64
+		if err := tx.Model(&tables.TableSkillFileBlob{}).Where("id = ?", *file.BlobID).Count(&blobCount).Error; err != nil {
+			return err
+		}
+		if blobCount == 0 {
+			return fmt.Errorf("blob_id %q does not exist", *file.BlobID)
+		}
+
+		var foreignCount int64
+		if err := tx.Model(&tables.TableSkillFile{}).
+			Joins("JOIN skill_versions ON skill_versions.id = skill_files.skill_version_id").
+			Where("skill_files.blob_id = ? AND skill_versions.skill_id <> ?", *file.BlobID, skillID).
+			Count(&foreignCount).Error; err != nil {
+			return err
+		}
+		if foreignCount > 0 {
+			return fmt.Errorf("blob_id %q is already bound to another skill", *file.BlobID)
+		}
+	}
+
+	if file.StorageKey != nil && strings.TrimSpace(*file.StorageKey) != "" {
+		key := strings.TrimSpace(*file.StorageKey)
+		if err := validateSkillStorageKeyScope(skillID, file, key); err != nil {
+			return err
+		}
+
+		var foreignCount int64
+		if err := tx.Model(&tables.TableSkillFile{}).
+			Joins("JOIN skill_versions ON skill_versions.id = skill_files.skill_version_id").
+			Where("skill_files.storage_key = ? AND skill_versions.skill_id <> ?", key, skillID).
+			Count(&foreignCount).Error; err != nil {
+			return err
+		}
+		if foreignCount > 0 {
+			return fmt.Errorf("storage_key %q is already bound to another skill", key)
+		}
+		file.StorageKey = &key
+	}
+	return nil
+}
+
+func decodeSkillDataURL(dataURL string) ([]byte, string, error) {
+	parsed, err := url.Parse(dataURL)
+	if err != nil || parsed.Scheme != "data" {
+		return nil, "", fmt.Errorf("dataurl must be a valid data: URL")
+	}
+	parts := strings.SplitN(dataURL, ",", 2)
+	if len(parts) != 2 || !strings.Contains(parts[0], ";base64") {
+		return nil, "", fmt.Errorf("dataurl must contain ;base64,")
+	}
+	// Reject oversized payloads before materializing the full decode in memory.
+	if base64.StdEncoding.DecodedLen(len(parts[1])) > MaxSkillFileContentSize {
+		return nil, "", fmt.Errorf("dataurl payload exceeds maximum size of %d bytes", MaxSkillFileContentSize)
+	}
+	mimeType := strings.TrimPrefix(strings.Split(parts[0], ";")[0], "data:")
+	data, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, "", fmt.Errorf("dataurl base64 decode failed: %w", err)
+	}
+	return data, mimeType, nil
+}
+
+func validateSkillFileSource(file *tables.TableSkillFile) ([]byte, error) {
+	// Reject files with both blob_id and storage_key — exactly one backing store is allowed.
+	hasBlobID := file.BlobID != nil && strings.TrimSpace(*file.BlobID) != ""
+	hasStorageKey := file.StorageKey != nil && strings.TrimSpace(*file.StorageKey) != ""
+	if hasBlobID && hasStorageKey {
+		return nil, fmt.Errorf("file %q must have either blob_id or storage_key, not both", file.Path)
+	}
+	switch file.SourceType {
+	case tables.SkillSourceTypeURL:
+		if file.SourceURL == nil || strings.TrimSpace(*file.SourceURL) == "" {
+			return nil, fmt.Errorf("url source_type requires source_url")
+		}
+		u, err := url.Parse(*file.SourceURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return nil, fmt.Errorf("source_url must be an http or https URL")
+		}
+		file.StorageKey = nil
+		file.BlobID = nil
+		return nil, nil
+	case tables.SkillSourceTypeText:
+		if file.InlineContent == nil || *file.InlineContent == "" {
+			if hasStorageKey || hasBlobID {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("text source_type requires content or an existing file reference")
+		}
+		data := []byte(*file.InlineContent)
+		if len(data) > MaxSkillFileContentSize {
+			return nil, fmt.Errorf("text file content exceeds maximum size of %d bytes", MaxSkillFileContentSize)
+		}
+		file.StorageKey = nil
+		file.BlobID = nil
+		return data, nil
+	case tables.SkillSourceTypeDataURL:
+		if file.DataURL == nil || strings.TrimSpace(*file.DataURL) == "" {
+			if hasStorageKey || hasBlobID {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("dataurl source_type requires dataurl or an existing file reference")
+		}
+		data, mimeType, err := decodeSkillDataURL(*file.DataURL)
+		if err != nil {
+			return nil, err
+		}
+		if len(data) > MaxSkillFileContentSize {
+			return nil, fmt.Errorf("dataurl file content exceeds maximum size of %d bytes", MaxSkillFileContentSize)
+		}
+		if file.MimeType == "" {
+			file.MimeType = mimeType
+		}
+		file.StorageKey = nil
+		file.BlobID = nil
+		return data, nil
+	case tables.SkillSourceTypeUpload:
+		if !hasStorageKey && !hasBlobID {
+			return nil, fmt.Errorf("upload source_type requires storage_key or blob_id")
+		}
+		return nil, nil
+	default:
+		return nil, validateSkillSourceType(file.SourceType)
+	}
+}
+
+// CreateSkill creates a skill with an initial version and its files.
+func (s *RDBConfigStore) CreateSkill(ctx context.Context, skill *tables.TableSkill, version string, objectStore objectstore.ObjectStore) error {
+	if err := ValidateSkill(skill, version); err != nil {
+		return err
+	}
+	var objectWrites []pendingSkillObjectWrite
+	var firstSkill bool
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing tables.TableSkill
+		if err := tx.First(&existing, "name = ?", skill.Name).Error; err == nil {
+			return fmt.Errorf("skill name %q already exists", skill.Name)
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		var existingSkillCount int64
+		if err := tx.Model(&tables.TableSkill{}).Count(&existingSkillCount).Error; err != nil {
+			return err
+		}
+		firstSkill = existingSkillCount == 0
+		if skill.ID == "" {
+			skill.ID = uuid.NewString()
+		}
+		skill.LatestVersion = version
+		files := skill.Files
+		skill.Files = nil
+		skill.Versions = nil
+		if err := tx.Create(skill).Error; err != nil {
+			return err
+		}
+		// Create the version row, then create files under it.
+		versionRow, err := createSkillVersion(tx, skill, version)
+		if err != nil {
+			return err
+		}
+		writes, err := createVersionFiles(ctx, tx, objectStore, skill.ID, versionRow.ID, files)
+		if err != nil {
+			return err
+		}
+		objectWrites = append(objectWrites, writes...)
+		// Populate transient Files for the response.
+		return populateSkillFiles(tx, skill)
+	}); err != nil {
+		return err
+	}
+	if err := runPendingSkillObjectWrites(ctx, s.DB().WithContext(ctx), objectStore, objectWrites, true, skill.ID, ""); err != nil {
+		return err
+	}
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return bumpAllSkillsVersionTx(ctx, tx, allSkillsVersionBumpMinor, firstSkill)
+	}); err != nil {
+		return fmt.Errorf("skill %q was created successfully but all-skills version could not be bumped; manually bump all-skills version with a minor bump to publish this create: %w", skill.Name, err)
+	}
+	return nil
+}
+
+// GetSkill returns a skill with lean version summaries (id, version, created_at) and serving files.
+func (s *RDBConfigStore) GetSkill(ctx context.Context, id string) (*tables.TableSkill, error) {
+	var skill tables.TableSkill
+	if err := s.ScopedDB(ctx).
+		Preload("Versions", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "skill_id", "version", "created_at").Order("created_at DESC")
+		}).
+		First(&skill, "skills.id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
+		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	return &skill, nil
+}
+
+// GetSkillLean returns a skill without versions preloaded (only serving files).
+func (s *RDBConfigStore) GetSkillLean(ctx context.Context, id string) (*tables.TableSkill, error) {
+	var skill tables.TableSkill
+	if err := s.ScopedDB(ctx).
+		First(&skill, "skills.id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
+		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	// Populate the most recently created version for bump validation.
+	latest, err := latestCreatedSkillVersion(s.ScopedDB(ctx), skill.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load latest created skill version: %w", err)
+	}
+	if latest != "" {
+		skill.HighestVersion = latest
+	}
+	return &skill, nil
+}
+
+// GetSkillByName returns a skill by name with lean version summaries and serving files.
+func (s *RDBConfigStore) GetSkillByName(ctx context.Context, name string) (*tables.TableSkill, error) {
+	var skill tables.TableSkill
+	if err := s.ScopedDB(ctx).
+		Preload("Versions", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "skill_id", "version", "created_at").Order("created_at DESC")
+		}).
+		First(&skill, "skills.name = ?", name).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
+		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	return &skill, nil
+}
+
+// ListSkillVersions returns paginated versions for a skill.
+func (s *RDBConfigStore) ListSkillVersions(ctx context.Context, skillID string, params SkillVersionListQueryParams) ([]tables.TableSkillVersion, int64, error) {
+	var total int64
+	db := s.ScopedDB(ctx).Model(&tables.TableSkillVersion{}).Where("skill_id = ?", skillID)
+	if err := db.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var versions []tables.TableSkillVersion
+	query := db.
+		Select("id", "skill_id", "version", "created_by", "created_at").
+		Order(skillVersionListOrder(params))
+	if params.Limit > 0 {
+		query = query.Limit(params.Limit)
+	}
+	if params.Offset > 0 {
+		query = query.Offset(params.Offset)
+	}
+	if err := query.Find(&versions).Error; err != nil {
+		return nil, 0, err
+	}
+	return versions, total, nil
+}
+
+// GetSkillVersion returns a specific version by skill ID and version string.
+func (s *RDBConfigStore) GetSkillVersion(ctx context.Context, skillID, version string) (*tables.TableSkillVersion, error) {
+	var v tables.TableSkillVersion
+	if err := s.ScopedDB(ctx).
+		Preload("Files").
+		Preload("Files.Blob").
+		First(&v, "skill_id = ? AND version = ?", skillID, version).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &v, nil
+}
+
+// UpdateSkill saves skill fields, creates a new version, and creates files under it.
+// When serve=true, the skill row is updated to serve this new version.
+// When serve=false, only the version and files are created; the skill continues serving its current version.
+//
+// The serve switch is deferred until after object-store writes succeed so the
+// skill never points at a version whose files failed to upload.
+func (s *RDBConfigStore) UpdateSkill(ctx context.Context, skill *tables.TableSkill, version string, serve bool, objectStore objectstore.ObjectStore) error {
+	if err := ValidateSkill(skill, version); err != nil {
+		return err
+	}
+
+	// Phase 1: Create the version and files inside a transaction, but do NOT
+	// update the skill's serving state yet. This keeps the skill pointing at
+	// the old version until uploads are confirmed.
+	var objectWrites []pendingSkillObjectWrite
+	var versionID string
+	var existingLatestVersion string
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing tables.TableSkill
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&existing, "id = ?", skill.ID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+		existingLatestVersion = existing.LatestVersion
+		latestCreatedVersion, err := latestCreatedSkillVersion(tx, skill.ID)
+		if err != nil {
+			return err
+		}
+		if latestCreatedVersion == "" {
+			latestCreatedVersion = existing.LatestVersion
+		}
+		if err := validateSkillVersionIncrement(latestCreatedVersion, version); err != nil {
+			return err
+		}
+		// Also check that this version doesn't already exist (handles shift-back scenarios
+		// where LatestVersion is older but higher versions exist in history).
+		var existingVersion tables.TableSkillVersion
+		if err := tx.First(&existingVersion, "skill_id = ? AND version = ?", skill.ID, version).Error; err == nil {
+			return fmt.Errorf("skill version %q already exists in version history", version)
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		files := skill.Files
+
+		versionRow, err := createSkillVersion(tx, skill, version)
+		if err != nil {
+			return err
+		}
+		versionID = versionRow.ID
+		writes, err := createVersionFiles(ctx, tx, objectStore, skill.ID, versionRow.ID, files)
+		if err != nil {
+			return err
+		}
+		objectWrites = append(objectWrites, writes...)
+
+		if !serve {
+			// Restore the existing serving data for the response.
+			skill.LatestVersion = existing.LatestVersion
+			skill.SkillMDBody = existing.SkillMDBody
+			skill.Description = existing.Description
+			skill.License = existing.License
+			skill.Compatibility = existing.Compatibility
+			skill.AllowedTools = existing.AllowedTools
+			skill.Metadata = existing.Metadata
+			skill.ExtraFrontmatter = existing.ExtraFrontmatter
+		}
+		return populateSkillFiles(tx, skill)
+	}); err != nil {
+		return err
+	}
+
+	// Phase 2: Upload objects to the store. On failure, delete the version row
+	// as compensation — the skill still serves its previous version safely.
+	if err := runPendingSkillObjectWrites(ctx, s.DB().WithContext(ctx), objectStore, objectWrites, false, skill.ID, versionID); err != nil {
+		return err
+	}
+
+	if !serve {
+		return nil
+	}
+
+	// Phase 3: Object writes succeeded — now atomically flip the skill to
+	// serve the new version and bump the all-skills governance version.
+	// If this fails, the skill continues serving its previous version safely.
+	// The new version row and its objects remain intact so the caller can
+	// retry serving (e.g. via shift-version) without re-uploading.
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		skill.LatestVersion = version
+		result := tx.Model(&tables.TableSkill{}).
+			Where("id = ?", skill.ID).
+			Select("Description", "License", "Compatibility", "Metadata", "ExtraFrontmatter", "AllowedTools", "SkillMDBody", "LatestVersion", "UpdatedAt").
+			Updates(skill)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		bump, err := allSkillsBumpForVersionChange(existingLatestVersion, version)
+		if err != nil {
+			return err
+		}
+		return bumpAllSkillsVersionTx(ctx, tx, bump, false)
+	}); err != nil {
+		return fmt.Errorf("version %s was created successfully but could not be served — use shift-version to retry: %w", version, err)
+	}
+	return nil
+}
+
+// DeleteSkill deletes a skill, cleaning up object-store files across ALL versions.
+func (s *RDBConfigStore) DeleteSkill(ctx context.Context, id string, objectStore objectstore.ObjectStore) error {
+	var keys []string
+	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var skill tables.TableSkill
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&skill, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+		// Collect ALL distinct storage keys across all versions' files for this skill.
+		if objectStore != nil {
+			if err := tx.Model(&tables.TableSkillFile{}).
+				Where("skill_version_id IN (?)",
+					tx.Model(&tables.TableSkillVersion{}).Select("id").Where("skill_id = ?", id),
+				).
+				Where("storage_key IS NOT NULL AND storage_key != ''").
+				Distinct("storage_key").
+				Pluck("storage_key", &keys).Error; err != nil {
+				return err
+			}
+		}
+		// DB cascade handles: skill → versions → files, files → blobs
+		if err := tx.Delete(&skill).Error; err != nil {
+			return err
+		}
+		return bumpAllSkillsVersionTx(ctx, tx, allSkillsVersionBumpMajor, false)
+	}); err != nil {
+		return err
+	}
+	runSkillObjectCleanup(ctx, s.logger, objectStore, keys)
+	return nil
+}
+
+// ListSkills returns paginated skills with the serving version's file count and total count.
+func (s *RDBConfigStore) ListSkills(ctx context.Context, params SkillListQueryParams) ([]tables.TableSkill, int64, error) {
+	var skills []tables.TableSkill
+	query := s.ScopedDB(ctx).Model(&tables.TableSkill{})
+	if params.Search != "" {
+		like := "%" + strings.ToLower(params.Search) + "%"
+		query = query.Where("LOWER(name) LIKE ? OR LOWER(description) LIKE ?", like, like)
+	}
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	query = query.Omit("skill_md_body").Order(skillListOrder(params))
+	if params.Limit > 0 {
+		query = query.Limit(params.Limit)
+	}
+	if params.Offset > 0 {
+		query = query.Offset(params.Offset)
+	}
+	if err := query.Find(&skills).Error; err != nil {
+		return nil, 0, err
+	}
+	if len(skills) > 0 {
+		type fileCountRow struct {
+			SkillID   string
+			FileCount int64
+		}
+		var rows []fileCountRow
+		if err := s.ScopedDB(ctx).
+			Table("skill_versions").
+			Select("skill_versions.skill_id AS skill_id, COUNT(skill_files.id) AS file_count").
+			Joins("JOIN skills ON skills.id = skill_versions.skill_id AND skills.latest_version = skill_versions.version").
+			Joins("LEFT JOIN skill_files ON skill_files.skill_version_id = skill_versions.id").
+			Where("skill_versions.skill_id IN ?", skillIDs(skills)).
+			Group("skill_versions.skill_id").
+			Scan(&rows).Error; err != nil {
+			return nil, 0, err
+		}
+		fileCounts := make(map[string]int64, len(rows))
+		for _, row := range rows {
+			fileCounts[row.SkillID] = row.FileCount
+		}
+		for i := range skills {
+			skills[i].FileCount = fileCounts[skills[i].ID]
+		}
+	}
+	return skills, total, nil
+}
+
+func skillListOrder(params SkillListQueryParams) string {
+	column := "created_at"
+	switch params.SortBy {
+	case "name":
+		column = "name"
+	case "updated_at":
+		column = "updated_at"
+	case "created_at", "":
+		column = "created_at"
+	}
+	return column + " " + normalizedSortOrder(params.Order) + ", id ASC"
+}
+
+func skillVersionListOrder(params SkillVersionListQueryParams) string {
+	column := "created_at"
+	switch params.SortBy {
+	case "version":
+		column = "version"
+	case "created_at", "":
+		column = "created_at"
+	}
+	return column + " " + normalizedSortOrder(params.Order) + ", id ASC"
+}
+
+func normalizedSortOrder(order string) string {
+	if strings.EqualFold(order, "asc") {
+		return "ASC"
+	}
+	return "DESC"
+}
+
+func skillIDs(skills []tables.TableSkill) []string {
+	ids := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		ids = append(ids, skill.ID)
+	}
+	return ids
+}
+
+// createVersionFiles creates file rows under a version, reusing blob/storage references
+// for existing files that already carry a blob_id or storage_key.
+func createVersionFiles(ctx context.Context, tx *gorm.DB, objectStore objectstore.ObjectStore, skillID, versionID string, files []tables.TableSkillFile) ([]pendingSkillObjectWrite, error) {
+	objectWrites := make([]pendingSkillObjectWrite, 0)
+	for i := range files {
+		file := &files[i]
+		file.ID = uuid.NewString()
+		file.SkillVersionID = versionID
+		data, err := validateSkillFileSource(file)
+		if err != nil {
+			return nil, err
+		}
+		if data != nil {
+			file.FileSizeBytes = int64(len(data))
+		}
+		if err := validateSkillFileReference(tx, skillID, file); err != nil {
+			return nil, err
+		}
+		if err := ValidateSkillFile(file); err != nil {
+			return nil, err
+		}
+		if err := tx.Create(file).Error; err != nil {
+			return nil, err
+		}
+		if data != nil {
+			write, err := StoreSkillFileContent(ctx, tx, objectStore, skillID, file, data)
+			if err != nil {
+				return nil, err
+			}
+			if write != nil {
+				objectWrites = append(objectWrites, *write)
+			}
+			if err := tx.Model(&tables.TableSkillFile{}).Where("id = ?", file.ID).Updates(map[string]any{
+				"storage_key":     file.StorageKey,
+				"blob_id":         file.BlobID,
+				"file_size_bytes": file.FileSizeBytes,
+				"mime_type":       file.MimeType,
+			}).Error; err != nil {
+				return nil, err
+			}
+		}
+	}
+	return objectWrites, nil
+}
+
+// createSkillVersion creates a version row with a frontmatter snapshot (no file snapshot needed;
+// files belong to the version via FK).
+func createSkillVersion(tx *gorm.DB, skill *tables.TableSkill, version string) (*tables.TableSkillVersion, error) {
+	frontmatter := tables.SkillJSONMap{
+		"description": skill.Description,
+	}
+	if skill.License != nil {
+		frontmatter["license"] = *skill.License
+	}
+	if skill.Compatibility != nil {
+		frontmatter["compatibility"] = *skill.Compatibility
+	}
+	if skill.AllowedTools != nil {
+		frontmatter["allowed-tools"] = *skill.AllowedTools
+	}
+	for key, value := range skill.ExtraFrontmatter {
+		if !IsSkillReservedFrontmatterField(key) {
+			frontmatter[key] = value
+		}
+	}
+	if len(skill.Metadata) > 0 {
+		frontmatter["metadata"] = skill.Metadata
+	}
+
+	versionRow := tables.TableSkillVersion{
+		ID:                  uuid.NewString(),
+		SkillID:             skill.ID,
+		Version:             version,
+		SkillMDBody:         skill.SkillMDBody,
+		FrontmatterSnapshot: frontmatter,
+		CreatedBy:           skill.CreatedBy,
+	}
+	if err := tx.Create(&versionRow).Error; err != nil {
+		return nil, err
+	}
+	return &versionRow, nil
+}
+
+// populateSkillFiles reloads the serving version's files into the transient skill.Files.
+func populateSkillFiles(tx *gorm.DB, skill *tables.TableSkill) error {
+	var version tables.TableSkillVersion
+	if err := tx.Preload("Files").
+		Preload("Files.Blob").
+		First(&version, "skill_id = ? AND version = ?", skill.ID, skill.LatestVersion).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("serving version %q for skill %q has no version row; data may be inconsistent", skill.LatestVersion, skill.ID)
+		}
+		return err
+	}
+	skill.Files = version.Files
+	return nil
+}
+
+// SkillFrontmatterFields contains skill fields reconstructed from a version frontmatter snapshot.
+// Name is not included because it is immutable after creation.
+type SkillFrontmatterFields struct {
+	Description      string
+	License          *string
+	Compatibility    *string
+	AllowedTools     *string
+	Metadata         tables.SkillStringMap
+	ExtraFrontmatter tables.SkillJSONMap
+}
+
+// ExtractSkillFieldsFromFrontmatter reconstructs skill fields from a version's frontmatter snapshot.
+func ExtractSkillFieldsFromFrontmatter(frontmatter tables.SkillJSONMap) SkillFrontmatterFields {
+	fields := SkillFrontmatterFields{ExtraFrontmatter: make(tables.SkillJSONMap)}
+	if v, ok := frontmatter["description"].(string); ok {
+		fields.Description = v
+	}
+	if v, ok := frontmatter["license"].(string); ok {
+		fields.License = &v
+	}
+	if v, ok := frontmatter["compatibility"].(string); ok {
+		fields.Compatibility = &v
+	}
+	if v, ok := frontmatter["allowed-tools"].(string); ok {
+		fields.AllowedTools = &v
+	}
+	if m, ok := frontmatter["metadata"].(map[string]any); ok {
+		fields.Metadata = make(tables.SkillStringMap, len(m))
+		for k, v := range m {
+			if s, ok := v.(string); ok {
+				fields.Metadata[k] = s
+			}
+		}
+	}
+	for k, v := range frontmatter {
+		if !IsSkillReservedFrontmatterField(k) {
+			fields.ExtraFrontmatter[k] = v
+		}
+	}
+	return fields
+}
+
+// ShiftSkillVersion shifts a skill to serve a previously-saved version.
+// Files already exist on the target version; only the skill row fields and latest_version pointer change.
+func (s *RDBConfigStore) ShiftSkillVersion(ctx context.Context, skillID string, targetVersion string, objectStore objectstore.ObjectStore) error {
+	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var skill tables.TableSkill
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&skill, "id = ?", skillID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+
+		var version tables.TableSkillVersion
+		if err := tx.First(&version, "skill_id = ? AND version = ?", skillID, targetVersion).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("version %q not found for this skill", targetVersion)
+			}
+			return err
+		}
+
+		if skill.LatestVersion == targetVersion {
+			return fmt.Errorf("skill is already serving version %q", targetVersion)
+		}
+
+		// Snapshot current state if not already versioned.
+		var existingSnapshot tables.TableSkillVersion
+		if err := tx.First(&existingSnapshot, "skill_id = ? AND version = ?", skillID, skill.LatestVersion).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				if _, err := createSkillVersion(tx, &skill, skill.LatestVersion); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+
+		// Extract fields from target version frontmatter and update skill row (name is immutable).
+		fields := ExtractSkillFieldsFromFrontmatter(version.FrontmatterSnapshot)
+		if err := tx.Model(&tables.TableSkill{}).Where("id = ?", skillID).Updates(map[string]any{
+			"description":       fields.Description,
+			"license":           fields.License,
+			"compatibility":     fields.Compatibility,
+			"allowed_tools":     fields.AllowedTools,
+			"metadata":          fields.Metadata,
+			"extra_frontmatter": fields.ExtraFrontmatter,
+			"skill_md_body":     version.SkillMDBody,
+			"latest_version":    targetVersion,
+		}).Error; err != nil {
+			return err
+		}
+		return bumpAllSkillsVersionTx(ctx, tx, allSkillsVersionBumpPatch, false)
+	})
+}
+
+// CreateSkillFileBlob creates an orphan blob record (e.g. for the upload endpoint's DB fallback).
+func (s *RDBConfigStore) CreateSkillFileBlob(ctx context.Context, blob *tables.TableSkillFileBlob) error {
+	if blob.ID == "" {
+		blob.ID = uuid.NewString()
+	}
+	return s.DB().WithContext(ctx).Create(blob).Error
+}
+
+// UpdateSkillConfigHash sets the config_hash on a skill row so config reconciliation
+// can detect subsequent no-change restarts without re-running UpdateSkill.
+func (s *RDBConfigStore) UpdateSkillConfigHash(ctx context.Context, skillID string, configHash string) error {
+	return s.DB().WithContext(ctx).
+		Model(&tables.TableSkill{}).
+		Where("id = ?", skillID).
+		Update("config_hash", configHash).Error
+}
+
+// CleanupOrphanSkillFileBlobs deletes DB fallback blobs not referenced by any skill file.
+// When force is false, a 30-minute grace period protects freshly uploaded pending blobs.
+func (s *RDBConfigStore) CleanupOrphanSkillFileBlobs(ctx context.Context, force bool) (int64, error) {
+	query := s.DB().WithContext(ctx)
+	if !force {
+		cutoff := time.Now().Add(-30 * time.Minute)
+		query = query.Where("created_at < ?", cutoff)
+	}
+	result := query.
+		Where("NOT EXISTS (?)",
+			s.DB().Model(&tables.TableSkillFile{}).
+				Select("1").
+				Where("skill_files.blob_id = skill_file_blobs.id"),
+		).
+		Delete(&tables.TableSkillFileBlob{})
+	return result.RowsAffected, result.Error
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/objectstore"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"gorm.io/gorm"
 )
@@ -35,6 +36,22 @@ type ModelConfigsQueryParams struct {
 	Search   string
 	Scope    string // optional; filters to an exact scope value (e.g. "global", "virtual_key")
 	Provider string // optional; filters to an exact provider value (e.g. "openai")
+}
+
+// SkillListQueryParams holds pagination, filtering, and search parameters for skill repository queries.
+type SkillListQueryParams struct {
+	Limit  int
+	Offset int
+	Search string
+	SortBy string // name, updated_at, created_at (default: created_at)
+	Order  string // asc, desc (default: desc)
+}
+
+type SkillVersionListQueryParams struct {
+	Limit  int
+	Offset int
+	SortBy string // version, created_at (default: created_at)
+	Order  string // asc, desc (default: desc)
 }
 
 // RoutingRulesQueryParams holds pagination, filtering, and search parameters for routing rules queries.
@@ -578,6 +595,23 @@ type ConfigStore interface {
 	GetLatestPromptVersion(ctx context.Context, promptID string) (*tables.TablePromptVersion, error)
 	CreatePromptVersion(ctx context.Context, version *tables.TablePromptVersion) error
 	DeletePromptVersion(ctx context.Context, id uint) error
+
+	// Skills Repository
+	CreateSkill(ctx context.Context, skill *tables.TableSkill, version string, objectStore objectstore.ObjectStore) error
+	GetSkill(ctx context.Context, id string) (*tables.TableSkill, error)
+	GetSkillLean(ctx context.Context, id string) (*tables.TableSkill, error)
+	GetSkillByName(ctx context.Context, name string) (*tables.TableSkill, error)
+	GetSkillVersion(ctx context.Context, skillID, version string) (*tables.TableSkillVersion, error)
+	ListSkillVersions(ctx context.Context, skillID string, params SkillVersionListQueryParams) ([]tables.TableSkillVersion, int64, error)
+	UpdateSkill(ctx context.Context, skill *tables.TableSkill, version string, serve bool, objectStore objectstore.ObjectStore) error
+	DeleteSkill(ctx context.Context, id string, objectStore objectstore.ObjectStore) error
+	ListSkills(ctx context.Context, params SkillListQueryParams) ([]tables.TableSkill, int64, error)
+	ShiftSkillVersion(ctx context.Context, skillID string, targetVersion string, objectStore objectstore.ObjectStore) error
+	GetAllSkillsVersion(ctx context.Context) (string, error)
+	BumpAllSkillsVersion(ctx context.Context, bump string) (string, error)
+	CreateSkillFileBlob(ctx context.Context, blob *tables.TableSkillFileBlob) error
+	CleanupOrphanSkillFileBlobs(ctx context.Context, force bool) (int64, error)
+	UpdateSkillConfigHash(ctx context.Context, skillID string, configHash string) error
 
 	// Prompt Repository - Sessions
 	GetPromptSessions(ctx context.Context, promptID string) ([]tables.TablePromptSession, error)

--- a/framework/configstore/tables/skills.go
+++ b/framework/configstore/tables/skills.go
@@ -1,0 +1,212 @@
+// Package tables provides tables for the configstore
+package tables
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	SkillSourceTypeURL     = "url"
+	SkillSourceTypeDataURL = "dataurl"
+	SkillSourceTypeText    = "text"
+	SkillSourceTypeUpload  = "upload"
+)
+
+// SkillStringMap is stored as JSON and represents spec metadata string pairs.
+type SkillStringMap map[string]string
+
+// SkillJSONMap is stored as JSON and represents arbitrary extra frontmatter.
+type SkillJSONMap map[string]any
+
+// Value implements driver.Valuer for SkillStringMap.
+func (m SkillStringMap) Value() (driver.Value, error) {
+	if m == nil {
+		return "{}", nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return string(data), nil
+}
+
+// Scan implements sql.Scanner for SkillStringMap.
+func (m *SkillStringMap) Scan(value any) error {
+	return scanSkillJSON(value, m)
+}
+
+// Value implements driver.Valuer for SkillJSONMap.
+func (m SkillJSONMap) Value() (driver.Value, error) {
+	if m == nil {
+		return "{}", nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return string(data), nil
+}
+
+// Scan implements sql.Scanner for SkillJSONMap.
+func (m *SkillJSONMap) Scan(value any) error {
+	return scanSkillJSON(value, m)
+}
+
+func scanSkillJSON(value any, dest any) error {
+	if value == nil {
+		return nil
+	}
+
+	var data []byte
+	switch v := value.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return fmt.Errorf("unsupported skill JSON value type %T", value)
+	}
+
+	if len(data) == 0 {
+		return nil
+	}
+	return json.Unmarshal(data, dest)
+}
+
+// TableSkill represents a skill in the repository. Every save creates a version snapshot.
+type TableSkill struct {
+	ID               string         `gorm:"type:varchar(36);primaryKey" json:"id"`
+	Name             string         `gorm:"type:varchar(64);not null;uniqueIndex" json:"name"`
+	Description      string         `gorm:"type:varchar(1024);not null" json:"description"`
+	License          *string        `gorm:"type:text" json:"license,omitempty"`
+	Compatibility    *string        `gorm:"type:varchar(500)" json:"compatibility,omitempty"`
+	Metadata         SkillStringMap `gorm:"type:json" json:"metadata,omitempty"`
+	ExtraFrontmatter SkillJSONMap   `gorm:"type:json;column:extra_frontmatter" json:"extra_frontmatter,omitempty"`
+	AllowedTools     *string        `gorm:"type:text;column:allowed_tools" json:"allowed_tools,omitempty"`
+	SkillMDBody      string         `gorm:"type:text;not null;column:skill_md_body" json:"skill_md_body"`
+	LatestVersion    string         `gorm:"type:varchar(100);not null;column:latest_version" json:"latest_version"`
+	CreatedBy        *string        `gorm:"type:varchar(255);column:created_by" json:"created_by,omitempty"`
+	ConfigHash       string         `gorm:"type:varchar(64)" json:"-"`
+	CreatedAt        time.Time      `gorm:"not null" json:"created_at"`
+	UpdatedAt        time.Time      `gorm:"not null" json:"updated_at"`
+
+	Versions []TableSkillVersion `gorm:"foreignKey:SkillID;constraint:OnDelete:CASCADE" json:"versions,omitempty"`
+
+	// Transient: populated from the serving version's files for API convenience.
+	// Not stored in the skills table; filled by the store layer on read.
+	Files []TableSkillFile `gorm:"-" json:"files,omitempty"`
+
+	// Transient: serving version file count for list responses.
+	// Not stored in the skills table; filled by the store layer on list reads.
+	FileCount int64 `gorm:"-" json:"file_count"`
+
+	// Transient: most recently created version string across all versions of this skill.
+	// Filled by the store layer; used by the frontend for version bump validation.
+	HighestVersion string `gorm:"-" json:"highest_version,omitempty"`
+}
+
+// TableName for TableSkill.
+func (TableSkill) TableName() string { return "skills" }
+
+// TableSkillVersion represents an immutable snapshot of a skill save.
+// Files belong to versions, not directly to skills.
+type TableSkillVersion struct {
+	ID                  string       `gorm:"type:varchar(36);primaryKey" json:"id"`
+	SkillID             string       `gorm:"type:varchar(36);not null;index;uniqueIndex:idx_skill_version" json:"skill_id"`
+	Version             string       `gorm:"type:varchar(100);not null;uniqueIndex:idx_skill_version" json:"version"`
+	SkillMDBody         string       `gorm:"type:text;not null;column:skill_md_body" json:"skill_md_body,omitempty"`
+	FrontmatterSnapshot SkillJSONMap `gorm:"type:json;column:frontmatter_snapshot" json:"frontmatter_snapshot,omitempty"`
+	CreatedBy           *string      `gorm:"type:varchar(255);column:created_by" json:"created_by,omitempty"`
+	CreatedAt           time.Time    `gorm:"not null" json:"created_at"`
+
+	Skill *TableSkill `gorm:"foreignKey:SkillID" json:"skill,omitempty"`
+
+	Files []TableSkillFile `gorm:"foreignKey:SkillVersionID;constraint:OnDelete:CASCADE" json:"files,omitempty"`
+}
+
+// TableName for TableSkillVersion.
+func (TableSkillVersion) TableName() string { return "skill_versions" }
+
+// TableSkillFile represents a file associated with a skill version.
+// The file row is a pointer to the underlying blob/storage; blobs are reused
+// across versions when the file content hasn't changed.
+type TableSkillFile struct {
+	ID             string    `gorm:"type:varchar(36);primaryKey" json:"id"`
+	SkillVersionID string    `gorm:"type:varchar(36);not null;index;uniqueIndex:idx_skill_file_path;column:skill_version_id" json:"skill_version_id"`
+	Path           string    `gorm:"type:varchar(1024);not null;uniqueIndex:idx_skill_file_path" json:"path"`
+	SourceType     string    `gorm:"type:varchar(32);not null;column:source_type" json:"source_type"`
+	SourceURL      *string   `gorm:"type:text;column:source_url" json:"source_url,omitempty"`
+	StorageKey     *string   `gorm:"type:text;column:storage_key" json:"storage_key,omitempty"`
+	BlobID         *string   `gorm:"type:varchar(36);index;column:blob_id" json:"blob_id,omitempty"`
+	MimeType       string    `gorm:"type:varchar(255);column:mime_type" json:"mime_type"`
+	FileSizeBytes  int64     `gorm:"not null;default:0;column:file_size_bytes" json:"file_size_bytes"`
+	CreatedAt      time.Time `gorm:"not null" json:"created_at"`
+	UpdatedAt      time.Time `gorm:"not null" json:"updated_at"`
+
+	SkillVersion *TableSkillVersion  `gorm:"foreignKey:SkillVersionID" json:"skill_version,omitempty"`
+	Blob         *TableSkillFileBlob `gorm:"foreignKey:BlobID;constraint:OnDelete:SET NULL" json:"blob,omitempty"`
+
+	InlineContent *string `gorm:"-" json:"content,omitempty"`
+	DataURL       *string `gorm:"-" json:"dataurl,omitempty"`
+	UploadID      *string `gorm:"-" json:"upload_id,omitempty"`
+}
+
+// TableName for TableSkillFile.
+func (TableSkillFile) TableName() string { return "skill_files" }
+
+// BeforeSave normalizes the path before persisting so the unique index enforces the canonical form.
+func (f *TableSkillFile) BeforeSave(tx *gorm.DB) error {
+	f.Path = strings.TrimSpace(f.Path)
+	return nil
+}
+
+// NormalizedPath returns a trimmed relative path so uniqueness logic is stable.
+func (f TableSkillFile) NormalizedPath() string {
+	return strings.TrimSpace(f.Path)
+}
+
+// TableSkillFileBlob stores fallback file bytes when object storage is unavailable.
+type TableSkillFileBlob struct {
+	ID        string    `gorm:"type:varchar(36);primaryKey" json:"id"`
+	Data      []byte    `gorm:"not null" json:"-"`
+	CreatedAt time.Time `gorm:"not null" json:"created_at"`
+}
+
+// TableName for TableSkillFileBlob.
+func (TableSkillFileBlob) TableName() string { return "skill_file_blobs" }
+
+// BeforeCreate ensures map fields are initialized before insertion.
+func (s *TableSkill) BeforeCreate(tx *gorm.DB) error {
+	if s.Metadata == nil {
+		s.Metadata = SkillStringMap{}
+	}
+	if s.ExtraFrontmatter == nil {
+		s.ExtraFrontmatter = SkillJSONMap{}
+	}
+	return nil
+}
+
+// BeforeSave ensures map fields are initialized before update.
+func (s *TableSkill) BeforeSave(tx *gorm.DB) error {
+	if s.Metadata == nil {
+		s.Metadata = SkillStringMap{}
+	}
+	if s.ExtraFrontmatter == nil {
+		s.ExtraFrontmatter = SkillJSONMap{}
+	}
+	return nil
+}
+
+// BeforeCreate ensures snapshot fields are initialized before insertion.
+func (v *TableSkillVersion) BeforeCreate(tx *gorm.DB) error {
+	if v.FrontmatterSnapshot == nil {
+		v.FrontmatterSnapshot = SkillJSONMap{}
+	}
+	return nil
+}

--- a/framework/objectstore/gcs.go
+++ b/framework/objectstore/gcs.go
@@ -12,6 +12,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/maximhq/bifrost/core/schemas"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
 
@@ -117,6 +118,23 @@ func (g *GCSObjectStore) Get(ctx context.Context, key string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+// ListByPrefix returns object keys matching the given prefix.
+func (g *GCSObjectStore) ListByPrefix(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	it := g.client.Bucket(g.bucket).Objects(ctx, &storage.Query{Prefix: prefix})
+	objects := make([]ObjectInfo, 0)
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("objectstore: gcs list prefix %s: %w", prefix, err)
+		}
+		objects = append(objects, ObjectInfo{Key: attrs.Name, LastModified: attrs.Updated})
+	}
+	return objects, nil
 }
 
 // Delete removes a single object by key.

--- a/framework/objectstore/mock.go
+++ b/framework/objectstore/mock.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strings"
 	"sync"
+	"time"
 )
 
 // InMemoryObjectStore is an in-memory ObjectStore implementation for testing.
 type InMemoryObjectStore struct {
-	mu      sync.RWMutex
-	objects map[string][]byte
-	tags    map[string]map[string]string
+	mu        sync.RWMutex
+	objects   map[string][]byte
+	tags      map[string]map[string]string
+	createdAt map[string]time.Time
 
 	// PutErr, if set, is returned by Put for simulating failures.
 	PutErr error
@@ -22,8 +25,9 @@ type InMemoryObjectStore struct {
 // NewInMemoryObjectStore creates a new in-memory object store.
 func NewInMemoryObjectStore() *InMemoryObjectStore {
 	return &InMemoryObjectStore{
-		objects: make(map[string][]byte),
-		tags:    make(map[string]map[string]string),
+		objects:   make(map[string][]byte),
+		tags:      make(map[string]map[string]string),
+		createdAt: make(map[string]time.Time),
 	}
 }
 
@@ -37,6 +41,9 @@ func (m *InMemoryObjectStore) Put(_ context.Context, key string, data []byte, ta
 	cp := make([]byte, len(data))
 	copy(cp, data)
 	m.objects[key] = cp
+	if _, exists := m.createdAt[key]; !exists {
+		m.createdAt[key] = time.Now()
+	}
 	if len(tags) > 0 {
 		tagsCp := make(map[string]string, len(tags))
 		maps.Copy(tagsCp, tags)
@@ -62,11 +69,24 @@ func (m *InMemoryObjectStore) Get(_ context.Context, key string) ([]byte, error)
 	return cp, nil
 }
 
+func (m *InMemoryObjectStore) ListByPrefix(_ context.Context, prefix string) ([]ObjectInfo, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	objects := make([]ObjectInfo, 0)
+	for key := range m.objects {
+		if key != "" && strings.HasPrefix(key, prefix) {
+			objects = append(objects, ObjectInfo{Key: key, LastModified: m.createdAt[key]})
+		}
+	}
+	return objects, nil
+}
+
 func (m *InMemoryObjectStore) Delete(_ context.Context, key string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.objects, key)
 	delete(m.tags, key)
+	delete(m.createdAt, key)
 	return nil
 }
 
@@ -76,6 +96,7 @@ func (m *InMemoryObjectStore) DeleteBatch(_ context.Context, keys []string) erro
 	for _, key := range keys {
 		delete(m.objects, key)
 		delete(m.tags, key)
+		delete(m.createdAt, key)
 	}
 	return nil
 }
@@ -117,4 +138,11 @@ func (m *InMemoryObjectStore) Keys() []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// SetCreatedAt overrides the creation time for the given key. For testing assertions.
+func (m *InMemoryObjectStore) SetCreatedAt(key string, t time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createdAt[key] = t
 }

--- a/framework/objectstore/objectstore.go
+++ b/framework/objectstore/objectstore.go
@@ -3,7 +3,16 @@
 // objects from S3, GCS (via S3 interop), MinIO, R2, or other S3-compatible stores.
 package objectstore
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// ObjectInfo describes a stored object returned by listing operations.
+type ObjectInfo struct {
+	Key          string
+	LastModified time.Time
+}
 
 // ObjectStore abstracts S3-compatible blob storage operations.
 type ObjectStore interface {
@@ -13,6 +22,9 @@ type ObjectStore interface {
 
 	// Get retrieves and decompresses data for the given key.
 	Get(ctx context.Context, key string) ([]byte, error)
+
+	// ListByPrefix returns objects matching the given prefix with metadata.
+	ListByPrefix(ctx context.Context, prefix string) ([]ObjectInfo, error)
 
 	// Delete removes an object by key.
 	Delete(ctx context.Context, key string) error

--- a/framework/objectstore/objectstore_test.go
+++ b/framework/objectstore/objectstore_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 )
 
@@ -103,6 +104,24 @@ func TestInMemoryObjectStore(t *testing.T) {
 	}
 	if store.Len() != 1 {
 		t.Fatalf("Len after batch delete: got %d, want 1", store.Len())
+	}
+
+	// ListByPrefix
+	_ = store.Put(ctx, "prefix/one", []byte("1"), nil)
+	_ = store.Put(ctx, "prefix/two", []byte("2"), nil)
+	_ = store.Put(ctx, "other/three", []byte("3"), nil)
+	objects, err := store.ListByPrefix(ctx, "prefix/")
+	if err != nil {
+		t.Fatalf("ListByPrefix: %v", err)
+	}
+	if len(objects) != 2 {
+		t.Fatalf("ListByPrefix got %d objects, want 2: %v", len(objects), objects)
+	}
+	gotKeys := []string{objects[0].Key, objects[1].Key}
+	sort.Strings(gotKeys)
+	wantKeys := []string{"prefix/one", "prefix/two"}
+	if gotKeys[0] != wantKeys[0] || gotKeys[1] != wantKeys[1] {
+		t.Fatalf("ListByPrefix keys: got %v, want %v", gotKeys, wantKeys)
 	}
 
 	// Ping and Close

--- a/framework/objectstore/s3.go
+++ b/framework/objectstore/s3.go
@@ -218,6 +218,34 @@ func (s *S3ObjectStore) DeleteBatch(ctx context.Context, keys []string) error {
 	return nil
 }
 
+// ListByPrefix returns all non-empty object keys matching the given prefix.
+func (s *S3ObjectStore) ListByPrefix(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(prefix),
+	})
+
+	objects := make([]ObjectInfo, 0)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("objectstore: list objects with prefix %s: %w", prefix, err)
+		}
+		for _, object := range page.Contents {
+			key := aws.ToString(object.Key)
+			if key != "" {
+				info := ObjectInfo{Key: key}
+				if object.LastModified != nil {
+					info.LastModified = *object.LastModified
+				}
+				objects = append(objects, info)
+			}
+		}
+	}
+
+	return objects, nil
+}
+
 // Ping checks connectivity by performing a HeadBucket call.
 // Note: HeadBucket requires the s3:ListBucket IAM permission on the bucket resource.
 func (s *S3ObjectStore) Ping(ctx context.Context) error {

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -170,6 +170,7 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 		}
 	}
 	mapConfig["is_db_connected"] = h.store.ConfigStore != nil
+	mapConfig["is_git_available"] = CheckGitAvailability()
 	mapConfig["is_cache_connected"] = h.store.VectorStore != nil
 	mapConfig["is_logs_connected"] = h.store.LogsStore != nil
 	// Fetching proxy config

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -858,6 +858,10 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 		// /api/oauth/config/* (admin-only) and bypass the temp-token fallback
 		// in tryTempTokenOrUnauthorized.
 		"/api/dev",
+		// Skills serving endpoints are public — marketplace URLs cannot carry
+		// credentials securely. Management endpoints under /api/skills (without
+		// /serve/) remain authenticated.
+		"/api/skills/serve/",
 	}
 	return m.middleware(func(authConfig *configstore.AuthConfig, url string) bool {
 		if slices.Contains(systemWhitelistedRoutes, url) ||
@@ -869,8 +873,8 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 		// Check user-configured whitelisted routes
 		if configuredRoutes := m.whitelistedRoutes.Load(); configuredRoutes != nil {
 			if slices.Contains(*configuredRoutes, url) || slices.IndexFunc(*configuredRoutes, func(route string) bool {
-				if strings.HasSuffix(route, "*") {
-					return strings.HasPrefix(url, strings.TrimSuffix(route, "*"))
+				if before, ok := strings.CutSuffix(route, "*"); ok {
+					return strings.HasPrefix(url, before)
 				}
 				return false
 			}) != -1 {

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -690,6 +690,50 @@ func TestAuthMiddleware_EnabledAuthConfig_NoAuth(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_SkillsPublicServeManagementSplit(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	am := &AuthMiddleware{}
+	am.UpdateAuthConfig(&configstore.AuthConfig{
+		AdminUserName: schemas.NewEnvVar("admin"),
+		AdminPassword: schemas.NewEnvVar("hashedpassword"),
+		IsEnabled:     true,
+	})
+
+	t.Run("serve routes bypass auth", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.SetRequestURI("/api/skills/serve/my-skill.git/info/refs?service=git-upload-pack")
+
+		nextCalled := false
+		handler := am.APIMiddleware()(func(ctx *fasthttp.RequestCtx) {
+			nextCalled = true
+		})
+		handler(ctx)
+
+		if !nextCalled {
+			t.Fatal("expected public skills serving route to bypass auth")
+		}
+	})
+
+	t.Run("management routes require auth", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.SetRequestURI("/api/skills")
+
+		nextCalled := false
+		handler := am.APIMiddleware()(func(ctx *fasthttp.RequestCtx) {
+			nextCalled = true
+		})
+		handler(ctx)
+
+		if nextCalled {
+			t.Fatal("expected skills management route to require auth")
+		}
+		if ctx.Response.StatusCode() != fasthttp.StatusUnauthorized {
+			t.Fatalf("expected %d, got %d", fasthttp.StatusUnauthorized, ctx.Response.StatusCode())
+		}
+	})
+}
+
 // TestAuthMiddleware_WhitelistedRoutes tests that whitelisted routes bypass auth
 func TestAuthMiddleware_WhitelistedRoutes(t *testing.T) {
 	SetLogger(&mockLogger{})

--- a/transports/bifrost-http/handlers/skills.go
+++ b/transports/bifrost-http/handlers/skills.go
@@ -1,0 +1,908 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fasthttp/router"
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// ============================================================================
+// Validation constants
+// ============================================================================
+
+// skillUploadObjectPrefix references the canonical prefix from configstore.
+var skillUploadObjectPrefix = configstore.SkillObjectPrefix + "uploads/"
+
+// Reserved frontmatter keys that cannot appear in extra_frontmatter.
+var reservedFrontmatterKeys = map[string]struct{}{
+	"name":          {},
+	"description":   {},
+	"license":       {},
+	"compatibility": {},
+	"metadata":      {},
+	"allowed-tools": {},
+}
+
+// ============================================================================
+// SkillsHandler
+// ============================================================================
+
+// SkillsHandler handles skill repository management endpoints.
+type SkillsHandler struct {
+	store       configstore.ConfigStore
+	objectStore objectstore.ObjectStore // nullable — object storage may not be configured
+}
+
+type SkillOrphanCleanupResult struct {
+	DeletedDBBlobs        int64 `json:"deleted_db_blobs"`
+	DeletedStorageObjects int   `json:"deleted_storage_objects"`
+}
+
+type AllSkillsVersionResponse struct {
+	Version string `json:"version"`
+}
+
+type BumpAllSkillsVersionRequest struct {
+	Bump string `json:"bump"`
+}
+
+// NewSkillsHandler creates a new SkillsHandler.
+// objectStore may be nil; when nil, file uploads fall back to DB blobs.
+func NewSkillsHandler(store configstore.ConfigStore, objectStore objectstore.ObjectStore) *SkillsHandler {
+	if store == nil {
+		return nil
+	}
+	return &SkillsHandler{store: store, objectStore: objectStore}
+}
+
+// RegisterRoutes registers the routes for the SkillsHandler.
+func (h *SkillsHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	// File uploads (before skill CRUD so /files/ prefix matches first)
+	r.POST("/api/skills/files/upload", lib.ChainMiddlewares(h.uploadFile, middlewares...))
+	r.DELETE("/api/skills/files/orphans", lib.ChainMiddlewares(h.cleanupOrphanFiles, middlewares...))
+	r.GET("/api/skills/all/version", lib.ChainMiddlewares(h.getAllSkillsVersion, middlewares...))
+	r.PUT("/api/skills/all/version", lib.ChainMiddlewares(h.bumpAllSkillsVersion, middlewares...))
+
+	// Skill CRUD
+	r.POST("/api/skills", lib.ChainMiddlewares(h.createSkill, middlewares...))
+	r.GET("/api/skills", lib.ChainMiddlewares(h.listSkills, middlewares...))
+	r.GET("/api/skills/{id}", lib.ChainMiddlewares(h.getSkill, middlewares...))
+	r.GET("/api/skills/{id}/versions", lib.ChainMiddlewares(h.listSkillVersions, middlewares...))
+	r.PUT("/api/skills/{id}", lib.ChainMiddlewares(h.updateSkill, middlewares...))
+	r.DELETE("/api/skills/{id}", lib.ChainMiddlewares(h.deleteSkill, middlewares...))
+	r.POST("/api/skills/{id}/shift-version", lib.ChainMiddlewares(h.shiftVersion, middlewares...))
+}
+
+// ============================================================================
+// Request/Response Types
+// ============================================================================
+
+// CreateSkillRequest is the JSON payload for creating a skill.
+type CreateSkillRequest struct {
+	Name             string            `json:"name"`
+	Description      string            `json:"description"`
+	License          *string           `json:"license,omitempty"`
+	Compatibility    *string           `json:"compatibility,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	ExtraFrontmatter map[string]any    `json:"extra_frontmatter,omitempty"`
+	AllowedTools     *string           `json:"allowed_tools,omitempty"`
+	SkillMDBody      string            `json:"skill_md_body"`
+	Version          string            `json:"version"`
+	Files            []SkillFileEntry  `json:"files,omitempty"`
+}
+
+// UpdateSkillRequest is the JSON payload for updating a skill.
+type UpdateSkillRequest struct {
+	Description      string            `json:"description"`
+	License          *string           `json:"license,omitempty"`
+	Compatibility    *string           `json:"compatibility,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	ExtraFrontmatter map[string]any    `json:"extra_frontmatter,omitempty"`
+	AllowedTools     *string           `json:"allowed_tools,omitempty"`
+	SkillMDBody      string            `json:"skill_md_body"`
+	Version          string            `json:"version"`
+	Files            []SkillFileEntry  `json:"files,omitempty"`
+	Serve            *bool             `json:"serve,omitempty"` // when false, creates a new version without switching serving
+}
+
+// SkillFileEntry represents a single file in the create/update request.
+type SkillFileEntry struct {
+	Path       string  `json:"path"`
+	SourceType string  `json:"source_type"`
+	Content    *string `json:"content,omitempty"`     // for source_type "text"
+	SourceURL  *string `json:"source_url,omitempty"`  // for source_type "url"
+	DataURL    *string `json:"dataurl,omitempty"`     // for source_type "dataurl"
+	UploadID   *string `json:"upload_id,omitempty"`   // for source_type "upload"
+	StorageKey *string `json:"storage_key,omitempty"` // existing stored file reference
+	BlobID     *string `json:"blob_id,omitempty"`     // existing DB fallback blob reference
+	MimeType   string  `json:"mime_type"`
+}
+
+// ============================================================================
+// File Upload Handlers
+// ============================================================================
+
+// uploadFile handles POST /api/skills/files/upload — multipart file upload.
+func (h *SkillsHandler) uploadFile(ctx *fasthttp.RequestCtx) {
+	form, err := ctx.MultipartForm()
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid multipart form data")
+		return
+	}
+
+	filePath := ""
+	if paths, ok := form.Value["path"]; ok && len(paths) > 0 {
+		filePath = paths[0]
+	}
+
+	files := form.File["file"]
+	if len(files) == 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, "file is required")
+		return
+	}
+	if len(files) > 1 {
+		SendError(ctx, fasthttp.StatusBadRequest, "only one file is allowed per upload request")
+		return
+	}
+	fileHeader := files[0]
+	filename := fileHeader.Filename
+	if filePath == "" {
+		filePath = filename
+	}
+	if errMsg := validateSkillFilePath(filePath); errMsg != "" {
+		SendError(ctx, fasthttp.StatusBadRequest, errMsg)
+		return
+	}
+
+	// Read file bytes.
+	if fileHeader.Size > configstore.MaxSkillFileContentSize {
+		SendError(ctx, fasthttp.StatusRequestEntityTooLarge, "file exceeds 50 MB upload limit")
+		return
+	}
+	f, err := fileHeader.Open()
+	if err != nil {
+		logger.Error("failed to open uploaded file: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to read uploaded file")
+		return
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, configstore.MaxSkillFileContentSize+1))
+	if err != nil {
+		logger.Error("failed to read uploaded file: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to read uploaded file")
+		return
+	}
+	if len(data) > configstore.MaxSkillFileContentSize {
+		SendError(ctx, fasthttp.StatusRequestEntityTooLarge, "file exceeds 50 MB upload limit")
+		return
+	}
+
+	uploadID := uuid.New().String()
+	mimeType := fileHeader.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
+	// Store in object storage if available, else create a DB blob.
+	if h.objectStore != nil {
+		storageKey := fmt.Sprintf("%s%s/%s", skillUploadObjectPrefix, uploadID, path.Base(filePath))
+		if err := h.objectStore.Put(ctx, storageKey, data, map[string]string{
+			"upload_id": uploadID,
+			"path":      filePath,
+		}); err != nil {
+			logger.Error("failed to store file in object storage: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to store uploaded file")
+			return
+		}
+
+		SendJSON(ctx, map[string]any{
+			"upload_id":       uploadID,
+			"storage_key":     storageKey,
+			"path":            filePath,
+			"filename":        filename,
+			"mime_type":       mimeType,
+			"file_size_bytes": int64(len(data)),
+		})
+		return
+	}
+
+	// Fallback: store as a DB blob.
+	blobID := uuid.New().String()
+	blob := &tables.TableSkillFileBlob{
+		ID:   blobID,
+		Data: data,
+	}
+	if err := h.store.CreateSkillFileBlob(ctx, blob); err != nil {
+		logger.Error("failed to store file blob: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to store uploaded file")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"upload_id":       uploadID,
+		"blob_id":         blobID,
+		"path":            filePath,
+		"filename":        filename,
+		"mime_type":       mimeType,
+		"file_size_bytes": int64(len(data)),
+	})
+}
+
+// cleanupOrphanFiles handles DELETE /api/skills/files/orphans.
+func (h *SkillsHandler) cleanupOrphanFiles(ctx *fasthttp.RequestCtx) {
+	force := string(ctx.QueryArgs().Peek("force")) == "true"
+	result, err := CleanupOrphanSkillFiles(ctx, h.store, h.objectStore, force)
+	if err != nil {
+		logger.Error("failed to cleanup orphan skill files: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to cleanup orphan files")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"deleted_db_blobs":          result.DeletedDBBlobs,
+		"deleted_storage_objects":   result.DeletedStorageObjects,
+		"object_storage_configured": h.objectStore != nil,
+		"message":                   "orphan skill files cleaned up successfully",
+	})
+}
+
+// CleanupOrphanSkillFiles removes DB fallback blobs and unreferenced upload objects.
+// When force is false, a 30-minute grace period protects freshly uploaded pending files.
+func CleanupOrphanSkillFiles(ctx context.Context, store configstore.ConfigStore, objectStore objectstore.ObjectStore, force bool) (SkillOrphanCleanupResult, error) {
+	var result SkillOrphanCleanupResult
+	if store == nil {
+		return result, fmt.Errorf("config store is required")
+	}
+
+	deletedDBBlobs, err := store.CleanupOrphanSkillFileBlobs(ctx, force)
+	if err != nil {
+		return result, fmt.Errorf("cleanup orphan skill file blobs: %w", err)
+	}
+	result.DeletedDBBlobs = deletedDBBlobs
+
+	if objectStore == nil {
+		return result, nil
+	}
+
+	uploadObjects, err := objectStore.ListByPrefix(ctx, configstore.SkillObjectPrefix)
+	if err != nil {
+		return result, fmt.Errorf("list skill upload objects: %w", err)
+	}
+	if len(uploadObjects) == 0 {
+		return result, nil
+	}
+
+	var referencedKeys []string
+	if err := store.DB().WithContext(ctx).
+		Model(&tables.TableSkillFile{}).
+		Where("storage_key IS NOT NULL AND storage_key != ''").
+		Distinct("storage_key").
+		Pluck("storage_key", &referencedKeys).Error; err != nil {
+		return result, fmt.Errorf("list referenced skill file storage keys: %w", err)
+	}
+
+	referenced := make(map[string]struct{}, len(referencedKeys))
+	for _, key := range referencedKeys {
+		referenced[key] = struct{}{}
+	}
+
+	// Only reap unreferenced objects older than 30 minutes unless force is set.
+	orphanKeys := make([]string, 0)
+	if force {
+		for _, obj := range uploadObjects {
+			if _, ok := referenced[obj.Key]; !ok {
+				orphanKeys = append(orphanKeys, obj.Key)
+			}
+		}
+	} else {
+		cutoff := time.Now().Add(-30 * time.Minute)
+		for _, obj := range uploadObjects {
+			if _, ok := referenced[obj.Key]; !ok && obj.LastModified.Before(cutoff) {
+				orphanKeys = append(orphanKeys, obj.Key)
+			}
+		}
+	}
+	if len(orphanKeys) == 0 {
+		return result, nil
+	}
+	if err := objectStore.DeleteBatch(ctx, orphanKeys); err != nil {
+		return result, fmt.Errorf("delete orphan skill upload objects: %w", err)
+	}
+	result.DeletedStorageObjects = len(orphanKeys)
+	return result, nil
+}
+
+func (h *SkillsHandler) getAllSkillsVersion(ctx *fasthttp.RequestCtx) {
+	version, err := h.store.GetAllSkillsVersion(ctx)
+	if err != nil {
+		logger.Error("failed to get all-skills version: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to get all-skills version")
+		return
+	}
+	SendJSON(ctx, AllSkillsVersionResponse{Version: version})
+}
+
+func (h *SkillsHandler) bumpAllSkillsVersion(ctx *fasthttp.RequestCtx) {
+	var req BumpAllSkillsVersionRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	version, err := h.store.BumpAllSkillsVersion(ctx, strings.ToLower(strings.TrimSpace(req.Bump)))
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	SendJSON(ctx, AllSkillsVersionResponse{Version: version})
+}
+
+// ============================================================================
+// Skill CRUD Handlers
+// ============================================================================
+
+// createSkill handles POST /api/skills.
+func (h *SkillsHandler) createSkill(ctx *fasthttp.RequestCtx) {
+	var req CreateSkillRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if errs := validateSkillRequest(req.Name, req.Description, req.SkillMDBody, req.Version, req.ExtraFrontmatter, req.Files, true); len(errs) > 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, strings.Join(errs, "; "))
+		return
+	}
+
+	if err := inferLiveFileMimeTypes(ctx, req.Files, "skills api create"); err != nil {
+		logger.Warn("%v", err)
+	}
+
+	skill := &tables.TableSkill{
+		ID:               uuid.New().String(),
+		Name:             req.Name,
+		Description:      req.Description,
+		License:          req.License,
+		Compatibility:    req.Compatibility,
+		Metadata:         tables.SkillStringMap(req.Metadata),
+		ExtraFrontmatter: tables.SkillJSONMap(req.ExtraFrontmatter),
+		AllowedTools:     req.AllowedTools,
+		SkillMDBody:      req.SkillMDBody,
+		LatestVersion:    req.Version,
+	}
+
+	// Build file records (SkillVersionID is set by the store).
+	for _, fe := range req.Files {
+		skill.Files = append(skill.Files, fileEntryToTableSkillFile(fe))
+	}
+
+	if err := h.store.CreateSkill(ctx, skill, req.Version, h.objectStore); err != nil {
+		if errors.Is(err, configstore.ErrAlreadyExists) {
+			SendError(ctx, fasthttp.StatusConflict, "a skill with this name already exists")
+			return
+		}
+		logger.Error("failed to create skill: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skill": skill,
+	})
+}
+
+func parseSkillSortParams(ctx *fasthttp.RequestCtx, allowed map[string]struct{}, defaultSortBy, defaultOrder string) (string, string) {
+	sortBy := string(ctx.QueryArgs().Peek("sort_by"))
+	if _, ok := allowed[sortBy]; !ok {
+		sortBy = defaultSortBy
+	}
+	order := strings.ToLower(string(ctx.QueryArgs().Peek("order")))
+	if order != "asc" && order != "desc" {
+		order = defaultOrder
+	}
+	return sortBy, order
+}
+
+// listSkills handles GET /api/skills.
+func (h *SkillsHandler) listSkills(ctx *fasthttp.RequestCtx) {
+	sortBy, order := parseSkillSortParams(ctx, map[string]struct{}{
+		"name":       {},
+		"updated_at": {},
+		"created_at": {},
+	}, "created_at", "desc")
+	params := configstore.SkillListQueryParams{
+		Search: string(ctx.QueryArgs().Peek("search")),
+		SortBy: sortBy,
+		Order:  order,
+	}
+
+	if limitStr := string(ctx.QueryArgs().Peek("limit")); limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil && v > 0 {
+			params.Limit = min(v, 100)
+		}
+	}
+	if params.Limit == 0 {
+		params.Limit = 50 // sensible default
+	}
+
+	if offsetStr := string(ctx.QueryArgs().Peek("offset")); offsetStr != "" {
+		if v, err := strconv.Atoi(offsetStr); err == nil && v >= 0 {
+			params.Offset = v
+		}
+	}
+
+	skills, total, err := h.store.ListSkills(ctx, params)
+	if err != nil {
+		logger.Error("failed to list skills: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skills": skills,
+		"total":  total,
+		"limit":  params.Limit,
+		"offset": params.Offset,
+	})
+}
+
+// getSkill handles GET /api/skills/{id}.
+func (h *SkillsHandler) getSkill(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	// Check for ?version=X.Y.Z query param to return a specific version's data.
+	if versionParam := string(ctx.QueryArgs().Peek("version")); versionParam != "" {
+		skill, err := h.store.GetSkillLean(ctx, id)
+		if err != nil {
+			if errors.Is(err, configstore.ErrNotFound) {
+				SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+				return
+			}
+			logger.Error("failed to get skill: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+			return
+		}
+		found, err := h.store.GetSkillVersion(ctx, id, versionParam)
+		if err != nil {
+			if errors.Is(err, configstore.ErrNotFound) {
+				SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("version %q not found", versionParam))
+				return
+			}
+			logger.Error("failed to get skill version: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+			return
+		}
+		// Overlay version data onto skill response (name is immutable, stays as current).
+		skill.SkillMDBody = found.SkillMDBody
+		skill.LatestVersion = found.Version
+		fields := configstore.ExtractSkillFieldsFromFrontmatter(found.FrontmatterSnapshot)
+		skill.Description = fields.Description
+		skill.License = fields.License
+		skill.Compatibility = fields.Compatibility
+		skill.AllowedTools = fields.AllowedTools
+		skill.Metadata = fields.Metadata
+		skill.ExtraFrontmatter = fields.ExtraFrontmatter
+		skill.Files = found.Files
+		SendJSON(ctx, map[string]any{
+			"skill": skill,
+		})
+		return
+	}
+
+	skill, err := h.store.GetSkillLean(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+			return
+		}
+		logger.Error("failed to get skill: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skill": skill,
+	})
+}
+
+// listSkillVersions handles GET /api/skills/{id}/versions.
+func (h *SkillsHandler) listSkillVersions(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	limit := 25
+	offset := 0
+	sortBy, order := parseSkillSortParams(ctx, map[string]struct{}{
+		"version":    {},
+		"created_at": {},
+	}, "created_at", "desc")
+	if n, err := strconv.Atoi(string(ctx.QueryArgs().Peek("limit"))); err == nil && n > 0 {
+		limit = min(n, 100)
+	}
+	if n, err := strconv.Atoi(string(ctx.QueryArgs().Peek("offset"))); err == nil && n >= 0 {
+		offset = n
+	}
+
+	versions, total, err := h.store.ListSkillVersions(ctx, id, configstore.SkillVersionListQueryParams{
+		Limit:  limit,
+		Offset: offset,
+		SortBy: sortBy,
+		Order:  order,
+	})
+	if err != nil {
+		logger.Error("failed to list skill versions: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"versions": versions,
+		"total":    total,
+		"limit":    limit,
+		"offset":   offset,
+	})
+}
+
+// shiftVersion handles POST /api/skills/{id}/shift-version.
+func (h *SkillsHandler) shiftVersion(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Version == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "version is required")
+		return
+	}
+
+	if err := h.store.ShiftSkillVersion(ctx, id, req.Version, h.objectStore); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+			return
+		}
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "already serving") {
+			SendError(ctx, fasthttp.StatusBadRequest, errMsg)
+			return
+		}
+		logger.Error("failed to shift skill version: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, errMsg)
+		return
+	}
+
+	skill, err := h.store.GetSkill(ctx, id)
+	if err != nil {
+		logger.Error("failed to reload skill after version shift: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "version shifted but failed to reload skill")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skill": skill,
+	})
+}
+
+// updateSkill handles PUT /api/skills/{id}.
+func (h *SkillsHandler) updateSkill(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	var req UpdateSkillRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if errs := validateSkillRequest("", req.Description, req.SkillMDBody, req.Version, req.ExtraFrontmatter, req.Files, false); len(errs) > 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, strings.Join(errs, "; "))
+		return
+	}
+
+	if err := inferLiveFileMimeTypes(ctx, req.Files, "skills api update"); err != nil {
+		logger.Warn("%v", err)
+	}
+
+	skill, err := h.store.GetSkill(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+			return
+		}
+		logger.Error("failed to get skill for update: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Apply updates (name is immutable after creation).
+	skill.Description = req.Description
+	skill.License = req.License
+	skill.Compatibility = req.Compatibility
+	skill.Metadata = tables.SkillStringMap(req.Metadata)
+	skill.ExtraFrontmatter = tables.SkillJSONMap(req.ExtraFrontmatter)
+	skill.AllowedTools = req.AllowedTools
+	skill.SkillMDBody = req.SkillMDBody
+
+	// Rebuild files from the request (SkillVersionID is set by the store).
+	var files []tables.TableSkillFile
+	for _, fe := range req.Files {
+		files = append(files, fileEntryToTableSkillFile(fe))
+	}
+	skill.Files = files
+
+	serve := req.Serve == nil || *req.Serve // default true for backward compat
+	if err := h.store.UpdateSkill(ctx, skill, req.Version, serve, h.objectStore); err != nil {
+		if errors.Is(err, configstore.ErrAlreadyExists) {
+			SendError(ctx, fasthttp.StatusConflict, fmt.Sprintf("version %s already exists for this skill; provide a new version", req.Version))
+			return
+		}
+		logger.Error("failed to update skill: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	reloadedSkill, err := h.store.GetSkill(ctx, id)
+	if err != nil {
+		logger.Error("failed to reload skill after update: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "skill updated but failed to reload skill")
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"skill": reloadedSkill,
+	})
+}
+
+// deleteSkill handles DELETE /api/skills/{id}.
+func (h *SkillsHandler) deleteSkill(ctx *fasthttp.RequestCtx) {
+	id, ok := extractStringParam(ctx, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.store.DeleteSkill(ctx, id, h.objectStore); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "skill not found")
+			return
+		}
+		logger.Error("failed to delete skill: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"message": "skill deleted successfully",
+	})
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// extractStringParam extracts a path param and sends an error if missing.
+func extractStringParam(ctx *fasthttp.RequestCtx, name string) (string, bool) {
+	val := ctx.UserValue(name)
+	if val == nil {
+		SendError(ctx, fasthttp.StatusBadRequest, name+" is required")
+		return "", false
+	}
+	s, ok := val.(string)
+	if !ok || s == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid "+name)
+		return "", false
+	}
+	return s, true
+}
+
+// inferLiveFileMimeTypes infers MIME for live URL references before validation/storage.
+// Uses the SSRF-protected skillURLClient for outbound HEAD requests to avoid
+// hitting private/loopback IPs or non-HTTP(S) schemes.
+// Failures are warnings only: live sources may become reachable later, so we
+// fall back to octet-stream instead of blocking registration.
+func inferLiveFileMimeTypes(ctx context.Context, files []SkillFileEntry, source string) error {
+	var warnings []string
+	for i := range files {
+		f := &files[i]
+		if f.SourceType != tables.SkillSourceTypeURL || f.SourceURL == nil || *f.SourceURL == "" {
+			continue
+		}
+		mimeType, err := inferMimeTypeFromURL(ctx, *f.SourceURL)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("file %q: could not infer MIME from URL %q: %v", f.Path, *f.SourceURL, err))
+			f.MimeType = "application/octet-stream"
+			continue
+		}
+		f.MimeType = mimeType
+	}
+	if len(warnings) > 0 {
+		return fmt.Errorf("%s MIME inference warnings: %s", source, strings.Join(warnings, "; "))
+	}
+	return nil
+}
+
+// inferMimeTypeFromURL performs a HEAD request using the SSRF-protected client
+// to infer the MIME type from the server's Content-Type header.
+func inferMimeTypeFromURL(ctx context.Context, rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("blocked non-HTTP(S) scheme: %s", parsed.Scheme)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := skillURLClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("HEAD returned status %d", resp.StatusCode)
+	}
+	mimeType := strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])
+	if mimeType == "" {
+		return "", fmt.Errorf("HEAD response did not include Content-Type")
+	}
+	return mimeType, nil
+}
+
+// fileEntryToTableSkillFile converts a request file entry to a TableSkillFile record.
+// SkillVersionID is set by the store layer during create/update.
+func fileEntryToTableSkillFile(fe SkillFileEntry) tables.TableSkillFile {
+	sf := tables.TableSkillFile{
+		Path:       fe.Path,
+		SourceType: fe.SourceType,
+		MimeType:   fe.MimeType,
+	}
+
+	switch fe.SourceType {
+	case tables.SkillSourceTypeURL:
+		sf.SourceURL = fe.SourceURL
+	case tables.SkillSourceTypeText:
+		sf.InlineContent = fe.Content
+		sf.StorageKey = fe.StorageKey
+		sf.BlobID = fe.BlobID
+	case tables.SkillSourceTypeDataURL:
+		sf.DataURL = fe.DataURL
+		sf.StorageKey = fe.StorageKey
+		sf.BlobID = fe.BlobID
+	case tables.SkillSourceTypeUpload:
+		sf.UploadID = fe.UploadID
+		sf.StorageKey = fe.StorageKey
+		sf.BlobID = fe.BlobID
+	}
+
+	return sf
+}
+
+// validateSkillRequest performs backend validation on skill fields.
+// When validateName is true, the name field is validated (used for create).
+// Returns a slice of error messages (empty if valid).
+func validateSkillRequest(name, description, body, version string, extraFM map[string]any, files []SkillFileEntry, validateName bool) []string {
+	var errs []string
+
+	// Name: 1-64 chars, lowercase alphanum + hyphens, no leading/trailing/consecutive hyphens.
+	if validateName {
+		if err := configstore.ValidateSkillName(name); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if description == "" {
+		errs = append(errs, "description is required")
+	} else if len(description) > 1024 {
+		errs = append(errs, "description must be at most 1024 characters")
+	}
+
+	// Body: non-empty.
+	if strings.TrimSpace(body) == "" {
+		errs = append(errs, "skill_md_body is required and must not be empty")
+	}
+
+	// Version: required.
+	if err := configstore.ValidateSkillVersion(version); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	// Extra frontmatter: no reserved keys.
+	for key := range extraFM {
+		if _, reserved := reservedFrontmatterKeys[key]; reserved {
+			errs = append(errs, fmt.Sprintf("extra_frontmatter key %q is reserved and cannot be used", key))
+		}
+	}
+
+	// Files: validate each entry.
+	seenPaths := make(map[string]bool, len(files))
+	for i, f := range files {
+		prefix := fmt.Sprintf("files[%d]", i)
+		if f.Path == "" {
+			errs = append(errs, prefix+": path is required")
+		}
+		if f.SourceType == "" {
+			errs = append(errs, prefix+": source_type is required")
+		}
+		if f.Path != "" {
+			normalized := path.Clean(f.Path)
+			if seenPaths[normalized] {
+				errs = append(errs, prefix+": duplicate file path "+f.Path)
+			}
+			seenPaths[normalized] = true
+			if errMsg := validateSkillFilePath(f.Path); errMsg != "" {
+				errs = append(errs, prefix+": "+errMsg)
+			}
+		}
+		// Source-type-specific checks.
+		switch f.SourceType {
+		case tables.SkillSourceTypeURL:
+			if f.SourceURL == nil || *f.SourceURL == "" {
+				errs = append(errs, prefix+": source_url is required for url source type")
+			} else if !strings.HasPrefix(*f.SourceURL, "http://") && !strings.HasPrefix(*f.SourceURL, "https://") {
+				errs = append(errs, prefix+": source_url must start with http:// or https://")
+			}
+		case tables.SkillSourceTypeText:
+			if (f.Content == nil || *f.Content == "") && f.StorageKey == nil && f.BlobID == nil {
+				errs = append(errs, prefix+": content or an existing file reference is required for text source type")
+			}
+		case tables.SkillSourceTypeDataURL:
+			if (f.DataURL == nil || *f.DataURL == "") && f.StorageKey == nil && f.BlobID == nil {
+				errs = append(errs, prefix+": dataurl or an existing file reference is required for dataurl source type")
+			} else if f.DataURL != nil && *f.DataURL != "" && (!strings.HasPrefix(*f.DataURL, "data:") || !strings.Contains(*f.DataURL, ";base64,")) {
+				errs = append(errs, prefix+": dataurl must be a valid data URL (data:...;base64,...)")
+			}
+		case tables.SkillSourceTypeUpload:
+			if f.StorageKey == nil && f.BlobID == nil {
+				errs = append(errs, prefix+": storage_key or blob_id is required for upload source type")
+			} else if f.StorageKey != nil && !strings.HasPrefix(*f.StorageKey, configstore.SkillObjectPrefix) {
+				errs = append(errs, prefix+": storage_key must be under the skills/ object prefix")
+			}
+		default:
+			if f.SourceType != "" {
+				errs = append(errs, prefix+": unknown source_type "+f.SourceType)
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateSkillFilePath checks that a relative file path is safe (no traversal).
+func validateSkillFilePath(p string) string {
+	if err := configstore.ValidateSkillFilePath(p); err != nil {
+		return err.Error()
+	}
+	return ""
+}

--- a/transports/bifrost-http/handlers/skills_cleanup_test.go
+++ b/transports/bifrost-http/handlers/skills_cleanup_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+)
+
+type testLogger struct{}
+
+func (testLogger) Debug(string, ...any) {}
+func (testLogger) Info(string, ...any)  {}
+func (testLogger) Warn(string, ...any)  {}
+func (testLogger) Error(string, ...any) {}
+func (testLogger) Fatal(msg string, args ...any) {
+	panic("fatal called")
+}
+func (testLogger) SetLevel(schemas.LogLevel)              {}
+func (testLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (testLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func newTestConfigStore(t *testing.T) configstore.ConfigStore {
+	t.Helper()
+	store, err := configstore.NewConfigStore(context.Background(), &configstore.Config{
+		Enabled: true,
+		Type:    configstore.ConfigStoreTypeSQLite,
+		Config: &configstore.SQLiteConfig{
+			Path: filepath.Join(t.TempDir(), "config.db"),
+		},
+	}, testLogger{})
+	if err != nil {
+		t.Fatalf("new config store: %v", err)
+	}
+	t.Cleanup(func() { store.Close(context.Background()) })
+	return store
+}
+
+func TestCleanupOrphanSkillFilesDeletesDBFallbackBlobs(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+	referencedBlobID := "referenced-blob"
+	orphanBlobID := "orphan-blob"
+
+	if err := store.CreateSkillFileBlob(ctx, &tables.TableSkillFileBlob{ID: referencedBlobID, Data: []byte("referenced")}); err != nil {
+		t.Fatalf("create referenced blob: %v", err)
+	}
+	if err := store.CreateSkillFileBlob(ctx, &tables.TableSkillFileBlob{ID: orphanBlobID, Data: []byte("orphan")}); err != nil {
+		t.Fatalf("create orphan blob: %v", err)
+	}
+	// Backdate the orphan blob so it exceeds the 30-minute grace period.
+	if err := store.DB().WithContext(ctx).Model(&tables.TableSkillFileBlob{}).Where("id = ?", orphanBlobID).Update("created_at", time.Now().Add(-1*time.Hour)).Error; err != nil {
+		t.Fatalf("backdate orphan blob: %v", err)
+	}
+	if err := store.CreateSkill(ctx, &tables.TableSkill{
+		Name:        "cleanup-db-test",
+		Description: "cleanup db test",
+		SkillMDBody: "body",
+		Files: []tables.TableSkillFile{{
+			Path:          "reference.txt",
+			SourceType:    tables.SkillSourceTypeUpload,
+			BlobID:        &referencedBlobID,
+			MimeType:      "text/plain",
+			FileSizeBytes: 10,
+		}},
+	}, "1.0.0", nil); err != nil {
+		t.Fatalf("create skill: %v", err)
+	}
+
+	result, err := CleanupOrphanSkillFiles(ctx, store, nil, false)
+	if err != nil {
+		t.Fatalf("cleanup orphan files: %v", err)
+	}
+	if result.DeletedDBBlobs != 1 {
+		t.Fatalf("DeletedDBBlobs got %d, want 1", result.DeletedDBBlobs)
+	}
+	if result.DeletedStorageObjects != 0 {
+		t.Fatalf("DeletedStorageObjects got %d, want 0", result.DeletedStorageObjects)
+	}
+
+	if err := store.DB().WithContext(ctx).First(&tables.TableSkillFileBlob{}, "id = ?", referencedBlobID).Error; err != nil {
+		t.Fatalf("referenced blob should remain: %v", err)
+	}
+	var remaining int64
+	if err := store.DB().WithContext(ctx).Model(&tables.TableSkillFileBlob{}).Where("id = ?", orphanBlobID).Count(&remaining).Error; err != nil {
+		t.Fatalf("count orphan blob: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("orphan blob remained")
+	}
+}
+
+func TestCleanupOrphanSkillFilesDeletesOnlyUnreferencedUploadObjects(t *testing.T) {
+	ctx := context.Background()
+	store := newTestConfigStore(t)
+	objStore := objectstore.NewInMemoryObjectStore()
+	referencedKey := configstore.SkillObjectPrefix + "uploads/referenced/file.txt"
+	orphanKey := configstore.SkillObjectPrefix + "uploads/orphan/file.txt"
+	outsidePrefixKey := "other/file.txt"
+
+	for key := range map[string]struct{}{referencedKey: {}, orphanKey: {}, outsidePrefixKey: {}} {
+		if err := objStore.Put(ctx, key, []byte(key), nil); err != nil {
+			t.Fatalf("put %s: %v", key, err)
+		}
+	}
+	// Backdate orphan object so it exceeds the 30-minute grace period.
+	objStore.SetCreatedAt(orphanKey, time.Now().Add(-1*time.Hour))
+	uploadID := "referenced"
+	if err := store.CreateSkill(ctx, &tables.TableSkill{
+		Name:        "cleanup-object-test",
+		Description: "cleanup object test",
+		SkillMDBody: "body",
+		Files: []tables.TableSkillFile{{
+			Path:          "file.txt",
+			SourceType:    tables.SkillSourceTypeUpload,
+			StorageKey:    &referencedKey,
+			UploadID:      &uploadID,
+			MimeType:      "text/plain",
+			FileSizeBytes: 10,
+		}},
+	}, "1.0.0", objStore); err != nil {
+		t.Fatalf("create skill: %v", err)
+	}
+
+	result, err := CleanupOrphanSkillFiles(ctx, store, objStore, false)
+	if err != nil {
+		t.Fatalf("cleanup orphan files: %v", err)
+	}
+	if result.DeletedStorageObjects != 1 {
+		t.Fatalf("DeletedStorageObjects got %d, want 1", result.DeletedStorageObjects)
+	}
+	if _, err := objStore.Get(ctx, referencedKey); err != nil {
+		t.Fatalf("referenced object should remain: %v", err)
+	}
+	if _, err := objStore.Get(ctx, outsidePrefixKey); err != nil {
+		t.Fatalf("outside-prefix object should remain: %v", err)
+	}
+	if _, err := objStore.Get(ctx, orphanKey); err == nil {
+		t.Fatalf("orphan object remained")
+	}
+}

--- a/transports/bifrost-http/handlers/skills_serving.go
+++ b/transports/bifrost-http/handlers/skills_serving.go
@@ -1,0 +1,1413 @@
+package handlers
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fasthttp/router"
+	billy "github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-billy/v5/osfs"
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+	"github.com/valyala/fasthttp"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// ============================================================================
+// Git binary availability check
+// ============================================================================
+
+// gitBinaryPath holds the resolved path to the git binary, or empty if unavailable.
+var gitBinaryPath string
+
+func init() {
+	gitBinaryPath, _ = exec.LookPath("git")
+}
+
+// CheckGitAvailability returns true if the git binary is available on PATH.
+func CheckGitAvailability() bool {
+	return gitBinaryPath != ""
+}
+
+// maxSkillGitRepoSize caps assembled git repo payloads before they are materialized into memfs.
+const maxSkillGitRepoSize = 500 * 1024 * 1024 // 500 MB
+
+// skillURLClient is a dedicated HTTP client for fetching URL-sourced skill content.
+// Uses a custom transport that blocks connections to private/loopback IPs to prevent SSRF.
+var skillURLClient = &http.Client{
+	Timeout: 15 * time.Second,
+	Transport: &http.Transport{
+		DialContext: ssrfSafeDialContext,
+	},
+}
+
+// ssrfSafeDialContext wraps the default dialer to reject connections to private,
+// loopback, and link-local IP addresses. This prevents SSRF attacks where an
+// admin-configured source_url points to internal infrastructure.
+func ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address %s: %w", addr, err)
+	}
+
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("DNS lookup failed for %s: %w", host, err)
+	}
+
+	for _, ip := range ips {
+		if isPrivateIP(ip.IP) {
+			return nil, fmt.Errorf("blocked connection to private/loopback IP %s (host: %s)", ip.IP, host)
+		}
+	}
+
+	// All IPs are public; dial one of the already-resolved IPs directly to
+	// prevent DNS rebinding attacks where a second resolution returns a
+	// different (private) IP.
+	return (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+}
+
+// isPrivateIP returns true for loopback, private, link-local, unspecified, and multicast addresses.
+func isPrivateIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast()
+}
+
+// fetchURLSafe fetches content from a URL with SSRF protection, timeout, and size cap.
+// Used by both serveSkillFile and fetchFileContentForArchive.
+func fetchURLSafe(ctx context.Context, rawURL string) ([]byte, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("blocked non-HTTP(S) scheme: %s", parsed.Scheme)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	resp, err := skillURLClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("URL returned status %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, configstore.MaxSkillFileContentSize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if int64(len(data)) > configstore.MaxSkillFileContentSize {
+		return nil, fmt.Errorf("response exceeds %d MB size limit", configstore.MaxSkillFileContentSize/(1024*1024))
+	}
+	return data, nil
+}
+
+// ============================================================================
+// SkillsServingHandler — public (no auth) marketplace and download endpoints
+// ============================================================================
+
+// SkillsServingHandler serves skill marketplace catalogs, plugin manifests,
+// composed SKILL.md files, individual file content, and zip archives.
+// All routes are public — intentionally NOT wrapped with auth middlewares.
+type SkillsServingHandler struct {
+	store        configstore.ConfigStore
+	objectStore  objectstore.ObjectStore // nullable — may not be configured
+	gitAvailable bool
+}
+
+// NewSkillsServingHandler creates a new SkillsServingHandler.
+// Returns nil if store is nil.
+func NewSkillsServingHandler(store configstore.ConfigStore, objectStore objectstore.ObjectStore) *SkillsServingHandler {
+	if store == nil {
+		return nil
+	}
+	return &SkillsServingHandler{store: store, objectStore: objectStore, gitAvailable: CheckGitAvailability()}
+}
+
+// RegisterRoutes registers public serving endpoints.
+// These routes are intentionally NOT wrapped with auth middlewares — marketplace
+// URLs cannot carry credentials securely.
+func (h *SkillsServingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	// Git-based marketplace routes only registered when git binary is available,
+	// since Claude Code and Codex require git clone support.
+	if h.gitAvailable {
+		// Claude Code marketplace
+		r.GET("/api/skills/serve/claude-code/.claude-plugin/marketplace.json", h.claudeCodeMarketplace)
+
+		// Codex marketplace — Codex expects .agents/plugins/marketplace.json
+		r.GET("/api/skills/serve/codex/.agents/plugins/marketplace.json", h.codexMarketplace)
+		// Codex marketplace git routes (Codex clones the marketplace URL itself)
+		codexMktBase := "/api/skills/serve/codex"
+		r.GET(codexMktBase+"/info/refs", h.codexMarketplaceGit())
+		r.POST(codexMktBase+"/git-upload-pack", h.codexMarketplaceGit())
+
+		// Git smart HTTP serving (shared by both Claude Code and Codex)
+		for _, harness := range configstore.SkillHarnessNames {
+			h.registerGitRoutes(r, harness)
+		}
+	} else {
+		logger.Warn("git binary not found — Claude Code / Codex marketplace routes disabled")
+	}
+
+	// Generic download (always available, no git required)
+	r.GET("/api/skills/serve/all/download.zip", h.allSkillsZipDownload)
+	r.GET("/api/skills/serve/{skill-name}/download.zip", h.genericZipDownload)
+	r.GET("/api/skills/serve/{skill-name}/files/{filepath:*}", h.genericFileDownload)
+}
+
+// pluginNamePrefix is prepended to all skill names when exposed as marketplace plugins.
+const pluginNamePrefix = "bifrost-"
+
+// allSkillsPluginName is the name of the bundled "all skills" plugin.
+const allSkillsPluginName = pluginNamePrefix + "all-skills"
+
+// ============================================================================
+// Marketplace JSON generation
+// ============================================================================
+
+// claudeCodeMarketplace generates GET /api/skills/serve/claude-code/.claude-plugin/marketplace.json
+func (h *SkillsServingHandler) claudeCodeMarketplace(ctx *fasthttp.RequestCtx) {
+	skills, err := h.listAllSkills(ctx)
+	if err != nil {
+		return
+	}
+
+	allSkillsVersion := "0.0.0"
+	if len(skills) > 0 {
+		allSkillsVersion, err = h.store.GetAllSkillsVersion(ctx)
+		if err != nil {
+			logger.Error("all-skills: failed to get version: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to get all-skills version")
+			return
+		}
+	}
+
+	baseURL := h.resolveBaseURL(ctx)
+	plugins := make([]map[string]any, 0, len(skills)+1)
+	for _, skillSummary := range skills {
+		plugins = append(plugins, map[string]any{
+			"name":        pluginNamePrefix + skillSummary.Name,
+			"description": skillSummary.Description,
+			"version":     skillSummary.LatestVersion,
+			"source": map[string]any{
+				"source": "url",
+				"url":    baseURL + "/api/skills/serve/claude-code/plugins/" + pluginNamePrefix + skillSummary.Name,
+			},
+		})
+	}
+	// Bundled "all skills" plugin
+	if len(skills) > 0 {
+		plugins = append(plugins, map[string]any{
+			"name":        allSkillsPluginName,
+			"description": "All Bifrost skills bundled in a single plugin.",
+			"version":     allSkillsVersion,
+			"source": map[string]any{
+				"source": "url",
+				"url":    baseURL + "/api/skills/serve/claude-code/plugins/" + allSkillsPluginName,
+			},
+		})
+	}
+
+	result := map[string]any{
+		"name": "bifrost-skills",
+		"owner": map[string]any{
+			"name": "Bifrost Gateway",
+		},
+		"plugins": plugins,
+	}
+
+	SendJSON(ctx, result)
+}
+
+// codexMarketplace generates GET /api/skills/serve/codex/.codex-plugin/marketplace.json
+func (h *SkillsServingHandler) codexMarketplace(ctx *fasthttp.RequestCtx) {
+	marketplaceJSON, err := h.buildCodexMarketplaceJSON(ctx)
+	if err != nil {
+		return // error already sent
+	}
+	ctx.SetContentType("application/json")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetBody(marketplaceJSON)
+}
+
+// buildCodexMarketplaceJSON builds the Codex marketplace JSON bytes.
+// Shared by both the plain HTTP endpoint and the git-clone endpoint.
+func (h *SkillsServingHandler) buildCodexMarketplaceJSON(ctx *fasthttp.RequestCtx) ([]byte, error) {
+	skills, err := h.listAllSkills(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	allSkillsVersion := "0.0.0"
+	if len(skills) > 0 {
+		allSkillsVersion, err = h.store.GetAllSkillsVersion(ctx)
+		if err != nil {
+			logger.Error("all-skills: failed to get version: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to get all-skills version")
+			return nil, err
+		}
+	}
+
+	baseURL := h.resolveBaseURL(ctx)
+	plugins := make([]map[string]any, 0, len(skills)+1)
+	for _, skillSummary := range skills {
+		plugins = append(plugins, map[string]any{
+			"name":        pluginNamePrefix + skillSummary.Name,
+			"description": skillSummary.Description,
+			"version":     skillSummary.LatestVersion,
+			"source": map[string]any{
+				"source": "url",
+				"url":    baseURL + "/api/skills/serve/codex/plugins/" + pluginNamePrefix + skillSummary.Name,
+			},
+			"policy": map[string]any{
+				"installation":   "AVAILABLE",
+				"authentication": "ON_INSTALL",
+			},
+			"category": "Productivity",
+		})
+	}
+	// Bundled "all skills" plugin
+	if len(skills) > 0 {
+		plugins = append(plugins, map[string]any{
+			"name":        allSkillsPluginName,
+			"description": "All Bifrost skills bundled in a single plugin.",
+			"version":     allSkillsVersion,
+			"source": map[string]any{
+				"source": "url",
+				"url":    baseURL + "/api/skills/serve/codex/plugins/" + allSkillsPluginName,
+			},
+			"policy": map[string]any{
+				"installation":   "AVAILABLE",
+				"authentication": "ON_INSTALL",
+			},
+			"category": "Productivity",
+		})
+	}
+
+	result := map[string]any{
+		"name": "bifrost-skills",
+		"interface": map[string]any{
+			"displayName": "Bifrost Skills",
+		},
+		"plugins": plugins,
+	}
+
+	return json.MarshalIndent(result, "", "  ")
+}
+
+// ============================================================================
+// Git repository abstraction
+// ============================================================================
+
+// GitRepoFile represents a single file to include in a generated git repository.
+type GitRepoFile struct {
+	Path    string // relative path within the repo (e.g. ".claude-plugin/plugin.json")
+	Content []byte
+}
+
+// GitRepoSpec describes the full contents of a git repository to be built.
+// All git serving paths (plugin install, marketplace clone) produce a
+// GitRepoSpec and then feed it through the same buildGitRepo → serveGitRepo
+// pipeline.
+type GitRepoSpec struct {
+	Files []GitRepoFile
+	Label string // human-readable label for error logs (e.g. skill name)
+}
+
+// buildGitRepo creates an in-memory bare git repository from a GitRepoSpec.
+func buildGitRepo(spec *GitRepoSpec) (*memory.Storage, error) {
+	storage := memory.NewStorage()
+	wt := memfs.New()
+	repo, err := git.Init(storage, wt)
+	if err != nil {
+		return nil, fmt.Errorf("git init: %w", err)
+	}
+
+	headRef := plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))
+	err = storage.SetReference(headRef)
+	if err != nil {
+		return nil, fmt.Errorf("set HEAD: %w", err)
+	}
+
+	for _, f := range spec.Files {
+		if err := writeBillyFile(wt, f.Path, f.Content); err != nil {
+			return nil, fmt.Errorf("write %s: %w", f.Path, err)
+		}
+	}
+
+	w, err := repo.Worktree()
+	if err != nil {
+		return nil, fmt.Errorf("get worktree: %w", err)
+	}
+	if _, err := w.Add("."); err != nil {
+		return nil, fmt.Errorf("stage files: %w", err)
+	}
+	// Use a fixed epoch so the same skill data always produces the same commit
+	// hash. Git clone does GET /info/refs then POST /git-upload-pack as two
+	// independent requests — if the commit hash changes between them (e.g. from
+	// time.Now()), the client's "want" hash won't exist in the second repo and
+	// git upload-pack fails with "not our ref".
+	_, err = w.Commit("serve "+spec.Label, &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Bifrost Gateway",
+			Email: "bifrost@getbifrost.ai",
+			When:  time.Unix(0, 0),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+	return storage, nil
+}
+
+// ============================================================================
+// Git repo spec assemblers
+// ============================================================================
+
+// assemblePluginRepoSpec builds a GitRepoSpec for a single skill plugin.
+// Layout:
+//
+//	.<harness>-plugin/plugin.json
+//	skills/<skill-name>/SKILL.md
+//	skills/<skill-name>/<file-path>...
+func (h *SkillsServingHandler) assemblePluginRepoSpec(ctx context.Context, skill *tables.TableSkill, harness string) (*GitRepoSpec, error) {
+	var files []GitRepoFile
+	var totalSize int64
+	addRepoFile := func(repoFile GitRepoFile) error {
+		totalSize += int64(len(repoFile.Content))
+		if totalSize > maxSkillGitRepoSize {
+			return fmt.Errorf("skill repo exceeds %d MB size limit", maxSkillGitRepoSize/(1024*1024))
+		}
+		files = append(files, repoFile)
+		return nil
+	}
+
+	// Plugin manifest
+	manifestDir := manifestDirName(harness)
+	manifestJSON, err := json.MarshalIndent(buildPluginManifest(skill, harness), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal plugin.json: %w", err)
+	}
+	if err := addRepoFile(GitRepoFile{Path: path.Join(manifestDir, "plugin.json"), Content: manifestJSON}); err != nil {
+		return nil, err
+	}
+
+	// SKILL.md
+	if err := addRepoFile(GitRepoFile{
+		Path:    path.Join("skills", skill.Name, "SKILL.md"),
+		Content: []byte(composeSkillMD(skill)),
+	}); err != nil {
+		return nil, err
+	}
+
+	// Attached files
+	for i := range skill.Files {
+		file := &skill.Files[i]
+		data, err := fetchFileContentForArchive(ctx, file, h.objectStore)
+		if err != nil {
+			logger.Error("skill %s: repo spec: failed to fetch file %s: %v", skill.Name, file.Path, err)
+			continue
+		}
+		if err := addRepoFile(GitRepoFile{
+			Path:    path.Join("skills", buildSkillFilePath(skill.Name, file)),
+			Content: data,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return &GitRepoSpec{Files: files, Label: skill.Name + " " + skill.LatestVersion}, nil
+}
+
+// assembleAllSkillsRepoSpec builds a GitRepoSpec bundling every skill into one plugin.
+// Layout:
+//
+//	.<harness>-plugin/plugin.json
+//	skills/<skill-name>/SKILL.md   (for each skill)
+//	skills/<skill-name>/<files>... (for each skill)
+func (h *SkillsServingHandler) assembleAllSkillsRepoSpec(ctx context.Context, harness string) (*GitRepoSpec, error) {
+	skills, _, err := h.store.ListSkills(ctx, configstore.SkillListQueryParams{Limit: 10000, SortBy: "name", Order: "asc"})
+	if err != nil {
+		return nil, fmt.Errorf("list skills: %w", err)
+	}
+	version, err := h.store.GetAllSkillsVersion(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get all-skills version: %w", err)
+	}
+
+	var repoFiles []GitRepoFile
+	var totalSize int64
+	addRepoFile := func(repoFile GitRepoFile) error {
+		totalSize += int64(len(repoFile.Content))
+		if totalSize > maxSkillGitRepoSize {
+			return fmt.Errorf("all-skills repo exceeds %d MB size limit", maxSkillGitRepoSize/(1024*1024))
+		}
+		repoFiles = append(repoFiles, repoFile)
+		return nil
+	}
+
+	// Plugin manifest — reuse buildPluginManifest with a synthetic skill record
+	allSkillsSkill := &tables.TableSkill{
+		Name:          strings.TrimPrefix(allSkillsPluginName, pluginNamePrefix),
+		Description:   "All Bifrost skills bundled in a single plugin.",
+		LatestVersion: version,
+	}
+	manifestDir := manifestDirName(harness)
+	manifestJSON, _ := json.MarshalIndent(buildPluginManifest(allSkillsSkill, harness), "", "  ")
+	if err := addRepoFile(GitRepoFile{Path: path.Join(manifestDir, "plugin.json"), Content: manifestJSON}); err != nil {
+		return nil, err
+	}
+
+	// Each skill's SKILL.md + files
+	for i := range skills {
+		// Fetch full skill with blob data
+		full, err := h.store.GetSkillByName(ctx, skills[i].Name)
+		if err != nil {
+			logger.Error("all-skills: failed to get skill %s: %v", skills[i].Name, err)
+			continue
+		}
+		if err := addRepoFile(GitRepoFile{
+			Path:    path.Join("skills", full.Name, "SKILL.md"),
+			Content: []byte(composeSkillMD(full)),
+		}); err != nil {
+			return nil, err
+		}
+		for j := range full.Files {
+			file := &full.Files[j]
+			data, err := fetchFileContentForArchive(ctx, file, h.objectStore)
+			if err != nil {
+				logger.Error("all-skills: failed to fetch file %s/%s: %v", full.Name, file.Path, err)
+				continue
+			}
+			if err := addRepoFile(GitRepoFile{
+				Path:    path.Join("skills", buildSkillFilePath(full.Name, file)),
+				Content: data,
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &GitRepoSpec{Files: repoFiles, Label: "all-skills"}, nil
+}
+
+// assembleMarketplaceRepoSpec builds a GitRepoSpec for a marketplace git repo.
+// Claude Code: .claude-plugin/marketplace.json
+// Codex:       .agents/plugins/marketplace.json
+func assembleMarketplaceRepoSpec(marketplaceJSON []byte, harness string) *GitRepoSpec {
+	var manifestPath string
+	switch harness {
+	case "codex":
+		manifestPath = ".agents/plugins/marketplace.json"
+	default:
+		manifestPath = path.Join(manifestDirName(harness), "marketplace.json")
+	}
+	return &GitRepoSpec{
+		Files: []GitRepoFile{
+			{Path: manifestPath, Content: marketplaceJSON},
+		},
+		Label: harness + "-marketplace",
+	}
+}
+
+// ============================================================================
+// Git smart HTTP serving via direct git upload-pack
+// ============================================================================
+
+// registerGitRoutes registers Git smart HTTP routes for a given harness.
+func (h *SkillsServingHandler) registerGitRoutes(r *router.Router, harness string) {
+	base := "/api/skills/serve/" + harness + "/plugins/{skill-name}"
+	r.GET(base+"/info/refs", h.servePluginGit(harness))
+	r.POST(base+"/git-upload-pack", h.servePluginGit(harness))
+}
+
+// servePluginGit handles git smart HTTP for per-plugin repos.
+// Plugin names in the URL are prefixed with "bifrost-". The special name
+// "bifrost-all-skills" serves a bundled repo containing every skill.
+func (h *SkillsServingHandler) servePluginGit(harness string) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		rawName := ""
+		if val := ctx.UserValue("skill-name"); val != nil {
+			rawName, _ = val.(string)
+		}
+		if rawName == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "skill name is required")
+			return
+		}
+
+		repoBase := "/api/skills/serve/" + harness + "/plugins/" + rawName
+
+		// Handle the bundled "all skills" plugin.
+		if rawName == allSkillsPluginName {
+			spec, err := h.assembleAllSkillsRepoSpec(ctx, harness)
+			if err != nil {
+				logger.Error("all-skills: failed to assemble repo spec: %v", err)
+				SendError(ctx, fasthttp.StatusInternalServerError, "failed to prepare all-skills plugin")
+				return
+			}
+			serveGitRepo(ctx, spec, repoBase)
+			return
+		}
+
+		// Strip the "bifrost-" prefix to look up the actual skill name.
+		skillName := strings.TrimPrefix(rawName, pluginNamePrefix)
+		skill, err := h.store.GetSkillByName(ctx, skillName)
+		if err != nil {
+			if errors.Is(err, configstore.ErrNotFound) {
+				SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("skill %q not found", skillName))
+				return
+			}
+			logger.Error("failed to get skill %s: %v", skillName, err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to retrieve skill")
+			return
+		}
+
+		spec, err := h.assemblePluginRepoSpec(ctx, skill, harness)
+		if err != nil {
+			logger.Error("skill %s: failed to assemble repo spec: %v", skill.Name, err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to prepare plugin git repository")
+			return
+		}
+
+		serveGitRepo(ctx, spec, repoBase)
+	}
+}
+
+// codexMarketplaceGit returns a handler that serves the Codex marketplace as a
+// git repo. Codex clones the marketplace URL itself (unlike Claude Code which
+// fetches marketplace.json as plain HTTP).
+func (h *SkillsServingHandler) codexMarketplaceGit() fasthttp.RequestHandler {
+	repoBase := "/api/skills/serve/codex"
+	return func(ctx *fasthttp.RequestCtx) {
+		marketplaceJSON, err := h.buildCodexMarketplaceJSON(ctx)
+		if err != nil {
+			return // error already sent
+		}
+
+		spec := assembleMarketplaceRepoSpec(marketplaceJSON, "codex")
+		serveGitRepo(ctx, spec, repoBase)
+	}
+}
+
+// serveGitRepo builds a git repo from a spec and serves it via direct git
+// upload-pack calls (inspired by go-git-http pattern). No CGI layer needed.
+func serveGitRepo(ctx *fasthttp.RequestCtx, spec *GitRepoSpec, repoBase string) {
+	storage, err := buildGitRepo(spec)
+	if err != nil {
+		logger.Error("%s: failed to build git repo: %v", spec.Label, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to build git repository")
+		return
+	}
+
+	tempDir, err := exportToTempBareRepo(storage)
+	if err != nil {
+		logger.Error("%s: failed to export bare repo: %v", spec.Label, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to prepare git repository")
+		return
+	}
+	defer os.RemoveAll(tempDir)
+
+	pathInfo := strings.TrimPrefix(string(ctx.Path()), repoBase)
+	if strings.HasSuffix(pathInfo, "/info/refs") {
+		serveInfoRefs(ctx, tempDir, spec.Label)
+	} else if strings.HasSuffix(pathInfo, "/git-upload-pack") {
+		serveUploadPack(ctx, tempDir, spec.Label)
+	} else {
+		SendError(ctx, fasthttp.StatusNotFound, "unknown git endpoint")
+	}
+}
+
+// serveInfoRefs handles GET /info/refs?service=git-upload-pack by running
+// `git upload-pack --stateless-rpc --advertise-refs` and wrapping the output
+// in the git smart HTTP advertisement format.
+func serveInfoRefs(ctx *fasthttp.RequestCtx, repoDir, label string) {
+	serviceName := string(ctx.QueryArgs().Peek("service"))
+	if serviceName == "" {
+		serviceName = "git-upload-pack"
+	}
+
+	// Only upload-pack is supported (read-only serving).
+	if serviceName != "git-upload-pack" {
+		SendError(ctx, fasthttp.StatusForbidden, "service not available")
+		return
+	}
+
+	// Bind to request context with a timeout so stalled git processes
+	// don't outlive a client disconnect or server shutdown. 30s is generous —
+	// upload-pack on these in-memory repos completes in <1s normally, but we
+	// allow headroom for large all-skills repos under load.
+	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cmdCtx, gitBinaryPath, "upload-pack", "--stateless-rpc", "--advertise-refs", ".") //nolint:gosec // gitBinaryPath is from exec.LookPath
+	cmd.Dir = repoDir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		logger.Error("%s: git upload-pack --advertise-refs failed: %v, stderr: %s", label, err, stderr.String())
+		SendError(ctx, fasthttp.StatusInternalServerError, "git info/refs failed")
+		return
+	}
+
+	ctx.Response.Header.Set("Cache-Control", "no-cache")
+	ctx.SetContentType(fmt.Sprintf("application/x-%s-advertisement", serviceName))
+	ctx.SetStatusCode(fasthttp.StatusOK)
+
+	// Write pkt-line service announcement header, then the advertised refs.
+	ctx.Write(pktLine("# service=" + serviceName + "\n")) //nolint:errcheck
+	ctx.Write(pktFlush())                                 //nolint:errcheck
+	ctx.Write(stdout.Bytes())                             //nolint:errcheck
+}
+
+// serveUploadPack handles POST /git-upload-pack by piping the request body
+// into `git upload-pack --stateless-rpc` and streaming the output back.
+func serveUploadPack(ctx *fasthttp.RequestCtx, repoDir, label string) {
+	// Bind to request context with a timeout so stalled git processes
+	// don't outlive a client disconnect or server shutdown. 30s is generous —
+	// upload-pack on these in-memory repos completes in <1s normally, but we
+	// allow headroom for large all-skills repos under load.
+	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cmdCtx, gitBinaryPath, "upload-pack", "--stateless-rpc", ".") //nolint:gosec // gitBinaryPath is from exec.LookPath
+	cmd.Dir = repoDir
+	cmd.Stdin = bytes.NewReader(ctx.PostBody())
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		logger.Error("%s: git upload-pack failed: %v, stderr: %s", label, err, stderr.String())
+		SendError(ctx, fasthttp.StatusInternalServerError, "git upload-pack failed")
+		return
+	}
+
+	ctx.Response.Header.Set("Cache-Control", "no-cache")
+	ctx.SetContentType("application/x-git-upload-pack-result")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetBody(stdout.Bytes())
+}
+
+// pktLine encodes a string as a git pkt-line (4-hex-digit length prefix + data).
+func pktLine(s string) []byte {
+	return []byte(fmt.Sprintf("%04x%s", len(s)+4, s))
+}
+
+// pktFlush returns the git pkt-line flush packet.
+func pktFlush() []byte {
+	return []byte("0000")
+}
+
+// exportToTempBareRepo exports an in-memory go-git storage to a temporary bare
+// git repository on disk, suitable for use with `git http-backend`.
+func exportToTempBareRepo(memStorage *memory.Storage) (string, error) {
+	tempDir, err := os.MkdirTemp("", "bifrost-skill-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+
+	// Create a bare repo on disk.
+	fs := osfs.New(tempDir)
+	dot, err := fs.Chroot(".")
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return "", fmt.Errorf("chroot: %w", err)
+	}
+	diskStorage := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+
+	if err := diskStorage.Init(); err != nil {
+		os.RemoveAll(tempDir)
+		return "", fmt.Errorf("init bare repo: %w", err)
+	}
+
+	// Copy all objects from memory to disk storage.
+	for _, objType := range []plumbing.ObjectType{plumbing.CommitObject, plumbing.TreeObject, plumbing.BlobObject, plumbing.TagObject} {
+		iter, err := memStorage.IterEncodedObjects(objType)
+		if err != nil {
+			continue
+		}
+		if err := iter.ForEach(func(obj plumbing.EncodedObject) error {
+			_, err := diskStorage.SetEncodedObject(obj)
+			return err
+		}); err != nil {
+			os.RemoveAll(tempDir)
+			return "", fmt.Errorf("copy %s objects: %w", objType, err)
+		}
+	}
+
+	// Copy all references from memory to disk storage.
+	refIter, err := memStorage.IterReferences()
+	if err == nil {
+		if err := refIter.ForEach(func(ref *plumbing.Reference) error {
+			return diskStorage.SetReference(ref)
+		}); err != nil {
+			os.RemoveAll(tempDir)
+			return "", fmt.Errorf("copy references: %w", err)
+		}
+	}
+
+	// Also copy HEAD.
+	head, err := memStorage.Reference(plumbing.HEAD)
+	if err == nil {
+		if err := diskStorage.SetReference(head); err != nil {
+			os.RemoveAll(tempDir)
+			return "", fmt.Errorf("copy HEAD: %w", err)
+		}
+	}
+
+	return tempDir, nil
+}
+
+// writeBillyFile writes data to a file in a billy in-memory filesystem,
+// creating parent directories as needed.
+func writeBillyFile(fs billy.Filesystem, filePath string, data []byte) error {
+	dir := path.Dir(filePath)
+	if dir != "." && dir != "/" {
+		if err := fs.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+	f, err := fs.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", filePath, err)
+	}
+	defer f.Close()
+	_, err = f.Write(data)
+	if err != nil {
+		return fmt.Errorf("write %s: %w", filePath, err)
+	}
+	return nil
+}
+
+// ============================================================================
+// Plugin manifest generation
+// ============================================================================
+
+// manifestDirName returns the plugin manifest directory name for a harness.
+// Claude Code uses ".claude-plugin", Codex uses ".codex-plugin".
+func manifestDirName(harness string) string {
+	switch harness {
+	case "claude-code":
+		return ".claude-plugin"
+	case "codex":
+		return ".codex-plugin"
+	default:
+		return "." + harness + "-plugin"
+	}
+}
+
+// buildPluginManifest creates the plugin.json for a given harness.
+func buildPluginManifest(skill *tables.TableSkill, harness string) map[string]any {
+	manifest := map[string]any{
+		"name":        pluginNamePrefix + skill.Name,
+		"description": skill.Description,
+		"version":     skill.LatestVersion,
+	}
+	if harness == "codex" {
+		// Format name for display: replace hyphens with spaces, title case
+		displayName := strings.ReplaceAll(skill.Name, "-", " ")
+		displayName = cases.Title(language.English).String(displayName) // simple title case is fine here
+		manifest["interface"] = map[string]any{
+			"displayName":      displayName,
+			"shortDescription": skill.Description,
+			"category":         "Productivity",
+		}
+	}
+	return manifest
+}
+
+// ============================================================================
+// SKILL.md composition
+// ============================================================================
+
+// composeSkillMD builds the full SKILL.md from DB fields:
+// YAML frontmatter (standard fields → extra_frontmatter → metadata) + body.
+func composeSkillMD(skill *tables.TableSkill) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+
+	// Standard fields first
+	b.WriteString("name: ")
+	b.WriteString(yamlScalar(skill.Name))
+	b.WriteString("\n")
+
+	b.WriteString("description: ")
+	b.WriteString(yamlScalar(skill.Description))
+	b.WriteString("\n")
+
+	if skill.License != nil && *skill.License != "" {
+		b.WriteString("license: ")
+		b.WriteString(yamlScalar(*skill.License))
+		b.WriteString("\n")
+	}
+	if skill.Compatibility != nil && *skill.Compatibility != "" {
+		b.WriteString("compatibility: ")
+		b.WriteString(yamlScalar(*skill.Compatibility))
+		b.WriteString("\n")
+	}
+	if skill.AllowedTools != nil && *skill.AllowedTools != "" {
+		b.WriteString("allowed-tools: ")
+		b.WriteString(yamlScalar(*skill.AllowedTools))
+		b.WriteString("\n")
+	}
+
+	// Extra frontmatter fields spread as top-level YAML keys
+	// Sort keys for deterministic output
+	if len(skill.ExtraFrontmatter) > 0 {
+		extraKeys := make([]string, 0, len(skill.ExtraFrontmatter))
+		for k := range skill.ExtraFrontmatter {
+			if !configstore.IsSkillReservedFrontmatterField(k) {
+				extraKeys = append(extraKeys, k)
+			}
+		}
+		sort.Strings(extraKeys)
+		for _, k := range extraKeys {
+			writeYAMLKeyValue(&b, k, skill.ExtraFrontmatter[k], 0)
+		}
+	}
+
+	// Metadata as nested block
+	if len(skill.Metadata) > 0 {
+		b.WriteString("metadata:\n")
+		metaKeys := make([]string, 0, len(skill.Metadata))
+		for k := range skill.Metadata {
+			metaKeys = append(metaKeys, k)
+		}
+		sort.Strings(metaKeys)
+		for _, k := range metaKeys {
+			b.WriteString("  ")
+			b.WriteString(k)
+			b.WriteString(": ")
+			b.WriteString(yamlMetadataScalar(skill.Metadata[k]))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("---\n")
+	b.WriteString(skill.SkillMDBody)
+
+	return b.String()
+}
+
+// yamlScalar returns a YAML-safe representation of a string value.
+// Always quotes the value to prevent YAML parsers from reinterpreting
+// strings that look like booleans, numbers, dates, or other scalars.
+func yamlScalar(s string) string {
+	if s == "" {
+		return `""`
+	}
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "\n", `\n`)
+	escaped = strings.ReplaceAll(escaped, "\r", `\r`)
+	return `"` + escaped + `"`
+}
+
+func yamlMetadataScalar(s string) string {
+	return s
+}
+
+// writeYAMLKeyValue writes a key-value pair to a YAML builder.
+// Handles nested maps and slices with indentation.
+func writeYAMLKeyValue(b *strings.Builder, key string, value any, indent int) {
+	prefix := strings.Repeat("  ", indent)
+	switch v := value.(type) {
+	case map[string]any:
+		b.WriteString(prefix)
+		b.WriteString(key)
+		b.WriteString(":\n")
+		writeYAMLMapEntries(b, v, indent+1)
+	case []any:
+		b.WriteString(prefix)
+		b.WriteString(key)
+		b.WriteString(":\n")
+		writeYAMLListItems(b, v, indent+1)
+	default:
+		b.WriteString(prefix)
+		b.WriteString(key)
+		b.WriteString(": ")
+		switch val := value.(type) {
+		case bool:
+			if val {
+				b.WriteString("true")
+			} else {
+				b.WriteString("false")
+			}
+		case float64:
+			// JSON numbers unmarshal as float64
+			if val == float64(int64(val)) {
+				fmt.Fprintf(b, "%d", int64(val))
+			} else {
+				fmt.Fprintf(b, "%g", val)
+			}
+		case string:
+			b.WriteString(yamlScalar(val))
+		default:
+			b.WriteString(yamlScalar(fmt.Sprintf("%v", value)))
+		}
+		b.WriteString("\n")
+	}
+}
+
+func writeYAMLMapEntries(b *strings.Builder, values map[string]any, indent int) {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeYAMLKeyValue(b, k, values[k], indent)
+	}
+}
+
+func writeYAMLListItems(b *strings.Builder, values []any, indent int) {
+	prefix := strings.Repeat("  ", indent)
+	for _, item := range values {
+		switch elem := item.(type) {
+		case map[string]any:
+			b.WriteString(prefix)
+			b.WriteString("-\n")
+			writeYAMLMapEntries(b, elem, indent+1)
+		case []any:
+			b.WriteString(prefix)
+			b.WriteString("-\n")
+			writeYAMLListItems(b, elem, indent+1)
+		default:
+			b.WriteString(prefix)
+			b.WriteString("- ")
+			writeYAMLInlineValue(b, elem)
+			b.WriteString("\n")
+		}
+	}
+}
+
+// writeYAMLInlineValue writes a scalar value inline (no key prefix, no newline).
+// Used for scalar values inside arrays.
+func writeYAMLInlineValue(b *strings.Builder, value any) {
+	switch v := value.(type) {
+	case bool:
+		if v {
+			b.WriteString("true")
+		} else {
+			b.WriteString("false")
+		}
+	case float64:
+		if v == float64(int64(v)) {
+			fmt.Fprintf(b, "%d", int64(v))
+		} else {
+			fmt.Fprintf(b, "%g", v)
+		}
+	case string:
+		b.WriteString(yamlScalar(v))
+	default:
+		b.WriteString(yamlScalar(fmt.Sprintf("%v", value)))
+	}
+}
+
+// ============================================================================
+// Individual file serving
+// ============================================================================
+
+// genericFileDownload serves GET /api/skills/serve/{skill-name}/files/{filepath:*}
+func (h *SkillsServingHandler) genericFileDownload(ctx *fasthttp.RequestCtx) {
+	h.doServeFileContent(ctx)
+}
+
+func (h *SkillsServingHandler) doServeFileContent(ctx *fasthttp.RequestCtx) {
+	skill, ok := h.lookupSkillByPathParam(ctx)
+	if !ok {
+		return
+	}
+
+	filePath := ""
+	if val := ctx.UserValue("filepath"); val != nil {
+		filePath, _ = val.(string)
+	}
+	if filePath == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "file path is required")
+		return
+	}
+
+	// Find matching file
+	var matchedFile *tables.TableSkillFile
+	for i := range skill.Files {
+		f := &skill.Files[i]
+		if f.NormalizedPath() == filePath {
+			matchedFile = f
+			break
+		}
+	}
+
+	if matchedFile == nil {
+		SendError(ctx, fasthttp.StatusNotFound, "file not found")
+		return
+	}
+
+	serveSkillFile(ctx, matchedFile, h.objectStore, skill.Name)
+}
+
+// serveSkillFile streams file content based on source type.
+func serveSkillFile(ctx *fasthttp.RequestCtx, file *tables.TableSkillFile, objStore objectstore.ObjectStore, skillName string) {
+	if file.MimeType != "" {
+		ctx.SetContentType(file.MimeType)
+	} else {
+		ctx.SetContentType("application/octet-stream")
+	}
+	ctx.Response.Header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, path.Base(file.Path)))
+
+	switch file.SourceType {
+	case tables.SkillSourceTypeURL:
+		if file.SourceURL == nil || *file.SourceURL == "" {
+			logger.Error("skill %s file %s: url source has no source_url", skillName, file.Path)
+			SendError(ctx, fasthttp.StatusInternalServerError, "file source URL not configured")
+			return
+		}
+		data, err := fetchURLSafe(ctx, *file.SourceURL)
+		if err != nil {
+			logger.Error("skill %s file %s: failed to fetch from URL %s: %v", skillName, file.Path, redactURLForLog(*file.SourceURL), err)
+			SendError(ctx, fasthttp.StatusBadGateway, "failed to fetch file from source URL")
+			return
+		}
+		ctx.SetStatusCode(fasthttp.StatusOK)
+		ctx.SetBody(data)
+
+	case tables.SkillSourceTypeText, tables.SkillSourceTypeDataURL, tables.SkillSourceTypeUpload:
+		data, err := fetchStoredFileContent(ctx, file, objStore)
+		if err != nil {
+			logger.Error("skill %s file %s: failed to retrieve stored content: %v", skillName, file.Path, err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "failed to retrieve file content")
+			return
+		}
+		ctx.SetStatusCode(fasthttp.StatusOK)
+		ctx.SetBody(data)
+
+	default:
+		SendError(ctx, fasthttp.StatusInternalServerError, "unsupported file source type")
+	}
+}
+
+func redactURLForLog(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+// fetchStoredFileContent retrieves file bytes from object storage or DB blob.
+func fetchStoredFileContent(ctx context.Context, file *tables.TableSkillFile, objStore objectstore.ObjectStore) ([]byte, error) {
+	// Try object storage first; fall back to DB blob if object store
+	// fails (e.g. files created before object store was configured still
+	// have their data in the blob table).
+	if objStore != nil && file.StorageKey != nil && *file.StorageKey != "" {
+		data, err := objStore.Get(ctx, *file.StorageKey)
+		if err == nil {
+			return data, nil
+		}
+		logger.Warn("object store get failed for key %s, falling back to blob: %v", *file.StorageKey, err)
+	}
+	// Fall back to DB blob
+	if file.Blob != nil {
+		return file.Blob.Data, nil
+	}
+	if file.BlobID != nil && *file.BlobID != "" {
+		return nil, fmt.Errorf("blob_id set but blob data not preloaded (blob_id=%s)", *file.BlobID)
+	}
+	return nil, fmt.Errorf("no storage_key or blob_id available for file %s", file.Path)
+}
+
+// fetchFileContentForArchive retrieves file bytes for archive generation.
+// Same logic as serveSkillFile but returns bytes instead of writing to response.
+func fetchFileContentForArchive(ctx context.Context, file *tables.TableSkillFile, objStore objectstore.ObjectStore) ([]byte, error) {
+	switch file.SourceType {
+	case tables.SkillSourceTypeURL:
+		if file.SourceURL == nil || *file.SourceURL == "" {
+			return nil, fmt.Errorf("url source has no source_url")
+		}
+		return fetchURLSafe(ctx, *file.SourceURL)
+
+	case tables.SkillSourceTypeText, tables.SkillSourceTypeDataURL, tables.SkillSourceTypeUpload:
+		// Handle transient pre-storage content (available at create/update time
+		// before files are persisted to blob/object storage).
+		if file.InlineContent != nil && *file.InlineContent != "" {
+			return []byte(*file.InlineContent), nil
+		}
+		if file.DataURL != nil && *file.DataURL != "" {
+			parts := strings.SplitN(*file.DataURL, ",", 2)
+			if len(parts) == 2 {
+				if strings.Contains(parts[0], ";base64") {
+					data, err := base64.StdEncoding.DecodeString(parts[1])
+					if err == nil {
+						return data, nil
+					}
+				} else {
+					// Plain data URL payloads are percent-encoded; '+' remains literal here.
+					data, err := url.PathUnescape(parts[1])
+					if err != nil {
+						return nil, fmt.Errorf("dataurl percent decode failed: %w", err)
+					}
+					return []byte(data), nil
+				}
+			}
+		}
+		return fetchStoredFileContent(ctx, file, objStore)
+
+	default:
+		return nil, fmt.Errorf("unsupported source type %s", file.SourceType)
+	}
+}
+
+// ============================================================================
+// Generic zip download
+// ============================================================================
+
+// allSkillsZipDownload serves GET /api/skills/serve/all/download.zip
+// Returns a zip archive containing all skills.
+func (h *SkillsServingHandler) allSkillsZipDownload(ctx *fasthttp.RequestCtx) {
+	skills, err := h.listAllSkills(ctx)
+	if err != nil {
+		logger.Error("all-skills zip: failed to list skills: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to list skills")
+		return
+	}
+
+	ctx.SetContentType("application/zip")
+	ctx.Response.Header.Set("Content-Disposition", `attachment; filename="all-skills.zip"`)
+	ctx.SetStatusCode(fasthttp.StatusOK)
+
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	requestDone := ctx.Done()
+	go func() {
+		select {
+		case <-requestDone:
+			cancelStream()
+		case <-streamCtx.Done():
+		}
+	}()
+
+	// Stream the zip directly to the response -- no full in-memory buffer.
+	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+		defer cancelStream()
+		zw := zip.NewWriter(w)
+
+		for _, s := range skills {
+			full, err := h.store.GetSkillByName(streamCtx, s.Name)
+			if err != nil {
+				logger.Error("all-skills zip: failed to get skill %s: %v", s.Name, err)
+				continue
+			}
+			composed := composeSkillMD(full)
+			if err := writeZipEntry(zw, path.Join(full.Name, "SKILL.md"), []byte(composed)); err != nil {
+				logger.Error("all-skills zip: failed to write skill %s manifest: %v", full.Name, err)
+				return
+			}
+
+			for i := range full.Files {
+				file := &full.Files[i]
+				data, err := fetchFileContentForArchive(streamCtx, file, h.objectStore)
+				if err != nil {
+					continue
+				}
+				filePath := buildSkillFilePath(full.Name, file)
+				if err := writeZipEntry(zw, filePath, data); err != nil {
+					logger.Error("all-skills zip: failed to write file %s/%s: %v", full.Name, file.Path, err)
+					return
+				}
+			}
+			// Flush after each skill so data trickles to the client
+			// instead of buffering the entire archive.
+			if err := w.Flush(); err != nil {
+				logger.Error("all-skills zip: failed to flush response: %v", err)
+				return
+			}
+		}
+
+		if err := zw.Close(); err != nil {
+			logger.Error("all-skills zip: failed to close zip: %v", err)
+			return
+		}
+		if err := w.Flush(); err != nil {
+			logger.Error("all-skills zip: failed to flush response: %v", err)
+		}
+	})
+}
+
+// genericZipDownload serves GET /api/skills/serve/{skill-name}/download.zip
+// Returns a raw Agent Skills directory zip without the plugin wrapper.
+func (h *SkillsServingHandler) genericZipDownload(ctx *fasthttp.RequestCtx) {
+	skill, ok := h.lookupSkillByPathParam(ctx)
+	if !ok {
+		return
+	}
+
+	ctx.SetContentType("application/zip")
+	ctx.Response.Header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.zip"`, skill.Name))
+	ctx.SetStatusCode(fasthttp.StatusOK)
+
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	requestDone := ctx.Done()
+	go func() {
+		select {
+		case <-requestDone:
+			cancelStream()
+		case <-streamCtx.Done():
+		}
+	}()
+
+	// Stream the zip directly to the response -- no full in-memory buffer.
+	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+		defer cancelStream()
+		zw := zip.NewWriter(w)
+
+		// Write SKILL.md
+		composed := composeSkillMD(skill)
+		if err := writeZipEntry(zw, path.Join(skill.Name, "SKILL.md"), []byte(composed)); err != nil {
+			logger.Error("skill %s: zip: failed to write manifest: %v", skill.Name, err)
+			return
+		}
+
+		// Write files
+		for i := range skill.Files {
+			file := &skill.Files[i]
+			data, err := fetchFileContentForArchive(streamCtx, file, h.objectStore)
+			if err != nil {
+				logger.Error("skill %s: zip: failed to fetch file %s: %v", skill.Name, file.Path, err)
+				continue
+			}
+
+			filePath := buildSkillFilePath(skill.Name, file)
+			if err := writeZipEntry(zw, filePath, data); err != nil {
+				logger.Error("skill %s: zip: failed to write file %s: %v", skill.Name, file.Path, err)
+				return
+			}
+			// Flush after each file so data trickles to the client.
+			if err := w.Flush(); err != nil {
+				logger.Error("skill %s: zip: failed to flush response: %v", skill.Name, err)
+				return
+			}
+		}
+
+		if err := zw.Close(); err != nil {
+			logger.Error("skill %s: failed to close zip: %v", skill.Name, err)
+			return
+		}
+		if err := w.Flush(); err != nil {
+			logger.Error("skill %s: zip: failed to flush response: %v", skill.Name, err)
+		}
+	})
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+func writeZipEntry(zw *zip.Writer, name string, data []byte) error {
+	fw, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	if _, err := fw.Write(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+// buildSkillFilePath computes the relative file path within the skill directory.
+// e.g., <skill-name>/nested/path/file.py
+func buildSkillFilePath(skillName string, file *tables.TableSkillFile) string {
+	return path.Join(skillName, file.Path)
+}
+
+// lookupSkillByPathParam extracts the skill-name path parameter and fetches the skill.
+func (h *SkillsServingHandler) lookupSkillByPathParam(ctx *fasthttp.RequestCtx) (*tables.TableSkill, bool) {
+	val := ctx.UserValue("skill-name")
+	if val == nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "skill name is required")
+		return nil, false
+	}
+	name, ok := val.(string)
+	if !ok || name == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid skill name")
+		return nil, false
+	}
+
+	skill, err := h.store.GetSkillByName(ctx, name)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("skill %q not found", name))
+			return nil, false
+		}
+		logger.Error("failed to get skill %s: %v", name, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to retrieve skill")
+		return nil, false
+	}
+	return skill, true
+}
+
+// listAllSkills fetches all skills for marketplace generation.
+func (h *SkillsServingHandler) listAllSkills(ctx *fasthttp.RequestCtx) ([]tables.TableSkill, error) {
+	// Use a large limit to get all skills for the marketplace catalog
+	skills, _, err := h.store.ListSkills(ctx, configstore.SkillListQueryParams{Limit: 10000, SortBy: "name", Order: "asc"})
+	if err != nil {
+		logger.Error("failed to list skills for marketplace: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to list skills")
+		return nil, err
+	}
+	return skills, nil
+}
+
+// resolveBaseURL derives the base URL from the request's Host header and scheme.
+func (h *SkillsServingHandler) resolveBaseURL(ctx *fasthttp.RequestCtx) string {
+	scheme := string(ctx.Request.Header.Peek("X-Forwarded-Proto"))
+	if scheme == "" {
+		if ctx.IsTLS() {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	host := string(ctx.Request.Header.Peek("X-Forwarded-Host"))
+	if host == "" {
+		host = string(ctx.Host())
+	}
+
+	return scheme + "://" + host
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -37,6 +37,7 @@ import (
 	"github.com/maximhq/bifrost/framework/mcpcatalog"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/framework/oauth2"
+	"github.com/maximhq/bifrost/framework/objectstore"
 	plugins "github.com/maximhq/bifrost/framework/plugins"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"github.com/maximhq/bifrost/plugins/compat"
@@ -178,6 +179,37 @@ type ConfigData struct {
 
 	presentSections           map[string]bool
 	presentGovernanceSections map[string]bool
+	SkillsRegistry            *SkillsRegistryConfig `json:"skills_registry,omitempty"`
+}
+
+// SkillsRegistryConfig defines declarative skill definitions in config.json.
+type SkillsRegistryConfig struct {
+	Enabled *bool                 `json:"enabled,omitempty"`
+	Skills  []SkillsRegistryEntry `json:"skills,omitempty"`
+}
+
+// SkillsRegistryEntry describes a single skill to reconcile from config.json.
+type SkillsRegistryEntry struct {
+	Name             string                 `json:"name"`
+	Description      string                 `json:"description"`
+	License          string                 `json:"license,omitempty"`
+	Compatibility    string                 `json:"compatibility,omitempty"`
+	AllowedTools     string                 `json:"allowed_tools,omitempty"`
+	ExtraFrontmatter map[string]interface{} `json:"extra_frontmatter,omitempty"`
+	Metadata         map[string]string      `json:"metadata,omitempty"`
+	SkillMDBody      string                 `json:"skill_md_body"`
+	Version          string                 `json:"version"`
+	Files            []SkillsRegistryFile   `json:"files,omitempty"`
+}
+
+// SkillsRegistryFile describes a file attached to a config-defined skill.
+type SkillsRegistryFile struct {
+	Path       string `json:"path"`
+	SourceType string `json:"source_type"`
+	// Source-type-specific fields
+	URL     string `json:"url,omitempty"` // for source_type "url"
+	Content  string `json:"content,omitempty"`  // for source_type "text"
+	DataURL  string `json:"dataurl,omitempty"`  // for source_type "dataurl"
 }
 
 // FeatureFlagsFileConfig is the config.json / Helm shape for feature flag
@@ -355,6 +387,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 		Plugins           []*schemas.PluginConfig               `json:"plugins,omitempty"`
 		WebSocket         *schemas.WebSocketConfig              `json:"websocket,omitempty"`
 		FeatureFlags      *FeatureFlagsFileConfig               `json:"feature_flags,omitempty"`
+		SkillsRegistry    *SkillsRegistryConfig                 `json:"skills_registry,omitempty"`
 	}
 
 	var temp TempConfigData
@@ -385,6 +418,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 			}
 		}
 	}
+	cd.SkillsRegistry = temp.SkillsRegistry
 	// Initialize providers map if nil
 	if cd.Providers == nil {
 		cd.Providers = make(map[string]configstore.ProviderConfig)
@@ -450,6 +484,7 @@ type Config struct {
 	ConfigStore configstore.ConfigStore
 	VectorStore vectorstore.VectorStore
 	LogsStore   logstore.LogStore
+	ObjectStore objectstore.ObjectStore
 
 	// In-memory storage
 	ServerConfig     *ServerConfig
@@ -837,11 +872,13 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 	loadAuthConfig(ctx, config, &configData)
 	// 9. Plugins
 	loadPlugins(ctx, config, &configData)
-	// 10. Framework config and pricing manager
+	// 10. Skills registry (after plugins, before framework)
+	loadSkillsRegistry(ctx, config, &configData)
+	// 11. Framework config and pricing manager
 	initFrameworkConfig(ctx, config, &configData)
-	// 11. Encryption sync
+	// 12. Encryption sync
 	syncEncryption(ctx, config)
-	// 12. WebSocket defaults
+	// 13. WebSocket defaults
 	if configData.WebSocket != nil {
 		configData.WebSocket.CheckAndSetDefaults()
 		config.WebSocketConfig = configData.WebSocket
@@ -903,6 +940,9 @@ func initStores(ctx context.Context, config *Config, configData *ConfigData, con
 		if err != nil {
 			return err
 		}
+		if err := initSkillsObjectStore(ctx, config, configData.LogsStoreConfig); err != nil {
+			return err
+		}
 		logger.Info("logs store initialized")
 	} else if configData.LogsStoreConfig == nil {
 		// No logs store section — check DB for stored config (if available), then fall back to default SQLite
@@ -952,6 +992,9 @@ func initStores(ctx context.Context, config *Config, configData *ConfigData, con
 			}
 		}
 		logger.Info("logs store initialized")
+		if err := initSkillsObjectStore(ctx, config, logStoreConfig); err != nil {
+			return err
+		}
 		if config.ConfigStore != nil {
 			if err = config.ConfigStore.UpdateLogsStoreConfig(ctx, logStoreConfig); err != nil {
 				return fmt.Errorf("failed to update logs store config: %w", err)
@@ -4779,9 +4822,33 @@ func (c *Config) Close(ctx context.Context) {
 	if c.LogsStore != nil {
 		c.LogsStore.Close(ctx)
 	}
+	if c.ObjectStore != nil {
+		if err := c.ObjectStore.Close(); err != nil {
+			logger.Warn("failed to close object store: %v", err)
+		}
+	}
 	if c.VectorStore != nil {
 		c.VectorStore.Close(ctx, "")
 	}
+}
+
+func initSkillsObjectStore(ctx context.Context, config *Config, logStoreConfig *logstore.Config) error {
+	if config == nil || config.ObjectStore != nil || logStoreConfig == nil || logStoreConfig.ObjectStorage == nil {
+		return nil
+	}
+	objStore, err := objectstore.NewObjectStore(ctx, logStoreConfig.ObjectStorage, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create skills object store: %w", err)
+	}
+	pingCtx, pingCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer pingCancel()
+	if err := objStore.Ping(pingCtx); err != nil {
+		_ = objStore.Close()
+		return fmt.Errorf("failed to ping skills object store: %w", err)
+	}
+	config.ObjectStore = objStore
+	logger.Info("skills object store initialized")
+	return nil
 }
 
 // initFeatureFlags constructs the feature flag store and applies overrides

--- a/transports/bifrost-http/lib/config_skills.go
+++ b/transports/bifrost-http/lib/config_skills.go
@@ -1,0 +1,232 @@
+package lib
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/objectstore"
+)
+
+// loadSkillsRegistry reconciles config-defined skills with the database on startup.
+func loadSkillsRegistry(ctx context.Context, config *Config, configData *ConfigData) {
+	if config.ConfigStore == nil {
+		return
+	}
+	if configData.SkillsRegistry == nil || len(configData.SkillsRegistry.Skills) == 0 {
+		return
+	}
+	// If enabled is explicitly set to false, skip
+	if configData.SkillsRegistry.Enabled != nil && !*configData.SkillsRegistry.Enabled {
+		return
+	}
+	reconcileSkillsRegistry(ctx, config.ConfigStore, configData.SkillsRegistry.Skills, config.ObjectStore)
+}
+
+// reconcileSkillsRegistry processes each config-defined skill entry: creates missing skills
+// or appends a new version if the definition changed and the provided version is valid.
+func reconcileSkillsRegistry(ctx context.Context, store configstore.ConfigStore, entries []SkillsRegistryEntry, objStore objectstore.ObjectStore) {
+	// Preflight: reject duplicate skill names before any writes.
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if _, dup := seen[entry.Name]; dup {
+			logger.Error("skills_registry: duplicate skill name %q in config — skipping entire skills_registry reconciliation", entry.Name)
+			return
+		}
+		seen[entry.Name] = struct{}{}
+	}
+
+	for i := range entries {
+		entry := &entries[i]
+		if err := reconcileOneSkill(ctx, store, entry, objStore); err != nil {
+			logger.Error("skills_registry: skill %q: %v", entry.Name, err)
+		}
+	}
+}
+
+func reconcileOneSkill(ctx context.Context, store configstore.ConfigStore, entry *SkillsRegistryEntry, objStore objectstore.ObjectStore) error {
+	// Reject upload source type in config — it requires the interactive/API upload flow
+	for _, f := range entry.Files {
+		if f.SourceType == configstoreTables.SkillSourceTypeUpload {
+			return fmt.Errorf("source_type \"upload\" is not supported in config.json; use dataurl, text, or url instead (file %q)", f.Path)
+		}
+	}
+
+	// Compute config hash first (cheap, in-memory) so we can skip unchanged
+	// entries before doing any network I/O (e.g. HEAD requests for URL files).
+	configHash, err := generateSkillRegistryEntryHash(entry)
+	if err != nil {
+		return fmt.Errorf("failed to generate config hash: %w", err)
+	}
+
+	// Check if skill already exists
+	existing, err := store.GetSkillByName(ctx, entry.Name)
+	if err != nil && err != configstore.ErrNotFound {
+		return fmt.Errorf("failed to look up existing skill: %w", err)
+	}
+
+	// Early exit on hash match — avoids file conversion, validation, and
+	// network I/O (URL MIME inference) when the config entry hasn't changed.
+	if existing != nil {
+		switch existing.ConfigHash {
+		case "":
+			// Skill was created via API/dashboard and is now appearing in config.json.
+			// Config takes ownership — warn so operators know the API-managed content
+			// is being superseded.
+			logger.Warn("skills_registry: skill %q was created via API/dashboard; config.json is now managing it", entry.Name)
+		case configHash:
+			logger.Debug("skills_registry: skill %q unchanged (hash match), skipping", entry.Name)
+			return nil
+		}
+	}
+
+	// Config changed, new skill, or claiming an API-created skill —
+	// now resolve files (may issue HEAD requests for URL sources).
+	skill := configEntryToTableSkill(entry)
+	files := configEntryToTableFiles(ctx, entry)
+
+	// Validate using the same pipeline as the management API
+	if err := configstore.ValidateSkill(&skill, entry.Version); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+	seenPaths := make(map[string]struct{}, len(files))
+	for i := range files {
+		if err := configstore.ValidateSkillFile(&files[i]); err != nil {
+			return fmt.Errorf("file %q validation failed: %w", files[i].Path, err)
+		}
+		if _, dup := seenPaths[files[i].Path]; dup {
+			return fmt.Errorf("duplicate file path %q", files[i].Path)
+		}
+		seenPaths[files[i].Path] = struct{}{}
+	}
+
+	if existing == nil {
+		// Skill does not exist — create with the provided version
+		skill.ConfigHash = configHash
+		skill.Files = files
+		if err := store.CreateSkill(ctx, &skill, entry.Version, objStore); err != nil {
+			return fmt.Errorf("failed to create skill: %w", err)
+		}
+		logger.Info("skills_registry: created skill %q version %s", entry.Name, entry.Version)
+		return nil
+	}
+
+	// Publish a new version and serve it directly.
+	skill.ID = existing.ID
+	skill.Files = files
+	if err := store.UpdateSkill(ctx, &skill, entry.Version, true, objStore); err != nil {
+		// If the version already exists or is behind, the config entry cannot be applied.
+		// Persist the config hash so subsequent restarts see a match and skip cleanly,
+		// avoiding noisy errors on every boot.
+		if strings.Contains(err.Error(), "already matches the latest version") ||
+			strings.Contains(err.Error(), "already exists in version history") {
+			if hashErr := store.UpdateSkillConfigHash(ctx, existing.ID, configHash); hashErr != nil {
+				logger.Warn("skills_registry: skill %q: version %q already exists but failed to update config hash: %v", entry.Name, entry.Version, hashErr)
+			} else {
+				logger.Info("skills_registry: skill %q: version %q already exists, adopted by config", entry.Name, entry.Version)
+			}
+			return nil
+		}
+		// Validation failure (e.g. version goes backwards) — do nothing, log and move on.
+		return fmt.Errorf("failed to update skill (check version %q against latest): %w", entry.Version, err)
+	}
+
+	// Version created successfully — update config hash.
+	if hashErr := store.UpdateSkillConfigHash(ctx, existing.ID, configHash); hashErr != nil {
+		logger.Warn("skills_registry: skill %q: version %s created but failed to update config hash: %v", entry.Name, entry.Version, hashErr)
+	}
+
+	logger.Info("skills_registry: updated skill %q to version %s", entry.Name, entry.Version)
+	return nil
+}
+
+// configEntryToTableSkill converts a SkillsRegistryEntry to a TableSkill.
+func configEntryToTableSkill(entry *SkillsRegistryEntry) configstoreTables.TableSkill {
+	skill := configstoreTables.TableSkill{
+		Name:             entry.Name,
+		Description:      entry.Description,
+		SkillMDBody:      entry.SkillMDBody,
+		Metadata:         configstoreTables.SkillStringMap(entry.Metadata),
+		ExtraFrontmatter: configstoreTables.SkillJSONMap(entry.ExtraFrontmatter),
+	}
+	if entry.License != "" {
+		skill.License = &entry.License
+	}
+	if entry.Compatibility != "" {
+		skill.Compatibility = &entry.Compatibility
+	}
+	if entry.AllowedTools != "" {
+		skill.AllowedTools = &entry.AllowedTools
+	}
+	return skill
+}
+
+// configEntryToTableFiles converts config file entries to TableSkillFile entries.
+func configEntryToTableFiles(ctx context.Context, entry *SkillsRegistryEntry) []configstoreTables.TableSkillFile {
+	files := make([]configstoreTables.TableSkillFile, 0, len(entry.Files))
+	for _, cf := range entry.Files {
+		file := configstoreTables.TableSkillFile{
+			Path:       cf.Path,
+			SourceType: cf.SourceType,
+		}
+		switch cf.SourceType {
+		case configstoreTables.SkillSourceTypeURL:
+			file.SourceURL = &cf.URL
+			if mimeType, err := inferConfigLiveURLMimeType(ctx, cf.URL); err != nil {
+				logger.Warn("skills_registry: skill %q file %q: could not infer MIME from URL %q: %v; using application/octet-stream", entry.Name, cf.Path, cf.URL, err)
+				file.MimeType = "application/octet-stream"
+			} else {
+				file.MimeType = mimeType
+			}
+		case configstoreTables.SkillSourceTypeText:
+			file.InlineContent = &cf.Content
+			file.MimeType = "text/plain"
+		case configstoreTables.SkillSourceTypeDataURL:
+			file.DataURL = &cf.DataURL
+		}
+		files = append(files, file)
+	}
+	return files
+}
+
+func inferConfigLiveURLMimeType(ctx context.Context, rawURL string) (string, error) {
+	client := http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("HEAD returned status %d", resp.StatusCode)
+	}
+	mimeType := strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])
+	if mimeType == "" {
+		return "", fmt.Errorf("HEAD response did not include Content-Type")
+	}
+	return mimeType, nil
+}
+
+// generateSkillRegistryEntryHash produces a deterministic SHA-256 hash of a config
+// entry so that unchanged entries are not re-applied on every restart.
+func generateSkillRegistryEntryHash(entry *SkillsRegistryEntry) (string, error) {
+	// Marshal the entire entry to JSON for a deterministic content hash.
+	// json.Marshal sorts map keys alphabetically (since Go 1.12), so the
+	// output is stable across restarts for the same Go values.
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:]), nil
+}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -373,6 +373,7 @@ import (
 	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/objectstore"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"github.com/maximhq/bifrost/plugins/governance/complexity"
 	otelPlugin "github.com/maximhq/bifrost/plugins/otel"
@@ -1846,6 +1847,66 @@ func (m *MockConfigStore) CreatePromptVersion(ctx context.Context, version *tabl
 	return nil
 }
 func (m *MockConfigStore) DeletePromptVersion(ctx context.Context, id uint) error { return nil }
+
+// Skills Repository
+func (m *MockConfigStore) CreateSkill(ctx context.Context, skill *tables.TableSkill, version string, objectStore objectstore.ObjectStore) error {
+	return nil
+}
+
+func (m *MockConfigStore) GetSkill(ctx context.Context, id string) (*tables.TableSkill, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) GetSkillLean(ctx context.Context, id string) (*tables.TableSkill, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) GetSkillByName(ctx context.Context, name string) (*tables.TableSkill, error) {
+	return nil, configstore.ErrNotFound
+}
+
+func (m *MockConfigStore) GetSkillVersion(ctx context.Context, skillID, version string) (*tables.TableSkillVersion, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) ListSkillVersions(ctx context.Context, skillID string, params configstore.SkillVersionListQueryParams) ([]tables.TableSkillVersion, int64, error) {
+	return nil, 0, nil
+}
+
+func (m *MockConfigStore) UpdateSkill(ctx context.Context, skill *tables.TableSkill, version string, serve bool, objectStore objectstore.ObjectStore) error {
+	return nil
+}
+
+func (m *MockConfigStore) DeleteSkill(ctx context.Context, id string, objectStore objectstore.ObjectStore) error {
+	return nil
+}
+
+func (m *MockConfigStore) ListSkills(ctx context.Context, params configstore.SkillListQueryParams) ([]tables.TableSkill, int64, error) {
+	return nil, 0, nil
+}
+
+func (m *MockConfigStore) ShiftSkillVersion(ctx context.Context, skillID string, targetVersion string, objectStore objectstore.ObjectStore) error {
+	return nil
+}
+
+func (m *MockConfigStore) GetAllSkillsVersion(ctx context.Context) (string, error) {
+	return "1.0.0", nil
+}
+
+func (m *MockConfigStore) BumpAllSkillsVersion(ctx context.Context, bump string) (string, error) {
+	return "1.0.1", nil
+}
+
+func (m *MockConfigStore) CreateSkillFileBlob(ctx context.Context, blob *tables.TableSkillFileBlob) error {
+	return nil
+}
+
+func (m *MockConfigStore) CleanupOrphanSkillFileBlobs(ctx context.Context, force bool) (int64, error) {
+	return 0, nil
+}
+func (m *MockConfigStore) UpdateSkillConfigHash(ctx context.Context, skillID string, configHash string) error {
+	return nil
+}
 
 // Prompt Repository - Sessions
 func (m *MockConfigStore) GetPromptSessions(ctx context.Context, promptID string) ([]tables.TablePromptSession, error) {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1411,6 +1411,14 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	if promptsHandler != nil {
 		promptsHandler.RegisterRoutes(s.Router, middlewares...)
 	}
+	skillsHandler := handlers.NewSkillsHandler(s.Config.ConfigStore, s.Config.ObjectStore)
+	if skillsHandler != nil {
+		skillsHandler.RegisterRoutes(s.Router, middlewares...)
+	}
+	skillsServingHandler := handlers.NewSkillsServingHandler(s.Config.ConfigStore, s.Config.ObjectStore)
+	if skillsServingHandler != nil {
+		skillsServingHandler.RegisterRoutes(s.Router, middlewares...)
+	}
 	cacheHandler.RegisterRoutes(s.Router, middlewares...)
 	if featureFlagsHandler != nil {
 		featureFlagsHandler.RegisterRoutes(s.Router, middlewares...)
@@ -1534,6 +1542,25 @@ func (s *BifrostHTTPServer) PrepareCommonMiddlewares() []schemas.BifrostHTTPMidd
 		}
 	})
 	return commonMiddlewares
+}
+
+func startSkillsOrphanCleanupWorker(ctx context.Context, config *lib.Config) {
+	if config == nil || config.ConfigStore == nil {
+		return
+	}
+
+	// Run once on startup asynchronously with a 10-minute timeout so a stalled
+	// DB or object-store call does not leave the goroutine hanging indefinitely.
+	go func() {
+		cleanupCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
+		result, err := handlers.CleanupOrphanSkillFiles(cleanupCtx, config.ConfigStore, config.ObjectStore, false)
+		if err != nil {
+			logger.Warn("skills orphan cleanup failed during startup: %v", err)
+		} else {
+			logger.Info("skills orphan cleanup completed during startup: deleted_db_blobs=%d deleted_storage_objects=%d", result.DeletedDBBlobs, result.DeletedStorageObjects)
+		}
+	}()
 }
 
 // Bootstrap initializes the Bifrost HTTP server with all necessary components.
@@ -1782,6 +1809,12 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		}
 		return fmt.Errorf("failed to initialize inference routes: %v", err)
 	}
+	// Serve a minimal robots.txt so crawlers/CLI tools (e.g. Claude Code) don't
+	// trigger 404 warnings when probing the host before marketplace fetches.
+	s.Router.GET("/robots.txt", func(ctx *fasthttp.RequestCtx) {
+		ctx.SetContentType("text/plain; charset=utf-8")
+		ctx.SetBodyString("User-agent: *\nAllow: /\n")
+	})
 	// Register UI handler
 	s.RegisterUIRoutes()
 	// Checking if config has server config and use it to set read buffer size
@@ -1792,6 +1825,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		MaxRequestBodySize: s.Config.ClientConfig.MaxRequestBodySizeMB * 1024 * 1024,
 		ReadBufferSize:     s.Config.ServerConfig.ReadBufferSize,
 	}
+	startSkillsOrphanCleanupWorker(s.Ctx, s.Config)
 	return nil
 }
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1287,6 +1287,75 @@
       },
       "additionalProperties": false
     },
+    "skills_registry": {
+      "type": "object",
+      "description": "Declarative Skills Repository definitions reconciled from config.json",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether config-defined skills should be reconciled at startup"
+        },
+        "skills": {
+          "type": "array",
+          "description": "Skills to create or update from config.json",
+          "items": {
+            "type": "object",
+            "required": ["name", "description", "skill_md_body", "version"],
+            "properties": {
+              "name": { "type": "string" },
+              "description": { "type": "string" },
+              "license": { "type": "string" },
+              "compatibility": { "type": "string" },
+              "allowed_tools": { "type": "string" },
+              "extra_frontmatter": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+              },
+              "skill_md_body": { "type": "string" },
+              "version": { "type": "string" },
+              "files": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["path", "source_type"],
+                  "properties": {
+                    "path": { "type": "string" },
+                    "source_type": {
+                      "type": "string",
+                      "enum": ["text", "url", "dataurl"]
+                    },
+                    "url": { "type": "string" },
+                    "content": { "type": "string" },
+                    "dataurl": { "type": "string" }
+                  },
+                  "additionalProperties": false,
+                  "oneOf": [
+                    {
+                      "properties": { "source_type": { "const": "url" } },
+                      "required": ["url"]
+                    },
+                    {
+                      "properties": { "source_type": { "const": "text" } },
+                      "required": ["content"]
+                    },
+                    {
+                      "properties": { "source_type": { "const": "dataurl" } },
+                      "required": ["dataurl"]
+                    }
+                  ]
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "plugins": {
       "type": "array",
       "description": "Plugins configuration",

--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -135,7 +135,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
           <Sidebar />
           <div className="dark:bg-card custom-scrollbar content-container my-[0.5rem] mr-[0.5rem] h-[calc(100dvh-1rem)] w-full min-w-xl overflow-auto rounded-md border border-gray-200 bg-white px-10 dark:border-zinc-800">
             <TrialExpiryBanner />
-            <main className="custom-scrollbar content-container-inner relative mx-auto flex flex-col overflow-y-hidden p-4">
+            <main className="custom-scrollbar content-container-inner relative mx-auto flex h-full min-h-0 flex-col overflow-y-hidden p-4">
               {isLoading ? (
                 <FullPageLoader />
               ) : (
@@ -156,7 +156,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
 function MinimalShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="dark:bg-card custom-scrollbar content-container my-[0.5rem] h-[calc(100dvh-1rem)] w-full overflow-auto rounded-md border border-gray-200 bg-white px-10 dark:border-zinc-800">
-      <main className="custom-scrollbar content-container-inner relative mx-auto flex flex-col overflow-y-hidden p-4">
+      <main className="custom-scrollbar content-container-inner relative mx-auto flex h-full min-h-0 flex-col overflow-y-hidden p-4">
         {children}
       </main>
     </div>

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -354,6 +354,20 @@ div.content-container:has(.no-border-parent) #trial-notification-banner {
 	fill: var(--foreground) !important;
 }
 
+@keyframes sidebar-new-badge-shine {
+	0% {
+		opacity: 0;
+		transform: translateX(-60%);
+	}
+	22% {
+		opacity: 0.75;
+	}
+	100% {
+		opacity: 0;
+		transform: translateX(200%);
+	}
+}
+
 /* Dynamic chain: dash period 3+5 = 8 — offset must move exactly one period per loop */
 @keyframes rf-routing-tree-dynamic-chain-dash {
 	from {
@@ -374,7 +388,8 @@ div.content-container:has(.no-border-parent) #trial-notification-banner {
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.rf-chain-legend-dynamic-dash {
+	.rf-chain-legend-dynamic-dash,
+	[data-new-badge="true"] {
 		animation: none;
 	}
 

--- a/ui/app/workspace/skills-repo/components/FileManager.tsx
+++ b/ui/app/workspace/skills-repo/components/FileManager.tsx
@@ -1,0 +1,1723 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Tree,
+  type BaseNodeData,
+  type TreeNode,
+} from "@/components/ui/treeView";
+import { getErrorMessage } from "@/lib/store/apis/baseApi";
+import { useUploadSkillFileMutation } from "@/lib/store/apis/skillsApi";
+import { SkillFileEntry } from "@/lib/types/skills";
+import {
+  validateFilePath,
+  validateFilename,
+  validateSkillFileSize,
+  validateSourceType,
+} from "@/lib/validators/skills";
+import {
+  AlertCircle,
+  BookOpen,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ChevronsDownUp,
+  ChevronsUpDown,
+  FileText,
+  Folder,
+  FolderPlus,
+  Info,
+  Loader2,
+  MoveRight,
+  Pencil,
+  Plus,
+  Search,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+import { formatFileSize } from "./helpers";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+
+const FILE_SOURCE_OPTIONS = [
+  { value: "text", label: "Via text", shortLabel: "Text" },
+  { value: "url", label: "Via URL", shortLabel: "URL" },
+  { value: "dataurl", label: "Via data URL", shortLabel: "Data URL" },
+  { value: "upload", label: "Via upload", shortLabel: "Upload" },
+];
+
+function getSourceOption(sourceType: string) {
+  return (
+    FILE_SOURCE_OPTIONS.find((option) => option.value === sourceType) ??
+    FILE_SOURCE_OPTIONS[0]
+  );
+}
+
+function joinPath(folder: string, filename: string) {
+  return [folder, filename.trim()].filter(Boolean).join("/");
+}
+
+function basename(path: string) {
+  return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+function dirname(path: string) {
+  const parts = path.split("/").filter(Boolean);
+  parts.pop();
+  return parts.join("/");
+}
+
+function normalizeFolderPath(path: string) {
+  return path.trim().replace(/^\/+|\/+$/g, "");
+}
+
+function getFolderAncestors(path: string) {
+  const parts = path.split("/").filter(Boolean);
+  parts.pop();
+  const folders: string[] = [];
+  let currentPath = "";
+  for (const part of parts) {
+    currentPath = joinPath(currentPath, part);
+    folders.push(currentPath);
+  }
+  return folders;
+}
+
+function getRelativeUploadPath(file: File) {
+  return (
+    (file as File & { webkitRelativePath?: string }).webkitRelativePath ||
+    file.name
+  );
+}
+
+interface FileAddFormProps {
+  folderPath: string;
+  initialSourceType: string;
+  initialEntry?: SkillFileEntry;
+  submitLabel?: string;
+  className?: string;
+  onAdd: (entry: SkillFileEntry) => void;
+  onCancel: () => void;
+}
+
+function FileAddForm({
+  folderPath,
+  initialSourceType,
+  initialEntry,
+  submitLabel,
+  onAdd,
+  onCancel,
+  className,
+}: FileAddFormProps) {
+  const [uploadSkillFile, { isLoading: isUploading }] =
+    useUploadSkillFileMutation();
+  const sourceType = initialSourceType;
+  const sourceOption = getSourceOption(sourceType);
+  const initialPath = initialEntry?.path ?? "";
+  const [filename, setFilename] = useState(
+    initialEntry ? basename(initialPath) : "",
+  );
+  const [url, setUrl] = useState(initialEntry?.source_url ?? "");
+  const [content, setContent] = useState(initialEntry?.content ?? "");
+  const [dataurl, setDataurl] = useState(initialEntry?.dataurl ?? "");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [mimeType, setMimeType] = useState(
+    initialEntry?.mime_type ?? "text/plain",
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const locationLabel = folderPath ? `${folderPath}/` : "root";
+
+  const handleUploadFileChange = (file: File | null) => {
+    setSelectedFile(file);
+    if (file) {
+      const sizeErr = validateSkillFileSize(file.size);
+      if (sizeErr) {
+        setError(sizeErr);
+        setSelectedFile(null);
+        return;
+      }
+      setFilename((current) => current || file.name);
+      setMimeType(file.type || "application/octet-stream");
+    }
+  };
+
+  const handleSubmit = async () => {
+    setError(null);
+    const filenameErr = validateFilename(filename);
+    if (filenameErr) return setError(filenameErr);
+
+    const fullPath = joinPath(folderPath, filename);
+    const pathErr = validateFilePath(fullPath);
+    if (pathErr) return setError(pathErr);
+
+    const srcErr = validateSourceType(sourceType, {
+      url,
+      dataurl,
+      content,
+      upload_id: selectedFile?.name,
+    });
+    if (srcErr) return setError(srcErr);
+
+    const entry: SkillFileEntry = {
+      path: fullPath,
+      source_type: sourceType as SkillFileEntry["source_type"],
+      mime_type: mimeType,
+      file_size_bytes: selectedFile?.size ?? initialEntry?.file_size_bytes,
+      __local: initialEntry?.__local ?? sourceType !== "upload",
+    };
+
+    if (sourceType === "upload") {
+      if (!selectedFile) return setError("Select a file to upload");
+      const sizeErr = validateSkillFileSize(selectedFile.size);
+      if (sizeErr) return setError(sizeErr);
+      try {
+        const upload = await uploadSkillFile({ file: selectedFile }).unwrap();
+        entry.upload_id = upload.upload_id;
+        entry.storage_key = upload.storage_key;
+        entry.blob_id = upload.blob_id;
+        entry.mime_type = upload.mime_type || mimeType;
+        entry.file_size_bytes = upload.file_size_bytes;
+      } catch (err: unknown) {
+        setError(getErrorMessage(err));
+        return;
+      }
+    }
+
+    if (sourceType === "url") entry.source_url = url;
+    if (sourceType === "text") entry.content = content;
+    if (sourceType === "dataurl") entry.dataurl = dataurl;
+    onAdd(entry);
+  };
+
+  return (
+    <div
+      className={cn(
+        "w-full rounded-sm border border-dashed p-2 space-y-3",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <span className="inline-flex h-5 shrink-0 items-center rounded-full border border-border/60 bg-transparent px-2 text-[10px] font-medium leading-none text-muted-foreground">
+          {sourceOption.label}
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          Location: {locationLabel}
+        </span>
+      </div>
+
+      <div>
+        <Label className="text-xs text-muted-foreground">Filename</Label>
+        <Input
+          data-testid="skill-file-filename-input"
+          value={filename}
+          onChange={(e) => setFilename(e.target.value)}
+          placeholder="review.py"
+          className="mt-1 font-mono text-xs h-8"
+        />
+      </div>
+
+      {sourceType === "url" && (
+        <Input
+          data-testid="skill-file-url-input"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com/file.py"
+          className="font-mono text-xs h-8"
+          aria-label="Source URL"
+        />
+      )}
+      {sourceType === "text" && (
+        <Textarea
+          data-testid="skill-file-content-textarea"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="File content..."
+          className="font-mono text-xs min-h-[80px]"
+          rows={4}
+          aria-label="File content"
+        />
+      )}
+      {sourceType === "dataurl" && (
+        <Textarea
+          data-testid="skill-file-dataurl-textarea"
+          value={dataurl}
+          onChange={(e) => setDataurl(e.target.value)}
+          placeholder="data:text/plain;base64,..."
+          className="font-mono text-xs"
+          rows={2}
+          aria-label="Data URL"
+        />
+      )}
+      {sourceType === "upload" && (
+        <div className="space-y-1.5">
+          <Input
+            data-testid="skill-file-upload-input"
+            type="file"
+            onChange={(e) =>
+              handleUploadFileChange(e.target.files?.[0] ?? null)
+            }
+            className="h-8 text-xs"
+            aria-label="Choose file to upload"
+          />
+          {selectedFile && (
+            <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+              <span className="font-mono truncate">{selectedFile.name}</span>
+              <span>{formatFileSize(selectedFile.size)}</span>
+              {selectedFile.type && <span>{selectedFile.type}</span>}
+            </div>
+          )}
+        </div>
+      )}
+
+      {sourceType === "url" && (
+        <div className="flex items-start gap-2 rounded-sm border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-200">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span>
+            This source is saved as a live reference. Bifrost will read from
+            this URL when the skill file is retrieved.
+          </span>
+        </div>
+      )}
+
+      {error && (
+        <div
+          className="flex items-center gap-2 text-destructive text-xs"
+          role="alert"
+        >
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          {error}
+        </div>
+      )}
+
+      <div className="flex gap-2 justify-end pt-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 text-xs"
+          data-testid="skill-file-cancel-btn"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          className="h-7 text-xs"
+          data-testid="skill-file-save-btn"
+          onClick={handleSubmit}
+          disabled={isUploading}
+        >
+          {isUploading ? (
+            <>
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Uploading...
+            </>
+          ) : (
+            <>
+              <Plus className="h-3 w-3" />
+              {submitLabel ??
+                (sourceType === "upload" ? "Upload & add" : "Add")}
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function fuzzyMatches(value: string, query: string) {
+  const normalizedValue = value.toLowerCase();
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  let queryIndex = 0;
+  for (const char of normalizedValue) {
+    if (char === normalizedQuery[queryIndex]) queryIndex += 1;
+    if (queryIndex === normalizedQuery.length) return true;
+  }
+  return false;
+}
+
+function getMovedPath(path: string, fromFolder: string, toFolder: string) {
+  const relativePath =
+    path === fromFolder ? basename(path) : path.slice(fromFolder.length + 1);
+  return joinPath(toFolder, relativePath);
+}
+
+interface MoveDestinationMenuProps {
+  destinations: string[];
+  currentFolder: string;
+  triggerLabel: string;
+  tooltip: string;
+  onMove: (folderPath: string) => void;
+  isDisabledDestination?: (folderPath: string) => boolean;
+}
+
+function MoveDestinationMenu({
+  destinations,
+  currentFolder,
+  triggerLabel,
+  tooltip,
+  onMove,
+  isDisabledDestination,
+}: MoveDestinationMenuProps) {
+  const [query, setQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const firstEnabledDestinationRef = useRef<HTMLDivElement | null>(null);
+  const filteredDestinations = useMemo(
+    () =>
+      destinations.filter((folderPath) =>
+        fuzzyMatches(folderPath || "root", query),
+      ),
+    [destinations, query],
+  );
+  const firstEnabledDestination = filteredDestinations.find((folderPath) => {
+    const isCurrent = folderPath === currentFolder;
+    return !isCurrent && !isDisabledDestination?.(folderPath);
+  });
+
+  return (
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (!open) {
+          setQuery("");
+          firstEnabledDestinationRef.current = null;
+        }
+      }}
+    >
+      <Tooltip>
+        <DropdownMenuTrigger asChild>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+              data-testid="skill-file-move-btn"
+              aria-label={triggerLabel}
+            >
+              <MoveRight className="h-3 w-3" />
+            </Button>
+          </TooltipTrigger>
+        </DropdownMenuTrigger>
+        <TooltipContent className="px-2 py-1 text-xs">{tooltip}</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end" className="w-64 p-1">
+        <div
+          className="relative p-1"
+          onKeyDown={(event) => {
+            event.stopPropagation();
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              firstEnabledDestinationRef.current?.focus();
+            }
+          }}
+        >
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            ref={searchInputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search folders..."
+            className="h-8 pl-8 font-mono text-xs"
+            autoFocus
+          />
+        </div>
+        <div className="max-h-64 overflow-y-auto py-1">
+          {filteredDestinations.length ? (
+            filteredDestinations.map((folderPath) => {
+              const isCurrent = folderPath === currentFolder;
+              const isDisabled =
+                isCurrent || isDisabledDestination?.(folderPath);
+              return (
+                <DropdownMenuItem
+                  key={folderPath || "root"}
+                  ref={(node) => {
+                    if (folderPath === firstEnabledDestination) {
+                      firstEnabledDestinationRef.current = node;
+                    }
+                  }}
+                  className="cursor-pointer font-mono text-xs"
+                  disabled={isDisabled}
+                  onKeyDown={(event) => {
+                    if (
+                      event.key === "ArrowUp" &&
+                      folderPath === firstEnabledDestination
+                    ) {
+                      event.preventDefault();
+                      searchInputRef.current?.focus();
+                    }
+                  }}
+                  onSelect={() => onMove(folderPath)}
+                >
+                  {folderPath || "root"}
+                </DropdownMenuItem>
+              );
+            })
+          ) : (
+            <div className="px-2 py-3 text-center text-xs text-muted-foreground">
+              No folders found
+            </div>
+          )}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface TreeFolder {
+  name: string;
+  path: string;
+  folders: Map<string, TreeFolder>;
+  files: { entry: SkillFileEntry; index: number }[];
+}
+
+function makeFolder(name: string, path: string): TreeFolder {
+  return { name, path, folders: new Map(), files: [] };
+}
+
+function buildTree(files: SkillFileEntry[]) {
+  const root = makeFolder("", "");
+  files.forEach((entry, index) => {
+    const segments = entry.path.split("/").filter(Boolean);
+    const fileName = segments.pop();
+    if (!fileName) return;
+    let folder = root;
+    let currentPath = "";
+    for (const segment of segments) {
+      currentPath = joinPath(currentPath, segment);
+      if (!folder.folders.has(segment))
+        folder.folders.set(segment, makeFolder(segment, currentPath));
+      folder = folder.folders.get(segment)!;
+    }
+    folder.files.push({ entry, index });
+  });
+  return root;
+}
+
+function AddMenu({ onSelect }: { onSelect: (sourceType: string) => void }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 text-xs text-muted-foreground"
+          data-testid="skill-file-add-btn"
+        >
+          <Plus className="h-3 w-3" />
+          Add file
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {FILE_SOURCE_OPTIONS.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            className="cursor-pointer"
+            onSelect={() => onSelect(option.value)}
+          >
+            {option.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface FileTreeNodeData extends BaseNodeData {
+  kind:
+    | "root"
+    | "folder"
+    | "file"
+    | "add-file"
+    | "add-folder"
+    | "edit-file"
+    | "empty-folder";
+  path: string;
+  folder?: TreeFolder;
+  file?: SkillFileEntry;
+  fileIndex?: number;
+}
+
+function folderToTreeNode(
+  folder: TreeFolder,
+  editingFullFileIndex: number | null,
+): TreeNode<FileTreeNodeData> {
+  const childFolders = [...folder.folders.values()].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  const childFiles = [...folder.files].sort((a, b) =>
+    basename(a.entry.path).localeCompare(basename(b.entry.path)),
+  );
+
+  return {
+    data: {
+      id: folder.path || "root",
+      name: folder.path ? folder.name : "root",
+      kind: folder.path ? "folder" : "root",
+      path: folder.path,
+      folder,
+    },
+    children: [
+      ...childFolders.map((childFolder) =>
+        folderToTreeNode(childFolder, editingFullFileIndex),
+      ),
+      ...childFiles.map(({ entry, index }) => ({
+        data: {
+          id:
+            editingFullFileIndex === index
+              ? `draft-edit:${index}:${entry.path}`
+              : `file:${index}:${entry.path}`,
+          name: basename(entry.path),
+          kind:
+            editingFullFileIndex === index
+              ? ("edit-file" as const)
+              : ("file" as const),
+          path: entry.path,
+          file: entry,
+          fileIndex: index,
+        },
+      })),
+    ],
+  };
+}
+
+function addChildNode(
+  node: TreeNode<FileTreeNodeData>,
+  parentPath: string,
+  child: TreeNode<FileTreeNodeData>,
+  placement: "start" | "end" = "end",
+): boolean {
+  if (node.data.path === parentPath) {
+    node.children =
+      placement === "start"
+        ? [child, ...(node.children ?? [])]
+        : [...(node.children ?? []), child];
+    return true;
+  }
+  for (const nested of node.children ?? []) {
+    if (addChildNode(nested, parentPath, child, placement)) return true;
+  }
+  return false;
+}
+
+export function FileManagerSection({
+  files,
+  onAddFile,
+  onRemoveFile,
+  onUpdateFile,
+  readOnly,
+}: {
+  files: SkillFileEntry[];
+  onAddFile: (entry: SkillFileEntry) => void;
+  onRemoveFile: (index: number) => void;
+  onUpdateFile: (index: number, updates: Partial<SkillFileEntry>) => void;
+  readOnly: boolean;
+}) {
+  const [uploadSkillFile] = useUploadSkillFileMutation();
+  const folderUploadInputRef = useRef<HTMLInputElement | null>(null);
+  const folderUploadTargetRef = useRef("");
+  const [folderUploadState, setFolderUploadState] = useState<{
+    folderPath: string;
+    total: number;
+    completed: number;
+  } | null>(null);
+  const [folderUploadError, setFolderUploadError] = useState<string | null>(
+    null,
+  );
+  const [editingFileIndex, setEditingFileIndex] = useState<number | null>(null);
+  const [editingFileOriginal, setEditingFileOriginal] = useState<{
+    path: string;
+  } | null>(null);
+  const [editingFullFileIndex, setEditingFullFileIndex] = useState<
+    number | null
+  >(null);
+  const [addingFile, setAddingFile] = useState<{
+    folderPath: string;
+    sourceType: string;
+  } | null>(null);
+  const [newFolderParent, setNewFolderParent] = useState<string | null>(null);
+  const [newFolderName, setNewFolderName] = useState("");
+  const [newFolderError, setNewFolderError] = useState<string | null>(null);
+  const [folders, setFolders] = useState<string[]>([]);
+  const [folderToDelete, setFolderToDelete] = useState<string | null>(null);
+  const [fileToRemove, setFileToRemove] = useState<{
+    index: number;
+    path: string;
+    isLocal: boolean;
+  } | null>(null);
+  // External expansion state so we can programmatically expand folders
+  const [expandedNodes, setExpandedNodes] = useState<Record<string, boolean>>(
+    {},
+  );
+
+  useEffect(() => {
+    const foldersFromFiles = files.flatMap((file) =>
+      getFolderAncestors(file.path),
+    );
+    if (foldersFromFiles.length === 0) return;
+    setFolders((prev) => {
+      const next = new Set(prev);
+      foldersFromFiles.forEach((folder) => next.add(folder));
+      return next.size === prev.length ? prev : [...next];
+    });
+  }, [files]);
+
+  const treeStates = useMemo(
+    () => ({ expandedNodes, setExpandedNodes }),
+    [expandedNodes],
+  );
+
+  const expandFolder = useCallback((folderPath: string) => {
+    // Expand root, the target folder, and all its ancestors
+    const normalizedFolderPath = folderPath === "root" ? "" : folderPath;
+    const ancestors = normalizedFolderPath.split("/").filter(Boolean);
+    setExpandedNodes((prev) => {
+      const next: Record<string, boolean> = { ...prev, root: true };
+      let path = "";
+      for (const part of ancestors) {
+        path = path ? `${path}/${part}` : part;
+        next[path] = true;
+      }
+      return next;
+    });
+  }, []);
+
+  const isFolderUploading = folderUploadState !== null;
+
+  const treeData = useMemo(() => {
+    const rootFolder = buildTree(files);
+    for (const folderPath of folders) {
+      const segments = folderPath.split("/").filter(Boolean);
+      let folder = rootFolder;
+      let currentPath = "";
+      for (const segment of segments) {
+        currentPath = joinPath(currentPath, segment);
+        if (!folder.folders.has(segment))
+          folder.folders.set(segment, makeFolder(segment, currentPath));
+        folder = folder.folders.get(segment)!;
+      }
+    }
+
+    const rootNode = folderToTreeNode(rootFolder, editingFullFileIndex);
+
+    if (newFolderParent !== null) {
+      addChildNode(
+        rootNode,
+        newFolderParent,
+        {
+          data: {
+            id: `draft-folder:${newFolderParent}`,
+            name: "New folder",
+            kind: "add-folder",
+            path: newFolderParent,
+          },
+        },
+        "start",
+      );
+    }
+
+    if (addingFile) {
+      addChildNode(
+        rootNode,
+        addingFile.folderPath,
+        {
+          data: {
+            id: `draft-file:${addingFile.folderPath}:${addingFile.sourceType}`,
+            name: "New file",
+            kind: "add-file",
+            path: addingFile.folderPath,
+          },
+        },
+        "start",
+      );
+    }
+
+    const addEmptyFolderDrafts = (node: TreeNode<FileTreeNodeData>) => {
+      for (const child of node.children ?? []) addEmptyFolderDrafts(child);
+      const isEmptyDraftFolder =
+        node.data.kind === "folder" &&
+        folders.includes(node.data.path) &&
+        (node.children?.length ?? 0) === 0;
+      if (isEmptyDraftFolder) {
+        node.children = [
+          {
+            data: {
+              id: `empty:${node.data.path}`,
+              name: "Empty folder",
+              kind: "empty-folder",
+              path: node.data.path,
+            },
+          },
+        ];
+      }
+    };
+    addEmptyFolderDrafts(rootNode);
+
+    return [rootNode];
+  }, [addingFile, editingFullFileIndex, files, folders, newFolderParent]);
+
+  const availableFolderPaths = useMemo(() => {
+    const folderSet = new Set<string>([""]);
+    folders.forEach((folder) => folderSet.add(folder));
+    files.forEach((file) => {
+      getFolderAncestors(file.path).forEach((folder) => folderSet.add(folder));
+    });
+    return [...folderSet].sort((a, b) => {
+      if (a === "") return -1;
+      if (b === "") return 1;
+      return a.localeCompare(b);
+    });
+  }, [files, folders]);
+
+  const handleFolderUploadClick = (folderPath: string) => {
+    if (isFolderUploading) return;
+    folderUploadTargetRef.current = folderPath;
+    setFolderUploadError(null);
+    folderUploadInputRef.current?.click();
+  };
+
+  const handleFolderUploadChange = async (
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const selectedFiles = Array.from(event.target.files ?? []);
+    event.target.value = "";
+    if (selectedFiles.length === 0) return;
+
+    const targetFolderPath = folderUploadTargetRef.current;
+    setFolderUploadError(null);
+    setAddingFile(null);
+    setEditingFileIndex(null);
+    setEditingFileOriginal(null);
+    setEditingFullFileIndex(null);
+
+    setFolderUploadState({
+      folderPath: targetFolderPath,
+      total: selectedFiles.length,
+      completed: 0,
+    });
+
+    try {
+      const importedFolders = new Set<string>();
+      const entries: SkillFileEntry[] = [];
+
+      for (const file of selectedFiles) {
+        const relativePath = normalizeFolderPath(getRelativeUploadPath(file));
+        if (!relativePath) continue;
+
+        const fullPath = joinPath(targetFolderPath, relativePath);
+        if (
+          files.some((f) => f.path === fullPath) ||
+          entries.some((e) => e.path === fullPath)
+        )
+          throw new Error(`${fullPath}: a file already exists at that path`);
+        const pathErr = validateFilePath(fullPath);
+        if (pathErr) throw new Error(`${fullPath}: ${pathErr}`);
+        const sizeErr = validateSkillFileSize(file.size);
+        if (sizeErr) throw new Error(`${fullPath}: ${sizeErr}`);
+
+        const upload = await uploadSkillFile({ file }).unwrap();
+        entries.push({
+          path: fullPath,
+          source_type: "upload",
+          upload_id: upload.upload_id,
+          storage_key: upload.storage_key,
+          blob_id: upload.blob_id,
+          mime_type:
+            upload.mime_type || file.type || "application/octet-stream",
+          file_size_bytes: upload.file_size_bytes,
+          __local: false,
+        });
+        getFolderAncestors(fullPath).forEach((folder) =>
+          importedFolders.add(folder),
+        );
+        setFolderUploadState((current) =>
+          current ? { ...current, completed: current.completed + 1 } : current,
+        );
+      }
+
+      entries.forEach(onAddFile);
+      setFolders((prev) => {
+        const next = new Set(prev);
+        importedFolders.forEach((folder) => next.add(folder));
+        return next.size === prev.length ? prev : [...next];
+      });
+    } catch (err: unknown) {
+      setFolderUploadError(getErrorMessage(err));
+    } finally {
+      setFolderUploadState(null);
+    }
+  };
+
+  const moveFileToFolder = (index: number, folderPath: string) => {
+    const file = files[index];
+    if (!file) return;
+    const nextPath = joinPath(folderPath, basename(file.path));
+    if (nextPath === file.path) return;
+    if (files.some((f, i) => i !== index && f.path === nextPath)) {
+      toast.error("A file already exists at that path");
+      return;
+    }
+    onUpdateFile(index, { path: nextPath });
+  };
+
+  const moveFolderToFolder = (folderPath: string, targetFolderPath: string) => {
+    const nextFolderPath = joinPath(targetFolderPath, basename(folderPath));
+    if (
+      nextFolderPath === folderPath ||
+      targetFolderPath === dirname(folderPath) ||
+      targetFolderPath === folderPath ||
+      targetFolderPath.startsWith(`${folderPath}/`)
+    ) {
+      return;
+    }
+
+    const hasCollision = files.some((file) => {
+      if (!file.path.startsWith(`${folderPath}/`)) return false;
+      const movedPath = getMovedPath(file.path, folderPath, nextFolderPath);
+      return files.some(
+        (f) => !f.path.startsWith(`${folderPath}/`) && f.path === movedPath,
+      );
+    });
+    if (hasCollision) {
+      toast.error("A file already exists at that path");
+      return;
+    }
+
+    files.forEach((file, index) => {
+      if (file.path.startsWith(`${folderPath}/`)) {
+        onUpdateFile(index, {
+          path: getMovedPath(file.path, folderPath, nextFolderPath),
+        });
+      }
+    });
+
+    setFolders((prev) => {
+      const next = new Set<string>();
+      prev.forEach((folder) => {
+        if (folder === folderPath || folder.startsWith(`${folderPath}/`)) {
+          next.add(getMovedPath(folder, folderPath, nextFolderPath));
+        } else {
+          next.add(folder);
+        }
+      });
+      next.add(nextFolderPath);
+      getFolderAncestors(`${nextFolderPath}/placeholder.txt`).forEach(
+        (folder) => next.add(folder),
+      );
+      return [...next];
+    });
+
+    if (
+      addingFile?.folderPath.startsWith(`${folderPath}/`) ||
+      addingFile?.folderPath === folderPath
+    ) {
+      setAddingFile({
+        ...addingFile,
+        folderPath: getMovedPath(
+          addingFile.folderPath,
+          folderPath,
+          nextFolderPath,
+        ),
+      });
+    }
+    if (
+      newFolderParent?.startsWith(`${folderPath}/`) ||
+      newFolderParent === folderPath
+    ) {
+      setNewFolderParent(
+        getMovedPath(newFolderParent, folderPath, nextFolderPath),
+      );
+    }
+  };
+
+  const removeFile = (index: number) => {
+    onRemoveFile(index);
+    if (editingFileIndex !== null) {
+      if (editingFileIndex === index) {
+        setEditingFileIndex(null);
+        setEditingFileOriginal(null);
+      } else if (index < editingFileIndex) {
+        setEditingFileIndex(editingFileIndex - 1);
+      }
+    }
+    if (editingFullFileIndex !== null) {
+      if (editingFullFileIndex === index) {
+        setEditingFullFileIndex(null);
+      } else if (index < editingFullFileIndex) {
+        setEditingFullFileIndex(editingFullFileIndex - 1);
+      }
+    }
+  };
+
+  const folderDeleteImpact = useMemo(() => {
+    if (!folderToDelete) return null;
+    const nestedFiles = files
+      .filter((file) => file.path.startsWith(`${folderToDelete}/`))
+      .map((file) => file.path)
+      .sort((a, b) => a.localeCompare(b));
+    const nestedFolders = folders
+      .filter(
+        (folder) =>
+          folder !== folderToDelete && folder.startsWith(`${folderToDelete}/`),
+      )
+      .sort((a, b) => a.localeCompare(b));
+
+    return { nestedFiles, nestedFolders };
+  }, [files, folderToDelete, folders]);
+
+  const removeFolder = (folderPath: string) => {
+    setFolders((prev) =>
+      prev.filter(
+        (folder) =>
+          folder !== folderPath && !folder.startsWith(`${folderPath}/`),
+      ),
+    );
+    const removedIndices = files
+      .map((file, index) => ({ file, index }))
+      .filter(
+        ({ file }) =>
+          file.path === folderPath || file.path.startsWith(`${folderPath}/`),
+      )
+      .map(({ index }) => index)
+      .sort((a, b) => b - a);
+
+    removedIndices.forEach((index) => onRemoveFile(index));
+
+    const adjustIndexAfterBatchRemove = (currentIndex: number | null) => {
+      if (currentIndex === null) return currentIndex;
+      if (removedIndices.includes(currentIndex)) return null;
+      const removedBeforeCurrent = removedIndices.filter(
+        (index) => index < currentIndex,
+      ).length;
+      return currentIndex - removedBeforeCurrent;
+    };
+
+    setEditingFileIndex((currentIndex) => {
+      const nextIndex = adjustIndexAfterBatchRemove(currentIndex);
+      if (nextIndex === null && currentIndex !== null) {
+        setEditingFileOriginal(null);
+      }
+      return nextIndex;
+    });
+    setEditingFullFileIndex(adjustIndexAfterBatchRemove);
+    if (
+      addingFile?.folderPath === folderPath ||
+      addingFile?.folderPath.startsWith(`${folderPath}/`)
+    )
+      setAddingFile(null);
+    if (
+      newFolderParent === folderPath ||
+      newFolderParent?.startsWith(`${folderPath}/`)
+    ) {
+      setNewFolderParent(null);
+      setNewFolderName("");
+      setNewFolderError(null);
+    }
+  };
+
+  const requestRemoveFolder = (folderPath: string) => {
+    const hasNestedFiles = files.some((file) =>
+      file.path.startsWith(`${folderPath}/`),
+    );
+    const hasNestedFolders = folders.some(
+      (folder) => folder !== folderPath && folder.startsWith(`${folderPath}/`),
+    );
+
+    if (hasNestedFiles || hasNestedFolders) {
+      setFolderToDelete(folderPath);
+      return;
+    }
+
+    removeFolder(folderPath);
+  };
+
+  const handleAdd = (entry: SkillFileEntry) => {
+    if (files.some((f) => f.path === entry.path)) {
+      toast.error("A file already exists at that path");
+      return;
+    }
+    onAddFile(entry);
+    // Expand the folder containing the new file so the user can see it
+    const folder = dirname(entry.path);
+    expandFolder(folder || "root");
+    setAddingFile(null);
+    setEditingFullFileIndex(null);
+  };
+
+  const addFolder = (parentPath: string) => {
+    setNewFolderError(null);
+    const nameErr = validateFilename(newFolderName);
+    if (nameErr) {
+      setNewFolderError(nameErr);
+      return;
+    }
+    const nextPath = joinPath(parentPath, newFolderName);
+    if (
+      folders.includes(nextPath) ||
+      files.some(
+        (file) =>
+          file.path === nextPath || file.path.startsWith(`${nextPath}/`),
+      )
+    ) {
+      setNewFolderError("A folder with this name already exists here");
+      return;
+    }
+    const pathErr = validateFilePath(`${nextPath}/placeholder.txt`);
+    if (pathErr) {
+      setNewFolderError(pathErr);
+      return;
+    }
+    setFolders((prev) =>
+      prev.includes(nextPath) ? prev : [...prev, nextPath],
+    );
+    setNewFolderName("");
+    setNewFolderError(null);
+    setNewFolderParent(null);
+  };
+
+  const renderItem = ({
+    item,
+    isExpanded,
+    hasChildren,
+    onToggle,
+    onExpandAll,
+    onCollapseAll,
+    isAllExpanded,
+    isAllCollapsed,
+  }: {
+    item: FileTreeNodeData;
+    level: number;
+    isExpanded: boolean;
+    hasChildren: boolean;
+    onToggle: () => void;
+    onExpandAll: () => void;
+    onCollapseAll: () => void;
+    isAllExpanded: boolean;
+    isAllCollapsed: boolean;
+  }) => {
+    if (item.kind === "add-folder") {
+      return (
+        <div className="space-y-1.5 py-1 ml-1">
+          <div className="flex items-center gap-2">
+            <Input
+              data-testid="skill-file-folder-name-input"
+              value={newFolderName}
+              onChange={(e) => {
+                setNewFolderName(normalizeFolderPath(e.target.value));
+                setNewFolderError(null);
+              }}
+              placeholder="folder-name"
+              className="h-7 max-w-xs font-mono text-xs"
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              data-testid="skill-file-folder-confirm-btn"
+              onClick={() => addFolder(item.path)}
+            >
+              <Check className="h-3 w-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              data-testid="skill-file-folder-cancel-btn"
+              onClick={() => {
+                setNewFolderParent(null);
+                setNewFolderName("");
+                setNewFolderError(null);
+              }}
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+          {newFolderError && (
+            <div
+              className="flex items-center gap-2 text-xs text-destructive"
+              role="alert"
+            >
+              <AlertCircle
+                className="h-3.5 w-3.5 shrink-0"
+                aria-hidden="true"
+              />
+              {newFolderError}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    if (item.kind === "add-file" && addingFile) {
+      return (
+        <FileAddForm
+          className="ml-1"
+          folderPath={addingFile.folderPath}
+          initialSourceType={addingFile.sourceType}
+          onAdd={handleAdd}
+          onCancel={() => setAddingFile(null)}
+        />
+      );
+    }
+
+    if (item.kind === "edit-file" && item.file && item.fileIndex != null) {
+      return (
+        <FileAddForm
+          className="ml-1"
+          folderPath={dirname(item.file.path)}
+          initialSourceType={item.file.source_type}
+          initialEntry={item.file}
+          submitLabel="Update"
+          onAdd={(entry) => {
+            if (
+              files.some(
+                (f, i) => i !== item.fileIndex && f.path === entry.path,
+              )
+            ) {
+              toast.error("A file already exists at that path");
+              return;
+            }
+            onUpdateFile(item.fileIndex!, entry);
+            setEditingFullFileIndex(null);
+          }}
+          onCancel={() => setEditingFullFileIndex(null)}
+        />
+      );
+    }
+
+    if (item.kind === "empty-folder") {
+      return (
+        <div className="flex items-center gap-2 py-1 text-xs text-muted-foreground ml-1">
+          <span>Empty folder</span>
+          <span className="text-[10px] text-muted-foreground/60">
+            Not saved until it contains a file.
+          </span>
+        </div>
+      );
+    }
+
+    if (item.kind === "file" && item.file && item.fileIndex != null) {
+      const file = item.file;
+      const index = item.fileIndex;
+      const canFullEdit = !!file.__local && file.source_type !== "upload";
+
+      if (editingFileIndex === index) {
+        return (
+          <div className="space-y-2 p-1 border rounded-sm border-dashed ml-1">
+            <div className="flex items-center gap-2">
+              <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <Input
+                value={basename(file.path)}
+                onChange={(e) => {
+                  const newPath = joinPath(dirname(file.path), e.target.value);
+                  if (files.some((f, i) => i !== index && f.path === newPath)) {
+                    toast.error("A file already exists at that path");
+                    return;
+                  }
+                  onUpdateFile(index, { path: newPath });
+                }}
+                placeholder="filename.ext"
+                className="h-7 font-mono text-xs"
+                aria-label="File name"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                onClick={() => {
+                  if (editingFileOriginal)
+                    onUpdateFile(index, { path: editingFileOriginal.path });
+                  setEditingFileIndex(null);
+                  setEditingFileOriginal(null);
+                }}
+              >
+                <X className="h-3 w-3" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 w-7 p-0 text-muted-foreground"
+                onClick={() => {
+                  const err = validateFilePath(file.path);
+                  const filenameErr = validateFilename(basename(file.path));
+                  if (!err && !filenameErr) {
+                    setEditingFileIndex(null);
+                    setEditingFileOriginal(null);
+                  }
+                }}
+              >
+                <Check className="h-3 w-3" />
+              </Button>
+            </div>
+            <div className="flex items-start gap-2 rounded-sm border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-200">
+              <Info
+                className="mt-0.5 h-3.5 w-3.5 shrink-0"
+                aria-hidden="true"
+              />
+              <span>
+                Committed files keep their stored reference. Rename here; use
+                Move to place the file in another folder.
+              </span>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <div className="group flex items-center gap-3 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted/50">
+          <div className="flex min-w-0 items-center gap-2">
+            <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="truncate font-mono text-xs">
+              {basename(file.path)}
+            </span>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex h-5 shrink-0 items-center rounded-full border border-border/60 bg-transparent px-2 text-[10px] font-medium leading-none text-muted-foreground">
+                  {file.source_type}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="px-2 py-1 text-xs">
+                Source
+              </TooltipContent>
+            </Tooltip>
+            {file.mime_type && (
+              <span className="shrink-0 text-[10px] text-muted-foreground/60">
+                {file.mime_type}
+              </span>
+            )}
+            {file.file_size_bytes != null && file.file_size_bytes > 0 && (
+              <span className="shrink-0 text-[10px] text-muted-foreground/60">
+                {formatFileSize(file.file_size_bytes)}
+              </span>
+            )}
+          </div>
+          {!readOnly && (
+            <div className="flex-1 justify-end flex shrink-0 items-center gap-1 opacity-100 md:opacity-0 transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100">
+              <MoveDestinationMenu
+                destinations={availableFolderPaths}
+                currentFolder={dirname(file.path)}
+                triggerLabel={`Move ${file.path}`}
+                tooltip="Move file"
+                onMove={(folderPath) => {
+                  setEditingFileIndex(null);
+                  setEditingFileOriginal(null);
+                  setEditingFullFileIndex(null);
+                  moveFileToFolder(index, folderPath);
+                }}
+              />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+                    data-testid={`skill-file-edit-${basename(file.path)}`}
+                    aria-label={`Edit ${file.path}`}
+                    onClick={() => {
+                      if (canFullEdit) {
+                        setAddingFile(null);
+                        setEditingFileIndex(null);
+                        setEditingFileOriginal(null);
+                        setEditingFullFileIndex(index);
+                        return;
+                      }
+                      setEditingFullFileIndex(null);
+                      setEditingFileIndex(index);
+                      setEditingFileOriginal({ path: file.path });
+                    }}
+                  >
+                    <Pencil className="h-3 w-3" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="px-2 py-1 text-xs">
+                  {canFullEdit ? "Edit file" : "Rename file"}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive"
+                    data-testid={`skill-file-delete-${basename(file.path)}`}
+                    aria-label={`Remove ${file.path}`}
+                    onClick={() =>
+                      setFileToRemove({
+                        index,
+                        path: file.path,
+                        isLocal: !!file.__local,
+                      })
+                    }
+                  >
+                    <X className="h-3 w-3" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="px-2 py-1 text-xs">
+                  Remove file
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    const isRoot = item.kind === "root";
+    return (
+      <div
+        className={cn(
+          "group flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-muted/40",
+          hasChildren && "cursor-pointer",
+        )}
+        onClick={() => {
+          if (hasChildren) onToggle();
+        }}
+        onKeyDown={(event) => {
+          if (hasChildren && (event.key === "Enter" || event.key === " ")) {
+            event.preventDefault();
+            onToggle();
+          }
+        }}
+        role={hasChildren ? "button" : undefined}
+        tabIndex={hasChildren ? 0 : undefined}
+        aria-label={
+          hasChildren
+            ? `${isExpanded ? "Collapse" : "Expand"} ${isRoot ? "root" : item.name}`
+            : undefined
+        }
+      >
+        {hasChildren ? (
+          <span
+            className="flex h-4 w-4 items-center justify-center text-muted-foreground"
+            aria-hidden="true"
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+            )}
+          </span>
+        ) : (
+          <span className="h-4 w-4" />
+        )}
+        {isRoot ? (
+          <BookOpen className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <Folder className="h-4 w-4 text-muted-foreground" />
+        )}
+        <span className="font-mono text-xs font-medium">
+          {isRoot ? "root" : `${item.name}/`}
+        </span>
+        {isRoot && (
+          <Badge variant="secondary" className="text-[10px]">
+            SKILL.md
+          </Badge>
+        )}
+        {!readOnly && editingFullFileIndex == null && (
+          <div
+            className="ml-auto flex items-center gap-1 opacity-100 md:opacity-0 transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100"
+            onClick={(event) => event.stopPropagation()}
+            onKeyDown={(event) => event.stopPropagation()}
+          >
+            {isRoot && (
+              <>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0 text-muted-foreground"
+                      data-testid="skill-file-expand-all-btn"
+                      aria-label="Expand all folders"
+                      onClick={onExpandAll}
+                      disabled={isAllExpanded}
+                    >
+                      <ChevronsUpDown className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent className="px-2 py-1 text-xs">
+                    Expand all
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0 text-muted-foreground"
+                      data-testid="skill-file-collapse-all-btn"
+                      aria-label="Collapse all folders"
+                      onClick={onCollapseAll}
+                      disabled={isAllCollapsed}
+                    >
+                      <ChevronsDownUp className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent className="px-2 py-1 text-xs">
+                    Collapse all
+                  </TooltipContent>
+                </Tooltip>
+              </>
+            )}
+            <AddMenu
+              onSelect={(sourceType) => {
+                expandFolder(item.path || "root");
+                setAddingFile({ folderPath: item.path, sourceType });
+                setEditingFileIndex(null);
+                setEditingFileOriginal(null);
+              }}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-muted-foreground"
+              data-testid="skill-file-folder-upload-btn"
+              onClick={() => handleFolderUploadClick(item.path)}
+              disabled={isFolderUploading}
+            >
+              {folderUploadState?.folderPath === item.path ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Upload className="h-3 w-3" />
+              )}
+              Upload folder
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-muted-foreground"
+              data-testid="skill-file-add-folder-btn"
+              onClick={() => {
+                setNewFolderParent(item.path);
+                setNewFolderName("");
+                setNewFolderError(null);
+              }}
+            >
+              <FolderPlus className="h-3 w-3" />
+              Folder
+            </Button>
+            {!isRoot && (
+              <MoveDestinationMenu
+                destinations={availableFolderPaths}
+                currentFolder={dirname(item.path)}
+                triggerLabel={`Move folder ${item.path}`}
+                tooltip="Move folder"
+                isDisabledDestination={(folderPath) =>
+                  folderPath === item.path ||
+                  folderPath.startsWith(`${item.path}/`)
+                }
+                onMove={(folderPath) => {
+                  setEditingFileIndex(null);
+                  setEditingFileOriginal(null);
+                  setEditingFullFileIndex(null);
+                  moveFolderToFolder(item.path, folderPath);
+                }}
+              />
+            )}
+            {!isRoot && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                data-testid={`skill-file-delete-folder-${item.name}`}
+                aria-label={`Delete folder ${item.path}`}
+                onClick={() => requestRemoveFolder(item.path)}
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <input
+        ref={folderUploadInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        aria-hidden="true"
+        tabIndex={-1}
+        onChange={handleFolderUploadChange}
+        {...{
+          webkitdirectory: "",
+          directory: "",
+        }}
+      />
+      {folderUploadState && (
+        <div className="mb-2 flex items-center gap-2 rounded-sm border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-200">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+          <span>
+            Uploading folder files {folderUploadState.completed}/
+            {folderUploadState.total}
+            {folderUploadState.folderPath
+              ? ` into ${folderUploadState.folderPath}/`
+              : " into root"}
+          </span>
+        </div>
+      )}
+      {folderUploadError && (
+        <div
+          className="mb-2 flex items-center gap-2 rounded-sm border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+          role="alert"
+        >
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          {folderUploadError}
+        </div>
+      )}
+      <Tree
+        data={treeData}
+        renderItem={renderItem}
+        indentSize={22}
+        levelsToExpandByDefault={1}
+        states={treeStates}
+      />
+
+      <AlertDialog
+        open={folderToDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setFolderToDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete folder?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {folderDeleteImpact?.nestedFiles.length ? (
+                <>
+                  This will remove the folder <b>{folderToDelete}</b>, its
+                  nested folders, and all files inside it from this skill draft.
+                </>
+              ) : folderDeleteImpact?.nestedFolders.length ? (
+                <>
+                  This will remove the folder <b>{folderToDelete}</b> and its
+                  nested folders from this skill draft. There are no files in
+                  the hierarchy of this folder.
+                </>
+              ) : (
+                <>
+                  This will remove the empty folder <b>{folderToDelete}</b> from
+                  this skill draft.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {folderDeleteImpact?.nestedFiles.length ? (
+            <div className="space-y-3 rounded-sm border bg-muted/20 p-3 text-xs">
+              <div className="space-y-1">
+                <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Files
+                </div>
+                <ul className="max-h-32 space-y-1 overflow-auto font-mono text-muted-foreground">
+                  {folderDeleteImpact.nestedFiles.map((file) => (
+                    <li key={file}>{file}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ) : null}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (folderToDelete) removeFolder(folderToDelete);
+                setFolderToDelete(null);
+              }}
+            >
+              Delete folder
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={fileToRemove !== null}
+        onOpenChange={(open) => {
+          if (!open) setFileToRemove(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove file?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {fileToRemove?.isLocal ? (
+                <>
+                  This will remove <b>{fileToRemove.path}</b> from this skill
+                  draft.
+                </>
+              ) : (
+                <>
+                  This will remove <b>{fileToRemove?.path}</b> from this skill
+                  draft. The file stops being tracked only after you save these
+                  changes. If you need it back before saving, reload the page to
+                  discard this draft state; any other unsaved changes will be
+                  lost too.
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {!fileToRemove?.isLocal && (
+            <div className="rounded-sm border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-200">
+              After saving, restoring this file requires re-adding or
+              re-uploading it again.
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (fileToRemove) removeFile(fileToRemove.index);
+                setFileToRemove(null);
+              }}
+            >
+              Remove file
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/ui/app/workspace/skills-repo/components/MetadataTableEditor.tsx
+++ b/ui/app/workspace/skills-repo/components/MetadataTableEditor.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { HeadersTable } from "@/components/ui/headersTable";
+
+// ---------- MetadataTableEditor ----------
+
+function parseMetadataValue(metadataJson: string): Record<string, string> {
+  if (!metadataJson.trim()) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(metadataJson) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).map(([key, value]) => [
+        key,
+        String(value ?? ""),
+      ]),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function serializeMetadataValue(value: Record<string, string>): string {
+  const validEntries = Object.entries(value).filter(([key]) => key.trim());
+  if (validEntries.length === 0) {
+    return "";
+  }
+
+  return JSON.stringify(Object.fromEntries(validEntries), null, 2);
+}
+
+export function MetadataTableEditor({
+  metadataJson,
+  onChange,
+  error,
+}: {
+  metadataJson: string;
+  onChange: (json: string) => void;
+  error?: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <HeadersTable
+        label=""
+        value={parseMetadataValue(metadataJson)}
+        onChange={(next) => onChange(serializeMetadataValue(next))}
+        keyPlaceholder="Metadata key"
+        valuePlaceholder="Metadata value"
+      />
+      {error && (
+        <p className="text-destructive text-xs mt-1" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/app/workspace/skills-repo/components/SkillCreateView.tsx
+++ b/ui/app/workspace/skills-repo/components/SkillCreateView.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useCreateSkillMutation } from "@/lib/store/apis/skillsApi";
+import { getErrorMessage } from "@/lib/store/apis/baseApi";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { toast } from "sonner";
+import { useSkillForm } from "./helpers";
+import { SkillEditView } from "./SkillEditView";
+
+// ---------- SkillCreateView ----------
+
+export function SkillCreateView({
+  onCreated,
+  onBack,
+}: {
+  onCreated: (id: string) => void;
+  onBack: () => void;
+}) {
+  const hasCreateAccess = useRbac(
+    RbacResource.SkillsRepository,
+    RbacOperation.Create,
+  );
+  const [createSkill, { isLoading }] = useCreateSkillMutation();
+  const form = useSkillForm();
+
+  // Create mode always serves the new version — serve param is intentionally unused
+  const handleCreate = async () => {
+    if (!form.runValidation()) return;
+
+    try {
+      const result = await createSkill(form.getPayload()).unwrap();
+      toast.success("Skill created successfully");
+      onCreated(result.skill.id);
+    } catch (err: unknown) {
+      toast.error("Failed to create skill", {
+        description: getErrorMessage(err),
+      });
+    }
+  };
+
+  if (!hasCreateAccess) {
+    return (
+      <div className="flex items-center justify-center h-[calc(100vh_-_50px)]">
+        <p className="text-muted-foreground">
+          You do not have permission to create skills.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <SkillEditView
+      form={form}
+      onSave={() => handleCreate()}
+      onCancel={onBack}
+      onBack={onBack}
+      isSaving={isLoading}
+      mode="create"
+    />
+  );
+}

--- a/ui/app/workspace/skills-repo/components/SkillDetailView.tsx
+++ b/ui/app/workspace/skills-repo/components/SkillDetailView.tsx
@@ -1,0 +1,474 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import FullPageLoader from "@/components/fullPageLoader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
+import {
+  useGetSkillQuery,
+  useUpdateSkillMutation,
+  useDeleteSkillMutation,
+  useListSkillVersionsQuery,
+} from "@/lib/store/apis/skillsApi";
+import { getErrorMessage } from "@/lib/store/apis/baseApi";
+import { SkillFile, SkillVersionSummary } from "@/lib/types/skills";
+import { validateVersionBump } from "@/lib/validators/skills";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+  MoreHorizontal,
+  Pencil,
+  Loader2,
+  Trash2,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  type SkillFormState,
+  composeFrontmatter,
+  formatDate,
+  useSkillForm,
+} from "./helpers";
+import { SkillHeader, FormSection } from "./shared";
+import { SkillFormFields } from "./SkillFormFields";
+import { SkillEditView } from "./SkillEditView";
+import { VersionDetailDialog } from "./VersionDetailDialog";
+
+// ---------- SkillDetailView ----------
+
+export function SkillDetailView({
+  skillId,
+  isEditing,
+  setIsEditing,
+  onBack,
+}: {
+  skillId: string;
+  isEditing: boolean;
+  setIsEditing: (editing: boolean) => void;
+  onBack: () => void;
+}) {
+  const hasEditAccess = useRbac(
+    RbacResource.SkillsRepository,
+    RbacOperation.Update,
+  );
+  const hasDeleteAccess = useRbac(
+    RbacResource.SkillsRepository,
+    RbacOperation.Delete,
+  );
+
+  const { data: skillData, isLoading } = useGetSkillQuery(skillId);
+  const [updateSkill, { isLoading: isUpdating }] = useUpdateSkillMutation();
+  const [deleteSkill, { isLoading: isDeleting }] = useDeleteSkillMutation();
+
+  const [selectedVersion, setSelectedVersion] = useState<SkillVersionSummary | null>(
+    null,
+  );
+  const [versionSortOrder, setVersionSortOrder] = useState<
+    "asc" | "desc" | null
+  >(null);
+  const [versionsPage, setVersionsPage] = useState(0);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const versionsPageSize = 10;
+
+  const form = useSkillForm();
+  const skill = skillData?.skill;
+
+  const { data: versionsData } = useListSkillVersionsQuery(
+    {
+      id: skillId,
+      limit: versionsPageSize,
+      offset: versionsPage * versionsPageSize,
+      sort_by: versionSortOrder ? "version" : undefined,
+      order: versionSortOrder || undefined,
+    },
+    { skip: !skill },
+  );
+
+  const highestVersion =
+    skill?.highest_version || skill?.latest_version || "0.0.0";
+
+  const getSkillFormState = useMemo(() => {
+    if (!skill) return null;
+    const state: SkillFormState = {
+      name: skill.name,
+      description: skill.description,
+      license: skill.license || "",
+      compatibility: skill.compatibility || "",
+      allowedTools: skill.allowed_tools || "",
+      extraFrontmatterJson:
+        skill.extra_frontmatter && Object.keys(skill.extra_frontmatter).length > 0
+          ? JSON.stringify(skill.extra_frontmatter, null, 2)
+          : "",
+      metadataJson:
+        skill.metadata && Object.keys(skill.metadata).length > 0
+          ? JSON.stringify(skill.metadata, null, 2)
+          : "",
+      skillMdBody: skill.skill_md_body,
+      version: highestVersion || "1.0.0",
+      files: skill.files
+        ? skill.files.map((f: SkillFile) => ({
+            path: f.path,
+            source_type: f.source_type,
+            source_url: f.source_url,
+            storage_key: f.storage_key,
+            blob_id: f.blob_id,
+            mime_type: f.mime_type,
+            file_size_bytes: f.file_size_bytes,
+          }))
+        : [],
+    };
+    return state;
+  }, [highestVersion, skill]);
+
+  // Populate form when skill loads
+  useEffect(() => {
+    if (getSkillFormState) form.reset(getSkillFormState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getSkillFormState]);
+
+  const handleSave = async (serve: boolean) => {
+    if (!form.runValidation()) return;
+    const bumpErr = validateVersionBump(form.version, highestVersion);
+    if (bumpErr) {
+      toast.error("Invalid version", { description: bumpErr });
+      return;
+    }
+
+    try {
+      const { name: _name, ...payload } = form.getPayload();
+      await updateSkill({
+        id: skillId,
+        data: { ...payload, serve },
+      }).unwrap();
+      toast.success(
+        serve
+          ? "Skill saved and now serving this version"
+          : "Version saved successfully",
+      );
+      setIsEditing(false);
+    } catch (err: unknown) {
+      toast.error("Failed to update skill", {
+        description: getErrorMessage(err),
+      });
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteSkill(skillId).unwrap();
+      toast.success("Skill deleted");
+      onBack();
+    } catch (err: unknown) {
+      toast.error("Failed to delete skill", {
+        description: getErrorMessage(err),
+      });
+    }
+  };
+
+  const handleCancelEdit = () => {
+    if (getSkillFormState) form.reset(getSkillFormState);
+    setIsEditing(false);
+  };
+
+  if (isLoading) {
+    return <FullPageLoader />;
+  }
+
+  if (!skill) {
+    return (
+      <div className="w-full min-h-0 flex-1 flex flex-col items-center justify-center p-4">
+        <p className="text-muted-foreground text-sm">Skill not found</p>
+        <Button variant="outline" size="sm" className="mt-3" onClick={onBack}>
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to list
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full flex-1 flex flex-col relative">
+      {/* Content */}
+      {isEditing ? (
+        <SkillEditView
+          form={form}
+          skillName={skill.name}
+          previousVersion={highestVersion}
+          onSave={handleSave}
+          onCancel={handleCancelEdit}
+          onBack={handleCancelEdit}
+          isSaving={isUpdating}
+        />
+      ) : (
+        <>
+          <SkillHeader
+            name={skill.name}
+            version={skill.latest_version}
+            description={skill.description}
+            license={skill.license}
+            compatibility={skill.compatibility}
+            allowedTools={skill.allowed_tools}
+            composedSkillMd={
+              composeFrontmatter({
+                name: skill.name,
+                description: skill.description,
+                license: skill.license || "",
+                compatibility: skill.compatibility || "",
+                allowed_tools: skill.allowed_tools || "",
+                extra_frontmatter_json:
+                  skill.extra_frontmatter &&
+                  Object.keys(skill.extra_frontmatter).length > 0
+                    ? JSON.stringify(skill.extra_frontmatter, null, 2)
+                    : "",
+                metadata_json:
+                  skill.metadata && Object.keys(skill.metadata).length > 0
+                    ? JSON.stringify(skill.metadata, null, 2)
+                    : "",
+              }) +
+              "\n\n" +
+              skill.skill_md_body
+            }
+            downloadSkillName={skill.name}
+            onBack={onBack}
+            actions={
+              <>
+                {(hasEditAccess || hasDeleteAccess) && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        aria-label={`Actions for ${skill.name}`}
+                      >
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {hasEditAccess && (
+                        <DropdownMenuItem
+                          className="cursor-pointer"
+                          onSelect={() => setIsEditing(true)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                          Edit
+                        </DropdownMenuItem>
+                      )}
+                      {hasDeleteAccess && (
+                        <DropdownMenuItem
+                          variant="destructive"
+                          className="cursor-pointer"
+                          disabled={isDeleting}
+                          onSelect={(event) => {
+                            event.preventDefault();
+                            setDeleteDialogOpen(true);
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+                <AlertDialog
+                  open={deleteDialogOpen}
+                  onOpenChange={setDeleteDialogOpen}
+                >
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete {skill.name}?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This action cannot be undone. The skill, its files, and
+                        version history will be permanently deleted.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction onClick={handleDelete} disabled={isDeleting}>
+                        {isDeleting ? (
+                          <><Loader2 className="h-3.5 w-3.5 animate-spin" /> Deleting...</>
+                        ) : (
+                          "Delete skill"
+                        )}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </>
+            }
+          />
+
+          <div className="mt-6 flex">
+            <div className="w-full min-w-0 flex flex-col gap-5">
+              <SkillFormFields skill={skill} />
+
+              {/* Version History Table */}
+              {versionsData && versionsData.versions.length > 0 && (
+                <FormSection title="Version History">
+                  <div className="overflow-hidden rounded-sm border">
+                    <Table>
+                      <TableHeader className="bg-muted">
+                        <TableRow className="hover:bg-transparent">
+                          <TableHead className="w-[200px]">
+                            <Button
+                              variant="ghost"
+                              aria-label="Sort by version"
+                              onClick={() => {
+                                setVersionsPage(0);
+                                if (versionSortOrder === null)
+                                  setVersionSortOrder("asc");
+                                else if (versionSortOrder === "asc")
+                                  setVersionSortOrder("desc");
+                                else setVersionSortOrder(null);
+                              }}
+                              className="!px-0"
+                            >
+                              Version
+                              {versionSortOrder === "asc" ? (
+                                <ArrowUp className="h-4 w-4 text-foreground" />
+                              ) : versionSortOrder === "desc" ? (
+                                <ArrowDown className="h-4 w-4 text-foreground" />
+                              ) : (
+                                <ArrowUpDown className="h-4 w-4" />
+                              )}
+                            </Button>
+                          </TableHead>
+                          <TableHead>Created</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {versionsData.versions.map((v) => {
+                          const isServing = v.version === skill.latest_version;
+                          return (
+                            <TableRow
+                              key={v.id}
+                              className="group hover:bg-muted/50 cursor-pointer transition-colors"
+                              tabIndex={0}
+                              onClick={() => setSelectedVersion(v)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  setSelectedVersion(v);
+                                }
+                              }}
+                            >
+                              <TableCell>
+                                <div className="flex items-center gap-2">
+                                  <span className="font-mono text-sm font-medium">
+                                    {v.version}
+                                  </span>
+                                  {isServing && (
+                                    <Badge
+                                      variant="secondary"
+                                      className="text-[10px] bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
+                                    >
+                                      Serving
+                                    </Badge>
+                                  )}
+                                </div>
+                              </TableCell>
+                              <TableCell className="text-muted-foreground text-sm">
+                                {formatDate(v.created_at)}
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
+                  {/* Pagination */}
+                  {versionsData.total > 0 && (
+                    <div className="flex shrink-0 items-center justify-between pt-3 text-xs">
+                      <div className="text-muted-foreground flex items-center gap-2">
+                        {(versionsPage * versionsPageSize + 1).toLocaleString()}
+                        –
+                        {Math.min(
+                          (versionsPage + 1) * versionsPageSize,
+                          versionsData.total,
+                        ).toLocaleString()}{" "}
+                        of {versionsData.total.toLocaleString()} entries
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setVersionsPage((p) => p - 1)}
+                          disabled={versionsPage === 0}
+                          aria-label="Previous page"
+                        >
+                          <ChevronLeft className="size-3" />
+                        </Button>
+                        <div className="flex items-center gap-1">
+                          <span>Page</span>
+                          <span>{versionsPage + 1}</span>
+                          <span>
+                            of{" "}
+                            {Math.ceil(versionsData.total / versionsPageSize)}
+                          </span>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setVersionsPage((p) => p + 1)}
+                          disabled={
+                            (versionsPage + 1) * versionsPageSize >=
+                            versionsData.total
+                          }
+                          aria-label="Next page"
+                        >
+                          <ChevronRight className="size-3" />
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </FormSection>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Version Detail Dialog */}
+      {selectedVersion && skill && (
+        <VersionDetailDialog
+          skillId={skillId}
+          version={selectedVersion.version}
+          isServingVersion={selectedVersion.version === skill.latest_version}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setSelectedVersion(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/ui/app/workspace/skills-repo/components/SkillEditView.tsx
+++ b/ui/app/workspace/skills-repo/components/SkillEditView.tsx
@@ -1,0 +1,562 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scrollArea";
+import { Textarea } from "@/components/ui/textarea";
+import { Markdown } from "@/components/ui/markdown";
+import { CodeEditor, type CompletionItem } from "@/components/ui/codeEditor";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { validateVersionBump } from "@/lib/validators/skills";
+import { cn } from "@/lib/utils";
+import { ArrowLeft, Check, Copy, Eye, Loader2, Plus, Save, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { type SkillFormReturn, composeFrontmatter } from "./helpers";
+import { FormSection } from "./shared";
+import { FileManagerSection } from "./FileManager";
+import { MetadataTableEditor } from "./MetadataTableEditor";
+
+// ---------- SkillEditView ----------
+
+export function SkillEditView({
+  form,
+  skillName,
+  previousVersion,
+  onSave,
+  onCancel,
+  onBack,
+  isSaving,
+  mode = "edit",
+}: {
+  form: SkillFormReturn;
+  skillName?: string;
+  previousVersion?: string;
+  onSave: (serve: boolean) => void;
+  onCancel: () => void;
+  onBack: () => void;
+  isSaving: boolean;
+  mode?: "edit" | "create";
+}) {
+  const isCreate = mode === "create";
+  const [bodyTab, setBodyTab] = useState<"edit" | "preview">("edit");
+  const [showPreviewDialog, setShowPreviewDialog] = useState(false);
+  const { copy: copyPreviewContent, copied: copiedPreviewContent } = useCopyToClipboard({
+    successMessage: "Copied raw SKILL.md",
+    errorMessage: "Failed to copy raw SKILL.md",
+  });
+
+  const previewContent = useMemo(() => {
+    return (
+      composeFrontmatter({
+        name: form.name,
+        description: form.description,
+        license: form.license,
+        compatibility: form.compatibility,
+        allowed_tools: form.allowedTools,
+        extra_frontmatter_json: form.extraFrontmatterJson,
+        metadata_json: form.metadataJson,
+      }) +
+      "\n\n" +
+      form.skillMdBody
+    );
+  }, [
+    form.name,
+    form.description,
+    form.license,
+    form.compatibility,
+    form.allowedTools,
+    form.extraFrontmatterJson,
+    form.metadataJson,
+    form.skillMdBody,
+  ]);
+
+  const filePathCompletions = useMemo<CompletionItem[]>(() => {
+    const completions: CompletionItem[] = [];
+    const folderPaths = new Set<string>();
+
+    form.files
+      .filter((file) => file.path)
+      .forEach((file) => {
+        const pathParts = file.path.split("/").filter(Boolean);
+        const fileName = pathParts.at(-1) ?? file.path;
+        const rootRelativePath = `./${file.path}`;
+
+        pathParts.slice(0, -1).forEach((_, index) => {
+          folderPaths.add(pathParts.slice(0, index + 1).join("/"));
+        });
+
+        completions.push({
+          label: fileName,
+          insertText: `@[${fileName}](${rootRelativePath})`,
+          type: "object" as const,
+          description: rootRelativePath,
+          documentation: `Full path: ${rootRelativePath}`,
+        });
+      });
+
+    folderPaths.forEach((folderPath) => {
+      const folderName = folderPath.split("/").filter(Boolean).pop() ?? folderPath;
+      const rootRelativePath = `./${folderPath}/`;
+      completions.push({
+        label: folderName,
+        insertText: `@[${folderName}](${rootRelativePath})`,
+        type: "folder" as const,
+        description: rootRelativePath,
+        documentation: `Full path: ${rootRelativePath}`,
+      });
+    });
+
+    return completions.sort((a, b) => a.description?.localeCompare(b.description ?? "") ?? 0);
+  }, [form.files]);
+
+  const descriptionLength = form.description.length;
+  const descriptionLimitColor =
+    descriptionLength > 1024
+      ? "text-destructive"
+      : descriptionLength > 900
+        ? "text-yellow-600 dark:text-yellow-500"
+        : "text-muted-foreground";
+
+  return (
+    <div className="animate-in fade-in duration-200">
+      <div className="px-4">
+        {/* Top bar with back button integrated */}
+        <div className="sticky top-0 z-10 flex items-center gap-3 py-4 bg-white dark:bg-card">
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="skill-back-btn"
+            onClick={onBack}
+            aria-label="Go back"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground min-w-0">
+            <span>{isCreate ? "Creating" : "Editing"}</span>
+            <span className="font-mono text-foreground truncate">
+              {isCreate ? form.name || "<new-skill>" : skillName}
+            </span>
+          </div>
+        </div>
+
+        {/* Edit sections */}
+        <div className="flex flex-col gap-8">
+          {/* Name — create mode only */}
+          {isCreate && (
+            <FormSection title="Name">
+              <Input
+                data-testid="skill-name-input"
+                value={form.name}
+                onChange={(e) => {
+                  form.setName(e.target.value);
+                  form.validateField("name", e.target.value);
+                }}
+                placeholder="my-skill-name"
+                className={cn(
+                  "font-mono",
+                  form.errors.name && "border-destructive",
+                )}
+              />
+              {form.errors.name && (
+                <p className="text-destructive text-xs" role="alert">
+                  {form.errors.name}
+                </p>
+              )}
+              <p className="text-muted-foreground text-xs">
+                Lowercase letters, numbers, and hyphens only.{" "}
+                <span className="font-bold">
+                  Cannot be changed after creation.
+                </span>
+              </p>
+            </FormSection>
+          )}
+
+          {/* Description */}
+          <FormSection title="Description">
+            <Textarea
+              data-testid="skill-description-input"
+              value={form.description}
+              onChange={(e) => {
+                form.setDescription(e.target.value);
+                form.validateField("description", e.target.value);
+              }}
+              placeholder="What does this skill do?"
+              rows={3}
+              className={cn(form.errors.description && "border-destructive")}
+            />
+            <div className="flex justify-between">
+              <span
+                className={cn(
+                  "text-xs tabular-nums transition-colors",
+                  descriptionLimitColor,
+                )}
+              >
+                {descriptionLength}/1024
+              </span>
+              {form.errors.description ? (
+                <p className="text-destructive text-xs" role="alert">
+                  {form.errors.description}
+                </p>
+              ) : (
+                <span />
+              )}
+            </div>
+          </FormSection>
+
+          {/* Spec Fields */}
+          <FormSection title="Spec Fields">
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground">License</Label>
+                <Input
+                  data-testid="skill-license-input"
+                  value={form.license}
+                  onChange={(e) => form.setLicense(e.target.value)}
+                  placeholder="MIT (optional)"
+                  className="text-sm"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground">
+                  Compatibility
+                </Label>
+                <Input
+                  data-testid="skill-compatibility-input"
+                  value={form.compatibility}
+                  onChange={(e) => form.setCompatibility(e.target.value)}
+                  placeholder="Claude Code, Codex (optional)"
+                  className="text-sm"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs text-muted-foreground">
+                  Allowed Tools
+                </Label>
+                <Input
+                  data-testid="skill-allowed-tools-input"
+                  value={form.allowedTools}
+                  onChange={(e) => form.setAllowedTools(e.target.value)}
+                  placeholder="Bash Read Grep (optional)"
+                  className="text-sm"
+                />
+              </div>
+            </div>
+          </FormSection>
+
+          {/* Extra Frontmatter */}
+          <FormSection title="Extra Frontmatter" optional>
+            <p className="text-xs text-muted-foreground -mt-1">
+              Enter valid JSON. Its top-level keys are merged into the SKILL.md YAML frontmatter.
+            </p>
+            <div className="overflow-hidden rounded-sm border">
+              <CodeEditor
+                className="z-0 w-full"
+                code={form.extraFrontmatterJson}
+                lang="json"
+                onChange={(value: string) => {
+                  form.setExtraFrontmatterJson(value);
+                  form.validateField("extra_frontmatter", value);
+                }}
+                autoResize
+                minHeight={80}
+                maxHeight={300}
+                wrap
+                options={{
+                  scrollBeyondLastLine: false,
+                  lineNumbers: "on",
+                  alwaysConsumeMouseWheel: false,
+                }}
+              />
+            </div>
+            {form.errors.extra_frontmatter && (
+              <p className="text-destructive text-xs" role="alert">
+                {form.errors.extra_frontmatter}
+              </p>
+            )}
+          </FormSection>
+
+          {/* Metadata */}
+          <FormSection title="Metadata" optional>
+            <p className="text-xs text-muted-foreground -mt-1">
+              Flat key-value pairs nested under{" "}
+              <code className="font-mono">metadata:</code> in SKILL.md
+            </p>
+            <MetadataTableEditor
+              metadataJson={form.metadataJson}
+              onChange={(json) => {
+                form.setMetadataJson(json);
+                form.validateField("metadata", json);
+              }}
+              error={form.errors.metadata}
+            />
+          </FormSection>
+
+          {/* SKILL.md Body */}
+          <FormSection
+            title="SKILL.md Body"
+            helperText={
+              <>
+                Use <code className="font-mono">@</code> to reference uploaded files.
+              </>
+            }
+          >
+            <div className="space-y-0">
+              <div
+                className="flex items-center gap-1 mb-2"
+                role="tablist"
+                aria-label="Body editor tabs"
+              >
+                <button
+                  type="button"
+                  className={cn(
+                    "px-3 py-1 text-xs rounded-sm transition-colors cursor-pointer",
+                    bodyTab === "edit"
+                      ? "bg-muted font-medium"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                  data-testid="skill-body-tab-edit"
+                  onClick={() => setBodyTab("edit")}
+                  role="tab"
+                  aria-selected={bodyTab === "edit"}
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  className={cn(
+                    "px-3 py-1 text-xs rounded-sm transition-colors cursor-pointer",
+                    bodyTab === "preview"
+                      ? "bg-muted font-medium"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                  data-testid="skill-body-tab-preview"
+                  onClick={() => setBodyTab("preview")}
+                  role="tab"
+                  aria-selected={bodyTab === "preview"}
+                >
+                  Preview
+                </button>
+              </div>
+              {bodyTab === "edit" ? (
+                <div className="overflow-hidden rounded-sm border">
+                  <CodeEditor
+                    className="z-0 w-full"
+                    code={form.skillMdBody}
+                    lang="markdown"
+                    onChange={(value: string) => form.setSkillMdBody(value)}
+                    autoResize
+                    minHeight={300}
+                    maxHeight={600}
+                    wrap
+                    customCompletions={filePathCompletions}
+                    options={{
+                      scrollBeyondLastLine: false,
+                      lineNumbers: "on",
+                      alwaysConsumeMouseWheel: false,
+                      quickSuggestions: false,
+                    }}
+                  />
+                </div>
+              ) : (
+                <div className="min-h-[300px] max-h-[600px] overflow-y-auto rounded-sm border p-4">
+                  <Markdown
+                    content={form.skillMdBody || ""}
+                    className="text-sm"
+                  />
+                </div>
+              )}
+            </div>
+            {form.errors.skill_md_body && (
+              <p className="text-destructive text-xs" role="alert">
+                {form.errors.skill_md_body}
+              </p>
+            )}
+            {form.bodyWarning && (
+              <p
+                className="text-yellow-600 dark:text-yellow-500 text-xs"
+                role="status"
+              >
+                {form.bodyWarning}
+              </p>
+            )}
+          </FormSection>
+
+          {/* Version */}
+          <FormSection title="Version">
+            {(() => {
+              const bumpError =
+                !isCreate &&
+                form.version &&
+                !form.errors.version &&
+                previousVersion
+                  ? validateVersionBump(form.version, previousVersion)
+                  : null;
+              const hasError = !!form.errors.version || !!bumpError;
+              return (
+                <>
+                  <div className="flex items-center gap-3">
+                    {!isCreate && previousVersion && (
+                      <>
+                        <span className="font-mono text-sm text-muted-foreground">
+                          {previousVersion}
+                        </span>
+                        <span className="text-muted-foreground/50">→</span>
+                      </>
+                    )}
+                    <Input
+                      data-testid="skill-version-input"
+                      value={form.version}
+                      onChange={(e) => {
+                        form.setVersion(e.target.value);
+                        form.validateField("version", e.target.value);
+                      }}
+                      placeholder="1.0.0"
+                      className={cn(
+                        "font-mono text-sm max-w-[200px]",
+                        hasError && "border-destructive",
+                      )}
+                    />
+                  </div>
+                  {form.errors.version && (
+                    <p className="text-destructive text-xs" role="alert">
+                      {form.errors.version}
+                    </p>
+                  )}
+                  {bumpError && (
+                    <p className="text-destructive text-xs" role="alert">
+                      {bumpError}
+                    </p>
+                  )}
+                </>
+              );
+            })()}
+          </FormSection>
+
+          {/* Files */}
+          <FormSection title="Files">
+            <FileManagerSection
+              files={form.files}
+              onAddFile={form.addFile}
+              onRemoveFile={form.removeFile}
+              onUpdateFile={form.updateFile}
+              readOnly={false}
+            />
+          </FormSection>
+        </div>
+      </div>
+
+      <div className="sticky bottom-0 z-20 mt-4 flex items-center justify-end gap-2 border-t bg-white/95 px-1 py-3 backdrop-blur dark:bg-card/95">
+        <Button
+          variant="ghost"
+          size="sm"
+          data-testid="skill-cancel-btn"
+          onClick={onCancel}
+          className="text-muted-foreground hover:bg-transparent hover:text-red-600 dark:hover:text-red-400"
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          data-testid="skill-preview-btn"
+          onClick={() => setShowPreviewDialog(true)}
+        >
+          <Eye className="h-3.5 w-3.5" />
+          Preview Raw SKILL.md
+        </Button>
+        {isCreate ? (
+          <Button
+            size="sm"
+            data-testid="skill-create-save-btn"
+            onClick={() => onSave(true)}
+            disabled={isSaving || form.hasErrors}
+          >
+            {isSaving ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Plus className="h-3.5 w-3.5" />
+            )}
+            {isSaving ? "Creating..." : "Create Skill"}
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="skill-save-btn"
+              onClick={() => onSave(false)}
+              disabled={isSaving || form.hasErrors}
+            >
+              {isSaving ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="h-3.5 w-3.5" />
+              )}
+              {isSaving ? "Saving..." : "Save"}
+            </Button>
+            <Button
+              size="sm"
+              data-testid="skill-save-serve-btn"
+              onClick={() => onSave(true)}
+              disabled={isSaving || form.hasErrors}
+            >
+              {isSaving ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="h-3.5 w-3.5" />
+              )}
+              {isSaving ? "Saving..." : "Save & Serve"}
+            </Button>
+          </>
+        )}
+      </div>
+
+      {/* Preview SKILL.md Dialog */}
+      <Dialog open={showPreviewDialog} onOpenChange={setShowPreviewDialog}>
+        <DialogContent
+          showCloseButton={false}
+          className="h-[90vh] max-h-[90vh] w-[95vw] sm:w-[80vw] md:w-[50vw] min-w-0 max-w-[95vw] sm:max-w-[80vw] md:max-w-[50vw] overflow-hidden border-0 bg-transparent p-0 shadow-none"
+        >
+          <DialogHeader className="sr-only">
+            <DialogTitle>SKILL.md Preview</DialogTitle>
+          </DialogHeader>
+          <div className="relative overflow-hidden rounded-sm border bg-muted shadow-lg">
+            <div className="absolute right-3 top-3 z-10 flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                data-testid="skill-preview-copy-btn"
+                className="h-8 w-8 rounded-sm bg-background/70 text-muted-foreground hover:bg-background/90 hover:text-foreground"
+                onClick={() => copyPreviewContent(previewContent)}
+                aria-label={copiedPreviewContent ? "Raw SKILL.md copied" : "Copy raw SKILL.md"}
+              >
+                {copiedPreviewContent ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+              <DialogClose className="cursor-pointer rounded-sm p-1.5 text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground">
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+              </DialogClose>
+            </div>
+            <ScrollArea className="h-[90vh]" viewportClassName="bg-muted">
+              <pre className="min-h-[420px] bg-muted p-5 pr-24 text-xs font-mono leading-5 whitespace-pre-wrap">
+                {previewContent}
+              </pre>
+            </ScrollArea>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/ui/app/workspace/skills-repo/components/SkillFormFields.tsx
+++ b/ui/app/workspace/skills-repo/components/SkillFormFields.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Skill, SkillFileEntry } from "@/lib/types/skills";
+import { composeFrontmatter } from "./helpers";
+import { SkillReadOnlyContent } from "./shared";
+
+// ---------- SkillFormFields ----------
+
+export function SkillFormFields({ skill }: { skill: Skill }) {
+  const files: SkillFileEntry[] = (skill.files ?? []).map((file) => ({
+    path: file.path,
+    source_type: file.source_type,
+    source_url: file.source_url,
+    storage_key: file.storage_key,
+    blob_id: file.blob_id,
+    mime_type: file.mime_type,
+    file_size_bytes: file.file_size_bytes,
+  }));
+
+  return (
+    <SkillReadOnlyContent
+      skillName={skill.name}
+      skillMdBody={skill.skill_md_body}
+      files={files}
+      extraFrontmatter={
+        skill.extra_frontmatter && Object.keys(skill.extra_frontmatter).length > 0
+          ? skill.extra_frontmatter
+          : null
+      }
+      metadata={
+        skill.metadata && Object.keys(skill.metadata).length > 0
+          ? skill.metadata
+          : null
+      }
+      composedSkillMd={
+        composeFrontmatter({
+          name: skill.name,
+          description: skill.description,
+          license: skill.license || "",
+          compatibility: skill.compatibility || "",
+          allowed_tools: skill.allowed_tools || "",
+          extra_frontmatter_json:
+            skill.extra_frontmatter &&
+            Object.keys(skill.extra_frontmatter).length > 0
+              ? JSON.stringify(skill.extra_frontmatter, null, 2)
+              : "",
+          metadata_json:
+            skill.metadata && Object.keys(skill.metadata).length > 0
+              ? JSON.stringify(skill.metadata, null, 2)
+              : "",
+        }) +
+        "\n\n" +
+        skill.skill_md_body
+      }
+    />
+  );
+}
+

--- a/ui/app/workspace/skills-repo/components/SkillsListView.tsx
+++ b/ui/app/workspace/skills-repo/components/SkillsListView.tsx
@@ -1,0 +1,795 @@
+"use client";
+
+import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import FullPageLoader from "@/components/fullPageLoader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  useListSkillsQuery,
+  useDeleteSkillMutation,
+  useGetAllSkillsVersionQuery,
+  useBumpAllSkillsVersionMutation,
+} from "@/lib/store/apis/skillsApi";
+import { getErrorMessage } from "@/lib/store/apis/baseApi";
+import { useGetCoreConfigQuery } from "@/lib/store";
+import { getApiBaseUrl } from "@/lib/utils/port";
+import { cn } from "@/lib/utils";
+import { SkillListItem, AllSkillsVersionBump } from "@/lib/types/skills";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Check,
+  Clipboard,
+  Info,
+  Download,
+  Loader2,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  MoreHorizontal,
+  Package,
+  Pencil,
+  Plus,
+  Search,
+  Trash2,
+  ChevronsDown,
+  ChevronDown,
+  ArrowUpRight,
+  BookOpenText,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { PAGE_SIZE, formatDateShort, useDebouncedValue } from "./helpers";
+
+// ---------- MarketplacePopover ----------
+
+function MarketplacePopover() {
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const marketplaceBaseUrl = getApiBaseUrl();
+
+  const items = [
+    {
+      key: "claude",
+      label: "Claude Code",
+      command: `claude plugin marketplace add ${marketplaceBaseUrl}/skills/serve/claude-code/.claude-plugin/marketplace.json`,
+    },
+    {
+      key: "codex",
+      label: "Codex",
+      command: `codex plugin marketplace add ${marketplaceBaseUrl}/skills/serve/codex`,
+    },
+  ];
+
+  const handleCopy = (key: string, text: string) => {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopiedKey(key);
+        toast.success("Copied to clipboard");
+        setTimeout(() => setCopiedKey(null), 2000);
+      })
+      .catch(() => {
+        toast.error("Failed to copy to clipboard");
+      });
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Package className="h-3.5 w-3.5" />
+          Register as Marketplace
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-auto max-w-md p-0">
+        <div className="px-3 py-2 border-b">
+          <p className="text-xs font-medium text-muted-foreground">
+            Copy CLI command to register this repository
+          </p>
+        </div>
+        <div className="py-1">
+          {items.map((item) => (
+            <button
+              key={item.key}
+              data-testid={`skill-copy-marketplace-${item.key}`}
+              className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-muted/50 transition-colors cursor-pointer"
+              aria-label={`Copy ${item.label} command`}
+              onClick={() => handleCopy(item.key, item.command)}
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-xs font-medium">{item.label}</p>
+                <p className="text-[11px] font-mono text-muted-foreground truncate mt-0.5">
+                  {item.command}
+                </p>
+              </div>
+              {copiedKey === item.key ? (
+                <Check className="h-3.5 w-3.5 shrink-0 text-green-500" />
+              ) : (
+                <Clipboard className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              )}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ---------- SortableHeader ----------
+
+type SortColumn = "name" | "updated_at";
+type SortOrder = "asc" | "desc";
+
+function SortableHeader({
+  column,
+  label,
+  sortBy,
+  order,
+  onToggle,
+}: {
+  column: SortColumn;
+  label: string;
+  sortBy: SortColumn | null;
+  order: SortOrder;
+  onToggle: (column: SortColumn) => void;
+}) {
+  const isActive = sortBy === column;
+  const Icon = isActive
+    ? order === "desc"
+      ? ArrowDown
+      : ArrowUp
+    : ArrowUpDown;
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => onToggle(column)}
+      className="!px-0"
+      data-testid={`skill-sort-${column}`}
+      aria-label={`Sort by ${label}`}
+    >
+      {label}
+      <Icon className={cn("h-4 w-4", isActive && "text-foreground")} />
+    </Button>
+  );
+}
+
+// ---------- SkillActionsMenu ----------
+
+function SkillActionsMenu({
+  skill,
+  hasEditAccess,
+  hasDeleteAccess,
+  isDeleting,
+  onEdit,
+  onDelete,
+}: {
+  skill: SkillListItem;
+  hasEditAccess: boolean;
+  hasDeleteAccess: boolean;
+  isDeleting: boolean;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => Promise<void>;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownload = async () => {
+    setIsDownloading(true);
+    let url: string | undefined;
+    try {
+      const res = await fetch(
+        `${getApiBaseUrl()}/skills/serve/${encodeURIComponent(skill.name)}/download.zip`,
+      );
+      if (!res.ok) throw new Error("Download failed");
+      const blob = await res.blob();
+      url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${skill.name}.zip`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch {
+      toast.error("Failed to download skill");
+    } finally {
+      if (url) URL.revokeObjectURL(url);
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <>
+      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            data-testid={`skill-actions-menu-${skill.name}`}
+            aria-label={`Actions for ${skill.name}`}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            className="cursor-pointer"
+            data-testid={`skill-download-btn-${skill.name}`}
+            disabled={isDownloading}
+            onSelect={(e) => {
+              e.preventDefault();
+              handleDownload();
+              setIsOpen(false);
+            }}
+          >
+            {isDownloading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="h-4 w-4" />
+            )}
+            {isDownloading ? "Downloading..." : "Download ZIP"}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            data-testid={`skill-edit-btn-${skill.name}`}
+            disabled={!hasEditAccess}
+            onSelect={(e) => {
+              e.preventDefault();
+              onEdit(skill.id);
+              setIsOpen(false);
+            }}
+          >
+            <Pencil className="h-4 w-4" />
+            Edit
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            className="cursor-pointer"
+            data-testid={`skill-delete-btn-${skill.name}`}
+            disabled={!hasDeleteAccess || isDeleting}
+            onSelect={(e) => {
+              e.preventDefault();
+              setDeleteOpen(true);
+              setIsOpen(false);
+            }}
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {skill.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. The skill, its files, and version
+              history will be permanently deleted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              data-testid="skill-delete-confirm-btn"
+              onClick={() => onDelete(skill.id)}
+              disabled={isDeleting}
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" /> Deleting...
+                </>
+              ) : (
+                "Delete skill"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+// ---------- SkillsListView ----------
+
+export function SkillsListView({
+  onSelectSkill,
+  onCreateNew,
+}: {
+  onSelectSkill: (id: string, edit?: boolean) => void;
+  onCreateNew: () => void;
+}) {
+  const hasCreateAccess = useRbac(
+    RbacResource.SkillsRepository,
+    RbacOperation.Create,
+  );
+  const hasEditAccess = useRbac(
+    RbacResource.SkillsRepository,
+    RbacOperation.Update,
+  );
+  const hasDeleteAccess = useRbac(
+    RbacResource.SkillsRepository,
+    RbacOperation.Delete,
+  );
+  const { data: bifrostConfig } = useGetCoreConfigQuery({});
+  const isGitAvailable = bifrostConfig?.is_git_available ?? false;
+  const [deleteSkill, { isLoading: isDeleting }] = useDeleteSkillMutation();
+  const { data: allSkillsVersionData, refetch: refetchAllSkillsVersion } =
+    useGetAllSkillsVersionQuery();
+  const [bumpAllSkillsVersion, { isLoading: isBumpingAllSkillsVersion }] =
+    useBumpAllSkillsVersionMutation();
+
+  const [isDownloadingAll, setIsDownloadingAll] = useState(false);
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const [offset, setOffset] = useState(0);
+  const [sortBy, setSortBy] = useState<SortColumn | null>(null);
+  const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
+
+  const { data, isLoading, isFetching, isError, refetch } = useListSkillsQuery({
+    limit: PAGE_SIZE,
+    offset,
+    search: debouncedSearch || undefined,
+    sort_by: sortBy || undefined,
+    order: sortBy ? sortOrder : undefined,
+  });
+
+  const skills = data?.skills || [];
+  const total = data?.total || 0;
+
+  const toggleSort = (column: SortColumn) => {
+    setOffset(0);
+    if (sortBy === column) {
+      if (sortOrder === "asc") {
+        setSortOrder("desc");
+      } else {
+        setSortBy(null);
+        setSortOrder("asc");
+      }
+    } else {
+      setSortBy(column);
+      setSortOrder("asc");
+    }
+  };
+
+  const handleDeleteSkill = async (id: string) => {
+    try {
+      await deleteSkill(id).unwrap();
+      toast.success("Skill deleted");
+    } catch (err: unknown) {
+      toast.error("Failed to delete skill", {
+        description: getErrorMessage(err),
+      });
+    }
+  };
+
+  const handleBumpAllSkillsVersion = async (bump: AllSkillsVersionBump) => {
+    try {
+      const result = await bumpAllSkillsVersion({ bump }).unwrap();
+      toast.success(`All-skills version bumped to ${result.version}`);
+      refetchAllSkillsVersion();
+    } catch (err: unknown) {
+      toast.error("Failed to bump all-skills version", {
+        description: getErrorMessage(err),
+      });
+    }
+  };
+
+  if (isLoading) {
+    return <FullPageLoader />;
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-20">
+        <p className="text-muted-foreground text-sm">Failed to load skills</p>
+        <Button variant="outline" size="sm" onClick={refetch}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  // True empty state: no skills at all (not just filtered to zero)
+  if (total === 0 && !search && !isFetching) {
+    return (
+      <div
+        className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center"
+        data-testid="skills-repo-empty-state"
+      >
+        <div className="text-muted-foreground">
+          <BookOpenText className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
+        </div>
+        <div className="flex flex-col gap-1">
+          <h1 className="text-muted-foreground text-xl font-medium">
+            Create and manage Agent Skills for AI coding assistants
+          </h1>
+          <div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
+            Build skills that extend the capabilities of Claude Code, Codex, and other AI harnesses. Register as a marketplace to distribute them.
+          </div>
+          <div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
+            <Button
+              variant="outline"
+              aria-label="Read more about skills (opens in new tab)"
+              data-testid="skills-button-read-more"
+              onClick={() => {
+                window.open("https://agentskills.io?utm_source=bfd", "_blank", "noopener,noreferrer");
+              }}
+            >
+              Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
+            </Button>
+            {hasCreateAccess && (
+              <Button
+                aria-label="Create your first skill"
+                data-testid="skill-create-btn"
+                onClick={onCreateNew}
+              >
+                Create Skill
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full min-h-0 flex-1 flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex shrink-0 items-center justify-between mb-4">
+        <div>
+          <h2 className="text-lg font-semibold">Skills Repository</h2>
+          <p className="text-muted-foreground text-sm">
+            Manage Agent Skills for distribution to AI coding assistants
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {isGitAvailable ? (
+            <MarketplacePopover />
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span tabIndex={0}>
+                  <Button variant="outline" size="sm" disabled>
+                    <Package className="h-3.5 w-3.5" />
+                    Register as Marketplace
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="max-w-xs text-xs">
+                  Git is not available on the server. Install git and restart
+                  Bifrost to enable marketplace registration for Claude Code and
+                  Codex.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="skill-download-all-btn"
+            onClick={async () => {
+              setIsDownloadingAll(true);
+              try {
+                const res = await fetch(
+                  `${getApiBaseUrl()}/skills/serve/all/download.zip`,
+                );
+                if (!res.ok) throw new Error("Download failed");
+                const blob = await res.blob();
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement("a");
+                link.href = url;
+                link.download = "all-skills.zip";
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                URL.revokeObjectURL(url);
+              } catch {
+                toast.error("Failed to download skills");
+              } finally {
+                setIsDownloadingAll(false);
+              }
+            }}
+            disabled={!skills?.length || isDownloadingAll}
+          >
+            {isDownloadingAll ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="h-4 w-4" />
+            )}
+            {isDownloadingAll ? "Downloading..." : "Download All Skills"}
+          </Button>
+          {hasCreateAccess && (
+            <Button
+              data-testid="skill-create-btn"
+              onClick={onCreateNew}
+              size="sm"
+            >
+              <Plus className="h-4 w-4" />
+              New Skill
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Search + All-skills version */}
+      <div className="flex items-center gap-3 mb-4">
+        <div className="relative max-w-sm flex-1">
+          <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+          <Input
+            data-testid="skill-search-input"
+            aria-label="Search skills by name"
+            placeholder="Search skills..."
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setOffset(0);
+            }}
+            className="pl-9"
+          />
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="max-w-xs text-xs">
+              When registered as a marketplace, an "all-skills" plugin is
+              available that installs every skill in this repository at once.
+              Its version bumps automatically on changes; use the dropdown to
+              bump manually if needed.
+            </TooltipContent>
+          </Tooltip>
+          <span className="text-muted-foreground whitespace-nowrap">
+            all-skills version
+          </span>
+          {hasEditAccess ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  data-testid="skill-bump-version-btn"
+                  disabled={isBumpingAllSkillsVersion}
+                  className="cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <Badge
+                    variant="secondary"
+                    className="font-mono text-xs hover:bg-muted transition-colors"
+                  >
+                    {isBumpingAllSkillsVersion ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <>
+                        {allSkillsVersionData?.version ?? "0.0.0"}
+                        <ChevronDown className="h-3 w-3" />
+                      </>
+                    )}
+                  </Badge>
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {(["patch", "minor", "major"] as AllSkillsVersionBump[]).map(
+                  (bump) => (
+                    <DropdownMenuItem
+                      key={bump}
+                      className="cursor-pointer capitalize"
+                      disabled={isBumpingAllSkillsVersion}
+                      onSelect={() => handleBumpAllSkillsVersion(bump)}
+                    >
+                      Bump {bump}
+                    </DropdownMenuItem>
+                  ),
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Badge variant="secondary" className="font-mono text-xs">
+              {allSkillsVersionData?.version ?? "0.0.0"}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="min-h-0 grow overflow-hidden rounded-sm border">
+        <Table
+          containerClassName="h-full overflow-auto"
+          className="w-full table-fixed"
+        >
+          <TableHeader className="bg-muted sticky top-0 z-20">
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="w-[240px]">
+                <SortableHeader
+                  column="name"
+                  label="Name"
+                  sortBy={sortBy}
+                  order={sortOrder}
+                  onToggle={toggleSort}
+                />
+              </TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead className="w-[140px]">Version</TableHead>
+              <TableHead className="w-[140px]">Files</TableHead>
+              <TableHead className="w-[170px]">
+                <SortableHeader
+                  column="updated_at"
+                  label="Updated"
+                  sortBy={sortBy}
+                  order={sortOrder}
+                  onToggle={toggleSort}
+                />
+              </TableHead>
+              <TableHead
+                className={`bg-muted sticky right-0 z-30 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}
+              >
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {skills.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center py-12">
+                  <div className="flex flex-col items-center gap-2">
+                    <FileText className="h-8 w-8 text-muted-foreground" />
+                    <p className="text-muted-foreground text-sm">
+                      {search
+                        ? "No skills match your search"
+                        : "No skills created yet"}
+                    </p>
+                    {!search && hasCreateAccess && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={onCreateNew}
+                        className="mt-2"
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                        Create your first skill
+                      </Button>
+                    )}
+                  </div>
+                </TableCell>
+              </TableRow>
+            ) : (
+              skills.map((skill) => {
+                const fileCount = skill.file_count ?? 0;
+
+                return (
+                  <TableRow
+                    key={skill.id}
+                    data-testid={`skill-row-${skill.name}`}
+                    className="group hover:bg-muted/50 cursor-pointer transition-colors"
+                    tabIndex={0}
+                    onClick={() => onSelectSkill(skill.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onSelectSkill(skill.id);
+                      }
+                    }}
+                  >
+                    <TableCell className="font-medium font-mono text-sm">
+                      {skill.name}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm max-w-[300px] truncate">
+                      {skill.description}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className="font-mono text-xs px-2.5 py-1"
+                      >
+                        {skill.latest_version}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-muted-foreground text-xs">
+                        <span className="font-mono text-foreground">
+                          {fileCount}
+                        </span>{" "}
+                        files
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatDateShort(skill.updated_at)}
+                    </TableCell>
+                    <TableCell
+                      className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <SkillActionsMenu
+                        skill={skill}
+                        hasEditAccess={hasEditAccess}
+                        hasDeleteAccess={hasDeleteAccess}
+                        isDeleting={isDeleting}
+                        onEdit={(id) => onSelectSkill(id, true)}
+                        onDelete={handleDeleteSkill}
+                      />
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {total > 0 && (
+        <div className="flex shrink-0 items-center justify-between text-xs">
+          <div className="text-muted-foreground flex items-center gap-2">
+            {(offset + 1).toLocaleString()}-
+            {Math.min(offset + PAGE_SIZE, total).toLocaleString()} of{" "}
+            {total.toLocaleString()} entries
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              data-testid="skill-pagination-prev"
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+              disabled={offset === 0 || isFetching}
+              aria-label="Previous page"
+            >
+              <ChevronLeft className="size-3" />
+            </Button>
+            <div className="flex items-center gap-1">
+              <span>Page</span>
+              <span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
+              <span>of {Math.ceil(total / PAGE_SIZE)}</span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              data-testid="skill-pagination-next"
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+              disabled={offset + PAGE_SIZE >= total || isFetching}
+              aria-label="Next page"
+            >
+              <ChevronRight className="size-3" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/app/workspace/skills-repo/components/VersionDetailDialog.tsx
+++ b/ui/app/workspace/skills-repo/components/VersionDetailDialog.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scrollArea";
+import {
+  useGetSkillQuery,
+  useShiftSkillVersionMutation,
+} from "@/lib/store/apis/skillsApi";
+import { getErrorMessage } from "@/lib/store/apis/baseApi";
+import { getApiBaseUrl } from "@/lib/utils/port";
+import { SkillFile, SkillFileEntry } from "@/lib/types/skills";
+import { Loader2, RefreshCw, Download, X } from "lucide-react";
+import { useMemo } from "react";
+import { toast } from "sonner";
+import { composeFrontmatter } from "./helpers";
+import { SkillHeader, SkillReadOnlyContent } from "./shared";
+
+// ---------- VersionDetailDialog ----------
+
+export function VersionDetailDialog({
+  skillId,
+  version,
+  isServingVersion,
+  open,
+  onOpenChange,
+}: {
+  skillId: string;
+  version: string;
+  isServingVersion: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { data: versionData, isLoading } = useGetSkillQuery(
+    { id: skillId, version },
+    { skip: !open },
+  );
+  const [shiftVersion, { isLoading: isShifting }] =
+    useShiftSkillVersionMutation();
+
+  const skill = versionData?.skill;
+
+  const extraFrontmatter = useMemo(() => {
+    if (
+      !skill?.extra_frontmatter ||
+      Object.keys(skill.extra_frontmatter).length === 0
+    )
+      return null;
+    return skill.extra_frontmatter;
+  }, [skill]);
+
+  const metadata = useMemo(() => {
+    if (!skill?.metadata || Object.keys(skill.metadata).length === 0)
+      return null;
+    return skill.metadata as Record<string, unknown>;
+  }, [skill]);
+
+  const composedSkillMd = useMemo(() => {
+    if (!skill) return "";
+    return (
+      composeFrontmatter({
+        name: skill.name,
+        description: skill.description,
+        license: skill.license || "",
+        compatibility: skill.compatibility || "",
+        allowed_tools: skill.allowed_tools || "",
+        extra_frontmatter_json: skill.extra_frontmatter
+          ? JSON.stringify(skill.extra_frontmatter)
+          : "",
+        metadata_json: skill.metadata ? JSON.stringify(skill.metadata) : "",
+      }) +
+      "\n\n" +
+      skill.skill_md_body
+    );
+  }, [skill]);
+
+  const fileEntries: SkillFileEntry[] = useMemo(() => {
+    if (!skill?.files) return [];
+    return skill.files.map((f: SkillFile) => ({
+      path: f.path,
+      source_type: f.source_type,
+      source_url: f.source_url,
+      storage_key: f.storage_key,
+      mime_type: f.mime_type,
+      file_size_bytes: f.file_size_bytes,
+    }));
+  }, [skill]);
+
+  const downloadUrl = skill
+    ? `${getApiBaseUrl()}/skills/serve/${encodeURIComponent(skill.name)}/download.zip?version=${encodeURIComponent(version)}`
+    : "";
+
+  const handleShiftVersion = async () => {
+    try {
+      await shiftVersion({ id: skillId, version }).unwrap();
+      toast.success(`Shifted to version ${version}`);
+      onOpenChange(false);
+    } catch (err: unknown) {
+      toast.error("Failed to shift version", {
+        description: getErrorMessage(err),
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="h-[90vh] max-h-[90vh] w-[95vw] sm:w-[85vw] md:w-[75vw] min-w-0 max-w-[95vw] sm:max-w-[85vw] md:max-w-[75vw] overflow-hidden p-0 gap-0"
+      >
+        <div className="flex items-center justify-between border-b pl-6 pr-2">
+          <DialogHeader className="p-0">
+            <DialogTitle>Version {version}</DialogTitle>
+          </DialogHeader>
+          <div className="flex items-center gap-1.5">
+            {downloadUrl && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                asChild
+                aria-label="Download ZIP"
+              >
+                <a href={downloadUrl} download>
+                  <Download className="h-4 w-4" />
+                  <span className="sr-only">Download ZIP</span>
+                </a>
+              </Button>
+            )}
+            <DialogClose asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="Close"
+              >
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+              </Button>
+            </DialogClose>
+          </div>
+        </div>
+        <ScrollArea className="h-[calc(90vh-57px)]">
+          <div className="p-6 space-y-6">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-20">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              </div>
+            ) : skill ? (
+              <>
+                <SkillHeader
+                  sticky={false}
+                  name={skill.name}
+                  version={version}
+                  description={skill.description}
+                  license={skill.license}
+                  compatibility={skill.compatibility}
+                  allowedTools={skill.allowed_tools}
+                  composedSkillMd={composedSkillMd}
+                  decorators={
+                    <>
+                      {isServingVersion && (
+                        <Badge
+                          variant="secondary"
+                          className="text-xs bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
+                        >
+                          Serving
+                        </Badge>
+                      )}
+                    </>
+                  }
+                  actions={
+                    !isServingVersion ? (
+                      <Button
+                        size="sm"
+                        onClick={handleShiftVersion}
+                        disabled={isShifting}
+                      >
+                        {isShifting ? (
+                          <>
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            Shifting...
+                          </>
+                        ) : (
+                          <>
+                            <RefreshCw className="h-3.5 w-3.5" />
+                            Shift to this version
+                          </>
+                        )}
+                      </Button>
+                    ) : undefined
+                  }
+                />
+
+                <SkillReadOnlyContent
+                  skillName={skill.name}
+                  skillMdBody={skill.skill_md_body}
+                  files={fileEntries}
+                  extraFrontmatter={extraFrontmatter}
+                  metadata={metadata}
+                  composedSkillMd={composedSkillMd}
+                />
+              </>
+            ) : (
+              <p className="text-muted-foreground text-sm text-center py-12">
+                Version data not found
+              </p>
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/app/workspace/skills-repo/components/helpers.ts
+++ b/ui/app/workspace/skills-repo/components/helpers.ts
@@ -1,0 +1,354 @@
+"use client";
+
+import { SkillFileEntry } from "@/lib/types/skills";
+import {
+  validateDescription,
+  validateExtraFrontmatter,
+  validateMetadata,
+  validateSkillForm,
+  validateSkillMdBody,
+  validateSkillName,
+  validateVersion,
+} from "@/lib/validators/skills";
+import { useCallback, useEffect, useState } from "react";
+
+// ---------- Constants ----------
+
+export const PAGE_SIZE = 25;
+
+// ---------- Helpers ----------
+
+export function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleString();
+}
+
+export function formatDateShort(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString();
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function yamlScalar(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  return JSON.stringify(String(value));
+}
+
+function yamlMetadataScalar(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  return String(value);
+}
+
+function yamlBlock(value: unknown, indent = 0): string[] {
+  const pad = " ".repeat(indent);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [`${pad}[]`];
+    return value.flatMap((item) => {
+      if (item !== null && typeof item === "object") {
+        const nested = yamlBlock(item, indent + 2);
+        return [`${pad}-`, ...nested];
+      }
+      return [`${pad}- ${yamlScalar(item)}`];
+    });
+  }
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return [`${pad}{}`];
+    return entries.flatMap(([key, item]) => {
+      if (item !== null && typeof item === "object") {
+        return [`${pad}${key}:`, ...yamlBlock(item, indent + 2)];
+      }
+      return [`${pad}${key}: ${yamlScalar(item)}`];
+    });
+  }
+  return [`${pad}${yamlScalar(value)}`];
+}
+
+export function yamlField(key: string, value: unknown): string[] {
+  if (value !== null && typeof value === "object") {
+    return [`${key}:`, ...yamlBlock(value, 2)];
+  }
+  return [`${key}: ${yamlScalar(value)}`];
+}
+
+function yamlMetadataBlock(value: unknown, indent = 0): string[] {
+  const pad = " ".repeat(indent);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [`${pad}[]`];
+    return value.flatMap((item) => {
+      if (item !== null && typeof item === "object") {
+        const nested = yamlMetadataBlock(item, indent + 2);
+        return [`${pad}-`, ...nested];
+      }
+      return [`${pad}- ${yamlMetadataScalar(item)}`];
+    });
+  }
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return [`${pad}{}`];
+    return entries.flatMap(([key, item]) => {
+      if (item !== null && typeof item === "object") {
+        return [`${pad}${key}:`, ...yamlMetadataBlock(item, indent + 2)];
+      }
+      return [`${pad}${key}: ${yamlMetadataScalar(item)}`];
+    });
+  }
+  return [`${pad}${yamlMetadataScalar(value)}`];
+}
+
+function yamlMetadataField(key: string, value: unknown): string[] {
+  if (value !== null && typeof value === "object") {
+    return [`${key}:`, ...yamlMetadataBlock(value, 2)];
+  }
+  return [`${key}: ${yamlMetadataScalar(value)}`];
+}
+
+export function composeFrontmatter(data: {
+  name: string;
+  description: string;
+  license: string;
+  compatibility: string;
+  allowed_tools: string;
+  extra_frontmatter_json: string;
+  metadata_json: string;
+}): string {
+  const lines: string[] = [];
+  lines.push(...yamlField("name", data.name));
+  lines.push(...yamlField("description", data.description));
+  if (data.license) lines.push(...yamlField("license", data.license));
+  if (data.compatibility)
+    lines.push(...yamlField("compatibility", data.compatibility));
+  if (data.allowed_tools)
+    lines.push(...yamlField("allowed-tools", data.allowed_tools));
+
+  // Extra frontmatter renders as top-level YAML, matching serve-time composition.
+  if (data.extra_frontmatter_json.trim()) {
+    try {
+      const ef = JSON.parse(data.extra_frontmatter_json) as Record<
+        string,
+        unknown
+      >;
+      for (const [key, value] of Object.entries(ef)) {
+        lines.push(...yamlField(key, value));
+      }
+    } catch {
+      /* skip if invalid */
+    }
+  }
+
+  // Metadata is always nested under the metadata: frontmatter key.
+  if (data.metadata_json.trim()) {
+    try {
+      const md = JSON.parse(data.metadata_json) as Record<string, string>;
+      if (Object.keys(md).length > 0)
+        lines.push(...yamlMetadataField("metadata", md));
+    } catch {
+      /* skip if invalid */
+    }
+  }
+
+  return `---\n${lines.join("\n")}\n---`;
+}
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedValue(value), delayMs);
+    return () => window.clearTimeout(timeout);
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}
+
+export function parseJsonRecord(value: string): Record<string, unknown> | null {
+  if (!value.trim()) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      return null;
+    const record = parsed as Record<string, unknown>;
+    return Object.keys(record).length > 0 ? record : null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatYamlRecord(value: Record<string, unknown>): string {
+  return Object.entries(value)
+    .flatMap(([key, item]) => yamlField(key, item))
+    .join("\n");
+}
+
+// ---------- Skill Form ----------
+
+export interface SkillFormState {
+  name: string;
+  description: string;
+  license: string;
+  compatibility: string;
+  allowedTools: string;
+  extraFrontmatterJson: string;
+  metadataJson: string;
+  skillMdBody: string;
+  version: string;
+  files: SkillFileEntry[];
+}
+
+export function useSkillForm(initial?: SkillFormState) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [license, setLicense] = useState(initial?.license ?? "");
+  const [compatibility, setCompatibility] = useState(
+    initial?.compatibility ?? "",
+  );
+  const [allowedTools, setAllowedTools] = useState(initial?.allowedTools ?? "");
+  const [extraFrontmatterJson, setExtraFrontmatterJson] = useState(
+    initial?.extraFrontmatterJson ?? "",
+  );
+  const [metadataJson, setMetadataJson] = useState(initial?.metadataJson ?? "");
+  const [skillMdBody, setSkillMdBody] = useState(initial?.skillMdBody ?? "");
+  const [version, setVersion] = useState(initial?.version ?? "1.0.0");
+  const [files, setFiles] = useState<SkillFileEntry[]>(initial?.files ?? []);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [bodyWarning, setBodyWarning] = useState<string | null>(null);
+
+  const validateField = useCallback((field: string, value: string) => {
+    let err: string | null = null;
+    switch (field) {
+      case "name":
+        err = validateSkillName(value);
+        break;
+      case "description":
+        err = validateDescription(value);
+        break;
+      case "version":
+        err = validateVersion(value);
+        break;
+      case "extra_frontmatter":
+        err = validateExtraFrontmatter(value);
+        break;
+      case "metadata":
+        err = validateMetadata(value);
+        break;
+    }
+    setErrors((prev) => {
+      const next = { ...prev };
+      if (err) next[field] = err;
+      else delete next[field];
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    const result = validateSkillMdBody(skillMdBody);
+    setBodyWarning(result.warning);
+    setErrors((prev) => {
+      const next = { ...prev };
+      if (result.error) next.skill_md_body = result.error;
+      else delete next.skill_md_body;
+      return next;
+    });
+  }, [skillMdBody]);
+
+  const hasErrors = Object.keys(errors).length > 0;
+
+  const getPayload = () => ({
+    name,
+    description,
+    license: license || undefined,
+    compatibility: compatibility || undefined,
+    metadata: metadataJson.trim()
+      ? (() => { try { return JSON.parse(metadataJson); } catch { return undefined; } })()
+      : undefined,
+    extra_frontmatter: extraFrontmatterJson.trim()
+      ? (() => { try { return JSON.parse(extraFrontmatterJson); } catch { return undefined; } })()
+      : undefined,
+    allowed_tools: allowedTools || undefined,
+    skill_md_body: skillMdBody,
+    version,
+    files: files.map(({ __local, ...file }) => file),
+  });
+
+  const runValidation = () => {
+    const validationErrors = validateSkillForm({
+      name,
+      description,
+      version,
+      skill_md_body: skillMdBody,
+      extra_frontmatter_json: extraFrontmatterJson || undefined,
+      metadata_json: metadataJson || undefined,
+    });
+    if (validationErrors.length > 0) {
+      const errMap: Record<string, string> = {};
+      for (const e of validationErrors) errMap[e.field] = e.message;
+      setErrors(errMap);
+      return false;
+    }
+    return true;
+  };
+
+  const addFile = (entry: SkillFileEntry) =>
+    setFiles((prev) => [...prev, entry]);
+  const removeFile = (index: number) =>
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+  const updateFile = (index: number, updates: Partial<SkillFileEntry>) =>
+    setFiles((prev) =>
+      prev.map((f, i) => (i === index ? { ...f, ...updates } : f)),
+    );
+
+  const reset = (state: SkillFormState) => {
+    setName(state.name);
+    setDescription(state.description);
+    setLicense(state.license);
+    setCompatibility(state.compatibility);
+    setAllowedTools(state.allowedTools);
+    setExtraFrontmatterJson(state.extraFrontmatterJson);
+    setMetadataJson(state.metadataJson);
+    setSkillMdBody(state.skillMdBody);
+    setVersion(state.version);
+    setFiles(state.files);
+    setErrors({});
+  };
+
+  return {
+    name,
+    setName,
+    description,
+    setDescription,
+    license,
+    setLicense,
+    compatibility,
+    setCompatibility,
+    allowedTools,
+    setAllowedTools,
+    extraFrontmatterJson,
+    setExtraFrontmatterJson,
+    metadataJson,
+    setMetadataJson,
+    skillMdBody,
+    setSkillMdBody,
+    version,
+    setVersion,
+    files,
+    addFile,
+    removeFile,
+    updateFile,
+    errors,
+    hasErrors,
+    bodyWarning,
+    validateField,
+    getPayload,
+    runValidation,
+    reset,
+  };
+}
+
+export type SkillFormReturn = ReturnType<typeof useSkillForm>;

--- a/ui/app/workspace/skills-repo/components/shared.tsx
+++ b/ui/app/workspace/skills-repo/components/shared.tsx
@@ -1,0 +1,823 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scrollArea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Markdown } from "@/components/ui/markdown";
+import {
+  Tree,
+  type BaseNodeData,
+  type TreeNode,
+} from "@/components/ui/treeView";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { SkillFileEntry } from "@/lib/types/skills";
+import { getApiBaseUrl } from "@/lib/utils/port";
+import { cn } from "@/lib/utils";
+import {
+  Check,
+  Bot,
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
+  ChevronsDown,
+  ChevronsUp,
+  ArrowLeft,
+  Copy,
+  Download,
+  FileText,
+  Folder,
+  FolderOpen,
+  Hammer,
+  Maximize2,
+  Scale,
+  X,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { formatFileSize, formatYamlRecord } from "./helpers";
+
+// ---------- HeaderMetaItem ----------
+
+export function HeaderMetaItem({
+  label,
+  value,
+  missingText,
+  icon: Icon,
+}: {
+  label: string;
+  value?: string;
+  missingText: string;
+  icon: typeof Scale;
+}) {
+  const hasValue = Boolean(value?.trim());
+
+  const pill = (
+    <div
+      className={cn(
+        "inline-flex max-w-full items-center gap-1.5 rounded-sm border bg-muted/20 px-2.5 py-1 text-xs",
+        !hasValue && "text-muted-foreground",
+      )}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span className={cn("truncate", hasValue && "font-mono")}>
+        {hasValue ? value : missingText}
+      </span>
+    </div>
+  );
+
+  if (!hasValue) return pill;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{pill}</TooltipTrigger>
+      <TooltipContent className="px-2 py-1 text-xs">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+// ---------- SkillHeader ----------
+
+export function SkillHeader({
+  name,
+  version,
+  description,
+  license,
+  compatibility,
+  allowedTools,
+  composedSkillMd,
+  downloadSkillName,
+  decorators,
+  actions,
+  onBack,
+  sticky = true,
+}: {
+  name: string;
+  version: string;
+  description: string;
+  license?: string;
+  compatibility?: string;
+  allowedTools?: string;
+  composedSkillMd?: string;
+  downloadSkillName?: string;
+  decorators?: React.ReactNode;
+  actions?: React.ReactNode;
+  onBack?: () => void;
+  sticky?: boolean;
+}) {
+  const [showRawDialog, setShowRawDialog] = useState(false);
+  const { copy: copyRawSkillMd, copied: copiedRawSkillMd } = useCopyToClipboard({
+    successMessage: "Copied raw SKILL.md",
+    errorMessage: "Failed to copy raw SKILL.md",
+  });
+
+  return (
+    <>
+      <div
+        className={cn(
+          "flex items-center gap-2 bg-white dark:bg-card",
+          sticky && "sticky top-0 z-30 py-4",
+        )}
+      >
+        {onBack && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0 shrink-0"
+            onClick={onBack}
+            aria-label="Go back"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        )}
+        <h2 className="min-w-0 truncate text-xl font-semibold tracking-tight">
+          {name}
+        </h2>
+        <Badge
+          variant="secondary"
+          className="font-mono text-xs shrink-0"
+          role="status"
+        >
+          v{version}
+        </Badge>
+        {composedSkillMd && (
+          <Button
+            variant="link"
+            size="sm"
+            className="h-auto shrink-0 px-1 py-0 text-xs text-blue-600 dark:text-blue-400"
+            onClick={() => setShowRawDialog(true)}
+          >
+            View raw SKILL.md
+          </Button>
+        )}
+        {decorators}
+        {(actions || downloadSkillName) && (
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            {downloadSkillName && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                asChild
+                aria-label="Download ZIP"
+              >
+                <a
+                  href={`${getApiBaseUrl()}/skills/serve/${encodeURIComponent(downloadSkillName)}/download.zip`}
+                  download
+                >
+                  <Download className="h-4 w-4" />
+                  <span className="sr-only">Download ZIP</span>
+                </a>
+              </Button>
+            )}
+            {actions}
+          </div>
+        )}
+      </div>
+      <p className="text-muted-foreground text-xs mt-0.5 max-w-3xl">
+        {description}
+      </p>
+      <TooltipProvider>
+        <div className="mt-3 flex flex-wrap items-center gap-2 pb-2">
+          <HeaderMetaItem
+            label="License"
+            value={license}
+            missingText="No license defined"
+            icon={Scale}
+          />
+          <HeaderMetaItem
+            label="Compatibility"
+            value={compatibility}
+            missingText="No compatibility defined"
+            icon={Bot}
+          />
+          <HeaderMetaItem
+            label="Allowed tools"
+            value={allowedTools}
+            missingText="No allowed tools defined"
+            icon={Hammer}
+          />
+        </div>
+      </TooltipProvider>
+      {composedSkillMd && (
+        <Dialog open={showRawDialog} onOpenChange={setShowRawDialog}>
+          <DialogContent
+            showCloseButton={false}
+            className="h-[90vh] max-h-[90vh] w-[95vw] sm:w-[80vw] md:w-[50vw] min-w-0 max-w-[95vw] sm:max-w-[80vw] md:max-w-[50vw] overflow-hidden border-0 bg-transparent p-0 shadow-none"
+          >
+            <DialogHeader className="sr-only">
+              <DialogTitle>Raw SKILL.md</DialogTitle>
+            </DialogHeader>
+            <div className="relative overflow-hidden rounded-sm border bg-muted shadow-lg">
+              <div className="absolute right-3 top-3 z-10 flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 rounded-sm bg-background/70 text-muted-foreground hover:bg-background/90 hover:text-foreground"
+                  onClick={() => copyRawSkillMd(composedSkillMd)}
+                  aria-label={copiedRawSkillMd ? "Raw SKILL.md copied" : "Copy raw SKILL.md"}
+                >
+                  {copiedRawSkillMd ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+                <DialogClose className="cursor-pointer rounded-sm p-1.5 text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground">
+                  <X className="h-4 w-4" />
+                  <span className="sr-only">Close</span>
+                </DialogClose>
+              </div>
+              <ScrollArea className="h-[90vh]" viewportClassName="bg-muted">
+                <pre className="min-h-[420px] bg-muted p-5 pr-24 text-xs font-mono leading-5 whitespace-pre-wrap">
+                  {composedSkillMd}
+                </pre>
+              </ScrollArea>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
+  );
+}
+
+// ---------- FormSection ----------
+
+export function FormSection({
+  title,
+  children,
+  className,
+  optional,
+  helperText,
+}: {
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+  optional?: boolean;
+  helperText?: React.ReactNode;
+}) {
+  return (
+    <section className={cn("space-y-3", className)}>
+      <div className="flex items-baseline gap-2 pb-1">
+        <h2 className="text-base font-semibold tracking-tight text-foreground">
+          {title}
+        </h2>
+        {optional && (
+          <span className="text-xs text-muted-foreground">optional</span>
+        )}
+        {helperText && (
+          <span className="text-xs text-muted-foreground">{helperText}</span>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+// ---------- ReadOnlyYamlBlock ----------
+export function ReadOnlyYamlBlock({
+  title,
+  value,
+}: {
+  title: string;
+  value: Record<string, unknown>;
+}) {
+  const yaml = formatYamlRecord(value);
+
+  return (
+    <FormSection title={title}>
+      <div>
+        <Markdown content={`\`\`\`yaml\n${yaml}\n\`\`\``} />
+      </div>
+    </FormSection>
+  );
+}
+
+// ---------- ReadOnlyMetadataTable ----------
+export function ReadOnlyMetadataTable({
+  value,
+}: {
+  value: Record<string, unknown>;
+}) {
+  const entries = Object.entries(value);
+
+  return (
+    <FormSection title="Metadata">
+      <div className="rounded-sm border">
+        <div className="grid grid-cols-2 border-b bg-muted/30 px-3 py-2 text-sm font-medium">
+          <span>Key</span>
+          <span>Value</span>
+        </div>
+        <div className="divide-y text-muted-foreground">
+          {entries.map(([key, item]) => (
+            <div
+              key={key}
+              className="grid grid-cols-2 gap-3 px-3 py-2.5 text-sm"
+            >
+              <p className="min-w-0 truncate font-mono text-xs">{key}</p>
+              <p className="min-w-0 break-words font-mono text-xs leading-5">
+                {String(item)}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </FormSection>
+  );
+}
+// ---------- ReadOnlySkillBody ----------
+
+export function ReadOnlySkillBody({ body }: { body: string }) {
+  const [activeTab, setActiveTab] = useState("rendered");
+  const [dialogTab, setDialogTab] = useState("rendered");
+  const [expandOpen, setExpandOpen] = useState(false);
+  return (
+    <FormSection title="SKILL.md Body">
+      <Tabs
+        defaultValue="rendered"
+        onValueChange={setActiveTab}
+        className="w-full"
+      >
+        <div
+          className={cn(
+            "relative h-[520px] overflow-hidden rounded-sm border",
+            activeTab === "raw" ? "bg-muted" : "bg-background",
+          )}
+        >
+          <div className="absolute right-3 top-3 z-10 flex items-center gap-1.5">
+            <TabsList className="h-8 bg-card shadow-sm backdrop-blur">
+              <TabsTrigger value="rendered" className="h-6 px-2.5 text-xs">
+                Rendered
+              </TabsTrigger>
+              <TabsTrigger value="raw" className="h-6 px-2.5 text-xs">
+                Raw
+              </TabsTrigger>
+            </TabsList>
+            <button
+              type="button"
+              className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm bg-card text-muted-foreground shadow-sm backdrop-blur transition-colors hover:text-foreground"
+              onClick={() => setExpandOpen(true)}
+              aria-label="Expand SKILL.md body"
+            >
+              <Maximize2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <TabsContent
+            value="rendered"
+            className="absolute inset-0 m-0 overflow-hidden"
+          >
+            <ScrollArea className="h-full">
+              <div className="min-w-0 p-4">
+                <Markdown
+                  content={body || ""}
+                  className="max-w-full text-sm break-words [overflow-wrap:anywhere] [&_*]:max-w-full [&_*]:break-words [&_*]:[overflow-wrap:anywhere] [&_a]:break-all [&_code]:whitespace-pre-wrap [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_table]:table-fixed"
+                />
+              </div>
+            </ScrollArea>
+          </TabsContent>
+          <TabsContent
+            value="raw"
+            className="absolute inset-0 m-0 overflow-hidden bg-muted"
+          >
+            <ScrollArea className="h-full" viewportClassName="bg-muted">
+              <pre className="min-h-full bg-muted p-4 text-xs font-mono leading-5 whitespace-pre-wrap">
+                {body || "(empty)"}
+              </pre>
+            </ScrollArea>
+          </TabsContent>
+        </div>
+      </Tabs>
+
+      <Dialog
+        open={expandOpen}
+        onOpenChange={(open) => {
+          setExpandOpen(open);
+          if (open) setDialogTab(activeTab);
+        }}
+      >
+        <DialogContent
+          showCloseButton={false}
+          className="h-[90vh] max-h-[90vh] w-[95vw] sm:w-[80vw] md:w-[50vw] min-w-0 max-w-[95vw] sm:max-w-[80vw] md:max-w-[50vw] overflow-hidden border-0 bg-transparent p-0 shadow-none"
+        >
+          <DialogHeader className="sr-only">
+            <DialogTitle>SKILL.md Body</DialogTitle>
+          </DialogHeader>
+          <Tabs
+            value={dialogTab}
+            onValueChange={setDialogTab}
+            className="h-full"
+          >
+            <div
+              className={cn(
+                "relative h-full overflow-hidden rounded-sm border shadow-lg",
+                dialogTab === "raw" ? "bg-muted" : "bg-background",
+              )}
+            >
+              <div className="absolute right-3 top-3 z-10 flex items-center gap-1.5">
+                <TabsList className="h-8 bg-card shadow-sm backdrop-blur">
+                  <TabsTrigger value="rendered" className="h-6 px-2.5 text-xs">
+                    Rendered
+                  </TabsTrigger>
+                  <TabsTrigger value="raw" className="h-6 px-2.5 text-xs">
+                    Raw
+                  </TabsTrigger>
+                </TabsList>
+                <DialogClose className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm bg-card text-muted-foreground shadow-sm backdrop-blur transition-colors hover:text-foreground">
+                  <X className="h-4 w-4" />
+                  <span className="sr-only">Close</span>
+                </DialogClose>
+              </div>
+              <TabsContent
+                value="rendered"
+                className="absolute inset-0 m-0 overflow-hidden"
+              >
+                <ScrollArea className="h-full">
+                  <div className="min-w-0 p-5">
+                    <Markdown
+                      content={body || ""}
+                      className="max-w-full text-sm break-words [overflow-wrap:anywhere] [&_*]:max-w-full [&_*]:break-words [&_*]:[overflow-wrap:anywhere] [&_a]:break-all [&_code]:whitespace-pre-wrap [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_table]:table-fixed"
+                    />
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+              <TabsContent
+                value="raw"
+                className="absolute inset-0 m-0 overflow-hidden bg-muted"
+              >
+                <ScrollArea className="h-full" viewportClassName="bg-muted">
+                  <pre className="min-h-full bg-muted p-5 text-xs font-mono leading-5 whitespace-pre-wrap">
+                    {body || "(empty)"}
+                  </pre>
+                </ScrollArea>
+              </TabsContent>
+            </div>
+          </Tabs>
+        </DialogContent>
+      </Dialog>
+    </FormSection>
+  );
+}
+
+// ---------- ReadOnlyFileTree ----------
+
+interface FileTreeNodeData extends BaseNodeData {
+  type: "root" | "folder" | "file" | "skillmd";
+  mime_type?: string;
+  source_type?: string;
+  file_size_bytes?: number;
+  path?: string;
+  childCount?: number;
+}
+
+function downloadTextAsFile(content: string, filename: string) {
+  const blob = new Blob([content], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function fileNameFromPath(filePath: string) {
+  return filePath.split("/").filter(Boolean).pop() || filePath;
+}
+
+export function ReadOnlyFileTree({
+  skillName,
+  files,
+  composedSkillMd,
+}: {
+  skillName: string;
+  files: SkillFileEntry[];
+  composedSkillMd: string;
+}) {
+  const treeData = useMemo((): TreeNode<FileTreeNodeData>[] => {
+    interface FolderBucket {
+      files: SkillFileEntry[];
+      subfolders: Record<string, FolderBucket>;
+    }
+    const rootBucket: FolderBucket = { files: [], subfolders: {} };
+
+    for (const file of files) {
+      const segments = file.path.split("/").filter(Boolean);
+      if (segments.length === 0) continue;
+      segments.pop();
+      let bucket = rootBucket;
+      for (const segment of segments) {
+        if (!bucket.subfolders[segment])
+          bucket.subfolders[segment] = { files: [], subfolders: {} };
+        bucket = bucket.subfolders[segment];
+      }
+      bucket.files.push(file);
+    }
+
+    const bucketToNodes = (
+      bucket: FolderBucket,
+      parentPath: string,
+    ): TreeNode<FileTreeNodeData>[] => {
+      const nodes: TreeNode<FileTreeNodeData>[] = [];
+      for (const [folderName, sub] of Object.entries(bucket.subfolders).sort(
+        ([a], [b]) => a.localeCompare(b),
+      )) {
+        const folderPath = parentPath
+          ? `${parentPath}/${folderName}`
+          : folderName;
+        const children = bucketToNodes(sub, folderPath);
+        const immediateCount =
+          Object.keys(sub.subfolders).length + sub.files.length;
+        nodes.push({
+          data: {
+            id: `folder-${folderPath}`,
+            name: `${folderName}/`,
+            type: "folder",
+            childCount: immediateCount,
+            path: folderPath,
+          },
+          children,
+        });
+      }
+      for (const file of bucket.files.sort((a, b) =>
+        fileNameFromPath(a.path).localeCompare(fileNameFromPath(b.path)),
+      )) {
+        nodes.push({
+          data: {
+            id: `file-${file.path}`,
+            name: fileNameFromPath(file.path),
+            type: "file",
+            mime_type: file.mime_type,
+            source_type: file.source_type,
+            file_size_bytes: file.file_size_bytes,
+            path: file.path,
+          },
+        });
+      }
+      return nodes;
+    };
+
+    return [
+      {
+        data: {
+          id: "root",
+          name: `${skillName || "skill"}/`,
+          type: "root",
+          childCount:
+            Object.keys(rootBucket.subfolders).length + rootBucket.files.length,
+        },
+        children: [
+          { data: { id: "skillmd", name: "SKILL.md", type: "skillmd" } },
+          ...bucketToNodes(rootBucket, ""),
+        ],
+      },
+    ];
+  }, [skillName, files]);
+
+  const downloadUrl = `${getApiBaseUrl()}/skills/serve/${encodeURIComponent(skillName)}/download.zip`;
+
+  return (
+    <FormSection title="Files">
+      <TooltipProvider>
+      <Tree<FileTreeNodeData>
+        data={treeData}
+        levelsToExpandByDefault={1}
+        indentSize={28}
+        renderItem={({
+          item,
+          isExpanded,
+          hasChildren,
+          onToggle,
+          onExpandAll,
+          onCollapseAll,
+          isAllExpanded,
+          isAllCollapsed,
+        }) => {
+          const isFolder = item.type === "root" || item.type === "folder";
+          const isSkillMd = item.type === "skillmd";
+          const isFile = item.type === "file";
+          const isDownloadable = isSkillMd || isFile;
+
+          const fileDownloadUrl =
+            isFile && item.path
+              ? `${getApiBaseUrl()}/skills/serve/${encodeURIComponent(skillName)}/files/${item.path.split("/").map(encodeURIComponent).join("/")}`
+              : undefined;
+
+          const handleClick = () => {
+            if (hasChildren) onToggle();
+            else if (isSkillMd) downloadTextAsFile(composedSkillMd, "SKILL.md");
+            else if (isFile && fileDownloadUrl) {
+              const a = document.createElement("a");
+              a.href = fileDownloadUrl;
+              a.download = item.name;
+              document.body.appendChild(a);
+              a.click();
+              document.body.removeChild(a);
+            }
+          };
+
+          return (
+            <div
+              className={cn(
+                "group flex h-9 items-center gap-2 rounded-sm px-2 text-sm transition-colors",
+                (hasChildren || isDownloadable) &&
+                  "cursor-pointer hover:bg-muted/50",
+              )}
+              onClick={handleClick}
+              onKeyDown={(e) => {
+                if (
+                  (e.key === "Enter" || e.key === " ") &&
+                  (hasChildren || isDownloadable)
+                ) {
+                  e.preventDefault();
+                  handleClick();
+                }
+              }}
+              role={hasChildren || isDownloadable ? "button" : undefined}
+              tabIndex={hasChildren || isDownloadable ? 0 : undefined}
+              aria-label={
+                isDownloadable
+                  ? `Download ${item.name}`
+                  : isFolder
+                    ? `${isExpanded ? "Collapse" : "Expand"} ${item.name}`
+                    : item.name
+              }
+            >
+              {hasChildren ? (
+                isExpanded ? (
+                  <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                )
+              ) : (
+                <span className="w-3.5 shrink-0" />
+              )}
+
+              {isDownloadable ? (
+                isSkillMd ? (
+                  <>
+                    <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground group-hover:hidden" />
+                    <Download className="h-4 w-4 shrink-0 text-muted-foreground hidden group-hover:block" />
+                  </>
+                ) : (
+                  <>
+                    <FileText className="h-4 w-4 shrink-0 text-muted-foreground group-hover:hidden" />
+                    <Download className="h-4 w-4 shrink-0 text-muted-foreground hidden group-hover:block" />
+                  </>
+                )
+              ) : isFolder ? (
+                isExpanded ? (
+                  <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                )
+              ) : null}
+
+              <span
+                className={cn("font-mono text-xs", isFolder && "font-medium")}
+              >
+                {item.name}
+              </span>
+
+              {isFolder &&
+                !isExpanded &&
+                item.childCount != null &&
+                item.childCount > 0 && (
+                  <span className="text-[10px] text-muted-foreground">
+                    {item.childCount} item{item.childCount !== 1 ? "s" : ""}
+                  </span>
+                )}
+
+              {isFile && (
+                <>
+                  {item.source_type && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex h-5 shrink-0 items-center rounded-full border border-border/60 bg-transparent px-2 text-[10px] font-medium leading-none text-muted-foreground">
+                          {item.source_type}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="px-2 py-1 text-xs">
+                        Source
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  {item.mime_type && (
+                    <span className="text-[10px] text-muted-foreground">
+                      {item.mime_type}
+                    </span>
+                  )}
+                  {item.file_size_bytes != null && item.file_size_bytes > 0 && (
+                    <span className="text-[10px] text-muted-foreground">
+                      {formatFileSize(item.file_size_bytes)}
+                    </span>
+                  )}
+                </>
+              )}
+
+              {item.type === "root" && (
+                <div
+                  className="ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100"
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => e.stopPropagation()}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0"
+                        aria-label="Expand all folders"
+                        onClick={onExpandAll}
+                        disabled={isAllExpanded}
+                      >
+                        <ChevronsDown className="h-3 w-3" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent className="px-2 py-1 text-xs">
+                      Expand all
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0"
+                        aria-label="Collapse all folders"
+                        onClick={onCollapseAll}
+                        disabled={isAllCollapsed}
+                      >
+                        <ChevronsUp className="h-3 w-3" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent className="px-2 py-1 text-xs">
+                      Collapse all
+                    </TooltipContent>
+                  </Tooltip>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2"
+                    asChild
+                  >
+                    <a href={downloadUrl} download>
+                      <Download className="h-3 w-3" />
+                      <span className="text-[10px]">ZIP</span>
+                    </a>
+                  </Button>
+                </div>
+              )}
+            </div>
+          );
+        }}
+      />
+      </TooltipProvider>
+    </FormSection>
+  );
+}
+
+// ---------- SkillReadOnlyContent ----------
+
+export function SkillReadOnlyContent({
+  skillName,
+  skillMdBody,
+  files,
+  extraFrontmatter,
+  metadata,
+  composedSkillMd,
+}: {
+  skillName: string;
+  skillMdBody: string;
+  files: SkillFileEntry[];
+  extraFrontmatter: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+  composedSkillMd: string;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      {extraFrontmatter && (
+        <ReadOnlyYamlBlock title="Extra Frontmatter" value={extraFrontmatter} />
+      )}
+      {metadata && <ReadOnlyMetadataTable value={metadata} />}
+      <ReadOnlySkillBody body={skillMdBody} />
+      <ReadOnlyFileTree
+        skillName={skillName}
+        files={files}
+        composedSkillMd={composedSkillMd}
+      />
+    </div>
+  );
+}

--- a/ui/app/workspace/skills-repo/page.tsx
+++ b/ui/app/workspace/skills-repo/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useQueryStates, parseAsBoolean, parseAsString } from "nuqs";
+import { SkillCreateView } from "./components/SkillCreateView";
+import { SkillDetailView } from "./components/SkillDetailView";
+import { SkillsListView } from "./components/SkillsListView";
+import { cn } from "@/lib/utils";
+
+export default function SkillsRepoPage() {
+  const [urlState, setUrlState] = useQueryStates(
+    {
+      skillId: parseAsString,
+      edit: parseAsBoolean.withDefault(false),
+      create: parseAsBoolean.withDefault(false),
+    },
+    { history: "push" },
+  );
+
+  const handleSelectSkill = (id: string, edit = false) => {
+    setUrlState({ skillId: id, edit, create: false });
+  };
+
+  const handleBack = () => {
+    setUrlState({ skillId: null, edit: false, create: false });
+  };
+
+  const handleCreated = (id: string) => {
+    setUrlState({ skillId: id, edit: false, create: false });
+  };
+
+  const setIsEditing = (editing: boolean) => {
+    setUrlState({ edit: editing });
+  };
+
+  // Create view
+  if (urlState.create) {
+    return (
+      <div className="no-padding-parent flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col">
+        <SkillCreateView onCreated={handleCreated} onBack={handleBack} />
+      </div>
+    );
+  }
+
+  // Detail view when skillId is set
+  if (urlState.skillId) {
+    return (
+      <div
+        className={cn(
+          "no-padding-parent flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col p-4 pt-0",
+          urlState.edit && "p-0",
+        )}
+      >
+        <SkillDetailView
+          skillId={urlState.skillId}
+          isEditing={urlState.edit}
+          setIsEditing={setIsEditing}
+          onBack={handleBack}
+        />
+      </div>
+    );
+  }
+
+  // List view
+  return (
+    <div className="no-padding-parent flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col p-4">
+      <SkillsListView
+        onSelectSkill={handleSelectSkill}
+        onCreateNew={() =>
+          setUrlState({ create: true, skillId: null, edit: false })
+        }
+      />
+    </div>
+  );
+}

--- a/ui/components/ui/codeEditor.tsx
+++ b/ui/components/ui/codeEditor.tsx
@@ -18,7 +18,7 @@ export type CompletionItem = {
 	insertText: string;
 	documentation?: string;
 	description?: string;
-	type: "variable" | "method" | "object";
+	type: "variable" | "method" | "object" | "folder";
 };
 
 export interface CodeEditorProps {
@@ -84,7 +84,14 @@ export function CodeEditor(props: CodeEditorProps) {
 	const { className, lang, code, onChange } = props;
 	const editorContainer = useRef<HTMLDivElement>(null);
 	const [isClient, setIsClient] = useState(false);
-	const [editorHeight, setEditorHeight] = useState<number | string>(props.height || props.minHeight || 200);
+	const [editorHeight, setEditorHeight] = useState<number | string>(
+		props.height || props.minHeight || 200,
+	);
+	const customCompletionsRef = useRef(props.customCompletions);
+
+	useEffect(() => {
+		customCompletionsRef.current = props.customCompletions;
+	}, [props.customCompletions]);
 
 	// Ensure we only render on client
 	useEffect(() => {
@@ -101,9 +108,62 @@ export function CodeEditor(props: CodeEditorProps) {
 	};
 
 	// Handle editor mount
-	const handleEditorDidMount = (editor: editor.IStandaloneCodeEditor) => {
+	const handleEditorDidMount = (editor: editor.IStandaloneCodeEditor, monaco: any) => {
 		if (props.autoFocus) {
 			editor.focus();
+		}
+
+		if (props.customCompletions) {
+			const languageId = lang || "javascript";
+			const provider = monaco.languages.registerCompletionItemProvider(languageId, {
+				triggerCharacters: ["@"],
+				provideCompletionItems: (model: any, position: any) => {
+					const completions = customCompletionsRef.current ?? [];
+					if (!completions.length) return { suggestions: [] };
+
+					const linePrefix = model.getLineContent(position.lineNumber).slice(0, position.column - 1);
+					const triggerMatch = linePrefix.match(/@([^\s@]*)$/);
+					if (!triggerMatch) return { suggestions: [] };
+
+					const replacementRange = new monaco.Range(
+						position.lineNumber,
+						position.column - triggerMatch[0].length,
+						position.lineNumber,
+						position.column,
+					);
+
+					const kindByType = {
+						variable: monaco.languages.CompletionItemKind.Variable,
+						method: monaco.languages.CompletionItemKind.Function,
+						object: monaco.languages.CompletionItemKind.File,
+						folder: monaco.languages.CompletionItemKind.Folder,
+					};
+
+					return {
+						suggestions: completions.map((completion) => ({
+							label: completion.label,
+							kind: kindByType[completion.type] ?? monaco.languages.CompletionItemKind.File,
+							insertText: completion.insertText,
+							filterText: `@${completion.label} ${completion.description ?? completion.insertText}`,
+							detail: completion.description,
+							documentation: completion.documentation,
+							range: replacementRange,
+						})),
+					};
+				},
+			});
+			const triggerSuggest = editor.onDidChangeModelContent((event) => {
+				const typedText = event.changes.at(-1)?.text;
+				if (typedText === "@") {
+					window.setTimeout(() => {
+						editor.getAction("editor.action.triggerSuggest")?.run();
+					}, 0);
+				}
+			});
+			editor.onDidDispose(() => {
+				provider.dispose();
+				triggerSuggest.dispose();
+			});
 		}
 
 		// Auto-resize logic
@@ -145,6 +205,9 @@ export function CodeEditor(props: CodeEditorProps) {
 		scrollBeyondLastLine: props.options?.scrollBeyondLastLine ?? false,
 		minimap: { enabled: false },
 		contextmenu: false,
+		// Use Monaco's supported switch instead of mutating window.EditContext. The
+		// native EditContext layer can render a duplicate caret in Chromium.
+		editContext: false,
 		fontFamily: "var(--font-geist-mono)",
 		fontSize: props.fontSize || 12.5,
 		padding: { top: 2, bottom: 2 },
@@ -169,7 +232,9 @@ export function CodeEditor(props: CodeEditorProps) {
 		hover: {
 			enabled: !props.options?.disableHover,
 		},
-		wordBasedSuggestions: "off" as const,
+		quickSuggestions: props.options?.quickSuggestions ?? false,
+		wordBasedSuggestions: "off",
+		suggestOnTriggerCharacters: true,
 		...props.options,
 	} as editor.IStandaloneEditorConstructionOptions;
 

--- a/ui/components/ui/treeView.tsx
+++ b/ui/components/ui/treeView.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+// ---- Types ----
+
+export interface BaseNodeData {
+  id: string;
+  name: string;
+}
+
+export interface TreeNode<T extends BaseNodeData> {
+  children?: TreeNode<T>[];
+  data: T;
+}
+
+export interface TreeProps<T extends BaseNodeData> {
+  data: TreeNode<T>[];
+  renderItem: (props: {
+    item: T;
+    level: number;
+    isExpanded: boolean;
+    hasChildren: boolean;
+    onToggle: () => void;
+    onExpandAll: () => void;
+    onCollapseAll: () => void;
+    isAllExpanded: boolean;
+    isAllCollapsed: boolean;
+  }) => React.ReactNode;
+  className?: string;
+  indentSize?: number;
+  lineColor?: string;
+  lineWidth?: number;
+  levelsToExpandByDefault?: number;
+  /** External expansion state control — parent can manage expandedNodes directly */
+  states?: {
+    expandedNodes: Record<string, boolean>;
+    setExpandedNodes: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
+  };
+}
+
+// ---- Helpers ----
+
+function collectDefaultExpanded<T extends BaseNodeData>(
+  nodes: TreeNode<T>[],
+  maxLevel: number,
+): Record<string, boolean> {
+  const result: Record<string, boolean> = {};
+  const traverse = (node: TreeNode<T>, level: number) => {
+    if (level >= maxLevel) return;
+    if (node.children && node.children.length > 0) {
+      result[node.data.id] = true;
+    }
+    node.children?.forEach((child) => traverse(child, level + 1));
+  };
+  nodes.forEach((n) => traverse(n, 0));
+  return result;
+}
+
+function collectExpandableNodeIds<T extends BaseNodeData>(
+  nodes: TreeNode<T>[],
+): string[] {
+  const result: string[] = [];
+  const traverse = (node: TreeNode<T>) => {
+    if (node.children && node.children.length > 0) {
+      result.push(node.data.id);
+      node.children.forEach(traverse);
+    }
+  };
+  nodes.forEach(traverse);
+  return result;
+}
+
+// ---- Node Component ----
+
+function TreeNodeComponent<T extends BaseNodeData>({
+  node,
+  level,
+  isLast,
+  renderItem,
+  indentSize,
+  lineColor,
+  lineWidth,
+  expandedNodes,
+  onToggle,
+  onExpandAll,
+  onCollapseAll,
+  isAllExpanded,
+  isAllCollapsed,
+}: {
+  node: TreeNode<T>;
+  level: number;
+  isLast: boolean;
+  renderItem: TreeProps<T>["renderItem"];
+  indentSize: number;
+  lineColor: string;
+  lineWidth: number;
+  expandedNodes: Record<string, boolean>;
+  onToggle: (id: string) => void;
+  onExpandAll: () => void;
+  onCollapseAll: () => void;
+  isAllExpanded: boolean;
+  isAllCollapsed: boolean;
+}) {
+  const hasChildren = Boolean(node.children?.length);
+  const isExpanded = expandedNodes[node.data.id] ?? false;
+
+  return (
+    <div className="relative">
+      {/* Vertical line from parent — spans the full node height (row + children) for sibling continuation */}
+      {level > 0 && !isLast && (
+        <div
+          className="absolute"
+          style={{
+            left: `${(level - 1) * indentSize + indentSize / 2}px`,
+            top: 0,
+            bottom: 0,
+            width: lineWidth,
+            backgroundColor: lineColor,
+          }}
+        />
+      )}
+
+      {/* Row wrapper — horizontal line positions relative to just this row */}
+      <div className="relative">
+        {/* Vertical line stub for last child — only goes to row center */}
+        {level > 0 && isLast && (
+          <div
+            className="absolute"
+            style={{
+              left: `${(level - 1) * indentSize + indentSize / 2}px`,
+              top: 0,
+              height: "50%",
+              width: lineWidth,
+              backgroundColor: lineColor,
+            }}
+          />
+        )}
+
+        {/* Horizontal connector from vertical line to the node */}
+        {level > 0 && (
+          <div
+            className="absolute"
+            style={{
+              left: `${(level - 1) * indentSize + indentSize / 2}px`,
+              top: "50%",
+              width: `${indentSize / 2 + 2}px`,
+              height: lineWidth,
+              backgroundColor: lineColor,
+            }}
+          />
+        )}
+
+        {/* Node content */}
+        <div
+          className="relative"
+          style={{ paddingLeft: `${level * indentSize}px` }}
+        >
+          <div className="py-0.5">
+            {renderItem({
+              item: node.data,
+              level,
+              isExpanded,
+              hasChildren,
+              onToggle: () => onToggle(node.data.id),
+              onExpandAll,
+              onCollapseAll,
+              isAllExpanded,
+              isAllCollapsed,
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Children */}
+      {isExpanded && node.children && (
+        <div className="relative">
+          {node.children.map((child, idx) => (
+            <TreeNodeComponent
+              key={child.data.id}
+              node={child}
+              level={level + 1}
+              isLast={idx === node.children!.length - 1}
+              renderItem={renderItem}
+              indentSize={indentSize}
+              lineColor={lineColor}
+              lineWidth={lineWidth}
+              expandedNodes={expandedNodes}
+              onToggle={onToggle}
+              onExpandAll={onExpandAll}
+              onCollapseAll={onCollapseAll}
+              isAllExpanded={isAllExpanded}
+              isAllCollapsed={isAllCollapsed}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Main Tree Component ----
+
+export function Tree<T extends BaseNodeData>({
+  data,
+  renderItem,
+  className,
+  indentSize = 24,
+  lineColor = "var(--border)",
+  lineWidth = 1,
+  levelsToExpandByDefault,
+  states,
+}: TreeProps<T>) {
+  const [localExpandedNodes, localSetExpandedNodes] = useState<Record<string, boolean>>(
+    () =>
+      levelsToExpandByDefault
+        ? collectDefaultExpanded(data, levelsToExpandByDefault)
+        : {},
+  );
+
+  // Use external state if provided, otherwise use local state
+  const expandedNodes = states?.expandedNodes ?? localExpandedNodes;
+  const setExpandedNodes = states?.setExpandedNodes ?? localSetExpandedNodes;
+
+
+  const handleToggle = useCallback(
+    (id: string) => {
+      setExpandedNodes((prev) => ({ ...prev, [id]: !prev[id] }));
+    },
+    [setExpandedNodes],
+  );
+
+  // Re-sync defaults when data changes and we have levelsToExpandByDefault
+  // Capture full tree shape so resync fires when children change, not just top-level IDs
+  const dataFingerprint = useMemo(() => {
+    const ids: string[] = [];
+    const walk = (nodes: TreeNode<T>[]) =>
+      nodes.forEach((n) => {
+        ids.push(n.data.id);
+        if (n.children) walk(n.children);
+      });
+    walk(data);
+    return ids.join(",");
+  }, [data]);
+  const expandableNodeIds = useMemo(
+    () => collectExpandableNodeIds(data),
+    [dataFingerprint],
+  );
+
+  const isAllExpanded = useMemo(
+    () =>
+      expandableNodeIds.length > 0 &&
+      expandableNodeIds.every((id) => expandedNodes[id]),
+    [expandableNodeIds, expandedNodes],
+  );
+
+  const isAllCollapsed = useMemo(
+    () => expandableNodeIds.every((id) => !expandedNodes[id]),
+    [expandableNodeIds, expandedNodes],
+  );
+
+  const handleExpandAll = useCallback(() => {
+    setExpandedNodes((prev) => {
+      const next = { ...prev };
+      expandableNodeIds.forEach((id) => {
+        next[id] = true;
+      });
+      return next;
+    });
+  }, [expandableNodeIds]);
+
+  const handleCollapseAll = useCallback(() => {
+    setExpandedNodes((prev) => {
+      const next = { ...prev };
+      expandableNodeIds.forEach((id) => {
+        next[id] = false;
+      });
+      return next;
+    });
+  }, [expandableNodeIds]);
+
+  useEffect(() => {
+    if (levelsToExpandByDefault) {
+      setExpandedNodes((prev) => {
+        const defaults = collectDefaultExpanded(data, levelsToExpandByDefault);
+        // Merge: keep user overrides for nodes that still exist, add new defaults
+        const validIds = new Set(expandableNodeIds);
+        const filtered = Object.fromEntries(
+          Object.entries(prev).filter(([id]) => validIds.has(id)),
+        );
+        return { ...defaults, ...filtered };
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataFingerprint, levelsToExpandByDefault]);
+
+  return (
+    <div className={cn("", className)}>
+      {data.map((node, idx) => (
+        <TreeNodeComponent
+          key={node.data.id}
+          node={node}
+          level={0}
+          isLast={idx === data.length - 1}
+          renderItem={renderItem}
+          indentSize={indentSize}
+          lineColor={lineColor}
+          lineWidth={lineWidth}
+          expandedNodes={expandedNodes}
+          onToggle={handleToggle}
+          onExpandAll={handleExpandAll}
+          onCollapseAll={handleCollapseAll}
+          isAllExpanded={isAllExpanded}
+          isAllCollapsed={isAllCollapsed}
+        />
+      ))}
+    </div>
+  );
+}

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -40,27 +40,27 @@ export const clearAuthStorage = () => {
 
 // Define the base query with authentication headers
 const baseQuery = fetchBaseQuery({
-	baseUrl: getApiBaseUrl(),
-	credentials: "include",
-	prepareHeaders: async (headers) => {
-    if (!headers.has("Content-Type")) {
-      headers.set("Content-Type", "application/json");
+  baseUrl: getApiBaseUrl(),
+  credentials: "include",
+  prepareHeaders: async (headers) => {
+    // Do not force a default Content-Type here. JSON bodies are handled by
+    // fetchBaseQuery, while FormData uploads need the browser-generated
+    // multipart boundary.
+    // Automatically include token from localStorage in Authorization header
+    const token = await getTokenFromStorage();
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
     }
-		// Automatically include token from localStorage in Authorization header
-		const token = await getTokenFromStorage();
-		if (token) {
-			headers.set("Authorization", `Bearer ${token}`);
-		}
-		// Attach a temp token when a TempTokenScope wrapper is mounted. The
-		// dashboard cookie (if present) still takes precedence on the server
-		// side; the temp token is the fallback that rescues unauthenticated
-		// browsers visiting a scoped page.
-		const tempToken = getActiveTempToken();
-		if (tempToken) {
-			headers.set("X-Bifrost-Temp-Token", tempToken);
-		}
-		return headers;
-	},
+    // Attach a temp token when a TempTokenScope wrapper is mounted. The
+    // dashboard cookie (if present) still takes precedence on the server
+    // side; the temp token is the fallback that rescues unauthenticated
+    // browsers visiting a scoped page.
+    const tempToken = getActiveTempToken();
+    if (tempToken) {
+      headers.set("X-Bifrost-Temp-Token", tempToken);
+    }
+    return headers;
+  },
 });
 
 // Wrap base query with enterprise refresh logic (or passthrough for non-enterprise)
@@ -79,21 +79,24 @@ const baseQueryWithErrorHandling: typeof baseQueryWithRefresh = async (
   if (result.error) {
     const error = result.error as any;
 
-		// Handle 401 for non-enterprise (no refresh available)
-		if (error?.status === 401 && !IS_ENTERPRISE) {
-			// When a TempTokenScope wrapper is active, the wrapped page handles
-			// its own 401 display (an "invalid/expired link" view). Skip the
-			// global redirect so the user stays on the page they opened.
-			if (getSuppressGlobal401()) {
-				return result;
-			}
-			clearAuthStorage();
-			if (typeof window !== "undefined" && !window.location.pathname.includes("/login")) {
-				const goto = window.location.pathname + window.location.search;
-				window.location.href = `/login?goto=${encodeURIComponent(goto)}`;
-			}
-			return result;
-		}
+    // Handle 401 for non-enterprise (no refresh available)
+    if (error?.status === 401 && !IS_ENTERPRISE) {
+      // When a TempTokenScope wrapper is active, the wrapped page handles
+      // its own 401 display (an "invalid/expired link" view). Skip the
+      // global redirect so the user stays on the page they opened.
+      if (getSuppressGlobal401()) {
+        return result;
+      }
+      clearAuthStorage();
+      if (
+        typeof window !== "undefined" &&
+        !window.location.pathname.includes("/login")
+      ) {
+        const goto = window.location.pathname + window.location.search;
+        window.location.href = `/login?goto=${encodeURIComponent(goto)}`;
+      }
+      return result;
+    }
 
     // Handle specific error types
     if (error?.status === "FETCH_ERROR") {
@@ -194,6 +197,7 @@ export const baseApi = createApi({
     "MCPLibrary",
     "FeatureFlags",
     "ComplexityAnalyzerConfig",
+    "Skills",
   ],
   endpoints: () => ({}),
 });

--- a/ui/lib/store/apis/index.ts
+++ b/ui/lib/store/apis/index.ts
@@ -1,5 +1,10 @@
 // Base API
-export { baseApi, clearAuthStorage, getErrorMessage, setAuthToken } from "./baseApi";
+export {
+  baseApi,
+  clearAuthStorage,
+  getErrorMessage,
+  setAuthToken,
+} from "./baseApi";
 
 // API slices and hooks
 export * from "./configApi";
@@ -15,3 +20,4 @@ export * from "./pluginsApi";
 export * from "./providersApi";
 export * from "./promptsApi";
 export * from "./sessionApi";
+export * from "./skillsApi";

--- a/ui/lib/store/apis/skillsApi.ts
+++ b/ui/lib/store/apis/skillsApi.ts
@@ -1,0 +1,178 @@
+import { baseApi } from "@/lib/store/apis/baseApi";
+import {
+  AllSkillsVersionResponse,
+  BumpAllSkillsVersionRequest,
+  CreateSkillRequest,
+  CreateSkillResponse,
+  GetSkillResponse,
+  ListSkillsResponse,
+  ListSkillVersionsResponse,
+  ShiftSkillVersionRequest,
+  UpdateSkillRequest,
+  UpdateSkillResponse,
+  UploadFileResponse,
+} from "@/lib/types/skills";
+
+// Inject Skills Repository endpoints into baseApi
+export const skillsApi = baseApi.injectEndpoints({
+  overrideExisting: true,
+  endpoints: (builder) => ({
+    // List all skills (paginated)
+    listSkills: builder.query<
+      ListSkillsResponse,
+      { limit?: number; offset?: number; search?: string; sort_by?: "name" | "updated_at" | "created_at"; order?: "asc" | "desc" } | void
+    >({
+      query: (params) => {
+        const searchParams = new URLSearchParams();
+        if (params?.limit != null) searchParams.set("limit", String(params.limit));
+        if (params?.offset != null) searchParams.set("offset", String(params.offset));
+        if (params?.search) searchParams.set("search", params.search);
+        if (params?.sort_by) searchParams.set("sort_by", params.sort_by);
+        if (params?.order) searchParams.set("order", params.order);
+        const qs = searchParams.toString();
+        return `/skills${qs ? `?${qs}` : ""}`;
+      },
+      providesTags: ["Skills"],
+    }),
+
+    // Get single skill by ID (optionally at a specific version)
+    getSkill: builder.query<
+      GetSkillResponse,
+      string | { id: string; version?: string }
+    >({
+      query: (arg) => {
+        const id = typeof arg === "string" ? arg : arg.id;
+        const version = typeof arg === "string" ? undefined : arg.version;
+        return `/skills/${id}${version ? `?version=${encodeURIComponent(version)}` : ""}`;
+      },
+      providesTags: (_result, _error, arg) => {
+        const id = typeof arg === "string" ? arg : arg.id;
+        return [{ type: "Skills", id }];
+      },
+    }),
+
+    // Create a new skill
+    createSkill: builder.mutation<CreateSkillResponse, CreateSkillRequest>({
+      query: (data) => ({
+        url: "/skills",
+        method: "POST",
+        body: data,
+      }),
+      invalidatesTags: ["Skills"],
+    }),
+
+    // Update an existing skill (creates a new version)
+    updateSkill: builder.mutation<
+      UpdateSkillResponse,
+      { id: string; data: UpdateSkillRequest }
+    >({
+      query: ({ id, data }) => ({
+        url: `/skills/${id}`,
+        method: "PUT",
+        body: data,
+      }),
+      invalidatesTags: (_result, _error, { id }) => [
+        "Skills",
+        { type: "Skills", id },
+      ],
+    }),
+
+    // Delete a skill
+    deleteSkill: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `/skills/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (_result, _error, id) => [
+        "Skills",
+        { type: "Skills", id },
+      ],
+    }),
+
+    // List versions for a skill (paginated)
+    listSkillVersions: builder.query<
+      ListSkillVersionsResponse,
+      { id: string; limit?: number; offset?: number; sort_by?: "version" | "created_at"; order?: "asc" | "desc" }
+    >({
+      query: ({ id, ...params }) => {
+        const searchParams = new URLSearchParams();
+        if (params?.limit != null) searchParams.set("limit", String(params.limit));
+        if (params?.offset != null) searchParams.set("offset", String(params.offset));
+        if (params?.sort_by) searchParams.set("sort_by", params.sort_by);
+        if (params?.order) searchParams.set("order", params.order);
+        const qs = searchParams.toString();
+        return `/skills/${id}/versions${qs ? `?${qs}` : ""}`;
+      },
+      providesTags: (_result, _error, { id }) => [
+        { type: "Skills", id: `${id}-versions` },
+      ],
+    }),
+
+    // Shift a skill to serve a specific version
+    shiftSkillVersion: builder.mutation<
+      GetSkillResponse,
+      ShiftSkillVersionRequest
+    >({
+      query: ({ id, version }) => ({
+        url: `/skills/${id}/shift-version`,
+        method: "POST",
+        body: { version },
+      }),
+      invalidatesTags: (_result, _error, { id }) => [
+        "Skills",
+        { type: "Skills", id },
+        { type: "Skills", id: `${id}-versions` },
+      ],
+    }),
+
+    // Current all-skills repository version
+    getAllSkillsVersion: builder.query<AllSkillsVersionResponse, void>({
+      query: () => "/skills/all/version",
+      providesTags: [{ type: "Skills", id: "all-version" }],
+    }),
+
+    // Manually bump the all-skills repository version
+    bumpAllSkillsVersion: builder.mutation<
+      AllSkillsVersionResponse,
+      BumpAllSkillsVersionRequest
+    >({
+      query: (data) => ({
+        url: "/skills/all/version",
+        method: "PUT",
+        body: data,
+      }),
+      invalidatesTags: [{ type: "Skills", id: "all-version" }],
+    }),
+
+    // Upload a skill file
+    uploadSkillFile: builder.mutation<UploadFileResponse, { file: File }>({
+      query: ({ file }) => {
+        const formData = new FormData();
+        formData.append("file", file);
+        return {
+          url: "/skills/files/upload",
+          method: "POST",
+          body: formData,
+          // Let the browser set the Content-Type with boundary for multipart
+          headers: {
+            // Remove the default Content-Type so fetch sets multipart boundary
+          },
+          formData: true,
+        };
+      },
+    }),
+  }),
+});
+
+export const {
+  useListSkillsQuery,
+  useGetSkillQuery,
+  useCreateSkillMutation,
+  useUpdateSkillMutation,
+  useDeleteSkillMutation,
+  useListSkillVersionsQuery,
+  useShiftSkillVersionMutation,
+  useGetAllSkillsVersionQuery,
+  useBumpAllSkillsVersionMutation,
+  useUploadSkillFileMutation,
+} = skillsApi;

--- a/ui/lib/types/skills.ts
+++ b/ui/lib/types/skills.ts
@@ -1,0 +1,138 @@
+// Skills Repository Types
+
+export interface Skill {
+  id: string;
+  name: string;
+  description: string;
+  license?: string;
+  compatibility?: string;
+  metadata: Record<string, string>;
+  extra_frontmatter: Record<string, unknown>;
+  allowed_tools?: string;
+  skill_md_body: string;
+  latest_version: string;
+  highest_version: string;
+  file_count?: number;
+  created_by?: string;
+  created_at: string;
+  updated_at: string;
+  files: SkillFile[];
+}
+
+export interface SkillFile {
+  id: string;
+  skill_version_id: string;
+  path: string;
+  source_type: "url" | "text" | "dataurl" | "upload";
+  source_url?: string;
+  storage_key?: string;
+  blob_id?: string;
+  mime_type: string;
+  file_size_bytes: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SkillVersion {
+  id: string;
+  skill_id: string;
+  version: string;
+  skill_md_body: string;
+  frontmatter_snapshot: Record<string, unknown>;
+  files: SkillFile[];
+  created_by?: string;
+  created_at: string;
+}
+
+// Lean version summary returned in skill detail and version list responses.
+export type SkillVersionSummary = Pick<
+  SkillVersion,
+  "id" | "skill_id" | "version" | "created_by" | "created_at"
+>;
+
+// Request/Response types
+
+export interface SkillFileEntry {
+  path: string;
+  source_type: "url" | "text" | "dataurl" | "upload";
+  content?: string; // text
+  source_url?: string; // url
+  dataurl?: string; // dataurl
+  upload_id?: string; // upload
+  storage_key?: string; // upload
+  blob_id?: string; // upload
+  file_size_bytes?: number;
+  mime_type: string;
+  __local?: boolean; // client-only: unsaved file row can reopen full source form
+}
+
+export interface CreateSkillRequest {
+  name: string;
+  description: string;
+  license?: string;
+  compatibility?: string;
+  metadata?: Record<string, string>;
+  extra_frontmatter?: Record<string, unknown>;
+  allowed_tools?: string;
+  skill_md_body: string;
+  version: string;
+  files?: SkillFileEntry[];
+}
+
+export type UpdateSkillRequest = Omit<CreateSkillRequest, "name"> & {
+  serve?: boolean; // when false, creates a new version without switching serving
+};
+
+export type SkillListItem = Omit<Skill, "skill_md_body" | "files"> & {
+  file_count: number;
+};
+
+export interface ListSkillsResponse {
+  skills: SkillListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface GetSkillResponse {
+  skill: Skill;
+}
+
+export interface CreateSkillResponse {
+  skill: Skill;
+}
+
+export interface UpdateSkillResponse {
+  skill: Skill;
+}
+
+export interface ListSkillVersionsResponse {
+  versions: SkillVersionSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface ShiftSkillVersionRequest {
+  id: string;
+  version: string;
+}
+
+export type AllSkillsVersionBump = "patch" | "minor" | "major";
+
+export interface AllSkillsVersionResponse {
+  version: string;
+}
+
+export interface BumpAllSkillsVersionRequest {
+  bump: AllSkillsVersionBump;
+}
+
+export interface UploadFileResponse {
+  upload_id: string;
+  storage_key?: string;
+  blob_id?: string;
+  filename: string;
+  mime_type: string;
+  file_size_bytes: number;
+}

--- a/ui/lib/validators/skills.ts
+++ b/ui/lib/validators/skills.ts
@@ -1,0 +1,358 @@
+// Frontend quick-check validators for Skills Repository
+// These run before any network request to give instant feedback.
+
+export const MAX_SKILL_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+export const MAX_SKILL_FILE_SIZE_LABEL = "50 MB";
+
+/** Reserved frontmatter keys that cannot be used in extra_frontmatter */
+const RESERVED_FRONTMATTER_KEYS = new Set([
+  "name",
+  "description",
+  "license",
+  "compatibility",
+  "metadata",
+  "allowed-tools",
+]);
+
+/** Skill name: lowercase alphanumeric + hyphens, 1-64 chars */
+const SKILL_NAME_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+/** Semver format: MAJOR.MINOR.PATCH with optional -suffix */
+const SEMVER_REGEX = /^(\d+)\.(\d+)\.(\d+)(-[a-zA-Z0-9._-]+)?$/;
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+/** Validate skill name against Agent Skills spec */
+export function validateSkillName(name: string): string | null {
+  if (!name) return "Name is required";
+  if (name.length > 64) return "Name must be 64 characters or fewer";
+  if (!SKILL_NAME_REGEX.test(name)) {
+    return "Name must be lowercase alphanumeric with hyphens only (no leading/trailing/consecutive hyphens)";
+  }
+  const reservedNames = ["all-skills", "all", "codex", "claude-code"];
+  if (reservedNames.includes(name)) {
+    return `"${name}" is a reserved name used by the skills serving layer`;
+  }
+  return null;
+}
+
+/** Validate description (hard limit 1024 chars) */
+export function validateDescription(description: string): string | null {
+  if (!description || !description.trim()) return "Description is required";
+  if (description.length > 1024)
+    return `Description exceeds 1024 character limit (${description.length}/1024)`;
+  return null;
+}
+
+/** Validate version string as semver */
+export function validateVersion(version: string): string | null {
+  if (!version) return "Version is required";
+  const match = SEMVER_REGEX.exec(version);
+  if (!match)
+    return "Version must be semver format (e.g., 1.0.0 or 1.0.0-beta.1)";
+  const [, major, minor, patch] = match;
+  if (parseInt(major) < 0 || parseInt(minor) < 0 || parseInt(patch) < 0) {
+    return "Version parts must be non-negative integers";
+  }
+  return null;
+}
+
+/**
+ * Parse a semver string into its numeric parts.
+ * Returns null if the string is not valid semver.
+ */
+function parseSemver(
+  version: string,
+): { major: number; minor: number; patch: number; suffix: string } | null {
+  const match = SEMVER_REGEX.exec(version);
+  if (!match) return null;
+  return {
+    major: parseInt(match[1]),
+    minor: parseInt(match[2]),
+    patch: parseInt(match[3]),
+    suffix: match[4] || "",
+  };
+}
+
+/**
+ * Compare two semver versions. Returns >0 if a > b, <0 if a < b, 0 if equal (ignoring suffix).
+ */
+function compareSemverNumeric(
+  a: { major: number; minor: number; patch: number },
+  b: { major: number; minor: number; patch: number },
+): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+/**
+ * Find the highest version string from a list of version strings.
+ * Returns the highest by semver comparison, or the first if none parse.
+ */
+export function findHighestVersion(versions: string[]): string {
+  if (versions.length === 0) return "0.0.0";
+  let highest = versions[0];
+  let highestParsed = parseSemver(highest);
+  for (let i = 1; i < versions.length; i++) {
+    const parsed = parseSemver(versions[i]);
+    if (!parsed) continue;
+    if (!highestParsed || compareSemverNumeric(parsed, highestParsed) > 0) {
+      highest = versions[i];
+      highestParsed = parsed;
+    }
+  }
+  return highest;
+}
+
+/**
+ * Check whether `newVersion` is a valid bump over `previousVersion`.
+ * A valid bump means the new version is strictly different via numeric parts or suffix.
+ * Returns null if the bump is valid, or an error message if not.
+ */
+export function validateVersionBump(
+  newVersion: string,
+  previousVersion: string,
+): string | null {
+  const prev = parseSemver(previousVersion);
+  const next = parseSemver(newVersion);
+  if (!prev || !next) return null; // let the format validator handle bad format
+
+  // Numeric bump is always valid
+  if (
+    next.major > prev.major ||
+    (next.major === prev.major && next.minor > prev.minor) ||
+    (next.major === prev.major &&
+      next.minor === prev.minor &&
+      next.patch > prev.patch)
+  ) {
+    return null;
+  }
+
+  // Same numeric parts — a different suffix is also a valid bump
+  if (
+    next.major === prev.major &&
+    next.minor === prev.minor &&
+    next.patch === prev.patch &&
+    next.suffix !== prev.suffix
+  ) {
+    return null;
+  }
+
+  return `Version must be different from ${previousVersion}. Bump at least one of: major (${prev.major + 1}.x.x), minor (${prev.major}.${prev.minor + 1}.x), patch (${prev.major}.${prev.minor}.${prev.patch + 1}), or change the suffix (e.g., -beta.1).`;
+}
+
+/** Validate extra_frontmatter keys don't conflict with reserved names */
+export function validateExtraFrontmatter(json: string): string | null {
+  if (!json || !json.trim()) return null;
+  try {
+    const parsed = JSON.parse(json);
+    if (
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      parsed === null
+    ) {
+      return "Extra frontmatter must be a JSON object";
+    }
+    const conflicts = Object.keys(parsed).filter((k) =>
+      RESERVED_FRONTMATTER_KEYS.has(k),
+    );
+    if (conflicts.length > 0) {
+      return `Reserved keys cannot be used: ${conflicts.join(", ")}`;
+    }
+    return null;
+  } catch {
+    return "Invalid JSON";
+  }
+}
+
+/** Validate metadata is a flat key-value object with string values */
+export function validateMetadata(json: string): string | null {
+  if (!json || !json.trim()) return null;
+  try {
+    const parsed = JSON.parse(json);
+    if (
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      parsed === null
+    ) {
+      return "Metadata must be a JSON object";
+    }
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof key !== "string") return "Metadata keys must be strings";
+      if (typeof value !== "string")
+        return `Metadata value for "${key}" must be a string`;
+    }
+    return null;
+  } catch {
+    return "Invalid JSON";
+  }
+}
+
+/** Validate skill_md_body (non-empty required) */
+export function validateSkillMdBody(body: string): {
+  error: string | null;
+  warning: string | null;
+} {
+  if (!body || !body.trim()) {
+    return { error: "SKILL.md body is required", warning: null };
+  }
+  // Soft limit warning (no blocking)
+  const warning =
+    body.length > 50000
+      ? "This SKILL.md body is above the recommended size. Consider moving detailed material into files under references/ and linking to them from the skill body."
+      : null;
+  return { error: null, warning };
+}
+
+// Removed directory-specific file extension restrictions: skills can contain arbitrary
+// top-level files and folders, and any supported source can live anywhere in the tree.
+/** Validate file extension against directory constraints */
+export function validateFileForDirectory(
+  _filename: string,
+  _directory: string,
+): string | null {
+  return null;
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function dataURLDecodedLength(value: string): number | null {
+  const marker = ";base64,";
+  const index = value.indexOf(marker);
+  if (index < 0) return null;
+  const payload = value.slice(index + marker.length).replace(/\s/g, "");
+  if (!payload) return 0;
+  const padding = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+  return Math.floor((payload.length * 3) / 4) - padding;
+}
+
+export function validateSkillFileSize(sizeBytes: number): string | null {
+  if (sizeBytes > MAX_SKILL_FILE_SIZE_BYTES) {
+    return `File exceeds ${MAX_SKILL_FILE_SIZE_LABEL} limit`;
+  }
+  return null;
+}
+
+/** Validate source type-specific fields */
+export function validateSourceType(
+  sourceType: string,
+  values: {
+    url?: string;
+    filepath?: string;
+    dataurl?: string;
+    content?: string;
+    upload_id?: string;
+  },
+): string | null {
+  switch (sourceType) {
+    case "url":
+      if (!values.url) return "URL is required";
+      if (
+        !values.url.startsWith("http://") &&
+        !values.url.startsWith("https://")
+      ) {
+        return "URL must start with http:// or https://";
+      }
+      return null;
+    case "dataurl":
+      if (!values.dataurl) return "Data URL is required";
+      if (
+        !values.dataurl.startsWith("data:") ||
+        !values.dataurl.includes(";base64,")
+      ) {
+        return "Data URL must start with data: and contain ;base64,";
+      }
+      {
+        const decodedLength = dataURLDecodedLength(values.dataurl);
+        if (decodedLength != null) {
+          const sizeErr = validateSkillFileSize(decodedLength);
+          if (sizeErr) return sizeErr;
+        }
+      }
+      return null;
+    case "text":
+      if (!values.content || !values.content.trim())
+        return "Text content is required";
+      return validateSkillFileSize(utf8ByteLength(values.content));
+    case "upload":
+      return null; // Upload validation happens during the upload process
+    default:
+      return `Unknown source type: ${sourceType}`;
+  }
+}
+
+/** Validate file basename (no separators, traversal, or reserved SKILL.md) */
+export function validateFilename(filename: string): string | null {
+  const value = filename.trim();
+  if (!value) return "Filename is required";
+  if (value === "." || value === "..") return "Filename cannot be . or ..";
+  if (value.includes("/") || value.includes("\\"))
+    return "Filename must not include folders";
+  if (value.toLowerCase() === "skill.md")
+    return "SKILL.md is managed by the skill body";
+  return null;
+}
+
+/** Validate relative file path (no traversal, absolute paths, or reserved SKILL.md) */
+export function validateFilePath(path: string | undefined): string | null {
+  if (!path || !path.trim()) return "File path is required";
+  const value = path.trim();
+  if (value.startsWith("/")) return "Path must be relative (no leading /)";
+  if (value.endsWith("/")) return "Path must point to a file, not a folder";
+  if (value.includes("\\")) return "Path must use forward slashes only";
+  const segments = value.split("/");
+  if (
+    segments.some(
+      (segment) => segment === "" || segment === "." || segment === "..",
+    )
+  ) {
+    return "Path must not contain empty, current, or parent directory segments";
+  }
+  if (segments.length === 1 && segments[0].toLowerCase() === "skill.md") {
+    return "SKILL.md is managed by the skill body";
+  }
+  return null;
+}
+
+/** Run all validations and return errors */
+export function validateSkillForm(data: {
+  name: string;
+  description: string;
+  version: string;
+  skill_md_body: string;
+  extra_frontmatter_json?: string;
+  metadata_json?: string;
+}): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  const nameErr = validateSkillName(data.name);
+  if (nameErr) errors.push({ field: "name", message: nameErr });
+
+  const descErr = validateDescription(data.description);
+  if (descErr) errors.push({ field: "description", message: descErr });
+
+  const versionErr = validateVersion(data.version);
+  if (versionErr) errors.push({ field: "version", message: versionErr });
+
+  const bodyResult = validateSkillMdBody(data.skill_md_body);
+  if (bodyResult.error)
+    errors.push({ field: "skill_md_body", message: bodyResult.error });
+
+  if (data.extra_frontmatter_json) {
+    const efErr = validateExtraFrontmatter(data.extra_frontmatter_json);
+    if (efErr) errors.push({ field: "extra_frontmatter", message: efErr });
+  }
+
+  if (data.metadata_json) {
+    const mdErr = validateMetadata(data.metadata_json);
+    if (mdErr) errors.push({ field: "metadata", message: mdErr });
+  }
+
+  return errors;
+}


### PR DESCRIPTION
## Summary

Adds the Skills Repository dashboard experience. Users can browse, search,
create, edit, version, organize, upload, and download skills from the workspace
UI.

## Changes

- Added the Skills Repository page and componentized list/detail/create/edit
  flows.
- Added RTK Query endpoints, TypeScript types, and client validators for skills.
- Added a tree-based file manager with arbitrary relative paths, folder
  creation, file upload, folder upload, rename, move, delete, and local
  empty-folder state.
- Added read-only skill detail rendering with composed SKILL.md,
  metadata/frontmatter sections, file tree, version history, and shift-version
  actions.
- Added full-page create/edit form with sticky bottom actions and Save / Save &
  Serve behavior.
- Added Monaco editor improvements, including file/folder reference completions
  and duplicate-caret mitigation.
- Added shared tree view UI and adjusted shared API handling for multipart
  uploads.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Validated with:

```sh
# From bifrost/ui
direnv exec . npm run build
```

Recommended manual UI verification before merge:

1. Open `/workspace/skills-repo`.
2. Create a skill with `SKILL.md` body content and attached files.
3. Add, rename, move, remove, and upload files/folders in the tree file manager.
4. Save a version without serving it, then save and serve a version.
5. Open the skill detail view, raw `SKILL.md` dialog, file tree, and version
   dialog.
6. Confirm marketplace registration commands and download actions render
   correctly.

No new configs or environment variables are added in this PR.

## Screenshots/Recordings

UI changes include the Skills Repository overview, detail, create/edit flow,
file manager, and version dialogs. Screenshots should be added before submitting
if required by review.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The dashboard calls protected management APIs and respects the API's file source
semantics. Uploads use multipart requests; text/dataurl sources remain in the
create/update payload; URL/filepath sources are resolved by the backend.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable