### PR TITLE
complexity router: remove config.json as authoritative as default and merge the keywords + move to hash based reconcilation

### DIFF
--- a/docs/deployment-guides/helm/governance.mdx
+++ b/docs/deployment-guides/helm/governance.mdx
@@ -388,7 +388,7 @@ bifrost:
 
 If you use `complexity_tier` in routing rules, you can seed the analyzer thresholds and keyword lists from Helm. The chart renders this block to `governance.complexity_analyzer_config` in `config.json`.
 
-Omit this block, or leave `complexityAnalyzerConfig: null`, to use the built-in defaults.
+Omit this block, or leave `complexityAnalyzerConfig: null`, to leave the stored runtime configuration unchanged. Fresh installs use the built-in defaults.
 
 ```yaml
 bifrost:
@@ -406,7 +406,7 @@ bifrost:
 ```
 
 <Note>
-When this block is present, it is reapplied from the generated `config.json` on restart. Runtime UI and API edits still hot-reload immediately, but Helm values remain the source of truth for the next rollout.
+In the default `source_of_truth: "split"` mode, Helm changes update tier boundaries and merge configured keywords with the stored lists as a union. Runtime UI and API edits are preserved in the store across restarts, but they are not written back to the rendered `config.json`. Set `bifrost.sourceOfTruth: "config.json"` when Helm should remain authoritative.
 </Note>
 
 ---

--- a/docs/features/governance/complexity-router.mdx
+++ b/docs/features/governance/complexity-router.mdx
@@ -181,9 +181,9 @@ curl -X POST http://localhost:8080/api/governance/complexity-analyzer-config/res
 Each keyword list requires at least one entry. Keywords are normalized to lowercase and deduplicated on save. Changes are hot-reloaded with no restart required.
 </Note>
 
-<Warning>
-If `governance.complexity_analyzer_config` is present in `config.json`, the file remains authoritative on restart. UI and API edits apply immediately, but the file values are re-applied on the next startup unless you update `config.json` too.
-</Warning>
+<Note>
+In the default `source_of_truth: "split"` mode, config file changes update tier boundaries and merge configured keywords with the stored lists as a union. UI and API edits are preserved in the store across restarts, but they are not written back to `config.json`. Set `source_of_truth: "config.json"` when the generated file should remain authoritative.
+</Note>
 
 </Tab>
 </Tabs>

--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -1,6 +1,8 @@
 package configstore
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -43,6 +45,7 @@ type ComplexityEditableKeywordConfig struct {
 type ComplexityAnalyzerConfig struct {
 	TierBoundaries ComplexityTierBoundaries        `json:"tier_boundaries"`
 	Keywords       ComplexityEditableKeywordConfig `json:"keywords"`
+	ConfigHash     string                          `json:"-"`
 }
 
 // Validate checks that the config is internally consistent.
@@ -86,7 +89,71 @@ func (c *ComplexityAnalyzerConfig) Normalized() ComplexityAnalyzerConfig {
 			TechnicalKeywords: normalizeComplexityKeywordList(c.Keywords.TechnicalKeywords),
 			SimpleKeywords:    normalizeComplexityKeywordList(c.Keywords.SimpleKeywords),
 		},
+		ConfigHash: c.ConfigHash,
 	}
+}
+
+// GenerateComplexityAnalyzerConfigHash returns a stable hash for config.json-sourced analyzer config.
+func GenerateComplexityAnalyzerConfigHash(config *ComplexityAnalyzerConfig) (string, error) {
+	if config == nil {
+		return "", fmt.Errorf("complexity analyzer config is nil")
+	}
+
+	normalized := config.Normalized()
+	normalized.ConfigHash = ""
+	if err := normalized.Validate(); err != nil {
+		return "", err
+	}
+
+	data, err := json.Marshal(normalized)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal complexity analyzer config for hash: %w", err)
+	}
+
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// MergeComplexityAnalyzerConfig overlays file boundaries and additively merges keyword lists.
+func MergeComplexityAnalyzerConfig(base, file *ComplexityAnalyzerConfig) (*ComplexityAnalyzerConfig, error) {
+	if file == nil {
+		if base == nil {
+			return nil, nil
+		}
+		normalized := base.Normalized()
+		if err := normalized.Validate(); err != nil {
+			return nil, err
+		}
+		return &normalized, nil
+	}
+
+	normalizedFile := file.Normalized()
+	if err := normalizedFile.Validate(); err != nil {
+		return nil, err
+	}
+
+	var normalizedBase ComplexityAnalyzerConfig
+	if base != nil {
+		normalizedBase = base.Normalized()
+		if err := normalizedBase.Validate(); err != nil {
+			return nil, err
+		}
+	}
+
+	merged := ComplexityAnalyzerConfig{
+		TierBoundaries: normalizedFile.TierBoundaries,
+		Keywords: ComplexityEditableKeywordConfig{
+			CodeKeywords:      mergeComplexityKeywordLists(normalizedBase.Keywords.CodeKeywords, normalizedFile.Keywords.CodeKeywords),
+			ReasoningKeywords: mergeComplexityKeywordLists(normalizedBase.Keywords.ReasoningKeywords, normalizedFile.Keywords.ReasoningKeywords),
+			TechnicalKeywords: mergeComplexityKeywordLists(normalizedBase.Keywords.TechnicalKeywords, normalizedFile.Keywords.TechnicalKeywords),
+			SimpleKeywords:    mergeComplexityKeywordLists(normalizedBase.Keywords.SimpleKeywords, normalizedFile.Keywords.SimpleKeywords),
+		},
+		ConfigHash: normalizedFile.ConfigHash,
+	}
+	if err := merged.Validate(); err != nil {
+		return nil, err
+	}
+	return &merged, nil
 }
 
 // DecodeComplexityAnalyzerConfig decodes raw JSON into a normalized, validated config.
@@ -127,4 +194,11 @@ func normalizeComplexityKeywordList(values []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func mergeComplexityKeywordLists(base, overlay []string) []string {
+	values := make([]string, 0, len(base)+len(overlay))
+	values = append(values, base...)
+	values = append(values, overlay...)
+	return normalizeComplexityKeywordList(values)
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4957,6 +4957,7 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 	}
 	var authConfig *AuthConfig
 	var complexityAnalyzerConfig *ComplexityAnalyzerConfig
+	var complexityAnalyzerConfigHash string
 	if len(governanceConfigs) > 0 {
 		// Checking if username and password is present
 		var username *string
@@ -4982,7 +4983,12 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 					continue
 				}
 				complexityAnalyzerConfig = decoded
+			case tables.ConfigComplexityAnalyzerConfigHashKey:
+				complexityAnalyzerConfigHash = strings.TrimSpace(entry.Value)
 			}
+		}
+		if complexityAnalyzerConfig != nil {
+			complexityAnalyzerConfig.ConfigHash = complexityAnalyzerConfigHash
 		}
 		if username != nil && password != nil {
 			authConfig = &AuthConfig{
@@ -5009,17 +5015,35 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 
 // GetComplexityAnalyzerConfig retrieves the typed complexity analyzer config.
 func (s *RDBConfigStore) GetComplexityAnalyzerConfig(ctx context.Context) (*ComplexityAnalyzerConfig, error) {
-	configEntry, err := s.GetConfig(ctx, tables.ConfigComplexityAnalyzerConfigKey)
-	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return nil, nil
-		}
+	var entries []tables.TableGovernanceConfig
+	if err := s.DB().WithContext(ctx).
+		Where("key IN ?", []string{
+			tables.ConfigComplexityAnalyzerConfigKey,
+			tables.ConfigComplexityAnalyzerConfigHashKey,
+		}).
+		Find(&entries).Error; err != nil {
 		return nil, err
 	}
-	if configEntry == nil || strings.TrimSpace(configEntry.Value) == "" {
+
+	var configValue string
+	var configHash string
+	for _, entry := range entries {
+		switch entry.Key {
+		case tables.ConfigComplexityAnalyzerConfigKey:
+			configValue = entry.Value
+		case tables.ConfigComplexityAnalyzerConfigHashKey:
+			configHash = strings.TrimSpace(entry.Value)
+		}
+	}
+	if strings.TrimSpace(configValue) == "" {
 		return nil, nil
 	}
-	return DecodeComplexityAnalyzerConfig([]byte(configEntry.Value))
+	decoded, err := DecodeComplexityAnalyzerConfig([]byte(configValue))
+	if err != nil {
+		return nil, err
+	}
+	decoded.ConfigHash = configHash
+	return decoded, nil
 }
 
 // UpdateComplexityAnalyzerConfig normalizes, validates, and persists the typed analyzer config.
@@ -5033,14 +5057,31 @@ func (s *RDBConfigStore) UpdateComplexityAnalyzerConfig(ctx context.Context, con
 		return err
 	}
 
+	if normalized.ConfigHash != "" && len(tx) == 0 {
+		return s.DB().WithContext(ctx).Transaction(func(transaction *gorm.DB) error {
+			return s.updateComplexityAnalyzerConfigTx(ctx, normalized, transaction)
+		})
+	}
+	return s.updateComplexityAnalyzerConfigTx(ctx, normalized, tx...)
+}
+
+func (s *RDBConfigStore) updateComplexityAnalyzerConfigTx(ctx context.Context, normalized ComplexityAnalyzerConfig, tx ...*gorm.DB) error {
 	raw, err := json.Marshal(normalized)
 	if err != nil {
 		return fmt.Errorf("failed to marshal complexity analyzer config: %w", err)
 	}
-
-	return s.UpdateConfig(ctx, &tables.TableGovernanceConfig{
+	if err := s.UpdateConfig(ctx, &tables.TableGovernanceConfig{
 		Key:   tables.ConfigComplexityAnalyzerConfigKey,
 		Value: string(raw),
+	}, tx...); err != nil {
+		return err
+	}
+	if normalized.ConfigHash == "" {
+		return nil
+	}
+	return s.UpdateConfig(ctx, &tables.TableGovernanceConfig{
+		Key:   tables.ConfigComplexityAnalyzerConfigHashKey,
+		Value: normalized.ConfigHash,
 	}, tx...)
 }
 

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -91,7 +91,9 @@ func TestRDBConfigStore_ComplexityAnalyzerConfigRoundTrip(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()
 
-	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, testComplexityAnalyzerConfig()))
+	cfg := testComplexityAnalyzerConfig()
+	cfg.ConfigHash = "file-hash-1"
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, cfg))
 
 	got, err := store.GetComplexityAnalyzerConfig(ctx)
 	require.NoError(t, err)
@@ -102,19 +104,82 @@ func TestRDBConfigStore_ComplexityAnalyzerConfigRoundTrip(t *testing.T) {
 		ComplexReasoning: 0.70,
 	}, got.TierBoundaries)
 	assert.Equal(t, []string{"api", "function"}, got.Keywords.CodeKeywords)
+	assert.Equal(t, "file-hash-1", got.ConfigHash)
+}
+
+func TestRDBConfigStore_UpdateComplexityAnalyzerConfigPreservesExistingHashOnRuntimeUpdate(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	fileConfig := testComplexityAnalyzerConfig()
+	fileConfig.ConfigHash = "file-hash-1"
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, fileConfig))
+
+	runtimeConfig := testComplexityAnalyzerConfig()
+	runtimeConfig.TierBoundaries.SimpleMedium = 0.12
+	runtimeConfig.ConfigHash = ""
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, runtimeConfig))
+
+	got, err := store.GetComplexityAnalyzerConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 0.12, got.TierBoundaries.SimpleMedium)
+	assert.Equal(t, "file-hash-1", got.ConfigHash)
 }
 
 func TestRDBConfigStore_GetGovernanceConfigIncludesComplexityAnalyzerConfig(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()
 
-	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, testComplexityAnalyzerConfig()))
+	cfg := testComplexityAnalyzerConfig()
+	cfg.ConfigHash = "file-hash-2"
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, cfg))
 
 	governanceConfig, err := store.GetGovernanceConfig(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, governanceConfig)
 	require.NotNil(t, governanceConfig.ComplexityAnalyzerConfig)
 	assert.Equal(t, 0.70, governanceConfig.ComplexityAnalyzerConfig.TierBoundaries.ComplexReasoning)
+	assert.Equal(t, "file-hash-2", governanceConfig.ComplexityAnalyzerConfig.ConfigHash)
+}
+
+func TestGenerateComplexityAnalyzerConfigHashCanonicalizesKeywords(t *testing.T) {
+	left := testComplexityAnalyzerConfig()
+	right := testComplexityAnalyzerConfig()
+	right.Keywords.CodeKeywords = []string{"api", "function"}
+	left.ConfigHash = "stored-file-hash-a"
+	right.ConfigHash = "stored-file-hash-b"
+
+	leftHash, err := GenerateComplexityAnalyzerConfigHash(left)
+	require.NoError(t, err)
+	rightHash, err := GenerateComplexityAnalyzerConfigHash(right)
+	require.NoError(t, err)
+
+	assert.Equal(t, leftHash, rightHash)
+}
+
+func TestMergeComplexityAnalyzerConfigAddsKeywordsAndOverlaysBoundaries(t *testing.T) {
+	base := testComplexityAnalyzerConfig()
+	file := testComplexityAnalyzerConfig()
+	file.TierBoundaries = ComplexityTierBoundaries{
+		SimpleMedium:     0.20,
+		MediumComplex:    0.40,
+		ComplexReasoning: 0.80,
+	}
+	file.Keywords.CodeKeywords = []string{"GraphQL", "api"}
+	file.Keywords.ReasoningKeywords = []string{"tradeoffs", "step by step"}
+	file.Keywords.TechnicalKeywords = []string{"latency", "kubernetes"}
+	file.Keywords.SimpleKeywords = []string{"hello", "thanks"}
+
+	merged, err := MergeComplexityAnalyzerConfig(base, file)
+	require.NoError(t, err)
+	require.NotNil(t, merged)
+
+	assert.Equal(t, file.TierBoundaries, merged.TierBoundaries)
+	assert.Equal(t, []string{"api", "function", "graphql"}, merged.Keywords.CodeKeywords)
+	assert.Equal(t, []string{"step by step", "tradeoffs"}, merged.Keywords.ReasoningKeywords)
+	assert.Equal(t, []string{"kubernetes", "latency"}, merged.Keywords.TechnicalKeywords)
+	assert.Equal(t, []string{"hello", "thanks"}, merged.Keywords.SimpleKeywords)
 }
 
 func TestRDBConfigStore_UpdateComplexityAnalyzerConfigRejectsInvalidConfig(t *testing.T) {

--- a/framework/configstore/tables/config.go
+++ b/framework/configstore/tables/config.go
@@ -9,8 +9,10 @@ const (
 	ConfigProxyKey         = "proxy_config"
 	// ConfigComplexityAnalyzerConfigKey stores the persisted analyzer config JSON.
 	ConfigComplexityAnalyzerConfigKey = "complexity_analyzer_config"
-	ConfigRestartRequiredKey          = "restart_required"
-	ConfigHeaderFilterKey             = "header_filter_config"
+	// ConfigComplexityAnalyzerConfigHashKey stores the last config.json hash synced for the analyzer config.
+	ConfigComplexityAnalyzerConfigHashKey = "complexity_analyzer_config_hash"
+	ConfigRestartRequiredKey              = "restart_required"
+	ConfigHeaderFilterKey                 = "header_filter_config"
 )
 
 // Keys for the ClientConfig.MetadataJSON blob.

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2363,21 +2363,7 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 		}
 	}
 
-	// File config stays authoritative for analyzer tuning when present.
-	if configData.Governance.ComplexityAnalyzerConfig != nil {
-		normalized, err := complexity.ValidateAndNormalize(configData.Governance.ComplexityAnalyzerConfig)
-		if err != nil {
-			logger.Error("invalid complexity analyzer config in config file: %v", err)
-		} else if normalized != nil {
-			current := config.GovernanceConfig.ComplexityAnalyzerConfig
-			config.GovernanceConfig.ComplexityAnalyzerConfig = normalized
-			if config.ConfigStore != nil && (current == nil || !reflect.DeepEqual(current, normalized)) {
-				if err := config.ConfigStore.UpdateComplexityAnalyzerConfig(ctx, normalized); err != nil {
-					logger.Warn("failed to sync complexity analyzer config from config file: %v", err)
-				}
-			}
-		}
-	}
+	reconcileComplexityAnalyzerConfig(ctx, config, configData)
 
 	// Sync pricing overrides into the model catalog in one batch to avoid
 	// rebuilding the lookup map on every iteration.
@@ -2397,6 +2383,87 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 	}
 	if configData.isConfigJSONSourceOfTruth() {
 		pruneGovernanceConfigToFile(ctx, config, configData)
+	}
+}
+
+// reconcileComplexityAnalyzerConfig applies config.json complexity analyzer changes without
+// clobbering runtime UI/API edits when the file has not changed.
+//
+// In split mode, config.json updates tier boundaries and adds keywords to the stored
+// runtime config. In config.json source-of-truth mode, the file remains authoritative.
+func reconcileComplexityAnalyzerConfig(ctx context.Context, config *Config, configData *ConfigData) {
+	if config == nil || configData == nil || configData.Governance == nil || configData.Governance.ComplexityAnalyzerConfig == nil {
+		return
+	}
+	if config.GovernanceConfig == nil {
+		config.GovernanceConfig = &configstore.GovernanceConfig{}
+	}
+
+	fileConfig, fileHash, ok := complexityAnalyzerConfigFromFile(configData)
+	if !ok {
+		return
+	}
+
+	current := config.GovernanceConfig.ComplexityAnalyzerConfig
+	if configData.isConfigJSONSourceOfTruth() {
+		fileConfig.ConfigHash = fileHash
+		syncComplexityAnalyzerConfig(ctx, config, current, fileConfig)
+		return
+	}
+
+	if current != nil && current.ConfigHash == fileHash {
+		logger.Debug("complexity analyzer config hash matches, keeping DB config")
+		return
+	}
+
+	merged, err := mergeComplexityAnalyzerConfigFromFile(current, fileConfig)
+	if err != nil {
+		logger.Warn("failed to merge complexity analyzer config from config file: %v", err)
+		return
+	}
+	merged.ConfigHash = fileHash
+	syncComplexityAnalyzerConfig(ctx, config, current, merged)
+}
+
+// complexityAnalyzerConfigFromFile validates the file-backed analyzer config and
+// returns the canonical hash used to detect whether config.json changed.
+func complexityAnalyzerConfigFromFile(configData *ConfigData) (*configstore.ComplexityAnalyzerConfig, string, bool) {
+	fileConfig, err := complexity.ValidateAndNormalize(configData.Governance.ComplexityAnalyzerConfig)
+	if err != nil {
+		logger.Error("invalid complexity analyzer config in config file: %v", err)
+		return nil, "", false
+	}
+	fileHash, err := configstore.GenerateComplexityAnalyzerConfigHash(fileConfig)
+	if err != nil {
+		logger.Warn("failed to generate complexity analyzer config hash: %v", err)
+		return nil, "", false
+	}
+	return fileConfig, fileHash, true
+}
+
+// mergeComplexityAnalyzerConfigFromFile overlays file boundaries and merges file
+// keywords into the current runtime config. On first startup, defaults are the
+// base so a partial seed does not erase the built-in keyword coverage.
+func mergeComplexityAnalyzerConfigFromFile(current, fileConfig *configstore.ComplexityAnalyzerConfig) (*configstore.ComplexityAnalyzerConfig, error) {
+	base := current
+	if base == nil {
+		defaults := complexity.DefaultAnalyzerConfig()
+		base = &defaults
+	}
+	return configstore.MergeComplexityAnalyzerConfig(base, fileConfig)
+}
+
+// syncComplexityAnalyzerConfig updates the in-memory config and persists it when
+// the stored value changed.
+func syncComplexityAnalyzerConfig(ctx context.Context, config *Config, current, next *configstore.ComplexityAnalyzerConfig) {
+	config.GovernanceConfig.ComplexityAnalyzerConfig = next
+	if config.ConfigStore != nil {
+		if current != nil && reflect.DeepEqual(current, next) {
+			return
+		}
+		if err := config.ConfigStore.UpdateComplexityAnalyzerConfig(ctx, next); err != nil {
+			logger.Warn("failed to sync complexity analyzer config from config file: %v", err)
+		}
 	}
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -983,6 +983,11 @@ func (m *MockConfigStore) UpdateComplexityAnalyzerConfig(ctx context.Context, co
 	if m.governanceConfig == nil {
 		m.governanceConfig = &configstore.GovernanceConfig{}
 	}
+	if config != nil && config.ConfigHash == "" && m.governanceConfig.ComplexityAnalyzerConfig != nil {
+		copy := *config
+		copy.ConfigHash = m.governanceConfig.ComplexityAnalyzerConfig.ConfigHash
+		config = &copy
+	}
 	m.governanceConfig.ComplexityAnalyzerConfig = config
 	return nil
 }
@@ -1466,10 +1471,10 @@ func TestMergeGovernanceConfig_SyncsComplexityAnalyzerConfig(t *testing.T) {
 			ComplexReasoning: 0.77,
 		},
 		Keywords: configstore.ComplexityEditableKeywordConfig{
-			CodeKeywords:      []string{" Function ", "api", "API"},
-			ReasoningKeywords: []string{"tradeoffs"},
-			TechnicalKeywords: []string{"latency"},
-			SimpleKeywords:    []string{"hello"},
+			CodeKeywords:      []string{"file-code"},
+			ReasoningKeywords: []string{"file-reason"},
+			TechnicalKeywords: []string{"file-tech"},
+			SimpleKeywords:    []string{"file-simple"},
 		},
 	}
 	configData := &ConfigData{
@@ -1484,8 +1489,148 @@ func TestMergeGovernanceConfig_SyncsComplexityAnalyzerConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	require.Equal(t, 0.77, stored.TierBoundaries.ComplexReasoning)
-	require.Equal(t, []string{"api", "function"}, stored.Keywords.CodeKeywords)
+	require.Contains(t, stored.Keywords.CodeKeywords, "file-code")
+	require.Contains(t, stored.Keywords.CodeKeywords, "algorithm")
+	require.Contains(t, stored.Keywords.ReasoningKeywords, "file-reason")
+	require.NotEmpty(t, stored.ConfigHash)
 	require.Equal(t, stored, config.GovernanceConfig.ComplexityAnalyzerConfig)
+}
+
+func TestMergeGovernanceConfig_PreservesComplexityAnalyzerConfigWhenFileHashMatches(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	fileConfig := testFileComplexityAnalyzerConfig()
+	fileHash, err := configstore.GenerateComplexityAnalyzerConfigHash(fileConfig)
+	require.NoError(t, err)
+
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHash = fileHash
+	dbConfig.TierBoundaries.SimpleMedium = 0.21
+	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+	configData := &ConfigData{
+		Governance: &configstore.GovernanceConfig{
+			ComplexityAnalyzerConfig: fileConfig,
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, 0.21, stored.TierBoundaries.SimpleMedium)
+	require.Equal(t, []string{"ui-code"}, stored.Keywords.CodeKeywords)
+	require.Equal(t, fileHash, stored.ConfigHash)
+}
+
+func TestMergeGovernanceConfig_MergesComplexityKeywordsWhenFileHashChanges(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHash = "old-file-hash"
+	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbConfig.Keywords.ReasoningKeywords = []string{"ui-reason"}
+	dbConfig.Keywords.TechnicalKeywords = []string{"ui-tech"}
+	dbConfig.Keywords.SimpleKeywords = []string{"ui-simple"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+	fileConfig := testFileComplexityAnalyzerConfig()
+	fileHash, err := configstore.GenerateComplexityAnalyzerConfigHash(fileConfig)
+	require.NoError(t, err)
+	configData := &ConfigData{
+		Governance: &configstore.GovernanceConfig{
+			ComplexityAnalyzerConfig: fileConfig,
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, fileConfig.TierBoundaries, stored.TierBoundaries)
+	require.ElementsMatch(t, []string{"file-code", "ui-code"}, stored.Keywords.CodeKeywords)
+	require.ElementsMatch(t, []string{"file-reason", "ui-reason"}, stored.Keywords.ReasoningKeywords)
+	require.ElementsMatch(t, []string{"file-tech", "ui-tech"}, stored.Keywords.TechnicalKeywords)
+	require.ElementsMatch(t, []string{"file-simple", "ui-simple"}, stored.Keywords.SimpleKeywords)
+	require.Equal(t, fileHash, stored.ConfigHash)
+}
+
+func TestMergeGovernanceConfig_SourceOfTruthConfigJSONUsesComplexityFileConfig(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHash = "old-file-hash"
+	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+	fileConfig := testFileComplexityAnalyzerConfig()
+	fileHash, err := configstore.GenerateComplexityAnalyzerConfigHash(fileConfig)
+	require.NoError(t, err)
+	configData := &ConfigData{
+		SourceOfTruth: SourceOfTruthConfigJSON,
+		Governance: &configstore.GovernanceConfig{
+			ComplexityAnalyzerConfig: fileConfig,
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, fileConfig.TierBoundaries, stored.TierBoundaries)
+	require.Equal(t, []string{"file-code"}, stored.Keywords.CodeKeywords)
+	require.Equal(t, fileHash, stored.ConfigHash)
+}
+
+func testRuntimeComplexityAnalyzerConfig() *configstore.ComplexityAnalyzerConfig {
+	return &configstore.ComplexityAnalyzerConfig{
+		TierBoundaries: configstore.ComplexityTierBoundaries{
+			SimpleMedium:     0.10,
+			MediumComplex:    0.30,
+			ComplexReasoning: 0.70,
+		},
+		Keywords: configstore.ComplexityEditableKeywordConfig{
+			CodeKeywords:      []string{"runtime-code"},
+			ReasoningKeywords: []string{"runtime-reason"},
+			TechnicalKeywords: []string{"runtime-tech"},
+			SimpleKeywords:    []string{"runtime-simple"},
+		},
+	}
+}
+
+func testFileComplexityAnalyzerConfig() *configstore.ComplexityAnalyzerConfig {
+	return &configstore.ComplexityAnalyzerConfig{
+		TierBoundaries: configstore.ComplexityTierBoundaries{
+			SimpleMedium:     0.22,
+			MediumComplex:    0.44,
+			ComplexReasoning: 0.88,
+		},
+		Keywords: configstore.ComplexityEditableKeywordConfig{
+			CodeKeywords:      []string{"file-code"},
+			ReasoningKeywords: []string{"file-reason"},
+			TechnicalKeywords: []string{"file-tech"},
+			SimpleKeywords:    []string{"file-simple"},
+		},
+	}
 }
 
 // Prompt Repository - Folders


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified governance complexity analyzer and Helm guidance for source_of_truth modes (split vs config.json), and when runtime/UI/API edits persist vs file config is authoritative.

* **New Features**
  * File-based complexity analyzer updates now merge with stored runtime values as appropriate and track a canonical file hash to guide reconciliation.

* **Tests**
  * Added tests for merging, hashing, and persistence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->