### PR TITLE
fix: avoid duplicating inference-provider segment in backfilled huggingface model IDs

### DIFF
--- a/core/providers/huggingface/models.go
+++ b/core/providers/huggingface/models.go
@@ -74,13 +74,26 @@ func (response *HuggingFaceListModelsResponse) ToBifrostListModelsResponse(provi
 		// or the "auto" policy. Prepending another segment here duplicates the
 		// provider in the compound ID and breaks request routing (#4215).
 		if first, _, found := strings.Cut(rawID, "/"); found && isKnownInferenceProviderOrPolicy(first) {
-			if !strings.EqualFold(first, string(inferenceProvider)) {
-				// The entry belongs to a different inference provider's listing
-				// (or names the "auto" policy, which no pass owns); skip it here
-				// to avoid duplicating the entry once per inference provider.
+			switch {
+			case strings.EqualFold(first, string(auto)):
+				// "auto" is owned by no inference-provider pass: the model
+				// listing loop iterates INFERENCE_PROVIDERS, which excludes it.
+				// Emit the entry exactly once, during the canonical first pass,
+				// so a routable auto-policy allowlist entry still surfaces in
+				// the listing instead of being dropped from every pass. Every
+				// other pass skips it to avoid duplicating it once per provider.
+				if len(INFERENCE_PROVIDERS) == 0 || inferenceProvider != INFERENCE_PROVIDERS[0] {
+					continue
+				}
+				m.ID = fmt.Sprintf("%s/%s", providerKey, rawID)
+			case !strings.EqualFold(first, string(inferenceProvider)):
+				// The entry belongs to a different inference provider's listing;
+				// it is emitted in that provider's pass. Skip it here to avoid
+				// duplicating the entry once per inference provider.
 				continue
+			default:
+				m.ID = fmt.Sprintf("%s/%s", providerKey, rawID)
 			}
-			m.ID = fmt.Sprintf("%s/%s", providerKey, rawID)
 		} else {
 			// Re-wrap the backfill ID to include the inferenceProvider segment
 			m.ID = fmt.Sprintf("%s/%s/%s", providerKey, inferenceProvider, rawID)

--- a/core/providers/huggingface/models.go
+++ b/core/providers/huggingface/models.go
@@ -68,13 +68,35 @@ func (response *HuggingFaceListModelsResponse) ToBifrostListModelsResponse(provi
 	// Backfill: use standard pipeline. Note that backfilled HF entries use a simplified
 	// compound ID since we don't know which inferenceProvider to assign them to.
 	for _, m := range pipeline.BackfillModels(included) {
-		// Re-wrap the backfill ID to include the inferenceProvider segment
 		rawID := strings.TrimPrefix(m.ID, string(providerKey)+"/")
-		m.ID = fmt.Sprintf("%s/%s/%s", providerKey, inferenceProvider, rawID)
+		// Allowlist entries selected from a previous ListModels response already
+		// carry an inference-provider segment (e.g. "featherless-ai/org/model").
+		// Prepending another segment here duplicates the provider in the compound
+		// ID and breaks request routing (#4215).
+		if first, _, found := strings.Cut(rawID, "/"); found && isKnownInferenceProvider(first) {
+			if !strings.EqualFold(first, string(inferenceProvider)) {
+				// The entry belongs to a different inference provider's listing;
+				// that provider's pass emits it, so skip it here to avoid
+				// duplicating the entry once per inference provider.
+				continue
+			}
+			m.ID = fmt.Sprintf("%s/%s", providerKey, rawID)
+		} else {
+			// Re-wrap the backfill ID to include the inferenceProvider segment
+			m.ID = fmt.Sprintf("%s/%s/%s", providerKey, inferenceProvider, rawID)
+		}
 		bifrostResponse.Data = append(bifrostResponse.Data, m)
 	}
 
 	return bifrostResponse
+}
+
+// isKnownInferenceProvider reports whether segment names one of the supported
+// inference providers (case-insensitive).
+func isKnownInferenceProvider(segment string) bool {
+	return slices.ContainsFunc(INFERENCE_PROVIDERS, func(p inferenceProvider) bool {
+		return strings.EqualFold(segment, string(p))
+	})
 }
 
 func deriveSupportedMethods(pipeline string, tags []string) []string {

--- a/core/providers/huggingface/models.go
+++ b/core/providers/huggingface/models.go
@@ -70,14 +70,14 @@ func (response *HuggingFaceListModelsResponse) ToBifrostListModelsResponse(provi
 	for _, m := range pipeline.BackfillModels(included) {
 		rawID := strings.TrimPrefix(m.ID, string(providerKey)+"/")
 		// Allowlist entries selected from a previous ListModels response already
-		// carry an inference-provider segment (e.g. "featherless-ai/org/model").
-		// Prepending another segment here duplicates the provider in the compound
-		// ID and breaks request routing (#4215).
-		if first, _, found := strings.Cut(rawID, "/"); found && isKnownInferenceProvider(first) {
+		// carry an inference-provider segment (e.g. "featherless-ai/org/model")
+		// or the "auto" policy. Prepending another segment here duplicates the
+		// provider in the compound ID and breaks request routing (#4215).
+		if first, _, found := strings.Cut(rawID, "/"); found && isKnownInferenceProviderOrPolicy(first) {
 			if !strings.EqualFold(first, string(inferenceProvider)) {
-				// The entry belongs to a different inference provider's listing;
-				// that provider's pass emits it, so skip it here to avoid
-				// duplicating the entry once per inference provider.
+				// The entry belongs to a different inference provider's listing
+				// (or names the "auto" policy, which no pass owns); skip it here
+				// to avoid duplicating the entry once per inference provider.
 				continue
 			}
 			m.ID = fmt.Sprintf("%s/%s", providerKey, rawID)
@@ -91,10 +91,10 @@ func (response *HuggingFaceListModelsResponse) ToBifrostListModelsResponse(provi
 	return bifrostResponse
 }
 
-// isKnownInferenceProvider reports whether segment names one of the supported
-// inference providers (case-insensitive).
-func isKnownInferenceProvider(segment string) bool {
-	return slices.ContainsFunc(INFERENCE_PROVIDERS, func(p inferenceProvider) bool {
+// isKnownInferenceProviderOrPolicy reports whether segment names one of the
+// supported inference providers or the "auto" policy (case-insensitive).
+func isKnownInferenceProviderOrPolicy(segment string) bool {
+	return slices.ContainsFunc(PROVIDERS_OR_POLICIES, func(p inferenceProvider) bool {
 		return strings.EqualFold(segment, string(p))
 	})
 }

--- a/core/providers/huggingface/models_test.go
+++ b/core/providers/huggingface/models_test.go
@@ -1,0 +1,71 @@
+package huggingface
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for https://github.com/maximhq/bifrost/issues/4215.
+//
+// Allowlist entries selected from a previous ListModels response carry an
+// inference-provider segment (e.g. "featherless-ai/org/model"). The backfill
+// re-wrap used to blindly prepend the current inference provider, producing
+// IDs like "huggingface/cohere/featherless-ai/org/model" that duplicate the
+// provider segment and fail request routing.
+func TestToBifrostListModelsResponse_AllowlistWithInferenceProviderSegment(t *testing.T) {
+	t.Parallel()
+
+	allowlist := schemas.WhiteList{"featherless-ai/deepseek-ai/DeepSeek-V4-Pro"}
+
+	t.Run("matching provider emits single correctly-prefixed entry", func(t *testing.T) {
+		t.Parallel()
+		response := &HuggingFaceListModelsResponse{
+			Models: []HuggingFaceModel{
+				{
+					ID:          "abc123",
+					ModelID:     "deepseek-ai/DeepSeek-V4-Pro",
+					PipelineTag: "conversational",
+				},
+			},
+		}
+
+		result := response.ToBifrostListModelsResponse(schemas.HuggingFace, featherlessAI, allowlist, nil, nil, false)
+		require.NotNil(t, result)
+		require.Len(t, result.Data, 1)
+		assert.Equal(t, "huggingface/featherless-ai/deepseek-ai/DeepSeek-V4-Pro", result.Data[0].ID)
+	})
+
+	t.Run("other providers do not duplicate the entry", func(t *testing.T) {
+		t.Parallel()
+		response := &HuggingFaceListModelsResponse{
+			Models: []HuggingFaceModel{
+				{
+					ID:          "def456",
+					ModelID:     "CohereLabs/aya-vision-32b",
+					PipelineTag: "conversational",
+				},
+			},
+		}
+
+		result := response.ToBifrostListModelsResponse(schemas.HuggingFace, cohere, allowlist, nil, nil, false)
+		require.NotNil(t, result)
+		assert.Empty(t, result.Data, "an allowlist entry pinned to featherless-ai must not be backfilled under cohere")
+	})
+}
+
+// Entries without an inference-provider segment keep the existing backfill
+// behavior: the current inference provider is prepended.
+func TestToBifrostListModelsResponse_BackfillWithoutInferenceProviderSegment(t *testing.T) {
+	t.Parallel()
+
+	response := &HuggingFaceListModelsResponse{Models: nil}
+	allowlist := schemas.WhiteList{"deepseek-ai/DeepSeek-V4-Pro"}
+
+	result := response.ToBifrostListModelsResponse(schemas.HuggingFace, featherlessAI, allowlist, nil, nil, false)
+	require.NotNil(t, result)
+	require.Len(t, result.Data, 1)
+	assert.Equal(t, "huggingface/featherless-ai/deepseek-ai/DeepSeek-V4-Pro", result.Data[0].ID)
+}

--- a/core/providers/huggingface/models_test.go
+++ b/core/providers/huggingface/models_test.go
@@ -56,6 +56,21 @@ func TestToBifrostListModelsResponse_AllowlistWithInferenceProviderSegment(t *te
 	})
 }
 
+// Allowlist entries prefixed with the "auto" policy must not be re-prefixed
+// with an inference provider either: "auto" is owned by no provider pass, so
+// the entry is skipped in every pass. It stays routable via requests because
+// splitIntoModelProvider recognizes "auto" as a valid policy segment.
+func TestToBifrostListModelsResponse_AllowlistWithAutoPolicySegment(t *testing.T) {
+	t.Parallel()
+
+	response := &HuggingFaceListModelsResponse{Models: nil}
+	allowlist := schemas.WhiteList{"auto/deepseek-ai/DeepSeek-V4-Pro"}
+
+	result := response.ToBifrostListModelsResponse(schemas.HuggingFace, featherlessAI, allowlist, nil, nil, false)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Data, "an auto-policy entry must not be re-prefixed with an inference provider")
+}
+
 // Entries without an inference-provider segment keep the existing backfill
 // behavior: the current inference provider is prepended.
 func TestToBifrostListModelsResponse_BackfillWithoutInferenceProviderSegment(t *testing.T) {

--- a/core/providers/huggingface/models_test.go
+++ b/core/providers/huggingface/models_test.go
@@ -57,18 +57,34 @@ func TestToBifrostListModelsResponse_AllowlistWithInferenceProviderSegment(t *te
 }
 
 // Allowlist entries prefixed with the "auto" policy must not be re-prefixed
-// with an inference provider either: "auto" is owned by no provider pass, so
-// the entry is skipped in every pass. It stays routable via requests because
-// splitIntoModelProvider recognizes "auto" as a valid policy segment.
+// with an inference provider: "auto" is owned by no provider pass (the listing
+// loop iterates INFERENCE_PROVIDERS, which excludes it). To keep the entry from
+// being dropped entirely, it is emitted exactly once during the canonical first
+// pass and skipped in every other pass, so it surfaces in the listing without
+// being duplicated once per provider. The "auto/" prefix is preserved, so it
+// stays routable: splitIntoModelProvider recognizes "auto" as a valid policy.
 func TestToBifrostListModelsResponse_AllowlistWithAutoPolicySegment(t *testing.T) {
 	t.Parallel()
 
-	response := &HuggingFaceListModelsResponse{Models: nil}
 	allowlist := schemas.WhiteList{"auto/deepseek-ai/DeepSeek-V4-Pro"}
 
-	result := response.ToBifrostListModelsResponse(schemas.HuggingFace, featherlessAI, allowlist, nil, nil, false)
-	require.NotNil(t, result)
-	assert.Empty(t, result.Data, "an auto-policy entry must not be re-prefixed with an inference provider")
+	t.Run("canonical first pass emits the auto-policy entry exactly once", func(t *testing.T) {
+		t.Parallel()
+		response := &HuggingFaceListModelsResponse{Models: nil}
+		result := response.ToBifrostListModelsResponse(schemas.HuggingFace, INFERENCE_PROVIDERS[0], allowlist, nil, nil, false)
+		require.NotNil(t, result)
+		require.Len(t, result.Data, 1)
+		assert.Equal(t, "huggingface/auto/deepseek-ai/DeepSeek-V4-Pro", result.Data[0].ID,
+			"the auto-policy entry keeps its prefix and is not re-wrapped with an inference provider")
+	})
+
+	t.Run("non-canonical passes do not duplicate the auto-policy entry", func(t *testing.T) {
+		t.Parallel()
+		response := &HuggingFaceListModelsResponse{Models: nil}
+		result := response.ToBifrostListModelsResponse(schemas.HuggingFace, featherlessAI, allowlist, nil, nil, false)
+		require.NotNil(t, result)
+		assert.Empty(t, result.Data, "a non-canonical pass must not re-emit the auto-policy entry")
+	})
 }
 
 // Entries without an inference-provider segment keep the existing backfill


### PR DESCRIPTION
## Summary

Closes #4215.

When individual HuggingFace models are selected on a key (instead of allow-all), `/v1/models` returns IDs with the inference-provider segment duplicated, e.g. `huggingface/cohere/featherless-ai/deepseek-ai/DeepSeek-V4-Pro`. Requests against those IDs fail because `splitIntoModelProvider` parses the first segment (`cohere`) as the inference provider and the rest as the model name.

Root cause: allowlist entries selected from a previous `ListModels` response already carry an inference-provider segment (`featherless-ai/deepseek-ai/DeepSeek-V4-Pro`). The hub fetch returns model IDs without that segment, so `FilterModel` never matches the entry and `BackfillModels` emits it verbatim. The backfill re-wrap in `huggingface/models.go` then blindly prepends the current goroutine's inference provider, duplicating the segment. Because `listModelsByKey` runs one conversion per inference provider and aggregates without dedupe, the same entry was also emitted once per provider, each with a different (wrong) prefix; that is why the reproduction log shows `cohere` in front of a `featherless-ai` model. Allow-all is unaffected since the backfill path never runs without a restricted allowlist.

## Changes

- In the backfill re-wrap, check whether the entry's first segment names a known inference provider. If it matches the current pass's provider, keep the ID as-is instead of prepending again. If it names a different provider, skip the entry; that provider's own pass emits it, which also stops the one-copy-per-provider duplication.
- Entries without an inference-provider segment keep the existing behavior (current provider prepended), since we cannot know which provider serves them.
- Added `isKnownInferenceProvider` next to the re-wrap and regression tests in `models_test.go`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/huggingface/ -run TestToBifrostListModelsResponse -v
```

Without the fix, the new tests reproduce both reported shapes:

```
--- Expected
+++ Actual
@@ -1 +1 @@
-huggingface/featherless-ai/deepseek-ai/DeepSeek-V4-Pro
+huggingface/featherless-ai/featherless-ai/deepseek-ai/DeepSeek-V4-Pro

Should be empty, but was [{huggingface/cohere/featherless-ai/deepseek-ai/DeepSeek-V4-Pro ...}]
```

With the fix, `go test ./providers/huggingface/` and `./providers/utils/` pass; `gofmt`, `go vet`, and `golangci-lint` are clean on the touched files.

Note: `core/go.sum` on current `dev` is missing the `go.mod` hashes for `github.com/aws/aws-sdk-go-v2` (and transitively `smithy-go`), so `go test ./...` fails at setup before this change; I ran `go mod download` locally to test and left `go.sum` untouched in this PR.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4215

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (N/A)
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable