### PR TITLE
update write kickoff based on last activity

### DIFF
--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -741,6 +741,9 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		CreatedAt:          time.Now(),
 		Status:             "processing",
 	}
+	// Seed LastActivity so the first idle-eviction check has a baseline even if no
+	// PostLLMHook chunk has fired yet.
+	pending.LastActivity.Store(pending.CreatedAt.UnixNano())
 	p.pendingLogsEntries.Store(effectiveRequestID, pending)
 	// Call callback synchronously for immediate UI feedback (WebSocket "processing" notification).
 	// The entry does not exist in the DB yet - it will be written when PostLLMHook fires.
@@ -859,6 +862,12 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	}
 
 	pending := pendingVal.(*PendingLogData)
+
+	// Refresh the idle clock on every PostLLMHook call (notably each streaming
+	// chunk) so a long-running stream is not evicted by cleanupStalePendingLogs
+	// before it finishes. Safe to mutate in place: pending is a pointer held in
+	// the sync.Map, and LastActivity is atomic.
+	pending.LastActivity.Store(time.Now().UnixNano())
 
 	// Should never happen, but just in case
 	// Fallback to request type from pending data if request type is not set

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -382,6 +382,76 @@ func TestCleanupStalePendingMCPLogsPersistsErrorFallback(t *testing.T) {
 	}
 }
 
+// TestActiveStreamSurvivesCleanup is the regression test for the prod issue where
+// streaming requests running longer than the pending TTL had their in-memory
+// pending entry evicted mid-flight (causing the final log row to be lost and a
+// per-chunk "no pending log data found" warning). An entry whose CreatedAt is
+// older than the TTL but whose LastActivity is recent must NOT be reaped.
+func TestActiveStreamSurvivesCleanup(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if cleanupErr := plugin.Cleanup(); cleanupErr != nil {
+			t.Errorf("Cleanup() error = %v", cleanupErr)
+		}
+	})
+
+	oldCreatedAt := time.Now().Add(-pendingLogTTL - time.Minute)
+	pending := &PendingLogData{
+		RequestID:   "req-active-stream",
+		Timestamp:   oldCreatedAt,
+		Status:      "processing",
+		InitialData: &InitialLogData{Object: "chat.completion.chunk"},
+		CreatedAt:   oldCreatedAt,
+	}
+	// Simulate a chunk that arrived just now: request started long ago but is
+	// still actively streaming.
+	pending.LastActivity.Store(time.Now().UnixNano())
+	plugin.pendingLogsEntries.Store("req-active-stream", pending)
+
+	plugin.cleanupStalePendingLogs()
+
+	if _, ok := plugin.pendingLogsEntries.Load("req-active-stream"); !ok {
+		t.Fatal("expected actively-streaming pending entry to survive cleanup")
+	}
+}
+
+// TestIdlePendingEntryEvicted verifies the reaper still removes genuinely dead
+// requests: an entry whose CreatedAt AND LastActivity are both older than the
+// TTL (no chunk activity for the whole idle window) must be deleted.
+func TestIdlePendingEntryEvicted(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if cleanupErr := plugin.Cleanup(); cleanupErr != nil {
+			t.Errorf("Cleanup() error = %v", cleanupErr)
+		}
+	})
+
+	stale := time.Now().Add(-pendingLogTTL - time.Minute)
+	pending := &PendingLogData{
+		RequestID:   "req-idle",
+		Timestamp:   stale,
+		Status:      "processing",
+		InitialData: &InitialLogData{Object: "chat.completion.chunk"},
+		CreatedAt:   stale,
+	}
+	pending.LastActivity.Store(stale.UnixNano())
+	plugin.pendingLogsEntries.Store("req-idle", pending)
+
+	plugin.cleanupStalePendingLogs()
+
+	if _, ok := plugin.pendingLogsEntries.Load("req-idle"); ok {
+		t.Fatal("expected idle pending entry to be evicted by cleanup")
+	}
+}
+
 // TestPreMCPHookSkipsPrefixedCodemodeTool verifies that PreMCP skips codemode
 // meta-tools invoked with a client prefix (e.g. "myclient-executeToolCode"),
 // not just bare names. Otherwise PostMCP — which sees the stripped bare name —

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -12,17 +13,22 @@ const (
 	// maxBatchSize is the maximum number of entries to collect before flushing
 	maxBatchSize = 1000
 	// batchInterval is the maximum time to wait before flushing a partial batch
-	batchInterval = 2 * time.Second
-	// maxBatchBytes is the approximate byte-size ceiling for a batch (100 MB).
+	batchInterval = 5 * time.Second
+	// maxBatchBytes is the approximate byte-size ceiling for a batch (300 MB).
 	// When the cumulative estimated size of queued entries hits this limit the
 	// batch is flushed immediately, even if maxBatchSize hasn't been reached.
-	maxBatchBytes = 100 * 1024 * 1024
+	maxBatchBytes = 300 * 1024 * 1024
 	// writeQueueCapacity is the buffer size for the write queue channel
 	writeQueueCapacity = 10000
 	// maxDeferredUsageConcurrency limits concurrent deferred usage DB updates
 	maxDeferredUsageConcurrency = 5
-	// pendingLogTTL is how long a pending log entry can stay in memory before cleanup
-	pendingLogTTL = 5 * time.Minute
+	// pendingLogTTL is the maximum idle gap (time since the last chunk/activity)
+	// a pending log entry can sit in memory before cleanup reclaims it. It is an
+	// idle timeout, not a total-lifetime cap: actively-streaming requests refresh
+	// their LastActivity on every chunk (see PostLLMHook), so a long-running stream
+	// is never evicted mid-flight. Matches the 30-minute window used by
+	// cleanupOldProcessingLogs so the two reapers agree on what "stale" means.
+	pendingLogTTL = 15 * time.Minute
 	// cleanupDrainTimeout caps how long Cleanup spends draining the write queue
 	// itself. Matches the outer server shutdown budget at server.go:1596 so the
 	// logging plugin can fully drain in the worst case; remaining entries beyond
@@ -41,6 +47,12 @@ type PendingLogData struct {
 	RoutingEnginesUsed []string
 	InitialData        *InitialLogData
 	CreatedAt          time.Time // For cleanup of stale entries
+	// LastActivity is the unix-nano timestamp of the most recent PostLLMHook
+	// activity (e.g. each streaming chunk). cleanupStalePendingLogs evicts on
+	// idle time using this value, so long-running streams that keep producing
+	// chunks are not reaped before they finish. Atomic because the cleanup
+	// goroutine reads it concurrently with per-chunk PostLLMHook writes.
+	LastActivity atomic.Int64
 }
 
 // pendingInjectEntries wraps a slice of log entries so it can be used with sync.Map.
@@ -221,7 +233,15 @@ func (p *LoggerPlugin) cleanupStalePendingLogs() {
 	cutoff := time.Now().Add(-pendingLogTTL)
 	p.pendingLogsEntries.Range(func(key, value any) bool {
 		if pending, ok := value.(*PendingLogData); ok {
-			if pending.CreatedAt.Before(cutoff) {
+			// Evict on idle time: use the last chunk/activity timestamp, falling
+			// back to CreatedAt for entries that never saw a PostLLMHook (e.g. a
+			// request abandoned before its first chunk). This keeps actively
+			// streaming requests alive past the TTL while still reaping dead ones.
+			lastActive := pending.CreatedAt
+			if nanos := pending.LastActivity.Load(); nanos > 0 {
+				lastActive = time.Unix(0, nanos)
+			}
+			if lastActive.Before(cutoff) {
 				p.pendingLogsEntries.Delete(key)
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes a production bug where streaming LLM requests running longer than the pending log TTL had their in-memory `PendingLogData` entry evicted mid-flight by `cleanupStalePendingLogs`. This caused the final log row to be silently dropped and a per-chunk "no pending log data found" warning to be emitted for every subsequent chunk.

## Changes

- Added an atomic `LastActivity` field to `PendingLogData` that tracks the unix-nano timestamp of the most recent `PostLLMHook` call (i.e. each streaming chunk).
- `cleanupStalePendingLogs` now evicts based on idle time (time since `LastActivity`) rather than total lifetime (`CreatedAt`), so actively-streaming requests are never reaped mid-flight.
- `PreLLMHook` seeds `LastActivity` with `CreatedAt` at entry creation so the idle clock has a valid baseline even before the first chunk arrives.
- `PostLLMHook` refreshes `LastActivity` on every call, keeping long-running streams alive through the cleanup window.
- `pendingLogTTL` changed from 5 minutes to 15 minutes (idle timeout, not lifetime cap), and its comment updated to reflect the new semantics.
- `batchInterval` increased from 2s to 5s and `maxBatchBytes` from 100 MB to 300 MB.
- Added two regression tests: `TestActiveStreamSurvivesCleanup` (entry with old `CreatedAt` but recent `LastActivity` must not be evicted) and `TestIdlePendingEntryEvicted` (entry with both `CreatedAt` and `LastActivity` past the TTL must be evicted).

## Type of change

- [x] Bug fix

## Affected areas

- [x] Plugins

## How to test

```sh
go test ./plugins/logging/... -run "TestActiveStreamSurvivesCleanup|TestIdlePendingEntryEvicted|TestCleanupStalePendingMCPLogsPersistsErrorFallback"
```

Expected: all three tests pass. To validate the fix end-to-end, send a streaming chat request that takes longer than the previous 5-minute TTL and confirm the final log row is persisted and no "no pending log data found" warnings appear.

## Breaking changes

- [x] No

## Related issues

Regression fix for prod issue where long-running streaming requests lost their final log entry due to premature in-memory eviction.

## Security considerations

None. The `LastActivity` field is an in-process atomic integer with no exposure to external input.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable