### PR TITLE
refactor: remove `enforceRoutingAllowlist` and its call sites from `handleRequest`/`handleStreamRequest`

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4626,55 +4626,6 @@ func (bifrost *Bifrost) shouldContinueWithFallbacks(fallback schemas.Fallback, f
 	return true
 }
 
-// filterFallbacksByAllowlist returns a new slice containing only the fallbacks whose Provider
-// is present in allowed. Used by handleRequest/handleStreamRequest to enforce the routing
-// allowlist published via BifrostContextKeyRoutingAllowedProviders — a plugin earlier in
-// PreRequestHook may have populated fallbacks that a later plugin's allowlist excludes.
-func filterFallbacksByAllowlist(fallbacks []schemas.Fallback, allowed []schemas.ModelProvider) []schemas.Fallback {
-	if len(fallbacks) == 0 {
-		return fallbacks
-	}
-	filtered := make([]schemas.Fallback, 0, len(fallbacks))
-	for _, fb := range fallbacks {
-		if slices.Contains(allowed, fb.Provider) {
-			filtered = append(filtered, fb)
-		}
-	}
-	return filtered
-}
-
-// enforceRoutingAllowlist gates the resolved provider against the routing
-// allowlist published via BifrostContextKeyRoutingAllowedProviders (e.g. by
-// the governance plugin) and prunes the fallback list to allowed providers.
-// Returns the (possibly filtered) fallback list, or a prepared BifrostError
-// when the resolved provider isn't on the allowlist. When no allowlist is
-// set on ctx, fallbacks pass through unchanged with a nil error.
-//
-// Side effect: when an allowlist is in effect, the filtered fallbacks are
-// written back to req via SetFallbacks so downstream phases observe the
-// pruned list.
-func enforceRoutingAllowlist(
-	ctx *schemas.BifrostContext,
-	req *schemas.BifrostRequest,
-	provider schemas.ModelProvider,
-	model string,
-	fallbacks []schemas.Fallback,
-) ([]schemas.Fallback, *schemas.BifrostError) {
-	allowed, ok := ctx.Value(schemas.BifrostContextKeyRoutingAllowedProviders).([]schemas.ModelProvider)
-	if !ok {
-		return fallbacks, nil
-	}
-	if !slices.Contains(allowed, provider) {
-		bifrostErr := newBifrostErrorFromMsg(fmt.Sprintf("provider %q is not permitted for this request (routing allowlist: %v)", provider, allowed))
-		bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
-		bifrostErr.StatusCode = schemas.Ptr(fasthttp.StatusBadRequest)
-		return nil, bifrostErr
-	}
-	filtered := filterFallbacksByAllowlist(fallbacks, allowed)
-	req.SetFallbacks(filtered)
-	return filtered, nil
-}
-
 // handleRequest handles the request to the provider based on the request type
 // It handles plugin hooks, request validation, response processing, and fallback providers.
 // If the primary provider fails, it will try each fallback provider in order until one succeeds.
@@ -4712,13 +4663,6 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		flushPluginLogs(ctx)
 		err.PopulateExtraFields(req.RequestType, provider, model, model)
 		return nil, err
-	}
-	// Enforce the routing-allowlist if any plugin published one. This guarantees no
-	// downstream layer (or user-specified provider prefix) can bypass governance VK
-	// restrictions or any other plugin-imposed allowlist.
-	var allowlistErr *schemas.BifrostError
-	if fallbacks, allowlistErr = enforceRoutingAllowlist(ctx, req, provider, model, fallbacks); allowlistErr != nil {
-		return nil, allowlistErr
 	}
 
 	bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))
@@ -4847,11 +4791,6 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 		flushPluginLogs(ctx)
 		err.PopulateExtraFields(req.RequestType, provider, model, model)
 		return nil, err
-	}
-	// Enforce the routing-allowlist if any plugin published one. See handleRequest.
-	var allowlistErr *schemas.BifrostError
-	if fallbacks, allowlistErr = enforceRoutingAllowlist(ctx, req, provider, model, fallbacks); allowlistErr != nil {
-		return nil, allowlistErr
 	}
 
 	bifrost.logger.Debug(fmt.Sprintf("primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))


### PR DESCRIPTION
## Summary

Removes the routing allowlist enforcement (`enforceRoutingAllowlist`) that was previously applied inside `handleRequest` and `handleStreamRequest`. This eliminates the gate that blocked requests when the resolved provider was not present in the `BifrostContextKeyRoutingAllowedProviders` allowlist published by plugins.

## Changes

- Removed the `enforceRoutingAllowlist` function entirely, which checked the resolved provider against a plugin-supplied allowlist and pruned fallbacks accordingly.
- Removed the calls to `enforceRoutingAllowlist` in both `handleRequest` and `handleStreamRequest`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Verify that requests to providers previously blocked by a routing allowlist now proceed without a `400 Bad Request` error. Confirm that plugin-based governance restrictions relying on `BifrostContextKeyRoutingAllowedProviders` no longer block routing at this layer.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

Any plugin that relied on `BifrostContextKeyRoutingAllowedProviders` to restrict which providers could be used will no longer have that restriction enforced at the routing layer. Governance plugins using this mechanism will need an alternative enforcement strategy.

## Related issues

N/A

## Security considerations

Previously, the allowlist enforcement ensured that plugin-imposed provider restrictions (e.g., governance or virtual key policies) could not be bypassed by user-specified provider prefixes or downstream layers. With this removal, that enforcement layer no longer exists. Any equivalent access control must now be handled elsewhere.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed routing allowlist enforcement and fallback pruning from the orchestration flow, so resolved primary providers and fallback lists are no longer validated or filtered at that stage. The existing fallback decision flow remains in place; overall routing orchestration logic is simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->