### PR TITLE
fix: stop double counting boundary hour in matview ranking trends

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -6037,7 +6037,6 @@ func migrationWidenEncryptedVarcharColumns(ctx context.Context, db *gorm.DB, log
 			}
 			logger.Info("[configstore] %s: processing %d stmts", migrationName, len(stmts))
 			for _, stmt := range stmts {
-				logger.Info("[configstore] %s: %s", migrationName, "executing stmt).Error; err != nil { return fmt.Errorf(\"failed to widen column (%s): %w\", s")
 				if err := tx.Exec(stmt).Error; err != nil {
 					return fmt.Errorf("failed to widen column (%s): %w", stmt, err)
 				}
@@ -9290,7 +9289,6 @@ func migrationAddOAuthAuthModeColumns(ctx context.Context, db *gorm.DB, logger s
 				}
 				logger.Info("[configstore] %s: processing %d dedupeStmts", migrationName, len(dedupeStmts))
 				for _, stmt := range dedupeStmts {
-					logger.Info("[configstore] %s: %s", migrationName, "executing stmt).Error; err != nil { return fmt.Errorf(\"dedupe legacy oauth_user_tokens bin")
 					if err := tx.Exec(stmt).Error; err != nil {
 						return fmt.Errorf("dedupe legacy oauth_user_tokens bindings: %w", err)
 					}
@@ -9323,7 +9321,6 @@ func migrationAddOAuthAuthModeColumns(ctx context.Context, db *gorm.DB, logger s
 				}
 				logger.Info("[configstore] %s: processing %d partialUniques", migrationName, len(partialUniques))
 				for _, stmt := range partialUniques {
-					logger.Info("[configstore] %s: %s", migrationName, "executing stmt).Error; err != nil { return fmt.Errorf(\"create partial unique index on oaut")
 					if err := tx.Exec(stmt).Error; err != nil {
 						return fmt.Errorf("create partial unique index on oauth_user_tokens: %w", err)
 					}
@@ -10222,7 +10219,6 @@ func migrationAddPerUserHeadersTables(ctx context.Context, db *gorm.DB, logger s
 			}
 			logger.Info("[configstore] %s: processing %d partialUniques", migrationName, len(partialUniques))
 			for _, stmt := range partialUniques {
-				logger.Info("[configstore] %s: %s", migrationName, "executing stmt).Error; err != nil { return fmt.Errorf(\"create partial unique index on mcp_")
 				if err := tx.Exec(stmt).Error; err != nil {
 					return fmt.Errorf("create partial unique index on mcp_per_user_header_credentials: %w", err)
 				}
@@ -10239,7 +10235,6 @@ func migrationAddPerUserHeadersTables(ctx context.Context, db *gorm.DB, logger s
 			}
 			logger.Info("[configstore] %s: processing %d statusIndexes", migrationName, len(statusIndexes))
 			for _, stmt := range statusIndexes {
-				logger.Info("[configstore] %s: %s", migrationName, "executing stmt).Error; err != nil { return fmt.Errorf(\"create status partial index on mcp_")
 				if err := tx.Exec(stmt).Error; err != nil {
 					return fmt.Errorf("create status partial index on mcp_per_user_header_credentials: %w", err)
 				}
@@ -11014,7 +11009,6 @@ func migrationAddCustomerNameUniqueConstraint(ctx context.Context, db *gorm.DB, 
 			} else {
 				stmt = "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS " + idxName + " ON governance_customers (name)"
 			}
-			logger.Info("[configstore] %s: %s", migrationName, "executing stmt).Error; err != nil { return fmt.Errorf(\"failed to create unique index on go")
 			if err := tx.Exec(stmt).Error; err != nil {
 				return fmt.Errorf("failed to create unique index on governance_customers.name: %w", err)
 			}

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -1634,9 +1634,20 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 	}
 	var prevResults []prevRow
 	if filters.StartTime != nil && filters.EndTime != nil {
-		duration := filters.EndTime.Sub(*filters.StartTime)
-		prevStart := filters.StartTime.Add(-duration)
-		prevEnd := filters.StartTime.Add(-time.Nanosecond)
+		// Anchor the previous period to the hour grid: the current period's
+		// hour >= date_trunc('hour', StartTime) predicate claims the bucket
+		// containing StartTime, so its effective span is [hourStart, EndTime].
+		// Derive the comparison duration from hourStart (not StartTime) so the
+		// previous window covers exactly the same effective interval; otherwise
+		// a sub-hour StartTime makes the current window longer by
+		// StartTime-hourStart and skews the trend. The previous period must
+		// also end strictly before that bucket: ending at StartTime-1ns would
+		// match the same bucket via hour <= prevEnd and double-count the
+		// boundary hour in both periods.
+		hourStart := filters.StartTime.Truncate(time.Hour)
+		duration := filters.EndTime.Sub(hourStart)
+		prevStart := hourStart.Add(-duration)
+		prevEnd := hourStart.Add(-time.Nanosecond)
 		prevFilters := filters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
@@ -1724,9 +1735,20 @@ func (s *RDBLogStore) getUserRankingsFromMatView(ctx context.Context, filters Se
 	}
 	var prevResults []prevRow
 	if filters.StartTime != nil && filters.EndTime != nil {
-		duration := filters.EndTime.Sub(*filters.StartTime)
-		prevStart := filters.StartTime.Add(-duration)
-		prevEnd := filters.StartTime.Add(-time.Nanosecond)
+		// Anchor the previous period to the hour grid: the current period's
+		// hour >= date_trunc('hour', StartTime) predicate claims the bucket
+		// containing StartTime, so its effective span is [hourStart, EndTime].
+		// Derive the comparison duration from hourStart (not StartTime) so the
+		// previous window covers exactly the same effective interval; otherwise
+		// a sub-hour StartTime makes the current window longer by
+		// StartTime-hourStart and skews the trend. The previous period must
+		// also end strictly before that bucket: ending at StartTime-1ns would
+		// match the same bucket via hour <= prevEnd and double-count the
+		// boundary hour in both periods.
+		hourStart := filters.StartTime.Truncate(time.Hour)
+		duration := filters.EndTime.Sub(hourStart)
+		prevStart := hourStart.Add(-duration)
+		prevEnd := hourStart.Add(-time.Nanosecond)
 		prevFilters := filters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
@@ -1826,9 +1848,20 @@ func (s *RDBLogStore) getDimensionRankingsFromMatView(ctx context.Context, filte
 	// Previous period
 	var prevResults []row
 	if filters.StartTime != nil && filters.EndTime != nil {
-		duration := filters.EndTime.Sub(*filters.StartTime)
-		prevStart := filters.StartTime.Add(-duration)
-		prevEnd := filters.StartTime.Add(-time.Nanosecond)
+		// Anchor the previous period to the hour grid: the current period's
+		// hour >= date_trunc('hour', StartTime) predicate claims the bucket
+		// containing StartTime, so its effective span is [hourStart, EndTime].
+		// Derive the comparison duration from hourStart (not StartTime) so the
+		// previous window covers exactly the same effective interval; otherwise
+		// a sub-hour StartTime makes the current window longer by
+		// StartTime-hourStart and skews the trend. The previous period must
+		// also end strictly before that bucket: ending at StartTime-1ns would
+		// match the same bucket via hour <= prevEnd and double-count the
+		// boundary hour in both periods.
+		hourStart := filters.StartTime.Truncate(time.Hour)
+		duration := filters.EndTime.Sub(hourStart)
+		prevStart := hourStart.Add(-duration)
+		prevEnd := hourStart.Add(-time.Nanosecond)
 		prevFilters := filters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -800,8 +800,9 @@ const freshAggregateMatViewMinWindow = 24 * time.Hour
 // (both StartTime and EndTime nil) are treated as matview-safe — a half-bounded
 // range has no measurable width and could still be a short window.
 //
-// Used by both /api/logs/stats (full metric payload) and /api/logs (pagination
-// total count) so those two surfaces stay consistent on the same window.
+// Used by /api/logs/stats (full metric payload), /api/logs (pagination total
+// count), and the model/user/dimension ranking readers so all those surfaces
+// stay consistent on the same window.
 func (s *RDBLogStore) canUseMatViewForFreshAggregate(f SearchFilters) bool {
 	if !s.canUseMatView(f) {
 		return false

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -1818,8 +1818,12 @@ func (s *RDBLogStore) buildLatencyHistogramResult(computedBuckets map[int64]Late
 }
 
 // GetModelRankings returns models ranked by usage with trend comparison to the previous period.
+// Uses the same fresh-aggregate matview gate as GetStats: short windows go to
+// the raw table because mv_logs_hourly rounds the window out to full hour
+// buckets, which visibly inflates rankings against the raw-path stats and
+// cost-histogram totals shown on the same dashboard.
 func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilters) (*ModelRankingResult, error) {
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
 		return s.getModelRankingsFromMatView(ctx, filters)
 	}
 	selectClause := `
@@ -1958,8 +1962,12 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 }
 
 // GetUserRankings returns users ranked by usage with trend comparison to the previous period.
+// Uses the same fresh-aggregate matview gate as GetStats: short windows go to
+// the raw table because mv_logs_hourly rounds the window out to full hour
+// buckets, which visibly inflates rankings against the raw-path stats and
+// cost-histogram totals shown on the same dashboard.
 func (s *RDBLogStore) GetUserRankings(ctx context.Context, filters SearchFilters) (*UserRankingResult, error) {
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
 		return s.getUserRankingsFromMatView(ctx, filters)
 	}
 	selectClause := `
@@ -2091,7 +2099,11 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		return q.Model(&Log{})
 	}
 
-	if fanoutFrom == "" && s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) {
+	// Fresh-aggregate gate (not bare canUseMatView): short windows go to the
+	// raw table because mv_logs_hourly rounds the window out to full hour
+	// buckets, which visibly inflates rankings against the raw-path stats and
+	// cost-histogram totals shown on the same dashboard.
+	if fanoutFrom == "" && s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
 		return s.getDimensionRankingsFromMatView(ctx, filters, dimension)
 	}
 


### PR DESCRIPTION
## Summary

When computing trend percentages in the materialized view rankings, the previous period's end time was calculated as `StartTime - 1ns`. Because the matview queries use `hour >= date_trunc('hour', StartTime)`, the boundary hour bucket is claimed by the current period. Using `StartTime - 1ns` as `prevEnd` caused that same boundary hour to also be matched by the previous period's `hour <= prevEnd` condition, resulting in the boundary hour being counted in both periods and skewing all trend percentages.

## Changes

- The previous period's end time is now anchored to the hour grid by truncating `StartTime` to the hour boundary (`hourStart`) and computing `prevEnd = hourStart - 1ns`, ensuring the boundary hour is only counted in the current period.
- `prevStart` is similarly shifted to start from `hourStart - duration` so the previous period remains the same length.
- This fix is applied consistently across `getModelRankingsFromMatView`, `getUserRankingsFromMatView`, and `getDimensionRankingsFromMatView`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify that trend percentages for model, user, and dimension rankings no longer double-count the boundary hour when the selected time range starts at a non-zero minute within an hour.

```sh
go test ./framework/logstore/...
```

Compare trend percentage values before and after for a time range such as `StartTime = 2024-01-01T10:30:00Z` to confirm the boundary hour (`10:00–11:00`) is no longer included in both the current and previous periods.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where trend comparisons were incorrectly calculated due to boundary-hour overlap in data aggregation. Trend percentages will now be computed more accurately with properly aligned time windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->