### PR TITLE
fix: fixes plugin names sanitization for live loaded plugins for connectors

### DIFF
--- a/core/schemas/span_filter.go
+++ b/core/schemas/span_filter.go
@@ -40,9 +40,15 @@ func (f *PluginSpanFilter) Validate() error {
 	}
 }
 
+// SanitizePluginSpanName normalizes a plugin's name into the form embedded in its
+// span names.
+func SanitizePluginSpanName(name string) string {
+	return strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+}
+
 // PluginNameFromSpan extracts "<name>" from a plugin span whose name follows the
 // core tracer contract "plugin.<name>.<stage>", where <stage> is one of prehook,
-// posthook, mcp_prehook, mcp_posthook, mcp_connect_prehook, or mcp_connect_posthook
+// posthook, prerequesthook, mcp_prehook, mcp_posthook, mcp_connect_prehook, or mcp_connect_posthook
 // (see core/bifrost.go). It returns "" for non-plugin spans or names that don't match
 // the contract (wrong prefix, or fewer than three segments), so malformed names pass
 // through ShouldExportSpan as exported rather than being silently filtered.

--- a/core/schemas/span_filter_test.go
+++ b/core/schemas/span_filter_test.go
@@ -52,6 +52,42 @@ func TestPluginNameFromSpan(t *testing.T) {
 	}
 }
 
+func TestSanitizePluginSpanName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"logging", "logging"},
+		{"enterprise-prompts", "enterprise-prompts"},
+		{"Model Catalog Resolver", "model-catalog-resolver"},
+		{"UPPER", "upper"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := SanitizePluginSpanName(tt.in); got != tt.want {
+			t.Errorf("SanitizePluginSpanName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestSanitizedNameMatchesSpanExtraction locks the invariant that the name used to build a
+// plugin span (SanitizePluginSpanName(GetName())) is exactly what PluginNameFromSpan extracts
+// back out. If these ever diverge, the UI's filterable-plugin list stops matching real spans
+// and span filtering silently no-ops — the bug this contract exists to prevent.
+func TestSanitizedNameMatchesSpanExtraction(t *testing.T) {
+	pluginNames := []string{"logging", "enterprise-prompts", "adaptive-loadbalancer", "Has Spaces", "MixedCase"}
+	stages := []string{"prehook", "posthook", "prerequesthook", "mcp_prehook", "mcp_connect_posthook"}
+	for _, raw := range pluginNames {
+		sanitized := SanitizePluginSpanName(raw)
+		for _, stage := range stages {
+			spanName := "plugin." + sanitized + "." + stage
+			if got := PluginNameFromSpan(pluginSpan("1", "", spanName)); got != sanitized {
+				t.Errorf("PluginNameFromSpan(%q) = %q, want %q", spanName, got, sanitized)
+			}
+		}
+	}
+}
+
 func TestPluginSpanFilter_ShouldExportSpan(t *testing.T) {
 	llm := &Span{SpanID: "llm", Name: "llm.call", Kind: SpanKindLLMCall}
 	logging := pluginSpan("p1", "", "plugin.logging.prehook")

--- a/core/utils.go
+++ b/core/utils.go
@@ -557,9 +557,9 @@ func ValidateExternalURL(urlStr string, allowPrivateNetwork bool) error {
 	return nil
 }
 
-// sanitizeSpanName sanitizes a span name to remove capital letters and spaces to make it a valid span name
+// sanitizeSpanName sanitizes a span name to remove capital letters and spaces to make it a valid span name.
 func sanitizeSpanName(name string) string {
-	return strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+	return schemas.SanitizePluginSpanName(name)
 }
 
 // IsCodemodeTool returns true if the given tool name is a codemode tool.

--- a/docs/enterprise/datadog-connector.mdx
+++ b/docs/enterprise/datadog-connector.mdx
@@ -447,7 +447,7 @@ By default every plugin's pre- and post-hook execution generates a span, which c
 | `exclude` | Export spans for all plugins **except** those listed |
 | `include` | Export spans **only** for the listed plugins |
 
-**Built-in plugin names** (for reference): `telemetry`, `prompts`, `logging`, `governance`, `otel`, `semantic_cache`, `compat`, `maxim`.
+**Plugin names:** list each plugin using the exact name shown for it in the **Configure Plugin Tracing** sheet — this is the same name that appears in the span (`plugin.<name>.<stage>`), and it is what the filter matches against. Note that some plugins are registered under a different name than their config key: the enterprise prompts and governance plugins appear as `enterprise-prompts` and `enterprise-governance` (not `prompts`/`governance`). Common names include `telemetry`, `logging`, `otel`, `semantic_cache`, `compat`, `maxim`, `enterprise-prompts`, `enterprise-governance`, `datadog`, `bigquery`, `guardrails`, `adaptive-loadbalancer`, and `model-catalog-resolver`. The exact set depends on which plugins are loaded in your deployment.
 
 When a plugin span is filtered out, its children are automatically re-parented to the nearest exported ancestor so the trace hierarchy stays connected. The filter applies to APM trace spans only; it does not change DogStatsD metrics, which are never derived from plugin spans.
 

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -1065,7 +1065,7 @@ By default every plugin's pre- and post-hook execution generates a span, which c
 | `exclude` | Export spans for all plugins **except** those listed |
 | `include` | Export spans **only** for the listed plugins |
 
-**Built-in plugin names** (for reference): `telemetry`, `prompts`, `logging`, `governance`, `otel`, `semantic_cache`, `compat`, `maxim`.
+**Plugin names:** list each plugin using the exact name shown for it in the **Configure Plugin Tracing** sheet — this is the same name that appears in the span (`plugin.<name>.<stage>`), and it is what the filter matches against. The built-in OSS plugins are `telemetry`, `prompts`, `logging`, `governance`, `otel`, `semantic_cache`, `compat`, and `maxim`. In enterprise deployments some plugins are registered under a different name than their config key — for example the prompts and governance plugins appear as `enterprise-prompts` and `enterprise-governance` — so always copy the name from the tracing sheet rather than assuming the config key.
 
 When a plugin span is filtered out, its children are automatically re-parented to the nearest exported ancestor so the trace hierarchy stays connected.
 

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -18,6 +18,7 @@ import (
 
 type PluginsLoader interface {
 	GetPluginStatus(ctx context.Context) map[string]schemas.PluginStatus
+	GetLoadedPluginNames() []string
 	ReloadPlugin(ctx context.Context, name string, path *string, pluginConfig any, placement *schemas.PluginPlacement, order *int) error
 	RemovePlugin(ctx context.Context, name string) error
 	// NormalizePluginConfig converts a raw config map to DB-storage format using
@@ -95,6 +96,7 @@ func (h *PluginsHandler) expandPluginConfigForAPI(name string, config map[string
 func (h *PluginsHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
 	r.GET("/api/plugins", lib.ChainMiddlewares(h.getPlugins, middlewares...))
 	r.GET("/api/plugins/builtins", lib.ChainMiddlewares(h.getBuiltinPlugins, middlewares...))
+	r.GET("/api/plugins/loaded", lib.ChainMiddlewares(h.getLoadedPlugins, middlewares...))
 	r.GET("/api/plugins/{name}", lib.ChainMiddlewares(h.getPlugin, middlewares...))
 	r.POST("/api/plugins", lib.ChainMiddlewares(h.createPlugin, middlewares...))
 	r.PUT("/api/plugins/{name}", lib.ChainMiddlewares(h.updatePlugin, middlewares...))
@@ -159,10 +161,18 @@ func (h *PluginsHandler) buildPluginResponseWithStatuses(plugin *configstoreTabl
 	}
 }
 
-// getBuiltinPlugins returns the canonical list of built-in plugin names
+// getBuiltinPlugins returns the canonical list of built-in plugin names.
 func (h *PluginsHandler) getBuiltinPlugins(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]any{
 		"plugins": lib.GetBuiltinPluginNames(),
+	})
+}
+
+// getLoadedPlugins returns the names of all plugins currently loaded at runtime, whose
+// spans an observability connector can filter.
+func (h *PluginsHandler) getLoadedPlugins(ctx *fasthttp.RequestCtx) {
+	SendJSON(ctx, map[string]any{
+		"plugins": h.pluginsLoader.GetLoadedPluginNames(),
 	})
 }
 

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -51,6 +51,7 @@ func (noopPluginsLoader) RemovePlugin(_ context.Context, _ string) error { retur
 func (noopPluginsLoader) GetPluginStatus(_ context.Context) map[string]schemas.PluginStatus {
 	return nil
 }
+func (noopPluginsLoader) GetLoadedPluginNames() []string { return nil }
 func (noopPluginsLoader) NormalizePluginConfig(_ string, _ map[string]any) (map[string]any, error) {
 	return nil, nil
 }
@@ -161,5 +162,47 @@ func TestUpdatePlugin_ConfigMerge_NewPlugin(t *testing.T) {
 	// Should succeed even when no existing plugin is found (creates then updates).
 	if ctx.Response.StatusCode() != 200 {
 		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+}
+
+// namedPluginsLoader is a noopPluginsLoader that returns a fixed set of loaded
+// plugin names, used to assert the getLoadedPlugins response contract.
+type namedPluginsLoader struct {
+	noopPluginsLoader
+	names []string
+}
+
+func (l namedPluginsLoader) GetLoadedPluginNames() []string { return l.names }
+
+// TestGetLoadedPlugins verifies that getLoadedPlugins returns the loader's plugin
+// names under the "plugins" JSON key, locking the response shape the UI depends on.
+func TestGetLoadedPlugins(t *testing.T) {
+	want := []string{"logging", "telemetry", "enterprise-governance"}
+	h := &PluginsHandler{
+		pluginsLoader: namedPluginsLoader{names: want},
+		configStore:   nil,
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	h.getLoadedPlugins(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+
+	var response struct {
+		Plugins []string `json:"plugins"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(response.Plugins) != len(want) {
+		t.Fatalf("expected %d plugins, got %d: %v", len(want), len(response.Plugins), response.Plugins)
+	}
+	for i, name := range want {
+		if response.Plugins[i] != name {
+			t.Errorf("plugins[%d] = %q, want %q", i, response.Plugins[i], name)
+		}
 	}
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -4415,6 +4415,30 @@ func (c *Config) GetLoadedLLMPlugins() []schemas.LLMPlugin {
 	return nil
 }
 
+// GetLoadedPluginNames returns the sanitized names of every currently loaded plugin,
+// matching the names embedded in their trace span names.
+func (c *Config) GetLoadedPluginNames() []string {
+	plugins := c.BasePlugins.Load()
+	if plugins == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(*plugins))
+	names := make([]string, 0, len(*plugins))
+	for _, p := range *plugins {
+		name := schemas.SanitizePluginSpanName(p.GetName())
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
 // pluginChunkInterceptor implements StreamChunkInterceptor by calling plugin hooks
 type pluginChunkInterceptor struct {
 	plugins []schemas.HTTPTransportPlugin

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -64,6 +64,7 @@ type ServerCallbacks interface {
 	ReloadPlugin(ctx context.Context, name string, path *string, pluginConfig any, placement *schemas.PluginPlacement, order *int) error
 	RemovePlugin(ctx context.Context, name string) error
 	GetPluginStatus(ctx context.Context) map[string]schemas.PluginStatus
+	GetLoadedPluginNames() []string
 	NormalizePluginConfig(name string, config map[string]any) (map[string]any, error)
 	ExpandPluginConfigForAPI(name string, config map[string]any) (map[string]any, error)
 	// Auth related callbacks
@@ -1156,6 +1157,15 @@ func (s *BifrostHTTPServer) GetUnfilteredModelsForProvider(provider schemas.Mode
 // Delegates to Config for centralized plugin status management
 func (s *BifrostHTTPServer) GetPluginStatus(ctx context.Context) map[string]schemas.PluginStatus {
 	return s.Config.GetPluginStatus()
+}
+
+// GetLoadedPluginNames returns the sanitized names of all currently loaded plugins,
+// matching the names embedded in their trace span names.
+func (s *BifrostHTTPServer) GetLoadedPluginNames() []string {
+	if s.Config == nil {
+		return []string{}
+	}
+	return s.Config.GetLoadedPluginNames()
 }
 
 // NormalizePluginConfig implements handlers.PluginsLoader. It looks up the plugin

--- a/ui/app/workspace/observability/sheets/pluginTracingSheet.tsx
+++ b/ui/app/workspace/observability/sheets/pluginTracingSheet.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { TriStateCheckbox } from "@/components/ui/tristateCheckbox";
-import { getErrorMessage, useGetBuiltinPluginsQuery, useGetPluginQuery, useGetPluginsQuery, useUpdatePluginMutation } from "@/lib/store";
+import { getErrorMessage, useGetLoadedPluginsQuery, useGetPluginQuery, useUpdatePluginMutation } from "@/lib/store";
 import { PluginSpanFilter } from "@/lib/types/config";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -60,10 +60,10 @@ function PluginRow({ name, checked, onChange }: { name: string; checked: boolean
 }
 
 export default function PluginTracingSheet({ open, onClose, pluginName, destination }: PluginTracingSheetProps) {
-	const { data: builtinPluginNames = [] } = useGetBuiltinPluginsQuery();
-	const { data: allPluginsData } = useGetPluginsQuery();
-	const customPluginNames = (allPluginsData ?? []).filter((p) => p.isCustom).map((p) => p.name);
-	const allPlugins = [...builtinPluginNames, ...customPluginNames];
+	// All currently loaded plugins (built-in, enterprise, custom, and auto-loaded) that can
+	// emit spans, named to match the connector's span filter. One flat list — the backend
+	// already returns the complete set, so there's no built-in/custom split to maintain.
+	const { data: allPlugins = [], isLoading: isLoadingLoadedPlugins } = useGetLoadedPluginsQuery();
 	const { data: targetPlugin } = useGetPluginQuery(pluginName);
 	const [updatePlugin, { isLoading }] = useUpdatePluginMutation();
 	const [toggles, setToggles] = useState<Record<string, boolean>>({});
@@ -73,12 +73,12 @@ export default function PluginTracingSheet({ open, onClose, pluginName, destinat
 		if (open && !wasOpenRef.current) {
 			if (!targetPlugin) return; // wait until persisted config is available
 			const filter = (targetPlugin.config?.plugin_span_filter as PluginSpanFilter | undefined) ?? null;
-			if (filter?.mode === "include" && allPlugins.length === 0) return;
+			if (isLoadingLoadedPlugins || allPlugins.length === 0) return;
 			setToggles(resolveToggleState(filter, allPlugins));
 			wasOpenRef.current = true;
 		}
 		if (!open) wasOpenRef.current = false;
-	}, [open, targetPlugin, allPlugins]);
+	}, [open, targetPlugin, allPlugins, isLoadingLoadedPlugins]);
 
 	const setToggle = useCallback((name: string, value: boolean) => {
 		setToggles((prev) => ({ ...prev, [name]: value }));
@@ -127,55 +127,28 @@ export default function PluginTracingSheet({ open, onClose, pluginName, destinat
 					<div className="flex flex-col gap-4">
 						<div>
 							<div className="mb-2 flex items-center justify-between">
-								<p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">Built-in Plugins</p>
+								<p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">Plugins</p>
 								<TriStateCheckbox
-									allIds={builtinPluginNames}
-									selectedIds={builtinPluginNames.filter((n) => toggles[n] ?? true)}
+									allIds={allPlugins}
+									selectedIds={allPlugins.filter((n) => toggles[n] ?? true)}
 									onChange={(next) => {
 										const nextSet = new Set(next);
 										setToggles((prev) => {
 											const updated = { ...prev };
-											for (const n of builtinPluginNames) updated[n] = nextSet.has(n);
+											for (const n of allPlugins) updated[n] = nextSet.has(n);
 											return updated;
 										});
 									}}
-									ariaLabel="Toggle all built-in plugin tracing"
-									data-testid="plugin-tracing-select-all-builtins"
+									ariaLabel="Toggle all plugin tracing"
+									data-testid="plugin-tracing-select-all"
 								/>
 							</div>
 							<div className="flex flex-col gap-1.5">
-								{builtinPluginNames.map((name) => (
+								{allPlugins.map((name) => (
 									<PluginRow key={name} name={name} checked={toggles[name] ?? true} onChange={(v) => setToggle(name, v)} />
 								))}
 							</div>
 						</div>
-
-						{customPluginNames.length > 0 && (
-							<div>
-								<div className="mb-2 flex items-center justify-between">
-									<p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">Custom Plugins</p>
-									<TriStateCheckbox
-										allIds={customPluginNames}
-										selectedIds={customPluginNames.filter((n) => toggles[n] ?? true)}
-										onChange={(next) => {
-											const nextSet = new Set(next);
-											setToggles((prev) => {
-												const updated = { ...prev };
-												for (const n of customPluginNames) updated[n] = nextSet.has(n);
-												return updated;
-											});
-										}}
-										ariaLabel="Toggle all custom plugin tracing"
-										data-testid="plugin-tracing-select-all-custom"
-									/>
-								</div>
-								<div className="flex flex-col gap-1.5">
-									{customPluginNames.map((name) => (
-										<PluginRow key={name} name={name} checked={toggles[name] ?? true} onChange={(v) => setToggle(name, v)} />
-									))}
-								</div>
-							</div>
-						)}
 					</div>
 				</div>
 

--- a/ui/lib/store/apis/pluginsApi.ts
+++ b/ui/lib/store/apis/pluginsApi.ts
@@ -10,6 +10,15 @@ export const pluginsApi = baseApi.injectEndpoints({
 			transformResponse: (response: { plugins: string[] }) => response.plugins || [],
 		}),
 
+		// Get the names of all currently loaded plugins (sanitized to match the names
+		// embedded in their trace span names). Used by the plugin tracing sheet so it
+		// lists every plugin that actually emits spans, including enterprise plugins.
+		getLoadedPlugins: builder.query<string[], void>({
+			query: () => "/plugins/loaded",
+			providesTags: ["Plugins"],
+			transformResponse: (response: { plugins: string[] }) => response.plugins || [],
+		}),
+
 		// Get all plugins
 		getPlugins: builder.query<Plugin[], void>({
 			query: () => "/plugins",
@@ -97,6 +106,7 @@ export const pluginsApi = baseApi.injectEndpoints({
 
 export const {
 	useGetBuiltinPluginsQuery,
+	useGetLoadedPluginsQuery,
 	useGetPluginsQuery,
 	useGetPluginQuery,
 	useCreatePluginMutation,


### PR DESCRIPTION
## Summary

The plugin tracing configuration sheet previously built its plugin list by merging a hardcoded built-in plugin list with custom plugins fetched from the config store. This meant enterprise plugins, auto-loaded plugins, and any plugin registered under a name different from its config key (e.g. `enterprise-prompts` instead of `prompts`) were silently missing from the list. As a result, users could not configure span filtering for those plugins, and any manually entered filter names could silently no-op.

This PR replaces that approach with a single `/api/plugins/loaded` endpoint that returns the sanitized names of every plugin actually loaded at runtime — the exact names embedded in their trace spans — and uses that list throughout the tracing sheet and filter logic.

## Changes

- Extracted `SanitizePluginSpanName` from `core/utils.go` into `core/schemas/span_filter.go` as an exported function so the same normalization logic is shared between span construction and span filtering.
- Added `GetLoadedPluginNames()` to `Config`, `BifrostHTTPServer`, and the `PluginsLoader`/`ServerCallbacks` interfaces, returning deduplicated, sorted, sanitized plugin names for all currently loaded plugins.
- Added a `GET /api/plugins/loaded` route backed by `getLoadedPlugins`, which returns the runtime plugin list.
- Added a `getLoadedPlugins` RTK Query endpoint (`useGetLoadedPluginsQuery`) in the UI.
- Replaced the built-in/custom split in `pluginTracingSheet.tsx` with a single flat list sourced from `useGetLoadedPluginsQuery`, removing the separate "Built-in Plugins" and "Custom Plugins" sections.
- Added `TestSanitizePluginSpanName` and `TestSanitizedNameMatchesSpanExtraction` to lock the invariant that names used to build spans round-trip correctly through `PluginNameFromSpan`.
- Updated the OTel and Datadog connector docs to clarify that plugin names in span filters must match the name shown in the tracing sheet, and that enterprise plugins like `enterprise-prompts` and `enterprise-governance` differ from their config keys.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./core/schemas/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

1. Start the gateway with a mix of built-in, enterprise, and custom plugins loaded.
2. Open the **Configure Plugin Tracing** sheet for an observability connector.
3. Verify the plugin list includes enterprise plugins (e.g. `enterprise-prompts`, `enterprise-governance`) and any auto-loaded plugins, not just the hardcoded built-in set.
4. Call `GET /api/plugins/loaded` directly and confirm the returned names match what appears in the sheet and in actual trace span names (`plugin.<name>.<stage>`).
5. Configure an `include` or `exclude` filter using a name from the sheet and verify spans are correctly filtered in the connected APM backend.

## Breaking changes

- [x] Yes
- [ ] No

`PluginsLoader` and `ServerCallbacks` interfaces gain a `GetLoadedPluginNames() []string` method. Any external implementations of these interfaces must add this method.

## Related issues

## Security considerations

The `/api/plugins/loaded` endpoint exposes the names of all loaded plugins. It should be protected by the same middleware chain as other `/api/plugins` routes, which it is via `ChainMiddlewares`.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API endpoint exposing currently loaded plugin names
  * Observability UI: unified "Plugins" list with improved initialization and select-all behavior
  * Consistent plugin name normalization so filter matching aligns with displayed plugin names

* **Documentation**
  * Clarified plugin name guidance for span filtering; instructs copying exact names from the UI

* **Tests**
  * Added tests for plugin name normalization and loaded-plugins endpoint
<!-- end of auto-generated comment: release notes by coderabbit.ai -->