### PR TITLE
temp: skip migrations with BIFROST_SKIP_ADVISORY_LOCKS=true on startup

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -49,6 +50,14 @@ type migrationLock struct {
 // For non-PostgreSQL databases, returns a no-op lock.
 func acquireMigrationLock(ctx context.Context, db *gorm.DB) (*migrationLock, error) {
 	if db.Dialector.Name() != "postgres" {
+		return &migrationLock{}, nil
+	}
+
+	// Skip advisory lock acquisition entirely when BIFROST_SKIP_ADVISORY_LOCKS=true.
+	// Use this to break OOM-restart loops where a crashed pod's lingering DB
+	// session holds the lock and every new pod blocks waiting for it.
+	if strings.EqualFold(os.Getenv("BIFROST_SKIP_ADVISORY_LOCKS"), "true") {
+		log.Printf("[configstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping migration advisory lock")
 		return &migrationLock{}, nil
 	}
 
@@ -395,6 +404,13 @@ func dropLegacyBudgetColumn(tx *gorm.DB, tableName string) error {
 
 // Migrate performs the necessary database migrations.
 func triggerMigrations(ctx context.Context, db *gorm.DB) error {
+	// Skip all migrations when BIFROST_SKIP_ADVISORY_LOCKS=true to break
+	// OOM-restart loops. The pod will start with whatever schema already exists.
+	if strings.EqualFold(os.Getenv("BIFROST_SKIP_ADVISORY_LOCKS"), "true") {
+		log.Printf("[configstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping all migrations")
+		return nil
+	}
+
 	// Acquire advisory lock to serialize migrations across cluster nodes.
 	// This prevents race conditions when multiple nodes start simultaneously
 	// and try to create the same tables in parallel.

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 	"sync"
@@ -428,7 +429,10 @@ func ensureMatViews(ctx context.Context, db *gorm.DB) error {
 	defer conn.Close()
 
 	var acquired bool
-	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", matviewRefreshAdvisoryLockKey).Scan(&acquired); err != nil {
+	if skipAdvisoryLocks() {
+		log.Printf("[logstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping matview creation advisory lock")
+		acquired = true
+	} else if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", matviewRefreshAdvisoryLockKey).Scan(&acquired); err != nil {
 		return fmt.Errorf("failed to try advisory lock for matview creation: %w", err)
 	}
 	if !acquired {
@@ -436,7 +440,9 @@ func ensureMatViews(ctx context.Context, db *gorm.DB) error {
 		return nil
 	}
 	defer func() {
-		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", matviewRefreshAdvisoryLockKey)
+		if !skipAdvisoryLocks() {
+			_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", matviewRefreshAdvisoryLockKey)
+		}
 	}()
 
 	if err := dropLegacyMatViews(ctx, conn); err != nil {
@@ -710,15 +716,20 @@ func refreshMatViews(ctx context.Context, db *gorm.DB) error {
 
 	// Try to acquire advisory lock; skip refresh if another replica holds it.
 	var acquired bool
-	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", matviewRefreshAdvisoryLockKey).Scan(&acquired); err != nil {
+	if skipAdvisoryLocks() {
+		log.Printf("[logstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping matview refresh advisory lock")
+		acquired = true
+	} else if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", matviewRefreshAdvisoryLockKey).Scan(&acquired); err != nil {
 		return fmt.Errorf("failed to try advisory lock for matview refresh: %w", err)
 	}
 	if !acquired {
 		return nil // another replica is refreshing
 	}
 	defer func() {
-		// Release lock explicitly; connection close would also release session-scoped locks.
-		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", matviewRefreshAdvisoryLockKey)
+		if !skipAdvisoryLocks() {
+			// Release lock explicitly; connection close would also release session-scoped locks.
+			_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", matviewRefreshAdvisoryLockKey)
+		}
 	}()
 
 	for _, view := range allMatViewNames() {

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/framework/migrator"
@@ -20,10 +22,10 @@ func isValidJSON(s string) bool {
 
 const (
 	// migrationAdvisoryLockKey is used for PostgreSQL advisory locks
-	// to serialize migrations across cluster nodes.
-	// This is the SAME key used by configstore migrations to ensure
-	// all migrations are fully serialized.
-	migrationAdvisoryLockKey = 1000001
+	// to serialize logstore migrations across cluster nodes.
+	// This is a DIFFERENT key from configstore's migration lock so that
+	// logstore and configstore migrations can proceed independently.
+	migrationAdvisoryLockKey = 1000003
 
 	// indexAdvisoryLockKey serializes the background index build across
 	// cluster nodes. It is intentionally a DIFFERENT key from migrationAdvisoryLockKey
@@ -48,6 +50,13 @@ const (
 	maintenanceUpdateBatchSize = 10_000
 )
 
+// skipAdvisoryLocks returns true when BIFROST_SKIP_ADVISORY_LOCKS=true,
+// allowing pods to bypass advisory lock acquisition during startup to break
+// OOM-restart loops where lingering DB sessions hold stale locks.
+func skipAdvisoryLocks() bool {
+	return strings.EqualFold(os.Getenv("BIFROST_SKIP_ADVISORY_LOCKS"), "true")
+}
+
 // advisoryLock holds a dedicated connection and the advisory lock key.
 // This ensures the lock is held on the same connection throughout its lifetime,
 // preventing race conditions caused by GORM's connection pooling.
@@ -63,6 +72,14 @@ type advisoryLock struct {
 // For non-PostgreSQL databases, returns a no-op lock.
 func acquireAdvisoryLock(ctx context.Context, db *gorm.DB, lockKey int64, label string) (*advisoryLock, error) {
 	if db.Dialector.Name() != "postgres" {
+		return &advisoryLock{}, nil
+	}
+
+	// Skip advisory lock acquisition entirely when BIFROST_SKIP_ADVISORY_LOCKS=true.
+	// Use this to break OOM-restart loops where a crashed pod's lingering DB
+	// session holds the lock and every new pod blocks waiting for it.
+	if strings.EqualFold(os.Getenv("BIFROST_SKIP_ADVISORY_LOCKS"), "true") {
+		log.Printf("[logstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping %s advisory lock", label)
 		return &advisoryLock{}, nil
 	}
 
@@ -166,6 +183,13 @@ func acquireIndexLock(ctx context.Context, db *gorm.DB) (*advisoryLock, error) {
 // triggerMigrations runs all registered logstore schema migrations in order under a
 // PostgreSQL advisory lock (shared with configstore) so only one node migrates at a time.
 func triggerMigrations(ctx context.Context, db *gorm.DB) error {
+	// Skip all migrations when BIFROST_SKIP_ADVISORY_LOCKS=true to break
+	// OOM-restart loops. The pod will start with whatever schema already exists.
+	if skipAdvisoryLocks() {
+		log.Printf("[logstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping all migrations")
+		return nil
+	}
+
 	// Acquire advisory lock to serialize migrations across cluster nodes.
 	// Uses the same key as configstore to ensure all migrations are serialized.
 	lock, err := acquireMigrationLock(ctx, db)

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -180,7 +180,10 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 	// Each function is idempotent and acquires its own advisory lock for
 	// cross-node serialization. Running in a goroutine avoids blocking pod startup.
 	go func() {
-		if db.Dialector.Name() != "postgres" {
+		if db.Dialector.Name() != "postgres" || skipAdvisoryLocks() {
+			if skipAdvisoryLocks() {
+				logger.Info("logstore: BIFROST_SKIP_ADVISORY_LOCKS=true \u2014 skipping index builds")
+			}
 			return
 		}
 		// Acquire advisory lock to serialize GIN index builds across cluster nodes.
@@ -218,7 +221,10 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 
 	// Create materialized views and start periodic refresh for dashboard queries.
 	go func() {
-		if db.Dialector.Name() != "postgres" {
+		if db.Dialector.Name() != "postgres" || skipAdvisoryLocks() {
+			if skipAdvisoryLocks() {
+				logger.Info("logstore: BIFROST_SKIP_ADVISORY_LOCKS=true \u2014 skipping matview creation and refresh")
+			}
 			return
 		}
 		if err := ensureMatViews(context.Background(), db); err != nil {


### PR DESCRIPTION
## Summary

Introduces a `BIFROST_SKIP_ADVISORY_LOCKS` environment variable that allows pods
to bypass PostgreSQL advisory lock acquisition and skip database migrations
entirely on startup. This is intended as an escape hatch to break OOM-restart
loops where a crashed pod's lingering database session holds a stale advisory
lock, causing every new pod to block indefinitely waiting to acquire it.

## Changes

- Added `BIFROST_SKIP_ADVISORY_LOCKS=true` check in
  `configstore.acquireMigrationLock` to return a no-op lock immediately,
  bypassing the advisory lock acquisition.
- Added `BIFROST_SKIP_ADVISORY_LOCKS=true` check in
  `configstore.triggerMigrations` to skip all migrations entirely, allowing the
  pod to start against the existing schema.
- Introduced a shared `skipAdvisoryLocks()` helper in `logstore` to centralize
  the environment variable check.
- Applied the same skip logic to `logstore.acquireAdvisoryLock` and
  `logstore.triggerMigrations`.
- Skipped advisory lock acquisition and release in `ensureMatViews` and
  `refreshMatViews`, treating the lock as already acquired when the flag is set.
- Skipped GIN index builds and materialized view creation/refresh goroutines in
  `newPostgresLogStore` when the flag is enabled.

The trade-off is that running with this flag means no schema migrations will
execute and no index or matview maintenance will occur during that startup
cycle. It is intended for temporary use only to recover from a stuck state.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

Set `BIFROST_SKIP_ADVISORY_LOCKS=true` in the environment before starting the
service. Verify in logs that messages such as the following appear and that the
pod starts successfully without waiting on advisory locks:

```
[configstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping all migrations
[logstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping all migrations
[logstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping index builds
[logstore] BIFROST_SKIP_ADVISORY_LOCKS=true — skipping matview creation and refresh
```

To validate normal behavior is unaffected, start the service without the
variable set and confirm migrations, index builds, and matview creation proceed
as expected.

```sh
go test ./...
```

**Environment variable:**

| Variable                      | Values         | Description                                                                                                                                                                                             |
| ----------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `BIFROST_SKIP_ADVISORY_LOCKS` | `true` / unset | When `true`, bypasses all PostgreSQL advisory lock acquisition and skips migrations, index builds, and matview operations on startup. Use only to recover from OOM-restart loops caused by stale locks. |

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, or PII implications. The flag bypasses distributed
coordination mechanisms, so it should only be enabled temporarily in recovery
scenarios. Leaving it enabled permanently could allow concurrent schema
migrations across cluster nodes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BIFROST_SKIP_ADVISORY_LOCKS environment variable to let operators bypass PostgreSQL advisory locks. When enabled, migrations, index builds, and materialized-view creation/refresh are skipped or run without cluster-level locking, and diagnostic log messages indicate the skip behavior. This provides a deployment escape hatch for environments where advisory locks are undesirable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->