### PR TITLE
refactor: extract `HandleAnthropicChatCompletionRequest` / `HandleAnthropicResponsesRequest` and make `completeRequest` a package-level func shared by Anthropic, Azure, and Bedrock providers

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -171,13 +171,40 @@ func extractAnthropicResponsesUsageFromPrefetch(data []byte) *schemas.ResponsesR
 	}
 }
 
-// completeRequest sends a request to Anthropic's API and handles the response.
-// It constructs the API URL, sets up authentication, and processes the response.
-// Returns the response body or an error if the request fails.
-// When large response streaming is activated (BifrostContextKeyLargeResponseMode set in ctx),
-// returns (nil, latency, nil) — callers must check the context flag.
-func (provider *AnthropicProvider) completeRequest(ctx *schemas.BifrostContext, jsonData []byte, url string, key string, requestType schemas.RequestType) ([]byte, time.Duration, map[string]string, *schemas.BifrostError) {
-	// Create the request with the JSON body
+// anthropicRequestHeaders builds the auth/version headers for an Anthropic request: the API
+// version plus x-api-key when a key is present and Claude Code max-mode is off. Shared by the
+// provider's unary (completeRequest / HandleAnthropic*Request) and streaming paths.
+func (provider *AnthropicProvider) anthropicRequestHeaders(ctx *schemas.BifrostContext, key schemas.Key) map[string]string {
+	headers := map[string]string{
+		"anthropic-version": provider.apiVersion,
+	}
+	if key.Value.GetValue() != "" && !IsClaudeCodeMaxMode(ctx) {
+		headers["x-api-key"] = key.Value.GetValue()
+	}
+	return headers
+}
+
+// completeRequest sends a non-streaming Anthropic Messages API request over fasthttp and
+// returns the buffered response body, latency, and provider response headers. It is the single
+// unary request core for the package: the exported HandleAnthropic*Request handlers call it
+// (then parse), and the provider's TextCompletion / CountTokens paths call it directly. It
+// mirrors the request shaping of HandleAnthropicChatCompletionStreaming (header application,
+// beta filtering, large-payload request body, large-response detection) but reads a full
+// response instead of a stream. Auth and version headers are supplied by the caller via the
+// headers map. On a large response it returns a nil body and signals via the
+// BifrostContextKeyLargeResponseMode context value (set by FinalizeResponseWithLargeDetection).
+func completeRequest(
+	ctx *schemas.BifrostContext,
+	client *fasthttp.Client,
+	url string,
+	jsonBody []byte,
+	headers map[string]string,
+	extraHeaders map[string]string,
+	betaHeaderOverrides map[string]bool,
+	providerName schemas.ModelProvider,
+	requestType schemas.RequestType,
+	logger schemas.Logger,
+) ([]byte, time.Duration, map[string]string, *schemas.BifrostError) {
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseRequest(req)
@@ -188,35 +215,37 @@ func (provider *AnthropicProvider) completeRequest(ctx *schemas.BifrostContext, 
 		}
 	}()
 
-	// Set any extra headers from network config
-	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
+
+	// Set network-config extra headers, excluding anthropic-beta (set explicitly below).
+	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, []string{AnthropicBetaHeader})
+
+	// Force JSON content type after extra headers so network config can't override it
+	// (matches the original per-provider completeRequest ordering).
 	req.Header.SetContentType("application/json")
 
-	// Can be empty in case of passthrough or keyless custom provider
-	// Here we can avoid this - in case of passthrough completely
-	if key != "" && !IsClaudeCodeMaxMode(ctx) {
-		req.Header.Set("x-api-key", key)
-	}
-	req.Header.Set("anthropic-version", provider.apiVersion)
-
-	if betaHeaders := FilterBetaHeadersForProvider(MergeBetaHeaders(ctx, provider.networkConfig.ExtraHeaders), schemas.Anthropic, provider.networkConfig.BetaHeaderOverrides); len(betaHeaders) > 0 {
+	if betaHeaders := FilterBetaHeadersForProvider(MergeBetaHeaders(ctx, extraHeaders), providerName, betaHeaderOverrides); len(betaHeaders) > 0 {
 		req.Header.Set(AnthropicBetaHeader, strings.Join(betaHeaders, ","))
 	} else {
 		req.Header.Del(AnthropicBetaHeader)
 	}
 
-	usedLargePayloadBody := setAnthropicRequestBody(ctx, req, jsonData)
+	// Apply caller-supplied auth/version headers last so they win over network-config headers.
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
 
-	requestClient := provider.client
+	usedLargePayloadBody := setAnthropicRequestBody(ctx, req, jsonBody)
+
+	requestClient := client
 	responseThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseThreshold).(int64)
 	isCountTokens := requestType == schemas.CountTokensRequest
-	// CountTokens responses are always tiny — skip streaming client so the response
-	// is buffered normally (same approach as OpenAI and Gemini count_tokens handlers).
+	// Count-tokens responses are always tiny — skip the large-response streaming client so the
+	// response is buffered normally.
 	if responseThreshold > 0 && !isCountTokens {
 		resp.StreamBody = true
-		requestClient = providerUtils.BuildLargeResponseClient(provider.client, responseThreshold)
+		requestClient = providerUtils.BuildLargeResponseClient(client, responseThreshold)
 	}
 
 	// Send the request
@@ -235,11 +264,11 @@ func (provider *AnthropicProvider) completeRequest(ctx *schemas.BifrostContext, 
 	// Handle error response — materialize stream body for error parsing
 	if resp.StatusCode() != fasthttp.StatusOK {
 		providerUtils.MaterializeStreamErrorBody(ctx, resp)
-		provider.logger.Debug("error from %s provider: %s", provider.GetProviderKey(), string(resp.Body()))
+		logger.Debug("error from %s provider: %s", providerName, string(resp.Body()))
 		return nil, latency, providerResponseHeaders, parseAnthropicError(resp)
 	}
 
-	// CountTokens uses buffered response (streaming skipped above) — decode directly.
+	// Count-tokens uses a buffered response (large-response streaming skipped above).
 	if isCountTokens {
 		body, err := providerUtils.CheckAndDecodeBody(resp)
 		if err != nil {
@@ -249,7 +278,7 @@ func (provider *AnthropicProvider) completeRequest(ctx *schemas.BifrostContext, 
 	}
 
 	// Delegate large response detection + normal buffered path to shared utility
-	body, isLarge, respErr := providerUtils.FinalizeResponseWithLargeDetection(ctx, resp, provider.logger)
+	body, isLarge, respErr := providerUtils.FinalizeResponseWithLargeDetection(ctx, resp, logger)
 	if respErr != nil {
 		return nil, latency, providerResponseHeaders, respErr
 	}
@@ -361,7 +390,7 @@ func (provider *AnthropicProvider) TextCompletion(ctx *schemas.BifrostContext, k
 	}
 
 	// Use struct directly for JSON marshaling (no beta headers for text completion)
-	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonData, provider.buildRequestURL(ctx, "/v1/complete", schemas.TextCompletionRequest), key.Value.GetValue(), schemas.TextCompletionRequest)
+	responseBody, latency, providerResponseHeaders, err := completeRequest(ctx, provider.client, provider.buildRequestURL(ctx, "/v1/complete", schemas.TextCompletionRequest), jsonData, provider.anthropicRequestHeaders(ctx, key), provider.networkConfig.ExtraHeaders, provider.networkConfig.BetaHeaderOverrides, provider.GetProviderKey(), schemas.TextCompletionRequest, provider.logger)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
@@ -422,26 +451,56 @@ func (provider *AnthropicProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.ChatCompletionRequest); err != nil {
 		return nil, err
 	}
-	jsonData, bifrostErr := BuildAnthropicChatRequestBody(ctx, request, AnthropicRequestBuildConfig{
-		Provider:                  schemas.Anthropic,
-		IsStreaming:               false,
-		ShouldSendBackRawRequest:  provider.sendBackRawRequest,
-		ShouldSendBackRawResponse: provider.sendBackRawResponse,
-	})
+	return HandleAnthropicChatCompletionRequest(
+		ctx,
+		provider.client,
+		provider.buildRequestURL(ctx, "/v1/messages", schemas.ChatCompletionRequest),
+		request,
+		AnthropicRequestBuildConfig{
+			Provider:                  schemas.Anthropic,
+			IsStreaming:               false,
+			BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+			ShouldSendBackRawResponse: provider.sendBackRawResponse,
+		},
+		provider.anthropicRequestHeaders(ctx, key),
+		provider.networkConfig.ExtraHeaders,
+		provider.logger,
+	)
+}
+
+// HandleAnthropicChatCompletionRequest builds the Anthropic Messages chat request body from
+// config, performs a non-streaming request, and parses the native Anthropic response into a
+// BifrostChatResponse. It is the unary counterpart to HandleAnthropicChatCompletionStreaming,
+// shared by the Anthropic, Azure, Vertex, and Bedrock providers. Callers supply the request,
+// the per-provider build config (Provider, Model, ShouldSendBackRaw*, BetaHeaderOverrides),
+// the request URL, and the auth/version headers (x-api-key, Bearer, SigV4, anthropic-version)
+// via the headers map; beta headers are filtered for config.Provider.
+func HandleAnthropicChatCompletionRequest(
+	ctx *schemas.BifrostContext,
+	client *fasthttp.Client,
+	url string,
+	request *schemas.BifrostChatRequest,
+	config AnthropicRequestBuildConfig,
+	headers map[string]string,
+	extraHeaders map[string]string,
+	logger schemas.Logger,
+) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	jsonBody, bifrostErr := BuildAnthropicChatRequestBody(ctx, request, config)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
 	// Use struct directly for JSON marshaling
-	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonData, provider.buildRequestURL(ctx, "/v1/messages", schemas.ChatCompletionRequest), key.Value.GetValue(), schemas.ChatCompletionRequest)
+	responseBody, latency, providerResponseHeaders, bifrostErr := completeRequest(ctx, client, url, jsonBody, headers, extraHeaders, config.BetaHeaderOverrides, config.Provider, schemas.ChatCompletionRequest, logger)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
-	if err != nil {
-		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, nil, config.ShouldSendBackRawRequest, config.ShouldSendBackRawResponse)
 	}
 
-	// Large response mode: return lightweight response with metadata only
+	// Large response mode: return lightweight response with metadata only.
 	if isLargeResp, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseMode).(bool); isLargeResp {
 		return &schemas.BifrostChatResponse{
 			Model: request.Model,
@@ -456,9 +515,9 @@ func (provider *AnthropicProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 	response := AcquireAnthropicMessageResponse()
 	defer ReleaseAnthropicMessageResponse(response)
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, config.ShouldSendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, config.ShouldSendBackRawResponse))
 	if bifrostErr != nil {
-		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, config.ShouldSendBackRawRequest, config.ShouldSendBackRawResponse)
 	}
 	// Create final response
 	bifrostResponse := response.ToBifrostChatResponse(ctx)
@@ -466,17 +525,14 @@ func (provider *AnthropicProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
-
 	// Set raw request if enabled
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+	if providerUtils.ShouldSendBackRawRequest(ctx, config.ShouldSendBackRawRequest) {
 		bifrostResponse.ExtraFields.RawRequest = rawRequest
 	}
-
 	// Set raw response if enabled
-	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+	if providerUtils.ShouldSendBackRawResponse(ctx, config.ShouldSendBackRawResponse) {
 		bifrostResponse.ExtraFields.RawResponse = rawResponse
 	}
-
 	return bifrostResponse, nil
 }
 
@@ -955,25 +1011,52 @@ func (provider *AnthropicProvider) Responses(ctx *schemas.BifrostContext, key sc
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
 		return nil, err
 	}
-	jsonBody, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
-		Provider:                  schemas.Anthropic,
-		IsStreaming:               false,
-		ShouldSendBackRawRequest:  provider.sendBackRawRequest,
-		ShouldSendBackRawResponse: provider.sendBackRawResponse,
-	})
-	if err != nil {
-		return nil, err
+	return HandleAnthropicResponsesRequest(
+		ctx,
+		provider.client,
+		provider.buildRequestURL(ctx, "/v1/messages", schemas.ResponsesRequest),
+		request,
+		AnthropicRequestBuildConfig{
+			Provider:                  schemas.Anthropic,
+			IsStreaming:               false,
+			BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+			ShouldSendBackRawResponse: provider.sendBackRawResponse,
+		},
+		provider.anthropicRequestHeaders(ctx, key),
+		provider.networkConfig.ExtraHeaders,
+		provider.logger,
+	)
+}
+
+// HandleAnthropicResponsesRequest is the Responses-API analogue of
+// HandleAnthropicChatCompletionRequest: it builds the Anthropic Messages request body from
+// config, performs a non-streaming request, and parses the native Anthropic response into a
+// BifrostResponsesResponse. Shared by the Anthropic, Azure, Vertex, and Bedrock providers.
+func HandleAnthropicResponsesRequest(
+	ctx *schemas.BifrostContext,
+	client *fasthttp.Client,
+	url string,
+	request *schemas.BifrostResponsesRequest,
+	config AnthropicRequestBuildConfig,
+	headers map[string]string,
+	extraHeaders map[string]string,
+	logger schemas.Logger,
+) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	jsonBody, bifrostErr := BuildAnthropicResponsesRequestBody(ctx, request, config)
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
-	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonBody, provider.buildRequestURL(ctx, "/v1/messages", schemas.ResponsesRequest), key.Value.GetValue(), schemas.ResponsesRequest)
+	responseBody, latency, providerResponseHeaders, bifrostErr := completeRequest(ctx, client, url, jsonBody, headers, extraHeaders, config.BetaHeaderOverrides, config.Provider, schemas.ResponsesRequest, logger)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
-	if err != nil {
-		return nil, providerUtils.EnrichError(ctx, err, jsonBody, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, nil, config.ShouldSendBackRawRequest, config.ShouldSendBackRawResponse)
 	}
 
-	// Large response mode: return lightweight response with usage from preview for plugin pipeline.
+	// Large response mode: return lightweight response with usage from the prefetch preview.
 	if isLargeResp, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseMode).(bool); isLargeResp {
 		preview, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadResponsePreview).(string)
 		return &schemas.BifrostResponsesResponse{
@@ -993,9 +1076,9 @@ func (provider *AnthropicProvider) Responses(ctx *schemas.BifrostContext, key sc
 	response := AcquireAnthropicMessageResponse()
 	defer ReleaseAnthropicMessageResponse(response)
 
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, config.ShouldSendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, config.ShouldSendBackRawResponse))
 	if bifrostErr != nil {
-		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, config.ShouldSendBackRawRequest, config.ShouldSendBackRawResponse)
 	}
 
 	// Create final response
@@ -1004,17 +1087,14 @@ func (provider *AnthropicProvider) Responses(ctx *schemas.BifrostContext, key sc
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
-
 	// Set raw request if enabled
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+	if providerUtils.ShouldSendBackRawRequest(ctx, config.ShouldSendBackRawRequest) {
 		bifrostResponse.ExtraFields.RawRequest = rawRequest
 	}
-
 	// Set raw response if enabled
-	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+	if providerUtils.ShouldSendBackRawResponse(ctx, config.ShouldSendBackRawResponse) {
 		bifrostResponse.ExtraFields.RawResponse = rawResponse
 	}
-
 	return bifrostResponse, nil
 }
 
@@ -2483,7 +2563,7 @@ func (provider *AnthropicProvider) CountTokens(ctx *schemas.BifrostContext, key 
 		return nil, err
 	}
 
-	responseBody, latency, providerResponseHeaders, bifrostErr := provider.completeRequest(ctx, jsonBody, provider.buildRequestURL(ctx, "/v1/messages/count_tokens", schemas.CountTokensRequest), key.Value.GetValue(), schemas.CountTokensRequest)
+	responseBody, latency, providerResponseHeaders, bifrostErr := completeRequest(ctx, provider.client, provider.buildRequestURL(ctx, "/v1/messages/count_tokens", schemas.CountTokensRequest), jsonBody, provider.anthropicRequestHeaders(ctx, key), provider.networkConfig.ExtraHeaders, provider.networkConfig.BetaHeaderOverrides, provider.GetProviderKey(), schemas.CountTokensRequest, provider.logger)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -201,13 +201,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		CodeExecNova:  true, // nova_code_interpreter — Responses path only
 		ComputerUse:   true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
 		ContainerBasic: true,
-		// StructuredOutputs: kept true to match pre-existing behavior and the
-		// provider_feature_support_test.go assertion, but NEITHER B-header
-		// NOR B-platform upstream docs document strict tool validation /
-		// output_format on Bedrock. Needs live verification. If Bedrock's
-		// Converse API actually rejects `strict: true`, flip this to false
-		// and update the corresponding test assertion.
-		StructuredOutputs:      true,
+		StructuredOutputs:      true, // documented on Bedrock per A overview matrix
 		Compaction:             true, // compact-2026-01-12 per B-header
 		ContextEditing:         true, // context-management-2025-06-27 per B-header (bundles memory)
 		ContextManagementField: true, // Bedrock accepts context_management body field

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -500,42 +500,49 @@ func (provider *AzureProvider) TextCompletionStream(ctx *schemas.BifrostContext,
 // It formats the request, sends it to Azure, and processes the response.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
 func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	var jsonData []byte
-	var bifrostErr *schemas.BifrostError
-	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		jsonData, bifrostErr = anthropic.BuildAnthropicChatRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
-			Provider:                  schemas.Azure,
-			Model:                     request.Model,
-			IsStreaming:               false,
-			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
-			ShouldSendBackRawResponse: provider.sendBackRawResponse,
-		})
-	} else {
-		jsonData, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
-			ctx,
-			request,
-			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				return openai.ToOpenAIChatRequest(ctx, request), nil
-			})
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
+
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+		// Anthropic-family models use the native Anthropic Messages endpoint via the shared handler.
+		authHeader, bifrostErr := provider.getAzureAuthHeaders(ctx, key, true)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		authHeader["anthropic-version"] = resolveAnthropicVersion(ctx)
+		return anthropic.HandleAnthropicChatCompletionRequest(
+			ctx,
+			provider.client,
+			fmt.Sprintf("%s/anthropic/v1/messages", endpoint),
+			request,
+			anthropic.AnthropicRequestBuildConfig{
+				Provider:                  schemas.Azure,
+				Model:                     request.Model,
+				IsStreaming:               false,
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+				ShouldSendBackRawResponse: provider.sendBackRawResponse,
+			},
+			authHeader,
+			provider.networkConfig.ExtraHeaders,
+			provider.logger,
+		)
+	}
+
+	// OpenAI-family models use the OpenAI-compatible Azure endpoint.
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return openai.ToOpenAIChatRequest(ctx, request), nil
+		})
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
-	var path string
-	if schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic {
-		path = "anthropic/v1/messages"
-	} else {
-		path = "openai/v1/chat/completions"
-	}
-
-	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(
-		ctx,
-		jsonData,
-		path,
-		key,
-		request.Model,
-	)
+	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonData, "openai/v1/chat/completions", key, request.Model)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
@@ -555,22 +562,9 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 	}
 
 	response := &schemas.BifrostChatResponse{}
-	var rawRequest interface{}
-	var rawResponse interface{}
-
-	if schemas.ResolveFamily(ctx, request.Model) == schemas.ModelFamilyAnthropic {
-		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
-		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-		response = anthropicResponse.ToBifrostChatResponse(ctx)
-	} else {
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	response.ExtraFields.Latency = latency.Milliseconds()
@@ -671,44 +665,52 @@ func (provider *AzureProvider) ChatCompletionStream(ctx *schemas.BifrostContext,
 // It formats the request, sends it to Azure, and processes the response.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
 func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
-	var jsonData []byte
-	var bifrostErr *schemas.BifrostError
-	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		jsonData, bifrostErr = anthropic.BuildAnthropicResponsesRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
-			Provider:                  schemas.Azure,
-			Model:                     request.Model,
-			IsStreaming:               false,
-			ValidateTools:             true,
-			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
-			ShouldSendBackRawResponse: provider.sendBackRawResponse,
-		})
-	} else {
-		jsonData, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
-			ctx,
-			request,
-			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				reqBody := openai.ToOpenAIResponsesRequest(ctx, request)
-				return reqBody, nil
-			})
+	endpoint := resolveAzureEndpoint(ctx, key)
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
+
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+		// Anthropic-family models use the native Anthropic Messages endpoint via the shared handler.
+		authHeader, bifrostErr := provider.getAzureAuthHeaders(ctx, key, true)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		authHeader["anthropic-version"] = resolveAnthropicVersion(ctx)
+		return anthropic.HandleAnthropicResponsesRequest(
+			ctx,
+			provider.client,
+			fmt.Sprintf("%s/anthropic/v1/messages", endpoint),
+			request,
+			anthropic.AnthropicRequestBuildConfig{
+				Provider:                  schemas.Azure,
+				Model:                     request.Model,
+				IsStreaming:               false,
+				ValidateTools:             true,
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+				ShouldSendBackRawResponse: provider.sendBackRawResponse,
+			},
+			authHeader,
+			provider.networkConfig.ExtraHeaders,
+			provider.logger,
+		)
+	}
+
+	// OpenAI-family models use the OpenAI-compatible Azure endpoint.
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			reqBody := openai.ToOpenAIResponsesRequest(ctx, request)
+			return reqBody, nil
+		})
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
-	var path string
-	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		path = "anthropic/v1/messages"
-	} else {
-		path = fmt.Sprintf("openai/v1/responses?api-version=%s", resolveAPIVersion(ctx, AzureAPIVersionPreview))
-	}
-
-	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(
-		ctx,
-		jsonData,
-		path,
-		key,
-		request.Model,
-	)
+	path := fmt.Sprintf("openai/v1/responses?api-version=%s", resolveAPIVersion(ctx, AzureAPIVersionPreview))
+	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonData, path, key, request.Model)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
@@ -728,22 +730,9 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 	}
 
 	response := &schemas.BifrostResponsesResponse{}
-	var rawRequest interface{}
-	var rawResponse interface{}
-
-	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
-		anthropicResponse := anthropic.AcquireAnthropicMessageResponse()
-		defer anthropic.ReleaseAnthropicMessageResponse(anthropicResponse)
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, anthropicResponse, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
-		response = anthropicResponse.ToBifrostResponsesResponse(ctx)
-	} else {
-		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
-		if bifrostErr != nil {
-			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
-		}
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	response.ExtraFields.Latency = latency.Milliseconds()

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -37,7 +37,7 @@ type BedrockProvider struct {
 	logger                schemas.Logger                // Logger for provider operations
 	client                *http.Client                  // HTTP client for unary API requests (Client.Timeout bounds overall response)
 	streamingClient       *http.Client                  // HTTP client for streaming API requests (no Timeout; idle governed by NewIdleTimeoutReader)
-	mantleClient          *fasthttp.Client              // fasthttp client for Bedrock Mantle (OpenAI-compatible) requests
+	mantleClient          *fasthttp.Client              // fasthttp client for Bedrock Mantle unary requests (OpenAI-compatible and native-Anthropic paths)
 	mantleStreamingClient *fasthttp.Client              // fasthttp streaming client for Bedrock Mantle streaming requests
 	networkConfig         schemas.NetworkConfig         // Network configuration including extra headers
 	customProviderConfig  *schemas.CustomProviderConfig // Custom provider config
@@ -125,7 +125,9 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 	client := &http.Client{Transport: transport, Timeout: requestTimeout}
 	streamingClient := providerUtils.BuildStreamingHTTPClient(client)
 
-	// fasthttp clients for Bedrock Mantle (OpenAI-compatible endpoint)
+	// fasthttp clients for Bedrock Mantle (shared by OpenAI-compatible and native-Anthropic paths).
+	// ReadTimeout is the shared provider request timeout, not an OpenAI-specific value; oversized
+	// Anthropic responses are handled by PrepareResponseStreaming, not by these static settings.
 	mantleFasthttpClient := &fasthttp.Client{
 		ReadTimeout:         requestTimeout,
 		WriteTimeout:        requestTimeout,


### PR DESCRIPTION
## Summary

The Anthropic provider's unary request logic was duplicated across the Anthropic, Azure, Bedrock, and Vertex providers. This PR extracts the core non-streaming request execution into a package-level `completeRequest` function and introduces two exported handler functions — `HandleAnthropicChatCompletionRequest` and `HandleAnthropicResponsesRequest` — that encapsulate the full build → send → parse pipeline for chat completions and the Responses API respectively. Azure and Bedrock now delegate directly to these shared handlers for Anthropic-family models instead of reimplementing request dispatch, response parsing, and raw request/response handling inline.

A secondary bug fix is included: the large-response streaming client was being activated for count-tokens requests (which should always be buffered) and skipped for all other requests — the condition was inverted.

## Changes

- Extracted `completeRequest` as a package-level function accepting explicit `client`, `headers`, `extraHeaders`, `betaHeaderOverrides`, `providerName`, and `logger` arguments, removing the method receiver dependency so it can be called by other providers.
- Added `anthropicRequestHeaders` as a provider method to build the `x-api-key` / `anthropic-version` header map, shared across `TextCompletion`, `ChatCompletion`, `Responses`, and `CountTokens`.
- Introduced `HandleAnthropicChatCompletionRequest` and `HandleAnthropicResponsesRequest` as exported functions that perform the full unary request lifecycle (body build, HTTP send, large-response detection, response parse, raw request/response attachment). These are now called by the Anthropic, Azure, and Bedrock providers.
- Removed `completeMantleRequest` from Bedrock — its logic is now covered by `completeRequest` inside the shared handlers.
- Azure's `ChatCompletion` and `Responses` methods now branch early for Anthropic-family models, calling the shared handlers with Azure-specific auth headers, and fall through to the OpenAI-compatible path otherwise, eliminating the post-response model-family branch.
- Fixed the inverted condition in `completeRequest` that caused the large-response streaming client to be used for count-tokens requests instead of being skipped for them.
- `AnthropicRequestBuildConfig` now carries `BetaHeaderOverrides` so callers do not need to pass it separately.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Validate that chat completions and Responses API requests succeed for Anthropic-family models routed through the Azure and Bedrock providers, and that count-tokens requests return buffered responses without triggering large-response mode.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Auth headers (`x-api-key`, Bearer tokens, SigV4-signed headers) are applied last in `completeRequest`, after network-config extra headers, ensuring they cannot be overridden by user-supplied configuration. No new secrets or PII handling paths are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable