### PR TITLE
feat(logging): redact trace content before connector export

### DIFF
--- a/core/schemas/redaction.go
+++ b/core/schemas/redaction.go
@@ -47,6 +47,27 @@ func SetRedactionDataOnContext(ctx *BifrostContext, data RedactionData) bool {
 	return true
 }
 
+// IsContentAttribute reports whether a span attribute may carry user or model content.
+func IsContentAttribute(key string) bool {
+	switch key {
+	case AttrInputMessages, AttrOutputMessages,
+		AttrInputText, AttrInputSpeech,
+		AttrInputEmbedding,
+		AttrPrompt, AttrInstructions,
+		AttrRespReasoningText:
+		return true
+	case AttrTools, AttrRespTools,
+		AttrToolName, AttrToolCallID,
+		AttrToolCallArguments, AttrToolCallResult,
+		AttrToolType,
+		AttrToolChoiceType, AttrToolChoiceName,
+		AttrRespToolChoiceType, AttrRespToolChoiceName:
+		return true
+	default:
+		return false
+	}
+}
+
 // ApplyLiteralReplacements performs deterministic best-effort string redaction.
 func ApplyLiteralReplacements(text string, replacements map[string]string) string {
 	if text == "" || len(replacements) == 0 {
@@ -69,4 +90,43 @@ func ApplyLiteralReplacements(text string, replacements map[string]string) strin
 		redacted = strings.ReplaceAll(redacted, raw, replacements[raw])
 	}
 	return redacted
+}
+
+// RedactAttributeValue applies literal replacements to supported attribute value shapes.
+func RedactAttributeValue(value any, replacements map[string]string) any {
+	if len(replacements) == 0 {
+		return value
+	}
+	switch v := value.(type) {
+	case string:
+		return ApplyLiteralReplacements(v, replacements)
+	case []string:
+		redacted := make([]string, len(v))
+		for i, item := range v {
+			redacted[i] = ApplyLiteralReplacements(item, replacements)
+		}
+		return redacted
+	case []any:
+		redacted := make([]any, len(v))
+		for i, item := range v {
+			redacted[i] = RedactAttributeValue(item, replacements)
+		}
+		return redacted
+	case map[string]any:
+		redacted := make(map[string]any, len(v))
+		for key, item := range v {
+			redactedKey := ApplyLiteralReplacements(key, replacements)
+			redacted[redactedKey] = RedactAttributeValue(item, replacements)
+		}
+		return redacted
+	case map[string]string:
+		redacted := make(map[string]string, len(v))
+		for key, item := range v {
+			redactedKey := ApplyLiteralReplacements(key, replacements)
+			redacted[redactedKey] = ApplyLiteralReplacements(item, replacements)
+		}
+		return redacted
+	default:
+		return value
+	}
 }

--- a/core/schemas/redaction_test.go
+++ b/core/schemas/redaction_test.go
@@ -2,8 +2,10 @@ package schemas
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,4 +60,116 @@ func TestApplyLiteralReplacementsLongestFirst(t *testing.T) {
 	got := ApplyLiteralReplacements("email alex@example.com uses example.com", replacements)
 
 	assert.Equal(t, "email [EMAIL-1] uses [DOMAIN]", got)
+}
+
+// TestIsContentAttribute verifies only prompt, response, and tool payload fields are treated as content.
+func TestIsContentAttribute(t *testing.T) {
+	assert.True(t, IsContentAttribute(AttrInputMessages))
+	assert.True(t, IsContentAttribute(AttrOutputMessages))
+	assert.True(t, IsContentAttribute(AttrToolCallArguments))
+	assert.True(t, IsContentAttribute(AttrInputEmbedding))
+	assert.True(t, IsContentAttribute(AttrPrompt))
+	assert.True(t, IsContentAttribute(AttrInstructions))
+	assert.True(t, IsContentAttribute(AttrRespReasoningText))
+
+	assert.False(t, IsContentAttribute(AttrRequestModel))
+	assert.False(t, IsContentAttribute(AttrProviderName))
+	assert.False(t, IsContentAttribute(TraceAttrSessionID))
+}
+
+// TestTraceApplyRedactionReplacementsRedactsContentAttributes verifies trace redaction touches all spans.
+func TestTraceApplyRedactionReplacementsRedactsContentAttributes(t *testing.T) {
+	trace := &Trace{}
+	root := &Span{}
+	child := &Span{}
+	trace.RootSpan = root
+	trace.Spans = []*Span{root, child}
+
+	root.SetAttribute(AttrInputMessages, `{"content":"email alex@example.com"}`)
+	root.SetAttribute(AttrRequestModel, "alex@example.com")
+	child.SetAttribute(AttrOutputMessages, []string{"reply to alex@example.com"})
+	child.SetAttribute(AttrToolCallArguments, map[string]any{
+		"customer": map[string]any{
+			"email": "alex@example.com",
+			"tags":  []any{"safe", "alex@example.com"},
+		},
+		"metadata": map[string]string{
+			"owner": "alex@example.com",
+		},
+		"literal_key_alex@example.com": "key should redact too",
+		"count":                        42,
+	})
+	child.AddEvent(SpanEvent{
+		Name: "llm.message",
+		Attributes: map[string]any{
+			AttrInputMessages: `{"content":"event alex@example.com"}`,
+			AttrRequestModel:  "alex@example.com",
+		},
+	})
+
+	trace.SetRedactionReplacements(map[string]string{"alex@example.com": "[EMAIL-1]"})
+	trace.ApplyRedactionReplacements()
+
+	assert.Equal(t, `{"content":"email [EMAIL-1]"}`, root.Attributes[AttrInputMessages])
+	assert.Equal(t, "alex@example.com", root.Attributes[AttrRequestModel])
+	assert.Equal(t, []string{"reply to [EMAIL-1]"}, child.Attributes[AttrOutputMessages])
+	assert.Equal(t, map[string]any{
+		"customer": map[string]any{
+			"email": "[EMAIL-1]",
+			"tags":  []any{"safe", "[EMAIL-1]"},
+		},
+		"metadata": map[string]string{
+			"owner": "[EMAIL-1]",
+		},
+		"literal_key_[EMAIL-1]": "key should redact too",
+		"count":                 42,
+	}, child.Attributes[AttrToolCallArguments])
+	require.Len(t, child.Events, 1)
+	assert.Equal(t, `{"content":"event [EMAIL-1]"}`, child.Events[0].Attributes[AttrInputMessages])
+	assert.Equal(t, "alex@example.com", child.Events[0].Attributes[AttrRequestModel])
+	assert.Nil(t, trace.redactionReplacements)
+}
+
+// TestTraceSetRedactionReplacementsMergesCalls verifies input/output replacement windows accumulate.
+func TestTraceSetRedactionReplacementsMergesCalls(t *testing.T) {
+	trace := &Trace{}
+	root := &Span{}
+	child := &Span{}
+	trace.RootSpan = root
+	trace.Spans = []*Span{root, child}
+
+	root.SetAttribute(AttrInputMessages, `{"content":"email input@example.com"}`)
+	child.SetAttribute(AttrOutputMessages, `{"content":"reply output@example.com"}`)
+
+	trace.SetRedactionReplacements(map[string]string{"input@example.com": "[EMAIL-1]"})
+	trace.SetRedactionReplacements(map[string]string{"output@example.com": "[EMAIL-2]"})
+	trace.ApplyRedactionReplacements()
+
+	assert.Equal(t, `{"content":"email [EMAIL-1]"}`, root.Attributes[AttrInputMessages])
+	assert.Equal(t, `{"content":"reply [EMAIL-2]"}`, child.Attributes[AttrOutputMessages])
+	assert.Nil(t, trace.redactionReplacements)
+}
+
+// TestTraceRedactionReplacementsDoNotSerialize verifies connector-facing replacements stay internal.
+func TestTraceRedactionReplacementsDoNotSerialize(t *testing.T) {
+	trace := &Trace{TraceID: "trace-1"}
+	trace.SetRedactionReplacements(map[string]string{"alex@example.com": "[EMAIL-1]"})
+
+	serialized, err := sonic.MarshalString(trace)
+	require.NoError(t, err)
+
+	assert.NotContains(t, serialized, "alex@example.com")
+	assert.NotContains(t, serialized, "[EMAIL-1]")
+	assert.False(t, strings.Contains(serialized, "redactionReplacements"))
+	assert.False(t, strings.Contains(serialized, "RedactionReplacements"))
+}
+
+// TestTraceResetClearsRedactionReplacements verifies pooled traces cannot retain request redaction data.
+func TestTraceResetClearsRedactionReplacements(t *testing.T) {
+	trace := &Trace{}
+	trace.SetRedactionReplacements(map[string]string{"alex@example.com": "[EMAIL-1]"})
+
+	trace.Reset()
+
+	assert.Nil(t, trace.redactionReplacements)
 }

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -9,17 +9,18 @@ import (
 
 // Trace represents a distributed trace that captures the full lifecycle of a request
 type Trace struct {
-	RequestID      string            // Request ID for the trace
-	TraceID        string            // Unique identifier for this trace
-	ParentID       string            // Parent trace ID from incoming W3C traceparent header
-	RootSpan       *Span             // The root span of this trace
-	Spans          []*Span           // All spans in this trace
-	StartTime      time.Time         // When the trace started
-	EndTime        time.Time         // When the trace completed
-	Attributes     map[string]any    // Additional attributes for the trace
-	RequestHeaders map[string]string // Lowercased request headers, populated only when a connector opts in
-	PluginLogs     []PluginLogEntry  // Plugin log entries accumulated during request processing
-	mu             sync.Mutex        // Mutex for thread-safe span operations
+	RequestID             string            // Request ID for the trace
+	TraceID               string            // Unique identifier for this trace
+	ParentID              string            // Parent trace ID from incoming W3C traceparent header
+	RootSpan              *Span             // The root span of this trace
+	Spans                 []*Span           // All spans in this trace
+	StartTime             time.Time         // When the trace started
+	EndTime               time.Time         // When the trace completed
+	Attributes            map[string]any    // Additional attributes for the trace
+	RequestHeaders        map[string]string // Lowercased request headers, populated only when a connector opts in
+	PluginLogs            []PluginLogEntry  // Plugin log entries accumulated during request processing
+	redactionReplacements map[string]string // Raw-to-placeholder replacements; unexported so connectors never serialize the map
+	mu                    sync.Mutex        // Mutex for thread-safe span operations
 }
 
 // Trace-level attribute keys. Unlike span attributes, trace attributes are never
@@ -74,6 +75,56 @@ func (t *Trace) SetRequestHeaders(headers map[string]string) {
 	t.RequestHeaders = headers
 }
 
+// SetRedactionReplacements merges connector-facing raw-to-placeholder replacements on the trace.
+func (t *Trace) SetRedactionReplacements(replacements map[string]string) {
+	if len(replacements) == 0 {
+		return
+	}
+	copied := make(map[string]string, len(replacements))
+	for raw, placeholder := range replacements {
+		if raw != "" {
+			copied[raw] = placeholder
+		}
+	}
+	if len(copied) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.redactionReplacements == nil {
+		t.redactionReplacements = make(map[string]string, len(copied))
+	}
+	for raw, placeholder := range copied {
+		t.redactionReplacements[raw] = placeholder
+	}
+}
+
+// ApplyRedactionReplacements redacts content attributes on every span in the trace and clears the replacement map.
+func (t *Trace) ApplyRedactionReplacements() {
+	t.mu.Lock()
+	if len(t.redactionReplacements) == 0 {
+		t.mu.Unlock()
+		return
+	}
+	replacements := make(map[string]string, len(t.redactionReplacements))
+	for raw, placeholder := range t.redactionReplacements {
+		replacements[raw] = placeholder
+		delete(t.redactionReplacements, raw)
+	}
+	t.redactionReplacements = nil
+	rootSpan := t.RootSpan
+	spans := append([]*Span(nil), t.Spans...)
+	t.mu.Unlock()
+
+	redactSpanAttributes(rootSpan, replacements)
+	for _, span := range spans {
+		if span == nil || span == rootSpan {
+			continue
+		}
+		redactSpanAttributes(span, replacements)
+	}
+}
+
 // SetAttribute sets a trace-level attribute in a thread-safe manner
 func (t *Trace) SetAttribute(key string, value any) {
 	if value == nil {
@@ -112,6 +163,10 @@ func (t *Trace) Reset() {
 	t.EndTime = time.Time{}
 	t.Attributes = nil
 	t.RequestHeaders = nil
+	for raw := range t.redactionReplacements {
+		delete(t.redactionReplacements, raw)
+	}
+	t.redactionReplacements = nil
 	for i := range t.PluginLogs {
 		t.PluginLogs[i] = PluginLogEntry{}
 	}
@@ -126,6 +181,27 @@ func (t *Trace) AppendPluginLogs(logs []PluginLogEntry) {
 	t.mu.Lock()
 	t.PluginLogs = append(t.PluginLogs, logs...)
 	t.mu.Unlock()
+}
+
+// redactSpanAttributes applies trace redaction replacements to one span's content attributes.
+func redactSpanAttributes(span *Span, replacements map[string]string) {
+	if span == nil || len(replacements) == 0 {
+		return
+	}
+	span.mu.Lock()
+	defer span.mu.Unlock()
+	for key, value := range span.Attributes {
+		if IsContentAttribute(key) {
+			span.Attributes[key] = RedactAttributeValue(value, replacements)
+		}
+	}
+	for i := range span.Events {
+		for key, value := range span.Events[i].Attributes {
+			if IsContentAttribute(key) {
+				span.Events[i].Attributes[key] = RedactAttributeValue(value, replacements)
+			}
+		}
+	}
 }
 
 // Span represents a single operation within a trace

--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -173,6 +173,9 @@ type Tracer interface {
 	// Thread-safe. Should be called after plugin hooks complete, before trace completion.
 	AttachPluginLogs(traceID string, logs []PluginLogEntry)
 
+	// SetTraceRedactionReplacements stores connector-facing raw-to-placeholder replacements on a trace.
+	SetTraceRedactionReplacements(traceID string, replacements map[string]string)
+
 	// CompleteAndFlushTrace ends a trace, exports it to observability plugins, and
 	// releases the trace resources. Used by transports that bypass normal HTTP trace completion.
 	CompleteAndFlushTrace(traceID string)
@@ -289,6 +292,9 @@ func (n *NoOpTracer) GateSend(_ string, chunk *BifrostStreamChunk, _ bool, _ boo
 
 // AttachPluginLogs does nothing.
 func (n *NoOpTracer) AttachPluginLogs(_ string, _ []PluginLogEntry) {}
+
+// SetTraceRedactionReplacements does nothing.
+func (n *NoOpTracer) SetTraceRedactionReplacements(_ string, _ map[string]string) {}
 
 // CompleteAndFlushTrace does nothing.
 func (n *NoOpTracer) CompleteAndFlushTrace(_ string) {}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -18,13 +18,13 @@ import (
 // framework's TraceStore implementation.
 // It also embeds a streaming.Accumulator for centralized streaming chunk accumulation.
 type Tracer struct {
-	store              *TraceStore
-	accumulator        *streaming.Accumulator
-	pricingManager     *modelcatalog.ModelCatalog
-	logger             schemas.Logger
-	obsPlugins         atomic.Pointer[[]schemas.ObservabilityPlugin]
-	cachedHdrPatterns  atomic.Pointer[[]string]
-	flushWG            sync.WaitGroup
+	store             *TraceStore
+	accumulator       *streaming.Accumulator
+	pricingManager    *modelcatalog.ModelCatalog
+	logger            schemas.Logger
+	obsPlugins        atomic.Pointer[[]schemas.ObservabilityPlugin]
+	cachedHdrPatterns atomic.Pointer[[]string]
+	flushWG           sync.WaitGroup
 }
 
 // NewTracer creates a new Tracer wrapping the given TraceStore.
@@ -108,6 +108,18 @@ func (t *Tracer) SetTraceRequestHeaders(traceID string, headers map[string]strin
 // directly off the completed trace.
 func (t *Tracer) SetTraceAttribute(traceID string, key string, value any) {
 	t.store.SetTraceAttribute(traceID, key, value)
+}
+
+// SetTraceRedactionReplacements stores connector-facing raw-to-placeholder replacements on a trace.
+func (t *Tracer) SetTraceRedactionReplacements(traceID string, replacements map[string]string) {
+	if t == nil || t.store == nil || strings.TrimSpace(traceID) == "" || len(replacements) == 0 {
+		return
+	}
+	trace := t.store.GetTrace(strings.TrimSpace(traceID))
+	if trace == nil {
+		return
+	}
+	trace.SetRedactionReplacements(replacements)
 }
 
 // CreateTrace creates a new trace with optional parent ID and returns the trace ID.
@@ -678,6 +690,8 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		// otherwise an unrecovered panic in this detached goroutine leaks the
 		// trace object and takes down the whole process.
 		defer t.ReleaseTrace(completedTrace)
+
+		completedTrace.ApplyRedactionReplacements()
 
 		var obsPlugins []schemas.ObservabilityPlugin
 		if loaded := t.obsPlugins.Load(); loaded != nil {

--- a/framework/tracing/tracer_test.go
+++ b/framework/tracing/tracer_test.go
@@ -2,14 +2,17 @@ package tracing
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
 type testRealtimeObservabilityPlugin struct {
-	injected chan *schemas.Trace
+	injected        chan *schemas.Trace
+	injectedPayload chan string
 }
 
 func (p *testRealtimeObservabilityPlugin) GetName() string { return "test-observability" }
@@ -24,6 +27,14 @@ func (p *testRealtimeObservabilityPlugin) PostLLMHook(_ *schemas.BifrostContext,
 	return resp, bifrostErr, nil
 }
 func (p *testRealtimeObservabilityPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
+	if p.injectedPayload != nil {
+		serialized, err := sonic.MarshalString(trace)
+		if err != nil {
+			return err
+		}
+		p.injectedPayload <- serialized
+		return nil
+	}
 	if trace == nil {
 		p.injected <- nil
 		return nil
@@ -59,6 +70,85 @@ func TestTracer_CompleteAndFlushTraceInjectsObservabilityPlugins(t *testing.T) {
 
 	if got := tracer.store.GetTrace(traceID); got != nil {
 		t.Fatalf("trace %q was not released after flush", traceID)
+	}
+}
+
+func TestTracer_CompleteAndFlushTraceRedactsContentBeforeInject(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	traceID := tracer.CreateTrace("")
+	plugin := &testRealtimeObservabilityPlugin{
+		injectedPayload: make(chan string, 1),
+	}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{plugin})
+
+	// Store replacements before output attributes are populated. This mirrors
+	// streaming, where the final accumulated output lands near trace completion.
+	tracer.SetTraceRedactionReplacements(traceID, map[string]string{
+		"alex@example.com": "[EMAIL-1]",
+	})
+
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	rootCtx, rootHandle := tracer.StartSpan(ctx, "http-request", schemas.SpanKindHTTPRequest)
+	tracer.SetAttribute(rootHandle, schemas.AttrInputMessages, `{"content":"email alex@example.com"}`)
+	_, childHandle := tracer.StartSpan(rootCtx, "llm-call", schemas.SpanKindLLMCall)
+	tracer.SetAttribute(childHandle, schemas.AttrOutputMessages, `{"content":"reply alex@example.com"}`)
+	tracer.SetAttribute(childHandle, schemas.AttrRequestModel, "gpt-4o-mini")
+
+	tracer.CompleteAndFlushTrace(traceID)
+
+	select {
+	case payload := <-plugin.injectedPayload:
+		if strings.Contains(payload, "alex@example.com") {
+			t.Fatalf("injected trace leaked raw content: %s", payload)
+		}
+		if !strings.Contains(payload, "[EMAIL-1]") {
+			t.Fatalf("injected trace missing redacted placeholder: %s", payload)
+		}
+		if !strings.Contains(payload, "gpt-4o-mini") {
+			t.Fatalf("injected trace should retain non-content attributes: %s", payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for observability inject")
+	}
+}
+
+func TestTracer_SetTraceRedactionReplacementsSurvivesLaterObservabilityPlugins(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	traceID := tracer.CreateTrace("")
+	tracer.SetTraceRedactionReplacements(traceID, map[string]string{
+		"alex@example.com": "[EMAIL-1]",
+	})
+
+	plugin := &testRealtimeObservabilityPlugin{
+		injectedPayload: make(chan string, 1),
+	}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{plugin})
+
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+	_, rootHandle := tracer.StartSpan(ctx, "http-request", schemas.SpanKindHTTPRequest)
+	tracer.SetAttribute(rootHandle, schemas.AttrInputMessages, `{"content":"email alex@example.com"}`)
+	tracer.CompleteAndFlushTrace(traceID)
+
+	select {
+	case payload := <-plugin.injectedPayload:
+		if strings.Contains(payload, "alex@example.com") {
+			t.Fatalf("trace redaction replacements should survive later observability plugin registration: %s", payload)
+		}
+		if !strings.Contains(payload, "[EMAIL-1]") {
+			t.Fatalf("injected trace missing redacted placeholder: %s", payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for observability inject")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds trace-level redaction of span content attributes before traces are exported to observability plugins. Connectors can register raw-to-placeholder replacement maps on a trace; when the trace completes, all content-bearing span attributes (messages, prompts, tool arguments, etc.) are rewritten in-place before any plugin receives the trace. The replacement map is stored in an unexported field so it is never serialized or leaked to connectors.

## Changes

- Added `IsContentAttribute(key string) bool` to classify which span attribute keys may carry user or model content (messages, prompts, embeddings, tool arguments, reasoning text, etc.).
- Added `RedactAttributeValue(value any, replacements map[string]string) any` to apply literal replacements across `string`, `[]string`, and `[]any` attribute shapes.
- Added `redactionReplacements` as an unexported field on `Trace` so the map is never JSON-serialized and cannot be observed by connectors.
- Added `Trace.SetRedactionReplacements` to store a defensive copy of the replacement map, stripping empty keys.
- Added `Trace.ApplyRedactionReplacements` to walk every span, redact content attributes, and clear the map atomically.
- Added `Trace.Reset` cleanup to ensure pooled traces cannot carry redaction data across requests.
- Added `redactSpanAttributes` as a package-private helper that locks a single span and rewrites its content attributes.
- Added `SetTraceRedactionReplacements` to the `Tracer` interface and its `NoOpTracer` implementation.
- Wired `ApplyRedactionReplacements` into `Tracer.CompleteAndFlushTrace` so redaction runs before any observability plugin `Inject` call.
- Added `Tracer.SetTraceRedactionReplacements` in the framework tracing layer to look up the live trace and delegate to `Trace.SetRedactionReplacements`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/tracing/...
```

Key scenarios covered by new tests:

- `TestIsContentAttribute` — verifies the content attribute classifier includes message, prompt, embedding, and tool fields while excluding metadata fields like model name and session ID.
- `TestTraceApplyRedactionReplacementsRedactsContentAttributes` — verifies replacements are applied to all spans and that non-content attributes are left untouched.
- `TestTraceRedactionReplacementsDoNotSerialize` — verifies the replacement map never appears in JSON output.
- `TestTraceResetClearsRedactionReplacements` — verifies pooled traces cannot retain replacement data.
- `TestTracer_CompleteAndFlushTraceRedactsContentBeforeInject` — end-to-end: replacements set before span population are applied before the observability plugin receives the trace.
- `TestTracer_SetTraceRedactionReplacementsSurvivesLaterObservabilityPlugins` — replacements set before plugin registration still take effect at flush time.

## Breaking changes

- [x] Yes
- [ ] No

The `Tracer` interface gains a new method `SetTraceRedactionReplacements`. Any external implementation of `Tracer` must add this method. The `NoOpTracer` implementation is provided as a reference no-op.

## Security considerations

The replacement map is stored in an unexported struct field (`redactionReplacements`) and is explicitly cleared after `ApplyRedactionReplacements` runs and during `Reset`. This prevents PII or secret values used as redaction keys from being serialized into trace payloads, retained across pooled trace reuse, or observed by observability plugin authors inspecting the exported `Trace` struct.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable