### PR TITLE
feat: improve skills repository UI with security warning, dropdown state, and copy fixes

### DIFF
--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1824,7 +1824,7 @@ func TestTriggerMigrationsAddsVKProviderConfigBlacklistColumnBeforeBackfill(t *t
 		VALUES ('vk-legacy-missing-blacklist', 'legacy-vk', 'vk-value', true, 'plain_text', ?, ?)`, now, now).Error
 	require.NoError(t, err)
 
-	err = triggerMigrations(ctx, db)
+	err = triggerMigrations(ctx, db, testMigrationLogger)
 	require.NoError(t, err)
 
 	require.True(t, db.Migrator().HasColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models"))

--- a/ui/app/workspace/skills-repo/components/FileManager.tsx
+++ b/ui/app/workspace/skills-repo/components/FileManager.tsx
@@ -384,6 +384,7 @@ interface MoveDestinationMenuProps {
   triggerLabel: string;
   tooltip: string;
   onMove: (folderPath: string) => void;
+  onOpenChange?: (open: boolean) => void;
   isDisabledDestination?: (folderPath: string) => boolean;
 }
 
@@ -393,6 +394,7 @@ function MoveDestinationMenu({
   triggerLabel,
   tooltip,
   onMove,
+  onOpenChange,
   isDisabledDestination,
 }: MoveDestinationMenuProps) {
   const [query, setQuery] = useState("");
@@ -413,6 +415,7 @@ function MoveDestinationMenu({
   return (
     <DropdownMenu
       onOpenChange={(open) => {
+        onOpenChange?.(open);
         if (!open) {
           setQuery("");
           firstEnabledDestinationRef.current = null;
@@ -528,9 +531,15 @@ function buildTree(files: SkillFileEntry[]) {
   return root;
 }
 
-function AddMenu({ onSelect }: { onSelect: (sourceType: string) => void }) {
+function AddMenu({
+  onSelect,
+  onOpenChange,
+}: {
+  onSelect: (sourceType: string) => void;
+  onOpenChange?: (open: boolean) => void;
+}) {
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
@@ -683,6 +692,9 @@ export function FileManagerSection({
   const [expandedNodes, setExpandedNodes] = useState<Record<string, boolean>>(
     {},
   );
+  const [activeDropdownNodeId, setActiveDropdownNodeId] = useState<
+    string | null
+  >(null);
 
   useEffect(() => {
     const foldersFromFiles = files.flatMap((file) =>
@@ -1297,8 +1309,15 @@ export function FileManagerSection({
         );
       }
 
+      const fileDropdownActive = activeDropdownNodeId === item.id;
+
       return (
-        <div className="group flex items-center gap-3 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted/50">
+        <div
+          className={cn(
+            "group flex items-center gap-3 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-muted/50",
+            fileDropdownActive && "bg-muted/50",
+          )}
+        >
           <div className="flex min-w-0 items-center gap-2">
             <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
             <span className="truncate font-mono text-xs">
@@ -1328,12 +1347,20 @@ export function FileManagerSection({
             )}
           </div>
           {!readOnly && (
-            <div className="flex-1 justify-end flex shrink-0 items-center gap-1 opacity-100 md:opacity-0 transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100">
+            <div
+              className={cn(
+                "flex-1 justify-end flex shrink-0 items-center gap-1 opacity-100 md:opacity-0 transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100",
+                fileDropdownActive && "md:opacity-100",
+              )}
+            >
               <MoveDestinationMenu
                 destinations={availableFolderPaths}
                 currentFolder={dirname(file.path)}
                 triggerLabel={`Move ${file.path}`}
                 tooltip="Move file"
+                onOpenChange={(open) =>
+                  setActiveDropdownNodeId(open ? item.id : null)
+                }
                 onMove={(folderPath) => {
                   setEditingFileIndex(null);
                   setEditingFileOriginal(null);
@@ -1399,11 +1426,14 @@ export function FileManagerSection({
     }
 
     const isRoot = item.kind === "root";
+    const folderDropdownActive = activeDropdownNodeId === item.id;
+
     return (
       <div
         className={cn(
           "group flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-muted/40",
           hasChildren && "cursor-pointer",
+          folderDropdownActive && "bg-muted/40",
         )}
         onClick={() => {
           if (hasChildren) onToggle();
@@ -1451,7 +1481,10 @@ export function FileManagerSection({
         )}
         {!readOnly && editingFullFileIndex == null && (
           <div
-            className="ml-auto flex items-center gap-1 opacity-100 md:opacity-0 transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100"
+            className={cn(
+              "ml-auto flex items-center gap-1 opacity-100 md:opacity-0 transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100",
+              folderDropdownActive && "md:opacity-100",
+            )}
             onClick={(event) => event.stopPropagation()}
             onKeyDown={(event) => event.stopPropagation()}
           >
@@ -1496,6 +1529,9 @@ export function FileManagerSection({
               </>
             )}
             <AddMenu
+              onOpenChange={(open) =>
+                setActiveDropdownNodeId(open ? item.id : null)
+              }
               onSelect={(sourceType) => {
                 expandFolder(item.path || "root");
                 setAddingFile({ folderPath: item.path, sourceType });
@@ -1538,6 +1574,9 @@ export function FileManagerSection({
                 currentFolder={dirname(item.path)}
                 triggerLabel={`Move folder ${item.path}`}
                 tooltip="Move folder"
+                onOpenChange={(open) =>
+                  setActiveDropdownNodeId(open ? item.id : null)
+                }
                 isDisabledDestination={(folderPath) =>
                   folderPath === item.path ||
                   folderPath.startsWith(`${item.path}/`)

--- a/ui/app/workspace/skills-repo/components/SkillEditView.tsx
+++ b/ui/app/workspace/skills-repo/components/SkillEditView.tsx
@@ -17,7 +17,7 @@ import { CodeEditor, type CompletionItem } from "@/components/ui/codeEditor";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { validateVersionBump } from "@/lib/validators/skills";
 import { cn } from "@/lib/utils";
-import { ArrowLeft, Check, Copy, Eye, Loader2, Plus, Save, X } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Check, Copy, Eye, Loader2, Plus, Save, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { type SkillFormReturn, composeFrontmatter } from "./helpers";
 import { FormSection } from "./shared";
@@ -145,6 +145,13 @@ export function SkillEditView({
               {isCreate ? form.name || "<new-skill>" : skillName}
             </span>
           </div>
+        </div>
+
+        <div className="mb-6 flex gap-3 rounded-sm border border-amber-500/40 bg-amber-50/80 p-3 text-sm text-amber-900 dark:border-amber-400/30 dark:bg-amber-950/40 dark:text-amber-200">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <p>
+            Files added to a skill can be downloaded from marketplace URLs without logging in. Anyone who can reach this Bifrost server can request them directly, so do not upload secrets, credentials, private code, or other sensitive files.
+          </p>
         </div>
 
         {/* Edit sections */}

--- a/ui/app/workspace/skills-repo/components/SkillsListView.tsx
+++ b/ui/app/workspace/skills-repo/components/SkillsListView.tsx
@@ -69,7 +69,6 @@ import {
   Plus,
   Search,
   Trash2,
-  ChevronsDown,
   ChevronDown,
   ArrowUpRight,
   BookOpenText,
@@ -78,10 +77,14 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { PAGE_SIZE, formatDateShort, useDebouncedValue } from "./helpers";
 
+const SKILLS_REPOSITORY_DOCS_URL =
+  "https://docs.getbifrost.ai/features/skills-repository";
+
 // ---------- MarketplacePopover ----------
 
 function MarketplacePopover() {
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
   const marketplaceBaseUrl = getApiBaseUrl();
 
   const items = [
@@ -102,6 +105,7 @@ function MarketplacePopover() {
       .writeText(text)
       .then(() => {
         setCopiedKey(key);
+        setOpen(false);
         toast.success("Copied to clipboard");
         setTimeout(() => setCopiedKey(null), 2000);
       })
@@ -111,7 +115,7 @@ function MarketplacePopover() {
   };
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm">
           <Package className="h-3.5 w-3.5" />
@@ -440,10 +444,12 @@ export function SkillsListView({
         </div>
         <div className="flex flex-col gap-1">
           <h1 className="text-muted-foreground text-xl font-medium">
-            Create and manage Agent Skills for AI coding assistants
+            Create, version, and share Agent Skills from Bifrost
           </h1>
           <div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-            Build skills that extend the capabilities of Claude Code, Codex, and other AI harnesses. Register as a marketplace to distribute them.
+            Manage SKILL.md instructions and supporting files in one place,
+            publish immutable versions, and expose them as installable plugins
+            for Claude Code, Codex, and other skill-aware clients.
           </div>
           <div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
             <Button
@@ -451,10 +457,15 @@ export function SkillsListView({
               aria-label="Read more about skills (opens in new tab)"
               data-testid="skills-button-read-more"
               onClick={() => {
-                window.open("https://agentskills.io?utm_source=bfd", "_blank", "noopener,noreferrer");
+                window.open(
+                  `${SKILLS_REPOSITORY_DOCS_URL}?utm_source=bfd`,
+                  "_blank",
+                  "noopener,noreferrer",
+                );
               }}
             >
-              Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
+              Read more{" "}
+              <ArrowUpRight className="text-muted-foreground h-3 w-3" />
             </Button>
             {hasCreateAccess && (
               <Button
@@ -476,7 +487,10 @@ export function SkillsListView({
       {/* Header */}
       <div className="flex shrink-0 items-center justify-between mb-4">
         <div>
-          <h2 className="text-lg font-semibold">Skills Repository</h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold">Skills Repository</h2>
+            <Badge aria-label="Skills Repository is in beta">Beta</Badge>
+          </div>
           <p className="text-muted-foreground text-sm">
             Manage Agent Skills for distribution to AI coding assistants
           </p>
@@ -707,11 +721,15 @@ export function SkillsListView({
                       }
                     }}
                   >
-                    <TableCell className="font-medium font-mono text-sm">
-                      {skill.name}
+                    <TableCell className="w-[240px] max-w-[240px] overflow-hidden font-medium font-mono text-sm">
+                      <div className="max-w-full truncate" title={skill.name}>
+                        {skill.name}
+                      </div>
                     </TableCell>
-                    <TableCell className="text-muted-foreground text-sm max-w-[300px] truncate">
-                      {skill.description}
+                    <TableCell className="text-muted-foreground overflow-hidden text-sm">
+                      <div className="truncate" title={skill.description}>
+                        {skill.description}
+                      </div>
                     </TableCell>
                     <TableCell>
                       <Badge

--- a/ui/app/workspace/skills-repo/components/shared.tsx
+++ b/ui/app/workspace/skills-repo/components/shared.tsx
@@ -33,8 +33,8 @@ import {
   BookOpen,
   ChevronDown,
   ChevronRight,
-  ChevronsDown,
-  ChevronsUp,
+  ChevronsDownUp,
+  ChevronsUpDown,
   ArrowLeft,
   Copy,
   Download,
@@ -118,10 +118,12 @@ export function SkillHeader({
   sticky?: boolean;
 }) {
   const [showRawDialog, setShowRawDialog] = useState(false);
-  const { copy: copyRawSkillMd, copied: copiedRawSkillMd } = useCopyToClipboard({
-    successMessage: "Copied raw SKILL.md",
-    errorMessage: "Failed to copy raw SKILL.md",
-  });
+  const { copy: copyRawSkillMd, copied: copiedRawSkillMd } = useCopyToClipboard(
+    {
+      successMessage: "Copied raw SKILL.md",
+      errorMessage: "Failed to copy raw SKILL.md",
+    },
+  );
 
   return (
     <>
@@ -227,7 +229,11 @@ export function SkillHeader({
                   size="icon"
                   className="h-8 w-8 rounded-sm bg-background/70 text-muted-foreground hover:bg-background/90 hover:text-foreground"
                   onClick={() => copyRawSkillMd(composedSkillMd)}
-                  aria-label={copiedRawSkillMd ? "Raw SKILL.md copied" : "Copy raw SKILL.md"}
+                  aria-label={
+                    copiedRawSkillMd
+                      ? "Raw SKILL.md copied"
+                      : "Copy raw SKILL.md"
+                  }
                 >
                   {copiedRawSkillMd ? (
                     <Check className="h-4 w-4" />
@@ -382,7 +388,7 @@ export function ReadOnlySkillBody({ body }: { body: string }) {
               <div className="min-w-0 p-4">
                 <Markdown
                   content={body || ""}
-                  className="max-w-full text-sm break-words [overflow-wrap:anywhere] [&_*]:max-w-full [&_*]:break-words [&_*]:[overflow-wrap:anywhere] [&_a]:break-all [&_code]:whitespace-pre-wrap [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_table]:table-fixed"
+                  className="max-w-full text-sm break-words [&_*]:max-w-full [&_*]:break-words [&_a]:break-all [&_code]:whitespace-pre-wrap [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_table]:table-fixed"
                 />
               </div>
             </ScrollArea>
@@ -447,7 +453,7 @@ export function ReadOnlySkillBody({ body }: { body: string }) {
                   <div className="min-w-0 p-5">
                     <Markdown
                       content={body || ""}
-                      className="max-w-full text-sm break-words [overflow-wrap:anywhere] [&_*]:max-w-full [&_*]:break-words [&_*]:[overflow-wrap:anywhere] [&_a]:break-all [&_code]:whitespace-pre-wrap [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_table]:table-fixed"
+                      className="max-w-full text-sm break-words [&_*]:max-w-full [&_*]:break-words [&_a]:break-all [&_code]:whitespace-pre-wrap [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_table]:table-fixed"
                     />
                   </div>
                 </ScrollArea>
@@ -591,199 +597,201 @@ export function ReadOnlyFileTree({
   return (
     <FormSection title="Files">
       <TooltipProvider>
-      <Tree<FileTreeNodeData>
-        data={treeData}
-        levelsToExpandByDefault={1}
-        indentSize={28}
-        renderItem={({
-          item,
-          isExpanded,
-          hasChildren,
-          onToggle,
-          onExpandAll,
-          onCollapseAll,
-          isAllExpanded,
-          isAllCollapsed,
-        }) => {
-          const isFolder = item.type === "root" || item.type === "folder";
-          const isSkillMd = item.type === "skillmd";
-          const isFile = item.type === "file";
-          const isDownloadable = isSkillMd || isFile;
+        <Tree<FileTreeNodeData>
+          data={treeData}
+          levelsToExpandByDefault={1}
+          indentSize={28}
+          renderItem={({
+            item,
+            isExpanded,
+            hasChildren,
+            onToggle,
+            onExpandAll,
+            onCollapseAll,
+            isAllExpanded,
+            isAllCollapsed,
+          }) => {
+            const isFolder = item.type === "root" || item.type === "folder";
+            const isSkillMd = item.type === "skillmd";
+            const isFile = item.type === "file";
+            const isDownloadable = isSkillMd || isFile;
 
-          const fileDownloadUrl =
-            isFile && item.path
-              ? `${getApiBaseUrl()}/skills/serve/${encodeURIComponent(skillName)}/files/${item.path.split("/").map(encodeURIComponent).join("/")}`
-              : undefined;
+            const fileDownloadUrl =
+              isFile && item.path
+                ? `${getApiBaseUrl()}/skills/serve/${encodeURIComponent(skillName)}/files/${item.path.split("/").map(encodeURIComponent).join("/")}`
+                : undefined;
 
-          const handleClick = () => {
-            if (hasChildren) onToggle();
-            else if (isSkillMd) downloadTextAsFile(composedSkillMd, "SKILL.md");
-            else if (isFile && fileDownloadUrl) {
-              const a = document.createElement("a");
-              a.href = fileDownloadUrl;
-              a.download = item.name;
-              document.body.appendChild(a);
-              a.click();
-              document.body.removeChild(a);
-            }
-          };
-
-          return (
-            <div
-              className={cn(
-                "group flex h-9 items-center gap-2 rounded-sm px-2 text-sm transition-colors",
-                (hasChildren || isDownloadable) &&
-                  "cursor-pointer hover:bg-muted/50",
-              )}
-              onClick={handleClick}
-              onKeyDown={(e) => {
-                if (
-                  (e.key === "Enter" || e.key === " ") &&
-                  (hasChildren || isDownloadable)
-                ) {
-                  e.preventDefault();
-                  handleClick();
-                }
-              }}
-              role={hasChildren || isDownloadable ? "button" : undefined}
-              tabIndex={hasChildren || isDownloadable ? 0 : undefined}
-              aria-label={
-                isDownloadable
-                  ? `Download ${item.name}`
-                  : isFolder
-                    ? `${isExpanded ? "Collapse" : "Expand"} ${item.name}`
-                    : item.name
+            const handleClick = () => {
+              if (hasChildren) onToggle();
+              else if (isSkillMd)
+                downloadTextAsFile(composedSkillMd, "SKILL.md");
+              else if (isFile && fileDownloadUrl) {
+                const a = document.createElement("a");
+                a.href = fileDownloadUrl;
+                a.download = item.name;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
               }
-            >
-              {hasChildren ? (
-                isExpanded ? (
-                  <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                ) : (
-                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                )
-              ) : (
-                <span className="w-3.5 shrink-0" />
-              )}
+            };
 
-              {isDownloadable ? (
-                isSkillMd ? (
-                  <>
-                    <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground group-hover:hidden" />
-                    <Download className="h-4 w-4 shrink-0 text-muted-foreground hidden group-hover:block" />
-                  </>
-                ) : (
-                  <>
-                    <FileText className="h-4 w-4 shrink-0 text-muted-foreground group-hover:hidden" />
-                    <Download className="h-4 w-4 shrink-0 text-muted-foreground hidden group-hover:block" />
-                  </>
-                )
-              ) : isFolder ? (
-                isExpanded ? (
-                  <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-                ) : (
-                  <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
-                )
-              ) : null}
-
-              <span
-                className={cn("font-mono text-xs", isFolder && "font-medium")}
+            return (
+              <div
+                className={cn(
+                  "group flex h-9 items-center gap-2 rounded-sm px-2 text-sm transition-colors",
+                  (hasChildren || isDownloadable) &&
+                    "cursor-pointer hover:bg-muted/50",
+                )}
+                onClick={handleClick}
+                onKeyDown={(e) => {
+                  if (
+                    (e.key === "Enter" || e.key === " ") &&
+                    (hasChildren || isDownloadable)
+                  ) {
+                    e.preventDefault();
+                    handleClick();
+                  }
+                }}
+                role={hasChildren || isDownloadable ? "button" : undefined}
+                tabIndex={hasChildren || isDownloadable ? 0 : undefined}
+                aria-label={
+                  isDownloadable
+                    ? `Download ${item.name}`
+                    : isFolder
+                      ? `${isExpanded ? "Collapse" : "Expand"} ${item.name}`
+                      : item.name
+                }
               >
-                {item.name}
-              </span>
-
-              {isFolder &&
-                !isExpanded &&
-                item.childCount != null &&
-                item.childCount > 0 && (
-                  <span className="text-[10px] text-muted-foreground">
-                    {item.childCount} item{item.childCount !== 1 ? "s" : ""}
-                  </span>
+                {hasChildren ? (
+                  isExpanded ? (
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  )
+                ) : (
+                  <span className="w-3.5 shrink-0" />
                 )}
 
-              {isFile && (
-                <>
-                  {item.source_type && (
+                {isDownloadable ? (
+                  isSkillMd ? (
+                    <>
+                      <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground group-hover:hidden" />
+                      <Download className="h-4 w-4 shrink-0 text-muted-foreground hidden group-hover:block" />
+                    </>
+                  ) : (
+                    <>
+                      <FileText className="h-4 w-4 shrink-0 text-muted-foreground group-hover:hidden" />
+                      <Download className="h-4 w-4 shrink-0 text-muted-foreground hidden group-hover:block" />
+                    </>
+                  )
+                ) : isFolder ? (
+                  isExpanded ? (
+                    <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  )
+                ) : null}
+
+                <span
+                  className={cn("font-mono text-xs", isFolder && "font-medium")}
+                >
+                  {item.name}
+                </span>
+
+                {isFolder &&
+                  !isExpanded &&
+                  item.childCount != null &&
+                  item.childCount > 0 && (
+                    <span className="text-[10px] text-muted-foreground">
+                      {item.childCount} item{item.childCount !== 1 ? "s" : ""}
+                    </span>
+                  )}
+
+                {isFile && (
+                  <>
+                    {item.source_type && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex h-5 shrink-0 items-center rounded-full border border-border/60 bg-transparent px-2 text-[10px] font-medium leading-none text-muted-foreground">
+                            {item.source_type}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent className="px-2 py-1 text-xs">
+                          Source
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                    {item.mime_type && (
+                      <span className="text-[10px] text-muted-foreground">
+                        {item.mime_type}
+                      </span>
+                    )}
+                    {item.file_size_bytes != null &&
+                      item.file_size_bytes > 0 && (
+                        <span className="text-[10px] text-muted-foreground">
+                          {formatFileSize(item.file_size_bytes)}
+                        </span>
+                      )}
+                  </>
+                )}
+
+                {item.type === "root" && (
+                  <div
+                    className="ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                  >
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span className="inline-flex h-5 shrink-0 items-center rounded-full border border-border/60 bg-transparent px-2 text-[10px] font-medium leading-none text-muted-foreground">
-                          {item.source_type}
-                        </span>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 w-6 p-0"
+                          aria-label="Expand all folders"
+                          onClick={onExpandAll}
+                          disabled={isAllExpanded}
+                        >
+                          <ChevronsUpDown className="h-3 w-3" />
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent className="px-2 py-1 text-xs">
-                        Source
+                        Expand all
                       </TooltipContent>
                     </Tooltip>
-                  )}
-                  {item.mime_type && (
-                    <span className="text-[10px] text-muted-foreground">
-                      {item.mime_type}
-                    </span>
-                  )}
-                  {item.file_size_bytes != null && item.file_size_bytes > 0 && (
-                    <span className="text-[10px] text-muted-foreground">
-                      {formatFileSize(item.file_size_bytes)}
-                    </span>
-                  )}
-                </>
-              )}
-
-              {item.type === "root" && (
-                <div
-                  className="ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100"
-                  onClick={(e) => e.stopPropagation()}
-                  onKeyDown={(e) => e.stopPropagation()}
-                >
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 w-6 p-0"
-                        aria-label="Expand all folders"
-                        onClick={onExpandAll}
-                        disabled={isAllExpanded}
-                      >
-                        <ChevronsDown className="h-3 w-3" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent className="px-2 py-1 text-xs">
-                      Expand all
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 w-6 p-0"
-                        aria-label="Collapse all folders"
-                        onClick={onCollapseAll}
-                        disabled={isAllCollapsed}
-                      >
-                        <ChevronsUp className="h-3 w-3" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent className="px-2 py-1 text-xs">
-                      Collapse all
-                    </TooltipContent>
-                  </Tooltip>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 px-2"
-                    asChild
-                  >
-                    <a href={downloadUrl} download>
-                      <Download className="h-3 w-3" />
-                      <span className="text-[10px]">ZIP</span>
-                    </a>
-                  </Button>
-                </div>
-              )}
-            </div>
-          );
-        }}
-      />
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 w-6 p-0"
+                          aria-label="Collapse all folders"
+                          onClick={onCollapseAll}
+                          disabled={isAllCollapsed}
+                        >
+                          <ChevronsDownUp className="h-3 w-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent className="px-2 py-1 text-xs">
+                        Collapse all
+                      </TooltipContent>
+                    </Tooltip>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2"
+                      asChild
+                    >
+                      <a href={downloadUrl} download>
+                        <Download className="h-3 w-3" />
+                        <span className="text-[10px]">ZIP</span>
+                      </a>
+                    </Button>
+                  </div>
+                )}
+              </div>
+            );
+          }}
+        />
       </TooltipProvider>
     </FormSection>
   );

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -1068,7 +1068,6 @@ export default function AppSidebar() {
               icon: BookOpenText,
               description: "Skills repository",
               hasAccess: hasSkillsRepositoryAccess,
-              new: true,
             },
           ]
         : []),


### PR DESCRIPTION
## Summary

Polishes the Skills Repository UI and fixes a configstore migration test call so
the latest migration runner signature is validated correctly.

## Changes

- Removed the **New** tag from the Skills Repository sidebar entry so the
  sidebar only shows the page name and icon.
- Added a **Beta** badge to the Skills Repository page header so users see the
  beta status in the main page UI instead of the sidebar.
- Updated the Skills Repository empty-state documentation link to point to
  `https://docs.getbifrost.ai/features/skills-repository` using the same
  `?utm_source=bfd` pattern as other empty states.
- Added a concise warning banner to the create/edit form explaining that skill
  files served through marketplace URLs can be downloaded without login by
  anyone who can reach the Bifrost server.
- Improved Skills Repository table layout by truncating long skill
  names/descriptions so the Name column does not overlap the Description column.
- Improved FileManager dropdown interactions by keeping folder/file rows
  visually active while Add file or Move menus are open.
- Expanded the target folder immediately when starting the Add file flow so the
  draft file row is visible inside collapsed folders.
- Closed the marketplace registration popover after a copy action succeeds.
- Updated the configstore migration test to pass `testMigrationLogger` into
  `triggerMigrations`, matching the current migration runner signature.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Validate the focused UI and configstore changes:

```sh
# UI
cd ui
npm run typecheck

# Configstore migrations
cd ..
direnv exec . go test ./framework/configstore/...
```

Expected outcomes:

- UI typecheck completes successfully.
- Configstore tests pass.
- In the Skills Repository UI:
  - The sidebar no longer shows a **New** tag for Skills Repository.
  - The page header shows a single **Beta** badge.
  - The empty-state **Read more** button opens
    `https://docs.getbifrost.ai/features/skills-repository?utm_source=bfd`.
  - Long skill names/descriptions truncate instead of overlapping table columns.
  - The create/edit form shows the marketplace download exposure warning.
  - Add file and Move dropdowns keep their row hover/active state while open.
  - Selecting Add file inside a collapsed folder expands that folder before
    showing the draft file row.
  - Copying a marketplace registration command closes the popover after a
    successful copy.

No new configs or environment variables were added.

## Screenshots/Recordings

UI changes are included. Add before/after screenshots or a short recording for:

- Skills Repository list header with the **Beta** badge.
- Long-name table truncation.
- Create/edit warning banner.
- FileManager dropdown active row state.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This PR adds a user-facing warning in the Skills Repository create/edit form
clarifying that skill files exposed via marketplace download URLs are served
without login. Anyone who can reach the Bifrost server can request those files
directly, so users should not upload secrets, credentials, private code, or
other sensitive files.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

