### PR TITLE
chore: bump Bifrost Helm chart to 2.1.23 with `sourceOfTruth`, `disable_content_logging`, and changelog docs for v2.1.22/v2.1.23

### DIFF
--- a/docs/changelogs/helm-v2.1.21.mdx
+++ b/docs/changelogs/helm-v2.1.21.mdx
@@ -7,6 +7,7 @@ description: "Helm v2.1.21 changelog - 2026-06-04"
 
 ## Changelog
 
-- Added `per_user_oauth` and `per_user_headers` to the MCP connection `authType` enum in `values.schema.json` (`bifrost.mcp.clientConfigs[].authType`). These per-user auth modes were already supported by the application but were previously rejected at chart validation time.
+- Add `per_user_oauth`/`per_user_headers` to `authType` enum in mcpClientConfig
+- Added `scope` and `scope_id` fields to `bifrost.governance.modelConfigs[]` items in `values.yaml` and `values.schema.json`. `scope` accepts `"global"` (default, applies to all traffic) or `"virtual_key"` (applies to a specific virtual key); `scope_id` is required when `scope` is `"virtual_key"` and must reference a virtual key `id`. The `_helpers.tpl` already passes `modelConfigs` through as-is so no template change was needed.
 
 </Update>

--- a/docs/changelogs/helm-v2.1.22.mdx
+++ b/docs/changelogs/helm-v2.1.22.mdx
@@ -1,0 +1,19 @@
+---
+title: "v2.1.22"
+description: "Helm v2.1.22 changelog - 2026-06-08"
+---
+
+<Update label="Bifrost Helm" description="v2.1.22">
+
+## Changelog
+
+- Added `bifrost.governance.roles` array to `values.yaml`, `values.schema.json`, and `_helpers.tpl`. Each role requires a `name` and accepts optional `description`, `dac` (`own-data` | `team-data` | `all-data`, default `all-data`), `access_profile`, and `permissions[]` (`resource` + `operation`).
+- `bifrost.plugins.otel.config` now accepts either the existing single-profile shape or a new `profiles` wrapper (`otelProfilesConfig`) with an array of profiles. Each profile is independently enabled/disabled. A shared `plugin_span_filter` can be set at the top level in either shape.
+- Added `otelPluginSpanFilter` (`mode`: `include`/`exclude`, `plugins` array) to the OTEL config schema, available in both single-profile and multi-profile shapes.
+- Added `calendar_aligned` to `bifrost.governance.modelConfigs[]`. 
+- Added `model_config_id` and `customer_id` as budget owner fields in `governance.budgets[]`, alongside the existing `virtual_key_id`, `provider_config_id`, and `team_id`.
+- Extended `attributeTeamMappings` and `attributeBusinessUnitMappings` in SCIM auth config with optional `attributeType` (`user` | `group`) and `attributeValue` fields to enable SCIM-driven team/business-unit provisioning.
+- Added OAuth MCP client config example to `values.yaml` showing `authType: oauth` with `oauthConfigId`.
+- Added `allow_private_network` to `networkConfig` in `values.schema.json`. When `true`, allows connections to RFC 1918 private IPs (10.x, 172.16.x, 192.168.x) — useful for providers on a k8s pod network, LAN, or private VPC.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.23.mdx
+++ b/docs/changelogs/helm-v2.1.23.mdx
@@ -1,0 +1,13 @@
+---
+title: "v2.1.23"
+description: "Helm v2.1.23 changelog - 2026-06-10"
+---
+
+<Update label="Bifrost Helm" description="v2.1.23">
+
+## Changelog
+
+- Added `bifrost.sourceOfTruth` (`split` | `config.json`, optional). When set to `"config.json"`, sections explicitly present in the file become authoritative on startup — database-only rows for those sections are pruned. Omitting the field preserves the default `"split"` merge behavior.
+- Added `disable_content_logging` to OTEL config (both single-profile and per-profile). When `true`, message content (input/output messages, embeddings, tool definitions, tool call arguments/results) is dropped from exported spans — only metadata (model, tokens, latency) is sent to the collector.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -828,6 +828,8 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.23",
+              "changelogs/helm-v2.1.22",
               "changelogs/helm-v2.1.21",
               "changelogs/helm-v2.1.20",
               "changelogs/helm-v2.1.19",

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.22
+version: 2.1.23
 appVersion: "1.5.9"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,21 +4,25 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.22
+**Latest Version:** 2.1.23
 
 ## Changelog
+
+### 2.1.23
+
+- Added `bifrost.sourceOfTruth` (`split` | `config.json`, optional). When set to `"config.json"`, sections explicitly present in the file become authoritative on startup — database-only rows for those sections are pruned. Omitting the field preserves the default `"split"` merge behavior.
+- Added `disable_content_logging` to OTEL config (both single-profile and per-profile). When `true`, message content (input/output messages, embeddings, tool definitions, tool call arguments/results) is dropped from exported spans — only metadata (model, tokens, latency) is sent to the collector.
+
 
 ### 2.1.22
 
 - Added `bifrost.governance.roles` array to `values.yaml`, `values.schema.json`, and `_helpers.tpl`. Each role requires a `name` and accepts optional `description`, `dac` (`own-data` | `team-data` | `all-data`, default `all-data`), `access_profile`, and `permissions[]` (`resource` + `operation`).
 - `bifrost.plugins.otel.config` now accepts either the existing single-profile shape or a new `profiles` wrapper (`otelProfilesConfig`) with an array of profiles. Each profile is independently enabled/disabled. A shared `plugin_span_filter` can be set at the top level in either shape.
-- Added `disable_content_logging` to OTEL config (both single-profile and per-profile). When `true`, message content (input/output messages, embeddings, tool definitions, tool call arguments/results) is dropped from exported spans — only metadata (model, tokens, latency) is sent to the collector.
 - Added `otelPluginSpanFilter` (`mode`: `include`/`exclude`, `plugins` array) to the OTEL config schema, available in both single-profile and multi-profile shapes.
 - Added `calendar_aligned` to `bifrost.governance.modelConfigs[]`. 
 - Added `model_config_id` and `customer_id` as budget owner fields in `governance.budgets[]`, alongside the existing `virtual_key_id`, `provider_config_id`, and `team_id`.
 - Extended `attributeTeamMappings` and `attributeBusinessUnitMappings` in SCIM auth config with optional `attributeType` (`user` | `group`) and `attributeValue` fields to enable SCIM-driven team/business-unit provisioning.
 - Added OAuth MCP client config example to `values.yaml` showing `authType: oauth` with `oauthConfigId`.
-- Added `bifrost.sourceOfTruth` (`split` | `config.json`, optional). When set to `"config.json"`, sections explicitly present in the file become authoritative on startup — database-only rows for those sections are pruned. Omitting the field preserves the default `"split"` merge behavior.
 - Added `allow_private_network` to `networkConfig` in `values.schema.json`. When `true`, allows connections to RFC 1918 private IPs (10.x, 172.16.x, 192.168.x) — useful for providers on a k8s pod network, LAN, or private VPC.
 
 

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,30 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.5.9
+    created: "2026-06-10T11:18:58.017519+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 47ff95c6a10190d8754cddfb682ae6a87a488ddc8a784293310e9ead7ef02bec
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://github.com/maximhq/bifrost/releases/download/helm-chart-v2.1.23/bifrost-2.1.23.tgz
+    version: 2.1.23
+  - apiVersion: v2
+    appVersion: 1.5.9
     created: "2026-06-08T15:13:28.66826+05:30"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
@@ -1036,4 +1060,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-06-08T15:13:28.664133+05:30"
+generated: "2026-06-10T11:18:58.012053+05:30"


### PR DESCRIPTION
## Summary

Releases Bifrost Helm chart v2.1.23, introducing `sourceOfTruth` configuration and content logging suppression for OTEL, while reorganizing changelog entries between v2.1.22 and v2.1.23.

## Changes

- Added `bifrost.sourceOfTruth` field (`split` | `config.json`). When set to `"config.json"`, sections present in the file become authoritative on startup and database-only rows for those sections are pruned. Omitting the field preserves the default `"split"` merge behavior.
- Added `disable_content_logging` to OTEL config (both single-profile and per-profile shapes). When `true`, message content (input/output messages, embeddings, tool definitions, tool call arguments/results) is dropped from exported spans, leaving only metadata (model, tokens, latency).
- Moved `disable_content_logging` and `sourceOfTruth` from the v2.1.22 changelog into a new v2.1.23 changelog entry to correctly reflect the release they shipped in.
- Bumped chart version from `2.1.22` to `2.1.23` in `Chart.yaml`, `README.md`, and `index.yaml`.
- Added `helm-v2.1.22` and `helm-v2.1.23` changelog pages to the docs navigation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
helm repo update
helm show values bifrost/bifrost --version 2.1.23

# Validate sourceOfTruth field is accepted
helm template bifrost bifrost/bifrost --version 2.1.23 \
  --set bifrost.sourceOfTruth=config.json

# Validate disable_content_logging is accepted in OTEL config
helm template bifrost bifrost/bifrost --version 2.1.23 \
  --set bifrost.plugins.otel.config.disable_content_logging=true
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

`disable_content_logging` directly addresses PII concerns by allowing operators to prevent message content (prompts, completions, tool arguments) from being exported to OTEL collectors, reducing the risk of sensitive data leaving the cluster.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable