### PR TITLE
feat: adds scripts to seed and delete bifrost and litellm entities

### DIFF
--- a/scripts/litellm-to-bifrost/scripts/create_organizations.sh
+++ b/scripts/litellm-to-bifrost/scripts/create_organizations.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# create_organizations.sh - seed a running LiteLLM instance with organizations.
+#
+# Usage:
+#   LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./create_organizations.sh
+
+set -euo pipefail
+
+LITELLM_URL="${LITELLM_URL:-http://localhost:4000}"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-1234}"
+DRY_RUN="${DRY_RUN:-0}"
+
+create_org() {
+  local description="$1" body="$2"
+  echo "==> ${description}"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    jq -c . <<<"${body}" 2>/dev/null || { echo "  INVALID JSON"; return; }
+    echo ""
+    return
+  fi
+  curl -sS --fail-with-body \
+    --location "${LITELLM_URL}/organization/new" \
+    --header "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+    --header "Content-Type: application/json" \
+    --data "${body}" \
+    && echo "" \
+    || echo "  (LiteLLM rejected this payload)"
+  echo ""
+}
+
+# --- Happy path: every field populated -------------------------------------
+# Expected Bifrost customer: name "seed-full", budget {500, "1M"},
+# rate_limit {token 2000 / "1m", request 120 / "1m"}.
+create_org "seed-full: budget + tpm + rpm + monthly reset" '{
+  "organization_alias": "seed-full",
+  "max_budget": 500,
+  "budget_duration": "1mo",
+  "tpm_limit": 2000,
+  "rpm_limit": 120
+}'
+
+# --- Budget only ------------------------------------------------------------
+# Expected: budget {100, "30d"}, no rate_limit.
+create_org "seed-budget-30d: budget only, 30d reset" '{
+  "organization_alias": "seed-budget-30d",
+  "max_budget": 100,
+  "budget_duration": "30d"
+}'
+
+# Expected: budget {250, "1M"} (mo -> M), no rate_limit.
+create_org "seed-budget-monthly: budget only, 1mo reset" '{
+  "organization_alias": "seed-budget-monthly",
+  "max_budget": 250,
+  "budget_duration": "1mo"
+}'
+
+# --- LiteLLM UI "Reset Budget" dropdown values -----------------------------
+# The UI shows daily/weekly/monthly but stores 24h/7d/30d. These migrate
+# straight through - Bifrost accepts the same units.
+# Expected: budget {10, "24h"}.
+create_org "seed-reset-daily: UI \"daily\" -> 24h" '{
+  "organization_alias": "seed-reset-daily",
+  "max_budget": 10,
+  "budget_duration": "24h"
+}'
+
+# Expected: budget {70, "7d"}.
+create_org "seed-reset-weekly: UI \"weekly\" -> 7d" '{
+  "organization_alias": "seed-reset-weekly",
+  "max_budget": 70,
+  "budget_duration": "7d"
+}'
+
+# Expected: budget {300, "30d"}.
+create_org "seed-reset-monthly: UI \"monthly\" -> 30d" '{
+  "organization_alias": "seed-reset-monthly",
+  "max_budget": 300,
+  "budget_duration": "30d"
+}'
+
+# --- Pure customer (no budget, no limits) ----------------------------------
+# Expected: name only, no budget, no rate_limit.
+create_org "seed-pure: no budget, no limits" '{
+  "organization_alias": "seed-pure"
+}'
+
+# --- Rate limits only -------------------------------------------------------
+# Expected: rate_limit {token 1000 / "1m"} only.
+create_org "seed-tpm-only: tpm only" '{
+  "organization_alias": "seed-tpm-only",
+  "tpm_limit": 1000
+}'
+
+# Expected: rate_limit {request 60 / "1m"} only.
+create_org "seed-rpm-only: rpm only" '{
+  "organization_alias": "seed-rpm-only",
+  "rpm_limit": 60
+}'
+
+# Expected: rate_limit {token 1500 / "1m", request 90 / "1m"}, no budget.
+create_org "seed-tpm-rpm: tpm + rpm, no budget" '{
+  "organization_alias": "seed-tpm-rpm",
+  "tpm_limit": 1500,
+  "rpm_limit": 90
+}'
+
+# Expected: rate_limit nil.
+create_org "seed-tpm-negative: negative tpm" '{
+  "organization_alias": "seed-tpm-negative",
+  "tpm_limit": -100
+}'
+
+# Expected: rate_limit nil.
+create_org "seed-tpm-zero: zero tpm" '{
+  "organization_alias": "seed-tpm-zero",
+  "tpm_limit": 0
+}'
+
+# Expected: no budget, no rate_limit.
+create_org "seed-budget-zero: zero max_budget" '{
+  "organization_alias": "seed-budget-zero",
+  "max_budget": 0,
+  "budget_duration": "30d"
+}'
+
+# Expected: no budget.
+create_org "seed-budget-negative: negative max_budget" '{
+  "organization_alias": "seed-budget-negative",
+  "max_budget": -50,
+  "budget_duration": "30d"
+}'
+
+# Expected: max_budget set with no reset window.
+create_org "seed-budget-noduration: max_budget without budget_duration" '{
+  "organization_alias": "seed-budget-noduration",
+  "max_budget": 100
+}'
+
+echo "Seeding complete."

--- a/scripts/litellm-to-bifrost/scripts/create_teams.sh
+++ b/scripts/litellm-to-bifrost/scripts/create_teams.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+#
+# create_teams.sh - seed a running LiteLLM instance with teams.
+#
+# Usage:
+#   LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./create_teams.sh
+
+set -euo pipefail
+
+LITELLM_URL="${LITELLM_URL:-http://localhost:4000}"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-1234}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# Stable ids reused across cases so the script is deterministic.
+ORG_ID="seed-team-org"
+ORG_ID_RESTRICTED="seed-team-org-restricted"
+USER_ADMIN="seed-team-user-admin"
+USER_MEMBER="seed-team-user-member"
+
+# post sends one management-API call. Args: METHOD, PATH, DESCRIPTION, BODY.
+# In DRY_RUN mode it prints the payload instead of sending it.
+post() {
+  local method="$1" path="$2" description="$3" body="$4"
+  echo "==> ${description}"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    jq -c . <<<"${body}" 2>/dev/null || { echo "  INVALID JSON"; return; }
+    echo ""
+    return
+  fi
+  curl -sS --fail-with-body \
+    --location "${LITELLM_URL}${path}" \
+    --header "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+    --header "Content-Type: application/json" \
+    --request "${method}" \
+    --data "${body}" \
+    && echo "" \
+    || echo "  (LiteLLM rejected this payload — may be a duplicate id or an enterprise-only field)"
+  echo ""
+}
+
+create_org() { post POST "/organization/new" "$1" "$2"; }
+create_team() { post POST "/team/new" "$1" "$2"; }
+create_user() { post POST "/user/new" "$1" "$2"; }
+
+# ---------------------------------------------------------------------------
+# Prerequisites: a permissive parent org and two users for membership cases.
+# ---------------------------------------------------------------------------
+echo "### Prerequisites ###"
+echo
+
+create_org "prereq org: ${ORG_ID}" '{
+  "organization_id": "'"${ORG_ID}"'",
+  "organization_alias": "seed-team-org",
+  "models": ["all-proxy-models"],
+  "max_budget": 100000,
+  "budget_duration": "30d",
+  "tpm_limit": 100000000,
+  "rpm_limit": 1000000
+}'
+
+# A second org that exposes only a subset of proxy models (not all-proxy-models).
+# Teams created inside it can only grant access to models within this allowlist.
+create_org "prereq org (restricted models): ${ORG_ID_RESTRICTED}" '{
+  "organization_id": "'"${ORG_ID_RESTRICTED}"'",
+  "organization_alias": "seed-team-org-restricted",
+  "models": ["openai-gpt-4o", "openai-gpt-4o-mini", "anthropic-claude-sonnet-4"],
+  "max_budget": 100000,
+  "budget_duration": "30d",
+  "tpm_limit": 100000000,
+  "rpm_limit": 1000000
+}'
+
+create_user "prereq user: ${USER_ADMIN}" '{
+  "user_id": "'"${USER_ADMIN}"'",
+  "user_email": "seed-team-admin@example.com",
+  "user_role": "internal_user",
+  "auto_create_key": false
+}'
+
+create_user "prereq user: ${USER_MEMBER}" '{
+  "user_id": "'"${USER_MEMBER}"'",
+  "user_email": "seed-team-member@example.com",
+  "user_role": "internal_user",
+  "auto_create_key": false
+}'
+
+echo "### Standalone teams (no organization) ###"
+echo
+
+# --- Case 1: minimal — alias only -----------------------------------------
+create_team "case01 minimal: alias only" '{
+  "team_alias": "seed-minimal"
+}'
+
+# --- Case 2: explicit team_id ----------------------------------------------
+create_team "case02 explicit team_id" '{
+  "team_id": "seed-team-explicit-id",
+  "team_alias": "seed-explicit-id"
+}'
+
+# --- Case 3: members_with_roles (admin + user by user_id) ------------------
+create_team "case03 members_with_roles (by user_id)" '{
+  "team_alias": "seed-members-by-id",
+  "members_with_roles": [
+    {"role": "admin", "user_id": "'"${USER_ADMIN}"'"},
+    {"role": "user", "user_id": "'"${USER_MEMBER}"'"}
+  ]
+}'
+
+# --- Case 4: member by user_email (auto-creates the user if missing) --------
+create_team "case04 member by user_email" '{
+  "team_alias": "seed-members-by-email",
+  "members_with_roles": [
+    {"role": "admin", "user_email": "seed-team-admin@example.com"}
+  ]
+}'
+
+# --- Case 5: budget — max + soft + duration --------------------------------
+create_team "case05 budget: max + soft + duration" '{
+  "team_alias": "seed-budget",
+  "max_budget": 500,
+  "soft_budget": 400,
+  "budget_duration": "30d"
+}'
+
+# --- Case 6: rate limits — tpm + rpm ---------------------------------------
+create_team "case06 rate limits: tpm + rpm" '{
+  "team_alias": "seed-rate-limits",
+  "tpm_limit": 2000,
+  "rpm_limit": 120
+}'
+
+# --- Case 7: rate-limit enforcement types ----------------------------------
+create_team "case07 limit types: guaranteed_throughput" '{
+  "team_alias": "seed-limit-types",
+  "tpm_limit": 5000,
+  "rpm_limit": 300,
+  "tpm_limit_type": "guaranteed_throughput",
+  "rpm_limit_type": "best_effort_throughput"
+}'
+
+# --- Case 8: per-model tpm/rpm limits --------------------------------------
+create_team "case08 per-model tpm/rpm limits" '{
+  "team_alias": "seed-per-model-limits",
+  "model_tpm_limit": {"gpt-4o": 1000, "claude-3-5-sonnet": 2000},
+  "model_rpm_limit": {"gpt-4o": 60, "claude-3-5-sonnet": 120}
+}'
+
+# --- Case 9: model access restriction --------------------------------------
+create_team "case09 models restriction list" '{
+  "team_alias": "seed-models-allowlist",
+  "models": ["gpt-4o", "claude-3-5-sonnet", "text-embedding-3-small"]
+}'
+
+# --- Case 10: model aliases (team-based routing) ---------------------------
+create_team "case10 model_aliases" '{
+  "team_alias": "seed-model-aliases",
+  "models": ["gpt-4o"],
+  "model_aliases": {"gpt-4": "gpt-4o", "fast": "gpt-4o"}
+}'
+
+# --- Case 11: metadata ------------------------------------------------------
+create_team "case11 metadata" '{
+  "team_alias": "seed-metadata",
+  "metadata": {"department": "platform", "cost_center": "CC-1234", "extra_info": "seed"}
+}'
+
+# --- Case 12: tags (spend tracking / tag routing) --------------------------
+create_team "case12 tags" '{
+  "team_alias": "seed-tags",
+  "tags": ["production", "team-platform", "tier-1"]
+}'
+
+# --- Case 13: blocked team --------------------------------------------------
+create_team "case13 blocked team" '{
+  "team_alias": "seed-blocked",
+  "blocked": true
+}'
+
+# --- Case 14: per-team-member controls -------------------------------------
+create_team "case14 per-member budget/limits/key-duration" '{
+  "team_alias": "seed-member-controls",
+  "team_member_budget": 50,
+  "team_member_budget_duration": "30d",
+  "team_member_rpm_limit": 30,
+  "team_member_tpm_limit": 10000,
+  "team_member_key_duration": "7d"
+}'
+
+# --- Case 15: concurrent budget windows (enterprise) -----------------------
+create_team "case15 budget_limits: multiple windows (enterprise)" '{
+  "team_alias": "seed-budget-windows",
+  "budget_limits": [
+    {"budget_limit": 10.0, "time_period": "1d"},
+    {"budget_limit": 50.0, "time_period": "7d"}
+  ]
+}'
+
+# --- Case 16: team_member_permissions (enterprise) -------------------------
+create_team "case16 team_member_permissions (enterprise)" '{
+  "team_alias": "seed-member-permissions",
+  "team_member_permissions": ["/key/generate", "/key/update", "/key/delete"]
+}'
+
+# --- Case 17: object_permission — vector stores (enterprise) ---------------
+create_team "case17 object_permission: vector_stores (enterprise)" '{
+  "team_alias": "seed-object-permission",
+  "object_permission": {"vector_stores": ["vector_store_1", "vector_store_2"]}
+}'
+
+# --- Case 18: guardrails (enterprise) --------------------------------------
+create_team "case18 guardrails (enterprise)" '{
+  "team_alias": "seed-guardrails",
+  "guardrails": ["my-pii-guard", "my-prompt-injection-guard"]
+}'
+
+# --- Case 19: default models for new members -------------------------------
+create_team "case19 default_team_member_models" '{
+  "team_alias": "seed-default-member-models",
+  "models": ["gpt-4o", "claude-3-5-sonnet"],
+  "default_team_member_models": ["gpt-4o"]
+}'
+
+# --- Case 20: enforced file/batch expiry -----------------------------------
+create_team "case20 enforced file/batch expiry" '{
+  "team_alias": "seed-file-expiry",
+  "enforced_file_expires_after": {"anchor": "created_at", "days": 30},
+  "enforced_batch_output_expires_after": {"anchor": "created_at", "days": 7}
+}'
+
+echo "### Teams inside the organization (${ORG_ID}) ###"
+echo
+
+# --- Case 21: minimal team in org ------------------------------------------
+create_team "case21 in-org: minimal" '{
+  "team_alias": "seed-org-minimal",
+  "organization_id": "'"${ORG_ID}"'"
+}'
+
+# --- Case 22: in-org team with members (auto-added to the org) -------------
+create_team "case22 in-org: with members (auto-added to org)" '{
+  "team_alias": "seed-org-members",
+  "organization_id": "'"${ORG_ID}"'",
+  "members_with_roles": [
+    {"role": "admin", "user_id": "'"${USER_ADMIN}"'"},
+    {"role": "user", "user_id": "'"${USER_MEMBER}"'"}
+  ]
+}'
+
+# --- Case 23: in-org team with budget within the org's budget --------------
+create_team "case23 in-org: budget within org limits" '{
+  "team_alias": "seed-org-budget",
+  "organization_id": "'"${ORG_ID}"'",
+  "max_budget": 1000,
+  "budget_duration": "30d",
+  "tpm_limit": 50000,
+  "rpm_limit": 500
+}'
+
+# --- Case 24: in-org kitchen sink ------------------------------------------
+create_team "case24 in-org: kitchen sink" '{
+  "team_id": "seed-org-kitchen-sink",
+  "team_alias": "seed-org-kitchen-sink",
+  "organization_id": "'"${ORG_ID}"'",
+  "members_with_roles": [
+    {"role": "admin", "user_id": "'"${USER_ADMIN}"'"},
+    {"role": "user", "user_id": "'"${USER_MEMBER}"'"}
+  ],
+  "models": ["gpt-4o", "claude-3-5-sonnet"],
+  "model_aliases": {"gpt-4": "gpt-4o"},
+  "max_budget": 2000,
+  "soft_budget": 1500,
+  "budget_duration": "30d",
+  "tpm_limit": 40000,
+  "rpm_limit": 400,
+  "team_member_budget": 100,
+  "team_member_budget_duration": "30d",
+  "tags": ["production", "org-team"],
+  "metadata": {"department": "research", "tier": "premium"}
+}'
+
+echo "### Teams inside the restricted-models organization (${ORG_ID_RESTRICTED}) ###"
+echo
+
+# --- Case 25: in-restricted-org team, no models (inherits org's subset) -----
+# The team grants no explicit models, so members are bounded by the org's
+# allowlist (openai-gpt-4o, openai-gpt-4o-mini, anthropic-claude-sonnet-4).
+create_team "case25 in-restricted-org: inherits org model subset" '{
+  "team_alias": "seed-restricted-org-inherit",
+  "organization_id": "'"${ORG_ID_RESTRICTED}"'"
+}'
+
+# --- Case 26: in-restricted-org team with an allowed-models subset ----------
+# The team narrows access further to a subset of the org's allowlist.
+create_team "case26 in-restricted-org: team model subset" '{
+  "team_alias": "seed-restricted-org-subset",
+  "organization_id": "'"${ORG_ID_RESTRICTED}"'",
+  "models": ["openai-gpt-4o", "anthropic-claude-sonnet-4"]
+}'
+
+# --- Case 27: in-restricted-org kitchen sink with model subset -------------
+create_team "case27 in-restricted-org: subset + aliases + members" '{
+  "team_id": "seed-restricted-org-kitchen-sink",
+  "team_alias": "seed-restricted-org-kitchen-sink",
+  "organization_id": "'"${ORG_ID_RESTRICTED}"'",
+  "members_with_roles": [
+    {"role": "admin", "user_id": "'"${USER_ADMIN}"'"},
+    {"role": "user", "user_id": "'"${USER_MEMBER}"'"}
+  ],
+  "models": ["openai-gpt-4o", "openai-gpt-4o-mini"],
+  "model_aliases": {"gpt-4": "openai-gpt-4o", "fast": "openai-gpt-4o-mini"},
+  "default_team_member_models": ["openai-gpt-4o-mini"],
+  "max_budget": 1000,
+  "budget_duration": "30d",
+  "tags": ["production", "restricted-org-team"],
+  "metadata": {"department": "platform", "tier": "restricted"}
+}'
+
+echo "Seeding complete."

--- a/scripts/litellm-to-bifrost/scripts/create_virtual_keys.sh
+++ b/scripts/litellm-to-bifrost/scripts/create_virtual_keys.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+#
+# create_virtual_keys.sh - seed a running LiteLLM instance with virtual keys
+#
+# Usage:
+#   LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./create_virtual_keys.sh
+
+set -euo pipefail
+
+LITELLM_URL="${LITELLM_URL:-http://localhost:4000}"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-1234}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# Stable ids reused across cases so the script is deterministic.
+ORG_ID="seed-key-org"
+USER_ID="seed-key-user"
+TEAM_ID="seed-key-team"
+BUDGET_ID="seed-key-budget"
+
+# post sends one management-API call. Args: METHOD, PATH, DESCRIPTION, BODY.
+# In DRY_RUN mode it prints the payload instead of sending it. Failures are
+# logged and never abort the run (matches create_teams.sh).
+post() {
+  local method="$1" path="$2" description="$3" body="$4"
+  echo "==> ${description}"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    jq -c . <<<"${body}" 2>/dev/null || { echo "  INVALID JSON"; return; }
+    echo ""
+    return
+  fi
+  curl -sS --fail-with-body \
+    --location "${LITELLM_URL}${path}" \
+    --header "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+    --header "Content-Type: application/json" \
+    --request "${method}" \
+    --data "${body}" \
+    && echo "" \
+    || echo "  (LiteLLM rejected this payload — may be a duplicate id/key or an enterprise-only field)"
+  echo ""
+}
+
+create_key() { post POST "/key/generate" "$1" "$2"; }
+
+# ---------------------------------------------------------------------------
+# Prerequisites: org, user, budget, and a permissive team for scoped keys.
+# ---------------------------------------------------------------------------
+echo "### Prerequisites ###"
+echo
+
+post POST "/organization/new" "prereq org: ${ORG_ID}" '{
+  "organization_id": "'"${ORG_ID}"'",
+  "organization_alias": "seed-key-org",
+  "models": ["all-proxy-models"],
+  "max_budget": 100000,
+  "budget_duration": "30d"
+}'
+
+post POST "/user/new" "prereq user: ${USER_ID}" '{
+  "user_id": "'"${USER_ID}"'",
+  "user_email": "seed-key-user@example.com",
+  "user_role": "internal_user",
+  "auto_create_key": false
+}'
+
+post POST "/budget/new" "prereq budget: ${BUDGET_ID}" '{
+  "budget_id": "'"${BUDGET_ID}"'",
+  "max_budget": 250,
+  "budget_duration": "30d",
+  "tpm_limit": 5000,
+  "rpm_limit": 300
+}'
+
+# Permissive team (empty models = all models allowed)
+post POST "/team/new" "prereq team: ${TEAM_ID}" '{
+  "team_id": "'"${TEAM_ID}"'",
+  "team_alias": "seed-key-team",
+  "organization_id": "'"${ORG_ID}"'"
+}'
+
+echo "### Standalone keys ###"
+echo
+
+# --- Case 1: minimal — auto-generated key, no params -----------------------
+create_key "case01 minimal: auto key" '{}'
+
+# --- Case 2: key_alias -----------------------------------------------------
+create_key "case02 key_alias" '{
+  "key_alias": "seed-key-alias"
+}'
+
+# --- Case 3: custom key value (NOT idempotent) -----------------------------
+create_key "case03 custom key value" '{
+  "key": "sk-seed-custom-0001",
+  "key_alias": "seed-custom-value"
+}'
+
+# --- Case 4: expiry duration -----------------------------------------------
+create_key "case04 expiry: duration 30d" '{
+  "key_alias": "seed-expiry",
+  "duration": "30d"
+}'
+
+# --- Case 5: model allowlist -----------------------------------------------
+create_key "case05 models allowlist" '{
+  "key_alias": "seed-models",
+  "models": ["gpt-4o", "claude-3-5-sonnet", "text-embedding-3-small"]
+}'
+
+# --- Case 6: model aliases (upgrade/downgrade) -----------------------------
+create_key "case06 model aliases" '{
+  "key_alias": "seed-aliases",
+  "models": ["gpt-4o"],
+  "aliases": {"gpt-4": "gpt-4o", "fast": "gpt-4o"}
+}'
+
+# --- Case 7: budget — max + soft + duration --------------------------------
+create_key "case07 budget: max + soft + duration" '{
+  "key_alias": "seed-budget",
+  "max_budget": 100,
+  "soft_budget": 80,
+  "budget_duration": "30d"
+}'
+
+# --- Case 8: rate limits — tpm + rpm + parallel ----------------------------
+create_key "case08 rate limits: tpm + rpm + parallel" '{
+  "key_alias": "seed-rate-limits",
+  "tpm_limit": 2000,
+  "rpm_limit": 120,
+  "max_parallel_requests": 10
+}'
+
+# --- Case 9: rate-limit enforcement types ----------------------------------
+create_key "case09 limit types" '{
+  "key_alias": "seed-limit-types",
+  "tpm_limit": 5000,
+  "rpm_limit": 300,
+  "tpm_limit_type": "guaranteed_throughput",
+  "rpm_limit_type": "best_effort_throughput"
+}'
+
+# --- Case 10: per-model budgets --------------------------------------------
+create_key "case10 model_max_budget" '{
+  "key_alias": "seed-model-budgets",
+  "model_max_budget": {"gpt-4o": {"budget_limit": 0.5, "time_period": "30d"}}
+}'
+
+# --- Case 11: per-model rpm/tpm limits -------------------------------------
+create_key "case11 per-model rpm/tpm" '{
+  "key_alias": "seed-per-model-limits",
+  "model_rpm_limit": {"gpt-4o": 60, "claude-3-5-sonnet": 120},
+  "model_tpm_limit": {"gpt-4o": 1000, "claude-3-5-sonnet": 2000}
+}'
+
+# --- Case 12: metadata -----------------------------------------------------
+create_key "case12 metadata" '{
+  "key_alias": "seed-metadata",
+  "metadata": {"team": "core-infra", "app": "app2", "email": "owner@example.com"}
+}'
+
+# --- Case 13: tags (spend tracking / tag routing) --------------------------
+create_key "case13 tags" '{
+  "key_alias": "seed-tags",
+  "tags": ["production", "team-platform", "tier-1"]
+}'
+
+# --- Case 14: permissions (pii controls) -----------------------------------
+create_key "case14 permissions" '{
+  "key_alias": "seed-permissions",
+  "permissions": {"allow_pii_controls": true}
+}'
+
+# --- Case 15: blocked key --------------------------------------------------
+create_key "case15 blocked" '{
+  "key_alias": "seed-blocked",
+  "blocked": true
+}'
+
+# --- Case 16: allowed_routes -----------------------------------------------
+create_key "case16 allowed_routes" '{
+  "key_alias": "seed-allowed-routes",
+  "allowed_routes": ["/chat/completions", "/embeddings"]
+}'
+
+# --- Case 17: allowed_cache_controls ---------------------------------------
+create_key "case17 allowed_cache_controls" '{
+  "key_alias": "seed-cache-controls",
+  "allowed_cache_controls": ["no-cache", "no-store"]
+}'
+
+# --- Case 18: key_type — read_only -----------------------------------------
+create_key "case18 key_type: read_only" '{
+  "key_alias": "seed-read-only",
+  "key_type": "read_only"
+}'
+
+# --- Case 19: key_type — management ----------------------------------------
+create_key "case19 key_type: management" '{
+  "key_alias": "seed-management",
+  "key_type": "management"
+}'
+
+# --- Case 20: config override ----------------------------------------------
+create_key "case20 config override" '{
+  "key_alias": "seed-config",
+  "config": {"num_retries": 3}
+}'
+
+echo "### Scoped keys (team / user / org / budget) ###"
+echo
+
+# --- Case 21: scoped to a team ---------------------------------------------
+create_key "case21 team-scoped" '{
+  "key_alias": "seed-team-scoped",
+  "team_id": "'"${TEAM_ID}"'"
+}'
+
+# --- Case 22: scoped to a user ---------------------------------------------
+create_key "case22 user-scoped" '{
+  "key_alias": "seed-user-scoped",
+  "user_id": "'"${USER_ID}"'"
+}'
+
+# --- Case 23: scoped to an organization ------------------------------------
+create_key "case23 org-scoped" '{
+  "key_alias": "seed-org-scoped",
+  "organization_id": "'"${ORG_ID}"'"
+}'
+
+# --- Case 24: linked to a shared budget ------------------------------------
+create_key "case24 budget_id-linked" '{
+  "key_alias": "seed-budget-linked",
+  "budget_id": "'"${BUDGET_ID}"'"
+}'
+
+# --- Case 25: team + user together -----------------------------------------
+create_key "case25 team + user" '{
+  "key_alias": "seed-team-user",
+  "team_id": "'"${TEAM_ID}"'",
+  "user_id": "'"${USER_ID}"'"
+}'
+
+echo "### Enterprise-only cases (may be rejected on OSS builds) ###"
+echo
+
+# --- Case 26: guardrails ---------------------------------------------------
+create_key "case26 guardrails (enterprise)" '{
+  "key_alias": "seed-guardrails",
+  "guardrails": ["my-pii-guard", "my-prompt-injection-guard"]
+}'
+
+# --- Case 27: object_permission — vector stores ----------------------------
+create_key "case27 object_permission (enterprise)" '{
+  "key_alias": "seed-object-permission",
+  "object_permission": {"vector_stores": ["vector_store_1", "vector_store_2"]}
+}'
+
+# --- Case 28: enforced_params ----------------------------------------------
+create_key "case28 enforced_params (enterprise)" '{
+  "key_alias": "seed-enforced-params",
+  "enforced_params": ["user", "metadata.generation_name"]
+}'
+
+# --- Case 29: concurrent budget windows ------------------------------------
+create_key "case29 budget_limits windows (enterprise)" '{
+  "key_alias": "seed-budget-windows",
+  "budget_limits": [
+    {"budget_limit": 10.0, "time_period": "1d"},
+    {"budget_limit": 50.0, "time_period": "7d"}
+  ]
+}'
+
+# --- Case 30: auto-rotation ------------------------------------------------
+create_key "case30 auto_rotate (enterprise)" '{
+  "key_alias": "seed-auto-rotate",
+  "auto_rotate": true,
+  "rotation_interval": "30d"
+}'
+
+echo "### Kitchen sink ###"
+echo
+
+# --- Case 31: everything together ------------------------------------------
+create_key "case31 kitchen sink" '{
+  "key_alias": "seed-kitchen-sink",
+  "team_id": "'"${TEAM_ID}"'",
+  "user_id": "'"${USER_ID}"'",
+  "models": ["gpt-4o", "claude-3-5-sonnet"],
+  "aliases": {"gpt-4": "gpt-4o"},
+  "max_budget": 200,
+  "soft_budget": 150,
+  "budget_duration": "30d",
+  "duration": "90d",
+  "tpm_limit": 4000,
+  "rpm_limit": 200,
+  "max_parallel_requests": 20,
+  "model_rpm_limit": {"gpt-4o": 100},
+  "tags": ["production", "kitchen-sink"],
+  "metadata": {"owner": "platform", "tier": "premium"},
+  "permissions": {"allow_pii_controls": true}
+}'
+
+echo "Seeding complete."

--- a/scripts/litellm-to-bifrost/scripts/delete_bifrost_entities.sh
+++ b/scripts/litellm-to-bifrost/scripts/delete_bifrost_entities.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+#
+# delete_bifrost_entities.sh — delete all migration entities from a running Bifrost
+# instance: virtual keys, model configs, teams, customers, users, provider keys 
+# and providers.
+#
+# Deletion order matters: virtual keys belong to teams/customers/users, model
+# configs own budgets/rate limits, teams belong to customers, and provider keys
+# belong to providers, so children are removed first. Deleting a user cascades
+# its own governance settings, team memberships and access profiles.
+#
+# Usage:
+#   BIFROST_URL=http://localhost:8080 BIFROST_API_KEY=<token> ./delete_bifrost_entities.sh
+#
+#   DRY_RUN=1 ./delete_bifrost_entities.sh              # list what would be deleted, delete nothing
+#   DELETE_VKS=0 ./delete_bifrost_entities.sh           # skip virtual keys (default: 1)
+#   DELETE_MODEL_CONFIGS=0 ./delete_bifrost_entities.sh # skip model configs
+#   DELETE_TEAMS=0 ./delete_bifrost__entities.sh        # skip teams
+#   DELETE_CUSTOMERS=0 ./delete_bifrost_entities.sh     # skip customers
+#   DELETE_USERS=0 ./delete_bifrost_entities.sh         # skip users
+#   DELETE_KEYS=0 ./delete_bifrost_entities.sh          # skip provider keys
+#   DELETE_PROVIDERS=0 ./delete_bifrost_entities.sh     # skip providers
+#
+# Endpoints used (Bifrost management API, all require a management bearer token):
+#   GET    {url}/api/governance/virtual-keys        DELETE {url}/api/governance/virtual-keys/{id}
+#   GET    {url}/api/governance/model-configs       DELETE {url}/api/governance/model-configs/{id}
+#   GET    {url}/api/governance/teams               DELETE {url}/api/governance/teams/{id}
+#   GET    {url}/api/governance/customers           DELETE {url}/api/governance/customers/{id}
+#   GET    {url}/api/users                          DELETE {url}/api/users/{id}
+#   GET    {url}/api/providers                      DELETE {url}/api/providers/{provider}
+#   GET    {url}/api/providers/{provider}/keys      DELETE {url}/api/providers/{provider}/keys/{key_id}
+#
+# Note: Bifrost exposes no batch delete for these entities, so each row is
+# deleted individually. Deleting your own user is rejected by the API; such a
+# failure is logged and counted, and does not abort the run.
+#
+# Requires: curl, jq.
+
+set -euo pipefail
+
+BIFROST_URL="${BIFROST_URL:-http://localhost:8080}"
+BIFROST_API_KEY="${BIFROST_API_KEY:-}"
+DRY_RUN="${DRY_RUN:-0}"
+DELETE_VKS="${DELETE_VKS:-1}"
+DELETE_MODEL_CONFIGS="${DELETE_MODEL_CONFIGS:-1}"
+DELETE_TEAMS="${DELETE_TEAMS:-1}"
+DELETE_CUSTOMERS="${DELETE_CUSTOMERS:-1}"
+DELETE_USERS="${DELETE_USERS:-1}"
+DELETE_KEYS="${DELETE_KEYS:-1}"
+DELETE_PROVIDERS="${DELETE_PROVIDERS:-1}"
+
+# curl_args adds the management bearer token only when one is configured, so the
+# script also works against a local dev instance with auth disabled.
+curl_args=(-sS --fail-with-body)
+if [[ -n "${BIFROST_API_KEY}" ]]; then
+  curl_args+=(--header "Authorization: Bearer ${BIFROST_API_KEY}")
+fi
+
+# get issues an authenticated GET against a Bifrost path and prints the body.
+get() {
+  curl "${curl_args[@]}" --location "${BIFROST_URL}$1"
+}
+
+# urlenc percent-encodes one URL path segment using jq's URI encoder.
+urlenc() {
+  jq -rn --arg v "$1" '$v|@uri'
+}
+
+# delete_one issues an authenticated DELETE for a single entity path, printing
+# OK/FAIL and returning non-zero on failure.
+delete_one() {
+  local label="$1" path="$2"
+  if curl "${curl_args[@]}" --request DELETE --location "${BIFROST_URL}${path}" >/dev/null; then
+    echo "    OK deleted ${label}"
+    return 0
+  fi
+  echo "    FAIL delete ${label}"
+  return 1
+}
+
+# delete_ids deletes every id read on stdin under the given path prefix,
+# printing a dry-run line instead when DRY_RUN is set. Echoes the failure count.
+delete_ids() {
+  local label="$1" prefix="$2" failed=0 id enc
+  while IFS= read -r id; do
+    [[ -z "${id}" ]] && continue
+    if [[ "${DRY_RUN}" == "1" ]]; then
+      echo "    DRY-RUN would delete ${label} ${id}"
+      continue
+    fi
+    enc="$(urlenc "${id}")"
+    delete_one "${label} ${id}" "${prefix}${enc}" || failed=$((failed + 1))
+  done
+  return "${failed}"
+}
+
+# delete_all_virtual_keys pages through /api/governance/virtual-keys (limit /
+# offset) and deletes every virtual key individually.
+delete_all_virtual_keys() {
+  echo "==> Listing virtual keys"
+  local ids limit=100 offset=0 page batch
+  ids=""
+  while :; do
+    page="$(get "/api/governance/virtual-keys?limit=${limit}&offset=${offset}")"
+    batch="$(jq -r '.virtual_keys[]?.id' <<<"${page}")"
+    [[ -z "${batch}" ]] && break
+    ids+="${batch}"$'\n'
+    offset=$((offset + limit))
+  done
+
+  local count
+  count="$(grep -c . <<<"${ids}" || true)"
+  echo "    found ${count} virtual key(s)"
+  [[ "${count}" -eq 0 ]] && return 0
+
+  local failed=0
+  delete_ids "virtual key" "/api/governance/virtual-keys/" <<<"${ids}" || failed=$?
+  [[ "${failed}" -gt 0 ]] && { echo "    ${failed} virtual key(s) failed"; return 1; }
+  return 0
+}
+
+# delete_all_model_configs pages through /api/governance/model-configs and
+# deletes every model config individually. Deleting a model config also deletes
+# its owned budgets and rate limits in Bifrost.
+delete_all_model_configs() {
+  echo "==> Listing model configs"
+  local ids limit=100 offset=0 page batch
+  ids=""
+  while :; do
+    page="$(get "/api/governance/model-configs?limit=${limit}&offset=${offset}")"
+    batch="$(jq -r '.model_configs[]?.id' <<<"${page}")"
+    [[ -z "${batch}" ]] && break
+    ids+="${batch}"$'\n'
+    offset=$((offset + limit))
+  done
+
+  local count
+  count="$(grep -c . <<<"${ids}" || true)"
+  echo "    found ${count} model config(s)"
+  [[ "${count}" -eq 0 ]] && return 0
+
+  local failed=0
+  delete_ids "model config" "/api/governance/model-configs/" <<<"${ids}" || failed=$?
+  [[ "${failed}" -gt 0 ]] && { echo "    ${failed} model config(s) failed"; return 1; }
+  return 0
+}
+
+# delete_all_teams deletes every team. /api/governance/teams returns the full
+# list (no pagination).
+delete_all_teams() {
+  echo "==> Listing teams"
+  local ids count
+  ids="$(get "/api/governance/teams" | jq -r '.teams[]?.id')"
+  count="$(grep -c . <<<"${ids}" || true)"
+  echo "    found ${count} team(s)"
+  [[ "${count}" -eq 0 ]] && return 0
+
+  local failed=0
+  delete_ids "team" "/api/governance/teams/" <<<"${ids}" || failed=$?
+  [[ "${failed}" -gt 0 ]] && { echo "    ${failed} team(s) failed"; return 1; }
+  return 0
+}
+
+# delete_all_customers deletes every customer. /api/governance/customers returns
+# the full list (no pagination).
+delete_all_customers() {
+  echo "==> Listing customers"
+  local ids count
+  ids="$(get "/api/governance/customers" | jq -r '.customers[]?.id')"
+  count="$(grep -c . <<<"${ids}" || true)"
+  echo "    found ${count} customer(s)"
+  [[ "${count}" -eq 0 ]] && return 0
+
+  local failed=0
+  delete_ids "customer" "/api/governance/customers/" <<<"${ids}" || failed=$?
+  [[ "${failed}" -gt 0 ]] && { echo "    ${failed} customer(s) failed"; return 1; }
+  return 0
+}
+
+# delete_all_users pages through /api/users (page / has_more) and deletes every
+# user individually. Deleting the caller's own user is rejected by the API and
+# counted as a failure.
+delete_all_users() {
+  echo "==> Listing users"
+  local ids="" limit=100 page=1 resp batch has_more
+  while :; do
+    resp="$(get "/api/users?page=${page}&limit=${limit}")"
+    batch="$(jq -r '.users[]?.id' <<<"${resp}")"
+    [[ -n "${batch}" ]] && ids+="${batch}"$'\n'
+    has_more="$(jq -r '.has_more // false' <<<"${resp}")"
+    [[ "${has_more}" != "true" ]] && break
+    page=$((page + 1))
+  done
+
+  local count
+  count="$(grep -c . <<<"${ids}" || true)"
+  echo "    found ${count} user(s)"
+  [[ "${count}" -eq 0 ]] && return 0
+
+  local failed=0
+  delete_ids "user" "/api/users/" <<<"${ids}" || failed=$?
+  [[ "${failed}" -gt 0 ]] && { echo "    ${failed} user(s) failed (a self-delete is expected to fail)"; return 1; }
+  return 0
+}
+
+# delete_all_provider_keys deletes every key under every configured provider.
+# Provider deletion usually cascades keys, but deleting keys first gives clearer
+# reset output and works when provider deletion is disabled.
+delete_all_provider_keys() {
+  echo "==> Listing provider keys"
+  local providers provider provider_path ids count total=0 failed=0 key_id key_path
+  providers="$(get "/api/providers" | jq -r '.providers[]?.name')"
+  count="$(grep -c . <<<"${providers}" || true)"
+  echo "    found ${count} provider(s) to inspect"
+  [[ "${count}" -eq 0 ]] && return 0
+
+  while IFS= read -r provider; do
+    [[ -z "${provider}" ]] && continue
+    provider_path="$(urlenc "${provider}")"
+    ids="$(get "/api/providers/${provider_path}/keys" | jq -r '.keys[]?.id')"
+    count="$(grep -c . <<<"${ids}" || true)"
+    echo "    provider ${provider}: found ${count} key(s)"
+    total=$((total + count))
+    while IFS= read -r key_id; do
+      [[ -z "${key_id}" ]] && continue
+      key_path="$(urlenc "${key_id}")"
+      if [[ "${DRY_RUN}" == "1" ]]; then
+        echo "    DRY-RUN would delete provider key ${provider}/${key_id}"
+        continue
+      fi
+      delete_one "provider key ${provider}/${key_id}" "/api/providers/${provider_path}/keys/${key_path}" || failed=$((failed + 1))
+    done <<<"${ids}"
+  done <<<"${providers}"
+
+  echo "    found ${total} provider key(s)"
+  [[ "${failed}" -gt 0 ]] && { echo "    ${failed} provider key(s) failed"; return 1; }
+  return 0
+}
+
+# delete_all_providers deletes every configured provider after keys are removed.
+delete_all_providers() {
+  echo "==> Listing providers"
+  local providers count failed=0 provider provider_path
+  providers="$(get "/api/providers" | jq -r '.providers[]?.name')"
+  count="$(grep -c . <<<"${providers}" || true)"
+  echo "    found ${count} provider(s)"
+  [[ "${count}" -eq 0 ]] && return 0
+
+  while IFS= read -r provider; do
+    [[ -z "${provider}" ]] && continue
+    provider_path="$(urlenc "${provider}")"
+    if [[ "${DRY_RUN}" == "1" ]]; then
+      echo "    DRY-RUN would delete provider ${provider}"
+      continue
+    fi
+    delete_one "provider ${provider}" "/api/providers/${provider_path}" || failed=$((failed + 1))
+  done <<<"${providers}"
+
+  [[ "${failed}" -gt 0 ]] && { echo "    ${failed} provider(s) failed"; return 1; }
+  return 0
+}
+
+main() {
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "DRY-RUN mode: nothing will be deleted."
+    echo
+  fi
+
+  [[ "${DELETE_VKS}" == "1" ]] && { delete_all_virtual_keys || true; echo; }
+  [[ "${DELETE_MODEL_CONFIGS}" == "1" ]] && { delete_all_model_configs || true; echo; }
+  [[ "${DELETE_TEAMS}" == "1" ]] && { delete_all_teams || true; echo; }
+  [[ "${DELETE_CUSTOMERS}" == "1" ]] && { delete_all_customers || true; echo; }
+  [[ "${DELETE_USERS}" == "1" ]] && { delete_all_users || true; echo; }
+  [[ "${DELETE_KEYS}" == "1" ]] && { delete_all_provider_keys || true; echo; }
+  [[ "${DELETE_PROVIDERS}" == "1" ]] && { delete_all_providers || true; echo; }
+
+  echo "Cleanup complete."
+}
+
+main "$@"

--- a/scripts/litellm-to-bifrost/scripts/delete_entities.sh
+++ b/scripts/litellm-to-bifrost/scripts/delete_entities.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+#
+# delete_entities.sh — delete ALL entities from a running LiteLLM instance.
+# Covers, in dependency order: virtual keys, teams, organizations, budgets,
+# (DB-backed) models and credentials. Use this to reset a LiteLLM instance before
+# re-running the org->customer migration (go run ./scripts/migration/litellm).
+#
+# Deletion order matters: keys and teams belong to organizations, so they are
+# removed first; budgets orphaned by org deletion are swept up afterwards.
+#
+# Usage:
+#   LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./delete_entities.sh
+#
+#   DRY_RUN=1 ./delete_entities.sh          # list what would be deleted, delete nothing
+#   DELETE_KEYS=0 ./delete_entities.sh      # skip virtual keys
+#   DELETE_TEAMS=0 ./delete_entities.sh     # skip teams
+#   DELETE_ORGS=0 ./delete_entities.sh      # skip organizations
+#   DELETE_BUDGETS=0 ./delete_entities.sh   # skip budgets
+#   DELETE_MODELS=0 ./delete_entities.sh    # skip models
+#   DELETE_CREDENTIALS=0 ./delete_entities.sh # skip credentials
+#
+# Endpoints used (LiteLLM management API):
+#   GET  {url}/key/list            POST   {url}/key/delete           (batch)
+#   GET  {url}/team/list           POST   {url}/team/delete          (batch)
+#   GET  {url}/organization/list   DELETE {url}/organization/delete  (batch)
+#   GET  {url}/budget/list         POST   {url}/budget/delete        (one at a time)
+#   GET  {url}/model/info          POST   {url}/model/delete         (one at a time)
+#   GET  {url}/credentials         DELETE {url}/credentials/{name}   (one at a time)
+#
+# Note: only DB-backed models (model_info.db_model == true) can be deleted via
+# the API; models defined in config.yaml are skipped.
+#
+# Requires: curl, jq.
+
+set -euo pipefail
+
+LITELLM_URL="${LITELLM_URL:-http://localhost:4000}"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-1234}"
+DRY_RUN="${DRY_RUN:-0}"
+DELETE_KEYS="${DELETE_KEYS:-1}"
+DELETE_TEAMS="${DELETE_TEAMS:-1}"
+DELETE_ORGS="${DELETE_ORGS:-1}"
+DELETE_BUDGETS="${DELETE_BUDGETS:-1}"
+DELETE_MODELS="${DELETE_MODELS:-1}"
+DELETE_CREDENTIALS="${DELETE_CREDENTIALS:-1}"
+
+AUTH_HEADER="Authorization: Bearer ${LITELLM_MASTER_KEY}"
+
+# get issues an authenticated GET and prints the response body.
+get() {
+  curl -sS --fail-with-body --location "${LITELLM_URL}$1" --header "${AUTH_HEADER}"
+}
+
+# delete_all_keys collects every virtual key across all pages of /key/list and
+# deletes them in a single batch /key/delete request.
+delete_all_keys() {
+  echo "==> Listing virtual keys"
+  local page1 total_pages keys count
+  page1="$(get "/key/list?page=1")"
+  total_pages="$(jq -r '.total_pages // 1' <<<"${page1}")"
+
+  keys="$(jq -c '[.keys[]? | if type == "string" then . else (.token // .key // .key_name // empty) end]' <<<"${page1}")"
+  local p
+  for ((p = 2; p <= total_pages; p++)); do
+    keys="$(jq -c --argjson more "$(get "/key/list?page=${p}" | jq -c '[.keys[]? | if type == "string" then . else (.token // .key // .key_name // empty) end]')" '. + $more' <<<"${keys}")"
+  done
+
+  count="$(jq 'length' <<<"${keys}")"
+  echo "    found ${count} virtual key(s)"
+  if [[ "${count}" -eq 0 ]]; then
+    return 0
+  fi
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "    DRY-RUN would delete ${count} virtual key(s)"
+    return 0
+  fi
+
+  echo "==> Deleting ${count} virtual key(s)"
+  curl -sS --fail-with-body --request POST --location "${LITELLM_URL}/key/delete" \
+    --header "${AUTH_HEADER}" \
+    --header "Content-Type: application/json" \
+    --data "{\"keys\": ${keys}}" >/dev/null \
+    && echo "    OK deleted ${count} virtual key(s)" \
+    || echo "    FAIL delete ${count} virtual key(s)"
+}
+
+# delete_all_teams enumerates every team and deletes them in a single batch
+# /team/delete request. Null team ids (the implicit default team) are skipped.
+delete_all_teams() {
+  echo "==> Listing teams"
+  local teams ids count
+  teams="$(get "/team/list")"
+  ids="$(jq -c '[.[].team_id | select(. != null)]' <<<"${teams}")"
+  count="$(jq 'length' <<<"${ids}")"
+  echo "    found ${count} team(s)"
+  if [[ "${count}" -eq 0 ]]; then
+    return 0
+  fi
+
+  jq -r '.[] | "    team \(.)"' <<<"${ids}"
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "    DRY-RUN would delete ${count} team(s)"
+    return 0
+  fi
+
+  echo "==> Deleting ${count} team(s)"
+  curl -sS --fail-with-body --request POST --location "${LITELLM_URL}/team/delete" \
+    --header "${AUTH_HEADER}" \
+    --header "Content-Type: application/json" \
+    --data "{\"team_ids\": ${ids}}" >/dev/null \
+    && echo "    OK deleted ${count} team(s)" \
+    || echo "    FAIL delete ${count} team(s)"
+}
+
+# delete_all_organizations enumerates every organization and deletes them in a
+# single batch /organization/delete request.
+delete_all_organizations() {
+  echo "==> Listing organizations"
+  local orgs ids count
+  orgs="$(get "/organization/list")"
+  ids="$(jq -c '[.[].organization_id | select(. != null)]' <<<"${orgs}")"
+  count="$(jq 'length' <<<"${ids}")"
+  echo "    found ${count} organization(s)"
+  if [[ "${count}" -eq 0 ]]; then
+    return 0
+  fi
+
+  jq -r '.[] | "    org \(.organization_id) (\(.organization_alias // "-"))"' <<<"${orgs}"
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "    DRY-RUN would delete ${count} organization(s)"
+    return 0
+  fi
+
+  echo "==> Deleting ${count} organization(s)"
+  curl -sS --fail-with-body --request DELETE --location "${LITELLM_URL}/organization/delete" \
+    --header "${AUTH_HEADER}" \
+    --header "Content-Type: application/json" \
+    --data "{\"organization_ids\": ${ids}}" >/dev/null \
+    && echo "    OK deleted ${count} organization(s)" \
+    || echo "    FAIL delete ${count} organization(s)"
+}
+
+# delete_all_budgets enumerates every budget and deletes them one at a time;
+# LiteLLM exposes no batch delete for budgets.
+delete_all_budgets() {
+  echo "==> Listing budgets"
+  local budgets count failed=0
+  budgets="$(get "/budget/list")"
+  count="$(jq 'length' <<<"${budgets}")"
+  echo "    found ${count} budget(s)"
+  if [[ "${count}" -eq 0 ]]; then
+    return 0
+  fi
+
+  while IFS= read -r budget_id; do
+    [[ -z "${budget_id}" ]] && continue
+    if [[ "${DRY_RUN}" == "1" ]]; then
+      echo "    DRY-RUN would delete budget ${budget_id}"
+      continue
+    fi
+    if curl -sS --fail-with-body --request POST --location "${LITELLM_URL}/budget/delete" \
+      --header "${AUTH_HEADER}" \
+      --header "Content-Type: application/json" \
+      --data "$(jq -n --arg id "${budget_id}" '{"id": $id}')" >/dev/null; then
+      echo "    OK deleted budget ${budget_id}"
+    else
+      echo "    FAIL delete budget ${budget_id}"
+      failed=$((failed + 1))
+    fi
+  done < <(jq -r '.[] | select(.budget_id != null) | .budget_id' <<<"${budgets}")
+
+  if [[ "${failed}" -gt 0 ]]; then
+    echo "    ${failed} budget(s) failed to delete"
+    return 1
+  fi
+}
+
+# delete_all_models enumerates DB-backed models and deletes them one at a time;
+# models defined in config.yaml (db_model == false) cannot be deleted via the
+# API and are skipped.
+delete_all_models() {
+  echo "==> Listing models"
+  local models db_ids count skipped failed=0
+  models="$(get "/model/info")"
+  db_ids="$(jq -c '[.data[] | select(.model_info.db_model == true and .model_info.id != null) | .model_info.id]' <<<"${models}")"
+  count="$(jq 'length' <<<"${db_ids}")"
+  skipped="$(jq '[.data[] | select(.model_info.db_model != true)] | length' <<<"${models}")"
+  echo "    found ${count} DB-backed model(s) (${skipped} config model(s) skipped)"
+  if [[ "${count}" -eq 0 ]]; then
+    return 0
+  fi
+
+  while IFS= read -r model_id; do
+    [[ -z "${model_id}" ]] && continue
+    if [[ "${DRY_RUN}" == "1" ]]; then
+      echo "    DRY-RUN would delete model ${model_id}"
+      continue
+    fi
+    if curl -sS --fail-with-body --request POST --location "${LITELLM_URL}/model/delete" \
+      --header "${AUTH_HEADER}" \
+      --header "Content-Type: application/json" \
+      --data "$(jq -n --arg id "${model_id}" '{"id": $id}')" >/dev/null; then
+      echo "    OK deleted model ${model_id}"
+    else
+      echo "    FAIL delete model ${model_id}"
+      failed=$((failed + 1))
+    fi
+  done < <(jq -r '.[]' <<<"${db_ids}")
+
+  if [[ "${failed}" -gt 0 ]]; then
+    echo "    ${failed} model(s) failed to delete"
+    return 1
+  fi
+}
+
+# delete_all_credentials enumerates every stored credential and deletes them one
+# at a time via DELETE /credentials/{credential_name}.
+delete_all_credentials() {
+  echo "==> Listing credentials"
+  local credentials count failed=0
+  credentials="$(get "/credentials")"
+  count="$(jq '.credentials // [] | length' <<<"${credentials}")"
+  echo "    found ${count} credential(s)"
+  if [[ "${count}" -eq 0 ]]; then
+    return 0
+  fi
+
+  while IFS=$'\t' read -r credential_name credential_path; do
+    [[ -z "${credential_name}" ]] && continue
+    if [[ "${DRY_RUN}" == "1" ]]; then
+      echo "    DRY-RUN would delete credential ${credential_name}"
+      continue
+    fi
+    if curl -sS --fail-with-body --request DELETE --location "${LITELLM_URL}/credentials/${credential_path}" \
+      --header "${AUTH_HEADER}" >/dev/null; then
+      echo "    OK deleted credential ${credential_name}"
+    else
+      echo "    FAIL delete credential ${credential_name}"
+      failed=$((failed + 1))
+    fi
+  done < <(jq -r '.credentials // [] | .[] | select(.credential_name != null) | [.credential_name, (.credential_name | @uri)] | @tsv' <<<"${credentials}")
+
+  if [[ "${failed}" -gt 0 ]]; then
+    echo "    ${failed} credential(s) failed to delete"
+    return 1
+  fi
+}
+
+main() {
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "DRY-RUN mode: nothing will be deleted."
+    echo
+  fi
+
+  [[ "${DELETE_KEYS}" == "1" ]] && { delete_all_keys || true; echo; }
+  [[ "${DELETE_TEAMS}" == "1" ]] && { delete_all_teams || true; echo; }
+  [[ "${DELETE_ORGS}" == "1" ]] && { delete_all_organizations || true; echo; }
+  [[ "${DELETE_BUDGETS}" == "1" ]] && { delete_all_budgets || true; echo; }
+  [[ "${DELETE_MODELS}" == "1" ]] && { delete_all_models || true; echo; }
+  [[ "${DELETE_CREDENTIALS}" == "1" ]] && { delete_all_credentials || true; echo; }
+
+  echo "Cleanup complete."
+}
+
+main "$@"

--- a/scripts/litellm-to-bifrost/scripts/seed_models.sh
+++ b/scripts/litellm-to-bifrost/scripts/seed_models.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# seed_models.sh - seed the comprehensive model fixture into a running LiteLLM
+# proxy via the management API (POST /model/new), instead of via config.yaml.
+#
+# Models added via /model/new are stored in the DB (db_model: true) and are
+# therefore deletable via delete_entities.sh in this directory.
+#
+# Usage:
+#   LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./seed_models.sh
+#
+#   DRY_RUN=1 ./seed_models.sh    # print payloads, POST nothing
+#
+# The proxy must run with `general_settings.store_model_in_db: True` and a DB
+# connection, otherwise /model/new returns 500.
+#
+# Requires: curl, jq.
+
+set -euo pipefail
+
+LITELLM_URL="${LITELLM_URL:-http://localhost:4000}"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-1234}"
+DRY_RUN="${DRY_RUN:-0}"
+
+added=0
+failed=0
+
+# add_model posts a single Deployment to /model/new. Args:
+#   $1 = human-readable description (logged only)
+#   $2 = JSON body ({model_name, litellm_params, model_info?})
+# In DRY_RUN mode it pretty-prints the body instead of sending it.
+add_model() {
+  local desc="$1" body="$2"
+
+  if ! jq -e . >/dev/null 2>&1 <<<"${body}"; then
+    echo "  SKIP ${desc}: invalid JSON payload"
+    failed=$((failed + 1))
+    return
+  fi
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "  DRY-RUN ${desc}:"
+    jq -c . <<<"${body}"
+    added=$((added + 1))
+    return
+  fi
+
+  if curl -sS --fail-with-body \
+      --request POST "${LITELLM_URL}/model/new" \
+      --header "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+      --header "Content-Type: application/json" \
+      --data "${body}" >/dev/null; then
+    echo "  OK   ${desc}"
+    added=$((added + 1))
+  else
+    echo "  FAIL ${desc}"
+    failed=$((failed + 1))
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# CASE 1 — Simple chat/completion, one representative model per provider.
+# -----------------------------------------------------------------------------
+echo "==> Case 1: simple chat per provider"
+add_model "openai chat"      '{"model_name":"openai-gpt-4o","litellm_params":{"model":"openai/gpt-4o","api_key":"os.environ/OPENAI_API_KEY"}}'
+add_model "anthropic chat"   '{"model_name":"anthropic-claude","litellm_params":{"model":"anthropic/claude-sonnet-4-20250514","api_key":"os.environ/ANTHROPIC_API_KEY"}}'
+add_model "gemini chat"      '{"model_name":"gemini-flash","litellm_params":{"model":"gemini/gemini-2.5-flash","api_key":"os.environ/GEMINI_API_KEY"}}'
+add_model "xai chat"         '{"model_name":"xai-grok","litellm_params":{"model":"xai/grok-3","api_key":"os.environ/XAI_API_KEY"}}'
+add_model "zai chat"         '{"model_name":"zai-glm","litellm_params":{"model":"zai/glm-4.6","api_key":"os.environ/ZAI_API_KEY"}}'
+add_model "mistral chat"     '{"model_name":"mistral-large","litellm_params":{"model":"mistral/mistral-large-latest","api_key":"os.environ/MISTRAL_API_KEY"}}'
+add_model "codestral chat"   '{"model_name":"codestral","litellm_params":{"model":"codestral/codestral-latest","api_key":"os.environ/CODESTRAL_API_KEY"}}'
+add_model "deepseek chat"    '{"model_name":"deepseek-chat","litellm_params":{"model":"deepseek/deepseek-chat","api_key":"os.environ/DEEPSEEK_API_KEY"}}'
+add_model "groq chat"        '{"model_name":"groq-llama","litellm_params":{"model":"groq/llama-3.3-70b-versatile","api_key":"os.environ/GROQ_API_KEY"}}'
+add_model "cerebras chat"    '{"model_name":"cerebras-llama","litellm_params":{"model":"cerebras/llama-3.3-70b","api_key":"os.environ/CEREBRAS_API_KEY"}}'
+add_model "cohere chat"      '{"model_name":"cohere-command","litellm_params":{"model":"cohere_chat/command-r-plus","api_key":"os.environ/COHERE_API_KEY"}}'
+add_model "together chat"    '{"model_name":"together-llama","litellm_params":{"model":"together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo","api_key":"os.environ/TOGETHERAI_API_KEY"}}'
+add_model "fireworks chat"   '{"model_name":"fireworks-llama","litellm_params":{"model":"fireworks_ai/accounts/fireworks/models/llama-v3p3-70b-instruct","api_key":"os.environ/FIREWORKS_AI_API_KEY"}}'
+add_model "openrouter chat"  '{"model_name":"openrouter-gpt","litellm_params":{"model":"openrouter/openai/gpt-4o","api_key":"os.environ/OPENROUTER_API_KEY"}}'
+add_model "perplexity chat"  '{"model_name":"perplexity-sonar","litellm_params":{"model":"perplexity/sonar","api_key":"os.environ/PERPLEXITYAI_API_KEY"}}'
+add_model "deepinfra chat"   '{"model_name":"deepinfra-llama","litellm_params":{"model":"deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct","api_key":"os.environ/DEEPINFRA_API_KEY"}}'
+add_model "sambanova chat"   '{"model_name":"sambanova-llama","litellm_params":{"model":"sambanova/Meta-Llama-3.3-70B-Instruct","api_key":"os.environ/SAMBANOVA_API_KEY"}}'
+add_model "nvidia nim chat"  '{"model_name":"nvidia-nim-llama","litellm_params":{"model":"nvidia_nim/meta/llama-3.1-70b-instruct","api_key":"os.environ/NVIDIA_NIM_API_KEY"}}'
+add_model "ai21 chat"        '{"model_name":"ai21-jamba","litellm_params":{"model":"ai21_chat/jamba-1.5-large","api_key":"os.environ/AI21_API_KEY"}}'
+add_model "replicate chat"   '{"model_name":"replicate-llama","litellm_params":{"model":"replicate/meta/meta-llama-3-70b-instruct","api_key":"os.environ/REPLICATE_API_KEY"}}'
+add_model "huggingface chat" '{"model_name":"huggingface-llama","litellm_params":{"model":"huggingface/meta-llama/Llama-3.1-8B-Instruct","api_key":"os.environ/HUGGINGFACE_API_KEY"}}'
+add_model "databricks chat"  '{"model_name":"databricks-dbrx","litellm_params":{"model":"databricks/databricks-dbrx-instruct","api_key":"os.environ/DATABRICKS_API_KEY","api_base":"os.environ/DATABRICKS_API_BASE"}}'
+add_model "predibase chat"   '{"model_name":"predibase-llama","litellm_params":{"model":"predibase/llama-3-8b-instruct","api_key":"os.environ/PREDIBASE_API_KEY","tenant_id":"os.environ/PREDIBASE_TENANT_ID"}}'
+add_model "nscale chat"      '{"model_name":"nscale-llama","litellm_params":{"model":"nscale/meta-llama/Llama-3.3-70B-Instruct","api_key":"os.environ/NSCALE_API_KEY"}}'
+add_model "novita chat"      '{"model_name":"novita-llama","litellm_params":{"model":"novita/meta-llama/llama-3.1-70b-instruct","api_key":"os.environ/NOVITA_API_KEY"}}'
+add_model "friendliai chat"  '{"model_name":"friendliai-llama","litellm_params":{"model":"friendliai/meta-llama-3.1-70b-instruct","api_key":"os.environ/FRIENDLI_TOKEN"}}'
+add_model "featherless chat" '{"model_name":"featherless-llama","litellm_params":{"model":"featherless_ai/meta-llama/Meta-Llama-3.1-8B-Instruct","api_key":"os.environ/FEATHERLESS_AI_API_KEY"}}'
+add_model "github chat"      '{"model_name":"github-gpt","litellm_params":{"model":"github/gpt-4o","api_key":"os.environ/GITHUB_API_KEY"}}'
+add_model "github copilot"   '{"model_name":"github-copilot-gpt","litellm_params":{"model":"github_copilot/gpt-4o"}}'
+add_model "cloudflare chat"  '{"model_name":"cloudflare-llama","litellm_params":{"model":"cloudflare/@cf/meta/llama-3.1-8b-instruct","api_key":"os.environ/CLOUDFLARE_API_KEY","api_base":"os.environ/CLOUDFLARE_API_BASE"}}'
+add_model "gigachat chat"    '{"model_name":"gigachat-pro","litellm_params":{"model":"gigachat/GigaChat-Pro","api_key":"os.environ/GIGACHAT_API_KEY"}}'
+add_model "moonshot chat"    '{"model_name":"moonshot-v1","litellm_params":{"model":"moonshot/moonshot-v1-8k","api_key":"os.environ/MOONSHOT_API_KEY"}}'
+add_model "dashscope chat"   '{"model_name":"dashscope-qwen","litellm_params":{"model":"dashscope/qwen-max","api_key":"os.environ/DASHSCOPE_API_KEY"}}'
+add_model "volcengine chat"  '{"model_name":"volcengine-doubao","litellm_params":{"model":"volcengine/doubao-pro-4k","api_key":"os.environ/VOLCENGINE_API_KEY"}}'
+add_model "nebius chat"      '{"model_name":"nebius-llama","litellm_params":{"model":"nebius/meta-llama/Meta-Llama-3.1-70B-Instruct","api_key":"os.environ/NEBIUS_API_KEY"}}'
+add_model "hyperbolic chat"  '{"model_name":"hyperbolic-llama","litellm_params":{"model":"hyperbolic/meta-llama/Meta-Llama-3.1-70B-Instruct","api_key":"os.environ/HYPERBOLIC_API_KEY"}}'
+add_model "lambda chat"      '{"model_name":"lambda-llama","litellm_params":{"model":"lambda_ai/llama3.1-70b-instruct-fp8","api_key":"os.environ/LAMBDA_API_KEY"}}'
+add_model "v0 chat"          '{"model_name":"v0-md","litellm_params":{"model":"v0/v0-1.5-md","api_key":"os.environ/V0_API_KEY"}}'
+add_model "morph chat"       '{"model_name":"morph-large","litellm_params":{"model":"morph/morph-v3-large","api_key":"os.environ/MORPH_API_KEY"}}'
+add_model "inception chat"   '{"model_name":"inception-mercury","litellm_params":{"model":"inception/mercury","api_key":"os.environ/INCEPTION_API_KEY"}}'
+add_model "maritalk chat"    '{"model_name":"maritalk-sabia","litellm_params":{"model":"maritalk/sabia-3","api_key":"os.environ/MARITALK_API_KEY"}}'
+add_model "meta llama api"   '{"model_name":"meta-llama-api","litellm_params":{"model":"meta_llama/Llama-3.3-70B-Instruct","api_key":"os.environ/LLAMA_API_KEY"}}'
+add_model "galadriel chat"   '{"model_name":"galadriel-llama","litellm_params":{"model":"galadriel/llama3.1","api_key":"os.environ/GALADRIEL_API_KEY"}}'
+add_model "aiml chat"        '{"model_name":"aiml-gpt","litellm_params":{"model":"aiml/gpt-4o","api_key":"os.environ/AIML_API_KEY"}}'
+add_model "cometapi chat"    '{"model_name":"cometapi-gpt","litellm_params":{"model":"cometapi/gpt-4o","api_key":"os.environ/COMETAPI_KEY"}}'
+add_model "vercel gateway"   '{"model_name":"vercel-gateway-gpt","litellm_params":{"model":"vercel_ai_gateway/openai/gpt-4o","api_key":"os.environ/VERCEL_AI_GATEWAY_API_KEY"}}'
+add_model "nano-gpt chat"    '{"model_name":"nano-gpt","litellm_params":{"model":"nano-gpt/gpt-4o","api_key":"os.environ/NANO_GPT_API_KEY"}}'
+add_model "chutes chat"      '{"model_name":"chutes-llama","litellm_params":{"model":"chutes/meta-llama/Llama-3.3-70B-Instruct","api_key":"os.environ/CHUTES_API_KEY"}}'
+add_model "minimax chat"     '{"model_name":"minimax-text","litellm_params":{"model":"minimax/MiniMax-Text-01","api_key":"os.environ/MINIMAX_API_KEY"}}'
+add_model "baseten chat"     '{"model_name":"baseten-llama","litellm_params":{"model":"baseten/llama-3-70b-instruct","api_key":"os.environ/BASETEN_API_KEY"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 2 — Self-hosted / OpenAI-compatible endpoints (require api_base).
+# -----------------------------------------------------------------------------
+echo "==> Case 2: self-hosted / OpenAI-compatible"
+add_model "ollama"           '{"model_name":"ollama-llama","litellm_params":{"model":"ollama_chat/llama3.1","api_base":"os.environ/OLLAMA_API_BASE"}}'
+add_model "hosted vllm"      '{"model_name":"vllm-llama","litellm_params":{"model":"hosted_vllm/meta-llama/Llama-3.1-8B-Instruct","api_base":"os.environ/HOSTED_VLLM_API_BASE"}}'
+add_model "lm studio"        '{"model_name":"lmstudio-llama","litellm_params":{"model":"lm_studio/llama-3.1-8b-instruct","api_base":"os.environ/LM_STUDIO_API_BASE"}}'
+add_model "llamafile"        '{"model_name":"llamafile-local","litellm_params":{"model":"llamafile/local-model","api_base":"os.environ/LLAMAFILE_API_BASE"}}'
+add_model "triton"           '{"model_name":"triton-model","litellm_params":{"model":"triton/ensemble","api_base":"os.environ/TRITON_API_BASE"}}'
+add_model "xinference"       '{"model_name":"xinference-llama","litellm_params":{"model":"xinference/llama-3-instruct","api_base":"os.environ/XINFERENCE_API_BASE"}}'
+add_model "openai-compat"    '{"model_name":"openai-compatible-custom","litellm_params":{"model":"openai/my-self-hosted-model","api_key":"os.environ/CUSTOM_LLM_API_KEY","api_base":"os.environ/CUSTOM_LLM_API_BASE"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 3 — Provider-specific credential shapes.
+# -----------------------------------------------------------------------------
+echo "==> Case 3: provider-specific credentials"
+add_model "vertex ai"        '{"model_name":"vertex-gemini","litellm_params":{"model":"vertex_ai/gemini-2.5-pro","vertex_project":"os.environ/VERTEX_PROJECT","vertex_location":"os.environ/VERTEX_LOCATION","vertex_credentials":"os.environ/VERTEX_CREDENTIALS"}}'
+add_model "bedrock keys"     '{"model_name":"bedrock-claude","litellm_params":{"model":"bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0","aws_access_key_id":"os.environ/AWS_ACCESS_KEY_ID","aws_secret_access_key":"os.environ/AWS_SECRET_ACCESS_KEY","aws_region_name":"os.environ/AWS_REGION_NAME"}}'
+add_model "bedrock role"     '{"model_name":"bedrock-claude-role","litellm_params":{"model":"bedrock/converse/anthropic.claude-3-5-sonnet-20241022-v2:0","aws_role_name":"os.environ/AWS_ROLE_NAME","aws_session_name":"litellm-session","aws_region_name":"os.environ/AWS_REGION_NAME"}}'
+add_model "sagemaker"        '{"model_name":"sagemaker-llama","litellm_params":{"model":"sagemaker/jumpstart-dft-meta-textgeneration-llama-3-8b","aws_region_name":"os.environ/AWS_REGION_NAME","input_cost_per_second":0.000420}}'
+add_model "watsonx"          '{"model_name":"watsonx-llama","litellm_params":{"model":"watsonx/meta-llama/llama-3-3-70b-instruct","api_key":"os.environ/WATSONX_API_KEY","api_base":"os.environ/WATSONX_URL","project_id":"os.environ/WATSONX_PROJECT_ID"}}'
+add_model "oci"              '{"model_name":"oci-cohere","litellm_params":{"model":"oci/cohere.command-r-plus","oci_region":"os.environ/OCI_REGION","oci_user":"os.environ/OCI_USER","oci_tenancy":"os.environ/OCI_TENANCY","oci_fingerprint":"os.environ/OCI_FINGERPRINT","oci_key_file":"os.environ/OCI_KEY_FILE"}}'
+add_model "snowflake"        '{"model_name":"snowflake-llama","litellm_params":{"model":"snowflake/llama3.1-70b","api_base":"os.environ/SNOWFLAKE_API_BASE","api_key":"os.environ/SNOWFLAKE_JWT"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 4 — Embeddings (mode: embedding).
+# -----------------------------------------------------------------------------
+echo "==> Case 4: embeddings"
+add_model "openai embed"     '{"model_name":"text-embedding-3-small","litellm_params":{"model":"openai/text-embedding-3-small","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"mode":"embedding","base_model":"text-embedding-3-small"}}'
+add_model "cohere embed"     '{"model_name":"cohere-embed","litellm_params":{"model":"cohere/embed-english-v3.0","api_key":"os.environ/COHERE_API_KEY"},"model_info":{"mode":"embedding"}}'
+add_model "mistral embed"    '{"model_name":"mistral-embed","litellm_params":{"model":"mistral/mistral-embed","api_key":"os.environ/MISTRAL_API_KEY"},"model_info":{"mode":"embedding"}}'
+add_model "voyage embed"     '{"model_name":"voyage-embed","litellm_params":{"model":"voyage/voyage-3","api_key":"os.environ/VOYAGE_API_KEY"},"model_info":{"mode":"embedding"}}'
+add_model "jina embed"       '{"model_name":"jina-embed","litellm_params":{"model":"jina_ai/jina-embeddings-v3","api_key":"os.environ/JINA_AI_API_KEY"},"model_info":{"mode":"embedding"}}'
+add_model "bedrock embed"    '{"model_name":"bedrock-titan-embed","litellm_params":{"model":"bedrock/amazon.titan-embed-text-v2:0","aws_region_name":"os.environ/AWS_REGION_NAME"},"model_info":{"mode":"embedding"}}'
+add_model "vertex embed"     '{"model_name":"vertex-embed","litellm_params":{"model":"vertex_ai/text-embedding-005","vertex_project":"os.environ/VERTEX_PROJECT","vertex_location":"os.environ/VERTEX_LOCATION"},"model_info":{"mode":"embedding"}}'
+add_model "infinity embed"   '{"model_name":"infinity-embed","litellm_params":{"model":"infinity/BAAI/bge-small-en-v1.5","api_base":"os.environ/INFINITY_API_BASE"},"model_info":{"mode":"embedding"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 5 — Image generation (mode: image_generation).
+# -----------------------------------------------------------------------------
+echo "==> Case 5: image generation"
+add_model "openai image"     '{"model_name":"gpt-image-1","litellm_params":{"model":"openai/gpt-image-1","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"mode":"image_generation"}}'
+add_model "vertex imagen"    '{"model_name":"vertex-imagen","litellm_params":{"model":"vertex_ai/imagen-3.0-generate-002","vertex_project":"os.environ/VERTEX_PROJECT","vertex_location":"os.environ/VERTEX_LOCATION"},"model_info":{"mode":"image_generation"}}'
+add_model "bedrock sd"       '{"model_name":"bedrock-sd","litellm_params":{"model":"bedrock/stability.sd3-large-v1:0","aws_region_name":"os.environ/AWS_REGION_NAME"},"model_info":{"mode":"image_generation"}}'
+add_model "flux pro"         '{"model_name":"flux-pro","litellm_params":{"model":"black_forest_labs/flux-pro-1.1","api_key":"os.environ/BFL_API_KEY"},"model_info":{"mode":"image_generation"}}'
+add_model "recraft image"    '{"model_name":"recraft-image","litellm_params":{"model":"recraft/recraftv3","api_key":"os.environ/RECRAFT_API_KEY"},"model_info":{"mode":"image_generation"}}'
+add_model "xai image"        '{"model_name":"xai-image","litellm_params":{"model":"xai/grok-2-image","api_key":"os.environ/XAI_API_KEY"},"model_info":{"mode":"image_generation"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 6 — Audio transcription (audio_transcription) & TTS (audio_speech).
+# -----------------------------------------------------------------------------
+echo "==> Case 6: audio (transcription + speech)"
+add_model "openai whisper"   '{"model_name":"whisper","litellm_params":{"model":"openai/whisper-1","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"mode":"audio_transcription"}}'
+add_model "groq whisper"     '{"model_name":"groq-whisper","litellm_params":{"model":"groq/whisper-large-v3","api_key":"os.environ/GROQ_API_KEY"},"model_info":{"mode":"audio_transcription"}}'
+add_model "deepgram"         '{"model_name":"deepgram-nova","litellm_params":{"model":"deepgram/nova-3","api_key":"os.environ/DEEPGRAM_API_KEY"},"model_info":{"mode":"audio_transcription"}}'
+add_model "assemblyai"       '{"model_name":"assemblyai-best","litellm_params":{"model":"assemblyai/best","api_key":"os.environ/ASSEMBLYAI_API_KEY"},"model_info":{"mode":"audio_transcription"}}'
+add_model "openai tts"       '{"model_name":"openai-tts","litellm_params":{"model":"openai/tts-1","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"mode":"audio_speech"}}'
+add_model "elevenlabs tts"   '{"model_name":"elevenlabs-tts","litellm_params":{"model":"elevenlabs/eleven_turbo_v2_5","api_key":"os.environ/ELEVENLABS_API_KEY"},"model_info":{"mode":"audio_speech"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 7 — Rerank (mode: rerank).
+# -----------------------------------------------------------------------------
+echo "==> Case 7: rerank"
+add_model "cohere rerank"    '{"model_name":"cohere-rerank","litellm_params":{"model":"cohere/rerank-english-v3.0","api_key":"os.environ/COHERE_API_KEY"},"model_info":{"mode":"rerank"}}'
+add_model "jina rerank"      '{"model_name":"jina-rerank","litellm_params":{"model":"jina_ai/jina-reranker-v2-base-multilingual","api_key":"os.environ/JINA_AI_API_KEY"},"model_info":{"mode":"rerank"}}'
+add_model "bedrock rerank"   '{"model_name":"bedrock-rerank","litellm_params":{"model":"bedrock/amazon.rerank-v1:0","aws_region_name":"os.environ/AWS_REGION_NAME"},"model_info":{"mode":"rerank"}}'
+add_model "voyage rerank"    '{"model_name":"voyage-rerank","litellm_params":{"model":"voyage/rerank-2","api_key":"os.environ/VOYAGE_API_KEY"},"model_info":{"mode":"rerank"}}'
+add_model "infinity rerank"  '{"model_name":"infinity-rerank","litellm_params":{"model":"infinity/BAAI/bge-reranker-base","api_base":"os.environ/INFINITY_API_BASE"},"model_info":{"mode":"rerank"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 8 — Other modes: moderation, completion, responses, realtime.
+# -----------------------------------------------------------------------------
+echo "==> Case 8: moderation / completion / responses / realtime"
+add_model "moderation"       '{"model_name":"omni-moderation","litellm_params":{"model":"openai/omni-moderation-latest","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"mode":"moderation"}}'
+add_model "text completion"  '{"model_name":"gpt-instruct","litellm_params":{"model":"text-completion-openai/gpt-3.5-turbo-instruct","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"mode":"completion"}}'
+add_model "responses api"    '{"model_name":"o1-responses","litellm_params":{"model":"openai/o1-pro","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"mode":"responses"}}'
+add_model "openai realtime"  '{"model_name":"openai-realtime","litellm_params":{"model":"openai/gpt-4o-realtime-preview","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"mode":"realtime"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 9 — Wildcard / pass-through routing.
+# -----------------------------------------------------------------------------
+echo "==> Case 9: wildcard routing"
+add_model "catch-all"        '{"model_name":"*","litellm_params":{"model":"openai/*","api_key":"os.environ/OPENAI_API_KEY"}}'
+add_model "anthropic/*"      '{"model_name":"anthropic/*","litellm_params":{"model":"anthropic/*","api_key":"os.environ/ANTHROPIC_API_KEY"}}'
+add_model "bedrock/*"        '{"model_name":"bedrock/*","litellm_params":{"model":"bedrock/*","aws_region_name":"os.environ/AWS_REGION_NAME"}}'
+add_model "groq/*"           '{"model_name":"groq/*","litellm_params":{"model":"groq/*","api_key":"os.environ/GROQ_API_KEY"}}'
+add_model "vertex_ai/*"      '{"model_name":"vertex_ai/*","litellm_params":{"model":"vertex_ai/*","vertex_project":"os.environ/VERTEX_PROJECT","vertex_location":"os.environ/VERTEX_LOCATION"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 10 — Multi-deployment load balancing (one model_name, many backends).
+# -----------------------------------------------------------------------------
+echo "==> Case 10: load-balanced deployments"
+add_model "balanced openai"  '{"model_name":"gpt-4-balanced","litellm_params":{"model":"openai/gpt-4o","api_key":"os.environ/OPENAI_API_KEY","rpm":480},"model_info":{"id":"balanced-openai"}}'
+
+# -----------------------------------------------------------------------------
+# CASE 11 — Metadata / params: explicit id, base_model, region, limits,
+# timeouts, retries, custom pricing, access groups, tags.
+# -----------------------------------------------------------------------------
+echo "==> Case 11: metadata & params"
+add_model "pinned id"        '{"model_name":"gpt-4o-pinned-id","litellm_params":{"model":"openai/gpt-4o","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"id":"my-stable-model-id-001","base_model":"gpt-4o"}}'
+add_model "region eu"        '{"model_name":"gpt-4o-eu","litellm_params":{"model":"openai/gpt-4o","api_key":"os.environ/OPENAI_API_KEY","region_name":"eu"}}'
+add_model "throttled"        '{"model_name":"gpt-4o-throttled","litellm_params":{"model":"openai/gpt-4o","api_key":"os.environ/OPENAI_API_KEY","rpm":100,"tpm":100000,"timeout":300,"stream_timeout":60,"max_retries":3}}'
+add_model "custom pricing"   '{"model_name":"custom-priced-model","litellm_params":{"model":"openai/gpt-4o","api_key":"os.environ/OPENAI_API_KEY","input_cost_per_token":0.0000025,"output_cost_per_token":0.00001}}'
+add_model "access groups"    '{"model_name":"gpt-4o-restricted","litellm_params":{"model":"openai/gpt-4o","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{"access_groups":["beta-users","internal"],"tags":["production","team-platform"]}}'
+
+echo
+echo "Seeding complete: ${added} model(s) ${DRY_RUN:+(dry-run) }processed, ${failed} failed."
+
+[[ "${failed}" -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
## Summary

Adds a suite of Bash seeding and cleanup scripts for the LiteLLM-to-Bifrost migration workflow. These scripts allow developers to populate a running LiteLLM instance with representative fixture data (organizations, teams, virtual keys, and models) and to cleanly tear down entities from both LiteLLM and Bifrost instances between migration runs.

## Changes

- `create_organizations.sh` — seeds LiteLLM with organizations covering the full range of budget/rate-limit field combinations, including edge cases such as zero/negative budgets, missing duration, and all UI reset-window variants (`24h`, `7d`, `30d`, `1mo`).
- `create_teams.sh` — seeds LiteLLM with 27 team cases: standalone teams, teams scoped to organizations, teams with members by user ID or email, budget/rate-limit/model/alias/metadata/tag/guardrail/enterprise-only field combinations, and teams inside a restricted-model org.
- `create_virtual_keys.sh` — seeds LiteLLM with 31 virtual key cases: minimal, aliased, custom key values, expiry, model allowlists, model aliases, budget, rate limits, per-model limits, metadata, tags, permissions, blocked keys, allowed routes, key types, config overrides, team/user/org/budget-scoped keys, and enterprise-only fields.
- `seed_models.sh` — seeds LiteLLM DB-backed model deployments across 11 categories: one representative model per supported provider, self-hosted/OpenAI-compatible endpoints, provider-specific credential shapes (Vertex AI, Bedrock, SageMaker, WatsonX, OCI, Snowflake), embeddings, image generation, audio transcription/TTS, rerank, moderation/completion/responses/realtime, wildcard routing, and metadata/pricing/access-group variants.
- `delete_entities.sh` — deletes all LiteLLM entities (virtual keys, teams, organizations, budgets, DB-backed models, credentials) in dependency order, with per-entity-type opt-out flags and a `DRY_RUN` mode.
- `delete_bifrost_entities.sh` — deletes all Bifrost entities (virtual keys, model configs, teams, customers, users, provider keys, providers) in dependency order, with per-entity-type opt-out flags and a `DRY_RUN` mode.

All scripts support `DRY_RUN=1` to print payloads without making any API calls, and accept `LITELLM_URL`/`LITELLM_MASTER_KEY` or `BIFROST_URL`/`BIFROST_API_KEY` via environment variables.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Seed a local LiteLLM instance with all fixture data
LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./scripts/litellm-to-bifrost/scripts/create_organizations.sh
LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./scripts/litellm-to-bifrost/scripts/create_teams.sh
LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./scripts/litellm-to-bifrost/scripts/create_virtual_keys.sh
LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./scripts/litellm-to-bifrost/scripts/seed_models.sh

# Dry-run any script to inspect payloads without sending requests
DRY_RUN=1 ./scripts/litellm-to-bifrost/scripts/create_teams.sh

# Reset a LiteLLM instance
LITELLM_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 ./scripts/litellm-to-bifrost/scripts/delete_entities.sh

# Reset a Bifrost instance
BIFROST_URL=http://localhost:8080 BIFROST_API_KEY=<token> ./scripts/litellm-to-bifrost/scripts/delete_bifrost_entities.sh

# Skip specific entity types during cleanup
DELETE_KEYS=0 DELETE_MODELS=0 ./scripts/litellm-to-bifrost/scripts/delete_entities.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Scripts accept API keys via environment variables only; no secrets are hardcoded. The `BIFROST_API_KEY` is optional — scripts operate without it against local dev instances with auth disabled.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated seeding scripts for generating deterministic test data: organizations, teams, virtual keys, and a comprehensive model fixture.
  * Added cleanup scripts to remove seeded entities from both LiteLLM and Bifrost instances, including targeted deletion by entity type.
  * All scripts use environment-driven configuration and support dry-run mode to preview actions without executing them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->