### PR TITLE
fix: vertex batch api tests

### DIFF
--- a/core/providers/gemini/batch.go
+++ b/core/providers/gemini/batch.go
@@ -236,16 +236,6 @@ func parseGeminiTimestamp(timestamp string) int64 {
 	return t.Unix()
 }
 
-// extractBatchIDFromName extracts the batch ID from the full resource name.
-// e.g., "batches/abc123" -> "abc123"
-func extractBatchIDFromName(name string) string {
-	if name == "" {
-		return ""
-	}
-	parts := strings.Split(name, "/")
-	return parts[len(parts)-1]
-}
-
 // downloadBatchResultsFile downloads and parses a batch results file from Gemini.
 // Returns the parsed result items from the JSONL file and any parse errors encountered.
 func (provider *GeminiProvider) downloadBatchResultsFile(ctx context.Context, key schemas.Key, fileName string) ([]schemas.BatchResultItem, []schemas.BatchError, *schemas.BifrostError) {

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2754,7 +2754,8 @@ func (provider *GeminiProvider) batchListByKey(ctx *schemas.BifrostContext, key 
 	data := make([]schemas.BifrostBatchRetrieveResponse, 0, len(geminiResp.Operations))
 	for _, batch := range geminiResp.Operations {
 		data = append(data, schemas.BifrostBatchRetrieveResponse{
-			ID:            extractBatchIDFromName(batch.Name),
+			// Full name (batches/<id>), matching create/retrieve so the id is stable.
+			ID:            batch.Name,
 			Object:        "batch",
 			Status:        ToBifrostBatchStatus(batch.Metadata.State),
 			CreatedAt:     parseGeminiTimestamp(batch.Metadata.CreateTime),

--- a/core/providers/vertex/batch.go
+++ b/core/providers/vertex/batch.go
@@ -50,8 +50,8 @@ func vertexBatchJobsBaseURL(key schemas.Key) (string, *schemas.BifrostError) {
 		return "", providerUtils.NewConfigurationError("project ID is not set")
 	}
 	region := key.VertexKeyConfig.Region.GetValue()
-	if region == "" || region == "global" {
-		return "", providerUtils.NewConfigurationError("a regional vertex key (e.g. us-central1) is required for batch prediction; global is not supported")
+	if region == "" {
+		return "", providerUtils.NewConfigurationError("region is required for batch prediction")
 	}
 	return getVertexProjectLocationURL(region, "v1", projectID), nil
 }
@@ -72,14 +72,6 @@ func vertexBatchJobURL(key schemas.Key, batchID string) (string, *schemas.Bifros
 		return "", cfgErr
 	}
 	return base + "/batchPredictionJobs/" + batchID, nil
-}
-
-// vertexBatchJobIDFromName extracts the bare job ID from a full resource name.
-func vertexBatchJobIDFromName(name string) string {
-	if idx := strings.LastIndexByte(name, '/'); idx >= 0 {
-		return name[idx+1:]
-	}
-	return name
 }
 
 // vertexBatchJobToBifrost maps a BatchPredictionJob resource to the Bifrost retrieve response.
@@ -145,11 +137,6 @@ func parseVertexJobAPIError(body []byte, statusCode int, op string) *schemas.Bif
 	return providerUtils.NewProviderAPIError(msg, nil, statusCode, nil, nil)
 }
 
-// vertexBatchControlParams are extra_params consumed by BatchCreate for Bifrost-side
-// storage/routing; they are stripped before the rest of extra_params is passed through to
-// the Vertex BatchPredictionJob body.
-var vertexBatchControlParams = []string{"output_uri", "gcs_bucket", "gcs_prefix"}
-
 // ToVertexBatchCreateRequest maps a Bifrost batch create request to a Vertex
 // BatchPredictionJob request. The model, display name and input/output GCS config are
 // mapped explicitly; every other field is taken from extra_params (e.g. modelParameters,
@@ -175,18 +162,6 @@ func ToVertexBatchCreateRequest(request *schemas.BifrostBatchCreateRequest, disp
 			GcsDestination:    &VertexGcsDestination{OutputUriPrefix: outputURI},
 		},
 		ExtraParams: request.ExtraParams,
-	}
-
-	// Strip Bifrost control keys so they are not forwarded to Vertex as unknown fields.
-	if len(req.ExtraParams) > 0 {
-		stripped := make(map[string]interface{}, len(req.ExtraParams))
-		for k, v := range req.ExtraParams {
-			stripped[k] = v
-		}
-		for _, k := range vertexBatchControlParams {
-			delete(stripped, k)
-		}
-		req.ExtraParams = stripped
 	}
 
 	return req

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -2642,78 +2642,84 @@ func stripVertexGeminiUnsupportedFieldsRaw(jsonBody []byte) []byte {
 //
 // The output destination is taken from the typed output_folder.url (a gs:// prefix).
 func (provider *VertexProvider) BatchCreate(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostBatchCreateRequest) (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
-	if request.Model == nil || *request.Model == "" {
-		return nil, providerUtils.NewBifrostOperationError("model is required for Vertex batch API", nil)
-	}
-	hasFileInput := request.InputFileID != ""
-	hasInlineRequests := len(request.Requests) > 0
-	if hasFileInput && hasInlineRequests {
-		return nil, providerUtils.NewBifrostOperationError("cannot specify both input_file_id and requests", nil)
-	}
-	if !hasFileInput && !hasInlineRequests {
-		return nil, providerUtils.NewBifrostOperationError("either input_file_id (gs:// JSONL URI) or requests is required for Vertex batch API", nil)
-	}
-
 	baseURL, cfgErr := vertexBatchJobsBaseURL(key)
 	if cfgErr != nil {
 		return nil, cfgErr
 	}
 
-	// Output destination is the typed output_folder.url (a gs:// prefix). Vertex writes
-	// results into its own subdirectory under this prefix.
-	outputURI := ""
-	if request.OutputFolder != nil {
-		outputURI = strings.TrimSpace(request.OutputFolder.URL)
-	}
-	if outputURI == "" {
-		return nil, providerUtils.NewBifrostOperationError("output_folder.url (gs:// prefix) is required for Vertex batch API", nil)
-	}
+	rawBody, hasRawBody := providerUtils.CheckAndGetRawRequestBody(ctx, request)
+	hasRawBody = hasRawBody && len(rawBody) > 0
 
-	jobName := fmt.Sprintf("bifrost-batch-%d", time.Now().Unix())
-	if request.DisplayName != nil && *request.DisplayName != "" {
-		jobName = *request.DisplayName
-	} else if request.Metadata != nil {
-		// Back-compat: OpenAI-compatible clients may pass the job name via metadata.
-		if name, ok := request.Metadata["job_name"]; ok && name != "" {
-			jobName = name
-		}
-	}
-
-	// Inline mode: convert to JSONL and upload next to the output location (Bedrock pattern).
 	inputFileID := request.InputFileID
-	if inputFileID == "" {
-		jsonlData, err := vertexConvertRequestsToJSONL(request.Requests)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError("failed to convert requests to Vertex JSONL", err)
+	jobName := ""
+	outputURI := ""
+	if !hasRawBody {
+		if request.Model == nil || *request.Model == "" {
+			return nil, providerUtils.NewBifrostOperationError("model is required for Vertex batch API", nil)
 		}
-		outBucket, outKey, parseErr := parseGCSURI(outputURI)
-		if parseErr != nil {
-			return nil, providerUtils.NewBifrostOperationError(parseErr.Error(), nil)
+		hasFileInput := request.InputFileID != ""
+		hasInlineRequests := len(request.Requests) > 0
+		if hasFileInput && hasInlineRequests {
+			return nil, providerUtils.NewBifrostOperationError("cannot specify both input_file_id and requests", nil)
 		}
-		// Place the input alongside the output directory (sibling, not child) so the
-		// generated JSONL does not live inside the directory Vertex writes results to.
-		inputPrefix := "vertex-batches-input"
-		if trimmed := strings.Trim(outKey, "/"); trimmed != "" {
-			if idx := strings.LastIndexByte(trimmed, '/'); idx >= 0 {
-				inputPrefix = trimmed[:idx] + "/input"
-			} else {
-				inputPrefix = "input"
+		if !hasFileInput && !hasInlineRequests {
+			return nil, providerUtils.NewBifrostOperationError("either input_file_id (gs:// JSONL URI) or requests is required for Vertex batch API", nil)
+		}
+
+		// Output destination is the typed output_folder.url (a gs:// prefix). Vertex writes
+		// results into its own subdirectory under this prefix.
+		if request.OutputFolder != nil {
+			outputURI = strings.TrimSpace(request.OutputFolder.URL)
+		}
+		if outputURI == "" {
+			return nil, providerUtils.NewBifrostOperationError("output_folder.url (gs:// prefix) is required for Vertex batch API", nil)
+		}
+
+		jobName = fmt.Sprintf("bifrost-batch-%d", time.Now().Unix())
+		if request.DisplayName != nil && *request.DisplayName != "" {
+			jobName = *request.DisplayName
+		} else if request.Metadata != nil {
+			// Back-compat: OpenAI-compatible clients may pass the job name via metadata.
+			if name, ok := request.Metadata["job_name"]; ok && name != "" {
+				jobName = name
 			}
 		}
-		uploadResp, uploadErr := provider.FileUpload(ctx, key, &schemas.BifrostFileUploadRequest{
-			Provider:    schemas.Vertex,
-			File:        jsonlData,
-			Filename:    jobName + "-input.jsonl",
-			Purpose:     schemas.FilePurposeBatch,
-			ContentType: schemas.Ptr("application/jsonl"),
-			StorageConfig: &schemas.FileStorageConfig{
-				GCS: &schemas.GCSStorageConfig{Bucket: outBucket, Prefix: inputPrefix},
-			},
-		})
-		if uploadErr != nil {
-			return nil, uploadErr
+
+		// Inline mode: convert to JSONL and upload next to the output location (Bedrock pattern).
+		if inputFileID == "" {
+			jsonlData, err := vertexConvertRequestsToJSONL(request.Requests)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError("failed to convert requests to Vertex JSONL", err)
+			}
+			outBucket, outKey, parseErr := parseGCSURI(outputURI)
+			if parseErr != nil {
+				return nil, providerUtils.NewBifrostOperationError(parseErr.Error(), nil)
+			}
+			// Place the input alongside the output directory (sibling, not child) so the
+			// generated JSONL does not live inside the directory Vertex writes results to.
+			inputPrefix := "vertex-batches-input"
+			if trimmed := strings.Trim(outKey, "/"); trimmed != "" {
+				if idx := strings.LastIndexByte(trimmed, '/'); idx >= 0 {
+					inputPrefix = trimmed[:idx] + "/input"
+				} else {
+					inputPrefix = "input"
+				}
+			}
+			uploadResp, uploadErr := provider.FileUpload(ctx, key, &schemas.BifrostFileUploadRequest{
+				Provider:    schemas.Vertex,
+				File:        jsonlData,
+				Filename:    jobName + "-input.jsonl",
+				Purpose:     schemas.FilePurposeBatch,
+				ContentType: schemas.Ptr("application/jsonl"),
+				StorageConfig: &schemas.FileStorageConfig{
+					GCS: &schemas.GCSStorageConfig{Bucket: outBucket, Prefix: inputPrefix},
+				},
+			})
+			if uploadErr != nil {
+				return nil, uploadErr
+			}
+			inputFileID = uploadResp.ID
 		}
-		inputFileID = uploadResp.ID
 	}
 
 	jsonData, bodyErr := providerUtils.CheckContextAndGetRequestBody(
@@ -2765,6 +2771,12 @@ func (provider *VertexProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 	rawRequest, rawResponse, parseErr := providerUtils.HandleProviderResponse(resp.Body(), &created, jsonData, sendBackRawRequest, sendBackRawResponse)
 	if parseErr != nil {
 		return nil, providerUtils.EnrichError(ctx, parseErr, jsonData, resp.Body(), provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// In raw-passthrough mode inputFileID may be empty (e.g. BigQuery or multi-URI inputs the
+	// typed path never sees); fall back to the GCS source the created job echoes back.
+	if inputFileID == "" && created.InputConfig.GcsSource != nil && len(created.InputConfig.GcsSource.Uris) > 0 {
+		inputFileID = created.InputConfig.GcsSource.Uris[0]
 	}
 
 	result := &schemas.BifrostBatchCreateResponse{
@@ -3057,7 +3069,8 @@ func (provider *VertexProvider) batchCancelByKey(ctx *schemas.BifrostContext, ke
 	}
 
 	return &schemas.BifrostBatchCancelResponse{
-		ID:           vertexBatchJobIDFromName(request.BatchID),
+		// Echo the caller's id so it stays stable across create/retrieve/cancel.
+		ID:           request.BatchID,
 		Object:       "batch",
 		Status:       schemas.BatchStatusCancelling,
 		CancellingAt: schemas.Ptr(startTime.Unix()),
@@ -3123,7 +3136,8 @@ func (provider *VertexProvider) batchDeleteByKey(ctx *schemas.BifrostContext, ke
 	}
 
 	return &schemas.BifrostBatchDeleteResponse{
-		ID:     vertexBatchJobIDFromName(request.BatchID),
+		// Echo the caller's id so it stays stable across create/retrieve/delete.
+		ID:     request.BatchID,
 		Object: "batch",
 		Status: schemas.BatchStatusDeleted,
 		ExtraFields: schemas.BifrostResponseExtraFields{

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -37,7 +37,7 @@
           "// Only register the content-shape test when the request actually succeeded.",
           "// Otherwise newman reports it as passing (because of an early return) which is misleading next to a failing status.",
           "var __u = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
-          "var __skipShape = (__u.indexOf('/files/') !== -1 && (__u.indexOf('/content?') !== -1 || __u.slice(-8) === '/content')) || __u.indexOf('storage.googleapis.com') !== -1;",
+          "var __skipShape = (__u.indexOf('/files/') !== -1 && (__u.indexOf('/content?') !== -1 || __u.slice(-8) === '/content')) || __u.indexOf('storage.googleapis.com') !== -1 || __u.indexOf('batchPredictionJobs') !== -1;",
           "if (pm.response.code < 400 && !__skipShape && (pm.response.headers.get('content-type') || '').indexOf('text/event-stream') === -1 && (pm.response.headers.get('content-type') || '').indexOf('vnd.amazon.eventstream') === -1) {",
           "  pm.test('Response has content (text or tool_use)', function () {",
           "    var j;",
@@ -143,7 +143,9 @@
     { "key": "bedrockGuardrailIdentifier", "value": "", "type": "string" },
     { "key": "bedrockGuardrailVersion", "value": "DRAFT", "type": "string" },
     { "key": "vertexGcsBucket", "value": "replace-me-bucket", "type": "string" },
-    { "key": "vertexGcsPrefix", "value": "bifrost-e2e/", "type": "string" }
+    { "key": "vertexGcsPrefix", "value": "bifrost-e2e/", "type": "string" },
+    { "key": "vertexProject", "value": "replace-me-project", "type": "string" },
+    { "key": "vertexLocation", "value": "us-central1", "type": "string" }
   ],
   "item": [
     {
@@ -2272,6 +2274,366 @@
                 "exec": [
                   "var j = pm.response.json();",
                   "pm.test('Vertex resumable cleanup: deleted', function () { pm.expect(j.deleted).to.eql(true); });"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "11c. Vertex Batches (/openai + native passthrough)",
+      "description": "Vertex batch prediction is GCS-backed. CRUD (create/list/retrieve/cancel) runs via the OpenAI drop-in (/openai/v1/batches, routed by provider=vertex); the base64 batch ids round-trip through every endpoint. The last two rows exercise the native genai surface raw passthrough: a verbatim Vertex BatchPredictionJob body POSTed to .../batchPredictionJobs is forwarded as-is and the native job resource is returned. All [PREVIEW]-tagged: needs a gateway Vertex provider key + a GCS bucket, plus vertexProject/vertexLocation for the native rows. Set vertexGcsBucket, vertexProject and run with --env-var include_preview=1.",
+      "item": [
+        {
+          "name": "[PREVIEW] Vertex: upload batch input (GCS, /openai)",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "src": "tests/e2e/api/fixtures/sample.jsonl",
+                  "type": "file"
+                },
+                {
+                  "key": "purpose",
+                  "value": "batch",
+                  "type": "text"
+                },
+                {
+                  "key": "provider",
+                  "value": "vertex",
+                  "type": "text"
+                },
+                {
+                  "key": "storage_config[gcs][bucket]",
+                  "value": "{{vertexGcsBucket}}",
+                  "type": "text"
+                },
+                {
+                  "key": "storage_config[gcs][prefix]",
+                  "value": "{{vertexGcsPrefix}}",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/files",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "files"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex batch input: gcs backend', function () { pm.expect(j.storage_backend).to.eql('gcs'); });",
+                  "pm.test('Vertex batch input: has id', function () { pm.expect(j.id).to.be.a('string').and.not.empty; });",
+                  "pm.collectionVariables.set('vertexBatchInputFileId', j.id);",
+                  "pm.collectionVariables.set('vertexBatchInputGcsUri', j.storage_uri);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: create batch (/openai)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"input_file_id\": \"{{vertexBatchInputFileId}}\",\n  \"endpoint\": \"/v1/chat/completions\",\n  \"completion_window\": \"24h\",\n  \"provider\": \"vertex\",\n  \"model\": \"gemini-2.5-flash\",\n  \"output_folder\": {\n    \"url\": \"gs://{{vertexGcsBucket}}/{{vertexGcsPrefix}}batch-output\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/batches",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "batches"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex create batch: object batch', function () { pm.expect(j.object).to.eql('batch'); });",
+                  "pm.test('Vertex create batch: has id', function () { pm.expect(j.id).to.be.a('string').and.not.empty; });",
+                  "pm.test('Vertex create batch: input_file_id round-trips', function () { pm.expect(j.input_file_id).to.eql(pm.collectionVariables.get('vertexBatchInputFileId')); });",
+                  "pm.collectionVariables.set('vertexBatchId', j.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: list batches (/openai)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/batches?provider=vertex",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "batches"
+              ],
+              "query": [
+                {
+                  "key": "provider",
+                  "value": "vertex"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex list batches: created batch present', function () { pm.expect((j.data || []).map(function (b) { return b.id; })).to.include(pm.collectionVariables.get('vertexBatchId')); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: retrieve batch (/openai)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/batches/{{vertexBatchId}}?provider=vertex",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "batches",
+                "{{vertexBatchId}}"
+              ],
+              "query": [
+                {
+                  "key": "provider",
+                  "value": "vertex"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex retrieve batch: object batch', function () { pm.expect(j.object).to.eql('batch'); });",
+                  "pm.test('Vertex retrieve batch: id matches create', function () { pm.expect(j.id).to.eql(pm.collectionVariables.get('vertexBatchId')); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: cancel batch (/openai)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"vertex\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/batches/{{vertexBatchId}}/cancel",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "batches",
+                "{{vertexBatchId}}",
+                "cancel"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex cancel batch: has id', function () { pm.expect(j.id).to.be.a('string').and.not.empty; });",
+                  "pm.test('Vertex cancel batch: cancelling/cancelled', function () { pm.expect(['cancelling','cancelled']).to.include(j.status); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: create batch RAW passthrough (native genai)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"displayName\": \"bifrost-harness-passthrough\",\n  \"model\": \"publishers/google/models/gemini-2.5-flash\",\n  \"inputConfig\": {\n    \"instancesFormat\": \"jsonl\",\n    \"gcsSource\": {\n      \"uris\": [\n        \"{{vertexBatchInputGcsUri}}\"\n      ]\n    }\n  },\n  \"outputConfig\": {\n    \"predictionsFormat\": \"jsonl\",\n    \"gcsDestination\": {\n      \"outputUriPrefix\": \"gs://{{vertexGcsBucket}}/{{vertexGcsPrefix}}batch-output\"\n    }\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1/projects/{{vertexProject}}/locations/{{vertexLocation}}/batchPredictionJobs",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1",
+                "projects",
+                "{{vertexProject}}",
+                "locations",
+                "{{vertexLocation}}",
+                "batchPredictionJobs"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Sends a verbatim Vertex BatchPredictionJob body; Bifrost passes it through (UseRawRequestBody)",
+                  "// and returns the native Vertex job resource. Proves the raw-passthrough path end to end.",
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex RAW passthrough: name is a batchPredictionJobs resource', function () { pm.expect(j.name).to.be.a('string'); pm.expect(j.name).to.include('batchPredictionJobs'); });",
+                  "pm.test('Vertex RAW passthrough: has JOB_STATE_ state', function () { pm.expect(j.state || '').to.match(/^JOB_STATE_/); });",
+                  "var parts = (j.name || '').split('/'); pm.collectionVariables.set('vertexRawBatchId', parts[parts.length - 1]);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: delete batch RAW passthrough (native genai, cleanup)",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1/projects/{{vertexProject}}/locations/{{vertexLocation}}/batchPredictionJobs/{{vertexRawBatchId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1",
+                "projects",
+                "{{vertexProject}}",
+                "locations",
+                "{{vertexLocation}}",
+                "batchPredictionJobs",
+                "{{vertexRawBatchId}}"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Vertex RAW passthrough cleanup: 2xx', function () { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[PREVIEW] Vertex: delete batch input file (/openai, cleanup)",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/files/{{vertexBatchInputFileId}}?provider=vertex",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "files",
+                "{{vertexBatchInputFileId}}"
+              ],
+              "query": [
+                {
+                  "key": "provider",
+                  "value": "vertex"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var j = pm.response.json();",
+                  "pm.test('Vertex batch input cleanup: deleted', function () { pm.expect(j.deleted).to.eql(true); });"
                 ]
               }
             }

--- a/tests/integrations/python/config.yml
+++ b/tests/integrations/python/config.yml
@@ -476,13 +476,13 @@ provider_scenarios:
     langchain_structured_output: true
     pydantic_structured_output: false  # PydanticAI structured output unreliable via Bifrost for Gemini
     pydanticai_streaming: false  # PydanticAI GoogleModel streaming has asyncio issues
-    batch_file_upload: false  # Gemini supports file upload via Files API
+    batch_file_upload: true  # Vertex batches read a gs:// JSONL uploaded via the Files API
     batch_create: false
-    batch_list: false
-    batch_retrieve: false
-    batch_cancel: false
-    batch_inline: false  # Gemini uses inline requests for batch (synchronous)
-    batch_s3: false  # Gemini does not use S3 for batch
+    batch_list: true  # Vertex lists batchPredictionJobs for the key's project/region
+    batch_retrieve: true  # Vertex retrieves a batchPredictionJob by id
+    batch_cancel: true  # Vertex cancels a running batchPredictionJob
+    batch_inline: false  # inline requests not wired through the OpenAI integration for Vertex
+    batch_s3: false  # Vertex uses GCS, not S3
     file_upload: true  # Vertex uploads files to a customer GCS bucket
     file_list: true  # Vertex lists files in the GCS bucket
     file_retrieve: true  # Vertex retrieves GCS object metadata

--- a/tests/integrations/python/tests/test_openai.py
+++ b/tests/integrations/python/tests/test_openai.py
@@ -179,6 +179,7 @@ from .utils.common import (
     get_content_string,
     get_provider_voice,
     get_provider_voices,
+    get_vertex_batch_dest_uri,
     get_vertex_gcs_config,
     mock_tool_response,
     skip_if_no_api_key,
@@ -3175,6 +3176,48 @@ class TestOpenAIIntegration:
                         print(f"Info: Could not cancel batch (may already be processed): {e}")
             return
 
+        # Vertex uses a customer-owned GCS bucket for input and an output_folder (gs:// prefix)
+        # instead of Bedrock's S3 role/URI. The uploaded file id is base64-encoded by the
+        # integration; the batch routes decode it back to gs:// before reaching the provider.
+        if provider == "vertex":
+            storage_config = get_file_storage_config(provider)  # skips if VERTEX_GCS_BUCKET unset
+            jsonl_content = create_batch_jsonl_content(model=model, num_requests=2, provider=provider)
+            uploaded_file = client.files.create(
+                file=("batch_create_file_test.jsonl", jsonl_content.encode(), "application/jsonl"),
+                purpose="batch",
+                extra_body={"provider": provider, "storage_config": storage_config},
+            )
+            batch = None
+            try:
+                batch = client.batches.create(
+                    input_file_id=uploaded_file.id,
+                    endpoint="/v1/chat/completions",
+                    completion_window="24h",
+                    extra_body={
+                        "provider": provider,
+                        "model": model,
+                        "output_folder": {"url": get_vertex_batch_dest_uri()},
+                    },
+                )
+                assert_valid_batch_response(batch)
+                assert (
+                    batch.input_file_id == uploaded_file.id
+                ), f"Input file ID should round-trip: expected {uploaded_file.id}, got {batch.input_file_id}"
+                print(
+                    f"Success: Created file-based batch with ID: {batch.id}, status: {batch.status} for provider {provider}"
+                )
+            finally:
+                if batch:
+                    try:
+                        client.batches.cancel(batch.id, extra_body={"provider": provider})
+                    except Exception as e:
+                        print(f"Info: Could not cancel batch (may already be processed): {e}")
+                try:
+                    client.files.delete(uploaded_file.id, extra_query={"provider": provider})
+                except Exception as e:
+                    print(f"Warning: Failed to clean up file: {e}")
+            return
+
         # File-based batching for other providers (Bedrock, OpenAI)
         config = get_config()
         integration_settings = config.get_integration_settings("bedrock")
@@ -3329,6 +3372,49 @@ class TestOpenAIIntegration:
                         pass
             return
 
+        # Vertex: GCS-backed file input + output_folder (gs:// prefix).
+        if provider == "vertex":
+            storage_config = get_file_storage_config(provider)  # skips if VERTEX_GCS_BUCKET unset
+            batch_id = None
+            uploaded_file = None
+            try:
+                jsonl_content = create_batch_jsonl_content(model=model, num_requests=1, provider=provider)
+                uploaded_file = client.files.create(
+                    file=("batch_retrieve_test.jsonl", jsonl_content.encode(), "application/jsonl"),
+                    purpose="batch",
+                    extra_body={"provider": provider, "storage_config": storage_config},
+                )
+                batch = client.batches.create(
+                    input_file_id=uploaded_file.id,
+                    endpoint="/v1/chat/completions",
+                    completion_window="24h",
+                    extra_body={
+                        "provider": provider,
+                        "model": model,
+                        "output_folder": {"url": get_vertex_batch_dest_uri()},
+                    },
+                )
+                batch_id = batch.id
+
+                retrieved_batch = client.batches.retrieve(batch_id, extra_query={"provider": provider})
+                assert_valid_batch_response(retrieved_batch)
+                assert retrieved_batch.id == batch_id
+                print(
+                    f"Success: Retrieved batch {batch_id}, status: {retrieved_batch.status} for provider {provider}"
+                )
+            finally:
+                if batch_id:
+                    try:
+                        client.batches.cancel(batch_id, extra_body={"provider": provider})
+                    except Exception:
+                        pass
+                if uploaded_file:
+                    try:
+                        client.files.delete(uploaded_file.id, extra_query={"provider": provider})
+                    except Exception:
+                        pass
+            return
+
         # File-based batching for other providers (Bedrock, OpenAI)
         config = get_config()
         integration_settings = config.get_integration_settings("bedrock")
@@ -3450,6 +3536,42 @@ class TestOpenAIIntegration:
                 pass
             return
 
+        # Vertex: GCS-backed file input + output_folder (gs:// prefix).
+        if provider == "vertex":
+            storage_config = get_file_storage_config(provider)  # skips if VERTEX_GCS_BUCKET unset
+            uploaded_file = None
+            try:
+                jsonl_content = create_batch_jsonl_content(model=model, num_requests=1, provider=provider)
+                uploaded_file = client.files.create(
+                    file=("batch_cancel_test.jsonl", jsonl_content.encode(), "application/jsonl"),
+                    purpose="batch",
+                    extra_body={"provider": provider, "storage_config": storage_config},
+                )
+                batch = client.batches.create(
+                    input_file_id=uploaded_file.id,
+                    endpoint="/v1/chat/completions",
+                    completion_window="24h",
+                    extra_body={
+                        "provider": provider,
+                        "model": model,
+                        "output_folder": {"url": get_vertex_batch_dest_uri()},
+                    },
+                )
+                cancelled_batch = client.batches.cancel(batch.id, extra_body={"provider": provider})
+                assert cancelled_batch is not None
+                assert cancelled_batch.id == batch.id
+                assert cancelled_batch.status in ["cancelling", "cancelled"]
+                print(
+                    f"Success: Cancelled batch {batch.id}, status: {cancelled_batch.status} for provider {provider}"
+                )
+            finally:
+                if uploaded_file:
+                    try:
+                        client.files.delete(uploaded_file.id, extra_query={"provider": provider})
+                    except Exception:
+                        pass
+            return
+
         # File-based batching for other providers (Bedrock, OpenAI)
         config = get_config()
         integration_settings = config.get_integration_settings("bedrock")
@@ -3536,6 +3658,70 @@ class TestOpenAIIntegration:
         if provider == "_no_providers_" or model == "_no_model_":
             pytest.skip("No providers configured for batch_file_upload scenario")
 
+        # Get provider-specific client
+        client = get_provider_openai_client(provider, vk_enabled=vk_enabled)
+
+        # Vertex: GCS-backed e2e (upload -> create -> poll -> verify in list). Handled before
+        # the Bedrock S3 config/skip below, since Vertex uses its own GCS bucket. Vertex batches
+        # are long-running, so we poll a few times but do not wait for a terminal state.
+        if provider == "vertex":
+            storage_config = get_file_storage_config(provider)  # skips if VERTEX_GCS_BUCKET unset
+            jsonl_content = create_batch_jsonl_content(model=model, num_requests=2, provider=provider)
+            print(f"Step 1: Uploading batch input file for provider {provider}...")
+            uploaded_file = client.files.create(
+                file=("batch_e2e_file_test.jsonl", jsonl_content.encode(), "application/jsonl"),
+                purpose="batch",
+                extra_body={"provider": provider, "storage_config": storage_config},
+            )
+            assert_valid_file_response(uploaded_file, expected_purpose="batch")
+            print(f"  Uploaded file: {uploaded_file.id}")
+            batch = None
+            try:
+                print("Step 2: Creating batch job with file ID...")
+                batch = client.batches.create(
+                    input_file_id=uploaded_file.id,
+                    endpoint="/v1/chat/completions",
+                    completion_window="24h",
+                    metadata={"test": "e2e_file", "source": "bifrost-integration-tests"},
+                    extra_body={
+                        "provider": provider,
+                        "model": model,
+                        "output_folder": {"url": get_vertex_batch_dest_uri()},
+                    },
+                )
+                assert_valid_batch_response(batch)
+                print(f"  Created batch: {batch.id}, status: {batch.status}")
+
+                print("Step 3: Polling batch status...")
+                for i in range(5):
+                    retrieved_batch = client.batches.retrieve(
+                        batch.id, extra_query={"provider": provider}
+                    )
+                    print(f"  Poll {i+1}: status = {retrieved_batch.status}")
+                    if retrieved_batch.status in ["completed", "failed", "expired", "cancelled"]:
+                        break
+                    time.sleep(2)
+
+                print("Step 4: Verifying batch in list...")
+                batch_list = client.batches.list(limit=20, extra_query={"provider": provider})
+                assert batch.id in [
+                    b.id for b in batch_list.data
+                ], f"Batch {batch.id} should be in the batch list"
+                print(f"Success: File API E2E completed for batch {batch.id} (provider: {provider})")
+            finally:
+                if batch:
+                    try:
+                        client.batches.cancel(batch.id, extra_body={"provider": provider})
+                        print(f"Cleanup: Cancelled batch {batch.id}")
+                    except Exception as e:
+                        print(f"Cleanup info: Could not cancel batch: {e}")
+                try:
+                    client.files.delete(uploaded_file.id, extra_query={"provider": provider})
+                    print(f"Cleanup: Deleted file {uploaded_file.id}")
+                except Exception as e:
+                    print(f"Cleanup info: Could not delete file: {e}")
+            return
+
         config = get_config()
         integration_settings = config.get_integration_settings("bedrock")
         s3_bucket = integration_settings.get("s3_bucket")
@@ -3544,9 +3730,6 @@ class TestOpenAIIntegration:
 
         if not s3_bucket:
             pytest.skip("S3 bucket not configured for file tests")
-
-        # Get provider-specific client
-        client = get_provider_openai_client(provider, vk_enabled=vk_enabled)
 
         # Anthropic uses inline requests instead of file-based batching
         if provider == "anthropic":

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -1421,6 +1421,12 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 								openaiReq.InputFileID = string(decodedFileID)
 							}
 						}
+					case schemas.Vertex:
+						if openaiReq.InputFileID != "" {
+							if decodedFileID, err := base64.RawURLEncoding.DecodeString(openaiReq.InputFileID); err == nil {
+								openaiReq.InputFileID = string(decodedFileID)
+							}
+						}
 					}
 					return &BatchRequest{
 						Type:          schemas.BatchCreateRequest,
@@ -1437,6 +1443,12 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 				case schemas.Bedrock:
 					resp.ID = base64.StdEncoding.EncodeToString([]byte(resp.ID))
 					resp.InputFileID = base64.StdEncoding.EncodeToString([]byte(resp.InputFileID))
+				case schemas.Vertex:
+					// id is a full resource name (projects/.../batchPredictionJobs/{id}) and
+					// input_file_id is a gs:// URI; both contain slashes. RawURLEncoding keeps
+					// them path-safe so callers can use them in retrieve/cancel without escaping.
+					resp.ID = base64.RawURLEncoding.EncodeToString([]byte(resp.ID))
+					resp.InputFileID = base64.RawURLEncoding.EncodeToString([]byte(resp.InputFileID))
 				}
 				return resp, nil
 			},
@@ -1570,6 +1582,11 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 						resp.Data[i].ID = base64.StdEncoding.EncodeToString([]byte(batch.ID))
 						resp.Data[i].InputFileID = base64.StdEncoding.EncodeToString([]byte(batch.InputFileID))
 					}
+				case schemas.Vertex:
+					for i, batch := range resp.Data {
+						resp.Data[i].ID = base64.RawURLEncoding.EncodeToString([]byte(batch.ID))
+						resp.Data[i].InputFileID = base64.RawURLEncoding.EncodeToString([]byte(batch.InputFileID))
+					}
 				}
 				return resp, nil
 			},
@@ -1609,6 +1626,11 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 						if decodedBatchID, err := base64.StdEncoding.DecodeString(retrieveReq.BatchID); err == nil {
 							retrieveReq.BatchID = string(decodedBatchID)
 						}
+					case schemas.Vertex:
+						// Reverse the RawURLEncoding applied to the full resource name.
+						if decodedBatchID, err := base64.RawURLEncoding.DecodeString(retrieveReq.BatchID); err == nil {
+							retrieveReq.BatchID = string(decodedBatchID)
+						}
 					}
 					return &BatchRequest{
 						Type:            schemas.BatchRetrieveRequest,
@@ -1625,6 +1647,9 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 				case schemas.Bedrock:
 					resp.ID = base64.StdEncoding.EncodeToString([]byte(resp.ID))
 					resp.InputFileID = base64.StdEncoding.EncodeToString([]byte(resp.InputFileID))
+				case schemas.Vertex:
+					resp.ID = base64.RawURLEncoding.EncodeToString([]byte(resp.ID))
+					resp.InputFileID = base64.RawURLEncoding.EncodeToString([]byte(resp.InputFileID))
 				}
 				return resp, nil
 			},
@@ -1664,6 +1689,11 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 						if decodedBatchID, err := base64.StdEncoding.DecodeString(cancelReq.BatchID); err == nil {
 							cancelReq.BatchID = string(decodedBatchID)
 						}
+					case schemas.Vertex:
+						// Reverse the RawURLEncoding applied to the full resource name.
+						if decodedBatchID, err := base64.RawURLEncoding.DecodeString(cancelReq.BatchID); err == nil {
+							cancelReq.BatchID = string(decodedBatchID)
+						}
 					}
 					return &BatchRequest{
 						Type:          schemas.BatchCancelRequest,
@@ -1678,6 +1708,8 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 					resp.ID = strings.Replace(resp.ID, "batches/", "batches-", 1)
 				case schemas.Bedrock:
 					resp.ID = base64.StdEncoding.EncodeToString([]byte(resp.ID))
+				case schemas.Vertex:
+					resp.ID = base64.RawURLEncoding.EncodeToString([]byte(resp.ID))
 				}
 				return resp, nil
 			},


### PR DESCRIPTION
## Summary

Adds full OpenAI-compatible batch API support for Vertex AI (create, retrieve, list, cancel) via the HTTP transport, and fixes ID stability issues in both the Vertex and Gemini batch implementations.

## Changes

- **Vertex batch IDs are now base64 (RawURLEncoding) encoded/decoded** in the OpenAI HTTP integration, matching the existing Bedrock pattern. Vertex batch IDs are full resource names (`projects/.../batchPredictionJobs/{id}`) and `input_file_id` values are `gs://` URIs — both contain slashes that would break URL path routing without encoding.
- **Gemini batch list** now returns the full resource name (`batches/<id>`) as the ID instead of stripping the prefix, making IDs stable and consistent with create/retrieve responses.
- **Vertex cancel and delete** now echo back the caller's batch ID directly instead of re-extracting a bare job ID from the resource name, keeping IDs stable across the full lifecycle.
- **`extractBatchIDFromName` (Gemini) and `vertexBatchJobIDFromName` (Vertex)** helper functions removed since IDs are no longer stripped.
- **Vertex `BatchCreate` supports raw-passthrough mode**: validation and typed-field extraction are skipped when a raw request body is present, allowing callers to pass arbitrary Vertex `BatchPredictionJob` payloads directly.
- **Vertex `BatchCreate` no longer strips `output_uri`/`gcs_bucket`/`gcs_prefix` control params** from `extra_params` before forwarding to Vertex, since those keys are no longer injected by the typed path.
- **Vertex region validation** relaxed: the `"global"` region is no longer explicitly rejected; only an empty region is an error.
- **Integration test config** updated to enable Vertex batch scenarios (`batch_file_upload`, `batch_list`, `batch_retrieve`, `batch_cancel`) and disable virtual key testing temporarily.
- **Integration tests** added for Vertex batch create-with-file, retrieve, cancel, and full e2e (upload → create → poll → list → cleanup).

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/vertex/...
go test ./core/providers/gemini/...
go test ./transports/bifrost-http/...
```

For integration tests, set the following environment variables and run the Python test suite:

```sh
export VERTEX_PROJECT_ID=<your-project>
export VERTEX_REGION=<e.g. us-central1>
export VERTEX_GCS_BUCKET=<your-bucket>
# Then run:
pytest tests/integrations/python/tests/test_openai.py -k "batch"
```

Expected: Vertex batch create, retrieve, cancel, list, and e2e file API tests pass. Batch IDs returned by create round-trip correctly through retrieve and cancel without modification.

## Breaking changes

- [x] Yes
- [ ] No

Vertex batch IDs returned by the OpenAI HTTP transport are now base64 (RawURLEncoding) encoded. Any client storing a Vertex batch ID from a previous version will need to re-create the batch, as old bare IDs will not decode correctly. Gemini batch list IDs now include the `batches/` prefix where previously only the suffix was returned.

## Related issues

## Security considerations

Batch IDs and `input_file_id` values are base64-encoded for URL safety only; no secrets or PII are introduced. GCS URIs passed as `input_file_id` are opaque to the transport layer and are only decoded immediately before being forwarded to the Vertex API.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vertex batch API now supports file uploads, batch operations (create, list, retrieve, cancel) with customer-owned GCS workflows.
  * Added raw request body passthrough mode for Vertex batch creation.
  * Improved batch ID handling with URL-safe encoding.

* **Tests**
  * Expanded integration and E2E test coverage for Vertex batch workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->