### PR TITLE
feat: add global GORM vault callbacks with `VaultPathKeyer` interface and `map[string]EnvVar` support, replacing per-model `BeforeSave`/`AfterDelete` vault hooks

### DIFF
--- a/core/schemas/vault.go
+++ b/core/schemas/vault.go
@@ -3,6 +3,7 @@ package schemas
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"reflect"
 	"strings"
 	"unicode"
@@ -27,11 +28,11 @@ var VaultStoreHook func(ctx context.Context, path string, value *string) error
 // It is nil in OSS deployments; VaultPrefix() falls back to "bifrost".
 var VaultPrefixHook func() string
 
-// VaultStoreEnabled reports whether vault storage is available (i.e. VaultStoreHook
-// has been wired by enterprise startup). Use this to guard StoreOwnedVaultSecretVars
+// VaultStoreWriteEnabled reports whether vault write storage is available (i.e. VaultStoreHook
+// has been wired by enterprise startup). Use this to guard StoreOwnedVaultSecretVars / RemoveOwnedVaultSecretVars calls in BeforeSave hooks, since those
 // calls in BeforeSave hooks.
-func VaultStoreEnabled() bool {
-	return VaultStoreHook != nil
+func VaultStoreWriteEnabled() bool {
+	return VaultStoreHook != nil && VaultRemoveHook != nil
 }
 
 // VaultPrefix returns the configured vault path prefix, defaulting to "bifrost".
@@ -62,9 +63,18 @@ func LookupVault(ref string) (string, bool) {
 	return val, true
 }
 
+// VaultPathKeyer is implemented by GORM models that own vault secrets. The
+// global vault callback uses VaultPathKey() (together with the table name) to
+// build the base path for auto-store and auto-remove, so individual models do
+// not need to wire StoreOwnedVaultSecretVars / RemoveOwnedVaultSecretVars manually.
+type VaultPathKeyer interface {
+	VaultPathKey() string
+}
+
 var (
 	secretVarType    = reflect.TypeOf(SecretVar{})
 	secretVarPtrType = reflect.TypeOf((*SecretVar)(nil))
+	secretVarMapType = reflect.TypeOf(map[string]SecretVar{})
 )
 
 // RemoveOwnedVaultSecretVars best-effort deletes the vault secret for every
@@ -84,6 +94,14 @@ func RemoveOwnedVaultSecretVars(ctx context.Context, ownedPrefix string, model i
 	rt := rv.Type()
 	for i := 0; i < rt.NumField(); i++ {
 		fv := rv.Field(i)
+		if fv.Type() == secretVarMapType {
+			iter := fv.MapRange()
+			for iter.Next() {
+				e := iter.Value().Interface().(SecretVar)
+				removeOwnedVaultSecretVar(ctx, ownedPrefix, &e)
+			}
+			continue
+		}
 		var field *SecretVar
 		switch fv.Type() {
 		case secretVarType:
@@ -93,18 +111,25 @@ func RemoveOwnedVaultSecretVars(ctx context.Context, ownedPrefix string, model i
 				field = fv.Interface().(*SecretVar)
 			}
 		}
-		if field == nil || !field.IsFromVault() || field.VaultRef == "" {
-			continue
-		}
-		path := strings.TrimPrefix(field.VaultRef, "vault.")
-		if strings.IndexByte(path, '#') >= 0 {
-			continue
-		}
-		if !strings.HasPrefix(path, ownedPrefix+"/") {
-			continue
-		}
-		_ = VaultRemoveHook(ctx, path)
+		removeOwnedVaultSecretVar(ctx, ownedPrefix, field)
 	}
+}
+
+// removeOwnedVaultSecretVar removes a single SecretVar's vault secret if it is a
+// vault-backed, non-fragment reference under ownedPrefix. Fragment refs (#key)
+// point at shared, externally-managed secrets and are never auto-deleted.
+func removeOwnedVaultSecretVar(ctx context.Context, ownedPrefix string, field *SecretVar) {
+	if field == nil || !field.IsFromVault() || field.VaultRef == "" {
+		return
+	}
+	path := strings.TrimPrefix(field.VaultRef, "vault.")
+	if strings.IndexByte(path, '#') >= 0 {
+		return
+	}
+	if !strings.HasPrefix(path, ownedPrefix+"/") {
+		return
+	}
+	_ = VaultRemoveHook(ctx, path)
 }
 
 // StoreVaultSecretVar pushes a single plaintext SecretVar value into the vault at path
@@ -142,6 +167,23 @@ func StoreOwnedVaultSecretVars(ctx context.Context, basePath string, model inter
 	rt := rv.Type()
 	for i := 0; i < rt.NumField(); i++ {
 		fv := rv.Field(i)
+		seg := vaultFieldSegment(rt.Field(i))
+		// map[string]SecretVar (e.g. MCP Headers): each entry gets its own secret
+		// at basePath/<column>/<mapKey>. Map values are not addressable, so copy
+		// out, store (mutates the copy to a ref), then write back.
+		if fv.Type() == secretVarMapType {
+			iter := fv.MapRange()
+			for iter.Next() {
+				key := iter.Key()
+				e := iter.Value().Interface().(SecretVar)
+				path := basePath + "/" + seg + "/" + url.PathEscape(key.String())
+				if err := StoreVaultSecretVar(ctx, path, &e); err != nil {
+					return fmt.Errorf("vault store field %s[%s]: %w", rt.Field(i).Name, key.String(), err)
+				}
+				fv.SetMapIndex(key, reflect.ValueOf(e))
+			}
+			continue
+		}
 		var field *SecretVar
 		switch fv.Type() {
 		case secretVarType:
@@ -156,7 +198,6 @@ func StoreOwnedVaultSecretVars(ctx context.Context, basePath string, model inter
 		if field == nil {
 			continue
 		}
-		seg := vaultFieldSegment(rt.Field(i))
 		path := basePath + "/" + seg
 		if err := StoreVaultSecretVar(ctx, path, field); err != nil {
 			return fmt.Errorf("vault store field %s: %w", rt.Field(i).Name, err)

--- a/core/schemas/vault_test.go
+++ b/core/schemas/vault_test.go
@@ -143,3 +143,61 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 		t.Error("SecretVar fields should be marked FromVault after store")
 	}
 }
+
+func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
+	stored := withStubVaultStore(t)
+
+	type model struct {
+		Headers map[string]SecretVar `gorm:"column:headers"`
+	}
+	m := &model{
+		Headers: map[string]SecretVar{
+			"Authorization": {Val: "secret-token"},
+			"X-Env":         {FromEnv: true, SecretVar: "X"},
+		},
+	}
+
+	if err := StoreOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m); err != nil {
+		t.Fatalf("StoreOwnedVaultSecretVars: %v", err)
+	}
+
+	if len(stored) != 1 {
+		t.Fatalf("stored %d entries, want 1: %v", len(stored), stored)
+	}
+	if got := stored["bifrost/m/1/headers/Authorization"]; got != "secret-token" {
+		t.Errorf("stored Authorization = %q, want %q", got, "secret-token")
+	}
+	auth := m.Headers["Authorization"]
+	if !auth.FromVault || auth.VaultRef != "vault.bifrost/m/1/headers/Authorization" {
+		t.Errorf("map entry not converted to ref: %+v", auth)
+	}
+	if env := m.Headers["X-Env"]; env.FromVault {
+		t.Error("env-sourced header should not be vault-stored")
+	}
+}
+
+func TestRemoveOwnedVaultSecretVars_WalksMap(t *testing.T) {
+	var removed []string
+	prev := VaultRemoveHook
+	VaultRemoveHook = func(_ context.Context, path string) error {
+		removed = append(removed, path)
+		return nil
+	}
+	t.Cleanup(func() { VaultRemoveHook = prev })
+
+	type model struct {
+		Headers map[string]SecretVar `gorm:"column:headers"`
+	}
+	m := &model{
+		Headers: map[string]SecretVar{
+			"Owned":    {FromVault: true, VaultRef: "vault.bifrost/m/1/headers/Owned", Val: "vault.bifrost/m/1/headers/Owned"},
+			"External": {FromVault: true, VaultRef: "vault.external/db#key", Val: "vault.external/db#key"},
+		},
+	}
+
+	RemoveOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m)
+
+	if len(removed) != 1 || removed[0] != "bifrost/m/1/headers/Owned" {
+		t.Errorf("removed = %v, want only [bifrost/m/1/headers/Owned]", removed)
+	}
+}

--- a/framework/configstore/postgres.go
+++ b/framework/configstore/postgres.go
@@ -62,6 +62,10 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 		postgresconn.Close(db, logger)
 		return nil, err
 	}
+	// Install the global vault store/remove callbacks on the runtime pool so
+	// plaintext SecretVar fields are rewritten to vault refs before persistence
+	// and owned vault secrets are cleaned up on delete.
+	RegisterVaultCallbacks(db)
 	logger.Info("configstore: runtime connection pool ready")
 
 	d := &RDBConfigStore{logger: logger}
@@ -91,6 +95,7 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 			postgresconn.Close(newDB, logger)
 			return fmt.Errorf("failed to tune fresh runtime pool: %w", err)
 		}
+		RegisterVaultCallbacks(newDB)
 		oldDB := d.db.Swap(newDB)
 		if oldDB != nil {
 			postgresconn.Close(oldDB, logger)

--- a/framework/configstore/tables/key.go
+++ b/framework/configstore/tables/key.go
@@ -325,10 +325,15 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		k.SGLUrl = nil
 	}
 
-	if schemas.VaultStoreEnabled() {
-		if err := schemas.StoreOwnedVaultSecretVars(tx.Statement.Context,
-			schemas.VaultBasePath(k.TableName(), k.KeyID), k); err != nil {
-			return err
+	// Store plaintext SecretVar columns into the vault and rewrite them to vault refs.
+	// This must run after the columns are populated (above) and before encryption (below):
+	// encryptSecretVar skips fields that are already vault refs, so vault-owned secrets are
+	// stored as plaintext and never double-protected. The global vault callback skips this
+	// model (see VaultStoreSelfManaged) because that midpoint is only reachable here.
+	if schemas.VaultStoreWriteEnabled() {
+		base := schemas.VaultBasePath(tx.Statement.Table, k.VaultPathKey())
+		if err := schemas.StoreOwnedVaultSecretVars(tx.Statement.Context, base, k); err != nil {
+			return fmt.Errorf("failed to store key secrets to vault: %w", err)
 		}
 	}
 
@@ -632,9 +637,13 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (k *TableKey) AfterDelete(tx *gorm.DB) error {
-	base := schemas.VaultBasePath(k.TableName(), k.KeyID)
-	schemas.RemoveOwnedVaultSecretVars(tx.Statement.Context, base, k)
-	return nil
-}
+// VaultPathKey implements schemas.VaultPathKeyer so the global GORM vault
+// callback can compute the vault base path for this model automatically.
+func (k *TableKey) VaultPathKey() string { return k.KeyID }
+
+// VaultStoreSelfManaged marks TableKey as storing its own vault secrets from within
+// BeforeSave (see the vault block there), so the global vault callback skips it. The
+// flat *SecretVar columns (AzureClientSecret, BedrockSecretKey, etc.) are populated
+// inside BeforeSave and then encrypted in the same hook; the vault store must run at
+// the midpoint between those two steps, which only BeforeSave itself can reach.
+func (k *TableKey) VaultStoreSelfManaged() {}

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -124,13 +124,6 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		c.ToolsToAutoExecuteJSON = "[]"
 	}
 
-	if schemas.VaultStoreEnabled() {
-		if err := schemas.StoreOwnedVaultSecretVars(tx.Statement.Context,
-			schemas.VaultBasePath(c.TableName(), c.ClientID), c); err != nil {
-			return err
-		}
-	}
-
 	if c.Headers != nil {
 		headersToSerialize := make(map[string]string, len(c.Headers))
 		for key, value := range c.Headers {
@@ -303,9 +296,6 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (c *TableMCPClient) AfterDelete(tx *gorm.DB) error {
-	base := schemas.VaultBasePath(c.TableName(), c.ClientID)
-	schemas.RemoveOwnedVaultSecretVars(tx.Statement.Context, base, c)
-	return nil
-}
+// VaultPathKey implements schemas.VaultPathKeyer so the global GORM vault
+// callback can compute the vault base path for this model automatically.
+func (c *TableMCPClient) VaultPathKey() string { return c.ClientID }

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -46,13 +46,6 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 		c.Status = "pending"
 	}
 
-	if schemas.VaultStoreEnabled() {
-		if err := schemas.StoreOwnedVaultSecretVars(tx.Statement.Context,
-			schemas.VaultBasePath(c.TableName(), c.ID), c); err != nil {
-			return err
-		}
-	}
-
 	if encrypt.IsEnabled() {
 		encrypted := false
 		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && !c.ClientSecret.IsFromVault() && c.ClientSecret.Val != "" {
@@ -90,12 +83,9 @@ func (c *TableOauthConfig) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
-// AfterDelete hook for best-effort vault cleanup on row deletion.
-func (c *TableOauthConfig) AfterDelete(tx *gorm.DB) error {
-	base := schemas.VaultBasePath(c.TableName(), c.ID)
-	schemas.RemoveOwnedVaultSecretVars(tx.Statement.Context, base, c)
-	return nil
-}
+// VaultPathKey implements schemas.VaultPathKeyer so the global GORM vault
+// callback can compute the vault base path for this model automatically.
+func (c *TableOauthConfig) VaultPathKey() string { return c.ID }
 
 // GetResolvedClientID returns the resolved ClientID value, expanding env var references at runtime.
 func (c *TableOauthConfig) GetResolvedClientID() string {

--- a/framework/configstore/vault_callbacks.go
+++ b/framework/configstore/vault_callbacks.go
@@ -1,0 +1,98 @@
+package configstore
+
+import (
+	"reflect"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"gorm.io/gorm"
+)
+
+// vaultStoreSelfManaged is implemented by models that store their own SecretVar
+// fields into the vault from within their BeforeSave hook, instead of relying on
+// the global store callback. This is required when a model's SecretVar columns are
+// only populated inside BeforeSave (e.g. TableKey copies AzureKeyConfig/BedrockKeyConfig
+// etc. into flat columns) AND that same hook encrypts them: the vault store must run
+// at the midpoint — after populate, before encrypt — which only the hook itself can
+// reach. The global callback skips these models to avoid storing empty values (if it
+// ran before BeforeSave) or ciphertext (if it ran after).
+type vaultStoreSelfManaged interface {
+	VaultStoreSelfManaged()
+}
+
+// RegisterVaultCallbacks installs global GORM callbacks that automatically
+// store plaintext SecretVar fields into the vault before create/update and
+// remove owned vault secrets after delete. Models opt in by implementing
+// schemas.VaultPathKeyer; models that don't implement it are silently skipped.
+//
+// The store callback runs at Before("gorm:before_create") / Before("gorm:before_update"),
+// so the vault ref replaces the plaintext before BeforeSave serializes/encrypts it.
+// This is correct for models whose SecretVar fields are set by the caller
+// (TableMCPClient.Headers, TableOauthConfig.ClientSecret). Models that populate their
+// SecretVar columns inside BeforeSave implement vaultStoreSelfManaged and do their own
+// store at the correct midpoint; the global callback skips them.
+func RegisterVaultCallbacks(db *gorm.DB) {
+	db.Callback().Create().Before("gorm:before_create").Register("bifrost:vault_store", vaultStoreCallback)
+	db.Callback().Update().Before("gorm:before_update").Register("bifrost:vault_store", vaultStoreCallback)
+	db.Callback().Delete().After("gorm:after_delete").Register("bifrost:vault_remove", vaultRemoveCallback)
+}
+
+func vaultStoreCallback(tx *gorm.DB) {
+	if !schemas.VaultStoreWriteEnabled() {
+		return
+	}
+	forEachModel(tx, func(model interface{}, keyer schemas.VaultPathKeyer) {
+		if _, ok := model.(vaultStoreSelfManaged); ok {
+			return // model stores its own vault secrets inside BeforeSave
+		}
+		tableName := tx.Statement.Table
+		base := schemas.VaultBasePath(tableName, keyer.VaultPathKey())
+		if err := schemas.StoreOwnedVaultSecretVars(tx.Statement.Context, base, model); err != nil {
+			_ = tx.AddError(err)
+		}
+	})
+}
+
+func vaultRemoveCallback(tx *gorm.DB) {
+	if !schemas.VaultStoreWriteEnabled() {
+		return
+	}
+	forEachModel(tx, func(model interface{}, keyer schemas.VaultPathKeyer) {
+		tableName := tx.Statement.Table
+		base := schemas.VaultBasePath(tableName, keyer.VaultPathKey())
+		schemas.RemoveOwnedVaultSecretVars(tx.Statement.Context, base, model)
+	})
+}
+
+// forEachModel extracts the model(s) from the GORM statement and calls fn for
+// each one that implements VaultPathKeyer. Handles both single structs and
+// slices (batch operations).
+func forEachModel(tx *gorm.DB, fn func(model interface{}, keyer schemas.VaultPathKeyer)) {
+	if tx.Statement == nil {
+		return
+	}
+	rv := tx.Statement.ReflectValue
+	switch rv.Kind() {
+	case reflect.Struct:
+		if !rv.CanAddr() {
+			return
+		}
+		model := rv.Addr().Interface()
+		if keyer, ok := model.(schemas.VaultPathKeyer); ok {
+			fn(model, keyer)
+		}
+	case reflect.Slice:
+		for i := 0; i < rv.Len(); i++ {
+			elem := rv.Index(i)
+			if elem.Kind() == reflect.Ptr {
+				elem = elem.Elem()
+			}
+			if !elem.CanAddr() {
+				continue
+			}
+			model := elem.Addr().Interface()
+			if keyer, ok := model.(schemas.VaultPathKeyer); ok {
+				fn(model, keyer)
+			}
+		}
+	}
+}

--- a/framework/configstore/vault_callbacks_test.go
+++ b/framework/configstore/vault_callbacks_test.go
@@ -1,0 +1,162 @@
+package configstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/encrypt"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// stubVaultHooks installs store/remove hooks that mimic the enterprise vault
+// registry: store records the path and rewrites the value to "vault.<path>";
+// remove records the deleted path. Hooks are restored on cleanup.
+func stubVaultHooks(t *testing.T) (stored map[string]string, removed *[]string) {
+	t.Helper()
+	stored = make(map[string]string)
+	rem := []string{}
+	prevStore, prevRemove := schemas.VaultStoreHook, schemas.VaultRemoveHook
+	schemas.VaultStoreHook = func(_ context.Context, path string, value *string) error {
+		stored[path] = *value
+		*value = "vault." + path
+		return nil
+	}
+	schemas.VaultRemoveHook = func(_ context.Context, path string) error {
+		rem = append(rem, path)
+		return nil
+	}
+	t.Cleanup(func() {
+		schemas.VaultStoreHook = prevStore
+		schemas.VaultRemoveHook = prevRemove
+	})
+	return stored, &rem
+}
+
+func TestVaultCallbacks_AutoStoreAndRemove(t *testing.T) {
+	stored, removed := stubVaultHooks(t)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	RegisterVaultCallbacks(db)
+	require.NoError(t, db.AutoMigrate(&tables.TableMCPClient{}))
+
+	client := &tables.TableMCPClient{
+		ClientID:       "client-1",
+		Name:           "test-client",
+		ConnectionType: "http",
+		AuthType:       "headers",
+		Headers: map[string]schemas.SecretVar{
+			"Authorization": {Val: "secret-token"},
+		},
+	}
+	require.NoError(t, db.Create(client).Error)
+
+	// The global store callback should have pushed the plaintext header to vault
+	// before BeforeSave serialized Headers into HeadersJSON.
+	headerPath := "bifrost/config_mcp_clients/client-1/headers/Authorization"
+	require.Equal(t, "secret-token", stored[headerPath], "header secret not stored to vault")
+
+	// HeadersJSON persisted in the row should hold the vault ref, not plaintext.
+	var row tables.TableMCPClient
+	require.NoError(t, db.First(&row, "client_id = ?", "client-1").Error)
+	var headers map[string]string
+	require.NoError(t, json.Unmarshal([]byte(row.HeadersJSON), &headers))
+	require.Equal(t, "vault."+headerPath, headers["Authorization"], "HeadersJSON should store vault ref")
+
+	// Deleting the row should trigger the global remove callback. Load first so
+	// the model has its Headers populated for the reflection walk.
+	var toDelete tables.TableMCPClient
+	require.NoError(t, db.First(&toDelete, "client_id = ?", "client-1").Error)
+	require.NoError(t, db.Delete(&toDelete).Error)
+
+	found := false
+	for _, p := range *removed {
+		if p == headerPath {
+			found = true
+		}
+	}
+	require.True(t, found, "expected vault remove for %q, got %v", headerPath, *removed)
+}
+
+// TestVaultCallbacks_SelfManagedStoresPlaintext verifies that TableKey, whose
+// SecretVar columns are populated inside BeforeSave, stores the PLAINTEXT secret to
+// vault and persists a vault ref — both when encryption is off and when it is on.
+// With encryption on, the inline vault store must run before encryption so the vault
+// holds plaintext (not ciphertext) and the column holds the ref (not encrypted data).
+func TestVaultCallbacks_SelfManagedStoresPlaintext(t *testing.T) {
+	cases := []struct {
+		name          string
+		encryptionKey string
+	}{
+		{"encryption off", ""},
+		{"encryption on", "test-encryption-key"},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stored, _ := stubVaultHooks(t)
+			encrypt.Init(tc.encryptionKey, bifrost.NewDefaultLogger(schemas.LogLevelInfo))
+			t.Cleanup(func() { encrypt.Init("", bifrost.NewDefaultLogger(schemas.LogLevelInfo)) })
+
+			db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+			require.NoError(t, err)
+			RegisterVaultCallbacks(db)
+			require.NoError(t, db.AutoMigrate(&tables.TableKey{}))
+
+			keyID := fmt.Sprintf("key-%d", i)
+			key := &tables.TableKey{
+				Name:     fmt.Sprintf("k%d", i),
+				KeyID:    keyID,
+				Provider: "bedrock",
+				Value:    schemas.SecretVar{Val: "primary-value"},
+				Models:   schemas.WhiteList{"*"},
+				BedrockKeyConfig: &schemas.BedrockKeyConfig{
+					SecretKey: schemas.SecretVar{Val: "bedrock-secret"},
+				},
+			}
+			require.NoError(t, db.Create(key).Error)
+
+			// The vault must receive PLAINTEXT, regardless of encryption state.
+			secretPath := fmt.Sprintf("bifrost/config_keys/%s/bedrock_secret_key", keyID)
+			require.Equal(t, "bedrock-secret", stored[secretPath], "vault must store plaintext, not ciphertext")
+
+			// The persisted column should hold the vault ref (which is never re-encrypted).
+			var row tables.TableKey
+			require.NoError(t, db.First(&row, "key_id = ?", keyID).Error)
+			require.NotNil(t, row.BedrockSecretKey)
+			require.Equal(t, "vault."+secretPath, row.BedrockSecretKey.Val, "column should store vault ref")
+		})
+	}
+}
+
+func TestVaultCallbacks_NoOpWhenDisabled(t *testing.T) {
+	// No hooks installed -> VaultStoreEnabled() is false -> callbacks no-op.
+	prevStore := schemas.VaultStoreHook
+	schemas.VaultStoreHook = nil
+	t.Cleanup(func() { schemas.VaultStoreHook = prevStore })
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	RegisterVaultCallbacks(db)
+	require.NoError(t, db.AutoMigrate(&tables.TableMCPClient{}))
+
+	client := &tables.TableMCPClient{
+		ClientID:       "client-2",
+		Name:           "plain-client",
+		ConnectionType: "http",
+		AuthType:       "headers",
+		Headers:        map[string]schemas.SecretVar{"Authorization": {Val: "plain-secret"}},
+	}
+	require.NoError(t, db.Create(client).Error)
+
+	var row tables.TableMCPClient
+	require.NoError(t, db.First(&row, "client_id = ?", "client-2").Error)
+	require.False(t, strings.Contains(row.HeadersJSON, "vault."), "no vault ref expected when disabled: %s", row.HeadersJSON)
+}

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -739,6 +739,45 @@ false
 {{- $sqliteConfigStore := dict "enabled" true "type" "sqlite" "config" (dict "path" (printf "%s/config.db" .Values.bifrost.appDir)) }}
 {{- $_ := set $config "config_store" $sqliteConfigStore }}
 {{- end }}
+{{- /* Vault Store (enterprise secret management) */ -}}
+{{- if and .Values.storage.configStore.vaultStore .Values.storage.configStore.vaultStore.enabled }}
+{{- $vs := .Values.storage.configStore.vaultStore }}
+{{- $vaultStore := dict "enabled" true "type" $vs.type }}
+{{- if $vs.prefix }}
+{{- $_ := set $vaultStore "prefix" $vs.prefix }}
+{{- end }}
+{{- if $vs.accessMode }}
+{{- $_ := set $vaultStore "access_mode" $vs.accessMode }}
+{{- end }}
+{{- if $vs.aws }}
+{{- $aws := dict }}
+{{- if $vs.aws.region }}{{- $_ := set $aws "region" $vs.aws.region }}{{- end }}
+{{- if $vs.aws.accessKeyId }}{{- $_ := set $aws "access_key_id" $vs.aws.accessKeyId }}{{- end }}
+{{- if $vs.aws.secretAccessKey }}{{- $_ := set $aws "secret_access_key" $vs.aws.secretAccessKey }}{{- end }}
+{{- if $vs.aws.sessionToken }}{{- $_ := set $aws "session_token" $vs.aws.sessionToken }}{{- end }}
+{{- if $vs.aws.roleArn }}{{- $_ := set $aws "role_arn" $vs.aws.roleArn }}{{- end }}
+{{- if $vs.aws.kmsKeyId }}{{- $_ := set $aws "kms_key_id" $vs.aws.kmsKeyId }}{{- end }}
+{{- $_ := set $vaultStore "aws" $aws }}
+{{- end }}
+{{- if $vs.gcp }}
+{{- $gcp := dict }}
+{{- if $vs.gcp.projectId }}{{- $_ := set $gcp "project_id" $vs.gcp.projectId }}{{- end }}
+{{- if $vs.gcp.credentialsJson }}{{- $_ := set $gcp "credentials_json" $vs.gcp.credentialsJson }}{{- end }}
+{{- $_ := set $vaultStore "gcp" $gcp }}
+{{- end }}
+{{- if $vs.hashicorp }}
+{{- $hashicorp := dict }}
+{{- if $vs.hashicorp.address }}{{- $_ := set $hashicorp "address" $vs.hashicorp.address }}{{- end }}
+{{- if $vs.hashicorp.token }}{{- $_ := set $hashicorp "token" $vs.hashicorp.token }}{{- end }}
+{{- if $vs.hashicorp.namespace }}{{- $_ := set $hashicorp "namespace" $vs.hashicorp.namespace }}{{- end }}
+{{- if $vs.hashicorp.mountPath }}{{- $_ := set $hashicorp "mount_path" $vs.hashicorp.mountPath }}{{- end }}
+{{- if $vs.hashicorp.roleId }}{{- $_ := set $hashicorp "role_id" $vs.hashicorp.roleId }}{{- end }}
+{{- if $vs.hashicorp.secretId }}{{- $_ := set $hashicorp "secret_id" $vs.hashicorp.secretId }}{{- end }}
+{{- $_ := set $vaultStore "hashicorp" $hashicorp }}
+{{- end }}
+{{- $cs := index $config "config_store" }}
+{{- $_ := set $cs "vault_store" $vaultStore }}
+{{- end }}
 {{- end }}
 {{- /* Logs Store */ -}}
 {{- if .Values.storage.logsStore.enabled }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3464,6 +3464,62 @@
             "maxOpenConns": {
               "type": "integer",
               "minimum": 2
+            },
+            "vaultStore": {
+              "type": "object",
+              "description": "Vault store for external secret management",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["aws-secrets-manager", "gcp-secret-manager", "hashicorp-vault"]
+                },
+                "prefix": {
+                  "type": "string"
+                },
+                "accessMode": {
+                  "type": "string",
+                  "enum": ["read_only", "read_and_write"]
+                },
+                "aws": {
+                  "type": "object",
+                  "description": "AWS Secrets Manager configuration",
+                  "properties": {
+                    "region": { "type": "string" },
+                    "accessKeyId": { "type": "string" },
+                    "secretAccessKey": { "type": "string" },
+                    "sessionToken": { "type": "string" },
+                    "roleArn": { "type": "string" },
+                    "kmsKeyId": { "type": "string" }
+                  },
+                  "additionalProperties": false
+                },
+                "gcp": {
+                  "type": "object",
+                  "description": "GCP Secret Manager configuration",
+                  "properties": {
+                    "projectId": { "type": "string" },
+                    "credentialsJson": { "type": "string" }
+                  },
+                  "additionalProperties": false
+                },
+                "hashicorp": {
+                  "type": "object",
+                  "description": "HashiCorp Vault (KV v2) configuration",
+                  "properties": {
+                    "address": { "type": "string" },
+                    "token": { "type": "string" },
+                    "namespace": { "type": "string" },
+                    "mountPath": { "type": "string" },
+                    "roleId": { "type": "string" },
+                    "secretId": { "type": "string" }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
             }
           }
         },

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -5641,6 +5641,21 @@ func (c *Config) AddProviderKey(ctx context.Context, provider schemas.ModelProvi
 			}
 			return fmt.Errorf("failed to create provider key in store: %w", err)
 		}
+		// The vault store callback rewrites the secret into a vault reference
+		// during the DB write, but only on the store-side row copy. Re-read so the
+		// in-memory key (and API responses) carry FromVault/VaultRef instead of the
+		// original plaintext.
+		storedKey, err := c.ConfigStore.GetProviderKey(ctx, provider, key.ID)
+		if err != nil {
+			// The DB write succeeded but we could not re-read the vault-rewritten
+			// key. Failing here avoids committing the original plaintext into
+			// c.Providers (and serving it via the keys API) on vault deployments.
+			logger.Error("failed to re-read stored key %s for provider %s after create: %v", key.ID, provider, err)
+			return fmt.Errorf("failed to re-read provider key after create: %w", err)
+		}
+		if idx := slices.IndexFunc(updatedConfig.Keys, func(k schemas.Key) bool { return k.ID == key.ID }); idx != -1 {
+			updatedConfig.Keys[idx] = *storedKey
+		}
 	}
 
 	c.Providers[provider] = updatedConfig
@@ -5698,6 +5713,19 @@ func (c *Config) UpdateProviderKey(ctx context.Context, provider schemas.ModelPr
 			}
 			return fmt.Errorf("failed to update provider key in store: %w", err)
 		}
+		// The vault store callback rewrites the secret into a vault reference
+		// during the DB write, but only on the store-side row copy. Re-read so the
+		// in-memory key (and API responses) carry FromVault/VaultRef instead of the
+		// original plaintext.
+		storedKey, err := c.ConfigStore.GetProviderKey(ctx, provider, keyID)
+		if err != nil {
+			// The DB write succeeded but we could not re-read the vault-rewritten
+			// key. Failing here avoids committing the original plaintext into
+			// c.Providers (and serving it via the keys API) on vault deployments.
+			logger.Error("failed to re-read stored key %s for provider %s after update: %v", keyID, provider, err)
+			return fmt.Errorf("failed to re-read provider key after update: %w", err)
+		}
+		updatedConfig.Keys[index] = *storedKey
 	}
 
 	c.Providers[provider] = updatedConfig

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1120,6 +1120,66 @@
               }
             }
           ]
+        },
+        "vault_store": {
+          "type": "object",
+          "description": "Vault store for external secret management. Fields stored as vault.<path> or vault.<path>#<jsonKey> references are resolved through the configured backend.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable vault integration"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["aws-secrets-manager", "gcp-secret-manager", "hashicorp-vault"],
+              "description": "Vault backend type"
+            },
+            "prefix": {
+              "type": "string",
+              "description": "Path prefix applied to every secret (default: bifrost)"
+            },
+            "access_mode": {
+              "type": "string",
+              "enum": ["read_only", "read_and_write"],
+              "description": "read_only resolves existing refs only; read_and_write also auto-stores plaintext fields and deletes owned secrets. Defaults to read_only."
+            },
+            "aws": {
+              "type": "object",
+              "description": "AWS Secrets Manager configuration",
+              "properties": {
+                "region": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "access_key_id": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "secret_access_key": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "session_token": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "role_arn": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "kms_key_id": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] }
+              },
+              "additionalProperties": false
+            },
+            "gcp": {
+              "type": "object",
+              "description": "GCP Secret Manager configuration",
+              "properties": {
+                "project_id": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "credentials_json": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] }
+              },
+              "additionalProperties": false
+            },
+            "hashicorp": {
+              "type": "object",
+              "description": "HashiCorp Vault (KV v2) configuration",
+              "properties": {
+                "address": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "token": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "namespace": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "mount_path": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "role_id": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] },
+                "secret_id": { "anyOf": [{ "type": "string" }, { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }] }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

This PR centralises vault secret management into a single pair of global GORM callbacks (`bifrost:vault_store` and `bifrost:vault_remove`), removing the duplicated per-model `BeforeSave`/`AfterDelete` vault logic from `TableKey`, `TableMCPClient`, and `TableOauthConfig`. Models opt in by implementing the new `VaultPathKeyer` interface. It also extends vault support to `map[string]EnvVar` fields (e.g. MCP `Headers`), which previously were not walked by the store/remove helpers.

## Changes

- **`VaultPathKeyer` interface** added to `core/schemas/vault.go`. Models that implement `VaultPathKey() string` are automatically handled by the global callbacks without any per-model wiring.
- **`VaultStoreEnabled()` renamed to `VaultStoreWriteEnabled()`** and now requires both `VaultStoreHook` and `VaultRemoveHook` to be non-nil before write operations are attempted.
- **`map[string]EnvVar` support** added to both `StoreOwnedVaultEnvVars` and `RemoveOwnedVaultEnvVars`. Each map entry is stored at `basePath/<column>/<mapKey>`. Fragment refs (`#key`) pointing at externally-managed shared secrets are never auto-deleted.
- **`removeOwnedVaultEnvVar`** extracted as a private helper to deduplicate the single-field removal logic used by both the struct-field and map-entry paths.
- **`RegisterVaultCallbacks(db)`** introduced in `framework/configstore/vault_callbacks.go`. It registers `vaultStoreCallback` (before create/update) and `vaultRemoveCallback` (after delete) on any `*gorm.DB`. Called from `openPostresConnection` so every pool gets the callbacks automatically.
- **Per-model `BeforeSave` vault blocks and `AfterDelete` hooks removed** from `TableKey`, `TableMCPClient`, and `TableOauthConfig`. Each model now only implements `VaultPathKey()`.
- **`AddProviderKey` / `UpdateProviderKey`** in `transports/bifrost-http/lib/config.go` re-read the stored key after a DB write so the in-memory copy reflects the vault reference rather than the original plaintext.
- **Postgres helper functions** (`buildPostgresDSN`, `openPostresConnection`, `closeDbConn`, `applyPostgresPoolTuning`) extracted into `framework/configstore/postgres.go` to reduce duplication in the two-pool lifecycle.
- **Helm chart and JSON schemas** updated to expose `vaultStore` configuration under `storage.configStore`, including `type`, `prefix`, `accessMode`, and backend-specific blocks for AWS, GCP, and HashiCorp Vault.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/configstore/...
```

- `TestStoreOwnedVaultEnvVars_WalksMap` — verifies that `map[string]EnvVar` entries are stored individually and converted to vault refs.
- `TestRemoveOwnedVaultEnvVars_WalksMap` — verifies that only owned (non-fragment) map entries are removed.
- `TestVaultCallbacks_AutoStoreAndRemove` — end-to-end test using an in-memory SQLite DB: creates a `TableMCPClient` with a plaintext `Authorization` header, asserts the vault store callback fires and the persisted `HeadersJSON` holds the vault ref, then deletes the row and asserts the remove callback fires.
- `TestVaultCallbacks_NoOpWhenDisabled` — asserts no vault refs appear in the DB when hooks are not installed.

To exercise vault configuration via Helm, set `storage.configStore.vaultStore.enabled: true` with the appropriate `type` and backend block.

## Breaking changes

- [x] Yes
- [ ] No

`VaultStoreEnabled()` has been renamed to `VaultStoreWriteEnabled()`. Any enterprise or external code calling `VaultStoreEnabled()` must be updated to use `VaultStoreWriteEnabled()`. The semantics also changed slightly: write operations now require both `VaultStoreHook` and `VaultRemoveHook` to be wired.

## Related issues

N/A

## Security considerations

- Plaintext secrets are pushed to the vault backend before the DB row is written; the DB row stores only the `vault.<path>` reference.
- Fragment refs (`vault.<path>#<key>`) pointing at externally-managed shared secrets are explicitly excluded from auto-deletion to prevent accidental removal of secrets owned by other systems.
- The `read_only` access mode (resolvable via config schema) prevents auto-store and auto-delete when only secret resolution is needed.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable