### PR TITLE
fix: read supports web search in datasheet

### DIFF
--- a/framework/modelcatalog/datasheet/capabilities_test.go
+++ b/framework/modelcatalog/datasheet/capabilities_test.go
@@ -1,6 +1,7 @@
 package datasheet
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -221,3 +222,59 @@ func TestCapabilityFieldsRoundTripThroughPricingConversions(t *testing.T) {
 }
 
 func capabilityIntPtr(v int) *int { return &v }
+
+func capabilityBoolPtr(v bool) *bool { return &v }
+
+// TestExtractSupportedParams_WebSearch guards the two web-search keys: the
+// model_parameters "web_search" id and the supports_web_search flag must each
+// yield both web_search (responses-path tool) and web_search_options (chat-path
+// param), so the compat plugin's drop checks match either way.
+func TestExtractSupportedParams_WebSearch(t *testing.T) {
+	webSearchParam := []struct {
+		ID string `json:"id"`
+	}{{ID: "web_search"}}
+
+	cases := []struct {
+		name   string
+		parsed *modelParametersParseResult
+	}{
+		{
+			name:   "web_search model parameter",
+			parsed: &modelParametersParseResult{ModelParameters: webSearchParam},
+		},
+		{
+			name:   "supports_web_search flag",
+			parsed: &modelParametersParseResult{SupportsWebSearch: capabilityBoolPtr(true)},
+		},
+		{
+			name: "both set",
+			parsed: &modelParametersParseResult{
+				ModelParameters:   webSearchParam,
+				SupportsWebSearch: capabilityBoolPtr(true),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractSupportedParams(tc.parsed)
+			for _, want := range []string{"web_search", "web_search_options"} {
+				if !slices.Contains(got, want) {
+					t.Errorf("expected supported params to contain %q, got %v", want, got)
+				}
+			}
+		})
+	}
+}
+
+// TestExtractSupportedParams_WebSearchAbsent confirms neither key is added when
+// the datasheet declares no web-search support, so the tool is still stripped
+// for models that genuinely lack it.
+func TestExtractSupportedParams_WebSearchAbsent(t *testing.T) {
+	got := extractSupportedParams(&modelParametersParseResult{SupportsWebSearch: capabilityBoolPtr(false)})
+	for _, unexpected := range []string{"web_search", "web_search_options"} {
+		if slices.Contains(got, unexpected) {
+			t.Errorf("expected supported params to omit %q, got %v", unexpected, got)
+		}
+	}
+}

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -309,6 +309,7 @@ type modelParametersParseResult struct {
 	SupportsResponseSchema          *bool `json:"supports_response_schema,omitempty"`
 	SupportsServiceTier             *bool `json:"supports_service_tier,omitempty"`
 	SupportsPromptCaching           *bool `json:"supports_prompt_caching,omitempty"`
+	SupportsWebSearch               *bool `json:"supports_web_search,omitempty"`
 	VertexMultiRegionOnly           *bool `json:"vertex_multi_region_only,omitempty"`
 }
 
@@ -447,7 +448,8 @@ func extractSupportedParams(parsed *modelParametersParseResult) []string {
 		case "reasoning_effort", "reasoning_summary":
 			addParam("reasoning")
 		case "web_search":
-			addParam("web_search_options")
+			addParam("web_search_options") // chat-path param
+			addParam("web_search")         // responses-path server tool
 		case "promptTools", "image_detail", "stream":
 			// skip — not top-level request parameters
 		default:
@@ -484,6 +486,10 @@ func extractSupportedParams(parsed *modelParametersParseResult) []string {
 		addParam("cache_control")
 		addParam("prompt_cache_key")
 		addParam("prompt_cache_retention")
+	}
+	if parsed.SupportsWebSearch != nil && *parsed.SupportsWebSearch {
+		addParam("web_search")
+		addParam("web_search_options")
 	}
 
 	return supported
@@ -721,4 +727,3 @@ func convertTableOverride(override *configstoreTables.TablePricingOverride) (Ove
 		Options:       options,
 	}, nil
 }
-


### PR DESCRIPTION
## Summary

Adds support for `web_search` as a standalone capability flag in the model datasheet parameter parsing, enabling models to declare web search support via a dedicated `supports_web_search` field. This ensures the `web_search` and `web_search_options` parameters are correctly surfaced for both the chat path and the responses-path server tool.

## Changes

- Added `SupportsWebSearch` field to `modelParametersParseResult` so models can explicitly declare web search support independent of parameter-level detection.
- When a `web_search` parameter is encountered during extraction, both `web_search_options` (chat path) and `web_search` (responses-path server tool) are now registered as supported params.
- When `SupportsWebSearch` is set to `true`, both `web_search` and `web_search_options` are added to the supported parameters list.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/datasheet/...
```

Verify that a model datasheet with `supports_web_search: true` results in both `web_search` and `web_search_options` appearing in the extracted supported parameters. Also verify that a model with a `web_search` parameter entry exposes both params.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects parameter capability advertisement in the model catalog.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added web search support to the model catalog, exposing web-search capability and its options when a model advertises support.

* **Tests**
  * Added tests to verify web-search parameters and options are included when supported and omitted when not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->