### PR TITLE
[fix]: drop non-text content blocks from lastUserMessage when ObjectStore is enabled

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+[fix]: drop non-text content blocks from last user message kept in DB when object store is enabled [@cprzytocki-ankored](https://github.com/cprzytocki-ankored)

--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -242,10 +242,12 @@ func prepareDBEntry(dbEntry *Log, excluded map[string]struct{}) {
 	dbEntry.ContentSummary = truncateTag(dbEntry.ContentSummary, maxContentSummaryBytes)
 
 	// Serialize last user message before ClearPayload zeros everything.
-	// msgs[idx:idx+1] reuses the backing array — no heap alloc, no struct copy.
+	// Non-text content blocks (image/audio/file attachments) are dropped so
+	// the DB row stays lightweight; the full message lives in object storage.
 	var lastUserMessage string
 	if idx >= 0 {
-		lastUserMessage, _ = sonic.MarshalString(dbEntry.InputHistoryParsed[idx : idx+1])
+		msg := dropNonTextContentBlocks(dbEntry.InputHistoryParsed[idx])
+		lastUserMessage, _ = sonic.MarshalString([]schemas.ChatMessage{msg})
 	}
 
 	ClearPayloadFiltered(dbEntry, excluded)

--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -207,6 +207,50 @@ func TestHybrid_FindByID_GracefulDegradation(t *testing.T) {
 	assert.Empty(t, found.OutputMessage, "output should be empty when S3 fails")
 }
 
+func TestHybrid_Create_DropsNonTextBlocksFromDBLastUserMessage(t *testing.T) {
+	// When the last user message carries attachments (image/audio/file blocks),
+	// only its text blocks should be kept in the DB row's input_history. The
+	// full message, attachments included, still goes to object storage.
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	question := "What is in this image?"
+	imageData := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="
+	entry := &Log{
+		ID:        "attach-1",
+		Timestamp: time.Now().UTC(),
+		Provider:  "openai",
+		Model:     "gpt-4o",
+		Status:    "success",
+		Object:    "chat.completion",
+		InputHistoryParsed: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{
+				{Type: schemas.ChatContentBlockTypeText, Text: &question},
+				{Type: schemas.ChatContentBlockTypeImage, ImageURLStruct: &schemas.ChatInputImage{URL: imageData}},
+			}}},
+		},
+	}
+	require.NoError(t, entry.SerializeFields())
+	require.NoError(t, hybrid.CreateIfNotExists(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	// DB row keeps the text block but not the attachment.
+	dbLog, err := inner.FindByID(ctx, "attach-1")
+	require.NoError(t, err)
+	assert.Contains(t, dbLog.InputHistory, "What is in this image?", "text block should be retained in DB")
+	assert.NotContains(t, dbLog.InputHistory, "base64", "attachment data must not be stored in DB")
+
+	// S3 payload keeps the full message including the attachment.
+	key := ObjectKey("test", entry.Timestamp, "attach-1")
+	rawPayload, err := objStore.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Contains(t, string(rawPayload), "base64", "attachment should be preserved in object storage")
+
+	// The caller's parsed message must not be mutated by the DB filtering.
+	require.Len(t, entry.InputHistoryParsed[0].Content.ContentBlocks, 2, "caller's message blocks must stay intact")
+}
+
 func TestHybrid_CreateAndFindMCPToolLog(t *testing.T) {
 	hybrid, inner, objStore := newTestHybrid(t)
 	defer hybrid.Close(context.Background())

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -464,6 +464,27 @@ func extractResponsesMessageText(msg *schemas.ResponsesMessage) string {
 	return ""
 }
 
+// dropNonTextContentBlocks returns a copy of msg with non-text content blocks
+// (images, audio, files) removed, so attachment payloads never land in the DB
+// row. The copy leaves msg untouched because the caller's parsed slice backs
+// the full payload that is uploaded to object storage. Messages with plain
+// string content (or no content) are returned as-is.
+func dropNonTextContentBlocks(msg schemas.ChatMessage) schemas.ChatMessage {
+	if msg.Content == nil || msg.Content.ContentBlocks == nil {
+		return msg
+	}
+	textBlocks := make([]schemas.ChatContentBlock, 0, len(msg.Content.ContentBlocks))
+	for _, block := range msg.Content.ContentBlocks {
+		if block.Type == schemas.ChatContentBlockTypeText {
+			textBlocks = append(textBlocks, block)
+		}
+	}
+	content := *msg.Content
+	content.ContentBlocks = textBlocks
+	msg.Content = &content
+	return msg
+}
+
 // findLastUserMessageIndex returns the index of the last ChatMessage with
 // role "user", or -1 if none exists. Used by both BuildInputContentSummary
 // and prepareDBEntry to avoid scanning the slice twice.


### PR DESCRIPTION
## Summary

When object store logging is enabled, the hybrid log store trims `input_history` in the DB row down to the last user message. That message was serialized verbatim, so attachment content blocks (base64 images, audio, files) ended up in the DB row — exactly what offloading payloads to object storage is meant to avoid. As discussed in #3390, non-text chunks should be dropped from `lastUserMessage`.

## Changes

- `framework/logstore/payload.go` — add `dropNonTextContentBlocks`, which returns a copy of a `ChatMessage` with only its `text` content blocks. It copies rather than mutates because the caller's parsed slice backs the full payload uploaded to object storage.
- `framework/logstore/hybrid.go` — `prepareDBEntry` now filters the last user message through this helper before serializing it into the DB row. Messages with plain string content are unaffected.
- `framework/logstore/hybrid_test.go` — regression test asserting the DB row keeps the text block but not the attachment, the object-store payload keeps the full message, and the caller's entry is not mutated.
- `framework/changelog.md` — changelog entry.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
make setup-workspace
cd framework
go test ./logstore/ -count=1
# focused: go test ./logstore/ -run TestHybrid_Create_DropsNonTextBlocksFromDBLastUserMessage -count=1
```

All `framework/logstore` tests pass locally; `gofmt` and `go vet` are clean.

## Breaking changes

- [ ] Yes
- [x] No

The DB row's `input_history` no longer contains attachment blocks of the last user message, but `FindByID` continues to hydrate the full message (attachments included) from object storage, so API responses are unchanged.

## Related issues

Closes #3390

## Security considerations

Slightly reduces surface area: attachment payloads (which can contain user-uploaded documents/images) no longer land in the relational DB when object store offloading is configured.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed (no doc changes required)
- [x] I verified builds succeed (Go)
- [x] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where non-text content blocks (images, attachments) from user messages were unnecessarily stored in the database when object store is enabled. Non-text content now only persists in the object store, reducing database bloat.

* **Tests**
  * Added test coverage verifying that non-text content is properly excluded from database storage while remaining available in the object store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->