### PR TITLE
fix(ui): remove broken delete-dialog refs and unsupported HeadersTable prop

### DIFF
--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
@@ -466,7 +466,6 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 									<HeadersTable
 										value={envVars}
 										onChange={setEnvVars}
-										fixedKeys={server.stdio_config.envs}
 										keyPlaceholder="Variable name"
 										valuePlaceholder="Value (or host env)"
 										label=""

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryServerCard.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryServerCard.tsx
@@ -5,7 +5,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import type { MCPLibraryEntry } from "@/lib/types/mcp";
 import { Link } from "@tanstack/react-router";
 import { BookIcon, Globe, Library, Radio, Terminal } from "lucide-react";
-import { MCPLibraryDeleteDialog } from "./mcpLibraryDeleteDialog";
 
 const MAX_VISIBLE_TAGS = 3;
 export const MCP_ICON_FALLBACK = "/images/mcp.svg";

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx
@@ -4,8 +4,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { MCPLibraryEntry } from "@/lib/types/mcp";
 import { Link } from "@tanstack/react-router";
-import { BookIcon, Check, Download, Library, LogIn } from "lucide-react";
-import { MCPLibraryDeleteDialog } from "./mcpLibraryDeleteDialog";
+import { BookIcon, Check, Download, LogIn } from "lucide-react";
 import { authLabel, MCP_ICON_FALLBACK, transportIcon, transportLabel } from "./mcpLibraryServerCard";
 
 interface MCPLibraryServersTableProps {
@@ -82,24 +81,6 @@ export function MCPLibraryServersTable({ servers, installedServerSlugs, canCreat
 								</TableCell>
 								<TableCell className="text-right">
 									<div className="flex justify-end gap-2">
-										{canDelete && (
-											<div className="hidden group-hover:block">
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<Button
-															variant="outline"
-															size="icon"
-															onClick={() => setServerToDelete(server)}
-															aria-label={`Remove ${server.name} from library`}
-															data-testid={`mcp-library-table-delete-${server.slug}`}
-														>
-															<Trash2 className="h-4 w-4" />
-														</Button>
-													</TooltipTrigger>
-													<TooltipContent>Remove from library</TooltipContent>
-												</Tooltip>
-											</div>
-										)}
 										{server.docs_url && (
 											<Tooltip>
 												<TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

Fixes three TypeScript errors introduced by #3986 (dynamic MCP library catalog) that break `npm run build-enterprise` and consequently the Docker image build (`transports/Dockerfile`, `ui-builder` stage). The errors only surface during a real build (`vite build` runs `tsc`) — they aren't caught by `npm run dev`'s loose checking.

The failing build (Docker, against `dev` HEAD) emits:

```
app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx(469,11): error TS2322: Type '{ ... fixedKeys: string[]; ... }' is not assignable to type 'IntrinsicAttributes & HeadersTableProps<string>'.
  Property 'fixedKeys' does not exist on type 'IntrinsicAttributes & HeadersTableProps<string>'.
app/workspace/mcp-registry/library/views/mcpLibraryServerCard.tsx(8,40): error TS2307: Cannot find module './mcpLibraryDeleteDialog' or its corresponding type declarations.
app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx(8,40): error TS2307: Cannot find module './mcpLibraryDeleteDialog' or its corresponding type declarations.
app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx(85,12): error TS2304: Cannot find name 'canDelete'.
app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx(92,31): error TS2304: Cannot find name 'setServerToDelete'.
app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx(96,17): error TS2304: Cannot find name 'Trash2'.
```

## Changes (minimum-touch)

1. **`mcpLibraryServerCard.tsx`** — drop unused `import { MCPLibraryDeleteDialog } from "./mcpLibraryDeleteDialog"`. The module does not exist anywhere in the tree, and the import is never referenced in JSX.
2. **`mcpLibraryServersTable.tsx`** — same unused import removed, and a dead delete-button block removed. The block referenced `canDelete`, `setServerToDelete`, and `Trash2`, none of which are declared as props, hooks/state, or imports.
3. **`mcpLibraryInstallSheet.tsx`** — remove `fixedKeys={server.stdio_config.envs}` from one `<HeadersTable />`. `HeadersTableProps` (`ui/components/ui/headersTable.tsx`) does not declare a `fixedKeys` prop, so this fails type-check.

Net diff: **+1/−22**.

## If a delete feature was intended

The pattern of these errors strongly suggests an in-progress "remove from library" feature that landed mid-way: the dialog file was never committed, the supporting props/state were never wired, and the `Trash2` icon was never imported. This patch restores buildability today; a follow-up that ships the dialog component, the props, the local state, and the icon import together is the right place to land that feature.

Same comment applies to the `fixedKeys` prop on `HeadersTable` — if envs from `stdio_config` should be pre-populated as fixed keys, that's a HeadersTable enhancement plus the prop wiring; out of scope for restoring the build.

## Test plan

- [x] Identified all three error sites in the failing build log.
- [x] Verified each fix removes the relevant error without changing rendered behavior (the deleted code paths were dead — `canDelete` was never truthy, `MCPLibraryDeleteDialog` was never rendered, and the `fixedKeys` prop was silently dropped before this typecheck-strict path).
- [ ] `npm run build-enterprise` from `ui/` succeeds. (Maintainers: please confirm in CI.)
- [ ] `docker build -f transports/Dockerfile .` succeeds. (Maintainers: please confirm in CI.)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined MCP library interface by removing redundant server actions and cleaning up unused components in the library views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->