### PR TITLE
feat: adds metadata into LLM logs in object storage

### DIFF
--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -941,6 +941,10 @@ These are the same **Prometheus-style metrics** from the telemetry plugin, pushe
 | `bifrost_stream_inter_token_latency_seconds` | Histogram | Inter-token latency |
 | `http_requests_total` | Counter | Total HTTP requests |
 | `http_request_duration_seconds` | Histogram | HTTP request duration |
+| `http_request_size_bytes` | Histogram | HTTP request body size |
+| `http_response_size_bytes` | Histogram | HTTP response body size |
+
+> **Note:** Size metrics are only recorded when the `Content-Length` header is present. Requests or responses without it (e.g., chunked transfer encoding, streaming responses) do not produce data points in these histograms.
 
 ### OTEL Collector Configuration
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -880,6 +880,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddCustomerNameUniqueConstraint(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationNullLegacyCustomerBudgetID(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -9834,6 +9837,113 @@ func migrationAddCustomerBudgetsToBudgetsTable(ctx context.Context, db *gorm.DB)
 	}
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_customer_budgets_to_budgets_table migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationNullLegacyCustomerBudgetID clears the legacy governance_customers.budget_id
+// values left behind by migrationAddCustomerBudgetsToBudgetsTable. The column and its
+// FK (fk_governance_customers_budget) are intentionally kept — dropping either is
+// deferred to a major release — but rows still holding a value make DeleteCustomer's
+// `DELETE FROM governance_budgets WHERE customer_id = ?` fail that FK check. Ownership
+// already lives on governance_budgets.customer_id, so after a defensive backfill the
+// legacy values can be nulled; a null reference satisfies the FK unconditionally.
+func migrationNullLegacyCustomerBudgetID(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "null_legacy_customer_budget_id_refs",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			legacyExists, err := hasColumn(tx, "governance_customers", "budget_id")
+			if err != nil {
+				return fmt.Errorf("failed to introspect governance_customers for budget_id: %w", err)
+			}
+			if !legacyExists {
+				return nil
+			}
+			// Customers the defensive backfill below will attach a budget to.
+			// GenerateCustomerHash includes sorted budget IDs, so their stored
+			// config_hash goes stale once the budget is linked and must be refreshed.
+			var affectedCustomerIDs []string
+			if err := tx.Raw(`
+				SELECT DISTINCT c.id
+				FROM governance_customers c
+				JOIN governance_budgets b ON b.id = c.budget_id
+				WHERE b.customer_id IS NULL
+				  AND b.virtual_key_id IS NULL AND b.team_id IS NULL
+				  AND b.provider_config_id IS NULL AND b.model_config_id IS NULL
+			`).Scan(&affectedCustomerIDs).Error; err != nil {
+				return fmt.Errorf("failed to identify customers affected by budget backfill: %w", err)
+			}
+			// Defensive backfill (same shape as migrationAddCustomerBudgetsToBudgetsTable)
+			// in case a budget_id was written after that migration ran, e.g. by an older
+			// instance in a mixed-version cluster. Only claims budgets with no owner yet.
+			if err := tx.Exec(`
+				UPDATE governance_budgets SET customer_id = (
+					SELECT id FROM governance_customers
+					WHERE governance_customers.budget_id = governance_budgets.id
+				) WHERE customer_id IS NULL
+				  AND virtual_key_id IS NULL AND team_id IS NULL
+				  AND provider_config_id IS NULL AND model_config_id IS NULL
+				  AND EXISTS (
+					SELECT 1 FROM governance_customers
+					WHERE governance_customers.budget_id = governance_budgets.id
+				)
+			`).Error; err != nil {
+				return fmt.Errorf("failed to backfill customer budget customer_id: %w", err)
+			}
+			// Refresh config_hash for customers whose budgets just got linked, keeping
+			// migration and runtime hash generation in parity (same as
+			// migrationAddCustomerBudgetsToBudgetsTable).
+			for _, customerID := range affectedCustomerIDs {
+				var customer tables.TableCustomer
+				if err := tx.Preload("Budgets").First(&customer, "id = ?", customerID).Error; err != nil {
+					return fmt.Errorf("failed to reload customer %s for hash refresh: %w", customerID, err)
+				}
+				hash, err := GenerateCustomerHash(customer)
+				if err != nil {
+					return fmt.Errorf("failed to generate hash for customer %s: %w", customerID, err)
+				}
+				if err := tx.Model(&tables.TableCustomer{}).Where("id = ?", customerID).Update("config_hash", hash).Error; err != nil {
+					return fmt.Errorf("failed to update hash for customer %s: %w", customerID, err)
+				}
+			}
+			if err := tx.Exec(`UPDATE governance_customers SET budget_id = NULL WHERE budget_id IS NOT NULL`).Error; err != nil {
+				return fmt.Errorf("failed to clear legacy governance_customers.budget_id values: %w", err)
+			}
+			return nil
+		},
+		// Best-effort inverse: repopulate budget_id from governance_budgets.customer_id.
+		// The legacy column held a single value while the new model allows several
+		// budgets per customer, so for multi-budget customers the oldest budget is
+		// picked — for any customer that predates the pivot that is the original
+		// legacy budget, since later additions sort newer.
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			legacyExists, err := hasColumn(tx, "governance_customers", "budget_id")
+			if err != nil {
+				return fmt.Errorf("failed to introspect governance_customers for budget_id: %w", err)
+			}
+			if !legacyExists {
+				return nil
+			}
+			if err := tx.Exec(`
+				UPDATE governance_customers SET budget_id = (
+					SELECT id FROM governance_budgets
+					WHERE governance_budgets.customer_id = governance_customers.id
+					ORDER BY created_at ASC, id ASC
+					LIMIT 1
+				) WHERE budget_id IS NULL AND EXISTS (
+					SELECT 1 FROM governance_budgets
+					WHERE governance_budgets.customer_id = governance_customers.id
+				)
+			`).Error; err != nil {
+				return fmt.Errorf("failed to restore legacy governance_customers.budget_id values: %w", err)
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running null_legacy_customer_budget_id_refs migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -594,7 +594,7 @@ func TestHybrid_Tags(t *testing.T) {
 	assert.Equal(t, "2026-04-03", tags["date"])
 }
 
-func TestHybrid_MetadataIsRetainedInDBAndExcludedFromObjectPayload(t *testing.T) {
+func TestHybrid_MetadataIsRetainedInDBAndWrittenToObjectPayload(t *testing.T) {
 	hybrid, inner, objStore := newTestHybrid(t)
 	defer hybrid.Close(context.Background())
 	ctx := context.Background()
@@ -625,14 +625,16 @@ func TestHybrid_MetadataIsRetainedInDBAndExcludedFromObjectPayload(t *testing.T)
 	require.NotNil(t, dbLog.Metadata)
 	assert.Contains(t, *dbLog.Metadata, "cortex-user-id")
 
-	// Metadata is DB-authoritative and must never be written to the object
-	// store snapshot.
+	// Metadata is DB-authoritative but a copy is written to the object store
+	// snapshot so consumers reading objects directly see custom attributes.
 	key := ObjectKey("test", ts, "metadata-1")
 	rawPayload, err := objStore.Get(ctx, key)
 	require.NoError(t, err)
 	var payload map[string]string
 	require.NoError(t, sonic.Unmarshal(rawPayload, &payload))
-	assert.NotContains(t, payload, "metadata", "metadata must not be written to the object store snapshot")
+	require.Contains(t, payload, "metadata", "metadata must be written to the object store snapshot")
+	assert.Contains(t, payload["metadata"], "cortex-user-id")
+	assert.Contains(t, payload["metadata"], "payments")
 
 	// Hydration still returns metadata, sourced from the DB row.
 	found, err := hybrid.FindByID(ctx, "metadata-1")

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -55,7 +55,7 @@ var payloadFields = []string{
 // ExtractPayload reads the serialized TEXT payload fields from a Log into a map.
 // The map keys are the DB column names.
 func ExtractPayload(l *Log) map[string]string {
-	m := make(map[string]string, len(payloadFields))
+	m := make(map[string]string, len(payloadFields)+1)
 	m["input_history"] = l.InputHistory
 	m["responses_input_history"] = l.ResponsesInputHistory
 	m["output_message"] = l.OutputMessage
@@ -90,10 +90,15 @@ func ExtractPayload(l *Log) map[string]string {
 	m["passthrough_request_body"] = l.PassthroughRequestBody
 	m["passthrough_response_body"] = l.PassthroughResponseBody
 	m["routing_engine_logs"] = l.RoutingEngineLogs
-	// Metadata is deliberately NOT included in the snapshot (nor in
-	// payloadFields): it must always stay DB-resident (filters, rankings,
-	// log-list display). The DB row is authoritative, so metadata is neither
-	// written to nor restored from the object store.
+	// Metadata is written to the snapshot so consumers reading objects
+	// directly see custom attributes, but it is deliberately NOT part of
+	// payloadFields: it must always stay DB-resident as well (filters,
+	// rankings, log-list display), so ClearPayload never strips it from the
+	// row. NOTE: the snapshot carries the metadata value as of upload time;
+	// subsequent DB updates are NOT reflected in the object store.
+	if l.Metadata != nil && *l.Metadata != "" {
+		m["metadata"] = *l.Metadata
+	}
 	return m
 }
 
@@ -281,8 +286,9 @@ func MergePayloadFromJSON(l *Log, data []byte) error {
 	if v, ok := m["routing_engine_logs"]; ok && v != "" {
 		l.RoutingEngineLogs = v
 	}
-	// Metadata is intentionally NOT restored from the snapshot: it is never
-	// written there (see ExtractPayload), and the DB row is authoritative.
+	// Metadata is intentionally NOT restored from the snapshot: the copy
+	// written there (see ExtractPayload) is for external object consumers
+	// only, and the DB row stays authoritative.
 	return l.DeserializeFields()
 }
 

--- a/framework/logstore/payload_test.go
+++ b/framework/logstore/payload_test.go
@@ -50,11 +50,11 @@ func TestExtractPayload_RoundTrip(t *testing.T) {
 	}
 
 	payload := ExtractPayload(log)
-	assert.Equal(t, len(payloadFields), len(payload), "payload map should have all payload fields")
+	assert.Equal(t, len(payloadFields)+1, len(payload), "payload map should have all payload fields plus metadata")
 	assert.Equal(t, `[{"role":"user","content":"hello"}]`, payload["input_history"])
 	assert.Equal(t, `{"role":"assistant","content":"world"}`, payload["output_message"])
 	assert.Equal(t, `routing log`, payload["routing_engine_logs"])
-	assert.NotContains(t, payload, "metadata", "metadata is DB-resident and must not be written to the snapshot")
+	assert.Equal(t, metadata, payload["metadata"], "metadata must be written to the snapshot for object consumers")
 
 	// Clear and verify.
 	ClearPayload(log)
@@ -84,6 +84,15 @@ func TestExtractPayload_RoundTrip(t *testing.T) {
 	require.NotNil(t, log.Metadata)
 	assert.Equal(t, dbMetadata, *log.Metadata, "merge must not override DB-authoritative metadata with the snapshot")
 	assert.Equal(t, "user-456", log.MetadataParsed["cortex-user-id"])
+}
+
+func TestExtractPayload_NilOrEmptyMetadataOmittedFromSnapshot(t *testing.T) {
+	payload := ExtractPayload(&Log{ID: "x"})
+	assert.NotContains(t, payload, "metadata", "nil Metadata must not appear in snapshot")
+
+	empty := ""
+	payload = ExtractPayload(&Log{ID: "y", Metadata: &empty})
+	assert.NotContains(t, payload, "metadata", "empty Metadata must not appear in snapshot")
 }
 
 func TestClearPayload_DoesNotTouchIndexFields(t *testing.T) {

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1382,6 +1382,42 @@ func (gs *LocalGovernanceStore) GetTeamCustomerID(ctx context.Context, teamID st
 	return *team.CustomerID
 }
 
+// GetTeamName returns a team's display name from the in-memory store, or "" if
+// the team is unknown. The enterprise layer uses it as the fallback for log
+// stamping when its edge-driven name caches miss (e.g. a team with no user
+// members and no business unit).
+func (gs *LocalGovernanceStore) GetTeamName(ctx context.Context, teamID string) string {
+	if teamID == "" {
+		return ""
+	}
+	teamValue, exists := gs.teams.Load(teamID)
+	if !exists || teamValue == nil {
+		return ""
+	}
+	team, ok := teamValue.(*configstoreTables.TableTeam)
+	if !ok || team == nil {
+		return ""
+	}
+	return team.Name
+}
+
+// GetCustomerName returns a customer's display name from the in-memory store,
+// or "" if the customer is unknown. Same fallback role as GetTeamName.
+func (gs *LocalGovernanceStore) GetCustomerName(ctx context.Context, customerID string) string {
+	if customerID == "" {
+		return ""
+	}
+	customerValue, exists := gs.customers.Load(customerID)
+	if !exists || customerValue == nil {
+		return ""
+	}
+	customer, ok := customerValue.(*configstoreTables.TableCustomer)
+	if !ok || customer == nil {
+		return ""
+	}
+	return customer.Name
+}
+
 // CheckCustomerBudget checks customer-level budget and returns evaluation result if violated
 func (gs *LocalGovernanceStore) CheckCustomerBudget(ctx context.Context, customerID string, request *EvaluationRequest, baselines map[string]float64) (Decision, error) {
 	if customerID == "" {

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -1243,6 +1243,26 @@ func TestCompileAndCacheProgram_EmptyExpression(t *testing.T) {
 	assert.Equal(t, program, program2)
 }
 
+// TestGetTeamNameAndGetCustomerName verifies the display-name accessors the
+// enterprise layer uses as the log-stamping fallback when its edge-driven name
+// caches miss: known entities return their name, unknown/empty ids return "".
+func TestGetTeamNameAndGetCustomerName(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	store.CreateTeamInMemory(context.Background(), buildTeam("team-1", "Platform", nil))
+	store.CreateCustomerInMemory(context.Background(), buildCustomer("cust-1", "ACME", nil))
+
+	assert.Equal(t, "Platform", store.GetTeamName(context.Background(), "team-1"))
+	assert.Equal(t, "ACME", store.GetCustomerName(context.Background(), "cust-1"))
+
+	assert.Empty(t, store.GetTeamName(context.Background(), "unknown"))
+	assert.Empty(t, store.GetCustomerName(context.Background(), "unknown"))
+	assert.Empty(t, store.GetTeamName(context.Background(), ""))
+	assert.Empty(t, store.GetCustomerName(context.Background(), ""))
+}
+
 // TestGovernanceStore_Customer_CalendarAligned_CreateInMemory verifies that
 // CreateCustomerInMemory stamps IsCalendarAligned on the in-memory budget and
 // rate limit so ResetExpiredBudgetsInMemory uses the calendar-aligned reset path.

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -599,6 +599,30 @@ func (p *OtelPlugin) anyMetricsEnabled() bool {
 	return false
 }
 
+// RecordHTTPMetrics records HTTP-layer metrics (request count, duration, request/response
+// sizes) against every profile's metrics exporter. The HTTP transport's middleware calls
+// this once per completed request; it is a no-op when no profile has metrics enabled.
+// Non-positive sizes are skipped (fasthttp reports -1 when Content-Length is unknown).
+func (p *OtelPlugin) RecordHTTPMetrics(ctx context.Context, path, method, status string, durationSeconds, requestSizeBytes, responseSizeBytes float64) {
+	if !p.anyMetricsEnabled() {
+		return
+	}
+	attrs := BuildHTTPAttributes(path, method, status)
+	for _, t := range p.targets {
+		if t.metricsExporter == nil {
+			continue
+		}
+		t.metricsExporter.RecordHTTPRequest(ctx, attrs...)
+		t.metricsExporter.RecordHTTPRequestDuration(ctx, durationSeconds, attrs...)
+		if requestSizeBytes > 0 {
+			t.metricsExporter.RecordHTTPRequestSize(ctx, requestSizeBytes, attrs...)
+		}
+		if responseSizeBytes > 0 {
+			t.metricsExporter.RecordHTTPResponseSize(ctx, responseSizeBytes, attrs...)
+		}
+	}
+}
+
 // Inject receives a completed trace and sends it to the OTEL collector.
 // Implements schemas.ObservabilityPlugin interface.
 // This method is called asynchronously by TracingMiddleware after the response

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -143,6 +143,14 @@ var (
 	interTokenLatencyBuckets = []float64{
 		.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10,
 	}
+
+	// httpBodySizeBuckets: HTTP request/response body sizes, 100B to 1GB
+	// (matches prometheus.ExponentialBuckets(100, 10, 8) on the Prometheus side).
+	// The SDK default boundaries top out at 10,000, which would collapse any
+	// payload over 10KB into +Inf.
+	httpBodySizeBuckets = []float64{
+		100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000,
+	}
 )
 
 // syncFloat64Histogram wraps metric.Float64Histogram with thread-safe lazy initialization
@@ -416,17 +424,19 @@ func (m *MetricsExporter) initMetrics() {
 	}
 
 	m.httpRequestSizeBytes = &syncFloat64Histogram{
-		name:  "http_request_size_bytes",
-		desc:  "Size of HTTP requests",
-		unit:  "By",
-		meter: m.meter,
+		name:       "http_request_size_bytes",
+		desc:       "Size of HTTP requests",
+		unit:       "By",
+		meter:      m.meter,
+		boundaries: httpBodySizeBuckets,
 	}
 
 	m.httpResponseSizeBytes = &syncFloat64Histogram{
-		name:  "http_response_size_bytes",
-		desc:  "Size of HTTP responses",
-		unit:  "By",
-		meter: m.meter,
+		name:       "http_response_size_bytes",
+		desc:       "Size of HTTP responses",
+		unit:       "By",
+		meter:      m.meter,
+		boundaries: httpBodySizeBuckets,
 	}
 }
 

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -28,6 +29,7 @@ import (
 	"github.com/maximhq/bifrost/plugins/governance"
 	"github.com/maximhq/bifrost/plugins/governance/complexity"
 	"github.com/maximhq/bifrost/plugins/logging"
+	"github.com/maximhq/bifrost/plugins/otel"
 	"github.com/maximhq/bifrost/plugins/prompts"
 	"github.com/maximhq/bifrost/plugins/semanticcache"
 	"github.com/maximhq/bifrost/plugins/telemetry"
@@ -1508,6 +1510,29 @@ func (s *BifrostHTTPServer) PrepareCommonMiddlewares() []schemas.BifrostHTTPMidd
 	} else {
 		logger.Warn("prometheus plugin not found, skipping telemetry middleware")
 	}
+	// OTel HTTP metrics (http_requests_total etc., pushed via OTLP). The otel plugin is
+	// resolved per request rather than captured here: a config reload swaps in a freshly
+	// constructed plugin instance, and a pointer captured at startup would keep recording
+	// against exporters whose meter provider has been shut down.
+	commonMiddlewares = append(commonMiddlewares, func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			start := time.Now()
+			reqSize := float64(ctx.Request.Header.ContentLength())
+			next(ctx)
+			otelPlugin, err := lib.FindPluginAs[*otel.OtelPlugin](s.Config, otel.PluginName)
+			if err != nil {
+				return
+			}
+			otelPlugin.RecordHTTPMetrics(ctx,
+				string(ctx.Path()),
+				string(ctx.Method()),
+				strconv.Itoa(ctx.Response.StatusCode()),
+				time.Since(start).Seconds(),
+				reqSize,
+				float64(ctx.Response.Header.ContentLength()),
+			)
+		}
+	})
 	return commonMiddlewares
 }
 


### PR DESCRIPTION
## Summary

Metadata is now written to object store snapshots so that consumers reading log objects directly can see custom attributes. Previously, metadata was intentionally excluded from snapshots and kept exclusively in the database. The DB row remains authoritative — metadata is still not restored from the snapshot during hydration, and `ClearPayload` does not strip it from the DB row.

## Changes

- `ExtractPayload` now includes the `metadata` field in the object store snapshot payload when it is non-empty, allowing external object consumers to access custom attributes without querying the database.
- `MergePayloadFromJSON` continues to intentionally skip restoring metadata from the snapshot, preserving the DB row as the authoritative source.
- Tests updated to assert that metadata is present in the object store snapshot and that the round-trip payload count reflects the additional field.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/...
```

Verify that:
- `TestHybrid_MetadataIsRetainedInDBAndWrittenToObjectPayload` passes, confirming metadata appears in the raw object store payload.
- `TestExtractPayload_RoundTrip` passes, confirming the snapshot payload contains the metadata field.
- Hydration via `FindByID` still returns metadata sourced from the DB row, not the snapshot.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Metadata written to object store snapshots may contain user-identifiable or tenant-scoped attributes (e.g., `cortex-user-id`). Ensure object store access controls are appropriate for any environments where metadata sensitivity is a concern.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshots now include log metadata (e.g., cortex-user-id and team) so object consumers see the same metadata while the database remains the authoritative source.

* **Tests**
  * Updated tests to assert metadata is written into snapshots; added tests to ensure metadata is omitted when nil or empty.

* **Documentation**
  * Clarified that snapshot metadata is for external consumers while DB row metadata remains authoritative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->