### PR TITLE
Fix mcp reconnect failure on startup

### DIFF
--- a/core/internal/mcptests/connect_ping_listtools_test.go
+++ b/core/internal/mcptests/connect_ping_listtools_test.go
@@ -388,13 +388,11 @@ func TestListToolsHook_InitialListToolsFailure_FailsConnect(t *testing.T) {
 
 	// AddClient cleans up the failed entry, so the client must not linger as a
 	// Connected-but-empty entry that would lie to /api/mcp/clients.
+	clientNames := make([]string, 0, len(manager.GetClients()))
 	for _, c := range manager.GetClients() {
-		if c.Name == "list_err" {
-			assert.NotEqual(t, schemas.MCPConnectionStateConnected, c.State,
-				"client with failed list_tools must not be marked Connected")
-			assert.Empty(t, c.ToolMap, "client with failed list_tools must not serve tools")
-		}
+		clientNames = append(clientNames, c.Name)
 	}
+	assert.NotContains(t, clientNames, "list_err", "failed list_tools client must be removed")
 
 	// tools/list (served via GetToolPerClient) must not surface this client's tools.
 	served := manager.GetToolPerClient(context.Background())

--- a/core/internal/mcptests/connect_ping_listtools_test.go
+++ b/core/internal/mcptests/connect_ping_listtools_test.go
@@ -363,30 +363,42 @@ func TestListToolsHook_PreHookShortCircuitWithSyntheticTools(t *testing.T) {
 	assert.False(t, hasEcho, "real server tools should not appear when PreHook short-circuited")
 }
 
-func TestListToolsHook_PreHookShortCircuitError_LeavesEmptyToolMap(t *testing.T) {
+// TestListToolsHook_InitialListToolsFailure_FailsConnect is the regression test for
+// issue #4314. A transport that connects+initializes but whose initial list_tools call
+// fails (here forced via a plugin error short-circuit) must NOT be registered as
+// Connected with an empty ToolMap. Previously the connect path swallowed the failure
+// and left a sticky "connected but serves zero tools" client that /api/mcp/clients
+// reported as healthy while tools/list returned nothing. The fix treats it as a
+// connection failure so the standard Disconnected + health-monitor reconnect path
+// retries a full connect+list.
+func TestListToolsHook_InitialListToolsFailure_FailsConnect(t *testing.T) {
 	t.Parallel()
 
 	plugin := NewTestListToolsPlugin()
 	plugin.SetShortCircuitError(&schemas.BifrostError{
 		IsBifrostError: false,
-		Error:          &schemas.ErrorField{Message: "list_tools blocked"},
+		Error:          &schemas.ErrorField{Message: "list_tools upstream timeout"},
 	})
 
 	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{plugin})
-	// AddClient should still succeed — the connect path tolerates list_tools failure
-	// and falls back to empty tools (matching pre-plugin behavior).
-	require.NoError(t, manager.AddClient(context.Background(), inProcessClientConfig("list_err", buildInProcessServer(t))))
 
-	clients := manager.GetClients()
-	var target *schemas.MCPClientState
-	for i := range clients {
-		if clients[i].Name == "list_err" {
-			target = &clients[i]
-			break
+	err := manager.AddClient(context.Background(), inProcessClientConfig("list_err", buildInProcessServer(t)))
+	require.Error(t, err, "AddClient must fail when initial list_tools errors")
+	assert.Contains(t, err.Error(), "list_tools upstream timeout")
+
+	// AddClient cleans up the failed entry, so the client must not linger as a
+	// Connected-but-empty entry that would lie to /api/mcp/clients.
+	for _, c := range manager.GetClients() {
+		if c.Name == "list_err" {
+			assert.NotEqual(t, schemas.MCPConnectionStateConnected, c.State,
+				"client with failed list_tools must not be marked Connected")
+			assert.Empty(t, c.ToolMap, "client with failed list_tools must not serve tools")
 		}
 	}
-	require.NotNil(t, target)
-	assert.Empty(t, target.ToolMap, "list_tools error short-circuit should result in empty ToolMap")
+
+	// tools/list (served via GetToolPerClient) must not surface this client's tools.
+	served := manager.GetToolPerClient(context.Background())
+	assert.Empty(t, served["list_err"], "no tools should be served for a client that failed list_tools")
 }
 
 func TestListToolsHook_FiresOnConnectAndAgain(t *testing.T) {

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -1455,6 +1455,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 
 	tools := make(map[string]schemas.ChatTool)
 	toolNameMapping := make(map[string]string)
+	var listToolsErr error
 	if externalClient == nil {
 		// Plugin short-circuited the connect with a success response; no live transport
 		// to query. Register the client as "connected" with an empty tool set — this is
@@ -1473,13 +1474,31 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 		defer toolRetrievalCancel()
 		t, mapping, err := m.runListToolsWithHooks(toolRetrievalCtx, externalClient, config.Name)
 		if err != nil {
+			listToolsErr = err
 			m.logger.Warn("%s Failed to retrieve tools from %s: %v", MCPLogPrefix, config.Name, err)
-			// Continue with connection even if tool retrieval fails
 		} else {
 			tools = t
 			toolNameMapping = mapping
 		}
 		m.logger.Debug("%s [%s] Retrieved %d tools", MCPLogPrefix, config.Name, len(tools))
+	}
+
+	// A live transport that cannot enumerate its tools is not healthy. Marking it
+	// Connected with an empty ToolMap makes /api/mcp/clients disagree with tools/list
+	// and is sticky — ping-based health keeps succeeding (transport is alive), so a
+	// reconnect that would re-run discovery never fires. Treat a failed initial
+	// list_tools as a connection failure: tear down the transport and return an error
+	// so the standard Disconnected + health-monitor reconnect path retries a full
+	// connect+list. A server that legitimately exposes zero tools returns success with
+	// an empty list (listToolsErr == nil) and is still marked Connected.
+	if listToolsErr != nil {
+		if (config.ConnectionType == schemas.MCPConnectionTypeSSE || config.ConnectionType == schemas.MCPConnectionTypeSTDIO) && cancel != nil {
+			cancel()
+		}
+		if closeErr := externalClient.Close(); closeErr != nil {
+			m.logger.Warn("%s Failed to close external client after tool retrieval failure: %v", MCPLogPrefix, closeErr)
+		}
+		return fmt.Errorf("failed to retrieve tools from MCP client %s: %w", config.Name, listToolsErr)
 	}
 
 	// Second lock: Update client with final connection details and tools


### PR DESCRIPTION
## Summary
  Fixes #4314. A live MCP transport whose initial `list_tools` call failed was still marked `Connected` with an empty `ToolMap`. The state was sticky: ping-based health checks kept passing (transport
  alive), so the reconnect that would re-run tool discovery never fired. The result was `/api/mcp/clients` reporting the client healthy while `tools/list` returned nothing - permanently, with no recovery.
  ## Changes
  - `core/mcp/clientmanager.go` (`connectToMCPClient`): treat a failed initial `list_tools` as a connection failure instead of swallowing it. Tear down the transport (`cancel()` for SSE/STDIO +
  `externalClient.Close()`) and return an error so `AddClient` cleans up the entry and the standard Disconnected + health-monitor reconnect path retries a full connect+list.
  - A server that legitimately exposes zero tools returns success with an empty list (no error) and is still marked `Connected` - that path is unchanged.
  - Added regression test `TestListToolsHook_InitialListToolsFailure_FailsConnect` in `core/internal/mcptests/connect_ping_listtools_test.go`.
  Design note: chose to fail the connect (vs. marking `Disconnected` and keeping the entry) so recovery flows entirely through the existing health-monitor reconnect path rather than introducing a new
  half-connected state.
  ## Type of change
  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Chore/CI
  ## Affected areas
  - [x] Core (Go)
  - [ ] Transports (HTTP)
  - [ ] Providers/Integrations
  - [ ] Plugins
  - [ ] UI (React)
  - [ ] Docs
  ## How to test
  ```sh
  # Regression test for the fix
  make test-mcp TESTCASE=TestListToolsHook_InitialListToolsFailure_FailsConnect
  # Broader MCP connect/health regression suites
  cd core && go test ./internal/mcptests/ -run 'ListTools|Connect|Health|Reconnect|PendingTools' -count=1
  # Build
  cd core && go build ./...
  ```
  Expected:
  - `TestListToolsHook_InitialListToolsFailure_FailsConnect` - PASS
  - connect/health suites - PASS
  - build - OK
  No new configs or environment variables.
  ## Screenshots/Recordings
  N/A - no UI changes.
  ## Breaking changes
  - [ ] Yes
  - [x] No
  ## Related issues
  Closes #4314
  ## Security considerations
  None. The change tightens connection-state correctness; it does not touch auth, secrets, or sandboxing. The connect path continues to strip the `Authorization` header from plugin-visible headers
  (unchanged).
  ## Checklist
  - [ ] I read `docs/contributing/README.md` and followed the guidelines
  - [x] I added/updated tests where appropriate
  - [ ] I updated documentation where needed
  - [x] I verified builds succeed (Go and UI) (Go only - no UI changes)
  - [x] I verified the CI pipeline passes locally if applicable (MCP test suites pass)