### PR TITLE
fix: include JSON parse error details

### DIFF
--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -719,7 +719,7 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 				if len(rawBody) > 0 {
 					if err := parseJSONRequestBody(rawBody, req); err != nil {
 						ctx.SetConnectionClose()
-						g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostErrorWithCode(err, "Invalid JSON", fasthttp.StatusBadRequest))
+						g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostErrorWithCode(err, fmt.Sprintf("Invalid JSON: %v", err), fasthttp.StatusBadRequest))
 						return
 					}
 				}

--- a/transports/bifrost-http/integrations/router_large_payload_test.go
+++ b/transports/bifrost-http/integrations/router_large_payload_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,6 +92,43 @@ func TestCreateHandler_UsesRequestParserWhenNotInLargePayloadMode(t *testing.T) 
 	handler(ctx)
 
 	assert.Equal(t, 1, parserCalls)
+}
+
+func TestCreateHandler_GenAIUnmarshalErrorIncludesSchemaDetail(t *testing.T) {
+	handlerStore := &mockHandlerStore{}
+
+	route := RouteConfig{
+		Type:   RouteConfigTypeGenAI,
+		Path:   "/v1beta/models/{model:*}",
+		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ResponsesRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &gemini.GeminiGenerationRequest{}
+		},
+		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
+			return nil, errors.New("unmarshal error should stop before conversion")
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return gemini.ToGeminiError(err)
+		},
+	}
+
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetBodyString(`{"contents":{"role":"user","parts":[{"text":"hi"}]}}`)
+	ctx.SetUserValue(schemas.BifrostContextKeyHTTPRequestType, schemas.ResponsesRequest)
+
+	handler := router.createHandler(route)
+	handler(ctx)
+
+	body := string(ctx.Response.Body())
+	assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
+	assert.Contains(t, body, "Invalid JSON: invalid JSON request body")
+	assert.Contains(t, body, "contents")
 }
 
 // ============================================================================

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -489,7 +489,8 @@ func TestCreateHandler_DefaultJSONParserFailureClosesConnection(t *testing.T) {
 
 	assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
 	assert.True(t, ctx.Response.ConnectionClose())
-	assert.Contains(t, string(ctx.Response.Body()), "invalid JSON request body")
+	assert.Contains(t, string(ctx.Response.Body()), "Invalid JSON: invalid JSON request body")
+	assert.Contains(t, string(ctx.Response.Body()), "invalid char")
 }
 
 func TestCreateHandler_ParseFailureClosesKeepAliveSocket(t *testing.T) {


### PR DESCRIPTION
Fixes #3468.

## Summary
- Preserve the HTTP 400 response for default JSON parse failures.
- Include the parser/unmarshal detail in the integration error message instead of returning only `Invalid JSON`.
- Add GenAI and generic default-parser regression coverage for malformed or schema-incompatible request bodies.

## Tests
- `GOWORK=/tmp/bifrost-go-work.<tmp> go test ./transports/bifrost-http/integrations -run 'TestCreateHandler_(GenAIUnmarshalErrorIncludesSchemaDetail|DefaultJSONParserFailureClosesConnection|CustomParserFailureClosesConnection|SkipsRequestParserInLargePayloadMode|UsesRequestParserWhenNotInLargePayloadMode)' -count=1`\n- `git diff --check`\n\nNote: this is a clean, rebased replacement for #3493, which had picked up unrelated commits during the earlier rebase.