### PR TITLE
fix: generate UUID for virtual key if ID is empty before creation

### DIFF
--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2136,10 +2136,16 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 		// Preparing hash
 		found := false
 		for j, existingVirtualKey := range governanceConfig.VirtualKeys {
-			if existingVirtualKey.ID == newVirtualKey.ID {
+			idMatch := existingVirtualKey.ID == newVirtualKey.ID
+			nameMatch := newVirtualKey.ID == "" && existingVirtualKey.Name == newVirtualKey.Name
+			if idMatch || nameMatch {
+				if nameMatch {
+					// Config file has no ID; adopt the DB record's ID so updates use the right primary key.
+					configData.Governance.VirtualKeys[i].ID = existingVirtualKey.ID
+				}
 				found = true
 				if existingVirtualKey.ConfigHash != fileVKHash {
-					logger.Debug("config hash mismatch for virtual key %s, syncing from config file", newVirtualKey.ID)
+					logger.Debug("config hash mismatch for virtual key %s, syncing from config file", existingVirtualKey.ID)
 					configData.Governance.VirtualKeys[i].ConfigHash = fileVKHash
 					// This is added for backward compatibility with existing configs
 					if configData.Governance.VirtualKeys[i].Value == "" && existingVirtualKey.Value != "" {
@@ -2781,6 +2787,9 @@ func updateGovernanceConfigInStore(
 		// Create virtual keys with explicit association handling
 		for i := range virtualKeysToAdd {
 			virtualKey := &virtualKeysToAdd[i]
+			if virtualKey.ID == "" {
+				virtualKey.ID = uuid.NewString()
+			}
 			providerConfigs := virtualKey.ProviderConfigs
 			mcpConfigs := virtualKey.MCPConfigs
 			virtualKey.ProviderConfigs = nil
@@ -3333,6 +3342,10 @@ func createGovernanceConfigInStore(ctx context.Context, config *Config) {
 			mcpConfigs := virtualKey.MCPConfigs
 			virtualKey.ProviderConfigs = nil
 			virtualKey.MCPConfigs = nil
+
+			if virtualKey.ID == "" {
+				virtualKey.ID = uuid.NewString()
+			}
 
 			if err := config.ConfigStore.CreateVirtualKey(ctx, virtualKey, tx); err != nil {
 				logger.Error("failed to create virtual key %s: %v", virtualKey.ID, err)


### PR DESCRIPTION
## Summary

When creating virtual keys via governance config, if a virtual key does not have an ID set, it would be stored without one, causing failures or inconsistent state. This PR ensures a UUID is automatically assigned to any virtual key that is missing an ID before it is persisted.

## Changes

- Added a check during governance config creation to assign a new UUID to any virtual key whose `ID` field is empty, preventing virtual keys from being created without a valid identifier.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Configure a governance config with a virtual key that has no `ID` field set and trigger the config store creation. Verify that the virtual key is created successfully with an auto-generated UUID.

```sh
go test ./transports/bifrost-http/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. UUID generation uses a standard random UUID, which does not expose any sensitive information.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual keys submitted without an identifier will now match existing keys by name and adopt the correct identifier, avoiding duplicate or mismatched entries.
  * During system initialization and governance updates, virtual keys lacking IDs are automatically assigned a unique identifier before being persisted, improving data consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->