### PR TITLE
refactor: extract shared `ParseAnthropicChatResponse`/`ParseAnthropicResponsesResponse` assemblers and reuse across Azure, Bedrock, and Vertex

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -452,32 +452,46 @@ func (provider *AnthropicProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 		}, nil
 	}
 
-	// Create response object from pool
-	response := AcquireAnthropicMessageResponse()
-	defer ReleaseAnthropicMessageResponse(response)
+	return ParseAnthropicChatResponse(ctx, responseBody, jsonData, latency, providerResponseHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
+}
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+// ParseAnthropicChatResponse parses a raw Anthropic Messages API response body into a
+// BifrostChatResponse, populating latency, provider response headers, and raw
+// request/response. Every provider targeting the Anthropic Messages endpoint (native
+// Anthropic, Bedrock InvokeModel, Vertex rawPredict, Azure) returns identical JSON here,
+// so only transport differs — callers do their own request/sign/send and hand the bytes
+// to this shared assembler. Callers set RequestType/Model afterward if they need to.
+func ParseAnthropicChatResponse(
+	ctx *schemas.BifrostContext,
+	responseBody, jsonBody []byte,
+	latency time.Duration,
+	providerResponseHeaders map[string]string,
+	sendBackRawRequest, sendBackRawResponse bool,
+) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	anthropicResponse := AcquireAnthropicMessageResponse()
+	defer ReleaseAnthropicMessageResponse(anthropicResponse)
+
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse))
 	if bifrostErr != nil {
-		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, sendBackRawRequest, sendBackRawResponse)
 	}
 	// Create final response
-	bifrostResponse := response.ToBifrostChatResponse(ctx)
+	response := anthropicResponse.ToBifrostChatResponse(ctx)
 
 	// Set ExtraFields
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
+	response.ExtraFields.Latency = latency.Milliseconds()
+	response.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
 
 	// Set raw request if enabled
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		bifrostResponse.ExtraFields.RawRequest = rawRequest
+	if providerUtils.ShouldSendBackRawRequest(ctx, sendBackRawRequest) {
+		response.ExtraFields.RawRequest = rawRequest
 	}
 
 	// Set raw response if enabled
-	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	if providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse) {
+		response.ExtraFields.RawResponse = rawResponse
 	}
-
-	return bifrostResponse, nil
+	return response, nil
 }
 
 // ChatCompletionStream performs a streaming chat completion request to the Anthropic API.
@@ -980,32 +994,44 @@ func (provider *AnthropicProvider) Responses(ctx *schemas.BifrostContext, key sc
 	}
 
 	// Create response object from pool
-	response := AcquireAnthropicMessageResponse()
-	defer ReleaseAnthropicMessageResponse(response)
+	return ParseAnthropicResponsesResponse(ctx, responseBody, jsonBody, latency, providerResponseHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
+}
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+// ParseAnthropicResponsesResponse is the Responses-API counterpart to
+// ParseAnthropicChatResponse: it assembles a BifrostResponsesResponse from a raw
+// Anthropic Messages API response body shared across all providers.
+func ParseAnthropicResponsesResponse(
+	ctx *schemas.BifrostContext,
+	responseBody, jsonBody []byte,
+	latency time.Duration,
+	providerResponseHeaders map[string]string,
+	sendBackRawRequest, sendBackRawResponse bool,
+) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	anthropicResponse := AcquireAnthropicMessageResponse()
+	defer ReleaseAnthropicMessageResponse(anthropicResponse)
+
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse))
 	if bifrostErr != nil {
-		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	// Create final response
-	bifrostResponse := response.ToBifrostResponsesResponse(ctx)
+	response := anthropicResponse.ToBifrostResponsesResponse(ctx)
 
 	// Set ExtraFields
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
+	response.ExtraFields.Latency = latency.Milliseconds()
+	response.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
 
 	// Set raw request if enabled
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		bifrostResponse.ExtraFields.RawRequest = rawRequest
+	if providerUtils.ShouldSendBackRawRequest(ctx, sendBackRawRequest) {
+		response.ExtraFields.RawRequest = rawRequest
 	}
 
 	// Set raw response if enabled
-	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	if providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse) {
+		response.ExtraFields.RawResponse = rawResponse
 	}
-
-	return bifrostResponse, nil
+	return response, nil
 }
 
 // ResponsesStream performs a streaming responses request to the Anthropic API.

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -523,7 +523,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 	}
 
 	var path string
-	if schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		path = "anthropic/v1/messages"
 	} else {
 		path = "openai/v1/chat/completions"
@@ -558,19 +558,13 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 	var rawRequest interface{}
 	var rawResponse interface{}
 
-	if schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic {
-		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
-		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-		response = anthropicResponse.ToBifrostChatResponse(ctx)
-	} else {
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+		// Parse Anthropic Messages API response (shared assembler).
+		return anthropic.ParseAnthropicChatResponse(ctx, responseBody, jsonData, latency, providerResponseHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+	rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	response.ExtraFields.Latency = latency.Milliseconds()
@@ -599,7 +593,7 @@ func (provider *AzureProvider) ChatCompletionStream(ctx *schemas.BifrostContext,
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
 	var url string
-	if schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic {
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
 		authHeader, err := provider.getAzureAuthHeaders(ctx, key, true)
 		if err != nil {
 			return nil, err
@@ -732,18 +726,12 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 	var rawResponse interface{}
 
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
-		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-		response = anthropicResponse.ToBifrostResponsesResponse(ctx)
-	} else {
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
+		// Parse Anthropic Messages API response (shared assembler).
+		return anthropic.ParseAnthropicResponsesResponse(ctx, responseBody, jsonData, latency, providerResponseHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+	rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	response.ExtraFields.Latency = latency.Milliseconds()

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1118,30 +1118,10 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
-	var bifrostResponse *schemas.BifrostChatResponse
-
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		// Parse Anthropic Messages API response
-		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
-		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
+		// Parse Anthropic Messages API response (shared assembler)
+		return anthropic.ParseAnthropicChatResponse(ctx, responseBody, jsonData, latency, providerResponseHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
 
-		rawRequest, rawResponse, err := providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if err != nil {
-			return nil, providerUtils.EnrichError(ctx, err, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-		bifrostResponse = anthropicResponse.ToBifrostChatResponse(ctx)
-
-		// Set ExtraFields
-		bifrostResponse.ExtraFields.RequestType = schemas.ChatCompletionRequest
-		bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-		bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
-
-		if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-			bifrostResponse.ExtraFields.RawRequest = rawRequest
-		}
-		if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-			bifrostResponse.ExtraFields.RawResponse = rawResponse
-		}
 	} else {
 		// Parse Bedrock Converse API response
 		bedrockResponse := acquireBedrockChatResponse()
@@ -1153,8 +1133,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 		}
 
 		// Convert using the new response converter
-		var err error
-		bifrostResponse, err = bedrockResponse.ToBifrostChatResponse(ctx, request.Model)
+		bifrostResponse, err := bedrockResponse.ToBifrostChatResponse(ctx, request.Model)
 		if err != nil {
 			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
@@ -1181,9 +1160,9 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 				bifrostResponse.ExtraFields.RawResponse = rawResponse
 			}
 		}
-	}
+		return bifrostResponse, nil
 
-	return bifrostResponse, nil
+	}
 }
 
 // ChatCompletionStream performs a streaming chat completion request to Bedrock's API.
@@ -1601,29 +1580,9 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
-	var bifrostResponse *schemas.BifrostResponsesResponse
-	var err error
-
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		// Parse Anthropic Messages API response
-		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
-		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
-
-		rawRequest, rawResponse, err := providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if err != nil {
-			return nil, providerUtils.EnrichError(ctx, err, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-		bifrostResponse = anthropicResponse.ToBifrostResponsesResponse(ctx)
-
-		bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-		bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
-
-		if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-			bifrostResponse.ExtraFields.RawRequest = rawRequest
-		}
-		if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-			bifrostResponse.ExtraFields.RawResponse = rawResponse
-		}
+		// Parse Anthropic Messages API response (shared assembler)
+		return anthropic.ParseAnthropicResponsesResponse(ctx, responseBody, jsonData, latency, providerResponseHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	} else {
 		// Parse Bedrock Converse API response
 		bedrockResponse := acquireBedrockChatResponse()
@@ -1635,7 +1594,7 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 		}
 
 		// Convert using the new response converter
-		bifrostResponse, err = bedrockResponse.ToBifrostResponsesResponse(ctx)
+		bifrostResponse, err := bedrockResponse.ToBifrostResponsesResponse(ctx)
 		if err != nil {
 			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
@@ -1658,9 +1617,8 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 				bifrostResponse.ExtraFields.RawResponse = rawResponse
 			}
 		}
+		return bifrostResponse, nil
 	}
-
-	return bifrostResponse, nil
 }
 
 // ResponsesStream performs a streaming chat completion request to Bedrock's API.

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -676,34 +676,9 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	}
 
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		// Create response object from pool
-		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
-		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
-
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-
-		// Create final response
-		response := anthropicResponse.ToBifrostChatResponse(ctx)
-
-		response.ExtraFields = schemas.BifrostResponseExtraFields{
-			Latency:                 latency.Milliseconds(),
-			ProviderResponseHeaders: providerUtils.ExtractProviderResponseHeaders(resp),
-		}
-
-		// Set raw request if enabled
-		if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-			response.ExtraFields.RawRequest = rawRequest
-		}
-
-		// Set raw response if enabled
-		if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-			response.ExtraFields.RawResponse = rawResponse
-		}
-
-		return response, nil
+		// Parse Anthropic Messages API response (shared assembler — Vertex rawPredict
+		// returns identical JSON to the native Anthropic endpoint).
+		return anthropic.ParseAnthropicChatResponse(ctx, responseBody, jsonBody, latency, providerUtils.ExtractProviderResponseHeaders(resp), provider.sendBackRawRequest, provider.sendBackRawResponse)
 	} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 		geminiResponse := gemini.GenerateContentResponse{}
 
@@ -1077,34 +1052,8 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 			}, nil
 		}
 
-		// Create response object from pool
-		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
-		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
-
-		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-
-		// Create final response
-		response := anthropicResponse.ToBifrostResponsesResponse(ctx)
-
-		response.ExtraFields = schemas.BifrostResponseExtraFields{
-			Latency: latency.Milliseconds(),
-		}
-
-		response.ExtraFields.ProviderResponseHeaders = providerUtils.ExtractProviderResponseHeaders(resp)
-		// Set raw request if enabled
-		if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-			response.ExtraFields.RawRequest = rawRequest
-		}
-
-		// Set raw response if enabled
-		if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-			response.ExtraFields.RawResponse = rawResponse
-		}
-
-		return response, nil
+		// Parse Anthropic Messages API response (shared assembler).
+		return anthropic.ParseAnthropicResponsesResponse(ctx, responseBody, jsonBody, latency, providerUtils.ExtractProviderResponseHeaders(resp), provider.sendBackRawRequest, provider.sendBackRawResponse)
 	} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
 		jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 			ctx,


### PR DESCRIPTION
## Summary

The Anthropic Messages API response JSON is identical across all providers that target it (native Anthropic, Bedrock InvokeModel, Vertex rawPredict, Azure). Previously, each provider duplicated the same pool acquire/release, `HandleProviderResponse`, `ToBifrostChatResponse`/`ToBifrostResponsesResponse`, and `ExtraFields` assembly logic inline. This PR extracts that repeated logic into two shared functions — `ParseAnthropicChatResponse` and `ParseAnthropicResponsesResponse` — and replaces all call sites with a single delegating call.

## Changes

- Extracted the Anthropic Messages API response parsing and assembly logic from `AnthropicProvider.ChatCompletion` and `AnthropicProvider.Responses` into exported functions `ParseAnthropicChatResponse` and `ParseAnthropicResponsesResponse` in the `anthropic` package.
- Replaced the duplicated inline Anthropic response handling in the Azure, Bedrock, and Vertex providers with calls to these shared assemblers.
- Replaced `schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic` comparisons in the Azure provider with the already-existing `schemas.IsAnthropicModelFamily` helper for consistency.
- The `else` branches in Bedrock's `ChatCompletion` and `Responses` now use short-scoped `:=` declarations, removing previously hoisted `var` declarations that were only needed to bridge the two branches.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Exercise chat completion and responses API calls against Azure, Bedrock (Anthropic models), Vertex (Anthropic models), and native Anthropic to confirm responses, latency, provider headers, raw request/response passthrough, and error enrichment all behave identically to before.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. No auth, secrets, or PII handling was changed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated Anthropic response parsing logic into shared helper functions, reducing code duplication across multiple providers (Azure, Bedrock, Vertex). Response handling and error management behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->