### PR TITLE
docs: add semantic cache latency warning, comparison table row, and routing harness ledger docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ examples/mcps/oauth-demo-server/oauth-demo-server
 # binaries
 tests/cmd/e2eseed/e2eseed
 tests/cmd/seedvks/seedvks
+
+# routing harness ledgers (local run journals, never committed)
+tests/e2e/api/routing/ledger-*

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -50,6 +50,14 @@ A few things that trip up first-time users — read these before configuring:
 
 **What gets cached:** chat completions, text completions, the Responses API (including WebSocket), embeddings, transcriptions, speech, and image generation — including their streaming variants.
 
+<Warning>
+**Latency overhead.** The cache lookup itself adds latency to every cache-enabled request, and the cost differs per path:
+
+- **Direct lookup** — one vector store round-trip per request, hit or miss. Sub-millisecond to a few milliseconds with a local Redis/Valkey; higher with remote or managed stores. (Computing the request hash itself is in-process and takes microseconds — the round-trip is the only real cost.)
+- **Semantic lookup** — runs on every direct miss, and must embed the incoming request *before* it can search. That means one embedding API call to your provider (typically tens to a few hundred milliseconds) plus a vector similarity search, paid upfront regardless of the outcome. A semantic **hit** therefore costs roughly an embedding round-trip — not the near-instant replay of a direct hit — and a semantic **miss** pays the embedding call *on top of* the full LLM call, making it slower than running without the cache.
+- **Cache writes** — asynchronous; they add no latency to the response.
+</Warning>
+
 ---
 
 ## Prerequisites
@@ -295,6 +303,7 @@ bifrostConfig := schemas.BifrostConfig{
 | **Matches** | Exact (normalized) request | Exact **and** semantically similar |
 | **Embedding provider** | Not needed | Required |
 | **Cost per miss** | Zero embedding cost | One embedding call per miss |
+| **Added latency** | One vector store round-trip per request | Store round-trip, plus an embedding call + similarity search on every direct miss |
 | **Best for** | Stable, repeated prompts; strict dedup | Paraphrased / varied user queries |
 | **`dimension`** | `1` | The model's real vector size (`> 1`) |
 

--- a/tests/e2e/api/README.md
+++ b/tests/e2e/api/README.md
@@ -88,6 +88,15 @@ From this directory (`tests/e2e/api`):
 ./runners/run-newman-inference-tests.sh --html --verbose
 ```
 
+### Routing Harness Ledger
+
+Harness days are journaled in `routing/ledger-YYYY-MM-DD.md` (gitignored, one
+file per day the routing/catalog suites run). Each ledger holds: an
+open-divergences snapshot, per-suite scenario tables (setup / expected /
+actual, with ✅ / ⚠️ recalibrated / 🐞 bug-found markers), the day's run
+results, and day notes. Append to the current day's file during a session;
+never rewrite past days.
+
 ### API Management Extensions
 
 The API management runner can merge additional Postman folders maintained


### PR DESCRIPTION
## Summary

This PR documents the latency trade-offs of semantic caching, introduces a local routing harness ledger convention for e2e test journaling, and adds the corresponding gitignore entry to keep those ledger files out of version control.

## Changes

- Added a `<Warning>` block to the semantic caching docs explaining the latency overhead for direct lookups, semantic lookups, and cache writes — including the nuance that a semantic cache hit still costs an embedding round-trip, and a semantic miss pays that cost on top of the full LLM call.
- Added a row to the direct vs. semantic comparison table covering added latency per mode.
- Added a `Routing Harness Ledger` section to the e2e API README describing the daily journaling convention (`routing/ledger-YYYY-MM-DD.md`), its structure, and the rule against rewriting past days.
- Added `tests/e2e/api/routing/ledger-*` to `.gitignore` so local run journals are never committed.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the docs render correctly and that the gitignore pattern excludes ledger files as expected:

```sh
# Confirm ledger files are ignored
touch tests/e2e/api/routing/ledger-2025-01-01.md
git status  # should not appear as an untracked file
```

Review the updated semantic caching docs to confirm the warning block and table row render as intended.

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

None. No code changes; no secrets, auth, or PII involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Latency overhead warning to semantic caching docs describing added costs for cache reads and asynchronous writes
  * Clarified direct vs. semantic caching comparison with an explicit “Added latency” row
  * Added routing harness ledger guidance describing daily, append-only ledger entries for test runs

* **Chores**
  * Updated ignore rules to exclude local test artifacts and routing ledger journal files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->