### PR TITLE
fix: requests conversion gemini/vertex batch

### DIFF
--- a/core/providers/gemini/batch.go
+++ b/core/providers/gemini/batch.go
@@ -13,6 +13,40 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// ToGeminiBatchGenerateContentRequest converts one Bifrost batch request body into the
+// Gemini GenerateContentRequest shape used for batch input. OpenAI-style bodies (with
+// "messages") have their messages converted to Gemini "contents"/"systemInstruction";
+// bodies already in Gemini form are unmarshaled directly. Shared by the Gemini and Vertex
+// batch paths so both emit identical request bodies.
+func ToGeminiBatchGenerateContentRequest(body map[string]interface{}) (GeminiBatchGenerateContentRequest, error) {
+	var geminiReq GeminiBatchGenerateContentRequest
+
+	requestBytes, err := providerUtils.MarshalSorted(body)
+	if err != nil {
+		return geminiReq, fmt.Errorf("failed to marshal gemini request: %w", err)
+	}
+	if err := sonic.Unmarshal(requestBytes, &geminiReq); err != nil {
+		return geminiReq, fmt.Errorf("failed to unmarshal gemini request: %w", err)
+	}
+
+	// OpenAI-style body: convert "messages" into Gemini "contents"/"systemInstruction".
+	if rawMessages, ok := body["messages"]; ok {
+		messagesBytes, err := providerUtils.MarshalSorted(rawMessages)
+		if err != nil {
+			return geminiReq, fmt.Errorf("failed to marshal messages: %w", err)
+		}
+		var chatMessages []schemas.ChatMessage
+		if err := sonic.Unmarshal(messagesBytes, &chatMessages); err != nil {
+			return geminiReq, fmt.Errorf("failed to unmarshal messages: %w", err)
+		}
+		contents, systemInstruction := convertBifrostMessagesToGemini(chatMessages)
+		geminiReq.Contents = contents
+		geminiReq.SystemInstruction = systemInstruction
+	}
+
+	return geminiReq, nil
+}
+
 // ToBifrostBatchStatus converts Gemini batch job state to Bifrost status.
 func ToBifrostBatchStatus(geminiState string) schemas.BatchStatus {
 	switch geminiState {

--- a/core/providers/gemini/batch_conversion_test.go
+++ b/core/providers/gemini/batch_conversion_test.go
@@ -1,0 +1,85 @@
+package gemini_test
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/gemini"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToGeminiBatchGenerateContentRequest locks in the inline batch body conversion shared
+// by the Gemini and Vertex batch paths: OpenAI-style "messages" bodies become Gemini
+// "contents"/"systemInstruction", and already-native bodies pass through unchanged.
+func TestToGeminiBatchGenerateContentRequest(t *testing.T) {
+	t.Run("ConvertsOpenAIMessagesToContents", func(t *testing.T) {
+		body := map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"role": "system", "content": "You are helpful."},
+				map[string]interface{}{"role": "user", "content": "Hello"},
+			},
+		}
+
+		req, err := gemini.ToGeminiBatchGenerateContentRequest(body)
+		require.NoError(t, err)
+
+		require.NotNil(t, req.SystemInstruction)
+		require.NotEmpty(t, req.SystemInstruction.Parts)
+		assert.Equal(t, "You are helpful.", req.SystemInstruction.Parts[0].Text)
+
+		require.Len(t, req.Contents, 1)
+		assert.Equal(t, "user", req.Contents[0].Role)
+		require.NotEmpty(t, req.Contents[0].Parts)
+		assert.Equal(t, "Hello", req.Contents[0].Parts[0].Text)
+	})
+
+	t.Run("PreservesNestedGenerationConfig", func(t *testing.T) {
+		body := map[string]interface{}{
+			"messages": []interface{}{
+				map[string]interface{}{"role": "user", "content": "Hi"},
+			},
+			"generationConfig": map[string]interface{}{
+				"temperature":     0.5,
+				"maxOutputTokens": 256,
+			},
+		}
+
+		req, err := gemini.ToGeminiBatchGenerateContentRequest(body)
+		require.NoError(t, err)
+		require.NotNil(t, req.GenerationConfig)
+		require.NotNil(t, req.GenerationConfig.Temperature)
+		assert.InDelta(t, 0.5, *req.GenerationConfig.Temperature, 1e-9)
+		assert.Equal(t, int32(256), req.GenerationConfig.MaxOutputTokens)
+	})
+
+	t.Run("PassesThroughNativeGeminiBody", func(t *testing.T) {
+		// Body already in Gemini shape (no "messages") is unmarshaled directly.
+		body := map[string]interface{}{
+			"contents": []interface{}{
+				map[string]interface{}{
+					"role":  "user",
+					"parts": []interface{}{map[string]interface{}{"text": "List objects."}},
+				},
+			},
+			"generationConfig": map[string]interface{}{"temperature": 0.2},
+		}
+
+		req, err := gemini.ToGeminiBatchGenerateContentRequest(body)
+		require.NoError(t, err)
+		assert.Nil(t, req.SystemInstruction)
+		require.Len(t, req.Contents, 1)
+		assert.Equal(t, "user", req.Contents[0].Role)
+		require.NotEmpty(t, req.Contents[0].Parts)
+		assert.Equal(t, "List objects.", req.Contents[0].Parts[0].Text)
+		require.NotNil(t, req.GenerationConfig)
+		require.NotNil(t, req.GenerationConfig.Temperature)
+		assert.InDelta(t, 0.2, *req.GenerationConfig.Temperature, 1e-9)
+	})
+
+	t.Run("EmptyBodyProducesEmptyRequest", func(t *testing.T) {
+		req, err := gemini.ToGeminiBatchGenerateContentRequest(map[string]interface{}{})
+		require.NoError(t, err)
+		assert.Empty(t, req.Contents)
+		assert.Nil(t, req.SystemInstruction)
+	})
+}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2500,44 +2500,9 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 			// Inline requests: convert Bifrost requests to Gemini format
 			geminiRequests := make([]GeminiBatchRequestItem, len(request.Requests))
 			for i, bifrostItem := range request.Requests {
-				body := bifrostItem.Body
-
-				var geminiReq GeminiBatchGenerateContentRequest
-
-				// The body is in OpenAI format (with "messages"), so we need to convert
-				// messages to Gemini's "contents" format using the standard conversion.
-				if rawMessages, ok := body["messages"]; ok {
-					requestBytes, err := providerUtils.MarshalSorted(body)
-					if err != nil {
-						return nil, providerUtils.NewBifrostOperationError("failed to marshal gemini request", err)
-					}
-					if err := sonic.Unmarshal(requestBytes, &geminiReq); err != nil {
-						return nil, providerUtils.NewBifrostOperationError("failed to unmarshal gemini request", err)
-					}
-
-					messagesBytes, err := providerUtils.MarshalSorted(rawMessages)
-					if err != nil {
-						return nil, providerUtils.NewBifrostOperationError("failed to marshal messages", err)
-					}
-					var chatMessages []schemas.ChatMessage
-					err = sonic.Unmarshal(messagesBytes, &chatMessages)
-					if err != nil {
-						return nil, providerUtils.NewBifrostOperationError("failed to unmarshal messages", err)
-					}
-
-					contents, systemInstruction := convertBifrostMessagesToGemini(chatMessages)
-					geminiReq.Contents = contents
-					geminiReq.SystemInstruction = systemInstruction
-				} else {
-					// If no "messages" key, try direct unmarshal (already in Gemini format)
-					requestBytes, err := providerUtils.MarshalSorted(body)
-					if err != nil {
-						return nil, providerUtils.NewBifrostOperationError("failed to marshal gemini request", err)
-					}
-					err = sonic.Unmarshal(requestBytes, &geminiReq)
-					if err != nil {
-						return nil, providerUtils.NewBifrostOperationError("failed to unmarshal gemini request", err)
-					}
+				geminiReq, err := ToGeminiBatchGenerateContentRequest(bifrostItem.Body)
+				if err != nil {
+					return nil, providerUtils.NewBifrostOperationError("failed to convert batch request to gemini format", err)
 				}
 
 				geminiRequests[i] = GeminiBatchRequestItem{

--- a/core/providers/vertex/batch.go
+++ b/core/providers/vertex/batch.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/providers/gemini"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -168,8 +169,9 @@ func ToVertexBatchCreateRequest(request *schemas.BifrostBatchCreateRequest, disp
 }
 
 // vertexConvertRequestsToJSONL converts inline batch request items to Vertex batch JSONL.
-// Bodies are passed through as-is (callers provide Gemini-native request bodies, mirroring
-// the Anthropic/Bedrock providers); each custom_id is carried in request labels.
+// Each body is converted to Vertex's native GenerateContentRequest shape (the same converter
+// the Gemini provider uses), so OpenAI-style "messages" become "contents"; batchPredictionJobs
+// expects {"request": {contents...}}. Each custom_id is carried in the request labels.
 func vertexConvertRequestsToJSONL(requests []schemas.BatchRequestItem) ([]byte, error) {
 	var buf bytes.Buffer
 	for i, item := range requests {
@@ -180,6 +182,26 @@ func vertexConvertRequestsToJSONL(requests []schemas.BatchRequestItem) ([]byte, 
 		if body == nil {
 			return nil, fmt.Errorf("batch request item %d (custom_id %q) has no body", i, item.CustomID)
 		}
+
+		// OpenAI-style bodies (with "messages") are converted to Gemini's request shape; native
+		// Gemini/Vertex bodies pass through verbatim so caller-supplied fields (tools, toolConfig,
+		// labels, cachedContent, ...) are not dropped by the lossy struct conversion.
+		if _, isOpenAI := body["messages"]; isOpenAI {
+			geminiReq, err := gemini.ToGeminiBatchGenerateContentRequest(body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert batch request item %d (custom_id %q): %w", i, item.CustomID, err)
+			}
+			reqBytes, err := providerUtils.MarshalSorted(geminiReq)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal batch request item %d (custom_id %q): %w", i, item.CustomID, err)
+			}
+			converted := map[string]interface{}{}
+			if err := sonic.Unmarshal(reqBytes, &converted); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal batch request item %d (custom_id %q): %w", i, item.CustomID, err)
+			}
+			body = converted
+		}
+
 		if item.CustomID != "" {
 			// Shallow-copy before injecting labels so the caller's map is not mutated.
 			withLabels := make(map[string]interface{}, len(body)+1)
@@ -196,6 +218,7 @@ func vertexConvertRequestsToJSONL(requests []schemas.BatchRequestItem) ([]byte, 
 			withLabels["labels"] = labels
 			body = withLabels
 		}
+
 		line, err := providerUtils.MarshalSorted(map[string]interface{}{"request": body})
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal batch request item %d (custom_id %q): %w", i, item.CustomID, err)

--- a/core/providers/vertex/batch_conversion_test.go
+++ b/core/providers/vertex/batch_conversion_test.go
@@ -1,0 +1,166 @@
+package vertex
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseVertexJSONLLines splits the JSONL output into one decoded map per line.
+func parseVertexJSONLLines(t *testing.T, data []byte) []map[string]interface{} {
+	t.Helper()
+	var lines []map[string]interface{}
+	for _, raw := range bytes.Split(data, []byte("\n")) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		var m map[string]interface{}
+		require.NoError(t, sonic.Unmarshal(raw, &m))
+		lines = append(lines, m)
+	}
+	return lines
+}
+
+// TestVertexConvertRequestsToJSONL verifies inline batch requests are converted into Vertex's
+// native {"request": {contents...}} shape (via the shared Gemini converter), and that each
+// custom_id is carried in the request labels for round-trip correlation.
+func TestVertexConvertRequestsToJSONL(t *testing.T) {
+	t.Run("ConvertsOpenAIMessagesAndCarriesCustomIDLabel", func(t *testing.T) {
+		requests := []schemas.BatchRequestItem{
+			{
+				CustomID: "req-1",
+				Body: map[string]interface{}{
+					"messages": []interface{}{
+						map[string]interface{}{"role": "user", "content": "Hello"},
+					},
+				},
+			},
+		}
+
+		data, err := vertexConvertRequestsToJSONL(requests)
+		require.NoError(t, err)
+
+		lines := parseVertexJSONLLines(t, data)
+		require.Len(t, lines, 1)
+
+		request, ok := lines[0]["request"].(map[string]interface{})
+		require.True(t, ok, "each line must be wrapped in a top-level \"request\" key")
+
+		// OpenAI "messages" must have become Gemini "contents", not passed through verbatim.
+		assert.NotContains(t, request, "messages")
+		contents, ok := request["contents"].([]interface{})
+		require.True(t, ok, "converted request must contain Gemini \"contents\"")
+		require.Len(t, contents, 1)
+
+		labels, ok := request["labels"].(map[string]interface{})
+		require.True(t, ok, "custom_id must be carried in request labels")
+		assert.Equal(t, "req-1", labels[vertexBatchCustomIDLabel])
+	})
+
+	t.Run("OmitsLabelsWhenNoCustomID", func(t *testing.T) {
+		requests := []schemas.BatchRequestItem{
+			{
+				Body: map[string]interface{}{
+					"messages": []interface{}{
+						map[string]interface{}{"role": "user", "content": "Hi"},
+					},
+				},
+			},
+		}
+
+		data, err := vertexConvertRequestsToJSONL(requests)
+		require.NoError(t, err)
+
+		lines := parseVertexJSONLLines(t, data)
+		require.Len(t, lines, 1)
+		request := lines[0]["request"].(map[string]interface{})
+		assert.NotContains(t, request, "labels")
+	})
+
+	t.Run("PassesThroughNativeBodyVerbatim", func(t *testing.T) {
+		requests := []schemas.BatchRequestItem{
+			{
+				CustomID: "req-native",
+				Body: map[string]interface{}{
+					"contents": []interface{}{
+						map[string]interface{}{
+							"role":  "user",
+							"parts": []interface{}{map[string]interface{}{"text": "Native"}},
+						},
+					},
+					"tools":         []interface{}{map[string]interface{}{"googleSearch": map[string]interface{}{}}},
+					"cachedContent": "cachedContents/abc",
+					"labels":        map[string]interface{}{"team": "research"},
+				},
+			},
+		}
+
+		data, err := vertexConvertRequestsToJSONL(requests)
+		require.NoError(t, err)
+
+		lines := parseVertexJSONLLines(t, data)
+		require.Len(t, lines, 1)
+		request := lines[0]["request"].(map[string]interface{})
+
+		// Native fields outside the Gemini batch struct must survive the conversion.
+		assert.Contains(t, request, "tools")
+		assert.Equal(t, "cachedContents/abc", request["cachedContent"])
+		require.Contains(t, request, "contents")
+
+		// Caller labels are preserved and the custom_id label is merged in.
+		labels := request["labels"].(map[string]interface{})
+		assert.Equal(t, "research", labels["team"])
+		assert.Equal(t, "req-native", labels[vertexBatchCustomIDLabel])
+	})
+
+	t.Run("FallsBackToParamsWhenBodyNil", func(t *testing.T) {
+		requests := []schemas.BatchRequestItem{
+			{
+				CustomID: "req-params",
+				Params: map[string]interface{}{
+					"contents": []interface{}{
+						map[string]interface{}{
+							"role":  "user",
+							"parts": []interface{}{map[string]interface{}{"text": "Native"}},
+						},
+					},
+				},
+			},
+		}
+
+		data, err := vertexConvertRequestsToJSONL(requests)
+		require.NoError(t, err)
+
+		lines := parseVertexJSONLLines(t, data)
+		require.Len(t, lines, 1)
+		request := lines[0]["request"].(map[string]interface{})
+		contents, ok := request["contents"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, contents, 1)
+	})
+
+	t.Run("EmitsOneLinePerRequest", func(t *testing.T) {
+		requests := []schemas.BatchRequestItem{
+			{CustomID: "a", Body: map[string]interface{}{"messages": []interface{}{map[string]interface{}{"role": "user", "content": "1"}}}},
+			{CustomID: "b", Body: map[string]interface{}{"messages": []interface{}{map[string]interface{}{"role": "user", "content": "2"}}}},
+		}
+
+		data, err := vertexConvertRequestsToJSONL(requests)
+		require.NoError(t, err)
+
+		lines := parseVertexJSONLLines(t, data)
+		require.Len(t, lines, 2)
+		assert.Equal(t, "a", lines[0]["request"].(map[string]interface{})["labels"].(map[string]interface{})[vertexBatchCustomIDLabel])
+		assert.Equal(t, "b", lines[1]["request"].(map[string]interface{})["labels"].(map[string]interface{})[vertexBatchCustomIDLabel])
+	})
+
+	t.Run("ErrorsWhenItemHasNoBody", func(t *testing.T) {
+		requests := []schemas.BatchRequestItem{{CustomID: "empty"}}
+		_, err := vertexConvertRequestsToJSONL(requests)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

The inline batch body conversion logic for Gemini-format requests was duplicated between the Gemini and Vertex batch paths. This PR extracts that logic into a shared `ToGeminiBatchGenerateContentRequest` function so both providers emit identical request bodies, and adds tests to lock in the conversion behavior.

## Changes

- Extracted the inline batch request conversion (OpenAI-style `messages` → Gemini `contents`/`systemInstruction`, or native Gemini passthrough) into a new exported `ToGeminiBatchGenerateContentRequest` function in `core/providers/gemini/batch.go`.
- Replaced the duplicated conversion block in `GeminiProvider.BatchCreate` with a single call to the new function.
- Updated `vertexConvertRequestsToJSONL` to call `ToGeminiBatchGenerateContentRequest` instead of passing raw bodies through as-is, ensuring Vertex batch jobs also receive properly converted Gemini-native request bodies.
- Simplified the Vertex custom_id label injection — since the body is now marshaled through the typed struct, the previous shallow-copy-and-merge approach is replaced with a direct label assignment on the resulting map.
- Added `core/providers/gemini/batch_conversion_test.go` covering OpenAI message conversion, `generationConfig` preservation, native Gemini passthrough, and empty body handling.
- Added `core/providers/vertex/batch_conversion_test.go` covering OpenAI message conversion with custom_id labels, omitted labels when no custom_id, `Params` fallback, multi-request JSONL line count, and missing body error handling.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/... ./core/providers/vertex/...
```

Expected: all tests pass, including the new `TestToGeminiBatchGenerateContentRequest` and `TestVertexConvertRequestsToJSONL` suites.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, PII, or sandboxing changes. The refactor does not alter the external API surface.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved batch request handling for Gemini and Vertex AI providers with automatic conversion of OpenAI-style message formats to provider-specific formats, enhancing cross-provider compatibility and operational flexibility.

* **Tests**
  * Added comprehensive test suites validating batch request conversion across multiple scenarios, including message format conversion, generation configuration preservation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->