### PR TITLE
feat: add `strategy` field to Bifrost Helm chart deployment

### DIFF
--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "bifrost.serverSelectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Summary

Adds support for configuring a deployment strategy in the Bifrost Helm chart, allowing users to define rolling update or recreate strategies via `values.yaml`.

## Changes

- Added an optional `strategy` block to the Bifrost `deployment.yaml` template, rendered using `toYaml` when `.Values.strategy` is set

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Bifrost Helm chart with a `strategy` value set in `values.yaml`, for example:

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxSurge: 1
    maxUnavailable: 0
```

Then verify the rendered deployment manifest includes the strategy block:

```sh
helm template bifrost ./helm-charts/bifrost -f values.yaml | grep -A 5 "strategy:"
```

Confirm the deployment applies successfully and the strategy is reflected in the cluster.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment strategy configuration is now available through Helm values, enabling customization of how deployments are rolled out and managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->