### PR TITLE
`docs: add required IAM permissions for AWS S3 storage to config-json and Helm deployment guides`

### DIFF
--- a/docs/deployment-guides/config-json/storage.mdx
+++ b/docs/deployment-guides/config-json/storage.mdx
@@ -259,6 +259,36 @@ Offload LLM request/response logs and MCP tool logs from the database to S3 or G
 <Tabs>
 <Tab title="AWS S3">
 
+#### Required IAM Permissions
+
+The IAM user or role needs the following permissions on your bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BucketAccess",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::bifrost-logs"
+    },
+    {
+      "Sid": "ObjectAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:PutObjectTagging",
+        "s3:GetObjectTagging"
+      ],
+      "Resource": "arn:aws:s3:::bifrost-logs/*"
+    }
+  ]
+}
+```
+
 ```json
 {
   "logs_store": {

--- a/docs/deployment-guides/helm/storage.mdx
+++ b/docs/deployment-guides/helm/storage.mdx
@@ -304,6 +304,36 @@ Offload large request/response payloads from the database to S3 or GCS. The DB r
 <Tabs>
 <Tab title="AWS S3">
 
+#### Required IAM Permissions
+
+The IAM user or role needs the following permissions on your bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BucketAccess",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::bifrost-logs"
+    },
+    {
+      "Sid": "ObjectAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:PutObjectTagging",
+        "s3:GetObjectTagging"
+      ],
+      "Resource": "arn:aws:s3:::bifrost-logs/*"
+    }
+  ]
+}
+```
+
 ```bash
 kubectl create secret generic s3-credentials \
   --from-literal=access-key-id='AKIAIOSFODNN7EXAMPLE' \

--- a/docs/enterprise/log-exports.mdx
+++ b/docs/enterprise/log-exports.mdx
@@ -34,6 +34,36 @@ Only **S3** and **GCS** are supported today. Azure Blob, local filesystem, and d
 
 ### Amazon S3
 
+#### Required IAM Permissions
+
+The IAM user or role needs the following permissions on your bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BucketAccess",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::bifrost-logs"
+    },
+    {
+      "Sid": "ObjectAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:PutObjectTagging",
+        "s3:GetObjectTagging"
+      ],
+      "Resource": "arn:aws:s3:::bifrost-logs/*"
+    }
+  ]
+}
+```
+
 ```json
 {
   "logs_store": {


### PR DESCRIPTION
## Summary

Adds the required IAM permissions policy to the AWS S3 storage documentation so users know exactly what permissions their IAM user or role needs when configuring S3 log offloading.

## Changes

- Added a `Required IAM Permissions` section with a ready-to-use IAM policy JSON to the `config-json` storage guide, `helm` storage guide, and `log-exports` enterprise docs, covering `s3:ListBucket` on the bucket and `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:PutObjectTagging`, and `s3:GetObjectTagging` on bucket objects.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated documentation pages for the `config-json` storage guide, `helm` storage guide, and `log-exports` enterprise docs and verify the IAM policy JSON renders correctly and appears before the configuration examples in the AWS S3 tab.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The IAM policy follows least-privilege principles, granting only the specific S3 actions required for log offloading rather than broad `s3:*` permissions.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable