### PR TITLE
tests: inference middleware regression tests

### DIFF
--- a/.github/workflows/scripts/test-e2e-api.sh
+++ b/.github/workflows/scripts/test-e2e-api.sh
@@ -176,5 +176,20 @@ if ! ./runners/run-newman-inference-features-tests.sh $REPORT_ARGS; then
   exit 1
 fi
 
+# The auth matrix boots its own servers (one per config combination), so it only
+# runs when we were given a binary to boot. When tests run against an externally
+# managed server we cannot vary its boot config, so the suite is skipped.
+if [ -n "${BIFROST_BINARY:-}" ]; then
+  echo "=========================================="
+  echo "Running auth matrix test suite..."
+  echo "=========================================="
+  if ! ./runners/individual/run-newman-auth-matrix-tests.sh --binary "$BIFROST_BINARY" --port "$((PORT + 7))" $REPORT_ARGS; then
+    echo "❌ auth matrix test suite failed"
+    exit 1
+  fi
+else
+  echo "ℹ️  Skipping auth matrix suite (no binary provided; it boots its own servers per config)"
+fi
+
 echo ""
-echo "✅ All E2E API tests passed (/v1, /integrations, /api, inference features)"
+echo "✅ All E2E API tests passed (/v1, /integrations, /api, inference features, auth matrix)"

--- a/tests/e2e/api/README.md
+++ b/tests/e2e/api/README.md
@@ -195,6 +195,39 @@ run-id namespacing. The runner also forwards the full per-provider credential se
 (`anthropic_api_key`, `azure_*`, `bedrock_*`, `vertex_*`, etc.) so per-provider
 expansion needs no runner change.
 
+### Auth Matrix Tests
+
+| Path | Description |
+|------|-------------|
+| `collections/bifrost-v1-auth-matrix.postman_collection.json` | Asserts the separation between inference auth (governance / virtual key) and dashboard auth (admin password on `/api/*`). |
+| `runners/individual/run-newman-auth-matrix-tests.sh` | Boots a fresh server per config combination and runs the collection against each. |
+
+Unlike the other runners, this one **boots its own servers** — each of the four
+combinations needs a different boot config, so it cannot reuse a shared running
+server. It requires a built `bifrost-http` binary.
+
+It sweeps the 2x2 of `client.enforce_auth_on_inference` x
+`governance.auth_config.is_enabled` (admin password) with a pre-seeded virtual key
+and an unreachable dummy provider (so "auth passed" surfaces as a non-401 upstream
+error). Per combination it asserts:
+
+- **VK-authenticated inference is never blocked by the auth layer** (never 401),
+  in every combination — including admin-password-on. This is the core regression
+  guard: the admin middleware must not reject virtual-key inference.
+- **No-VK inference** is rejected by governance with `virtual_key_required` only
+  when `enforce_auth_on_inference` is on; otherwise it passes the auth layer.
+- **Admin Basic auth is not a substitute for a VK** on inference (same governance
+  rejection when enforce is on).
+- **`/api/config`** requires admin creds (admin-middleware `Unauthorized`) only
+  when admin password auth is on; it is open otherwise.
+
+Run locally (from this directory):
+
+```bash
+./runners/individual/run-newman-auth-matrix-tests.sh --binary /path/to/bifrost-http
+# options: --port <port> (default 8090), --html, --json, --verbose, --bail
+```
+
 ### Test Success Criteria
 
 A request **passes** if either:

--- a/tests/e2e/api/collections/bifrost-v1-auth-matrix.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-v1-auth-matrix.postman_collection.json
@@ -1,0 +1,238 @@
+{
+  "info": {
+    "name": "Bifrost V1 - Auth Matrix",
+    "description": "Validates the separation between inference auth (governance / virtual key) and dashboard auth (admin password on /api/*). Driven by two env-vars set per boot config: enforce_auth (client.enforce_auth_on_inference) and admin_auth (governance.auth_config.is_enabled). The runner boots a fresh server per combination with a pre-seeded VK. Asserts: (1) VK-authenticated inference always passes the auth layer regardless of admin password; (2) inference without a VK is rejected by governance only when enforce_auth is on; (3) admin Basic auth is NOT a substitute for a VK on inference; (4) /api/* requires admin creds only when admin_auth is on.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "base_url", "value": "http://localhost:8090", "type": "string" },
+    { "key": "chat_model", "value": "openai/gpt-4o", "type": "string" },
+    { "key": "vk_value", "value": "sk-bf-matrix-test-key", "type": "string" },
+    { "key": "admin_auth_header", "value": "", "type": "string" },
+    { "key": "enforce_auth", "value": "", "type": "string" },
+    { "key": "admin_auth", "value": "", "type": "string" }
+  ],
+  "item": [
+    {
+      "name": "Inference",
+      "item": [
+        {
+          "name": "Inference with VK passes auth layer",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Core regression guard: a VK-authenticated inference request must pass the",
+                  "// auth layer in EVERY combination (including admin password on). The dummy",
+                  "// provider is unreachable, so 'auth passed' surfaces as a non-401 upstream",
+                  "// error, never a 401.",
+                  "var code = pm.response.code;",
+                  "pm.test('VK inference is not blocked by auth (code != 401)', function () {",
+                  "  pm.expect(code, 'body: ' + pm.response.text()).to.not.equal(401);",
+                  "});",
+                  "pm.test('VK inference response carries no virtual_key rejection', function () {",
+                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_required');",
+                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_not_found');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-bf-vk", "value": "{{vk_value}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "chat", "completions"]
+            }
+          }
+        },
+        {
+          "name": "Inference without credentials",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var enforce = String(pm.variables.get('enforce_auth') || '') === '1';",
+                  "var code = pm.response.code;",
+                  "if (enforce) {",
+                  "  pm.test('No-VK inference is rejected by governance (401)', function () {",
+                  "    pm.expect(code, 'body: ' + pm.response.text()).to.equal(401);",
+                  "  });",
+                  "  pm.test('Rejection comes from governance (virtual_key_required)', function () {",
+                  "    pm.expect(pm.response.text()).to.include('virtual_key');",
+                  "    pm.expect(pm.response.text(), 'must not be the admin-middleware 401').to.not.equal('Unauthorized');",
+                  "  });",
+                  "} else {",
+                  "  pm.test('No-VK inference passes auth layer when enforce is off (code != 401)', function () {",
+                  "    pm.expect(code, 'body: ' + pm.response.text()).to.not.equal(401);",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "chat", "completions"]
+            }
+          }
+        },
+        {
+          "name": "Inference with admin Basic but no VK",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Send admin Basic auth (when configured) but deliberately no VK. Admin",
+                  "// creds must NOT substitute for a VK on inference.",
+                  "var adminHeader = pm.variables.get('admin_auth_header');",
+                  "if (adminHeader) { pm.request.headers.upsert({ key: 'Authorization', value: adminHeader }); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var enforce = String(pm.variables.get('enforce_auth') || '') === '1';",
+                  "var code = pm.response.code;",
+                  "if (enforce) {",
+                  "  pm.test('Admin Basic is not a VK substitute on inference (401)', function () {",
+                  "    pm.expect(code, 'body: ' + pm.response.text()).to.equal(401);",
+                  "  });",
+                  "  pm.test('Rejection comes from governance (virtual_key_required)', function () {",
+                  "    pm.expect(pm.response.text()).to.include('virtual_key');",
+                  "  });",
+                  "} else {",
+                  "  pm.test('Admin Basic / no VK passes auth layer when enforce is off (code != 401)', function () {",
+                  "    pm.expect(code, 'body: ' + pm.response.text()).to.not.equal(401);",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": ["{{base_url}}"],
+              "path": ["v1", "chat", "completions"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Dashboard API",
+      "item": [
+        {
+          "name": "GET /api/config without admin creds",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var admin = String(pm.variables.get('admin_auth') || '') === '1';",
+                  "var code = pm.response.code;",
+                  "if (admin) {",
+                  "  pm.test('Admin route requires admin auth (401)', function () {",
+                  "    pm.expect(code, 'body: ' + pm.response.text()).to.equal(401);",
+                  "  });",
+                  "  pm.test('Rejection is the admin-middleware Unauthorized', function () {",
+                  "    pm.expect(pm.response.text()).to.include('Unauthorized');",
+                  "  });",
+                  "} else {",
+                  "  pm.test('Admin route is open when admin auth is off (200)', function () {",
+                  "    pm.expect(code, 'body: ' + pm.response.text()).to.equal(200);",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/config",
+              "host": ["{{base_url}}"],
+              "path": ["api", "config"]
+            }
+          }
+        },
+        {
+          "name": "GET /api/config with admin creds",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var adminHeader = pm.variables.get('admin_auth_header');",
+                  "if (adminHeader) { pm.request.headers.upsert({ key: 'Authorization', value: adminHeader }); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Admin creds (when set) open the route; when admin auth is off the route is",
+                  "// open anyway. Either way: 200.",
+                  "pm.test('Admin route is accessible with admin creds (200)', function () {",
+                  "  pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/config",
+              "host": ["{{base_url}}"],
+              "path": ["api", "config"]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/api/runners/individual/run-newman-auth-matrix-tests.sh
+++ b/tests/e2e/api/runners/individual/run-newman-auth-matrix-tests.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+
+# Bifrost Auth Matrix Newman Test Runner
+#
+# Boots a fresh Bifrost server (sqlite, pre-seeded virtual key, unreachable dummy
+# provider) once per combination of:
+#   - client.enforce_auth_on_inference        (enforce VK on inference)
+#   - governance.auth_config.is_enabled        (admin password on /api/*)
+# and runs collections/bifrost-v1-auth-matrix.postman_collection.json against each.
+#
+# Guards the separation: inference auth is owned by governance (virtual key),
+# admin password guards only /api/* — a VK-authenticated inference request must
+# never be rejected by the admin middleware, in any combination.
+#
+# Requires a built bifrost-http binary; this runner boots its own servers (it does
+# not reuse the shared e2e server, since each combination needs a different boot
+# config).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$API_DIR"
+
+COLLECTION="collections/bifrost-v1-auth-matrix.postman_collection.json"
+REPORT_DIR="newman-reports/auth-matrix"
+ADMIN_USER="admin"
+ADMIN_PASS="matrix-admin-pass"
+VK_VALUE="sk-bf-matrix-test-key"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+BIFROST_BINARY=""
+PORT="8090"
+REPORTERS="cli"
+VERBOSE=""
+BAIL=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --binary)
+            BIFROST_BINARY="$2"; shift 2 ;;
+        --port)
+            PORT="$2"; shift 2 ;;
+        --html)
+            REPORTERS="${REPORTERS},html"; shift ;;
+        --json)
+            REPORTERS="${REPORTERS},json"; shift ;;
+        --verbose)
+            VERBOSE="--verbose"; shift ;;
+        --bail)
+            BAIL="--bail"; shift ;;
+        --help)
+            echo "Usage: $0 --binary <path-to-bifrost-http> [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --binary <path>   Path to a built bifrost-http binary (required)"
+            echo "  --port <port>     Port to boot each server on (default: 8090)"
+            echo "  --html            Generate HTML report"
+            echo "  --json            Generate JSON report"
+            echo "  --verbose         Show detailed Newman output"
+            echo "  --bail            Stop on first failure"
+            echo "  --help            Show this help message"
+            exit 0 ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"; exit 1 ;;
+    esac
+done
+
+echo -e "${GREEN}==============================================${NC}"
+echo -e "${GREEN}Bifrost Auth Matrix Test Runner${NC}"
+echo -e "${GREEN}==============================================${NC}"
+echo ""
+
+if ! command -v newman &>/dev/null; then
+    echo -e "${RED}Error: Newman is not installed${NC}"
+    echo "Install it with: npm install -g newman"
+    exit 1
+fi
+if [ -z "$BIFROST_BINARY" ] || [ ! -x "$BIFROST_BINARY" ]; then
+    echo -e "${RED}Error: --binary must point to an executable bifrost-http binary${NC}"
+    exit 1
+fi
+if [ ! -f "$COLLECTION" ]; then
+    echo -e "${RED}Error: Collection file not found: $COLLECTION${NC}"
+    exit 1
+fi
+
+mkdir -p "$REPORT_DIR"
+
+ADMIN_HEADER="Basic $(printf '%s:%s' "$ADMIN_USER" "$ADMIN_PASS" | base64 | tr -d '\n')"
+
+# Tracks the running server + its temp dir so the trap can always clean up.
+CURRENT_PID=""
+CURRENT_DIR=""
+OVERALL_EXIT=0
+
+cleanup() {
+    if [ -n "$CURRENT_PID" ] && kill -0 "$CURRENT_PID" 2>/dev/null; then
+        kill "$CURRENT_PID" 2>/dev/null || true
+        wait "$CURRENT_PID" 2>/dev/null || true
+    fi
+    [ -n "$CURRENT_DIR" ] && rm -rf "$CURRENT_DIR"
+}
+trap cleanup EXIT
+
+# write_config <dir> <enforce_bool true|false> <admin 1|"">
+write_config() {
+    local dir="$1" enforce="$2" admin="$3"
+    local auth_block=""
+    if [ "$admin" = "1" ]; then
+        auth_block="\"auth_config\": { \"is_enabled\": true, \"admin_username\": \"$ADMIN_USER\", \"admin_password\": \"$ADMIN_PASS\" },"
+    fi
+    cat > "$dir/config.json" <<EOF
+{
+  "\$schema": "https://www.getbifrost.ai/schema",
+  "client": {
+    "drop_excess_requests": false,
+    "initial_pool_size": 50,
+    "allowed_origins": ["*"],
+    "enable_logging": false,
+    "enforce_auth_on_inference": $enforce,
+    "max_request_body_size_mb": 100
+  },
+  "config_store": { "enabled": true, "type": "sqlite", "config": { "path": "$dir/config.db" } },
+  "logs_store": { "enabled": false },
+  "providers": {
+    "openai": {
+      "keys": [{ "name": "matrix-dummy", "value": "sk-matrix-dummy", "weight": 1 }],
+      "network_config": { "base_url": "http://127.0.0.1:1", "default_request_timeout_in_seconds": 5 }
+    }
+  },
+  "governance": {
+    $auth_block
+    "virtual_keys": [{
+      "name": "Matrix VK",
+      "id": "vk-matrix",
+      "value": "$VK_VALUE",
+      "is_active": true,
+      "provider_configs": [{ "provider": "openai", "allowed_models": ["*"], "key_ids": ["*"], "weight": 1.0 }]
+    }]
+  }
+}
+EOF
+}
+
+# run_combo <label> <enforce true|false> <admin 1|"">
+run_combo() {
+    local label="$1" enforce="$2" admin="$3"
+    local enforce_flag="" admin_flag="" admin_header=""
+    [ "$enforce" = "true" ] && enforce_flag="1"
+    [ "$admin" = "1" ] && { admin_flag="1"; admin_header="$ADMIN_HEADER"; }
+
+    echo -e "${GREEN}----------------------------------------------${NC}"
+    echo -e "${GREEN}Combination: ${label}${NC}"
+    echo -e "  enforce_auth_on_inference: ${YELLOW}${enforce}${NC}   admin password: ${YELLOW}$([ "$admin" = "1" ] && echo on || echo off)${NC}"
+    echo -e "${GREEN}----------------------------------------------${NC}"
+
+    CURRENT_DIR="$(mktemp -d)"
+    write_config "$CURRENT_DIR" "$enforce" "$admin"
+    local server_log="$CURRENT_DIR/server.log"
+
+    "$BIFROST_BINARY" --app-dir "$CURRENT_DIR" --port "$PORT" --log-level info > "$server_log" 2>&1 &
+    CURRENT_PID=$!
+
+    local elapsed=0
+    while [ $elapsed -lt 60 ]; do
+        if grep -q "successfully started bifrost" "$server_log" 2>/dev/null; then
+            break
+        fi
+        if ! kill -0 "$CURRENT_PID" 2>/dev/null; then
+            echo -e "${RED}   Server exited before becoming ready${NC}"
+            cat "$server_log"
+            OVERALL_EXIT=1
+            CURRENT_PID=""
+            rm -rf "$CURRENT_DIR"; CURRENT_DIR=""
+            return
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    if [ $elapsed -ge 60 ]; then
+        echo -e "${RED}   Server did not start within 60s${NC}"
+        cat "$server_log"
+        OVERALL_EXIT=1
+    else
+        local report_prefix="${REPORT_DIR}/${label}"
+        local cmd=(newman run "$COLLECTION"
+            --env-var "base_url=http://localhost:$PORT"
+            --env-var "enforce_auth=$enforce_flag"
+            --env-var "admin_auth=$admin_flag"
+            --env-var "admin_auth_header=$admin_header"
+            --env-var "vk_value=$VK_VALUE"
+            --timeout-script 60000 --timeout 120000
+            -r "$REPORTERS")
+        [[ "$REPORTERS" == *"html"* ]] && cmd+=(--reporter-html-export "${report_prefix}.html")
+        [[ "$REPORTERS" == *"json"* ]] && cmd+=(--reporter-json-export "${report_prefix}.json")
+        [ -n "$VERBOSE" ] && cmd+=("$VERBOSE")
+        [ -n "$BAIL" ] && cmd+=("$BAIL")
+
+        set +e
+        "${cmd[@]}"
+        local code=$?
+        set -e
+        [ $code -ne 0 ] && OVERALL_EXIT=1
+    fi
+
+    # Tear down this combination's server before the next boot.
+    if [ -n "$CURRENT_PID" ] && kill -0 "$CURRENT_PID" 2>/dev/null; then
+        kill "$CURRENT_PID" 2>/dev/null || true
+        wait "$CURRENT_PID" 2>/dev/null || true
+    fi
+    CURRENT_PID=""
+    rm -rf "$CURRENT_DIR"; CURRENT_DIR=""
+    echo ""
+}
+
+run_combo "enforce-off_admin-off" false ""
+run_combo "enforce-on_admin-off"  true  ""
+run_combo "enforce-off_admin-on"  false 1
+run_combo "enforce-on_admin-on"   true  1
+
+echo ""
+if [ $OVERALL_EXIT -eq 0 ]; then
+    echo -e "${GREEN}✓ All auth matrix combinations passed!${NC}"
+else
+    echo -e "${RED}✗ Some auth matrix combinations failed${NC}"
+fi
+if [[ "$REPORTERS" == *"html"* ]] || [[ "$REPORTERS" == *"json"* ]]; then
+    echo ""
+    echo -e "Reports saved to: ${YELLOW}$REPORT_DIR${NC}"
+    ls -lh "$REPORT_DIR" 2>/dev/null | tail -n +2
+fi
+
+exit $OVERALL_EXIT


### PR DESCRIPTION
## Summary

Adds an auth matrix test suite that validates the separation between inference auth (governed by virtual keys) and dashboard auth (admin password on `/api/*`). The core regression guard ensures that a VK-authenticated inference request is never rejected by the admin middleware, across all combinations of `enforce_auth_on_inference` and `governance.auth_config.is_enabled`.

## Changes

- Added `collections/bifrost-v1-auth-matrix.postman_collection.json` — a Postman collection that sweeps the 2×2 matrix of `enforce_auth_on_inference` × `admin_auth.is_enabled` and asserts:
  - VK-authenticated inference always passes the auth layer (never 401), even when admin password is enabled
  - Inference without a VK is rejected by governance (`virtual_key_required`) only when `enforce_auth_on_inference` is on
  - Admin Basic auth is not a substitute for a virtual key on inference endpoints
  - `/api/config` requires admin credentials only when admin password auth is enabled
- Added `runners/individual/run-newman-auth-matrix-tests.sh` — boots a fresh server per config combination (sqlite, pre-seeded VK, unreachable dummy provider) and runs the collection against each of the four combinations
- Integrated the auth matrix runner into `test-e2e-api.sh`; the suite is skipped when no `BIFROST_BINARY` is provided (e.g., when running against an externally managed server), since each combination requires a distinct boot config
- Updated `README.md` with documentation for the new suite

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the auth matrix suite locally from `tests/e2e/api/`:

```sh
./runners/individual/run-newman-auth-matrix-tests.sh --binary /path/to/bifrost-http

# Optional flags:
# --port <port>   Port to boot each server on (default: 8090)
# --html          Generate HTML report
# --json          Generate JSON report
# --verbose       Show detailed Newman output
# --bail          Stop on first failure
```

The runner boots four servers sequentially (`enforce-off/admin-off`, `enforce-on/admin-off`, `enforce-off/admin-on`, `enforce-on/admin-on`) and exits non-zero if any combination fails.

In CI, the suite runs automatically when `BIFROST_BINARY` is set and is silently skipped otherwise.

## Breaking changes

- [x] No

## Security considerations

The suite specifically guards against the admin password middleware incorrectly intercepting virtual-key inference requests. Each test server uses an unreachable dummy provider (`http://127.0.0.1:1`) so no real credentials are exercised and no external network calls are made. Admin credentials used are ephemeral, test-only values scoped to the temporary server instance.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Introduced comprehensive authentication matrix end-to-end tests that validate authentication separation between inference and dashboard authentication across various configurations.

* **Documentation**
  * Documented the new authentication matrix test suite, including test expectations and local execution instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->