### PR TITLE
fix: skills apis backend response bloat clearing + cleanup orphans grace period change

### DIFF
--- a/framework/configstore/skills.go
+++ b/framework/configstore/skills.go
@@ -652,13 +652,10 @@ func (s *RDBConfigStore) CreateSkill(ctx context.Context, skill *tables.TableSki
 	return nil
 }
 
-// GetSkill returns a skill with lean version summaries (id, version, created_at) and serving files.
+// GetSkill returns a skill with serving files. Version history is loaded through ListSkillVersions.
 func (s *RDBConfigStore) GetSkill(ctx context.Context, id string) (*tables.TableSkill, error) {
 	var skill tables.TableSkill
 	if err := s.ScopedDB(ctx).
-		Preload("Versions", func(db *gorm.DB) *gorm.DB {
-			return db.Select("id", "skill_id", "version", "created_at").Order("created_at DESC")
-		}).
 		First(&skill, "skills.id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
@@ -667,6 +664,15 @@ func (s *RDBConfigStore) GetSkill(ctx context.Context, id string) (*tables.Table
 	}
 	if err := populateSkillFiles(s.ScopedDB(ctx), &skill); err != nil {
 		return nil, fmt.Errorf("load serving files: %w", err)
+	}
+	// Populate the most recently created version for bump validation without
+	// returning the full version history from this endpoint.
+	latest, err := latestCreatedSkillVersion(s.ScopedDB(ctx), skill.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load latest created skill version: %w", err)
+	}
+	if latest != "" {
+		skill.HighestVersion = latest
 	}
 	return &skill, nil
 }
@@ -1081,6 +1087,7 @@ func populateSkillFiles(tx *gorm.DB, skill *tables.TableSkill) error {
 		return err
 	}
 	skill.Files = version.Files
+	skill.FileCount = int64(len(version.Files))
 	return nil
 }
 
@@ -1197,12 +1204,14 @@ func (s *RDBConfigStore) UpdateSkillConfigHash(ctx context.Context, skillID stri
 		Update("config_hash", configHash).Error
 }
 
+const SkillOrphanCleanupGracePeriod = 24 * time.Hour
+
 // CleanupOrphanSkillFileBlobs deletes DB fallback blobs not referenced by any skill file.
-// When force is false, a 30-minute grace period protects freshly uploaded pending blobs.
+// When force is false, a 24-hour grace period protects freshly uploaded pending blobs.
 func (s *RDBConfigStore) CleanupOrphanSkillFileBlobs(ctx context.Context, force bool) (int64, error) {
 	query := s.DB().WithContext(ctx)
 	if !force {
-		cutoff := time.Now().Add(-30 * time.Minute)
+		cutoff := time.Now().Add(-SkillOrphanCleanupGracePeriod)
 		query = query.Where("created_at < ?", cutoff)
 	}
 	result := query.

--- a/transports/bifrost-http/handlers/skills.go
+++ b/transports/bifrost-http/handlers/skills.go
@@ -265,7 +265,7 @@ func (h *SkillsHandler) cleanupOrphanFiles(ctx *fasthttp.RequestCtx) {
 }
 
 // CleanupOrphanSkillFiles removes DB fallback blobs and unreferenced upload objects.
-// When force is false, a 30-minute grace period protects freshly uploaded pending files.
+// When force is false, a 24-hour grace period protects freshly uploaded pending files.
 func CleanupOrphanSkillFiles(ctx context.Context, store configstore.ConfigStore, objectStore objectstore.ObjectStore, force bool) (SkillOrphanCleanupResult, error) {
 	var result SkillOrphanCleanupResult
 	if store == nil {
@@ -304,7 +304,7 @@ func CleanupOrphanSkillFiles(ctx context.Context, store configstore.ConfigStore,
 		referenced[key] = struct{}{}
 	}
 
-	// Only reap unreferenced objects older than 30 minutes unless force is set.
+	// Only reap unreferenced objects older than the grace period unless force is set.
 	orphanKeys := make([]string, 0)
 	if force {
 		for _, obj := range uploadObjects {
@@ -313,7 +313,7 @@ func CleanupOrphanSkillFiles(ctx context.Context, store configstore.ConfigStore,
 			}
 		}
 	} else {
-		cutoff := time.Now().Add(-30 * time.Minute)
+		cutoff := time.Now().Add(-configstore.SkillOrphanCleanupGracePeriod)
 		for _, obj := range uploadObjects {
 			if _, ok := referenced[obj.Key]; !ok && obj.LastModified.Before(cutoff) {
 				orphanKeys = append(orphanKeys, obj.Key)

--- a/transports/bifrost-http/handlers/skills_cleanup_test.go
+++ b/transports/bifrost-http/handlers/skills_cleanup_test.go
@@ -55,8 +55,8 @@ func TestCleanupOrphanSkillFilesDeletesDBFallbackBlobs(t *testing.T) {
 	if err := store.CreateSkillFileBlob(ctx, &tables.TableSkillFileBlob{ID: orphanBlobID, Data: []byte("orphan")}); err != nil {
 		t.Fatalf("create orphan blob: %v", err)
 	}
-	// Backdate the orphan blob so it exceeds the 30-minute grace period.
-	if err := store.DB().WithContext(ctx).Model(&tables.TableSkillFileBlob{}).Where("id = ?", orphanBlobID).Update("created_at", time.Now().Add(-1*time.Hour)).Error; err != nil {
+	// Backdate the orphan blob so it exceeds the 24-hour grace period.
+	if err := store.DB().WithContext(ctx).Model(&tables.TableSkillFileBlob{}).Where("id = ?", orphanBlobID).Update("created_at", time.Now().Add(-25*time.Hour)).Error; err != nil {
 		t.Fatalf("backdate orphan blob: %v", err)
 	}
 	if err := store.CreateSkill(ctx, &tables.TableSkill{
@@ -110,8 +110,8 @@ func TestCleanupOrphanSkillFilesDeletesOnlyUnreferencedUploadObjects(t *testing.
 			t.Fatalf("put %s: %v", key, err)
 		}
 	}
-	// Backdate orphan object so it exceeds the 30-minute grace period.
-	objStore.SetCreatedAt(orphanKey, time.Now().Add(-1*time.Hour))
+	// Backdate orphan object so it exceeds the 24-hour grace period.
+	objStore.SetCreatedAt(orphanKey, time.Now().Add(-25*time.Hour))
 	uploadID := "referenced"
 	if err := store.CreateSkill(ctx, &tables.TableSkill{
 		Name:        "cleanup-object-test",

--- a/ui/lib/types/skills.ts
+++ b/ui/lib/types/skills.ts
@@ -44,7 +44,7 @@ export interface SkillVersion {
   created_at: string;
 }
 
-// Lean version summary returned in skill detail and version list responses.
+// Lean version summary returned in version list responses.
 export type SkillVersionSummary = Pick<
   SkillVersion,
   "id" | "skill_id" | "version" | "created_by" | "created_at"


### PR DESCRIPTION
## Summary

This PR decouples version history loading from the `GetSkill` endpoint, extends
the orphan file cleanup grace period from 30 minutes to 24 hours, and populates
`HighestVersion` and `FileCount` fields directly on the skill struct during
retrieval.

## Changes

- `GetSkill` no longer eagerly preloads the full version list. Instead, it
  fetches only the most recently created version via `latestCreatedSkillVersion`
  and assigns it to `skill.HighestVersion` for bump validation. Full version
  history is now exclusively loaded through `ListSkillVersions`.
- `populateSkillFiles` now also sets `skill.FileCount` from the length of the
  loaded files slice.
- The orphan blob and upload object cleanup grace period has been increased from
  30 minutes to 24 hours, extracted into a named constant
  `SkillOrphanCleanupGracePeriod` shared between the configstore and HTTP
  handler layers.
- Tests updated to backdate orphan blobs and objects by 25 hours instead of 1
  hour to correctly exceed the new grace period.
- The `SkillVersionSummary` type comment updated to reflect that it is only
  returned in version list responses, not skill detail responses.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./transports/bifrost-http/handlers/...
```

Verify that:

- `GetSkill` returns the correct `HighestVersion` without including a full
  version list in the response.
- `FileCount` is populated correctly on the returned skill.
- Orphan cleanup does not reap blobs or objects created within the last 24 hours
  when `force` is false.
- Orphan cleanup correctly removes blobs and objects older than 24 hours.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

