### PR TITLE
feat: resolve provider `key_ids` names to UUIDs when merging virtual key provider configs from config file

### DIFF
--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2662,6 +2662,13 @@
                         }
                       },
                       "additionalProperties": false
+                    },
+                    "key_ids": {
+                      "type": "array",
+                      "description": "Key names (or UUIDs) allowed for this provider. Use [\"*\"] to allow all keys; empty array denies all.",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": ["provider_name"],

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -861,6 +861,7 @@ bifrost:
     #     - provider_name: "openai"
     #       all_models_allowed: false
     #       allowed_models: ["gpt-4o", "gpt-4o-mini"]
+    #       key_ids: ["*"]               # ["*"] = all keys; [] = deny all; ["key-name"] = specific key by name or UUID
     #   mcp_tool_groups:
     #     - tool_group_id: 1
     #   mcp_servers:

--- a/plugins/modelcatalogresolver/go.mod
+++ b/plugins/modelcatalogresolver/go.mod
@@ -13,7 +13,7 @@ require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	cloud.google.com/go/iam v1.5.3 // indirect
+	cloud.google.com/go/iam v1.7.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	cloud.google.com/go/storage v1.61.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
@@ -25,13 +25,13 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.12 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.11 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
@@ -43,7 +43,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
-	github.com/aws/smithy-go v1.25.1 // indirect
+	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/plugins/modelcatalogresolver/go.sum
+++ b/plugins/modelcatalogresolver/go.sum
@@ -6,7 +6,7 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
-cloud.google.com/go/iam v1.5.3 h1:+vMINPiDF2ognBJ97ABAYYwRgsaqxPbQDlMnbHMjolc=
+cloud.google.com/go/iam v1.7.0 h1:JD3zh0C6LHl16aCn5Akff0+GELdp1+4hmh6ndoFLl8U=
 cloud.google.com/go/logging v1.13.2 h1:qqlHCBvieJT9Cdq4QqYx1KPadCQ2noD4FK02eNqHAjA=
 cloud.google.com/go/longrunning v0.8.0 h1:LiKK77J3bx5gDLi4SMViHixjD2ohlkwBi+mKA7EhfW8=
 cloud.google.com/go/monitoring v1.24.3 h1:dde+gMNc0UhPZD1Azu6at2e79bfdztVDS5lvhOdsgaE=
@@ -27,13 +27,13 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
-github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.12 h1:DIKX2c31ekm9RA2D9FBj1EWXx++9AdAqRw+e78Tq2Ck=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/config v1.32.11 h1:ftxI5sgz8jZkckuUHXfC/wMUc8u3fG1vQS0plr2F2Zs=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 h1:Xf2j7NdVcUKomlZ4iihOP4AZ3Fzlr8h4yKpXeP+OFPg=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 h1:KqIfN9kpkKkcBqBbNpNGTIrXO6ExTUvFKvXkC+YAzVo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.5 h1:clHU5fm//kWS1C2HgtgWxfQbFbx4b6rx+5jzhgX9HrI=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=
@@ -45,7 +45,7 @@ github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1K
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 h1:lFd1+ZSEYJZYvv9d6kXzhkZu07si3f+GQ1AaYwa2LUM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6fuOwWlWpD2StNLTceKpys=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBUdErbMnAFFp12Lm/U=
-github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2122,6 +2122,19 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 			teamsToAdd = append(teamsToAdd, configData.Governance.Teams[i])
 		}
 	}
+	// Build provider key name→UUID map once for resolveVKProviderKeyIDs below.
+	// Use config.Providers (post-processed, UUIDs assigned) not configData.Providers (raw parse).
+	providerKeysByName := make(map[string]map[string]string) // provider → name → UUID
+	for providerName, providerCfg := range config.Providers {
+		nameMap := make(map[string]string, len(providerCfg.Keys))
+		for _, k := range providerCfg.Keys {
+			if k.Name != "" && k.ID != "" {
+				nameMap[k.Name] = k.ID
+			}
+		}
+		providerKeysByName[strings.ToLower(string(providerName))] = nameMap
+	}
+
 	// Merge VirtualKeys by ID with hash comparison
 	virtualKeysToAdd := make([]configstoreTables.TableVirtualKey, 0)
 	virtualKeysToUpdate := make([]configstoreTables.TableVirtualKey, 0)
@@ -2164,6 +2177,8 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 					// Resolve MCP client names to IDs for config file mcp_configs
 					configData.Governance.VirtualKeys[i].MCPConfigs = resolveMCPConfigClientIDs(
 						ctx, config.ConfigStore, configData.Governance.VirtualKeys[i].MCPConfigs, newVirtualKey.ID)
+					configData.Governance.VirtualKeys[i].ProviderConfigs = resolveVKProviderKeyIDs(
+						providerKeysByName, configData.Governance.VirtualKeys[i].ProviderConfigs)
 					virtualKeysToUpdate = append(virtualKeysToUpdate, configData.Governance.VirtualKeys[i])
 					governanceConfig.VirtualKeys[j] = configData.Governance.VirtualKeys[i]
 				} else {
@@ -2194,6 +2209,8 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 			// Resolve MCP client names to IDs for config file mcp_configs
 			configData.Governance.VirtualKeys[i].MCPConfigs = resolveMCPConfigClientIDs(
 				ctx, config.ConfigStore, configData.Governance.VirtualKeys[i].MCPConfigs, newVirtualKey.ID)
+			configData.Governance.VirtualKeys[i].ProviderConfigs = resolveVKProviderKeyIDs(
+				providerKeysByName, configData.Governance.VirtualKeys[i].ProviderConfigs)
 			virtualKeysToAdd = append(virtualKeysToAdd, configData.Governance.VirtualKeys[i])
 		}
 	}
@@ -2392,15 +2409,25 @@ func pruneGovernanceConfigToFile(ctx context.Context, config *Config, configData
 	logger.Debug("source_of_truth=config.json: pruning governance rows not present in config file")
 	err := config.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		if configData.governanceSectionPresent("virtual_keys") {
+			providerKeysByName := make(map[string]map[string]string, len(config.Providers))
+			for providerName, providerCfg := range config.Providers {
+				nameMap := make(map[string]string, len(providerCfg.Keys))
+				for _, k := range providerCfg.Keys {
+					if k.Name != "" && k.ID != "" {
+						nameMap[k.Name] = k.ID
+					}
+				}
+				providerKeysByName[strings.ToLower(string(providerName))] = nameMap
+			}
 			keep := make(map[string]bool, len(configData.Governance.VirtualKeys))
 			for i := range configData.Governance.VirtualKeys {
 				vk := &configData.Governance.VirtualKeys[i]
 				keep[vk.ID] = true
-				// Unchanged VKs never went through resolveMCPConfigClientIDs in
-				// mergeGovernanceConfig, so their MCPConfigs may still carry
-				// mcp_client_name with MCPClientID==0. Resolve before reconciling
-				// to avoid creating/deleting client-id 0 associations.
+				// Unchanged VKs never went through resolveMCPConfigClientIDs /
+				// resolveVKProviderKeyIDs in mergeGovernanceConfig, so their configs
+				// may still carry unresolved names. Resolve before reconciling.
 				vk.MCPConfigs = resolveMCPConfigClientIDs(ctx, config.ConfigStore, vk.MCPConfigs, vk.ID)
+				vk.ProviderConfigs = resolveVKProviderKeyIDs(providerKeysByName, vk.ProviderConfigs)
 				if err := reconcileVirtualKeyAssociations(ctx, config.ConfigStore, tx, vk.ID, vk.ProviderConfigs, vk.MCPConfigs); err != nil {
 					return fmt.Errorf("failed to reconcile associations for virtual key %s: %w", vk.ID, err)
 				}
@@ -4156,6 +4183,43 @@ func resolveMCPConfigClientIDs(
 	}
 
 	return resolvedConfigs
+}
+
+// resolveVKProviderKeyIDs resolves key name references inside a virtual key's provider configs.
+// providerKeysByName is a pre-built map of provider → (name → UUID) from configData.Providers,
+// built once before the VK loop to avoid repeated DB calls. Entries whose key_id already looks
+// like a UUID (not found by name) are passed through for CreateVirtualKeyProviderConfig to handle.
+func resolveVKProviderKeyIDs(
+	providerKeysByName map[string]map[string]string,
+	providerConfigs []configstoreTables.TableVirtualKeyProviderConfig,
+) []configstoreTables.TableVirtualKeyProviderConfig {
+	if len(providerKeysByName) == 0 {
+		return providerConfigs
+	}
+	for i := range providerConfigs {
+		pc := &providerConfigs[i]
+		if pc.AllowAllKeys || len(pc.Keys) == 0 {
+			continue
+		}
+		byName := providerKeysByName[strings.ToLower(pc.Provider)]
+		if len(byName) == 0 {
+			continue
+		}
+		resolved := make([]configstoreTables.TableKey, 0, len(pc.Keys))
+		for _, stub := range pc.Keys {
+			if stub.KeyID == "" {
+				continue
+			}
+			if uuid, ok := byName[stub.KeyID]; ok {
+				resolved = append(resolved, configstoreTables.TableKey{KeyID: uuid})
+			} else {
+				// Already a UUID or unknown — pass through for DB resolution.
+				resolved = append(resolved, stub)
+			}
+		}
+		pc.Keys = resolved
+	}
+	return providerConfigs
 }
 
 // reconcileVirtualKeyAssociations reconciles ProviderConfigs and MCPConfigs associations


### PR DESCRIPTION
## Summary

Adds support for a `key_ids` field on virtual key provider configs, allowing operators to restrict which provider API keys a virtual key is permitted to use. This enables fine-grained key-level access control per provider within a virtual key definition in `config.yaml`/`values.yaml`.

## Changes

- Added `key_ids` to the Helm chart JSON schema for virtual key provider configs, accepting an array of strings (key names or UUIDs). `["*"]` allows all keys; `[]` denies all; specific entries restrict to named or UUID-identified keys.
- Added a `key_ids` example comment in `values.yaml` to document the new field.
- Introduced `resolveVKProviderKeyIDs`, which translates human-readable key names (from `config.Providers`) into their corresponding UUIDs before virtual keys are persisted. This mirrors the existing `resolveMCPConfigClientIDs` pattern.
- Built a `providerKeysByName` lookup map once before the virtual key merge loop (using post-processed provider configs where UUIDs are already assigned) and applied `resolveVKProviderKeyIDs` for both new and updated virtual keys.
- Key IDs that are already UUIDs or are otherwise unrecognized by name are passed through unchanged for downstream DB resolution.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Define a virtual key in `config.yaml` with a `provider_configs` entry that includes `key_ids`:

```yaml
virtual_keys:
  - name: "test-vk"
    provider_configs:
      - provider_name: "openai"
        all_models_allowed: true
        key_ids: ["my-openai-key"]   # key name defined under providers
```

Then verify:
1. The virtual key is created/updated without error.
2. The resolved provider config stores the UUID of `my-openai-key`, not the name.
3. Using `["*"]` allows all keys for that provider.
4. Using `[]` denies all keys for that provider.

```sh
go test ./transports/bifrost-http/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `key_ids` field restricts which underlying provider API keys a virtual key can route through, reducing the blast radius if a virtual key is compromised. Key name-to-UUID resolution happens server-side at config load time, so raw key material is never exposed in the config file.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `key_ids` configuration field to access profiles to control which provider keys are accessible. Use `["*"]` to allow all keys or an empty array to deny all.

* **Bug Fixes**
  * Improved handling of provider key identifiers so referenced key names are resolved consistently during configuration updates and pruning, preventing mismatches and ensuring stable virtual-key associations.

* **Documentation**
  * Helm chart schema and example values updated to document `key_ids` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->