### PR TITLE
fix: metadata filters and pagination total_count for Postgres logstore

### DIFF
--- a/framework/logstore/metadata_filter_fix_test.go
+++ b/framework/logstore/metadata_filter_fix_test.go
@@ -1,0 +1,197 @@
+package logstore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// insertLogWithMetadata inserts a log row with the given JSON metadata string via raw SQL,
+// bypassing GORM serialization so the exact byte sequence reaches the database.
+func insertLogWithMetadata(t *testing.T, store *RDBLogStore, id string, metadataJSON string, ts time.Time) {
+	t.Helper()
+	err := store.db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status, metadata, created_at)
+		VALUES (?, ?, 'chat.completion', 'openai', 'gpt-4o', 'success', ?, ?)
+	`, id, ts, metadataJSON, ts).Error
+	require.NoError(t, err, "failed to insert log %q", id)
+}
+
+// runMetadataStringMatchingSuite verifies that metadata filter values that look like numbers
+// are matched as JSON strings. Both SQLite and Postgres store all metadata values as JSON
+// strings (from HTTP headers), so both dialects must match them correctly.
+//
+// Boolean values ("true"/"false") are excluded: SQLite intentionally uses json_type to match
+// JSON booleans for those values, while Postgres always uses string matching after Fix 1.
+func runMetadataStringMatchingSuite(t *testing.T, store *RDBLogStore) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertLogWithMetadata(t, store, "meta-num", `{"chat-id": "4000126002"}`, now.Add(-1*time.Second))
+	insertLogWithMetadata(t, store, "meta-float", `{"score": "3.14"}`, now.Add(-2*time.Second))
+	insertLogWithMetadata(t, store, "meta-str", `{"env": "production"}`, now.Add(-3*time.Second))
+	// Row with different value — must NOT appear in filtered results.
+	insertLogWithMetadata(t, store, "meta-other", `{"chat-id": "9999"}`, now.Add(-4*time.Second))
+
+	tests := []struct {
+		name     string
+		filters  map[string]string
+		wantIDs  []string
+		wantMiss []string
+	}{
+		{
+			name:     "numeric_string_value_matches",
+			filters:  map[string]string{"chat-id": "4000126002"},
+			wantIDs:  []string{"meta-num"},
+			wantMiss: []string{"meta-other"},
+		},
+		{
+			name:    "float_string_matches",
+			filters: map[string]string{"score": "3.14"},
+			wantIDs: []string{"meta-float"},
+		},
+		{
+			name:    "plain_string_matches",
+			filters: map[string]string{"env": "production"},
+			wantIDs: []string{"meta-str"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := store.SearchLogs(ctx, SearchFilters{MetadataFilters: tc.filters}, PaginationOptions{Limit: 100})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			gotIDs := make(map[string]bool, len(result.Logs))
+			for _, l := range result.Logs {
+				gotIDs[l.ID] = true
+			}
+			for _, wantID := range tc.wantIDs {
+				assert.True(t, gotIDs[wantID], "expected log %q to be returned by filter %v", wantID, tc.filters)
+			}
+			for _, missID := range tc.wantMiss {
+				assert.False(t, gotIDs[missID], "log %q should NOT be returned by filter %v", missID, tc.filters)
+			}
+		})
+	}
+}
+
+// runPostgresMetadataBooleanStringMatchingSuite verifies Postgres-specific Fix 1 behaviour:
+// values like "true" and "false" that come from HTTP headers are stored as JSON strings and
+// must match as strings via JSONB @> containment. Before the fix, the old code emitted a
+// JSON boolean fragment {"active": true} which never matched the stored string "true".
+func runPostgresMetadataBooleanStringMatchingSuite(t *testing.T, store *RDBLogStore) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertLogWithMetadata(t, store, "pg-bool-true", `{"active": "true"}`, now.Add(-1*time.Second))
+	insertLogWithMetadata(t, store, "pg-bool-false", `{"active": "false"}`, now.Add(-2*time.Second))
+
+	t.Run("boolean_true_string_matches", func(t *testing.T) {
+		result, err := store.SearchLogs(ctx, SearchFilters{MetadataFilters: map[string]string{"active": "true"}}, PaginationOptions{Limit: 100})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		gotIDs := make(map[string]bool)
+		for _, l := range result.Logs {
+			gotIDs[l.ID] = true
+		}
+		assert.True(t, gotIDs["pg-bool-true"], "stored string 'true' must match filter active=true on Postgres")
+		assert.False(t, gotIDs["pg-bool-false"], "log with active='false' must not match filter active=true")
+	})
+
+	t.Run("boolean_false_string_matches", func(t *testing.T) {
+		result, err := store.SearchLogs(ctx, SearchFilters{MetadataFilters: map[string]string{"active": "false"}}, PaginationOptions{Limit: 100})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		gotIDs := make(map[string]bool)
+		for _, l := range result.Logs {
+			gotIDs[l.ID] = true
+		}
+		assert.True(t, gotIDs["pg-bool-false"], "stored string 'false' must match filter active=false on Postgres")
+		assert.False(t, gotIDs["pg-bool-true"], "log with active='true' must not match filter active=false")
+	})
+}
+
+// runPaginationTotalCountSuite verifies that SearchLogs sets pagination.TotalCount correctly.
+// Before Fix 4, totalCount was computed but only stored in Stats.TotalRequests — never
+// assigned to Pagination.TotalCount — so every response returned total_count: 0.
+func runPaginationTotalCountSuite(t *testing.T, store *RDBLogStore) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	const total = 5
+	const pageLimit = 2
+
+	for i := 0; i < total; i++ {
+		err := store.Create(ctx, &Log{
+			ID:        fmt.Sprintf("%s-log-%d", t.Name(), i),
+			Timestamp: now.Add(-time.Duration(i) * time.Second),
+			Object:    "chat.completion",
+			Provider:  "openai",
+			Model:     "gpt-4o",
+			Status:    "success",
+			CreatedAt: now,
+		})
+		require.NoError(t, err, "failed to insert log %d", i)
+	}
+
+	// Page 1: limit < total — TotalCount must equal total, not just the page size.
+	result, err := store.SearchLogs(ctx, SearchFilters{}, PaginationOptions{Limit: pageLimit})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(total), result.Pagination.TotalCount,
+		"TotalCount should equal total rows (%d), not page size (%d)", total, pageLimit)
+	assert.Len(t, result.Logs, pageLimit, "result page should have %d rows", pageLimit)
+
+	// Page 2: with offset — TotalCount must still equal total.
+	result2, err := store.SearchLogs(ctx, SearchFilters{}, PaginationOptions{Limit: pageLimit, Offset: pageLimit})
+	require.NoError(t, err)
+	require.NotNil(t, result2)
+	assert.Equal(t, int64(total), result2.Pagination.TotalCount,
+		"TotalCount should be stable across pages")
+
+	// No results: TotalCount should be 0.
+	result3, err := store.SearchLogs(ctx, SearchFilters{Models: []string{"nonexistent-model-xyz"}}, PaginationOptions{Limit: 100})
+	require.NoError(t, err)
+	require.NotNil(t, result3)
+	assert.Equal(t, int64(0), result3.Pagination.TotalCount,
+		"TotalCount should be 0 when no rows match")
+}
+
+// TestSearchLogs_MetadataFilter_StringMatching_SQLite exercises Fix 1 (numeric string
+// matching) on the SQLite dialect.
+func TestSearchLogs_MetadataFilter_StringMatching_SQLite(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	defer store.Close(context.Background())
+	runMetadataStringMatchingSuite(t, store)
+}
+
+// TestSearchLogs_MetadataFilter_StringMatching_Postgres exercises Fix 1 on Postgres,
+// where the old code generated JSONB number fragments that never matched stored string values.
+// Also implicitly exercises Fix 2 (jsonb_typeof guard in applyFilters) and Fix 3 (GIN index predicate).
+func TestSearchLogs_MetadataFilter_StringMatching_Postgres(t *testing.T) {
+	store, _ := setupPerfTestDB(t)
+	runMetadataStringMatchingSuite(t, store)
+	runPostgresMetadataBooleanStringMatchingSuite(t, store)
+}
+
+// TestSearchLogs_PaginationTotalCount_SQLite exercises Fix 4 on SQLite.
+func TestSearchLogs_PaginationTotalCount_SQLite(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	defer store.Close(context.Background())
+	runPaginationTotalCountSuite(t, store)
+}
+
+// TestSearchLogs_PaginationTotalCount_Postgres exercises Fix 4 on Postgres.
+func TestSearchLogs_PaginationTotalCount_Postgres(t *testing.T) {
+	store, _ := setupPerfTestDB(t)
+	runPaginationTotalCountSuite(t, store)
+}

--- a/framework/logstore/metadata_filter_fix_test.go
+++ b/framework/logstore/metadata_filter_fix_test.go
@@ -26,7 +26,7 @@ func insertLogWithMetadata(t *testing.T, store *RDBLogStore, id string, metadata
 // strings (from HTTP headers), so both dialects must match them correctly.
 //
 // Boolean values ("true"/"false") are excluded: SQLite intentionally uses json_type to match
-// JSON booleans for those values, while Postgres always uses string matching after Fix 1.
+// JSON booleans for those values, while Postgres always matches as a JSON string.
 func runMetadataStringMatchingSuite(t *testing.T, store *RDBLogStore) {
 	t.Helper()
 	ctx := context.Background()
@@ -82,10 +82,10 @@ func runMetadataStringMatchingSuite(t *testing.T, store *RDBLogStore) {
 	}
 }
 
-// runPostgresMetadataBooleanStringMatchingSuite verifies Postgres-specific Fix 1 behaviour:
-// values like "true" and "false" that come from HTTP headers are stored as JSON strings and
-// must match as strings via JSONB @> containment. Before the fix, the old code emitted a
-// JSON boolean fragment {"active": true} which never matched the stored string "true".
+// runPostgresMetadataBooleanStringMatchingSuite verifies that values like "true" and "false"
+// that come from HTTP headers are stored as JSON strings and match as strings via JSONB @>
+// containment. The old code emitted a JSON boolean fragment {"active": true} which never
+// matched the stored string "true".
 func runPostgresMetadataBooleanStringMatchingSuite(t *testing.T, store *RDBLogStore) {
 	t.Helper()
 	ctx := context.Background()
@@ -120,7 +120,7 @@ func runPostgresMetadataBooleanStringMatchingSuite(t *testing.T, store *RDBLogSt
 }
 
 // runPaginationTotalCountSuite verifies that SearchLogs sets pagination.TotalCount correctly.
-// Before Fix 4, totalCount was computed but only stored in Stats.TotalRequests — never
+// Previously, totalCount was computed but only stored in Stats.TotalRequests — never
 // assigned to Pagination.TotalCount — so every response returned total_count: 0.
 func runPaginationTotalCountSuite(t *testing.T, store *RDBLogStore) {
 	t.Helper()
@@ -166,31 +166,29 @@ func runPaginationTotalCountSuite(t *testing.T, store *RDBLogStore) {
 		"TotalCount should be 0 when no rows match")
 }
 
-// TestSearchLogs_MetadataFilter_StringMatching_SQLite exercises Fix 1 (numeric string
-// matching) on the SQLite dialect.
+// TestSearchLogs_MetadataFilter_StringMatching_SQLite exercises the metadata string matching fix on SQLite.
 func TestSearchLogs_MetadataFilter_StringMatching_SQLite(t *testing.T) {
 	store := newTestSQLiteStore(t)
 	defer store.Close(context.Background())
 	runMetadataStringMatchingSuite(t, store)
 }
 
-// TestSearchLogs_MetadataFilter_StringMatching_Postgres exercises Fix 1 on Postgres,
-// where the old code generated JSONB number fragments that never matched stored string values.
-// Also implicitly exercises Fix 2 (jsonb_typeof guard in applyFilters) and Fix 3 (GIN index predicate).
+// TestSearchLogs_MetadataFilter_StringMatching_Postgres exercises the metadata string matching fix on Postgres,
+// where the old code generated JSONB number/boolean fragments that never matched stored string values.
 func TestSearchLogs_MetadataFilter_StringMatching_Postgres(t *testing.T) {
 	store, _ := setupPerfTestDB(t)
 	runMetadataStringMatchingSuite(t, store)
 	runPostgresMetadataBooleanStringMatchingSuite(t, store)
 }
 
-// TestSearchLogs_PaginationTotalCount_SQLite exercises Fix 4 on SQLite.
+// TestSearchLogs_PaginationTotalCount_SQLite verifies pagination.TotalCount on SQLite.
 func TestSearchLogs_PaginationTotalCount_SQLite(t *testing.T) {
 	store := newTestSQLiteStore(t)
 	defer store.Close(context.Background())
 	runPaginationTotalCountSuite(t, store)
 }
 
-// TestSearchLogs_PaginationTotalCount_Postgres exercises Fix 4 on Postgres.
+// TestSearchLogs_PaginationTotalCount_Postgres verifies pagination.TotalCount on Postgres.
 func TestSearchLogs_PaginationTotalCount_Postgres(t *testing.T) {
 	store, _ := setupPerfTestDB(t)
 	runPaginationTotalCountSuite(t, store)

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/framework/migrator"
@@ -2066,39 +2065,24 @@ func migrationAddMultiTeamBusinessUnitGINIndexes(ctx context.Context, db *gorm.D
 func ensureMetadataGINIndex(ctx context.Context, conn *sql.Conn) error {
 	// pg_index.indisvalid is false when a CONCURRENTLY build was interrupted.
 	// COALESCE returns false when no row matches (index does not exist yet).
-	// MAX(pg_get_expr) captures the stored predicate so we can detect a stale
-	// IS JSON OBJECT predicate (PG 15+ only) left by an older deployment.
 	var indexValid bool
-	var indexPredicate sql.NullString
 
 	if err := conn.QueryRowContext(ctx, `
-		SELECT COALESCE(bool_and(pi.indisvalid), false),
-		       MAX(pg_get_expr(pi.indpred, pi.indrelid))
+		SELECT COALESCE(bool_and(pi.indisvalid), false)
 		FROM pg_class pc
 		JOIN pg_index pi ON pi.indrelid = pc.oid
 		JOIN pg_class ic ON ic.oid = pi.indexrelid
 		WHERE pc.relname = 'logs'
 		  AND ic.relname = 'idx_logs_metadata_gin'
-	`).Scan(&indexValid, &indexPredicate); err != nil {
+	`).Scan(&indexValid); err != nil {
 		return fmt.Errorf("failed to query GIN index validity: %w", err)
 	}
 
 	if indexValid {
-		// If the stored predicate still uses the PG 15+ IS JSON OBJECT guard, the
-		// new jsonb_typeof() guard in rdb.go won't satisfy it and the planner will
-		// fall back to sequential scans. Drop the stale index so it gets rebuilt
-		// with the compatible predicate below.
-		if indexPredicate.Valid && strings.Contains(strings.ToLower(indexPredicate.String), "is json") {
-			if _, err := conn.ExecContext(ctx, "DROP INDEX CONCURRENTLY IF EXISTS idx_logs_metadata_gin"); err != nil {
-				return fmt.Errorf("failed to drop stale metadata GIN index: %w", err)
-			}
-			// Fall through to rebuild with the jsonb_typeof predicate.
-		} else {
-			if err := cleanupInvalidLogMetadata(ctx, conn); err != nil {
-				return err
-			}
-			return nil
+		if err := cleanupInvalidLogMetadata(ctx, conn); err != nil {
+			return err
 		}
+		return nil
 	}
 
 	// Drop any INVALID remnant left by a prior interrupted CONCURRENTLY build.
@@ -2128,11 +2112,10 @@ func ensureMetadataGINIndex(ctx context.Context, conn *sql.Conn) error {
 	// and value separately, making the index ~3x smaller and faster to build.
 	// It supports the @> containment operator used by all metadata filter queries.
 	//
-	// The partial predicate skips NULL and non-object rows, further reducing build
-	// time and index size. Queries that filter on metadata always include the same
-	// guard (rdb.go) so the planner will use this index.
-	// Use jsonb_typeof (PG 9.4+) instead of IS JSON OBJECT (PG 15+) for compatibility.
-	if _, err := conn.ExecContext(ctx, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_metadata_gin ON logs USING gin ((metadata::jsonb) jsonb_path_ops) WHERE metadata IS NOT NULL AND jsonb_typeof(metadata::jsonb) = 'object'"); err != nil {
+	// The partial predicate (WHERE metadata IS NOT NULL AND metadata IS JSON OBJECT) skips NULL and non-object rows,
+	// further reducing build time and index size. Queries that filter on metadata
+	// always include an IS NOT NULL guard (rdb.go) so the planner will use this index.
+	if _, err := conn.ExecContext(ctx, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_metadata_gin ON logs USING gin ((metadata::jsonb) jsonb_path_ops) WHERE metadata IS NOT NULL AND metadata IS JSON OBJECT"); err != nil {
 		return fmt.Errorf("failed to create metadata GIN index: %w", err)
 	}
 	return nil
@@ -2144,7 +2127,7 @@ func cleanupInvalidLogMetadata(ctx context.Context, conn *sql.Conn) error {
 			SELECT ctid
 			FROM logs
 			WHERE metadata IS NOT NULL
-			  AND jsonb_typeof(metadata::jsonb) <> 'object'
+			  AND metadata IS NOT JSON OBJECT
 			LIMIT $1
 			FOR UPDATE SKIP LOCKED
 		)

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -2112,10 +2112,11 @@ func ensureMetadataGINIndex(ctx context.Context, conn *sql.Conn) error {
 	// and value separately, making the index ~3x smaller and faster to build.
 	// It supports the @> containment operator used by all metadata filter queries.
 	//
-	// The partial predicate (WHERE metadata IS NOT NULL AND metadata IS JSON OBJECT) skips NULL and non-object rows,
-	// further reducing build time and index size. Queries that filter on metadata
-	// always include an IS NOT NULL guard (rdb.go) so the planner will use this index.
-	if _, err := conn.ExecContext(ctx, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_metadata_gin ON logs USING gin ((metadata::jsonb) jsonb_path_ops) WHERE metadata IS NOT NULL AND metadata IS JSON OBJECT"); err != nil {
+	// The partial predicate skips NULL and non-object rows, further reducing build
+	// time and index size. Queries that filter on metadata always include the same
+	// guard (rdb.go) so the planner will use this index.
+	// Use jsonb_typeof (PG 9.4+) instead of IS JSON OBJECT (PG 15+) for compatibility.
+	if _, err := conn.ExecContext(ctx, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_metadata_gin ON logs USING gin ((metadata::jsonb) jsonb_path_ops) WHERE metadata IS NOT NULL AND jsonb_typeof(metadata::jsonb) = 'object'"); err != nil {
 		return fmt.Errorf("failed to create metadata GIN index: %w", err)
 	}
 	return nil

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/framework/migrator"
@@ -2065,24 +2066,39 @@ func migrationAddMultiTeamBusinessUnitGINIndexes(ctx context.Context, db *gorm.D
 func ensureMetadataGINIndex(ctx context.Context, conn *sql.Conn) error {
 	// pg_index.indisvalid is false when a CONCURRENTLY build was interrupted.
 	// COALESCE returns false when no row matches (index does not exist yet).
+	// MAX(pg_get_expr) captures the stored predicate so we can detect a stale
+	// IS JSON OBJECT predicate (PG 15+ only) left by an older deployment.
 	var indexValid bool
+	var indexPredicate sql.NullString
 
 	if err := conn.QueryRowContext(ctx, `
-		SELECT COALESCE(bool_and(pi.indisvalid), false)
+		SELECT COALESCE(bool_and(pi.indisvalid), false),
+		       MAX(pg_get_expr(pi.indpred, pi.indrelid))
 		FROM pg_class pc
 		JOIN pg_index pi ON pi.indrelid = pc.oid
 		JOIN pg_class ic ON ic.oid = pi.indexrelid
 		WHERE pc.relname = 'logs'
 		  AND ic.relname = 'idx_logs_metadata_gin'
-	`).Scan(&indexValid); err != nil {
+	`).Scan(&indexValid, &indexPredicate); err != nil {
 		return fmt.Errorf("failed to query GIN index validity: %w", err)
 	}
 
 	if indexValid {
-		if err := cleanupInvalidLogMetadata(ctx, conn); err != nil {
-			return err
+		// If the stored predicate still uses the PG 15+ IS JSON OBJECT guard, the
+		// new jsonb_typeof() guard in rdb.go won't satisfy it and the planner will
+		// fall back to sequential scans. Drop the stale index so it gets rebuilt
+		// with the compatible predicate below.
+		if indexPredicate.Valid && strings.Contains(strings.ToLower(indexPredicate.String), "is json") {
+			if _, err := conn.ExecContext(ctx, "DROP INDEX CONCURRENTLY IF EXISTS idx_logs_metadata_gin"); err != nil {
+				return fmt.Errorf("failed to drop stale metadata GIN index: %w", err)
+			}
+			// Fall through to rebuild with the jsonb_typeof predicate.
+		} else {
+			if err := cleanupInvalidLogMetadata(ctx, conn); err != nil {
+				return err
+			}
+			return nil
 		}
-		return nil
 	}
 
 	// Drop any INVALID remnant left by a prior interrupted CONCURRENTLY build.
@@ -2128,7 +2144,7 @@ func cleanupInvalidLogMetadata(ctx context.Context, conn *sql.Conn) error {
 			SELECT ctid
 			FROM logs
 			WHERE metadata IS NOT NULL
-			  AND metadata IS NOT JSON OBJECT
+			  AND jsonb_typeof(metadata::jsonb) <> 'object'
 			LIMIT $1
 			FOR UPDATE SKIP LOCKED
 		)

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -317,7 +317,7 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		// Guard must match the partial-index predicate so the planner uses the GIN index.
 		// SQLite does not support IS JSON OBJECT, so fall back to the equivalent json_type check.
 		if dialect == "postgres" {
-			baseQuery = baseQuery.Where("metadata IS NOT NULL AND metadata IS JSON OBJECT")
+			baseQuery = baseQuery.Where("metadata IS NOT NULL AND jsonb_typeof(metadata::jsonb) = 'object'")
 		} else {
 			baseQuery = baseQuery.Where("metadata IS NOT NULL AND json_valid(metadata) AND json_type(metadata) = 'object'")
 		}
@@ -327,17 +327,10 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 			}
 			switch dialect {
 			case "postgres":
-				// Use @> containment operator to leverage GIN index on metadata::jsonb
-				// Preserve value type (number/boolean) for JSON containment
-				var jsonFragment string
-				if value == "true" || value == "false" {
-					jsonFragment = fmt.Sprintf(`{%q: %s}`, key, value)
-				} else if f, err := strconv.ParseFloat(value, 64); err == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
-					// Reject NaN/Inf which would produce invalid JSON; normalize the number
-					jsonFragment = fmt.Sprintf(`{%q: %s}`, key, strconv.FormatFloat(f, 'f', -1, 64))
-				} else {
-					jsonFragment = fmt.Sprintf(`{%q: %q}`, key, value)
-				}
+				// Use @> containment operator to leverage GIN index on metadata::jsonb.
+				// Metadata values always originate from HTTP headers and are stored as JSON
+				// strings — always match as a string to avoid type mismatch with jsonb.
+				jsonFragment := fmt.Sprintf(`{%q: %q}`, key, value)
 				baseQuery = baseQuery.Where("metadata::jsonb @> ?::jsonb", jsonFragment)
 			default:
 				// SQLite: quote the member name so dots/hyphens stay part of the key
@@ -691,6 +684,7 @@ func (s *RDBLogStore) SearchLogs(ctx context.Context, filters SearchFilters, pag
 		}
 	}
 
+	pagination.TotalCount = totalCount
 	return &SearchResult{
 		Logs:       logs,
 		Pagination: pagination,
@@ -3357,7 +3351,7 @@ func (s *RDBLogStore) GetDistinctMetadataKeys(ctx context.Context, limit int, qu
 	// Guard must match the partial-index predicate so the planner uses the GIN index.
 	var metadataGuard string
 	if s.db.Dialector.Name() == "postgres" {
-		metadataGuard = "metadata IS NOT NULL AND metadata IS JSON OBJECT AND metadata != '{}' AND timestamp >= ?"
+		metadataGuard = "metadata IS NOT NULL AND jsonb_typeof(metadata::jsonb) = 'object' AND metadata != '{}' AND timestamp >= ?"
 	} else {
 		metadataGuard = "metadata IS NOT NULL AND json_valid(metadata) AND json_type(metadata) = 'object' AND metadata != '{}' AND timestamp >= ?"
 	}

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -317,7 +317,7 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		// Guard must match the partial-index predicate so the planner uses the GIN index.
 		// SQLite does not support IS JSON OBJECT, so fall back to the equivalent json_type check.
 		if dialect == "postgres" {
-			baseQuery = baseQuery.Where("metadata IS NOT NULL AND jsonb_typeof(metadata::jsonb) = 'object'")
+			baseQuery = baseQuery.Where("metadata IS NOT NULL AND metadata IS JSON OBJECT")
 		} else {
 			baseQuery = baseQuery.Where("metadata IS NOT NULL AND json_valid(metadata) AND json_type(metadata) = 'object'")
 		}
@@ -3351,7 +3351,7 @@ func (s *RDBLogStore) GetDistinctMetadataKeys(ctx context.Context, limit int, qu
 	// Guard must match the partial-index predicate so the planner uses the GIN index.
 	var metadataGuard string
 	if s.db.Dialector.Name() == "postgres" {
-		metadataGuard = "metadata IS NOT NULL AND jsonb_typeof(metadata::jsonb) = 'object' AND metadata != '{}' AND timestamp >= ?"
+		metadataGuard = "metadata IS NOT NULL AND metadata IS JSON OBJECT AND metadata != '{}' AND timestamp >= ?"
 	} else {
 		metadataGuard = "metadata IS NOT NULL AND json_valid(metadata) AND json_type(metadata) = 'object' AND metadata != '{}' AND timestamp >= ?"
 	}


### PR DESCRIPTION


## Summary

Resolves #4223 by always comparing metadata fields as strings. 

I noticed an issue where logging metadata via `x-bf-lh-*` headers like this "123456" would cause type comparison issues between the query the UI ran to filter logs and the datatype being stored in postgres. This updates the comparison to always compare string to string values.

## Changes

- Always match metadata values as JSON strings in the Postgres JSONB containment query; header-sourced values are always stored as strings, so the previous numeric/boolean type detection caused zero results.
- Assign pagination.TotalCount = totalCount in SearchLogs; it was only stored in Stats.TotalRequests, so every response returned total_count: 0.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [X] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

All of the usual tests apply. There are details in the attached issue on how to replicate this problem, follow the same steps on this branch to see the issue resolved.

## Screenshots/Recordings

No UI changes.

## Breaking changes

- [ ] Yes
- [X] No


## Related issues

Closes #4223 

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [X] I read `docs/contributing/README.md` and followed the guidelines
- [X] I added/updated tests where appropriate
- [X] I updated documentation where needed
- [X] I verified builds succeed (Go and UI)
- [X] I verified the CI pipeline passes locally if applicable




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed metadata filtering to correctly treat numeric-looking and boolean-like string values during searches
  * Fixed pagination to properly display the total count of matching records across all pages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->