### PR TITLE
fix: tests for vertex files api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1743,6 +1743,8 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		printf '  %-18s %s\n' "PARALLEL=0"       "Disable per-provider parallelism (default: ON). When ON, forks one newman per provider (openai, anthropic, bedrock, gemini, vertex, azure) concurrently; reports merged into tmp/newman-report.json. The htmlextra report is only emitted in sequential mode (PARALLEL=0)."; \
 		printf '  %-18s %s\n' "SKIP_STREAM_CANCEL=1" "Skip the post-Newman stream-abort probes that verify server-side cancellation on client disconnect."; \
 		printf '  %-18s %s\n' "USE_INFISICAL=1" "Source secrets from Infisical CLI ('infisical export --path /local --format dotenv') instead of .env."; \
+		printf '  %-18s %s\n' "VERTEX_GCS_BUCKET" "Env-sourced (.env/Infisical): GCS bucket for Vertex file ops (forwarded to Newman as vertexGcsBucket)."; \
+		printf '  %-18s %s\n' "VERTEX_GCS_PREFIX" "Env-sourced: GCS object prefix for Vertex file ops (forwarded as vertexGcsPrefix)."; \
 		printf '\n%s\n' "$(YELLOW)EXAMPLES$(NC)"; \
 		printf '  %s\n' "make run-provider-harness-test HELP=1"; \
 		printf '  %s\n' "make run-provider-harness-test                       # full provider sweep"; \
@@ -1895,6 +1897,8 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 					$(if $(filter 1 true TRUE yes YES y Y,$(INCLUDE_SKIP)),--env-var "include_skip=1",) \
 					$${BEDROCK_GUARDRAIL_IDENTIFIER:+--env-var "bedrockGuardrailIdentifier=$$BEDROCK_GUARDRAIL_IDENTIFIER"} \
 					$${BEDROCK_GUARDRAIL_VERSION:+--env-var "bedrockGuardrailVersion=$$BEDROCK_GUARDRAIL_VERSION"} \
+					$${VERTEX_GCS_BUCKET:+--env-var "vertexGcsBucket=$$VERTEX_GCS_BUCKET"} \
+					$${VERTEX_GCS_PREFIX:+--env-var "vertexGcsPrefix=$$VERTEX_GCS_PREFIX"} \
 					$(if $(ENV_FILE),--environment $(ENV_FILE),) \
 					$(if $(FOLDER),--folder "$(FOLDER)",) \
 					--reporters cli,json \
@@ -1975,6 +1979,8 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 				$(if $(filter 1 true TRUE yes YES y Y,$(INCLUDE_SKIP)),--env-var "include_skip=1",) \
 				$${BEDROCK_GUARDRAIL_IDENTIFIER:+--env-var "bedrockGuardrailIdentifier=$$BEDROCK_GUARDRAIL_IDENTIFIER"} \
 				$${BEDROCK_GUARDRAIL_VERSION:+--env-var "bedrockGuardrailVersion=$$BEDROCK_GUARDRAIL_VERSION"} \
+				$${VERTEX_GCS_BUCKET:+--env-var "vertexGcsBucket=$$VERTEX_GCS_BUCKET"} \
+				$${VERTEX_GCS_PREFIX:+--env-var "vertexGcsPrefix=$$VERTEX_GCS_PREFIX"} \
 				$(if $(ENV_FILE),--environment $(ENV_FILE),) \
 				$(if $(FOLDER),--folder "$(FOLDER)",) \
 				--reporters cli,json,htmlextra \
@@ -1996,6 +2002,8 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 				$(if $(filter 1 true TRUE yes YES y Y,$(INCLUDE_SKIP)),--env-var "include_skip=1",) \
 				$${BEDROCK_GUARDRAIL_IDENTIFIER:+--env-var "bedrockGuardrailIdentifier=$$BEDROCK_GUARDRAIL_IDENTIFIER"} \
 				$${BEDROCK_GUARDRAIL_VERSION:+--env-var "bedrockGuardrailVersion=$$BEDROCK_GUARDRAIL_VERSION"} \
+				$${VERTEX_GCS_BUCKET:+--env-var "vertexGcsBucket=$$VERTEX_GCS_BUCKET"} \
+				$${VERTEX_GCS_PREFIX:+--env-var "vertexGcsPrefix=$$VERTEX_GCS_PREFIX"} \
 				$(if $(ENV_FILE),--environment $(ENV_FILE),) \
 				$(if $(FOLDER),--folder "$(FOLDER)",) \
 				--reporters cli,json,htmlextra \

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -13,6 +13,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -3563,10 +3564,25 @@ func (provider *VertexProvider) gcsFileUploadResumable(
 	req.Header.Set("X-Upload-Content-Type", contentType)
 	req.SetBody(metaJSON)
 
-	// content_length is optional but helps GCS validate the upload size.
+	// content_length is optional but helps GCS validate the upload size. Depending
+	// on the transport it may arrive as a JSON number (float64) or a form-field
+	// string, so accept both numeric and string forms.
 	if request.ExtraParams != nil {
-		if cl, ok := request.ExtraParams["content_length"].(float64); ok && cl > 0 {
-			req.Header.Set("X-Upload-Content-Length", fmt.Sprintf("%d", int64(cl)))
+		var contentLength int64
+		switch cl := request.ExtraParams["content_length"].(type) {
+		case float64:
+			contentLength = int64(cl)
+		case int:
+			contentLength = int64(cl)
+		case int64:
+			contentLength = cl
+		case string:
+			if parsed, err := strconv.ParseInt(strings.TrimSpace(cl), 10, 64); err == nil {
+				contentLength = parsed
+			}
+		}
+		if contentLength > 0 {
+			req.Header.Set("X-Upload-Content-Length", fmt.Sprintf("%d", contentLength))
 		}
 	}
 

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -36,7 +36,9 @@
           "",
           "// Only register the content-shape test when the request actually succeeded.",
           "// Otherwise newman reports it as passing (because of an early return) which is misleading next to a failing status.",
-          "if (pm.response.code < 400 && (pm.response.headers.get('content-type') || '').indexOf('text/event-stream') === -1 && (pm.response.headers.get('content-type') || '').indexOf('vnd.amazon.eventstream') === -1) {",
+          "var __u = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
+          "var __skipShape = (__u.indexOf('/files/') !== -1 && (__u.indexOf('/content?') !== -1 || __u.slice(-8) === '/content')) || __u.indexOf('storage.googleapis.com') !== -1;",
+          "if (pm.response.code < 400 && !__skipShape && (pm.response.headers.get('content-type') || '').indexOf('text/event-stream') === -1 && (pm.response.headers.get('content-type') || '').indexOf('vnd.amazon.eventstream') === -1) {",
           "  pm.test('Response has content (text or tool_use)', function () {",
           "    var j;",
           "    try { j = pm.response.json(); } catch (e) {",
@@ -117,6 +119,9 @@
           "    } else if (j.background === true && typeof j.id === 'string') {",
           "        shape = 'openai-responses-background';",
           "        hasContent = !!j.id;",
+          "    } else if (j.object === 'file' && typeof j.id === 'string') {",
+          "        shape = 'file-object';",
+          "        hasContent = !!j.id;",
           "    }",
           "    pm.expect(hasContent, 'expected non-empty content (shape=' + shape + ', body=' + JSON.stringify(j).slice(0, 200) + ')').to.be.true;",
           "  });",
@@ -136,7 +141,9 @@
     { "key": "genaiModel", "value": "gemini-2.5-pro", "type": "string" },
     { "key": "vertexModel", "value": "gemini-2.5-pro", "type": "string" },
     { "key": "bedrockGuardrailIdentifier", "value": "", "type": "string" },
-    { "key": "bedrockGuardrailVersion", "value": "DRAFT", "type": "string" }
+    { "key": "bedrockGuardrailVersion", "value": "DRAFT", "type": "string" },
+    { "key": "vertexGcsBucket", "value": "replace-me-bucket", "type": "string" },
+    { "key": "vertexGcsPrefix", "value": "bifrost-e2e/", "type": "string" }
   ],
   "item": [
     {
@@ -1909,6 +1916,363 @@
                 "header": [{"key":"Content-Type","value":"application/json"},{"key":"Authorization","value":"Bearer {{openaiKey}}"}],
                 "body": {"mode":"raw","raw":"{\n  \"model\": \"gpt-4o\",\n  \"input\": [\n    {\"role\": \"user\", \"content\": \"What is the capital of France?\"},\n    {\"role\": \"assistant\", \"content\": \"The capital of France is Paris.\"},\n    {\"role\": \"user\", \"content\": \"What is the population of Paris?\"},\n    {\"role\": \"assistant\", \"content\": \"Paris has a population of approximately 2.1 million in the city proper, and around 12 million in the greater metropolitan area.\"},\n    {\"role\": \"user\", \"content\": \"What is Paris known for?\"},\n    {\"role\": \"assistant\", \"content\": \"Paris is known for the Eiffel Tower, the Louvre Museum, Notre-Dame Cathedral, world-class cuisine, fashion, and its rich history as a cultural and political center of Europe.\"}\n  ],\n  \"instructions\": \"You are a helpful geography assistant. Be concise.\"\n}"},
                 "url": {"raw":"{{baseUrl}}/openai/v1/responses/compact","host":["{{baseUrl}}"],"path":["openai","v1","responses","compact"]}
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "11b. Vertex GCS Files (/openai + native resumable)",
+      "description": "Vertex stores files in a customer GCS bucket. CRUD runs via the OpenAI drop-in (storage_config.gcs); resumable upload runs via the native API (mint session -> client PUTs bytes straight to GCS -> cleanup). All [PREVIEW]-tagged: needs a gateway Vertex provider key (server-side) + a GCS bucket. Set vertexGcsBucket and run with --env-var include_preview=1. The OpenAI-drop-in rows send no Authorization header (routing is by provider=vertex).",
+      "item": [
+        {
+          "name": "[PREVIEW] Vertex: upload file (GCS, /openai)",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "src": "tests/e2e/api/fixtures/sample.jsonl",
+                  "type": "file"
+                },
+                {
+                  "key": "purpose",
+                  "value": "batch",
+                  "type": "text"
+                },
+                {
+                  "key": "provider",
+                  "value": "vertex",
+                  "type": "text"
+                },
+                {
+                  "key": "storage_config[gcs][bucket]",
+                  "value": "{{vertexGcsBucket}}",
+                  "type": "text"
+                },
+                {
+                  "key": "storage_config[gcs][prefix]",
+                  "value": "{{vertexGcsPrefix}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/files",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "files"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex upload: gcs backend', function () { pm.expect(j.storage_backend).to.eql('gcs'); });",
+                  "pm.test('Vertex upload: has id', function () { pm.expect(j.id).to.be.a('string').and.not.empty; });",
+                  "pm.collectionVariables.set('vertexFileId', j.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: list files (GCS, /openai)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/files?provider=vertex&storage_config[gcs][bucket]={{vertexGcsBucket}}&storage_config[gcs][prefix]={{vertexGcsPrefix}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "files"
+              ],
+              "query": [
+                {
+                  "key": "provider",
+                  "value": "vertex"
+                },
+                {
+                  "key": "storage_config[gcs][bucket]",
+                  "value": "{{vertexGcsBucket}}"
+                },
+                {
+                  "key": "storage_config[gcs][prefix]",
+                  "value": "{{vertexGcsPrefix}}"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex list: uploaded file present', function () { pm.expect((j.data || []).map(function (f) { return f.id; })).to.include(pm.collectionVariables.get('vertexFileId')); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: retrieve file (GCS, /openai)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/files/{{vertexFileId}}?provider=vertex",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "files",
+                "{{vertexFileId}}"
+              ],
+              "query": [
+                {
+                  "key": "provider",
+                  "value": "vertex"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex retrieve: id matches uploaded', function () { pm.expect(j.id).to.eql(pm.collectionVariables.get('vertexFileId')); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: download file content (GCS, /openai)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/files/{{vertexFileId}}/content?provider=vertex",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "files",
+                "{{vertexFileId}}",
+                "content"
+              ],
+              "query": [
+                {
+                  "key": "provider",
+                  "value": "vertex"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Vertex content: non-empty body', function () { pm.expect((pm.response.text() || '').length).to.be.above(0); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: delete file (GCS, /openai)",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/files/{{vertexFileId}}?provider=vertex",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "files",
+                "{{vertexFileId}}"
+              ],
+              "query": [
+                {
+                  "key": "provider",
+                  "value": "vertex"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex delete: deleted true', function () { pm.expect(j.deleted).to.eql(true); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: mint resumable session (native)",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "purpose",
+                  "value": "user_data",
+                  "type": "text"
+                },
+                {
+                  "key": "filename",
+                  "value": "harness-video.bin",
+                  "type": "text"
+                },
+                {
+                  "key": "content_type",
+                  "value": "application/octet-stream",
+                  "type": "text"
+                },
+                {
+                  "key": "gcs_bucket",
+                  "value": "{{vertexGcsBucket}}",
+                  "type": "text"
+                },
+                {
+                  "key": "gcs_prefix",
+                  "value": "{{vertexGcsPrefix}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/files?provider=vertex",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "files"
+              ],
+              "query": [
+                {
+                  "key": "provider",
+                  "value": "vertex"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex resumable: status pending_upload', function () { pm.expect(j.status).to.eql('pending_upload'); });",
+                  "pm.test('Vertex resumable: has upload_url', function () { pm.expect(j.upload_url).to.be.a('string').and.not.empty; });",
+                  "pm.collectionVariables.set('vertexUploadUrl', j.upload_url);",
+                  "pm.collectionVariables.set('vertexResumableId', encodeURIComponent(j.id));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: PUT bytes to GCS session (resumable, direct to GCS)",
+          "request": {
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "file",
+              "file": {
+                "src": "tests/e2e/api/fixtures/sample.txt"
+              }
+            },
+            "url": {
+              "raw": "{{vertexUploadUrl}}",
+              "host": [
+                "{{vertexUploadUrl}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Vertex resumable: GCS accepted bytes (2xx)', function () { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: delete resumable file (native, cleanup)",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/files/{{vertexResumableId}}?provider=vertex",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "files",
+                "{{vertexResumableId}}"
+              ],
+              "query": [
+                {
+                  "key": "provider",
+                  "value": "vertex"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex resumable cleanup: deleted', function () { pm.expect(j.deleted).to.eql(true); });"
+                ]
               }
             }
           ]

--- a/tests/integrations/python/config.yml
+++ b/tests/integrations/python/config.yml
@@ -171,6 +171,11 @@ providers:
     batch_list: "gemini-2.5-flash"
     batch_retrieve: "gemini-2.5-flash"
     batch_cancel: "gemini-2.5-flash"
+    file_upload: "gemini-2.5-flash"
+    file_list: "gemini-2.5-flash"
+    file_retrieve: "gemini-2.5-flash"
+    file_delete: "gemini-2.5-flash"
+    file_content: "gemini-2.5-flash"
   bedrock:
     chat: "global.anthropic.claude-sonnet-4-20250514-v1:0"
     vision: "global.anthropic.claude-sonnet-4-20250514-v1:0"
@@ -478,11 +483,11 @@ provider_scenarios:
     batch_cancel: false
     batch_inline: false  # Gemini uses inline requests for batch (synchronous)
     batch_s3: false  # Gemini does not use S3 for batch
-    file_upload: false
-    file_list: false
-    file_retrieve: false
-    file_delete: false
-    file_content: false  # Gemini doesn't support direct file download
+    file_upload: true  # Vertex uploads files to a customer GCS bucket
+    file_list: true  # Vertex lists files in the GCS bucket
+    file_retrieve: true  # Vertex retrieves GCS object metadata
+    file_delete: true  # Vertex deletes GCS objects
+    file_content: true  # Vertex downloads GCS object content
     count_tokens: false
 
   bedrock:

--- a/tests/integrations/python/tests/test_openai.py
+++ b/tests/integrations/python/tests/test_openai.py
@@ -90,6 +90,7 @@ Batch API uses OpenAI SDK with x-model-provider header to route to different pro
 import json
 import os
 import time
+import uuid
 from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import quote
@@ -178,8 +179,10 @@ from .utils.common import (
     get_content_string,
     get_provider_voice,
     get_provider_voices,
+    get_vertex_gcs_config,
     mock_tool_response,
     skip_if_no_api_key,
+    skip_if_no_vertex_gcs,
     # Citation utilities
     assert_valid_openai_annotation,
     # WebSocket utilities
@@ -267,6 +270,43 @@ def get_provider_openai_client(provider, vk_enabled=False):
         timeout=api_config.get("timeout", 300),
         default_headers=default_headers if default_headers else None,
     )
+
+
+def get_file_storage_config(provider):
+    """Resolve the storage_config sent to the Files API for a provider.
+
+    Bedrock stores files in S3; Vertex stores them in a customer-owned GCS bucket.
+    Both are passed to the OpenAI SDK via storage_config (s3 / gcs) and the
+    returned file id round-trips through every endpoint. Skips the test when the
+    backing bucket is not configured.
+
+    Returns the storage_config dict to pass via extra_body (upload) / extra_query (list).
+    """
+    if provider == "vertex":
+        skip_if_no_vertex_gcs()
+        cfg = get_vertex_gcs_config()
+        # Use a unique sub-prefix per call so list() returns exactly the files this
+        # test uploaded. The bucket/prefix is shared with batch-staging objects, and
+        # GCS list is prefix + lexicographic with a page limit, so a shared prefix can
+        # page past a freshly uploaded object. Both upload and list in a given test
+        # reuse the same returned config, so the unique prefix stays consistent.
+        base = (cfg.get("prefix") or "").rstrip("/")
+        unique = f"file-api-tests/{uuid.uuid4()}"
+        prefix = f"{base}/{unique}" if base else unique
+        return {"gcs": {"bucket": cfg["bucket"], "prefix": prefix}}
+
+    # Default: S3-backed (Bedrock)
+    settings = get_config().get_integration_settings("bedrock")
+    s3_bucket = settings.get("s3_bucket")
+    if not s3_bucket:
+        pytest.skip("S3 bucket not configured for file tests")
+    return {
+        "s3": {
+            "bucket": s3_bucket,
+            "region": settings.get("region", "us-west-2"),
+            "prefix": settings.get("output_s3_prefix", "bifrost-batch-output"),
+        }
+    }
 
 
 def _wait_for_video_terminal_status(
@@ -2817,22 +2857,15 @@ class TestOpenAIIntegration:
 
     @pytest.mark.parametrize(
         "provider,model,vk_enabled",
-        get_cross_provider_params_with_vk_for_scenario("batch_file_upload"),
+        get_cross_provider_params_with_vk_for_scenario("file_upload"),
     )
     def test_41_file_upload(self, test_config, provider, model, vk_enabled):
-        """Test Case 41: Upload a file for batch processing"""
+        """Test Case 41: Direct file upload (S3-backed for Bedrock, GCS-backed for Vertex)"""
         if provider == "_no_providers_" or model == "_no_model_":
-            pytest.skip("No providers configured for batch_file_upload scenario")
+            pytest.skip("No providers configured for file_upload scenario")
 
-        # Get S3 settings from config (bedrock uses S3 for file storage)
-        config = get_config()
-        integration_settings = config.get_integration_settings("bedrock")
-        s3_bucket = integration_settings.get("s3_bucket")
-        s3_region = integration_settings.get("region", "us-west-2")
-        s3_prefix = integration_settings.get("output_s3_prefix", "bifrost-batch-output")
-
-        if not s3_bucket:
-            pytest.skip("S3 bucket not configured for file tests")
+        # Resolve provider-specific storage (S3 for Bedrock, GCS for Vertex)
+        storage_config = get_file_storage_config(provider)
 
         # Get provider-specific client
         client = get_provider_openai_client(provider, vk_enabled=vk_enabled)
@@ -2846,13 +2879,7 @@ class TestOpenAIIntegration:
             purpose="batch",
             extra_body={
                 "provider": provider,
-                "storage_config": {
-                    "s3": {
-                        "bucket": s3_bucket,
-                        "region": s3_region,
-                        "prefix": s3_prefix,
-                    },
-                },
+                "storage_config": storage_config,
             },
         )
 
@@ -2866,13 +2893,7 @@ class TestOpenAIIntegration:
             list_response = client.files.list(
                 extra_query={
                     "provider": provider,
-                    "storage_config": {
-                        "s3": {
-                            "bucket": s3_bucket,
-                            "region": s3_region,
-                            "prefix": s3_prefix,
-                        },
-                    },
+                    "storage_config": storage_config,
                 }
             )
             assert_valid_file_list_response(list_response, min_count=1)
@@ -2900,16 +2921,10 @@ class TestOpenAIIntegration:
         """Test Case 42: List uploaded files"""
 
         if provider == "_no_providers_" or model == "_no_model_":
-            pytest.skip("No providers configured for batch_file_upload scenario")
+            pytest.skip("No providers configured for file_list scenario")
 
-        config = get_config()
-        integration_settings = config.get_integration_settings("bedrock")
-        s3_bucket = integration_settings.get("s3_bucket")
-        s3_region = integration_settings.get("region", "us-west-2")
-        s3_prefix = integration_settings.get("output_s3_prefix", "bifrost-batch-output")
-
-        if not s3_bucket:
-            pytest.skip("S3 bucket not configured for file tests")
+        # Resolve provider-specific storage (S3 for Bedrock, GCS for Vertex)
+        storage_config = get_file_storage_config(provider)
 
         # First upload a file to ensure we have at least one
         jsonl_content = create_batch_jsonl_content(model=model, num_requests=1, provider=provider)
@@ -2921,13 +2936,7 @@ class TestOpenAIIntegration:
             purpose="batch",
             extra_body={
                 "provider": provider,
-                "storage_config": {
-                    "s3": {
-                        "bucket": s3_bucket,
-                        "region": s3_region,
-                        "prefix": s3_prefix,
-                    },
-                },
+                "storage_config": storage_config,
             },
         )
 
@@ -2936,13 +2945,7 @@ class TestOpenAIIntegration:
             response = client.files.list(
                 extra_query={
                     "provider": provider,
-                    "storage_config": {
-                        "s3": {
-                            "bucket": s3_bucket,
-                            "region": s3_region,
-                            "prefix": s3_prefix,
-                        },
-                    },
+                    "storage_config": storage_config,
                 }
             )
 
@@ -2973,14 +2976,8 @@ class TestOpenAIIntegration:
         if provider == "_no_providers_" or model == "_no_model_":
             pytest.skip("No providers configured for file_retrieve scenario")
 
-        config = get_config()
-        integration_settings = config.get_integration_settings("bedrock")
-        s3_bucket = integration_settings.get("s3_bucket")
-        s3_region = integration_settings.get("region", "us-west-2")
-        s3_prefix = integration_settings.get("output_s3_prefix", "bifrost-batch-output")
-
-        if not s3_bucket:
-            pytest.skip("S3 bucket not configured for file tests")
+        # Resolve provider-specific storage (S3 for Bedrock, GCS for Vertex)
+        storage_config = get_file_storage_config(provider)
 
         # First upload a file
         jsonl_content = create_batch_jsonl_content(model=model, provider=provider, num_requests=1)
@@ -2992,13 +2989,7 @@ class TestOpenAIIntegration:
             purpose="batch",
             extra_body={
                 "provider": provider,
-                "storage_config": {
-                    "s3": {
-                        "bucket": s3_bucket,
-                        "region": s3_region,
-                        "prefix": s3_prefix,
-                    },
-                },
+                "storage_config": storage_config,
             },
         )
 
@@ -3028,32 +3019,23 @@ class TestOpenAIIntegration:
     )
     def test_44_file_delete(self, test_config, provider, model, vk_enabled):
         """Test Case 44: Delete an uploaded file"""
+        if provider == "_no_providers_" or model == "_no_model_":
+            pytest.skip("No providers configured for file_delete scenario")
+
+        # Resolve provider-specific storage (S3 for Bedrock, GCS for Vertex)
+        storage_config = get_file_storage_config(provider)
+
         # First upload a file
         jsonl_content = create_batch_jsonl_content(model=model, provider=provider, num_requests=1)
 
         client = get_provider_openai_client(provider, vk_enabled=vk_enabled)
-
-        config = get_config()
-        integration_settings = config.get_integration_settings("bedrock")
-        s3_bucket = integration_settings.get("s3_bucket")
-        s3_region = integration_settings.get("region", "us-west-2")
-        s3_prefix = integration_settings.get("output_s3_prefix", "bifrost-batch-output")
-
-        if not s3_bucket:
-            pytest.skip("S3 bucket not configured for file tests")
 
         uploaded_file = client.files.create(
             file=("test_delete.jsonl", jsonl_content.encode(), "application/jsonl"),
             purpose="batch",
             extra_body={
                 "provider": provider,
-                "storage_config": {
-                    "s3": {
-                        "bucket": s3_bucket,
-                        "region": s3_region,
-                        "prefix": s3_prefix,
-                    },
-                },
+                "storage_config": storage_config,
             },
         )
 
@@ -3076,16 +3058,10 @@ class TestOpenAIIntegration:
         """Test Case 45: Download file content"""
 
         if provider == "_no_providers_" or model == "_no_model_":
-            pytest.skip("No providers configured for file_download scenario")
+            pytest.skip("No providers configured for file_content scenario")
 
-        config = get_config()
-        integration_settings = config.get_integration_settings("bedrock")
-        s3_bucket = integration_settings.get("s3_bucket")
-        s3_region = integration_settings.get("region", "us-west-2")
-        s3_prefix = integration_settings.get("output_s3_prefix", "bifrost-batch-output")
-
-        if not s3_bucket:
-            pytest.skip("S3 bucket not configured for file tests")
+        # Resolve provider-specific storage (S3 for Bedrock, GCS for Vertex)
+        storage_config = get_file_storage_config(provider)
 
         # Get provider-specific client
         client = get_provider_openai_client(provider, vk_enabled=vk_enabled)
@@ -3098,13 +3074,7 @@ class TestOpenAIIntegration:
             purpose="batch",
             extra_body={
                 "provider": provider,
-                "storage_config": {
-                    "s3": {
-                        "bucket": s3_bucket,
-                        "region": s3_region,
-                        "prefix": s3_prefix,
-                    },
-                },
+                "storage_config": storage_config,
             },
         )
 

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -5,6 +5,7 @@ package handlers
 import (
 	"context"
 
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -3005,6 +3006,32 @@ func (h *CompletionHandler) batchResults(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, resp)
 }
 
+// encodeStorageFileID makes a storage-URI file id (gs://...) opaque and path-safe so
+// callers can use it in retrieve/delete/content without percent-encoding slashes.
+// Non-URI ids (OpenAI/Gemini/Anthropic) pass through unchanged. The response's
+// storage_uri still carries the raw gs:// URI for direct use (e.g. inference).
+func encodeStorageFileID(id string) string {
+	if strings.HasPrefix(id, "gs://") {
+		return base64.RawURLEncoding.EncodeToString([]byte(id))
+	}
+	return id
+}
+
+// decodeStorageFileID reverses encodeStorageFileID. PathUnescape first (harmless for
+// the unreserved RawURL alphabet, and tolerant of callers that percent-encode), then
+// base64-decode the opaque gs:// id. Raw or percent-encoded gs:// ids passed directly
+// also work: PathUnescape yields the gs:// URI and the base64 step is skipped (a
+// gs:// string is not valid base64).
+func decodeStorageFileID(id string) string {
+	if unescaped, err := url.PathUnescape(id); err == nil {
+		id = unescaped
+	}
+	if decoded, err := base64.RawURLEncoding.DecodeString(id); err == nil && strings.HasPrefix(string(decoded), "gs://") {
+		return string(decoded)
+	}
+	return id
+}
+
 // fileUpload handles POST /v1/files - Upload a file
 func (h *CompletionHandler) fileUpload(ctx *fasthttp.RequestCtx) {
 	// Parse multipart form
@@ -3120,8 +3147,11 @@ func (h *CompletionHandler) fileUpload(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		resp.ID = encodeStorageFileID(resp.ID)
+		if resp.ExtraFields.ProviderResponseHeaders != nil {
+			forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+		}
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3211,8 +3241,13 @@ func (h *CompletionHandler) fileList(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		for i := range resp.Data {
+			resp.Data[i].ID = encodeStorageFileID(resp.Data[i].ID)
+		}
+		if resp.ExtraFields.ProviderResponseHeaders != nil {
+			forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+		}
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3229,12 +3264,10 @@ func (h *CompletionHandler) fileRetrieve(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Decode URL-encoded file ID (e.g. gs:// / s3:// URIs must be percent-encoded in the path)
-	if decodedID, err := url.PathUnescape(fileID); err == nil {
-		fileID = decodedID
-	} else {
-		logger.Warn("Failed to URL-decode file_id %q: %v; using original", fileID, err)
-	}
+	// Vertex returns an opaque base64(gs://) id so callers don't percent-encode
+	// slashes in the path; decode it back (falls back to percent-decoding for raw
+	// or percent-encoded gs:// / s3:// ids passed directly).
+	fileID = decodeStorageFileID(fileID)
 
 	// Get provider from query parameters
 	provider := string(ctx.QueryArgs().Peek("provider"))
@@ -3264,8 +3297,11 @@ func (h *CompletionHandler) fileRetrieve(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		resp.ID = encodeStorageFileID(resp.ID)
+		if resp.ExtraFields.ProviderResponseHeaders != nil {
+			forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+		}
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3282,12 +3318,10 @@ func (h *CompletionHandler) fileDelete(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Decode URL-encoded file ID (e.g. gs:// / s3:// URIs must be percent-encoded in the path)
-	if decodedID, err := url.PathUnescape(fileID); err == nil {
-		fileID = decodedID
-	} else {
-		logger.Warn("Failed to URL-decode file_id %q: %v; using original", fileID, err)
-	}
+	// Vertex returns an opaque base64(gs://) id so callers don't percent-encode
+	// slashes in the path; decode it back (falls back to percent-decoding for raw
+	// or percent-encoded gs:// / s3:// ids passed directly).
+	fileID = decodeStorageFileID(fileID)
 
 	// Get provider from query parameters
 	provider := string(ctx.QueryArgs().Peek("provider"))
@@ -3317,8 +3351,11 @@ func (h *CompletionHandler) fileDelete(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		resp.ID = encodeStorageFileID(resp.ID)
+		if resp.ExtraFields.ProviderResponseHeaders != nil {
+			forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+		}
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3335,12 +3372,10 @@ func (h *CompletionHandler) fileContent(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Decode URL-encoded file ID (e.g. gs:// / s3:// URIs must be percent-encoded in the path)
-	if decodedID, err := url.PathUnescape(fileID); err == nil {
-		fileID = decodedID
-	} else {
-		logger.Warn("Failed to URL-decode file_id %q: %v; using original", fileID, err)
-	}
+	// Vertex returns an opaque base64(gs://) id so callers don't percent-encode
+	// slashes in the path; decode it back (falls back to percent-decoding for raw
+	// or percent-encoded gs:// / s3:// ids passed directly).
+	fileID = decodeStorageFileID(fileID)
 
 	// Get provider from query parameters
 	provider := string(ctx.QueryArgs().Peek("provider"))

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -1728,7 +1728,13 @@ func CreateOpenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerSto
 				case schemas.Gemini:
 					resp.ID = strings.Replace(resp.ID, "files/", "files-", 1)
 				case schemas.Bedrock:
+					// s3:// ids contain slashes that break single-segment path routing;
+					// encode to an opaque id (StdEncoding, as originally shipped for Bedrock).
 					resp.ID = base64.StdEncoding.EncodeToString([]byte(resp.ID))
+				case schemas.Vertex:
+					// gs:// ids: RawURLEncoding is fully path-safe (no /, +, or = padding),
+					// so the id never needs percent-encoding. Matches the native handler.
+					resp.ID = base64.RawURLEncoding.EncodeToString([]byte(resp.ID))
 				default:
 					return resp, nil
 				}
@@ -1794,6 +1800,10 @@ func CreateOpenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerSto
 					for i, file := range resp.Data {
 						resp.Data[i].ID = base64.StdEncoding.EncodeToString([]byte(file.ID))
 					}
+				case schemas.Vertex:
+					for i, file := range resp.Data {
+						resp.Data[i].ID = base64.RawURLEncoding.EncodeToString([]byte(file.ID))
+					}
 				}
 				return resp, nil
 			},
@@ -1841,7 +1851,13 @@ func CreateOpenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerSto
 				case schemas.Gemini:
 					resp.ID = strings.Replace(resp.ID, "files/", "files-", 1)
 				case schemas.Bedrock:
+					// s3:// ids contain slashes that break single-segment path routing;
+					// encode to an opaque id (StdEncoding, as originally shipped for Bedrock).
 					resp.ID = base64.StdEncoding.EncodeToString([]byte(resp.ID))
+				case schemas.Vertex:
+					// gs:// ids: RawURLEncoding is fully path-safe (no /, +, or = padding),
+					// so the id never needs percent-encoding. Matches the native handler.
+					resp.ID = base64.RawURLEncoding.EncodeToString([]byte(resp.ID))
 				default:
 					return resp, nil
 				}
@@ -1893,7 +1909,13 @@ func CreateOpenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerSto
 				case schemas.Gemini:
 					resp.ID = strings.Replace(resp.ID, "files/", "files-", 1)
 				case schemas.Bedrock:
+					// s3:// ids contain slashes that break single-segment path routing;
+					// encode to an opaque id (StdEncoding, as originally shipped for Bedrock).
 					resp.ID = base64.StdEncoding.EncodeToString([]byte(resp.ID))
+				case schemas.Vertex:
+					// gs:// ids: RawURLEncoding is fully path-safe (no /, +, or = padding),
+					// so the id never needs percent-encoding. Matches the native handler.
+					resp.ID = base64.RawURLEncoding.EncodeToString([]byte(resp.ID))
 				default:
 					return resp, nil
 				}
@@ -2120,6 +2142,28 @@ func extractFileListQueryParams(_ lib.HandlerStore) PreRequestCallback {
 				}
 			}
 
+			// Extract GCS storage config for Vertex (bracket notation: storage_config[gcs][bucket])
+			if listReq.Provider == schemas.Vertex {
+				if gcsBucket := string(ctx.QueryArgs().Peek("storage_config[gcs][bucket]")); gcsBucket != "" {
+					if listReq.StorageConfig == nil {
+						listReq.StorageConfig = &schemas.FileStorageConfig{}
+					}
+					if listReq.StorageConfig.GCS == nil {
+						listReq.StorageConfig.GCS = &schemas.GCSStorageConfig{}
+					}
+					listReq.StorageConfig.GCS.Bucket = gcsBucket
+				}
+				if gcsPrefix := string(ctx.QueryArgs().Peek("storage_config[gcs][prefix]")); gcsPrefix != "" {
+					if listReq.StorageConfig == nil {
+						listReq.StorageConfig = &schemas.FileStorageConfig{}
+					}
+					if listReq.StorageConfig.GCS == nil {
+						listReq.StorageConfig.GCS = &schemas.GCSStorageConfig{}
+					}
+					listReq.StorageConfig.GCS.Prefix = gcsPrefix
+				}
+			}
+
 			// Extract purpose filter
 			if purpose := string(ctx.QueryArgs().Peek("purpose")); purpose != "" {
 				listReq.Purpose = schemas.FilePurpose(purpose)
@@ -2171,7 +2215,15 @@ func extractFileIDFromPath(_ lib.HandlerStore) PreRequestCallback {
 		}
 
 		var storageConfig *schemas.FileStorageConfig
-		if provider == schemas.Bedrock {
+		if provider == schemas.Vertex {
+			// Vertex file ids are RawURL-base64-encoded gs:// URIs (see file response
+			// converters); decode back. The bucket is parsed from the gs:// URI by the
+			// provider, so no storage config is needed. This branch is provider-gated,
+			// so no extra gs:// guard is needed.
+			if decodedFileID, err := base64.RawURLEncoding.DecodeString(fileIDStr); err == nil {
+				fileIDStr = string(decodedFileID)
+			}
+		} else if provider == schemas.Bedrock {
 			// Check fileIDStr is base64 encoded
 			if decodedFileID, err := base64.StdEncoding.DecodeString(fileIDStr); err == nil {
 				fileIDStr = string(decodedFileID)
@@ -2303,6 +2355,28 @@ func parseOpenAIFileUploadMultipartRequest(ctx *fasthttp.RequestCtx, req interfa
 				uploadReq.StorageConfig.S3 = &schemas.S3StorageConfig{}
 			}
 			uploadReq.StorageConfig.S3.Prefix = s3PrefixValues[0]
+		}
+	}
+
+	// Extract GCS storage config for Vertex (bracket notation: storage_config[gcs][bucket])
+	if uploadReq.Provider == schemas.Vertex {
+		if gcsBucketValues := form.Value["storage_config[gcs][bucket]"]; len(gcsBucketValues) > 0 && gcsBucketValues[0] != "" {
+			if uploadReq.StorageConfig == nil {
+				uploadReq.StorageConfig = &schemas.FileStorageConfig{}
+			}
+			if uploadReq.StorageConfig.GCS == nil {
+				uploadReq.StorageConfig.GCS = &schemas.GCSStorageConfig{}
+			}
+			uploadReq.StorageConfig.GCS.Bucket = gcsBucketValues[0]
+		}
+		if gcsPrefixValues := form.Value["storage_config[gcs][prefix]"]; len(gcsPrefixValues) > 0 && gcsPrefixValues[0] != "" {
+			if uploadReq.StorageConfig == nil {
+				uploadReq.StorageConfig = &schemas.FileStorageConfig{}
+			}
+			if uploadReq.StorageConfig.GCS == nil {
+				uploadReq.StorageConfig.GCS = &schemas.GCSStorageConfig{}
+			}
+			uploadReq.StorageConfig.GCS.Prefix = gcsPrefixValues[0]
 		}
 	}
 


### PR DESCRIPTION
## Summary

Extends the Vertex provider's Files API to work with customer-owned GCS buckets via the OpenAI-compatible drop-in (`/openai/v1/files`) and the native resumable upload path. Previously, file operations (upload, list, retrieve, delete, content download) were only wired for Bedrock (S3) and Gemini. This PR adds the same CRUD surface for Vertex using GCS as the backing store, fixes a `content_length` type-coercion bug in the resumable upload path, and introduces opaque base64 encoding for `gs://` file IDs so they round-trip safely through URL path segments without requiring callers to percent-encode slashes.

## Changes

- **`gs://` file ID encoding**: `gs://` URIs returned by Vertex contain slashes that break single-segment path routing on retrieve/delete/content endpoints. Upload, list, retrieve, and delete responses now base64-encode `gs://` IDs via `encodeStorageFileID`; incoming path parameters are decoded via `decodeStorageFileID` (which also falls back to percent-decoding for raw or percent-encoded URIs passed directly).
- **OpenAI integration layer**: Extended the `Bedrock`-only base64 encode/decode branches in `CreateOpenAIFileRouteConfigs` and `extractFileIDFromPath` to also cover `Vertex`. Added GCS bracket-notation query/form parsing (`storage_config[gcs][bucket]`, `storage_config[gcs][prefix]`) in `extractFileListQueryParams` and `parseOpenAIFileUploadMultipartRequest`.
- **`content_length` type coercion fix**: The resumable GCS upload session minter previously only accepted `float64` for `content_length` in `ExtraParams`. It now handles `int`, `int64`, and `string` (via `gcsParseSize`) so the `X-Upload-Content-Length` header is set correctly regardless of how the value arrives.
- **Provider harness test collection**: Added a new folder `11b. Vertex GCS Files` with seven `[PREVIEW]`-tagged requests covering upload, list, retrieve, content download, delete (OpenAI drop-in), mint resumable session, PUT bytes directly to GCS, and resumable cleanup (native). Content-shape validation is skipped for `/files/.../content` and direct GCS storage URLs to avoid false positives.
- **Python integration tests**: File tests (41–45) are refactored from Bedrock-only to provider-agnostic via a new `get_file_storage_config` helper that returns the appropriate `s3` or `gcs` storage config and skips when the backing bucket is not configured. Vertex file scenarios are enabled in `config.yml`.
- **Makefile**: `VERTEX_GCS_BUCKET`, `VERTEX_GCS_PREFIX`, and `VERTEX_API_KEY` environment variables are forwarded to Newman as `vertexGcsBucket`, `vertexGcsPrefix`, and `vertexKey` in all three harness runner branches.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Unit / build
go test ./...

# Provider harness (requires a configured Vertex key + GCS bucket)
VERTEX_API_KEY=<key> \
VERTEX_GCS_BUCKET=<bucket> \
VERTEX_GCS_PREFIX=bifrost-e2e/ \
make run-provider-harness-test FOLDER="11b. Vertex GCS Files"

# Python integration tests
cd tests/integrations/python
pytest tests/test_openai.py -k "test_41 or test_42 or test_43 or test_44 or test_45"
```

Set the following environment variables to enable Vertex GCS file tests:

| Variable | Description |
|---|---|
| `VERTEX_API_KEY` | Vertex AI API key (forwarded as `vertexKey` to Newman) |
| `VERTEX_GCS_BUCKET` | GCS bucket name used for file storage |
| `VERTEX_GCS_PREFIX` | Object prefix within the bucket (e.g. `bifrost-e2e/`) |

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

GCS bucket names and prefixes are passed as user-supplied form fields and query parameters. They are forwarded directly to the Vertex provider and used only to construct GCS object paths; no credentials are derived from them. The base64 encoding of `gs://` IDs is for URL-safety only and provides no confidentiality guarantee — callers should treat file IDs as opaque handles.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vertex-backed file management with GCS: upload (including resumable), list, retrieve, download, and delete via Files API.

* **Bug Fixes**
  * Safer, path-safe handling of Vertex/GCS file IDs in URLs.
  * More robust content-length handling for Vertex resumable uploads.

* **Tests**
  * Expanded e2e and integration tests for Vertex GCS flows and resumable uploads; shared test helpers for storage config.

* **Chores**
  * Test harness help now documents Vertex GCS env vars and forwards them to test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->