### PR TITLE
feat: enforce VK tool-grant boundary on caller-provided `x-bf-mcp-include-tools` lists via `pruneMCPIncludeToolsFromContext`

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -428,14 +428,16 @@ func (p *GovernancePlugin) runPreRequestRouting(ctx *schemas.BifrostContext, vir
 			return modelIn, err
 		}
 
+		// A caller-provided include-tools list can only narrow the virtual key's
+		// tool grant, never expand it — prune entries the key does not allow.
+		callerProvided := p.pruneMCPIncludeToolsFromContext(ctx, virtualKey)
+
 		p.cfgMutex.RLock()
 		autoInjectDisabled := p.disableAutoToolInject != nil && *p.disableAutoToolInject
 		p.cfgMutex.RUnlock()
-		if !autoInjectDisabled {
-			if existing := ctx.Value(schemas.MCPContextKeyIncludeTools); existing == nil {
-				if tools := p.computeMCPIncludeTools(virtualKey); tools != nil {
-					ctx.SetValue(schemas.MCPContextKeyIncludeTools, tools)
-				}
+		if !callerProvided && !autoInjectDisabled {
+			if tools := p.computeMCPIncludeTools(virtualKey); tools != nil {
+				ctx.SetValue(schemas.MCPContextKeyIncludeTools, tools)
 			}
 		}
 	}
@@ -781,13 +783,19 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 // directly; callers store it via ctx.SetValue(schemas.MCPContextKeyIncludeTools, ...). VK-specific
 // MCP configs take precedence over AllowOnAllVirtualKeys clients.
 func (p *GovernancePlugin) computeMCPIncludeTools(virtualKey *configstoreTables.TableVirtualKey) []string {
-	executeOnlyTools := make([]string, 0)
-
-	// Build a lookup of AllowOnAllVirtualKeys clients: clientID -> clientName
 	var allowAllVKsClients map[string]string
 	if p.inMemoryStore != nil {
 		allowAllVKsClients = p.inMemoryStore.GetMCPClientsAllowingAllVirtualKeys()
 	}
+	return p.computeMCPIncludeToolsWith(virtualKey, allowAllVKsClients)
+}
+
+// computeMCPIncludeToolsWith is the computeMCPIncludeTools variant taking a pre-fetched
+// AllowOnAllVirtualKeys map (clientID → clientName), so callers that make multiple
+// grant decisions per request can evaluate them all against one consistent snapshot.
+func (p *GovernancePlugin) computeMCPIncludeToolsWith(virtualKey *configstoreTables.TableVirtualKey, allowAllVKsClients map[string]string) []string {
+	executeOnlyTools := make([]string, 0)
+
 	if allowAllVKsClients == nil {
 		allowAllVKsClients = make(map[string]string)
 	}
@@ -824,6 +832,67 @@ func (p *GovernancePlugin) computeMCPIncludeTools(virtualKey *configstoreTables.
 	}
 
 	return executeOnlyTools
+}
+
+// pruneMCPIncludeToolsFromContext narrows a caller-provided include-tools list (stamped on ctx
+// from the x-bf-mcp-include-tools header in lib/ctx.go) down to the tools the virtual key
+// allows, and writes the pruned list back to ctx. Returns true when a caller list was present,
+// regardless of how many entries survived. Entries the key does not grant are dropped; a
+// "client-*" wildcard is kept only when the key itself is unrestricted for that client,
+// otherwise it is replaced by the key's specific grants for that client (passing the wildcard
+// through would read downstream as "all tools of this client").
+func (p *GovernancePlugin) pruneMCPIncludeToolsFromContext(ctx *schemas.BifrostContext, virtualKey *configstoreTables.TableVirtualKey) bool {
+	existing := ctx.Value(schemas.MCPContextKeyIncludeTools)
+	if existing == nil {
+		return false
+	}
+	requested, _ := existing.([]string)
+
+	// Fetch the AllowOnAllVirtualKeys snapshot once so the wildcard checks (via vkSet)
+	// and the per-tool checks (via isMCPToolAllowedByVKWith) can't observe different
+	// states across a concurrent config reload.
+	var allowAllClients map[string]string
+	if p.inMemoryStore != nil {
+		allowAllClients = p.inMemoryStore.GetMCPClientsAllowingAllVirtualKeys()
+	}
+
+	vkTools := p.computeMCPIncludeToolsWith(virtualKey, allowAllClients)
+	vkSet := make(map[string]struct{}, len(vkTools))
+	for _, tool := range vkTools {
+		vkSet[tool] = struct{}{}
+	}
+
+	pruned := make([]string, 0, len(requested))
+	seen := make(map[string]struct{}, len(requested))
+	add := func(tool string) {
+		if _, dup := seen[tool]; !dup {
+			seen[tool] = struct{}{}
+			pruned = append(pruned, tool)
+		}
+	}
+	for _, pattern := range requested {
+		if pattern == "" {
+			continue
+		}
+		if clientName, isWildcard := strings.CutSuffix(pattern, "-*"); isWildcard {
+			if _, ok := vkSet[pattern]; ok {
+				add(pattern)
+				continue
+			}
+			for _, tool := range vkTools {
+				if strings.HasPrefix(tool, clientName+"-") {
+					add(tool)
+				}
+			}
+			continue
+		}
+		if p.isMCPToolAllowedByVKWith(virtualKey, pattern, allowAllClients) {
+			add(pattern)
+		}
+	}
+
+	ctx.SetValue(schemas.MCPContextKeyIncludeTools, pruned)
+	return true
 }
 
 // EvaluateGovernanceRequest is a common function that handles virtual key validation
@@ -1152,15 +1221,16 @@ func (p *GovernancePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *sche
 			return err
 		}
 
+		// A caller-provided include-tools list can only narrow the virtual key's
+		// tool grant, never expand it — prune entries the key does not allow.
+		callerProvided := p.pruneMCPIncludeToolsFromContext(ctx, virtualKey)
+
 		p.cfgMutex.RLock()
 		autoInjectDisabled := p.disableAutoToolInject != nil && *p.disableAutoToolInject
 		p.cfgMutex.RUnlock()
-		if !autoInjectDisabled {
-			// Don't overwrite a caller-provided include-tools value (set via header in lib/ctx.go).
-			if existing := ctx.Value(schemas.MCPContextKeyIncludeTools); existing == nil {
-				if tools := p.computeMCPIncludeTools(virtualKey); tools != nil {
-					ctx.SetValue(schemas.MCPContextKeyIncludeTools, tools)
-				}
+		if !callerProvided && !autoInjectDisabled {
+			if tools := p.computeMCPIncludeTools(virtualKey); tools != nil {
+				ctx.SetValue(schemas.MCPContextKeyIncludeTools, tools)
 			}
 		}
 	}

--- a/plugins/governance/prunemcpincludetools_test.go
+++ b/plugins/governance/prunemcpincludetools_test.go
@@ -1,0 +1,187 @@
+package governance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCtxWithIncludeTools returns a BifrostContext pre-stamped with a caller-provided
+// include-tools list, mirroring what lib/ctx.go does for the x-bf-mcp-include-tools header.
+func newCtxWithIncludeTools(tools []string) *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.MCPContextKeyIncludeTools, tools)
+	return ctx
+}
+
+// includeToolsFromCtx reads back the (possibly pruned) include-tools list from ctx.
+func includeToolsFromCtx(t *testing.T, ctx *schemas.BifrostContext) []string {
+	t.Helper()
+	value := ctx.Value(schemas.MCPContextKeyIncludeTools)
+	require.NotNil(t, value, "include-tools ctx value should be set")
+	tools, ok := value.([]string)
+	require.True(t, ok, "include-tools ctx value should be a []string")
+	return tools
+}
+
+// No caller-provided list on ctx → returns false and leaves ctx untouched.
+func TestPruneMCPIncludeTools_NoCallerList(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"find_projects"})
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	assert.False(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Nil(t, ctx.Value(schemas.MCPContextKeyIncludeTools),
+		"ctx should remain unset when the caller provided no list")
+}
+
+// A tool the VK does not grant is dropped; the result is an empty (deny-all) list.
+func TestPruneMCPIncludeTools_DisallowedToolDropped(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"find_projects"})
+	ctx := newCtxWithIncludeTools([]string{"sentry-search_tools"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Empty(t, includeToolsFromCtx(t, ctx),
+		"a tool outside the VK grant must be pruned, leaving a deny-all list")
+}
+
+// A tool the VK explicitly grants survives pruning.
+func TestPruneMCPIncludeTools_GrantedToolKept(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"find_projects", "search_issues"})
+	ctx := newCtxWithIncludeTools([]string{"sentry-find_projects", "sentry-search_tools"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Equal(t, []string{"sentry-find_projects"}, includeToolsFromCtx(t, ctx),
+		"granted entries survive, ungranted entries are dropped")
+}
+
+// A specific tool requested under an unrestricted ("*") VK grant survives — the
+// header narrows within the wildcard grant.
+func TestPruneMCPIncludeTools_SpecificToolUnderUnrestrictedGrant(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"*"})
+	ctx := newCtxWithIncludeTools([]string{"sentry-search_tools"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Equal(t, []string{"sentry-search_tools"}, includeToolsFromCtx(t, ctx),
+		"specific request should be allowed by the client's unrestricted grant")
+}
+
+// A caller wildcard is kept verbatim only when the VK itself is unrestricted for that client.
+func TestPruneMCPIncludeTools_WildcardKeptWhenVKUnrestricted(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"*"})
+	ctx := newCtxWithIncludeTools([]string{"sentry-*"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Equal(t, []string{"sentry-*"}, includeToolsFromCtx(t, ctx))
+}
+
+// A caller wildcard against a specific VK grant is narrowed to the grant's entries —
+// passing the wildcard through would read downstream as "all tools of this client".
+func TestPruneMCPIncludeTools_WildcardNarrowedToSpecificGrants(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"find_projects", "search_issues"})
+	ctx := newCtxWithIncludeTools([]string{"sentry-*"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Equal(t, []string{"sentry-find_projects", "sentry-search_issues"}, includeToolsFromCtx(t, ctx))
+}
+
+// A caller wildcard for a client the VK does not grant at all yields nothing.
+func TestPruneMCPIncludeTools_WildcardForUngrantedClientDropped(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"find_projects"})
+	ctx := newCtxWithIncludeTools([]string{"github-*"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Empty(t, includeToolsFromCtx(t, ctx))
+}
+
+// An empty header value (parsed as [""] by lib/ctx.go) prunes to a deny-all list,
+// letting callers suppress tool injection for a request.
+func TestPruneMCPIncludeTools_EmptyHeaderOptOut(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"*"})
+	ctx := newCtxWithIncludeTools([]string{""})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Empty(t, includeToolsFromCtx(t, ctx))
+}
+
+// Wildcard expansion plus an overlapping specific request must not produce duplicates.
+func TestPruneMCPIncludeTools_DedupAcrossWildcardAndSpecific(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"find_projects", "search_issues"})
+	ctx := newCtxWithIncludeTools([]string{"sentry-*", "sentry-find_projects"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Equal(t, []string{"sentry-find_projects", "sentry-search_issues"}, includeToolsFromCtx(t, ctx))
+}
+
+// AllowOnAllVirtualKeys client with no explicit VK config: both specific and wildcard
+// requests survive (the implicit grant is client-wide).
+func TestPruneMCPIncludeTools_AllowOnAllVirtualKeysClient(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{
+		allowAllClients: map[string]string{"client-1": "youtube"},
+	})
+	vk := buildVKNoMCPConfigs()
+	ctx := newCtxWithIncludeTools([]string{"youtube-search", "youtube-*", "github-list_repos"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Equal(t, []string{"youtube-search", "youtube-*"}, includeToolsFromCtx(t, ctx),
+		"AllowOnAllVirtualKeys grants the whole client; other clients are still pruned")
+}
+
+// An explicit empty VK config (deny-all) overrides the client's AllowOnAllVirtualKeys flag.
+func TestPruneMCPIncludeTools_ExplicitEmptyConfigOverridesAllowAll(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{
+		allowAllClients: map[string]string{"client-1": "youtube"},
+	})
+	vk := buildVKWithMCPConfigs("client-1", "youtube", []string{})
+	ctx := newCtxWithIncludeTools([]string{"youtube-search", "youtube-*"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Empty(t, includeToolsFromCtx(t, ctx))
+}
+
+// Pruning spans multiple VK clients independently.
+func TestPruneMCPIncludeTools_MultipleClients(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := &configstoreTables.TableVirtualKey{
+		ID:   "vk-multi",
+		Name: "test-vk-multi",
+		MCPConfigs: []configstoreTables.TableVirtualKeyMCPConfig{
+			{
+				MCPClient:      configstoreTables.TableMCPClient{ClientID: "client-1", Name: "sentry"},
+				ToolsToExecute: []string{"find_projects"},
+			},
+			{
+				MCPClient:      configstoreTables.TableMCPClient{ClientID: "client-2", Name: "github"},
+				ToolsToExecute: []string{"*"},
+			},
+		},
+	}
+	ctx := newCtxWithIncludeTools([]string{"sentry-find_projects", "sentry-search_issues", "github-list_repos", "github-*"})
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Equal(t, []string{"sentry-find_projects", "github-list_repos", "github-*"}, includeToolsFromCtx(t, ctx))
+}
+
+// A ctx value of the wrong type fails closed: treated as a present-but-empty caller list.
+func TestPruneMCPIncludeTools_WrongTypeFailsClosed(t *testing.T) {
+	p := newPluginWithInMemoryStore(&mockInMemoryStore{})
+	vk := buildVKWithMCPConfigs("client-1", "sentry", []string{"*"})
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.MCPContextKeyIncludeTools, "sentry-search_tools")
+
+	assert.True(t, p.pruneMCPIncludeToolsFromContext(ctx, vk))
+	assert.Empty(t, includeToolsFromCtx(t, ctx),
+		"a malformed ctx value must prune to deny-all, not pass through")
+}


### PR DESCRIPTION
## Summary

Caller-provided MCP include-tools lists (set via the `x-bf-mcp-include-tools` header) could previously reference tools that the virtual key does not grant, effectively allowing callers to expand their own tool access beyond what the key permits. This PR enforces that a caller-provided list can only narrow the virtual key's tool grant, never expand it.

## Changes

- Introduced `pruneMCPIncludeToolsFromContext`, which reads a caller-provided include-tools list from the context, intersects it with the tools the virtual key actually grants, and writes the pruned result back to the context.
- Caller wildcards (e.g. `sentry-*`) are kept verbatim only when the virtual key itself is unrestricted for that client; otherwise they are expanded to the key's specific grants to prevent the wildcard from being interpreted downstream as "all tools for this client."
- Auto-injection of the computed tool list is now skipped when a caller-provided list was present (even if it pruned to empty), replacing the previous check that only skipped injection when the context key was unset.
- Pruning is applied in both `runPreRequestRouting` and `PreRequestHook`, replacing the earlier pattern of checking for an existing context value before injecting.
- A wrong-type context value fails closed, pruning to a deny-all empty list rather than passing through.
- Added a dedicated test file covering: no caller list, disallowed tools dropped, granted tools kept, specific tools under unrestricted grants, wildcard passthrough vs. narrowing, ungranted client wildcards, empty header opt-out, deduplication, `AllowOnAllVirtualKeys` clients, explicit empty config overriding allow-all, multi-client pruning, and wrong-type fail-closed behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

The new test file `prunemcpincludetools_test.go` covers all pruning scenarios. Verify that:
- A caller requesting a tool not in the virtual key's grant receives an empty (deny-all) list.
- A caller requesting a subset of granted tools receives only that subset.
- A caller wildcard is narrowed to the key's specific grants when the key is not itself unrestricted for that client.
- Auto-injection does not overwrite a caller-provided list, even when the pruned result is empty.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change closes a privilege escalation path where a caller could use the `x-bf-mcp-include-tools` header to request tools beyond what their virtual key grants. The pruning logic ensures the effective tool set is always bounded by the virtual key's configured permissions, and any ambiguous or malformed input fails closed to a deny-all state.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Caller-provided MCP include-tools lists are now pruned to only the tools allowed for the active virtual key; auto-injection of tools occurs only when callers provide no list and auto-injection isn’t disabled.

* **Tests**
  * Added comprehensive tests covering pruning behavior, wildcards, deduplication, opt-out cases, multi-client scenarios, and fail-closed handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->