### PR TITLE
feat: advisor tool compatibility claude

### DIFF
--- a/core/providers/anthropic/advisor_test.go
+++ b/core/providers/anthropic/advisor_test.go
@@ -1,0 +1,360 @@
+package anthropic
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+)
+
+const advisorToolJSON = `{"type":"advisor_20260301","name":"advisor","model":"claude-opus-4-8","max_uses":3,"max_tokens":2048,"caching":{"type":"ephemeral","ttl":"5m"}}`
+
+// rawAdvisorResponse mirrors the user-reported Anthropic response: an assistant
+// turn containing server_tool_use(advisor) + advisor_tool_result + text.
+const rawAdvisorResponse = `{
+  "model": "claude-sonnet-4-6",
+  "id": "msg_01V5B47VyNHS4XfYEvUEgbBs",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    { "type": "server_tool_use", "id": "srvtoolu_01WJ", "name": "advisor", "input": {} },
+    {
+      "type": "advisor_tool_result",
+      "tool_use_id": "srvtoolu_01WJ",
+      "content": { "type": "advisor_result", "text": "Use a channel-based coordination pattern." }
+    },
+    { "type": "text", "text": "Here is the implementation." }
+  ],
+  "stop_reason": "end_turn",
+  "usage": { "input_tokens": 2733, "output_tokens": 3909 }
+}`
+
+func newAdvisorStreamState() *AnthropicResponsesStreamState {
+	return &AnthropicResponsesStreamState{
+		ContentIndexToOutputIndex: make(map[int]int),
+		ContentIndexToBlockType:   make(map[int]AnthropicContentBlockType),
+		ToolArgumentBuffers:       make(map[int]string),
+		MCPCallOutputIndices:      make(map[int]bool),
+		ItemIDs:                   make(map[int]string),
+		OutputItems:               make(map[int]*schemas.ResponsesMessage),
+		ReasoningSignatures:       make(map[int]string),
+		TextContentIndices:        make(map[int]bool),
+		ReasoningContentIndices:   make(map[int]bool),
+		TextBuffers:               make(map[int]*strings.Builder),
+		CompactionContentIndices:  make(map[int]*schemas.CacheControl),
+		CurrentOutputIndex:        0,
+		CreatedAt:                 1234567890,
+		HasEmittedCreated:         true,
+		HasEmittedInProgress:      true,
+	}
+}
+
+// TestAnthropicTool_AdvisorMarshalRoundTrip verifies the advisor tool survives
+// Unmarshal/Marshal through AnthropicTool — in particular that the unique
+// `model` field is preserved despite `max_uses` being shared (embedded) with
+// the web_search/web_fetch variant structs.
+func TestAnthropicTool_AdvisorMarshalRoundTrip(t *testing.T) {
+	var tool AnthropicTool
+	if err := sonic.Unmarshal([]byte(advisorToolJSON), &tool); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if tool.Type == nil || *tool.Type != AnthropicToolTypeAdvisor20260301 {
+		t.Fatalf("type not parsed: %+v", tool.Type)
+	}
+	if tool.AnthropicToolAdvisor == nil {
+		t.Fatal("AnthropicToolAdvisor is nil after unmarshal")
+	}
+	if tool.AnthropicToolAdvisor.Model != "claude-opus-4-8" {
+		t.Errorf("model = %q, want claude-opus-4-8", tool.AnthropicToolAdvisor.Model)
+	}
+	if tool.AnthropicToolAdvisor.MaxTokens == nil || *tool.AnthropicToolAdvisor.MaxTokens != 2048 {
+		t.Errorf("max_tokens not parsed: %+v", tool.AnthropicToolAdvisor.MaxTokens)
+	}
+	if tool.AnthropicToolAdvisor.Caching == nil || tool.AnthropicToolAdvisor.Caching.TTL != "5m" {
+		t.Errorf("caching not parsed: %+v", tool.AnthropicToolAdvisor.Caching)
+	}
+
+	out, err := sonic.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{`"type":"advisor_20260301"`, `"model":"claude-opus-4-8"`, `"max_tokens":2048`, `"ttl":"5m"`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("marshaled JSON missing %q: %s", want, s)
+		}
+	}
+}
+
+// TestAdvisor_ResponsesRoundTrip verifies the advisor tool round-trips through
+// the neutral ResponsesTool schema (Anthropic -> Bifrost -> Anthropic) with its
+// type, name, and model intact.
+func TestAdvisor_ResponsesRoundTrip(t *testing.T) {
+	var tool AnthropicTool
+	if err := sonic.Unmarshal([]byte(advisorToolJSON), &tool); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	bifrostTool := convertAnthropicToolToBifrost(&tool)
+	if bifrostTool == nil {
+		t.Fatal("convertAnthropicToolToBifrost returned nil")
+	}
+	if bifrostTool.Type != schemas.ResponsesToolTypeAdvisor {
+		t.Fatalf("neutral type = %q, want advisor", bifrostTool.Type)
+	}
+	if bifrostTool.ResponsesToolAdvisor == nil || bifrostTool.ResponsesToolAdvisor.Model != "claude-opus-4-8" {
+		t.Fatalf("neutral advisor model not carried: %+v", bifrostTool.ResponsesToolAdvisor)
+	}
+	if bifrostTool.ResponsesToolAdvisor.MaxUses == nil || *bifrostTool.ResponsesToolAdvisor.MaxUses != 3 {
+		t.Fatalf("neutral advisor max_uses not carried: %+v", bifrostTool.ResponsesToolAdvisor.MaxUses)
+	}
+	if bifrostTool.ResponsesToolAdvisor.MaxTokens == nil || *bifrostTool.ResponsesToolAdvisor.MaxTokens != 2048 {
+		t.Fatalf("neutral advisor max_tokens not carried: %+v", bifrostTool.ResponsesToolAdvisor.MaxTokens)
+	}
+	if bifrostTool.ResponsesToolAdvisor.Caching == nil ||
+		bifrostTool.ResponsesToolAdvisor.Caching.Type != "ephemeral" ||
+		bifrostTool.ResponsesToolAdvisor.Caching.TTL != "5m" {
+		t.Fatalf("neutral advisor caching not carried: %+v", bifrostTool.ResponsesToolAdvisor.Caching)
+	}
+
+	back := convertBifrostToolToAnthropic("claude-sonnet-4-6", bifrostTool, schemas.Anthropic, false)
+	if back == nil || back.Type == nil || *back.Type != AnthropicToolTypeAdvisor20260301 {
+		t.Fatalf("rebuilt type wrong: %+v", back)
+	}
+	if back.Name != string(AnthropicToolNameAdvisor) {
+		t.Errorf("rebuilt name = %q, want advisor", back.Name)
+	}
+	if back.AnthropicToolAdvisor == nil || back.AnthropicToolAdvisor.Model != "claude-opus-4-8" {
+		t.Fatalf("rebuilt advisor model lost: %+v", back.AnthropicToolAdvisor)
+	}
+	if back.AnthropicToolAdvisor.MaxUses == nil || *back.AnthropicToolAdvisor.MaxUses != 3 {
+		t.Fatalf("rebuilt advisor max_uses lost: %+v", back.AnthropicToolAdvisor.MaxUses)
+	}
+	if back.AnthropicToolAdvisor.MaxTokens == nil || *back.AnthropicToolAdvisor.MaxTokens != 2048 {
+		t.Fatalf("rebuilt advisor max_tokens lost: %+v", back.AnthropicToolAdvisor.MaxTokens)
+	}
+	if back.AnthropicToolAdvisor.Caching == nil ||
+		back.AnthropicToolAdvisor.Caching.Type != "ephemeral" ||
+		back.AnthropicToolAdvisor.Caching.TTL != "5m" {
+		t.Fatalf("rebuilt advisor caching lost: %+v", back.AnthropicToolAdvisor.Caching)
+	}
+}
+
+// TestAdvisor_ProviderGating verifies advisor is supported only on Anthropic.
+func TestAdvisor_ProviderGating(t *testing.T) {
+	cases := []struct {
+		provider schemas.ModelProvider
+		want     bool
+	}{
+		{schemas.Anthropic, true},
+		{schemas.Vertex, false},
+		{schemas.Bedrock, false},
+		{schemas.Azure, false},
+	}
+	for _, c := range cases {
+		got := isAnthropicServerToolSupported(string(AnthropicToolTypeAdvisor20260301), ProviderFeatures[c.provider])
+		if got != c.want {
+			t.Errorf("isAnthropicServerToolSupported advisor on %s = %v, want %v", c.provider, got, c.want)
+		}
+
+		err := ValidateToolsForProvider([]schemas.ResponsesTool{{
+			Type: schemas.ResponsesToolTypeAdvisor,
+		}}, c.provider)
+		if c.want && err != nil {
+			t.Errorf("ValidateToolsForProvider advisor on %s returned error: %v", c.provider, err)
+		}
+		if !c.want && err == nil {
+			t.Errorf("ValidateToolsForProvider advisor on %s should have errored", c.provider)
+		}
+	}
+}
+
+// TestAdvisor_RawToolGating verifies advisor tools in a raw passthrough body are
+// rejected for every non-Anthropic Claude provider (Vertex, Bedrock, Azure) and
+// allowed for Anthropic. Covers the raw path (unsupportedRawToolTypes), the
+// counterpart to TestAdvisor_ProviderGating's normalized-path coverage.
+func TestAdvisor_RawToolGating(t *testing.T) {
+	rawBody := []byte(`{"model":"claude-opus-4-8","tools":[{"type":"advisor_20260301","model":"claude-opus-4-8"}]}`)
+	for _, p := range []schemas.ModelProvider{schemas.Vertex, schemas.Bedrock, schemas.Azure} {
+		if _, err := RemapRawToolVersionsForProvider(rawBody, p, "claude-opus-4-8"); err == nil {
+			t.Errorf("RemapRawToolVersionsForProvider advisor on %s should have errored", p)
+		}
+	}
+	if _, err := RemapRawToolVersionsForProvider(rawBody, schemas.Anthropic, "claude-opus-4-8"); err != nil {
+		t.Errorf("RemapRawToolVersionsForProvider advisor on Anthropic returned error: %v", err)
+	}
+}
+
+// TestAdvisor_BetaHeaderFiltering verifies the advisor beta header survives for
+// Anthropic and is dropped for providers that don't support advisor.
+func TestAdvisor_BetaHeaderFiltering(t *testing.T) {
+	in := []string{AnthropicAdvisorBetaHeader}
+
+	if got := FilterBetaHeadersForProvider(in, schemas.Anthropic); len(got) != 1 || got[0] != AnthropicAdvisorBetaHeader {
+		t.Errorf("Anthropic should keep advisor header, got %v", got)
+	}
+	for _, p := range []schemas.ModelProvider{schemas.Vertex, schemas.Bedrock, schemas.Azure} {
+		if got := FilterBetaHeadersForProvider(in, p); len(got) != 0 {
+			t.Errorf("%s should drop advisor header, got %v", p, got)
+		}
+	}
+}
+
+// TestAdvisorResponse_RoundTripPreservesBlocks is the regression test for the
+// user-reported bug: Anthropic -> Bifrost -> Anthropic dropped the advisor
+// server_tool_use and advisor_tool_result blocks, leaving only the text block.
+func TestAdvisorResponse_RoundTripPreservesBlocks(t *testing.T) {
+	var resp AnthropicMessageResponse
+	if err := sonic.Unmarshal([]byte(rawAdvisorResponse), &resp); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+	bifrostResp := resp.ToBifrostResponsesResponse(ctx)
+	if bifrostResp == nil {
+		t.Fatal("ToBifrostResponsesResponse returned nil")
+	}
+
+	var foundAdvisor bool
+	for _, out := range bifrostResp.Output {
+		if out.Type != nil && *out.Type == schemas.ResponsesMessageTypeAdvisorCall {
+			foundAdvisor = true
+			if out.ResponsesToolMessage == nil || out.ResponsesToolMessage.ResponsesAdvisorCall == nil {
+				t.Fatal("advisor_call present but ResponsesAdvisorCall payload missing")
+			}
+			adv := out.ResponsesToolMessage.ResponsesAdvisorCall
+			if adv.ResultType != "advisor_result" {
+				t.Errorf("advisor result_type = %q, want advisor_result", adv.ResultType)
+			}
+			if adv.Text == nil || *adv.Text != "Use a channel-based coordination pattern." {
+				t.Errorf("advisor text not carried: %+v", adv.Text)
+			}
+		}
+	}
+	if !foundAdvisor {
+		t.Fatal("neutral output has no advisor_call message — advisor blocks dropped on parse")
+	}
+
+	back := ToAnthropicResponsesResponse(ctx, bifrostResp)
+	if back == nil {
+		t.Fatal("ToAnthropicResponsesResponse returned nil")
+	}
+	out, err := sonic.Marshal(back)
+	if err != nil {
+		t.Fatalf("marshal back: %v", err)
+	}
+
+	blocks := gjson.GetBytes(out, "content")
+	var types []string
+	var advisorText, serverToolName, advisorToolUseID string
+	blocks.ForEach(func(_, b gjson.Result) bool {
+		bt := b.Get("type").String()
+		types = append(types, bt)
+		switch bt {
+		case "server_tool_use":
+			serverToolName = b.Get("name").String()
+		case "advisor_tool_result":
+			advisorToolUseID = b.Get("tool_use_id").String()
+			// Anthropic types advisor_tool_result.content as a single object, not an array.
+			if content := b.Get("content"); !content.IsObject() {
+				t.Errorf("advisor_tool_result.content = %q, want a single object", content.Raw)
+			}
+			advisorText = b.Get("content.text").String()
+		}
+		return true
+	})
+
+	if len(types) != 3 || types[0] != "server_tool_use" || types[1] != "advisor_tool_result" || types[2] != "text" {
+		t.Fatalf("converted content blocks = %v, want [server_tool_use advisor_tool_result text]\n%s", types, out)
+	}
+	if serverToolName != "advisor" {
+		t.Errorf("server_tool_use name = %q, want advisor", serverToolName)
+	}
+	if advisorToolUseID != "srvtoolu_01WJ" {
+		t.Errorf("advisor_tool_result tool_use_id = %q, want srvtoolu_01WJ", advisorToolUseID)
+	}
+	if advisorText != "Use a channel-based coordination pattern." {
+		t.Errorf("advisor text not preserved through round-trip: %q", advisorText)
+	}
+}
+
+// advisorStreamEvents is the user-reported raw Anthropic stream (trimmed): the
+// advisor server_tool_use + advisor_tool_result arrive before the text block.
+var advisorStreamEvents = []string{
+	`{"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_019M","type":"message","role":"assistant","content":[],"stop_reason":null,"usage":{"input_tokens":999,"output_tokens":35}}}`,
+	`{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_01Y14","name":"advisor","input":{}}}`,
+	`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`,
+	`{"type":"content_block_stop","index":0}`,
+	`{"type":"content_block_start","index":1,"content_block":{"type":"advisor_tool_result","tool_use_id":"srvtoolu_01Y14","content":{"type":"advisor_result","text":"Decide what graceful means."}}}`,
+	`{"type":"content_block_stop","index":1}`,
+	`{"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}`,
+	`{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"# Worker Pool"}}`,
+	`{"type":"content_block_stop","index":2}`,
+	`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3777}}`,
+	`{"type":"message_stop"}`,
+}
+
+// TestAdvisorStream_RoundTrip checks whether the advisor server_tool_use and
+// advisor_tool_result blocks survive the streaming converter round-trip
+// (Anthropic SSE -> Bifrost stream -> Anthropic SSE) on the normalized path.
+func TestAdvisorStream_RoundTrip(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	state := newAdvisorStreamState()
+
+	var emitted []*AnthropicStreamEvent
+	seq := 0
+	for _, raw := range advisorStreamEvents {
+		var chunk AnthropicStreamEvent
+		if err := sonic.Unmarshal([]byte(raw), &chunk); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+		responses, bErr, _ := chunk.ToBifrostResponsesStream(ctx, seq, state)
+		if bErr != nil {
+			t.Fatalf("ToBifrostResponsesStream error: %v", bErr)
+		}
+		for _, r := range responses {
+			seq++
+			emitted = append(emitted, ToAnthropicResponsesStreamResponse(ctx, r)...)
+		}
+	}
+
+	var sawAdvisorServerToolUse, sawAdvisorResult, sawText bool
+	var advisorText string
+	for _, e := range emitted {
+		if e.Type != AnthropicStreamEventTypeContentBlockStart || e.ContentBlock == nil {
+			continue
+		}
+		switch e.ContentBlock.Type {
+		case AnthropicContentBlockTypeServerToolUse:
+			if e.ContentBlock.Name != nil && *e.ContentBlock.Name == string(AnthropicToolNameAdvisor) {
+				sawAdvisorServerToolUse = true
+			}
+		case AnthropicContentBlockTypeAdvisorToolResult:
+			sawAdvisorResult = true
+			if e.ContentBlock.Content != nil && e.ContentBlock.Content.ContentObj != nil {
+				if txt := e.ContentBlock.Content.ContentObj.Text; txt != nil {
+					advisorText = *txt
+				}
+			}
+		case AnthropicContentBlockTypeText:
+			sawText = true
+		}
+	}
+
+	if !sawAdvisorServerToolUse {
+		t.Error("STREAM GAP: advisor server_tool_use block dropped")
+	}
+	if !sawAdvisorResult {
+		t.Error("STREAM GAP: advisor_tool_result block dropped")
+	}
+	if !strings.Contains(advisorText, "graceful") {
+		t.Errorf("STREAM GAP: advisor result text lost (got %q)", advisorText)
+	}
+	if !sawText {
+		t.Error("text block dropped")
+	}
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -34,6 +34,11 @@ type AnthropicResponsesStreamState struct {
 	WebFetchToolID      *string // Tool ID of active web fetch
 	WebFetchOutputIndex *int    // Output index for this fetch
 
+	// Advisor tool accumulation
+	AdvisorToolID      *string                // Tool ID of active advisor call
+	AdvisorOutputIndex *int                   // Output index for this advisor call
+	AdvisorResult      *AnthropicContentBlock // advisor_tool_result block when it arrives
+
 	// OpenAI Responses API mapping state
 	ContentIndexToOutputIndex map[int]int                       // Maps Anthropic content_index to OpenAI output_index
 	ContentIndexToBlockType   map[int]AnthropicContentBlockType // Tracks content block types
@@ -174,6 +179,9 @@ func acquireAnthropicResponsesStreamState() *AnthropicResponsesStreamState {
 	state.WebSearchResult = nil
 	state.WebFetchToolID = nil
 	state.WebFetchOutputIndex = nil
+	state.AdvisorToolID = nil
+	state.AdvisorOutputIndex = nil
+	state.AdvisorResult = nil
 	state.CurrentOutputIndex = 0
 	state.MessageID = nil
 	state.StopReason = nil
@@ -207,6 +215,9 @@ func (state *AnthropicResponsesStreamState) flush() {
 	state.WebSearchResult = nil
 	state.WebFetchToolID = nil
 	state.WebFetchOutputIndex = nil
+	state.AdvisorToolID = nil
+	state.AdvisorOutputIndex = nil
+	state.AdvisorResult = nil
 	state.ContentIndexToOutputIndex = nil
 	state.ContentIndexToBlockType = nil
 	state.ToolArgumentBuffers = nil
@@ -537,6 +548,54 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 					}}, nil, false
 				}
 
+				return nil, nil, false
+			}
+
+			// Handle advisor server_tool_use (the call; input is always empty).
+			// The paired advisor_tool_result is emitted as output_item.done when
+			// the result block's content_block_stop arrives (mirrors web_search).
+			if chunk.ContentBlock.Type == AnthropicContentBlockTypeServerToolUse &&
+				chunk.ContentBlock.Name != nil &&
+				*chunk.ContentBlock.Name == string(AnthropicToolNameAdvisor) &&
+				chunk.ContentBlock.ID != nil {
+
+				state.SeenRealToolCall = true
+				state.ChunkIndex = chunk.Index // absorbs the empty advisor input_json_delta
+				state.AccumulatedJSON = ""
+				state.AdvisorToolID = chunk.ContentBlock.ID
+				state.AdvisorOutputIndex = schemas.Ptr(outputIndex)
+				state.ItemIDs[outputIndex] = *chunk.ContentBlock.ID
+
+				item := &schemas.ResponsesMessage{
+					ID:     chunk.ContentBlock.ID,
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeAdvisorCall),
+					Status: schemas.Ptr("in_progress"),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID: chunk.ContentBlock.ID,
+						Name:   schemas.Ptr(string(AnthropicToolNameAdvisor)),
+					},
+				}
+
+				return []*schemas.BifrostResponsesStreamResponse{{
+					Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
+					SequenceNumber: sequenceNumber,
+					OutputIndex:    schemas.Ptr(outputIndex),
+					ContentIndex:   chunk.Index,
+					Item:           item,
+				}}, nil, false
+			}
+
+			// Handle advisor_tool_result block (arrives complete in one event).
+			// Store it; the output_item.done is emitted on its content_block_stop.
+			if chunk.ContentBlock.Type == AnthropicContentBlockTypeAdvisorToolResult &&
+				chunk.ContentBlock.ToolUseID != nil {
+
+				if chunk.Index != nil {
+					state.ContentIndexToBlockType[*chunk.Index] = AnthropicContentBlockTypeAdvisorToolResult
+				}
+				if state.AdvisorToolID != nil && *state.AdvisorToolID == *chunk.ContentBlock.ToolUseID {
+					state.AdvisorResult = chunk.ContentBlock
+				}
 				return nil, nil, false
 			}
 
@@ -1039,6 +1098,12 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 					state.ChunkIndex = nil
 					return nil, nil, false
 				}
+
+				// Advisor server_tool_use block ended — wait for the result block.
+				if state.AdvisorToolID != nil {
+					state.ChunkIndex = nil
+					return nil, nil, false
+				}
 			}
 
 			// Check if this is the end of a web_search_tool_result block
@@ -1118,12 +1183,65 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				}, nil, false
 			}
 
+			// End of an advisor_tool_result block — emit the advisor_call done.
+			if state.AdvisorResult != nil && state.AdvisorToolID != nil {
+				advisor := &schemas.ResponsesAdvisorCall{}
+				// content is a single object on the wire (ContentObj); UnmarshalJSON
+				// wraps incoming objects into ContentBlocks, so accept either.
+				if c := state.AdvisorResult.Content; c != nil {
+					inner := c.ContentObj
+					if inner == nil && len(c.ContentBlocks) > 0 {
+						inner = &c.ContentBlocks[0]
+					}
+					if inner != nil {
+						advisor.ResultType = string(inner.Type)
+						advisor.Text = inner.Text
+						advisor.EncryptedContent = inner.EncryptedContent
+						advisor.ErrorCode = inner.ErrorCode
+						advisor.StopReason = inner.StopReason
+					}
+				}
+				item := &schemas.ResponsesMessage{
+					ID:     state.AdvisorToolID,
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeAdvisorCall),
+					Status: schemas.Ptr("completed"),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID:               state.AdvisorToolID,
+						Name:                 schemas.Ptr(string(AnthropicToolNameAdvisor)),
+						ResponsesAdvisorCall: advisor,
+					},
+				}
+				outputIdx := state.AdvisorOutputIndex
+				// Persist into OutputItems so message_stop includes the advisor_call
+				// in response.completed (mirrors the web_search_call handling).
+				if outputIdx != nil {
+					cloned := *item
+					clonedToolMsg := *item.ResponsesToolMessage
+					cloned.ResponsesToolMessage = &clonedToolMsg
+					state.OutputItems[*outputIdx] = &cloned
+				}
+				state.AdvisorToolID = nil
+				state.AdvisorOutputIndex = nil
+				state.AdvisorResult = nil
+				if chunk.Index != nil {
+					delete(state.ContentIndexToBlockType, *chunk.Index)
+				}
+				return []*schemas.BifrostResponsesStreamResponse{{
+					Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
+					SequenceNumber: sequenceNumber,
+					OutputIndex:    outputIdx,
+					ContentIndex:   chunk.Index,
+					Item:           item,
+				}}, nil, false
+			}
+
 			// Skip generic output_item.done if this is a web_search_tool_result or compaction block
 			// (their handlers already emitted the proper done event)
 			if chunk.Index != nil {
 				if blockType, exists := state.ContentIndexToBlockType[*chunk.Index]; exists {
 					if blockType == AnthropicContentBlockTypeWebSearchToolResult ||
-						blockType == AnthropicContentBlockTypeWebFetchToolResult {
+						blockType == AnthropicContentBlockTypeWebFetchToolResult ||
+						blockType == AnthropicContentBlockTypeAdvisorToolResult {
 						delete(state.ContentIndexToBlockType, *chunk.Index)
 						return nil, nil, false
 					}
@@ -1589,6 +1707,27 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			contentBlock.Input = json.RawMessage("{}")
 
 			streamResp.ContentBlock = contentBlock
+		} else if bifrostResp.Item != nil &&
+			bifrostResp.Item.Type != nil &&
+			*bifrostResp.Item.Type == schemas.ResponsesMessageTypeAdvisorCall {
+
+			// Advisor call - emit content_block_start with server_tool_use (input is always empty)
+			streamResp.Type = AnthropicStreamEventTypeContentBlockStart
+			if bifrostResp.ContentIndex != nil {
+				streamResp.Index = bifrostResp.ContentIndex
+			} else if bifrostResp.OutputIndex != nil {
+				streamResp.Index = bifrostResp.OutputIndex
+			}
+			toolUseID := bifrostResp.Item.ID
+			if bifrostResp.Item.ResponsesToolMessage != nil && bifrostResp.Item.ResponsesToolMessage.CallID != nil {
+				toolUseID = bifrostResp.Item.ResponsesToolMessage.CallID
+			}
+			streamResp.ContentBlock = &AnthropicContentBlock{
+				Type:  AnthropicContentBlockTypeServerToolUse,
+				ID:    toolUseID,
+				Name:  schemas.Ptr(string(AnthropicToolNameAdvisor)),
+				Input: json.RawMessage("{}"),
+			}
 		} else {
 			// Text or other content blocks - emit content_block_start
 			streamResp.Type = AnthropicStreamEventTypeContentBlockStart
@@ -2040,6 +2179,71 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				}
 				events = append(events, resultStopEvent)
 			}
+
+			return events
+		} else if bifrostResp.Item != nil &&
+			bifrostResp.Item.Type != nil &&
+			*bifrostResp.Item.Type == schemas.ResponsesMessageTypeAdvisorCall {
+
+			// Advisor call complete - emit content_block_stop for the server_tool_use
+			// block, then the advisor_tool_result block (start + stop) at the next index.
+			var events []*AnthropicStreamEvent
+
+			toolUseID := bifrostResp.Item.ID
+			if bifrostResp.Item.ResponsesToolMessage != nil && bifrostResp.Item.ResponsesToolMessage.CallID != nil {
+				toolUseID = bifrostResp.Item.ResponsesToolMessage.CallID
+			}
+
+			var serverIdx *int
+			if bifrostResp.OutputIndex != nil {
+				serverIdx = bifrostResp.OutputIndex
+			} else if bifrostResp.ContentIndex != nil {
+				serverIdx = bifrostResp.ContentIndex
+			}
+
+			// 1. content_block_stop for the server_tool_use block.
+			events = append(events, &AnthropicStreamEvent{
+				Type:  AnthropicStreamEventTypeContentBlockStop,
+				Index: serverIdx,
+			})
+
+			// 2. content_block_start for advisor_tool_result at the next index.
+			var resultIdx *int
+			if serverIdx != nil {
+				next := *serverIdx + 1
+				resultIdx = &next
+			}
+			resultBlock := &AnthropicContentBlock{
+				Type:      AnthropicContentBlockTypeAdvisorToolResult,
+				ToolUseID: toolUseID,
+			}
+			if bifrostResp.Item.ResponsesToolMessage != nil && bifrostResp.Item.ResponsesToolMessage.ResponsesAdvisorCall != nil {
+				adv := bifrostResp.Item.ResponsesToolMessage.ResponsesAdvisorCall
+				resultType := adv.ResultType
+				if resultType == "" {
+					resultType = "advisor_result"
+				}
+				resultBlock.Content = &AnthropicContent{
+					ContentObj: &AnthropicContentBlock{
+						Type:             AnthropicContentBlockType(resultType),
+						Text:             adv.Text,
+						EncryptedContent: adv.EncryptedContent,
+						ErrorCode:        adv.ErrorCode,
+						StopReason:       adv.StopReason,
+					},
+				}
+			}
+			events = append(events, &AnthropicStreamEvent{
+				Type:         AnthropicStreamEventTypeContentBlockStart,
+				Index:        resultIdx,
+				ContentBlock: resultBlock,
+			})
+
+			// 3. content_block_stop for the advisor_tool_result block.
+			events = append(events, &AnthropicStreamEvent{
+				Type:  AnthropicStreamEventTypeContentBlockStop,
+				Index: resultIdx,
+			})
 
 			return events
 		} else if bifrostResp.Item != nil &&
@@ -3484,6 +3688,32 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 				}
 			}
 
+		case schemas.ResponsesMessageTypeAdvisorCall:
+			// Advisor calls, like web search, emit a server_tool_use + result
+			// pair that lives inside the assistant message.
+			flushPendingToolResults()
+			advisorBlocks := convertBifrostAdvisorCallToAnthropicBlocks(&msg)
+			if len(advisorBlocks) > 0 {
+				if currentAssistantMessage == nil {
+					currentAssistantMessage = &AnthropicMessage{
+						Role: AnthropicMessageRoleAssistant,
+					}
+				}
+				if len(pendingReasoningContentBlocks) > 0 {
+					copied := make([]AnthropicContentBlock, len(pendingReasoningContentBlocks))
+					copy(copied, pendingReasoningContentBlocks)
+					pendingToolCalls = append(copied, pendingToolCalls...)
+					pendingReasoningContentBlocks = nil
+				}
+				pendingToolCalls = append(pendingToolCalls, advisorBlocks...)
+				if advisorBlocks[0].ID != nil {
+					if currentToolCallIDs == nil {
+						currentToolCallIDs = make(map[string]bool)
+					}
+					currentToolCallIDs[*advisorBlocks[0].ID] = true
+				}
+			}
+
 		case schemas.ResponsesMessageTypeWebFetchCall:
 			flushPendingToolResults()
 
@@ -4259,6 +4489,54 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					bifrostMsg.ID = block.ID
 					bifrostMessages = append(bifrostMessages, bifrostMsg)
 				}
+			} else if block.Name != nil && *block.Name == string(AnthropicToolNameAdvisor) {
+				// advisor server_tool_use — the paired advisor_tool_result is
+				// attached onto this message when it is encountered below.
+				bifrostMsg := schemas.ResponsesMessage{
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeAdvisorCall),
+					ID:     block.ID,
+					Status: schemas.Ptr("completed"),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						Name:   schemas.Ptr(string(AnthropicToolNameAdvisor)),
+						CallID: block.ID,
+					},
+				}
+				if isOutputMessage {
+					bifrostMessages = append(bifrostMessages, bifrostMsg)
+				}
+			}
+
+		case AnthropicContentBlockTypeAdvisorToolResult:
+			// Attach the advisor result onto the matching advisor_call.
+			if block.ToolUseID != nil {
+				for i := len(bifrostMessages) - 1; i >= 0; i-- {
+					msg := &bifrostMessages[i]
+					if msg.Type == nil || *msg.Type != schemas.ResponsesMessageTypeAdvisorCall {
+						continue
+					}
+					if msg.ResponsesToolMessage == nil || msg.ResponsesToolMessage.CallID == nil ||
+						*msg.ResponsesToolMessage.CallID != *block.ToolUseID {
+						continue
+					}
+					advisor := &schemas.ResponsesAdvisorCall{}
+					// content is a single object on the wire (ContentObj); UnmarshalJSON
+					// wraps incoming objects into ContentBlocks, so accept either.
+					if c := block.Content; c != nil {
+						inner := c.ContentObj
+						if inner == nil && len(c.ContentBlocks) > 0 {
+							inner = &c.ContentBlocks[0]
+						}
+						if inner != nil {
+							advisor.ResultType = string(inner.Type)
+							advisor.Text = inner.Text
+							advisor.EncryptedContent = inner.EncryptedContent
+							advisor.ErrorCode = inner.ErrorCode
+							advisor.StopReason = inner.StopReason
+						}
+					}
+					msg.ResponsesToolMessage.ResponsesAdvisorCall = advisor
+					break
+				}
 			}
 
 		case AnthropicContentBlockTypeWebSearchToolResult:
@@ -4849,6 +5127,51 @@ func convertBifrostWebSearchCallToAnthropicBlocks(msg *schemas.ResponsesMessage)
 	return blocks
 }
 
+// convertBifrostAdvisorCallToAnthropicBlocks rebuilds the advisor server_tool_use
+// block and its paired advisor_tool_result block from a neutral advisor_call.
+// Anthropic requires both blocks to appear together in the assistant message.
+func convertBifrostAdvisorCallToAnthropicBlocks(msg *schemas.ResponsesMessage) []AnthropicContentBlock {
+	// Resolve the tool-use id (server_tool_use.id == advisor_tool_result.tool_use_id).
+	var toolUseID *string
+	if msg.ResponsesToolMessage != nil && msg.ResponsesToolMessage.CallID != nil {
+		toolUseID = msg.ResponsesToolMessage.CallID
+	} else {
+		toolUseID = msg.ID
+	}
+
+	// 1. server_tool_use block — advisor input is always empty.
+	serverToolUseBlock := AnthropicContentBlock{
+		Type:  AnthropicContentBlockTypeServerToolUse,
+		ID:    toolUseID,
+		Name:  schemas.Ptr(string(AnthropicToolNameAdvisor)),
+		Input: json.RawMessage("{}"),
+	}
+
+	// 2. advisor_tool_result block carrying the advisor's result content.
+	resultBlock := AnthropicContentBlock{
+		Type:      AnthropicContentBlockTypeAdvisorToolResult,
+		ToolUseID: toolUseID,
+	}
+	if msg.ResponsesToolMessage != nil && msg.ResponsesToolMessage.ResponsesAdvisorCall != nil {
+		adv := msg.ResponsesToolMessage.ResponsesAdvisorCall
+		resultType := adv.ResultType
+		if resultType == "" {
+			resultType = "advisor_result"
+		}
+		resultBlock.Content = &AnthropicContent{
+			ContentObj: &AnthropicContentBlock{
+				Type:             AnthropicContentBlockType(resultType),
+				Text:             adv.Text,
+				EncryptedContent: adv.EncryptedContent,
+				ErrorCode:        adv.ErrorCode,
+				StopReason:       adv.StopReason,
+			},
+		}
+	}
+
+	return []AnthropicContentBlock{serverToolUseBlock, resultBlock}
+}
+
 // convertBifrostUnsupportedToolCallToAnthropicMessage converts unsupported tool calls to text messages
 func convertBifrostUnsupportedToolCallToAnthropicMessage(msg *schemas.ResponsesMessage, msgType schemas.ResponsesMessageType) *AnthropicMessage {
 	if msg.ResponsesToolMessage != nil {
@@ -5037,6 +5360,25 @@ func convertAnthropicToolToBifrost(tool *AnthropicTool) *schemas.ResponsesTool {
 				Type: schemas.ResponsesToolType(AnthropicToolTypeTextEditor20250728),
 				Name: &tool.Name,
 			}
+
+		case AnthropicToolTypeAdvisor20260301:
+			bifrostTool := &schemas.ResponsesTool{
+				Type: schemas.ResponsesToolTypeAdvisor,
+			}
+			if tool.AnthropicToolAdvisor != nil {
+				bifrostTool.ResponsesToolAdvisor = &schemas.ResponsesToolAdvisor{
+					Model:     tool.AnthropicToolAdvisor.Model,
+					MaxUses:   tool.AnthropicToolAdvisor.MaxUses,
+					MaxTokens: tool.AnthropicToolAdvisor.MaxTokens,
+				}
+				if tool.AnthropicToolAdvisor.Caching != nil {
+					bifrostTool.ResponsesToolAdvisor.Caching = &schemas.ResponsesToolAdvisorCaching{
+						Type: tool.AnthropicToolAdvisor.Caching.Type,
+						TTL:  tool.AnthropicToolAdvisor.Caching.TTL,
+					}
+				}
+			}
+			return bifrostTool
 		}
 	}
 
@@ -5395,6 +5737,24 @@ func convertBifrostToolToAnthropic(model string, tool *schemas.ResponsesTool, pr
 		return &AnthropicTool{
 			Type: schemas.Ptr(AnthropicToolTypeTextEditor20250728),
 			Name: string(AnthropicToolNameTextEditor),
+		}
+	case schemas.ResponsesToolTypeAdvisor:
+		advisor := &AnthropicToolAdvisor{}
+		if tool.ResponsesToolAdvisor != nil {
+			advisor.Model = tool.ResponsesToolAdvisor.Model
+			advisor.MaxUses = tool.ResponsesToolAdvisor.MaxUses
+			advisor.MaxTokens = tool.ResponsesToolAdvisor.MaxTokens
+			if tool.ResponsesToolAdvisor.Caching != nil {
+				advisor.Caching = &AnthropicToolAdvisorCaching{
+					Type: tool.ResponsesToolAdvisor.Caching.Type,
+					TTL:  tool.ResponsesToolAdvisor.Caching.TTL,
+				}
+			}
+		}
+		return &AnthropicTool{
+			Type:                 schemas.Ptr(AnthropicToolTypeAdvisor20260301),
+			Name:                 string(AnthropicToolNameAdvisor),
+			AnthropicToolAdvisor: advisor,
 		}
 	}
 

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/sjson"
 )
 
 // Since Anthropic always needs to have a max_tokens parameter, we set a default value if not provided.
@@ -56,6 +58,8 @@ const (
 	AnthropicRedactThinkingBetaHeader = "redact-thinking-2026-02-12"
 	// AnthropicTaskBudgetsBetaHeader is required for output_config.task_budget (Opus 4.7+).
 	AnthropicTaskBudgetsBetaHeader = "task-budgets-2026-03-13"
+	// AnthropicAdvisorBetaHeader is required for the advisor_20260301 server tool. Anthropic API only.
+	AnthropicAdvisorBetaHeader = "advisor-tool-2026-03-01"
 	// AnthropicEagerInputStreamingBetaHeader is required for eager_input_streaming
 	// on custom tools (streams input_json_delta before full args are determined).
 	// Per Table 20: GA on Anthropic/Bedrock/Vertex, Beta on Azure.
@@ -84,6 +88,7 @@ const (
 	AnthropicEagerInputStreamingBetaHeaderPrefix = "fine-grained-tool-streaming-"
 	AnthropicContextManagementBetaHeaderPrefix   = "context-management-"
 	AnthropicCompactionBetaHeaderPrefix          = "compact-"
+	AnthropicAdvisorBetaHeaderPrefix             = "advisor-tool-"
 )
 
 // ProviderFeatureSupport defines which Anthropic features a given provider supports.
@@ -817,6 +822,9 @@ type AnthropicMessage struct {
 type AnthropicContent struct {
 	ContentStr    *string
 	ContentBlocks []AnthropicContentBlock
+	// ContentObj marshals as a single bare object (not wrapped in an array).
+	// Used for fields Anthropic types as a single object, e.g. advisor_tool_result.content.
+	ContentObj *AnthropicContentBlock
 }
 
 // MarshalJSON implements custom JSON marshalling for AnthropicContent.
@@ -829,6 +837,9 @@ func (mc AnthropicContent) MarshalJSON() ([]byte, error) {
 
 	if mc.ContentStr != nil {
 		return providerUtils.MarshalSorted(*mc.ContentStr)
+	}
+	if mc.ContentObj != nil {
+		return providerUtils.MarshalSorted(mc.ContentObj)
 	}
 	if mc.ContentBlocks != nil {
 		return providerUtils.MarshalSorted(mc.ContentBlocks)
@@ -940,6 +951,7 @@ type AnthropicContentBlock struct {
 	EncryptedContent *string                   `json:"encrypted_content,omitempty"` // web_search_result, advisor_redacted_result, compaction
 	PageAge          *string                   `json:"page_age,omitempty"`          // web_search_result
 	ErrorCode        *string                   `json:"error_code,omitempty"`        // any *_tool_result_error variant
+	StopReason       *string                   `json:"stop_reason,omitempty"`       // advisor_result / advisor_redacted_result inner block; present when advisor tool max_tokens is set
 	Caller           *AnthropicToolCaller      `json:"caller,omitempty"`            // tool_use, server_tool_use, every *_tool_result block
 
 	// search_result block: the API uses the literal key "source" with a plain
@@ -1206,6 +1218,11 @@ const (
 	AnthropicToolTypeToolSearchBM2520251119  AnthropicToolType = "tool_search_tool_bm25_20251119"
 	AnthropicToolTypeToolSearchRegex         AnthropicToolType = "tool_search_tool_regex"
 	AnthropicToolTypeToolSearchRegex20251119 AnthropicToolType = "tool_search_tool_regex_20251119"
+
+	// Advisor server tool — pairs the executor model with a higher-intelligence
+	// advisor model mid-generation. Anthropic API only; requires the
+	// advisor-tool-2026-03-01 beta header.
+	AnthropicToolTypeAdvisor20260301 AnthropicToolType = "advisor_20260301"
 )
 
 type AnthropicToolName string
@@ -1223,6 +1240,7 @@ const (
 	AnthropicToolNameMemory           AnthropicToolName = "memory"
 	AnthropicToolNameToolSearchBM25   AnthropicToolName = "tool_search_tool_bm25"
 	AnthropicToolNameToolSearchRegex  AnthropicToolName = "tool_search_tool_regex"
+	AnthropicToolNameAdvisor          AnthropicToolName = "advisor"
 )
 
 type AnthropicToolComputerUse struct {
@@ -1263,6 +1281,22 @@ type AnthropicToolTextEditor struct {
 	MaxCharacters *int `json:"max_characters,omitempty"` // text_editor_20250728+ only
 }
 
+// AnthropicToolAdvisorCaching toggles advisor-side prompt caching across calls
+// within a conversation. Not a breakpoint marker — an on/off switch.
+type AnthropicToolAdvisorCaching struct {
+	Type string `json:"type"`          // "ephemeral"
+	TTL  string `json:"ttl,omitempty"` // "5m" | "1h"
+}
+
+// AnthropicToolAdvisor holds fields specific to the advisor_20260301 server
+// tool. Anthropic API only; requires the advisor-tool-2026-03-01 beta header.
+type AnthropicToolAdvisor struct {
+	Model     string                       `json:"model,omitempty"`      // advisor model id (required by Anthropic; must form a valid executor/advisor pair)
+	MaxUses   *int                         `json:"max_uses,omitempty"`   // per-request cap on advisor calls
+	MaxTokens *int                         `json:"max_tokens,omitempty"` // caps advisor output (thinking + text) per call; minimum 1024
+	Caching   *AnthropicToolAdvisorCaching `json:"caching,omitempty"`    // advisor-side prompt caching toggle
+}
+
 // AnthropicToolInputExample represents an input example for a tool (beta feature)
 type AnthropicToolInputExample struct {
 	Input       json.RawMessage `json:"input"`
@@ -1286,6 +1320,7 @@ type AnthropicTool struct {
 	*AnthropicToolWebSearch
 	*AnthropicToolWebFetch
 	*AnthropicToolTextEditor
+	*AnthropicToolAdvisor
 
 	// MCP toolset (mcp-client-2025-11-20 format) — embedded when Type is nil and MCPToolset is set
 	MCPToolset *AnthropicMCPToolsetTool `json:"-"` // Serialized via custom MarshalJSON
@@ -1299,7 +1334,47 @@ func (t AnthropicTool) MarshalJSON() ([]byte, error) {
 	}
 	// Use an alias to avoid infinite recursion
 	type Alias AnthropicTool
-	return providerUtils.MarshalSorted((Alias)(t))
+	data, err := providerUtils.MarshalSorted((Alias)(t))
+	if err != nil {
+		return nil, err
+	}
+	// max_uses (web_search/web_fetch/advisor) and allowed_domains/blocked_domains
+	// (web_search/web_fetch) share JSON tags across the anonymously-embedded
+	// variant structs, so the encoder drops them. Re-inject from the active
+	// variant in a fixed order — deterministic, which is all the prompt-cache
+	// prefix needs (see InputSchema.Normalized()).
+	maxUses, allowed, blocked := t.sharedServerToolFields()
+	if maxUses != nil {
+		if data, err = sjson.SetBytes(data, "max_uses", *maxUses); err != nil {
+			return nil, err
+		}
+	}
+	if len(allowed) > 0 {
+		if data, err = sjson.SetBytes(data, "allowed_domains", allowed); err != nil {
+			return nil, err
+		}
+	}
+	if len(blocked) > 0 {
+		if data, err = sjson.SetBytes(data, "blocked_domains", blocked); err != nil {
+			return nil, err
+		}
+	}
+	return data, nil
+}
+
+// sharedServerToolFields returns the max_uses/allowed_domains/blocked_domains of
+// whichever server-tool variant is active. These share JSON tags across the
+// embedded variant structs and are (un)marshaled explicitly by AnthropicTool.
+func (t AnthropicTool) sharedServerToolFields() (maxUses *int, allowed, blocked []string) {
+	switch {
+	case t.AnthropicToolWebSearch != nil:
+		return t.AnthropicToolWebSearch.MaxUses, t.AnthropicToolWebSearch.AllowedDomains, t.AnthropicToolWebSearch.BlockedDomains
+	case t.AnthropicToolWebFetch != nil:
+		return t.AnthropicToolWebFetch.MaxUses, t.AnthropicToolWebFetch.AllowedDomains, t.AnthropicToolWebFetch.BlockedDomains
+	case t.AnthropicToolAdvisor != nil:
+		return t.AnthropicToolAdvisor.MaxUses, nil, nil
+	}
+	return nil, nil, nil
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for AnthropicTool.
@@ -1320,7 +1395,51 @@ func (t *AnthropicTool) UnmarshalJSON(data []byte) error {
 	}
 	// Default unmarshaling for all other tool types
 	type Alias AnthropicTool
-	return sonic.Unmarshal(data, (*Alias)(t))
+	if err := sonic.Unmarshal(data, (*Alias)(t)); err != nil {
+		return err
+	}
+	// The embedded variant structs share these JSON tags, so the decoder drops
+	// them. Re-read and route them into the active variant by tool type.
+	var shared struct {
+		MaxUses        *int     `json:"max_uses"`
+		AllowedDomains []string `json:"allowed_domains"`
+		BlockedDomains []string `json:"blocked_domains"`
+	}
+	if err := sonic.Unmarshal(data, &shared); err != nil {
+		return err
+	}
+	t.applySharedServerToolFields(shared.MaxUses, shared.AllowedDomains, shared.BlockedDomains)
+	return nil
+}
+
+// applySharedServerToolFields routes the shared (collision-dropped)
+// max_uses/allowed_domains/blocked_domains into the embedded variant struct that
+// matches the tool type, allocating it if the default decode left it nil.
+func (t *AnthropicTool) applySharedServerToolFields(maxUses *int, allowed, blocked []string) {
+	if t.Type == nil || (maxUses == nil && allowed == nil && blocked == nil) {
+		return
+	}
+	switch typeStr := string(*t.Type); {
+	case strings.HasPrefix(typeStr, "web_search"):
+		if t.AnthropicToolWebSearch == nil {
+			t.AnthropicToolWebSearch = &AnthropicToolWebSearch{}
+		}
+		t.AnthropicToolWebSearch.MaxUses = maxUses
+		t.AnthropicToolWebSearch.AllowedDomains = allowed
+		t.AnthropicToolWebSearch.BlockedDomains = blocked
+	case strings.HasPrefix(typeStr, "web_fetch"):
+		if t.AnthropicToolWebFetch == nil {
+			t.AnthropicToolWebFetch = &AnthropicToolWebFetch{}
+		}
+		t.AnthropicToolWebFetch.MaxUses = maxUses
+		t.AnthropicToolWebFetch.AllowedDomains = allowed
+		t.AnthropicToolWebFetch.BlockedDomains = blocked
+	case strings.HasPrefix(typeStr, "advisor"):
+		if t.AnthropicToolAdvisor == nil {
+			t.AnthropicToolAdvisor = &AnthropicToolAdvisor{}
+		}
+		t.AnthropicToolAdvisor.MaxUses = maxUses
+	}
 }
 
 // AnthropicToolChoice represents tool choice in Anthropic format

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -34,6 +34,7 @@ var anthropicToolTypePrefixToFeature = map[string]func(ProviderFeatureSupport) b
 	"memory_":           func(f ProviderFeatureSupport) bool { return f.Memory },
 	"text_editor_":      func(f ProviderFeatureSupport) bool { return f.TextEditor },
 	"tool_search_tool_": func(f ProviderFeatureSupport) bool { return f.ToolSearch },
+	"advisor_":          func(f ProviderFeatureSupport) bool { return f.AdvisorTool },
 }
 
 // isAnthropicServerToolSupported returns whether the given Anthropic server-tool
@@ -137,6 +138,10 @@ func ValidateToolsForProvider(tools []schemas.ResponsesTool, provider schemas.Mo
 			}
 		case schemas.ResponsesToolTypeImageGeneration:
 			if !features.ImageGeneration {
+				return fmt.Errorf("tool type '%s' is not supported by provider '%s'", tool.Type, provider)
+			}
+		case schemas.ResponsesToolTypeAdvisor:
+			if !features.AdvisorTool {
 				return fmt.Errorf("tool type '%s' is not supported by provider '%s'", tool.Type, provider)
 			}
 			// ResponsesToolTypeFunction, ResponsesToolTypeCustom, etc. are always allowed
@@ -981,6 +986,10 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 					if !hasProvider || features.ComputerUse {
 						headers = appendUniqueHeader(headers, AnthropicComputerUseBetaHeader20250124)
 					}
+				case AnthropicToolTypeAdvisor20260301:
+					if !hasProvider || features.AdvisorTool {
+						headers = appendUniqueHeader(headers, AnthropicAdvisorBetaHeader)
+					}
 				}
 			}
 			// Check for strict (structured-outputs)
@@ -1174,6 +1183,7 @@ var betaHeaderPrefixKnown = []string{
 	AnthropicRedactThinkingBetaHeaderPrefix,
 	AnthropicTaskBudgetsBetaHeaderPrefix,
 	AnthropicEagerInputStreamingBetaHeaderPrefix,
+	AnthropicAdvisorBetaHeaderPrefix,
 }
 
 // betaHeaderPrefixExists checks if any header in existing shares a known prefix with newHeader.
@@ -1238,11 +1248,16 @@ var unsupportedRawToolTypes = map[schemas.ModelProvider][]string{
 	schemas.Vertex: {
 		"web_fetch_",     // No web fetch support on Vertex
 		"code_execution", // No code execution on Vertex
+		"advisor_",       // Advisor tool is Anthropic API only
 	},
 	schemas.Bedrock: {
 		"web_search_",    // No web search on Bedrock
 		"web_fetch_",     // No web fetch on Bedrock
 		"code_execution", // No code execution on Bedrock
+		"advisor_",       // Advisor tool is Anthropic API only
+	},
+	schemas.Azure: {
+		"advisor_", // Advisor tool is Anthropic API only (Azure supports all other tools)
 	},
 }
 
@@ -1485,6 +1500,7 @@ var betaHeaderPrefixToFeature = map[string]func(ProviderFeatureSupport) bool{
 	AnthropicRedactThinkingBetaHeaderPrefix:      func(f ProviderFeatureSupport) bool { return f.RedactThinking },
 	AnthropicTaskBudgetsBetaHeaderPrefix:         func(f ProviderFeatureSupport) bool { return f.TaskBudgets },
 	AnthropicEagerInputStreamingBetaHeaderPrefix: func(f ProviderFeatureSupport) bool { return f.EagerInputStreaming },
+	AnthropicAdvisorBetaHeaderPrefix:             func(f ProviderFeatureSupport) bool { return f.AdvisorTool },
 }
 
 // MergeBetaHeaders collects anthropic-beta values from provider ExtraHeaders and

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -848,6 +848,54 @@ func TestAddMissingBetaHeadersToContext_PerProvider(t *testing.T) {
 			expectHeaders: []string{AnthropicMCPClientBetaHeader},
 		},
 		{
+			name:     "Anthropic gets advisor header",
+			provider: schemas.Anthropic,
+			req: &AnthropicMessageRequest{
+				Tools: []AnthropicTool{{
+					Type:                 schemas.Ptr(AnthropicToolTypeAdvisor20260301),
+					Name:                 string(AnthropicToolNameAdvisor),
+					AnthropicToolAdvisor: &AnthropicToolAdvisor{Model: "claude-opus-4-8"},
+				}},
+			},
+			expectHeaders: []string{AnthropicAdvisorBetaHeader},
+		},
+		{
+			name:     "Vertex skips advisor header",
+			provider: schemas.Vertex,
+			req: &AnthropicMessageRequest{
+				Tools: []AnthropicTool{{
+					Type:                 schemas.Ptr(AnthropicToolTypeAdvisor20260301),
+					Name:                 string(AnthropicToolNameAdvisor),
+					AnthropicToolAdvisor: &AnthropicToolAdvisor{Model: "claude-opus-4-8"},
+				}},
+			},
+			unexpectHeaders: []string{AnthropicAdvisorBetaHeader},
+		},
+		{
+			name:     "Bedrock skips advisor header",
+			provider: schemas.Bedrock,
+			req: &AnthropicMessageRequest{
+				Tools: []AnthropicTool{{
+					Type:                 schemas.Ptr(AnthropicToolTypeAdvisor20260301),
+					Name:                 string(AnthropicToolNameAdvisor),
+					AnthropicToolAdvisor: &AnthropicToolAdvisor{Model: "claude-opus-4-8"},
+				}},
+			},
+			unexpectHeaders: []string{AnthropicAdvisorBetaHeader},
+		},
+		{
+			name:     "Azure skips advisor header",
+			provider: schemas.Azure,
+			req: &AnthropicMessageRequest{
+				Tools: []AnthropicTool{{
+					Type:                 schemas.Ptr(AnthropicToolTypeAdvisor20260301),
+					Name:                 string(AnthropicToolNameAdvisor),
+					AnthropicToolAdvisor: &AnthropicToolAdvisor{Model: "claude-opus-4-8"},
+				}},
+			},
+			unexpectHeaders: []string{AnthropicAdvisorBetaHeader},
+		},
+		{
 			name:     "Vertex gets compaction header",
 			provider: schemas.Vertex,
 			req: &AnthropicMessageRequest{

--- a/core/providers/openai/advisor_filter_test.go
+++ b/core/providers/openai/advisor_filter_test.go
@@ -1,0 +1,58 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestToOpenAIResponsesRequest_DropsAdvisorTool verifies the Anthropic-only
+// advisor_20260301 server tool is stripped before reaching OpenAI, so a request
+// carrying it (e.g. via fallback/routing from an Anthropic-shaped client) does
+// not get forwarded as an unknown tool type that OpenAI would reject. The
+// function tool alongside it must survive.
+func TestToOpenAIResponsesRequest_DropsAdvisorTool(t *testing.T) {
+	model := "claude-opus-4-8"
+	bifrostReq := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("hello"),
+				},
+			},
+		},
+		Params: &schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{
+				{
+					Type:                 schemas.ResponsesToolTypeAdvisor,
+					Name:                 schemas.Ptr("advisor"),
+					ResponsesToolAdvisor: &schemas.ResponsesToolAdvisor{Model: model},
+				},
+				{
+					Type: schemas.ResponsesToolTypeFunction,
+					Name: schemas.Ptr("test_func"),
+					ResponsesToolFunction: &schemas.ResponsesToolFunction{
+						Parameters: &schemas.ToolFunctionParameters{Type: "object"},
+					},
+				},
+			},
+		},
+	}
+
+	result := ToOpenAIResponsesRequest(bifrostReq)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	for _, tool := range result.Tools {
+		if tool.Type == schemas.ResponsesToolTypeAdvisor {
+			t.Fatalf("advisor tool should have been stripped before OpenAI, got %+v", tool)
+		}
+	}
+	if len(result.Tools) != 1 || result.Tools[0].Type != schemas.ResponsesToolTypeFunction {
+		t.Fatalf("expected only the function tool to survive, got %+v", result.Tools)
+	}
+}

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -894,6 +894,7 @@ const (
 	ResponsesMessageTypeItemReference        ResponsesMessageType = "item_reference"
 	ResponsesMessageTypeRefusal              ResponsesMessageType = "refusal"
 	ResponsesMessageTypeCompaction           ResponsesMessageType = "compaction"
+	ResponsesMessageTypeAdvisorCall          ResponsesMessageType = "advisor_call" // Anthropic advisor server tool (server_tool_use + advisor_tool_result)
 )
 
 // ResponsesMessage is a union type that can contain different types of input items
@@ -1106,6 +1107,19 @@ type ResponsesToolMessage struct {
 	// MCP-specific
 	*ResponsesMCPListTools
 	*ResponsesMCPApprovalResponse
+
+	// Anthropic advisor-specific (advisor_call): carries the advisor_tool_result payload
+	*ResponsesAdvisorCall
+}
+
+// ResponsesAdvisorCall carries the Anthropic advisor_tool_result content
+// (a discriminated union) alongside an advisor_call. Anthropic-only.
+type ResponsesAdvisorCall struct {
+	ResultType       string  `json:"result_type,omitempty"`       // "advisor_result" | "advisor_redacted_result" | "advisor_tool_result_error"
+	Text             *string `json:"advisor_text,omitempty"`      // advisor_result variant
+	EncryptedContent *string `json:"advisor_encrypted_content,omitempty"` // advisor_redacted_result variant
+	ErrorCode        *string `json:"advisor_error_code,omitempty"`        // advisor_tool_result_error variant
+	StopReason       *string `json:"advisor_stop_reason,omitempty"`       // present when max_tokens is set on the tool
 }
 
 type ResponsesToolMessageActionStruct struct {
@@ -1716,6 +1730,7 @@ const (
 	ResponsesToolTypeToolSearch         ResponsesToolType = "tool_search"
 	ResponsesToolTypeNamespace          ResponsesToolType = "namespace"
 	ResponsesToolTypeXSearch            ResponsesToolType = "x_search"
+	ResponsesToolTypeAdvisor            ResponsesToolType = "advisor"
 )
 
 // normalizeResponsesToolType maps versioned/provider-specific tool type strings
@@ -1744,6 +1759,9 @@ func normalizeResponsesToolType(t ResponsesToolType) ResponsesToolType {
 		return ResponsesToolTypeCodeInterpreter
 	case strings.HasPrefix(s, "memory") && t != ResponsesToolTypeMemory:
 		return ResponsesToolTypeMemory
+	case strings.HasPrefix(s, "advisor") && t != ResponsesToolTypeAdvisor:
+		// Covers "advisor_20260301" and future dated versions.
+		return ResponsesToolTypeAdvisor
 	default:
 		return t
 	}
@@ -1780,6 +1798,7 @@ type ResponsesTool struct {
 	*ResponsesToolToolSearch
 	*ResponsesToolNamespace
 	*ResponsesToolXSearch
+	*ResponsesToolAdvisor
 }
 
 // mergeJSONFields merges all top-level fields from src into dst using sjson,
@@ -1917,6 +1936,10 @@ func (t ResponsesTool) MarshalJSON() ([]byte, error) {
 	case ResponsesToolTypeXSearch:
 		if t.ResponsesToolXSearch != nil {
 			typeBytes, err = MarshalSorted(t.ResponsesToolXSearch)
+		}
+	case ResponsesToolTypeAdvisor: // Anthropic advisor server tool
+		if t.ResponsesToolAdvisor != nil {
+			typeBytes, err = MarshalSorted(t.ResponsesToolAdvisor)
 		}
 	}
 	if err != nil {
@@ -2099,6 +2122,13 @@ func (t *ResponsesTool) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		t.ResponsesToolXSearch = &xSearchTool
+
+	case ResponsesToolTypeAdvisor: // Anthropic advisor server tool
+		var advisorTool ResponsesToolAdvisor
+		if err := Unmarshal(data, &advisorTool); err != nil {
+			return err
+		}
+		t.ResponsesToolAdvisor = &advisorTool
 	}
 
 	return nil
@@ -2518,6 +2548,21 @@ type ResponsesToolWebFetch struct {
 	MaxUses          *int                           `json:"max_uses,omitempty"`
 	Filters          *ResponsesToolWebSearchFilters `json:"filters,omitempty"`
 	MaxContentTokens *int                           `json:"max_content_tokens,omitempty"`
+}
+
+// ResponsesToolAdvisorCaching toggles advisor-side prompt caching.
+type ResponsesToolAdvisorCaching struct {
+	Type string `json:"type"`          // "ephemeral"
+	TTL  string `json:"ttl,omitempty"` // "5m" | "1h"
+}
+
+// ResponsesToolAdvisor carries the Anthropic advisor_20260301 server-tool
+// config. Anthropic-only; ignored by providers that don't support it.
+type ResponsesToolAdvisor struct {
+	Model     string                       `json:"model,omitempty"`      // advisor model id (required by Anthropic)
+	MaxUses   *int                         `json:"max_uses,omitempty"`   // per-request cap on advisor calls
+	MaxTokens *int                         `json:"max_tokens,omitempty"` // caps advisor output per call; minimum 1024
+	Caching   *ResponsesToolAdvisorCaching `json:"caching,omitempty"`    // advisor-side prompt caching toggle
 }
 
 // ResponsesToolNamespace represents a namespace tool that groups related function tools.

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -748,6 +748,8 @@ func TestResponsesTool_MarshalJSON_RoundTrip(t *testing.T) {
 		`{"type":"function","name":"get_weather","description":"Get weather","strict":true}`,
 		`{"type":"function","name":"search_db","description":"Search database","cache_control":{"type":"ephemeral"},"strict":false}`,
 		`{"type":"file_search","vector_store_ids":["vs_1"],"max_num_results":10}`,
+		// Anthropic advisor server tool: model/max_uses/max_tokens/caching must survive the JSON boundary.
+		`{"type":"advisor","name":"advisor","model":"claude-opus-4-8","max_uses":3,"max_tokens":2048,"caching":{"type":"ephemeral","ttl":"5m"}}`,
 	}
 
 	for _, input := range inputs {
@@ -1214,6 +1216,8 @@ func TestResponsesTool_UnmarshalJSON_NormalizesVersionedToolTypes(t *testing.T) 
 		wantWebFetch   bool
 		wantComputer   bool
 		wantCodeInterp bool
+		wantAdvisor    bool
+		wantModel      string
 	}{
 		// web_search variants
 		{name: "web_search canonical", input: `{"type":"web_search"}`, wantType: ResponsesToolTypeWebSearch, wantWebSearch: true},
@@ -1240,6 +1244,10 @@ func TestResponsesTool_UnmarshalJSON_NormalizesVersionedToolTypes(t *testing.T) 
 		{name: "code_execution_20250522", input: `{"type":"code_execution_20250522"}`, wantType: ResponsesToolTypeCodeInterpreter, wantCodeInterp: true},
 		{name: "code_execution_20250825", input: `{"type":"code_execution_20250825"}`, wantType: ResponsesToolTypeCodeInterpreter, wantCodeInterp: true},
 
+		// advisor variants → advisor
+		{name: "advisor canonical", input: `{"type":"advisor","name":"advisor","model":"claude-opus-4-8"}`, wantType: ResponsesToolTypeAdvisor, wantAdvisor: true, wantModel: "claude-opus-4-8"},
+		{name: "advisor_20260301", input: `{"type":"advisor_20260301","name":"advisor","model":"claude-opus-4-8"}`, wantType: ResponsesToolTypeAdvisor, wantAdvisor: true, wantModel: "claude-opus-4-8"},
+
 		// unrecognized types pass through unchanged
 		{name: "function unchanged", input: `{"type":"function","name":"foo","strict":true}`, wantType: ResponsesToolTypeFunction},
 		{name: "custom unchanged", input: `{"type":"custom","name":"bar"}`, wantType: ResponsesToolTypeCustom},
@@ -1263,6 +1271,10 @@ func TestResponsesTool_UnmarshalJSON_NormalizesVersionedToolTypes(t *testing.T) 
 			}
 			if tt.wantCodeInterp {
 				assert.NotNil(t, tool.ResponsesToolCodeInterpreter, "ResponsesToolCodeInterpreter should be populated")
+			}
+			if tt.wantAdvisor {
+				require.NotNil(t, tool.ResponsesToolAdvisor, "ResponsesToolAdvisor should be populated")
+				assert.Equal(t, tt.wantModel, tool.ResponsesToolAdvisor.Model)
 			}
 		})
 	}

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -12,9 +12,9 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
 
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
-	"github.com/tidwall/gjson"
 	"github.com/valyala/fasthttp"
 )
 


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end Anthropic “advisor” tool support across streaming and non-streaming conversions, including call/result pairing, preserved content ordering, and full tool configuration mapping.

* **Behavior**
  * Auto-injects the advisor beta header for Anthropic requests only; omits it for other providers.
  * Enforces provider/tool gating and rejects unsupported raw advisor tools.

* **Tests**
  * Expanded unit and regression coverage for advisor JSON round-trips, conversion correctness, streaming preservation, gating, and beta-header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->