### PR TITLE
fix(Dockerfile.local): add modelcatalogresolver to go workspace

### DIFF
--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -42,6 +42,7 @@
     go work use ./plugins/logging && \
     go work use ./plugins/maxim && \
     go work use ./plugins/mocker && \
+    go work use ./plugins/modelcatalogresolver && \
     go work use ./plugins/otel && \
     go work use ./plugins/prompts && \
     go work use ./plugins/semanticcache && \


### PR DESCRIPTION
## Problem

`Dockerfile.local` build on `dev` tip (`e8986467`) fails with:

```
bifrost-http/handlers/webrtc_realtime.go:171:48:    undefined: modelcatalogresolver.ResolveProviderFromCatalog
bifrost-http/handlers/webrtc_realtime.go:203:48:    undefined: modelcatalogresolver.ResolveProviderFromCatalog
bifrost-http/handlers/webrtc_realtime.go:1240:48:   undefined: modelcatalogresolver.ResolveProviderFromCatalog
bifrost-http/handlers/realtime_client_secrets.go:235:48: undefined: modelcatalogresolver.ResolveProviderFromCatalog
```

The function IS defined at `plugins/modelcatalogresolver/main.go:140` on dev tip. But `Dockerfile.local`'s `go work use ...` block didn't include `./plugins/modelcatalogresolver`, so the workspace falls back to the published pseudo-version `v0.0.0-20260531215024-856c9963e662` (pinned in `transports/go.mod`) which predates that function.

The other 11 plugin modules (`compat`, `governance`, `jsonparser`, `logging`, `maxim`, `mocker`, `otel`, `prompts`, `semanticcache`, `telemetry`, plus `core`/`framework`/`transports`) are already in the list. This adds the missing entry, alphabetically between `mocker` and `otel`.

## Fix

One line added to `transports/Dockerfile.local`:

```dockerfile
    go work use ./plugins/modelcatalogresolver && \
```

## Verification

Repro of the failure (canonical upstream `dev`, fresh `Dockerfile.local` build):
https://github.com/intarweb/bifrost/actions/runs/27328995915

Confirmed `ResolveProviderFromCatalog` exists at `plugins/modelcatalogresolver/main.go:140` on dev tip:

```go
func ResolveProviderFromCatalog(ctx *schemas.BifrostContext, catalog *modelcatalog.ModelCatalog, model string) (schemas.ModelProvider, []schemas.ModelProvider) {
```

No behavior change — purely a build-infrastructure fix that lets the workspace resolve to the local source like every other plugin module.

## Companion

Filing this separately from the now-closed #4273. That PR's original symptoms (slug / syncMu / urlFetchMaxRetries / WithRetries) were resolved by #3987 — confirmed those compile errors are gone. This is a different break in the same area that surfaced once #3987 landed and the modelcatalogresolver imports started getting exercised. Context: https://github.com/maximhq/bifrost/pull/4273#issuecomment-4677952606

A separate `transports/Dockerfile` (canonical / non-workspace) failure remains — `go.sum` is missing entries for the modelcatalogresolver pseudo-version + transitive AWS / GCP modules. That's a `go mod tidy` problem rather than a Dockerfile bug; not addressed here. Happy to follow up with a tidy-bump PR if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build configuration to ensure proper module resolution during pre-release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->