### PR TITLE
fix: max reasoning effort for deepseek v4

### DIFF
--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -107,8 +107,14 @@ func TestToOpenAIChatRequest_PreservesN(t *testing.T) {
 }
 
 func TestToOpenAIChatRequest_NormalizesReasoningEffort(t *testing.T) {
+	// DeepSeek is configured as a custom OpenAI-compatible provider, which registers
+	// itself so ParseModelString can strip its prefix from "deepseek/deepseek-v4-pro".
+	schemas.RegisterKnownProvider(schemas.ModelProvider("deepseek"))
+	defer schemas.UnregisterKnownProvider(schemas.ModelProvider("deepseek"))
+
 	tests := []struct {
 		name     string
+		provider schemas.ModelProvider
 		model    string
 		effort   string
 		expected string
@@ -167,12 +173,37 @@ func TestToOpenAIChatRequest_NormalizesReasoningEffort(t *testing.T) {
 			effort:   "max",
 			expected: "high",
 		},
+		{
+			name:     "preserves max for deepseek-v4-pro",
+			provider: schemas.ModelProvider("deepseek"),
+			model:    "deepseek-v4-pro",
+			effort:   "max",
+			expected: "max",
+		},
+		{
+			name:     "preserves max for deepseek-v4-flash",
+			provider: schemas.ModelProvider("deepseek"),
+			model:    "deepseek-v4-flash",
+			effort:   "max",
+			expected: "max",
+		},
+		{
+			name:     "preserves max for provider-prefixed deepseek-v4",
+			provider: schemas.ModelProvider("deepseek"),
+			model:    "deepseek/deepseek-v4-pro",
+			effort:   "max",
+			expected: "max",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			provider := tt.provider
+			if provider == "" {
+				provider = schemas.OpenAI
+			}
 			req := &schemas.BifrostChatRequest{
-				Provider: schemas.OpenAI,
+				Provider: provider,
 				Model:    tt.model,
 				Input: []schemas.ChatMessage{{
 					Role: schemas.ChatMessageRoleUser,
@@ -280,6 +311,10 @@ func TestToOpenAIChatRequest_VertexDropsNoneReasoningEffort(t *testing.T) {
 }
 
 func TestOpenAIChatRequest_FilterOpenAISpecificParameters_NormalizesReasoningEffort(t *testing.T) {
+	// Register the custom "deepseek" provider so ParseModelString strips its prefix.
+	schemas.RegisterKnownProvider(schemas.ModelProvider("deepseek"))
+	defer schemas.UnregisterKnownProvider(schemas.ModelProvider("deepseek"))
+
 	tests := []struct {
 		name     string
 		model    string
@@ -339,6 +374,24 @@ func TestOpenAIChatRequest_FilterOpenAISpecificParameters_NormalizesReasoningEff
 			model:    "gpt-5.1",
 			effort:   "max",
 			expected: "high",
+		},
+		{
+			name:     "preserves max for deepseek-v4-pro",
+			model:    "deepseek-v4-pro",
+			effort:   "max",
+			expected: "max",
+		},
+		{
+			name:     "preserves max for deepseek-v4-flash",
+			model:    "deepseek-v4-flash",
+			effort:   "max",
+			expected: "max",
+		},
+		{
+			name:     "preserves max for provider-prefixed deepseek-v4",
+			model:    "deepseek/deepseek-v4-pro",
+			effort:   "max",
+			expected: "max",
 		},
 	}
 

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -302,8 +302,13 @@ func TestToOpenAIResponsesRequest_ReasoningStringContent(t *testing.T) {
 }
 
 func TestToOpenAIResponsesRequest_NormalizesReasoningEffort(t *testing.T) {
+	// Register the custom "deepseek" provider so ParseModelString strips its prefix.
+	schemas.RegisterKnownProvider(schemas.ModelProvider("deepseek"))
+	defer schemas.UnregisterKnownProvider(schemas.ModelProvider("deepseek"))
+
 	tests := []struct {
 		name     string
+		provider schemas.ModelProvider
 		model    string
 		effort   string
 		expected string
@@ -386,12 +391,39 @@ func TestToOpenAIResponsesRequest_NormalizesReasoningEffort(t *testing.T) {
 			effort:   "max",
 			expected: "high",
 		},
+		{
+			// DeepSeek V4 is routed via a custom OpenAI-compatible provider, so the
+			// OpenAI-only reasoning-stripping doesn't apply and "max" passes through.
+			name:     "preserves max for deepseek-v4-pro",
+			provider: schemas.ModelProvider("deepseek"),
+			model:    "deepseek-v4-pro",
+			effort:   "max",
+			expected: "max",
+		},
+		{
+			name:     "preserves max for deepseek-v4-flash",
+			provider: schemas.ModelProvider("deepseek"),
+			model:    "deepseek-v4-flash",
+			effort:   "max",
+			expected: "max",
+		},
+		{
+			name:     "preserves max for provider-prefixed deepseek-v4",
+			provider: schemas.ModelProvider("deepseek"),
+			model:    "deepseek/deepseek-v4-pro",
+			effort:   "max",
+			expected: "max",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			provider := tt.provider
+			if provider == "" {
+				provider = schemas.OpenAI
+			}
 			req := ToOpenAIResponsesRequest(&schemas.BifrostResponsesRequest{
-				Provider: schemas.OpenAI,
+				Provider: provider,
 				Model:    tt.model,
 				Input: []schemas.ResponsesMessage{{
 					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -101,6 +101,9 @@ func normalizeOpenAIReasoningEffort(model string, effort string) string {
 	case "minimal":
 		return "low"
 	case "max":
+		if supportsMaxReasoningEffort(model) {
+			return effort
+		}
 		if supportsOpenAIXHighReasoningEffort(model) {
 			return "xhigh"
 		}
@@ -125,6 +128,15 @@ func supportsOpenAIXHighReasoningEffort(model string) bool {
 		strings.HasPrefix(modelLower, "gpt-5.3-codex") ||
 		strings.HasPrefix(modelLower, "gpt-5.4") ||
 		strings.HasPrefix(modelLower, "gpt-5.5")
+}
+
+// supportsMaxReasoningEffort reports models that natively accept "max" effort (e.g. DeepSeek V4).
+func supportsMaxReasoningEffort(model string) bool {
+	_, parsedModel := schemas.ParseModelString(model, schemas.OpenAI)
+	if parsedModel != "" {
+		model = parsedModel
+	}
+	return strings.HasPrefix(strings.ToLower(model), "deepseek-v4")
 }
 
 // MaxUserFieldLength for OpenAI enforces a 64 character maximum on the user field


### PR DESCRIPTION
## Summary

DeepSeek V4 models (`deepseek-v4-pro`, `deepseek-v4-flash`) natively accept `"max"` as a reasoning effort value. Previously, the normalization logic would convert `"max"` to `"high"` (or `"xhigh"` for supported OpenAI models) for all models, which incorrectly stripped the valid `"max"` value when routing through DeepSeek's OpenAI-compatible provider.  
  
closes #4320

## Changes

- Added `supportsMaxReasoningEffort` helper in `utils.go` that identifies models with a `deepseek-v4` prefix as natively supporting `"max"` reasoning effort.
- Updated `normalizeOpenAIReasoningEffort` to short-circuit and return `"max"` unchanged for those models before applying the OpenAI-specific `"high"`/`"xhigh"` mapping.
- Extended tests in `chat_test.go` and `responses_test.go` to cover the `"max"` passthrough behavior for `deepseek-v4-pro` and `deepseek-v4-flash`.
- Updated the responses test harness to accept a configurable `provider` field so DeepSeek-routed requests can be tested independently from OpenAI-routed ones.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/...
```

Verify that the new test cases `"preserves max for deepseek-v4-pro"` and `"preserves max for deepseek-v4-flash"` pass in both `TestToOpenAIChatRequest_NormalizesReasoningEffort`, `TestOpenAIChatRequest_FilterOpenAISpecificParameters_NormalizesReasoningEffort`, and `TestToOpenAIResponsesRequest_NormalizesReasoningEffort`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added official support for DeepSeek V4 models (deepseek-v4-pro, deepseek-v4-flash), including recognition of provider-prefixed model identifiers.

* **Bug Fixes**
  * Reasoning-effort handling now preserves the "max" setting for DeepSeek V4 models across requests and responses, ensuring expected high-effort behavior is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->