### PR TITLE
feat: add vault reference support (`vault.*`) to `EnvVar` with store/resolve/remove hooks and UI badge

### DIFF
--- a/core/schemas/envvar.go
+++ b/core/schemas/envvar.go
@@ -10,11 +10,15 @@ import (
 	"github.com/bytedance/sonic"
 )
 
-// EnvVar is a wrapper around a value that can be sourced from an environment variable.
+// EnvVar is a wrapper around a value that can be sourced from an environment variable
+// or an external vault (e.g. AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault).
+// Three reference forms are accepted: plain text, "env.VAR_NAME", and "vault.path/to/secret".
 type EnvVar struct {
-	Val     string `json:"value"`
-	EnvVar  string `json:"env_var"`
-	FromEnv bool   `json:"from_env"`
+	Val       string `json:"value"`
+	EnvVar    string `json:"env_var"`
+	FromEnv   bool   `json:"from_env"`
+	VaultRef  string `json:"vault_var,omitempty"`
+	FromVault bool   `json:"from_vault,omitempty"`
 }
 
 // NewEnvVar creates a new EnvValue from a string.
@@ -37,9 +41,22 @@ func NewEnvVar(value string) *EnvVar {
 			var envVar envVarAlias
 			if err := sonic.Unmarshal([]byte(value), &envVar); err == nil {
 				e := &EnvVar{
-					Val:     envVar.Val,
-					FromEnv: envVar.FromEnv,
-					EnvVar:  envVar.EnvVar,
+					Val:       envVar.Val,
+					FromEnv:   envVar.FromEnv,
+					EnvVar:    envVar.EnvVar,
+					FromVault: envVar.FromVault,
+					VaultRef:  envVar.VaultRef,
+				}
+				// Explicit vault reference: {from_vault: true, vault_var: "vault.path"}
+				if e.FromVault && e.VaultRef != "" {
+					if !strings.HasPrefix(e.VaultRef, "vault.") {
+						e.VaultRef = "vault." + e.VaultRef
+					}
+					e.Val = e.VaultRef
+					if vaultValue, ok := LookupVault(e.VaultRef); ok {
+						e.Val = vaultValue
+					}
+					return e
 				}
 				// Old format: value == env_var == "env.XXX"
 				if strings.HasPrefix(e.Val, "env.") && e.Val == e.EnvVar {
@@ -62,6 +79,17 @@ func NewEnvVar(value string) *EnvVar {
 			}
 		}
 	}
+	if strings.HasPrefix(val, "vault.") {
+		e := &EnvVar{
+			Val:       val,
+			VaultRef:  val,
+			FromVault: true,
+		}
+		if vaultValue, ok := LookupVault(e.VaultRef); ok {
+			e.Val = vaultValue
+		}
+		return e
+	}
 	if envKey, ok := strings.CutPrefix(val, "env."); ok {
 		if envValue, ok := os.LookupEnv(envKey); ok {
 			return &EnvVar{
@@ -83,13 +111,21 @@ func NewEnvVar(value string) *EnvVar {
 	}
 }
 
-// IsRedacted returns true if the value is redacted.
-func (e *EnvVar) IsRedacted() bool {
-	if e.Val == "" && !e.FromEnv {
+// IsFromVault returns true if the value is sourced from an external vault.
+func (e *EnvVar) IsFromVault() bool {
+	if e == nil {
 		return false
 	}
-	// Check if it's an environment variable reference
-	if e.FromEnv {
+	return e.FromVault
+}
+
+// IsRedacted returns true if the value is redacted.
+func (e *EnvVar) IsRedacted() bool {
+	if e.Val == "" && !e.FromEnv && !e.FromVault {
+		return false
+	}
+	// Vault and env references are treated as redacted (the real value is external)
+	if e.FromEnv || e.FromVault {
 		return true
 	}
 	if len(e.Val) <= 8 {
@@ -123,7 +159,9 @@ func (e *EnvVar) Equals(other *EnvVar) bool {
 	}
 	return e.Val == other.Val &&
 		e.EnvVar == other.EnvVar &&
-		e.FromEnv == other.FromEnv
+		e.FromEnv == other.FromEnv &&
+		e.VaultRef == other.VaultRef &&
+		e.FromVault == other.FromVault
 }
 
 // Redacted returns a new SecretKey with the value redacted.
@@ -133,17 +171,21 @@ func (e *EnvVar) Redacted() *EnvVar {
 	}
 	if e.Val == "" {
 		return &EnvVar{
-			Val:     "",
-			FromEnv: e.FromEnv,
-			EnvVar:  e.EnvVar,
+			Val:       "",
+			FromEnv:   e.FromEnv,
+			EnvVar:    e.EnvVar,
+			FromVault: e.FromVault,
+			VaultRef:  e.VaultRef,
 		}
 	}
 	// If key is 8 characters or less, just return all asterisks
 	if len(e.Val) <= 8 {
 		return &EnvVar{
-			Val:     strings.Repeat("*", len(e.Val)),
-			FromEnv: e.FromEnv,
-			EnvVar:  e.EnvVar,
+			Val:       strings.Repeat("*", len(e.Val)),
+			FromEnv:   e.FromEnv,
+			EnvVar:    e.EnvVar,
+			FromVault: e.FromVault,
+			VaultRef:  e.VaultRef,
 		}
 	}
 	// Show first 4 and last 4 characters, replace middle with asterisks
@@ -152,41 +194,42 @@ func (e *EnvVar) Redacted() *EnvVar {
 	middle := strings.Repeat("*", 24)
 
 	return &EnvVar{
-		Val:     prefix + middle + suffix,
-		FromEnv: e.FromEnv,
-		EnvVar:  e.EnvVar,
+		Val:       prefix + middle + suffix,
+		FromEnv:   e.FromEnv,
+		EnvVar:    e.EnvVar,
+		FromVault: e.FromVault,
+		VaultRef:  e.VaultRef,
 	}
 }
 
 // FullyRedacted returns a copy of the EnvVar with Val replaced by a fixed placeholder
 // so no substring of the original value is exposed. Use for API responses where
-// Redacted is unsafe (e.g. literal proxy passwords). FromEnv and EnvVar are preserved
-// so env references remain visible and round-trip update merges still match via Equals.
+// Redacted is unsafe (e.g. literal proxy passwords). FromEnv/EnvVar and
+// FromVault/VaultRef are preserved so references remain visible.
 func (e *EnvVar) FullyRedacted() *EnvVar {
 	if e == nil {
 		return nil
 	}
 	if e.Val == "" {
 		return &EnvVar{
-			Val:     "",
-			FromEnv: e.FromEnv,
-			EnvVar:  e.EnvVar,
+			Val:       "",
+			FromEnv:   e.FromEnv,
+			EnvVar:    e.EnvVar,
+			FromVault: e.FromVault,
+			VaultRef:  e.VaultRef,
 		}
 	}
 	return &EnvVar{
-		Val:     "<REDACTED>",
-		FromEnv: e.FromEnv,
-		EnvVar:  e.EnvVar,
+		Val:       "<REDACTED>",
+		FromEnv:   e.FromEnv,
+		EnvVar:    e.EnvVar,
+		FromVault: e.FromVault,
+		VaultRef:  e.VaultRef,
 	}
 }
 
 // UnmarshalJSON unmarshals the value from JSON.
 func (e *EnvVar) UnmarshalJSON(data []byte) error {
-	// This is always going to be value
-	// Here we will first considering this as value
-	// if it has env. then we will process it and set the FromEnv to true
-	// if it doesn't have env. then we will set the FromEnv to false
-	// if it has env. then we will process it and set the FromEnv to true
 	val := string(data)
 	// Cleanup string if required
 	// Use strconv.Unquote to properly handle JSON string escape sequences
@@ -194,8 +237,7 @@ func (e *EnvVar) UnmarshalJSON(data []byte) error {
 	if unquoted, err := strconv.Unquote(val); err == nil {
 		val = unquoted
 	}
-	// Here we will need to check if the incoming data is a valid JSON object
-	// If it's a valid JSON object and follows the EnvVar schema, then we will unmarshal it into an EnvVar object
+	// Check if the incoming data is a valid JSON object matching the EnvVar schema.
 	if sonic.Valid(data) {
 		valueNode, _ := sonic.Get(data, "value")
 		envNode, _ := sonic.Get(data, "env_var")
@@ -207,10 +249,23 @@ func (e *EnvVar) UnmarshalJSON(data []byte) error {
 				e.Val = envVar.Val
 				e.FromEnv = envVar.FromEnv
 				e.EnvVar = envVar.EnvVar
+				e.FromVault = envVar.FromVault
+				e.VaultRef = envVar.VaultRef
+
+				// Explicit vault reference: {from_vault: true, vault_var: "vault.path"}
+				if e.FromVault && e.VaultRef != "" {
+					if !strings.HasPrefix(e.VaultRef, "vault.") {
+						e.VaultRef = "vault." + e.VaultRef
+					}
+					e.Val = e.VaultRef
+					if vaultValue, ok := LookupVault(e.VaultRef); ok {
+						e.Val = vaultValue
+					}
+					return nil
+				}
 				// Old format: value == env_var == "env.XXX"
 				if strings.HasPrefix(e.Val, "env.") && e.Val == e.EnvVar {
 					e.Val = ""
-					// Load the environment variable value
 					envValue, ok := os.LookupEnv(strings.TrimPrefix(e.EnvVar, "env."))
 					if ok {
 						e.Val = envValue
@@ -228,6 +283,18 @@ func (e *EnvVar) UnmarshalJSON(data []byte) error {
 			// Else the value is JSON, so we will treat this as a normal value
 		}
 	}
+	// Plain string forms: "vault.path/to/secret", "env.VAR", or literal value
+	if strings.HasPrefix(val, "vault.") {
+		e.VaultRef = val
+		e.FromVault = true
+		e.Val = val
+		e.FromEnv = false
+		e.EnvVar = ""
+		if vaultValue, ok := LookupVault(val); ok {
+			e.Val = vaultValue
+		}
+		return nil
+	}
 	if envKey, ok := strings.CutPrefix(val, "env."); ok {
 		if envValue, ok := os.LookupEnv(envKey); ok {
 			e.Val = envValue
@@ -238,11 +305,15 @@ func (e *EnvVar) UnmarshalJSON(data []byte) error {
 		e.Val = ""
 		e.FromEnv = true
 		e.EnvVar = val
+		e.FromVault = false
+		e.VaultRef = ""
 		return nil
 	}
 	e.Val = val
 	e.FromEnv = false
 	e.EnvVar = ""
+	e.FromVault = false
+	e.VaultRef = ""
 	return nil
 }
 
@@ -257,6 +328,8 @@ func (e *EnvVar) Scan(value any) error {
 		e.Val = ""
 		e.FromEnv = false
 		e.EnvVar = ""
+		e.FromVault = false
+		e.VaultRef = ""
 		return nil
 	}
 	switch v := value.(type) {
@@ -266,30 +339,54 @@ func (e *EnvVar) Scan(value any) error {
 		// Cleanup string if required
 		// The string may have "\"env.TEST\"", "env.TEST" or "env.TEST\"", we need to clean it up to "env.TEST"
 		val := strings.Trim(v, "\"")
+		// Vault reference: keep the reference in Val so the AfterFind GORM hook
+		// (resolveVaultEnvVar) can resolve it via ResolveString(&e.Val). VaultRef
+		// preserves the original path so it survives resolution and can be surfaced
+		// in API responses and re-stored correctly on writes.
+		if strings.HasPrefix(val, "vault.") {
+			e.Val = val
+			e.VaultRef = val
+			e.FromVault = true
+			e.FromEnv = false
+			e.EnvVar = ""
+			if vaultValue, ok := LookupVault(val); ok {
+				e.Val = vaultValue
+			}
+			return nil
+		}
 		if envKey, ok := strings.CutPrefix(val, "env."); ok {
 			if envValue, ok := os.LookupEnv(envKey); ok {
 				e.Val = envValue
 				e.FromEnv = true
 				e.EnvVar = val
+				e.FromVault = false
+				e.VaultRef = ""
 				return nil
 			}
 			e.Val = ""
 			e.FromEnv = true
 			e.EnvVar = val
+			e.FromVault = false
+			e.VaultRef = ""
 			return nil
 		}
 		e.Val = val
 		e.FromEnv = false
 		e.EnvVar = ""
+		e.FromVault = false
+		e.VaultRef = ""
 		return nil
 	}
 	return fmt.Errorf("failed to scan value: %v", value)
 }
 
 // Value implements driver.Valuer for database storage.
-// It stores the original env reference (e.g., "env.API_KEY") if FromEnv is true,
-// otherwise stores the raw value.
+// It stores the vault reference (e.g., "vault.path/to/secret") if FromVault is true,
+// the env reference (e.g., "env.API_KEY") if FromEnv is true, otherwise the raw value.
 func (e EnvVar) Value() (driver.Value, error) {
+	if e.FromVault {
+		return e.VaultRef, nil
+	}
 	if e.FromEnv {
 		return e.EnvVar, nil
 	}
@@ -298,30 +395,36 @@ func (e EnvVar) Value() (driver.Value, error) {
 
 // IsFromEnv returns true if the value is sourced from an environment variable.
 func (e *EnvVar) IsFromEnv() bool {
+	if e == nil {
+		return false
+	}
 	return e.FromEnv
 }
 
 // ShouldPreserveStored returns true when the EnvVar is a client-side placeholder
-// that should not overwrite the stored encrypted credential. Returns true for a
-// nil receiver, an empty non-env value, or a redacted non-env value. Returns false
-// for env var references (always intentional) and plain non-empty values.
+// that should not overwrite the stored credential. Returns true for a nil receiver,
+// an empty non-env/non-vault value, or a redacted non-env/non-vault value. Returns
+// false for env/vault references (always intentional) and plain non-empty values.
 func (e *EnvVar) ShouldPreserveStored() bool {
 	if e == nil {
 		return true
 	}
-	if e.IsFromEnv() {
+	if e.IsFromEnv() || e.IsFromVault() {
 		return false
 	}
 	return e.GetValue() == "" || e.IsRedacted()
 }
 
-// IsSet returns true if the EnvVar has a resolved value or an environment variable reference.
-// This should be used instead of GetValue() != "" when checking whether a field was configured,
-// because env var references may have an empty Val before resolution (e.g., when the env var
-// is not available in the current environment).
+// IsSet returns true if the EnvVar has a resolved value or an environment variable
+// or vault reference. This should be used instead of GetValue() != "" when checking
+// whether a field was configured, because references may have an empty Val before
+// resolution (e.g., when the env var is not set in the current environment).
 func (e *EnvVar) IsSet() bool {
 	if e == nil {
 		return false
+	}
+	if e.IsFromVault() {
+		return e.VaultRef != ""
 	}
 	if e.IsFromEnv() {
 		return e.EnvVar != ""
@@ -329,7 +432,7 @@ func (e *EnvVar) IsSet() bool {
 	return e.Val != ""
 }
 
-// GetValue returns the value.
+// GetValue returns the resolved value.
 func (e *EnvVar) GetValue() string {
 	if e == nil {
 		return ""

--- a/core/schemas/envvar_test.go
+++ b/core/schemas/envvar_test.go
@@ -517,6 +517,16 @@ func TestEnvVar_IsSet(t *testing.T) {
 			input:    &EnvVar{FromEnv: true},
 			expected: false,
 		},
+		{
+			name:     "vault reference set",
+			input:    &EnvVar{VaultRef: "vault.bifrost/key", FromVault: true, Val: "vault.bifrost/key"},
+			expected: true,
+		},
+		{
+			name:     "FromVault true but no reference",
+			input:    &EnvVar{FromVault: true},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -525,6 +535,176 @@ func TestEnvVar_IsSet(t *testing.T) {
 				t.Errorf("IsSet() = %v, want %v", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestEnvVar_Scan_VaultRef(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		wantVal           string
+		wantVaultRef      string
+		wantFromVault     bool
+		wantFromEnv       bool
+	}{
+		{
+			name:          "plain vault reference",
+			input:         "vault.bifrost/providers/openai/key",
+			wantVal:       "vault.bifrost/providers/openai/key",
+			wantVaultRef:  "vault.bifrost/providers/openai/key",
+			wantFromVault: true,
+		},
+		{
+			name:          "vault reference with quoted wrapping",
+			input:         `"vault.myproject/secret"`,
+			wantVal:       "vault.myproject/secret",
+			wantVaultRef:  "vault.myproject/secret",
+			wantFromVault: true,
+		},
+		{
+			name:        "env reference still works",
+			input:       "env.MY_VAR",
+			wantFromEnv: true,
+		},
+		{
+			name:    "plain string unaffected",
+			input:   "sk-abc123",
+			wantVal: "sk-abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var e EnvVar
+			if err := e.Scan(tt.input); err != nil {
+				t.Fatalf("Scan() error: %v", err)
+			}
+			if tt.wantFromVault {
+				if !e.FromVault {
+					t.Errorf("FromVault = false, want true")
+				}
+				if e.VaultRef != tt.wantVaultRef {
+					t.Errorf("VaultRef = %q, want %q", e.VaultRef, tt.wantVaultRef)
+				}
+				if e.Val != tt.wantVal {
+					t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
+				}
+			}
+			if tt.wantFromEnv && !e.FromEnv {
+				t.Errorf("FromEnv = false, want true")
+			}
+			if !tt.wantFromVault && !tt.wantFromEnv && e.Val != tt.wantVal {
+				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestEnvVar_UnmarshalJSON_VaultRef(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantVal       string
+		wantVaultRef  string
+		wantFromVault bool
+	}{
+		{
+			name:          "struct form with from_vault",
+			input:         `{"value":"","env_var":"","from_env":false,"vault_var":"vault.bifrost/key","from_vault":true}`,
+			wantVal:       "vault.bifrost/key",
+			wantVaultRef:  "vault.bifrost/key",
+			wantFromVault: true,
+		},
+		{
+			name:          "struct form vault_var without vault. prefix — prefix auto-added",
+			input:         `{"value":"","env_var":"","from_env":false,"vault_var":"bifrost/key","from_vault":true}`,
+			wantVal:       "vault.bifrost/key",
+			wantVaultRef:  "vault.bifrost/key",
+			wantFromVault: true,
+		},
+		{
+			name:          "plain string vault reference",
+			input:         `"vault.myproject/secret"`,
+			wantVal:       "vault.myproject/secret",
+			wantVaultRef:  "vault.myproject/secret",
+			wantFromVault: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var e EnvVar
+			if err := json.Unmarshal([]byte(tt.input), &e); err != nil {
+				t.Fatalf("UnmarshalJSON() error: %v", err)
+			}
+			if e.FromVault != tt.wantFromVault {
+				t.Errorf("FromVault = %v, want %v", e.FromVault, tt.wantFromVault)
+			}
+			if e.VaultRef != tt.wantVaultRef {
+				t.Errorf("VaultRef = %q, want %q", e.VaultRef, tt.wantVaultRef)
+			}
+			if e.Val != tt.wantVal {
+				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestEnvVar_Value_VaultRef(t *testing.T) {
+	e := &EnvVar{
+		Val:       "actual-secret",
+		VaultRef:  "vault.bifrost/key",
+		FromVault: true,
+	}
+	got, err := e.Value()
+	if err != nil {
+		t.Fatalf("Value() error: %v", err)
+	}
+	if got != "vault.bifrost/key" {
+		t.Errorf("Value() = %q, want %q", got, "vault.bifrost/key")
+	}
+}
+
+func TestEnvVar_Redacted_VaultRef(t *testing.T) {
+	e := &EnvVar{
+		Val:       "actual-secret-value",
+		VaultRef:  "vault.bifrost/key",
+		FromVault: true,
+	}
+	r := e.Redacted()
+	wantVal := "actu************************alue"
+	if r.Val != wantVal {
+		t.Errorf("Redacted().Val = %q, want %q", r.Val, wantVal)
+	}
+	if !r.FromVault {
+		t.Errorf("Redacted().FromVault = false, want true")
+	}
+	if r.VaultRef != "vault.bifrost/key" {
+		t.Errorf("Redacted().VaultRef = %q, want %q", r.VaultRef, "vault.bifrost/key")
+	}
+}
+
+func TestEnvVar_IsSet_VaultRef(t *testing.T) {
+	set := &EnvVar{VaultRef: "vault.bifrost/key", FromVault: true, Val: "vault.bifrost/key"}
+	unset := &EnvVar{FromVault: true}
+	if !set.IsSet() {
+		t.Error("IsSet() = false for vault ref, want true")
+	}
+	if unset.IsSet() {
+		t.Error("IsSet() = true for empty vault ref, want false")
+	}
+}
+
+func TestNewEnvVar_VaultRef(t *testing.T) {
+	e := NewEnvVar("vault.bifrost/mykey")
+	if !e.FromVault {
+		t.Error("FromVault = false, want true")
+	}
+	if e.VaultRef != "vault.bifrost/mykey" {
+		t.Errorf("VaultRef = %q, want %q", e.VaultRef, "vault.bifrost/mykey")
+	}
+	if e.Val != "vault.bifrost/mykey" {
+		t.Errorf("Val = %q, want %q", e.Val, "vault.bifrost/mykey")
 	}
 }
 

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -40,6 +40,9 @@ func EnvVarAsString(e *EnvVar) string {
 	if e.IsFromEnv() {
 		return e.EnvVar
 	}
+	if e.IsFromVault() {
+		return e.VaultRef
+	}
 	return e.GetValue()
 }
 

--- a/core/schemas/vault.go
+++ b/core/schemas/vault.go
@@ -1,0 +1,197 @@
+package schemas
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+const defaultVaultPrefix = "bifrost"
+
+// VaultResolveHook is wired by enterprise startup to the vault registry's ResolveString.
+// It is nil in OSS deployments; GetValue() is a no-op when nil.
+var VaultResolveHook func(ctx context.Context, value *string) error
+
+// VaultRemoveHook deletes the secret at path (best-effort; errors are ignored by callers).
+// It is nil in OSS deployments.
+var VaultRemoveHook func(ctx context.Context, path string) error
+
+// VaultStoreHook stores a plaintext secret at path and rewrites *value to a
+// "vault.<canonical>" reference. It is wired by enterprise startup to the vault
+// registry's StoreString and is nil in OSS deployments (store helpers no-op).
+var VaultStoreHook func(ctx context.Context, path string, value *string) error
+
+// VaultPrefixHook returns the configured vault path prefix (e.g. "bifrost").
+// It is nil in OSS deployments; VaultPrefix() falls back to "bifrost".
+var VaultPrefixHook func() string
+
+// VaultStoreEnabled reports whether vault storage is available (i.e. VaultStoreHook
+// has been wired by enterprise startup). Use this to guard StoreOwnedVaultEnvVars
+// calls in BeforeSave hooks.
+func VaultStoreEnabled() bool {
+	return VaultStoreHook != nil
+}
+
+// VaultPrefix returns the configured vault path prefix, defaulting to "bifrost".
+func VaultPrefix() string {
+	if VaultPrefixHook != nil {
+		return VaultPrefixHook()
+	}
+	return defaultVaultPrefix
+}
+
+// VaultBasePath returns the standard vault path prefix for a table row.
+func VaultBasePath(tableName, primaryKey string) string {
+	return fmt.Sprintf("%s/%s/%s", VaultPrefix(), tableName, primaryKey)
+}
+
+// LookupVault resolves a vault reference string (e.g. "vault.path/to/secret") via
+// the registered resolver, returning the resolved secret and true on success —
+// analogous to os.LookupEnv. Returns ("", false) when ref doesn't have the "vault."
+// prefix or no resolver is registered (OSS deployments / before enterprise startup).
+func LookupVault(ref string) (string, bool) {
+	if !strings.HasPrefix(ref, "vault.") || VaultResolveHook == nil {
+		return "", false
+	}
+	val := ref
+	if err := VaultResolveHook(context.Background(), &val); err != nil {
+		return "", false
+	}
+	return val, true
+}
+
+var (
+	envVarType    = reflect.TypeOf(EnvVar{})
+	envVarPtrType = reflect.TypeOf((*EnvVar)(nil))
+)
+
+// RemoveOwnedVaultEnvVars best-effort deletes the vault secret for every
+// EnvVar / *EnvVar field in model whose VaultRef starts with
+// ownedPrefix+"/". Refs outside that prefix are user-provided and are left alone.
+func RemoveOwnedVaultEnvVars(ctx context.Context, ownedPrefix string, model interface{}) {
+	if VaultRemoveHook == nil {
+		return
+	}
+	rv := reflect.ValueOf(model)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return
+	}
+	rt := rv.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		fv := rv.Field(i)
+		var field *EnvVar
+		switch fv.Type() {
+		case envVarType:
+			field = fv.Addr().Interface().(*EnvVar)
+		case envVarPtrType:
+			if !fv.IsNil() {
+				field = fv.Interface().(*EnvVar)
+			}
+		}
+		if field == nil || !field.IsFromVault() || field.VaultRef == "" {
+			continue
+		}
+		path := strings.TrimPrefix(field.VaultRef, "vault.")
+		if strings.IndexByte(path, '#') >= 0 {
+			continue
+		}
+		if !strings.HasPrefix(path, ownedPrefix+"/") {
+			continue
+		}
+		_ = VaultRemoveHook(ctx, path)
+	}
+}
+
+// StoreVaultEnvVar pushes a single plaintext EnvVar value into the vault at path
+// and converts the field to a vault reference. No-op when vault disabled, field
+// is nil, env/vault-sourced, empty, or redacted.
+func StoreVaultEnvVar(ctx context.Context, path string, e *EnvVar) error {
+	if VaultStoreHook == nil || e == nil {
+		return nil
+	}
+	if e.IsFromEnv() || e.IsFromVault() || e.Val == "" || e.IsRedacted() {
+		return nil
+	}
+	if err := VaultStoreHook(ctx, path, &e.Val); err != nil {
+		return err
+	}
+	e.VaultRef = e.Val
+	e.FromVault = true
+	return nil
+}
+
+// StoreOwnedVaultEnvVars stores every plaintext EnvVar / *EnvVar struct field of
+// model into the vault under basePath/<column>, converting each to a vault ref.
+// The reflection walk mirrors RemoveOwnedVaultEnvVars.
+func StoreOwnedVaultEnvVars(ctx context.Context, basePath string, model interface{}) error {
+	if VaultStoreHook == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(model)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil
+	}
+	rt := rv.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		fv := rv.Field(i)
+		var field *EnvVar
+		switch fv.Type() {
+		case envVarType:
+			field = fv.Addr().Interface().(*EnvVar)
+		case envVarPtrType:
+			if !fv.IsNil() {
+				field = fv.Interface().(*EnvVar)
+			}
+		default:
+			continue
+		}
+		if field == nil {
+			continue
+		}
+		seg := vaultFieldSegment(rt.Field(i))
+		path := basePath + "/" + seg
+		if err := StoreVaultEnvVar(ctx, path, field); err != nil {
+			return fmt.Errorf("vault store field %s: %w", rt.Field(i).Name, err)
+		}
+	}
+	return nil
+}
+
+// vaultFieldSegment returns the vault path segment for a struct field.
+// It prefers the gorm column tag; otherwise it converts the Go field name to snake_case.
+func vaultFieldSegment(f reflect.StructField) string {
+	if tag := f.Tag.Get("gorm"); tag != "" {
+		for _, part := range strings.Split(tag, ";") {
+			if col, ok := strings.CutPrefix(strings.TrimSpace(part), "column:"); ok {
+				col = strings.TrimSpace(col)
+				if col != "" {
+					return col
+				}
+			}
+		}
+	}
+	return toSnakeCase(f.Name)
+}
+
+func toSnakeCase(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(unicode.ToLower(r))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/core/schemas/vault_test.go
+++ b/core/schemas/vault_test.go
@@ -1,0 +1,145 @@
+package schemas
+
+import (
+	"context"
+	"testing"
+)
+
+// withStubVaultStore installs a VaultStoreHook that records stored paths and
+// rewrites the value to "vault.<path>", mimicking vault.StoreString. It restores
+// the previous hook on cleanup.
+func withStubVaultStore(t *testing.T) map[string]string {
+	t.Helper()
+	stored := make(map[string]string)
+	prev := VaultStoreHook
+	VaultStoreHook = func(_ context.Context, path string, value *string) error {
+		stored[path] = *value
+		*value = "vault." + path
+		return nil
+	}
+	t.Cleanup(func() { VaultStoreHook = prev })
+	return stored
+}
+
+func TestStoreVaultEnvVar_StoresPlaintext(t *testing.T) {
+	stored := withStubVaultStore(t)
+
+	e := &EnvVar{Val: "secret-key"}
+	if err := StoreVaultEnvVar(context.Background(), "bifrost/tbl/id/value", e); err != nil {
+		t.Fatalf("StoreVaultEnvVar: %v", err)
+	}
+	if got := stored["bifrost/tbl/id/value"]; got != "secret-key" {
+		t.Errorf("stored plaintext = %q, want %q", got, "secret-key")
+	}
+	if !e.FromVault {
+		t.Error("FromVault should be true after store")
+	}
+	if e.VaultRef != "vault.bifrost/tbl/id/value" {
+		t.Errorf("VaultRef = %q, want %q", e.VaultRef, "vault.bifrost/tbl/id/value")
+	}
+	if e.Val != "vault.bifrost/tbl/id/value" {
+		t.Errorf("Val = %q, want rewritten to vault ref", e.Val)
+	}
+}
+
+func TestStoreVaultEnvVar_NoOps(t *testing.T) {
+	cases := []struct {
+		name string
+		e    *EnvVar
+	}{
+		{"nil", nil},
+		{"env-sourced", &EnvVar{FromEnv: true, EnvVar: "MY_VAR"}},
+		{"already-vault", &EnvVar{FromVault: true, VaultRef: "vault.some/path", Val: "vault.some/path"}},
+		{"empty", &EnvVar{Val: ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stored := withStubVaultStore(t)
+			if err := StoreVaultEnvVar(context.Background(), "bifrost/tbl/id/f", tc.e); err != nil {
+				t.Fatalf("StoreVaultEnvVar: %v", err)
+			}
+			if len(stored) != 0 {
+				t.Errorf("expected no store, got %v", stored)
+			}
+		})
+	}
+}
+
+func TestStoreVaultEnvVar_NoHookNoOp(t *testing.T) {
+	prev := VaultStoreHook
+	VaultStoreHook = nil
+	t.Cleanup(func() { VaultStoreHook = prev })
+
+	e := &EnvVar{Val: "secret"}
+	if err := StoreVaultEnvVar(context.Background(), "p", e); err != nil {
+		t.Fatalf("StoreVaultEnvVar: %v", err)
+	}
+	if e.FromVault || e.VaultRef != "" || e.Val != "secret" {
+		t.Errorf("expected no mutation when hook nil, got %+v", e)
+	}
+}
+
+func TestRemoveOwnedVaultEnvVars_SkipsFragmentRefs(t *testing.T) {
+	var removed []string
+	prev := VaultRemoveHook
+	VaultRemoveHook = func(_ context.Context, path string) error {
+		removed = append(removed, path)
+		return nil
+	}
+	t.Cleanup(func() { VaultRemoveHook = prev })
+
+	type model struct {
+		Normal   EnvVar `gorm:"column:normal"`
+		Fragment EnvVar `gorm:"column:fragment"`
+	}
+	m := &model{
+		Normal:   EnvVar{FromVault: true, VaultRef: "vault.bifrost/m/1/normal", Val: "vault.bifrost/m/1/normal"},
+		Fragment: EnvVar{FromVault: true, VaultRef: "vault.external/db#apiKey", Val: "vault.external/db#apiKey"},
+	}
+
+	RemoveOwnedVaultEnvVars(context.Background(), "bifrost/m/1", m)
+
+	if len(removed) != 1 || removed[0] != "bifrost/m/1/normal" {
+		t.Errorf("removed = %v, want only [bifrost/m/1/normal]", removed)
+	}
+}
+
+func TestStoreOwnedVaultEnvVars_WalksFields(t *testing.T) {
+	stored := withStubVaultStore(t)
+
+	type model struct {
+		Plain    EnvVar  `gorm:"column:plain_col"`
+		Ptr      *EnvVar `gorm:"column:ptr_col"`
+		NilPtr   *EnvVar
+		Snake    EnvVar // no gorm tag -> snake_case of field name
+		Ignored  string
+		EnvBased EnvVar `gorm:"column:env_col"`
+	}
+	m := &model{
+		Plain:    EnvVar{Val: "p1"},
+		Ptr:      &EnvVar{Val: "p2"},
+		Snake:    EnvVar{Val: "p3"},
+		EnvBased: EnvVar{FromEnv: true, EnvVar: "X"},
+	}
+
+	if err := StoreOwnedVaultEnvVars(context.Background(), "bifrost/m/1", m); err != nil {
+		t.Fatalf("StoreOwnedVaultEnvVars: %v", err)
+	}
+
+	want := map[string]string{
+		"bifrost/m/1/plain_col": "p1",
+		"bifrost/m/1/ptr_col":   "p2",
+		"bifrost/m/1/snake":     "p3",
+	}
+	if len(stored) != len(want) {
+		t.Fatalf("stored %d entries, want %d: %v", len(stored), len(want), stored)
+	}
+	for path, val := range want {
+		if stored[path] != val {
+			t.Errorf("stored[%q] = %q, want %q", path, stored[path], val)
+		}
+	}
+	if !m.Plain.FromVault || !m.Ptr.FromVault || !m.Snake.FromVault {
+		t.Error("EnvVar fields should be marked FromVault after store")
+	}
+}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -361,6 +361,8 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 	if c.MCPExternalClientURL.IsSet() {
 		if c.MCPExternalClientURL.IsFromEnv() {
 			hash.Write([]byte("externalClientURL:env:" + c.MCPExternalClientURL.EnvVar))
+		} else if c.MCPExternalClientURL.IsFromVault() {
+			hash.Write([]byte("externalClientURL:vault:" + c.MCPExternalClientURL.VaultRef))
 		} else {
 			hash.Write([]byte("externalClientURL:val:" + c.MCPExternalClientURL.GetValue()))
 		}
@@ -393,7 +395,7 @@ func (c *ClientConfig) GenerateClientConfigHashWithToolManager(tm *schemas.MCPTo
 // Redacted returns a copy of ClientConfig with any env-backed EnvVar fields masked.
 func (c *ClientConfig) Redacted() ClientConfig {
 	out := *c
-	if c.MCPExternalClientURL != nil && c.MCPExternalClientURL.IsFromEnv() {
+	if c.MCPExternalClientURL != nil && (c.MCPExternalClientURL.IsFromEnv() || c.MCPExternalClientURL.IsFromVault()) {
 		out.MCPExternalClientURL = c.MCPExternalClientURL.Redacted()
 	}
 	return out
@@ -481,7 +483,7 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		// Redact Azure key config if present
 		if key.AzureKeyConfig != nil {
 			azureConfig := &schemas.AzureKeyConfig{}
-			if key.AzureKeyConfig.Endpoint.IsFromEnv() {
+			if key.AzureKeyConfig.Endpoint.IsFromEnv() || key.AzureKeyConfig.Endpoint.IsFromVault() {
 				azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.Redacted()
 			} else {
 				azureConfig.Endpoint = key.AzureKeyConfig.Endpoint
@@ -653,6 +655,8 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	// Hash Value (prefix with source type to prevent collisions between env and literal)
 	if key.Value.IsFromEnv() {
 		hash.Write([]byte("env:" + key.Value.EnvVar))
+	} else if key.Value.IsFromVault() {
+		hash.Write([]byte("vault:" + key.Value.VaultRef))
 	} else {
 		hash.Write([]byte("val:" + key.Value.Val))
 	}
@@ -1327,6 +1331,8 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 	if m.ConnectionString != nil {
 		if m.ConnectionString.IsFromEnv() {
 			hash.Write([]byte(m.ConnectionString.EnvVar))
+		} else if m.ConnectionString.IsFromVault() {
+			hash.Write([]byte(m.ConnectionString.VaultRef))
 		} else {
 			hash.Write([]byte(m.ConnectionString.Val))
 		}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2045,6 +2045,8 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			for key, value := range clientConfigCopy.Headers {
 				if value.IsFromEnv() {
 					headersToSerialize[key] = value.EnvVar
+				} else if value.IsFromVault() {
+					headersToSerialize[key] = value.VaultRef
 				} else {
 					headersToSerialize[key] = value.GetValue()
 				}
@@ -2163,7 +2165,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if clientConfigCopy.ConfigHash != "" {
 			connectionStringToPersist := clientConfigCopy.ConnectionString
 			if encrypt.IsEnabled() && connectionStringToPersist != nil &&
-				!connectionStringToPersist.IsFromEnv() && connectionStringToPersist.GetValue() != "" {
+				!connectionStringToPersist.IsFromEnv() && !connectionStringToPersist.IsFromVault() && connectionStringToPersist.GetValue() != "" {
 				// Mirror TableMCPClient.BeforeSave behavior for map-based Updates.
 				cs := *connectionStringToPersist
 				encryptedConnString, encErr := encrypt.Encrypt(cs.Val)

--- a/framework/configstore/tables/encryption.go
+++ b/framework/configstore/tables/encryption.go
@@ -1,9 +1,6 @@
 package tables
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/encrypt"
 )
@@ -15,90 +12,12 @@ const (
 	EncryptionStatusEncrypted = "encrypted"
 	// EncryptionStatusVault indicates the row's sensitive fields are stored as vault references.
 	EncryptionStatusVault = "vault"
-
-	// defaultVaultPrefix is the path prefix used when VaultHooks.Prefix is not set.
-	defaultVaultPrefix = "bifrost"
 )
 
-// VaultHooks is populated at startup when a vault backend is configured.
-// OSS table hooks check these function pointers before falling through to AES encryption.
-var VaultHooks struct {
-	// IsEnabled reports whether vault is active.
-	IsEnabled func() bool
-	// Prefix returns the configured vault path prefix (e.g. "bifrost").
-	Prefix func() string
-	// StoreString vaults *value at path, then replaces *value with the vault reference.
-	StoreString func(ctx context.Context, path string, value *string) error
-	// ResolveString resolves a vault reference, replacing *value with the secret.
-	ResolveString func(ctx context.Context, value *string) error
-	// Remove deletes the secret at path (best-effort; errors are ignored by callers).
-	Remove func(ctx context.Context, path string) error
-}
-
-func VaultIsEnabled() bool {
-	return VaultHooks.IsEnabled != nil && VaultHooks.IsEnabled() &&
-		VaultHooks.StoreString != nil && VaultHooks.ResolveString != nil
-}
-
-func VaultPrefix() string {
-	if VaultHooks.Prefix != nil {
-		return VaultHooks.Prefix()
-	}
-	return defaultVaultPrefix
-}
-
-// vaultEnvVar vaults the Val field of an EnvVar at path, replacing it with a vault reference.
-// No-op if nil, references an env var, or empty. Returns an error if the hook is not configured.
-func vaultEnvVar(ctx context.Context, path string, field *schemas.EnvVar) error {
-	if field == nil || field.IsFromEnv() || field.GetValue() == "" {
-		return nil
-	}
-	if VaultHooks.StoreString == nil {
-		return fmt.Errorf("vault store hook is not configured")
-	}
-	return VaultHooks.StoreString(ctx, path, &field.Val)
-}
-
-// resolveVaultEnvVar resolves a vault reference stored in EnvVar.Val.
-// No-op if nil, references an env var, or empty. Returns an error if the hook is not configured.
-func resolveVaultEnvVar(ctx context.Context, field *schemas.EnvVar) error {
-	if field == nil || field.IsFromEnv() || field.GetValue() == "" {
-		return nil
-	}
-	if VaultHooks.ResolveString == nil {
-		return fmt.Errorf("vault resolve hook is not configured")
-	}
-	return VaultHooks.ResolveString(ctx, &field.Val)
-}
-
-// vaultString stores *value at path in vault, replacing it with a vault reference.
-// No-op if nil or empty. Returns an error if the hook is not configured.
-func vaultString(ctx context.Context, path string, value *string) error {
-	if value == nil || *value == "" {
-		return nil
-	}
-	if VaultHooks.StoreString == nil {
-		return fmt.Errorf("vault store hook is not configured")
-	}
-	return VaultHooks.StoreString(ctx, path, value)
-}
-
-// resolveVaultString resolves a vault reference in *value, replacing it with the secret.
-// No-op if nil or empty. Returns an error if the hook is not configured.
-func resolveVaultString(ctx context.Context, value *string) error {
-	if value == nil || *value == "" {
-		return nil
-	}
-	if VaultHooks.ResolveString == nil {
-		return fmt.Errorf("vault resolve hook is not configured")
-	}
-	return VaultHooks.ResolveString(ctx, value)
-}
-
 // encryptEnvVar encrypts the Val field of an EnvVar in place using AES-256-GCM.
-// It is a no-op if the field is nil, references an environment variable, or has an empty value.
+// It is a no-op if the field is nil, references an environment variable or vault, or has an empty value.
 func encryptEnvVar(field *schemas.EnvVar) error {
-	if field == nil || field.IsFromEnv() || field.GetValue() == "" {
+	if field == nil || field.IsFromEnv() || field.IsFromVault() || field.GetValue() == "" {
 		return nil
 	}
 	encrypted, err := encrypt.Encrypt(field.Val)
@@ -110,9 +29,9 @@ func encryptEnvVar(field *schemas.EnvVar) error {
 }
 
 // decryptEnvVar decrypts the Val field of an EnvVar in place using AES-256-GCM.
-// It is a no-op if the field is nil, references an environment variable, or has an empty value.
+// It is a no-op if the field is nil, references an environment variable or vault, or has an empty value.
 func decryptEnvVar(field *schemas.EnvVar) error {
-	if field == nil || field.IsFromEnv() || field.GetValue() == "" {
+	if field == nil || field.IsFromEnv() || field.IsFromVault() || field.GetValue() == "" {
 		return nil
 	}
 	decrypted, err := encrypt.Decrypt(field.Val)
@@ -167,30 +86,4 @@ func decryptString(value *string) error {
 	}
 	*value = decrypted
 	return nil
-}
-
-// removeVaultEnvVar best-effort removes a vault secret for the given EnvVar field.
-// Called in BeforeSave when a field is nil, env-backed, or empty so stale vault
-// entries are cleaned up when a field is cleared or switched away from a literal value.
-func removeVaultEnvVar(ctx context.Context, path string, field *schemas.EnvVar) {
-	if VaultHooks.Remove == nil {
-		return
-	}
-	if field != nil && !field.IsFromEnv() && field.GetValue() != "" {
-		return // field has a real value; vaultEnvVar will overwrite it, no cleanup needed
-	}
-	_ = VaultHooks.Remove(ctx, path)
-}
-
-// removeVaultString best-effort removes a vault secret for the given string field.
-// Called in BeforeSave when a field is nil or empty so stale vault entries are
-// cleaned up when a field is cleared.
-func removeVaultString(ctx context.Context, path string, value *string) {
-	if VaultHooks.Remove == nil {
-		return
-	}
-	if value != nil && *value != "" {
-		return // field has a real value; vaultString will overwrite it, no cleanup needed
-	}
-	_ = VaultHooks.Remove(ctx, path)
 }

--- a/framework/configstore/tables/key.go
+++ b/framework/configstore/tables/key.go
@@ -1,7 +1,6 @@
 package tables
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -326,103 +325,15 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		k.SGLUrl = nil
 	}
 
+	if schemas.VaultStoreEnabled() {
+		if err := schemas.StoreOwnedVaultEnvVars(tx.Statement.Context,
+			schemas.VaultBasePath(k.TableName(), k.KeyID), k); err != nil {
+			return err
+		}
+	}
+
 	// Encrypt sensitive fields after serialization
-	if VaultIsEnabled() {
-		base := fmt.Sprintf("%s/%s/%s", VaultPrefix(), k.TableName(), k.KeyID)
-		namer := tx.Statement.DB.NamingStrategy
-		col := func(field string) string { return base + "/" + namer.ColumnName("", field) }
-		// For each field: best-effort remove stale vault entry when the field is being cleared
-		// or switched to an env-var, then store the new value (no-op if nil/empty/env-backed).
-		removeVaultEnvVar(tx.Statement.Context, col("Value"), &k.Value)
-		if err := vaultEnvVar(tx.Statement.Context, col("Value"), &k.Value); err != nil {
-			return fmt.Errorf("failed to vault key value: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("AzureEndpoint"), k.AzureEndpoint)
-		if err := vaultEnvVar(tx.Statement.Context, col("AzureEndpoint"), k.AzureEndpoint); err != nil {
-			return fmt.Errorf("failed to vault azure endpoint: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("AzureClientID"), k.AzureClientID)
-		if err := vaultEnvVar(tx.Statement.Context, col("AzureClientID"), k.AzureClientID); err != nil {
-			return fmt.Errorf("failed to vault azure client id: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("AzureClientSecret"), k.AzureClientSecret)
-		if err := vaultEnvVar(tx.Statement.Context, col("AzureClientSecret"), k.AzureClientSecret); err != nil {
-			return fmt.Errorf("failed to vault azure client secret: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("AzureTenantID"), k.AzureTenantID)
-		if err := vaultEnvVar(tx.Statement.Context, col("AzureTenantID"), k.AzureTenantID); err != nil {
-			return fmt.Errorf("failed to vault azure tenant id: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("VertexProjectID"), k.VertexProjectID)
-		if err := vaultEnvVar(tx.Statement.Context, col("VertexProjectID"), k.VertexProjectID); err != nil {
-			return fmt.Errorf("failed to vault vertex project id: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("VertexProjectNumber"), k.VertexProjectNumber)
-		if err := vaultEnvVar(tx.Statement.Context, col("VertexProjectNumber"), k.VertexProjectNumber); err != nil {
-			return fmt.Errorf("failed to vault vertex project number: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("VertexRegion"), k.VertexRegion)
-		if err := vaultEnvVar(tx.Statement.Context, col("VertexRegion"), k.VertexRegion); err != nil {
-			return fmt.Errorf("failed to vault vertex region: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("VertexAuthCredentials"), k.VertexAuthCredentials)
-		if err := vaultEnvVar(tx.Statement.Context, col("VertexAuthCredentials"), k.VertexAuthCredentials); err != nil {
-			return fmt.Errorf("failed to vault vertex auth credentials: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("BedrockAccessKey"), k.BedrockAccessKey)
-		if err := vaultEnvVar(tx.Statement.Context, col("BedrockAccessKey"), k.BedrockAccessKey); err != nil {
-			return fmt.Errorf("failed to vault bedrock access key: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("BedrockSecretKey"), k.BedrockSecretKey)
-		if err := vaultEnvVar(tx.Statement.Context, col("BedrockSecretKey"), k.BedrockSecretKey); err != nil {
-			return fmt.Errorf("failed to vault bedrock secret key: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("BedrockSessionToken"), k.BedrockSessionToken)
-		if err := vaultEnvVar(tx.Statement.Context, col("BedrockSessionToken"), k.BedrockSessionToken); err != nil {
-			return fmt.Errorf("failed to vault bedrock session token: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("BedrockRegion"), k.BedrockRegion)
-		if err := vaultEnvVar(tx.Statement.Context, col("BedrockRegion"), k.BedrockRegion); err != nil {
-			return fmt.Errorf("failed to vault bedrock region: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("BedrockARN"), k.BedrockARN)
-		if err := vaultEnvVar(tx.Statement.Context, col("BedrockARN"), k.BedrockARN); err != nil {
-			return fmt.Errorf("failed to vault bedrock arn: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("BedrockRoleARN"), k.BedrockRoleARN)
-		if err := vaultEnvVar(tx.Statement.Context, col("BedrockRoleARN"), k.BedrockRoleARN); err != nil {
-			return fmt.Errorf("failed to vault bedrock role arn: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("BedrockExternalID"), k.BedrockExternalID)
-		if err := vaultEnvVar(tx.Statement.Context, col("BedrockExternalID"), k.BedrockExternalID); err != nil {
-			return fmt.Errorf("failed to vault bedrock external id: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("BedrockRoleSessionName"), k.BedrockRoleSessionName)
-		if err := vaultEnvVar(tx.Statement.Context, col("BedrockRoleSessionName"), k.BedrockRoleSessionName); err != nil {
-			return fmt.Errorf("failed to vault bedrock role session name: %w", err)
-		}
-		removeVaultString(tx.Statement.Context, col("BedrockBatchS3ConfigJSON"), k.BedrockBatchS3ConfigJSON)
-		if err := vaultString(tx.Statement.Context, col("BedrockBatchS3ConfigJSON"), k.BedrockBatchS3ConfigJSON); err != nil {
-			return fmt.Errorf("failed to vault bedrock batch s3 config: %w", err)
-		}
-		removeVaultString(tx.Statement.Context, col("AliasesJSON"), k.AliasesJSON)
-		if err := vaultString(tx.Statement.Context, col("AliasesJSON"), k.AliasesJSON); err != nil {
-			return fmt.Errorf("failed to vault aliases: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("VLLMUrl"), k.VLLMUrl)
-		if err := vaultEnvVar(tx.Statement.Context, col("VLLMUrl"), k.VLLMUrl); err != nil {
-			return fmt.Errorf("failed to vault vllm url: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("OllamaUrl"), k.OllamaUrl)
-		if err := vaultEnvVar(tx.Statement.Context, col("OllamaUrl"), k.OllamaUrl); err != nil {
-			return fmt.Errorf("failed to vault ollama url: %w", err)
-		}
-		removeVaultEnvVar(tx.Statement.Context, col("SGLUrl"), k.SGLUrl)
-		if err := vaultEnvVar(tx.Statement.Context, col("SGLUrl"), k.SGLUrl); err != nil {
-			return fmt.Errorf("failed to vault sgl url: %w", err)
-		}
-		k.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() {
+	if encrypt.IsEnabled() {
 		if err := encryptEnvVar(&k.Value); err != nil {
 			return fmt.Errorf("failed to encrypt key value: %w", err)
 		}
@@ -505,79 +416,7 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 // structs after reading from the database. Decryption runs first so that value copies into
 // AzureKeyConfig, VertexKeyConfig, etc. receive plaintext data.
 func (k *TableKey) AfterFind(tx *gorm.DB) error {
-	// Decrypt sensitive fields before deserialization/reconstruction
 	switch k.EncryptionStatus {
-	case EncryptionStatusVault:
-		ctx := context.Background()
-		if tx != nil && tx.Statement != nil && tx.Statement.Context != nil {
-			ctx = tx.Statement.Context
-		}
-		if err := resolveVaultEnvVar(ctx, &k.Value); err != nil {
-			return fmt.Errorf("failed to resolve vault key value: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.AzureEndpoint); err != nil {
-			return fmt.Errorf("failed to resolve vault azure endpoint: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.AzureClientID); err != nil {
-			return fmt.Errorf("failed to resolve vault azure client id: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.AzureClientSecret); err != nil {
-			return fmt.Errorf("failed to resolve vault azure client secret: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.AzureTenantID); err != nil {
-			return fmt.Errorf("failed to resolve vault azure tenant id: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.VertexProjectID); err != nil {
-			return fmt.Errorf("failed to resolve vault vertex project id: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.VertexProjectNumber); err != nil {
-			return fmt.Errorf("failed to resolve vault vertex project number: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.VertexRegion); err != nil {
-			return fmt.Errorf("failed to resolve vault vertex region: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.VertexAuthCredentials); err != nil {
-			return fmt.Errorf("failed to resolve vault vertex auth credentials: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.BedrockAccessKey); err != nil {
-			return fmt.Errorf("failed to resolve vault bedrock access key: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.BedrockSecretKey); err != nil {
-			return fmt.Errorf("failed to resolve vault bedrock secret key: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.BedrockSessionToken); err != nil {
-			return fmt.Errorf("failed to resolve vault bedrock session token: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.BedrockRegion); err != nil {
-			return fmt.Errorf("failed to resolve vault bedrock region: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.BedrockARN); err != nil {
-			return fmt.Errorf("failed to resolve vault bedrock arn: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.BedrockRoleARN); err != nil {
-			return fmt.Errorf("failed to resolve vault bedrock role arn: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.BedrockExternalID); err != nil {
-			return fmt.Errorf("failed to resolve vault bedrock external id: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.BedrockRoleSessionName); err != nil {
-			return fmt.Errorf("failed to resolve vault bedrock role session name: %w", err)
-		}
-		if err := resolveVaultString(ctx, k.BedrockBatchS3ConfigJSON); err != nil {
-			return fmt.Errorf("failed to resolve vault bedrock batch s3 config: %w", err)
-		}
-		if err := resolveVaultString(ctx, k.AliasesJSON); err != nil {
-			return fmt.Errorf("failed to resolve vault aliases: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.VLLMUrl); err != nil {
-			return fmt.Errorf("failed to resolve vault vllm url: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.OllamaUrl); err != nil {
-			return fmt.Errorf("failed to resolve vault ollama url: %w", err)
-		}
-		if err := resolveVaultEnvVar(ctx, k.SGLUrl); err != nil {
-			return fmt.Errorf("failed to resolve vault sgl url: %w", err)
-		}
 	case EncryptionStatusEncrypted:
 		if err := decryptEnvVar(&k.Value); err != nil {
 			return fmt.Errorf("failed to decrypt key value: %w", err)
@@ -795,23 +634,7 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 
 // AfterDelete hook for best-effort vault cleanup on row deletion.
 func (k *TableKey) AfterDelete(tx *gorm.DB) error {
-	if k.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	colName := func(field string) string {
-		return tx.Statement.DB.NamingStrategy.ColumnName("", field)
-	}
-	base := fmt.Sprintf("%s/%s/%s", VaultPrefix(), k.TableName(), k.KeyID)
-	for _, field := range []string{
-		"Value",
-		"AzureEndpoint", "AzureClientID", "AzureClientSecret", "AzureTenantID",
-		"VertexProjectID", "VertexProjectNumber", "VertexRegion", "VertexAuthCredentials",
-		"BedrockAccessKey", "BedrockSecretKey", "BedrockSessionToken", "BedrockRegion",
-		"BedrockARN", "BedrockRoleARN", "BedrockExternalID", "BedrockRoleSessionName",
-		"BedrockBatchS3ConfigJSON", "AliasesJSON",
-		"VLLMUrl", "OllamaUrl", "SGLUrl",
-	} {
-		_ = VaultHooks.Remove(tx.Statement.Context, fmt.Sprintf("%s/%s", base, colName(field)))
-	}
+	base := schemas.VaultBasePath(k.TableName(), k.KeyID)
+	schemas.RemoveOwnedVaultEnvVars(tx.Statement.Context, base, k)
 	return nil
 }

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -124,11 +124,20 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		c.ToolsToAutoExecuteJSON = "[]"
 	}
 
+	if schemas.VaultStoreEnabled() {
+		if err := schemas.StoreOwnedVaultEnvVars(tx.Statement.Context,
+			schemas.VaultBasePath(c.TableName(), c.ClientID), c); err != nil {
+			return err
+		}
+	}
+
 	if c.Headers != nil {
 		headersToSerialize := make(map[string]string, len(c.Headers))
 		for key, value := range c.Headers {
 			if value.IsFromEnv() {
 				headersToSerialize[key] = value.EnvVar
+			} else if value.IsFromVault() {
+				headersToSerialize[key] = value.VaultRef
 			} else {
 				headersToSerialize[key] = value.GetValue()
 			}
@@ -195,7 +204,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 	// Always set EncryptionStatus when encryption is enabled so the startup
 	// batch pass does not re-process this row indefinitely.
 	if encrypt.IsEnabled() {
-		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && c.ConnectionString.GetValue() != "" {
+		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && !c.ConnectionString.IsFromVault() && c.ConnectionString.GetValue() != "" {
 			// Copy to avoid encrypting the shared ConnectionString through the pointer
 			cs := *c.ConnectionString
 			enc, err := encrypt.Encrypt(cs.Val)
@@ -229,7 +238,7 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 			}
 			c.HeadersJSON = decrypted
 		}
-		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && c.ConnectionString.GetValue() != "" {
+		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && !c.ConnectionString.IsFromVault() && c.ConnectionString.GetValue() != "" {
 			decrypted, err := encrypt.Decrypt(c.ConnectionString.Val)
 			if err != nil {
 				return fmt.Errorf("failed to decrypt mcp connection string: %w", err)
@@ -291,5 +300,12 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 			return err
 		}
 	}
+	return nil
+}
+
+// AfterDelete hook for best-effort vault cleanup on row deletion.
+func (c *TableMCPClient) AfterDelete(tx *gorm.DB) error {
+	base := schemas.VaultBasePath(c.TableName(), c.ClientID)
+	schemas.RemoveOwnedVaultEnvVars(tx.Statement.Context, base, c)
 	return nil
 }

--- a/framework/configstore/tables/mcp_per_user_headers.go
+++ b/framework/configstore/tables/mcp_per_user_headers.go
@@ -1,7 +1,6 @@
 package tables
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -121,30 +120,6 @@ func (c *TableMCPPerUserHeaderCredential) AfterFind(tx *gorm.DB) error {
 		}
 	}
 	return nil
-}
-
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (c *TableMCPPerUserHeaderCredential) AfterDelete(tx *gorm.DB) error {
-	if c.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	headersField := tx.Statement.DB.NamingStrategy.ColumnName("", "HeadersJSON")
-	path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ID, headersField)
-	_ = VaultHooks.Remove(tx.Statement.Context, path)
-	return nil
-}
-
-// DeleteVaultSecrets removes vault entries for the given credential IDs.
-// Called after a batch delete so vault cleanup runs even when AfterDelete can't fire.
-func (TableMCPPerUserHeaderCredential) DeleteVaultSecrets(ctx context.Context, ids []string) {
-	if VaultHooks.Remove == nil {
-		return
-	}
-	tableName := TableMCPPerUserHeaderCredential{}.TableName()
-	for _, id := range ids {
-		path := fmt.Sprintf("%s/%s/%s/headers_json", VaultPrefix(), tableName, id)
-		_ = VaultHooks.Remove(ctx, path)
-	}
 }
 
 // SetHeaders serializes the caller-supplied header map into HeadersJSON.

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -46,30 +46,16 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 		c.Status = "pending"
 	}
 
-	if VaultIsEnabled() {
-		vaulted := false
-		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && c.ClientSecret.Val != "" {
-			path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ID,
-				tx.Statement.DB.NamingStrategy.ColumnName("", "ClientSecret"))
-			if err := vaultEnvVar(tx.Statement.Context, path, c.ClientSecret); err != nil {
-				return fmt.Errorf("failed to vault oauth client secret: %w", err)
-			}
-			vaulted = true
+	if schemas.VaultStoreEnabled() {
+		if err := schemas.StoreOwnedVaultEnvVars(tx.Statement.Context,
+			schemas.VaultBasePath(c.TableName(), c.ID), c); err != nil {
+			return err
 		}
-		if c.CodeVerifier != "" {
-			path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ID,
-				tx.Statement.DB.NamingStrategy.ColumnName("", "CodeVerifier"))
-			if err := vaultString(tx.Statement.Context, path, &c.CodeVerifier); err != nil {
-				return fmt.Errorf("failed to vault oauth code verifier: %w", err)
-			}
-			vaulted = true
-		}
-		if vaulted {
-			c.EncryptionStatus = EncryptionStatusVault
-		}
-	} else if encrypt.IsEnabled() {
+	}
+
+	if encrypt.IsEnabled() {
 		encrypted := false
-		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && c.ClientSecret.Val != "" {
+		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && !c.ClientSecret.IsFromVault() && c.ClientSecret.Val != "" {
 			if err := encryptString(&c.ClientSecret.Val); err != nil {
 				return fmt.Errorf("failed to encrypt oauth client secret: %w", err)
 			}
@@ -91,15 +77,8 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 // AfterFind hook to decrypt sensitive fields
 func (c *TableOauthConfig) AfterFind(tx *gorm.DB) error {
 	switch c.EncryptionStatus {
-	case EncryptionStatusVault:
-		if err := resolveVaultEnvVar(tx.Statement.Context, c.ClientSecret); err != nil {
-			return fmt.Errorf("failed to resolve vault oauth client secret: %w", err)
-		}
-		if err := resolveVaultString(tx.Statement.Context, &c.CodeVerifier); err != nil {
-			return fmt.Errorf("failed to resolve vault oauth code verifier: %w", err)
-		}
 	case EncryptionStatusEncrypted:
-		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && c.ClientSecret.Val != "" {
+		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && !c.ClientSecret.IsFromVault() && c.ClientSecret.Val != "" {
 			if err := decryptString(&c.ClientSecret.Val); err != nil {
 				return fmt.Errorf("failed to decrypt oauth client secret: %w", err)
 			}
@@ -113,13 +92,8 @@ func (c *TableOauthConfig) AfterFind(tx *gorm.DB) error {
 
 // AfterDelete hook for best-effort vault cleanup on row deletion.
 func (c *TableOauthConfig) AfterDelete(tx *gorm.DB) error {
-	if c.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	secretField := tx.Statement.DB.NamingStrategy.ColumnName("", "ClientSecret")
-	verifierField := tx.Statement.DB.NamingStrategy.ColumnName("", "CodeVerifier")
-	_ = VaultHooks.Remove(tx.Statement.Context, fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ID, secretField))
-	_ = VaultHooks.Remove(tx.Statement.Context, fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), c.TableName(), c.ID, verifierField))
+	base := schemas.VaultBasePath(c.TableName(), c.ID)
+	schemas.RemoveOwnedVaultEnvVars(tx.Statement.Context, base, c)
 	return nil
 }
 

--- a/framework/configstore/tables/plugin.go
+++ b/framework/configstore/tables/plugin.go
@@ -53,14 +53,7 @@ func (p *TablePlugin) BeforeSave(tx *gorm.DB) error {
 	}
 
 	// Encrypt config after serialization
-	if VaultIsEnabled() && p.ConfigJSON != "" && p.ConfigJSON != "{}" {
-		fieldName := tx.Statement.DB.NamingStrategy.ColumnName("", "ConfigJSON")
-		path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), p.TableName(), p.Name, fieldName)
-		if err := vaultString(tx.Statement.Context, path, &p.ConfigJSON); err != nil {
-			return fmt.Errorf("failed to vault plugin config: %w", err)
-		}
-		p.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() && p.ConfigJSON != "" && p.ConfigJSON != "{}" {
+	if encrypt.IsEnabled() && p.ConfigJSON != "" && p.ConfigJSON != "{}" {
 		encrypted, err := encrypt.Encrypt(p.ConfigJSON)
 		if err != nil {
 			return fmt.Errorf("failed to encrypt plugin config: %w", err)
@@ -76,12 +69,6 @@ func (p *TablePlugin) BeforeSave(tx *gorm.DB) error {
 // deserializes it back into the runtime Config field after reading from the database.
 func (p *TablePlugin) AfterFind(tx *gorm.DB) error {
 	switch p.EncryptionStatus {
-	case EncryptionStatusVault:
-		if p.ConfigJSON != "" {
-			if err := resolveVaultString(tx.Statement.Context, &p.ConfigJSON); err != nil {
-				return fmt.Errorf("failed to resolve vault plugin config: %w", err)
-			}
-		}
 	case EncryptionStatusEncrypted:
 		if p.ConfigJSON != "" {
 			decrypted, err := encrypt.Decrypt(p.ConfigJSON)
@@ -102,13 +89,3 @@ func (p *TablePlugin) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (p *TablePlugin) AfterDelete(tx *gorm.DB) error {
-	if p.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	fieldName := tx.Statement.DB.NamingStrategy.ColumnName("", "ConfigJSON")
-	path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), p.TableName(), p.Name, fieldName)
-	_ = VaultHooks.Remove(tx.Statement.Context, path)
-	return nil
-}

--- a/framework/configstore/tables/provider.go
+++ b/framework/configstore/tables/provider.go
@@ -118,14 +118,7 @@ func (p *TableProvider) BeforeSave(tx *gorm.DB) error {
 	}
 
 	// Encrypt proxy config after serialization (only if there's data to encrypt)
-	if VaultIsEnabled() && p.ProxyConfigJSON != "" && p.ProxyConfigJSON != "{}" {
-		fieldName := tx.Statement.DB.NamingStrategy.ColumnName("", "ProxyConfigJSON")
-		path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), p.TableName(), p.Name, fieldName)
-		if err := vaultString(tx.Statement.Context, path, &p.ProxyConfigJSON); err != nil {
-			return fmt.Errorf("failed to vault proxy config: %w", err)
-		}
-		p.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() && p.ProxyConfigJSON != "" {
+	if encrypt.IsEnabled() && p.ProxyConfigJSON != "" {
 		encrypted, err := encrypt.Encrypt(p.ProxyConfigJSON)
 		if err != nil {
 			return fmt.Errorf("failed to encrypt proxy config: %w", err)
@@ -163,11 +156,6 @@ func (p *TableProvider) AfterFind(tx *gorm.DB) error {
 		}
 		p.ProxyConfigJSON = decrypted
 	}
-	if p.EncryptionStatus == EncryptionStatusVault && p.ProxyConfigJSON != "" {
-		if err := resolveVaultString(tx.Statement.Context, &p.ProxyConfigJSON); err != nil {
-			return fmt.Errorf("failed to resolve vault proxy config: %w", err)
-		}
-	}
 	if p.ProxyConfigJSON != "" {
 		var proxyConfig schemas.ProxyConfig
 		if err := json.Unmarshal([]byte(p.ProxyConfigJSON), &proxyConfig); err != nil {
@@ -195,13 +183,3 @@ func (p *TableProvider) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (p *TableProvider) AfterDelete(tx *gorm.DB) error {
-	if p.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	fieldName := tx.Statement.DB.NamingStrategy.ColumnName("", "ProxyConfigJSON")
-	path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), p.TableName(), p.Name, fieldName)
-	_ = VaultHooks.Remove(tx.Statement.Context, path)
-	return nil
-}

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -267,14 +267,7 @@ func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
 	if vk.Value != "" {
 		vk.ValueHash = encrypt.HashSHA256(vk.Value)
 	}
-	if VaultIsEnabled() && vk.Value != "" {
-		fieldName := tx.Statement.DB.NamingStrategy.ColumnName("", "Value")
-		path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), vk.TableName(), vk.ID, fieldName)
-		if err := vaultString(tx.Statement.Context, path, &vk.Value); err != nil {
-			return fmt.Errorf("failed to vault virtual key value: %w", err)
-		}
-		vk.EncryptionStatus = EncryptionStatusVault
-	} else if encrypt.IsEnabled() && vk.Value != "" {
+	if encrypt.IsEnabled() && vk.Value != "" {
 		if err := encryptString(&vk.Value); err != nil {
 			return fmt.Errorf("failed to encrypt virtual key value: %w", err)
 		}
@@ -290,10 +283,6 @@ func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
 // every VK update.
 func (vk *TableVirtualKey) AfterFind(tx *gorm.DB) error {
 	switch vk.EncryptionStatus {
-	case EncryptionStatusVault:
-		if err := resolveVaultString(tx.Statement.Context, &vk.Value); err != nil {
-			return fmt.Errorf("failed to resolve vault virtual key value: %w", err)
-		}
 	case EncryptionStatusEncrypted:
 		if err := decryptString(&vk.Value); err != nil {
 			return fmt.Errorf("failed to decrypt virtual key value: %w", err)
@@ -317,13 +306,3 @@ func (vk *TableVirtualKey) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (vk *TableVirtualKey) AfterDelete(tx *gorm.DB) error {
-	if vk.EncryptionStatus != EncryptionStatusVault || VaultHooks.Remove == nil {
-		return nil
-	}
-	fieldName := tx.Statement.DB.NamingStrategy.ColumnName("", "Value")
-	path := fmt.Sprintf("%s/%s/%s/%s", VaultPrefix(), vk.TableName(), vk.ID, fieldName)
-	_ = VaultHooks.Remove(tx.Statement.Context, path)
-	return nil
-}

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -295,7 +295,7 @@ func redactHeaderValue(v string) string {
 // consumers can tell the value exists without leaking env content. Unresolved env
 // references keep an empty Val, while preserving env_var for round-trip edits.
 func hideResolvedEnvValue(v *schemas.EnvVar) *schemas.EnvVar {
-	if v == nil || !v.IsFromEnv() {
+	if v == nil || (!v.IsFromEnv() && !v.IsFromVault()) {
 		return v
 	}
 	return v.Redacted()

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -128,7 +128,7 @@ func (c *Config) Redacted() *Config {
 // For env var references it zeroes out the resolved Val so the actual env content is
 // not leaked in API responses, while keeping the env_var name for round-trip edits.
 func hideResolvedEnvValue(v *schemas.EnvVar) *schemas.EnvVar {
-	if v == nil || !v.IsFromEnv() {
+	if v == nil || (!v.IsFromEnv() && !v.IsFromVault()) {
 		return v
 	}
 	return v.Redacted()

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -142,6 +142,12 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 					EnvVar:  authConfig.AdminPassword.EnvVar,
 					FromEnv: true,
 				}
+			} else if authConfig.AdminPassword != nil && authConfig.AdminPassword.IsFromVault() {
+				passwordEnvVar = &schemas.EnvVar{
+					Val:       "",
+					FromVault: true,
+					VaultRef:  authConfig.AdminPassword.VaultRef,
+				}
 			} else {
 				passwordEnvVar = &schemas.EnvVar{
 					Val:     "<redacted>",

--- a/ui/components/ui/badge.tsx
+++ b/ui/components/ui/badge.tsx
@@ -16,6 +16,7 @@ const badgeVariants = cva(
 					"border-transparent bg-destructive/10 border-destructive/50 text-black dark:text-destructive-foreground [a&]:hover:bg-destructive/90 [a&]:hover:text-destructive-foreground focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
 				outline: "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
 				success: "border-transparent bg-green-100 border-green-500 text-black [a&]:hover:bg-green-700/90 [a&]:hover:text-white",
+				warning: "border-transparent bg-yellow-100 border-yellow-500 text-black [a&]:hover:bg-yellow-600/90 [a&]:hover:text-white",
 			},
 		},
 		defaultVariants: {

--- a/ui/components/ui/envVarInput.tsx
+++ b/ui/components/ui/envVarInput.tsx
@@ -72,7 +72,9 @@ export const EnvVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEleme
 		}, [value]);
 
 		// Show badge when value is from env (server-synced or user-typed)
-		const showBadge = value?.from_env && value?.env_var;
+		const showEnvBadge = value?.from_env && value?.env_var;
+		const showVaultBadge = value?.from_vault && value?.vault_var;
+		const showBadge = showEnvBadge || showVaultBadge;
 		const rawValue = value?.value ?? "";
 		const displayValue =
 			showBadge && hideValueWhenEnv && !hasChanged.current
@@ -97,16 +99,18 @@ export const EnvVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEleme
 			}
 			hasChanged.current = true;
 			isUserChange.current = true;
-			// Auto-detect env var prefix
+			// Auto-detect env var / vault reference prefix
 			if (newValue.startsWith("env.")) {
-				onChange?.({ value: newValue, env_var: newValue, from_env: true });
+				onChange?.({ value: newValue, env_var: newValue, from_env: true, vault_var: "", from_vault: false });
+			} else if (newValue.startsWith("vault.")) {
+				onChange?.({ value: newValue, env_var: "", from_env: false, vault_var: newValue, from_vault: true });
 			} else {
-				onChange?.({ value: newValue, env_var: "", from_env: false });
+				onChange?.({ value: newValue, env_var: "", from_env: false, vault_var: "", from_vault: false });
 			}
 		};
 
-		// Show hint when user is typing an env var (from_env is true but no resolved value yet)
-		const showEnvHint = value?.from_env && value?.env_var && hasChanged.current;
+		// Show hint when user is typing an env var / vault ref (reference set but no resolved value yet)
+		const showEnvHint = ((value?.from_env && value?.env_var) || (value?.from_vault && value?.vault_var)) && hasChanged.current;
 
 		const isTextarea = variant === "textarea";
 
@@ -149,9 +153,14 @@ export const EnvVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEleme
 							{...(props as Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange">)}
 						/>
 					)}
-					{showBadge && (
+					{showEnvBadge && (
 						<Badge variant="success" className={cn("mr-2 whitespace-nowrap", isTextarea && "mb-2")}>
 							{value?.env_var}
+						</Badge>
+					)}
+					{showVaultBadge && (
+						<Badge variant="warning" className={cn("mr-2 whitespace-nowrap", isTextarea && "mb-2")}>
+							{value?.vault_var}
 						</Badge>
 					)}
 				</div>

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -61,17 +61,20 @@ export const _envVarBase = z.object({
 	value: z.string().optional(),
 	env_var: z.string().optional(),
 	from_env: z.boolean().optional(),
+	vault_var: z.string().optional(),
+	from_vault: z.boolean().optional(),
 });
 
 // Extending the base schema
 export const envVarSchema = Object.assign(_envVarBase, {
-	required: (message: string) => _envVarBase.refine((v) => !!v?.value?.trim() || !!v?.env_var?.trim(), message),
+	required: (message: string) =>
+		_envVarBase.refine((v) => !!v?.value?.trim() || !!v?.env_var?.trim() || !!v?.vault_var?.trim(), message),
 });
 
-// Helper to check if an envVar field has a value or env reference
-function isEnvVarSet(v: { value?: string; env_var?: string } | undefined): boolean {
+// Helper to check if an envVar field has a value, env reference, or vault reference
+function isEnvVarSet(v: { value?: string; env_var?: string; vault_var?: string } | undefined): boolean {
 	if (!v) return false;
-	return !!v.value?.trim() || !!v.env_var?.trim();
+	return !!v.value?.trim() || !!v.env_var?.trim() || !!v.vault_var?.trim();
 }
 
 // Azure key config schema
@@ -454,6 +457,7 @@ export const proxyConfigSchema = z
 		(data) =>
 			!(data.type === "http" || data.type === "socks5") ||
 			data.url?.from_env === true ||
+			data.url?.from_vault === true ||
 			(data.url?.value && data.url.value.trim().length > 0),
 		{
 			message: "Proxy URL is required when using HTTP or SOCKS5 proxy",
@@ -498,7 +502,7 @@ export const proxyFormConfigSchema = z
 			// URL is required when proxy type is http or socks5
 			if (data.type === "http" || data.type === "socks5") {
 				// Env-backed URLs may have empty resolved value before env resolution.
-				if (data.url?.from_env || data.url?.env_var?.startsWith("env.")) return true;
+				if (data.url?.from_env || data.url?.env_var?.startsWith("env.") || data.url?.from_vault || data.url?.vault_var?.startsWith("vault.")) return true;
 				// Literal URLs must be non-empty.
 				if (!data.url?.value || data.url.value.trim().length === 0) return false;
 			}
@@ -876,9 +880,9 @@ export const otelConfigSchema = z
 
 		// Validate collector_url format — skip format check for env var references
 		const collectorUrl = (data.collector_url?.value || "").trim();
-		if (collectorUrl && !data.collector_url?.from_env && protocol === "http") {
+		if (collectorUrl && !data.collector_url?.from_env && !data.collector_url?.from_vault && protocol === "http") {
 			validateHttpUrl(collectorUrl, ["collector_url"]);
-		} else if (collectorUrl && !data.collector_url?.from_env && protocol === "grpc") {
+		} else if (collectorUrl && !data.collector_url?.from_env && !data.collector_url?.from_vault && protocol === "grpc") {
 			validateHostPort(collectorUrl, ["collector_url"], "otel-collector:4317");
 		}
 
@@ -891,9 +895,9 @@ export const otelConfigSchema = z
 					path: ["metrics_endpoint"],
 					message: "Metrics endpoint is required when metrics push is enabled",
 				});
-			} else if (metricsEndpoint && !data.metrics_endpoint?.from_env && protocol === "http") {
+			} else if (metricsEndpoint && !data.metrics_endpoint?.from_env && !data.metrics_endpoint?.from_vault && protocol === "http") {
 				validateHttpUrl(metricsEndpoint, ["metrics_endpoint"]);
-			} else if (metricsEndpoint && !data.metrics_endpoint?.from_env && protocol === "grpc") {
+			} else if (metricsEndpoint && !data.metrics_endpoint?.from_env && !data.metrics_endpoint?.from_vault && protocol === "grpc") {
 				validateHostPort(metricsEndpoint, ["metrics_endpoint"], "otel-collector:4317");
 			}
 		}
@@ -951,7 +955,7 @@ export const prometheusConfigSchema = z
 	.superRefine((data, ctx) => {
 		// Validate push_gateway_url format — skip for env var references
 		const url = (data.push_gateway_url?.value || "").trim();
-		if (url && !data.push_gateway_url?.from_env) {
+		if (url && !data.push_gateway_url?.from_env && !data.push_gateway_url?.from_vault) {
 			try {
 				const u = new URL(url);
 				if (!(u.protocol === "http:" || u.protocol === "https:")) {

--- a/ui/lib/utils/envVarForm.ts
+++ b/ui/lib/utils/envVarForm.ts
@@ -1,23 +1,30 @@
 import { type EnvVar } from "@/lib/types/schemas";
 
-export const emptyEnvVar = (): EnvVar => ({ value: "", env_var: "", from_env: false });
+export const emptyEnvVar = (): EnvVar => ({ value: "", env_var: "", from_env: false, vault_var: "", from_vault: false });
 
 export const toEnvVarFormValue = (field?: EnvVar | string): EnvVar => {
 	if (!field) return emptyEnvVar();
 	if (typeof field === "string") {
 		const value = field.trim();
 		if (!value) return emptyEnvVar();
+		if (value.startsWith("vault.")) {
+			return { value: "", env_var: "", from_env: false, vault_var: value, from_vault: true };
+		}
 		const isEnvRef = value.startsWith("env.");
 		return {
 			value: isEnvRef ? "" : value,
 			env_var: isEnvRef ? value : "",
 			from_env: isEnvRef,
+			vault_var: "",
+			from_vault: false,
 		};
 	}
 	return {
 		value: field.value || "",
 		env_var: field.env_var || "",
 		from_env: field.from_env ?? false,
+		vault_var: field.vault_var || "",
+		from_vault: field.from_vault ?? false,
 	};
 };
 
@@ -27,9 +34,11 @@ export const toEnvVarMapFormValue = (map?: Record<string, string | EnvVar>): Rec
 };
 
 // toEnvRefString flattens an EnvVar form value to its persisted string form:
-// the "env.VAR" reference when sourced from the environment, otherwise the literal value.
+// the "vault.path" reference when vault-backed, the "env.VAR" reference when sourced
+// from the environment, otherwise the literal value.
 export const toEnvRefString = (field?: EnvVar): string => {
 	if (!field) return "";
+	if (field.from_vault) return (field.vault_var || "").trim();
 	if (field.from_env) return (field.env_var || "").trim();
 	return (field.value || "").trim();
 };
@@ -48,13 +57,22 @@ export const toHeaderStringMap = (headers?: Record<string, EnvVar>): Record<stri
 	return out;
 };
 
-export const toOptionalEnvVarPayload = (field?: { value?: string; env_var?: string; from_env?: boolean }) => {
+export const toOptionalEnvVarPayload = (field?: {
+	value?: string;
+	env_var?: string;
+	from_env?: boolean;
+	vault_var?: string;
+	from_vault?: boolean;
+}) => {
 	const envVar = field?.env_var?.trim();
+	const vaultVar = field?.vault_var?.trim();
 	const value = field?.value?.trim();
-	if (!value && !(field?.from_env && envVar)) return undefined;
+	if (!value && !(field?.from_env && envVar) && !(field?.from_vault && vaultVar)) return undefined;
 	return {
 		value: value || "",
 		env_var: envVar || "",
 		from_env: field?.from_env ?? false,
+		vault_var: vaultVar || "",
+		from_vault: field?.from_vault ?? false,
 	};
 };


### PR DESCRIPTION
## Summary

This PR extends the `EnvVar` type to support external vault backends (AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault, etc.) as a first-class secret source alongside the existing environment variable and plaintext forms. A `vault.path/to/secret` reference prefix is now recognized everywhere `env.VAR` references are handled.

## Changes

- Added `VaultRef` and `FromVault` fields to `EnvVar`, with JSON tags `vault_var` and `from_vault`. All existing methods (`IsSet`, `IsRedacted`, `Equals`, `Redacted`, `FullyRedacted`, `ShouldPreserveStored`, `GetValue`, `Scan`, `UnmarshalJSON`, `Value`) are updated to handle vault references consistently with env references.
- Introduced `core/schemas/vault.go` with hook function pointers (`VaultResolveHook`, `VaultRemoveHook`, `VaultStoreHook`, `VaultPrefixHook`) that are wired at enterprise startup and no-op in OSS deployments. Helpers `LookupVault`, `StoreVaultEnvVar`, `StoreOwnedVaultEnvVars`, `RemoveOwnedVaultEnvVars`, and `VaultBasePath` provide reflection-based bulk store/remove operations over struct fields.
- Removed the `VaultHooks` struct and all per-field vault store/resolve/remove logic from `tables/encryption.go`, `key.go`, `oauth.go`, `plugin.go`, `provider.go`, `virtualkey.go`, and `mcp_per_user_headers.go`. `BeforeSave` hooks now delegate to `schemas.StoreOwnedVaultEnvVars` and `AfterDelete` hooks delegate to `schemas.RemoveOwnedVaultEnvVars`, eliminating the large per-field repetition. `AfterFind` vault resolution is now handled lazily via `GetValue()` and `LookupVault` rather than eagerly in GORM hooks.
- AES encryption helpers (`encryptEnvVar`, `decryptEnvVar`) now skip vault-backed fields to prevent double-processing.
- Hash generation in `clientconfig.go` and `rdb.go` includes a `vault:` prefix for vault-backed values to prevent collisions with env and literal values.
- `EnvVarAsString` in `utils.go` returns `VaultRef` for vault-backed fields.
- The HTTP config handler exposes vault-backed admin passwords with their reference intact rather than a generic redacted placeholder.
- UI `EnvVar` schema and form utilities (`envVarForm.ts`, `envVarInput.tsx`, `schemas.ts`) add `vault_var` and `from_vault` fields. The `EnvVarInput` component auto-detects `vault.` prefixes and displays a yellow warning badge for vault references, distinct from the green badge used for env references.
- A `warning` badge variant is added to the UI badge component.
- Tests cover `Scan`, `UnmarshalJSON`, `Value`, `Redacted`, `IsSet`, `NewEnvVar`, `StoreVaultEnvVar`, `StoreOwnedVaultEnvVars` for vault paths, including no-op cases and hook-absent scenarios.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/schemas/... ./framework/configstore/...

# UI
cd ui
pnpm i
pnpm build
```

To exercise vault resolution end-to-end, wire `schemas.VaultResolveHook` and `schemas.VaultStoreHook` to a vault backend and set a field value to `vault.your/path`. On save the reference is stored; on load `GetValue()` resolves it via the hook.

## Breaking changes

- [x] Yes
- [ ] No

The `EnvVar` JSON representation gains two new optional fields (`vault_var`, `from_vault`). Existing serialized values without these fields deserialize correctly with zero values. The `VaultHooks` struct in `tables/encryption.go` is removed; any enterprise code wiring `VaultHooks` directly must be updated to set the `schemas.Vault*Hook` function pointers instead.

## Security considerations

Vault references are treated as redacted in all API responses — the same policy applied to env var references. The resolved secret value is never serialized back to the database; only the `vault.path` reference is persisted. `FullyRedacted` and `Redacted` preserve `VaultRef` so round-trip update merges can match via `Equals` without exposing the secret.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)