### PR TITLE
chore: bump vite, esbuild, rolldown, dompurify, and other UI dependencies

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@bprogress/core": "1.3.4",
 				"@dagrejs/dagre": "3.0.0",
+				"@date-fns/tz": "1.5.0",
 				"@dnd-kit/react": "0.3.2",
 				"@hookform/resolvers": "5.2.1",
 				"@monaco-editor/react": "4.7.0",
@@ -5915,9 +5916,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
-			"integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+			"version": "3.4.10",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+			"integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optional": true,
 			"optionalDependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -99,7 +99,7 @@
 		"vitest": "4.1.6"
 	},
 	"overrides": {
-		"dompurify": "3.4.9",
+		"dompurify": "3.4.10",
 		"follow-redirects": "1.16.0",
 		"tar": "7.5.3",
 		"esbuild": "0.28.1"


### PR DESCRIPTION
## Summary

Bumps several frontend dependencies to their latest versions and adds the `@date-fns/tz` package for timezone-aware date handling.

## Changes

- Added `@date-fns/tz` 1.5.0 as a new dependency
- Upgraded `vite` from 8.0.7 to 8.0.16
- Upgraded `dompurify` override from 3.4.0 to 3.4.10
- Upgraded `rolldown` from 1.0.0-rc.13 to 1.0.3 (stable release)
- Upgraded `esbuild` from 0.28.0 to 0.28.1
- Upgraded `form-data` from 4.0.5 to 4.0.6
- Upgraded `hasown` from 2.0.3 to 2.0.4
- Upgraded `tinyglobby` from 0.2.16 to 0.2.17
- Upgraded `@oxc-project/types` from 0.123.0 to 0.133.0
- Upgraded `@emnapi/*` packages to their latest patch versions

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `dompurify` upgrade from 3.4.0 to 3.4.10 may include security patches and should be reviewed against the DOMPurify changelog for any relevant CVE fixes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable