### PR TITLE
refactor: extract `StreamAnthropicChatEvents`/`StreamAnthropicResponsesEvents` and route Bedrock Claude streams through shared Anthropic loop via `bedrockAnthropicEventReader`

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -530,6 +530,29 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 	)
 }
 
+// StreamReaderError lets a custom SSEEventReader surface a fully-formed
+// *schemas.BifrostError through the ReadEvent contract. The shared stream
+// loops (StreamAnthropicChatEvents / StreamAnthropicResponsesEvents) detect it
+// via errors.As and forward the embedded error verbatim, preserving any status
+// code so the retry gate behaves as the provider intends.
+//
+// This is what allows Bedrock — whose AWS EventStream framing carries
+// retryable exception frames (throttling, serviceUnavailable, …) and transport
+// errors with provider-specific retry classification — to reuse the SSE loop
+// without losing its retry semantics. The native SSE reader never returns this
+// type, so SSE callers are unaffected.
+type StreamReaderError struct {
+	BifrostError *schemas.BifrostError
+}
+
+// Error implements the error interface.
+func (e *StreamReaderError) Error() string {
+	if e.BifrostError != nil && e.BifrostError.Error != nil {
+		return e.BifrostError.Error.Message
+	}
+	return "anthropic stream reader error"
+}
+
 // HandleAnthropicChatCompletionStreaming handles streaming for Anthropic-compatible APIs.
 // This shared function reduces code duplication between providers that use the same SSE event format.
 func HandleAnthropicChatCompletionStreaming(
@@ -658,242 +681,261 @@ func HandleAnthropicChatCompletionStreaming(
 
 		sseReader := providerUtils.GetSSEEventReader(ctx, reader)
 
-		chunkIndex := 0
+		StreamAnthropicChatEvents(ctx, sseReader, responseChan, jsonBody, startTime, sendBackRawRequest, sendBackRawResponse, providerName, postHookRunner, postResponseConverter, logger, postHookSpanFinalizer)
+	}()
 
-		lastChunkTime := startTime
+	return responseChan, nil
+}
 
-		// Track minimal state needed for response format
-		var messageID string
-		var modelName string
-		var finishReason *string
+// StreamAnthropicChatEvents runs the Anthropic chat-completion streaming event loop
+// against any SSEEventReader. Transport and stream lifecycle (request, idle timeout,
+// cancellation, channel close) stay with the caller; this owns only the per-event
+// processing and final-chunk emission, so providers with different wire framing
+// (native SSE, Bedrock AWS EventStream) can share it by supplying a suitable reader.
+func StreamAnthropicChatEvents(ctx *schemas.BifrostContext, sseReader providerUtils.SSEEventReader, responseChan chan *schemas.BifrostStreamChunk, jsonBody []byte, startTime time.Time, sendBackRawRequest bool, sendBackRawResponse bool, providerName schemas.ModelProvider, postHookRunner schemas.PostHookRunner, postResponseConverter func(*schemas.BifrostChatResponse) *schemas.BifrostChatResponse, logger schemas.Logger, postHookSpanFinalizer func(context.Context)) {
+	chunkIndex := 0
 
-		usage := &schemas.BifrostLLMUsage{}
+	lastChunkTime := startTime
 
-		// Check for structured output tool name and track state
-		var structuredOutputToolName string
-		var isAccumulatingStructuredOutput bool
-		var consumedStructuredOutput bool // true once the SO tool block has been fully streamed as content
-		if toolName, ok := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string); ok {
-			structuredOutputToolName = toolName
+	// Track minimal state needed for response format
+	var messageID string
+	var modelName string
+	var finishReason *string
+
+	usage := &schemas.BifrostLLMUsage{}
+
+	// Check for structured output tool name and track state
+	var structuredOutputToolName string
+	var isAccumulatingStructuredOutput bool
+	var consumedStructuredOutput bool // true once the SO tool block has been fully streamed as content
+	if toolName, ok := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string); ok {
+		structuredOutputToolName = toolName
+	}
+
+	// Per-response tool-call index state
+	streamState := NewAnthropicStreamState()
+
+	for {
+		// If context was cancelled/timed out, let defer handle it
+		if ctx.Err() != nil {
+			return
 		}
-
-		// Per-response tool-call index state
-		streamState := NewAnthropicStreamState()
-
-		for {
-			// If context was cancelled/timed out, let defer handle it
+		eventType, eventDataBytes, readErr := sseReader.ReadEvent()
+		if readErr != nil {
+			// Recheck context cancellation
 			if ctx.Err() != nil {
 				return
 			}
-			eventType, eventDataBytes, readErr := sseReader.ReadEvent()
-			if readErr != nil {
-				// Recheck context cancellation
-				if ctx.Err() != nil {
-					return
-				}
-				if readErr != io.EOF {
-					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-					logger.Warn("Error reading %s stream: %v", providerName, readErr)
+			if readErr != io.EOF {
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				logger.Warn("Error reading %s stream: %v", providerName, readErr)
+				// A reader may surface a provider-classified BifrostError (e.g. Bedrock's
+				// retryable AWS exception frames) — forward it verbatim to preserve its
+				// status code and retry semantics; otherwise treat it as a generic error.
+				var readerErr *StreamReaderError
+				if errors.As(readErr, &readerErr) && readerErr.BifrostError != nil {
+					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, readerErr.BifrostError, responseChan, logger, postHookSpanFinalizer)
+				} else {
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
-					return
 				}
-				break
+				return
 			}
-			eventData := string(eventDataBytes)
-			if eventType == "" || eventData == "" {
-				continue
+			break
+		}
+		eventData := string(eventDataBytes)
+		if eventType == "" || eventData == "" {
+			continue
+		}
+		var event AnthropicStreamEvent
+		if err := sonic.Unmarshal([]byte(eventData), &event); err != nil {
+			logger.Warn("Failed to parse message_start event: %v", err)
+			continue
+		}
+		if event.Type == AnthropicStreamEventTypeMessageStart && event.Message != nil && event.Message.ID != "" {
+			messageID = event.Message.ID
+		}
+		// Check for usage in both top-level event.Usage and nested event.Message.Usage
+		// message_start events have usage nested in message.usage, while message_delta has it at top level
+		var usageToProcess *AnthropicUsage
+		if event.Usage != nil {
+			usageToProcess = event.Usage
+		} else if event.Message != nil && event.Message.Usage != nil {
+			usageToProcess = event.Message.Usage
+		}
+		if usageToProcess != nil {
+			// Collect usage information and send at the end of the stream
+			// Here in some cases usage comes before final message
+			// So we need to check if the response.Usage is nil and then if usage != nil
+			// then add up all tokens
+			if usageToProcess.InputTokens > usage.PromptTokens {
+				usage.PromptTokens = usageToProcess.InputTokens
 			}
-			var event AnthropicStreamEvent
-			if err := sonic.Unmarshal([]byte(eventData), &event); err != nil {
-				logger.Warn("Failed to parse message_start event: %v", err)
-				continue
+			if usageToProcess.OutputTokens > usage.CompletionTokens {
+				usage.CompletionTokens = usageToProcess.OutputTokens
 			}
-			if event.Type == AnthropicStreamEventTypeMessageStart && event.Message != nil && event.Message.ID != "" {
-				messageID = event.Message.ID
+			calculatedTotal := usage.PromptTokens + usage.CompletionTokens
+			if calculatedTotal > usage.TotalTokens {
+				usage.TotalTokens = calculatedTotal
 			}
-			// Check for usage in both top-level event.Usage and nested event.Message.Usage
-			// message_start events have usage nested in message.usage, while message_delta has it at top level
-			var usageToProcess *AnthropicUsage
-			if event.Usage != nil {
-				usageToProcess = event.Usage
-			} else if event.Message != nil && event.Message.Usage != nil {
-				usageToProcess = event.Message.Usage
-			}
-			if usageToProcess != nil {
-				// Collect usage information and send at the end of the stream
-				// Here in some cases usage comes before final message
-				// So we need to check if the response.Usage is nil and then if usage != nil
-				// then add up all tokens
-				if usageToProcess.InputTokens > usage.PromptTokens {
-					usage.PromptTokens = usageToProcess.InputTokens
+			// Handle cached tokens if present
+			if usageToProcess.CacheReadInputTokens > 0 {
+				if usage.PromptTokensDetails == nil {
+					usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
 				}
-				if usageToProcess.OutputTokens > usage.CompletionTokens {
-					usage.CompletionTokens = usageToProcess.OutputTokens
+				if usageToProcess.CacheReadInputTokens > usage.PromptTokensDetails.CachedReadTokens {
+					usage.PromptTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
 				}
-				calculatedTotal := usage.PromptTokens + usage.CompletionTokens
-				if calculatedTotal > usage.TotalTokens {
-					usage.TotalTokens = calculatedTotal
+			}
+			if usageToProcess.CacheCreationInputTokens > 0 {
+				if usage.PromptTokensDetails == nil {
+					usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
 				}
-				// Handle cached tokens if present
-				if usageToProcess.CacheReadInputTokens > 0 {
-					if usage.PromptTokensDetails == nil {
-						usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+				if usageToProcess.CacheCreationInputTokens > usage.PromptTokensDetails.CachedWriteTokens {
+					usage.PromptTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
+				}
+				if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
+					if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
+						usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
 					}
-					if usageToProcess.CacheReadInputTokens > usage.PromptTokensDetails.CachedReadTokens {
-						usage.PromptTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
+					if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
+						usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
 					}
-				}
-				if usageToProcess.CacheCreationInputTokens > 0 {
-					if usage.PromptTokensDetails == nil {
-						usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
-					}
-					if usageToProcess.CacheCreationInputTokens > usage.PromptTokensDetails.CachedWriteTokens {
-						usage.PromptTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
-					}
-					if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
-						if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
-							usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
-						}
-						if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
-							usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
-						}
-						if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
-							usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
-						}
-					}
-				}
-			}
-			if event.Message != nil {
-				modelName = event.Message.Model
-			}
-
-			// Extract finish reason from event delta
-			if event.Delta != nil && event.Delta.StopReason != nil {
-				mappedReason := ConvertAnthropicFinishReasonToBifrost(*event.Delta.StopReason)
-				finishReason = &mappedReason
-
-				// Override finish reason for structured output only when the SO tool
-				// was consumed into content AND no real tool calls were also emitted.
-				// streamState.nextToolCallIndex > 0 means real tool_use blocks were seen.
-				if consumedStructuredOutput && streamState.nextToolCallIndex == 0 &&
-					*finishReason == string(schemas.BifrostFinishReasonToolCalls) {
-					stopReason := string(schemas.BifrostFinishReasonStop)
-					finishReason = &stopReason
-				}
-			}
-
-			// Handle structured output: intercept tool calls for the structured output tool
-			// and convert them to content instead of forwarding as tool calls
-			if structuredOutputToolName != "" {
-				// Check for tool use start event
-				if event.Type == AnthropicStreamEventTypeContentBlockStart {
-					if event.ContentBlock != nil && event.ContentBlock.Type == AnthropicContentBlockTypeToolUse {
-						if event.ContentBlock.Name != nil && *event.ContentBlock.Name == structuredOutputToolName {
-							isAccumulatingStructuredOutput = true
-							continue
-						}
+					if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
+						usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
 					}
 				}
+			}
+		}
+		if event.Message != nil {
+			modelName = event.Message.Model
+		}
 
-				// Check for tool use delta event
-				if event.Type == AnthropicStreamEventTypeContentBlockDelta && isAccumulatingStructuredOutput {
-					if event.Delta != nil && event.Delta.Type == AnthropicStreamDeltaTypeInputJSON && event.Delta.PartialJSON != nil {
-						// Convert tool use delta to content delta
-						content := *event.Delta.PartialJSON
-						response := &schemas.BifrostChatResponse{
-							ID:     messageID,
-							Object: "chat.completion.chunk",
-							Choices: []schemas.BifrostResponseChoice{
-								{
-									Index: 0,
-									ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
-										Delta: &schemas.ChatStreamResponseChoiceDelta{
-											Content: &content,
-										},
-									},
-								},
-							},
-							ExtraFields: schemas.BifrostResponseExtraFields{
-								ChunkIndex: chunkIndex,
-								Latency:    time.Since(lastChunkTime).Milliseconds(),
-							},
-						}
-						lastChunkTime = time.Now()
-						chunkIndex++
+		// Extract finish reason from event delta
+		if event.Delta != nil && event.Delta.StopReason != nil {
+			mappedReason := ConvertAnthropicFinishReasonToBifrost(*event.Delta.StopReason)
+			finishReason = &mappedReason
 
-						if sendBackRawResponse {
-							response.ExtraFields.RawResponse = eventData
-						}
+			// Override finish reason for structured output only when the SO tool
+			// was consumed into content AND no real tool calls were also emitted.
+			// streamState.nextToolCallIndex > 0 means real tool_use blocks were seen.
+			if consumedStructuredOutput && streamState.nextToolCallIndex == 0 &&
+				*finishReason == string(schemas.BifrostFinishReasonToolCalls) {
+				stopReason := string(schemas.BifrostFinishReasonStop)
+				finishReason = &stopReason
+			}
+		}
 
-						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
+		// Handle structured output: intercept tool calls for the structured output tool
+		// and convert them to content instead of forwarding as tool calls
+		if structuredOutputToolName != "" {
+			// Check for tool use start event
+			if event.Type == AnthropicStreamEventTypeContentBlockStart {
+				if event.ContentBlock != nil && event.ContentBlock.Type == AnthropicContentBlockTypeToolUse {
+					if event.ContentBlock.Name != nil && *event.ContentBlock.Name == structuredOutputToolName {
+						isAccumulatingStructuredOutput = true
 						continue
 					}
 				}
+			}
 
-				// Check for content block stop
-				if event.Type == AnthropicStreamEventTypeContentBlockStop && isAccumulatingStructuredOutput {
-					isAccumulatingStructuredOutput = false
-					consumedStructuredOutput = true
+			// Check for tool use delta event
+			if event.Type == AnthropicStreamEventTypeContentBlockDelta && isAccumulatingStructuredOutput {
+				if event.Delta != nil && event.Delta.Type == AnthropicStreamDeltaTypeInputJSON && event.Delta.PartialJSON != nil {
+					// Convert tool use delta to content delta
+					content := *event.Delta.PartialJSON
+					response := &schemas.BifrostChatResponse{
+						ID:     messageID,
+						Object: "chat.completion.chunk",
+						Choices: []schemas.BifrostResponseChoice{
+							{
+								Index: 0,
+								ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+									Delta: &schemas.ChatStreamResponseChoiceDelta{
+										Content: &content,
+									},
+								},
+							},
+						},
+						ExtraFields: schemas.BifrostResponseExtraFields{
+							ChunkIndex: chunkIndex,
+							Latency:    time.Since(lastChunkTime).Milliseconds(),
+						},
+					}
+					lastChunkTime = time.Now()
+					chunkIndex++
+
+					if sendBackRawResponse {
+						response.ExtraFields.RawResponse = eventData
+					}
+
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
 					continue
 				}
 			}
 
-			response, bifrostErr, isLastChunk := event.ToBifrostChatCompletionStream(ctx, structuredOutputToolName, streamState)
-			if bifrostErr != nil {
-				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
-				break
+			// Check for content block stop
+			if event.Type == AnthropicStreamEventTypeContentBlockStop && isAccumulatingStructuredOutput {
+				isAccumulatingStructuredOutput = false
+				consumedStructuredOutput = true
+				continue
 			}
-			if response != nil {
-				response.ExtraFields = schemas.BifrostResponseExtraFields{
-					ChunkIndex: chunkIndex,
-					Latency:    time.Since(lastChunkTime).Milliseconds(),
-				}
-				if postResponseConverter != nil {
-					response = postResponseConverter(response)
-					if response == nil {
-						logger.Warn("postResponseConverter returned nil; skipping chunk")
-						continue
-					}
-				}
-				response.ID = messageID
-				lastChunkTime = time.Now()
-				chunkIndex++
+		}
 
-				if sendBackRawResponse {
-					response.ExtraFields.RawResponse = eventData
+		response, bifrostErr, isLastChunk := event.ToBifrostChatCompletionStream(ctx, structuredOutputToolName, streamState)
+		if bifrostErr != nil {
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
+			break
+		}
+		if response != nil {
+			response.ExtraFields = schemas.BifrostResponseExtraFields{
+				ChunkIndex: chunkIndex,
+				Latency:    time.Since(lastChunkTime).Milliseconds(),
+			}
+			// Assign the upstream message ID before the converter runs so a caller-supplied
+			// converter (e.g. Bedrock overriding ID/model) has the final say on these fields.
+			response.ID = messageID
+			if postResponseConverter != nil {
+				response = postResponseConverter(response)
+				if response == nil {
+					logger.Warn("postResponseConverter returned nil; skipping chunk")
+					continue
 				}
+			}
+			lastChunkTime = time.Now()
+			chunkIndex++
 
-				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
+			if sendBackRawResponse {
+				response.ExtraFields.RawResponse = eventData
 			}
-			if isLastChunk {
-				break
-			}
-		}
-		if usage.PromptTokensDetails != nil {
-			usage.PromptTokens = usage.PromptTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
-			usage.TotalTokens = usage.TotalTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
-		}
-		response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, modelName, 0)
-		if postResponseConverter != nil {
-			response = postResponseConverter(response)
-			if response == nil {
-				logger.Warn("postResponseConverter returned nil; skipping chunk")
-				// Setting error on the context to signal to the defer that we need to close the stream
-				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-				return
-			}
-		}
-		// Set raw request if enabled
-		if sendBackRawRequest {
-			providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonBody)
-		}
-		response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
-		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-		providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
-	}()
 
-	return responseChan, nil
+			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
+		}
+		if isLastChunk {
+			break
+		}
+	}
+	if usage.PromptTokensDetails != nil {
+		usage.PromptTokens = usage.PromptTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
+		usage.TotalTokens = usage.TotalTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
+	}
+	response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, modelName, 0)
+	if postResponseConverter != nil {
+		response = postResponseConverter(response)
+		if response == nil {
+			logger.Warn("postResponseConverter returned nil; skipping chunk")
+			// Setting error on the context to signal to the defer that we need to close the stream
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			return
+		}
+	}
+	// Set raw request if enabled
+	if sendBackRawRequest {
+		providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonBody)
+	}
+	response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+	providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
 }
 
 // Responses performs a chat completion request to Anthropic's API.
@@ -1144,195 +1186,211 @@ func HandleAnthropicResponsesStream(
 		defer stopCancellation()
 
 		sseReader := providerUtils.GetSSEEventReader(ctx, reader)
-		chunkIndex := 0
+		StreamAnthropicResponsesEvents(ctx, sseReader, responseChan, jsonBody, startTime, sendBackRawRequest, sendBackRawResponse, providerName, postHookRunner, postResponseConverter, logger, postHookSpanFinalizer)
+	}()
 
-		lastChunkTime := startTime
+	return responseChan, nil
+}
 
-		// Track minimal state needed for response format
-		usage := &schemas.ResponsesResponseUsage{}
+// StreamAnthropicResponsesEvents runs the Anthropic Responses streaming event loop
+// against any SSEEventReader. As with StreamAnthropicChatEvents, transport and stream
+// lifecycle stay with the caller; this owns only per-event processing, the final-chunk
+// finalisation (driven by the isLastChunk signal), and stream-state pooling.
+func StreamAnthropicResponsesEvents(ctx *schemas.BifrostContext, sseReader providerUtils.SSEEventReader, responseChan chan *schemas.BifrostStreamChunk, jsonBody []byte, startTime time.Time, sendBackRawRequest bool, sendBackRawResponse bool, providerName schemas.ModelProvider, postHookRunner schemas.PostHookRunner, postResponseConverter func(*schemas.BifrostResponsesStreamResponse) *schemas.BifrostResponsesStreamResponse, logger schemas.Logger, postHookSpanFinalizer func(context.Context)) {
+	chunkIndex := 0
 
-		// Create stream state for stateful conversions
-		streamState := AcquireAnthropicResponsesStreamState()
-		defer ReleaseAnthropicResponsesStreamState(streamState)
+	lastChunkTime := startTime
 
-		// Set structured output tool name if present
-		if toolName, ok := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string); ok {
-			streamState.StructuredOutputToolName = toolName
+	// Track minimal state needed for response format
+	usage := &schemas.ResponsesResponseUsage{}
+
+	// Create stream state for stateful conversions
+	streamState := AcquireAnthropicResponsesStreamState()
+	defer ReleaseAnthropicResponsesStreamState(streamState)
+
+	// Set structured output tool name if present
+	if toolName, ok := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string); ok {
+		streamState.StructuredOutputToolName = toolName
+	}
+
+	var modelName string
+
+	for {
+		// If context was cancelled/timed out, let defer handle it
+		if ctx.Err() != nil {
+			return
+		}
+		eventType, eventDataBytes, readErr := sseReader.ReadEvent()
+		if readErr != nil {
+			// Recheck context cancellation
+			if ctx.Err() != nil {
+				return
+			}
+			if readErr != io.EOF {
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				logger.Warn("Error reading %s stream: %v", providerName, readErr)
+				// A reader may surface a provider-classified BifrostError (e.g. Bedrock's
+				// retryable AWS exception frames) — forward it verbatim to preserve its
+				// status code and retry semantics; otherwise treat it as a generic error.
+				var readerErr *StreamReaderError
+				if errors.As(readErr, &readerErr) && readerErr.BifrostError != nil {
+					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, readerErr.BifrostError, responseChan, logger, postHookSpanFinalizer)
+				} else {
+					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
+				}
+			}
+			break
+		}
+		eventData := string(eventDataBytes)
+		if eventType == "" || eventData == "" {
+			continue
+		}
+		var event AnthropicStreamEvent
+		if err := sonic.Unmarshal([]byte(eventData), &event); err != nil {
+			logger.Warn("Failed to parse message_start event: %v", err)
+			continue
+		}
+		if event.Message != nil && modelName == "" {
+			modelName = event.Message.Model
+		}
+		// Note: response.created and response.in_progress are now emitted by ToBifrostResponsesStream
+		// from the message_start event, so we don't need to call them manually here
+
+		// Check for usage in both top-level event.Usage and nested event.Message.Usage
+		// message_start events have usage nested in message.usage, while message_delta has it at top level
+		var usageToProcess *AnthropicUsage
+		if event.Usage != nil {
+			usageToProcess = event.Usage
+		} else if event.Message != nil && event.Message.Usage != nil {
+			usageToProcess = event.Message.Usage
 		}
 
-		var modelName string
+		if usageToProcess != nil {
+			// Collect usage information and send at the end of the stream
+			// Here in some cases usage comes before final message
+			// So we need to check if the response.Usage is nil and then if usage != nil
+			// then add up all tokens
+			if usageToProcess.InputTokens > usage.InputTokens {
+				usage.InputTokens = usageToProcess.InputTokens
+			}
+			if usageToProcess.OutputTokens > usage.OutputTokens {
+				usage.OutputTokens = usageToProcess.OutputTokens
+			}
+			calculatedTotal := usage.InputTokens + usage.OutputTokens
+			if calculatedTotal > usage.TotalTokens {
+				usage.TotalTokens = calculatedTotal
+			}
+			// Handle cached tokens if present
+			if usageToProcess.CacheReadInputTokens > 0 {
+				if usage.InputTokensDetails == nil {
+					usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+				}
+				if usageToProcess.CacheReadInputTokens > usage.InputTokensDetails.CachedReadTokens {
+					usage.InputTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
+				}
+			}
+			// Handle cached tokens if present
+			if usageToProcess.CacheCreationInputTokens > 0 {
+				if usage.InputTokensDetails == nil {
+					usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+				}
+				if usageToProcess.CacheCreationInputTokens > usage.InputTokensDetails.CachedWriteTokens {
+					usage.InputTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
+				}
+				if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
+					if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
+						usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+					}
+					if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
+						usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
+					}
+					if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
+						usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
+					}
+				}
+			}
+		}
 
-		for {
+		responses, bifrostErr, isLastChunk := event.ToBifrostResponsesStream(ctx, chunkIndex, streamState)
+		// Propagate message_delta emission flag to context so the output converter
+		// (ToAnthropicResponsesStreamResponse) can skip synthesizing a duplicate.
+		if streamState.HasEmittedMessageDelta {
+			ctx.SetValue(schemas.BifrostContextKeyHasEmittedMessageDelta, true)
+		}
+		if bifrostErr != nil {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
 				return
 			}
-			eventType, eventDataBytes, readErr := sseReader.ReadEvent()
-			if readErr != nil {
-				// Recheck context cancellation
-				if ctx.Err() != nil {
-					return
-				}
-				if readErr != io.EOF {
-					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-					logger.Warn("Error reading %s stream: %v", providerName, readErr)
-					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
-				}
-				break
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
+			break
+		}
+		// Passthrough: when conversion returns no responses but we need to forward raw events,
+		// create a minimal pass-through response to carry the raw event data.
+		// This ensures events like compaction content_block_start/stop are not silently dropped.
+		if len(responses) == 0 && sendBackRawResponse {
+			passthroughResp := &schemas.BifrostResponsesStreamResponse{
+				Type:           schemas.ResponsesStreamResponseType(eventType),
+				SequenceNumber: chunkIndex,
+				ExtraFields: schemas.BifrostResponseExtraFields{
+					ChunkIndex:  chunkIndex,
+					Latency:     time.Since(lastChunkTime).Milliseconds(),
+					RawResponse: eventData,
+				},
 			}
-			eventData := string(eventDataBytes)
-			if eventType == "" || eventData == "" {
-				continue
-			}
-			var event AnthropicStreamEvent
-			if err := sonic.Unmarshal([]byte(eventData), &event); err != nil {
-				logger.Warn("Failed to parse message_start event: %v", err)
-				continue
-			}
-			if event.Message != nil && modelName == "" {
-				modelName = event.Message.Model
-			}
-			// Note: response.created and response.in_progress are now emitted by ToBifrostResponsesStream
-			// from the message_start event, so we don't need to call them manually here
-
-			// Check for usage in both top-level event.Usage and nested event.Message.Usage
-			// message_start events have usage nested in message.usage, while message_delta has it at top level
-			var usageToProcess *AnthropicUsage
-			if event.Usage != nil {
-				usageToProcess = event.Usage
-			} else if event.Message != nil && event.Message.Usage != nil {
-				usageToProcess = event.Message.Usage
-			}
-
-			if usageToProcess != nil {
-				// Collect usage information and send at the end of the stream
-				// Here in some cases usage comes before final message
-				// So we need to check if the response.Usage is nil and then if usage != nil
-				// then add up all tokens
-				if usageToProcess.InputTokens > usage.InputTokens {
-					usage.InputTokens = usageToProcess.InputTokens
+			lastChunkTime = time.Now()
+			chunkIndex++
+			providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+				providerUtils.GetBifrostResponseForStreamResponse(nil, nil, passthroughResp, nil, nil, nil),
+				responseChan, postHookSpanFinalizer)
+			continue
+		}
+		// Handle each response in the slice
+		for i, response := range responses {
+			if response != nil {
+				response.ExtraFields = schemas.BifrostResponseExtraFields{
+					ChunkIndex: chunkIndex,
+					Latency:    time.Since(lastChunkTime).Milliseconds(),
 				}
-				if usageToProcess.OutputTokens > usage.OutputTokens {
-					usage.OutputTokens = usageToProcess.OutputTokens
-				}
-				calculatedTotal := usage.InputTokens + usage.OutputTokens
-				if calculatedTotal > usage.TotalTokens {
-					usage.TotalTokens = calculatedTotal
-				}
-				// Handle cached tokens if present
-				if usageToProcess.CacheReadInputTokens > 0 {
-					if usage.InputTokensDetails == nil {
-						usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+				if postResponseConverter != nil {
+					response = postResponseConverter(response)
+					if response == nil {
+						logger.Warn("postResponseConverter returned nil; skipping chunk")
+						continue
 					}
-					if usageToProcess.CacheReadInputTokens > usage.InputTokensDetails.CachedReadTokens {
-						usage.InputTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
-					}
-				}
-				// Handle cached tokens if present
-				if usageToProcess.CacheCreationInputTokens > 0 {
-					if usage.InputTokensDetails == nil {
-						usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
-					}
-					if usageToProcess.CacheCreationInputTokens > usage.InputTokensDetails.CachedWriteTokens {
-						usage.InputTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
-					}
-					if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
-						if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
-							usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
-						}
-						if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
-							usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
-						}
-						if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
-							usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
-						}
-					}
-				}
-			}
-
-			responses, bifrostErr, isLastChunk := event.ToBifrostResponsesStream(ctx, chunkIndex, streamState)
-			// Propagate message_delta emission flag to context so the output converter
-			// (ToAnthropicResponsesStreamResponse) can skip synthesizing a duplicate.
-			if streamState.HasEmittedMessageDelta {
-				ctx.SetValue(schemas.BifrostContextKeyHasEmittedMessageDelta, true)
-			}
-			if bifrostErr != nil {
-				// If context was cancelled/timed out, let defer handle it
-				if ctx.Err() != nil {
-					return
-				}
-				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
-				break
-			}
-			// Passthrough: when conversion returns no responses but we need to forward raw events,
-			// create a minimal pass-through response to carry the raw event data.
-			// This ensures events like compaction content_block_start/stop are not silently dropped.
-			if len(responses) == 0 && sendBackRawResponse {
-				passthroughResp := &schemas.BifrostResponsesStreamResponse{
-					Type:           schemas.ResponsesStreamResponseType(eventType),
-					SequenceNumber: chunkIndex,
-					ExtraFields: schemas.BifrostResponseExtraFields{
-						ChunkIndex:  chunkIndex,
-						Latency:     time.Since(lastChunkTime).Milliseconds(),
-						RawResponse: eventData,
-					},
 				}
 				lastChunkTime = time.Now()
 				chunkIndex++
-				providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
-					providerUtils.GetBifrostResponseForStreamResponse(nil, nil, passthroughResp, nil, nil, nil),
-					responseChan, postHookSpanFinalizer)
-				continue
-			}
-			// Handle each response in the slice
-			for i, response := range responses {
-				if response != nil {
-					response.ExtraFields = schemas.BifrostResponseExtraFields{
-						ChunkIndex: chunkIndex,
-						Latency:    time.Since(lastChunkTime).Milliseconds(),
-					}
-					if postResponseConverter != nil {
-						response = postResponseConverter(response)
-						if response == nil {
-							logger.Warn("postResponseConverter returned nil; skipping chunk")
-							continue
-						}
-					}
-					lastChunkTime = time.Now()
-					chunkIndex++
 
-					// Only add raw response to the last chunk of the incoming event
-					if providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse) && i == len(responses)-1 {
-						response.ExtraFields.RawResponse = eventData
-					}
-
-					if isLastChunk && i == len(responses)-1 {
-						if response.Response == nil {
-							response.Response = &schemas.BifrostResponsesResponse{}
-						}
-						if usage.InputTokensDetails != nil {
-							usage.InputTokens = usage.InputTokens + usage.InputTokensDetails.CachedReadTokens + usage.InputTokensDetails.CachedWriteTokens
-							usage.TotalTokens = usage.TotalTokens + usage.InputTokensDetails.CachedReadTokens + usage.InputTokensDetails.CachedWriteTokens
-						}
-						response.Response.Usage = usage
-						// Set raw request if enabled
-						if sendBackRawRequest {
-							providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonBody)
-						}
-						response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
-						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
-						return
-					}
-					providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+				// Only add raw response to the last chunk of the incoming event
+				if providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse) && i == len(responses)-1 {
+					response.ExtraFields.RawResponse = eventData
 				}
+
+				if isLastChunk && i == len(responses)-1 {
+					if response.Response == nil {
+						response.Response = &schemas.BifrostResponsesResponse{}
+					}
+					if usage.InputTokensDetails != nil {
+						usage.InputTokens = usage.InputTokens + usage.InputTokensDetails.CachedReadTokens + usage.InputTokensDetails.CachedWriteTokens
+						usage.TotalTokens = usage.TotalTokens + usage.InputTokensDetails.CachedReadTokens + usage.InputTokensDetails.CachedWriteTokens
+					}
+					response.Response.Usage = usage
+					// Set raw request if enabled
+					if sendBackRawRequest {
+						providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonBody)
+					}
+					response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+					return
+				}
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
 			}
-
 		}
-	}()
 
-	return responseChan, nil
+	}
 }
 
 // BatchCreate creates a new batch job.

--- a/core/providers/bedrock/anthropicstream.go
+++ b/core/providers/bedrock/anthropicstream.go
@@ -1,0 +1,123 @@
+package bedrock
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// bedrockAnthropicEventReader adapts Bedrock's AWS EventStream framing to the
+// providerUtils.SSEEventReader contract so that Claude-on-Bedrock streams can be
+// driven by the shared anthropic.StreamAnthropicChatEvents /
+// StreamAnthropicResponsesEvents loops.
+//
+// Bedrock's invoke-with-response-stream returns binary EventStream frames, each
+// "event" frame carrying one native Anthropic SSE chunk inside a {"bytes": ...}
+// payload. This reader decodes a frame, unwraps the inner chunk, and derives the
+// SSE-style event type from the chunk's own "type" field (the same value the
+// native `event:` line carries). AWS exception frames and transport failures are
+// surfaced as *anthropic.StreamReaderError so the shared loop can forward a
+// BifrostError with the right retry status code.
+type bedrockAnthropicEventReader struct {
+	decoder      *eventstream.Decoder
+	src          io.Reader
+	payloadBuf   []byte
+	providerName schemas.ModelProvider
+}
+
+// newBedrockAnthropicEventReader builds a reader over an already-wrapped body
+// stream (idle-timeout + cancellation wrapping is the caller's responsibility).
+func newBedrockAnthropicEventReader(src io.Reader, providerName schemas.ModelProvider) *bedrockAnthropicEventReader {
+	return &bedrockAnthropicEventReader{
+		decoder:      eventstream.NewDecoder(),
+		src:          src,
+		payloadBuf:   make([]byte, 0, 1024*1024), // 1MB payload buffer
+		providerName: providerName,
+	}
+}
+
+// ReadEvent implements providerUtils.SSEEventReader. It returns the next decoded
+// Anthropic chunk as (eventType, rawChunkJSON), io.EOF at end of stream, or an
+// error. Retryable AWS exceptions and transport errors are wrapped in
+// *anthropic.StreamReaderError carrying a classified *schemas.BifrostError.
+func (r *bedrockAnthropicEventReader) ReadEvent() (string, []byte, error) {
+	for {
+		message, err := r.decoder.Decode(r.src, r.payloadBuf)
+		if err != nil {
+			if err == io.EOF {
+				return "", nil, io.EOF
+			}
+			// Transport-level errors (stale/closed connection, unexpected EOF,
+			// checksum) are retryable — emit a non-Bifrost network error so the
+			// retry gate in executeRequestWithRetries can retry transparently.
+			if isStreamTransportError(err) {
+				return "", nil, &anthropic.StreamReaderError{BifrostError: &schemas.BifrostError{
+					IsBifrostError: false,
+					Error: &schemas.ErrorField{
+						Message: schemas.ErrProviderNetworkError,
+						Error:   err,
+					},
+				}}
+			}
+			return "", nil, err
+		}
+
+		if len(message.Payload) == 0 {
+			continue
+		}
+
+		// Non-"event" message types carry AWS exception details in their headers.
+		if msgTypeHeader := message.Headers.Get(":message-type"); msgTypeHeader != nil {
+			if msgType := msgTypeHeader.String(); msgType != "event" {
+				excType := msgType
+				if excHeader := message.Headers.Get(":exception-type"); excHeader != nil {
+					if v := excHeader.String(); v != "" {
+						excType = v
+					}
+				}
+				errMsg := string(message.Payload)
+				var bedrockErr BedrockError
+				if e := sonic.Unmarshal(message.Payload, &bedrockErr); e == nil && bedrockErr.Message != "" {
+					errMsg = bedrockErr.Message
+				}
+				// Retryable AWS exceptions must not set IsBifrostError:true — that would
+				// bypass the retry gate. Emit IsBifrostError:false with the equivalent
+				// HTTP status code so transientServerStatusCodes / perKeyFailureStatusCodes
+				// drive the retry.
+				if statusCode, ok := retryableBedrockExceptions[excType]; ok {
+					return "", nil, &anthropic.StreamReaderError{BifrostError: &schemas.BifrostError{
+						IsBifrostError: false,
+						StatusCode:     &statusCode,
+						Error: &schemas.ErrorField{
+							Message: fmt.Sprintf("%s stream %s: %s", r.providerName, excType, errMsg),
+						},
+					}}
+				}
+				// Non-retryable exceptions (e.g. validationException, accessDeniedException)
+				// are terminal — return a plain error so the shared loop forwards them via
+				// ProcessAndSendError (IsBifrostError:true) and they are NOT retried.
+				return "", nil, fmt.Errorf("%s stream %s: %s", r.providerName, excType, errMsg)
+			}
+		}
+
+		// Normal event: payload wraps a native Anthropic SSE chunk in its bytes field.
+		var chunkPayload struct {
+			Bytes []byte `json:"bytes"`
+		}
+		if e := sonic.Unmarshal(message.Payload, &chunkPayload); e != nil {
+			return "", nil, e
+		}
+
+		// Derive the SSE-style event type from the embedded chunk's "type" field,
+		// mirroring the native Anthropic `event:` line that the shared loop expects.
+		var typed struct {
+			Type string `json:"type"`
+		}
+		_ = sonic.Unmarshal(chunkPayload.Bytes, &typed)
+		return typed.Type, chunkPayload.Bytes, nil
+	}
+}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1265,6 +1265,34 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.Body, provider.logger)
 		defer stopCancellation()
 
+		// Claude models stream native Anthropic SSE chunks wrapped in EventStream
+		// frames — drive them through the shared Anthropic loop via an adapter reader.
+		// The post-response converter preserves Bedrock's response identity (a locally
+		// generated id and the requested model id).
+		if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+			id := uuid.New().String()
+			providerName := provider.GetProviderKey()
+			anthropic.StreamAnthropicChatEvents(
+				ctx,
+				newBedrockAnthropicEventReader(idleReader, providerName),
+				responseChan,
+				jsonData,
+				startTime,
+				providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+				providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+				providerName,
+				postHookRunner,
+				func(r *schemas.BifrostChatResponse) *schemas.BifrostChatResponse {
+					r.ID = id
+					r.Model = request.Model
+					return r
+				},
+				provider.logger,
+				postHookSpanFinalizer,
+			)
+			return
+		}
+
 		// Process AWS Event Stream format
 		usage := &schemas.BifrostLLMUsage{}
 		var finishReason *string
@@ -1286,14 +1314,6 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 		}
 
 		streamState := NewBedrockStreamStateWithContext(ctx)
-		// Anthropic chat-completion stream state — must persist across the
-		// entire stream so parallel tool calls receive sequential indices.
-		// Nil-passing into ToBifrostChatCompletionStream creates fresh state
-		// per chunk and resets nextToolCallIndex to 0 every time.
-		var anthropicChatStreamState *anthropic.AnthropicStreamState
-		if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-			anthropicChatStreamState = anthropic.NewAnthropicStreamState()
-		}
 		var isAccumulatingStructuredOutput bool
 		var structuredOutputBuilder strings.Builder
 
@@ -1361,237 +1381,105 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 					}
 				}
 
-				if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-					// For Anthropic models via InvokeModel, each EventStream event wraps
-					// an Anthropic SSE chunk in its bytes field.
-					var chunkPayload struct {
-						Bytes []byte `json:"bytes"`
-					}
-					if err := sonic.Unmarshal(message.Payload, &chunkPayload); err != nil {
-						provider.logger.Debug("Failed to parse EventStream chunk payload: %v", err)
-						providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
-						return
-					}
+				// Converse API path: parse Bedrock Converse-specific stream events
+				var streamEvent BedrockStreamEvent
+				if err := sonic.Unmarshal(message.Payload, &streamEvent); err != nil {
+					provider.logger.Debug("Failed to parse JSON from event buffer: %v, data: %s", err, string(message.Payload))
+					providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
+					return
+				}
 
-					var streamEvent anthropic.AnthropicStreamEvent
-					if err := sonic.Unmarshal(chunkPayload.Bytes, &streamEvent); err != nil {
-						provider.logger.Debug("Failed to parse Anthropic stream event: %v, data: %s", err, string(chunkPayload.Bytes))
-						providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
-						return
+				if streamEvent.Usage != nil {
+					// Accumulate usage information instead of overwriting
+					// In some cases usage comes in multiple events, so we need to take the maximum values
+					if streamEvent.Usage.InputTokens > usage.PromptTokens {
+						usage.PromptTokens = streamEvent.Usage.InputTokens
 					}
-
-					// Accumulate usage from Anthropic events
-					var usageToProcess *anthropic.AnthropicUsage
-					if streamEvent.Usage != nil {
-						usageToProcess = streamEvent.Usage
-					} else if streamEvent.Message != nil && streamEvent.Message.Usage != nil {
-						usageToProcess = streamEvent.Message.Usage
+					if streamEvent.Usage.OutputTokens > usage.CompletionTokens {
+						usage.CompletionTokens = streamEvent.Usage.OutputTokens
 					}
-					if usageToProcess != nil {
-						if usageToProcess.InputTokens > usage.PromptTokens {
-							usage.PromptTokens = usageToProcess.InputTokens
+					if streamEvent.Usage.TotalTokens > usage.TotalTokens {
+						usage.TotalTokens = streamEvent.Usage.TotalTokens
+					}
+					// Handle cached tokens if present
+					if streamEvent.Usage.CacheReadInputTokens > 0 {
+						if usage.PromptTokensDetails == nil {
+							usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
 						}
-						if usageToProcess.OutputTokens > usage.CompletionTokens {
-							usage.CompletionTokens = usageToProcess.OutputTokens
+						if streamEvent.Usage.CacheReadInputTokens > usage.PromptTokensDetails.CachedReadTokens {
+							usage.PromptTokensDetails.CachedReadTokens = streamEvent.Usage.CacheReadInputTokens
 						}
-						calculatedTotal := usage.PromptTokens + usage.CompletionTokens
-						if calculatedTotal > usage.TotalTokens {
-							usage.TotalTokens = calculatedTotal
+					}
+					if streamEvent.Usage.CacheWriteInputTokens > 0 {
+						if usage.PromptTokensDetails == nil {
+							usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
 						}
-						if usageToProcess.CacheReadInputTokens > 0 {
-							if usage.PromptTokensDetails == nil {
-								usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
-							}
-							if usageToProcess.CacheReadInputTokens > usage.PromptTokensDetails.CachedReadTokens {
-								usage.PromptTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
-							}
+						if streamEvent.Usage.CacheWriteInputTokens > usage.PromptTokensDetails.CachedWriteTokens {
+							usage.PromptTokensDetails.CachedWriteTokens = streamEvent.Usage.CacheWriteInputTokens
 						}
-						if usageToProcess.CacheCreationInputTokens > 0 {
-							if usage.PromptTokensDetails == nil {
-								usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+						if streamEvent.Usage.CacheDetails != nil {
+							if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
+								usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
 							}
-							if usageToProcess.CacheCreationInputTokens > usage.PromptTokensDetails.CachedWriteTokens {
-								usage.PromptTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
-							}
-							if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
-								if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
-									usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+							for _, cacheDetail := range *streamEvent.Usage.CacheDetails {
+								if cacheDetail.TTL == BedrockCacheWriteTTL5m {
+									usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
 								}
-								if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
-									usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
-								}
-								if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
-									usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
+								if cacheDetail.TTL == BedrockCacheWriteTTL1h {
+									usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
 								}
 							}
 						}
 					}
+				}
 
-					if streamEvent.Delta != nil && streamEvent.Delta.StopReason != nil {
-						mapped := anthropic.ConvertAnthropicFinishReasonToBifrost(*streamEvent.Delta.StopReason)
-						finishReason = &mapped
-						if structuredOutputToolName != "" && *finishReason == string(schemas.BifrostFinishReasonToolCalls) {
-							finishReason = schemas.Ptr(string(schemas.BifrostFinishReasonStop))
+				if streamEvent.StopReason != nil {
+					finishReason = schemas.Ptr(anthropic.ConvertAnthropicFinishReasonToBifrost(anthropic.AnthropicStopReason(*streamEvent.StopReason)))
+
+					// Override finish reason for structured output
+					// When structured output is used, tool_use stop reason should appear as "stop" to the client
+					if structuredOutputToolName != "" && *finishReason == string(schemas.BifrostFinishReasonToolCalls) {
+						finishReason = schemas.Ptr(string(schemas.BifrostFinishReasonStop))
+					}
+				}
+
+				// Handle structured output: intercept tool calls for the structured output tool
+				// and convert them to content instead of forwarding as tool calls
+				if structuredOutputToolName != "" {
+					// Check for tool use start event
+					if streamEvent.Start != nil && streamEvent.Start.ToolUse != nil {
+						if streamEvent.Start.ToolUse.Name == structuredOutputToolName {
+							// This is the structured output tool - start accumulating, don't forward
+							isAccumulatingStructuredOutput = true
+							continue
 						}
 					}
 
-					response, bifrostErr, isLastChunk := streamEvent.ToBifrostChatCompletionStream(ctx, structuredOutputToolName, anthropicChatStreamState)
-					if bifrostErr != nil {
-						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
-						return
-					}
-					if response != nil {
-						response.ID = id
-						response.Model = request.Model
-						response.ExtraFields = schemas.BifrostResponseExtraFields{
-							ChunkIndex: chunkIndex,
-							Latency:    time.Since(lastChunkTime).Milliseconds(),
-						}
-						chunkIndex++
-						lastChunkTime = time.Now()
-						if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-							response.ExtraFields.RawResponse = string(chunkPayload.Bytes)
-						}
-						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
-					}
-					if isLastChunk {
-						break
-					}
-				} else {
-					// Converse API path: parse Bedrock Converse-specific stream events
-					var streamEvent BedrockStreamEvent
-					if err := sonic.Unmarshal(message.Payload, &streamEvent); err != nil {
-						provider.logger.Debug("Failed to parse JSON from event buffer: %v, data: %s", err, string(message.Payload))
-						providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
-						return
-					}
+					// Check for tool use delta event
+					if streamEvent.Delta != nil && streamEvent.Delta.ToolUse != nil && isAccumulatingStructuredOutput {
+						// Accumulate the input for tracking purposes
+						structuredOutputBuilder.WriteString(streamEvent.Delta.ToolUse.Input)
 
-					if streamEvent.Usage != nil {
-						// Accumulate usage information instead of overwriting
-						// In some cases usage comes in multiple events, so we need to take the maximum values
-						if streamEvent.Usage.InputTokens > usage.PromptTokens {
-							usage.PromptTokens = streamEvent.Usage.InputTokens
-						}
-						if streamEvent.Usage.OutputTokens > usage.CompletionTokens {
-							usage.CompletionTokens = streamEvent.Usage.OutputTokens
-						}
-						if streamEvent.Usage.TotalTokens > usage.TotalTokens {
-							usage.TotalTokens = streamEvent.Usage.TotalTokens
-						}
-						// Handle cached tokens if present
-						if streamEvent.Usage.CacheReadInputTokens > 0 {
-							if usage.PromptTokensDetails == nil {
-								usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
-							}
-							if streamEvent.Usage.CacheReadInputTokens > usage.PromptTokensDetails.CachedReadTokens {
-								usage.PromptTokensDetails.CachedReadTokens = streamEvent.Usage.CacheReadInputTokens
-							}
-						}
-						if streamEvent.Usage.CacheWriteInputTokens > 0 {
-							if usage.PromptTokensDetails == nil {
-								usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
-							}
-							if streamEvent.Usage.CacheWriteInputTokens > usage.PromptTokensDetails.CachedWriteTokens {
-								usage.PromptTokensDetails.CachedWriteTokens = streamEvent.Usage.CacheWriteInputTokens
-							}
-							if streamEvent.Usage.CacheDetails != nil {
-								if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
-									usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
-								}
-								for _, cacheDetail := range *streamEvent.Usage.CacheDetails {
-									if cacheDetail.TTL == BedrockCacheWriteTTL5m {
-										usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
-									}
-									if cacheDetail.TTL == BedrockCacheWriteTTL1h {
-										usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
-									}
-								}
-							}
-						}
-					}
-
-					if streamEvent.StopReason != nil {
-						finishReason = schemas.Ptr(anthropic.ConvertAnthropicFinishReasonToBifrost(anthropic.AnthropicStopReason(*streamEvent.StopReason)))
-
-						// Override finish reason for structured output
-						// When structured output is used, tool_use stop reason should appear as "stop" to the client
-						if structuredOutputToolName != "" && *finishReason == string(schemas.BifrostFinishReasonToolCalls) {
-							finishReason = schemas.Ptr(string(schemas.BifrostFinishReasonStop))
-						}
-					}
-
-					// Handle structured output: intercept tool calls for the structured output tool
-					// and convert them to content instead of forwarding as tool calls
-					if structuredOutputToolName != "" {
-						// Check for tool use start event
-						if streamEvent.Start != nil && streamEvent.Start.ToolUse != nil {
-							if streamEvent.Start.ToolUse.Name == structuredOutputToolName {
-								// This is the structured output tool - start accumulating, don't forward
-								isAccumulatingStructuredOutput = true
-								continue
-							}
-						}
-
-						// Check for tool use delta event
-						if streamEvent.Delta != nil && streamEvent.Delta.ToolUse != nil && isAccumulatingStructuredOutput {
-							// Accumulate the input for tracking purposes
-							structuredOutputBuilder.WriteString(streamEvent.Delta.ToolUse.Input)
-
-							// Convert tool use delta to content delta
-							content := streamEvent.Delta.ToolUse.Input
-							response := &schemas.BifrostChatResponse{
-								ID:     id,
-								Model:  request.Model,
-								Object: "chat.completion.chunk",
-								Choices: []schemas.BifrostResponseChoice{
-									{
-										Index: 0,
-										ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
-											Delta: &schemas.ChatStreamResponseChoiceDelta{
-												Content: &content,
-											},
+						// Convert tool use delta to content delta
+						content := streamEvent.Delta.ToolUse.Input
+						response := &schemas.BifrostChatResponse{
+							ID:     id,
+							Model:  request.Model,
+							Object: "chat.completion.chunk",
+							Choices: []schemas.BifrostResponseChoice{
+								{
+									Index: 0,
+									ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+										Delta: &schemas.ChatStreamResponseChoiceDelta{
+											Content: &content,
 										},
 									},
 								},
-								ExtraFields: schemas.BifrostResponseExtraFields{
-									ChunkIndex: chunkIndex,
-									Latency:    time.Since(lastChunkTime).Milliseconds(),
-								},
-							}
-							chunkIndex++
-							lastChunkTime = time.Now()
-
-							if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-								response.ExtraFields.RawResponse = string(message.Payload)
-							}
-
-							providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
-							continue
-						}
-
-						// Suppress non-tool content events that would leak into the
-						// assembled structured output (mirrors ResponsesStreamRequest).
-						if streamEvent.Delta != nil && (streamEvent.Delta.Text != nil || streamEvent.Delta.ReasoningContent != nil) {
-							continue
-						}
-						if streamEvent.Start != nil && streamEvent.Start.ToolUse == nil {
-							continue // non-tool content-block start (text block) — drop
-						}
-					}
-
-					response, bifrostErr, _ := streamEvent.ToBifrostChatCompletionStream(streamState)
-					if bifrostErr != nil {
-						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
-						return
-					}
-					if response != nil {
-						response.ID = id
-						response.Model = request.Model
-						response.ExtraFields = schemas.BifrostResponseExtraFields{
-							ChunkIndex: chunkIndex,
-							Latency:    time.Since(lastChunkTime).Milliseconds(),
+							},
+							ExtraFields: schemas.BifrostResponseExtraFields{
+								ChunkIndex: chunkIndex,
+								Latency:    time.Since(lastChunkTime).Milliseconds(),
+							},
 						}
 						chunkIndex++
 						lastChunkTime = time.Now()
@@ -1601,11 +1489,44 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 						}
 
 						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
+						continue
 					}
 
-					if usage.PromptTokensDetails != nil {
-						usage.PromptTokens = usage.PromptTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
+					// Suppress non-tool content events that would leak into the
+					// assembled structured output (mirrors ResponsesStreamRequest).
+					if streamEvent.Delta != nil && (streamEvent.Delta.Text != nil || streamEvent.Delta.ReasoningContent != nil) {
+						continue
 					}
+					if streamEvent.Start != nil && streamEvent.Start.ToolUse == nil {
+						continue // non-tool content-block start (text block) — drop
+					}
+				}
+
+				response, bifrostErr, _ := streamEvent.ToBifrostChatCompletionStream(streamState)
+				if bifrostErr != nil {
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
+					return
+				}
+				if response != nil {
+					response.ID = id
+					response.Model = request.Model
+					response.ExtraFields = schemas.BifrostResponseExtraFields{
+						ChunkIndex: chunkIndex,
+						Latency:    time.Since(lastChunkTime).Milliseconds(),
+					}
+					chunkIndex++
+					lastChunkTime = time.Now()
+
+					if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+						response.ExtraFields.RawResponse = string(message.Payload)
+					}
+
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
+				}
+
+				if usage.PromptTokensDetails != nil {
+					usage.PromptTokens = usage.PromptTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
 				}
 			}
 		}
@@ -1823,6 +1744,29 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.Body, provider.logger)
 		defer stopCancellation()
 
+		// Claude models stream native Anthropic SSE chunks wrapped in EventStream
+		// frames — drive them through the shared Anthropic Responses loop via an
+		// adapter reader. Identity/model are carried by the converted events, so no
+		// post-response converter is needed.
+		if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+			providerName := provider.GetProviderKey()
+			anthropic.StreamAnthropicResponsesEvents(
+				ctx,
+				newBedrockAnthropicEventReader(idleReader, providerName),
+				responseChan,
+				jsonData,
+				startTime,
+				providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+				providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+				providerName,
+				postHookRunner,
+				nil,
+				provider.logger,
+				postHookSpanFinalizer,
+			)
+			return
+		}
+
 		// Process AWS Event Stream format
 		usage := &schemas.ResponsesResponseUsage{}
 		var streamTrace *BedrockConverseTrace
@@ -1833,13 +1777,6 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 		streamState.Model = &request.Model
 		streamState.Ctx = ctx
 		defer releaseBedrockResponsesStreamState(streamState)
-
-		// Create stream state for Anthropic path
-		var anthropicStreamState *anthropic.AnthropicResponsesStreamState
-		if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-			anthropicStreamState = anthropic.AcquireAnthropicResponsesStreamState()
-			defer anthropic.ReleaseAnthropicResponsesStreamState(anthropicStreamState)
-		}
 
 		// Check for structured output mode - if set, we need to intercept tool calls
 		// and convert them to content instead of forwarding as tool calls
@@ -1868,31 +1805,29 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 				if err == io.EOF {
 					// For Converse API: finalize any open items at end of stream.
 					// For Anthropic path the stream terminates via isLastChunk signal instead.
-					if !schemas.IsAnthropicModelFamily(ctx, request.Model) {
-						finalResponses := FinalizeBedrockStream(streamState, chunkIndex, usage, streamTrace)
-						for i, finalResponse := range finalResponses {
-							finalResponse.ExtraFields = schemas.BifrostResponseExtraFields{
-								ChunkIndex: chunkIndex,
-								Latency:    time.Since(lastChunkTime).Milliseconds(),
-							}
-							chunkIndex++
-							lastChunkTime = time.Now()
-
-							if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-								finalResponse.ExtraFields.RawResponse = "{}" // Final event has no payload
-							}
-
-							if i == len(finalResponses)-1 {
-								// Set raw request if enabled
-								ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-								if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-									providerUtils.ParseAndSetRawRequest(&finalResponse.ExtraFields, jsonData)
-								}
-								finalResponse.ExtraFields.Latency = time.Since(startTime).Milliseconds()
-							}
-
-							providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, finalResponse, nil, nil, nil), responseChan, postHookSpanFinalizer)
+					finalResponses := FinalizeBedrockStream(streamState, chunkIndex, usage, streamTrace)
+					for i, finalResponse := range finalResponses {
+						finalResponse.ExtraFields = schemas.BifrostResponseExtraFields{
+							ChunkIndex: chunkIndex,
+							Latency:    time.Since(lastChunkTime).Milliseconds(),
 						}
+						chunkIndex++
+						lastChunkTime = time.Now()
+
+						if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+							finalResponse.ExtraFields.RawResponse = "{}" // Final event has no payload
+						}
+
+						if i == len(finalResponses)-1 {
+							// Set raw request if enabled
+							ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+							if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+								providerUtils.ParseAndSetRawRequest(&finalResponse.ExtraFields, jsonData)
+							}
+							finalResponse.ExtraFields.Latency = time.Since(startTime).Milliseconds()
+						}
+
+						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, finalResponse, nil, nil, nil), responseChan, postHookSpanFinalizer)
 					}
 					break
 				}
@@ -1945,265 +1880,132 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 					}
 				}
 
-				if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-					// For Anthropic models via InvokeModel, each EventStream event wraps
-					// an Anthropic SSE chunk in its bytes field.
-					var chunkPayload struct {
-						Bytes []byte `json:"bytes"`
-					}
-					if err := sonic.Unmarshal(message.Payload, &chunkPayload); err != nil {
-						provider.logger.Debug("Failed to parse EventStream chunk payload: %v", err)
-						providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
-						return
-					}
+				// Converse API path: parse Bedrock Converse-specific stream events
+				var streamEvent BedrockStreamEvent
+				if err := sonic.Unmarshal(message.Payload, &streamEvent); err != nil {
+					provider.logger.Debug("Failed to parse JSON from event buffer: %v, data: %s", err, string(message.Payload))
+					providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
+					return
+				}
 
-					var streamEvent anthropic.AnthropicStreamEvent
-					if err := sonic.Unmarshal(chunkPayload.Bytes, &streamEvent); err != nil {
-						provider.logger.Debug("Failed to parse Anthropic stream event: %v, data: %s", err, string(chunkPayload.Bytes))
-						providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
-						return
-					}
+				if streamEvent.Trace != nil {
+					streamTrace = streamEvent.Trace
+				}
 
-					// Accumulate usage from Anthropic events
-					var usageToProcess *anthropic.AnthropicUsage
-					if streamEvent.Usage != nil {
-						usageToProcess = streamEvent.Usage
-					} else if streamEvent.Message != nil && streamEvent.Message.Usage != nil {
-						usageToProcess = streamEvent.Message.Usage
+				if streamEvent.Usage != nil {
+					// Accumulate usage information instead of overwriting
+					// In some cases usage comes in multiple events, so we need to take the maximum values
+					if streamEvent.Usage.InputTokens > usage.InputTokens {
+						usage.InputTokens = streamEvent.Usage.InputTokens
 					}
-					if usageToProcess != nil {
-						if usageToProcess.InputTokens > usage.InputTokens {
-							usage.InputTokens = usageToProcess.InputTokens
+					if streamEvent.Usage.OutputTokens > usage.OutputTokens {
+						usage.OutputTokens = streamEvent.Usage.OutputTokens
+					}
+					if streamEvent.Usage.TotalTokens > usage.TotalTokens {
+						usage.TotalTokens = streamEvent.Usage.TotalTokens
+					}
+					// Handle cached tokens if present
+					if streamEvent.Usage.CacheReadInputTokens > 0 {
+						if usage.InputTokensDetails == nil {
+							usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
 						}
-						if usageToProcess.OutputTokens > usage.OutputTokens {
-							usage.OutputTokens = usageToProcess.OutputTokens
+						if streamEvent.Usage.CacheReadInputTokens > usage.InputTokensDetails.CachedReadTokens {
+							usage.InputTokensDetails.CachedReadTokens = streamEvent.Usage.CacheReadInputTokens
 						}
-						calculatedTotal := usage.InputTokens + usage.OutputTokens
-						if calculatedTotal > usage.TotalTokens {
-							usage.TotalTokens = calculatedTotal
+					}
+					if streamEvent.Usage.CacheWriteInputTokens > 0 {
+						if usage.InputTokensDetails == nil {
+							usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
 						}
-						if usageToProcess.CacheReadInputTokens > 0 {
-							if usage.InputTokensDetails == nil {
-								usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
-							}
-							if usageToProcess.CacheReadInputTokens > usage.InputTokensDetails.CachedReadTokens {
-								usage.InputTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
-							}
+						if streamEvent.Usage.CacheWriteInputTokens > usage.InputTokensDetails.CachedWriteTokens {
+							usage.InputTokensDetails.CachedWriteTokens = streamEvent.Usage.CacheWriteInputTokens
 						}
-						if usageToProcess.CacheCreationInputTokens > 0 {
-							if usage.InputTokensDetails == nil {
-								usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+						if streamEvent.Usage.CacheDetails != nil {
+							if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
+								usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
 							}
-							if usageToProcess.CacheCreationInputTokens > usage.InputTokensDetails.CachedWriteTokens {
-								usage.InputTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
-							}
-							if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
-								if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
-									usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+							for _, cacheDetail := range *streamEvent.Usage.CacheDetails {
+								if cacheDetail.TTL == BedrockCacheWriteTTL5m {
+									usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
 								}
-								if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
-									usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
-								}
-								if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
-									usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
+								if cacheDetail.TTL == BedrockCacheWriteTTL1h {
+									usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
 								}
 							}
 						}
 					}
+				}
 
-					responses, bifrostErr, isLastChunk := streamEvent.ToBifrostResponsesStream(ctx, chunkIndex, anthropicStreamState)
-					// Propagate message_delta emission flag to context so the output converter
-					// (ToAnthropicResponsesStreamResponse) can skip synthesizing a duplicate.
-					if anthropicStreamState != nil && anthropicStreamState.HasEmittedMessageDelta {
-						ctx.SetValue(schemas.BifrostContextKeyHasEmittedMessageDelta, true)
+				// Handle structured output: intercept tool calls for the structured output tool
+				// and convert them to content instead of forwarding as tool calls
+				if structuredOutputToolName != "" {
+					// Check for tool use start event
+					if streamEvent.Start != nil && streamEvent.Start.ToolUse != nil {
+						if streamEvent.Start.ToolUse.Name == structuredOutputToolName {
+							// This is the structured output tool - start accumulating, don't forward
+							isAccumulatingStructuredOutput = true
+							streamState.UsedStructuredOutputTool = true
+							continue
+						}
 					}
-					if bifrostErr != nil {
-						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
-						return
-					}
-					// Passthrough: when conversion returns no responses but we need to forward raw events,
-					// create a minimal pass-through response to carry the raw event data.
-					// This ensures events like compaction content_block_start/stop are not silently dropped.
-					if len(responses) == 0 && providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-						passthroughResp := &schemas.BifrostResponsesStreamResponse{
-							Type:           schemas.ResponsesStreamResponseType(streamEvent.Type),
+
+					// Check for tool use delta event
+					if streamEvent.Delta != nil && streamEvent.Delta.ToolUse != nil && isAccumulatingStructuredOutput {
+						// Convert tool use delta to text delta
+						content := streamEvent.Delta.ToolUse.Input
+						response := &schemas.BifrostResponsesStreamResponse{
+							Type:           schemas.ResponsesStreamResponseTypeOutputTextDelta,
 							SequenceNumber: chunkIndex,
+							Delta:          &content,
 							ExtraFields: schemas.BifrostResponseExtraFields{
-								ChunkIndex:  chunkIndex,
-								Latency:     time.Since(lastChunkTime).Milliseconds(),
-								RawResponse: string(chunkPayload.Bytes),
+								ChunkIndex: chunkIndex,
+								Latency:    time.Since(lastChunkTime).Milliseconds(),
 							},
 						}
-						lastChunkTime = time.Now()
 						chunkIndex++
-						providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
-							providerUtils.GetBifrostResponseForStreamResponse(nil, nil, passthroughResp, nil, nil, nil),
-							responseChan, postHookSpanFinalizer)
-					}
-					for i, response := range responses {
-						if response != nil {
-							response.ExtraFields = schemas.BifrostResponseExtraFields{
-								ChunkIndex: chunkIndex,
-								Latency:    time.Since(lastChunkTime).Milliseconds(),
-							}
-							chunkIndex++
-							lastChunkTime = time.Now()
-							// Only attach raw response to the last response of the incoming event
-							if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) && i == len(responses)-1 {
-								response.ExtraFields.RawResponse = string(chunkPayload.Bytes)
-							}
-							// Finalize the very last chunk of the stream with accumulated usage,
-							// raw request, total latency, and the stream-end indicator.
-							if isLastChunk && i == len(responses)-1 {
-								if response.Response == nil {
-									response.Response = &schemas.BifrostResponsesResponse{}
-								}
-								if usage.InputTokensDetails != nil {
-									usage.InputTokens = usage.InputTokens + usage.InputTokensDetails.CachedReadTokens + usage.InputTokensDetails.CachedWriteTokens
-									usage.TotalTokens = usage.TotalTokens + usage.InputTokensDetails.CachedReadTokens + usage.InputTokensDetails.CachedWriteTokens
-								}
-								response.Response.Usage = usage
-								if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-									providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonData)
-								}
-								response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
-								ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-							}
-							providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+						lastChunkTime = time.Now()
+
+						if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+							response.ExtraFields.RawResponse = string(message.Payload)
 						}
-					}
-					if isLastChunk {
-						return
-					}
-				} else {
-					// Converse API path: parse Bedrock Converse-specific stream events
-					var streamEvent BedrockStreamEvent
-					if err := sonic.Unmarshal(message.Payload, &streamEvent); err != nil {
-						provider.logger.Debug("Failed to parse JSON from event buffer: %v, data: %s", err, string(message.Payload))
-						providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
-						return
+
+						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+						continue
 					}
 
-					if streamEvent.Trace != nil {
-						streamTrace = streamEvent.Trace
+					// Suppress non-tool content events that would leak into the
+					// assembled structured output. Bedrock Claude can emit prose
+					// alongside the forced tool call (markdown, preambles, reasoning
+					// blocks); forwarding those as text deltas corrupts the JSON
+					// the client assembles from the structured-output stream.
+					if streamEvent.Delta != nil && (streamEvent.Delta.Text != nil || streamEvent.Delta.ReasoningContent != nil) {
+						continue
 					}
-
-					if streamEvent.Usage != nil {
-						// Accumulate usage information instead of overwriting
-						// In some cases usage comes in multiple events, so we need to take the maximum values
-						if streamEvent.Usage.InputTokens > usage.InputTokens {
-							usage.InputTokens = streamEvent.Usage.InputTokens
-						}
-						if streamEvent.Usage.OutputTokens > usage.OutputTokens {
-							usage.OutputTokens = streamEvent.Usage.OutputTokens
-						}
-						if streamEvent.Usage.TotalTokens > usage.TotalTokens {
-							usage.TotalTokens = streamEvent.Usage.TotalTokens
-						}
-						// Handle cached tokens if present
-						if streamEvent.Usage.CacheReadInputTokens > 0 {
-							if usage.InputTokensDetails == nil {
-								usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
-							}
-							if streamEvent.Usage.CacheReadInputTokens > usage.InputTokensDetails.CachedReadTokens {
-								usage.InputTokensDetails.CachedReadTokens = streamEvent.Usage.CacheReadInputTokens
-							}
-						}
-						if streamEvent.Usage.CacheWriteInputTokens > 0 {
-							if usage.InputTokensDetails == nil {
-								usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
-							}
-							if streamEvent.Usage.CacheWriteInputTokens > usage.InputTokensDetails.CachedWriteTokens {
-								usage.InputTokensDetails.CachedWriteTokens = streamEvent.Usage.CacheWriteInputTokens
-							}
-							if streamEvent.Usage.CacheDetails != nil {
-								if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
-									usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
-								}
-								for _, cacheDetail := range *streamEvent.Usage.CacheDetails {
-									if cacheDetail.TTL == BedrockCacheWriteTTL5m {
-										usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
-									}
-									if cacheDetail.TTL == BedrockCacheWriteTTL1h {
-										usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
-									}
-								}
-							}
-						}
+					if streamEvent.Start != nil && streamEvent.Start.ToolUse == nil {
+						continue // non-tool content-block start (text block) — drop
 					}
+				}
 
-					// Handle structured output: intercept tool calls for the structured output tool
-					// and convert them to content instead of forwarding as tool calls
-					if structuredOutputToolName != "" {
-						// Check for tool use start event
-						if streamEvent.Start != nil && streamEvent.Start.ToolUse != nil {
-							if streamEvent.Start.ToolUse.Name == structuredOutputToolName {
-								// This is the structured output tool - start accumulating, don't forward
-								isAccumulatingStructuredOutput = true
-								streamState.UsedStructuredOutputTool = true
-								continue
-							}
+				responses, bifrostErr, _ := streamEvent.ToBifrostResponsesStream(chunkIndex, streamState)
+				if bifrostErr != nil {
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
+					return
+				}
+				for _, response := range responses {
+					if response != nil {
+						response.ExtraFields = schemas.BifrostResponseExtraFields{
+							ChunkIndex: chunkIndex,
+							Latency:    time.Since(lastChunkTime).Milliseconds(),
+						}
+						chunkIndex++
+						lastChunkTime = time.Now()
+
+						if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+							response.ExtraFields.RawResponse = string(message.Payload)
 						}
 
-						// Check for tool use delta event
-						if streamEvent.Delta != nil && streamEvent.Delta.ToolUse != nil && isAccumulatingStructuredOutput {
-							// Convert tool use delta to text delta
-							content := streamEvent.Delta.ToolUse.Input
-							response := &schemas.BifrostResponsesStreamResponse{
-								Type:           schemas.ResponsesStreamResponseTypeOutputTextDelta,
-								SequenceNumber: chunkIndex,
-								Delta:          &content,
-								ExtraFields: schemas.BifrostResponseExtraFields{
-									ChunkIndex: chunkIndex,
-									Latency:    time.Since(lastChunkTime).Milliseconds(),
-								},
-							}
-							chunkIndex++
-							lastChunkTime = time.Now()
-
-							if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-								response.ExtraFields.RawResponse = string(message.Payload)
-							}
-
-							providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
-							continue
-						}
-
-						// Suppress non-tool content events that would leak into the
-						// assembled structured output. Bedrock Claude can emit prose
-						// alongside the forced tool call (markdown, preambles, reasoning
-						// blocks); forwarding those as text deltas corrupts the JSON
-						// the client assembles from the structured-output stream.
-						if streamEvent.Delta != nil && (streamEvent.Delta.Text != nil || streamEvent.Delta.ReasoningContent != nil) {
-							continue
-						}
-						if streamEvent.Start != nil && streamEvent.Start.ToolUse == nil {
-							continue // non-tool content-block start (text block) — drop
-						}
-					}
-
-					responses, bifrostErr, _ := streamEvent.ToBifrostResponsesStream(chunkIndex, streamState)
-					if bifrostErr != nil {
-						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
-						return
-					}
-					for _, response := range responses {
-						if response != nil {
-							response.ExtraFields = schemas.BifrostResponseExtraFields{
-								ChunkIndex: chunkIndex,
-								Latency:    time.Since(lastChunkTime).Milliseconds(),
-							}
-							chunkIndex++
-							lastChunkTime = time.Now()
-
-							if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-								response.ExtraFields.RawResponse = string(message.Payload)
-							}
-
-							providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
-						}
+						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Claude-on-Bedrock streaming previously duplicated the entire Anthropic SSE event loop inline, maintaining its own per-chunk state and accumulating usage independently. This PR replaces that duplicated path with a shared `bedrockAnthropicEventReader` adapter that translates Bedrock's binary AWS EventStream framing into the `SSEEventReader` contract, allowing both `ChatCompletionStream` and `ResponsesStream` for Anthropic models on Bedrock to be driven by the canonical `StreamAnthropicChatEvents` / `StreamAnthropicResponsesEvents` loops.

## Changes

- Extracted the Anthropic SSE event loop out of the inline goroutine closure in `HandleAnthropicChatCompletionStreaming` and `HandleAnthropicResponsesStream` into standalone exported functions `StreamAnthropicChatEvents` and `StreamAnthropicResponsesEvents`. These accept any `SSEEventReader`, decoupling wire framing from event processing.
- Introduced `StreamReaderError`, a sentinel error type that lets a custom `SSEEventReader` surface a fully-formed `*schemas.BifrostError` through the `ReadEvent` contract. The shared loops detect it via `errors.As` and forward the embedded error verbatim, preserving status codes so the retry gate behaves correctly. The native SSE reader never returns this type, so existing SSE callers are unaffected.
- Added `bedrockAnthropicEventReader` (in `core/providers/bedrock/anthropicstream.go`), which decodes AWS EventStream frames, unwraps the inner Anthropic SSE chunk from the `{"bytes": ...}` payload, and derives the SSE-style event type from the chunk's own `type` field. AWS exception frames are classified as retryable or terminal and surfaced as `*StreamReaderError` or plain errors respectively, preserving Bedrock's retry semantics.
- In `BedrockProvider.ChatCompletionStream` and `BedrockProvider.ResponsesStream`, Anthropic model families now early-exit into `StreamAnthropicChatEvents` / `StreamAnthropicResponsesEvents` via the adapter reader. A post-response converter on the chat path stamps each chunk with a locally generated ID and the requested model ID. The Converse API path for non-Anthropic models is unchanged.
- Removed the now-redundant inline Anthropic stream state (`anthropicChatStreamState`, `anthropicStreamState`), duplicated usage accumulation, and the per-chunk `ToBifrostChatCompletionStream` / `ToBifrostResponsesStream` dispatch that previously lived inside the Bedrock event loop for Anthropic models.
- Fixed a minor ordering issue in the chat event loop: `response.ID = messageID` is now assigned before `postResponseConverter` runs, giving converters (e.g. Bedrock's ID/model override) the final say on those fields.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Invoke a Claude model via Bedrock with `ChatCompletionStream` and verify streamed chunks arrive with correct IDs, model names, usage, and finish reasons.
- Invoke a Claude model via Bedrock with `ResponsesStream` and verify the same.
- Trigger a throttling or `serviceUnavailableException` from Bedrock and confirm the retry gate fires as expected (retryable status code preserved).
- Invoke a non-Anthropic Bedrock model (e.g. Titan, Llama) and confirm the Converse API path is unaffected.
- Run a structured output request through both the Anthropic and Bedrock Claude paths and confirm the finish reason is `stop` and content is correctly assembled.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. No new auth surfaces, secrets handling, or PII exposure introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and recovery for streaming failures across Anthropic and Bedrock providers.

* **Refactor**
  * Consolidated streaming logic for Anthropic models in Bedrock to reduce code duplication and ensure consistent behavior.
  * Enhanced structured-output handling during streaming responses for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->