### PR TITLE
feat: removes from_memory handling from API handlers to make them only serve data from DB

### DIFF
--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1012,41 +1012,6 @@ func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 
 // getVirtualKeys handles GET /api/governance/virtual-keys - Get all virtual keys with relationships
 func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		// Convert map to slice to match the non-memory response format (array)
-		virtualKeys := make([]*configstoreTables.TableVirtualKey, 0, len(data.VirtualKeys))
-		for _, vk := range data.VirtualKeys {
-			virtualKeys = append(virtualKeys, vk)
-		}
-		sort.Slice(virtualKeys, func(i, j int) bool {
-			return virtualKeys[i].CreatedAt.Before(virtualKeys[j].CreatedAt)
-		})
-		byKey := buildVKModelConfigIndex(data.ModelConfigs)
-		hydratedVKs := make([]*configstoreTables.TableVirtualKey, len(virtualKeys))
-		for i, vk := range virtualKeys {
-			clone := *vk
-			pcs := make([]configstoreTables.TableVirtualKeyProviderConfig, len(vk.ProviderConfigs))
-			copy(pcs, vk.ProviderConfigs)
-			clone.ProviderConfigs = pcs
-			applyVKGovernanceFromModelConfigs(&clone, byKey)
-			hydratedVKs[i] = &clone
-		}
-		SendJSON(ctx, map[string]interface{}{
-			"virtual_keys": hydratedVKs,
-			"count":        len(hydratedVKs),
-			"total_count":  len(hydratedVKs),
-			"limit":        len(hydratedVKs),
-			"offset":       0,
-		})
-		return
-	}
 	// Check for pagination/filter parameters
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
@@ -1339,31 +1304,6 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 // getVirtualKey handles GET /api/governance/virtual-keys/{vk_id} - Get a specific virtual key
 func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 	vkID := ctx.UserValue("vk_id").(string)
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		byKey := buildVKModelConfigIndex(data.ModelConfigs)
-		for _, vk := range data.VirtualKeys {
-			if vk.ID == vkID {
-				clone := *vk
-				pcs := make([]configstoreTables.TableVirtualKeyProviderConfig, len(vk.ProviderConfigs))
-				copy(pcs, vk.ProviderConfigs)
-				clone.ProviderConfigs = pcs
-				applyVKGovernanceFromModelConfigs(&clone, byKey)
-				SendJSON(ctx, map[string]interface{}{
-					"virtual_key": &clone,
-				})
-				return
-			}
-		}
-		SendError(ctx, 404, "Virtual key not found")
-		return
-	}
 	vk, err := h.configStore.GetVirtualKey(ctx, vkID)
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {


### PR DESCRIPTION
## Summary

Removes the `from_memory` query parameter support from the `GET /api/governance/virtual-keys` and `GET /api/governance/virtual-keys/{vk_id}` endpoints. Previously, callers could bypass the config store and read virtual key data directly from in-memory governance state. These code paths have been removed so both endpoints exclusively use the config store.

## Changes

- Removed the `from_memory` branch from `getVirtualKeys`, which previously read from `GetGovernanceData`, hydrated virtual keys with model config governance rules, and returned a sorted slice.
- Removed the `from_memory` branch from `getVirtualKey`, which previously looked up a single virtual key by ID from in-memory state and applied model config governance before responding.
- Both endpoints now always delegate to the config store, simplifying the handler logic and eliminating a parallel read path.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that `GET /api/governance/virtual-keys?from_memory=true` and `GET /api/governance/virtual-keys/{vk_id}?from_memory=true` behave identically to requests without the parameter — the query argument should now be silently ignored and the config store response returned in both cases.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

Callers explicitly passing `from_memory=true` will no longer receive in-memory data. The parameter is now ignored and the config store is always queried. Any client relying on the in-memory read path must be updated to use the standard config store response.

## Related issues

N/A

## Security considerations

Removing the in-memory read path reduces the surface area for stale or inconsistent data being served to callers. No auth, secrets, or PII implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced governance handling for virtual keys with improved data hydration and consistency.
  * Added support for additional filtering parameters to provide more flexible control over virtual key retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->