### PR TITLE
fix(configstore): run VK provider blacklist migration before backfill

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -643,6 +643,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddAllowAllKeysToProviderConfig(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddVirtualKeyBlacklistedModelsColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationBackfillEmptyVirtualKeyConfigs(ctx, db); err != nil {
 		return err
 	}
@@ -803,9 +806,6 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 		return err
 	}
 	if err := migrationAddTempTokensTable(ctx, db); err != nil {
-		return err
-	}
-	if err := migrationAddVirtualKeyBlacklistedModelsColumn(ctx, db); err != nil {
 		return err
 	}
 	if err := migrationBackfillVirtualKeyBlacklistedModels(ctx, db); err != nil {

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1793,6 +1793,54 @@ func TestMigrationBackfillEmptyVirtualKeyConfigs(t *testing.T) {
 	assert.NotEmpty(t, vkHash, "VK config_hash should be recomputed after backfill")
 }
 
+func TestTriggerMigrationsAddsVKProviderConfigBlacklistColumnBeforeBackfill(t *testing.T) {
+	_, db := setupFullMigrationDB(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Simulate an existing DB that has provider configs but predates the
+	// provider-config blacklisted_models migration. This matches upgrades where
+	// backfill_empty_virtual_key_configs has not run yet.
+	require.NoError(t, db.Exec(`DELETE FROM migrations WHERE id IN (
+		'add_vk_provider_config_blacklisted_models_column',
+		'backfill_vk_provider_config_blacklisted_models',
+		'backfill_empty_virtual_key_configs'
+	)`).Error)
+
+	if db.Migrator().HasColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models") {
+		require.NoError(t, db.Migrator().DropColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models"))
+	}
+	require.False(t, db.Migrator().HasColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models"))
+
+	err := db.Exec(`INSERT INTO config_providers (name, encryption_status, created_at, updated_at)
+		VALUES ('legacy-openai', 'plain_text', ?, ?)`, now, now).Error
+	require.NoError(t, err)
+
+	err = db.Exec(`INSERT INTO governance_virtual_keys (id, name, value, is_active, encryption_status, created_at, updated_at)
+		VALUES ('vk-legacy-missing-blacklist', 'legacy-vk', 'vk-value', true, 'plain_text', ?, ?)`, now, now).Error
+	require.NoError(t, err)
+
+	err = triggerMigrations(ctx, db)
+	require.NoError(t, err)
+
+	require.True(t, db.Migrator().HasColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models"))
+
+	var providerConfigCount int64
+	err = db.Table("governance_virtual_key_provider_configs").
+		Where("virtual_key_id = ?", "vk-legacy-missing-blacklist").
+		Count(&providerConfigCount).Error
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), providerConfigCount)
+
+	var blacklistedModels string
+	err = db.Table("governance_virtual_key_provider_configs").
+		Select("blacklisted_models").
+		Where("virtual_key_id = ?", "vk-legacy-missing-blacklist").
+		Scan(&blacklistedModels).Error
+	require.NoError(t, err)
+	assert.Equal(t, "[]", blacklistedModels)
+}
+
 func TestMigrationBackfillAllowedModelsWildcard(t *testing.T) {
 	_, db := setupFullMigrationDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes config-store migration ordering so upgraded databases add the virtual-key provider `blacklisted_models` column before the empty virtual-key config backfill writes provider-config rows.

Concretely, this was encountered while upgrading an existing pgsql config store from v1.4.24 to v1.5.7.

## Changes

- Run `migrationAddVirtualKeyBlacklistedModelsColumn` before `migrationBackfillEmptyVirtualKeyConfigs`.
- Keep `migrationBackfillVirtualKeyBlacklistedModels` after the empty-config backfill so both existing and newly-created provider configs are normalized to `[]`.
- Add a regression test for an upgraded DB where `governance_virtual_key_provider_configs` exists without `blacklisted_models` and empty VK provider configs still need to be backfilled.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd framework
go test ./configstore -run 'TestTriggerMigrationsAddsVKProviderConfigBlacklistColumnBeforeBackfill|TestMigrationBackfillEmptyVirtualKeyConfigs'
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No auth, secret, or PII behavior changes. This only changes migration ordering and adds regression coverage.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the order of database migrations to ensure virtual key configuration features initialize properly and reliably during upgrades.

* **Tests**
  * Added test coverage to validate migration sequence execution and verify data consistency across upgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->