### PR TITLE
test(compat): cover should_drop_params end to end + seedable model-catalog helper

### DIFF
--- a/framework/modelcatalog/datasheet/store.go
+++ b/framework/modelcatalog/datasheet/store.go
@@ -419,6 +419,16 @@ func NewTestStore(baseModelIndex map[string]string) *Store {
 	}
 }
 
+// NewTestStoreWithParams is like NewTestStore but also seeds the per-model
+// supported-parameter index, letting tests exercise parameter-dropping logic.
+func NewTestStoreWithParams(baseModelIndex map[string]string, supportedParams map[string][]string) *Store {
+	s := NewTestStore(baseModelIndex)
+	for model, params := range supportedParams {
+		s.supportedParams[model] = slices.Clone(params)
+	}
+	return s
+}
+
 // --- Internal: rebuild the datasheet view from current pricingData ---
 
 // rebuildDatasheetViewUnsafe regenerates baseModelIndex and datasheetByProvider

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -629,3 +629,11 @@ func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
 		done:      make(chan struct{}),
 	}
 }
+
+// NewTestCatalogWithParams is like NewTestCatalog but also seeds per-model
+// supported parameters, letting tests exercise parameter-dropping logic.
+func NewTestCatalogWithParams(baseModelIndex map[string]string, supportedParams map[string][]string) *ModelCatalog {
+	mc := NewTestCatalog(baseModelIndex)
+	mc.datasheet = datasheet.NewTestStoreWithParams(baseModelIndex, supportedParams)
+	return mc
+}

--- a/plugins/compat/dropparams_test.go
+++ b/plugins/compat/dropparams_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
 )
 
 func newTestContext() *schemas.BifrostContext {
@@ -169,4 +171,63 @@ func TestDropUnsupportedParams_ChatMaxCompletionTokensUnchanged(t *testing.T) {
 	if drop.ChatRequest.Params.MaxCompletionTokens != nil {
 		t.Errorf("max_completion_tokens = preserved, want dropped (no token cap supported)")
 	}
+}
+
+// TestPreLLMHook_ShouldDropParams_MaxOutputTokens exercises the user-facing
+// compat.should_drop_params toggle end to end through PreLLMHook and the model
+// catalog: with dropping enabled and a chat-named catalog (max_tokens only, the
+// real gpt-4o-mini case) the Responses token cap must survive, and with dropping
+// disabled the request is left untouched.
+func TestPreLLMHook_ShouldDropParams_MaxOutputTokens(t *testing.T) {
+	mc := modelcatalog.NewTestCatalogWithParams(nil, map[string][]string{
+		"gpt-4o-mini": {"temperature", "max_tokens"},
+	})
+	logger := bifrost.NewNoOpLogger()
+
+	// top_p is absent from the catalog (only temperature + max_tokens). Each
+	// subtest checks it too, so the drop path is proven to actually run:
+	// dropped when dropping is enabled, kept when it is disabled.
+	t.Run("should_drop_params=true keeps max_output_tokens, drops unsupported params", func(t *testing.T) {
+		p, err := Init(Config{ShouldDropParams: true}, logger, mc)
+		if err != nil {
+			t.Fatalf("Init() error = %v", err)
+		}
+		req := newResponsesRequest(schemas.OpenAI, "gpt-4o-mini", &schemas.ResponsesParameters{
+			MaxOutputTokens: schemas.Ptr(16),
+			TopP:            schemas.Ptr(0.9),
+		})
+		out, _, err := p.PreLLMHook(newTestContext(), req)
+		if err != nil {
+			t.Fatalf("PreLLMHook() error = %v", err)
+		}
+		if out.ResponsesRequest.Params.MaxOutputTokens == nil {
+			t.Errorf("max_output_tokens = dropped, want preserved")
+		}
+		// Confirms the drop branch actually executed (not silently skipped).
+		if out.ResponsesRequest.Params.TopP != nil {
+			t.Errorf("top_p = preserved, want dropped (unsupported, dropping enabled)")
+		}
+	})
+
+	t.Run("should_drop_params=false leaves request untouched", func(t *testing.T) {
+		p, err := Init(Config{ShouldDropParams: false}, logger, mc)
+		if err != nil {
+			t.Fatalf("Init() error = %v", err)
+		}
+		req := newResponsesRequest(schemas.OpenAI, "gpt-4o-mini", &schemas.ResponsesParameters{
+			MaxOutputTokens: schemas.Ptr(16),
+			TopP:            schemas.Ptr(0.9),
+		})
+		out, _, err := p.PreLLMHook(newTestContext(), req)
+		if err != nil {
+			t.Fatalf("PreLLMHook() error = %v", err)
+		}
+		// Dropping disabled: every param survives untouched, even unsupported ones.
+		if out.ResponsesRequest.Params.MaxOutputTokens == nil {
+			t.Errorf("max_output_tokens = dropped, want preserved (dropping disabled)")
+		}
+		if out.ResponsesRequest.Params.TopP == nil {
+			t.Errorf("top_p = dropped, want preserved (dropping disabled)")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Test-infrastructure follow-up to #4362. Adds end-to-end coverage for the `compat.should_drop_params` toggle and a seedable model-catalog test helper that makes the parameter-dropping path testable.

> ⚠️ **Depends on #4362** — this PR is stacked on that fix and opened as a **Draft**. Until #4362 merges, this diff also shows the fix (`plugins/compat/dropparams.go`) and its leaf tests; they drop out automatically once #4362 lands in `dev`. I'll rebase and mark this ready for review then.

## Changes

- `framework/modelcatalog/{main.go,datasheet/store.go}`: add `NewTestCatalogWithParams` / `NewTestStoreWithParams` — like the existing `NewTestCatalog` / `NewTestStore` but they also seed the per-model supported-parameter index. The existing helpers only seed the base-model index, which left the compat parameter-dropping path untestable. `NewTestCatalogWithParams` delegates to `NewTestCatalog` (per the earlier review suggestion).
- `plugins/compat/dropparams_test.go`: add `TestPreLLMHook_ShouldDropParams_MaxOutputTokens` — drives the real `PreLLMHook` entry point with `should_drop_params` `true` / `false` against a chat-named catalog (`max_tokens` only, the `gpt-4o-mini` case), asserting the Responses token cap survives when dropping is enabled and the request is left untouched when disabled.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

(The `framework/modelcatalog` change is a test-only helper.)

## How to test

With a local Go workspace (`make ... LOCAL=1`, or `go work use ./core ./framework ./plugins/compat`):

```sh
cd plugins/compat && go test ./... -run TestPreLLMHook_ShouldDropParams -v
```

`go vet ./...` and `gofmt -l` are clean.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Depends on #4362. Both stem from #4354.

## Security considerations

None — test-only changes (new test plus test-only catalog helpers).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable