### PR TITLE
adds missing tally widgets

### DIFF
--- a/docs/tally-embed.js
+++ b/docs/tally-embed.js
@@ -1,0 +1,22 @@
+// Loads the Tally embed runtime so `data-tally-open` popup buttons work across the docs.
+// Mintlify includes any .js file in the content directory on every page, after the page
+// becomes interactive. See https://www.mintlify.com/docs/customize/custom-scripts
+(function () {
+  var widgetScriptSrc = "https://tally.so/widgets/embed.js";
+
+  var load = function () {
+    if (typeof Tally !== "undefined") {
+      Tally.loadEmbeds();
+    }
+  };
+
+  if (typeof Tally !== "undefined") {
+    load();
+  } else if (document.querySelector('script[src="' + widgetScriptSrc + '"]') == null) {
+    var script = document.createElement("script");
+    script.src = widgetScriptSrc;
+    script.onload = load;
+    script.onerror = load;
+    document.body.appendChild(script);
+  }
+})();


### PR DESCRIPTION
## Summary

Adds the Tally embed runtime to the docs site so that `data-tally-open` popup buttons work correctly on every page.

## Changes

- Added `docs/tally-embed.js`, which lazily loads the Tally widget script (`https://tally.so/widgets/embed.js`) and calls `Tally.loadEmbeds()` once available. Mintlify automatically includes any `.js` file in the content directory on every page after it becomes interactive, making this the appropriate place to initialize the embed runtime globally.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Open any docs page that contains a button with a `data-tally-open` attribute.
2. Click the button and confirm the Tally popup opens correctly.
3. Verify no console errors related to Tally or the embed script appear on page load.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The script loads an external resource from `tally.so`. This is a trusted third-party embed provider, but it should be noted that the script is fetched from an external CDN and executed in the page context. No secrets or PII are handled by this script.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added embedded interactive forms to documentation pages, enabling direct user feedback and engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->