### PR TITLE
pprof viewer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,14 @@ VERSION ?= dev-build
 LOCAL ?=
 DEBUG ?=
 COMPAT ?=
+PPROFVIEWER_ADDR ?= :7777
+PPROF_FILES ?=
+PPROF_HEAP ?=
+PPROF_ALLOCS ?=
+PPROF_CPU ?=
+PPROF_GOROUTINE ?=
+PPROF_BLOCK ?=
+PPROF_MUTEX ?=
 
 # Colors for output
 RED=\033[0;31m
@@ -67,7 +75,7 @@ define EXPOSE_ENV
 	fi
 endef
 
-.PHONY: all help dev dev-pulse build-ui build build-cli run run-cli install-air install-pulse clean test test-cli install-ui setup-workspace work-init work-clean docs docker-image docker-run cleanup-enterprise mod-tidy test-integrations-py test-integrations-ts install-playwright run-e2e run-e2e-ui run-e2e-headed run-e2e-api format ui install-newman run-provider-harness-test run-cli-harness-test test-semantic-cache test-semantic-cache-complete _test-semantic-cache-complete-inner helm-index
+.PHONY: all help dev dev-pulse build-ui build build-cli run run-cli pprofviewer install-air install-pulse clean test test-cli install-ui setup-workspace work-init work-clean docs docker-image docker-run cleanup-enterprise mod-tidy test-integrations-py test-integrations-ts install-playwright run-e2e run-e2e-ui run-e2e-headed run-e2e-api format ui install-newman run-provider-harness-test run-cli-harness-test test-semantic-cache test-semantic-cache-complete _test-semantic-cache-complete-inner helm-index
 
 all: help
 
@@ -91,6 +99,10 @@ help: ## Show this help message
 	@$(ECHO) "  APP_DIR           App data directory inside container (default: /app/data)"
 	@$(ECHO) "  LOCAL             Use local go.work for builds (e.g., make build LOCAL=1)"
 	@$(ECHO) "  DEBUG             Enable delve debugger on port 2345 (e.g., make dev DEBUG=1, make test-core DEBUG=1, make test-governance DEBUG=1)"
+	@$(ECHO) "  PPROFVIEWER_ADDR  pprofviewer listen address (default: :7777)"
+	@$(ECHO) "  PPROF_FILES       Space-separated profile paths for direct viewer URLs"
+	@$(ECHO) "  PPROF_HEAP/ALLOCS/CPU/GOROUTINE/BLOCK/MUTEX"
+	@$(ECHO) "                    Optional typed profile paths for direct viewer URLs"
 	@$(ECHO) ""
 	@$(ECHO) "$(YELLOW)Test Configuration:$(NC)"
 	@$(ECHO) "  TEST_REPORTS_DIR  Directory for HTML test reports (default: test-reports)"
@@ -455,6 +467,26 @@ run: build ## Build and run bifrost-http (no hot reload)
 		-log-level "$(LOG_LEVEL)" \
 		$(if $(PROMETHEUS_LABELS),-prometheus-labels "$(PROMETHEUS_LABELS)") \
 		$(if $(APP_DIR),-app-dir "$(abspath $(APP_DIR))")
+
+pprofviewer: install-air ## Run standalone pprof viewer with air reload (Usage: make pprofviewer [PPROFVIEWER_ADDR=:7777] [PPROF_FILES="/tmp/heap.pprof /tmp/cpu.pprof"] [PPROF_HEAP=/tmp/heap.pprof] [PPROF_CPU=/tmp/cpu.pprof])
+	@addr="$(PPROFVIEWER_ADDR)"; \
+	base="http://localhost$${addr}"; \
+	if [[ "$$addr" != :* ]]; then base="http://$${addr}"; fi; \
+	$(ECHO) "$(GREEN)Starting pprofviewer at $$base$(NC)"; \
+	$(ECHO) "$(YELLOW)Upload profiles at $$base or open direct profile URLs below.$(NC)"; \
+	for profile in $(PPROF_FILES) $(PPROF_HEAP) $(PPROF_ALLOCS) $(PPROF_CPU) $(PPROF_GOROUTINE) $(PPROF_BLOCK) $(PPROF_MUTEX); do \
+		if [ -n "$$profile" ]; then \
+			sample=""; \
+			if [ "$$profile" = "$(PPROF_HEAP)" ]; then sample="&sample=inuse_space"; fi; \
+			if [ "$$profile" = "$(PPROF_ALLOCS)" ]; then sample="&sample=alloc_space"; fi; \
+			if [ "$$profile" = "$(PPROF_CPU)" ]; then sample="&sample=samples"; fi; \
+			if [ "$$profile" = "$(PPROF_GOROUTINE)" ]; then sample="&sample=goroutine"; fi; \
+			if [ "$$profile" = "$(PPROF_BLOCK)" ]; then sample="&sample=delay"; fi; \
+			if [ "$$profile" = "$(PPROF_MUTEX)" ]; then sample="&sample=contentions"; fi; \
+			$(ECHO) "  $$base/?path=$$profile$$sample"; \
+		fi; \
+	done; \
+	cd pprofviewer && GOWORK=off air -c .air.toml -- -addr "$$addr"
 
 run-cli: build-cli ## Run bifrost CLI (Usage: make run-cli [ARGS="--config ~/.bifrost/config.json"])
 	@$(ECHO) "$(GREEN)Running bifrost CLI...$(NC)"

--- a/pprofviewer/.air.toml
+++ b/pprofviewer/.air.toml
@@ -1,0 +1,21 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "GOWORK=off go build -o ./tmp/pprofviewer ./cmd/pprofviewer"
+bin = "./tmp/pprofviewer"
+delay = 500
+exclude_dir = ["tmp"]
+exclude_regex = ["_test.go"]
+include_dir = ["cmd", "internal"]
+include_ext = ["go", "html"]
+kill_delay = "500ms"
+log = "tmp/air-build.log"
+send_interrupt = true
+stop_on_error = true
+
+[log]
+time = true
+
+[misc]
+clean_on_exit = true

--- a/pprofviewer/README.md
+++ b/pprofviewer/README.md
@@ -1,0 +1,68 @@
+# pprofviewer
+
+Independent web service for quickly inspecting Go pprof files.
+
+## Run
+
+```bash
+cd pprofviewer
+GOWORK=off go run ./cmd/pprofviewer -addr :7777
+```
+
+Open `http://localhost:7777`, upload a pprof dump folder or select multiple profile files, then click Analyze. The viewer auto-detects common filenames:
+
+- `heap.prof`
+- `allocs.prof`
+- `cpu.prof`
+- `goroutine.prof`
+- `block.prof`
+- `mutex.prof`
+
+From the repository root:
+
+```bash
+make pprofviewer
+make pprofviewer PPROF_FILES="/tmp/heap.pprof /tmp/cpu.pprof"
+make pprofviewer PPROF_HEAP=/tmp/heap.pprof PPROF_CPU=/tmp/cpu.pprof
+make pprofviewer PPROF_ALLOCS=/tmp/allocs.prof PPROF_BLOCK=/tmp/block.prof PPROF_MUTEX=/tmp/mutex.prof
+```
+
+The Makefile recipe prints direct viewer URLs for each supplied profile path. Direct URLs also render automatically:
+
+```text
+http://localhost:7777/?path=/tmp/heap.pprof&sample=inuse_space
+```
+
+## API
+
+Analyze a local file from the server process:
+
+```bash
+curl "http://localhost:7777/api/analyze?path=/tmp/heap.pprof&sample=inuse_space"
+```
+
+Analyze an uploaded profile:
+
+```bash
+curl -F "profile=@/tmp/cpu.pprof" "http://localhost:7777/api/analyze"
+```
+
+Analyze a multi-profile upload:
+
+```bash
+curl \
+  -F "profiles=@/tmp/heap.prof" \
+  -F "profiles=@/tmp/allocs.prof" \
+  -F "profiles=@/tmp/cpu.prof" \
+  -F "profiles=@/tmp/goroutine.prof" \
+  -F "profiles=@/tmp/block.prof" \
+  -F "profiles=@/tmp/mutex.prof" \
+  "http://localhost:7777/api/analyze-set"
+```
+
+The response includes:
+
+- `nodes`: graph nodes sized by cumulative allocation or CPU sample value
+- `edges`: weighted call-path edges
+- `leaks`: retained heap candidates with stack paths
+- `top_paths`: heaviest stack paths in the profile

--- a/pprofviewer/cmd/pprofviewer/main.go
+++ b/pprofviewer/cmd/pprofviewer/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/maximhq/bifrost/pprofviewer/internal/server"
+)
+
+func main() {
+	addr := flag.String("addr", ":7777", "HTTP listen address")
+	flag.Parse()
+
+	srv := &http.Server{
+		Addr:              *addr,
+		Handler:           server.New(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	log.Printf("pprofviewer listening on http://localhost%s", *addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
+}

--- a/pprofviewer/go.mod
+++ b/pprofviewer/go.mod
@@ -1,0 +1,5 @@
+module github.com/maximhq/bifrost/pprofviewer
+
+go 1.26.4
+
+require github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f

--- a/pprofviewer/go.sum
+++ b/pprofviewer/go.sum
@@ -1,0 +1,2 @@
+github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f h1:HU1RgM6NALf/KW9HEY6zry3ADbDKcmpQ+hJedoNGQYQ=
+github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f/go.mod h1:67FPmZWbr+KDT/VlpWtw6sO9XSjpJmLuHpoLmWiTGgY=

--- a/pprofviewer/internal/analyzer/analyzer.go
+++ b/pprofviewer/internal/analyzer/analyzer.go
@@ -1,0 +1,629 @@
+package analyzer
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/google/pprof/profile"
+)
+
+const (
+	maxGraphNodes = 120
+	maxGraphEdges = 260
+	maxLeaks      = 25
+	maxPaths      = 30
+	maxCrossItems = 80
+)
+
+type ProfileSet struct {
+	ID       string          `json:"id,omitempty"`
+	Profiles []NamedAnalysis `json:"profiles"`
+	Overall  OverallUsage    `json:"overall"`
+	CrossMap []CrossMapItem  `json:"cross_map"`
+}
+
+type NamedAnalysis struct {
+	Name    string    `json:"name"`
+	Profile *Analysis `json:"profile"`
+}
+
+type OverallUsage struct {
+	HeapBytes       int64 `json:"heap_bytes,omitempty"`
+	AllocatedBytes  int64 `json:"allocated_bytes,omitempty"`
+	CPUSamples      int64 `json:"cpu_samples,omitempty"`
+	CPUTimeNanos    int64 `json:"cpu_time_nanos,omitempty"`
+	Goroutines      int64 `json:"goroutines,omitempty"`
+	ProfiledSamples int64 `json:"profiled_samples,omitempty"`
+}
+
+type CrossMapItem struct {
+	Function       string   `json:"function"`
+	File           string   `json:"file,omitempty"`
+	HeapBytes      int64    `json:"heap_bytes,omitempty"`
+	AllocatedBytes int64    `json:"allocated_bytes,omitempty"`
+	CPUValue       int64    `json:"cpu_value,omitempty"`
+	CPUUnit        string   `json:"cpu_unit,omitempty"`
+	Goroutines     int64    `json:"goroutines,omitempty"`
+	Profiles       []string `json:"profiles"`
+	Score          float64  `json:"score"`
+}
+
+type Analysis struct {
+	ID          string          `json:"id,omitempty"`
+	ProfileType string          `json:"profile_type"`
+	SampleType  string          `json:"sample_type"`
+	Unit        string          `json:"unit"`
+	Total       int64           `json:"total"`
+	Nodes       []GraphNode     `json:"nodes"`
+	Edges       []GraphEdge     `json:"edges"`
+	Leaks       []LeakCandidate `json:"leaks"`
+	TopPaths    []StackPath     `json:"top_paths"`
+	SampleTypes []SampleType    `json:"sample_types"`
+}
+
+type SampleType struct {
+	Type string `json:"type"`
+	Unit string `json:"unit"`
+}
+
+type GraphNode struct {
+	ID         string  `json:"id"`
+	Name       string  `json:"name"`
+	File       string  `json:"file,omitempty"`
+	Line       int64   `json:"line,omitempty"`
+	Flat       int64   `json:"flat"`
+	Cumulative int64   `json:"cumulative"`
+	Percent    float64 `json:"percent"`
+	Kind       string  `json:"kind"`
+}
+
+type GraphEdge struct {
+	From    string  `json:"from"`
+	To      string  `json:"to"`
+	Value   int64   `json:"value"`
+	Percent float64 `json:"percent"`
+}
+
+type LeakCandidate struct {
+	Function      string   `json:"function"`
+	File          string   `json:"file,omitempty"`
+	Line          int64    `json:"line,omitempty"`
+	RetainedBytes int64    `json:"retained_bytes"`
+	AllocBytes    int64    `json:"alloc_bytes,omitempty"`
+	Objects       int64    `json:"objects,omitempty"`
+	Score         float64  `json:"score"`
+	Reason        string   `json:"reason"`
+	Path          []string `json:"path"`
+}
+
+type StackPath struct {
+	Value   int64    `json:"value"`
+	Percent float64  `json:"percent"`
+	Path    []string `json:"path"`
+}
+
+type nodeAgg struct {
+	node GraphNode
+}
+
+type leakAgg struct {
+	fn       frame
+	retain   int64
+	alloc    int64
+	objects  int64
+	bestPath []string
+}
+
+type frame struct {
+	id   string
+	name string
+	file string
+	line int64
+}
+
+func Analyze(r io.Reader, requestedSample string) (*Analysis, error) {
+	data, err := io.ReadAll(io.LimitReader(r, 512<<20))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty profile")
+	}
+
+	prof, err := profile.Parse(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	if err := prof.CheckValid(); err != nil {
+		return nil, err
+	}
+
+	valueIdx := chooseSampleIndex(prof, requestedSample)
+	if valueIdx < 0 {
+		return nil, fmt.Errorf("profile has no supported sample values")
+	}
+
+	retainIdx := sampleIndex(prof, "inuse_space")
+	allocIdx := sampleIndex(prof, "alloc_space")
+	objectIdx := sampleIndex(prof, "inuse_objects")
+	if retainIdx < 0 {
+		retainIdx = valueIdx
+	}
+	if allocIdx < 0 {
+		allocIdx = valueIdx
+	}
+
+	nodes := make(map[string]*nodeAgg)
+	edges := make(map[string]*GraphEdge)
+	leaks := make(map[string]*leakAgg)
+	pathValues := make(map[string]*StackPath)
+	var total int64
+
+	for _, sample := range prof.Sample {
+		if valueIdx >= len(sample.Value) {
+			continue
+		}
+		value := sample.Value[valueIdx]
+		if value <= 0 {
+			continue
+		}
+		total += value
+
+		stack := stackFrames(sample)
+		if len(stack) == 0 {
+			continue
+		}
+
+		leaf := stack[len(stack)-1]
+		for i := range stack {
+			f := stack[i]
+			agg := nodes[f.id]
+			if agg == nil {
+				agg = &nodeAgg{node: GraphNode{
+					ID:   f.id,
+					Name: f.name,
+					File: f.file,
+					Line: f.line,
+					Kind: nodeKind(f.name),
+				}}
+				nodes[f.id] = agg
+			}
+			agg.node.Cumulative += value
+		}
+		nodes[leaf.id].node.Flat += value
+
+		for i := 0; i < len(stack)-1; i++ {
+			key := stack[i].id + "\x00" + stack[i+1].id
+			edge := edges[key]
+			if edge == nil {
+				edge = &GraphEdge{From: stack[i].id, To: stack[i+1].id}
+				edges[key] = edge
+			}
+			edge.Value += value
+		}
+
+		path := frameNames(stack)
+		pathKey := strings.Join(path, "\x00")
+		sp := pathValues[pathKey]
+		if sp == nil {
+			sp = &StackPath{Path: path}
+			pathValues[pathKey] = sp
+		}
+		sp.Value += value
+
+		retained := sampleValue(sample, retainIdx)
+		allocated := sampleValue(sample, allocIdx)
+		objects := sampleValue(sample, objectIdx)
+		if retained > 0 {
+			la := leaks[leaf.id]
+			if la == nil {
+				la = &leakAgg{fn: leaf}
+				leaks[leaf.id] = la
+			}
+			la.retain += retained
+			la.alloc += allocated
+			la.objects += objects
+			if retained >= la.retain || len(la.bestPath) == 0 {
+				la.bestPath = path
+			}
+		}
+	}
+
+	a := &Analysis{
+		ProfileType: profileType(prof, valueIdx),
+		SampleType:  prof.SampleType[valueIdx].Type,
+		Unit:        prof.SampleType[valueIdx].Unit,
+		Total:       total,
+		SampleTypes: sampleTypes(prof),
+		Nodes:       topNodes(nodes, total),
+		TopPaths:    topPaths(pathValues, total),
+		Leaks:       topLeaks(leaks),
+	}
+	a.Edges = topEdges(edges, a.Nodes, total)
+	return a, nil
+}
+
+func AnalyzeSet(profiles map[string]io.Reader) (*ProfileSet, error) {
+	out := &ProfileSet{}
+	byName := make(map[string]*Analysis)
+	for _, name := range ProfileSetNames() {
+		reader := profiles[name]
+		if reader == nil {
+			continue
+		}
+		analysis, err := Analyze(reader, defaultSampleFor(name))
+		if err != nil {
+			return nil, fmt.Errorf("%s profile: %w", name, err)
+		}
+		analysis.ProfileType = name
+		out.Profiles = append(out.Profiles, NamedAnalysis{Name: name, Profile: analysis})
+		byName[name] = analysis
+	}
+	if len(out.Profiles) == 0 {
+		return nil, fmt.Errorf("no profiles supplied")
+	}
+	out.Overall = overallUsage(byName)
+	out.CrossMap = crossMap(byName)
+	return out, nil
+}
+
+func ProfileSetNames() []string {
+	return []string{"heap", "allocs", "cpu", "goroutine", "block", "mutex"}
+}
+
+func defaultSampleFor(name string) string {
+	switch name {
+	case "heap":
+		return "inuse_space"
+	case "allocs":
+		return "alloc_space"
+	case "cpu":
+		return "samples"
+	case "goroutine":
+		return "goroutine"
+	case "block":
+		return "delay"
+	case "mutex":
+		return "contentions"
+	default:
+		return ""
+	}
+}
+
+func chooseSampleIndex(prof *profile.Profile, requested string) int {
+	if requested != "" {
+		if idx := sampleIndex(prof, requested); idx >= 0 {
+			return idx
+		}
+	}
+	for _, name := range []string{"alloc_space", "inuse_space", "cpu", "samples", "goroutine", "delay", "contentions"} {
+		if idx := sampleIndex(prof, name); idx >= 0 {
+			return idx
+		}
+	}
+	if len(prof.SampleType) > 0 {
+		return 0
+	}
+	return -1
+}
+
+func sampleIndex(prof *profile.Profile, name string) int {
+	for i, st := range prof.SampleType {
+		if st.Type == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func sampleValue(sample *profile.Sample, idx int) int64 {
+	if idx < 0 || idx >= len(sample.Value) {
+		return 0
+	}
+	return sample.Value[idx]
+}
+
+func stackFrames(sample *profile.Sample) []frame {
+	out := make([]frame, 0, len(sample.Location))
+	for i := len(sample.Location) - 1; i >= 0; i-- {
+		loc := sample.Location[i]
+		if loc == nil {
+			continue
+		}
+		out = append(out, frameForLocation(loc))
+	}
+	return out
+}
+
+func frameForLocation(loc *profile.Location) frame {
+	if len(loc.Line) == 0 {
+		return frame{
+			id:   fmt.Sprintf("addr:%x", loc.Address),
+			name: fmt.Sprintf("0x%x", loc.Address),
+		}
+	}
+	line := loc.Line[0]
+	fn := "<unknown>"
+	file := ""
+	if line.Function != nil {
+		fn = line.Function.Name
+		file = line.Function.Filename
+	}
+	return frame{
+		id:   fmt.Sprintf("%s:%d", fn, line.Line),
+		name: fn,
+		file: file,
+		line: line.Line,
+	}
+}
+
+func frameNames(stack []frame) []string {
+	out := make([]string, 0, len(stack))
+	for _, f := range stack {
+		if f.file != "" && f.line > 0 {
+			out = append(out, fmt.Sprintf("%s (%s:%d)", f.name, trimPath(f.file), f.line))
+			continue
+		}
+		out = append(out, f.name)
+	}
+	return out
+}
+
+func topNodes(nodes map[string]*nodeAgg, total int64) []GraphNode {
+	out := make([]GraphNode, 0, len(nodes))
+	for _, agg := range nodes {
+		n := agg.node
+		n.Percent = pct(n.Cumulative, total)
+		out = append(out, n)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Cumulative == out[j].Cumulative {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Cumulative > out[j].Cumulative
+	})
+	if len(out) > maxGraphNodes {
+		out = out[:maxGraphNodes]
+	}
+	return out
+}
+
+func topEdges(edges map[string]*GraphEdge, nodes []GraphNode, total int64) []GraphEdge {
+	allowed := make(map[string]struct{}, len(nodes))
+	for _, n := range nodes {
+		allowed[n.ID] = struct{}{}
+	}
+	out := make([]GraphEdge, 0, len(edges))
+	for _, e := range edges {
+		if _, ok := allowed[e.From]; !ok {
+			continue
+		}
+		if _, ok := allowed[e.To]; !ok {
+			continue
+		}
+		edge := *e
+		edge.Percent = pct(edge.Value, total)
+		out = append(out, edge)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Value > out[j].Value })
+	if len(out) > maxGraphEdges {
+		out = out[:maxGraphEdges]
+	}
+	return out
+}
+
+func topLeaks(leaks map[string]*leakAgg) []LeakCandidate {
+	out := make([]LeakCandidate, 0, len(leaks))
+	for _, la := range leaks {
+		if la.retain <= 0 {
+			continue
+		}
+		retention := 1.0
+		if la.alloc > 0 {
+			retention = math.Min(1, float64(la.retain)/float64(la.alloc))
+		}
+		score := float64(la.retain) * (0.65 + retention*0.35)
+		reason := "high retained heap on this allocation path"
+		if retention > 0.75 && la.alloc > 0 {
+			reason = "large retained share of allocated bytes"
+		}
+		out = append(out, LeakCandidate{
+			Function:      la.fn.name,
+			File:          la.fn.file,
+			Line:          la.fn.line,
+			RetainedBytes: la.retain,
+			AllocBytes:    la.alloc,
+			Objects:       la.objects,
+			Score:         score,
+			Reason:        reason,
+			Path:          la.bestPath,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Score > out[j].Score })
+	if len(out) > maxLeaks {
+		out = out[:maxLeaks]
+	}
+	return out
+}
+
+func topPaths(paths map[string]*StackPath, total int64) []StackPath {
+	out := make([]StackPath, 0, len(paths))
+	for _, p := range paths {
+		p.Percent = pct(p.Value, total)
+		out = append(out, *p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Value > out[j].Value })
+	if len(out) > maxPaths {
+		out = out[:maxPaths]
+	}
+	return out
+}
+
+func sampleTypes(prof *profile.Profile) []SampleType {
+	out := make([]SampleType, 0, len(prof.SampleType))
+	for _, st := range prof.SampleType {
+		out = append(out, SampleType{Type: st.Type, Unit: st.Unit})
+	}
+	return out
+}
+
+func profileType(prof *profile.Profile, idx int) string {
+	if idx >= 0 && idx < len(prof.SampleType) {
+		t := prof.SampleType[idx].Type
+		if strings.Contains(t, "alloc") || strings.Contains(t, "inuse") {
+			return "heap"
+		}
+		if t == "goroutine" {
+			return "goroutine"
+		}
+		if t == "cpu" || t == "samples" {
+			return "cpu"
+		}
+	}
+	return "profile"
+}
+
+func overallUsage(profiles map[string]*Analysis) OverallUsage {
+	var out OverallUsage
+	for _, profile := range profiles {
+		if profile != nil {
+			out.ProfiledSamples += profile.Total
+		}
+	}
+	if heap := profiles["heap"]; heap != nil {
+		for _, st := range heap.SampleTypes {
+			switch st.Type {
+			case "inuse_space":
+				if heap.SampleType == st.Type {
+					out.HeapBytes = heap.Total
+				}
+			case "alloc_space":
+				if heap.SampleType == st.Type {
+					out.AllocatedBytes = heap.Total
+				}
+			}
+		}
+		if out.HeapBytes == 0 && heap.Unit == "bytes" {
+			out.HeapBytes = heap.Total
+		}
+	}
+	if allocs := profiles["allocs"]; allocs != nil && allocs.Unit == "bytes" {
+		out.AllocatedBytes = allocs.Total
+	}
+	if cpu := profiles["cpu"]; cpu != nil {
+		if cpu.Unit == "nanoseconds" {
+			out.CPUTimeNanos = cpu.Total
+		} else {
+			out.CPUSamples = cpu.Total
+		}
+	}
+	if goroutine := profiles["goroutine"]; goroutine != nil {
+		out.Goroutines = goroutine.Total
+	}
+	return out
+}
+
+func crossMap(profiles map[string]*Analysis) []CrossMapItem {
+	type agg struct {
+		item CrossMapItem
+		seen map[string]struct{}
+	}
+	rows := make(map[string]*agg)
+	add := func(profileName string, n GraphNode, unit string) {
+		key := normalizedFunction(n.Name)
+		if key == "" {
+			return
+		}
+		row := rows[key]
+		if row == nil {
+			row = &agg{item: CrossMapItem{Function: n.Name, File: n.File}, seen: make(map[string]struct{})}
+			rows[key] = row
+		}
+		row.seen[profileName] = struct{}{}
+		switch profileName {
+		case "heap":
+			if unit == "bytes" {
+				row.item.HeapBytes += n.Cumulative
+			} else {
+				row.item.AllocatedBytes += n.Cumulative
+			}
+		case "cpu":
+			row.item.CPUValue += n.Cumulative
+			row.item.CPUUnit = unit
+		case "goroutine":
+			row.item.Goroutines += n.Cumulative
+		}
+	}
+	for name, analysis := range profiles {
+		if analysis == nil {
+			continue
+		}
+		for _, n := range analysis.Nodes {
+			add(name, n, analysis.Unit)
+		}
+	}
+	out := make([]CrossMapItem, 0, len(rows))
+	for _, row := range rows {
+		for profileName := range row.seen {
+			row.item.Profiles = append(row.item.Profiles, profileName)
+		}
+		sort.Strings(row.item.Profiles)
+		if len(row.item.Profiles) < 2 {
+			continue
+		}
+		row.item.Score = math.Log1p(float64(row.item.HeapBytes+row.item.AllocatedBytes))*1.4 +
+			math.Log1p(float64(row.item.CPUValue))*1.2 +
+			math.Log1p(float64(row.item.Goroutines))
+		out = append(out, row.item)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Score > out[j].Score })
+	if len(out) > maxCrossItems {
+		out = out[:maxCrossItems]
+	}
+	return out
+}
+
+func normalizedFunction(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.HasPrefix(name, "runtime.") {
+		return name
+	}
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
+}
+
+func pct(v, total int64) float64 {
+	if total <= 0 {
+		return 0
+	}
+	return float64(v) / float64(total) * 100
+}
+
+func trimPath(path string) string {
+	parts := strings.Split(path, "/")
+	if len(parts) <= 3 {
+		return path
+	}
+	return strings.Join(parts[len(parts)-3:], "/")
+}
+
+func nodeKind(name string) string {
+	switch {
+	case strings.HasPrefix(name, "runtime."):
+		return "runtime"
+	case strings.HasPrefix(name, "net/http."):
+		return "http"
+	case strings.Contains(name, "/vendor/"):
+		return "vendor"
+	case strings.Contains(name, "."):
+		return "app"
+	default:
+		return "other"
+	}
+}

--- a/pprofviewer/internal/analyzer/analyzer_test.go
+++ b/pprofviewer/internal/analyzer/analyzer_test.go
@@ -1,0 +1,74 @@
+package analyzer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/pprof/profile"
+)
+
+func TestAnalyzeHeapProfile(t *testing.T) {
+	prof := &profile.Profile{
+		SampleType: []*profile.ValueType{
+			{Type: "alloc_space", Unit: "bytes"},
+			{Type: "inuse_space", Unit: "bytes"},
+			{Type: "inuse_objects", Unit: "count"},
+		},
+		Sample: []*profile.Sample{
+			{
+				Location: []*profile.Location{
+					location(1, "github.com/acme/service.leaf", "/repo/service/leaf.go", 12),
+					location(2, "github.com/acme/service.root", "/repo/service/root.go", 8),
+				},
+				Value: []int64{2048, 1024, 4},
+			},
+		},
+		Location: []*profile.Location{
+			location(1, "github.com/acme/service.leaf", "/repo/service/leaf.go", 12),
+			location(2, "github.com/acme/service.root", "/repo/service/root.go", 8),
+		},
+		Function: []*profile.Function{
+			function(1, "github.com/acme/service.leaf", "/repo/service/leaf.go"),
+			function(2, "github.com/acme/service.root", "/repo/service/root.go"),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := prof.Write(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Analyze(&buf, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ProfileType != "heap" {
+		t.Fatalf("profile type = %q, want heap", got.ProfileType)
+	}
+	if got.Total != 2048 {
+		t.Fatalf("total = %d, want 2048", got.Total)
+	}
+	if len(got.Nodes) == 0 {
+		t.Fatal("expected graph nodes")
+	}
+	if len(got.Leaks) != 1 {
+		t.Fatalf("leaks = %d, want 1", len(got.Leaks))
+	}
+	if got.Leaks[0].RetainedBytes != 1024 {
+		t.Fatalf("retained = %d, want 1024", got.Leaks[0].RetainedBytes)
+	}
+}
+
+func location(id uint64, name, file string, line int64) *profile.Location {
+	return &profile.Location{
+		ID: id,
+		Line: []profile.Line{{
+			Function: function(id, name, file),
+			Line:     line,
+		}},
+	}
+}
+
+func function(id uint64, name, file string) *profile.Function {
+	return &profile.Function{ID: id, Name: name, SystemName: name, Filename: file}
+}

--- a/pprofviewer/internal/server/server.go
+++ b/pprofviewer/internal/server/server.go
@@ -1,0 +1,296 @@
+package server
+
+import (
+	"crypto/rand"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/maximhq/bifrost/pprofviewer/internal/analyzer"
+)
+
+//go:embed static/*
+var staticFS embed.FS
+
+var results = resultCache{items: make(map[string][]byte)}
+
+type resultCache struct {
+	mu    sync.RWMutex
+	items map[string][]byte
+}
+
+func New() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", index)
+	mux.HandleFunc("/api/analyze", analyze)
+	mux.HandleFunc("/api/analyze-set", analyzeSet)
+	mux.HandleFunc("/api/result", cachedResult)
+	return mux
+}
+
+func index(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	data, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(data)
+}
+
+func analyze(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost && r.Method != http.MethodGet {
+		http.Error(w, "use POST with a pprof file or GET ?path=/path/to/profile", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sample := r.URL.Query().Get("sample")
+	reader, closeFn, err := profileReader(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer closeFn()
+
+	result, err := analyzer.Analyze(reader, sample)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	result.ID = newResultID()
+	writeCachedJSON(w, result.ID, result)
+}
+
+func analyzeSet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost && r.Method != http.MethodGet {
+		http.Error(w, "use POST multipart profile fields or GET *_path query params", http.StatusMethodNotAllowed)
+		return
+	}
+
+	readers, closeFn, err := profileSetReaders(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer closeFn()
+
+	result, err := analyzer.AnalyzeSet(readers)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	result.ID = newResultID()
+	writeCachedJSON(w, result.ID, result)
+}
+
+func cachedResult(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "use GET", http.StatusMethodNotAllowed)
+		return
+	}
+	id := strings.TrimSpace(r.URL.Query().Get("id"))
+	if id == "" {
+		http.Error(w, "missing id", http.StatusBadRequest)
+		return
+	}
+	data, ok := results.get(id)
+	if !ok {
+		http.Error(w, "result not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
+}
+
+func writeCachedJSON(w http.ResponseWriter, id string, v any) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	results.set(id, data)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
+}
+
+func newResultID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func (c *resultCache) set(id string, data []byte) {
+	if id == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items[id] = append([]byte(nil), data...)
+}
+
+func (c *resultCache) get(id string) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	data, ok := c.items[id]
+	if !ok {
+		return nil, false
+	}
+	return append([]byte(nil), data...), true
+}
+
+func profileReader(r *http.Request) (io.Reader, func(), error) {
+	if r.Method == http.MethodGet {
+		path := r.URL.Query().Get("path")
+		if strings.TrimSpace(path) == "" {
+			return nil, func() {}, fmt.Errorf("missing path")
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return f, func() { _ = f.Close() }, nil
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if strings.HasPrefix(contentType, "multipart/form-data") {
+		if err := r.ParseMultipartForm(512 << 20); err != nil {
+			return nil, func() {}, err
+		}
+		f, _, err := r.FormFile("profile")
+		if err != nil {
+			return nil, func() {}, fmt.Errorf("missing multipart field %q", "profile")
+		}
+		return f, func() { _ = f.Close() }, nil
+	}
+
+	return r.Body, func() { _ = r.Body.Close() }, nil
+}
+
+func profileSetReaders(r *http.Request) (map[string]io.Reader, func(), error) {
+	readers := make(map[string]io.Reader)
+	var closers []io.Closer
+	closeFn := func() {
+		for _, closer := range closers {
+			_ = closer.Close()
+		}
+	}
+
+	if r.Method == http.MethodGet {
+		for _, name := range analyzer.ProfileSetNames() {
+			path := strings.TrimSpace(r.URL.Query().Get(name + "_path"))
+			if path == "" {
+				continue
+			}
+			f, err := os.Open(path)
+			if err != nil {
+				closeFn()
+				return nil, func() {}, fmt.Errorf("%s_path: %w", name, err)
+			}
+			readers[name] = f
+			closers = append(closers, f)
+		}
+		return readers, closeFn, nil
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "multipart/form-data") {
+		return nil, func() {}, fmt.Errorf("combined analysis requires multipart form data")
+	}
+	if err := r.ParseMultipartForm(512 << 20); err != nil {
+		return nil, func() {}, err
+	}
+	for _, name := range analyzer.ProfileSetNames() {
+		f, header, err := r.FormFile(name)
+		if err != nil {
+			continue
+		}
+		addProfileReader(readers, &closers, name, f, header)
+	}
+	if r.MultipartForm != nil {
+		for _, headers := range r.MultipartForm.File {
+			for _, header := range headers {
+				name := inferProfileName(header.Filename)
+				if name == "" {
+					continue
+				}
+				if _, exists := readers[name]; exists {
+					continue
+				}
+				f, err := header.Open()
+				if err != nil {
+					closeFn()
+					return nil, func() {}, err
+				}
+				addProfileReader(readers, &closers, name, f, header)
+			}
+		}
+	}
+	return readers, closeFn, nil
+}
+
+func addProfileReader(readers map[string]io.Reader, closers *[]io.Closer, name string, f multipart.File, _ *multipart.FileHeader) {
+	if _, exists := readers[name]; exists {
+		_ = f.Close()
+		return
+	}
+	readers[name] = f
+	*closers = append(*closers, f)
+}
+
+func inferProfileName(name string) string {
+	base := strings.ToLower(filepath.Base(name))
+	base = strings.TrimSuffix(base, ".gz")
+	base = strings.TrimSuffix(base, ".pb")
+	base = strings.TrimSuffix(base, ".pprof")
+	base = strings.TrimSuffix(base, ".prof")
+	base = strings.TrimSuffix(base, ".txt")
+	base = strings.TrimSuffix(base, ".out")
+	switch base {
+	case "heap", "inuse", "mem", "memory":
+		return "heap"
+	case "alloc", "allocs", "allocations":
+		return "allocs"
+	case "cpu", "profile":
+		return "cpu"
+	case "goroutine", "goroutines":
+		return "goroutine"
+	case "block", "blocking":
+		return "block"
+	case "mutex", "mutator":
+		return "mutex"
+	}
+	normalized := strings.NewReplacer("-", "_", ".", "_", " ", "_").Replace(base)
+	for _, part := range strings.Split(normalized, "_") {
+		switch part {
+		case "heap", "inuse":
+			return "heap"
+		case "alloc", "allocs":
+			return "allocs"
+		case "cpu":
+			return "cpu"
+		case "goroutine", "goroutines":
+			return "goroutine"
+		case "block":
+			return "block"
+		case "mutex":
+			return "mutex"
+		}
+	}
+	return ""
+}

--- a/pprofviewer/internal/server/server_test.go
+++ b/pprofviewer/internal/server/server_test.go
@@ -1,0 +1,23 @@
+package server
+
+import "testing"
+
+func TestInferProfileName(t *testing.T) {
+	tests := map[string]string{
+		"/tmp/run/heap.prof":         "heap",
+		"/tmp/run/allocs.prof":       "allocs",
+		"/tmp/run/cpu.prof":          "cpu",
+		"/tmp/run/goroutine.prof":    "goroutine",
+		"/tmp/run/block.prof":        "block",
+		"/tmp/run/mutex.prof":        "mutex",
+		"pod/profile-cpu.pb.gz":      "cpu",
+		"pod/service-allocs.pprof":   "allocs",
+		"pod/service-goroutines.out": "goroutine",
+		"pod/notes.txt":              "",
+	}
+	for name, want := range tests {
+		if got := inferProfileName(name); got != want {
+			t.Fatalf("inferProfileName(%q) = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/pprofviewer/internal/server/static/index.html
+++ b/pprofviewer/internal/server/static/index.html
@@ -1,0 +1,1724 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>pprof viewer</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fb;
+      --panel: #ffffff;
+      --ink: #111827;
+      --muted: #5b6472;
+      --line: #d9dee8;
+      --accent: #0f766e;
+      --hot: #b42318;
+      --runtime: #6d28d9;
+      --shadow: 0 8px 24px rgba(15, 23, 42, .08);
+    }
+    * { box-sizing: border-box; }
+    html, body {
+      height: 100%;
+    }
+    body {
+      margin: 0;
+      font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--ink);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      padding: 14px 20px;
+      border-bottom: 1px solid var(--line);
+      background: var(--panel);
+      flex: 0 0 auto;
+    }
+    h1 { font-size: 18px; margin: 0; letter-spacing: 0; }
+    main {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 380px;
+      gap: 16px;
+      padding: 16px;
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: hidden;
+    }
+    form {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-left: auto;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+    .file-field {
+      display: grid;
+      grid-template-columns: auto minmax(180px, 220px);
+      align-items: center;
+      gap: 8px;
+    }
+    .file-field span {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      min-width: 64px;
+      text-align: right;
+    }
+    input, select, button {
+      height: 34px;
+      border: 1px solid var(--line);
+      background: #fff;
+      color: var(--ink);
+      border-radius: 6px;
+      padding: 0 10px;
+      font: inherit;
+    }
+    input[type="file"] {
+      width: 220px;
+      max-width: 22vw;
+      padding: 4px 8px;
+      line-height: 24px;
+    }
+    .bulk-field {
+      grid-template-columns: auto minmax(220px, 300px);
+    }
+    .bulk-field input[type="file"] {
+      width: 300px;
+    }
+    select { min-width: 220px; }
+    button {
+      background: var(--accent);
+      color: #fff;
+      border-color: var(--accent);
+      cursor: pointer;
+      font-weight: 650;
+    }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      min-width: 0;
+      min-height: 0;
+    }
+    .panel h2 {
+      margin: 0;
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--line);
+      font-size: 14px;
+    }
+    .graph-head {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      justify-content: space-between;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--line);
+    }
+    .graph-head h2 {
+      border: 0;
+      padding: 0;
+      white-space: nowrap;
+    }
+    .graph-tools {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+    .active-filter {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+      max-width: 340px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .active-filter strong {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--ink);
+      font-weight: 650;
+    }
+    .graph-tools label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 12px;
+      min-width: 260px;
+    }
+    input[type="range"] {
+      width: 160px;
+      min-width: 120px;
+      padding: 0;
+      border: 0;
+      height: 24px;
+    }
+    .ghost-btn {
+      height: 30px;
+      background: #fff;
+      color: var(--ink);
+      border-color: var(--line);
+      font-weight: 600;
+    }
+    .report-panel {
+      margin: 0 14px 12px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+    }
+    .report-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 10px;
+      border-bottom: 1px solid var(--line);
+    }
+    .report-actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    #report-output {
+      width: 100%;
+      min-height: 280px;
+      max-height: 520px;
+      border: 0;
+      resize: vertical;
+      padding: 12px;
+      font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      color: var(--ink);
+    }
+    .tabs {
+      display: flex;
+      gap: 6px;
+      padding: 10px 14px 0;
+      flex-wrap: wrap;
+    }
+    .tab {
+      height: 30px;
+      background: #fff;
+      color: var(--ink);
+      border-color: var(--line);
+      font-weight: 650;
+    }
+    .tab.active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+    .view-tabs {
+      display: flex;
+      gap: 6px;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--line);
+      flex-wrap: wrap;
+    }
+    .view {
+      min-height: 0;
+      background: #fbfcfe;
+      border-radius: 0 0 8px 8px;
+    }
+    .hidden { display: none !important; }
+    #graph, .chart {
+      width: 100%;
+      height: calc(100vh - 180px);
+      min-height: 0;
+      display: block;
+      background: #fbfcfe;
+      border-radius: 0 0 8px 8px;
+      cursor: grab;
+      touch-action: none;
+      user-select: none;
+    }
+    .chart { cursor: default; }
+    #graph.dragging { cursor: grabbing; }
+    .node { cursor: grab; }
+    .node.dragging { cursor: grabbing; }
+    .node circle { transition: stroke-width .15s ease, opacity .15s ease; }
+    .node.dim, .edge.dim { opacity: .16; }
+    .node.selected circle {
+      stroke: #111827;
+      stroke-width: 3;
+    }
+    .edge {
+      transition: opacity .15s ease, stroke .15s ease;
+    }
+    aside {
+      display: grid;
+      gap: 16px;
+      align-content: start;
+      min-height: 0;
+      overflow: auto;
+    }
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 8px;
+      padding: 12px;
+    }
+    .metric {
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 8px;
+      min-width: 0;
+    }
+    .metric span {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .metric strong {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .list { padding: 8px 12px 12px; }
+    .ranked-list {
+      height: calc(100vh - 180px);
+      overflow: auto;
+      background: #fbfcfe;
+      border-radius: 0 0 8px 8px;
+    }
+    .rank-row {
+      border-bottom: 1px solid var(--line);
+      padding: 0;
+    }
+    .rank-row summary {
+      display: grid;
+      grid-template-columns: 56px minmax(0, 1fr) 130px 74px;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      cursor: pointer;
+      list-style: none;
+    }
+    .rank-row summary::-webkit-details-marker { display: none; }
+    .rank-row strong, .rank-row code {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .rank-row code {
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .rank-body {
+      padding: 0 14px 12px 80px;
+      color: var(--muted);
+    }
+    .rank-body code {
+      display: block;
+      white-space: normal;
+      overflow-wrap: anywhere;
+      margin-top: 6px;
+    }
+    .scroll-list {
+      max-height: 32vh;
+      min-height: 0;
+      overflow: auto;
+    }
+    .item {
+      border-bottom: 1px solid var(--line);
+      padding: 10px 0;
+    }
+    .item.clickable {
+      cursor: pointer;
+      border-radius: 6px;
+      padding: 8px;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 30px;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      overflow: hidden;
+    }
+    .item.clickable:hover {
+      background: #f1f5f9;
+    }
+    .item:last-child { border-bottom: 0; }
+    .item strong {
+      display: block;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .filter-btn {
+      width: 30px;
+      height: 30px;
+      padding: 0;
+      display: inline-grid;
+      place-items: center;
+      background: #fff;
+      color: var(--muted);
+      border-color: var(--line);
+      border-radius: 6px;
+      font-size: 15px;
+      line-height: 1;
+    }
+    .filter-btn:hover, .filter-btn.active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+    .item code {
+      display: block;
+      color: var(--muted);
+      overflow-wrap: anywhere;
+      margin-top: 4px;
+    }
+    .bar {
+      height: 6px;
+      background: #e7ecef;
+      border-radius: 99px;
+      margin-top: 6px;
+      overflow: hidden;
+    }
+    .bar > i {
+      display: block;
+      height: 100%;
+      background: var(--accent);
+    }
+    .status {
+      color: var(--muted);
+      min-width: 180px;
+    }
+    dialog {
+      width: min(760px, calc(100vw - 32px));
+      max-height: min(760px, calc(100vh - 32px));
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 0;
+      color: var(--ink);
+      box-shadow: var(--shadow);
+    }
+    dialog::backdrop {
+      background: rgba(15, 23, 42, .45);
+    }
+    .detail-dialog-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 14px;
+      border-bottom: 1px solid var(--line);
+    }
+    .detail-dialog-head h2 {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      font-size: 15px;
+    }
+    .detail-dialog-head button {
+      height: 28px;
+      padding: 0 9px;
+    }
+    .detail-dialog-body {
+      padding: 14px;
+      overflow: auto;
+      max-height: calc(100vh - 130px);
+    }
+    .detail-dialog-body dl {
+      display: grid;
+      grid-template-columns: 120px minmax(0, 1fr);
+      gap: 8px 12px;
+      margin: 0 0 14px;
+    }
+    .detail-dialog-body dt {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .detail-dialog-body dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+    .detail-dialog-body code {
+      display: block;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: #fbfcfe;
+      padding: 10px;
+      color: var(--muted);
+    }
+    @media (max-width: 980px) {
+      header { align-items: flex-start; flex-direction: column; }
+      form { margin-left: 0; width: 100%; }
+      .file-field { width: 100%; grid-template-columns: 82px minmax(0, 1fr); }
+      .file-field span { text-align: left; }
+      input[type="file"], select { width: 100%; max-width: none; }
+      .graph-head { align-items: flex-start; flex-direction: column; }
+      .graph-tools { width: 100%; justify-content: flex-start; }
+      .graph-tools label { min-width: 100%; }
+      main { grid-template-columns: 1fr; }
+      body { overflow: auto; }
+      main { overflow: visible; }
+      aside { overflow: visible; }
+      #graph, .chart, .ranked-list { height: 62vh; }
+      .rank-row summary { grid-template-columns: 42px minmax(0, 1fr); }
+      .rank-row summary span, .rank-row summary code { grid-column: 2; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>pprof viewer</h1>
+    <div id="status" class="status">Upload a pprof folder or profile files.</div>
+    <form id="upload">
+      <label class="file-field bulk-field"><span>Files</span><input id="profile-files" name="profiles" type="file" title="profile files" multiple></label>
+      <label class="file-field bulk-field"><span>Folder</span><input id="profile-folder" name="profile_folder" type="file" title="profile folder" multiple webkitdirectory directory></label>
+      <button type="submit">Analyze</button>
+    </form>
+  </header>
+
+  <main>
+    <section class="panel">
+      <div id="tabs" class="tabs"></div>
+      <div id="view-tabs" class="view-tabs"></div>
+      <div class="graph-head">
+        <h2>Allocation / CPU Views</h2>
+        <div class="graph-tools">
+          <label>
+            min node
+            <input id="min-filter" type="range" min="0" max="100" value="0" step="1">
+            <strong id="min-filter-label">all</strong>
+          </label>
+          <div id="active-filter" class="active-filter hidden">
+            filter <strong id="active-filter-label"></strong>
+            <button id="clear-active-filter" class="ghost-btn" type="button">Clear</button>
+          </div>
+          <button id="reset-view" class="ghost-btn" type="button">Reset</button>
+          <button id="generate-report" class="ghost-btn" type="button">Report</button>
+        </div>
+      </div>
+      <div id="report-panel" class="report-panel hidden">
+        <div class="report-head">
+          <strong>Harness Report</strong>
+          <div class="report-actions">
+            <button id="copy-report" class="ghost-btn" type="button">Copy</button>
+            <button id="download-report" class="ghost-btn" type="button">Download</button>
+          </div>
+        </div>
+        <textarea id="report-output" spellcheck="false"></textarea>
+      </div>
+      <svg id="graph" class="view" role="img" aria-label="profile graph"></svg>
+      <div id="profile-list" class="view ranked-list hidden"></div>
+      <svg id="line-chart" class="view chart hidden" role="img" aria-label="ranked line chart"></svg>
+      <svg id="pie-chart" class="view chart hidden" role="img" aria-label="profile pie chart"></svg>
+    </section>
+    <aside>
+      <section class="panel">
+        <h2>Profile</h2>
+        <div class="metrics">
+          <div class="metric"><span>type</span><strong id="m-type">-</strong></div>
+          <div class="metric"><span>sample</span><strong id="m-sample">-</strong></div>
+          <div class="metric"><span>total</span><strong id="m-total">-</strong></div>
+          <div class="metric"><span>heap</span><strong id="m-heap">-</strong></div>
+          <div class="metric"><span>cpu</span><strong id="m-cpu">-</strong></div>
+          <div class="metric"><span>goroutines</span><strong id="m-goroutines">-</strong></div>
+        </div>
+      </section>
+      <section class="panel">
+        <h2>Potential Leaks</h2>
+        <div id="leaks" class="list scroll-list"></div>
+      </section>
+      <section class="panel">
+        <h2>Hot Paths</h2>
+        <div id="paths" class="list scroll-list"></div>
+      </section>
+    </aside>
+  </main>
+
+  <dialog id="detail-dialog">
+    <div class="detail-dialog-head">
+      <h2 id="detail-title">Details</h2>
+      <button id="detail-close" class="ghost-btn" type="button">Close</button>
+    </div>
+    <div id="detail-body" class="detail-dialog-body"></div>
+  </dialog>
+
+  <script>
+    const form = document.querySelector('#upload');
+    const profileFiles = document.querySelector('#profile-files');
+    const profileFolder = document.querySelector('#profile-folder');
+    const statusEl = document.querySelector('#status');
+    const minFilter = document.querySelector('#min-filter');
+    const minFilterLabel = document.querySelector('#min-filter-label');
+    const activeFilterEl = document.querySelector('#active-filter');
+    const activeFilterLabel = document.querySelector('#active-filter-label');
+    const clearActiveFilter = document.querySelector('#clear-active-filter');
+    const resetView = document.querySelector('#reset-view');
+    const generateReport = document.querySelector('#generate-report');
+    const reportPanel = document.querySelector('#report-panel');
+    const reportOutput = document.querySelector('#report-output');
+    const copyReport = document.querySelector('#copy-report');
+    const downloadReport = document.querySelector('#download-report');
+    const tabs = document.querySelector('#tabs');
+    const viewTabs = document.querySelector('#view-tabs');
+    const graphView = document.querySelector('#graph');
+    const listView = document.querySelector('#profile-list');
+    const lineChart = document.querySelector('#line-chart');
+    const pieChart = document.querySelector('#pie-chart');
+    const detailDialog = document.querySelector('#detail-dialog');
+    const detailTitle = document.querySelector('#detail-title');
+    const detailBody = document.querySelector('#detail-body');
+    const detailClose = document.querySelector('#detail-close');
+    const profileSetNames = ['heap', 'allocs', 'cpu', 'goroutine', 'block', 'mutex'];
+    let currentData = null;
+    let currentSet = null;
+    let activeTab = 'cross';
+    let activeView = 'graph';
+    let activeFilter = null;
+    let graphState = newGraphState();
+
+    function newGraphState() {
+      return { scale: 1, tx: 0, ty: 0, selected: null, positions: {} };
+    }
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const files = selectedProfileFiles();
+      if (!files.length) return;
+      await analyzeSet(files);
+    });
+
+    profileFiles.addEventListener('change', () => updateUploadStatus());
+    profileFolder.addEventListener('change', () => updateUploadStatus());
+
+    minFilter.addEventListener('input', () => {
+      if (currentData) renderRepresentation(currentData);
+    });
+
+    resetView.addEventListener('click', () => {
+      activeFilter = null;
+      graphState = newGraphState();
+      renderFilterState();
+      if (currentData) renderRepresentation(currentData);
+    });
+
+    clearActiveFilter.addEventListener('click', () => {
+      activeFilter = null;
+      graphState = newGraphState();
+      renderFilterState();
+      if (currentData) renderRepresentation(currentData);
+    });
+
+    generateReport.addEventListener('click', () => {
+      if (!currentData && !currentSet) return;
+      reportOutput.value = buildHarnessReport();
+      reportPanel.classList.remove('hidden');
+      statusEl.textContent = 'Generated harness report.';
+    });
+
+    copyReport.addEventListener('click', async () => {
+      if (!reportOutput.value) return;
+      try {
+        await navigator.clipboard.writeText(reportOutput.value);
+        statusEl.textContent = 'Copied harness report.';
+      } catch {
+        reportOutput.focus();
+        reportOutput.select();
+        statusEl.textContent = 'Select-all report text for copying.';
+      }
+    });
+
+    downloadReport.addEventListener('click', () => {
+      if (!reportOutput.value) return;
+      const blob = new Blob([reportOutput.value], {type: 'text/markdown'});
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `pprof-harness-report-${new Date().toISOString().replace(/[:.]/g, '-')}.md`;
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+
+    detailClose.addEventListener('click', () => detailDialog.close());
+
+    window.addEventListener('DOMContentLoaded', async () => {
+      const params = new URLSearchParams(location.search);
+      const resultID = params.get('result_id') || localStorage.getItem('pprofviewer:last_result_id');
+      if (resultID && !params.get('path') && !hasProfilePathParam(params)) {
+        await restoreResult(resultID);
+        return;
+      }
+      const path = params.get('path');
+      const sampleType = params.get('sample') || '';
+      if (path) {
+        await analyzePath(path, sampleType);
+        return;
+      }
+      if (hasProfilePathParam(params)) {
+        await analyzePathSet(params);
+      }
+    });
+
+    async function analyze(profileFile, sampleType) {
+      statusEl.textContent = 'Analyzing...';
+      const body = new FormData();
+      body.append('profile', profileFile);
+      const res = await fetch('/api/analyze' + (sampleType ? '?sample=' + encodeURIComponent(sampleType) : ''), {
+        method: 'POST',
+        body
+      });
+      if (!res.ok) {
+        statusEl.textContent = await res.text();
+        return;
+      }
+      const data = await res.json();
+      render(data);
+      rememberResult(data);
+      statusEl.textContent = `${data.nodes.length} nodes, ${data.edges.length} edges`;
+    }
+
+    async function analyzeSet(files) {
+      statusEl.textContent = 'Analyzing profiles...';
+      const body = new FormData();
+      for (const profileFile of files) {
+        body.append('profiles', profileFile, profileFile.webkitRelativePath || profileFile.name);
+      }
+      const res = await fetch('/api/analyze-set', { method: 'POST', body });
+      if (!res.ok) {
+        statusEl.textContent = await res.text();
+        return;
+      }
+      const data = await res.json();
+      renderSet(data);
+      rememberResult(data);
+      statusEl.textContent = `${(data.profiles || []).map(p => p.name).join(', ')} profiles loaded`;
+    }
+
+    function selectedProfileFiles() {
+      const files = [
+        ...Array.from(profileFiles.files || []),
+        ...Array.from(profileFolder.files || [])
+      ];
+      const seen = new Set();
+      return files.filter(file => {
+        const key = `${file.webkitRelativePath || file.name}:${file.size}:${file.lastModified}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return isLikelyProfileFile(file);
+      });
+    }
+
+    function updateUploadStatus() {
+      const files = selectedProfileFiles();
+      if (!files.length) {
+        statusEl.textContent = 'Upload a pprof folder or profile files.';
+        return;
+      }
+      const inferred = files.map(file => inferProfileName(file.webkitRelativePath || file.name)).filter(Boolean);
+      statusEl.textContent = inferred.length
+        ? `Ready: ${[...new Set(inferred)].join(', ')}`
+        : `${files.length} profile file${files.length === 1 ? '' : 's'} selected`;
+    }
+
+    function isLikelyProfileFile(file) {
+      const path = (file.webkitRelativePath || file.name || '').toLowerCase();
+      if (path.endsWith('.prof') || path.endsWith('.pprof') || path.endsWith('.pb') || path.endsWith('.pb.gz')) return true;
+      return Boolean(inferProfileName(path));
+    }
+
+    function inferProfileName(path) {
+      const base = String(path || '').split('/').pop().toLowerCase()
+        .replace(/\.gz$/, '')
+        .replace(/\.pb$/, '')
+        .replace(/\.pprof$/, '')
+        .replace(/\.prof$/, '')
+        .replace(/\.txt$/, '')
+        .replace(/\.out$/, '');
+      if (['heap', 'inuse', 'mem', 'memory'].includes(base)) return 'heap';
+      if (['alloc', 'allocs', 'allocations'].includes(base)) return 'allocs';
+      if (['cpu', 'profile'].includes(base)) return 'cpu';
+      if (['goroutine', 'goroutines'].includes(base)) return 'goroutine';
+      if (['block', 'blocking'].includes(base)) return 'block';
+      if (['mutex', 'mutator'].includes(base)) return 'mutex';
+      for (const part of base.replace(/[-. ]/g, '_').split('_')) {
+        if (part === 'heap' || part === 'inuse') return 'heap';
+        if (part === 'alloc' || part === 'allocs') return 'allocs';
+        if (part === 'cpu') return 'cpu';
+        if (part === 'goroutine' || part === 'goroutines') return 'goroutine';
+        if (part === 'block') return 'block';
+        if (part === 'mutex') return 'mutex';
+      }
+      return '';
+    }
+
+    async function analyzePath(path, sampleType) {
+      statusEl.textContent = 'Analyzing path...';
+      const params = new URLSearchParams({ path });
+      if (sampleType) params.set('sample', sampleType);
+      const res = await fetch('/api/analyze?' + params.toString());
+      if (!res.ok) {
+        statusEl.textContent = await res.text();
+        return;
+      }
+      const data = await res.json();
+      render(data);
+      rememberResult(data);
+      statusEl.textContent = `${data.nodes.length} nodes, ${data.edges.length} edges`;
+    }
+
+    async function analyzePathSet(params) {
+      statusEl.textContent = 'Analyzing profile paths...';
+      const res = await fetch('/api/analyze-set?' + params.toString());
+      if (!res.ok) {
+        statusEl.textContent = await res.text();
+        return;
+      }
+      const data = await res.json();
+      renderSet(data);
+      rememberResult(data);
+    }
+
+    async function restoreResult(id) {
+      statusEl.textContent = 'Restoring cached profiles...';
+      const res = await fetch('/api/result?id=' + encodeURIComponent(id));
+      if (!res.ok) {
+        localStorage.removeItem('pprofviewer:last_result_id');
+        statusEl.textContent = 'Cached profiles expired. Upload the files again.';
+        return;
+      }
+      const data = await res.json();
+      if (data.profiles) {
+        renderSet(data);
+        statusEl.textContent = 'Restored cached profile set.';
+      } else {
+        render(data);
+        statusEl.textContent = 'Restored cached profile.';
+      }
+      rememberResult(data);
+    }
+
+    function rememberResult(data) {
+      if (!data || !data.id) return;
+      localStorage.setItem('pprofviewer:last_result_id', data.id);
+      const params = new URLSearchParams(location.search);
+      params.delete('path');
+      params.delete('sample');
+      for (const name of profileSetNames) params.delete(`${name}_path`);
+      params.set('result_id', data.id);
+      history.replaceState(null, '', `${location.pathname}?${params.toString()}`);
+    }
+
+    function hasProfilePathParam(params) {
+      return profileSetNames.some(name => params.get(`${name}_path`));
+    }
+
+    function render(data) {
+      currentSet = null;
+      currentData = data;
+      activeFilter = null;
+      graphState.selected = null;
+      activeTab = data.profile_type || 'profile';
+      renderTabs([{name: activeTab}]);
+      renderViewTabs();
+      document.querySelector('#m-type').textContent = data.profile_type;
+      document.querySelector('#m-sample').textContent = `${data.sample_type} (${data.unit})`;
+      document.querySelector('#m-total').textContent = formatValue(data.total, data.unit);
+      document.querySelector('#m-heap').textContent = data.profile_type === 'heap' ? formatValue(data.total, data.unit) : '-';
+      document.querySelector('#m-cpu').textContent = data.profile_type === 'cpu' ? formatValue(data.total, data.unit) : '-';
+      document.querySelector('#m-goroutines').textContent = data.profile_type === 'goroutine' ? formatValue(data.total, data.unit) : '-';
+      updateSampleOptions(data.sample_types, data.sample_type);
+      renderFilterState();
+      renderRepresentation(data);
+      renderLeaks(data);
+      renderPaths(data);
+    }
+
+    function updateSampleOptions(types, selected) {
+      void types;
+      void selected;
+    }
+
+    function renderSet(data) {
+      currentSet = data;
+      activeFilter = null;
+      graphState.selected = null;
+      const names = (data.profiles || []).map(p => p.name);
+      activeTab = names.length > 1 && data.cross_map ? 'cross' : names[0];
+      renderTabs([{name: 'cross'}, ...(data.profiles || [])].filter(t => t.name !== 'cross' || (data.cross_map || []).length));
+      renderViewTabs();
+      renderFilterState();
+      renderOverall(data);
+      renderActiveTab();
+    }
+
+    function renderTabs(items) {
+      tabs.innerHTML = '';
+      for (const item of items) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'tab' + (item.name === activeTab ? ' active' : '');
+        btn.textContent = item.name;
+        btn.addEventListener('click', () => {
+          activeTab = item.name;
+          activeFilter = null;
+          graphState = newGraphState();
+          renderFilterState();
+          renderTabs(items);
+          renderActiveTab();
+        });
+        tabs.appendChild(btn);
+      }
+    }
+
+    function renderViewTabs() {
+      const views = [
+        ['graph', 'Graph Nodes'],
+        ['list', 'List'],
+        ['line', 'Line Graph'],
+        ['pie', 'Pie Chart']
+      ];
+      viewTabs.innerHTML = '';
+      for (const [id, label] of views) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'tab' + (id === activeView ? ' active' : '');
+        btn.textContent = label;
+        btn.addEventListener('click', () => {
+          activeView = id;
+          renderViewTabs();
+          if (currentData) renderRepresentation(currentData);
+        });
+        viewTabs.appendChild(btn);
+      }
+    }
+
+    function renderOverall(data) {
+      document.querySelector('#m-type').textContent = (data.profiles || []).map(p => p.name).join(' + ') || '-';
+      document.querySelector('#m-sample').textContent = 'combined';
+      document.querySelector('#m-total').textContent = formatValue(data.overall?.profiled_samples || 0, 'samples');
+      document.querySelector('#m-heap').textContent = data.overall?.heap_bytes ? formatValue(data.overall.heap_bytes, 'bytes') : '-';
+      document.querySelector('#m-cpu').textContent = data.overall?.cpu_time_nanos ? formatValue(data.overall.cpu_time_nanos, 'nanoseconds') : (data.overall?.cpu_samples ? formatValue(data.overall.cpu_samples, 'samples') : '-');
+      document.querySelector('#m-goroutines').textContent = data.overall?.goroutines ? formatValue(data.overall.goroutines, 'goroutines') : '-';
+    }
+
+    function renderActiveTab() {
+      if (!currentSet) return;
+      if (activeTab === 'cross') {
+        const cross = crossAnalysis(currentSet);
+        currentData = cross;
+        renderRepresentation(cross);
+        renderCrossMap(currentSet);
+        renderPaths(cross);
+        return;
+      }
+      const found = (currentSet.profiles || []).find(p => p.name === activeTab);
+      if (!found) return;
+      currentData = found.profile;
+      document.querySelector('#m-sample').textContent = `${found.profile.sample_type} (${found.profile.unit})`;
+      document.querySelector('#m-total').textContent = formatValue(found.profile.total, found.profile.unit);
+      renderRepresentation(found.profile);
+      renderLeaks(found.profile);
+      renderPaths(found.profile);
+    }
+
+    function buildHarnessReport() {
+      const lines = [];
+      const resultID = currentSet?.id || currentData?.id || '';
+      lines.push('# pprof Harness Investigation Report');
+      lines.push('');
+      lines.push(`Generated: ${new Date().toISOString()}`);
+      if (resultID) lines.push(`Viewer result id: ${resultID}`);
+      lines.push(`Active profile tab: ${activeTab}`);
+      lines.push(`Active representation: ${activeView}`);
+      lines.push(`Minimum node filter: ${minFilter.value}%`);
+      lines.push('');
+
+      if (currentSet) {
+        appendSetSummary(lines, currentSet);
+        appendCrossMapReport(lines, currentSet);
+        for (const entry of currentSet.profiles || []) {
+          appendProfileReport(lines, entry.name, entry.profile);
+        }
+      } else if (currentData) {
+        appendProfileReport(lines, currentData.profile_type || 'profile', currentData);
+      }
+
+      lines.push('## Suggested Coding Harness Prompts');
+      lines.push('');
+      lines.push('- Inspect the top functions above in the repository and map them to long-lived owners, caches, goroutines, request paths, or provider clients.');
+      lines.push('- For heap-heavy functions, look for retained references, unbounded maps/slices, missed Close/Release calls, and pool objects not fully reset before Put.');
+      lines.push('- For CPU-heavy functions, inspect tight loops, repeated parsing/marshalling, lock contention, and retry/fallback amplification.');
+      lines.push('- For goroutine-heavy paths, inspect blocked channel sends/receives, missing context cancellation, background workers, stream readers, and HTTP client response handling.');
+      lines.push('- If cross-map rows exist, prioritize functions that are simultaneously heap-heavy and CPU/goroutine-heavy before isolated hotspots.');
+      lines.push('');
+      lines.push('## Raw JSON Pointers');
+      lines.push('');
+      lines.push('- `profiles[].profile.nodes[]`: ranked graph/list nodes with `flat`, `cumulative`, `file`, and `line`.');
+      lines.push('- `profiles[].profile.leaks[]`: retained heap candidates with stack paths.');
+      lines.push('- `profiles[].profile.top_paths[]`: hottest stack paths.');
+      lines.push('- `cross_map[]`: functions shared across heap, CPU, and goroutine profiles.');
+      return lines.join('\n');
+    }
+
+    function appendSetSummary(lines, data) {
+      lines.push('## Overall Usage');
+      lines.push('');
+      lines.push(`- Profiles: ${(data.profiles || []).map(p => p.name).join(', ') || 'none'}`);
+      lines.push(`- Heap: ${data.overall?.heap_bytes ? formatValue(data.overall.heap_bytes, 'bytes') : 'n/a'}`);
+      lines.push(`- CPU: ${data.overall?.cpu_time_nanos ? formatValue(data.overall.cpu_time_nanos, 'nanoseconds') : (data.overall?.cpu_samples ? formatValue(data.overall.cpu_samples, 'samples') : 'n/a')}`);
+      lines.push(`- Goroutines: ${data.overall?.goroutines ? formatValue(data.overall.goroutines, 'goroutines') : 'n/a'}`);
+      lines.push(`- Profiled samples total: ${formatValue(data.overall?.profiled_samples || 0, 'samples')}`);
+      lines.push('');
+    }
+
+    function appendCrossMapReport(lines, data) {
+      lines.push('## Cross-Profile Map');
+      lines.push('');
+      const rows = data.cross_map || [];
+      if (!rows.length) {
+        lines.push('No shared functions were found across the supplied profiles.');
+        lines.push('');
+        return;
+      }
+      lines.push('| Rank | Function | Profiles | Heap | CPU | Goroutines | File |');
+      lines.push('|---:|---|---|---:|---:|---:|---|');
+      rows.slice(0, 25).forEach((row, i) => {
+        lines.push(`| ${i + 1} | ${md(row.function)} | ${md((row.profiles || []).join(' + '))} | ${row.heap_bytes ? formatValue(row.heap_bytes, 'bytes') : '-'} | ${row.cpu_value ? formatValue(row.cpu_value, row.cpu_unit || 'samples') : '-'} | ${row.goroutines ? formatValue(row.goroutines, 'goroutines') : '-'} | ${md(row.file || '-')} |`);
+      });
+      lines.push('');
+    }
+
+    function appendProfileReport(lines, name, profile) {
+      if (!profile) return;
+      lines.push(`## ${name} Profile`);
+      lines.push('');
+      lines.push(`- Type: ${profile.profile_type}`);
+      lines.push(`- Sample: ${profile.sample_type} (${profile.unit})`);
+      lines.push(`- Total: ${formatValue(profile.total, profile.unit)}`);
+      lines.push('');
+      lines.push('### Top Nodes');
+      lines.push('');
+      lines.push('| Rank | Function | Cumulative | Flat | Percent | Location |');
+      lines.push('|---:|---|---:|---:|---:|---|');
+      filteredReportNodes(profile).slice(0, 30).forEach((node, i) => {
+        lines.push(`| ${i + 1} | ${md(node.name)} | ${formatValue(node.cumulative, profile.unit)} | ${formatValue(node.flat, profile.unit)} | ${node.percent.toFixed(1)}% | ${md(locationFor(node))} |`);
+      });
+      lines.push('');
+      if (profile.leaks && profile.leaks.length) {
+        lines.push('### Potential Leaks');
+        lines.push('');
+        profile.leaks.slice(0, 15).forEach((leak, i) => {
+          lines.push(`${i + 1}. ${leak.function} - ${formatValue(leak.retained_bytes, 'bytes')} retained`);
+          lines.push(`   - Reason: ${leak.reason}`);
+          lines.push(`   - Location: ${locationFor(leak)}`);
+          lines.push(`   - Path: ${(leak.path || []).join(' -> ')}`);
+        });
+        lines.push('');
+      }
+      if (profile.top_paths && profile.top_paths.length) {
+        lines.push('### Hot Paths');
+        lines.push('');
+        profile.top_paths.slice(0, 10).forEach((path, i) => {
+          lines.push(`${i + 1}. ${formatValue(path.value, profile.unit)} (${path.percent.toFixed(1)}%)`);
+          lines.push(`   - ${(path.path || []).join(' -> ')}`);
+        });
+        lines.push('');
+      }
+    }
+
+    function filteredReportNodes(profile) {
+      const nodes = filteredNodes(profile);
+      return nodes.length ? nodes : (profile.nodes || []);
+    }
+
+    function locationFor(item) {
+      if (!item.file) return '-';
+      return `${item.file}${item.line ? ':' + item.line : ''}`;
+    }
+
+    function md(value) {
+      return String(value || '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+    }
+
+    function renderLeaks(data) {
+      const leaks = document.querySelector('#leaks');
+      leaks.innerHTML = '';
+      if (!data.leaks || data.leaks.length === 0) {
+        leaks.textContent = data.profile_type === 'heap' ? 'No retained heap samples found.' : 'Leak hints are available for heap profiles.';
+        return;
+      }
+      for (const leak of data.leaks.slice(0, 12)) {
+        const el = document.createElement('div');
+        el.className = 'item clickable';
+        el.tabIndex = 0;
+        el.innerHTML = `<strong>${escapeHtml(shortName(leak.function))}</strong>`;
+        attachDetailOpen(el, () => showDetailDialog('Potential Leak', [
+          ['Function', leak.function],
+          ['Retained', formatValue(leak.retained_bytes, 'bytes')],
+          ['Allocated', leak.alloc_bytes ? formatValue(leak.alloc_bytes, 'bytes') : '-'],
+          ['Objects', leak.objects ? leak.objects.toLocaleString() : '-'],
+          ['Reason', leak.reason],
+          ['Location', locationFor(leak)]
+        ], (leak.path || []).join(' -> ')));
+        el.appendChild(filterButton(`Filter by ${shortName(leak.function)}`, leak.function, leakFilterTerms(leak)));
+        leaks.appendChild(el);
+      }
+    }
+
+    function renderCrossMap(data) {
+      const leaks = document.querySelector('#leaks');
+      leaks.innerHTML = '';
+      const rows = data.cross_map || [];
+      if (!rows.length) {
+        leaks.textContent = 'No shared functions found across the supplied profiles.';
+        return;
+      }
+      for (const row of rows.slice(0, 30)) {
+        const el = document.createElement('div');
+        el.className = 'item clickable';
+        el.tabIndex = 0;
+        el.innerHTML = `<strong>${escapeHtml(shortName(row.function))}</strong>`;
+        attachDetailOpen(el, () => showDetailDialog('Cross-Profile Hotspot', [
+          ['Function', row.function],
+          ['Profiles', (row.profiles || []).join(' + ')],
+          ['Heap', row.heap_bytes ? formatValue(row.heap_bytes, 'bytes') : '-'],
+          ['Allocated', row.allocated_bytes ? formatValue(row.allocated_bytes, 'bytes') : '-'],
+          ['CPU', row.cpu_value ? formatValue(row.cpu_value, row.cpu_unit || 'samples') : '-'],
+          ['Goroutines', row.goroutines ? formatValue(row.goroutines, 'goroutines') : '-'],
+          ['File', row.file || '-']
+        ], ''));
+        el.appendChild(filterButton(`Filter by ${shortName(row.function)}`, row.function, [row.function]));
+        leaks.appendChild(el);
+      }
+    }
+
+    function renderPaths(data) {
+      const paths = document.querySelector('#paths');
+      paths.innerHTML = '';
+      for (const path of (data.top_paths || []).slice(0, 10)) {
+        const el = document.createElement('div');
+        el.className = 'item clickable';
+        el.tabIndex = 0;
+        const title = (path.path || [])[0] || `${formatValue(path.value, data.unit)} path`;
+        el.innerHTML = `<strong>${escapeHtml(shortName(title))}</strong>`;
+        attachDetailOpen(el, () => showDetailDialog('Hot Path', [
+          ['Value', formatValue(path.value, data.unit)],
+          ['Percent', `${path.percent.toFixed(1)}%`],
+          ['Sample', `${data.sample_type} (${data.unit})`]
+        ], (path.path || []).join(' -> ')));
+        el.appendChild(filterButton(`Filter by ${shortName(title)}`, title, pathFilterTerms(path)));
+        paths.appendChild(el);
+      }
+    }
+
+    function attachDetailOpen(el, open) {
+      el.addEventListener('click', open);
+      el.addEventListener('keydown', event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          open();
+        }
+      });
+    }
+
+    function filterButton(title, label, terms) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'filter-btn' + (isSameFilter(terms) ? ' active' : '');
+      btn.title = title;
+      btn.setAttribute('aria-label', title);
+      btn.textContent = '⌕';
+      btn.addEventListener('click', event => {
+        event.stopPropagation();
+        activeFilter = { label, terms: normalizeTerms(terms) };
+        graphState = newGraphState();
+        renderFilterState();
+        if (currentData) renderRepresentation(currentData);
+      });
+      return btn;
+    }
+
+    function isSameFilter(terms) {
+      if (!activeFilter) return false;
+      const next = normalizeTerms(terms);
+      return next.length === activeFilter.terms.length && next.every((term, index) => term === activeFilter.terms[index]);
+    }
+
+    function renderFilterState() {
+      if (!activeFilter || !activeFilter.terms.length) {
+        activeFilterEl.classList.add('hidden');
+        activeFilterLabel.textContent = '';
+        return;
+      }
+      activeFilterEl.classList.remove('hidden');
+      activeFilterLabel.textContent = activeFilter.label;
+    }
+
+    function leakFilterTerms(leak) {
+      return [leak.function, leak.file, ...(leak.path || [])];
+    }
+
+    function pathFilterTerms(path) {
+      return path.path || [];
+    }
+
+    function normalizeTerms(terms) {
+      const out = [];
+      const seen = new Set();
+      for (const term of terms || []) {
+        for (const candidate of termCandidates(term)) {
+          if (!candidate || seen.has(candidate)) continue;
+          seen.add(candidate);
+          out.push(candidate);
+        }
+      }
+      return out;
+    }
+
+    function termCandidates(value) {
+      const raw = String(value || '').trim();
+      if (!raw) return [];
+      const withoutLocation = raw.replace(/\s+\([^)]*\)$/, '');
+      const short = shortName(withoutLocation);
+      return [raw, withoutLocation, short].map(normalizeMatchText).filter(Boolean);
+    }
+
+    function normalizeMatchText(value) {
+      return String(value || '').toLowerCase().replace(/\s+/g, ' ').trim();
+    }
+
+    function showDetailDialog(title, rows, code) {
+      detailTitle.textContent = title;
+      const dl = document.createElement('dl');
+      for (const [label, value] of rows) {
+        const dt = document.createElement('dt');
+        dt.textContent = label;
+        const dd = document.createElement('dd');
+        dd.textContent = value || '-';
+        dl.append(dt, dd);
+      }
+      detailBody.innerHTML = '';
+      detailBody.appendChild(dl);
+      if (code) {
+        const block = document.createElement('code');
+        block.textContent = code;
+        detailBody.appendChild(block);
+      }
+      detailDialog.showModal();
+    }
+
+    function crossAnalysis(data) {
+      const rows = data.cross_map || [];
+      const total = Math.max(rows.reduce((sum, row) => sum + Math.round(row.score * 1000), 0), 1);
+      const nodes = rows.slice(0, 80).map((row, i) => {
+        const value = Math.max(1, Math.round(row.score * 1000));
+        return {
+          id: `cross:${i}:${row.function}`,
+          name: row.function,
+          file: row.file,
+          flat: value,
+          cumulative: value,
+          percent: value / total * 100,
+          kind: row.profiles && row.profiles.length > 2 ? 'hot' : 'app'
+        };
+      });
+      return {
+        profile_type: 'cross',
+        sample_type: 'cross_score',
+        unit: 'score',
+        total,
+        nodes,
+        edges: [],
+        leaks: [],
+        top_paths: rows.slice(0, 20).map(row => ({
+          value: Math.round(row.score * 1000),
+          percent: row.score,
+          path: [
+            row.function,
+            `profiles: ${(row.profiles || []).join(' + ')}`,
+            [
+              row.heap_bytes ? `heap ${formatValue(row.heap_bytes, 'bytes')}` : '',
+              row.cpu_value ? `cpu ${formatValue(row.cpu_value, row.cpu_unit || 'samples')}` : '',
+              row.goroutines ? `goroutines ${formatValue(row.goroutines, 'goroutines')}` : ''
+            ].filter(Boolean).join(' · ')
+          ].filter(Boolean)
+        })),
+        sample_types: []
+      };
+    }
+
+    function renderRepresentation(data) {
+      for (const el of [graphView, listView, lineChart, pieChart]) el.classList.add('hidden');
+      graphHeadVisible(activeView === 'graph');
+      if (activeView === 'graph') {
+        graphView.classList.remove('hidden');
+        renderGraph(data);
+        return;
+      }
+      if (activeView === 'list') {
+        listView.classList.remove('hidden');
+        renderNodeList(data);
+        return;
+      }
+      if (activeView === 'line') {
+        lineChart.classList.remove('hidden');
+        renderLineChart(data);
+        return;
+      }
+      pieChart.classList.remove('hidden');
+      renderPieChart(data);
+    }
+
+    function graphHeadVisible(visible) {
+      void visible;
+      document.querySelector('.graph-head').style.display = 'flex';
+    }
+
+    function filteredNodes(data) {
+      const sourceNodes = data.nodes || [];
+      const activeNodes = activeFilter?.terms?.length ? sourceNodes.filter(nodeMatchesActiveFilter) : sourceNodes;
+      const fullMax = Math.max(...activeNodes.map(n => n.cumulative), 1);
+      const threshold = fullMax * Number(minFilter.value || 0) / 100;
+      minFilterLabel.textContent = threshold > 0 ? formatValue(threshold, data.unit) : 'all';
+      return activeNodes
+        .filter(n => n.cumulative >= threshold)
+        .sort((a, b) => b.cumulative - a.cumulative);
+    }
+
+    function nodeMatchesActiveFilter(node) {
+      if (!activeFilter?.terms?.length) return true;
+      const haystack = normalizeMatchText([node.name, node.file, node.kind].filter(Boolean).join(' '));
+      return activeFilter.terms.some(term => haystack.includes(term) || term.includes(normalizeMatchText(node.name)));
+    }
+
+    function renderNodeList(data) {
+      const nodes = filteredNodes(data);
+      listView.innerHTML = '';
+      const max = Math.max(...nodes.map(n => n.cumulative), 1);
+      nodes.forEach((node, index) => {
+        const row = document.createElement('details');
+        row.className = 'rank-row';
+        row.innerHTML = `<summary>
+            <span>#${index + 1}</span>
+            <strong>${escapeHtml(node.name)}</strong>
+            <span>${formatValue(node.cumulative, data.unit)}</span>
+            <span>${node.percent.toFixed(1)}%</span>
+          </summary>
+          <div class="rank-body">
+            <div class="bar"><i style="width:${Math.max(2, node.cumulative / max * 100)}%"></i></div>
+            <code>${escapeHtml(node.file || '')}${node.line ? ':' + node.line : ''}</code>
+            <code>flat ${formatValue(node.flat, data.unit)} · cumulative ${formatValue(node.cumulative, data.unit)} · kind ${escapeHtml(node.kind || '-')}</code>
+          </div>`;
+        listView.appendChild(row);
+      });
+      statusEl.textContent = `${nodes.length} ranked nodes`;
+    }
+
+    function renderLineChart(data) {
+      const svg = lineChart;
+      svg.innerHTML = '';
+      const nodes = filteredNodes(data).slice(0, 80);
+      const width = svg.clientWidth || 900;
+      const height = svg.clientHeight || 560;
+      const pad = {left: 56, right: 22, top: 28, bottom: 54};
+      svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+      drawAxes(svg, width, height, pad);
+      if (!nodes.length) return;
+      const max = Math.max(...nodes.map(n => n.cumulative), 1);
+      const points = nodes.map((node, i) => {
+        const x = pad.left + (nodes.length === 1 ? 0 : i / (nodes.length - 1)) * (width - pad.left - pad.right);
+        const y = height - pad.bottom - (node.cumulative / max) * (height - pad.top - pad.bottom);
+        return {x, y, node};
+      });
+      svg.appendChild(svgEl('polyline', {
+        points: points.map(p => `${p.x},${p.y}`).join(' '),
+        fill: 'none',
+        stroke: '#0f766e',
+        'stroke-width': 3
+      }));
+      for (const p of points) {
+        const dot = svgEl('circle', {cx: p.x, cy: p.y, r: 4, fill: colorFor(p.node)});
+        const title = svgEl('title', {});
+        title.textContent = `${p.node.name}\n${formatValue(p.node.cumulative, data.unit)}`;
+        dot.appendChild(title);
+        svg.appendChild(dot);
+      }
+      svg.appendChild(svgText(12, 18, `Highest to lowest ${data.sample_type}`, 13, '#111827'));
+      statusEl.textContent = `${nodes.length} ranked points`;
+    }
+
+    function renderPieChart(data) {
+      const svg = pieChart;
+      svg.innerHTML = '';
+      const nodes = filteredNodes(data).slice(0, 20);
+      const width = svg.clientWidth || 900;
+      const height = svg.clientHeight || 560;
+      svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+      if (!nodes.length) return;
+      const cx = Math.min(width * .38, width - 300);
+      const cy = height / 2;
+      const r = Math.min(width, height) * .32;
+      const total = nodes.reduce((sum, n) => sum + n.cumulative, 0);
+      let angle = -Math.PI / 2;
+      nodes.forEach((node, i) => {
+        const slice = node.cumulative / total * Math.PI * 2;
+        const path = pieSlice(cx, cy, r, angle, angle + slice);
+        const el = svgEl('path', {d: path, fill: palette(i), stroke: '#fff', 'stroke-width': 1.5});
+        const title = svgEl('title', {});
+        title.textContent = `${node.name}\n${formatValue(node.cumulative, data.unit)} · ${((node.cumulative / total) * 100).toFixed(1)}%`;
+        el.appendChild(title);
+        svg.appendChild(el);
+        angle += slice;
+      });
+      nodes.slice(0, 14).forEach((node, i) => {
+        const y = 38 + i * 28;
+        svg.appendChild(svgEl('rect', {x: width * .64, y: y - 10, width: 12, height: 12, fill: palette(i)}));
+        svg.appendChild(svgText(width * .64 + 18, y, `${shortName(node.name)} · ${formatValue(node.cumulative, data.unit)}`, 12, '#111827'));
+      });
+      statusEl.textContent = `${nodes.length} pie slices`;
+    }
+
+    function drawAxes(svg, width, height, pad) {
+      svg.appendChild(svgEl('line', {x1: pad.left, y1: height - pad.bottom, x2: width - pad.right, y2: height - pad.bottom, stroke: '#9aa5b1'}));
+      svg.appendChild(svgEl('line', {x1: pad.left, y1: pad.top, x2: pad.left, y2: height - pad.bottom, stroke: '#9aa5b1'}));
+      svg.appendChild(svgText(pad.left, height - 18, 'rank', 12, '#5b6472'));
+      svg.appendChild(svgText(12, pad.top + 8, 'value', 12, '#5b6472'));
+    }
+
+    function pieSlice(cx, cy, r, start, end) {
+      const large = end - start > Math.PI ? 1 : 0;
+      const x1 = cx + Math.cos(start) * r;
+      const y1 = cy + Math.sin(start) * r;
+      const x2 = cx + Math.cos(end) * r;
+      const y2 = cy + Math.sin(end) * r;
+      return `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${large} 1 ${x2} ${y2} Z`;
+    }
+
+    function palette(i) {
+      return ['#0f766e', '#b42318', '#2563eb', '#d97706', '#7c3aed', '#059669', '#be185d', '#4f46e5', '#0891b2', '#ca8a04'][i % 10];
+    }
+
+    function svgText(x, y, text, size, fill) {
+      const el = svgEl('text', {x, y, 'font-size': size, fill});
+      el.textContent = text;
+      return el;
+    }
+
+    function renderGraph(data) {
+      const svg = document.querySelector('#graph');
+      svg.innerHTML = '';
+      const width = svg.clientWidth || 900;
+      const height = svg.clientHeight || 640;
+      svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+      const sourceNodes = data.nodes || [];
+      const filtered = filteredNodes(data);
+      const keptIDs = new Set(filtered.map(n => n.id));
+      const nodes = sourceNodes.filter(n => keptIDs.has(n.id)).map(node => ({...node}));
+      const byID = new Map(nodes.map(n => [n.id, n]));
+      const edges = (data.edges || []).map(e => ({...e, source: byID.get(e.from), target: byID.get(e.to)})).filter(e => e.source && e.target);
+      const max = Math.max(...nodes.map(n => n.cumulative), 1);
+      const connected = connectedIDs(edges, graphState.selected);
+      for (const n of nodes) n.r = 7 + Math.sqrt(n.cumulative / max) * 42;
+
+      layoutTree(nodes, edges, width, height);
+      applyManualNodePositions(nodes);
+
+      const viewport = svgEl('g', {transform: transformAttr()});
+      const linkGroup = svgEl('g', {stroke: '#9aa5b1', 'stroke-opacity': .42});
+      const nodeGroup = svgEl('g', {});
+      viewport.append(linkGroup, nodeGroup);
+      svg.append(viewport);
+
+      for (const e of edges) {
+        const path = svgEl('path', {
+          d: edgePath(e),
+          fill: 'none',
+          'stroke-width': Math.max(1, Math.sqrt(e.value / max) * 8),
+          'data-from': e.from,
+          'data-to': e.to,
+          class: edgeClass(e, connected)
+        });
+        linkGroup.appendChild(path);
+      }
+
+      for (const n of nodes) {
+        const g = svgEl('g', {class: nodeClass(n, connected), transform: `translate(${n.x} ${n.y})`, 'data-node-id': n.id});
+        const title = svgEl('title', {});
+        title.textContent = `${n.name}\n${formatValue(n.cumulative, data.unit)} cumulative\n${formatValue(n.flat, data.unit)} flat`;
+        g.appendChild(title);
+        g.appendChild(svgEl('circle', {cx: 0, cy: 0, r: n.r, fill: colorFor(n), stroke: '#fff', 'stroke-width': 1.5}));
+        const label = svgEl('text', {x: n.r + 8, y: 4, 'text-anchor': 'start', 'font-size': 11, fill: '#1f2937'});
+        label.textContent = shortName(n.name);
+        g.appendChild(label);
+        attachNodeDrag(g, n, data, nodes, edges);
+        nodeGroup.appendChild(g);
+      }
+
+      attachViewportPanZoom(svg, viewport);
+      statusEl.textContent = `${nodes.length}/${sourceNodes.length} nodes, ${edges.length} edges`;
+    }
+
+    function applyManualNodePositions(nodes) {
+      const positions = graphState.positions || {};
+      for (const node of nodes) {
+        const saved = positions[node.id];
+        if (!saved) continue;
+        node.x = saved.x;
+        node.y = saved.y;
+      }
+    }
+
+    function layoutTree(nodes, edges, width, height) {
+      if (!nodes.length) return;
+      const incoming = new Map(nodes.map(n => [n.id, 0]));
+      const outgoing = new Map(nodes.map(n => [n.id, []]));
+      for (const e of edges) {
+        incoming.set(e.to, (incoming.get(e.to) || 0) + 1);
+        outgoing.get(e.from)?.push(e.to);
+      }
+      for (const ids of outgoing.values()) {
+        ids.sort((a, b) => (nodeValue(b, nodes) - nodeValue(a, nodes)) || String(a).localeCompare(String(b)));
+      }
+
+      const roots = nodes
+        .filter(n => (incoming.get(n.id) || 0) === 0)
+        .sort((a, b) => b.cumulative - a.cumulative);
+      if (!roots.length) roots.push(...[...nodes].sort((a, b) => b.cumulative - a.cumulative).slice(0, 1));
+
+      const depth = new Map();
+      const queue = roots.map(n => ({id: n.id, depth: 0}));
+      for (const root of roots) depth.set(root.id, 0);
+      while (queue.length) {
+        const item = queue.shift();
+        for (const child of outgoing.get(item.id) || []) {
+          const nextDepth = item.depth + 1;
+          if (depth.has(child) && depth.get(child) <= nextDepth) continue;
+          depth.set(child, nextDepth);
+          queue.push({id: child, depth: nextDepth});
+        }
+      }
+      for (const n of nodes) {
+        if (!depth.has(n.id)) depth.set(n.id, 0);
+      }
+
+      const levels = new Map();
+      for (const n of nodes) {
+        const d = depth.get(n.id) || 0;
+        if (!levels.has(d)) levels.set(d, []);
+        levels.get(d).push(n);
+      }
+      const maxDepth = Math.max(...levels.keys(), 0);
+      const xPad = 96;
+      const yPad = 76;
+      for (const [d, levelNodes] of levels) {
+        levelNodes.sort((a, b) => b.cumulative - a.cumulative);
+        const y = maxDepth === 0 ? height / 2 : yPad + (d / maxDepth) * Math.max(1, height - yPad * 2);
+        const usableWidth = Math.max(1, width - xPad * 2);
+        levelNodes.forEach((n, i) => {
+          n.x = xPad + ((i + 1) / (levelNodes.length + 1)) * usableWidth;
+          n.y = y;
+        });
+      }
+    }
+
+    function nodeValue(id, nodes) {
+      const n = nodes.find(node => node.id === id);
+      return n ? n.cumulative : 0;
+    }
+
+    function edgePath(edge) {
+      const sx = edge.source.x;
+      const sy = edge.source.y + edge.source.r;
+      const tx = edge.target.x;
+      const ty = edge.target.y - edge.target.r;
+      const mid = sy + Math.max(36, (ty - sy) / 2);
+      return `M ${sx} ${sy} C ${sx} ${mid}, ${tx} ${mid}, ${tx} ${ty}`;
+    }
+
+    function connectedIDs(edges, selected) {
+      if (!selected) return null;
+      const ids = new Set([selected]);
+      for (const e of edges) {
+        if (e.from === selected) ids.add(e.to);
+        if (e.to === selected) ids.add(e.from);
+      }
+      return ids;
+    }
+
+    function nodeClass(node, connected) {
+      const classes = ['node'];
+      if (graphState.selected === node.id) classes.push('selected');
+      if (connected && !connected.has(node.id)) classes.push('dim');
+      return classes.join(' ');
+    }
+
+    function edgeClass(edge, connected) {
+      const classes = ['edge'];
+      if (connected && edge.from !== graphState.selected && edge.to !== graphState.selected) classes.push('dim');
+      return classes.join(' ');
+    }
+
+    function transformAttr() {
+      return `translate(${graphState.tx} ${graphState.ty}) scale(${graphState.scale})`;
+    }
+
+    function attachViewportPanZoom(svg, viewport) {
+      let panning = false;
+      let startX = 0;
+      let startY = 0;
+      let startTx = 0;
+      let startTy = 0;
+
+      svg.onpointerdown = (event) => {
+        if (event.target.closest && event.target.closest('.node')) return;
+        panning = true;
+        startX = event.clientX;
+        startY = event.clientY;
+        startTx = graphState.tx;
+        startTy = graphState.ty;
+        svg.classList.add('dragging');
+        svg.setPointerCapture(event.pointerId);
+      };
+      svg.onpointermove = (event) => {
+        if (!panning) return;
+        graphState.tx = startTx + event.clientX - startX;
+        graphState.ty = startTy + event.clientY - startY;
+        viewport.setAttribute('transform', transformAttr());
+      };
+      svg.onpointerup = (event) => {
+        panning = false;
+        svg.classList.remove('dragging');
+        if (svg.hasPointerCapture(event.pointerId)) svg.releasePointerCapture(event.pointerId);
+      };
+      svg.onpointercancel = svg.onpointerup;
+      svg.onwheel = (event) => {
+        event.preventDefault();
+        const oldScale = graphState.scale;
+        const nextScale = clamp(oldScale * (event.deltaY < 0 ? 1.12 : 0.88), 0.35, 4);
+        const rect = svg.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+        graphState.tx = x - (x - graphState.tx) * (nextScale / oldScale);
+        graphState.ty = y - (y - graphState.ty) * (nextScale / oldScale);
+        graphState.scale = nextScale;
+        viewport.setAttribute('transform', transformAttr());
+      };
+    }
+
+    function attachNodeDrag(g, node, data, nodes, edges) {
+      let dragging = false;
+      let moved = false;
+      let startX = 0;
+      let startY = 0;
+      let nodeX = 0;
+      let nodeY = 0;
+
+      g.onpointerdown = event => {
+        dragging = true;
+        moved = false;
+        startX = event.clientX;
+        startY = event.clientY;
+        nodeX = node.x;
+        nodeY = node.y;
+        g.classList.add('dragging');
+        g.setPointerCapture(event.pointerId);
+        event.stopPropagation();
+      };
+      g.onpointermove = event => {
+        if (!dragging) return;
+        const dx = (event.clientX - startX) / graphState.scale;
+        const dy = (event.clientY - startY) / graphState.scale;
+        moved = moved || Math.abs(dx) + Math.abs(dy) > 3;
+        node.x = nodeX + dx;
+        node.y = nodeY + dy;
+        graphState.positions[node.id] = { x: node.x, y: node.y };
+        updateGraphPositions(nodes, edges);
+        event.stopPropagation();
+      };
+      g.onpointerup = event => {
+        dragging = false;
+        g.classList.remove('dragging');
+        if (g.hasPointerCapture(event.pointerId)) g.releasePointerCapture(event.pointerId);
+        if (!moved) {
+          graphState.selected = graphState.selected === node.id ? null : node.id;
+          renderGraph(data);
+        }
+        event.stopPropagation();
+      };
+      g.onpointercancel = event => {
+        dragging = false;
+        g.classList.remove('dragging');
+        if (g.hasPointerCapture(event.pointerId)) g.releasePointerCapture(event.pointerId);
+      };
+    }
+
+    function updateGraphPositions(nodes, edges) {
+      for (const n of nodes) {
+        const el = document.querySelector(`[data-node-id="${cssEscape(n.id)}"]`);
+        if (el) el.setAttribute('transform', `translate(${n.x} ${n.y})`);
+      }
+      for (const e of edges) {
+        const el = document.querySelector(`[data-from="${cssEscape(e.from)}"][data-to="${cssEscape(e.to)}"]`);
+        if (el) el.setAttribute('d', edgePath(e));
+      }
+    }
+
+    function cssEscape(value) {
+      if (window.CSS && CSS.escape) return CSS.escape(value);
+      return String(value).replace(/["\\]/g, '\\$&');
+    }
+
+    function svgEl(name, attrs) {
+      const el = document.createElementNS('http://www.w3.org/2000/svg', name);
+      for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+      return el;
+    }
+
+    function colorFor(n) {
+      if (n.kind === 'hot') return '#b42318';
+      if (n.kind === 'runtime') return '#7c3aed';
+      if (n.kind === 'http') return '#2563eb';
+      if (n.percent > 20) return '#b42318';
+      if (n.percent > 8) return '#d97706';
+      return '#0f766e';
+    }
+
+    function formatValue(value, unit) {
+      if (unit === 'bytes') {
+        const units = ['B', 'KiB', 'MiB', 'GiB'];
+        let n = value, i = 0;
+        while (n >= 1024 && i < units.length - 1) { n /= 1024; i++; }
+        return `${n.toFixed(i ? 1 : 0)} ${units[i]}`;
+      }
+      if (unit === 'nanoseconds') return `${(value / 1e6).toFixed(1)} ms`;
+      if (unit === 'goroutines') return `${value.toLocaleString()} goroutines`;
+      if (unit === 'samples') return `${value.toLocaleString()} samples`;
+      if (unit === 'score') return `${value.toLocaleString()} score`;
+      return `${value.toLocaleString()} ${unit || ''}`.trim();
+    }
+
+    function shortName(name) {
+      const parts = name.split('/');
+      const last = parts[parts.length - 1];
+      return last.length > 42 ? last.slice(0, 39) + '...' : last;
+    }
+
+    function escapeHtml(text) {
+      return String(text || '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+    }
+
+    function clamp(n, min, max) { return Math.max(min, Math.min(max, n)); }
+  </script>
+</body>
+</html>

--- a/ui/app/pprof/page.tsx
+++ b/ui/app/pprof/page.tsx
@@ -1,19 +1,7 @@
 import { useGetDevGoroutinesQuery, useGetDevPprofQuery } from "@/lib/store";
 import type { AllocationInfo, GoroutineGroup } from "@/lib/store/apis/devApi";
-import {
-	Activity,
-	AlertTriangle,
-	ArrowDown,
-	ArrowUp,
-	ChevronDown,
-	ChevronRight,
-	Cpu,
-	EyeOff,
-	HardDrive,
-	RefreshCw,
-	RotateCcw,
-	TrendingUp,
-} from "lucide-react";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Activity, AlertTriangle, ArrowDown, ArrowUp, Cpu, EyeOff, HardDrive, RefreshCw, RotateCcw, TrendingUp } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
@@ -256,14 +244,154 @@ function StatCard({
 	);
 }
 
+function StackTraceBlock({ stack }: { stack: string[] }) {
+	return (
+		<div>
+			<div className="mb-2 text-xs font-medium text-zinc-500">Stack Trace</div>
+			<div className="max-h-[52vh] space-y-0.5 overflow-y-auto rounded border border-zinc-800 bg-zinc-950 p-3 font-mono text-xs">
+				{stack.map((line, j) => (
+					<div key={j} className="break-all text-zinc-400">
+						{line}
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function DetailStat({ label, value, className = "text-zinc-300" }: { label: string; value: React.ReactNode; className?: string }) {
+	return (
+		<div className="rounded border border-zinc-800 bg-zinc-950 px-3 py-2">
+			<div className="text-xs text-zinc-500">{label}</div>
+			<div className={`mt-1 font-mono text-sm ${className}`}>{value}</div>
+		</div>
+	);
+}
+
+function AllocationDetailsDialog({
+	allocation,
+	title,
+	bytesColorClass = "text-rose-400",
+	onOpenChange,
+}: {
+	allocation: AllocationInfo | null;
+	title: string;
+	bytesColorClass?: string;
+	onOpenChange: (open: boolean) => void;
+}) {
+	return (
+		<Dialog open={allocation !== null} onOpenChange={onOpenChange}>
+			<DialogContent className="border-zinc-800 bg-zinc-900 text-zinc-100 sm:max-w-4xl">
+				{allocation && (
+					<>
+						<DialogHeader>
+							<DialogTitle>{title}</DialogTitle>
+							<DialogDescription>
+								<code className="break-all text-zinc-400">{allocation.function}</code>
+							</DialogDescription>
+						</DialogHeader>
+						<div className="grid gap-3 sm:grid-cols-3">
+							<DetailStat label="Bytes" value={formatBytes(allocation.bytes)} className={bytesColorClass} />
+							<DetailStat label="Count" value={allocation.count.toLocaleString()} />
+							<DetailStat label="File" value={`${allocation.file}:${allocation.line}`} />
+						</div>
+						<StackTraceBlock stack={allocation.stack ?? []} />
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function LeakDetailsDialog({ candidate, onOpenChange }: { candidate: LeakCandidate | null; onOpenChange: (open: boolean) => void }) {
+	return (
+		<Dialog open={candidate !== null} onOpenChange={onOpenChange}>
+			<DialogContent className="border-zinc-800 bg-zinc-900 text-zinc-100 sm:max-w-4xl">
+				{candidate && (
+					<>
+						<DialogHeader>
+							<DialogTitle>Potential Leak Details</DialogTitle>
+							<DialogDescription>
+								<code className="break-all text-zinc-400">{candidate.function}</code>
+							</DialogDescription>
+						</DialogHeader>
+						<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+							<DetailStat
+								label="Severity"
+								value={
+									<span className={`rounded border px-2 py-0.5 text-xs uppercase ${getLeakSeverityClasses(candidate.severity)}`}>
+										{candidate.severity}
+									</span>
+								}
+							/>
+							<DetailStat label="Live" value={formatBytes(candidate.liveBytes)} className="text-emerald-400" />
+							<DetailStat label="Cumulative" value={formatBytes(candidate.cumulativeBytes)} />
+							<DetailStat
+								label="Retention"
+								value={`${(candidate.retention * 100).toFixed(1)}%`}
+								className={getRetentionColor(candidate.retention)}
+							/>
+							<DetailStat label="Live Count" value={candidate.liveCount.toLocaleString()} />
+							<DetailStat
+								label="Trend"
+								value={candidate.isGrowing ? `+${formatBytes(candidate.growthBytes)}` : "stable"}
+								className={candidate.isGrowing ? "text-rose-400" : "text-zinc-400"}
+							/>
+							<DetailStat label="File" value={`${candidate.file}:${candidate.line}`} />
+							{candidate.samples.length >= 2 && (
+								<DetailStat
+									label={`Last ${candidate.samples.length * 10}s`}
+									value={candidate.samples.map((b) => formatBytes(b)).join(" -> ")}
+								/>
+							)}
+						</div>
+						<StackTraceBlock stack={candidate.stack} />
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function GoroutineDetailsDialog({ group, onOpenChange }: { group: GoroutineGroup | null; onOpenChange: (open: boolean) => void }) {
+	return (
+		<Dialog open={group !== null} onOpenChange={onOpenChange}>
+			<DialogContent className="border-zinc-800 bg-zinc-900 text-zinc-100 sm:max-w-4xl">
+				{group && (
+					<>
+						<DialogHeader>
+							<DialogTitle>Goroutine Details</DialogTitle>
+							<DialogDescription>
+								<code className="break-all text-zinc-400">{group.top_func}</code>
+							</DialogDescription>
+						</DialogHeader>
+						<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+							<DetailStat
+								label="Category"
+								value={<span className={`rounded border px-2 py-0.5 text-xs ${getCategoryColor(group.category)}`}>{group.category}</span>}
+							/>
+							<DetailStat label="Count" value={`${group.count}x`} />
+							<DetailStat label="State" value={group.state} />
+							{group.wait_minutes != null && group.wait_minutes > 0 && (
+								<DetailStat label="Waiting" value={`${group.wait_minutes}m`} className="text-amber-400" />
+							)}
+							{group.wait_reason && <DetailStat label="Wait Reason" value={group.wait_reason} className="text-amber-400" />}
+						</div>
+						<StackTraceBlock stack={group.stack} />
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}
+
 // Allocation Table Component
 function AllocationTable({
 	allocations,
 	sortField,
 	sortDirection,
 	onSort,
-	expandedKeys,
-	onToggle,
+	onSelect,
 	bytesColorClass = "text-rose-400",
 	testIdPrefix = "pprof-sort",
 }: {
@@ -271,8 +399,7 @@ function AllocationTable({
 	sortField: AllocationSortField;
 	sortDirection: SortDirection;
 	onSort: (field: AllocationSortField) => void;
-	expandedKeys: Set<string>;
-	onToggle: (key: string) => void;
+	onSelect: (allocation: AllocationInfo) => void;
 	bytesColorClass?: string;
 	testIdPrefix?: string;
 }) {
@@ -301,7 +428,6 @@ function AllocationTable({
 			<table className="w-full">
 				<thead>
 					<tr className="border-b border-zinc-800">
-						<th scope="col" className="w-8 px-2 py-3" aria-label="Expand" />
 						<SortHeader field="function">Function</SortHeader>
 						<SortHeader field="file">File:Line</SortHeader>
 						<SortHeader field="bytes">Bytes</SortHeader>
@@ -312,72 +438,45 @@ function AllocationTable({
 					{allocations.map((alloc) => {
 						const hasStack = alloc.stack && alloc.stack.length > 0;
 						const key = hasStack ? makeStackKey(alloc.stack) : `${alloc.function}:${alloc.file}:${alloc.line}`;
-						const isExpanded = expandedKeys.has(key);
 						return (
-							<React.Fragment key={key}>
-								<tr
-									role={hasStack ? "button" : undefined}
-									tabIndex={hasStack ? 0 : undefined}
-									aria-expanded={hasStack ? isExpanded : undefined}
-									onClick={hasStack ? () => onToggle(key) : undefined}
-									onKeyDown={
-										hasStack
-											? (e) => {
-													if (e.key === "Enter" || e.key === " ") {
-														e.preventDefault();
-														onToggle(key);
-													}
+							<tr
+								key={key}
+								role={hasStack ? "button" : undefined}
+								tabIndex={hasStack ? 0 : undefined}
+								onClick={hasStack ? () => onSelect(alloc) : undefined}
+								onKeyDown={
+									hasStack
+										? (e) => {
+												if (e.key === "Enter" || e.key === " ") {
+													e.preventDefault();
+													onSelect(alloc);
 												}
-											: undefined
-									}
-									data-testid="pprof-alloc-row"
-									className={`border-b border-zinc-800/50 hover:bg-zinc-800/30 ${hasStack ? "cursor-pointer" : ""}`}
-								>
-									<td className="w-8 px-2 py-3 align-top">
-										{hasStack ? (
-											isExpanded ? (
-												<ChevronDown className="h-4 w-4 text-zinc-500" />
-											) : (
-												<ChevronRight className="h-4 w-4 text-zinc-500" />
-											)
-										) : null}
-									</td>
-									<td className="px-4 py-3">
-										<code className="text-sm break-all text-zinc-200">{alloc.function}</code>
-									</td>
-									<td className="px-4 py-3">
-										<code className="text-sm text-zinc-400">
-											{alloc.file}:{alloc.line}
-										</code>
-									</td>
-									<td className="px-4 py-3">
-										<span className={`font-mono text-sm ${bytesColorClass}`}>{formatBytes(alloc.bytes)}</span>
-									</td>
-									<td className="px-4 py-3">
-										<span className="font-mono text-sm text-zinc-300">{alloc.count.toLocaleString()}</span>
-									</td>
-								</tr>
-								{isExpanded && hasStack && (
-									<tr className="border-b border-zinc-800/50 bg-zinc-900/50">
-										<td />
-										<td colSpan={4} className="px-4 py-3">
-											<div className="mb-2 text-xs font-medium text-zinc-500">Stack Trace</div>
-											<div className="space-y-0.5 font-mono text-xs">
-												{alloc.stack.map((line, j) => (
-													<div key={j} className="break-all text-zinc-400">
-														{line}
-													</div>
-												))}
-											</div>
-										</td>
-									</tr>
-								)}
-							</React.Fragment>
+											}
+										: undefined
+								}
+								data-testid="pprof-alloc-row"
+								className={`border-b border-zinc-800/50 hover:bg-zinc-800/30 ${hasStack ? "cursor-pointer" : ""}`}
+							>
+								<td className="px-4 py-3">
+									<code className="text-sm break-all text-zinc-200">{alloc.function}</code>
+								</td>
+								<td className="px-4 py-3">
+									<code className="text-sm text-zinc-400">
+										{alloc.file}:{alloc.line}
+									</code>
+								</td>
+								<td className="px-4 py-3">
+									<span className={`font-mono text-sm ${bytesColorClass}`}>{formatBytes(alloc.bytes)}</span>
+								</td>
+								<td className="px-4 py-3">
+									<span className="font-mono text-sm text-zinc-300">{alloc.count.toLocaleString()}</span>
+								</td>
+							</tr>
 						);
 					})}
 					{allocations.length === 0 && (
 						<tr>
-							<td colSpan={5} className="px-4 py-8 text-center text-zinc-500">
+							<td colSpan={4} className="px-4 py-8 text-center text-zinc-500">
 								No allocations data available
 							</td>
 						</tr>
@@ -389,21 +488,12 @@ function AllocationTable({
 }
 
 // Leak Candidates Table
-function LeakTable({
-	candidates,
-	expandedKeys,
-	onToggle,
-}: {
-	candidates: LeakCandidate[];
-	expandedKeys: Set<string>;
-	onToggle: (key: string) => void;
-}) {
+function LeakTable({ candidates, onSelect }: { candidates: LeakCandidate[]; onSelect: (candidate: LeakCandidate) => void }) {
 	return (
 		<div className="overflow-x-auto">
 			<table className="w-full">
 				<thead>
 					<tr className="border-b border-zinc-800">
-						<th scope="col" className="w-8 px-2 py-3" aria-label="Expand" />
 						<th scope="col" className="px-4 py-3 text-left text-sm font-medium text-zinc-400">
 							Severity
 						</th>
@@ -430,93 +520,56 @@ function LeakTable({
 				<tbody>
 					{candidates.map((c) => {
 						const rowKey = c.key;
-						const isExpanded = expandedKeys.has(rowKey);
 						return (
-							<React.Fragment key={rowKey}>
-								<tr
-									role="button"
-									tabIndex={0}
-									aria-expanded={isExpanded}
-									onClick={() => onToggle(rowKey)}
-									onKeyDown={(e) => {
-										if (e.key === "Enter" || e.key === " ") {
-											e.preventDefault();
-											onToggle(rowKey);
-										}
-									}}
-									data-testid="pprof-leak-row"
-									className="cursor-pointer border-b border-zinc-800/50 hover:bg-zinc-800/30"
-								>
-									<td className="w-8 px-2 py-3 align-top">
-										{isExpanded ? <ChevronDown className="h-4 w-4 text-zinc-500" /> : <ChevronRight className="h-4 w-4 text-zinc-500" />}
-									</td>
-									<td className="px-4 py-3">
-										<span className={`rounded border px-2 py-0.5 text-xs uppercase ${getLeakSeverityClasses(c.severity)}`}>
-											{c.severity}
+							<tr
+								key={rowKey}
+								role="button"
+								tabIndex={0}
+								onClick={() => onSelect(c)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault();
+										onSelect(c);
+									}
+								}}
+								data-testid="pprof-leak-row"
+								className="cursor-pointer border-b border-zinc-800/50 hover:bg-zinc-800/30"
+							>
+								<td className="px-4 py-3">
+									<span className={`rounded border px-2 py-0.5 text-xs uppercase ${getLeakSeverityClasses(c.severity)}`}>{c.severity}</span>
+								</td>
+								<td className="px-4 py-3">
+									<code className="text-sm break-all text-zinc-200">{c.function}</code>
+								</td>
+								<td className="px-4 py-3">
+									<code className="text-sm text-zinc-400">
+										{c.file}:{c.line}
+									</code>
+								</td>
+								<td className="px-4 py-3">
+									<span className="font-mono text-sm text-emerald-400">{formatBytes(c.liveBytes)}</span>
+								</td>
+								<td className="px-4 py-3">
+									<span className={`font-mono text-sm ${getRetentionColor(c.retention)}`}>{(c.retention * 100).toFixed(0)}%</span>
+								</td>
+								<td className="px-4 py-3">
+									{c.isGrowing ? (
+										<span className="flex items-center gap-1 text-xs text-rose-400">
+											<TrendingUp className="h-3 w-3" />+{formatBytes(c.growthBytes)}
 										</span>
-									</td>
-									<td className="px-4 py-3">
-										<code className="text-sm break-all text-zinc-200">{c.function}</code>
-									</td>
-									<td className="px-4 py-3">
-										<code className="text-sm text-zinc-400">
-											{c.file}:{c.line}
-										</code>
-									</td>
-									<td className="px-4 py-3">
-										<span className="font-mono text-sm text-emerald-400">{formatBytes(c.liveBytes)}</span>
-									</td>
-									<td className="px-4 py-3">
-										<span className={`font-mono text-sm ${getRetentionColor(c.retention)}`}>{(c.retention * 100).toFixed(0)}%</span>
-									</td>
-									<td className="px-4 py-3">
-										{c.isGrowing ? (
-											<span className="flex items-center gap-1 text-xs text-rose-400">
-												<TrendingUp className="h-3 w-3" />+{formatBytes(c.growthBytes)}
-											</span>
-										) : (
-											<span className="text-xs text-zinc-500">stable</span>
-										)}
-									</td>
-									<td className="px-4 py-3">
-										<span className="font-mono text-sm text-zinc-300">{c.liveCount.toLocaleString()}</span>
-									</td>
-								</tr>
-								{isExpanded && (
-									<tr className="border-b border-zinc-800/50 bg-zinc-900/50">
-										<td />
-										<td colSpan={7} className="px-4 py-3">
-											<div className="mb-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
-												<span>
-													Cumulative: <span className="text-zinc-300">{formatBytes(c.cumulativeBytes)}</span>
-												</span>
-												<span>
-													Retained: <span className="text-zinc-300">{(c.retention * 100).toFixed(1)}%</span>
-												</span>
-												{c.samples.length >= 2 && (
-													<span>
-														Last {c.samples.length * 10}s:{" "}
-														<span className="text-zinc-300">{c.samples.map((b) => formatBytes(b)).join(" → ")}</span>
-													</span>
-												)}
-											</div>
-											<div className="mb-2 text-xs font-medium text-zinc-500">Stack Trace</div>
-											<div className="space-y-0.5 font-mono text-xs">
-												{c.stack.map((line, j) => (
-													<div key={j} className="break-all text-zinc-400">
-														{line}
-													</div>
-												))}
-											</div>
-										</td>
-									</tr>
-								)}
-							</React.Fragment>
+									) : (
+										<span className="text-xs text-zinc-500">stable</span>
+									)}
+								</td>
+								<td className="px-4 py-3">
+									<span className="font-mono text-sm text-zinc-300">{c.liveCount.toLocaleString()}</span>
+								</td>
+							</tr>
 						);
 					})}
 					{candidates.length === 0 && (
 						<tr>
-							<td colSpan={8} className="px-4 py-8 text-center text-zinc-500">
+							<td colSpan={7} className="px-4 py-8 text-center text-zinc-500">
 								No obvious leak signatures — all live allocations have normal retention ratios.
 							</td>
 						</tr>
@@ -528,37 +581,23 @@ function LeakTable({
 }
 
 // Goroutine Group Component
-function GoroutineGroupRow({
-	group,
-	isExpanded,
-	onToggle,
-	onSkip,
-}: {
-	group: GoroutineGroup;
-	isExpanded: boolean;
-	onToggle: () => void;
-	onSkip: (filePath: string) => void;
-}) {
+function GoroutineGroupRow({ group, onOpen, onSkip }: { group: GoroutineGroup; onOpen: () => void; onSkip: (filePath: string) => void }) {
 	return (
 		<div className="border-b border-zinc-800/50">
 			<div
 				role="button"
 				tabIndex={0}
-				onClick={onToggle}
+				onClick={onOpen}
 				onKeyDown={(e) => {
 					if (e.target !== e.currentTarget) return;
 					if (e.key === "Enter" || e.key === " ") {
 						e.preventDefault();
-						onToggle();
+						onOpen();
 					}
 				}}
-				aria-expanded={isExpanded}
 				data-testid="pprof-goroutine-toggle"
 				className="group flex w-full cursor-pointer items-start gap-3 px-4 py-3 hover:bg-zinc-800/30"
 			>
-				<div className="mt-1 shrink-0">
-					{isExpanded ? <ChevronDown className="h-4 w-4 text-zinc-500" /> : <ChevronRight className="h-4 w-4 text-zinc-500" />}
-				</div>
 				<div className="min-w-0 flex-1">
 					<div className="flex flex-wrap items-center gap-2">
 						<code className="text-sm break-all text-zinc-200">{group.top_func}</code>
@@ -591,18 +630,6 @@ function GoroutineGroupRow({
 					<EyeOff className="h-4 w-4" />
 				</button>
 			</div>
-			{isExpanded && (
-				<div className="border-t border-zinc-800/50 bg-zinc-900/50 px-4 py-3">
-					<div className="mb-2 text-xs font-medium text-zinc-500">Stack Trace</div>
-					<div className="space-y-0.5 font-mono text-xs">
-						{group.stack.map((line, j) => (
-							<div key={j} className="break-all text-zinc-400">
-								{line}
-							</div>
-						))}
-					</div>
-				</div>
-			)}
 		</div>
 	);
 }
@@ -612,14 +639,14 @@ function GoroutineGroupRow({
 // ============================================================================
 
 export default function PprofPage() {
-	const [expandedGoroutines, setExpandedGoroutines] = useState<Set<string>>(new Set());
 	const [skippedGoroutines, setSkippedGoroutines] = useState<Set<string>>(new Set());
 	const [hasLoadedSkipped, setHasLoadedSkipped] = useState(false);
 	const [allocationSort, setAllocationSort] = useState<AllocationSortState>({ field: "bytes", direction: "desc" });
 	const [inuseSort, setInuseSort] = useState<AllocationSortState>({ field: "bytes", direction: "desc" });
-	const [expandedAlloc, setExpandedAlloc] = useState<Set<string>>(new Set());
-	const [expandedInuse, setExpandedInuse] = useState<Set<string>>(new Set());
-	const [expandedLeaks, setExpandedLeaks] = useState<Set<string>>(new Set());
+	const [selectedAllocation, setSelectedAllocation] = useState<AllocationInfo | null>(null);
+	const [selectedInuseAllocation, setSelectedInuseAllocation] = useState<AllocationInfo | null>(null);
+	const [selectedLeak, setSelectedLeak] = useState<LeakCandidate | null>(null);
+	const [selectedGoroutine, setSelectedGoroutine] = useState<GoroutineGroup | null>(null);
 	const inuseHistoryRef = useRef<Map<string, number[]>>(new Map());
 	const lastInuseSnapshotRef = useRef<string | null>(null);
 	const [historyVersion, setHistoryVersion] = useState(0);
@@ -704,7 +731,10 @@ export default function PprofPage() {
 	}, [data?.timestamp, data?.inuse_allocations]);
 
 	const leakCandidates = useMemo(
-		() => detectLeaks(data?.top_allocations ?? [], data?.inuse_allocations ?? [], inuseHistoryRef.current),
+		() => {
+			void historyVersion;
+			return detectLeaks(data?.top_allocations ?? [], data?.inuse_allocations ?? [], inuseHistoryRef.current);
+		},
 		// historyVersion bumps when the ref is mutated; top/inuse refs change per poll
 		[data?.top_allocations, data?.inuse_allocations, historyVersion],
 	);
@@ -724,7 +754,7 @@ export default function PprofPage() {
 		const isGrowing = current > avg * 1.1;
 		const growthPercent = avg > 0 ? ((current - avg) / avg) * 100 : 0;
 		return { isGrowing, growthPercent, avg };
-	}, [data?.history, data?.runtime?.num_goroutine]);
+	}, [data?.history, data?.runtime]);
 
 	// Filter problem goroutines
 	const filteredGoroutines = useMemo(() => {
@@ -757,54 +787,6 @@ export default function PprofPage() {
 			field,
 			direction: prev.field === field && prev.direction === "desc" ? "asc" : "desc",
 		}));
-	}, []);
-
-	const toggleAllocExpand = useCallback((key: string) => {
-		setExpandedAlloc((prev) => {
-			const next = new Set(prev);
-			if (next.has(key)) {
-				next.delete(key);
-			} else {
-				next.add(key);
-			}
-			return next;
-		});
-	}, []);
-
-	const toggleInuseExpand = useCallback((key: string) => {
-		setExpandedInuse((prev) => {
-			const next = new Set(prev);
-			if (next.has(key)) {
-				next.delete(key);
-			} else {
-				next.add(key);
-			}
-			return next;
-		});
-	}, []);
-
-	const toggleLeakExpand = useCallback((key: string) => {
-		setExpandedLeaks((prev) => {
-			const next = new Set(prev);
-			if (next.has(key)) {
-				next.delete(key);
-			} else {
-				next.add(key);
-			}
-			return next;
-		});
-	}, []);
-
-	const toggleGoroutineExpand = useCallback((id: string) => {
-		setExpandedGoroutines((prev) => {
-			const next = new Set(prev);
-			if (next.has(id)) {
-				next.delete(id);
-			} else {
-				next.add(id);
-			}
-			return next;
-		});
 	}, []);
 
 	const handleSkipGoroutine = useCallback((filePath: string) => {
@@ -1064,7 +1046,7 @@ export default function PprofPage() {
 								upward over the last minute. Growth + high retention together is the strongest leak signal.
 							</p>
 						</div>
-						<LeakTable candidates={leakCandidates} expandedKeys={expandedLeaks} onToggle={toggleLeakExpand} />
+						<LeakTable candidates={leakCandidates} onSelect={setSelectedLeak} />
 					</div>
 
 					{/* Live Heap Allocations — what's currently consuming the heap */}
@@ -1075,17 +1057,14 @@ export default function PprofPage() {
 								<span className="font-medium text-zinc-300">Live Heap Allocations</span>
 								<span className="text-sm text-zinc-500">({sortedInuseAllocations.length} sites)</span>
 							</div>
-							<p className="mt-1 text-xs text-zinc-500">
-								Call stacks currently holding memory on the heap right now — expand a row to see the full stack.
-							</p>
+							<p className="mt-1 text-xs text-zinc-500">Call stacks currently holding memory on the heap right now.</p>
 						</div>
 						<AllocationTable
 							allocations={sortedInuseAllocations}
 							sortField={inuseSort.field}
 							sortDirection={inuseSort.direction}
 							onSort={handleInuseSort}
-							expandedKeys={expandedInuse}
-							onToggle={toggleInuseExpand}
+							onSelect={setSelectedInuseAllocation}
 							bytesColorClass="text-emerald-400"
 							testIdPrefix="pprof-inuse-sort"
 						/>
@@ -1099,17 +1078,14 @@ export default function PprofPage() {
 								<span className="font-medium text-zinc-300">Cumulative Memory Allocations</span>
 								<span className="text-sm text-zinc-500">({sortedAllocations.length} sites)</span>
 							</div>
-							<p className="mt-1 text-xs text-zinc-500">
-								Total bytes allocated since process start (includes memory already freed) — expand a row to see the full stack.
-							</p>
+							<p className="mt-1 text-xs text-zinc-500">Total bytes allocated since process start, including memory already freed.</p>
 						</div>
 						<AllocationTable
 							allocations={sortedAllocations}
 							sortField={allocationSort.field}
 							sortDirection={allocationSort.direction}
 							onSort={handleAllocationSort}
-							expandedKeys={expandedAlloc}
-							onToggle={toggleAllocExpand}
+							onSelect={setSelectedAllocation}
 						/>
 					</div>
 
@@ -1183,15 +1159,7 @@ export default function PprofPage() {
 						<div className="max-h-[600px] overflow-y-auto">
 							{filteredGoroutines.map((g) => {
 								const gid = getGoroutineId(g);
-								return (
-									<GoroutineGroupRow
-										key={gid}
-										group={g}
-										isExpanded={expandedGoroutines.has(gid)}
-										onToggle={() => toggleGoroutineExpand(gid)}
-										onSkip={handleSkipGoroutine}
-									/>
-								);
+								return <GoroutineGroupRow key={gid} group={g} onOpen={() => setSelectedGoroutine(g)} onSkip={handleSkipGoroutine} />;
 							})}
 							{filteredGoroutines.length === 0 && (
 								<div className="px-4 py-8 text-center text-zinc-500">
@@ -1202,6 +1170,20 @@ export default function PprofPage() {
 							)}
 						</div>
 					</div>
+
+					<LeakDetailsDialog candidate={selectedLeak} onOpenChange={(open) => !open && setSelectedLeak(null)} />
+					<AllocationDetailsDialog
+						allocation={selectedInuseAllocation}
+						title="Live Heap Allocation Details"
+						bytesColorClass="text-emerald-400"
+						onOpenChange={(open) => !open && setSelectedInuseAllocation(null)}
+					/>
+					<AllocationDetailsDialog
+						allocation={selectedAllocation}
+						title="Cumulative Allocation Details"
+						onOpenChange={(open) => !open && setSelectedAllocation(null)}
+					/>
+					<GoroutineDetailsDialog group={selectedGoroutine} onOpenChange={(open) => !open && setSelectedGoroutine(null)} />
 
 					{/* Runtime Info Footer */}
 					<div className="rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3">


### PR DESCRIPTION
## Summary

Adds a standalone `pprofviewer` web service for inspecting Go heap, CPU, and goroutine pprof files without requiring external tooling. It provides an interactive browser UI with graph, list, line chart, and pie chart views, along with leak detection, hot path analysis, and cross-profile correlation.

## Changes

- Added `pprofviewer/` as an independent Go module with its own `go.mod` and `go.sum`, depending only on `github.com/google/pprof`
- Implemented `internal/analyzer` package that parses pprof profiles, builds call-graph nodes and edges, scores retained-heap leak candidates, extracts top stack paths, and produces cross-profile correlation maps when multiple profiles are supplied simultaneously
- Implemented `internal/server` package with four HTTP endpoints: `GET/POST /api/analyze` (single profile by file upload or local path), `GET/POST /api/analyze-set` (combined heap+cpu+goroutine), `GET /api/result` (cached result by ID), and `GET /` (embedded HTML UI)
- Added `pprofviewer/internal/server/static/index.html` — a self-contained single-page app with SVG force-directed graph, ranked list, line chart, pie chart, cross-map panel, leak/hot-path sidebars, and a markdown harness report generator
- Added `.air.toml` for hot-reload development via `air`
- Added `make pprofviewer` target with `air` reload support; accepts `PPROFVIEWER_ADDR`, `PPROF_FILES`, `PPROF_HEAP`, and `PPROF_CPU` variables and prints direct viewer URLs for each supplied profile path
- Added `pprofviewer/README.md` documenting run instructions, Makefile usage, and the REST API

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run the viewer with hot reload
make pprofviewer

# Run with specific profile paths and print direct URLs
make pprofviewer PPROF_HEAP=/tmp/heap.pprof PPROF_CPU=/tmp/cpu.pprof

# Run directly without air
cd pprofviewer
GOWORK=off go run ./cmd/pprofviewer -addr :7777

# Run analyzer unit tests
cd pprofviewer
GOWORK=off go test ./internal/analyzer/...

# Analyze a local file via API
curl "http://localhost:7777/api/analyze?path=/tmp/heap.pprof&sample=inuse_space"

# Upload a profile via API
curl -F "profile=@/tmp/cpu.pprof" "http://localhost:7777/api/analyze"

# Combined set analysis
curl -F "heap=@/tmp/heap.pprof" -F "cpu=@/tmp/cpu.pprof" "http://localhost:7777/api/analyze-set"
```

Open `http://localhost:7777` in a browser, upload one or more profiles, and use the tab and view controls to explore the results.

New Makefile variables:

| Variable | Default | Description |
|---|---|---|
| `PPROFVIEWER_ADDR` | `:7777` | HTTP listen address |
| `PPROF_FILES` | _(empty)_ | Space-separated profile paths for direct viewer URLs |
| `PPROF_HEAP` | _(empty)_ | Heap profile path for direct viewer URL |
| `PPROF_CPU` | _(empty)_ | CPU profile path for direct viewer URL |

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `/api/analyze` and `/api/analyze-set` GET endpoints accept arbitrary local filesystem paths and open them as the server process user. This is intentional for local developer use but the service should not be exposed on a network-accessible interface in shared or production environments.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable