### PR TITLE
docs fix

### DIFF
--- a/docs/changelogs/ent-v1.4.9.mdx
+++ b/docs/changelogs/ent-v1.4.9.mdx
@@ -104,7 +104,7 @@ require (
 	github.com/maximhq/bifrost/plugins/logging v1.5.19
 	github.com/maximhq/bifrost/plugins/prompts v1.0.19
 	github.com/maximhq/bifrost/plugins/semanticcache v1.5.19
-	github.com/maximhq/bifrost/transports v1.5.12
+	github.com/maximhq/bifrost/transports v1.5.13
 	github.com/nakabonne/tstorage v0.3.6
 	github.com/segmentio/kafka-go v0.4.47
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Summary

Bumps the `bifrost/transports` dependency to `v1.5.13` in the enterprise v1.4.9 changelog.

## Changes

- Updated `github.com/maximhq/bifrost/transports` from `v1.5.12` to `v1.5.13` in the `ent-v1.4.9` changelog dependency listing.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go dependency version reference in plugin compilation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->