### PR TITLE
fix(compat): preserve max_output_tokens on Responses requests

### DIFF
--- a/plugins/compat/dropparams.go
+++ b/plugins/compat/dropparams.go
@@ -128,7 +128,12 @@ func dropUnsupportedParams(ctx *schemas.BifrostContext, req *schemas.BifrostRequ
 	if req.ResponsesRequest != nil && req.ResponsesRequest.Params != nil {
 		params := req.ResponsesRequest.Params
 
-		if params.MaxOutputTokens != nil && !isSupported["max_output_tokens"] {
+		// max_output_tokens is the Responses-API equivalent of chat max_tokens / max_completion_tokens.
+		// so if any of those token-cap spellings is supported, we let max_output_tokens pass through.
+		if params.MaxOutputTokens != nil &&
+			!isSupported["max_output_tokens"] &&
+			!isSupported["max_tokens"] &&
+			!isSupported["max_completion_tokens"] {
 			params.MaxOutputTokens = nil
 			dropped = append(dropped, "max_output_tokens")
 		}

--- a/plugins/compat/dropparams_test.go
+++ b/plugins/compat/dropparams_test.go
@@ -1,0 +1,172 @@
+package compat
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func newTestContext() *schemas.BifrostContext {
+	return schemas.NewBifrostContext(context.Background(), time.Time{})
+}
+
+func newResponsesRequest(provider schemas.ModelProvider, model string, params *schemas.ResponsesParameters) *schemas.BifrostRequest {
+	return &schemas.BifrostRequest{
+		RequestType:      schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{Provider: provider, Model: model, Params: params},
+	}
+}
+
+// TestDropUnsupportedParams_MaxOutputTokens verifies that the Responses-API
+// max_output_tokens cap is preserved whenever the (chat-named) model parameter
+// catalog authorizes the token cap under any spelling
+// (max_output_tokens / max_tokens / max_completion_tokens), and dropped only
+// when none of them is supported.
+func TestDropUnsupportedParams_MaxOutputTokens(t *testing.T) {
+	tests := []struct {
+		name          string
+		provider      schemas.ModelProvider
+		model         string
+		supported     []string
+		wantPreserved bool
+	}{
+		{
+			name:          "openai gpt-4o-mini lists chat max_tokens only",
+			provider:      schemas.OpenAI,
+			model:         "gpt-4o-mini",
+			supported:     []string{"temperature", "top_p", "max_tokens", "stop", "tools"},
+			wantPreserved: true,
+		},
+		{
+			name:          "openai o4-mini lists max_completion_tokens",
+			provider:      schemas.OpenAI,
+			model:         "o4-mini",
+			supported:     []string{"temperature", "max_completion_tokens"},
+			wantPreserved: true,
+		},
+		{
+			name:          "model lists max_output_tokens explicitly",
+			provider:      schemas.OpenAI,
+			model:         "gpt-oss-120b",
+			supported:     []string{"temperature", "max_output_tokens"},
+			wantPreserved: true,
+		},
+		{
+			name:          "anthropic claude lists max_tokens",
+			provider:      schemas.Anthropic,
+			model:         "claude-sonnet-4",
+			supported:     []string{"temperature", "max_tokens", "top_p"},
+			wantPreserved: true,
+		},
+		{
+			name:          "vertex gemini lists max_tokens",
+			provider:      schemas.Vertex,
+			model:         "gemini-2.5-pro",
+			supported:     []string{"temperature", "max_tokens"},
+			wantPreserved: true,
+		},
+		{
+			name:          "no token cap supported drops max_output_tokens",
+			provider:      schemas.OpenAI,
+			model:         "no-token-cap-model",
+			supported:     []string{"temperature", "top_p"},
+			wantPreserved: false,
+		},
+		{
+			name:          "unknown model with empty catalog drops max_output_tokens",
+			provider:      schemas.OpenAI,
+			model:         "unknown-model",
+			supported:     []string{},
+			wantPreserved: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := newResponsesRequest(tt.provider, tt.model, &schemas.ResponsesParameters{
+				MaxOutputTokens: schemas.Ptr(16),
+				Temperature:     schemas.Ptr(0.5),
+			})
+
+			dropped := dropUnsupportedParams(newTestContext(), req, tt.supported)
+			got := req.ResponsesRequest.Params.MaxOutputTokens
+
+			if tt.wantPreserved {
+				if got == nil {
+					t.Fatalf("max_output_tokens = dropped, want preserved (supported=%v)", tt.supported)
+				}
+				if *got != 16 {
+					t.Errorf("max_output_tokens = %d, want 16", *got)
+				}
+				if slices.Contains(dropped, "max_output_tokens") {
+					t.Errorf("max_output_tokens reported in dropped=%v, want absent", dropped)
+				}
+				return
+			}
+
+			if got != nil {
+				t.Fatalf("max_output_tokens = %d, want dropped (supported=%v)", *got, tt.supported)
+			}
+			if !slices.Contains(dropped, "max_output_tokens") {
+				t.Errorf("max_output_tokens not reported in dropped=%v, want present", dropped)
+			}
+		})
+	}
+}
+
+// TestDropUnsupportedParams_MaxOutputTokensSurgical verifies the fix is
+// surgical: within one Responses request, max_output_tokens is preserved (chat
+// token cap supported) while an unsupported sibling (top_p) is still dropped.
+func TestDropUnsupportedParams_MaxOutputTokensSurgical(t *testing.T) {
+	req := newResponsesRequest(schemas.OpenAI, "gpt-4o-mini", &schemas.ResponsesParameters{
+		MaxOutputTokens: schemas.Ptr(16),
+		TopP:            schemas.Ptr(0.9),
+		Temperature:     schemas.Ptr(0.5),
+	})
+
+	dropped := dropUnsupportedParams(newTestContext(), req, []string{"max_tokens", "temperature"})
+
+	p := req.ResponsesRequest.Params
+	if p.MaxOutputTokens == nil {
+		t.Errorf("max_output_tokens = dropped, want preserved")
+	}
+	if p.TopP != nil {
+		t.Errorf("top_p = preserved, want dropped")
+	}
+	if p.Temperature == nil {
+		t.Errorf("temperature = dropped, want preserved")
+	}
+	if !slices.Contains(dropped, "top_p") {
+		t.Errorf("top_p not reported in dropped=%v, want present", dropped)
+	}
+}
+
+// TestDropUnsupportedParams_ChatMaxCompletionTokensUnchanged guards the
+// pre-existing chat-branch behaviour that the Responses fix mirrors.
+func TestDropUnsupportedParams_ChatMaxCompletionTokensUnchanged(t *testing.T) {
+	newChat := func() *schemas.BifrostRequest {
+		return &schemas.BifrostRequest{
+			RequestType: schemas.ChatCompletionRequest,
+			ChatRequest: &schemas.BifrostChatRequest{
+				Provider: schemas.OpenAI,
+				Model:    "gpt-4o-mini",
+				Params:   &schemas.ChatParameters{MaxCompletionTokens: schemas.Ptr(16)},
+			},
+		}
+	}
+
+	keep := newChat()
+	dropUnsupportedParams(newTestContext(), keep, []string{"max_tokens"})
+	if keep.ChatRequest.Params.MaxCompletionTokens == nil {
+		t.Errorf("max_completion_tokens = dropped, want preserved (max_tokens supported)")
+	}
+
+	drop := newChat()
+	dropUnsupportedParams(newTestContext(), drop, []string{"temperature"})
+	if drop.ChatRequest.Params.MaxCompletionTokens != nil {
+		t.Errorf("max_completion_tokens = preserved, want dropped (no token cap supported)")
+	}
+}


### PR DESCRIPTION
## Summary

`compat.should_drop_params` silently drops `max_output_tokens` from `POST /v1/responses` requests, so the token cap never reaches the provider and the model generates up to its own default limit. Fixes #4354.

Root cause: the model-parameter catalog is chat-named. It lists `max_tokens` for ~9.8k models but `max_output_tokens` for only 3, so `dropUnsupportedParams` treats the Responses-API token cap as "unsupported" for virtually every model (e.g. `gpt-4o-mini`) and strips it, while `temperature` and the other params survive.

The chat branch already handles the same equivalence for `max_completion_tokens` — it is kept when `max_tokens` is supported. This applies the identical rule to the Responses-API `max_output_tokens` field.

## Changes

- `plugins/compat/dropparams.go`: keep `max_output_tokens` when the model supports the token cap under any spelling (`max_output_tokens`, `max_tokens`, or `max_completion_tokens`), mirroring the existing `max_completion_tokens` rule in the chat branch.
- `plugins/compat/dropparams_test.go` (new): first unit tests for the compat plugin — a model matrix (OpenAI / Anthropic / Vertex), a surgical case (genuinely unsupported siblings such as `top_p` are still dropped), and a chat-branch regression guard.

Single-module change. A follow-up PR will add an end-to-end `PreLLMHook` test for the `should_drop_params` toggle plus a small `modelcatalog` test helper to seed supported parameters — that helper would make the compat module depend on an as-yet-unreleased `framework` symbol, so it is kept out of this fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd plugins/compat && go test ./...
```

Reverting `dropparams.go` makes `TestDropUnsupportedParams_MaxOutputTokens` fail; with the fix, all pass. `go vet ./...` and `gofmt -l` are clean.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes #4354

## Security considerations

None. The change only affects which request parameters are forwarded. It does not relax validation: a parameter a model genuinely does not support is still dropped, and `should_drop_params: false` already forwards everything. If a provider rejects a forwarded param it surfaces as a provider error rather than a silent drop — consistent with the existing `max_completion_tokens` behaviour.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced output token parameter filtering to be more permissive: output token parameters now pass through when at least one alternative token-cap parameter spelling is supported, improving compatibility across different providers.

* **Tests**
  * Added comprehensive unit tests validating token parameter handling across various provider configurations, including edge cases for unsupported parameter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->