### PR TITLE
fix(complexity):complexity router keyword merging and removal via config.json changes

### DIFF
--- a/docs/deployment-guides/helm/governance.mdx
+++ b/docs/deployment-guides/helm/governance.mdx
@@ -406,7 +406,7 @@ bifrost:
 ```
 
 <Note>
-When this block is present, it is reapplied from the generated `config.json` on restart. Runtime UI and API edits still hot-reload immediately, but Helm values remain the source of truth for the next rollout.
+In the default split mode, runtime UI and API edits are preserved while the matching Helm-rendered section is unchanged. When Helm changes a section, tier boundaries are replaced from the rendered `config.json`, while keyword lists are merged additively with stored runtime keywords (union with duplicates removed). Use `bifrost.governance.sourceOfTruth: config.json` only when Helm should replace stored governance state.
 </Note>
 
 ---

--- a/docs/features/governance/complexity-router.mdx
+++ b/docs/features/governance/complexity-router.mdx
@@ -182,7 +182,7 @@ Each keyword list requires at least one entry. Keywords are normalized to lowerc
 </Note>
 
 <Warning>
-If `governance.complexity_analyzer_config` is present in `config.json`, the file remains authoritative on restart. UI and API edits apply immediately, but the file values are re-applied on the next startup unless you update `config.json` too.
+When `governance.complexity_analyzer_config` is present in `config.json`, the default split mode preserves UI and API edits across restarts while the matching file section is unchanged. When a section changes, tier boundaries are replaced from `config.json`, while keyword lists are merged additively with stored runtime keywords (union with duplicates removed). Set top-level `source_of_truth` to `"config.json"` in `config.json`, or `bifrost.governance.sourceOfTruth: config.json` in Helm values, only when the file should replace the stored analyzer config.
 </Warning>
 
 </Tab>

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"hash"
 	"maps"
 	"math"
@@ -1112,6 +1113,58 @@ func GenerateProviderGovernanceHash(p tables.TableProvider) (string, error) {
 	writeHashField(hash, "budget_id", derefStr(p.BudgetID))
 	writeHashField(hash, "rate_limit_id", derefStr(p.RateLimitID))
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// GenerateComplexityAnalyzerConfigHashes returns stable section hashes for
+// config.json-sourced analyzer config.
+func GenerateComplexityAnalyzerConfigHashes(config *ComplexityAnalyzerConfig) (ComplexityAnalyzerConfigHashes, error) {
+	if config == nil {
+		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("complexity analyzer config is nil")
+	}
+
+	normalized := config.Normalized()
+	normalized.ConfigHashes = ComplexityAnalyzerConfigHashes{}
+	if err := normalized.Validate(); err != nil {
+		return ComplexityAnalyzerConfigHashes{}, err
+	}
+
+	tierHash, err := hashComplexityValue(normalized.TierBoundaries)
+	if err != nil {
+		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash tier boundaries: %w", err)
+	}
+	codeHash, err := hashComplexityValue(normalized.Keywords.CodeKeywords)
+	if err != nil {
+		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash code keywords: %w", err)
+	}
+	reasoningHash, err := hashComplexityValue(normalized.Keywords.ReasoningKeywords)
+	if err != nil {
+		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash reasoning keywords: %w", err)
+	}
+	technicalHash, err := hashComplexityValue(normalized.Keywords.TechnicalKeywords)
+	if err != nil {
+		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash technical keywords: %w", err)
+	}
+	simpleHash, err := hashComplexityValue(normalized.Keywords.SimpleKeywords)
+	if err != nil {
+		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash simple keywords: %w", err)
+	}
+
+	return ComplexityAnalyzerConfigHashes{
+		TierBoundaries:    tierHash,
+		CodeKeywords:      codeHash,
+		ReasoningKeywords: reasoningHash,
+		TechnicalKeywords: technicalHash,
+		SimpleKeywords:    simpleHash,
+	}, nil
+}
+
+func hashComplexityValue(value any) (string, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
 }
 
 // writeHashField writes a field identifier and a length-prefixed value so the

--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -39,10 +39,46 @@ type ComplexityEditableKeywordConfig struct {
 	SimpleKeywords    []string `json:"simple_keywords"`
 }
 
+// ComplexityAnalyzerConfigHashes tracks the config.json hash for each editable
+// analyzer section. It is persisted with the config row, but not exposed through
+// API responses or config.json.
+type ComplexityAnalyzerConfigHashes struct {
+	TierBoundaries    string `json:"tier_boundaries,omitempty"`
+	CodeKeywords      string `json:"code_keywords,omitempty"`
+	ReasoningKeywords string `json:"reasoning_keywords,omitempty"`
+	TechnicalKeywords string `json:"technical_keywords,omitempty"`
+	SimpleKeywords    string `json:"simple_keywords,omitempty"`
+}
+
+// Empty reports whether no file-backed section hashes are present.
+func (h ComplexityAnalyzerConfigHashes) Empty() bool {
+	return h.TierBoundaries == "" &&
+		h.CodeKeywords == "" &&
+		h.ReasoningKeywords == "" &&
+		h.TechnicalKeywords == "" &&
+		h.SimpleKeywords == ""
+}
+
+// Equal reports whether all section hashes match.
+func (h ComplexityAnalyzerConfigHashes) Equal(other ComplexityAnalyzerConfigHashes) bool {
+	return h.TierBoundaries == other.TierBoundaries &&
+		h.CodeKeywords == other.CodeKeywords &&
+		h.ReasoningKeywords == other.ReasoningKeywords &&
+		h.TechnicalKeywords == other.TechnicalKeywords &&
+		h.SimpleKeywords == other.SimpleKeywords
+}
+
 // ComplexityAnalyzerConfig is the persisted runtime configuration for the complexity analyzer.
 type ComplexityAnalyzerConfig struct {
 	TierBoundaries ComplexityTierBoundaries        `json:"tier_boundaries"`
 	Keywords       ComplexityEditableKeywordConfig `json:"keywords"`
+	ConfigHashes   ComplexityAnalyzerConfigHashes  `json:"-"`
+}
+
+type complexityAnalyzerConfigRecord struct {
+	TierBoundaries ComplexityTierBoundaries        `json:"tier_boundaries"`
+	Keywords       ComplexityEditableKeywordConfig `json:"keywords"`
+	ConfigHashes   ComplexityAnalyzerConfigHashes  `json:"_config_hashes,omitempty"`
 }
 
 // Validate checks that the config is internally consistent.
@@ -86,7 +122,96 @@ func (c *ComplexityAnalyzerConfig) Normalized() ComplexityAnalyzerConfig {
 			TechnicalKeywords: normalizeComplexityKeywordList(c.Keywords.TechnicalKeywords),
 			SimpleKeywords:    normalizeComplexityKeywordList(c.Keywords.SimpleKeywords),
 		},
+		ConfigHashes: c.ConfigHashes,
 	}
+}
+
+// MergeComplexityAnalyzerConfig overlays file boundaries and additively merges keyword lists.
+func MergeComplexityAnalyzerConfig(base, file *ComplexityAnalyzerConfig) (*ComplexityAnalyzerConfig, error) {
+	if file == nil {
+		if base == nil {
+			return nil, nil
+		}
+		normalized := base.Normalized()
+		if err := normalized.Validate(); err != nil {
+			return nil, err
+		}
+		return &normalized, nil
+	}
+
+	normalizedFile := file.Normalized()
+	if err := normalizedFile.Validate(); err != nil {
+		return nil, err
+	}
+
+	var normalizedBase ComplexityAnalyzerConfig
+	if base != nil {
+		normalizedBase = base.Normalized()
+		if err := normalizedBase.Validate(); err != nil {
+			return nil, err
+		}
+	}
+
+	merged := ComplexityAnalyzerConfig{
+		TierBoundaries: normalizedFile.TierBoundaries,
+		Keywords: ComplexityEditableKeywordConfig{
+			CodeKeywords:      mergeComplexityKeywordLists(normalizedBase.Keywords.CodeKeywords, normalizedFile.Keywords.CodeKeywords),
+			ReasoningKeywords: mergeComplexityKeywordLists(normalizedBase.Keywords.ReasoningKeywords, normalizedFile.Keywords.ReasoningKeywords),
+			TechnicalKeywords: mergeComplexityKeywordLists(normalizedBase.Keywords.TechnicalKeywords, normalizedFile.Keywords.TechnicalKeywords),
+			SimpleKeywords:    mergeComplexityKeywordLists(normalizedBase.Keywords.SimpleKeywords, normalizedFile.Keywords.SimpleKeywords),
+		},
+		ConfigHashes: normalizedFile.ConfigHashes,
+	}
+	if err := merged.Validate(); err != nil {
+		return nil, err
+	}
+	return &merged, nil
+}
+
+// MergeComplexityAnalyzerConfigByHashes overlays only file-backed sections whose
+// config.json hash changed. Keyword sections are additive; tier boundaries replace.
+func MergeComplexityAnalyzerConfigByHashes(base, file *ComplexityAnalyzerConfig) (*ComplexityAnalyzerConfig, error) {
+	if file == nil {
+		return MergeComplexityAnalyzerConfig(base, nil)
+	}
+
+	normalizedFile := file.Normalized()
+	if err := normalizedFile.Validate(); err != nil {
+		return nil, err
+	}
+
+	var merged ComplexityAnalyzerConfig
+	if base != nil {
+		merged = base.Normalized()
+		if err := merged.Validate(); err != nil {
+			return nil, err
+		}
+	}
+
+	if merged.ConfigHashes.TierBoundaries != normalizedFile.ConfigHashes.TierBoundaries {
+		merged.TierBoundaries = normalizedFile.TierBoundaries
+		merged.ConfigHashes.TierBoundaries = normalizedFile.ConfigHashes.TierBoundaries
+	}
+	if merged.ConfigHashes.CodeKeywords != normalizedFile.ConfigHashes.CodeKeywords {
+		merged.Keywords.CodeKeywords = mergeComplexityKeywordLists(merged.Keywords.CodeKeywords, normalizedFile.Keywords.CodeKeywords)
+		merged.ConfigHashes.CodeKeywords = normalizedFile.ConfigHashes.CodeKeywords
+	}
+	if merged.ConfigHashes.ReasoningKeywords != normalizedFile.ConfigHashes.ReasoningKeywords {
+		merged.Keywords.ReasoningKeywords = mergeComplexityKeywordLists(merged.Keywords.ReasoningKeywords, normalizedFile.Keywords.ReasoningKeywords)
+		merged.ConfigHashes.ReasoningKeywords = normalizedFile.ConfigHashes.ReasoningKeywords
+	}
+	if merged.ConfigHashes.TechnicalKeywords != normalizedFile.ConfigHashes.TechnicalKeywords {
+		merged.Keywords.TechnicalKeywords = mergeComplexityKeywordLists(merged.Keywords.TechnicalKeywords, normalizedFile.Keywords.TechnicalKeywords)
+		merged.ConfigHashes.TechnicalKeywords = normalizedFile.ConfigHashes.TechnicalKeywords
+	}
+	if merged.ConfigHashes.SimpleKeywords != normalizedFile.ConfigHashes.SimpleKeywords {
+		merged.Keywords.SimpleKeywords = mergeComplexityKeywordLists(merged.Keywords.SimpleKeywords, normalizedFile.Keywords.SimpleKeywords)
+		merged.ConfigHashes.SimpleKeywords = normalizedFile.ConfigHashes.SimpleKeywords
+	}
+	if err := merged.Validate(); err != nil {
+		return nil, err
+	}
+	return &merged, nil
 }
 
 // DecodeComplexityAnalyzerConfig decodes raw JSON into a normalized, validated config.
@@ -95,16 +220,34 @@ func DecodeComplexityAnalyzerConfig(data []byte) (*ComplexityAnalyzerConfig, err
 		return nil, nil
 	}
 
-	var cfg ComplexityAnalyzerConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	var record complexityAnalyzerConfigRecord
+	if err := json.Unmarshal(data, &record); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal complexity analyzer config: %w", err)
 	}
 
+	cfg := ComplexityAnalyzerConfig{
+		TierBoundaries: record.TierBoundaries,
+		Keywords:       record.Keywords,
+		ConfigHashes:   record.ConfigHashes,
+	}
 	normalized := cfg.Normalized()
 	if err := normalized.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid complexity analyzer config: %w", err)
 	}
 	return &normalized, nil
+}
+
+func encodeComplexityAnalyzerConfig(config ComplexityAnalyzerConfig) ([]byte, error) {
+	record := complexityAnalyzerConfigRecord{
+		TierBoundaries: config.TierBoundaries,
+		Keywords:       config.Keywords,
+		ConfigHashes:   config.ConfigHashes,
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal complexity analyzer config: %w", err)
+	}
+	return data, nil
 }
 
 func normalizeComplexityKeywordList(values []string) []string {
@@ -127,4 +270,11 @@ func normalizeComplexityKeywordList(values []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func mergeComplexityKeywordLists(base, overlay []string) []string {
+	values := make([]string, 0, len(base)+len(overlay))
+	values = append(values, base...)
+	values = append(values, overlay...)
+	return normalizeComplexityKeywordList(values)
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -5011,17 +5011,30 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 
 // GetComplexityAnalyzerConfig retrieves the typed complexity analyzer config.
 func (s *RDBConfigStore) GetComplexityAnalyzerConfig(ctx context.Context) (*ComplexityAnalyzerConfig, error) {
-	configEntry, err := s.GetConfig(ctx, tables.ConfigComplexityAnalyzerConfigKey)
+	return s.getComplexityAnalyzerConfigWithDB(ctx, s.DB())
+}
+
+func (s *RDBConfigStore) getComplexityAnalyzerConfigWithDB(ctx context.Context, db *gorm.DB) (*ComplexityAnalyzerConfig, error) {
+	if db == nil {
+		db = s.DB()
+	}
+
+	var configEntry tables.TableGovernanceConfig
+	err := db.WithContext(ctx).First(&configEntry, "key = ?", tables.ConfigComplexityAnalyzerConfigKey).Error
 	if err != nil {
-		if errors.Is(err, ErrNotFound) {
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, ErrNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	if configEntry == nil || strings.TrimSpace(configEntry.Value) == "" {
+	if strings.TrimSpace(configEntry.Value) == "" {
 		return nil, nil
 	}
-	return DecodeComplexityAnalyzerConfig([]byte(configEntry.Value))
+	decoded, err := DecodeComplexityAnalyzerConfig([]byte(configEntry.Value))
+	if err != nil {
+		return nil, err
+	}
+	return decoded, nil
 }
 
 // UpdateComplexityAnalyzerConfig normalizes, validates, and persists the typed analyzer config.
@@ -5035,11 +5048,25 @@ func (s *RDBConfigStore) UpdateComplexityAnalyzerConfig(ctx context.Context, con
 		return err
 	}
 
-	raw, err := json.Marshal(normalized)
-	if err != nil {
-		return fmt.Errorf("failed to marshal complexity analyzer config: %w", err)
+	txDB := s.DB()
+	if len(tx) > 0 && tx[0] != nil {
+		txDB = tx[0]
 	}
 
+	if normalized.ConfigHashes.Empty() {
+		existing, err := s.getComplexityAnalyzerConfigWithDB(ctx, txDB)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			normalized.ConfigHashes = existing.ConfigHashes
+		}
+	}
+
+	raw, err := encodeComplexityAnalyzerConfig(normalized)
+	if err != nil {
+		return err
+	}
 	return s.UpdateConfig(ctx, &tables.TableGovernanceConfig{
 		Key:   tables.ConfigComplexityAnalyzerConfigKey,
 		Value: string(raw),

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -91,7 +91,15 @@ func TestRDBConfigStore_ComplexityAnalyzerConfigRoundTrip(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()
 
-	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, testComplexityAnalyzerConfig()))
+	cfg := testComplexityAnalyzerConfig()
+	cfg.ConfigHashes = ComplexityAnalyzerConfigHashes{
+		TierBoundaries:    "tier-hash-1",
+		CodeKeywords:      "code-hash-1",
+		ReasoningKeywords: "reason-hash-1",
+		TechnicalKeywords: "tech-hash-1",
+		SimpleKeywords:    "simple-hash-1",
+	}
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, cfg))
 
 	got, err := store.GetComplexityAnalyzerConfig(ctx)
 	require.NoError(t, err)
@@ -102,19 +110,134 @@ func TestRDBConfigStore_ComplexityAnalyzerConfigRoundTrip(t *testing.T) {
 		ComplexReasoning: 0.70,
 	}, got.TierBoundaries)
 	assert.Equal(t, []string{"api", "function"}, got.Keywords.CodeKeywords)
+	assert.Equal(t, cfg.ConfigHashes, got.ConfigHashes)
+}
+
+func TestRDBConfigStore_GetComplexityAnalyzerConfigMissingReturnsNil(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	got, err := store.GetComplexityAnalyzerConfig(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestRDBConfigStore_UpdateComplexityAnalyzerConfigPreservesExistingHashesOnRuntimeUpdate(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	fileConfig := testComplexityAnalyzerConfig()
+	fileConfig.ConfigHashes = ComplexityAnalyzerConfigHashes{
+		TierBoundaries:    "tier-hash-1",
+		CodeKeywords:      "code-hash-1",
+		ReasoningKeywords: "reason-hash-1",
+		TechnicalKeywords: "tech-hash-1",
+		SimpleKeywords:    "simple-hash-1",
+	}
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, fileConfig))
+
+	runtimeConfig := testComplexityAnalyzerConfig()
+	runtimeConfig.TierBoundaries.SimpleMedium = 0.12
+	runtimeConfig.ConfigHashes = ComplexityAnalyzerConfigHashes{}
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, runtimeConfig))
+
+	got, err := store.GetComplexityAnalyzerConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 0.12, got.TierBoundaries.SimpleMedium)
+	assert.Equal(t, fileConfig.ConfigHashes, got.ConfigHashes)
+}
+
+func TestGenerateComplexityAnalyzerConfigHashesCanonicalizesKeywords(t *testing.T) {
+	left := testComplexityAnalyzerConfig()
+	right := testComplexityAnalyzerConfig()
+	right.Keywords.CodeKeywords = []string{"api", "function"}
+	left.ConfigHashes = ComplexityAnalyzerConfigHashes{CodeKeywords: "stored-code-hash-a"}
+	right.ConfigHashes = ComplexityAnalyzerConfigHashes{CodeKeywords: "stored-code-hash-b"}
+
+	leftHashes, err := GenerateComplexityAnalyzerConfigHashes(left)
+	require.NoError(t, err)
+	rightHashes, err := GenerateComplexityAnalyzerConfigHashes(right)
+	require.NoError(t, err)
+
+	assert.Equal(t, leftHashes, rightHashes)
+}
+
+func TestMergeComplexityAnalyzerConfigAddsKeywordsAndOverlaysBoundaries(t *testing.T) {
+	base := testComplexityAnalyzerConfig()
+	file := testComplexityAnalyzerConfig()
+	file.TierBoundaries = ComplexityTierBoundaries{
+		SimpleMedium:     0.20,
+		MediumComplex:    0.40,
+		ComplexReasoning: 0.80,
+	}
+	file.Keywords.CodeKeywords = []string{"GraphQL", "api"}
+	file.Keywords.ReasoningKeywords = []string{"tradeoffs", "step by step"}
+	file.Keywords.TechnicalKeywords = []string{"latency", "kubernetes"}
+	file.Keywords.SimpleKeywords = []string{"hello", "thanks"}
+
+	merged, err := MergeComplexityAnalyzerConfig(base, file)
+	require.NoError(t, err)
+	require.NotNil(t, merged)
+
+	assert.Equal(t, file.TierBoundaries, merged.TierBoundaries)
+	assert.Equal(t, []string{"api", "function", "graphql"}, merged.Keywords.CodeKeywords)
+	assert.Equal(t, []string{"step by step", "tradeoffs"}, merged.Keywords.ReasoningKeywords)
+	assert.Equal(t, []string{"kubernetes", "latency"}, merged.Keywords.TechnicalKeywords)
+	assert.Equal(t, []string{"hello", "thanks"}, merged.Keywords.SimpleKeywords)
+}
+
+func TestMergeComplexityAnalyzerConfigByHashesOnlyAppliesChangedSections(t *testing.T) {
+	base := testComplexityAnalyzerConfig()
+	base.ConfigHashes = ComplexityAnalyzerConfigHashes{
+		TierBoundaries:    "tier-hash-1",
+		CodeKeywords:      "code-hash-1",
+		ReasoningKeywords: "reason-hash-1",
+		TechnicalKeywords: "tech-hash-1",
+		SimpleKeywords:    "simple-hash-1",
+	}
+	base.TierBoundaries.SimpleMedium = 0.12
+	base.Keywords.CodeKeywords = []string{"ui-code"}
+	base.Keywords.ReasoningKeywords = []string{"ui-reason"}
+
+	file := testComplexityAnalyzerConfig()
+	file.ConfigHashes = base.ConfigHashes
+	file.ConfigHashes.CodeKeywords = "code-hash-2"
+	file.TierBoundaries.SimpleMedium = 0.20
+	file.Keywords.CodeKeywords = []string{"file-code"}
+	file.Keywords.ReasoningKeywords = []string{"file-reason"}
+
+	merged, err := MergeComplexityAnalyzerConfigByHashes(base, file)
+	require.NoError(t, err)
+	require.NotNil(t, merged)
+
+	assert.Equal(t, 0.12, merged.TierBoundaries.SimpleMedium)
+	assert.Equal(t, []string{"file-code", "ui-code"}, merged.Keywords.CodeKeywords)
+	assert.Equal(t, []string{"ui-reason"}, merged.Keywords.ReasoningKeywords)
+	assert.Equal(t, "code-hash-2", merged.ConfigHashes.CodeKeywords)
+	assert.Equal(t, "reason-hash-1", merged.ConfigHashes.ReasoningKeywords)
 }
 
 func TestRDBConfigStore_GetGovernanceConfigIncludesComplexityAnalyzerConfig(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()
 
-	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, testComplexityAnalyzerConfig()))
+	cfg := testComplexityAnalyzerConfig()
+	cfg.ConfigHashes = ComplexityAnalyzerConfigHashes{
+		TierBoundaries:    "tier-hash-2",
+		CodeKeywords:      "code-hash-2",
+		ReasoningKeywords: "reason-hash-2",
+		TechnicalKeywords: "tech-hash-2",
+		SimpleKeywords:    "simple-hash-2",
+	}
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, cfg))
 
 	governanceConfig, err := store.GetGovernanceConfig(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, governanceConfig)
 	require.NotNil(t, governanceConfig.ComplexityAnalyzerConfig)
 	assert.Equal(t, 0.70, governanceConfig.ComplexityAnalyzerConfig.TierBoundaries.ComplexReasoning)
+	assert.Equal(t, cfg.ConfigHashes, governanceConfig.ComplexityAnalyzerConfig.ConfigHashes)
 }
 
 func TestRDBConfigStore_UpdateComplexityAnalyzerConfigRejectsInvalidConfig(t *testing.T) {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -55,15 +55,15 @@ type MCPClientsQueryParams struct {
 // parameters for MCP library catalog queries. All fields are optional — an
 // empty struct returns the first default-sized page ordered by name.
 type MCPLibraryQueryParams struct {
-	Limit          int
-	Offset         int
-	Search         string   // matches name/description/publisher (case-insensitive)
-	Categories     []string // exact category filter(s), OR semantics
+	Limit           int
+	Offset          int
+	Search          string   // matches name/description/publisher (case-insensitive)
+	Categories      []string // exact category filter(s), OR semantics
 	ConnectionTypes []string // exact connection_type filter(s) (http | stdio | sse)
-	AuthTypes      []string // exact auth_type filter(s)
-	Tags           []string // match rows carrying any of these tags
-	SortBy         string // name, category, publisher, created_at, updated_at (default: name)
-	Order          string // asc, desc (default: asc)
+	AuthTypes       []string // exact auth_type filter(s)
+	Tags            []string // match rows carrying any of these tags
+	SortBy          string   // name, category, publisher, created_at, updated_at (default: name)
+	Order           string   // asc, desc (default: asc)
 }
 
 // MCPLibraryFilterData holds the distinct facet values surfaced by the filter

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2358,6 +2358,7 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 	config.GovernanceConfig.PricingOverrides = append(governanceConfig.PricingOverrides, pricingOverridesToAdd...)
 	config.GovernanceConfig.ModelConfigs = append(governanceConfig.ModelConfigs, modelConfigsToAdd...)
 	config.GovernanceConfig.Providers = append(governanceConfig.Providers, providersToAdd...)
+	complexityAnalyzerConfigToUpdate := planComplexityAnalyzerConfigUpdate(config, configData)
 	// Update store with merged config items
 	hasChanges := len(budgetsToAdd) > 0 || len(budgetsToUpdate) > 0 ||
 		len(rateLimitsToAdd) > 0 || len(rateLimitsToUpdate) > 0 ||
@@ -2367,7 +2368,11 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 		len(routingRulesToAdd) > 0 || len(routingRulesToUpdate) > 0 ||
 		len(pricingOverridesToAdd) > 0 || len(pricingOverridesToUpdate) > 0 ||
 		len(modelConfigsToAdd) > 0 || len(modelConfigsToUpdate) > 0 ||
-		len(providersToAdd) > 0 || len(providersToUpdate) > 0
+		len(providersToAdd) > 0 || len(providersToUpdate) > 0 ||
+		complexityAnalyzerConfigToUpdate != nil
+	if config.ConfigStore == nil && complexityAnalyzerConfigToUpdate != nil {
+		config.GovernanceConfig.ComplexityAnalyzerConfig = complexityAnalyzerConfigToUpdate
+	}
 	if config.ConfigStore != nil && hasChanges {
 		err := updateGovernanceConfigInStore(ctx, config,
 			budgetsToAdd, budgetsToUpdate,
@@ -2378,25 +2383,10 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 			routingRulesToAdd, routingRulesToUpdate,
 			pricingOverridesToAdd, pricingOverridesToUpdate,
 			modelConfigsToAdd, modelConfigsToUpdate,
-			providersToAdd, providersToUpdate)
+			providersToAdd, providersToUpdate,
+			complexityAnalyzerConfigToUpdate)
 		if err != nil {
 			logger.Fatal("failed to sync governance config: %v", err)
-		}
-	}
-
-	// File config stays authoritative for analyzer tuning when present.
-	if configData.Governance.ComplexityAnalyzerConfig != nil {
-		normalized, err := complexity.ValidateAndNormalize(configData.Governance.ComplexityAnalyzerConfig)
-		if err != nil {
-			logger.Error("invalid complexity analyzer config in config file: %v", err)
-		} else if normalized != nil {
-			current := config.GovernanceConfig.ComplexityAnalyzerConfig
-			config.GovernanceConfig.ComplexityAnalyzerConfig = normalized
-			if config.ConfigStore != nil && (current == nil || !reflect.DeepEqual(current, normalized)) {
-				if err := config.ConfigStore.UpdateComplexityAnalyzerConfig(ctx, normalized); err != nil {
-					logger.Warn("failed to sync complexity analyzer config from config file: %v", err)
-				}
-			}
 		}
 	}
 
@@ -2419,6 +2409,86 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 	if configData.isConfigJSONSourceOfTruth() {
 		pruneGovernanceConfigToFile(ctx, config, configData)
 	}
+}
+
+// planComplexityAnalyzerConfigUpdate applies config.json complexity analyzer
+// reconciliation rules and returns the next singleton config when it should be
+// persisted. Store writes happen in updateGovernanceConfigInStore with the rest
+// of the planned governance updates.
+//
+// In split mode, unchanged section hashes preserve runtime UI/API edits. When a
+// section changes in config.json, tier boundaries are replaced and keyword lists
+// are merged additively with the stored runtime lists.
+func planComplexityAnalyzerConfigUpdate(config *Config, configData *ConfigData) *configstore.ComplexityAnalyzerConfig {
+	if config == nil || configData == nil || configData.Governance == nil || configData.Governance.ComplexityAnalyzerConfig == nil {
+		return nil
+	}
+	if config.GovernanceConfig == nil {
+		config.GovernanceConfig = &configstore.GovernanceConfig{}
+	}
+
+	fileConfig, fileHashes, ok := complexityAnalyzerConfigFromFile(configData)
+	if !ok {
+		return nil
+	}
+	current := config.GovernanceConfig.ComplexityAnalyzerConfig
+	if configData.isConfigJSONSourceOfTruth() {
+		if current != nil && reflect.DeepEqual(current, fileConfig) {
+			return nil
+		}
+		return fileConfig
+	}
+	if current != nil && current.ConfigHashes.Empty() {
+		normalized := current.Normalized()
+		normalized.ConfigHashes = fileHashes
+		logger.Debug("complexity analyzer config missing section hashes, backfilling without applying config file values")
+		if reflect.DeepEqual(current, &normalized) {
+			return nil
+		}
+		return &normalized
+	}
+	if current != nil && current.ConfigHashes.Equal(fileHashes) {
+		logger.Debug("complexity analyzer config section hashes match, keeping DB config")
+		return nil
+	}
+
+	merged, err := mergeComplexityAnalyzerConfigFromFile(current, fileConfig)
+	if err != nil {
+		logger.Warn("failed to merge complexity analyzer config from config file: %v", err)
+		return nil
+	}
+	if current != nil && reflect.DeepEqual(current, merged) {
+		return nil
+	}
+	return merged
+}
+
+// complexityAnalyzerConfigFromFile validates the file-backed analyzer config and
+// returns the canonical section hashes used to detect whether config.json changed.
+func complexityAnalyzerConfigFromFile(configData *ConfigData) (*configstore.ComplexityAnalyzerConfig, configstore.ComplexityAnalyzerConfigHashes, bool) {
+	fileConfig, err := complexity.ValidateAndNormalize(configData.Governance.ComplexityAnalyzerConfig)
+	if err != nil {
+		logger.Error("invalid complexity analyzer config in config file: %v", err)
+		return nil, configstore.ComplexityAnalyzerConfigHashes{}, false
+	}
+	fileHashes, err := configstore.GenerateComplexityAnalyzerConfigHashes(fileConfig)
+	if err != nil {
+		logger.Warn("failed to generate complexity analyzer config hashes: %v", err)
+		return nil, configstore.ComplexityAnalyzerConfigHashes{}, false
+	}
+	fileConfig.ConfigHashes = fileHashes
+	return fileConfig, fileHashes, true
+}
+
+// mergeComplexityAnalyzerConfigFromFile uses defaults as the first split-mode
+// base so config.json seeds do not erase built-in keyword coverage.
+func mergeComplexityAnalyzerConfigFromFile(current, fileConfig *configstore.ComplexityAnalyzerConfig) (*configstore.ComplexityAnalyzerConfig, error) {
+	base := current
+	if base == nil {
+		defaults := complexity.DefaultAnalyzerConfig()
+		base = &defaults
+	}
+	return configstore.MergeComplexityAnalyzerConfigByHashes(base, fileConfig)
 }
 
 // pruneGovernanceConfigToFile removes DB-only governance rows for file-present collections.
@@ -2596,6 +2666,7 @@ func updateGovernanceConfigInStore(
 	modelConfigsToUpdate []configstoreTables.TableModelConfig,
 	providersToAdd []configstoreTables.TableProvider,
 	providersToUpdate []configstoreTables.TableProvider,
+	complexityAnalyzerConfigToUpdate *configstore.ComplexityAnalyzerConfig,
 ) error {
 	logger.Debug("updating governance config in store with merged items")
 	return config.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
@@ -2975,6 +3046,14 @@ func updateGovernanceConfigInStore(
 					provider.BudgetID,
 					provider.RateLimitID,
 				)
+			}
+		}
+
+		if complexityAnalyzerConfigToUpdate != nil {
+			if err := config.ConfigStore.UpdateComplexityAnalyzerConfig(ctx, complexityAnalyzerConfigToUpdate, tx); err != nil {
+				logger.Warn("failed to sync complexity analyzer config from config file: %v", err)
+			} else {
+				config.GovernanceConfig.ComplexityAnalyzerConfig = complexityAnalyzerConfigToUpdate
 			}
 		}
 
@@ -3453,6 +3532,11 @@ func createGovernanceConfigInStore(ctx context.Context, config *Config) {
 			if err != nil {
 				logger.Warn("invalid complexity analyzer config in config file: %v", err)
 			} else if normalized != nil {
+				fileHashes, err := configstore.GenerateComplexityAnalyzerConfigHashes(normalized)
+				if err != nil {
+					return fmt.Errorf("failed to generate complexity analyzer config hashes: %w", err)
+				}
+				normalized.ConfigHashes = fileHashes
 				config.GovernanceConfig.ComplexityAnalyzerConfig = normalized
 				if err := config.ConfigStore.UpdateComplexityAnalyzerConfig(ctx, normalized, tx); err != nil {
 					return fmt.Errorf("failed to create complexity analyzer config: %w", err)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -374,6 +374,7 @@ import (
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/framework/vectorstore"
+	"github.com/maximhq/bifrost/plugins/governance/complexity"
 	otelPlugin "github.com/maximhq/bifrost/plugins/otel"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
@@ -388,6 +389,7 @@ type MockConfigStore struct {
 	governanceConfig *configstore.GovernanceConfig
 	authConfig       *configstore.AuthConfig
 	frameworkConfig  *tables.TableFrameworkConfig
+	configEntries    map[string]string
 	vectorConfig     *vectorstore.Config
 	logsConfig       *logstore.Config
 	plugins          []*tables.TablePlugin
@@ -413,7 +415,8 @@ type MockConfigStore struct {
 // NewMockConfigStore creates a new mock config store
 func NewMockConfigStore() *MockConfigStore {
 	return &MockConfigStore{
-		providers: make(map[schemas.ModelProvider]configstore.ProviderConfig),
+		providers:     make(map[schemas.ModelProvider]configstore.ProviderConfig),
+		configEntries: make(map[string]string),
 	}
 }
 
@@ -965,10 +968,17 @@ func (m *MockConfigStore) GetLogsStoreConfig(ctx context.Context) (*logstore.Con
 
 // Config
 func (m *MockConfigStore) GetConfig(ctx context.Context, key string) (*tables.TableGovernanceConfig, error) {
-	return nil, nil
+	if value, ok := m.configEntries[key]; ok {
+		return &tables.TableGovernanceConfig{Key: key, Value: value}, nil
+	}
+	return nil, configstore.ErrNotFound
 }
 
 func (m *MockConfigStore) UpdateConfig(ctx context.Context, config *tables.TableGovernanceConfig, tx ...*gorm.DB) error {
+	if m.configEntries == nil {
+		m.configEntries = make(map[string]string)
+	}
+	m.configEntries[config.Key] = config.Value
 	return nil
 }
 
@@ -982,6 +992,11 @@ func (m *MockConfigStore) GetComplexityAnalyzerConfig(ctx context.Context) (*con
 func (m *MockConfigStore) UpdateComplexityAnalyzerConfig(ctx context.Context, config *configstore.ComplexityAnalyzerConfig, tx ...*gorm.DB) error {
 	if m.governanceConfig == nil {
 		m.governanceConfig = &configstore.GovernanceConfig{}
+	}
+	if config != nil && config.ConfigHashes.Empty() && m.governanceConfig.ComplexityAnalyzerConfig != nil {
+		copy := *config
+		copy.ConfigHashes = m.governanceConfig.ComplexityAnalyzerConfig.ConfigHashes
+		config = &copy
 	}
 	m.governanceConfig.ComplexityAnalyzerConfig = config
 	return nil
@@ -1466,10 +1481,10 @@ func TestMergeGovernanceConfig_SyncsComplexityAnalyzerConfig(t *testing.T) {
 			ComplexReasoning: 0.77,
 		},
 		Keywords: configstore.ComplexityEditableKeywordConfig{
-			CodeKeywords:      []string{" Function ", "api", "API"},
-			ReasoningKeywords: []string{"tradeoffs"},
-			TechnicalKeywords: []string{"latency"},
-			SimpleKeywords:    []string{"hello"},
+			CodeKeywords:      []string{" Function ", "api", "API", "file-code-seed"},
+			ReasoningKeywords: []string{"tradeoffs", "file-reason-seed"},
+			TechnicalKeywords: []string{"latency", "file-tech-seed"},
+			SimpleKeywords:    []string{"hello", "file-simple-seed"},
 		},
 	}
 	configData := &ConfigData{
@@ -1484,8 +1499,293 @@ func TestMergeGovernanceConfig_SyncsComplexityAnalyzerConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	require.Equal(t, 0.77, stored.TierBoundaries.ComplexReasoning)
-	require.Equal(t, []string{"api", "function"}, stored.Keywords.CodeKeywords)
+	defaults := complexity.DefaultAnalyzerConfig()
+	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.CodeKeywords, fileConfig.Keywords.CodeKeywords), stored.Keywords.CodeKeywords)
+	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.ReasoningKeywords, fileConfig.Keywords.ReasoningKeywords), stored.Keywords.ReasoningKeywords)
+	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.TechnicalKeywords, fileConfig.Keywords.TechnicalKeywords), stored.Keywords.TechnicalKeywords)
+	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.SimpleKeywords, fileConfig.Keywords.SimpleKeywords), stored.Keywords.SimpleKeywords)
+	require.False(t, stored.ConfigHashes.Empty())
 	require.Equal(t, stored, config.GovernanceConfig.ComplexityAnalyzerConfig)
+}
+
+func TestMergeGovernanceConfig_BackfillsLegacyComplexityHashesWithoutApplyingFileValues(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.TierBoundaries.SimpleMedium = 0.12
+	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+	fileConfig := testFileComplexityAnalyzerConfig()
+	fileHashes, err := configstore.GenerateComplexityAnalyzerConfigHashes(fileConfig)
+	require.NoError(t, err)
+	configData := &ConfigData{
+		Governance: &configstore.GovernanceConfig{
+			ComplexityAnalyzerConfig: fileConfig,
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, 0.12, stored.TierBoundaries.SimpleMedium)
+	require.Equal(t, []string{"ui-code"}, stored.Keywords.CodeKeywords)
+	require.Equal(t, fileHashes, stored.ConfigHashes)
+}
+
+func expectedMergedComplexityKeywords(base, overlay []string) []string {
+	seen := make(map[string]struct{}, len(base)+len(overlay))
+	out := make([]string, 0, len(base)+len(overlay))
+	for _, value := range append(append([]string{}, base...), overlay...) {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestMergeGovernanceConfig_PreservesComplexityAnalyzerConfigWhenSectionHashesMatch(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	fileConfig := testFileComplexityAnalyzerConfig()
+	fileHashes, err := configstore.GenerateComplexityAnalyzerConfigHashes(fileConfig)
+	require.NoError(t, err)
+
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHashes = fileHashes
+	dbConfig.TierBoundaries.SimpleMedium = 0.21
+	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+	configData := &ConfigData{
+		Governance: &configstore.GovernanceConfig{
+			ComplexityAnalyzerConfig: fileConfig,
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, 0.21, stored.TierBoundaries.SimpleMedium)
+	require.Equal(t, []string{"ui-code"}, stored.Keywords.CodeKeywords)
+	require.Equal(t, fileHashes, stored.ConfigHashes)
+}
+
+func TestMergeGovernanceConfig_MergesComplexityKeywordsWhenSectionHashesChange(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHashes = configstore.ComplexityAnalyzerConfigHashes{
+		TierBoundaries:    "old-tier-hash",
+		CodeKeywords:      "old-code-hash",
+		ReasoningKeywords: "old-reason-hash",
+		TechnicalKeywords: "old-tech-hash",
+		SimpleKeywords:    "old-simple-hash",
+	}
+	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbConfig.Keywords.ReasoningKeywords = []string{"ui-reason"}
+	dbConfig.Keywords.TechnicalKeywords = []string{"ui-tech"}
+	dbConfig.Keywords.SimpleKeywords = []string{"ui-simple"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+	fileConfig := testFileComplexityAnalyzerConfig()
+	fileHashes, err := configstore.GenerateComplexityAnalyzerConfigHashes(fileConfig)
+	require.NoError(t, err)
+	configData := &ConfigData{
+		Governance: &configstore.GovernanceConfig{
+			ComplexityAnalyzerConfig: fileConfig,
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, fileConfig.TierBoundaries, stored.TierBoundaries)
+	require.ElementsMatch(t, []string{"file-code", "ui-code"}, stored.Keywords.CodeKeywords)
+	require.ElementsMatch(t, []string{"file-reason", "ui-reason"}, stored.Keywords.ReasoningKeywords)
+	require.ElementsMatch(t, []string{"file-tech", "ui-tech"}, stored.Keywords.TechnicalKeywords)
+	require.ElementsMatch(t, []string{"file-simple", "ui-simple"}, stored.Keywords.SimpleKeywords)
+	require.Equal(t, fileHashes, stored.ConfigHashes)
+}
+
+func TestMergeGovernanceConfig_OnlyChangedComplexitySectionsApply(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	oldFileConfig := testFileComplexityAnalyzerConfig()
+	oldFileHashes, err := configstore.GenerateComplexityAnalyzerConfigHashes(oldFileConfig)
+	require.NoError(t, err)
+
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHashes = oldFileHashes
+	dbConfig.TierBoundaries.SimpleMedium = 0.21
+	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbConfig.Keywords.ReasoningKeywords = []string{"ui-reason"}
+	dbConfig.Keywords.TechnicalKeywords = []string{"ui-tech"}
+	dbConfig.Keywords.SimpleKeywords = []string{"ui-simple"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+
+	newFileConfig := testFileComplexityAnalyzerConfig()
+	newFileConfig.Keywords.CodeKeywords = []string{"file-code", "file-code-new"}
+	newFileHashes, err := configstore.GenerateComplexityAnalyzerConfigHashes(newFileConfig)
+	require.NoError(t, err)
+	configData := &ConfigData{
+		Governance: &configstore.GovernanceConfig{
+			ComplexityAnalyzerConfig: newFileConfig,
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, 0.21, stored.TierBoundaries.SimpleMedium)
+	require.ElementsMatch(t, []string{"file-code", "file-code-new", "ui-code"}, stored.Keywords.CodeKeywords)
+	require.Equal(t, []string{"ui-reason"}, stored.Keywords.ReasoningKeywords)
+	require.Equal(t, []string{"ui-tech"}, stored.Keywords.TechnicalKeywords)
+	require.Equal(t, []string{"ui-simple"}, stored.Keywords.SimpleKeywords)
+	require.Equal(t, oldFileHashes.TierBoundaries, stored.ConfigHashes.TierBoundaries)
+	require.Equal(t, newFileHashes.CodeKeywords, stored.ConfigHashes.CodeKeywords)
+	require.Equal(t, oldFileHashes.ReasoningKeywords, stored.ConfigHashes.ReasoningKeywords)
+	require.Equal(t, oldFileHashes.TechnicalKeywords, stored.ConfigHashes.TechnicalKeywords)
+	require.Equal(t, oldFileHashes.SimpleKeywords, stored.ConfigHashes.SimpleKeywords)
+}
+
+func TestMergeGovernanceConfig_SourceOfTruthConfigJSONUsesComplexityFileConfig(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHashes = configstore.ComplexityAnalyzerConfigHashes{
+		TierBoundaries:    "old-tier-hash",
+		CodeKeywords:      "old-code-hash",
+		ReasoningKeywords: "old-reason-hash",
+		TechnicalKeywords: "old-tech-hash",
+		SimpleKeywords:    "old-simple-hash",
+	}
+	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+	fileConfig := testFileComplexityAnalyzerConfig()
+	fileHashes, err := configstore.GenerateComplexityAnalyzerConfigHashes(fileConfig)
+	require.NoError(t, err)
+	configData := &ConfigData{
+		SourceOfTruth: SourceOfTruthConfigJSON,
+		Governance: &configstore.GovernanceConfig{
+			ComplexityAnalyzerConfig: fileConfig,
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, fileConfig.TierBoundaries, stored.TierBoundaries)
+	require.Equal(t, []string{"file-code"}, stored.Keywords.CodeKeywords)
+	require.Equal(t, fileHashes, stored.ConfigHashes)
+}
+
+func TestMergeGovernanceConfig_SourceOfTruthConfigJSONMissingComplexityLeavesDBConfig(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHashes = configstore.ComplexityAnalyzerConfigHashes{
+		TierBoundaries:    "old-tier-hash",
+		CodeKeywords:      "old-code-hash",
+		ReasoningKeywords: "old-reason-hash",
+		TechnicalKeywords: "old-tech-hash",
+		SimpleKeywords:    "old-simple-hash",
+	}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	store.configEntries[tables.ConfigComplexityAnalyzerConfigKey] = "stored"
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+	configData := &ConfigData{
+		SourceOfTruth: SourceOfTruthConfigJSON,
+		Governance:    &configstore.GovernanceConfig{},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	require.Same(t, dbConfig, config.GovernanceConfig.ComplexityAnalyzerConfig)
+	entry, err := store.GetConfig(context.Background(), tables.ConfigComplexityAnalyzerConfigKey)
+	require.NoError(t, err)
+	require.Equal(t, "stored", entry.Value)
+}
+
+func testRuntimeComplexityAnalyzerConfig() *configstore.ComplexityAnalyzerConfig {
+	return &configstore.ComplexityAnalyzerConfig{
+		TierBoundaries: configstore.ComplexityTierBoundaries{
+			SimpleMedium:     0.10,
+			MediumComplex:    0.30,
+			ComplexReasoning: 0.70,
+		},
+		Keywords: configstore.ComplexityEditableKeywordConfig{
+			CodeKeywords:      []string{"runtime-code"},
+			ReasoningKeywords: []string{"runtime-reason"},
+			TechnicalKeywords: []string{"runtime-tech"},
+			SimpleKeywords:    []string{"runtime-simple"},
+		},
+	}
+}
+
+func testFileComplexityAnalyzerConfig() *configstore.ComplexityAnalyzerConfig {
+	return &configstore.ComplexityAnalyzerConfig{
+		TierBoundaries: configstore.ComplexityTierBoundaries{
+			SimpleMedium:     0.20,
+			MediumComplex:    0.40,
+			ComplexReasoning: 0.80,
+		},
+		Keywords: configstore.ComplexityEditableKeywordConfig{
+			CodeKeywords:      []string{"file-code"},
+			ReasoningKeywords: []string{"file-reason"},
+			TechnicalKeywords: []string{"file-tech"},
+			SimpleKeywords:    []string{"file-simple"},
+		},
+	}
 }
 
 // Prompt Repository - Folders
@@ -13093,6 +13393,7 @@ func TestUpdateGovernanceConfigInStore_RejectsSharedGovernanceIDs(t *testing.T) 
 			nil, nil, // pricing overrides
 			modelAdds, modelUpdates,
 			providerAdds, providerUpdates,
+			nil,
 		)
 	}
 


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-section deterministic hashes for complexity config enable targeted merges: only changed sections are applied; keyword lists are merged additively and tier boundaries refreshed when replaced.

* **Bug Fixes**
  * Preserves existing stored hashes during runtime updates and handles missing/blank analyzer configs more robustly during reads/writes.

* **Tests**
  * Added/updated tests for deterministic hash persistence, merge semantics, and preservation/overlay behaviors.

* **Documentation**
  * Clarified split-mode vs file-as-source-of-truth and merge/refresh behavior in Helm and governance docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->