### PR TITLE
fix: use openai/v1 path for Bedrock Mantle responses API

### DIFF
--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -24,6 +24,11 @@ func mantleURL(region, path string) string {
 	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/v1/%s", region, path)
 }
 
+// mantleOpenAIURL builds the Bedrock Mantle OpenAI-prefixed endpoint URL for the given region and API path.
+func mantleOpenAIURL(region, path string) string {
+	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai/v1/%s", region, path)
+}
+
 // mantleSigV4Headers computes SigV4 auth headers for a mantle request by signing a dummy
 // net/http.Request. jsonData must be the exact bytes that will be sent. accept must match
 // the Accept header the actual request will send, since SigV4 signs all request headers.
@@ -163,7 +168,7 @@ func (provider *BedrockProvider) responsesViaMantle(
 	request *schemas.BifrostResponsesRequest,
 ) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleURL(region, "responses")
+	url := mantleOpenAIURL(region, "responses")
 
 	extraHeaders := make(map[string]string, len(provider.networkConfig.ExtraHeaders))
 	maps.Copy(extraHeaders, provider.networkConfig.ExtraHeaders)
@@ -205,7 +210,7 @@ func (provider *BedrockProvider) responsesStreamViaMantle(
 	request *schemas.BifrostResponsesRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleURL(region, "responses")
+	url := mantleOpenAIURL(region, "responses")
 
 	// Bearer: identical to Groq / any OpenAI-compatible provider.
 	if key.Value.GetValue() != "" {


### PR DESCRIPTION
## Summary

When routing requests to Bedrock Mantle for the Responses API, Bifrost was hitting \`/v1/responses\` instead of the correct \`/openai/v1/responses\` endpoint, causing Bedrock to return a 400 error.

## Changes

- Added \`mantleOpenAIURL\` helper in \`core/providers/bedrock/mantle.go\` that builds URLs with the \`/openai/v1/\` prefix
- Updated \`responsesViaMantle\` and \`responsesStreamViaMantle\` to use \`mantleOpenAIURL\` instead of \`mantleURL\`
- \`mantleURL\` (used for chat completions) is unchanged

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Configure Bifrost with Bedrock as provider
2. Send a request using a Mantle model (e.g. \`openai.gpt-5.5\`) to \`/openai/v1/responses\`
3. Request should succeed instead of returning "The model does not support the '/v1/responses' API"

Full integration testing requires AWS Bedrock Mantle credentials.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4407


