### PR TITLE
fallback pages for bifrost edge

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -934,7 +934,7 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 		}
 	}
 	p.cfgMutex.RLock()
-	if !isVirtualKeyValid && evaluationRequest.UserID == "" && p.isVkMandatory != nil && *p.isVkMandatory {
+	if !isVirtualKeyValid && !hasDirectKeyAuth(ctx) && evaluationRequest.UserID == "" && p.isVkMandatory != nil && *p.isVkMandatory {
 		message := "virtual key is required. Provide a virtual key via the x-bf-vk header."
 		if p.isEnterprise {
 			message = "authentication is required. Provide a virtual key (x-bf-vk), API key, or user token."
@@ -1114,6 +1114,15 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 			},
 		}
 	}
+}
+
+// hasDirectKeyAuth returns true when the transport accepted an admin-enabled direct provider key.
+func hasDirectKeyAuth(ctx *schemas.BifrostContext) bool {
+	if ctx == nil {
+		return false
+	}
+	_, ok := ctx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key)
+	return ok
 }
 
 // isMCPToolAllowedByVK checks whether a tool pattern (in "clientName-toolName" or "clientName-*"

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -122,6 +122,75 @@ func TestBudgetResolver_EvaluateRequest_ModelBlocked(t *testing.T) {
 	assertDecision(t, DecisionModelBlocked, result)
 }
 
+// TestGovernancePlugin_EvaluateGovernanceRequest_DirectKeySatisfiesMandatoryAuth verifies direct provider keys satisfy mandatory auth after transport validation.
+func TestGovernancePlugin_EvaluateGovernanceRequest_DirectKeySatisfiesMandatoryAuth(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	mandatory := true
+	plugin := &GovernancePlugin{
+		store:         store,
+		resolver:      NewBudgetResolver(store, nil, logger, nil),
+		isVkMandatory: &mandatory,
+		isEnterprise:  true,
+	}
+
+	ctx := &schemas.BifrostContext{}
+	ctx.SetValue(schemas.BifrostContextKeyDirectKey, schemas.Key{
+		ID:    "header-provided",
+		Name:  "header-provided",
+		Value: schemas.EnvVar{Val: "sk-real-openai-key"},
+	})
+
+	result, bifrostErr := plugin.EvaluateGovernanceRequest(ctx, &EvaluationRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+	}, schemas.PassthroughRequest)
+
+	require.Nil(t, bifrostErr)
+	assertDecision(t, DecisionAllow, result)
+}
+
+// TestGovernancePlugin_EvaluateGovernanceRequest_HeaderWithoutContextDoesNotSatisfyMandatoryAuth verifies callers cannot spoof direct-key auth with only a request header.
+func TestGovernancePlugin_EvaluateGovernanceRequest_HeaderWithoutContextDoesNotSatisfyMandatoryAuth(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	mandatory := true
+	plugin := &GovernancePlugin{
+		store:         store,
+		resolver:      NewBudgetResolver(store, nil, logger, nil),
+		isVkMandatory: &mandatory,
+		isEnterprise:  true,
+	}
+
+	_, bifrostErr := plugin.EvaluateGovernanceRequest(&schemas.BifrostContext{}, &EvaluationRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+	}, schemas.PassthroughRequest)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, 401, *bifrostErr.StatusCode)
+	assert.Equal(t, "authentication is required. Provide a virtual key (x-bf-vk), API key, or user token.", bifrostErr.Error.Message)
+}
+
+// TestHasDirectKeyAuth reads only the transport-owned direct-key context value.
+func TestHasDirectKeyAuth(t *testing.T) {
+	ctx := &schemas.BifrostContext{}
+	assert.False(t, hasDirectKeyAuth(ctx))
+
+	ctx.SetValue(schemas.BifrostContextKeyDirectKey, schemas.Key{
+		ID:    "header-provided",
+		Name:  "header-provided",
+		Value: schemas.EnvVar{Val: "sk-real-openai-key"},
+	})
+
+	assert.True(t, hasDirectKeyAuth(ctx))
+}
+
 // TestBudgetResolver_EvaluateRequest_RateLimitExceeded_TokenLimit tests token limit
 func TestBudgetResolver_EvaluateRequest_RateLimitExceeded_TokenLimit(t *testing.T) {
 	logger := NewMockLogger()

--- a/plugins/modelcatalogresolver/go.sum
+++ b/plugins/modelcatalogresolver/go.sum
@@ -45,8 +45,7 @@ github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eT
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
-github.com/aws/aws-sdk-go-v2 v1.41.12 h1:DIKX2c31ekm9RA2D9FBj1EWXx++9AdAqRw+e78Tq2Ck=
-github.com/aws/aws-sdk-go-v2 v1.41.12/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
+github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.32.11 h1:ftxI5sgz8jZkckuUHXfC/wMUc8u3fG1vQS0plr2F2Zs=
@@ -55,10 +54,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8TH
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 h1:Xf2j7NdVcUKomlZ4iihOP4AZ3Fzlr8h4yKpXeP+OFPg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28/go.mod h1:O8cDo1dW63jU7ki//kRe1z+tLGcpnD1jrouitsQddDw=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 h1:KqIfN9kpkKkcBqBbNpNGTIrXO6ExTUvFKvXkC+YAzVo=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28/go.mod h1:uxtQiKvLtNS4iXVsH2McVD/ls8FKN/uUhe1hGxPjrw0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.5 h1:clHU5fm//kWS1C2HgtgWxfQbFbx4b6rx+5jzhgX9HrI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.5/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -501,15 +501,10 @@ func runTransportPostHooksCaptured(capturedReq *schemas.HTTPRequest, capturedRes
 	defer schemas.ReleaseHTTPRequest(req)
 	req.Method = capturedReq.Method
 	req.Path = capturedReq.Path
-	for k, v := range capturedReq.Headers {
-		req.Headers[k] = v
-	}
-	for k, v := range capturedReq.Query {
-		req.Query[k] = v
-	}
-	for k, v := range capturedReq.PathParams {
-		req.PathParams[k] = v
-	}
+
+	maps.Copy(req.Headers, capturedReq.Headers)
+	maps.Copy(req.Query, capturedReq.Query)
+	maps.Copy(req.PathParams, capturedReq.PathParams)
 
 	httpResp := schemas.AcquireHTTPResponse()
 	defer schemas.ReleaseHTTPResponse(httpResp)
@@ -853,7 +848,7 @@ func (m *AuthMiddleware) tryTempTokenOrUnauthorized(ctx *fasthttp.RequestCtx, ne
 func (m *AuthMiddleware) InferenceMiddleware() schemas.BifrostHTTPMiddleware {
 	return m.middleware(func(authConfig *configstore.AuthConfig, url string) bool {
 		return true
-	})
+	}, true)
 }
 
 // APIMiddleware is for API requests if authConfig is set, it will verify authentication based on the request type.

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -666,6 +666,9 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 	// Direct key bypass: requires both the server-side AllowDirectKeys setting and the
 	// per-request x-bf-direct-key: true header. The server setting is the admin opt-in;
 	// the header is the per-request opt-in from the caller.
+	// Enterprise SCIM inference auth runs before this context conversion, so it mirrors
+	// this config/header gate separately to avoid validating provider bearer tokens as
+	// SCIM user JWTs before direct-key extraction can happen here.
 	if store != nil && store.ShouldAllowDirectKeys() && string(ctx.Request.Header.Peek("x-bf-direct-key")) == "true" {
 		var apiKey string
 		authHeader := string(ctx.Request.Header.Peek("Authorization"))

--- a/ui/app/_fallbacks/enterprise/components/edge-control/configView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/edge-control/configView.tsx
@@ -1,0 +1,14 @@
+import { SlidersHorizontal } from "lucide-react";
+import EdgeControlFallbackView from "./fallbackWrapper";
+
+export default function ConfigView() {
+	return (
+		<EdgeControlFallbackView
+			icon={<SlidersHorizontal className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+			title="Unlock edge control to govern devices at the edge"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/edge/admin-configurations"
+			testIdPrefix="edge-config"
+		/>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/components/edge-control/devicesView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/edge-control/devicesView.tsx
@@ -1,0 +1,14 @@
+import { MonitorSmartphone } from "lucide-react";
+import EdgeControlFallbackView from "./fallbackWrapper";
+
+export default function DevicesView() {
+	return (
+		<EdgeControlFallbackView
+			icon={<MonitorSmartphone className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+			title="Unlock edge control to manage your devices"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/edge/admin-devices"
+			testIdPrefix="edge-devices"
+		/>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/components/edge-control/fallbackWrapper.tsx
+++ b/ui/app/_fallbacks/enterprise/components/edge-control/fallbackWrapper.tsx
@@ -1,0 +1,24 @@
+import ContactUsView from "../views/contactUsView";
+
+interface EdgeControlFallbackViewProps {
+	icon: React.ReactNode;
+	title: string;
+	description: string;
+	readmeLink: string;
+	testIdPrefix?: string;
+}
+
+export default function EdgeControlFallbackView({ icon, title, description, readmeLink, testIdPrefix }: EdgeControlFallbackViewProps) {
+	return (
+		<div className="h-full w-full">
+			<ContactUsView
+				className="mx-auto min-h-[80vh]"
+				icon={icon}
+				title={title}
+				description={description}
+				readmeLink={readmeLink}
+				testIdPrefix={testIdPrefix}
+			/>
+		</div>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/components/edge-control/inventoryView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/edge-control/inventoryView.tsx
@@ -1,0 +1,14 @@
+import { ShieldCheck } from "lucide-react";
+import EdgeControlFallbackView from "./fallbackWrapper";
+
+export default function InventoryView() {
+	return (
+		<EdgeControlFallbackView
+			icon={<ShieldCheck className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+			title="Unlock edge control to approve apps and MCP servers"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/edge/admin-approvals"
+			testIdPrefix="edge-inventory"
+		/>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -2,97 +2,94 @@ import { createContext, useContext } from "react";
 
 // RBAC Resource Names (must match backend definitions)
 export enum RbacResource {
-  GuardrailsConfig = "GuardrailsConfig",
-  GuardrailsProviders = "GuardrailsProviders",
-  GuardrailRules = "GuardrailRules",
-  UserProvisioning = "UserProvisioning",
-  Cluster = "Cluster",
-  Settings = "Settings",
-  Users = "Users",
-  Logs = "Logs",
-  Observability = "Observability",
-  Dashboard = "Dashboard",
-  VirtualKeys = "VirtualKeys",
-  ModelProvider = "ModelProvider",
-  Plugins = "Plugins",
-  MCPGateway = "MCPGateway",
-  MCPToolGroups = "MCPToolGroups",
-  MCPLogs = "MCPLogs",
-  AdaptiveRouter = "AdaptiveRouter",
-  AuditLogs = "AuditLogs",
-  Customers = "Customers",
-  Teams = "Teams",
-  RBAC = "RBAC",
-  Governance = "Governance",
-  RoutingRules = "RoutingRules",
-  PIIRedactor = "PIIRedactor",
-  PromptRepository = "PromptRepository",
-  PromptDeploymentStrategy = "PromptDeploymentStrategy",
-  SkillsRepository = "SkillsRepository",
-  AccessProfiles = "AccessProfiles",
-  APIKeys = "APIKeys",
-  Inference = "Inference",
-  Metrics = "Metrics",
-  FeatureFlags = "FeatureFlags",
-  Devices = "Devices",
-  Inventory = "Inventory",
-  EdgeConfig = "EdgeConfig",
+	GuardrailsConfig = "GuardrailsConfig",
+	GuardrailsProviders = "GuardrailsProviders",
+	GuardrailRules = "GuardrailRules",
+	UserProvisioning = "UserProvisioning",
+	Cluster = "Cluster",
+	Settings = "Settings",
+	Users = "Users",
+	Logs = "Logs",
+	Observability = "Observability",
+	Dashboard = "Dashboard",
+	VirtualKeys = "VirtualKeys",
+	ModelProvider = "ModelProvider",
+	Plugins = "Plugins",
+	MCPGateway = "MCPGateway",
+	MCPToolGroups = "MCPToolGroups",
+	MCPLogs = "MCPLogs",
+	AdaptiveRouter = "AdaptiveRouter",
+	AuditLogs = "AuditLogs",
+	Customers = "Customers",
+	Teams = "Teams",
+	RBAC = "RBAC",
+	Governance = "Governance",
+	RoutingRules = "RoutingRules",
+	PIIRedactor = "PIIRedactor",
+	PromptRepository = "PromptRepository",
+	PromptDeploymentStrategy = "PromptDeploymentStrategy",
+	AccessProfiles = "AccessProfiles",
+	APIKeys = "APIKeys",
+	Inference = "Inference",
+	Metrics = "Metrics",
+	FeatureFlags = "FeatureFlags",
+	Devices = "Devices",
+	Inventory = "Inventory",
+	EdgeConfig = "EdgeConfig",
+	SkillsRepository = "SkillsRepository",
 }
 
 // RBAC Operation Names (must match backend definitions)
 export enum RbacOperation {
-  Read = "Read",
-  View = "View",
-  Create = "Create",
-  Update = "Update",
-  Delete = "Delete",
-  Download = "Download",
+	Read = "Read",
+	View = "View",
+	Create = "Create",
+	Update = "Update",
+	Delete = "Delete",
+	Download = "Download",
 }
 
 interface RbacContextType {
-  isAllowed: (resource: RbacResource, operation: RbacOperation) => boolean;
-  permissions: Record<string, Record<string, boolean>>;
-  isLoading: boolean;
-  refetch: () => void;
+	isAllowed: (resource: RbacResource, operation: RbacOperation) => boolean;
+	permissions: Record<string, Record<string, boolean>>;
+	isLoading: boolean;
+	refetch: () => void;
 }
 
 const RbacContext = createContext<RbacContextType | null>(null);
 
 // Dummy provider that allows all permissions
 export function RbacProvider({ children }: { children: React.ReactNode }) {
-  return (
-    <RbacContext.Provider
-      value={{
-        isAllowed: () => true, // Always allow in OSS
-        permissions: {},
-        isLoading: false,
-        refetch: () => {},
-      }}
-    >
-      {children}
-    </RbacContext.Provider>
-  );
+	return (
+		<RbacContext.Provider
+			value={{
+				isAllowed: () => true, // Always allow in OSS
+				permissions: {},
+				isLoading: false,
+				refetch: () => {},
+			}}
+		>
+			{children}
+		</RbacContext.Provider>
+	);
 }
 
 // Hook that always returns true (no restrictions in OSS)
-export function useRbac(
-  _resource: RbacResource,
-  _operation: RbacOperation,
-): boolean {
-  return true;
+export function useRbac(_resource: RbacResource, _operation: RbacOperation): boolean {
+	return true;
 }
 
 // Hook to access full RBAC context
 export function useRbacContext() {
-  const context = useContext(RbacContext);
-  if (!context) {
-    // Return dummy values if used outside provider
-    return {
-      isAllowed: () => true,
-      permissions: {},
-      isLoading: false,
-      refetch: () => {},
-    };
-  }
-  return context;
+	const context = useContext(RbacContext);
+	if (!context) {
+		// Return dummy values if used outside provider
+		return {
+			isAllowed: () => true,
+			permissions: {},
+			isLoading: false,
+			refetch: () => {},
+		};
+	}
+	return context;
 }


### PR DESCRIPTION
## Summary

Adds enterprise fallback UI components for the Edge Control feature and introduces new RBAC resource types to support edge device management. Also includes a dependency addition for UUID support in the logging plugin and bumps AWS SDK v2 dependencies.

## Changes

- Added three new enterprise fallback views for Edge Control: `ConfigView`, `DevicesView`, and `InventoryView`, each rendering a "Contact Us" upsell screen with relevant icons and documentation links
- Added `Devices`, `Inventory`, and `EdgeConfig` to the `RbacResource` enum to support RBAC enforcement on edge control resources
- Added `github.com/google/uuid v1.6.0` as a dependency to the logging plugin
- Bumped `aws-sdk-go-v2` and related internal packages to their latest patch versions in the model catalog resolver
- Fixed `InferenceMiddleware` to pass `true` as a second argument to `m.middleware(...)`, aligning it with the expected function signature

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

The three new Edge Control fallback views (`ConfigView`, `DevicesView`, `InventoryView`) should render their respective "Contact Us" upsell screens with the correct icons (`SlidersHorizontal`, `MonitorSmartphone`, `ShieldCheck`) and links to the Bifrost edge documentation.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `InferenceMiddleware` fix ensures the middleware is invoked with the correct arguments, preventing potential auth bypass or misconfiguration in inference request handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable