### PR TITLE
fix: gate ranking readers on fresh-aggregate matview window

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -800,8 +800,9 @@ const freshAggregateMatViewMinWindow = 24 * time.Hour
 // (both StartTime and EndTime nil) are treated as matview-safe — a half-bounded
 // range has no measurable width and could still be a short window.
 //
-// Used by both /api/logs/stats (full metric payload) and /api/logs (pagination
-// total count) so those two surfaces stay consistent on the same window.
+// Used by /api/logs/stats (full metric payload), /api/logs (pagination total
+// count), and the model/user/dimension ranking readers so all those surfaces
+// stay consistent on the same window.
 func (s *RDBLogStore) canUseMatViewForFreshAggregate(f SearchFilters) bool {
 	if !s.canUseMatView(f) {
 		return false

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -1818,8 +1818,12 @@ func (s *RDBLogStore) buildLatencyHistogramResult(computedBuckets map[int64]Late
 }
 
 // GetModelRankings returns models ranked by usage with trend comparison to the previous period.
+// Uses the same fresh-aggregate matview gate as GetStats: short windows go to
+// the raw table because mv_logs_hourly rounds the window out to full hour
+// buckets, which visibly inflates rankings against the raw-path stats and
+// cost-histogram totals shown on the same dashboard.
 func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilters) (*ModelRankingResult, error) {
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
 		return s.getModelRankingsFromMatView(ctx, filters)
 	}
 	selectClause := `
@@ -1958,8 +1962,12 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 }
 
 // GetUserRankings returns users ranked by usage with trend comparison to the previous period.
+// Uses the same fresh-aggregate matview gate as GetStats: short windows go to
+// the raw table because mv_logs_hourly rounds the window out to full hour
+// buckets, which visibly inflates rankings against the raw-path stats and
+// cost-histogram totals shown on the same dashboard.
 func (s *RDBLogStore) GetUserRankings(ctx context.Context, filters SearchFilters) (*UserRankingResult, error) {
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
 		return s.getUserRankingsFromMatView(ctx, filters)
 	}
 	selectClause := `
@@ -2091,7 +2099,11 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		return q.Model(&Log{})
 	}
 
-	if fanoutFrom == "" && s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) {
+	// Fresh-aggregate gate (not bare canUseMatView): short windows go to the
+	// raw table because mv_logs_hourly rounds the window out to full hour
+	// buckets, which visibly inflates rankings against the raw-path stats and
+	// cost-histogram totals shown on the same dashboard.
+	if fanoutFrom == "" && s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
 		return s.getDimensionRankingsFromMatView(ctx, filters, dimension)
 	}
 


### PR DESCRIPTION
## Summary

Ranking readers (`GetModelRankings`, `GetUserRankings`, `GetDimensionRankings`) were using `canUseMatView` to decide whether to query `mv_logs_hourly`. For short time windows, `mv_logs_hourly` rounds the window out to full hour buckets, which inflates ranking totals relative to the raw-path stats and cost-histogram numbers shown on the same dashboard. This PR switches all three ranking readers to use `canUseMatViewForFreshAggregate` — the same gate already used by `/api/logs/stats` and `/api/logs` — so that short windows consistently fall back to the raw table across all surfaces.

## Changes

- `GetModelRankings`, `GetUserRankings`, and `GetDimensionRankings` now call `canUseMatViewForFreshAggregate` instead of `canUseMatView`, ensuring short windows bypass the materialized view.
- The `canUseMatViewForFreshAggregate` doc comment is updated to reflect that ranking readers are now also governed by this gate.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the log store tests and verify that ranking queries for short time windows (less than 24 hours) route to the raw table rather than the materialized view.

```sh
go test ./framework/logstore/...
```

Manually verify on a dashboard with a short time window (e.g. last 1 hour) that model/user/dimension ranking totals match the stats and cost-histogram totals shown alongside them.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified time window handling requirements for ranking queries to ensure consistent metrics.

* **Refactor**
  * Updated ranking query optimization logic to improve consistency across different time windows and data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->