### PR TITLE
tests: add e2e fallback routing scenarios and setup clear-providers step

### DIFF
--- a/tests/e2e/api/collections/bifrost-model-catalog-wiring.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-model-catalog-wiring.postman_collection.json
@@ -15,6 +15,16 @@
       "key": "run_id",
       "value": "",
       "type": "string"
+    },
+    {
+      "key": "__purge_target",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "__purge_queue",
+      "value": "",
+      "type": "string"
     }
   ],
   "event": [
@@ -34,6 +44,94 @@
     }
   ],
   "item": [
+    {
+      "id": "setup-clear-providers",
+      "name": "Setup: clear providers",
+      "item": [
+        {
+          "id": "setup-list-providers",
+          "name": "setup: list providers to clear",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('setup: list providers', function () { pm.expect(pm.response.code, pm.response.text()).to.equal(200); });",
+                  "if (pm.response.code !== 200) { return; }",
+                  "var provs = ((pm.response.json() || {}).providers || []).map(function (p) { return p.name; }).filter(Boolean);",
+                  "if (provs.length === 0) { pm.collectionVariables.set('__purge_target', ''); pm.collectionVariables.set('__purge_queue', ''); return; }",
+                  "pm.collectionVariables.set('__purge_target', provs[0]);",
+                  "pm.collectionVariables.set('__purge_queue', provs.slice(1).join(','));",
+                  "pm.execution.setNextRequest(\"setup: delete provider\");"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            }
+          }
+        },
+        {
+          "id": "setup-delete-provider",
+          "name": "setup: delete provider",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get('__purge_target')) { pm.execution.skipRequest(); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('setup: delete provider', function () { pm.expect([200, 204, 404], 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code); });",
+                  "var queue = (pm.collectionVariables.get('__purge_queue') || '').split(',').filter(Boolean);",
+                  "if (queue.length) {",
+                  "  pm.collectionVariables.set('__purge_target', queue[0]);",
+                  "  pm.collectionVariables.set('__purge_queue', queue.slice(1).join(','));",
+                  "  pm.execution.setNextRequest(\"setup: delete provider\");",
+                  "} else {",
+                  "  pm.collectionVariables.set('__purge_target', '');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/providers/{{__purge_target}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "{{__purge_target}}"
+              ]
+            }
+          }
+        }
+      ]
+    },
     {
       "name": "Add provider and key surfaces models (openai)",
       "description": "A fresh provider plus one gated key surfaces that key's allowed model in the catalog.",

--- a/tests/e2e/api/collections/bifrost-routing-wiring.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-routing-wiring.postman_collection.json
@@ -15,6 +15,16 @@
       "key": "run_id",
       "value": "",
       "type": "string"
+    },
+    {
+      "key": "__purge_target",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "__purge_queue",
+      "value": "",
+      "type": "string"
     }
   ],
   "event": [
@@ -34,6 +44,94 @@
     }
   ],
   "item": [
+    {
+      "id": "setup-clear-providers",
+      "name": "Setup: clear providers",
+      "item": [
+        {
+          "id": "setup-list-providers",
+          "name": "setup: list providers to clear",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('setup: list providers', function () { pm.expect(pm.response.code, pm.response.text()).to.equal(200); });",
+                  "if (pm.response.code !== 200) { return; }",
+                  "var provs = ((pm.response.json() || {}).providers || []).map(function (p) { return p.name; }).filter(Boolean);",
+                  "if (provs.length === 0) { pm.collectionVariables.set('__purge_target', ''); pm.collectionVariables.set('__purge_queue', ''); return; }",
+                  "pm.collectionVariables.set('__purge_target', provs[0]);",
+                  "pm.collectionVariables.set('__purge_queue', provs.slice(1).join(','));",
+                  "pm.execution.setNextRequest(\"setup: delete provider\");"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            }
+          }
+        },
+        {
+          "id": "setup-delete-provider",
+          "name": "setup: delete provider",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get('__purge_target')) { pm.execution.skipRequest(); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('setup: delete provider', function () { pm.expect([200, 204, 404], 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code); });",
+                  "var queue = (pm.collectionVariables.get('__purge_queue') || '').split(',').filter(Boolean);",
+                  "if (queue.length) {",
+                  "  pm.collectionVariables.set('__purge_target', queue[0]);",
+                  "  pm.collectionVariables.set('__purge_queue', queue.slice(1).join(','));",
+                  "  pm.execution.setNextRequest(\"setup: delete provider\");",
+                  "} else {",
+                  "  pm.collectionVariables.set('__purge_target', '');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/providers/{{__purge_target}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "{{__purge_target}}"
+              ]
+            }
+          }
+        }
+      ]
+    },
     {
       "name": "VK allows model, key allows — request routes",
       "description": "A VK whose allowed_models includes the request, over a key that allows it, routes successfully and records the key.",
@@ -12827,6 +12925,1974 @@
                     "api",
                     "providers",
                     "bedrock"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var required = [];",
+              "for (var i = 0; i < required.length; i++) {",
+              "  var v = required[i];",
+              "  if (!pm.variables.get(v) && !pm.environment.get(v)) {",
+              "    console.log('SKIP: missing ' + v);",
+              "    pm.execution.skipRequest();",
+              "    return;",
+              "  }",
+              "}"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "A request fails over to a healthy provider via a request-level fallback",
+      "description": "The primary provider's key is invalid, so its attempt fails upstream; a request-level fallback to a second provider serving the same model succeeds. routing_info marks the fallback and records the original primary provider/model. The /v1 endpoint takes fallbacks in the string \"provider/model\" form.",
+      "item": [
+        {
+          "id": "rt-fallback-cross-provider-01-add-provider",
+          "name": "01. add provider [fallback-cross-provider]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-cross-provider]\";",
+                  "pm.test(\"01. add provider [fallback-cross-provider]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-fallback-cross-provider-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-cross-provider-02-add-key",
+          "name": "02. add key kbad [fallback-cross-provider]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-cross-provider]\";",
+                  "pm.test(\"02. add key kbad [fallback-cross-provider]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-cross-provider-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-fallback-cross-provider-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"kbad-{{run_id}}\",\"name\":\"catwiring-rt-fallback-cross-provider-kbad-{{run_id}}\",\"models\":[\"gpt-4o-mini\"],\"enabled\":true,\"value\":\"sk-deadbeef-invalid-000\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-cross-provider-03-add-provider",
+          "name": "03. add provider (b) [fallback-cross-provider]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-cross-provider]\";",
+                  "pm.test(\"03. add provider (b) [fallback-cross-provider]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-fallback-cross-provider-b-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-cross-provider-04-add-key",
+          "name": "04. add key kgood (b) [fallback-cross-provider]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-cross-provider]\";",
+                  "pm.test(\"04. add key kgood (b) [fallback-cross-provider]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-cross-provider-b-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-fallback-cross-provider-b-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"kgood-{{run_id}}\",\"name\":\"catwiring-rt-fallback-cross-provider-kgood-{{run_id}}\",\"models\":[\"gpt-4o-mini\"],\"enabled\":true,\"value\":\"env.OPENAI_API_KEY\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-cross-provider-05-route",
+          "name": "05. primary fails; request fallback serves (200, is_fallback) [fallback-cross-provider]",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var pollKey = '__poll_' + pm.info.requestName;",
+                  "var attempt = parseInt(pm.collectionVariables.get(pollKey) || '0', 10);",
+                  "pm.collectionVariables.set('__cur_poll_key', pollKey);",
+                  "pm.collectionVariables.set('__cur_poll_attempt', String(attempt));",
+                  "if (attempt === 0) { var __ws = Date.now(); while (Date.now() - __ws < 1000) {} }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var maxAttempts = 8;",
+                  "var pollKey = pm.collectionVariables.get('__cur_poll_key');",
+                  "var attempt = parseInt(pm.collectionVariables.get('__cur_poll_attempt') || '0', 10);",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-cross-provider]\";",
+                  "function assertNow() {",
+                  "  if (pm.response.code !== 200) { throw new Error('route status ' + pm.response.code + ' body ' + pm.response.text()); }",
+                  "  var body = pm.response.json();",
+                  "  if (!body.choices || body.choices.length === 0) { throw new Error('no choices'); }",
+                  "  var ri = (body.extra_fields || {}).routing_info || {};",
+                  "  var allowedProviders = ['catwiring-rt-fallback-cross-provider-b-' + pm.variables.get('run_id')];",
+                  "  if (allowedProviders.indexOf(ri.provider) < 0) { throw new Error('routing_info.provider=' + ri.provider + ' not in ' + JSON.stringify(allowedProviders)); }",
+                  "  if (Boolean(ri.is_fallback) !== true) { throw new Error('is_fallback=' + ri.is_fallback); }",
+                  "  var expectedPrimary = 'catwiring-rt-fallback-cross-provider-' + pm.variables.get('run_id');",
+                  "  if (ri.primary_provider !== expectedPrimary) { throw new Error('primary_provider=' + ri.primary_provider + ' expected ' + expectedPrimary); }",
+                  "  if (ri.primary_model !== \"gpt-4o-mini\") { throw new Error('primary_model=' + ri.primary_model); }",
+                  "}",
+                  "var ok = true, errMsg = '';",
+                  "try { assertNow(); } catch (e) { ok = false; errMsg = e.message; }",
+                  "if (ok) {",
+                  "  pm.collectionVariables.set(pollKey, '0');",
+                  "  pm.test(\"05. primary fails; request fallback serves (200, is_fallback) [fallback-cross-provider]\", function () { pm.expect(true, 'assertion satisfied').to.be.true; });",
+                  "} else if (attempt < maxAttempts) {",
+                  "  pm.collectionVariables.set(pollKey, String(attempt + 1));",
+                  "  var sleepMs = Math.min(250 * Math.pow(2, attempt), 4000);",
+                  "  var start = Date.now(); while (Date.now() - start < sleepMs) {}",
+                  "  pm.execution.setNextRequest(pm.info.requestName);",
+                  "} else {",
+                  "  pm.collectionVariables.set(pollKey, '0');",
+                  "  pm.test(\"05. primary fails; request fallback serves (200, is_fallback) [fallback-cross-provider]\", function () { throw new Error(errMsg); });",
+                  "  pm.execution.setNextRequest(cleanupReq);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"catwiring-rt-fallback-cross-provider-{{run_id}}/gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5,\"fallbacks\":[\"catwiring-rt-fallback-cross-provider-b-{{run_id}}/gpt-4o-mini\"]}"
+            }
+          }
+        },
+        {
+          "name": "Cleanup",
+          "item": [
+            {
+              "id": "rt-fallback-cross-provider-cleanup-provider-self",
+              "name": "cleanup: delete provider [fallback-cross-provider]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider [fallback-cross-provider]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-cross-provider-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-fallback-cross-provider-{{run_id}}"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "rt-fallback-cross-provider-cleanup-provider-b",
+              "name": "cleanup: delete provider b [fallback-cross-provider]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider b [fallback-cross-provider]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-cross-provider-b-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-fallback-cross-provider-b-{{run_id}}"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var required = [];",
+              "for (var i = 0; i < required.length; i++) {",
+              "  var v = required[i];",
+              "  if (!pm.variables.get(v) && !pm.environment.get(v)) {",
+              "    console.log('SKIP: missing ' + v);",
+              "    pm.execution.skipRequest();",
+              "    return;",
+              "  }",
+              "}"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Fallbacks are tried in order until one succeeds",
+      "description": "The primary and the first fallback both have invalid keys; the second fallback succeeds. routing_info reports the surviving provider and still names the original primary.",
+      "item": [
+        {
+          "id": "rt-fallback-chain-first-healthy-wins-01-add-provider",
+          "name": "01. add provider [fallback-chain-first-healthy-wins]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-chain-first-healthy-wins]\";",
+                  "pm.test(\"01. add provider [fallback-chain-first-healthy-wins]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-fallback-chain-first-healthy-wins-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-chain-first-healthy-wins-02-add-key",
+          "name": "02. add key kbad1 [fallback-chain-first-healthy-wins]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-chain-first-healthy-wins]\";",
+                  "pm.test(\"02. add key kbad1 [fallback-chain-first-healthy-wins]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-chain-first-healthy-wins-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-fallback-chain-first-healthy-wins-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"kbad1-{{run_id}}\",\"name\":\"catwiring-rt-fallback-chain-first-healthy-wins-kbad1-{{run_id}}\",\"models\":[\"gpt-4o-mini\"],\"enabled\":true,\"value\":\"sk-deadbeef-invalid-000\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-chain-first-healthy-wins-03-add-provider",
+          "name": "03. add provider (b) [fallback-chain-first-healthy-wins]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-chain-first-healthy-wins]\";",
+                  "pm.test(\"03. add provider (b) [fallback-chain-first-healthy-wins]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-fallback-chain-first-healthy-wins-b-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-chain-first-healthy-wins-04-add-key",
+          "name": "04. add key kbad2 (b) [fallback-chain-first-healthy-wins]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-chain-first-healthy-wins]\";",
+                  "pm.test(\"04. add key kbad2 (b) [fallback-chain-first-healthy-wins]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-chain-first-healthy-wins-b-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-fallback-chain-first-healthy-wins-b-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"kbad2-{{run_id}}\",\"name\":\"catwiring-rt-fallback-chain-first-healthy-wins-kbad2-{{run_id}}\",\"models\":[\"gpt-4o-mini\"],\"enabled\":true,\"value\":\"sk-deadbeef-invalid-000\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-chain-first-healthy-wins-05-add-provider",
+          "name": "05. add provider (c) [fallback-chain-first-healthy-wins]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-chain-first-healthy-wins]\";",
+                  "pm.test(\"05. add provider (c) [fallback-chain-first-healthy-wins]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-fallback-chain-first-healthy-wins-c-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-chain-first-healthy-wins-06-add-key",
+          "name": "06. add key kgood (c) [fallback-chain-first-healthy-wins]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-chain-first-healthy-wins]\";",
+                  "pm.test(\"06. add key kgood (c) [fallback-chain-first-healthy-wins]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-chain-first-healthy-wins-c-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-fallback-chain-first-healthy-wins-c-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"kgood-{{run_id}}\",\"name\":\"catwiring-rt-fallback-chain-first-healthy-wins-kgood-{{run_id}}\",\"models\":[\"gpt-4o-mini\"],\"enabled\":true,\"value\":\"env.OPENAI_API_KEY\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-chain-first-healthy-wins-07-route",
+          "name": "07. chain falls through to the only healthy provider (200) [fallback-chain-first-healthy-wins]",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var pollKey = '__poll_' + pm.info.requestName;",
+                  "var attempt = parseInt(pm.collectionVariables.get(pollKey) || '0', 10);",
+                  "pm.collectionVariables.set('__cur_poll_key', pollKey);",
+                  "pm.collectionVariables.set('__cur_poll_attempt', String(attempt));",
+                  "if (attempt === 0) { var __ws = Date.now(); while (Date.now() - __ws < 1000) {} }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var maxAttempts = 8;",
+                  "var pollKey = pm.collectionVariables.get('__cur_poll_key');",
+                  "var attempt = parseInt(pm.collectionVariables.get('__cur_poll_attempt') || '0', 10);",
+                  "var cleanupReq = \"cleanup: delete provider [fallback-chain-first-healthy-wins]\";",
+                  "function assertNow() {",
+                  "  if (pm.response.code !== 200) { throw new Error('route status ' + pm.response.code + ' body ' + pm.response.text()); }",
+                  "  var body = pm.response.json();",
+                  "  if (!body.choices || body.choices.length === 0) { throw new Error('no choices'); }",
+                  "  var ri = (body.extra_fields || {}).routing_info || {};",
+                  "  var allowedProviders = ['catwiring-rt-fallback-chain-first-healthy-wins-c-' + pm.variables.get('run_id')];",
+                  "  if (allowedProviders.indexOf(ri.provider) < 0) { throw new Error('routing_info.provider=' + ri.provider + ' not in ' + JSON.stringify(allowedProviders)); }",
+                  "  if (Boolean(ri.is_fallback) !== true) { throw new Error('is_fallback=' + ri.is_fallback); }",
+                  "  var expectedPrimary = 'catwiring-rt-fallback-chain-first-healthy-wins-' + pm.variables.get('run_id');",
+                  "  if (ri.primary_provider !== expectedPrimary) { throw new Error('primary_provider=' + ri.primary_provider + ' expected ' + expectedPrimary); }",
+                  "  if (ri.primary_model !== \"gpt-4o-mini\") { throw new Error('primary_model=' + ri.primary_model); }",
+                  "}",
+                  "var ok = true, errMsg = '';",
+                  "try { assertNow(); } catch (e) { ok = false; errMsg = e.message; }",
+                  "if (ok) {",
+                  "  pm.collectionVariables.set(pollKey, '0');",
+                  "  pm.test(\"07. chain falls through to the only healthy provider (200) [fallback-chain-first-healthy-wins]\", function () { pm.expect(true, 'assertion satisfied').to.be.true; });",
+                  "} else if (attempt < maxAttempts) {",
+                  "  pm.collectionVariables.set(pollKey, String(attempt + 1));",
+                  "  var sleepMs = Math.min(250 * Math.pow(2, attempt), 4000);",
+                  "  var start = Date.now(); while (Date.now() - start < sleepMs) {}",
+                  "  pm.execution.setNextRequest(pm.info.requestName);",
+                  "} else {",
+                  "  pm.collectionVariables.set(pollKey, '0');",
+                  "  pm.test(\"07. chain falls through to the only healthy provider (200) [fallback-chain-first-healthy-wins]\", function () { throw new Error(errMsg); });",
+                  "  pm.execution.setNextRequest(cleanupReq);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"catwiring-rt-fallback-chain-first-healthy-wins-{{run_id}}/gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5,\"fallbacks\":[\"catwiring-rt-fallback-chain-first-healthy-wins-b-{{run_id}}/gpt-4o-mini\",\"catwiring-rt-fallback-chain-first-healthy-wins-c-{{run_id}}/gpt-4o-mini\"]}"
+            }
+          }
+        },
+        {
+          "name": "Cleanup",
+          "item": [
+            {
+              "id": "rt-fallback-chain-first-healthy-wins-cleanup-provider-self",
+              "name": "cleanup: delete provider [fallback-chain-first-healthy-wins]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider [fallback-chain-first-healthy-wins]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-chain-first-healthy-wins-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-fallback-chain-first-healthy-wins-{{run_id}}"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "rt-fallback-chain-first-healthy-wins-cleanup-provider-b",
+              "name": "cleanup: delete provider b [fallback-chain-first-healthy-wins]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider b [fallback-chain-first-healthy-wins]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-chain-first-healthy-wins-b-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-fallback-chain-first-healthy-wins-b-{{run_id}}"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "rt-fallback-chain-first-healthy-wins-cleanup-provider-c",
+              "name": "cleanup: delete provider c [fallback-chain-first-healthy-wins]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider c [fallback-chain-first-healthy-wins]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-chain-first-healthy-wins-c-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-fallback-chain-first-healthy-wins-c-{{run_id}}"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var required = [];",
+              "for (var i = 0; i < required.length; i++) {",
+              "  var v = required[i];",
+              "  if (!pm.variables.get(v) && !pm.environment.get(v)) {",
+              "    console.log('SKIP: missing ' + v);",
+              "    pm.execution.skipRequest();",
+              "    return;",
+              "  }",
+              "}"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "A fallback to a provider off the VK allowlist is pruned, not tried",
+      "description": "Under a VK that permits only the primary provider, a request-level fallback to a healthy off-allowlist provider is pruned before the attempt loop. The primary's invalid key fails with a 401 and the pruned provider — which has a valid key and would otherwise return 200 — never rescues it, proving it was dropped.",
+      "item": [
+        {
+          "id": "rt-fallback-pruned-by-vk-allowlist-01-add-provider",
+          "name": "01. add provider [fallback-pruned-by-vk-allowlist]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete vk [fallback-pruned-by-vk-allowlist]\";",
+                  "pm.test(\"01. add provider [fallback-pruned-by-vk-allowlist]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-fallback-pruned-by-vk-allowlist-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-pruned-by-vk-allowlist-02-add-key",
+          "name": "02. add key kbad [fallback-pruned-by-vk-allowlist]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete vk [fallback-pruned-by-vk-allowlist]\";",
+                  "pm.test(\"02. add key kbad [fallback-pruned-by-vk-allowlist]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-pruned-by-vk-allowlist-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-fallback-pruned-by-vk-allowlist-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"kbad-{{run_id}}\",\"name\":\"catwiring-rt-fallback-pruned-by-vk-allowlist-kbad-{{run_id}}\",\"models\":[\"gpt-4o-mini\"],\"enabled\":true,\"value\":\"sk-deadbeef-invalid-000\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-pruned-by-vk-allowlist-03-add-provider",
+          "name": "03. add provider (b) [fallback-pruned-by-vk-allowlist]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete vk [fallback-pruned-by-vk-allowlist]\";",
+                  "pm.test(\"03. add provider (b) [fallback-pruned-by-vk-allowlist]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-fallback-pruned-by-vk-allowlist-b-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-pruned-by-vk-allowlist-04-add-key",
+          "name": "04. add key kgood (b) [fallback-pruned-by-vk-allowlist]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete vk [fallback-pruned-by-vk-allowlist]\";",
+                  "pm.test(\"04. add key kgood (b) [fallback-pruned-by-vk-allowlist]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-pruned-by-vk-allowlist-b-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-fallback-pruned-by-vk-allowlist-b-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"kgood-{{run_id}}\",\"name\":\"catwiring-rt-fallback-pruned-by-vk-allowlist-kgood-{{run_id}}\",\"models\":[\"gpt-4o-mini\"],\"enabled\":true,\"value\":\"env.OPENAI_API_KEY\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-pruned-by-vk-allowlist-05-create-vk",
+          "name": "05. create vk [fallback-pruned-by-vk-allowlist]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete vk [fallback-pruned-by-vk-allowlist]\";",
+                  "var ok = pm.response.code === 200 || pm.response.code === 201;",
+                  "pm.test(\"05. create vk [fallback-pruned-by-vk-allowlist]\", function () {",
+                  "  pm.expect([200, 201], 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (ok) {",
+                  "  var vk = (pm.response.json() || {}).virtual_key || {};",
+                  "  pm.collectionVariables.set('vkval_fallback-pruned-by-vk-allowlist', vk.value || '');",
+                  "  pm.collectionVariables.set('vkid_fallback-pruned-by-vk-allowlist', vk.id || '');",
+                  "} else { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"catwiring-rtvk-fallback-pruned-by-vk-allowlist-{{run_id}}\",\"is_active\":true,\"provider_configs\":[{\"provider\":\"catwiring-rt-fallback-pruned-by-vk-allowlist-{{run_id}}\",\"key_ids\":[\"*\"],\"allowed_models\":[\"*\"],\"blacklisted_models\":[],\"weight\":1}]}"
+            }
+          }
+        },
+        {
+          "id": "rt-fallback-pruned-by-vk-allowlist-06-route",
+          "name": "06. off-allowlist fallback pruned; request fails on the primary (401) [fallback-pruned-by-vk-allowlist]",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var pollKey = '__poll_' + pm.info.requestName;",
+                  "var attempt = parseInt(pm.collectionVariables.get(pollKey) || '0', 10);",
+                  "pm.collectionVariables.set('__cur_poll_key', pollKey);",
+                  "pm.collectionVariables.set('__cur_poll_attempt', String(attempt));",
+                  "if (attempt === 0) { var __ws = Date.now(); while (Date.now() - __ws < 1000) {} }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var maxAttempts = 8;",
+                  "var pollKey = pm.collectionVariables.get('__cur_poll_key');",
+                  "var attempt = parseInt(pm.collectionVariables.get('__cur_poll_attempt') || '0', 10);",
+                  "var cleanupReq = \"cleanup: delete vk [fallback-pruned-by-vk-allowlist]\";",
+                  "function assertNow() {",
+                  "  if (pm.response.code !== 401) { throw new Error('expected status 401 got ' + pm.response.code + ' body ' + pm.response.text()); }",
+                  "  var body = pm.response.json();",
+                  "  var msg = (body.error && (body.error.message || body.error)) || body.message || '';",
+                  "  if (String(msg).indexOf(\"Incorrect API key\") < 0) { throw new Error('error message=' + msg); }",
+                  "}",
+                  "var ok = true, errMsg = '';",
+                  "try { assertNow(); } catch (e) { ok = false; errMsg = e.message; }",
+                  "if (ok) {",
+                  "  pm.collectionVariables.set(pollKey, '0');",
+                  "  pm.test(\"06. off-allowlist fallback pruned; request fails on the primary (401) [fallback-pruned-by-vk-allowlist]\", function () { pm.expect(true, 'assertion satisfied').to.be.true; });",
+                  "} else if (attempt < maxAttempts) {",
+                  "  pm.collectionVariables.set(pollKey, String(attempt + 1));",
+                  "  var sleepMs = Math.min(250 * Math.pow(2, attempt), 4000);",
+                  "  var start = Date.now(); while (Date.now() - start < sleepMs) {}",
+                  "  pm.execution.setNextRequest(pm.info.requestName);",
+                  "} else {",
+                  "  pm.collectionVariables.set(pollKey, '0');",
+                  "  pm.test(\"06. off-allowlist fallback pruned; request fails on the primary (401) [fallback-pruned-by-vk-allowlist]\", function () { throw new Error(errMsg); });",
+                  "  pm.execution.setNextRequest(cleanupReq);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "x-bf-vk",
+                "value": "{{vkval_fallback-pruned-by-vk-allowlist}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"catwiring-rt-fallback-pruned-by-vk-allowlist-{{run_id}}/gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5,\"fallbacks\":[\"catwiring-rt-fallback-pruned-by-vk-allowlist-b-{{run_id}}/gpt-4o-mini\"]}"
+            }
+          }
+        },
+        {
+          "name": "Cleanup",
+          "item": [
+            {
+              "id": "rt-fallback-pruned-by-vk-allowlist-cleanup-vk",
+              "name": "cleanup: delete vk [fallback-pruned-by-vk-allowlist]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete vk [fallback-pruned-by-vk-allowlist]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/governance/virtual-keys/{{vkid_fallback-pruned-by-vk-allowlist}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "governance",
+                    "virtual-keys",
+                    "{{vkid_fallback-pruned-by-vk-allowlist}}"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "rt-fallback-pruned-by-vk-allowlist-cleanup-provider-self",
+              "name": "cleanup: delete provider [fallback-pruned-by-vk-allowlist]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider [fallback-pruned-by-vk-allowlist]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-pruned-by-vk-allowlist-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-fallback-pruned-by-vk-allowlist-{{run_id}}"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "rt-fallback-pruned-by-vk-allowlist-cleanup-provider-b",
+              "name": "cleanup: delete provider b [fallback-pruned-by-vk-allowlist]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider b [fallback-pruned-by-vk-allowlist]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-fallback-pruned-by-vk-allowlist-b-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-fallback-pruned-by-vk-allowlist-b-{{run_id}}"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var required = [];",
+              "for (var i = 0; i < required.length; i++) {",
+              "  var v = required[i];",
+              "  if (!pm.variables.get(v) && !pm.environment.get(v)) {",
+              "    console.log('SKIP: missing ' + v);",
+              "    pm.execution.skipRequest();",
+              "    return;",
+              "  }",
+              "}"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "A VK with weighted providers auto-attaches the others as fallbacks",
+      "description": "A VK weights two providers that both serve the model; the dominant-weight provider's key is invalid. With no request-level fallbacks, governance auto-attaches the remaining weighted config as a fallback, so every request still lands on the healthy low-weight provider — whether it was the load-balanced primary or the fallback.",
+      "item": [
+        {
+          "id": "rt-vk-auto-attached-fallback-01-add-provider",
+          "name": "01. add provider [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "pm.test(\"01. add provider [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-vk-auto-attached-fallback-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-02-add-key",
+          "name": "02. add key kbad [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "pm.test(\"02. add key kbad [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-vk-auto-attached-fallback-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-vk-auto-attached-fallback-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"kbad-{{run_id}}\",\"name\":\"catwiring-rt-vk-auto-attached-fallback-kbad-{{run_id}}\",\"models\":[\"gpt-4o-mini\"],\"enabled\":true,\"value\":\"sk-deadbeef-invalid-000\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-03-add-provider",
+          "name": "03. add provider (b) [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "pm.test(\"03. add provider (b) [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-vk-auto-attached-fallback-b-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-04-add-key",
+          "name": "04. add key kgood (b) [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "pm.test(\"04. add key kgood (b) [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-vk-auto-attached-fallback-b-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-vk-auto-attached-fallback-b-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"kgood-{{run_id}}\",\"name\":\"catwiring-rt-vk-auto-attached-fallback-kgood-{{run_id}}\",\"models\":[\"gpt-4o-mini\"],\"enabled\":true,\"value\":\"env.OPENAI_API_KEY\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-05-create-vk",
+          "name": "05. create vk [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "var ok = pm.response.code === 200 || pm.response.code === 201;",
+                  "pm.test(\"05. create vk [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect([200, 201], 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (ok) {",
+                  "  var vk = (pm.response.json() || {}).virtual_key || {};",
+                  "  pm.collectionVariables.set('vkval_vk-auto-attached-fallback', vk.value || '');",
+                  "  pm.collectionVariables.set('vkid_vk-auto-attached-fallback', vk.id || '');",
+                  "} else { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"catwiring-rtvk-vk-auto-attached-fallback-{{run_id}}\",\"is_active\":true,\"provider_configs\":[{\"provider\":\"catwiring-rt-vk-auto-attached-fallback-{{run_id}}\",\"key_ids\":[\"*\"],\"allowed_models\":[\"*\"],\"blacklisted_models\":[],\"weight\":100},{\"provider\":\"catwiring-rt-vk-auto-attached-fallback-b-{{run_id}}\",\"key_ids\":[\"*\"],\"allowed_models\":[\"*\"],\"blacklisted_models\":[],\"weight\":1}]}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-06-pdist-sample",
+          "name": "06. sample 1/6 (gpt-4o-mini) [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "pm.collectionVariables.set('pdist_vk-auto-attached-fallback', '');",
+                  "if (pm.response.code === 200) {",
+                  "  var p = ((pm.response.json().extra_fields || {}).routing_info || {}).provider || '';",
+                  "  var cur = pm.collectionVariables.get('pdist_vk-auto-attached-fallback') || '';",
+                  "  var set = cur ? cur.split(',') : [];",
+                  "  if (p && set.indexOf(p) < 0) { set.push(p); pm.collectionVariables.set('pdist_vk-auto-attached-fallback', set.join(',')); }",
+                  "}",
+                  "pm.test(\"06. sample 1/6 (gpt-4o-mini) [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(pm.response.code, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.equal(200);",
+                  "});",
+                  "if (pm.response.code !== 200) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "x-bf-vk",
+                "value": "{{vkval_vk-auto-attached-fallback}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-07-pdist-sample",
+          "name": "07. sample 2/6 (gpt-4o-mini) [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "if (pm.response.code === 200) {",
+                  "  var p = ((pm.response.json().extra_fields || {}).routing_info || {}).provider || '';",
+                  "  var cur = pm.collectionVariables.get('pdist_vk-auto-attached-fallback') || '';",
+                  "  var set = cur ? cur.split(',') : [];",
+                  "  if (p && set.indexOf(p) < 0) { set.push(p); pm.collectionVariables.set('pdist_vk-auto-attached-fallback', set.join(',')); }",
+                  "}",
+                  "pm.test(\"07. sample 2/6 (gpt-4o-mini) [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(pm.response.code, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.equal(200);",
+                  "});",
+                  "if (pm.response.code !== 200) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "x-bf-vk",
+                "value": "{{vkval_vk-auto-attached-fallback}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-08-pdist-sample",
+          "name": "08. sample 3/6 (gpt-4o-mini) [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "if (pm.response.code === 200) {",
+                  "  var p = ((pm.response.json().extra_fields || {}).routing_info || {}).provider || '';",
+                  "  var cur = pm.collectionVariables.get('pdist_vk-auto-attached-fallback') || '';",
+                  "  var set = cur ? cur.split(',') : [];",
+                  "  if (p && set.indexOf(p) < 0) { set.push(p); pm.collectionVariables.set('pdist_vk-auto-attached-fallback', set.join(',')); }",
+                  "}",
+                  "pm.test(\"08. sample 3/6 (gpt-4o-mini) [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(pm.response.code, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.equal(200);",
+                  "});",
+                  "if (pm.response.code !== 200) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "x-bf-vk",
+                "value": "{{vkval_vk-auto-attached-fallback}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-09-pdist-sample",
+          "name": "09. sample 4/6 (gpt-4o-mini) [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "if (pm.response.code === 200) {",
+                  "  var p = ((pm.response.json().extra_fields || {}).routing_info || {}).provider || '';",
+                  "  var cur = pm.collectionVariables.get('pdist_vk-auto-attached-fallback') || '';",
+                  "  var set = cur ? cur.split(',') : [];",
+                  "  if (p && set.indexOf(p) < 0) { set.push(p); pm.collectionVariables.set('pdist_vk-auto-attached-fallback', set.join(',')); }",
+                  "}",
+                  "pm.test(\"09. sample 4/6 (gpt-4o-mini) [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(pm.response.code, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.equal(200);",
+                  "});",
+                  "if (pm.response.code !== 200) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "x-bf-vk",
+                "value": "{{vkval_vk-auto-attached-fallback}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-10-pdist-sample",
+          "name": "10. sample 5/6 (gpt-4o-mini) [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "if (pm.response.code === 200) {",
+                  "  var p = ((pm.response.json().extra_fields || {}).routing_info || {}).provider || '';",
+                  "  var cur = pm.collectionVariables.get('pdist_vk-auto-attached-fallback') || '';",
+                  "  var set = cur ? cur.split(',') : [];",
+                  "  if (p && set.indexOf(p) < 0) { set.push(p); pm.collectionVariables.set('pdist_vk-auto-attached-fallback', set.join(',')); }",
+                  "}",
+                  "pm.test(\"10. sample 5/6 (gpt-4o-mini) [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(pm.response.code, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.equal(200);",
+                  "});",
+                  "if (pm.response.code !== 200) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "x-bf-vk",
+                "value": "{{vkval_vk-auto-attached-fallback}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-11-pdist-sample",
+          "name": "11. sample 6/6 (gpt-4o-mini) [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "if (pm.response.code === 200) {",
+                  "  var p = ((pm.response.json().extra_fields || {}).routing_info || {}).provider || '';",
+                  "  var cur = pm.collectionVariables.get('pdist_vk-auto-attached-fallback') || '';",
+                  "  var set = cur ? cur.split(',') : [];",
+                  "  if (p && set.indexOf(p) < 0) { set.push(p); pm.collectionVariables.set('pdist_vk-auto-attached-fallback', set.join(',')); }",
+                  "}",
+                  "pm.test(\"11. sample 6/6 (gpt-4o-mini) [vk-auto-attached-fallback]\", function () {",
+                  "  pm.expect(pm.response.code, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.equal(200);",
+                  "});",
+                  "if (pm.response.code !== 200) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "x-bf-vk",
+                "value": "{{vkval_vk-auto-attached-fallback}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5}"
+            }
+          }
+        },
+        {
+          "id": "rt-vk-auto-attached-fallback-12-pdist-assert",
+          "name": "12. every request lands on the healthy provider via the auto-attached fallback [vk-auto-attached-fallback]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete vk [vk-auto-attached-fallback]\";",
+                  "var ok = true, errMsg = '';",
+                  "try {",
+                  "  var seen = (pm.collectionVariables.get('pdist_vk-auto-attached-fallback') || '').split(',').filter(Boolean);",
+                  "  var only = ['catwiring-rt-vk-auto-attached-fallback-b-' + pm.variables.get('run_id')];",
+                  "  var never = [];",
+                  "  var all = [];",
+                  "  if (seen.length === 0) throw new Error('no provider observed across samples');",
+                  "  seen.forEach(function (p) {",
+                  "    if (only.length && only.indexOf(p) < 0) throw new Error('provider ' + p + ' served but not in expectOnly ' + JSON.stringify(only));",
+                  "    if (never.indexOf(p) >= 0) throw new Error('provider ' + p + ' served but was expectNever; observed ' + JSON.stringify(seen));",
+                  "  });",
+                  "  all.forEach(function (p) { if (seen.indexOf(p) < 0) throw new Error('provider ' + p + ' expected to serve but did not; observed ' + JSON.stringify(seen)); });",
+                  "} catch (e) { ok = false; errMsg = e.message; }",
+                  "pm.test(\"12. every request lands on the healthy provider via the auto-attached fallback [vk-auto-attached-fallback]\", function () { if (!ok) throw new Error(errMsg); });",
+                  "if (!ok) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/health",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "health"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Cleanup",
+          "item": [
+            {
+              "id": "rt-vk-auto-attached-fallback-cleanup-vk",
+              "name": "cleanup: delete vk [vk-auto-attached-fallback]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete vk [vk-auto-attached-fallback]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/governance/virtual-keys/{{vkid_vk-auto-attached-fallback}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "governance",
+                    "virtual-keys",
+                    "{{vkid_vk-auto-attached-fallback}}"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "rt-vk-auto-attached-fallback-cleanup-provider-self",
+              "name": "cleanup: delete provider [vk-auto-attached-fallback]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider [vk-auto-attached-fallback]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-vk-auto-attached-fallback-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-vk-auto-attached-fallback-{{run_id}}"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "rt-vk-auto-attached-fallback-cleanup-provider-b",
+              "name": "cleanup: delete provider b [vk-auto-attached-fallback]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider b [vk-auto-attached-fallback]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-vk-auto-attached-fallback-b-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-vk-auto-attached-fallback-b-{{run_id}}"
                   ]
                 }
               }

--- a/tests/e2e/api/runners/build-routing-wiring.mjs
+++ b/tests/e2e/api/runners/build-routing-wiring.mjs
@@ -101,8 +101,8 @@ const MODEL_B = PROVIDERS.openai.model; // gpt-4o-mini
 // Spec helpers
 // --------------------------------------------------------------------------- //
 
-function key({ id, models = [], blacklisted = [], enabled = true, aliases = {}, weight } = {}) {
-  return { id, models, blacklisted, enabled, aliases, weight };
+function key({ id, models = [], blacklisted = [], enabled = true, aliases = {}, weight, badKey = false } = {}) {
+  return { id, models, blacklisted, enabled, aliases, weight, badKey };
 }
 
 // Key names must be unique across all providers, so namespace by scenario + key
@@ -111,7 +111,12 @@ function key({ id, models = [], blacklisted = [], enabled = true, aliases = {}, 
 // provider-specific key config (e.g. vertex_key_config) when prov.keyConfig is set.
 function keyBody(k, name, prov) {
   const out = { id: keyId(k.id), name, models: [...k.models], enabled: k.enabled };
-  if (prov.keyConfig) Object.assign(out, prov.keyConfig);
+  if (k.badKey) {
+    // A deliberately invalid credential so the provider attempt fails upstream
+    // (e.g. a 401), exercising the fallback path. The provider itself is real
+    // and capable of the model — only the credential is broken.
+    out.value = "sk-deadbeef-invalid-000";
+  } else if (prov.keyConfig) Object.assign(out, prov.keyConfig);
   else out.value = `env.${prov.env}`;
   if (k.blacklisted.length) out.blacklisted_models = [...k.blacklisted];
   // prov.aliasFor lets a provider expose a common model name (e.g. Bedrock maps
@@ -166,6 +171,16 @@ function routeAssertLines(sid, step, jsNameOf) {
       lines.push(
         `if (!ri.resolved_key_alias || ri.resolved_key_alias.model_id !== ${JSON.stringify(step.expectResolvedModelId)}) { throw new Error('resolved_key_alias=' + JSON.stringify(ri.resolved_key_alias)); }`
       );
+    }
+    if (step.expectIsFallback != null) {
+      lines.push(`if (Boolean(ri.is_fallback) !== ${JSON.stringify(step.expectIsFallback)}) { throw new Error('is_fallback=' + ri.is_fallback); }`);
+    }
+    if (step.expectPrimaryProviderRef != null) {
+      lines.push(`var expectedPrimary = ${jsNameOf(step.expectPrimaryProviderRef)};`);
+      lines.push("if (ri.primary_provider !== expectedPrimary) { throw new Error('primary_provider=' + ri.primary_provider + ' expected ' + expectedPrimary); }");
+    }
+    if (step.expectPrimaryModel != null) {
+      lines.push(`if (ri.primary_model !== ${JSON.stringify(step.expectPrimaryModel)}) { throw new Error('primary_model=' + ri.primary_model); }`);
     }
     return lines;
   }
@@ -387,6 +402,11 @@ function expandScenario(sc) {
           messages: [{ role: "user", content: "Reply with the single word: ok." }],
           max_tokens: 5,
         };
+        // Request-level fallbacks. The /v1 OpenAI-compatible endpoint takes the
+        // string "provider/model" form (not the {provider,model} object form).
+        if (step.fallbacks) {
+          body.fallbacks = step.fallbacks.map((f) => `${nameOf(f.providerRef)}/${f.model}`);
+        }
         items.push(item(nextId("route"), name, request("POST", url(["v1", "chat", "completions"]), body, headers),
           events(pollPrerequest(step.waitSeconds), pollTest(name, routeAssertLines(sid, step, jsNameOf), cleanupTarget))));
         break;
@@ -820,6 +840,53 @@ const SCENARIOS = [
       { type: "createVK", providerConfigs: [vkProvider({ providerRef: "self", allowedModels: ["*"] }), vkProvider({ providerRef: "vtx", allowedModels: ["*"] }), vkProvider({ providerRef: "bdr", allowedModels: ["*"] })] },
       { type: "route", model: "claude-sonnet-4-5", bareModel: true, expectStatus: 200, expectProviderOneOf: ["self", "vtx", "bdr"], waitSeconds: 3, label: "bare claude model routes via anthropic, vertex, or bedrock (200)" },
       { type: "assertRoutingTrail", expectSubstrings: ["Load balancing model claude-sonnet-4-5", "Selected provider"], waitSeconds: 2, label: "log detail records cross-provider LB trail" },
+      { type: "cleanup" },
+    ],
+  },
+  {
+    id: "fallback-cross-provider",
+    title: "A request fails over to a healthy provider via a request-level fallback",
+    description: "The primary provider's key is invalid, so its attempt fails upstream; a request-level fallback to a second provider serving the same model succeeds. routing_info marks the fallback and records the original primary provider/model. The /v1 endpoint takes fallbacks in the string \"provider/model\" form.",
+    steps: [
+      { type: "addProvider", ref: "self", keys: [key({ id: "kbad", models: [MODEL_B], badKey: true })] },
+      { type: "addProvider", ref: "b", keys: [key({ id: "kgood", models: [MODEL_B] })] },
+      { type: "route", model: MODEL_B, routeRef: "self", useVk: false, fallbacks: [{ providerRef: "b", model: MODEL_B }], expectStatus: 200, expectProviderOneOf: ["b"], expectIsFallback: true, expectPrimaryProviderRef: "self", expectPrimaryModel: MODEL_B, waitSeconds: 1, label: "primary fails; request fallback serves (200, is_fallback)" },
+      { type: "cleanup" },
+    ],
+  },
+  {
+    id: "fallback-chain-first-healthy-wins",
+    title: "Fallbacks are tried in order until one succeeds",
+    description: "The primary and the first fallback both have invalid keys; the second fallback succeeds. routing_info reports the surviving provider and still names the original primary.",
+    steps: [
+      { type: "addProvider", ref: "self", keys: [key({ id: "kbad1", models: [MODEL_B], badKey: true })] },
+      { type: "addProvider", ref: "b", keys: [key({ id: "kbad2", models: [MODEL_B], badKey: true })] },
+      { type: "addProvider", ref: "c", keys: [key({ id: "kgood", models: [MODEL_B] })] },
+      { type: "route", model: MODEL_B, routeRef: "self", useVk: false, fallbacks: [{ providerRef: "b", model: MODEL_B }, { providerRef: "c", model: MODEL_B }], expectStatus: 200, expectProviderOneOf: ["c"], expectIsFallback: true, expectPrimaryProviderRef: "self", expectPrimaryModel: MODEL_B, waitSeconds: 1, label: "chain falls through to the only healthy provider (200)" },
+      { type: "cleanup" },
+    ],
+  },
+  {
+    id: "fallback-pruned-by-vk-allowlist",
+    title: "A fallback to a provider off the VK allowlist is pruned, not tried",
+    description: "Under a VK that permits only the primary provider, a request-level fallback to a healthy off-allowlist provider is pruned before the attempt loop. The primary's invalid key fails with a 401 and the pruned provider — which has a valid key and would otherwise return 200 — never rescues it, proving it was dropped.",
+    steps: [
+      { type: "addProvider", ref: "self", keys: [key({ id: "kbad", models: [MODEL_B], badKey: true })] },
+      { type: "addProvider", ref: "b", keys: [key({ id: "kgood", models: [MODEL_B] })] },
+      { type: "createVK", providerConfigs: [vkProvider({ providerRef: "self", allowedModels: ["*"] })] },
+      { type: "route", model: MODEL_B, routeRef: "self", fallbacks: [{ providerRef: "b", model: MODEL_B }], expectStatus: 401, expectErrorSubstr: "Incorrect API key", waitSeconds: 1, label: "off-allowlist fallback pruned; request fails on the primary (401)" },
+      { type: "cleanup" },
+    ],
+  },
+  {
+    id: "vk-auto-attached-fallback",
+    title: "A VK with weighted providers auto-attaches the others as fallbacks",
+    description: "A VK weights two providers that both serve the model; the dominant-weight provider's key is invalid. With no request-level fallbacks, governance auto-attaches the remaining weighted config as a fallback, so every request still lands on the healthy low-weight provider — whether it was the load-balanced primary or the fallback.",
+    steps: [
+      { type: "addProvider", ref: "self", keys: [key({ id: "kbad", models: [MODEL_B], badKey: true })] },
+      { type: "addProvider", ref: "b", keys: [key({ id: "kgood", models: [MODEL_B] })] },
+      { type: "createVK", providerConfigs: [vkProvider({ providerRef: "self", weight: 100, allowedModels: ["*"] }), vkProvider({ providerRef: "b", weight: 1, allowedModels: ["*"] })] },
+      { type: "providerDistribution", model: MODEL_B, bareModel: true, n: 6, expectOnly: ["b"], label: "every request lands on the healthy provider via the auto-attached fallback" },
       { type: "cleanup" },
     ],
   },

--- a/tests/e2e/api/runners/lib/collection-builder.mjs
+++ b/tests/e2e/api/runners/lib/collection-builder.mjs
@@ -116,6 +116,55 @@ export function cleanupTest(testname) {
   ];
 }
 
+// A setup folder that deletes every provider before any scenario runs, so the
+// suite starts from a clean slate. Standard (non-custom) providers are global
+// singletons keyed by name — a leftover `openai`/`azure`/... from a prior or
+// interrupted run makes a scenario's create fail with 409 "already exists".
+// Clearing up front removes that whole class of cross-run collisions. Scenarios
+// recreate every provider they need (keys resolve via Bifrost's env.<NAME>, not
+// from any pre-existing provider), so nothing depends on what was there before.
+//
+// Implemented as a two-request loop: "list" reads all provider names into a
+// queue and seeds the first target; "delete" removes the current target, then
+// re-points the queue's next entry at itself until the queue drains.
+export function clearProvidersFolder() {
+  const LIST = "setup: list providers to clear";
+  const DEL = "setup: delete provider";
+  const listTest = [
+    "pm.test('setup: list providers', function () { pm.expect(pm.response.code, pm.response.text()).to.equal(200); });",
+    "if (pm.response.code !== 200) { return; }",
+    "var provs = ((pm.response.json() || {}).providers || []).map(function (p) { return p.name; }).filter(Boolean);",
+    "if (provs.length === 0) { pm.collectionVariables.set('__purge_target', ''); pm.collectionVariables.set('__purge_queue', ''); return; }",
+    "pm.collectionVariables.set('__purge_target', provs[0]);",
+    "pm.collectionVariables.set('__purge_queue', provs.slice(1).join(','));",
+    `pm.execution.setNextRequest(${JSON.stringify(DEL)});`,
+  ];
+  const delPre = [
+    // No target → nothing to clear (empty instance, or the queue just drained):
+    // skip this request and fall through to the first scenario.
+    "if (!pm.collectionVariables.get('__purge_target')) { pm.execution.skipRequest(); }",
+  ];
+  const delTest = [
+    "pm.test('setup: delete provider', function () { pm.expect([200, 204, 404], 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code); });",
+    "var queue = (pm.collectionVariables.get('__purge_queue') || '').split(',').filter(Boolean);",
+    "if (queue.length) {",
+    "  pm.collectionVariables.set('__purge_target', queue[0]);",
+    "  pm.collectionVariables.set('__purge_queue', queue.slice(1).join(','));",
+    `  pm.execution.setNextRequest(${JSON.stringify(DEL)});`,
+    "} else {",
+    "  pm.collectionVariables.set('__purge_target', '');",
+    "}",
+  ];
+  return {
+    id: "setup-clear-providers",
+    name: "Setup: clear providers",
+    item: [
+      item("setup-list-providers", LIST, request("GET", url(["api", "providers"]), null), events(null, listTest)),
+      item("setup-delete-provider", DEL, request("DELETE", url(["api", "providers", "{{__purge_target}}"]), null), events(delPre, delTest)),
+    ],
+  };
+}
+
 // --------------------------------------------------------------------------- //
 // Postman item primitives
 // --------------------------------------------------------------------------- //
@@ -165,10 +214,14 @@ export function buildCollection({ id, name, description, expandedScenarios, extr
     variable: [
       { key: "base_url", value: "http://localhost:8080", type: "string" },
       { key: "run_id", value: "", type: "string" },
+      { key: "__purge_target", value: "", type: "string" },
+      { key: "__purge_queue", value: "", type: "string" },
       ...(extraVariables || []),
     ],
     event: events(collectionPrerequest(), null),
-    item: expandedScenarios,
+    // The clear-providers setup folder always runs first so every run starts
+    // from a clean provider slate.
+    item: [clearProvidersFolder(), ...expandedScenarios],
   };
 }
 


### PR DESCRIPTION
## Summary

Adds end-to-end test coverage for request-level fallback routing and VK-governed fallback behaviour. Previously, the routing wiring collection had no tests exercising the fallback path. This PR introduces four new scenarios covering the core fallback contract and adds a pre-run setup step that clears all providers before any scenario executes, eliminating cross-run collisions caused by leftover providers from prior or interrupted runs.

## Changes

- Added a `clearProvidersFolder()` helper in `collection-builder.mjs` that emits a two-request loop (list → delete) at the top of every collection, draining all existing providers before scenarios begin. The `__purge_target` and `__purge_queue` collection variables that drive the loop are declared in `buildCollection`.
- Added a `badKey` flag to the `key()` helper and `keyBody()` in `build-routing-wiring.mjs`. When set, the key receives a hardcoded invalid credential (`sk-deadbeef-invalid-000`) instead of a real env-backed value, forcing an upstream auth failure to exercise the fallback path without needing a separate provider type.
- Added `expectIsFallback`, `expectPrimaryProviderRef`, and `expectPrimaryModel` assertion fields to `routeAssertLines()`, and a `fallbacks` field to route steps that serialises fallback targets as `"provider/model"` strings on the `/v1/chat/completions` request body.
- Added four new routing scenarios:
  - **`fallback-cross-provider`**: primary has an invalid key; a single request-level fallback to a healthy second provider succeeds, and `routing_info` reports `is_fallback=true` with the original primary recorded.
  - **`fallback-chain-first-healthy-wins`**: primary and first fallback both have invalid keys; the second fallback in the chain succeeds.
  - **`fallback-pruned-by-vk-allowlist`**: a VK that permits only the primary provider causes the off-allowlist fallback to be pruned before the attempt loop, so the request fails with 401 rather than being rescued.
  - **`vk-auto-attached-fallback`**: a VK with two weighted providers auto-attaches the non-primary configs as fallbacks; with the dominant-weight provider's key broken, all six sampled requests land on the healthy low-weight provider.
- Regenerated both `bifrost-routing-wiring.postman_collection.json` and `bifrost-model-catalog-wiring.postman_collection.json` to include the clear-providers setup folder and the new scenario items.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the routing wiring collection against a local Bifrost instance with `OPENAI_API_KEY` set in the environment:

```sh
newman run tests/e2e/api/collections/bifrost-routing-wiring.postman_collection.json \
  --env-var base_url=http://localhost:8080 \
  --env-var run_id=$(date +%s)
```

The four new scenarios (`fallback-cross-provider`, `fallback-chain-first-healthy-wins`, `fallback-pruned-by-vk-allowlist`, `vk-auto-attached-fallback`) should all pass. The setup folder at the top of the run should complete without error regardless of whether providers already exist on the instance.

To regenerate the collection from the builder after further changes:

```sh
node tests/e2e/api/runners/build-routing-wiring.mjs
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The invalid credentials used in `badKey` scenarios (`sk-deadbeef-invalid-000`) are intentionally non-functional placeholder values and are never sourced from environment secrets.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive E2E coverage for fallback routing: request-level provider failovers, ordered fallback chaining, allowlist pruning of fallbacks, and governance-driven auto-attached fallbacks when primaries fail.
  * Implemented automated provider cleanup as part of test setup to ensure a clean, deterministic environment before running E2E suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->