### PR TITLE
fix: run `vite build` before `typecheck` in build scripts

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,9 +4,9 @@
 	"private": true,
 	"scripts": {
 		"dev": "vite",
-		"build-enterprise": "npm run typecheck && vite build",
+		"build-enterprise": "vite build && npm run typecheck",
 		"typecheck": "tsc --noEmit",
-		"build": "npm run typecheck && vite build && npm run copy-build",
+		"build": "vite build && npm run typecheck && npm run copy-build",
 		"copy-build": "rm -rf ../transports/bifrost-http/ui && cp -r out ../transports/bifrost-http/ui",
 		"start": "vite preview",
 		"lint": "oxlint",


### PR DESCRIPTION
## Summary

Moves the TypeScript type check (`tsc --noEmit`) to run **after** the Vite build step rather than before, for both the `build` and `build-enterprise` scripts. This allows the build artifact to be produced even when there are type errors, which is useful for unblocking deployments or debugging build output when type issues are present.

## Changes

- In `build-enterprise`: `typecheck` now runs after `vite build` instead of before.
- In `build`: `typecheck` now runs after `vite build` instead of before, while `copy-build` remains the final step.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
npm i
npm run build
npm run build-enterprise
```

Verify that the build output is generated successfully and that type checking still runs and reports any errors after the build completes.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script execution order. Type-checking now runs after the build process completes in both standard and enterprise builds, rather than before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->