### PR TITLE
fix: removed redundant provider stripping from anthropic converter

### DIFF
--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -306,16 +306,9 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 	switch r := req.(type) {
 	case *anthropic.AnthropicTextRequest:
 		provider, model = schemas.ParseModelString(r.Model, "")
-		// Strip the explicit `anthropic/` prefix so downstream code sees the bare model.
-		if provider == schemas.Anthropic {
-			r.Model = model
-		}
 
 	case *anthropic.AnthropicMessageRequest:
 		provider, model = schemas.ParseModelString(r.Model, "")
-		if provider == schemas.Anthropic {
-			r.Model = model
-		}
 	}
 
 	headers := extractHeadersFromRequest(ctx)


### PR DESCRIPTION
## Summary

Removes the logic that stripped the `anthropic/` provider prefix from the model field in Anthropic passthrough requests. Previously, when a model string like `anthropic/claude-3` was parsed and the provider was identified as Anthropic, the code would rewrite the model field to just the bare model name (e.g., `claude-3`). This stripping behavior has been removed so the model field is left as-is after parsing.

## Changes

- Removed the conditional `r.Model = model` assignments in `checkAnthropicPassthrough` for both `AnthropicTextRequest` and `AnthropicMessageRequest` when the provider is `schemas.Anthropic`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a passthrough request to the Anthropic integration using a model string with an explicit `anthropic/` prefix (e.g., `anthropic/claude-3-opus`) and verify the model field is handled correctly downstream without the prefix being stripped.

```sh
go test ./transports/bifrost-http/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable