### PR TITLE
fix: load-test script build paths and provider config

### DIFF
--- a/.github/workflows/scripts/load-test.sh
+++ b/.github/workflows/scripts/load-test.sh
@@ -172,8 +172,8 @@ build_bifrost_http() {
   cd "${BIFROST_HTTP_DIR}"
 
   # Ensure ui directory exists for //go:embed all:ui (load test does not need the real UI assets)
-  if [ ! -d "${BIFROST_HTTP_DIR}/ui" ]; then
-    mkdir -p "${BIFROST_HTTP_DIR}/ui"
+  mkdir -p "${BIFROST_HTTP_DIR}/ui"
+  if [ ! -f "${BIFROST_HTTP_DIR}/ui/.gitkeep" ]; then
     echo "placeholder" > "${BIFROST_HTTP_DIR}/ui/.gitkeep"
   fi
 

--- a/.github/workflows/scripts/load-test.sh
+++ b/.github/workflows/scripts/load-test.sh
@@ -169,7 +169,13 @@ build_bifrost_http() {
   fi
 
   log_info "Building bifrost-http..."
-  cd "${TRANSPORTS_DIR}"
+  cd "${BIFROST_HTTP_DIR}"
+
+  # Ensure ui directory exists for //go:embed all:ui (load test does not need the real UI assets)
+  if [ ! -d "${BIFROST_HTTP_DIR}/ui" ]; then
+    mkdir -p "${BIFROST_HTTP_DIR}/ui"
+    echo "placeholder" > "${BIFROST_HTTP_DIR}/ui/.gitkeep"
+  fi
 
   if go build -o ${REPO_ROOT}/tmp/bifrost-http .; then
     log_success "bifrost-http built successfully"
@@ -190,8 +196,9 @@ setup_mocker() {
     cd "${WORK_DIR}"
   else
     log_info "Cloning bifrost-benchmarking repository..."
-    cd "${WORK_DIR}"
+    cd "${REPO_ROOT}/.."
     git clone --depth 1 https://github.com/maximhq/bifrost-benchmarking.git
+    cd "${WORK_DIR}"
   fi
 
   log_success "Mocker setup complete"
@@ -242,7 +249,8 @@ create_config() {
         {
           "name": "mocker-key",
           "value": "Bearer mocker-key",
-          "weight": 1
+          "weight": 1,
+          "models": ["*"]
         }
       ],
       "network_config": {
@@ -252,14 +260,6 @@ create_config() {
       "concurrency_and_buffer_size": {
         "concurrency": 20000,
         "buffer_size": 40000
-      },
-      "custom_provider_config": {
-        "base_provider_type": "openai",
-        "allowed_requests": {
-          "list_models": false,
-          "chat_completion": true,
-          "chat_completion_stream": true
-        }
       }
     }
   }
@@ -848,3 +848,4 @@ main() {
 }
 
 main "$@"
+


### PR DESCRIPTION
## Summary

`.github/workflows/scripts/load-test.sh` could not run successfully due to several issues: wrong working directory for go build, wrong clone location for the bifrost-benchmarking mocker repo, an invalid openai provider config in the generated config.json, and a missing ui/ directory required by the //go:embed all:ui directive in transports/bifrost-http/main.go. This PR fixes the script so it can run end-to-end.

## Changes

- build_bifrost_http: cd "${BIFROST_HTTP_DIR}" (was ${TRANSPORTS_DIR}). go build must run from transports/bifrost-http/, which contains main.go.
- build_bifrost_http: create transports/bifrost-http/ui/ with a placeholder file before building, to satisfy //go:embed all:ui. This mirrors what run-migration-tests.sh already does; the load test does not need real UI assets.
- setup_mocker: git clone into ${REPO_ROOT}/.. instead of ${WORK_DIR}, so the cloned path matches MOCKER_DIR=${REPO_ROOT}/../bifrost-benchmarking/mocker.
- create_config: add the required "models": ["*"] field to the openai key (per the schemas.Key whitelist requirement).
- create_config: remove custom_provider_config from the openai provider — that block is only valid for custom providers (where base_provider_type is set) and causes validation errors under the standard openai provider.

No design trade-offs — all changes are mechanical bug fixes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs
- [x] CI scripts (.github/workflows/scripts/)

## How to test

# From the repo root:
bash `.github/workflows/scripts/load-test.sh`

Expected:
- bifrost-http builds successfully from transports/bifrost-http/
- bifrost-benchmarking is cloned to ../bifrost-benchmarking (sibling of repo root)
- config.json is generated and accepted by bifrost-http at startup (no provider validation error)
- The calibration phase, overhead phase, and stress phase run to completion and the script prints the final summary table

No new configs or environment variables introduced.

## Screenshots/Recordings

N/A — CI-only shell script.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

None.

## Security considerations

None. Only changes a load-test shell script and its generated config; no auth, secrets, PII, or sandboxing changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved local load-testing and build setup to ensure UI assets are present during local builds.
  * Updated mock provider configuration to permit all models for broader testing coverage.
  * Streamlined mock setup/clone process for more reliable initialization in local runs.
  * Minor script formatting tweak for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->