### PR TITLE
fix: MCP usage guide trigger button(Connect agent) styling

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/mcpUsageGuideSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/mcpUsageGuideSheet.tsx
@@ -124,12 +124,11 @@ export function MCPUsageGuideSheet() {
 	// ── Render ───────────────────────────────────────────────────────────
 	return (
 		<>
-			<Button
-				type="button"
+			<Button type="button"
 				onClick={() => setOpen(true)}
 				data-testid="mcp-usage-guide-trigger"
 				variant="outline"
-				className="group h-8 gap-1.5 border-dotted border-primary bg-muted/40 px-2.5 font-mono text-xs tracking-tight shadow-none hover:border-primary/50 hover:bg-muted dark:bg-muted/25"
+				className="h-8"
 			>
 				<SquareTerminal />
 				<span className="hidden sm:inline">Connect agent</span>


### PR DESCRIPTION
## Summary

Simplifies the styling of the "Connect agent" button in the MCP Usage Guide sheet by removing custom Tailwind classes and reducing it to a minimal height class.

## Changes

- Removed the verbose custom `className` from the `MCPUsageGuideSheet` trigger button, replacing it with a simple `h-8` class
- Collapsed the `Button` opening tag onto a single line

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Navigate to the MCP Registry page and verify the "Connect agent" button renders correctly with the updated styling.

## Screenshots/Recordings

Before/after screenshots of the "Connect agent" button appearance recommended to confirm the visual change is acceptable.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable