### PR TITLE
fix: increase provider HTTP client read buffer to 64KB for large response headers

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -90,6 +90,7 @@ func NewAnthropicProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Pre-warm response pools

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -182,6 +182,7 @@ func NewAzureProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*A
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -133,6 +133,7 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 	mantleFasthttpClient = providerUtils.ConfigureProxy(mantleFasthttpClient, config.ProxyConfig, logger)
 	mantleFasthttpClient = providerUtils.ConfigureDialer(mantleFasthttpClient, config.NetworkConfig.AllowPrivateNetwork)

--- a/core/providers/cerebras/cerebras.go
+++ b/core/providers/cerebras/cerebras.go
@@ -37,6 +37,7 @@ func NewCerebrasProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -110,6 +110,7 @@ func NewCohereProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Setting proxy and retry policy

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -44,6 +44,7 @@ func NewElevenlabsProvider(config *schemas.ProviderConfig, logger schemas.Logger
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/fireworks/fireworks.go
+++ b/core/providers/fireworks/fireworks.go
@@ -37,6 +37,7 @@ func NewFireworksProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -71,6 +71,7 @@ func NewGeminiProvider(config *schemas.ProviderConfig, logger schemas.Logger) *G
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/groq/groq.go
+++ b/core/providers/groq/groq.go
@@ -37,6 +37,7 @@ func NewGroqProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*Gr
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// // Pre-warm response pools

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -79,6 +79,7 @@ func NewHuggingFaceProvider(config *schemas.ProviderConfig, logger schemas.Logge
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Pre-warm response pools

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -42,6 +42,7 @@ func NewMistralProvider(config *schemas.ProviderConfig, logger schemas.Logger) *
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Pre-warm response pools

--- a/core/providers/nebius/nebius.go
+++ b/core/providers/nebius/nebius.go
@@ -40,6 +40,7 @@ func NewNebiusProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -38,6 +38,7 @@ func NewOllamaProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// // Pre-warm response pools

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -49,6 +49,7 @@ func NewOpenAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) *O
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// // Pre-warm response pools

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -39,6 +39,7 @@ func NewOpenRouterProvider(config *schemas.ProviderConfig, logger schemas.Logger
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/parasail/parasail.go
+++ b/core/providers/parasail/parasail.go
@@ -38,6 +38,7 @@ func NewParasailProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -40,6 +40,7 @@ func NewPerplexityProvider(config *schemas.ProviderConfig, logger schemas.Logger
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -47,6 +47,7 @@ func NewReplicateProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/providers/runway/runway.go
+++ b/core/providers/runway/runway.go
@@ -38,6 +38,7 @@ func NewRunwayProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy if provided

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -38,6 +38,7 @@ func NewSGLProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*SGL
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Pre-warm response pools

--- a/core/providers/utils/readbuffer_test.go
+++ b/core/providers/utils/readbuffer_test.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttputil"
+)
+
+// newLargeHeaderTestServer creates an in-memory fasthttp server that responds with
+// response headers larger than fasthttp's default 4KB client read buffer, mimicking
+// upstreams behind Cloudflare that attach large Set-Cookie and CSP headers.
+// Returns a dial function for clients to connect to it and a cleanup function.
+func newLargeHeaderTestServer(t *testing.T) (func(addr string) (net.Conn, error), func()) {
+	t.Helper()
+	ln := fasthttputil.NewInmemoryListener()
+
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			// ~6KB cookie + ~2KB CSP header, comfortably above the 4096-byte default
+			ctx.Response.Header.Set("Set-Cookie", "ph_bootstrap="+strings.Repeat("a", 6*1024)+"; Path=/; Secure")
+			ctx.Response.Header.Set("Content-Security-Policy", strings.Repeat("connect-src https://example.com ", 64))
+			ctx.SetStatusCode(fasthttp.StatusOK)
+			ctx.SetBody([]byte(`{"ok":true}`))
+		},
+	}
+
+	go server.Serve(ln) //nolint:errcheck
+
+	return func(addr string) (net.Conn, error) {
+			return ln.Dial()
+		}, func() {
+			ln.Close()
+		}
+}
+
+// TestMakeRequestWithContext_LargeResponseHeaders verifies that provider clients
+// configured with schemas.DefaultClientReadBufferSize can read responses whose
+// headers exceed fasthttp's 4KB default read buffer (see issue #4264), while a
+// client left at the default fails with a small-read-buffer error.
+func TestMakeRequestWithContext_LargeResponseHeaders(t *testing.T) {
+	dial, cleanup := newLargeHeaderTestServer(t)
+	defer cleanup()
+
+	t.Run("default_read_buffer_fails", func(t *testing.T) {
+		client := &fasthttp.Client{
+			Dial:        dial,
+			ReadTimeout: 5 * time.Second,
+		}
+
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(req)
+		defer fasthttp.ReleaseResponse(resp)
+		req.SetRequestURI("http://test/")
+
+		_, bifrostErr, wait := MakeRequestWithContext(context.Background(), client, req, resp)
+		defer wait()
+
+		if bifrostErr == nil {
+			t.Fatal("expected small read buffer error with fasthttp's default ReadBufferSize, got success")
+		}
+	})
+
+	t.Run("default_client_read_buffer_size_succeeds", func(t *testing.T) {
+		client := &fasthttp.Client{
+			Dial:           dial,
+			ReadTimeout:    5 * time.Second,
+			ReadBufferSize: schemas.DefaultClientReadBufferSize,
+		}
+
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+		defer fasthttp.ReleaseRequest(req)
+		defer fasthttp.ReleaseResponse(resp)
+		req.SetRequestURI("http://test/")
+
+		_, bifrostErr, wait := MakeRequestWithContext(context.Background(), client, req, resp)
+		defer wait()
+
+		if bifrostErr != nil {
+			t.Fatalf("expected success with %d-byte read buffer, got: %v", schemas.DefaultClientReadBufferSize, bifrostErr.Error.Message)
+		}
+		if resp.StatusCode() != fasthttp.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode())
+		}
+	})
+}

--- a/core/providers/utils/readbuffer_test.go
+++ b/core/providers/utils/readbuffer_test.go
@@ -65,6 +65,9 @@ func TestMakeRequestWithContext_LargeResponseHeaders(t *testing.T) {
 		if bifrostErr == nil {
 			t.Fatal("expected small read buffer error with fasthttp's default ReadBufferSize, got success")
 		}
+		// GetErrorString() is not used here: it returns only the generic
+		// classification message (ErrProviderDoRequest); the fasthttp
+		// "small read buffer" detail lives in the wrapped Error.Error.
 		errText := bifrostErr.Error.Message
 		if bifrostErr.Error.Error != nil {
 			errText += " " + bifrostErr.Error.Error.Error()

--- a/core/providers/utils/readbuffer_test.go
+++ b/core/providers/utils/readbuffer_test.go
@@ -65,6 +65,13 @@ func TestMakeRequestWithContext_LargeResponseHeaders(t *testing.T) {
 		if bifrostErr == nil {
 			t.Fatal("expected small read buffer error with fasthttp's default ReadBufferSize, got success")
 		}
+		errText := bifrostErr.Error.Message
+		if bifrostErr.Error.Error != nil {
+			errText += " " + bifrostErr.Error.Error.Error()
+		}
+		if !strings.Contains(errText, "small read buffer") {
+			t.Fatalf("expected small read buffer error, got: %s", errText)
+		}
 	})
 
 	t.Run("default_client_read_buffer_size_succeeds", func(t *testing.T) {

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -109,6 +109,7 @@ func NewVertexProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 		MaxConnDuration:        time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:       fasthttp.FIFO,
 		DisablePathNormalizing: true,
+		ReadBufferSize:         schemas.DefaultClientReadBufferSize,
 	}
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -40,6 +40,7 @@ func NewVLLMProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*VL
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)

--- a/core/providers/xai/xai.go
+++ b/core/providers/xai/xai.go
@@ -38,6 +38,7 @@ func NewXAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*XAI
 		MaxConnWaitTimeout:  requestTimeout,
 		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
 		ConnPoolStrategy:    fasthttp.FIFO,
+		ReadBufferSize:      schemas.DefaultClientReadBufferSize,
 	}
 
 	// Configure proxy and retry policy

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -14,7 +14,8 @@ const (
 	DefaultRetryBackoffInitial        = 500 * time.Millisecond
 	DefaultRetryBackoffMax            = 5 * time.Second
 	DefaultRequestTimeoutInSeconds    = 300
-	DefaultMaxConnDurationInSeconds   = 300 // 5 minutes — forces connection recycling to prevent stale connections from NAT/LB silent drops
+	DefaultMaxConnDurationInSeconds   = 300       // 5 minutes — forces connection recycling to prevent stale connections from NAT/LB silent drops
+	DefaultClientReadBufferSize       = 64 * 1024 // 64KB read buffer for provider HTTP clients, matching the bifrost HTTP server setting — fasthttp's 4KB default overflows on large response headers (e.g. Cloudflare cookies + CSP headers)
 	DefaultBufferSize                 = 5000
 	DefaultConcurrency                = 1000
 	DefaultStreamBufferSize           = 256


### PR DESCRIPTION
## Summary

Fixes #4264. Requests to providers behind Cloudflare (reported with OpenRouter) fail with `small read buffer. Increase ReadBufferSize. Buffer size=4096` when the upstream response carries large headers — e.g. a `ph_bootstrap` cookie plus a Stripe CSP header easily exceed fasthttp's 4096-byte default client read buffer. @guptasanchit90's diagnosis in the issue is exactly right.

This is the provider-client counterpart of #2498, which fixed the same failure on the plugin-install client by giving it a 64KB read buffer to match the bifrost HTTP server setting (`transports/bifrost-http/server/server.go` uses `ReadBufferSize: 1024 * 64`).

## Changes

- Added `schemas.DefaultClientReadBufferSize = 64 * 1024` alongside the other client defaults in `core/schemas/provider.go`.
- Set `ReadBufferSize: schemas.DefaultClientReadBufferSize` on every provider's fasthttp client construction (22 providers plus Bedrock's Mantle client). Streaming clients inherit it automatically — `BuildStreamingClient` clones `ReadBufferSize` via `CloneFastHTTPClientConfig`.
- Added a regression test in `core/providers/utils/readbuffer_test.go` using the existing in-memory listener harness: a server emitting ~8KB of response headers fails against fasthttp's default buffer and succeeds with `DefaultClientReadBufferSize`.

Note: `core/network`'s `HTTPClientFactory` (SCIM/API-purpose clients) has the same 4KB default. Left untouched to keep this scoped to the reported provider path — happy to align it in a follow-up if you'd like.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go build ./...
go test -run TestMakeRequestWithContext_LargeResponseHeaders ./providers/utils/ -v
go test ./providers/utils/ ./schemas/
```

The new test's `default_read_buffer_fails` subtest reproduces the reported failure mode; `default_client_read_buffer_size_succeeds` verifies the fix. To validate end-to-end, route a request through OpenRouter (their Cloudflare edge attaches the large cookie/CSP headers from the report) — it fails with `small read buffer` before this change and succeeds after.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

Per-connection memory grows from 4KB to 64KB for the read buffer, the same trade-off accepted in #2498 and already paid on the server side.

## Related issues

Closes #4264

## Security considerations

None — buffer sizing only; no changes to auth, TLS, dialing, or proxy behavior.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable