### PR TITLE
feat: adds host and port support for DD plugin

### DIFF
--- a/docs/deployment-guides/helm/plugins.mdx
+++ b/docs/deployment-guides/helm/plugins.mdx
@@ -332,13 +332,20 @@ Sends traces to a Datadog Agent running in the cluster.
 | `bifrost.plugins.datadog.enabled` | Enable Datadog tracing | `false` |
 | `bifrost.plugins.datadog.version` | Plugin config version for DB-backed update tracking (`1` to `32767`) | `1` |
 | `bifrost.plugins.datadog.config.service_name` | Service name | `"bifrost"` |
-| `bifrost.plugins.datadog.config.agent_addr` | Datadog Agent address | `"localhost:8126"` |
+| `bifrost.plugins.datadog.config.agent_addr` | Datadog Agent address as combined `host:port`. Overridden by `agent_host` | `"localhost:8126"` |
+| `bifrost.plugins.datadog.config.agent_host` | Datadog Agent host, set separately from the port. Supports `env.VAR_NAME`. Takes precedence over `agent_addr` | `""` |
+| `bifrost.plugins.datadog.config.agent_port` | Datadog Agent port, used with `agent_host` | `"8126"` |
+| `bifrost.plugins.datadog.config.dogstatsd_addr` | DogStatsD address as combined `host:port`. Overridden by `dogstatsd_host` | `"localhost:8125"` |
+| `bifrost.plugins.datadog.config.dogstatsd_host` | DogStatsD host, set separately from the port. Supports `env.VAR_NAME`. Takes precedence over `dogstatsd_addr` | `""` |
+| `bifrost.plugins.datadog.config.dogstatsd_port` | DogStatsD port, used with `dogstatsd_host` | `"8125"` |
 | `bifrost.plugins.datadog.config.env` | Deployment environment tag | `""` |
 | `bifrost.plugins.datadog.config.version` | Version tag | `""` |
 | `bifrost.plugins.datadog.config.enable_traces` | Enable trace collection | `true` |
 | `bifrost.plugins.datadog.config.custom_tags` | Extra tags on all spans | `{}` |
 
 The Datadog Agent is typically deployed via the [Datadog Helm chart](https://docs.datadoghq.com/containers/kubernetes/installation/) as a DaemonSet, making it available at the node's hostIP.
+
+Inject the node IP via the downward API and reference it with `agent_host` / `dogstatsd_host`. The host comes from the cluster (the node IP) and the port is fixed, so the two can't be collapsed into one variable — use the separate host/port fields rather than `agent_addr`.
 
 ```yaml
 # datadog-values.yaml
@@ -351,7 +358,9 @@ bifrost:
       enabled: true
       config:
         service_name: "bifrost"
-        agent_addr: "$(HOST_IP):8126"   # uses Datadog DaemonSet pattern
+        agent_host: "env.HOST_IP"        # node-local DaemonSet agent (APM traces)
+        dogstatsd_host: "env.HOST_IP"    # node-local DaemonSet agent (metrics)
+        # agent_port / dogstatsd_port default to 8126 / 8125 — set only for non-standard ports
         env: "production"
         version: "v1.4.11"
         enable_traces: true
@@ -366,6 +375,10 @@ env:
       fieldRef:
         fieldPath: status.hostIP
 ```
+
+<Note>
+Use the `env.HOST_IP` reference (resolved by Bifrost), not `$(HOST_IP)`. Kubernetes only expands `$(VAR)` syntax in a container's `env`, `command`, and `args` — **not** inside a mounted ConfigMap file, which is where this config lands. Bifrost's own `env.` prefix resolves the variable at load time, so it works regardless of where the value is rendered.
+</Note>
 
 ```bash
 helm upgrade bifrost bifrost/bifrost --reuse-values -f datadog-values.yaml

--- a/docs/enterprise/datadog-connector.mdx
+++ b/docs/enterprise/datadog-connector.mdx
@@ -62,8 +62,12 @@ This mode requires an API key but simplifies deployment by eliminating the need 
 |-------|------|----------|---------|-------------|
 | `service_name` | `string` | No | `bifrost` | Service name displayed in Datadog APM |
 | `ml_app` | `string` | No | (uses `service_name`) | ML application name for LLM Observability grouping |
-| `agent_addr` | `string` | No | `localhost:8126` | Datadog Agent address (agent mode only, supports `env.VAR_NAME`) |
-| `dogstatsd_addr` | `string` | No | `localhost:8125` | DogStatsD server address (agent mode only, supports `env.VAR_NAME`) |
+| `agent_addr` | `string` | No | `localhost:8126` | Datadog Agent address as combined `host:port` (agent mode only, supports `env.VAR_NAME`). Overridden by `agent_host` when set |
+| `agent_host` | `string` | No | - | Datadog Agent host, set separately from the port (agent mode only, supports `env.VAR_NAME`). Takes precedence over `agent_addr` |
+| `agent_port` | `string` | No | `8126` | Datadog Agent port, used with `agent_host` (agent mode only, supports `env.VAR_NAME`) |
+| `dogstatsd_addr` | `string` | No | `localhost:8125` | DogStatsD server address as combined `host:port` (agent mode only, supports `env.VAR_NAME`). Overridden by `dogstatsd_host` when set |
+| `dogstatsd_host` | `string` | No | - | DogStatsD server host, set separately from the port (agent mode only, supports `env.VAR_NAME`). Takes precedence over `dogstatsd_addr` |
+| `dogstatsd_port` | `string` | No | `8125` | DogStatsD server port, used with `dogstatsd_host` (agent mode only, supports `env.VAR_NAME`) |
 | `env` | `string` | No | - | Environment tag (e.g., `production`, `staging`) |
 | `version` | `string` | No | - | Service version tag |
 | `custom_tags` | `object` | No | - | Additional tags for all traces and metrics |
@@ -76,7 +80,7 @@ This mode requires an API key but simplifies deployment by eliminating the need 
 
 ### Environment Variable Substitution
 
-The `api_key`, `agent_addr`, `dogstatsd_addr`, and `custom_tags` fields support environment variable substitution using the `env.` prefix:
+The `api_key`, `agent_addr`, `agent_host`, `agent_port`, `dogstatsd_addr`, `dogstatsd_host`, `dogstatsd_port`, and `custom_tags` fields support environment variable substitution using the `env.` prefix:
 
 ```json
 {
@@ -88,6 +92,31 @@ The `api_key`, `agent_addr`, `dogstatsd_addr`, and `custom_tags` fields support 
     "cost_center": "env.COST_CENTER"
   }
 }
+```
+
+<Note>
+Substitution is **whole-value only** — `"env.DD_HOST:8125"` does not work, because the entire field is treated as one variable reference. If your environment exposes the agent host and port as separate variables (common in Kubernetes, where the host is injected from the downward API `status.hostIP` and the port is fixed), use the separate `agent_host` / `agent_port` and `dogstatsd_host` / `dogstatsd_port` fields instead of `agent_addr` / `dogstatsd_addr`. When a `*_host` field is set it takes precedence over the combined `*_addr`, and the matching `*_port` defaults to `8126` (agent) / `8125` (DogStatsD).
+</Note>
+
+#### Separate host and port (Kubernetes)
+
+```json
+{
+  "dogstatsd_host": "env.DD_AGENT_HOST",
+  "agent_host": "env.DD_AGENT_HOST"
+}
+```
+
+The ports are omitted here because they default to `8126` (agent) and `8125` (DogStatsD). Set `agent_port` / `dogstatsd_port` (literal or `env.` reference) only if your agent listens on non-standard ports.
+
+With the Kubernetes downward API injecting the node IP:
+
+```yaml
+env:
+  - name: DD_AGENT_HOST
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
 ```
 
 ---

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1207,8 +1207,20 @@ false
 {{- if $inputConfig.agent_addr }}
 {{- $_ := set $datadogConfig "agent_addr" $inputConfig.agent_addr }}
 {{- end }}
+{{- if $inputConfig.agent_host }}
+{{- $_ := set $datadogConfig "agent_host" $inputConfig.agent_host }}
+{{- end }}
+{{- if $inputConfig.agent_port }}
+{{- $_ := set $datadogConfig "agent_port" $inputConfig.agent_port }}
+{{- end }}
 {{- if $inputConfig.dogstatsd_addr }}
 {{- $_ := set $datadogConfig "dogstatsd_addr" $inputConfig.dogstatsd_addr }}
+{{- end }}
+{{- if $inputConfig.dogstatsd_host }}
+{{- $_ := set $datadogConfig "dogstatsd_host" $inputConfig.dogstatsd_host }}
+{{- end }}
+{{- if $inputConfig.dogstatsd_port }}
+{{- $_ := set $datadogConfig "dogstatsd_port" $inputConfig.dogstatsd_port }}
 {{- end }}
 {{- if $inputConfig.env }}
 {{- $_ := set $datadogConfig "env" $inputConfig.env }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -975,11 +975,27 @@
                     },
                     "agent_addr": {
                       "type": "string",
-                      "description": "Datadog Agent address for APM traces (agent mode only). Supports env.VAR_NAME prefix for environment variable substitution (e.g. env.DD_AGENT_ADDR)"
+                      "description": "Datadog Agent address for APM traces as combined host:port (agent mode only). Supports env.VAR_NAME prefix for environment variable substitution (e.g. env.DD_AGENT_ADDR). Overridden by agent_host when set"
+                    },
+                    "agent_host": {
+                      "type": "string",
+                      "description": "Datadog Agent host for APM traces, set separately from the port (agent mode only). Supports env.VAR_NAME prefix (e.g. env.DD_AGENT_HOST). Takes precedence over agent_addr. Useful in Kubernetes where the host is injected via the downward API (status.hostIP)"
+                    },
+                    "agent_port": {
+                      "type": "string",
+                      "description": "Datadog Agent port for APM traces, used with agent_host (agent mode only). Supports env.VAR_NAME prefix. Defaults to 8126; has no effect when agent_host is unset"
                     },
                     "dogstatsd_addr": {
                       "type": "string",
-                      "description": "DogStatsD server address for metrics (agent mode only). Supports env.VAR_NAME prefix for environment variable substitution (e.g. env.DD_DOGSTATSD_ADDR)"
+                      "description": "DogStatsD server address for metrics as combined host:port (agent mode only). Supports env.VAR_NAME prefix for environment variable substitution (e.g. env.DD_DOGSTATSD_ADDR). Overridden by dogstatsd_host when set"
+                    },
+                    "dogstatsd_host": {
+                      "type": "string",
+                      "description": "DogStatsD server host for metrics, set separately from the port (agent mode only). Supports env.VAR_NAME prefix (e.g. env.DD_DOGSTATSD_HOST). Takes precedence over dogstatsd_addr. Useful in Kubernetes where the host is injected via the downward API (status.hostIP)"
+                    },
+                    "dogstatsd_port": {
+                      "type": "string",
+                      "description": "DogStatsD server port for metrics, used with dogstatsd_host (agent mode only). Supports env.VAR_NAME prefix. Defaults to 8125; has no effect when dogstatsd_host is unset"
                     },
                     "env": {
                       "type": "string"

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -552,6 +552,14 @@ bifrost:
         # top-level `env:` (e.g. from status.hostIP for a node-local agent DaemonSet).
         agent_addr: "localhost:8126"
         # dogstatsd_addr: "localhost:8125"  # DogStatsD address (supports env.VAR_NAME)
+        # Alternatively, set host and port separately (common in Kubernetes, where the
+        # host comes from the downward API status.hostIP and the port is fixed — the two
+        # can't be collapsed into one env var). When a *_host is set it takes precedence
+        # over the matching *_addr; the *_port defaults to 8126 (agent) / 8125 (DogStatsD).
+        # agent_host: "env.DD_AGENT_HOST"
+        # agent_port: "8126"
+        # dogstatsd_host: "env.DD_AGENT_HOST"
+        # dogstatsd_port: "8125"
         env: ""
         version: ""
         custom_tags: {}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1774,13 +1774,31 @@
                     },
                     "agent_addr": {
                       "type": "string",
-                      "description": "Address of the Datadog Agent for APM traces (agent mode only, can use env. prefix)",
+                      "description": "Combined host:port address of the Datadog Agent for APM traces (agent mode only, can use env. prefix). Overridden by agent_host when set.",
                       "default": "localhost:8126"
+                    },
+                    "agent_host": {
+                      "type": "string",
+                      "description": "Host of the Datadog Agent for APM traces, provided separately from the port (agent mode only, can use env. prefix). Takes precedence over agent_addr when set. Useful in Kubernetes where the host is injected via the downward API (status.hostIP)."
+                    },
+                    "agent_port": {
+                      "type": "string",
+                      "description": "Port of the Datadog Agent for APM traces (agent mode only, can use env. prefix). Used only when agent_host is set (defaults to 8126); has no effect when agent_host is unset, in which case agent_addr supplies the port.",
+                      "default": "8126"
                     },
                     "dogstatsd_addr": {
                       "type": "string",
-                      "description": "Address of the DogStatsD server for metrics (agent mode only, can use env. prefix)",
+                      "description": "Combined host:port address of the DogStatsD server for metrics (agent mode only, can use env. prefix). Overridden by dogstatsd_host when set.",
                       "default": "localhost:8125"
+                    },
+                    "dogstatsd_host": {
+                      "type": "string",
+                      "description": "Host of the DogStatsD server for metrics, provided separately from the port (agent mode only, can use env. prefix). Takes precedence over dogstatsd_addr when set. Useful in Kubernetes where the host is injected via the downward API (status.hostIP)."
+                    },
+                    "dogstatsd_port": {
+                      "type": "string",
+                      "description": "Port of the DogStatsD server for metrics (agent mode only, can use env. prefix). Used only when dogstatsd_host is set (defaults to 8125); has no effect when dogstatsd_host is unset, in which case dogstatsd_addr supplies the port.",
+                      "default": "8125"
                     },
                     "env": {
                       "type": "string",


### PR DESCRIPTION
## Summary

Adds separate `agent_host` / `agent_port` and `dogstatsd_host` / `dogstatsd_port` configuration fields to the Datadog connector. This solves a limitation where environment variable substitution only works on whole field values, making it impossible to use `env.VAR_NAME` for just the host portion of a combined `host:port` address. This is particularly relevant in Kubernetes environments where the node IP is injected via the downward API (`status.hostIP`) as a separate variable while the port remains fixed.

## Changes

- Added `agent_host` and `agent_port` fields as alternatives to `agent_addr`, where `agent_host` takes precedence over `agent_addr` when set
- Added `dogstatsd_host` and `dogstatsd_port` fields as alternatives to `dogstatsd_addr`, where `dogstatsd_host` takes precedence over `dogstatsd_addr` when set
- Updated the config schema (`config.schema.json`) with the new fields and their descriptions
- Updated documentation to reflect the new fields, their precedence rules, and added a Kubernetes-specific example using the downward API to inject `DD_AGENT_HOST`
- Added a note clarifying that environment variable substitution is whole-value only, explaining why the split fields are necessary

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Configure the Datadog connector in agent mode using the new split fields and verify that the agent and DogStatsD connections resolve correctly:

```json
{
  "agent_host": "env.DD_AGENT_HOST",
  "agent_port": "8126",
  "dogstatsd_host": "env.DD_AGENT_HOST",
  "dogstatsd_port": "8125"
}
```

In a Kubernetes environment, inject `DD_AGENT_HOST` via the downward API:

```yaml
env:
  - name: DD_AGENT_HOST
    valueFrom:
      fieldRef:
        fieldPath: status.hostIP
```

Verify that:
- Setting `agent_host` overrides `agent_addr`
- Setting `dogstatsd_host` overrides `dogstatsd_addr`
- `agent_port` defaults to `8126` and `dogstatsd_port` defaults to `8125` when only the host is provided
- Environment variable substitution works correctly for all new fields

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The new fields support the same `env.` prefix substitution as existing address fields, meaning secrets or sensitive host values can be injected via environment variables rather than hardcoded in configuration.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable