### PR TITLE
feat: add timezone selector to date range picker with localStorage persistence

### DIFF
--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { LogsFilterSidebar } from "@/components/filters/logsFilterSidebar";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { ScrollArea } from "@/components/ui/scrollArea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
 import { useGetMCPAvailableFilterDataQuery } from "@/lib/store";
 import type { LogFilters, MCPToolLogFilters } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
@@ -28,6 +29,8 @@ export default function DashboardPage() {
 	const { data: mcpFilterData } = useGetMCPAvailableFilterDataQuery();
 
 	const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
+
+	const [timezone, setTimezone] = useTimezonePreference();
 
 	const { search } = useLocation();
 	const hasExplicitTimeRange = (search as Record<string, unknown>)?.start_time && (search as Record<string, unknown>)?.end_time;
@@ -113,9 +116,9 @@ export default function DashboardPage() {
 			...(urlState.period
 				? { period: urlState.period }
 				: {
-					start_time: dateUtils.toISOString(urlState.start_time),
-					end_time: dateUtils.toISOString(urlState.end_time),
-				}),
+						start_time: dateUtils.toISOString(urlState.start_time),
+						end_time: dateUtils.toISOString(urlState.end_time),
+					}),
 			...(selectedProviders.length > 0 && { providers: selectedProviders }),
 			...(selectedModels.length > 0 && { models: selectedModels }),
 			...(selectedKeyIds.length > 0 && { selected_key_ids: selectedKeyIds }),
@@ -134,8 +137,8 @@ export default function DashboardPage() {
 			...(missingCostOnly && { missing_cost_only: true }),
 			...(metadataFilters &&
 				Object.keys(metadataFilters).length > 0 && {
-				metadata_filters: metadataFilters,
-			}),
+					metadata_filters: metadataFilters,
+				}),
 			...(urlState.parent_request_id && { parent_request_id: urlState.parent_request_id }),
 			...(selectedUserIds.length > 0 && { user_ids: selectedUserIds }),
 			...(selectedTeamIds.length > 0 && { team_ids: selectedTeamIds }),
@@ -172,9 +175,9 @@ export default function DashboardPage() {
 			...(urlState.period
 				? { period: urlState.period }
 				: {
-					start_time: dateUtils.toISOString(urlState.start_time),
-					end_time: dateUtils.toISOString(urlState.end_time),
-				}),
+						start_time: dateUtils.toISOString(urlState.start_time),
+						end_time: dateUtils.toISOString(urlState.end_time),
+					}),
 			...(selectedMcpToolNames.length > 0 && {
 				tool_names: selectedMcpToolNames,
 			}),
@@ -207,7 +210,16 @@ export default function DashboardPage() {
 	const buRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
 	const userRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
 
-	const allRefs = [overviewRef, providerRef, mcpRef, modelRankingsRef, teamRankingsRef, customerRankingsRef, buRankingsRef, userRankingsRef];
+	const allRefs = [
+		overviewRef,
+		providerRef,
+		mcpRef,
+		modelRankingsRef,
+		teamRankingsRef,
+		customerRankingsRef,
+		buRankingsRef,
+		userRankingsRef,
+	];
 
 	const getDashboardData = useCallback((): DashboardData => {
 		const merged: Partial<DashboardData> = {};
@@ -471,6 +483,9 @@ export default function DashboardPage() {
 							onPredefinedPeriodChange={handlePeriodChange}
 							triggerTestId="dashboard-filter-daterange"
 							popupAlignment="end"
+							showTimezone
+							timezone={timezone}
+							onTimezoneChange={setTimezone}
 						/>
 					</div>
 				</div>

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -4,6 +4,7 @@ import { Command, CommandItem, CommandList } from "@/components/ui/command";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
 import { getErrorMessage, useRecalculateLogCostsMutation } from "@/lib/store";
 import type { LogFilters as LogFiltersType } from "@/lib/types/logs";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
@@ -50,6 +51,8 @@ export function LogsHeaderView({
 	const searchTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 	const filtersRef = useRef<LogFiltersType>(filters);
 	const [recalculateCosts] = useRecalculateLogCostsMutation();
+
+	const [timezone, setTimezone] = useTimezonePreference();
 
 	const [startTime, setStartTime] = useState<Date | undefined>(filters.start_time ? new Date(filters.start_time) : undefined);
 	const [endTime, setEndTime] = useState<Date | undefined>(filters.end_time ? new Date(filters.end_time) : undefined);
@@ -141,6 +144,9 @@ export function LogsHeaderView({
 				triggerTestId="filter-date-range"
 				dateTime={{ from: startTime, to: endTime }}
 				predefinedPeriod={period || undefined}
+				showTimezone
+				timezone={timezone}
+				onTimezoneChange={setTimezone}
 				onDateTimeUpdate={(p) => {
 					setStartTime(p.from);
 					setEndTime(p.to);

--- a/ui/app/workspace/mcp-logs/views/mcpHeaderView.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpHeaderView.tsx
@@ -2,6 +2,7 @@ import { ColumnConfigDropdown, type ColumnConfigEntry } from "@/components/table
 import { Button } from "@/components/ui/button";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { Input } from "@/components/ui/input";
+import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
 import type { MCPToolLogFilters } from "@/lib/types/logs";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
 import { Radio, RefreshCw, Search } from "lucide-react";
@@ -38,6 +39,7 @@ export function McpHeaderView({
 	onResetColumns,
 }: McpHeaderViewProps) {
 	const [localSearch, setLocalSearch] = useState(filters.content_search || "");
+	const [timezone, setTimezone] = useTimezonePreference();
 	const [startTime, setStartTime] = useState<Date | undefined>(filters.start_time ? new Date(filters.start_time) : undefined);
 	const [endTime, setEndTime] = useState<Date | undefined>(filters.end_time ? new Date(filters.end_time) : undefined);
 	const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -106,6 +108,9 @@ export function McpHeaderView({
 			<DateTimePickerWithRange
 				dateTime={{ from: startTime, to: endTime }}
 				predefinedPeriod={period || undefined}
+				showTimezone
+				timezone={timezone}
+				onTimezoneChange={setTimezone}
 				onDateTimeUpdate={(p) => {
 					setStartTime(p.from);
 					setEndTime(p.to);

--- a/ui/components/ui/datePickerWithRange.tsx
+++ b/ui/components/ui/datePickerWithRange.tsx
@@ -1,10 +1,13 @@
 import { cn } from "@/lib/utils";
+import { getSupportedTimezones } from "@/lib/timezones";
+import { TZDate, tz, tzName } from "@date-fns/tz";
 import { format } from "date-fns";
-import { Calendar as CalendarIcon } from "lucide-react";
+import { Calendar as CalendarIcon, Globe } from "lucide-react";
 import React, { useEffect, useMemo } from "react";
 import { DateRange } from "react-day-picker";
 import { Button } from "./button";
 import { Calendar } from "./calendar";
+import { ComboboxSelect } from "./combobox";
 import { Label } from "./label";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import { TimePicker, TimeValue } from "./timePicker";
@@ -13,6 +16,23 @@ export type TimeRange = {
 	from: TimeValue;
 	to: TimeValue;
 };
+
+/**
+ * Builds the searchable timezone option list. Each label pairs the IANA id
+ * with its short abbreviation in the given zone (e.g. "America/New_York (EST)").
+ */
+function buildTimezoneOptions(referenceDate: Date): { label: string; value: string }[] {
+	const zones = getSupportedTimezones();
+	return zones.map((zone) => {
+		let abbr = "";
+		try {
+			abbr = tzName(zone, referenceDate, "short");
+		} catch {
+			// Some runtimes may not resolve an abbreviation; fall back to id only.
+		}
+		return { value: zone, label: abbr ? `${zone} (${abbr})` : zone };
+	});
+}
 
 interface DatePickerWithRangeProps extends React.HTMLAttributes<HTMLDivElement> {
 	buttonClassName?: string;
@@ -39,17 +59,39 @@ interface DateTimePickerWithRangeProps extends DatePickerWithRangeProps {
 	onOpenChange?: (open: boolean) => void;
 	/** Optional data-testid for the trigger button (e.g. for E2E tests) */
 	triggerTestId?: string;
+	/** Enables the timezone display + selection UI. When false/undefined, dates are handled in browser-local time (unchanged). */
+	showTimezone?: boolean;
+	/** Controlled active IANA timezone (e.g. "America/New_York"). Only used when showTimezone is true. */
+	timezone?: string;
+	/** Fired when the user picks a new timezone from the dropdown. */
+	onTimezoneChange?: (timezone: string) => void;
 }
 
 export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 	const { className, buttonClassName, triggerLabel, onTrigger, dateTime } = props;
+	const activeTimezone = props.showTimezone ? props.timezone : undefined;
+
+	/** Extract wall-clock hours/minutes from a Date, interpreting in the active timezone when set. */
+	const extractTime = (d: Date | undefined, fallback: TimeValue): TimeValue => {
+		if (!d) return fallback;
+		if (activeTimezone) {
+			// Read wall-clock in the target zone
+			const zoned = new TZDate(d.getTime(), activeTimezone);
+			return { hour: zoned.getHours(), minute: zoned.getMinutes() };
+		}
+		return { hour: d.getHours(), minute: d.getMinutes() };
+	};
+
 	const [date, setDate] = React.useState<DateRange | undefined>(dateTime);
 	const [timeValue, setTimeValue] = React.useState<TimeRange>({
-		from: dateTime?.from ? { hour: dateTime.from.getHours(), minute: dateTime.from.getMinutes() } : { hour: 0, minute: 0 },
-		to: dateTime?.to ? { hour: dateTime.to.getHours(), minute: dateTime.to.getMinutes() } : { hour: 23, minute: 59 },
+		from: extractTime(dateTime?.from, { hour: 0, minute: 0 }),
+		to: extractTime(dateTime?.to, { hour: 23, minute: 59 }),
 	});
 	const [isOpen, setIsOpen] = React.useState<boolean>(false);
 	const [predefinedPeriod, setPredefinedPeriod] = React.useState<string | undefined>(props.predefinedPeriod);
+
+	const timezoneOptions = useMemo(() => (props.showTimezone ? buildTimezoneOptions(new Date()) : []), [props.showTimezone, activeTimezone]);
+
 	const disabledDateRange = useMemo(() => {
 		if (!props.disabledBefore && !props.disabledAfter) return undefined;
 		let range: any = {};
@@ -71,32 +113,50 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 		return `${hour}:${minute} ${period}`;
 	};
 
+	/**
+	 * Combine a calendar date and a wall-clock time into an absolute Date.
+	 * When `activeTimezone` is set, the wall-clock is interpreted in that zone
+	 * (via TZDate) so the returned epoch reflects the correct absolute instant.
+	 */
 	const getDateTime = (date: Date | undefined, time: TimeValue | undefined | null): Date | undefined => {
 		if (!date || !time) return undefined;
 
-		// Create a date object from the selected calendar date (which is at midnight local time)
-		const localDate = new Date(date);
+		if (activeTimezone) {
+			// Interpret wall-clock in the target timezone → correct absolute instant.
+			const zoned = new TZDate(date.getTime(), activeTimezone);
+			return new TZDate(zoned.getFullYear(), zoned.getMonth(), zoned.getDate(), time.hour, time.minute, 0, 0, activeTimezone);
+		}
 
-		// Manually set the time in the local timezone. This is more robust than using `new Date(y,m,d,h,m)`.
-		localDate.setHours(time.hour, time.minute, 0, 0);
-
-		// new Date(year, month, day, hour, minute) can be problematic.
-		// A more robust way is to get the epoch time for the date at midnight,
-		// then add the hours and minutes in milliseconds.
+		// Local-time path (unchanged legacy behavior).
 		const dateAtMidnight = new Date(date.getFullYear(), date.getMonth(), date.getDate());
 		const epochTime = dateAtMidnight.getTime() + time.hour * 60 * 60 * 1000 + time.minute * 60 * 1000;
-
-		// Create a new Date object from the calculated epoch time.
 		return new Date(epochTime);
 	};
+
+	/** Format a date for the trigger button, respecting the active timezone. */
+	const formatDate = (d: Date, fmt: string): string => {
+		if (activeTimezone) return format(d, fmt, { in: tz(activeTimezone) });
+		return format(d, fmt);
+	};
+
+	/** Short timezone abbreviation for the trigger button label. */
+	const tzAbbreviation = useMemo(() => {
+		if (!activeTimezone) return "";
+		try {
+			return tzName(activeTimezone, new Date(), "short");
+		} catch {
+			return "";
+		}
+	}, [activeTimezone]);
 
 	useEffect(() => {
 		setDate(dateTime);
 		setTimeValue({
-			from: dateTime?.from ? { hour: dateTime.from.getHours(), minute: dateTime.from.getMinutes() } : { hour: 0, minute: 0 },
-			to: dateTime?.to ? { hour: dateTime.to.getHours(), minute: dateTime.to.getMinutes() } : { hour: 23, minute: 59 },
+			from: extractTime(dateTime?.from, { hour: 0, minute: 0 }),
+			to: extractTime(dateTime?.to, { hour: 23, minute: 59 }),
 		});
-	}, [dateTime]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [dateTime, activeTimezone]);
 
 	useEffect(() => {
 		setPredefinedPeriod(props.predefinedPeriod);
@@ -125,17 +185,20 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 					>
 						<CalendarIcon className="h-4 w-4" strokeWidth={1.5} />
 						{predefinedPeriod ? (
+							// Relative periods are durations (last hour, last 7 days) and are
+							// timezone-independent, so we intentionally omit the timezone badge here.
 							<span>{props.preDefinedPeriods?.find((p) => p.value === predefinedPeriod)?.label}</span>
 						) : (
 							<>
 								{dateTime?.from ? (
 									dateTime.to ? (
 										<>
-											{format(dateTime.from, "LLL dd, y")} {printTimeValue(timeValue?.from)} - {format(dateTime.to, "LLL dd, y")}{" "}
+											{formatDate(dateTime.from, "LLL dd, y")} {printTimeValue(timeValue?.from)} - {formatDate(dateTime.to, "LLL dd, y")}{" "}
 											{printTimeValue(timeValue?.to)}
+											{props.showTimezone && tzAbbreviation ? ` · ${tzAbbreviation}` : ""}
 										</>
 									) : (
-										format(dateTime.from, "LLL dd, y")
+										formatDate(dateTime.from, "LLL dd, y")
 									)
 								) : (
 									<span>Pick a date</span>
@@ -185,16 +248,14 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 										className=""
 										value={timeValue?.from}
 										onChange={(v) => {
-											if (!date || !date.from) return;
-											if (v) setTimeValue({ from: v, to: timeValue.to });
-											const from = new Date(date.from);
-											if (v) from.setHours(v.hour, v.minute);
-											setDate({ from: from, to: date.to });
-											if (from.toISOString() !== props.dateTime?.from?.toISOString()) {
+											if (!date || !date.from || !v) return;
+											setTimeValue({ from: v, to: timeValue.to });
+											const nextFrom = getDateTime(date.from, v);
+											if (nextFrom?.toISOString() !== props.dateTime?.from?.toISOString()) {
 												// Checking if range is valid
 												props.onDateTimeUpdate &&
 													props.onDateTimeUpdate({
-														from: getDateTime(from, v),
+														from: nextFrom,
 														to: getDateTime(date.to, timeValue?.to),
 													});
 											}
@@ -208,16 +269,14 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 										className=""
 										value={timeValue?.to}
 										onChange={(v) => {
-											if (!date || !date.to) return;
-											if (v) setTimeValue({ ...timeValue, to: v });
-											const to = new Date(date.to);
-											if (v) to.setHours(v.hour, v.minute);
-											setDate({ from: date.from, to: to });
-											if (to.toISOString() !== props.dateTime?.to?.toISOString()) {
+											if (!date || !date.to || !v) return;
+											setTimeValue({ ...timeValue, to: v });
+											const nextTo = getDateTime(date.to, v);
+											if (nextTo?.toISOString() !== props.dateTime?.to?.toISOString()) {
 												props.onDateTimeUpdate &&
 													props.onDateTimeUpdate({
 														from: getDateTime(date.from, timeValue?.from),
-														to: getDateTime(to, v),
+														to: nextTo,
 													});
 											}
 										}}
@@ -245,6 +304,52 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 							</div>
 						)}
 					</div>
+					{props.showTimezone && (
+						<div className="flex items-center gap-2 border-t px-3 py-2">
+							<Globe className="text-muted-foreground size-4 shrink-0" />
+							<Label className="text-muted-foreground shrink-0 text-xs">Timezone</Label>
+							<div className="ml-auto w-[260px]">
+								<ComboboxSelect
+									options={timezoneOptions}
+									value={activeTimezone ?? null}
+									onValueChange={(v) => {
+										if (!v) return;
+										props.onTimezoneChange?.(v);
+										// Wall-clock stays fixed: re-emit the same calendar day + time
+										// interpreted in the newly selected zone so the query shifts.
+										if (date?.from && date?.to) {
+											const fromInActiveTimezone = activeTimezone ? new TZDate(date.from.getTime(), activeTimezone) : date.from;
+											const toInActiveTimezone = activeTimezone ? new TZDate(date.to.getTime(), activeTimezone) : date.to;
+											const from = new TZDate(
+												fromInActiveTimezone.getFullYear(),
+												fromInActiveTimezone.getMonth(),
+												fromInActiveTimezone.getDate(),
+												timeValue.from.hour,
+												timeValue.from.minute,
+												0,
+												0,
+												v,
+											);
+											const to = new TZDate(
+												toInActiveTimezone.getFullYear(),
+												toInActiveTimezone.getMonth(),
+												toInActiveTimezone.getDate(),
+												timeValue.to.hour,
+												timeValue.to.minute,
+												0,
+												0,
+												v,
+											);
+											props.onDateTimeUpdate?.({ from, to });
+										}
+									}}
+									hideClear
+									placeholder="Select timezone"
+									data-testid="datepicker-timezone-select"
+								/>
+							</div>
+						</div>
+					)}
 					{triggerLabel && onTrigger && (
 						<div className="mt-1 mb-2 flex w-full px-3">
 							<Button

--- a/ui/lib/hooks/useTimezonePreference.ts
+++ b/ui/lib/hooks/useTimezonePreference.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { getSupportedTimezones } from "../timezones";
+
+export { getSupportedTimezones };
+
+const STORAGE_KEY = "bifrost.timezone";
+
+/** Returns the browser's local IANA timezone (e.g. "America/New_York"). */
+function getLocalTimezone(): string {
+	return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+/** Validates an IANA timezone string against the supported list. */
+function isValidTimezone(tz: string): boolean {
+	return getSupportedTimezones().includes(tz);
+}
+
+/**
+ * Hook that persists the user's preferred timezone in localStorage.
+ *
+ * Returns a `[timezone, setTimezone]` tuple. Defaults to the browser's
+ * local timezone. Invalid stored values are silently replaced with the default.
+ *
+ * Safe for SSR/Next.js — reads localStorage lazily in an effect to avoid
+ * hydration mismatches.
+ */
+export function useTimezonePreference(): [string, (tz: string) => void] {
+	const [timezone, setTimezoneState] = useState<string>(getLocalTimezone);
+
+	// Hydrate from localStorage after mount (client-only).
+	useEffect(() => {
+		try {
+			const stored = localStorage.getItem(STORAGE_KEY);
+			if (stored && isValidTimezone(stored)) {
+				setTimezoneState(stored);
+			}
+		} catch {
+			// localStorage unavailable (e.g. SSR, privacy mode) — keep default.
+		}
+	}, []);
+
+	const setTimezone = useCallback((tz: string) => {
+		setTimezoneState(tz);
+		try {
+			localStorage.setItem(STORAGE_KEY, tz);
+		} catch {
+			// localStorage unavailable — preference won't persist.
+		}
+	}, []);
+
+	return [timezone, setTimezone];
+}

--- a/ui/lib/timezones.ts
+++ b/ui/lib/timezones.ts
@@ -1,0 +1,30 @@
+export const FALLBACK_TIMEZONES = [
+	"UTC",
+	"America/New_York",
+	"America/Chicago",
+	"America/Denver",
+	"America/Los_Angeles",
+	"America/Anchorage",
+	"Pacific/Honolulu",
+	"Europe/London",
+	"Europe/Paris",
+	"Europe/Berlin",
+	"Asia/Tokyo",
+	"Asia/Shanghai",
+	"Asia/Kolkata",
+	"Asia/Dubai",
+	"Australia/Sydney",
+	"Pacific/Auckland",
+];
+
+/** Returns the full list of IANA timezone identifiers, or a curated fallback. */
+export function getSupportedTimezones(): string[] {
+	try {
+		if (typeof Intl.supportedValuesOf === "function") {
+			return Intl.supportedValuesOf("timeZone");
+		}
+	} catch {
+		// Fallback for older runtimes
+	}
+	return FALLBACK_TIMEZONES;
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,6 +17,7 @@
 	"dependencies": {
 		"@bprogress/core": "1.3.4",
 		"@dagrejs/dagre": "3.0.0",
+		"@date-fns/tz": "1.5.0",
 		"@dnd-kit/react": "0.3.2",
 		"@hookform/resolvers": "5.2.1",
 		"@monaco-editor/react": "4.7.0",


### PR DESCRIPTION
## Summary

Adds timezone-aware date range selection to the Dashboard, Logs, and MCP Logs pages. Users can now pick any IANA timezone from a dropdown within the date picker, and their preference is persisted to `localStorage` so it survives page reloads.

## Changes

- Added a `useTimezonePreference` hook that reads/writes the user's chosen IANA timezone to `localStorage` under the key `bifrost.timezone`, defaulting to the browser's local timezone. Handles SSR safely by hydrating from storage in a `useEffect`.
- Extended `DateTimePickerWithRange` with three new optional props (`showTimezone`, `timezone`, `onTimezoneChange`) that, when enabled, render a timezone selector (using `ComboboxSelect`) at the bottom of the picker popover. The trigger button label also appends the short timezone abbreviation (e.g. `· EST`).
- Date construction and formatting inside `DateTimePickerWithRange` now uses `@date-fns/tz` (`TZDate`, `tz`, `tzName`) to correctly interpret wall-clock times in the selected timezone, producing the right absolute UTC instant for queries.
- Wired `useTimezonePreference` and the new timezone props into the Dashboard, Logs header, and MCP Logs header views.
- Added `@date-fns/tz@1.5.0` as a dependency.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
```

1. Open the Dashboard, Logs, or MCP Logs page.
2. Click the date range picker — a **Timezone** row with a globe icon should appear at the bottom of the popover.
3. Select a timezone different from your local one (e.g. `Asia/Tokyo`).
4. Verify the trigger button label updates to show the timezone abbreviation (e.g. `· JST`).
5. Reload the page and reopen the picker — the previously selected timezone should still be active.
6. Verify that changing the timezone re-emits the date range with the wall-clock times reinterpreted in the new zone.

## Screenshots/Recordings

_Add before/after screenshots of the date picker with and without the timezone selector visible._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Timezone preference is stored in `localStorage` only — no PII or secrets involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable