### PR TITLE
feat: add MCP library config, provider aliases schema, and SCIM `attributeType`/`attributeValue` mappings to Helm chart and config schemas

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -332,7 +332,13 @@ false
 {{- if .Values.bifrost.framework.pricing.pricingSyncInterval }}
 {{- $_ := set $pricing "pricing_sync_interval" .Values.bifrost.framework.pricing.pricingSyncInterval }}
 {{- end }}
-{{- if or $pricing.pricing_url $pricing.pricing_sync_interval }}
+{{- if .Values.bifrost.framework.pricing.mcpLibraryUrl }}
+{{- $_ := set $pricing "mcp_library_url" .Values.bifrost.framework.pricing.mcpLibraryUrl }}
+{{- end }}
+{{- if .Values.bifrost.framework.pricing.mcpLibrarySyncInterval }}
+{{- $_ := set $pricing "mcp_library_sync_interval" .Values.bifrost.framework.pricing.mcpLibrarySyncInterval }}
+{{- end }}
+{{- if or $pricing.pricing_url $pricing.model_parameters_url $pricing.pricing_sync_interval $pricing.mcp_library_url $pricing.mcp_library_sync_interval }}
 {{- $_ := set $framework "pricing" $pricing }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -485,6 +485,19 @@
                   "description": "Pricing sync interval in seconds. Default is 24 hours. Minimum is 3600 seconds (1 hour).",
                   "default": 86400,
                   "minimum": 3600
+                },
+                "mcpLibraryUrl": {
+                  "description": "URL to a custom MCP server catalog. Leave empty to use the default Bifrost catalog.",
+                  "anyOf": [
+                    {"type": "string", "format": "uri"},
+                    {"const": ""}
+                  ]
+                },
+                "mcpLibrarySyncInterval": {
+                  "type": "integer",
+                  "description": "MCP library sync interval in seconds. Default is 24 hours. Minimum is 3600 seconds (1 hour).",
+                  "default": 86400,
+                  "minimum": 3600
                 }
               },
               "additionalProperties": false
@@ -2174,6 +2187,15 @@
                             "role": {
                               "type": "string",
                               "description": "Bifrost role to assign on match"
+                            },
+                            "attributeType": {
+                              "type": "string",
+                              "enum": ["user", "group"],
+                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
+                            },
+                            "attributeValue": {
+                              "type": "string",
+                              "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
                             }
                           },
                           "required": ["attribute", "value", "role"],
@@ -2216,7 +2238,7 @@
                           "type": "object",
                           "properties": {
                             "attribute": { "type": "string", "description": "JWT claim name" },
-                            "value": { "type": "string", "description": "Claim value to match" },
+                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
                             "business_unit": {
                               "type": "string",
                               "description": "Bifrost business unit slug to assign"
@@ -2231,7 +2253,7 @@
                               "description": "SCIM attribute value to match (for 'user': SCIM user attribute value; for 'group': SCIM group displayName, auto-set to 'displayName')"
                             }
                           },
-                          "required": ["attribute", "value", "business_unit"],
+                          "required": ["attribute", "value"],
                           "additionalProperties": false
                         }
                       }
@@ -2319,6 +2341,15 @@
                             "role": {
                               "type": "string",
                               "description": "Bifrost role to assign on match"
+                            },
+                            "attributeType": {
+                              "type": "string",
+                              "enum": ["user", "group"],
+                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
+                            },
+                            "attributeValue": {
+                              "type": "string",
+                              "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
                             }
                           },
                           "required": ["attribute", "value", "role"],
@@ -2327,13 +2358,22 @@
                       },
                       "attributeTeamMappings": {
                         "type": "array",
-                        "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through (every claim value becomes a team name).",
+                        "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through. Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string" },
-                            "team": { "type": "string" }
+                            "attribute": { "type": "string", "description": "JWT claim name" },
+                            "value": { "type": "string", "description": "Claim value to match, or '*' for pass-through" },
+                            "team": { "type": "string", "description": "Bifrost team slug to assign. In case of '*' value, leave this empty" },
+                            "attributeType": {
+                              "type": "string",
+                              "enum": ["user", "group"],
+                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
+                            },
+                            "attributeValue": {
+                              "type": "string",
+                              "description": "SCIM attribute value to match (for 'user': SCIM user attribute value; for 'group': SCIM group displayName, auto-set to 'displayName')"
+                            }
                           },
                           "required": ["attribute", "value", "team"],
                           "additionalProperties": false
@@ -2341,15 +2381,24 @@
                       },
                       "attributeBusinessUnitMappings": {
                         "type": "array",
-                        "description": "Attribute -> business-unit mappings (all matches apply).",
+                        "description": "Attribute -> business-unit mappings (all matches apply). Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string" },
-                            "business_unit": { "type": "string" }
+                            "attribute": { "type": "string", "description": "JWT claim name" },
+                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
+                            "business_unit": { "type": "string", "description": "Bifrost business unit slug to assign. In case of '*' value, leave this empty" },
+                            "attributeType": {
+                              "type": "string",
+                              "enum": ["user", "group"],
+                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
+                            },
+                            "attributeValue": {
+                              "type": "string",
+                              "description": "SCIM attribute value to match (for 'user': SCIM user attribute value; for 'group': SCIM group displayName, auto-set to 'displayName')"
+                            }
                           },
-                          "required": ["attribute", "value", "business_unit"],
+                          "required": ["attribute", "value"],
                           "additionalProperties": false
                         }
                       }
@@ -2458,10 +2507,10 @@
                           "type": "object",
                           "properties": {
                             "attribute": { "type": "string" },
-                            "value": { "type": "string" },
+                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
                             "business_unit": { "type": "string" }
                           },
-                          "required": ["attribute", "value", "business_unit"],
+                          "required": ["attribute", "value"],
                           "additionalProperties": false
                         }
                       }
@@ -2560,10 +2609,10 @@
                           "type": "object",
                           "properties": {
                             "attribute": { "type": "string" },
-                            "value": { "type": "string" },
+                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
                             "business_unit": { "type": "string" }
                           },
-                          "required": ["attribute", "value", "business_unit"],
+                          "required": ["attribute", "value"],
                           "additionalProperties": false
                         }
                       }
@@ -2672,10 +2721,10 @@
                           "type": "object",
                           "properties": {
                             "attribute": { "type": "string" },
-                            "value": { "type": "string" },
+                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
                             "business_unit": { "type": "string" }
                           },
-                          "required": ["attribute", "value", "business_unit"],
+                          "required": ["attribute", "value"],
                           "additionalProperties": false
                         }
                       }
@@ -4292,6 +4341,78 @@
           },
           "required": ["url", "model_name"],
           "additionalProperties": false
+        },
+        "aliases": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "description": "Legacy shape: a bare provider-specific identifier. Equivalent to {\"model_id\": \"<value>\"}."
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "model_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Provider-specific identifier sent on the wire (deployment name, inference profile ID, fine-tuned model ID, etc.)."
+                  },
+                  "model_name": {
+                    "type": "string",
+                    "description": "Canonical model name used for pricing, logging, and family inference."
+                  },
+                  "model_family": {
+                    "type": "string",
+                    "enum": ["anthropic", "openai", "mistral", "cohere", "gemini", "nova", "titan"],
+                    "description": "Underlying model family. Used by provider routing without substring-sniffing the wire model ID."
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "Per-alias region override (can use env. prefix)."
+                  },
+                  "api_version": {
+                    "type": "string",
+                    "description": "Azure OpenAI api-version override for this alias."
+                  },
+                  "anthropic_version": {
+                    "type": "string",
+                    "description": "Azure anthropic-version header override for Claude-on-Azure deployments."
+                  },
+                  "endpoint": {
+                    "type": "string",
+                    "description": "Per-alias Azure endpoint override (can use env. prefix)."
+                  },
+                  "project_id": {
+                    "type": "string",
+                    "description": "Per-alias Vertex project ID override (can use env. prefix)."
+                  },
+                  "project_number": {
+                    "type": "string",
+                    "description": "Per-alias Vertex project number override (can use env. prefix)."
+                  },
+                  "inference_profile_arn": {
+                    "type": "string",
+                    "description": "Per-alias Bedrock inference profile ARN (can use env. prefix)."
+                  },
+                  "use_deployments_endpoint": {
+                    "type": "boolean",
+                    "description": "Replicate: use the deployments endpoint instead of the predictions endpoint for this alias."
+                  }
+                },
+                "required": ["model_id"],
+                "additionalProperties": false
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "description": "Model alias mappings: each entry maps a user-facing model name to either a bare provider identifier (legacy string shape) or an AliasConfig object carrying the wire identifier plus optional canonical name, family, and provider-specific overrides."
         }
       },
       "required": ["name", "weight"],

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -266,6 +266,10 @@ bifrost:
       modelParametersUrl: "https://getbifrost.ai/datasheet/model-parameters"
       # Sync interval in seconds (default: 86400 = 24 hours, minimum: 3600)
       pricingSyncInterval: 86400
+      # Custom MCP server catalog URL (optional, leave empty to use the default Bifrost catalog)
+      # mcpLibraryUrl: ""
+      # MCP library sync interval in seconds (default: 86400 = 24 hours, minimum: 3600)
+      # mcpLibrarySyncInterval: 86400
 
   # Provider configurations (add your provider keys here)
   # You can specify API keys directly or use env.VAR_NAME syntax to reference environment variables


### PR DESCRIPTION
## Summary

This PR extends the Bifrost Helm chart and transport config schemas with two new capabilities: configurable MCP server catalog settings, and SCIM provisioning support (`attributeType`/`attributeValue`) across role, team, and business unit attribute mappings. It also introduces a structured `aliases` schema for provider configurations and tightens up previously loose schema definitions for Keycloak and other OIDC attribute mapping arrays.

## Changes

- Added `mcpLibraryUrl` and `mcpLibrarySyncInterval` to `bifrost.framework` in `values.yaml`, `values.schema.json`, and `_helpers.tpl`, allowing operators to point Bifrost at a custom MCP server catalog with a configurable sync interval (minimum 3600s, default 86400s).
- Added `attributeType` (`user` | `group`) and `attributeValue` fields to `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` across all OIDC provider sections (Azure AD, Keycloak, and generic JWT) in both `values.schema.json` and `transports/config.schema.json`, enabling SCIM-aware provisioning rules.
- Made `business_unit` optional in `attributeBusinessUnitMappings` (removed from `required`) to support wildcard `*` pass-through mappings where the claim value itself becomes the business unit name.
- Replaced the previously untyped (`"type": "object"`) Keycloak attribute mapping item schemas with fully specified property definitions including `required` constraints and `additionalProperties: false`.
- Added a new `aliases` object schema to the provider configuration, supporting both a legacy bare-string shape and a rich `AliasConfig` object with fields for `model_id`, `model_name`, `model_family`, per-alias region/endpoint/API version overrides, and provider-specific fields (Bedrock ARN, Vertex project IDs, Azure versioning, Replicate deployment endpoint toggle).
- Clarified descriptions for wildcard `*` behavior in `value` fields across team and business unit mappings.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate the Helm chart renders correctly with the new MCP library fields:

```sh
helm template bifrost ./helm-charts/bifrost \
  --set bifrost.framework.mcpLibraryUrl="https://example.com/mcp-catalog" \
  --set bifrost.framework.mcpLibrarySyncInterval=7200
```

Confirm `mcp_library_url` and `mcp_library_sync_interval` appear in the rendered config.

Validate schema acceptance of new SCIM fields in attribute mappings:

```sh
# Lint the Helm chart values against the schema
helm lint ./helm-charts/bifrost
```

Verify that `attributeBusinessUnitMappings` entries without `business_unit` (wildcard pass-through) pass schema validation, and that entries with `attributeType`/`attributeValue` are accepted in role, team, and business unit mapping arrays.

Verify the `aliases` object schema accepts both the legacy string shape and the full `AliasConfig` object shape for a provider entry.

**New config fields:**

| Field | Location | Description |
|---|---|---|
| `bifrost.framework.mcpLibraryUrl` | `values.yaml` | URL to a custom MCP server catalog |
| `bifrost.framework.mcpLibrarySyncInterval` | `values.yaml` | Sync interval in seconds (min: 3600, default: 86400) |
| `attributeType` | Attribute mapping arrays | SCIM provisioning type: `user` or `group` |
| `attributeValue` | Attribute mapping arrays | SCIM attribute value to match |
| `aliases` | Provider config | Model alias map supporting legacy string or full `AliasConfig` object |

## Breaking changes

- [x] No

The `business_unit` field being removed from `required` in `attributeBusinessUnitMappings` is backward compatible — existing configs with `business_unit` present continue to work.

## Security considerations

- `attributeType`/`attributeValue` fields are used for SCIM provisioning matching. Operators should ensure SCIM group `displayName` values used in mappings are not user-controlled to avoid privilege escalation via group name manipulation.
- `mcpLibraryUrl` accepts an arbitrary URI; operators should ensure this points to a trusted catalog endpoint.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP (Model Context Protocol) library configuration options: customizable catalog URL and sync interval
  * Enhanced SCIM/SSO identity provider mappings with support for attribute type and value customization across Okta, Microsoft Entra, Keycloak, Zitadel, and Google
  * Expanded provider alias configuration to support structured alias definitions with optional canonical and provider-specific fields
  * Made business-unit mapping optional in identity provider integrations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->