### PR TITLE
fix: stamp virtual key tool allowlist when `include-clients` filter bypasses `autoInjectDisabled`

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -430,12 +430,16 @@ func (p *GovernancePlugin) runPreRequestRouting(ctx *schemas.BifrostContext, vir
 
 		// A caller-provided include-tools list can only narrow the virtual key's
 		// tool grant, never expand it — prune entries the key does not allow.
-		callerProvided := p.pruneMCPIncludeToolsFromContext(ctx, virtualKey)
+		includeToolsProvided := p.pruneMCPIncludeToolsFromContext(ctx, virtualKey)
 
 		p.cfgMutex.RLock()
 		autoInjectDisabled := p.disableAutoToolInject != nil && *p.disableAutoToolInject
 		p.cfgMutex.RUnlock()
-		if !callerProvided && !autoInjectDisabled {
+		// An include-clients filter opts the request into tool injection even when
+		// auto-injection is disabled (see ParseAndAddToolsToRequest in core/mcp), so
+		// the key's allowlist must be stamped on every path where injection can run.
+		includeClientsPresent := ctx.Value(schemas.MCPContextKeyIncludeClients) != nil
+		if !includeToolsProvided && (!autoInjectDisabled || includeClientsPresent) {
 			if tools := p.computeMCPIncludeTools(virtualKey); tools != nil {
 				ctx.SetValue(schemas.MCPContextKeyIncludeTools, tools)
 			}
@@ -1223,12 +1227,16 @@ func (p *GovernancePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *sche
 
 		// A caller-provided include-tools list can only narrow the virtual key's
 		// tool grant, never expand it — prune entries the key does not allow.
-		callerProvided := p.pruneMCPIncludeToolsFromContext(ctx, virtualKey)
+		includeToolsProvided := p.pruneMCPIncludeToolsFromContext(ctx, virtualKey)
 
 		p.cfgMutex.RLock()
 		autoInjectDisabled := p.disableAutoToolInject != nil && *p.disableAutoToolInject
 		p.cfgMutex.RUnlock()
-		if !callerProvided && !autoInjectDisabled {
+		// An include-clients filter opts the request into tool injection even when
+		// auto-injection is disabled (see ParseAndAddToolsToRequest in core/mcp), so
+		// the key's allowlist must be stamped on every path where injection can run.
+		includeClientsPresent := ctx.Value(schemas.MCPContextKeyIncludeClients) != nil
+		if !includeToolsProvided && (!autoInjectDisabled || includeClientsPresent) {
 			if tools := p.computeMCPIncludeTools(virtualKey); tools != nil {
 				ctx.SetValue(schemas.MCPContextKeyIncludeTools, tools)
 			}


### PR DESCRIPTION
## Summary

When a request includes an `include-clients` filter, `ParseAndAddToolsToRequest` in `core/mcp` opts the request into tool injection even if auto-injection is globally disabled. Previously, the virtual key's tool allowlist was only stamped onto the context when auto-injection was enabled, meaning requests that bypassed the auto-injection gate via `include-clients` could run without the key's tool restrictions applied.

## Changes

- Renamed `callerProvided` to `includeToolsProvided` in both `runPreRequestRouting` and `PreRequestHook` for clarity.
- Added a check for `MCPContextKeyIncludeClients` in the context. When this key is present, the virtual key's tool allowlist (`computeMCPIncludeTools`) is stamped onto the context regardless of whether auto-injection is disabled, ensuring the key's grants are enforced on every code path where injection can occur.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request with an `include-clients` filter set and `disableAutoToolInject` enabled on the governance plugin. Verify that the virtual key's tool allowlist is applied and that tools outside the key's grant are not injected.

```sh
go test ./plugins/governance/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This fix closes a gap where a caller could use an `include-clients` filter to trigger tool injection while bypassing the virtual key's tool allowlist. The key's grants are now enforced on all injection paths, preventing potential privilege escalation through MCP tool access.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool injection so filters that request client-specific tools still trigger tool availability even when automatic injection is disabled.
  * Ensured previous pruning/default behavior remains unchanged while correctly honoring explicit client-filter requests for tool inclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->