### PR TITLE
fix(complexity): removing the backfill check on empty hash

### DIFF
--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2450,15 +2450,6 @@ func planComplexityAnalyzerConfigUpdate(config *Config, configData *ConfigData) 
 		}
 		return fileConfig
 	}
-	if current != nil && current.ConfigHashes.Empty() {
-		normalized := current.Normalized()
-		normalized.ConfigHashes = fileHashes
-		logger.Debug("complexity analyzer config missing section hashes, backfilling without applying config file values")
-		if reflect.DeepEqual(current, &normalized) {
-			return nil
-		}
-		return &normalized
-	}
 	if current != nil && current.ConfigHashes.Equal(fileHashes) {
 		logger.Debug("complexity analyzer config section hashes match, keeping DB config")
 		return nil

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1508,13 +1508,14 @@ func TestMergeGovernanceConfig_SyncsComplexityAnalyzerConfig(t *testing.T) {
 	require.Equal(t, stored, config.GovernanceConfig.ComplexityAnalyzerConfig)
 }
 
-func TestMergeGovernanceConfig_BackfillsLegacyComplexityHashesWithoutApplyingFileValues(t *testing.T) {
+func TestMergeGovernanceConfig_AppliesComplexityAnalyzerConfigWhenHashesAreEmpty(t *testing.T) {
 	initTestLogger()
 
 	store := NewMockConfigStore()
 	dbConfig := testRuntimeComplexityAnalyzerConfig()
 	dbConfig.TierBoundaries.SimpleMedium = 0.12
 	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbConfig.ConfigHashes = configstore.ComplexityAnalyzerConfigHashes{}
 	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
 	store.governanceConfig = dbGovernance
 	config := &Config{
@@ -1535,8 +1536,8 @@ func TestMergeGovernanceConfig_BackfillsLegacyComplexityHashesWithoutApplyingFil
 	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, stored)
-	require.Equal(t, 0.12, stored.TierBoundaries.SimpleMedium)
-	require.Equal(t, []string{"ui-code"}, stored.Keywords.CodeKeywords)
+	require.Equal(t, fileConfig.TierBoundaries, stored.TierBoundaries)
+	require.ElementsMatch(t, []string{"file-code", "ui-code"}, stored.Keywords.CodeKeywords)
 	require.Equal(t, fileHashes, stored.ConfigHashes)
 }
 


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed complexity analyzer configuration handling to properly merge and apply file-driven settings when existing configuration hashes are not present. Tier boundaries and code keywords are now correctly updated from configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->