### PR TITLE
feat: add loading skeletons and fix scrolling layout for MCP library page

### DIFF
--- a/ui/app/workspace/mcp-registry/library/page.tsx
+++ b/ui/app/workspace/mcp-registry/library/page.tsx
@@ -14,8 +14,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { MCPLibraryAddServerSheet } from "./views/mcpLibraryAddServerSheet";
 import { MCPLibraryFilterSidebar, type MCPLibraryFilters } from "./views/mcpLibraryFilterSidebar";
 import { MCPLibraryInstallSheet, sanitizeServerName } from "./views/mcpLibraryInstallSheet";
-import { MCPLibraryServerCard } from "./views/mcpLibraryServerCard";
-import { MCPLibraryServersTable } from "./views/mcpLibraryServersTable";
+import { MCPLibraryServerCard, MCPLibraryServerCardSkeleton } from "./views/mcpLibraryServerCard";
+import { MCPLibraryServersTable, MCPLibraryServersTableSkeleton } from "./views/mcpLibraryServersTable";
 import { MCPLibrarySettingsSheet } from "./views/mcpLibrarySettingsSheet";
 
 const PAGE_SIZE = 24;
@@ -159,8 +159,8 @@ export default function MCPLibraryPage() {
 				<MCPLibraryFilterSidebar filters={filters} onFiltersChange={setFilters} />
 
 				{/* Main Content */}
-				<ScrollArea className="bg-card w-full rounded-l-md">
-					<div className="flex min-w-0 flex-1 flex-col gap-4 p-4 pb-2">
+				<div className="bg-card w-full rounded-l-md h-full">
+					<div className="flex flex-col gap-4 p-4 pb-2 h-full">
 						{/* Header */}
 						<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
 							<div className="space-y-1">
@@ -185,7 +185,7 @@ export default function MCPLibraryPage() {
 
 						{/* Search */}
 						{!isCatalogEmpty && (
-							<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between -mx-2 px-2 py-2 sticky top-0 z-20 bg-card">
+							<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between -mx-2 px-2 py-2">
 								<div className="relative max-w-md flex-1">
 									<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 									<Input
@@ -235,106 +235,123 @@ export default function MCPLibraryPage() {
 								</div>
 							</div>
 						)}
+						<div className="grow overflow-hidden flex flex-col">
 
-						{/* Grid or empty state */}
-						{servers.length === 0 && !isFetching ? (
-							<div
-								className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center"
-								data-testid="mcp-library-empty-state"
-							>
-								<div className="text-muted-foreground">
-									<Library className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-								</div>
-								<div className="flex flex-col gap-1">
-									<h1 className="text-muted-foreground text-xl font-medium">
-										{isCatalogEmpty ? "No synced servers yet" : "No servers found"}
-									</h1>
-									<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-										{isCatalogEmpty
-											? "Configure the library sync source in Settings to populate this catalog."
-											: "Try adjusting your search or filters."}
-									</div>
-									{isCatalogEmpty && hasSettingsAccess && (
-										<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-											<Button onClick={() => setSettingsOpen(true)} data-testid="mcp-library-empty-settings-btn">
-												<Settings className="h-4 w-4" />
-												Configure sync
-											</Button>
+							{/* Loading skeletons */}
+							{isFetching && servers.length === 0 ? (
+								viewMode === "grid" ? (
+									<ScrollArea className="overflow-y-auto mb-2">
+										<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3" data-testid="mcp-library-grid-skeleton">
+											{Array.from({ length: 6 }).map((_, i) => (
+												// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders have no stable id
+												<MCPLibraryServerCardSkeleton key={i} />
+											))}
 										</div>
-									)}
-								</div>
-							</div>
-						) : (
-							<>
-								{viewMode === "grid" ? (
-									<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3" data-testid="mcp-library-grid-view">
-										{servers.map((server) => {
-											const isInstalled = installedServerSlugs.has(server.slug);
-											return (
-												<MCPLibraryServerCard
-													key={server.slug}
-													server={server}
-													isInstalled={isInstalled}
-													canCreateMCPClient={hasCreateMCPClientAccess}
-													canDelete={hasDeleteMCPLibraryAccess}
-													onInstall={setSelectedServer}
-												/>
-											);
-										})}
-									</div>
+									</ScrollArea>
 								) : (
-									<MCPLibraryServersTable
-										servers={servers}
-										installedServerSlugs={installedServerSlugs}
-										canCreateMCPClient={hasCreateMCPClientAccess}
-										canDelete={hasDeleteMCPLibraryAccess}
-										onInstall={setSelectedServer}
-									/>
-								)}
-
-								{/* Pagination */}
-								{totalCount > 0 && (
-									<div className="mt-auto flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-										<div className="text-muted-foreground flex items-center gap-2">
-											{(urlState.offset + 1).toLocaleString()}-{Math.min(urlState.offset + PAGE_SIZE, totalCount).toLocaleString()} of{" "}
-											{totalCount.toLocaleString()} entries
+									<MCPLibraryServersTableSkeleton />
+								)
+							) : servers.length === 0 ? (
+								<div
+									className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center"
+									data-testid="mcp-library-empty-state"
+								>
+									<div className="text-muted-foreground">
+										<Library className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
+									</div>
+									<div className="flex flex-col gap-1">
+										<h1 className="text-muted-foreground text-xl font-medium">
+											{isCatalogEmpty ? "No synced servers yet" : "No servers found"}
+										</h1>
+										<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
+											{isCatalogEmpty
+												? "Configure the library sync source in Settings to populate this catalog."
+												: "Try adjusting your search or filters."}
 										</div>
+										{isCatalogEmpty && hasSettingsAccess && (
+											<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
+												<Button onClick={() => setSettingsOpen(true)} data-testid="mcp-library-empty-settings-btn">
+													<Settings className="h-4 w-4" />
+													Configure sync
+												</Button>
+											</div>
+										)}
+									</div>
+								</div>
+							) : (
+								<>
+									{viewMode === "grid" ? (
+										<ScrollArea className="overflow-y-auto mb-2">
+											<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3" data-testid="mcp-library-grid-view">
+												{servers.map((server) => {
+													const isInstalled = installedServerSlugs.has(server.slug);
+													return (
+														<MCPLibraryServerCard
+															key={server.slug}
+															server={server}
+															isInstalled={isInstalled}
+															canCreateMCPClient={hasCreateMCPClientAccess}
+															canDelete={hasDeleteMCPLibraryAccess}
+															onInstall={setSelectedServer}
+														/>
+													);
+												})}
+											</div>
+										</ScrollArea>
+									) : (
+										<MCPLibraryServersTable
+											servers={servers}
+											installedServerSlugs={installedServerSlugs}
+											canCreateMCPClient={hasCreateMCPClientAccess}
+											canDelete={hasDeleteMCPLibraryAccess}
+											onInstall={setSelectedServer}
+										/>
+									)}
 
-										<div className="flex items-center gap-2">
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={() => setUrlState({ offset: Math.max(0, urlState.offset - PAGE_SIZE) }, { history: "push" })}
-												disabled={urlState.offset === 0}
-												data-testid="mcp-library-pagination-prev-btn"
-												aria-label="Previous page"
-											>
-												<ChevronLeft className="size-3" />
-											</Button>
-
-											<div className="flex items-center gap-1">
-												<span>Page</span>
-												<span>{currentPage}</span>
-												<span>of {totalPages}</span>
+									{/* Pagination */}
+									{totalCount > 0 && (
+										<div className="mt-auto flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+											<div className="text-muted-foreground flex items-center gap-2">
+												{(urlState.offset + 1).toLocaleString()}-{Math.min(urlState.offset + PAGE_SIZE, totalCount).toLocaleString()} of{" "}
+												{totalCount.toLocaleString()} entries
 											</div>
 
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={() => setUrlState({ offset: urlState.offset + PAGE_SIZE }, { history: "push" })}
-												disabled={urlState.offset + PAGE_SIZE >= totalCount}
-												data-testid="mcp-library-pagination-next-btn"
-												aria-label="Next page"
-											>
-												<ChevronRight className="size-3" />
-											</Button>
+											<div className="flex items-center gap-2">
+												<Button
+													variant="ghost"
+													size="sm"
+													onClick={() => setUrlState({ offset: Math.max(0, urlState.offset - PAGE_SIZE) }, { history: "push" })}
+													disabled={urlState.offset === 0}
+													data-testid="mcp-library-pagination-prev-btn"
+													aria-label="Previous page"
+												>
+													<ChevronLeft className="size-3" />
+												</Button>
+
+												<div className="flex items-center gap-1">
+													<span>Page</span>
+													<span>{currentPage}</span>
+													<span>of {totalPages}</span>
+												</div>
+
+												<Button
+													variant="ghost"
+													size="sm"
+													onClick={() => setUrlState({ offset: urlState.offset + PAGE_SIZE }, { history: "push" })}
+													disabled={urlState.offset + PAGE_SIZE >= totalCount}
+													data-testid="mcp-library-pagination-next-btn"
+													aria-label="Next page"
+												>
+													<ChevronRight className="size-3" />
+												</Button>
+											</div>
 										</div>
-									</div>
-								)}
-							</>
-						)}
+									)}
+								</>
+							)}
+						</div>
 					</div>
-				</ScrollArea>
+				</div>
 			</div>
 
 			{/* Install sheet */}

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryServerCard.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryServerCard.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getErrorMessage, useDeleteMCPLibraryEntryMutation } from "@/lib/store";
 import type { MCPLibraryEntry } from "@/lib/types/mcp";
@@ -222,6 +223,41 @@ export function MCPLibraryServerCard({ server, isInstalled, canCreateMCPClient, 
 				onConfirm={handleDelete}
 				confirmTestId={`mcp-library-delete-confirm-${server.slug}`}
 			/>
+		</Card>
+	);
+}
+
+/** Skeleton placeholder mirroring the card layout while the library catalog loads. */
+export function MCPLibraryServerCardSkeleton() {
+	return (
+		<Card className="h-full gap-0 overflow-hidden py-0 shadow-none" data-testid="mcp-library-card-skeleton">
+			<CardHeader className="bg-muted/20 border-b px-4 py-4">
+				<div className="flex min-w-0 items-start gap-3">
+					<Skeleton className="h-12 w-12 shrink-0 rounded-md" />
+					<div className="min-w-0 flex-1 space-y-2">
+						<Skeleton className="h-4 w-3/4" />
+						<div className="flex items-center gap-1.5">
+							<Skeleton className="h-5 w-16 rounded-full" />
+							<Skeleton className="h-4 w-20" />
+						</div>
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent className="flex flex-1 flex-col gap-3 px-4 py-3">
+				<div className="min-h-10 space-y-2">
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-5/6" />
+				</div>
+				<div className="flex flex-wrap items-center gap-1.5">
+					<Skeleton className="h-5 w-14 rounded-full" />
+					<Skeleton className="h-5 w-16 rounded-full" />
+					<Skeleton className="h-5 w-12 rounded-full" />
+				</div>
+			</CardContent>
+			<CardFooter className="bg-muted/10 mt-auto justify-between gap-3 border-t px-4 py-3 !pt-3">
+				<Skeleton className="h-4 w-24" />
+				<Skeleton className="h-8 w-20 rounded-md" />
+			</CardFooter>
 		</Card>
 	);
 }

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getErrorMessage, useDeleteMCPLibraryEntryMutation } from "@/lib/store";
@@ -35,9 +36,9 @@ export function MCPLibraryServersTable({ servers, installedServerSlugs, canCreat
 	};
 
 	return (
-		<div className="overflow-hidden rounded-md border" data-testid="mcp-library-table-view">
-			<Table>
-				<TableHeader>
+		<div className="overflow-y-auto rounded-md border mb-2" data-testid="mcp-library-table-view">
+			<Table containerClassName="overflow-x-clip">
+				<TableHeader className="sticky top-0 z-10 bg-muted">
 					<TableRow>
 						<TableHead className="w-16">Icon</TableHead>
 						<TableHead>Server</TableHead>
@@ -102,7 +103,7 @@ export function MCPLibraryServersTable({ servers, installedServerSlugs, canCreat
 								<TableCell className="text-right">
 									<div className="flex justify-end gap-2">
 										{canDelete && (
-											<div className="hidden group-hover:block">
+											<div className="opacity-0 group-hover:opacity-100">
 												<Tooltip>
 													<TooltipTrigger asChild>
 														<Button
@@ -180,6 +181,48 @@ export function MCPLibraryServersTable({ servers, installedServerSlugs, canCreat
 				onConfirm={handleDelete}
 				confirmTestId="mcp-library-table-delete-confirm"
 			/>
+		</div>
+	);
+}
+
+/** Skeleton placeholder mirroring the table layout while the library catalog loads. */
+export function MCPLibraryServersTableSkeleton({ rows = 8 }: { rows?: number }) {
+	return (
+		<div className="overflow-y-auto rounded-md border mb-2" data-testid="mcp-library-table-skeleton">
+			<Table containerClassName="overflow-x-clip">
+				<TableHeader className="sticky top-0 z-10 bg-muted">
+					<TableRow>
+						<TableHead className="w-16">Icon</TableHead>
+						<TableHead>Server</TableHead>
+						<TableHead className="hidden w-10 lg:table-cell">Details</TableHead>
+						<TableHead className="w-32 text-right">Actions</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{Array.from({ length: rows }).map((_, index) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholders have no stable id
+						<TableRow key={index}>
+							<TableCell>
+								<Skeleton className="h-10 w-10 rounded-md" />
+							</TableCell>
+							<TableCell className="min-w-72 whitespace-normal">
+								<div className="space-y-2">
+									<Skeleton className="h-4 w-40" />
+									<Skeleton className="h-3 w-64" />
+								</div>
+							</TableCell>
+							<TableCell className="hidden lg:table-cell">
+								<Skeleton className="h-3 w-28" />
+							</TableCell>
+							<TableCell className="text-right">
+								<div className="flex justify-end gap-2">
+									<Skeleton className="h-9 w-9 rounded-md" />
+								</div>
+							</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Adds skeleton loading states to the MCP Library page for both grid and table view modes, so users see a structured placeholder instead of a blank screen while the catalog is fetching. Also fixes the scrolling behavior of the main content area by replacing the outer `ScrollArea` with a native overflow container and moving scroll handling into the individual view components.

## Changes

- Added `MCPLibraryServerCardSkeleton` component that mirrors the card layout with animated skeleton placeholders for the icon, title, description, tags, and action button.
- Added `MCPLibraryServersTableSkeleton` component that mirrors the table layout with skeleton rows for icon, server name/description, details, and action columns.
- The library page now renders the appropriate skeleton (grid or table) when `isFetching` is true and no servers have loaded yet, rather than showing nothing.
- Replaced the outer `ScrollArea` wrapper with a plain `div` using `overflow-hidden` and moved `ScrollArea`/`overflow-y-auto` into the grid and table views respectively, so each view manages its own scroll independently.
- Made the table header sticky (`sticky top-0`) so column labels remain visible while scrolling through results.
- Changed the delete button visibility from `hidden/block` toggling to `opacity-0/opacity-100` so the button retains its layout space and avoids layout shift on hover.
- Removed the `sticky` positioning from the search bar since the scroll context changed.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the MCP Registry Library page and observe the loading state on initial page load or when switching pages/filters.

1. Open the MCP Library page.
2. Observe that skeleton cards (grid mode) or skeleton table rows (table mode) appear while the catalog is loading.
3. Switch between grid and table view modes and confirm the correct skeleton is shown for each.
4. Confirm that after loading, the content renders correctly and scrolls as expected with a sticky table header in table view.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Add before/after screenshots showing the skeleton loading state in both grid and table views.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added skeleton loaders for better loading state feedback when fetching MCP server data.
  * Improved layout and scrolling behavior in the library view.
  * Enhanced empty state messaging with contextual configuration options.
  * Better visibility of action controls in table view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->