### PR TITLE
feat: support web_search_options for Gemini/Vertex chat completions

### DIFF
--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -273,6 +273,9 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 			ContentBlocks: contentBlocks,
 		}
 
+		// Grounding metadata is only emitted here when there are content parts.
+		// Google Search grounding responses always include content, so this is fine;
+		// grounding metadata without content parts would be silently dropped.
 		annotations := convertGroundingMetadataToChatAnnotations(candidate.GroundingMetadata)
 		if len(toolCalls) > 0 || len(reasoningDetails) > 0 || len(annotations) > 0 {
 			message.ChatAssistantMessage = &schemas.ChatAssistantMessage{
@@ -606,8 +609,17 @@ func createErrorResponse(response *GenerateContentResponse, finishReason string,
 
 // convertGroundingMetadataToChatAnnotations converts Gemini grounding metadata
 // (Google Search results) into OpenAI-style url_citation annotations.
-// One annotation per (support, web chunk) pair; falls back to bare web sources
-// (no segment indices) when no usable supports are present.
+//
+// Unlike emitAnnotationsFromGroundingSupports in responses.go which picks only
+// index [0] per support, this function emits one annotation per (support, web
+// chunk) pair, iterating ALL GroundingChunkIndices of each support.
+//
+// Segment indices from Gemini are byte offsets; OpenAI expects character offsets.
+// This skew is a known pre-existing limitation shared with the Responses path and
+// is left unresolved here.
+//
+// Falls back to bare web sources (no segment indices) when no usable supports are
+// present.
 func convertGroundingMetadataToChatAnnotations(metadata *GroundingMetadata) []schemas.ChatAssistantMessageAnnotation {
 	if metadata == nil {
 		return nil
@@ -624,7 +636,7 @@ func convertGroundingMetadataToChatAnnotations(metadata *GroundingMetadata) []sc
 				continue
 			}
 			chunk := metadata.GroundingChunks[chunkIdx]
-			if chunk == nil || chunk.Web == nil {
+			if chunk == nil || chunk.Web == nil || chunk.Web.URI == "" {
 				continue
 			}
 			annotations = append(annotations, schemas.ChatAssistantMessageAnnotation{
@@ -641,7 +653,7 @@ func convertGroundingMetadataToChatAnnotations(metadata *GroundingMetadata) []sc
 
 	if len(annotations) == 0 {
 		for _, chunk := range metadata.GroundingChunks {
-			if chunk == nil || chunk.Web == nil {
+			if chunk == nil || chunk.Web == nil || chunk.Web.URI == "" {
 				continue
 			}
 			annotations = append(annotations, schemas.ChatAssistantMessageAnnotation{

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -502,8 +502,14 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream(state *Ge
 		}
 	}
 
+	// Attach url_citation annotations when this chunk carries grounding metadata
+	// (Google Search results arrive on the trailing chunks).
+	if annotations := convertGroundingMetadataToChatAnnotations(candidate.GroundingMetadata); len(annotations) > 0 {
+		delta.Annotations = annotations
+	}
+
 	// Check if delta has any content - if not and it's not the last chunk, skip it
-	hasDeltaContent := delta.Role != nil || delta.Content != nil || len(delta.ToolCalls) > 0 || len(delta.ReasoningDetails) > 0
+	hasDeltaContent := delta.Role != nil || delta.Content != nil || len(delta.ToolCalls) > 0 || len(delta.ReasoningDetails) > 0 || len(delta.Annotations) > 0
 	if !hasDeltaContent && !isLastChunk {
 		return nil, nil, false
 	}

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -273,10 +273,12 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 			ContentBlocks: contentBlocks,
 		}
 
-		if len(toolCalls) > 0 || len(reasoningDetails) > 0 {
+		annotations := convertGroundingMetadataToChatAnnotations(candidate.GroundingMetadata)
+		if len(toolCalls) > 0 || len(reasoningDetails) > 0 || len(annotations) > 0 {
 			message.ChatAssistantMessage = &schemas.ChatAssistantMessage{
 				ToolCalls:        toolCalls,
 				ReasoningDetails: reasoningDetails,
+				Annotations:      annotations,
 			}
 		}
 
@@ -600,4 +602,57 @@ func createErrorResponse(response *GenerateContentResponse, finishReason string,
 	}
 
 	return errorResp
+}
+
+// convertGroundingMetadataToChatAnnotations converts Gemini grounding metadata
+// (Google Search results) into OpenAI-style url_citation annotations.
+// One annotation per (support, web chunk) pair; falls back to bare web sources
+// (no segment indices) when no usable supports are present.
+func convertGroundingMetadataToChatAnnotations(metadata *GroundingMetadata) []schemas.ChatAssistantMessageAnnotation {
+	if metadata == nil {
+		return nil
+	}
+
+	var annotations []schemas.ChatAssistantMessageAnnotation
+
+	for _, support := range metadata.GroundingSupports {
+		if support == nil || support.Segment == nil {
+			continue
+		}
+		for _, chunkIdx := range support.GroundingChunkIndices {
+			if chunkIdx < 0 || int(chunkIdx) >= len(metadata.GroundingChunks) {
+				continue
+			}
+			chunk := metadata.GroundingChunks[chunkIdx]
+			if chunk == nil || chunk.Web == nil {
+				continue
+			}
+			annotations = append(annotations, schemas.ChatAssistantMessageAnnotation{
+				Type: "url_citation",
+				URLCitation: schemas.ChatAssistantMessageAnnotationCitation{
+					StartIndex: int(support.Segment.StartIndex),
+					EndIndex:   int(support.Segment.EndIndex),
+					Title:      chunk.Web.Title,
+					URL:        schemas.Ptr(chunk.Web.URI),
+				},
+			})
+		}
+	}
+
+	if len(annotations) == 0 {
+		for _, chunk := range metadata.GroundingChunks {
+			if chunk == nil || chunk.Web == nil {
+				continue
+			}
+			annotations = append(annotations, schemas.ChatAssistantMessageAnnotation{
+				Type: "url_citation",
+				URLCitation: schemas.ChatAssistantMessageAnnotationCitation{
+					Title: chunk.Web.Title,
+					URL:   schemas.Ptr(chunk.Web.URI),
+				},
+			})
+		}
+	}
+
+	return annotations
 }

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -52,9 +52,12 @@ func ToGeminiChatCompletionRequestWithImageURLSchemes(ctx *schemas.BifrostContex
 		}
 
 		// OpenAI-style web_search_options enables Google Search grounding.
-		// Must work even when no function tools are declared.
+		// GoogleSearch and FunctionDeclarations cannot coexist in a Gemini
+		// request, so function tools are dropped (same policy as the
+		// Responses path).
 		if bifrostReq.Params.WebSearchOptions != nil {
-			geminiReq.Tools = append(geminiReq.Tools, Tool{GoogleSearch: &GoogleSearch{}})
+			geminiReq.Tools = []Tool{{GoogleSearch: &GoogleSearch{}}}
+			geminiReq.ToolConfig = nil
 		}
 
 		if bifrostReq.Params.ServiceTier != nil {

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -321,8 +321,9 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 
 // GeminiStreamState tracks tool-call index across streaming chunks.
 type GeminiStreamState struct {
-	nextToolCallIndex int
-	hadToolCalls      bool // true if any tool calls were seen in this stream
+	nextToolCallIndex    int
+	hadToolCalls         bool // true if any tool calls were seen in this stream
+	hasEmittedAnnotations bool // true once grounding annotations have been sent, to avoid duplicates
 }
 
 // NewGeminiStreamState returns initialised stream state for one streaming response.
@@ -503,9 +504,13 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream(state *Ge
 	}
 
 	// Attach url_citation annotations when this chunk carries grounding metadata
-	// (Google Search results arrive on the trailing chunks).
-	if annotations := convertGroundingMetadataToChatAnnotations(candidate.GroundingMetadata); len(annotations) > 0 {
-		delta.Annotations = annotations
+	// (Google Search results arrive on the trailing chunks). Emitted at most
+	// once per stream in case Gemini repeats the metadata on several chunks.
+	if !state.hasEmittedAnnotations {
+		if annotations := convertGroundingMetadataToChatAnnotations(candidate.GroundingMetadata); len(annotations) > 0 {
+			delta.Annotations = annotations
+			state.hasEmittedAnnotations = true
+		}
 	}
 
 	// Check if delta has any content - if not and it's not the last chunk, skip it

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -51,6 +51,12 @@ func ToGeminiChatCompletionRequestWithImageURLSchemes(ctx *schemas.BifrostContex
 			}
 		}
 
+		// OpenAI-style web_search_options enables Google Search grounding.
+		// Must work even when no function tools are declared.
+		if bifrostReq.Params.WebSearchOptions != nil {
+			geminiReq.Tools = append(geminiReq.Tools, Tool{GoogleSearch: &GoogleSearch{}})
+		}
+
 		if bifrostReq.Params.ServiceTier != nil {
 			geminiReq.ServiceTier = mapBifrostServiceTierToGemini(*bifrostReq.Params.ServiceTier)
 		}

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -321,8 +321,8 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 
 // GeminiStreamState tracks tool-call index across streaming chunks.
 type GeminiStreamState struct {
-	nextToolCallIndex    int
-	hadToolCalls         bool // true if any tool calls were seen in this stream
+	nextToolCallIndex     int
+	hadToolCalls          bool // true if any tool calls were seen in this stream
 	hasEmittedAnnotations bool // true once grounding annotations have been sent, to avoid duplicates
 }
 

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4616,3 +4616,90 @@ func TestGroundingMetadataToChatAnnotations(t *testing.T) {
 		}
 	})
 }
+
+func TestGroundingMetadataToChatStreamAnnotations(t *testing.T) {
+	metadata := &gemini.GroundingMetadata{
+		GroundingChunks: []*gemini.GroundingChunk{
+			{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/a", Title: "Source A"}},
+		},
+		GroundingSupports: []*gemini.GroundingSupport{
+			{
+				Segment:               &gemini.Segment{StartIndex: 0, EndIndex: 10},
+				GroundingChunkIndices: []int32{0},
+			},
+		},
+	}
+
+	t.Run("chunk carrying groundingMetadata emits delta annotations", func(t *testing.T) {
+		response := &gemini.GenerateContentResponse{
+			ResponseID:   "resp-1",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*gemini.Candidate{
+				{
+					Content: &gemini.Content{
+						Role:  "model",
+						Parts: []*gemini.Part{{Text: "Paris."}},
+					},
+					FinishReason:      gemini.FinishReasonStop,
+					GroundingMetadata: metadata,
+				},
+			},
+			UsageMetadata: &gemini.GenerateContentResponseUsageMetadata{TotalTokenCount: 10},
+		}
+
+		state := gemini.NewGeminiStreamState()
+		streamResp, bifrostErr, isLast := response.ToBifrostChatCompletionStream(state)
+		require.Nil(t, bifrostErr)
+		require.NotNil(t, streamResp)
+		assert.True(t, isLast)
+
+		require.Len(t, streamResp.Choices, 1)
+		delta := streamResp.Choices[0].ChatStreamResponseChoice.Delta
+		require.Len(t, delta.Annotations, 1)
+		assert.Equal(t, "url_citation", delta.Annotations[0].Type)
+		require.NotNil(t, delta.Annotations[0].URLCitation.URL)
+		assert.Equal(t, "https://example.com/a", *delta.Annotations[0].URLCitation.URL)
+	})
+
+	t.Run("chunk with annotations but no text is not filtered out", func(t *testing.T) {
+		response := &gemini.GenerateContentResponse{
+			ResponseID:   "resp-2",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*gemini.Candidate{
+				{
+					Content:           &gemini.Content{Role: "model", Parts: []*gemini.Part{}},
+					GroundingMetadata: metadata,
+				},
+			},
+		}
+
+		state := gemini.NewGeminiStreamState()
+		streamResp, bifrostErr, _ := response.ToBifrostChatCompletionStream(state)
+		require.Nil(t, bifrostErr)
+		require.NotNil(t, streamResp, "chunk with annotations only must not be skipped")
+		delta := streamResp.Choices[0].ChatStreamResponseChoice.Delta
+		require.Len(t, delta.Annotations, 1)
+	})
+
+	t.Run("chunk without grounding has no annotations", func(t *testing.T) {
+		response := &gemini.GenerateContentResponse{
+			ResponseID:   "resp-3",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*gemini.Candidate{
+				{
+					Content: &gemini.Content{
+						Role:  "model",
+						Parts: []*gemini.Part{{Text: "Bonjour."}},
+					},
+				},
+			},
+		}
+
+		state := gemini.NewGeminiStreamState()
+		streamResp, bifrostErr, _ := response.ToBifrostChatCompletionStream(state)
+		require.Nil(t, bifrostErr)
+		require.NotNil(t, streamResp)
+		delta := streamResp.Choices[0].ChatStreamResponseChoice.Delta
+		assert.Empty(t, delta.Annotations)
+	})
+}

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4413,3 +4413,73 @@ func TestImagenImageEditSizeRoundtrip(t *testing.T) {
 	require.NotNil(t, imagenReq.Parameters.AspectRatio, "AspectRatio must be derived from Size on edit path")
 	assert.Equal(t, "1:1", *imagenReq.Parameters.AspectRatio)
 }
+
+func TestWebSearchOptionsEnablesGoogleSearchTool(t *testing.T) {
+	userMessage := []schemas.ChatMessage{
+		{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("quoi de neuf ?")}},
+	}
+
+	t.Run("web_search_options seul ajoute googleSearch", func(t *testing.T) {
+		req := &schemas.BifrostChatRequest{
+			Model: "gemini-2.5-flash",
+			Input: userMessage,
+			Params: &schemas.ChatParameters{
+				WebSearchOptions: &schemas.ChatWebSearchOptions{},
+			},
+		}
+		geminiReq, err := gemini.ToGeminiChatCompletionRequest(nil, req)
+		require.NoError(t, err)
+		require.NotNil(t, geminiReq)
+		require.Len(t, geminiReq.Tools, 1)
+		assert.NotNil(t, geminiReq.Tools[0].GoogleSearch)
+	})
+
+	t.Run("web_search_options coexiste avec des tools function", func(t *testing.T) {
+		req := &schemas.BifrostChatRequest{
+			Model: "gemini-2.5-flash",
+			Input: userMessage,
+			Params: &schemas.ChatParameters{
+				WebSearchOptions: &schemas.ChatWebSearchOptions{},
+				Tools: []schemas.ChatTool{
+					{
+						Type: schemas.ChatToolTypeFunction,
+						Function: &schemas.ChatToolFunction{
+							Name: "get_weather",
+						},
+					},
+				},
+			},
+		}
+		geminiReq, err := gemini.ToGeminiChatCompletionRequest(nil, req)
+		require.NoError(t, err)
+		require.NotNil(t, geminiReq)
+
+		var hasGoogleSearch, hasFunction bool
+		for _, tool := range geminiReq.Tools {
+			if tool.GoogleSearch != nil {
+				hasGoogleSearch = true
+			}
+			if len(tool.FunctionDeclarations) > 0 {
+				hasFunction = true
+			}
+		}
+		assert.True(t, hasGoogleSearch, "googleSearch tool missing")
+		assert.True(t, hasFunction, "function declarations missing")
+	})
+
+	t.Run("sans web_search_options pas de googleSearch", func(t *testing.T) {
+		req := &schemas.BifrostChatRequest{
+			Model: "gemini-2.5-flash",
+			Input: userMessage,
+			Params: &schemas.ChatParameters{
+				Temperature: schemas.Ptr(0.5),
+			},
+		}
+		geminiReq, err := gemini.ToGeminiChatCompletionRequest(nil, req)
+		require.NoError(t, err)
+		require.NotNil(t, geminiReq)
+		for _, tool := range geminiReq.Tools {
+			assert.Nil(t, tool.GoogleSearch)
+		}
+	})
+}

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4484,3 +4484,95 @@ func TestWebSearchOptionsEnablesGoogleSearchTool(t *testing.T) {
 		}
 	})
 }
+
+func TestGroundingMetadataToChatAnnotations(t *testing.T) {
+	buildResponse := func(metadata *gemini.GroundingMetadata) *gemini.GenerateContentResponse {
+		return &gemini.GenerateContentResponse{
+			ResponseID:   "resp-1",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*gemini.Candidate{
+				{
+					Content: &gemini.Content{
+						Role:  "model",
+						Parts: []*gemini.Part{{Text: "Paris est la capitale de la France."}},
+					},
+					FinishReason:      gemini.FinishReasonStop,
+					GroundingMetadata: metadata,
+				},
+			},
+		}
+	}
+
+	t.Run("supports with web chunks produce indexed url_citations", func(t *testing.T) {
+		metadata := &gemini.GroundingMetadata{
+			GroundingChunks: []*gemini.GroundingChunk{
+				{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/a", Title: "Source A"}},
+				{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/b", Title: "Source B"}},
+			},
+			GroundingSupports: []*gemini.GroundingSupport{
+				{
+					Segment:               &gemini.Segment{StartIndex: 0, EndIndex: 20},
+					GroundingChunkIndices: []int32{0, 1},
+				},
+			},
+		}
+		resp := buildResponse(metadata).ToBifrostChatResponse()
+		require.Len(t, resp.Choices, 1)
+		msg := resp.Choices[0].ChatNonStreamResponseChoice.Message
+		require.NotNil(t, msg.ChatAssistantMessage)
+		annotations := msg.ChatAssistantMessage.Annotations
+		require.Len(t, annotations, 2)
+
+		assert.Equal(t, "url_citation", annotations[0].Type)
+		assert.Equal(t, 0, annotations[0].URLCitation.StartIndex)
+		assert.Equal(t, 20, annotations[0].URLCitation.EndIndex)
+		assert.Equal(t, "Source A", annotations[0].URLCitation.Title)
+		require.NotNil(t, annotations[0].URLCitation.URL)
+		assert.Equal(t, "https://example.com/a", *annotations[0].URLCitation.URL)
+
+		assert.Equal(t, "Source B", annotations[1].URLCitation.Title)
+	})
+
+	t.Run("web chunks without supports produce citations without indices", func(t *testing.T) {
+		metadata := &gemini.GroundingMetadata{
+			GroundingChunks: []*gemini.GroundingChunk{
+				{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/c", Title: "Source C"}},
+			},
+		}
+		resp := buildResponse(metadata).ToBifrostChatResponse()
+		msg := resp.Choices[0].ChatNonStreamResponseChoice.Message
+		require.NotNil(t, msg.ChatAssistantMessage)
+		annotations := msg.ChatAssistantMessage.Annotations
+		require.Len(t, annotations, 1)
+		assert.Equal(t, "Source C", annotations[0].URLCitation.Title)
+		assert.Equal(t, 0, annotations[0].URLCitation.StartIndex)
+		assert.Equal(t, 0, annotations[0].URLCitation.EndIndex)
+	})
+
+	t.Run("non-web chunks are ignored", func(t *testing.T) {
+		metadata := &gemini.GroundingMetadata{
+			GroundingChunks: []*gemini.GroundingChunk{
+				{RetrievedContext: &gemini.GroundingChunkRetrievedContext{URI: "gs://bucket/doc", Title: "Doc"}},
+			},
+			GroundingSupports: []*gemini.GroundingSupport{
+				{
+					Segment:               &gemini.Segment{StartIndex: 0, EndIndex: 5},
+					GroundingChunkIndices: []int32{0},
+				},
+			},
+		}
+		resp := buildResponse(metadata).ToBifrostChatResponse()
+		msg := resp.Choices[0].ChatNonStreamResponseChoice.Message
+		if msg.ChatAssistantMessage != nil {
+			assert.Empty(t, msg.ChatAssistantMessage.Annotations)
+		}
+	})
+
+	t.Run("no grounding no annotations", func(t *testing.T) {
+		resp := buildResponse(nil).ToBifrostChatResponse()
+		msg := resp.Choices[0].ChatNonStreamResponseChoice.Message
+		if msg.ChatAssistantMessage != nil {
+			assert.Empty(t, msg.ChatAssistantMessage.Annotations)
+		}
+	})
+}

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4547,6 +4547,46 @@ func TestGroundingMetadataToChatAnnotations(t *testing.T) {
 		assert.Equal(t, "Source C", annotations[0].URLCitation.Title)
 		assert.Equal(t, 0, annotations[0].URLCitation.StartIndex)
 		assert.Equal(t, 0, annotations[0].URLCitation.EndIndex)
+		require.NotNil(t, annotations[0].URLCitation.URL, "URL must not be nil")
+		assert.NotEmpty(t, *annotations[0].URLCitation.URL, "URL must not be empty")
+	})
+
+	t.Run("web chunk with empty URI in fallback is skipped", func(t *testing.T) {
+		metadata := &gemini.GroundingMetadata{
+			GroundingChunks: []*gemini.GroundingChunk{
+				{Web: &gemini.GroundingChunkWeb{URI: "", Title: "No URI"}},
+				{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/d", Title: "Source D"}},
+			},
+		}
+		resp := buildResponse(metadata).ToBifrostChatResponse()
+		msg := resp.Choices[0].ChatNonStreamResponseChoice.Message
+		require.NotNil(t, msg.ChatAssistantMessage)
+		annotations := msg.ChatAssistantMessage.Annotations
+		require.Len(t, annotations, 1, "empty-URI chunk must be skipped")
+		require.NotNil(t, annotations[0].URLCitation.URL)
+		assert.Equal(t, "https://example.com/d", *annotations[0].URLCitation.URL)
+	})
+
+	t.Run("web chunk with empty URI in supports loop is skipped", func(t *testing.T) {
+		metadata := &gemini.GroundingMetadata{
+			GroundingChunks: []*gemini.GroundingChunk{
+				{Web: &gemini.GroundingChunkWeb{URI: "", Title: "No URI"}},
+				{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/e", Title: "Source E"}},
+			},
+			GroundingSupports: []*gemini.GroundingSupport{
+				{
+					Segment:               &gemini.Segment{StartIndex: 0, EndIndex: 10},
+					GroundingChunkIndices: []int32{0, 1},
+				},
+			},
+		}
+		resp := buildResponse(metadata).ToBifrostChatResponse()
+		msg := resp.Choices[0].ChatNonStreamResponseChoice.Message
+		require.NotNil(t, msg.ChatAssistantMessage)
+		annotations := msg.ChatAssistantMessage.Annotations
+		require.Len(t, annotations, 1, "empty-URI chunk must be skipped in supports loop")
+		require.NotNil(t, annotations[0].URLCitation.URL)
+		assert.Equal(t, "https://example.com/e", *annotations[0].URLCitation.URL)
 	})
 
 	t.Run("non-web chunks are ignored", func(t *testing.T) {

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4674,9 +4674,10 @@ func TestGroundingMetadataToChatStreamAnnotations(t *testing.T) {
 		}
 
 		state := gemini.NewGeminiStreamState()
-		streamResp, bifrostErr, _ := response.ToBifrostChatCompletionStream(state)
+		streamResp, bifrostErr, isLast := response.ToBifrostChatCompletionStream(state)
 		require.Nil(t, bifrostErr)
 		require.NotNil(t, streamResp, "chunk with annotations only must not be skipped")
+		assert.False(t, isLast)
 		delta := streamResp.Choices[0].ChatStreamResponseChoice.Delta
 		require.Len(t, delta.Annotations, 1)
 	})
@@ -4701,5 +4702,50 @@ func TestGroundingMetadataToChatStreamAnnotations(t *testing.T) {
 		require.NotNil(t, streamResp)
 		delta := streamResp.Choices[0].ChatStreamResponseChoice.Delta
 		assert.Empty(t, delta.Annotations)
+	})
+
+	t.Run("grounding metadata repeated on several chunks is emitted once", func(t *testing.T) {
+		firstResponse := &gemini.GenerateContentResponse{
+			ResponseID:   "resp-4a",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*gemini.Candidate{
+				{
+					Content: &gemini.Content{
+						Role:  "model",
+						Parts: []*gemini.Part{{Text: "Paris."}},
+					},
+					GroundingMetadata: metadata,
+				},
+			},
+		}
+		finishReason := gemini.FinishReasonStop
+		secondResponse := &gemini.GenerateContentResponse{
+			ResponseID:   "resp-4b",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*gemini.Candidate{
+				{
+					Content:           &gemini.Content{Role: "model", Parts: []*gemini.Part{}},
+					FinishReason:      finishReason,
+					GroundingMetadata: metadata,
+				},
+			},
+			UsageMetadata: &gemini.GenerateContentResponseUsageMetadata{TotalTokenCount: 10},
+		}
+
+		state := gemini.NewGeminiStreamState()
+
+		firstResp, bifrostErr, isLast := firstResponse.ToBifrostChatCompletionStream(state)
+		require.Nil(t, bifrostErr)
+		require.NotNil(t, firstResp)
+		assert.False(t, isLast)
+		firstDelta := firstResp.Choices[0].ChatStreamResponseChoice.Delta
+		assert.Len(t, firstDelta.Annotations, 1, "first chunk must carry the annotation")
+
+		secondResp, bifrostErr, isLast := secondResponse.ToBifrostChatCompletionStream(state)
+		require.Nil(t, bifrostErr)
+		require.NotNil(t, secondResp)
+		assert.True(t, isLast)
+		secondDelta := secondResp.Choices[0].ChatStreamResponseChoice.Delta
+		assert.Empty(t, secondDelta.Annotations, "second chunk must not repeat the annotation")
 	})
 }

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4416,10 +4416,10 @@ func TestImagenImageEditSizeRoundtrip(t *testing.T) {
 
 func TestWebSearchOptionsEnablesGoogleSearchTool(t *testing.T) {
 	userMessage := []schemas.ChatMessage{
-		{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("quoi de neuf ?")}},
+		{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("what's new?")}},
 	}
 
-	t.Run("web_search_options seul ajoute googleSearch", func(t *testing.T) {
+	t.Run("web_search_options alone adds googleSearch", func(t *testing.T) {
 		req := &schemas.BifrostChatRequest{
 			Model: "gemini-2.5-flash",
 			Input: userMessage,
@@ -4434,7 +4434,7 @@ func TestWebSearchOptionsEnablesGoogleSearchTool(t *testing.T) {
 		assert.NotNil(t, geminiReq.Tools[0].GoogleSearch)
 	})
 
-	t.Run("web_search_options coexiste avec des tools function", func(t *testing.T) {
+	t.Run("web_search_options replaces function tools", func(t *testing.T) {
 		req := &schemas.BifrostChatRequest{
 			Model: "gemini-2.5-flash",
 			Input: userMessage,
@@ -4464,10 +4464,11 @@ func TestWebSearchOptionsEnablesGoogleSearchTool(t *testing.T) {
 			}
 		}
 		assert.True(t, hasGoogleSearch, "googleSearch tool missing")
-		assert.True(t, hasFunction, "function declarations missing")
+		assert.False(t, hasFunction, "function declarations should be dropped when googleSearch is used")
+		assert.Nil(t, geminiReq.ToolConfig, "ToolConfig should be cleared when function tools are dropped")
 	})
 
-	t.Run("sans web_search_options pas de googleSearch", func(t *testing.T) {
+	t.Run("no googleSearch without web_search_options", func(t *testing.T) {
 		req := &schemas.BifrostChatRequest{
 			Model: "gemini-2.5-flash",
 			Input: userMessage,

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4603,17 +4603,13 @@ func TestGroundingMetadataToChatAnnotations(t *testing.T) {
 		}
 		resp := buildResponse(metadata).ToBifrostChatResponse()
 		msg := resp.Choices[0].ChatNonStreamResponseChoice.Message
-		if msg.ChatAssistantMessage != nil {
-			assert.Empty(t, msg.ChatAssistantMessage.Annotations)
-		}
+		assert.Nil(t, msg.ChatAssistantMessage)
 	})
 
 	t.Run("no grounding no annotations", func(t *testing.T) {
 		resp := buildResponse(nil).ToBifrostChatResponse()
 		msg := resp.Choices[0].ChatNonStreamResponseChoice.Message
-		if msg.ChatAssistantMessage != nil {
-			assert.Empty(t, msg.ChatAssistantMessage.Annotations)
-		}
+		assert.Nil(t, msg.ChatAssistantMessage)
 	})
 }
 

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1552,8 +1552,9 @@ type ChatStreamResponseChoiceDelta struct {
 	Refusal          *string                        `json:"refusal,omitempty"`   // Refusal content if any
 	Audio            *ChatAudioMessageAudio         `json:"audio,omitempty"`     // Audio data if any
 	Reasoning        *string                        `json:"reasoning,omitempty"` // May be empty string or null
-	ReasoningDetails []ChatReasoningDetails         `json:"reasoning_details,omitempty"`
-	ToolCalls        []ChatAssistantMessageToolCall `json:"tool_calls,omitempty"` // If tool calls used (supports incremental updates)
+	ReasoningDetails []ChatReasoningDetails           `json:"reasoning_details,omitempty"`
+	Annotations      []ChatAssistantMessageAnnotation `json:"annotations,omitempty"` // URL citations (web search)
+	ToolCalls        []ChatAssistantMessageToolCall   `json:"tool_calls,omitempty"` // If tool calls used (supports incremental updates)
 }
 
 // UnmarshalJSON implements custom unmarshalling for ChatStreamResponseChoiceDelta.

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1547,14 +1547,14 @@ type ChatStreamResponseChoice struct {
 
 // ChatStreamResponseChoiceDelta represents a delta in the stream response
 type ChatStreamResponseChoiceDelta struct {
-	Role             *string                        `json:"role,omitempty"`      // Only in the first chunk
-	Content          *string                        `json:"content,omitempty"`   // May be empty string or null
-	Refusal          *string                        `json:"refusal,omitempty"`   // Refusal content if any
-	Audio            *ChatAudioMessageAudio         `json:"audio,omitempty"`     // Audio data if any
-	Reasoning        *string                        `json:"reasoning,omitempty"` // May be empty string or null
+	Role             *string                          `json:"role,omitempty"`      // Only in the first chunk
+	Content          *string                          `json:"content,omitempty"`   // May be empty string or null
+	Refusal          *string                          `json:"refusal,omitempty"`   // Refusal content if any
+	Audio            *ChatAudioMessageAudio           `json:"audio,omitempty"`     // Audio data if any
+	Reasoning        *string                          `json:"reasoning,omitempty"` // May be empty string or null
 	ReasoningDetails []ChatReasoningDetails           `json:"reasoning_details,omitempty"`
 	Annotations      []ChatAssistantMessageAnnotation `json:"annotations,omitempty"` // URL citations (web search)
-	ToolCalls        []ChatAssistantMessageToolCall   `json:"tool_calls,omitempty"` // If tool calls used (supports incremental updates)
+	ToolCalls        []ChatAssistantMessageToolCall   `json:"tool_calls,omitempty"`  // If tool calls used (supports incremental updates)
 }
 
 // UnmarshalJSON implements custom unmarshalling for ChatStreamResponseChoiceDelta.

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1574,7 +1574,16 @@ func TestChatStreamResponseChoiceDeltaAnnotationsSerialization(t *testing.T) {
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
-	if len(decoded.Annotations) != 1 || decoded.Annotations[0].URLCitation.Title != "Example" {
+	if len(decoded.Annotations) != 1 {
+		t.Fatalf("annotations not round-tripped: %+v", decoded.Annotations)
+	}
+	got := decoded.Annotations[0]
+	if got.Type != "url_citation" ||
+		got.URLCitation.StartIndex != 0 ||
+		got.URLCitation.EndIndex != 10 ||
+		got.URLCitation.Title != "Example" ||
+		got.URLCitation.URL == nil ||
+		*got.URLCitation.URL != "https://example.com" {
 		t.Fatalf("annotations not round-tripped: %+v", decoded.Annotations)
 	}
 

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1545,3 +1545,45 @@ func TestSonic_ToolFunctionParameters_DeepCopy_KeyOrderIndependent(t *testing.T)
 	assert.NotEqual(t, original.keyOrder.keys[0], copied.keyOrder.keys[0], "copy must not share JSONKeyOrder.keys backing array")
 	assert.Equal(t, "$defs", copied.keyOrder.keys[0])
 }
+
+func TestChatStreamResponseChoiceDeltaAnnotationsSerialization(t *testing.T) {
+	delta := ChatStreamResponseChoiceDelta{
+		Content: Ptr("voir source"),
+		Annotations: []ChatAssistantMessageAnnotation{
+			{
+				Type: "url_citation",
+				URLCitation: ChatAssistantMessageAnnotationCitation{
+					StartIndex: 0,
+					EndIndex:   10,
+					Title:      "Example",
+					URL:        Ptr("https://example.com"),
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(delta)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(data), `"annotations"`) {
+		t.Fatalf("expected annotations in JSON, got: %s", string(data))
+	}
+
+	var decoded ChatStreamResponseChoiceDelta
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(decoded.Annotations) != 1 || decoded.Annotations[0].URLCitation.Title != "Example" {
+		t.Fatalf("annotations not round-tripped: %+v", decoded.Annotations)
+	}
+
+	// omitempty : pas d'annotations => pas de clé dans le JSON
+	empty, err := json.Marshal(ChatStreamResponseChoiceDelta{})
+	if err != nil {
+		t.Fatalf("marshal empty failed: %v", err)
+	}
+	if strings.Contains(string(empty), `"annotations"`) {
+		t.Fatalf("empty delta must omit annotations key, got: %s", string(empty))
+	}
+}

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -12,6 +12,37 @@ import (
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 )
 
+func deepCopyChatAnnotations(src []schemas.ChatAssistantMessageAnnotation) []schemas.ChatAssistantMessageAnnotation {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]schemas.ChatAssistantMessageAnnotation, len(src))
+	for i, a := range src {
+		c := schemas.ChatAssistantMessageAnnotation{
+			Type: a.Type,
+			URLCitation: schemas.ChatAssistantMessageAnnotationCitation{
+				StartIndex: a.URLCitation.StartIndex,
+				EndIndex:   a.URLCitation.EndIndex,
+				Title:      a.URLCitation.Title,
+			},
+		}
+		if a.URLCitation.URL != nil {
+			u := *a.URLCitation.URL
+			c.URLCitation.URL = &u
+		}
+		if a.URLCitation.Sources != nil {
+			s := *a.URLCitation.Sources
+			c.URLCitation.Sources = &s
+		}
+		if a.URLCitation.Type != nil {
+			t := *a.URLCitation.Type
+			c.URLCitation.Type = &t
+		}
+		dst[i] = c
+	}
+	return dst
+}
+
 // deepCopyChatStreamDelta creates a deep copy of ChatStreamResponseChoiceDelta
 // to prevent shared data mutation between different chunks
 func deepCopyChatStreamDelta(original *schemas.ChatStreamResponseChoiceDelta) *schemas.ChatStreamResponseChoiceDelta {
@@ -104,7 +135,7 @@ func deepCopyChatStreamDelta(original *schemas.ChatStreamResponseChoiceDelta) *s
 
 	// Deep copy Annotations slice
 	if len(original.Annotations) > 0 {
-		copy.Annotations = append([]schemas.ChatAssistantMessageAnnotation(nil), original.Annotations...)
+		copy.Annotations = deepCopyChatAnnotations(original.Annotations)
 	}
 
 	// Deep copy Audio
@@ -243,7 +274,7 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 			}
 			completeMessage.ChatAssistantMessage.Annotations = append(
 				completeMessage.ChatAssistantMessage.Annotations,
-				chunk.Delta.Annotations...,
+				deepCopyChatAnnotations(chunk.Delta.Annotations)...,
 			)
 		}
 		// Accumulate tool calls by index

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -236,6 +236,16 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 				completeMessage.ChatAssistantMessage.Audio.ExpiresAt = chunk.Delta.Audio.ExpiresAt
 			}
 		}
+		// Accumulate annotations
+		if len(chunk.Delta.Annotations) > 0 {
+			if completeMessage.ChatAssistantMessage == nil {
+				completeMessage.ChatAssistantMessage = &schemas.ChatAssistantMessage{}
+			}
+			completeMessage.ChatAssistantMessage.Annotations = append(
+				completeMessage.ChatAssistantMessage.Annotations,
+				chunk.Delta.Annotations...,
+			)
+		}
 		// Accumulate tool calls by index
 		for _, deltaToolCall := range chunk.Delta.ToolCalls {
 			if tcAccums == nil {

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -102,6 +102,11 @@ func deepCopyChatStreamDelta(original *schemas.ChatStreamResponseChoiceDelta) *s
 		}
 	}
 
+	// Deep copy Annotations slice
+	if len(original.Annotations) > 0 {
+		copy.Annotations = append([]schemas.ChatAssistantMessageAnnotation(nil), original.Annotations...)
+	}
+
 	// Deep copy Audio
 	if original.Audio != nil {
 		copy.Audio = &schemas.ChatAudioMessageAudio{

--- a/plugins/jsonparser/utils.go
+++ b/plugins/jsonparser/utils.go
@@ -324,6 +324,37 @@ func (p *JsonParserPlugin) deepCopyChatStreamResponseChoice(original *schemas.Ch
 	return result
 }
 
+func deepCopyChatAnnotations(src []schemas.ChatAssistantMessageAnnotation) []schemas.ChatAssistantMessageAnnotation {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]schemas.ChatAssistantMessageAnnotation, len(src))
+	for i, a := range src {
+		c := schemas.ChatAssistantMessageAnnotation{
+			Type: a.Type,
+			URLCitation: schemas.ChatAssistantMessageAnnotationCitation{
+				StartIndex: a.URLCitation.StartIndex,
+				EndIndex:   a.URLCitation.EndIndex,
+				Title:      a.URLCitation.Title,
+			},
+		}
+		if a.URLCitation.URL != nil {
+			u := *a.URLCitation.URL
+			c.URLCitation.URL = &u
+		}
+		if a.URLCitation.Sources != nil {
+			s := *a.URLCitation.Sources
+			c.URLCitation.Sources = &s
+		}
+		if a.URLCitation.Type != nil {
+			t := *a.URLCitation.Type
+			c.URLCitation.Type = &t
+		}
+		dst[i] = c
+	}
+	return dst
+}
+
 // deepCopyChatStreamResponseChoiceDelta creates a deep copy of ChatStreamResponseChoiceDelta
 func (p *JsonParserPlugin) deepCopyChatStreamResponseChoiceDelta(original *schemas.ChatStreamResponseChoiceDelta) *schemas.ChatStreamResponseChoiceDelta {
 	if original == nil {
@@ -332,10 +363,10 @@ func (p *JsonParserPlugin) deepCopyChatStreamResponseChoiceDelta(original *schem
 
 	result := &schemas.ChatStreamResponseChoiceDelta{
 		Role:        original.Role,
-		Reasoning:   original.Reasoning,   // Shallow copy
-		Refusal:     original.Refusal,     // Shallow copy
-		ToolCalls:   original.ToolCalls,   // Shallow copy - we don't modify tool calls
-		Annotations: original.Annotations, // Shallow copy
+		Reasoning:   original.Reasoning, // Shallow copy
+		Refusal:     original.Refusal,   // Shallow copy
+		ToolCalls:   original.ToolCalls, // Shallow copy - we don't modify tool calls
+		Annotations: deepCopyChatAnnotations(original.Annotations),
 	}
 
 	// Deep copy Content pointer if it exists (this is what we modify)

--- a/plugins/jsonparser/utils.go
+++ b/plugins/jsonparser/utils.go
@@ -331,10 +331,11 @@ func (p *JsonParserPlugin) deepCopyChatStreamResponseChoiceDelta(original *schem
 	}
 
 	result := &schemas.ChatStreamResponseChoiceDelta{
-		Role:      original.Role,
-		Reasoning: original.Reasoning, // Shallow copy
-		Refusal:   original.Refusal,   // Shallow copy
-		ToolCalls: original.ToolCalls, // Shallow copy - we don't modify tool calls
+		Role:        original.Role,
+		Reasoning:   original.Reasoning,   // Shallow copy
+		Refusal:     original.Refusal,     // Shallow copy
+		ToolCalls:   original.ToolCalls,   // Shallow copy - we don't modify tool calls
+		Annotations: original.Annotations, // Shallow copy
 	}
 
 	// Deep copy Content pointer if it exists (this is what we modify)


### PR DESCRIPTION
## What

OpenAI's `web_search_options` chat completions parameter now works for Gemini models served through the Gemini and Vertex providers.

- Request: `web_search_options` maps to the native Gemini `googleSearch` grounding tool in `gemini.ToGeminiChatCompletionRequest` (reused by Vertex). Per the Gemini API constraint (functionDeclarations and googleSearch cannot coexist), googleSearch replaces function tools and clears ToolConfig, same policy as the existing Responses path.
- Response (non-stream): `candidate.GroundingMetadata` is converted to OpenAI `url_citation` annotations on `message.annotations`.
- Response (stream): new additive `annotations` field on the stream delta schema, emitted at most once per stream; metadata-only trailing chunks are not dropped; the framework streaming accumulator and both delta copy helpers propagate annotations.

## Why

Calling the gateway through the openai TypeScript library with a Vertex Gemini model and `web_search_options: {}` previously did nothing: the parameter was parsed but never translated to the native grounding tool, and grounding sources were never surfaced back. This matches the behavior of Google's own OpenAI-compat endpoint.

```ts
const res = await client.chat.completions.create({
  model: "vertex/gemini-2.5-flash",
  messages: [{ role: "user", content: "What's new today?" }],
  web_search_options: {},
});
// res.choices[0].message.annotations contains url_citation entries
```

## Notes

- `search_context_size` and `user_location` are intentionally ignored (no Gemini equivalent).
- Gemini Segment indices are byte offsets while OpenAI expects character offsets; documented as a known limitation shared with the Responses path.
- framework and plugins/jsonparser pin the published core version; their small propagation fixes compile once core is bumped on the next release cycle.

## Tests

941 tests pass across core/schemas, providers/gemini, providers/vertex, providers/openai. New coverage: request mapping (with and without function tools), grounding-to-annotations conversion (indexed, fallback without supports, non-web chunks, empty URI), stream emission (metadata-only chunk kept, dedup across repeated chunks), delta schema serialization round-trip.