### PR TITLE
feat: refactors tracers to correctly set trace level attributes

### DIFF
--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -22,6 +22,18 @@ type Trace struct {
 	mu             sync.Mutex        // Mutex for thread-safe span operations
 }
 
+// Trace-level attribute keys. Unlike span attributes, trace attributes are never
+// exported as OTEL/Datadog span attributes — observability connectors (BigQuery,
+// Datadog) read them directly off the completed trace.
+const (
+	// TraceAttrSessionID holds the session ID from the x-bf-session-id request
+	// header. The key matches the header name because connectors already read it.
+	TraceAttrSessionID = "x-bf-session-id"
+	// TraceAttrDimensions holds the map[string]string of request dimensions
+	// parsed from x-bf-dim-* headers, keyed by bare dimension name.
+	TraceAttrDimensions = "bifrost.dimensions"
+)
+
 // AddSpan adds a span to the trace in a thread-safe manner
 func (t *Trace) AddSpan(span *Span) {
 	t.mu.Lock()
@@ -60,6 +72,28 @@ func (t *Trace) SetRequestHeaders(headers map[string]string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.RequestHeaders = headers
+}
+
+// SetAttribute sets a trace-level attribute in a thread-safe manner
+func (t *Trace) SetAttribute(key string, value any) {
+	if value == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.Attributes == nil {
+		t.Attributes = make(map[string]any)
+	}
+	t.Attributes[key] = value
+}
+
+// GetAttribute retrieves a trace-level attribute in a thread-safe manner.
+// The second return value reports whether the key was present.
+func (t *Trace) GetAttribute(key string) (any, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	value, ok := t.Attributes[key]
+	return value, ok
 }
 
 // Reset clears the trace for reuse from pool

--- a/framework/tracing/store.go
+++ b/framework/tracing/store.go
@@ -139,6 +139,15 @@ func (s *TraceStore) SetRequestHeaders(traceID string, headers map[string]string
 	trace.SetRequestHeaders(headers)
 }
 
+// SetTraceAttribute sets a trace-level attribute on the trace
+func (s *TraceStore) SetTraceAttribute(traceID string, key string, value any) {
+	trace := s.GetTrace(traceID)
+	if trace == nil {
+		return
+	}
+	trace.SetAttribute(key, value)
+}
+
 // CompleteTrace marks the trace as complete, removes it from store, and returns it for flushing
 func (s *TraceStore) CompleteTrace(traceID string) *schemas.Trace {
 	// Clear any deferred span for this trace

--- a/framework/tracing/store_test.go
+++ b/framework/tracing/store_test.go
@@ -250,3 +250,32 @@ func TestGenerateSpanID_Format(t *testing.T) {
 		t.Errorf("generateSpanID() = %q, not valid hex", id)
 	}
 }
+
+func TestSetTraceAttribute(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	traceID := store.CreateTrace("")
+	dims := map[string]string{"environment": "prod"}
+	store.SetTraceAttribute(traceID, schemas.TraceAttrDimensions, dims)
+	store.SetTraceAttribute(traceID, schemas.TraceAttrSessionID, "sess-1")
+
+	trace := store.GetTrace(traceID)
+	if trace == nil {
+		t.Fatal("GetTrace() returned nil")
+	}
+	dimsAttr, _ := trace.GetAttribute(schemas.TraceAttrDimensions)
+	got, ok := dimsAttr.(map[string]string)
+	if !ok || got["environment"] != "prod" {
+		t.Errorf("trace dimensions attribute = %v, want map with environment=prod", dimsAttr)
+	}
+	if sessionAttr, _ := trace.GetAttribute(schemas.TraceAttrSessionID); sessionAttr != "sess-1" {
+		t.Errorf("trace session attribute = %v, want sess-1", sessionAttr)
+	}
+	if _, ok := trace.GetAttribute("missing"); ok {
+		t.Error("GetAttribute(missing) reported present, want absent")
+	}
+
+	// Unknown trace ID must be a no-op, not a panic.
+	store.SetTraceAttribute("does-not-exist", "k", "v")
+}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -103,6 +103,13 @@ func (t *Tracer) SetTraceRequestHeaders(traceID string, headers map[string]strin
 	t.store.SetRequestHeaders(traceID, matched)
 }
 
+// SetTraceAttribute sets a trace-level attribute. Trace attributes are never
+// exported as OTEL/Datadog span attributes; observability connectors read them
+// directly off the completed trace.
+func (t *Tracer) SetTraceAttribute(traceID string, key string, value any) {
+	t.store.SetTraceAttribute(traceID, key, value)
+}
+
 // CreateTrace creates a new trace with optional parent ID and returns the trace ID.
 func (t *Tracer) CreateTrace(parentID string, requestID ...string) string {
 	return t.store.CreateTrace(parentID, requestID...)

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -1083,20 +1084,25 @@ type TracingMiddleware struct {
 	tracer atomic.Pointer[tracing.Tracer]
 }
 
-func attachDimensionAttributesToHTTPSpan(ctx *fasthttp.RequestCtx, setAttribute func(key string, value any)) {
-	if ctx == nil || setAttribute == nil {
-		return
+// collectDimensionHeaders gathers x-bf-dim-* request headers into a map keyed by
+// the bare dimension name. TracingMiddleware runs before ConvertToBifrostContext,
+// so it reads the headers directly rather than BifrostContextKeyDimensions.
+func collectDimensionHeaders(ctx *fasthttp.RequestCtx) map[string]string {
+	if ctx == nil {
+		return nil
 	}
-	// Root HTTP span starts before ConvertToBifrostContext, so read x-bf-dim-* directly.
+	var dims map[string]string
 	ctx.Request.Header.All()(func(key, value []byte) bool {
 		keyStr := strings.ToLower(string(key))
 		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-dim-"); ok && labelName != "" {
-			if labelName != "path" && labelName != "method" {
-				setAttribute(labelName, string(value))
+			if dims == nil {
+				dims = make(map[string]string)
 			}
+			dims[labelName] = string(value)
 		}
 		return true
 	})
+	return dims
 }
 
 // NewTracingMiddleware creates a new tracing middleware
@@ -1142,6 +1148,18 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 			inheritedTraceID := tracing.ExtractParentID(&ctx.Request.Header)
 			// Create trace in store - only ID returned (trace data stays in store)
 			traceID := tracer.CreateTrace(inheritedTraceID, requestID)
+			// Store dimensions and session ID at the trace level (not as span
+			// attributes) so connectors like BigQuery can export them without
+			// changing the OTEL/Datadog span payloads.
+			dimensions := collectDimensionHeaders(ctx)
+			if len(dimensions) > 0 {
+				// Hand the trace its own copy — connectors read the attribute
+				// asynchronously and must never observe later mutations.
+				tracer.SetTraceAttribute(traceID, schemas.TraceAttrDimensions, maps.Clone(dimensions))
+			}
+			if sessionID := strings.TrimSpace(string(ctx.Request.Header.Peek("x-bf-session-id"))); sessionID != "" {
+				tracer.SetTraceAttribute(traceID, schemas.TraceAttrSessionID, sessionID)
+			}
 			// Only trace ID goes into context (lightweight, no bloat)
 			ctx.SetUserValue(schemas.BifrostContextKeyTraceID, traceID)
 			// Extract parent span ID from W3C traceparent header (if present)
@@ -1174,9 +1192,12 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 			// Create root span for the HTTP request
 			spanCtx, rootSpan := tracer.StartSpan(ctx, string(ctx.RequestURI()), schemas.SpanKindHTTPRequest)
 			if rootSpan != nil {
-				attachDimensionAttributesToHTTPSpan(ctx, func(key string, value any) {
-					tracer.SetAttribute(rootSpan, key, value)
-				})
+				for name, value := range dimensions {
+					// "path" and "method" stay reserved for the standard http.* attributes.
+					if name != "path" && name != "method" {
+						tracer.SetAttribute(rootSpan, name, value)
+					}
+				}
 				tracer.SetAttribute(rootSpan, "http.method", string(ctx.Method()))
 				tracer.SetAttribute(rootSpan, "http.url", string(ctx.RequestURI()))
 				tracer.SetAttribute(rootSpan, "http.user_agent", string(ctx.Request.Header.UserAgent()))

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -2129,3 +2129,26 @@ func TestTracingMiddleware_StreamingRootSpanEndsAfterLLMSpan(t *testing.T) {
 		t.Fatalf("root span has non-positive duration: start=%v, end=%v", plugin.rootStart, plugin.rootEnd)
 	}
 }
+
+func TestCollectDimensionHeaders(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("X-BF-Dim-Environment", "prod")
+	ctx.Request.Header.Set("x-bf-dim-team", "ml")
+	ctx.Request.Header.Set("x-bf-dim-", "ignored")  // empty dimension name
+	ctx.Request.Header.Set("x-request-id", "req-1") // non-dimension header
+
+	dims := collectDimensionHeaders(ctx)
+	if len(dims) != 2 {
+		t.Fatalf("collectDimensionHeaders() = %v, want 2 entries", dims)
+	}
+	if dims["environment"] != "prod" || dims["team"] != "ml" {
+		t.Errorf("collectDimensionHeaders() = %v, want environment=prod team=ml", dims)
+	}
+
+	if got := collectDimensionHeaders(&fasthttp.RequestCtx{}); got != nil {
+		t.Errorf("collectDimensionHeaders(no dims) = %v, want nil", got)
+	}
+	if got := collectDimensionHeaders(nil); got != nil {
+		t.Errorf("collectDimensionHeaders(nil) = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary

Introduces trace-level attributes for session ID and request dimensions, allowing observability connectors (e.g. BigQuery, Datadog) to read these values directly off the completed trace without polluting OTEL/Datadog span payloads.

## Changes

- Added `TraceAttrSessionID` (`x-bf-session-id`) and `TraceAttrDimensions` (`bifrost.dimensions`) constants to define the canonical keys for trace-level attributes.
- Added a thread-safe `SetAttribute` method on `Trace` and wired it through `TraceStore.SetTraceAttribute` and `Tracer.SetTraceAttribute`.
- Replaced `attachDimensionAttributesToHTTPSpan` with `collectDimensionHeaders`, which gathers all `x-bf-dim-*` headers into a `map[string]string` once at trace creation time. The map is stored as a trace attribute and also iterated when setting span attributes on the root HTTP span (excluding reserved `path` and `method` keys).
- The `x-bf-session-id` header is captured and stored as a trace attribute at the same point.
- This design means dimension and session data is available to connectors that read the completed trace, while the span-level attribute behaviour for OTEL/Datadog remains unchanged.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/tracing/... ./transports/bifrost-http/handlers/...
```

- `TestSetTraceAttribute` verifies that dimensions and session ID are stored correctly on the trace and that an unknown trace ID is a no-op.
- `TestCollectDimensionHeaders` verifies header parsing, case normalisation, empty dimension name filtering, and nil/empty context handling.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Session IDs and dimension values sourced from request headers are stored in-memory on the trace object and forwarded only to configured observability connectors. No new external exposure is introduced beyond what those connectors already handle.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Set and retrieve attributes on traces (including session IDs and dimensions)
  * HTTP request headers for session ID and dimensions are captured and applied to traces and root spans
* **Tests**
  * Added tests for setting trace attributes and for collecting dimension headers from requests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->