### PR TITLE
chore: remove vault encryption hooks from certain GORM tables in favor of AES-only encryption

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1828,31 +1828,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		}
 
 		headersJSONStr := string(headersJSON)
-		vaultEnabled := tables.VaultIsEnabled()
-		mcpTableName := tables.TableMCPClient{}.TableName()
-		vaultPfx := tables.VaultPrefix()
-		if tables.VaultHooks.Prefix != nil {
-			vaultPfx = tables.VaultHooks.Prefix()
-		}
-		headersPath := fmt.Sprintf("%s/%s/%s/headers_json", vaultPfx, mcpTableName, id)
-		connPath := fmt.Sprintf("%s/%s/%s/connection_string", vaultPfx, mcpTableName, id)
-		// StoreString runs before Updates so the vault ref is available to write to DB.
-		// vaultStoredPaths tracks paths written to vault so we can compensate (remove)
-		// if the subsequent DB write fails — preventing vault/DB divergence.
-		// vaultRemovePaths tracks cleared/env-backed paths to remove post-commit so a
-		// DB failure doesn't leave DB holding a ref to an already-deleted vault entry.
-		var vaultStoredPaths []string
-		var vaultRemovePaths []string
-		if vaultEnabled {
-			if headersJSONStr != "" && headersJSONStr != "{}" {
-				if err := tables.VaultHooks.StoreString(ctx, headersPath, &headersJSONStr); err != nil {
-					return fmt.Errorf("failed to vault mcp headers: %w", err)
-				}
-				vaultStoredPaths = append(vaultStoredPaths, headersPath)
-			} else if tables.VaultHooks.Remove != nil {
-				vaultRemovePaths = append(vaultRemovePaths, headersPath)
-			}
-		} else if encrypt.IsEnabled() && headersJSONStr != "" && headersJSONStr != "{}" {
+		if encrypt.IsEnabled() && headersJSONStr != "" && headersJSONStr != "{}" {
 			encrypted, encErr := encrypt.Encrypt(headersJSONStr)
 			if encErr != nil {
 				return fmt.Errorf("failed to encrypt mcp headers: %w", encErr)
@@ -1875,9 +1851,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			"disabled":                   clientConfigCopy.Disabled,
 			"updated_at":                 time.Now(),
 		}
-		if vaultEnabled {
-			updates["encryption_status"] = tables.EncryptionStatusVault
-		} else if encrypt.IsEnabled() {
+		if encrypt.IsEnabled() {
 			updates["encryption_status"] = encryptionStatusEncrypted
 		}
 		if clientConfigCopy.OauthConfigID != nil {
@@ -1901,19 +1875,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		// also sync connection/auth metadata from config.json and persist the hash.
 		if clientConfigCopy.ConfigHash != "" {
 			connectionStringToPersist := clientConfigCopy.ConnectionString
-			if vaultEnabled {
-				if connectionStringToPersist != nil && !connectionStringToPersist.IsFromEnv() && connectionStringToPersist.GetValue() != "" {
-					// Mirror TableMCPClient.BeforeSave vault behavior for map-based Updates.
-					cs := *connectionStringToPersist
-					if err := tables.VaultHooks.StoreString(ctx, connPath, &cs.Val); err != nil {
-						return fmt.Errorf("failed to vault mcp connection string: %w", err)
-					}
-					connectionStringToPersist = &cs
-					vaultStoredPaths = append(vaultStoredPaths, connPath)
-				} else if tables.VaultHooks.Remove != nil {
-					vaultRemovePaths = append(vaultRemovePaths, connPath)
-				}
-			} else if encrypt.IsEnabled() && connectionStringToPersist != nil &&
+			if encrypt.IsEnabled() && connectionStringToPersist != nil &&
 				!connectionStringToPersist.IsFromEnv() && connectionStringToPersist.GetValue() != "" {
 				// Mirror TableMCPClient.BeforeSave behavior for map-based Updates.
 				cs := *connectionStringToPersist
@@ -1942,20 +1904,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		}
 
 		if err := tx.WithContext(ctx).Model(&existingClient).Updates(updates).Error; err != nil {
-			// DB write failed — compensate by removing any vault entries we just wrote
-			// so vault and DB don't diverge (old DB ref would point to nothing).
-			if tables.VaultHooks.Remove != nil {
-				for _, p := range vaultStoredPaths {
-					_ = tables.VaultHooks.Remove(ctx, p)
-				}
-			}
 			return s.parseGormError(err)
-		}
-		// Post-commit: best-effort vault removal for cleared/env-backed fields.
-		// Runs after DB succeeds so a failed Updates doesn't leave DB holding a
-		// ref to a vault entry we already deleted.
-		for _, p := range vaultRemovePaths {
-			_ = tables.VaultHooks.Remove(ctx, p)
 		}
 		return nil
 	})
@@ -1963,45 +1912,16 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 
 // DeleteMCPClientConfig deletes an MCP client configuration from the database.
 func (s *RDBConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) error {
-	// Find existing client upfront so we can pre-select vault-backed rows.
-	var existingClient tables.TableMCPClient
-	if err := s.DB().WithContext(ctx).Where("client_id = ?", id).First(&existingClient).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("MCP client with id '%s' not found", id)
+	return s.DB().Transaction(func(tx *gorm.DB) error {
+		// Find existing client
+		var existingClient tables.TableMCPClient
+		if err := dbForUpdate(tx.WithContext(ctx)).Where("client_id = ?", id).First(&existingClient).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("MCP client with id '%s' not found", id)
+			}
+			return err
 		}
-		return err
-	}
 
-	// Fetch IDs of vault-backed rows before deletion for post-tx cleanup.
-	var vaultTokenIDs, vaultSessionIDs, vaultCredIDs []string
-	if tables.VaultHooks.Remove != nil {
-		var tokens []tables.TableOauthUserToken
-		if err := s.DB().WithContext(ctx).Select("id").
-			Where("mcp_client_id = ? AND encryption_status = ?", existingClient.ClientID, tables.EncryptionStatusVault).
-			Find(&tokens).Error; err == nil {
-			for _, t := range tokens {
-				vaultTokenIDs = append(vaultTokenIDs, t.ID)
-			}
-		}
-		var sessions []tables.TableOauthUserSession
-		if err := s.DB().WithContext(ctx).Select("id").
-			Where("mcp_client_id = ? AND encryption_status = ?", existingClient.ClientID, tables.EncryptionStatusVault).
-			Find(&sessions).Error; err == nil {
-			for _, sess := range sessions {
-				vaultSessionIDs = append(vaultSessionIDs, sess.ID)
-			}
-		}
-		var creds []tables.TableMCPPerUserHeaderCredential
-		if err := s.DB().WithContext(ctx).Select("id").
-			Where("mcp_client_id = ? AND encryption_status = ?", existingClient.ClientID, tables.EncryptionStatusVault).
-			Find(&creds).Error; err == nil {
-			for _, c := range creds {
-				vaultCredIDs = append(vaultCredIDs, c.ID)
-			}
-		}
-	}
-
-	err := s.DB().Transaction(func(tx *gorm.DB) error {
 		// Delete any virtual key MCP configs that reference this client
 		var configIDs []uint
 		if err := dbForUpdate(tx.WithContext(ctx)).
@@ -2038,20 +1958,6 @@ func (s *RDBConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) e
 		// Delete the client (this will also handle foreign key cascades)
 		return tx.WithContext(ctx).Delete(&existingClient).Error
 	})
-	if err != nil {
-		return err
-	}
-
-	// Best-effort vault cleanup after successful transaction.
-	if len(vaultTokenIDs) > 0 || len(vaultSessionIDs) > 0 || len(vaultCredIDs) > 0 {
-		go func() {
-			tables.TableOauthUserToken{}.DeleteVaultSecrets(context.Background(), vaultTokenIDs)
-			tables.TableOauthUserSession{}.DeleteVaultSecrets(context.Background(), vaultSessionIDs)
-			tables.TableMCPPerUserHeaderCredential{}.DeleteVaultSecrets(context.Background(), vaultCredIDs)
-		}()
-	}
-
-	return nil
 }
 
 // GetVectorStoreConfig retrieves the vector store configuration from the database.
@@ -5106,20 +5012,11 @@ func (s *RDBConfigStore) DeleteTempTokensByResourceID(ctx context.Context, scope
 	if len(tx) > 0 {
 		db = tx[0]
 	}
-	var vaultIDs []string
-	if tables.VaultHooks.Remove != nil {
-		db.WithContext(ctx).Model(&tables.TempToken{}).
-			Where("scope = ? AND resource_id = ? AND encryption_status = ?", scope, resourceID, tables.EncryptionStatusVault).
-			Pluck("id", &vaultIDs)
-	}
 	res := db.WithContext(ctx).
 		Where("scope = ? AND resource_id = ?", scope, resourceID).
 		Delete(&tables.TempToken{})
 	if res.Error != nil {
 		return 0, res.Error
-	}
-	if len(vaultIDs) > 0 {
-		go tables.TempToken{}.DeleteVaultSecrets(context.Background(), vaultIDs)
 	}
 	return res.RowsAffected, nil
 }
@@ -5127,18 +5024,9 @@ func (s *RDBConfigStore) DeleteTempTokensByResourceID(ctx context.Context, scope
 // DeleteExpiredTempTokens hard-deletes rows whose expires_at is at or before
 // the given cutoff. Returns the number of rows deleted.
 func (s *RDBConfigStore) DeleteExpiredTempTokens(ctx context.Context, before time.Time) (int64, error) {
-	var vaultIDs []string
-	if tables.VaultHooks.Remove != nil {
-		s.DB().WithContext(ctx).Model(&tables.TempToken{}).
-			Where("expires_at <= ? AND encryption_status = ?", before, tables.EncryptionStatusVault).
-			Pluck("id", &vaultIDs)
-	}
 	res := s.DB().WithContext(ctx).Where("expires_at <= ?", before).Delete(&tables.TempToken{})
 	if res.Error != nil {
 		return 0, res.Error
-	}
-	if len(vaultIDs) > 0 {
-		go tables.TempToken{}.DeleteVaultSecrets(context.Background(), vaultIDs)
 	}
 	return res.RowsAffected, nil
 }

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -194,31 +194,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 	// Encrypt sensitive fields after serialization.
 	// Always set EncryptionStatus when encryption is enabled so the startup
 	// batch pass does not re-process this row indefinitely.
-	if VaultIsEnabled() {
-		connPath := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ClientID,
-			tx.Statement.DB.NamingStrategy.ColumnName("", "ConnectionString"))
-		headersPath := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ClientID,
-			tx.Statement.DB.NamingStrategy.ColumnName("", "HeadersJSON"))
-		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && c.ConnectionString.GetValue() != "" {
-			cs := *c.ConnectionString
-			if err := vaultEnvVar(tx.Statement.Context, connPath, &cs); err != nil {
-				return fmt.Errorf("failed to vault mcp connection string: %w", err)
-			}
-			c.ConnectionString = &cs
-		} else {
-			// Field cleared or switched to env-var — remove any stale vault entry.
-			removeVaultEnvVar(tx.Statement.Context, connPath, c.ConnectionString)
-		}
-		if c.HeadersJSON != "" && c.HeadersJSON != "{}" {
-			if err := vaultString(tx.Statement.Context, headersPath, &c.HeadersJSON); err != nil {
-				return fmt.Errorf("failed to vault mcp headers: %w", err)
-			}
-		} else {
-			// Headers cleared — remove any stale vault entry.
-			removeVaultString(tx.Statement.Context, headersPath, &c.HeadersJSON)
-		}
-		c.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() {
+	if encrypt.IsEnabled() {
 		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && c.ConnectionString.GetValue() != "" {
 			// Copy to avoid encrypting the shared ConnectionString through the pointer
 			cs := *c.ConnectionString
@@ -245,19 +221,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 // AfterFind is a GORM hook that decrypts the connection string and headers (if encrypted)
 // and deserializes JSON columns back into runtime structs after reading from the database.
 func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
-	switch c.EncryptionStatus {
-	case EncryptionStatusVault:
-		if c.HeadersJSON != "" && c.HeadersJSON != "{}" {
-			if err := resolveVaultString(tx.Statement.Context, &c.HeadersJSON); err != nil {
-				return fmt.Errorf("failed to resolve vault mcp headers: %w", err)
-			}
-		}
-		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && c.ConnectionString.GetValue() != "" {
-			if err := resolveVaultEnvVar(tx.Statement.Context, c.ConnectionString); err != nil {
-				return fmt.Errorf("failed to resolve vault mcp connection string: %w", err)
-			}
-		}
-	case EncryptionStatusEncrypted:
+	if c.EncryptionStatus == EncryptionStatusEncrypted {
 		if c.HeadersJSON != "" && c.HeadersJSON != "{}" {
 			decrypted, err := encrypt.Decrypt(c.HeadersJSON)
 			if err != nil {
@@ -327,17 +291,5 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 			return err
 		}
 	}
-	return nil
-}
-
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (c *TableMCPClient) AfterDelete(tx *gorm.DB) error {
-	if c.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	connField := tx.Statement.DB.NamingStrategy.ColumnName("", "ConnectionString")
-	headersField := tx.Statement.DB.NamingStrategy.ColumnName("", "HeadersJSON")
-	_ = VaultHooks.Remove(tx.Statement.Context, fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ClientID, connField))
-	_ = VaultHooks.Remove(tx.Statement.Context, fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ClientID, headersField))
 	return nil
 }

--- a/framework/configstore/tables/mcp_per_user_headers.go
+++ b/framework/configstore/tables/mcp_per_user_headers.go
@@ -104,14 +104,7 @@ func (c *TableMCPPerUserHeaderCredential) BeforeSave(tx *gorm.DB) error {
 	if c.HeadersJSON == "" {
 		c.HeadersJSON = "{}"
 	}
-	if VaultIsEnabled() && c.HeadersJSON != "{}" {
-		path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ID,
-			tx.Statement.DB.NamingStrategy.ColumnName("", "HeadersJSON"))
-		if err := vaultString(tx.Statement.Context, path, &c.HeadersJSON); err != nil {
-			return fmt.Errorf("failed to vault mcp per-user header credential headers: %w", err)
-		}
-		c.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() {
+	if encrypt.IsEnabled() {
 		if err := encryptString(&c.HeadersJSON); err != nil {
 			return fmt.Errorf("failed to encrypt mcp per-user header credential headers: %w", err)
 		}
@@ -122,14 +115,7 @@ func (c *TableMCPPerUserHeaderCredential) BeforeSave(tx *gorm.DB) error {
 
 // AfterFind decrypts HeadersJSON when the row is marked encrypted.
 func (c *TableMCPPerUserHeaderCredential) AfterFind(tx *gorm.DB) error {
-	switch c.EncryptionStatus {
-	case EncryptionStatusVault:
-		if c.HeadersJSON != "" && c.HeadersJSON != "{}" {
-			if err := resolveVaultString(tx.Statement.Context, &c.HeadersJSON); err != nil {
-				return fmt.Errorf("failed to resolve vault mcp per-user header credential headers: %w", err)
-			}
-		}
-	case EncryptionStatusEncrypted:
+	if c.EncryptionStatus == EncryptionStatusEncrypted {
 		if err := decryptString(&c.HeadersJSON); err != nil {
 			return fmt.Errorf("failed to decrypt mcp per-user header credential headers: %w", err)
 		}

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -1,7 +1,6 @@
 package tables
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -161,20 +160,11 @@ func (TableOauthToken) TableName() string {
 
 // BeforeSave hook
 func (t *TableOauthToken) BeforeSave(tx *gorm.DB) error {
+	// Ensure token type is set
 	if t.TokenType == "" {
 		t.TokenType = "Bearer"
 	}
-	if VaultIsEnabled() {
-		base := fmt.Sprintf("%s/%s/%s", VaultPrefix(), t.TableName(), t.ID)
-		namer := tx.Statement.DB.NamingStrategy
-		if err := vaultString(tx.Statement.Context, base+"/"+namer.ColumnName("", "AccessToken"), &t.AccessToken); err != nil {
-			return fmt.Errorf("failed to vault oauth access token: %w", err)
-		}
-		if err := vaultString(tx.Statement.Context, base+"/"+namer.ColumnName("", "RefreshToken"), &t.RefreshToken); err != nil {
-			return fmt.Errorf("failed to vault oauth refresh token: %w", err)
-		}
-		t.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() {
+	if encrypt.IsEnabled() {
 		if err := encryptString(&t.AccessToken); err != nil {
 			return fmt.Errorf("failed to encrypt oauth access token: %w", err)
 		}
@@ -188,15 +178,7 @@ func (t *TableOauthToken) BeforeSave(tx *gorm.DB) error {
 
 // AfterFind hook to decrypt sensitive fields
 func (t *TableOauthToken) AfterFind(tx *gorm.DB) error {
-	switch t.EncryptionStatus {
-	case EncryptionStatusVault:
-		if err := resolveVaultString(tx.Statement.Context, &t.AccessToken); err != nil {
-			return fmt.Errorf("failed to resolve vault oauth access token: %w", err)
-		}
-		if err := resolveVaultString(tx.Statement.Context, &t.RefreshToken); err != nil {
-			return fmt.Errorf("failed to resolve vault oauth refresh token: %w", err)
-		}
-	case EncryptionStatusEncrypted:
+	if t.EncryptionStatus == EncryptionStatusEncrypted {
 		if err := decryptString(&t.AccessToken); err != nil {
 			return fmt.Errorf("failed to decrypt oauth access token: %w", err)
 		}
@@ -204,18 +186,6 @@ func (t *TableOauthToken) AfterFind(tx *gorm.DB) error {
 			return fmt.Errorf("failed to decrypt oauth refresh token: %w", err)
 		}
 	}
-	return nil
-}
-
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (t *TableOauthToken) AfterDelete(tx *gorm.DB) error {
-	if t.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	base := fmt.Sprintf("%s/%s/%s", VaultPrefix(), t.TableName(), t.ID)
-	namer := tx.Statement.DB.NamingStrategy
-	_ = VaultHooks.Remove(tx.Statement.Context, base+"/"+namer.ColumnName("", "AccessToken"))
-	_ = VaultHooks.Remove(tx.Statement.Context, base+"/"+namer.ColumnName("", "RefreshToken"))
 	return nil
 }
 
@@ -268,14 +238,7 @@ func (s *TableOauthUserSession) BeforeSave(tx *gorm.DB) error {
 	if s.Status == "" {
 		s.Status = "pending"
 	}
-	if VaultIsEnabled() && s.CodeVerifier != "" {
-		path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), s.TableName(), s.ID,
-			tx.Statement.DB.NamingStrategy.ColumnName("", "CodeVerifier"))
-		if err := vaultString(tx.Statement.Context, path, &s.CodeVerifier); err != nil {
-			return fmt.Errorf("failed to vault oauth user session code verifier: %w", err)
-		}
-		s.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() {
+	if encrypt.IsEnabled() {
 		if s.CodeVerifier != "" {
 			if err := encryptString(&s.CodeVerifier); err != nil {
 				return fmt.Errorf("failed to encrypt oauth user session code verifier: %w", err)
@@ -287,43 +250,12 @@ func (s *TableOauthUserSession) BeforeSave(tx *gorm.DB) error {
 }
 
 func (s *TableOauthUserSession) AfterFind(tx *gorm.DB) error {
-	switch s.EncryptionStatus {
-	case EncryptionStatusVault:
-		if err := resolveVaultString(tx.Statement.Context, &s.CodeVerifier); err != nil {
-			return fmt.Errorf("failed to resolve vault oauth user session code verifier: %w", err)
-		}
-	case EncryptionStatusEncrypted:
-		if s.CodeVerifier != "" {
-			if err := decryptString(&s.CodeVerifier); err != nil {
-				return fmt.Errorf("failed to decrypt oauth user session code verifier: %w", err)
-			}
+	if s.EncryptionStatus == EncryptionStatusEncrypted && s.CodeVerifier != "" {
+		if err := decryptString(&s.CodeVerifier); err != nil {
+			return fmt.Errorf("failed to decrypt oauth user session code verifier: %w", err)
 		}
 	}
 	return nil
-}
-
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (s *TableOauthUserSession) AfterDelete(tx *gorm.DB) error {
-	if s.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), s.TableName(), s.ID,
-		tx.Statement.DB.NamingStrategy.ColumnName("", "CodeVerifier"))
-	_ = VaultHooks.Remove(tx.Statement.Context, path)
-	return nil
-}
-
-// DeleteVaultSecrets removes vault entries for the given session IDs.
-// Called after a batch delete so vault cleanup runs even when AfterDelete can't fire.
-func (TableOauthUserSession) DeleteVaultSecrets(ctx context.Context, ids []string) {
-	if VaultHooks.Remove == nil {
-		return
-	}
-	tableName := TableOauthUserSession{}.TableName()
-	for _, id := range ids {
-		path := fmt.Sprintf("%s/%s/%s/code_verifier", VaultPrefix(), tableName, id)
-		_ = VaultHooks.Remove(ctx, path)
-	}
 }
 
 // TableOauthUserToken stores per-user OAuth credentials.
@@ -365,17 +297,7 @@ func (t *TableOauthUserToken) BeforeSave(tx *gorm.DB) error {
 	if t.TokenType == "" {
 		t.TokenType = "Bearer"
 	}
-	if VaultIsEnabled() {
-		base := fmt.Sprintf("%s/%s/%s", VaultPrefix(), t.TableName(), t.ID)
-		namer := tx.Statement.DB.NamingStrategy
-		if err := vaultString(tx.Statement.Context, base+"/"+namer.ColumnName("", "AccessToken"), &t.AccessToken); err != nil {
-			return fmt.Errorf("failed to vault oauth user access token: %w", err)
-		}
-		if err := vaultString(tx.Statement.Context, base+"/"+namer.ColumnName("", "RefreshToken"), &t.RefreshToken); err != nil {
-			return fmt.Errorf("failed to vault oauth user refresh token: %w", err)
-		}
-		t.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() {
+	if encrypt.IsEnabled() {
 		if err := encryptString(&t.AccessToken); err != nil {
 			return fmt.Errorf("failed to encrypt oauth user access token: %w", err)
 		}
@@ -388,15 +310,7 @@ func (t *TableOauthUserToken) BeforeSave(tx *gorm.DB) error {
 }
 
 func (t *TableOauthUserToken) AfterFind(tx *gorm.DB) error {
-	switch t.EncryptionStatus {
-	case EncryptionStatusVault:
-		if err := resolveVaultString(tx.Statement.Context, &t.AccessToken); err != nil {
-			return fmt.Errorf("failed to resolve vault oauth user access token: %w", err)
-		}
-		if err := resolveVaultString(tx.Statement.Context, &t.RefreshToken); err != nil {
-			return fmt.Errorf("failed to resolve vault oauth user refresh token: %w", err)
-		}
-	case EncryptionStatusEncrypted:
+	if t.EncryptionStatus == EncryptionStatusEncrypted {
 		if err := decryptString(&t.AccessToken); err != nil {
 			return fmt.Errorf("failed to decrypt oauth user access token: %w", err)
 		}
@@ -405,30 +319,4 @@ func (t *TableOauthUserToken) AfterFind(tx *gorm.DB) error {
 		}
 	}
 	return nil
-}
-
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (t *TableOauthUserToken) AfterDelete(tx *gorm.DB) error {
-	if t.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	base := fmt.Sprintf("%s/%s/%s", VaultPrefix(), t.TableName(), t.ID)
-	namer := tx.Statement.DB.NamingStrategy
-	_ = VaultHooks.Remove(tx.Statement.Context, base+"/"+namer.ColumnName("", "AccessToken"))
-	_ = VaultHooks.Remove(tx.Statement.Context, base+"/"+namer.ColumnName("", "RefreshToken"))
-	return nil
-}
-
-// DeleteVaultSecrets removes vault entries for the given token IDs.
-// Called after a batch delete so vault cleanup runs even when AfterDelete can't fire.
-func (TableOauthUserToken) DeleteVaultSecrets(ctx context.Context, ids []string) {
-	if VaultHooks.Remove == nil {
-		return
-	}
-	tableName := TableOauthUserToken{}.TableName()
-	for _, id := range ids {
-		base := fmt.Sprintf("%s/%s/%s", VaultPrefix(), tableName, id)
-		_ = VaultHooks.Remove(ctx, base+"/access_token")
-		_ = VaultHooks.Remove(ctx, base+"/refresh_token")
-	}
 }

--- a/framework/configstore/tables/sessions.go
+++ b/framework/configstore/tables/sessions.go
@@ -28,13 +28,7 @@ func (s *SessionsTable) BeforeSave(tx *gorm.DB) error {
 	if s.Token != "" {
 		s.TokenHash = encrypt.HashSHA256(s.Token)
 	}
-	if VaultIsEnabled() && s.Token != "" {
-		path := fmt.Sprintf("%s/%s/%s", VaultPrefix(), s.TableName(), s.TokenHash)
-		if err := vaultString(tx.Statement.Context, path, &s.Token); err != nil {
-			return fmt.Errorf("failed to vault session token: %w", err)
-		}
-		s.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() && s.Token != "" {
+	if encrypt.IsEnabled() && s.Token != "" {
 		if err := encryptString(&s.Token); err != nil {
 			return fmt.Errorf("failed to encrypt session token: %w", err)
 		}
@@ -45,25 +39,10 @@ func (s *SessionsTable) BeforeSave(tx *gorm.DB) error {
 
 // AfterFind hook to decrypt the session token
 func (s *SessionsTable) AfterFind(tx *gorm.DB) error {
-	switch s.EncryptionStatus {
-	case EncryptionStatusVault:
-		if err := resolveVaultString(tx.Statement.Context, &s.Token); err != nil {
-			return fmt.Errorf("failed to resolve vault session token: %w", err)
-		}
-	case EncryptionStatusEncrypted:
+	if s.EncryptionStatus == EncryptionStatusEncrypted {
 		if err := decryptString(&s.Token); err != nil {
 			return fmt.Errorf("failed to decrypt session token: %w", err)
 		}
 	}
-	return nil
-}
-
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (s *SessionsTable) AfterDelete(tx *gorm.DB) error {
-	if s.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	path := fmt.Sprintf("%s/%s/%s", VaultPrefix(), s.TableName(), s.TokenHash)
-	_ = VaultHooks.Remove(tx.Statement.Context, path)
 	return nil
 }

--- a/framework/configstore/tables/temp_token.go
+++ b/framework/configstore/tables/temp_token.go
@@ -1,7 +1,6 @@
 package tables
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -38,13 +37,7 @@ func (t *TempToken) BeforeSave(tx *gorm.DB) error {
 	if t.Token != "" {
 		t.TokenHash = encrypt.HashSHA256(t.Token)
 	}
-	if VaultIsEnabled() && t.Token != "" {
-		path := fmt.Sprintf("%s/%s/%s/token", VaultPrefix(), t.TableName(), t.ID)
-		if err := vaultString(tx.Statement.Context, path, &t.Token); err != nil {
-			return fmt.Errorf("failed to vault temp token: %w", err)
-		}
-		t.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() && t.Token != "" {
+	if encrypt.IsEnabled() && t.Token != "" {
 		if err := encryptString(&t.Token); err != nil {
 			return fmt.Errorf("failed to encrypt temp token: %w", err)
 		}
@@ -55,38 +48,10 @@ func (t *TempToken) BeforeSave(tx *gorm.DB) error {
 
 // AfterFind decrypts the stored plaintext when encryption is in effect.
 func (t *TempToken) AfterFind(tx *gorm.DB) error {
-	switch t.EncryptionStatus {
-	case EncryptionStatusVault:
-		if err := resolveVaultString(tx.Statement.Context, &t.Token); err != nil {
-			return fmt.Errorf("failed to resolve vault temp token: %w", err)
-		}
-	case EncryptionStatusEncrypted:
+	if t.EncryptionStatus == EncryptionStatusEncrypted {
 		if err := decryptString(&t.Token); err != nil {
 			return fmt.Errorf("failed to decrypt temp token: %w", err)
 		}
 	}
 	return nil
-}
-
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (t *TempToken) AfterDelete(tx *gorm.DB) error {
-	if t.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	path := fmt.Sprintf("%s/%s/%s/token", VaultPrefix(), t.TableName(), t.ID)
-	_ = VaultHooks.Remove(tx.Statement.Context, path)
-	return nil
-}
-
-// DeleteVaultSecrets removes vault entries for the given temp token IDs.
-// Called after a batch delete so vault cleanup runs even when AfterDelete can't fire.
-func (TempToken) DeleteVaultSecrets(ctx context.Context, ids []string) {
-	if VaultHooks.Remove == nil {
-		return
-	}
-	tableName := TempToken{}.TableName()
-	for _, id := range ids {
-		path := fmt.Sprintf("%s/%s/%s/token", VaultPrefix(), tableName, id)
-		_ = VaultHooks.Remove(ctx, path)
-	}
 }

--- a/framework/configstore/tables/vectorstore.go
+++ b/framework/configstore/tables/vectorstore.go
@@ -27,14 +27,7 @@ func (TableVectorStoreConfig) TableName() string { return "config_vector_store" 
 
 // BeforeSave hook to encrypt sensitive config
 func (vs *TableVectorStoreConfig) BeforeSave(tx *gorm.DB) error {
-	if VaultIsEnabled() && vs.Config != nil && *vs.Config != "" {
-		fieldName := tx.Statement.DB.NamingStrategy.ColumnName("", "Config")
-		path := fmt.Sprintf("%s/%s/%s", VaultPrefix(), vs.TableName(), fieldName)
-		if err := vaultString(tx.Statement.Context, path, vs.Config); err != nil {
-			return fmt.Errorf("failed to vault vector store config: %w", err)
-		}
-		vs.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() && vs.Config != nil && *vs.Config != "" {
+	if encrypt.IsEnabled() && vs.Config != nil && *vs.Config != "" {
 		if err := encryptString(vs.Config); err != nil {
 			return fmt.Errorf("failed to encrypt vector store config: %w", err)
 		}
@@ -45,28 +38,10 @@ func (vs *TableVectorStoreConfig) BeforeSave(tx *gorm.DB) error {
 
 // AfterFind hook to decrypt sensitive config
 func (vs *TableVectorStoreConfig) AfterFind(tx *gorm.DB) error {
-	if vs.Config != nil && *vs.Config != "" {
-		switch vs.EncryptionStatus {
-		case EncryptionStatusVault:
-			if err := resolveVaultString(tx.Statement.Context, vs.Config); err != nil {
-				return fmt.Errorf("failed to resolve vault vector store config: %w", err)
-			}
-		case EncryptionStatusEncrypted:
-			if err := decryptString(vs.Config); err != nil {
-				return fmt.Errorf("failed to decrypt vector store config: %w", err)
-			}
+	if vs.EncryptionStatus == EncryptionStatusEncrypted && vs.Config != nil && *vs.Config != "" {
+		if err := decryptString(vs.Config); err != nil {
+			return fmt.Errorf("failed to decrypt vector store config: %w", err)
 		}
 	}
-	return nil
-}
-
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (vs *TableVectorStoreConfig) AfterDelete(tx *gorm.DB) error {
-	if vs.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	fieldName := tx.Statement.DB.NamingStrategy.ColumnName("", "Config")
-	path := fmt.Sprintf("%s/%s/%s", VaultPrefix(), vs.TableName(), fieldName)
-	_ = VaultHooks.Remove(tx.Statement.Context, path)
 	return nil
 }

--- a/plugins/modelcatalogresolver/go.mod
+++ b/plugins/modelcatalogresolver/go.mod
@@ -13,7 +13,7 @@ require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	cloud.google.com/go/iam v1.5.3 // indirect
+	cloud.google.com/go/iam v1.7.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	cloud.google.com/go/storage v1.61.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
@@ -25,13 +25,13 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.12 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.11 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
@@ -43,7 +43,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
-	github.com/aws/smithy-go v1.25.1 // indirect
+	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/plugins/modelcatalogresolver/go.sum
+++ b/plugins/modelcatalogresolver/go.sum
@@ -6,7 +6,7 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
-cloud.google.com/go/iam v1.5.3 h1:+vMINPiDF2ognBJ97ABAYYwRgsaqxPbQDlMnbHMjolc=
+cloud.google.com/go/iam v1.7.0 h1:JD3zh0C6LHl16aCn5Akff0+GELdp1+4hmh6ndoFLl8U=
 cloud.google.com/go/logging v1.13.2 h1:qqlHCBvieJT9Cdq4QqYx1KPadCQ2noD4FK02eNqHAjA=
 cloud.google.com/go/longrunning v0.8.0 h1:LiKK77J3bx5gDLi4SMViHixjD2ohlkwBi+mKA7EhfW8=
 cloud.google.com/go/monitoring v1.24.3 h1:dde+gMNc0UhPZD1Azu6at2e79bfdztVDS5lvhOdsgaE=
@@ -27,13 +27,13 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
-github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.12 h1:DIKX2c31ekm9RA2D9FBj1EWXx++9AdAqRw+e78Tq2Ck=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/config v1.32.11 h1:ftxI5sgz8jZkckuUHXfC/wMUc8u3fG1vQS0plr2F2Zs=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 h1:Xf2j7NdVcUKomlZ4iihOP4AZ3Fzlr8h4yKpXeP+OFPg=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 h1:KqIfN9kpkKkcBqBbNpNGTIrXO6ExTUvFKvXkC+YAzVo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.5 h1:clHU5fm//kWS1C2HgtgWxfQbFbx4b6rx+5jzhgX9HrI=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=
@@ -45,7 +45,7 @@ github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1K
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 h1:lFd1+ZSEYJZYvv9d6kXzhkZu07si3f+GQ1AaYwa2LUM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6fuOwWlWpD2StNLTceKpys=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBUdErbMnAFFp12Lm/U=
-github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=


### PR DESCRIPTION
## Summary

Removes Vault-based secret storage from all sensitive-field GORM hooks and related database operations, leaving only the standard `encrypt` package path for at-rest encryption. This eliminates the dual-path complexity that existed for MCP client configs, OAuth tokens, sessions, temp tokens, and vector store configs.

## Changes

- Removed all `VaultIsEnabled()` branches from `BeforeSave`, `AfterFind`, and `AfterDelete` hooks across `TableMCPClient`, `TableMCPPerUserHeaderCredential`, `TableOauthToken`, `TableOauthUserSession`, `TableOauthUserToken`, `SessionsTable`, `TempToken`, and `TableVectorStoreConfig`.
- Removed `AfterDelete` vault cleanup hooks from all affected table types.
- Removed `DeleteVaultSecrets` helper methods from `TableOauthUserToken`, `TableOauthUserSession`, and `TempToken`.
- Removed pre/post-transaction vault compensation logic (`vaultStoredPaths`, `vaultRemovePaths`) from `UpdateMCPClientConfig` in `rdb.go`.
- Removed the pre-transaction vault ID collection and post-transaction goroutine vault cleanup from `DeleteMCPClientConfig`, moving the record lookup inside the transaction instead.
- Removed vault ID pre-collection and post-delete goroutine cleanup from `DeleteTempTokensByResourceID` and `DeleteExpiredTempTokens`.
- Bumped `cloud.google.com/go/iam`, `aws-sdk-go-v2`, and `smithy-go` dependency versions in the `modelcatalogresolver` plugin.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./framework/configstore/tables/...
```

Verify that MCP client configs, OAuth tokens, sessions, and temp tokens are correctly encrypted and decrypted using the `encrypt` package when `encrypt.IsEnabled()` is true, and that no vault-related paths are written or read.

## Breaking changes

- [x] Yes
- [ ] No

Any deployments that previously relied on Vault-backed secret storage for these table types will no longer have secrets written to or read from Vault. Rows with `encryption_status = 'vault'` will not be decrypted correctly after this change. A migration to re-encrypt existing vault-backed rows using the standard encryption path is required before deploying.

## Security considerations

Vault integration for field-level secret storage has been removed. All sensitive fields (OAuth tokens, MCP connection strings, headers, session tokens, temp tokens, vector store config) are now exclusively encrypted via the `encrypt` package. Ensure the `encrypt` package key material is properly secured in your deployment environment, as Vault is no longer available as an alternative secret backend.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable