### PR TITLE
fix: parse provider-prefixed model string in `runPreRequestRouting` large-payload path

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -408,9 +408,13 @@ func (p *GovernancePlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req
 // otherwise). Used by PreRequestHook's large-payload branch where req.Model is empty because
 // the body wasn't parsed.
 func (p *GovernancePlugin) runPreRequestRouting(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey, hasRoutingRules bool, modelIn string, requestType schemas.RequestType) (string, error) {
+	// Parse a provider-prefixed model string the same way the transport does for
+	// body-having requests, so an explicit prefix like "openai/gpt-4o" lands in
+	// ChatRequest.Provider and load balancing honors the caller's routing intent.
+	providerIn, parsedModel := schemas.ParseModelString(modelIn, "")
 	synthetic := &schemas.BifrostRequest{
 		RequestType: requestType,
-		ChatRequest: &schemas.BifrostChatRequest{Model: modelIn},
+		ChatRequest: &schemas.BifrostChatRequest{Provider: providerIn, Model: parsedModel},
 	}
 
 	if hasRoutingRules {

--- a/plugins/governance/prerequestrouting_test.go
+++ b/plugins/governance/prerequestrouting_test.go
@@ -1,0 +1,74 @@
+package governance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newPreRequestRoutingPlugin(t *testing.T, vk *configstoreTables.TableVirtualKey) *GovernancePlugin {
+	t.Helper()
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+	return &GovernancePlugin{
+		logger:   logger,
+		store:    store,
+		resolver: NewBudgetResolver(store, nil, logger, nil),
+	}
+}
+
+// TestRunPreRequestRouting_ExplicitProviderPrefixSkipsLoadBalancing covers the
+// large-payload path: metadata.Model arrives provider-prefixed and unparsed, and
+// the explicit prefix must win over VK load balancing even when multiple weighted
+// providers allow the model.
+func TestRunPreRequestRouting_ExplicitProviderPrefixSkipsLoadBalancing(t *testing.T) {
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-lb", "LB VK", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"*"}),
+		buildProviderConfig("anthropic", []string{"*"}),
+	})
+	p := newPreRequestRoutingPlugin(t, vk)
+
+	for range 20 {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		got, err := p.runPreRequestRouting(ctx, vk, false, "openai/gpt-4o", schemas.ChatCompletionRequest)
+		require.NoError(t, err)
+		assert.Equal(t, "openai/gpt-4o", got)
+	}
+}
+
+// TestRunPreRequestRouting_UnprefixedModelLoadBalances verifies that a bare model
+// string still goes through VK load balancing and comes back provider-prefixed.
+func TestRunPreRequestRouting_UnprefixedModelLoadBalances(t *testing.T) {
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-lb", "LB VK", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"*"}),
+	})
+	p := newPreRequestRoutingPlugin(t, vk)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	got, err := p.runPreRequestRouting(ctx, vk, false, "gpt-4o", schemas.ChatCompletionRequest)
+	require.NoError(t, err)
+	assert.Equal(t, "openai/gpt-4o", got)
+}
+
+// TestRunPreRequestRouting_UnknownPrefixIsTreatedAsModelNamespace verifies that a
+// "/" prefix that is not a known provider (e.g. a HuggingFace-style namespace) is
+// kept as part of the model name and load balancing still applies.
+func TestRunPreRequestRouting_UnknownPrefixIsTreatedAsModelNamespace(t *testing.T) {
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-lb", "LB VK", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("groq", []string{"*"}),
+	})
+	p := newPreRequestRoutingPlugin(t, vk)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	got, err := p.runPreRequestRouting(ctx, vk, false, "meta-llama/llama-3.1-8b-instant", schemas.ChatCompletionRequest)
+	require.NoError(t, err)
+	assert.Equal(t, "groq/meta-llama/llama-3.1-8b-instant", got)
+}


### PR DESCRIPTION
## Summary

When a large-payload request arrives via the `PreRequestHook` path, the request body is not parsed, so `req.Model` is taken directly from metadata and may carry a provider-prefixed string like `openai/gpt-4o`. Previously, `runPreRequestRouting` passed this raw string directly as the model name without parsing the provider prefix, causing load balancing to ignore the caller's explicit routing intent. This change ensures the provider prefix is extracted and honored in the same way the transport layer handles body-having requests.

## Changes

- `runPreRequestRouting` now calls `schemas.ParseModelString` on the incoming model string before constructing the synthetic `BifrostRequest`, populating both `Provider` and `Model` on the `ChatRequest` so that an explicit prefix like `openai/gpt-4o` correctly pins routing to that provider instead of being subject to VK load balancing.
- Added `prerequestrouting_test.go` covering three cases: an explicit provider prefix bypasses load balancing and always resolves to the specified provider; a bare model string still goes through VK load balancing and returns provider-prefixed; and an unknown slash-containing prefix (e.g. a HuggingFace-style namespace like `meta-llama/llama-3.1-8b-instant`) is treated as part of the model name with load balancing still applied.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

Expected: all three new tests pass, confirming that provider-prefixed models in the large-payload path are routed to the correct provider, bare models still load balance, and unknown slash-prefixes are preserved as model namespaces.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only affects internal routing logic for constructing synthetic requests during pre-request hook processing.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed request routing to properly preserve explicit provider specifications in model names (e.g., `provider/model` format), ensuring routing intent is maintained for large-payload requests.

* **Tests**
  * Added comprehensive tests for pre-request routing behavior, including explicit provider prefix handling and load balancing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->