### PR TITLE
[fix]: synthesize per-query rerank usage for Bedrock and Vertex

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2119,12 +2119,12 @@ func (provider *BedrockProvider) Rerank(ctx *schemas.BifrostContext, key schemas
 
 	// Bedrock returns rerank input token usage only in the X-Amzn-Bedrock-Input-Token-Count
 	// response header (it is absent from the body); backfill Usage from it. (#3917)
-	if bifrostResponse.Usage == nil {
-		if inputTokens, ok := inputTokensFromHeaders(providerResponseHeaders); ok {
-			bifrostResponse.Usage = &schemas.BifrostLLMUsage{
-				PromptTokens: inputTokens,
-				TotalTokens:  inputTokens,
-			}
+	// ToBifrostRerankResponse always synthesizes a non-nil Usage (with NumSearchQueries),
+	// so only merge in token fields that are still missing.
+	if inputTokens, ok := inputTokensFromHeaders(providerResponseHeaders); ok {
+		if bifrostResponse.Usage.PromptTokens == 0 {
+			bifrostResponse.Usage.PromptTokens = inputTokens
+			bifrostResponse.Usage.TotalTokens += inputTokens
 		}
 	}
 

--- a/core/providers/bedrock/rerank.go
+++ b/core/providers/bedrock/rerank.go
@@ -123,6 +123,15 @@ func (response *BedrockRerankResponse) ToBifrostRerankResponse(documents []schem
 		}
 	}
 
+	// Bedrock bills rerank per query but returns no usage payload in the body,
+	// so synthesize the billable query count: one call is one query. Input
+	// tokens are backfilled separately from response headers (#3917).
+	bifrostResponse.Usage = &schemas.BifrostLLMUsage{
+		CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{
+			NumSearchQueries: new(1),
+		},
+	}
+
 	return bifrostResponse
 }
 

--- a/core/providers/bedrock/rerank_test.go
+++ b/core/providers/bedrock/rerank_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestToBedrockRerankRequest verifies Bifrost rerank requests convert to the
+// Bedrock wire format with documents, top_n, and model ARN in place.
 func TestToBedrockRerankRequest(t *testing.T) {
 	topN := 10
 	maxTokensPerDoc := 512
@@ -48,6 +50,8 @@ func TestToBedrockRerankRequest(t *testing.T) {
 	assert.Equal(t, "END", fields["truncate"])
 }
 
+// TestBedrockRerankResponseToBifrostRerankResponse verifies result ordering
+// and document parsing when converting a Bedrock rerank response.
 func TestBedrockRerankResponseToBifrostRerankResponse(t *testing.T) {
 	response := (&BedrockRerankResponse{
 		Results: []BedrockRerankResult{
@@ -85,6 +89,8 @@ func TestBedrockRerankResponseToBifrostRerankResponse(t *testing.T) {
 	assert.Equal(t, "doc-1", response.Results[1].Document.Text)
 }
 
+// TestBedrockRerankResponseToBifrostRerankResponseReturnDocuments verifies
+// request documents are echoed back onto results when return_documents is set.
 func TestBedrockRerankResponseToBifrostRerankResponseReturnDocuments(t *testing.T) {
 	requestDocs := []schemas.RerankDocument{
 		{Text: "request-doc-0"},
@@ -132,6 +138,8 @@ func TestBedrockRerankResponseToBifrostRerankResponseReturnDocuments(t *testing.
 	assert.Equal(t, "request-doc-2", response.Results[2].Document.Text)
 }
 
+// TestBedrockRerankRequestToBifrostRerankRequest verifies the Bedrock rerank
+// request converts back to the Bifrost request shape.
 func TestBedrockRerankRequestToBifrostRerankRequest(t *testing.T) {
 	topN := 3
 	bedrockReq := &BedrockRerankRequest{
@@ -191,11 +199,15 @@ func TestBedrockRerankRequestToBifrostRerankRequest(t *testing.T) {
 	assert.Equal(t, "END", result.Params.ExtraParams["truncate"])
 }
 
+// TestBedrockRerankRequestToBifrostRerankRequestNil verifies a nil request
+// converts to nil instead of panicking.
 func TestBedrockRerankRequestToBifrostRerankRequestNil(t *testing.T) {
 	var req *BedrockRerankRequest
 	assert.Nil(t, req.ToBifrostRerankRequest(nil))
 }
 
+// TestResolveBedrockDeployment verifies deployment resolution falls back to
+// the requested model when no deployment mapping exists.
 func TestResolveBedrockDeployment(t *testing.T) {
 	key := schemas.Key{
 		Aliases: schemas.KeyAliases{
@@ -209,6 +221,8 @@ func TestResolveBedrockDeployment(t *testing.T) {
 	assert.Equal(t, "", key.Aliases.Resolve(""))
 }
 
+// TestBedrockRerankRequiresARNModelIdentifier verifies rerank rejects
+// non-ARN model identifiers with a configuration error.
 func TestBedrockRerankRequiresARNModelIdentifier(t *testing.T) {
 	provider := &BedrockProvider{}
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -230,4 +244,58 @@ func TestBedrockRerankRequiresARNModelIdentifier(t *testing.T) {
 	require.NotNil(t, bifrostErr)
 	require.NotNil(t, bifrostErr.Error)
 	assert.Contains(t, bifrostErr.Error.Message, "requires an ARN")
+}
+
+// TestBedrockRerankResponseToBifrostRerankResponseSynthesizesQueryUsage verifies
+// that the conversion synthesizes per-query usage (one billable query per call),
+// since Bedrock's rerank response body carries no usage payload.
+func TestBedrockRerankResponseToBifrostRerankResponseSynthesizesQueryUsage(t *testing.T) {
+	response := (&BedrockRerankResponse{
+		Results: []BedrockRerankResult{
+			{Index: 0, RelevanceScore: 0.91},
+		},
+	}).ToBifrostRerankResponse(nil, false)
+
+	require.NotNil(t, response)
+	require.NotNil(t, response.Usage)
+	require.NotNil(t, response.Usage.CompletionTokensDetails)
+	require.NotNil(t, response.Usage.CompletionTokensDetails.NumSearchQueries)
+	assert.Equal(t, 1, *response.Usage.CompletionTokensDetails.NumSearchQueries)
+}
+
+// TestBedrockRerankResponseToBifrostRerankResponseUsageIsolated confirms the
+// converter sets only the synthesized query count and no spurious token fields,
+// so the unconditional Usage assignment has nothing to clobber. The Bedrock
+// header-token backfill (#3917) is the only path that adds PromptTokens, and it
+// merges in (guarded on PromptTokens == 0) rather than replacing Usage.
+func TestBedrockRerankResponseToBifrostRerankResponseUsageIsolated(t *testing.T) {
+	response := (&BedrockRerankResponse{
+		Results: []BedrockRerankResult{
+			{Index: 0, RelevanceScore: 0.91},
+		},
+	}).ToBifrostRerankResponse(nil, false)
+
+	require.NotNil(t, response)
+	require.NotNil(t, response.Usage)
+	// Only the per-query count is synthesized; token fields stay zero so a later
+	// header-token backfill can populate them without being overwritten.
+	assert.Equal(t, 0, response.Usage.PromptTokens)
+	assert.Equal(t, 0, response.Usage.CompletionTokens)
+	assert.Equal(t, 0, response.Usage.TotalTokens)
+	require.NotNil(t, response.Usage.CompletionTokensDetails)
+	require.NotNil(t, response.Usage.CompletionTokensDetails.NumSearchQueries)
+	assert.Equal(t, 1, *response.Usage.CompletionTokensDetails.NumSearchQueries)
+}
+
+// TestBedrockRerankResponseToBifrostRerankResponseSynthesizesQueryUsageEmptyResults
+// confirms one billable query is recorded even when the response carries no
+// results, since Bedrock bills per call regardless of result count.
+func TestBedrockRerankResponseToBifrostRerankResponseSynthesizesQueryUsageEmptyResults(t *testing.T) {
+	response := (&BedrockRerankResponse{}).ToBifrostRerankResponse(nil, false)
+
+	require.NotNil(t, response)
+	require.NotNil(t, response.Usage)
+	require.NotNil(t, response.Usage.CompletionTokensDetails)
+	require.NotNil(t, response.Usage.CompletionTokensDetails.NumSearchQueries)
+	assert.Equal(t, 1, *response.Usage.CompletionTokensDetails.NumSearchQueries)
 }

--- a/core/providers/vertex/rerank.go
+++ b/core/providers/vertex/rerank.go
@@ -259,8 +259,15 @@ func (response *VertexRankResponse) ToBifrostRerankResponse(documents []schemas.
 		return results[i].RelevanceScore > results[j].RelevanceScore
 	})
 
+	// The Vertex AI Ranking API bills per query but returns no usage payload,
+	// so synthesize the billable query count: one call is one query.
 	return &schemas.BifrostRerankResponse{
 		Results: results,
+		Usage: &schemas.BifrostLLMUsage{
+			CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{
+				NumSearchQueries: new(1),
+			},
+		},
 	}, nil
 }
 

--- a/core/providers/vertex/rerank_test.go
+++ b/core/providers/vertex/rerank_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBuildVertexRankingConfig verifies the ranking config path is built from
+// project ID and optional ranking config parameters.
 func TestBuildVertexRankingConfig(t *testing.T) {
 	t.Parallel()
 
@@ -28,6 +30,8 @@ func TestBuildVertexRankingConfig(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestToVertexRankRequest verifies Bifrost rerank requests convert to the
+// Vertex rank wire format with records and options in place.
 func TestToVertexRankRequest(t *testing.T) {
 	t.Parallel()
 
@@ -63,6 +67,8 @@ func TestToVertexRankRequest(t *testing.T) {
 	assert.True(t, *req.IgnoreRecordDetailsInResponse)
 }
 
+// TestToVertexRankRequestTooManyRecords verifies conversion fails when the
+// document count exceeds the Vertex per-call record limit.
 func TestToVertexRankRequestTooManyRecords(t *testing.T) {
 	t.Parallel()
 
@@ -85,6 +91,8 @@ func TestToVertexRankRequestTooManyRecords(t *testing.T) {
 	assert.Contains(t, err.Error(), "supports up to")
 }
 
+// TestGetVertexRerankOptions verifies extra params are parsed into Vertex
+// rerank options with defaults applied.
 func TestGetVertexRerankOptions(t *testing.T) {
 	t.Parallel()
 
@@ -103,6 +111,8 @@ func TestGetVertexRerankOptions(t *testing.T) {
 	assert.Equal(t, map[string]string{"env": "test"}, options.UserLabels)
 }
 
+// TestVertexRankResponseToBifrostRerankResponse verifies result ordering and
+// document echo when converting a Vertex rank response.
 func TestVertexRankResponseToBifrostRerankResponse(t *testing.T) {
 	t.Parallel()
 
@@ -130,6 +140,8 @@ func TestVertexRankResponseToBifrostRerankResponse(t *testing.T) {
 	assert.Equal(t, "doc-0", response.Results[0].Document.Text)
 }
 
+// TestVertexRankRequestToBifrostRerankRequest verifies the Vertex rank
+// request converts back to the Bifrost request shape.
 func TestVertexRankRequestToBifrostRerankRequest(t *testing.T) {
 	t.Parallel()
 
@@ -185,6 +197,8 @@ func TestVertexRankRequestToBifrostRerankRequest(t *testing.T) {
 	assert.Equal(t, map[string]string{"env": "test"}, result.Params.ExtraParams["user_labels"])
 }
 
+// TestVertexRankRequestToBifrostRerankRequestNil verifies a nil request
+// converts to nil instead of panicking.
 func TestVertexRankRequestToBifrostRerankRequestNil(t *testing.T) {
 	t.Parallel()
 
@@ -192,6 +206,8 @@ func TestVertexRankRequestToBifrostRerankRequestNil(t *testing.T) {
 	assert.Nil(t, req.ToBifrostRerankRequest(nil))
 }
 
+// TestVertexRankResponseToBifrostRerankResponseInvalidID verifies malformed
+// record IDs surface as a conversion error.
 func TestVertexRankResponseToBifrostRerankResponseInvalidID(t *testing.T) {
 	t.Parallel()
 
@@ -202,4 +218,24 @@ func TestVertexRankResponseToBifrostRerankResponseInvalidID(t *testing.T) {
 	}).ToBifrostRerankResponse([]schemas.RerankDocument{{Text: "doc"}}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid record id")
+}
+
+// TestVertexRankResponseToBifrostRerankResponseSynthesizesQueryUsage verifies
+// that the conversion synthesizes per-query usage (one billable query per call),
+// since the Vertex AI Ranking API response carries no usage payload.
+func TestVertexRankResponseToBifrostRerankResponseSynthesizesQueryUsage(t *testing.T) {
+	t.Parallel()
+
+	response, err := (&VertexRankResponse{
+		Records: []VertexRankedRecord{
+			{ID: "idx:0", Score: 0.91},
+		},
+	}).ToBifrostRerankResponse([]schemas.RerankDocument{{Text: "doc-0"}}, false)
+	require.NoError(t, err)
+
+	require.NotNil(t, response)
+	require.NotNil(t, response.Usage)
+	require.NotNil(t, response.Usage.CompletionTokensDetails)
+	require.NotNil(t, response.Usage.CompletionTokensDetails.NumSearchQueries)
+	assert.Equal(t, 1, *response.Usage.CompletionTokensDetails.NumSearchQueries)
 }


### PR DESCRIPTION
## Summary

Bedrock and Vertex bill rerank per query, but neither API returns a usage
payload, so rerank cost for these providers always computed to 0. Vertex left
`Usage` nil entirely (cost calculation bails out before pricing is resolved);
Bedrock carried only header-derived input tokens (#3917), but datasheet rerank
entries have zero per-token rates and `num_search_queries` was never set, so
`computeRerankCost` still returned 0 — the billable unit was simply never
tracked. This PR synthesizes the billable query count at conversion time,
mirroring what the #4239 fix does with Cohere's provider-reported
`search_units`.

## Changes

- `BedrockRerankResponse.ToBifrostRerankResponse` and
  `VertexRankResponse.ToBifrostRerankResponse` now synthesize a non-nil `Usage`
  with `CompletionTokensDetails.NumSearchQueries = 1` — one rerank call is one
  billable query. The synthesis lives in the rerank mapping itself (the
  conversion functions are only ever invoked from the rerank flow), so it
  cannot leak into any other request type.
- Bedrock's header-token backfill (#3917) now merges into the synthesized
  `Usage` instead of only creating `Usage` when nil — token fields are still
  only filled when missing, preserving the original backfill semantics, so the
  final Bedrock `Usage` carries both the header-derived input tokens and the
  query count.
- Regression tests for both conversions asserting the synthesized
  `num_search_queries`.

Note: per-query rerank cost also needs the datasheet's `input_cost_per_query`
rate, which is parsed as of #4277 — the two changes are independent but
compose; with both in place `computeRerankCost` produces a non-zero cost for
these providers. One assumption worth confirming: that a single call always
equals one billable query for AWS/GCP (both APIs cap documents per call).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
go test ./core/providers/bedrock/... -run SynthesizesQueryUsage -v
go test ./core/providers/vertex/... -run SynthesizesQueryUsage -v
go test ./core/providers/bedrock/... ./core/providers/vertex/...
```

Expected: both new synthesis tests pass; the full vertex suite passes; the
bedrock suite passes except `TestBedrockRerankRequestToBifrostRerankRequest`,
which is a pre-existing failure on `dev` that reproduces identically on a
clean checkout without this change.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No


## Related issues

Fixes #4321 

## Security considerations

N/A

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable