### PR TITLE
adds chatgpt passthrough

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -7063,16 +7063,7 @@ func (provider *OpenAIProvider) Passthrough(
 		return nil, err
 	}
 
-	path := req.Path
-	// if path has v1 or v1/ remove it
-	if after, ok := strings.CutPrefix(path, "/v1"); ok {
-		path = after
-	}
-
-	url := provider.networkConfig.BaseURL + "/v1" + path
-	if req.RawQuery != "" {
-		url += "?" + req.RawQuery
-	}
+	url := provider.buildPassthroughURL(req)
 
 	fasthttpReq := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -7128,6 +7119,34 @@ func (provider *OpenAIProvider) Passthrough(
 	return bifrostResponse, nil
 }
 
+// buildPassthroughURL returns the upstream URL for raw passthrough requests.
+func (provider *OpenAIProvider) buildPassthroughURL(req *schemas.BifrostPassthroughRequest) string {
+	path := req.Path
+	baseURL := provider.networkConfig.BaseURL
+	if req.UpstreamURL != "" {
+		baseURL = strings.TrimRight(req.UpstreamURL, "/")
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		url := baseURL + path
+		if req.RawQuery != "" {
+			url += "?" + req.RawQuery
+		}
+		return url
+	}
+
+	// if path has v1 or v1/ remove it
+	if after, ok := strings.CutPrefix(path, "/v1"); ok {
+		path = after
+	}
+
+	url := baseURL + "/v1" + path
+	if req.RawQuery != "" {
+		url += "?" + req.RawQuery
+	}
+	return url
+}
+
 func (provider *OpenAIProvider) PassthroughStream(
 	ctx *schemas.BifrostContext,
 	postHookRunner schemas.PostHookRunner,
@@ -7140,14 +7159,7 @@ func (provider *OpenAIProvider) PassthroughStream(
 	}
 
 	providerUtils.SetStreamIdleTimeoutIfEmpty(ctx, provider.networkConfig.StreamIdleTimeoutInSeconds)
-	path := req.Path
-	if after, ok := strings.CutPrefix(path, "/v1"); ok {
-		path = after
-	}
-	url := provider.networkConfig.BaseURL + "/v1" + path
-	if req.RawQuery != "" {
-		url += "?" + req.RawQuery
-	}
+	url := provider.buildPassthroughURL(req)
 
 	fasthttpReq := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()

--- a/core/providers/openai/passthrough_test.go
+++ b/core/providers/openai/passthrough_test.go
@@ -1,0 +1,92 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestBuildPassthroughURLWithUpstreamOverride verifies host-backed passthrough
+// routes do not receive OpenAI's /v1 prefix.
+func TestBuildPassthroughURLWithUpstreamOverride(t *testing.T) {
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{}, passthroughTestLogger{})
+
+	req := &schemas.BifrostPassthroughRequest{
+		Path:        "/backend-api/codex/responses",
+		RawQuery:    "conversation=abc",
+		UpstreamURL: "https://chatgpt.com",
+	}
+
+	got := provider.buildPassthroughURL(req)
+	want := "https://chatgpt.com/backend-api/codex/responses?conversation=abc"
+	if got != want {
+		t.Fatalf("buildPassthroughURL = %q, want %q", got, want)
+	}
+}
+
+// TestBuildPassthroughURLDefaultsToOpenAIV1 verifies normal OpenAI passthrough
+// routes keep the existing /v1 URL construction.
+func TestBuildPassthroughURLDefaultsToOpenAIV1(t *testing.T) {
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{}, passthroughTestLogger{})
+
+	req := &schemas.BifrostPassthroughRequest{
+		Path:     "/v1/responses",
+		RawQuery: "stream=true",
+	}
+
+	got := provider.buildPassthroughURL(req)
+	want := "https://api.openai.com/v1/responses?stream=true"
+	if got != want {
+		t.Fatalf("buildPassthroughURL = %q, want %q", got, want)
+	}
+}
+
+// passthroughTestLogger discards provider logs in passthrough URL tests.
+type passthroughTestLogger struct{}
+
+// Debug discards a debug log.
+func (passthroughTestLogger) Debug(string, ...any) {}
+
+// Info discards an info log.
+func (passthroughTestLogger) Info(string, ...any) {}
+
+// Warn discards a warning log.
+func (passthroughTestLogger) Warn(string, ...any) {}
+
+// Error discards an error log.
+func (passthroughTestLogger) Error(string, ...any) {}
+
+// Fatal discards a fatal log.
+func (passthroughTestLogger) Fatal(string, ...any) {}
+
+// SetLevel ignores log level changes.
+func (passthroughTestLogger) SetLevel(schemas.LogLevel) {}
+
+// SetOutputType ignores output type changes.
+func (passthroughTestLogger) SetOutputType(schemas.LoggerOutputType) {}
+
+// LogHTTPRequest returns a no-op structured log builder.
+func (passthroughTestLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return passthroughTestLogEvent{}
+}
+
+// passthroughTestLogEvent discards structured HTTP log fields.
+type passthroughTestLogEvent struct{}
+
+// Str discards a string field.
+func (passthroughTestLogEvent) Str(string, string) schemas.LogEventBuilder {
+	return passthroughTestLogEvent{}
+}
+
+// Int discards an integer field.
+func (passthroughTestLogEvent) Int(string, int) schemas.LogEventBuilder {
+	return passthroughTestLogEvent{}
+}
+
+// Int64 discards an int64 field.
+func (passthroughTestLogEvent) Int64(string, int64) schemas.LogEventBuilder {
+	return passthroughTestLogEvent{}
+}
+
+// Send discards the built log event.
+func (passthroughTestLogEvent) Send() {}

--- a/core/schemas/passthrough.go
+++ b/core/schemas/passthrough.go
@@ -6,6 +6,7 @@ type BifrostPassthroughRequest struct {
 	Method      string
 	Path        string // stripped path, e.g. "/v1/fine-tuning/jobs"
 	RawQuery    string // raw query string, no "?"
+	UpstreamURL string // optional base URL override for host-backed passthrough routes
 	Body        []byte
 	SafeHeaders map[string]string // client headers, auth already stripped
 }

--- a/transports/bifrost-http/handlers/integrations.go
+++ b/transports/bifrost-http/handlers/integrations.go
@@ -34,6 +34,7 @@ func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStor
 		integrations.NewBedrockRouter(client, handlerStore, logger),
 		// passthrough routers
 		integrations.NewGenAIPassthroughRouter(client, handlerStore, logger),
+		integrations.NewChatGPTPassthroughRouter(client, handlerStore, logger),
 		integrations.NewOpenAIPassthroughRouter(client, handlerStore, logger),
 		integrations.NewAnthropicPassthroughRouter(client, handlerStore, logger),
 		integrations.NewAzurePassthroughRouter(client, handlerStore, logger),

--- a/transports/bifrost-http/integrations/passthrough.go
+++ b/transports/bifrost-http/integrations/passthrough.go
@@ -47,6 +47,17 @@ func NewOpenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.Handle
 	})
 }
 
+// NewChatGPTPassthroughRouter creates a passthrough router for /chatgpt_passthrough.
+func NewChatGPTPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+		Provider:    schemas.OpenAI,
+		UpstreamURL: "https://chatgpt.com",
+		StripPrefix: []string{
+			"/chatgpt_passthrough",
+		},
+	})
+}
+
 // NewAzurePassthroughRouter creates a passthrough router for /azure_passthrough.
 func NewAzurePassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
 	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -508,6 +508,7 @@ type PassthroughConfig struct {
 	Provider         schemas.ModelProvider                                              // which provider's key pool to draw from
 	ProviderDetector func(ctx *fasthttp.RequestCtx, model string) schemas.ModelProvider // optional: dynamic provider detection
 	StripPrefix      []string                                                           // e.g. "/openai" — stripped before forwarding
+	UpstreamURL      string                                                             // optional upstream base URL override
 }
 
 // LargePayloadHook is called before body parsing to detect and set up large payload streaming.
@@ -2937,6 +2938,7 @@ func (g *GenericRouter) handlePassthrough(ctx *fasthttp.RequestCtx) {
 		Method:      string(ctx.Method()),
 		Path:        path,
 		RawQuery:    string(ctx.URI().QueryString()),
+		UpstreamURL: cfg.UpstreamURL,
 		Body:        body,
 		SafeHeaders: safeHeaders,
 		Provider:    provider,

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/fasthttp/router"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/openai"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -36,6 +37,24 @@ func TestParsePassthroughBody_MultipartExtractsModelAfterFilePart(t *testing.T) 
 	model, stream := parsePassthroughBody(writer.FormDataContentType(), body.Bytes())
 	assert.Equal(t, "openai/whisper-1", model)
 	assert.True(t, stream)
+}
+
+func TestChatGPTPassthroughRouterRegistersCodexResponsesPost(t *testing.T) {
+	r := router.New()
+	passthroughRouter := NewChatGPTPassthroughRouter(nil, &mockHandlerStore{}, &testLogger{})
+	passthroughRouter.RegisterRoutes(r, func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			ctx.SetStatusCode(fasthttp.StatusNoContent)
+		}
+	})
+
+	var ctx fasthttp.RequestCtx
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetRequestURI("/chatgpt_passthrough/backend-api/codex/responses")
+
+	r.Handler(&ctx)
+
+	require.Equal(t, fasthttp.StatusNoContent, ctx.Response.StatusCode())
 }
 
 func TestRequestWithSettableExtraParams_OpenAIChatRequest(t *testing.T) {

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -48,7 +48,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.7.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
-	cloud.google.com/go/storage v1.61.3 // indirect
+	cloud.google.com/go/storage v1.62.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -58,8 +58,6 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7D
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go-v2 v1.41.12 h1:DIKX2c31ekm9RA2D9FBj1EWXx++9AdAqRw+e78Tq2Ck=
-github.com/aws/aws-sdk-go-v2 v1.41.12/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
 github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -15,8 +15,6 @@ import {
 	FlaskConical,
 	FolderGit,
 	Globe,
-	KeyRound,
-	Landmark,
 	Hexagon,
 	BadgeCheck,
 	LaptopMinimalCheck,


### PR DESCRIPTION
## Summary

Adds a `/chatgpt_passthrough` route that forwards requests to `https://chatgpt.com` instead of the standard OpenAI API, enabling passthrough to host-backed ChatGPT endpoints (e.g. `/backend-api/codex/responses`) that do not use the `/v1` prefix.

## Changes

- Added `UpstreamURL` field to `BifrostPassthroughRequest` and `PassthroughConfig` to allow per-route base URL overrides.
- Extracted URL construction logic in the OpenAI provider into a `buildPassthroughURL` helper. When `UpstreamURL` is set, the helper uses it directly without injecting the `/v1` prefix; otherwise it falls back to the existing OpenAI base URL + `/v1` behaviour.
- Applied `buildPassthroughURL` to both `Passthrough` and `PassthroughStream` to eliminate duplicated URL-building logic.
- Registered `NewChatGPTPassthroughRouter` in the integration handler, pointing at `https://chatgpt.com` and stripping the `/chatgpt_passthrough` prefix before forwarding.
- Added unit tests for `buildPassthroughURL` covering both the upstream override path and the default OpenAI `/v1` path.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... ./transports/bifrost-http/...
```

To validate end-to-end, send a request to `/chatgpt_passthrough/backend-api/codex/responses` with a valid OpenAI key configured. The request should be forwarded to `https://chatgpt.com/backend-api/codex/responses` without a `/v1` prefix injected.

To confirm existing OpenAI passthrough is unaffected, send a request to `/openai_passthrough/v1/models` and verify it reaches `https://api.openai.com/v1/models`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `UpstreamURL` override is set statically at router registration time and is not user-controlled at request time, so there is no risk of SSRF via client-supplied URLs. Auth headers are stripped from forwarded requests as with all existing passthrough routes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable