### PR TITLE
fix: pass extra parameters for custom providers

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5984,7 +5984,6 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		}
 		isCustomProvider := IsCustomProvider(config)
 		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, isCustomProvider)
-		req.Context.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, isCustomProvider)
 
 		// Determine whether this provider attempt should capture raw payloads.
 		//

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5984,9 +5984,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		}
 		isCustomProvider := IsCustomProvider(config)
 		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, isCustomProvider)
-		if isCustomProvider {
-			req.Context.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
-		}
+		req.Context.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, isCustomProvider)
 
 		// Determine whether this provider attempt should capture raw payloads.
 		//

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5982,7 +5982,11 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		if cfg := config.CustomProviderConfig; cfg != nil && cfg.BaseProviderType != "" {
 			baseProvider = cfg.BaseProviderType
 		}
-		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, IsCustomProvider(config))
+		isCustomProvider := IsCustomProvider(config)
+		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, isCustomProvider)
+		if isCustomProvider {
+			req.Context.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+		}
 
 		// Determine whether this provider attempt should capture raw payloads.
 		//

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5982,7 +5982,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		if cfg := config.CustomProviderConfig; cfg != nil && cfg.BaseProviderType != "" {
 			baseProvider = cfg.BaseProviderType
 		}
-		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
+		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, IsCustomProvider(config))
 
 		// Determine whether this provider attempt should capture raw payloads.
 		//

--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -248,7 +248,7 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 			return nil, newErr(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), jsonBody)
 		}
 
-		if ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+		if providerUtils.ShouldPassthroughExtraParams(ctx) {
 			extraParams := reqBody.GetExtraParams()
 			if len(extraParams) > 0 {
 				jsonBody, err = providerUtils.MergeExtraParamsIntoJSON(jsonBody, extraParams)

--- a/core/providers/anthropic/requestbuilder_test.go
+++ b/core/providers/anthropic/requestbuilder_test.go
@@ -436,6 +436,7 @@ func TestBuildAnthropicResponsesRequestBody_TypedPath(t *testing.T) {
 	t.Run("custom_provider_forwards_extra_params_automatically", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
 		ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+		ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 
 		request := &schemas.BifrostResponsesRequest{
 			Provider: schemas.ModelProvider("custom-anthropic"),

--- a/core/providers/anthropic/requestbuilder_test.go
+++ b/core/providers/anthropic/requestbuilder_test.go
@@ -433,6 +433,39 @@ func TestBuildAnthropicResponsesRequestBody_TypedPath(t *testing.T) {
 		}
 	})
 
+	t.Run("custom_provider_forwards_extra_params_automatically", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.ModelProvider("custom-anthropic"),
+			Model:    "claude-sonnet-4-5",
+			Input:    makeSimpleInput("Hello!"),
+			Params: &schemas.ResponsesParameters{
+				ExtraParams: map[string]interface{}{
+					"custom_parameter": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+			},
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		customParameter := providerUtils.GetJSONField(result, "custom_parameter")
+		if !customParameter.Exists() {
+			t.Fatal("expected custom_parameter to be forwarded")
+		}
+		if !customParameter.Get("enabled").Bool() {
+			t.Fatal("expected custom_parameter.enabled to be true")
+		}
+	})
+
 	t.Run("typed_path_vertex_deletes_model", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
 

--- a/core/providers/bedrock/embedding_test.go
+++ b/core/providers/bedrock/embedding_test.go
@@ -116,6 +116,7 @@ func TestToBedrockCohereEmbeddingRequestBodyOmitsModel(t *testing.T) {
 func TestCustomProviderExtraParamsForwardedAutomatically(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
 	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 
 	text := "hello"
 	req := &schemas.BifrostEmbeddingRequest{

--- a/core/providers/bedrock/embedding_test.go
+++ b/core/providers/bedrock/embedding_test.go
@@ -112,3 +112,30 @@ func TestToBedrockCohereEmbeddingRequestBodyOmitsModel(t *testing.T) {
 		"embedding_types": ["float"]
 	}`, string(wireBody))
 }
+
+func TestCustomProviderExtraParamsForwardedAutomatically(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+
+	text := "hello"
+	req := &schemas.BifrostEmbeddingRequest{
+		Provider: schemas.ModelProvider("custom-bedrock"),
+		Model:    "amazon.titan-embed-text-v2:0",
+		Input:    &schemas.EmbeddingInput{Text: &text},
+		Params: &schemas.EmbeddingParameters{
+			ExtraParams: map[string]interface{}{
+				"trace_id": "req-123",
+			},
+		},
+	}
+
+	wireBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		req,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToBedrockTitanEmbeddingRequest(req)
+		},
+	)
+	require.Nil(t, bifrostErr)
+	assert.Equal(t, "req-123", providerUtils.GetJSONField(wireBody, "trace_id").String())
+}

--- a/core/providers/cohere/embedding_test.go
+++ b/core/providers/cohere/embedding_test.go
@@ -87,3 +87,30 @@ func TestToCohereEmbeddingRequestBodyIncludesModelForDirectCohere(t *testing.T) 
 		"texts": ["hello"]
 	}`, string(wireBody))
 }
+
+func TestCustomProviderExtraParamsForwardedAutomatically(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+
+	text := "hello"
+	req := &schemas.BifrostEmbeddingRequest{
+		Provider: schemas.ModelProvider("custom-cohere"),
+		Model:    "embed-v4.0",
+		Input:    &schemas.EmbeddingInput{Text: &text},
+		Params: &schemas.EmbeddingParameters{
+			ExtraParams: map[string]interface{}{
+				"priority": "high",
+			},
+		},
+	}
+
+	wireBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		req,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToCohereEmbeddingRequest(req), nil
+		},
+	)
+	require.Nil(t, bifrostErr)
+	assert.Equal(t, "high", providerUtils.GetJSONField(wireBody, "priority").String())
+}

--- a/core/providers/cohere/embedding_test.go
+++ b/core/providers/cohere/embedding_test.go
@@ -91,6 +91,7 @@ func TestToCohereEmbeddingRequestBodyIncludesModelForDirectCohere(t *testing.T) 
 func TestCustomProviderExtraParamsForwardedAutomatically(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
 	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 
 	text := "hello"
 	req := &schemas.BifrostEmbeddingRequest{

--- a/core/providers/gemini/payload_ordering_test.go
+++ b/core/providers/gemini/payload_ordering_test.go
@@ -58,6 +58,7 @@ func TestPayloadOrdering_GeminiGenerationRequest(t *testing.T) {
 func TestCustomProviderExtraParamsForwardedAutomatically(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
 	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 
 	req := &schemas.BifrostChatRequest{
 		Provider: schemas.ModelProvider("custom-gemini"),

--- a/core/providers/gemini/payload_ordering_test.go
+++ b/core/providers/gemini/payload_ordering_test.go
@@ -55,6 +55,37 @@ func TestPayloadOrdering_GeminiGenerationRequest(t *testing.T) {
 	}
 }
 
+func TestCustomProviderExtraParamsForwardedAutomatically(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+
+	req := &schemas.BifrostChatRequest{
+		Provider: schemas.ModelProvider("custom-gemini"),
+		Model:    "gemini-2.0-flash",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser}},
+		Params: &schemas.ChatParameters{
+			ExtraParams: map[string]interface{}{
+				"customParameter": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+		},
+	}
+
+	wireBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		req,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiChatCompletionRequest(req)
+		},
+	)
+	require.Nil(t, bifrostErr)
+
+	customParameter := providerUtils.GetJSONField(wireBody, "customParameter")
+	require.True(t, customParameter.Exists())
+	assert.True(t, customParameter.Get("enabled").Bool())
+}
+
 func TestNormalizeRawGenerateContentRequestForCompatibility(t *testing.T) {
 	t.Run("keeps valid audio and removes unsupported generation config fields", func(t *testing.T) {
 		raw := []byte(`{"contents":[{"parts":[{"text":"Transcribe"},{"inlineData":{"mimeType":"audio/wav","data":"UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YQAAAAA="}}]}],"generationConfig":{"responseLogprobs":true,"logprobs":3,"presencePenalty":0.5,"frequencyPenalty":0.5,"temperature":0.2}}`)

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -133,6 +133,46 @@ func TestCustomProviderExtraParamsForwardedAutomatically(t *testing.T) {
 	}
 }
 
+func TestStandardProviderExtraParamsNotForwardedAutomatically(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+
+	req := &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser}},
+		Params: &schemas.ChatParameters{
+			ExtraParams: map[string]interface{}{
+				"thinking": true,
+				"chat_template_kwargs": map[string]interface{}{
+					"enable_thinking": true,
+				},
+			},
+		},
+	}
+
+	wireBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		req,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIChatRequest(ctx, req), nil
+		},
+	)
+	if bifrostErr != nil {
+		t.Fatalf("failed to build request body: %v", bifrostErr.Error.Message)
+	}
+
+	var body map[string]interface{}
+	if err := sonic.Unmarshal(wireBody, &body); err != nil {
+		t.Fatalf("failed to parse request body: %v", err)
+	}
+	if _, ok := body["thinking"]; ok {
+		t.Fatal("thinking must not be forwarded for a standard provider")
+	}
+	if _, ok := body["chat_template_kwargs"]; ok {
+		t.Fatal("chat_template_kwargs must not be forwarded for a standard provider")
+	}
+}
+
 func TestToOpenAIChatRequest_PreservesN(t *testing.T) {
 	req := &schemas.BifrostChatRequest{
 		Provider: schemas.OpenAI,

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -81,11 +81,11 @@ func TestToOpenAIChatRequest_ToolNormalization(t *testing.T) {
 }
 
 // TestCustomProviderExtraParamsForwardedAutomatically verifies that custom
-// OpenAI-compatible providers preserve provider-specific extra params without
-// requiring BifrostContextKeyPassthroughExtraParams.
+// OpenAI-compatible providers preserve provider-specific extra params.
 func TestCustomProviderExtraParamsForwardedAutomatically(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
 	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 
 	req := &schemas.BifrostChatRequest{
 		Provider: schemas.ModelProvider("custom-openai"),

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -80,6 +80,59 @@ func TestToOpenAIChatRequest_ToolNormalization(t *testing.T) {
 	}
 }
 
+// TestCustomProviderExtraParamsForwardedAutomatically verifies that custom
+// OpenAI-compatible providers preserve provider-specific extra params without
+// requiring BifrostContextKeyPassthroughExtraParams.
+func TestCustomProviderExtraParamsForwardedAutomatically(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+
+	req := &schemas.BifrostChatRequest{
+		Provider: schemas.ModelProvider("custom-openai"),
+		Model:    "deepseek-v4",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser}},
+		Params: &schemas.ChatParameters{
+			ExtraParams: map[string]interface{}{
+				"thinking": false,
+				"chat_template_kwargs": map[string]interface{}{
+					"enable_thinking": false,
+				},
+			},
+		},
+	}
+
+	wireBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		req,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIChatRequest(ctx, req), nil
+		},
+	)
+	if bifrostErr != nil {
+		t.Fatalf("failed to build request body: %v", bifrostErr.Error.Message)
+	}
+
+	var body map[string]interface{}
+	if err := sonic.Unmarshal(wireBody, &body); err != nil {
+		t.Fatalf("failed to parse request body: %v", err)
+	}
+	if body["thinking"] != false {
+		t.Fatalf("expected thinking=false, got %v", body["thinking"])
+	}
+
+	rawKwargs, ok := body["chat_template_kwargs"]
+	if !ok {
+		t.Fatal("chat_template_kwargs missing from outgoing request body")
+	}
+	kwargs, ok := rawKwargs.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected chat_template_kwargs to be an object, got %T", rawKwargs)
+	}
+	if kwargs["enable_thinking"] != false {
+		t.Fatalf("expected enable_thinking=false, got %v", kwargs["enable_thinking"])
+	}
+}
+
 func TestToOpenAIChatRequest_PreservesN(t *testing.T) {
 	req := &schemas.BifrostChatRequest{
 		Provider: schemas.OpenAI,

--- a/core/providers/replicate/custom_provider_test.go
+++ b/core/providers/replicate/custom_provider_test.go
@@ -12,6 +12,7 @@ import (
 func TestCustomProviderTopLevelExtraParamsForwardedAutomatically(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
 	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 
 	req := &schemas.BifrostVideoGenerationRequest{
 		Provider: schemas.ModelProvider("custom-replicate"),

--- a/core/providers/replicate/custom_provider_test.go
+++ b/core/providers/replicate/custom_provider_test.go
@@ -1,0 +1,36 @@
+package replicate
+
+import (
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomProviderTopLevelExtraParamsForwardedAutomatically(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+
+	req := &schemas.BifrostVideoGenerationRequest{
+		Provider: schemas.ModelProvider("custom-replicate"),
+		Model:    "openai/sora-2-pro",
+		Input:    &schemas.VideoGenerationInput{Prompt: "hello"},
+		Params: &schemas.VideoGenerationParameters{
+			ExtraParams: map[string]interface{}{
+				"custom_parameter": "value",
+			},
+		},
+	}
+
+	wireBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		req,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToReplicateVideoGenerationInput(req)
+		},
+	)
+	require.Nil(t, bifrostErr)
+	assert.Equal(t, "value", providerUtils.GetJSONField(wireBody, "custom_parameter").String())
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1272,8 +1272,7 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 // should be preserved in the outbound request.
 func ShouldPassthroughExtraParams(ctx context.Context) bool {
 	passthroughExtraParams, _ := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams).(bool)
-	isCustomProvider, _ := ctx.Value(schemas.BifrostContextKeyIsCustomProvider).(bool)
-	return passthroughExtraParams || isCustomProvider
+	return passthroughExtraParams
 }
 
 // SetExtraHeadersHTTP sets additional headers from NetworkConfig to the standard HTTP request.

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1272,7 +1272,8 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 // should be preserved in the outbound request.
 func ShouldPassthroughExtraParams(ctx context.Context) bool {
 	passthroughExtraParams, _ := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams).(bool)
-	return passthroughExtraParams
+	isCustomProvider, _ := ctx.Value(schemas.BifrostContextKeyIsCustomProvider).(bool)
+	return passthroughExtraParams || isCustomProvider
 }
 
 // SetExtraHeadersHTTP sets additional headers from NetworkConfig to the standard HTTP request.

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1251,7 +1251,7 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 			return nil, NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 		}
 		// Merge ExtraParams into the JSON if passthrough is enabled
-		if ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams) != nil && ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+		if ShouldPassthroughExtraParams(ctx) {
 			extraParams := convertedBody.GetExtraParams()
 			if len(extraParams) > 0 {
 				// Use order-preserving merge to avoid destroying key ordering in
@@ -1266,6 +1266,14 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 	} else {
 		return rawBody, nil
 	}
+}
+
+// ShouldPassthroughExtraParams reports whether provider-specific parameters
+// should be preserved in the outbound request.
+func ShouldPassthroughExtraParams(ctx context.Context) bool {
+	passthroughExtraParams, _ := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams).(bool)
+	isCustomProvider, _ := ctx.Value(schemas.BifrostContextKeyIsCustomProvider).(bool)
+	return passthroughExtraParams || isCustomProvider
 }
 
 // SetExtraHeadersHTTP sets additional headers from NetworkConfig to the standard HTTP request.

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1145,10 +1145,9 @@ func TestMergeExtraParamsIntoJSON_DeepMerge(t *testing.T) {
 
 func TestShouldPassthroughExtraParams(t *testing.T) {
 	tests := []struct {
-		name             string
-		passthrough      bool
-		isCustomProvider bool
-		want             bool
+		name        string
+		passthrough bool
+		want        bool
 	}{
 		{
 			name: "disabled",
@@ -1158,18 +1157,12 @@ func TestShouldPassthroughExtraParams(t *testing.T) {
 			passthrough: true,
 			want:        true,
 		},
-		{
-			name:             "custom provider",
-			isCustomProvider: true,
-			want:             true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 			ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, tt.passthrough)
-			ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, tt.isCustomProvider)
 
 			if got := ShouldPassthroughExtraParams(ctx); got != tt.want {
 				t.Fatalf("ShouldPassthroughExtraParams() = %t, want %t", got, tt.want)

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1145,9 +1145,10 @@ func TestMergeExtraParamsIntoJSON_DeepMerge(t *testing.T) {
 
 func TestShouldPassthroughExtraParams(t *testing.T) {
 	tests := []struct {
-		name        string
-		passthrough bool
-		want        bool
+		name             string
+		passthrough      bool
+		isCustomProvider bool
+		want             bool
 	}{
 		{
 			name: "disabled",
@@ -1157,12 +1158,18 @@ func TestShouldPassthroughExtraParams(t *testing.T) {
 			passthrough: true,
 			want:        true,
 		},
+		{
+			name:             "custom provider",
+			isCustomProvider: true,
+			want:             true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 			ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, tt.passthrough)
+			ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, tt.isCustomProvider)
 
 			if got := ShouldPassthroughExtraParams(ctx); got != tt.want {
 				t.Fatalf("ShouldPassthroughExtraParams() = %t, want %t", got, tt.want)

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1143,6 +1143,41 @@ func TestMergeExtraParamsIntoJSON_DeepMerge(t *testing.T) {
 	}
 }
 
+func TestShouldPassthroughExtraParams(t *testing.T) {
+	tests := []struct {
+		name             string
+		passthrough      bool
+		isCustomProvider bool
+		want             bool
+	}{
+		{
+			name: "disabled",
+		},
+		{
+			name:        "explicit passthrough",
+			passthrough: true,
+			want:        true,
+		},
+		{
+			name:             "custom provider",
+			isCustomProvider: true,
+			want:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, tt.passthrough)
+			ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, tt.isCustomProvider)
+
+			if got := ShouldPassthroughExtraParams(ctx); got != tt.want {
+				t.Fatalf("ShouldPassthroughExtraParams() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMergeExtraParamsIntoJSON_EmptyExtraParams(t *testing.T) {
 	jsonBody := []byte(`{"a": 1, "b": 2}`)
 	result, err := MergeExtraParamsIntoJSON(jsonBody, map[string]interface{}{})

--- a/core/utils.go
+++ b/core/utils.go
@@ -351,6 +351,11 @@ func IsStandardProvider(providerKey schemas.ModelProvider) bool {
 	return ok
 }
 
+// IsCustomProvider reports whether config defines a custom provider.
+func IsCustomProvider(config *schemas.ProviderConfig) bool {
+	return config != nil && config.CustomProviderConfig != nil
+}
+
 // IsStreamRequestType returns true if the given request type is a stream request.
 func IsStreamRequestType(reqType schemas.RequestType) bool {
 	return reqType == schemas.TextCompletionStreamRequest || reqType == schemas.ChatCompletionStreamRequest || reqType == schemas.ResponsesStreamRequest || reqType == schemas.SpeechStreamRequest || reqType == schemas.TranscriptionStreamRequest || reqType == schemas.ImageGenerationStreamRequest || reqType == schemas.ImageEditStreamRequest || reqType == schemas.PassthroughStreamRequest || reqType == schemas.WebSocketResponsesRequest || reqType == schemas.RealtimeRequest

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/maximhq/bifrost/core/network"
+	"github.com/maximhq/bifrost/core/schemas"
 )
 
 func TestValidateExternalURL(t *testing.T) {
@@ -273,3 +274,35 @@ func TestIsPrivateIP(t *testing.T) {
 	}
 }
 
+func TestIsCustomProvider(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *schemas.ProviderConfig
+		want   bool
+	}{
+		{
+			name: "nil config",
+		},
+		{
+			name:   "standard provider config",
+			config: &schemas.ProviderConfig{},
+		},
+		{
+			name: "custom provider with standard base provider",
+			config: &schemas.ProviderConfig{
+				CustomProviderConfig: &schemas.CustomProviderConfig{
+					BaseProviderType: schemas.OpenAI,
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCustomProvider(tt.config); got != tt.want {
+				t.Fatalf("IsCustomProvider() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4272 #3181

## Changes

This handles issue of dropping extra parameters for custom providers.
It introduces IsCustomProvider helper (might be useful in future too if another provider will decide to reinvent the wheel and introduce yet another api) and reworks merging path a bit - checking if provider is custom and enabling extra parameters passing in case it's true. Actual code change is minimal, majority of it are just tests - verifying both passing parameters in case of custom and retaining old behavior for "native" ones.

It's mostly done for openai and anthropic providers, but since it affects every custom provider, i also covered bedrock, replicate, etc, although i'm not aware of any 3rd party provider actually exposing them.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Tests pass, but actual change can only be tested by adding real 3rd party provider (like dashscope) and checking against bifrost if, for example, thinking can be disabled/enabled

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

https://github.com/maximhq/bifrost/issues/4272 - my issue
https://github.com/maximhq/bifrost/issues/969 - since stuff like chat_template_kwargs can be passed now, it fully supports llamacpp/llamaswap
https://github.com/maximhq/bifrost/issues/3492 - fully supported now (initial issue was due to user's misconfiguration, and additional parameters should pass now.

Maybe more where people complained about they can't use options like thinking, max_tokens, etc in custom openai-compatible endpoints.

## Security considerations

Strictly theoretically if someone relied on sanitization of outgoing requests using current behavior, it will change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines - such file do not exist, by the way.
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable