### PR TITLE
feat: add virtual key rankings dimension to dashboard

### DIFF
--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1646,6 +1646,7 @@ const (
 	RankingDimensionCustomer     RankingDimension = "customer"
 	RankingDimensionBusinessUnit RankingDimension = "business_unit"
 	RankingDimensionUser         RankingDimension = "user"
+	RankingDimensionVirtualKey   RankingDimension = "virtual_key"
 )
 
 var ValidRankingDimensions = map[RankingDimension]bool{
@@ -1653,6 +1654,7 @@ var ValidRankingDimensions = map[RankingDimension]bool{
 	RankingDimensionCustomer:     true,
 	RankingDimensionBusinessUnit: true,
 	RankingDimensionUser:         true,
+	RankingDimensionVirtualKey:   true,
 }
 
 type dimensionColumnDef struct {
@@ -1665,6 +1667,7 @@ var dimensionColumns = map[RankingDimension]dimensionColumnDef{
 	RankingDimensionCustomer:     {IDCol: "customer_id", NameCol: "customer_name"},
 	RankingDimensionBusinessUnit: {IDCol: "business_unit_id", NameCol: "business_unit_name"},
 	RankingDimensionUser:         {IDCol: "user_id", NameCol: "user_name"},
+	RankingDimensionVirtualKey:   {IDCol: "virtual_key_id", NameCol: "virtual_key_name"},
 }
 
 func DimensionColumnDef(d RankingDimension) (idCol, nameCol string, ok bool) {

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -209,6 +209,7 @@ export default function DashboardPage() {
 	const customerRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
 	const buRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
 	const userRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
+	const virtualKeyRankingsRef = useRef<DimensionRankingsTabViewHandle>(null);
 
 	const allRefs = [
 		overviewRef,
@@ -219,6 +220,7 @@ export default function DashboardPage() {
 		customerRankingsRef,
 		buRankingsRef,
 		userRankingsRef,
+		virtualKeyRankingsRef,
 	];
 
 	const getDashboardData = useCallback((): DashboardData => {
@@ -240,6 +242,7 @@ export default function DashboardPage() {
 			customerRankingsData: null,
 			buRankingsData: null,
 			userRankingsData: null,
+			virtualKeyRankingsData: null,
 			mcpHistogramData: null,
 			mcpCostData: null,
 			mcpTopToolsData: null,
@@ -401,6 +404,7 @@ export default function DashboardPage() {
 			"dashboard-section-customer-rankings",
 			"dashboard-section-bu-rankings",
 			"dashboard-section-user-rankings",
+			"dashboard-section-virtual-key-rankings",
 		];
 		return ids.map((id) => document.getElementById(id)).filter(Boolean) as HTMLElement[];
 	}, [handlePreloadData]);
@@ -511,6 +515,9 @@ export default function DashboardPage() {
 							</TabsTrigger>
 							<TabsTrigger value="user-rankings" data-testid="dashboard-tab-user-rankings">
 								User Rankings
+							</TabsTrigger>
+							<TabsTrigger value="virtual-key-rankings" data-testid="dashboard-tab-virtual-key-rankings">
+								Virtual Key Rankings
 							</TabsTrigger>
 							<TabsTrigger value="customer-rankings" data-testid="dashboard-tab-customer-rankings">
 								Customer Rankings
@@ -658,6 +665,21 @@ export default function DashboardPage() {
 									dimensionLabel="User"
 									testIdPrefix="dashboard-user-rankings"
 									dataKey="userRankingsData"
+								/>
+							</div>
+						</TabsContent>
+
+						{/* Virtual Key Rankings Tab */}
+						<TabsContent value="virtual-key-rankings" {...(pdfMode && { forceMount: true })}>
+							<div id="dashboard-section-virtual-key-rankings">
+								<DimensionRankingsTabView
+									ref={virtualKeyRankingsRef}
+									filters={filters}
+									active={activeTab === "virtual-key-rankings" || pdfMode}
+									dimension="virtual_key"
+									dimensionLabel="Virtual Key"
+									testIdPrefix="dashboard-virtual-key-rankings"
+									dataKey="virtualKeyRankingsData"
 								/>
 							</div>
 						</TabsContent>

--- a/ui/app/workspace/dashboard/utils/exportUtils.ts
+++ b/ui/app/workspace/dashboard/utils/exportUtils.ts
@@ -195,13 +195,14 @@ export interface DashboardData {
 	customerRankingsData: DimensionRankingsResponse | null;
 	buRankingsData: DimensionRankingsResponse | null;
 	userRankingsData: DimensionRankingsResponse | null;
+	virtualKeyRankingsData: DimensionRankingsResponse | null;
 	// MCP
 	mcpHistogramData: MCPHistogramResponse | null;
 	mcpCostData: MCPCostHistogramResponse | null;
 	mcpTopToolsData: MCPTopToolsResponse | null;
 }
 
-export type ExportTab = "all" | "overview" | "provider-usage" | "rankings" | "team-rankings" | "customer-rankings" | "bu-rankings" | "user-rankings" | "mcp";
+export type ExportTab = "all" | "overview" | "provider-usage" | "rankings" | "team-rankings" | "customer-rankings" | "bu-rankings" | "user-rankings" | "virtual-key-rankings" | "mcp";
 
 /** Return all CSV sections for the selected scope. Each entry becomes its own sheet / file section. */
 export function getCSVSections(data: DashboardData, tab: ExportTab): { name: string; csv: CSVData }[] {
@@ -243,6 +244,10 @@ export function getCSVSections(data: DashboardData, tab: ExportTab): { name: str
 
 	if (tab === "all" || tab === "user-rankings") {
 		sections.push({ name: "user-rankings", csv: dimensionRankingsToCSV(data.userRankingsData, "User") });
+	}
+
+	if (tab === "all" || tab === "virtual-key-rankings") {
+		sections.push({ name: "virtual-key-rankings", csv: dimensionRankingsToCSV(data.virtualKeyRankingsData, "Virtual Key") });
 	}
 
 	if (tab === "all" || tab === "mcp") {

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -1189,7 +1189,7 @@ export interface UserRankingsResponse {
 	rankings: UserRankingEntry[];
 }
 
-export type RankingDimension = "team" | "customer" | "business_unit" | "user";
+export type RankingDimension = "team" | "customer" | "business_unit" | "user" | "virtual_key";
 
 export interface DimensionRankingTrend {
 	has_previous_period: boolean;


### PR DESCRIPTION
## Summary

Adds "Virtual Key" as a new ranking dimension across the backend and dashboard UI, allowing users to view and export usage rankings broken down by virtual key.

## Changes

- Added `RankingDimensionVirtualKey` constant and registered it in `ValidRankingDimensions` and `dimensionColumns` with `virtual_key_id` and `virtual_key_name` column mappings
- Added `virtual_key` to the `RankingDimension` TypeScript union type
- Added `virtualKeyRankingsData` to the `DashboardData` interface and initialized it as `null` in the dashboard state
- Added a "Virtual Key Rankings" tab to the dashboard with a `DimensionRankingsTabView` component wired to the `virtual_key` dimension
- Added `virtual-key-rankings` to the `ExportTab` type and included it in CSV export logic via `dimensionRankingsToCSV`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the dashboard and confirm a "Virtual Key Rankings" tab appears alongside the existing User, Customer, and Business Unit rankings tabs.
2. Select the Virtual Key Rankings tab and verify rankings data loads correctly with virtual key names and IDs.
3. Export the dashboard data (CSV) and confirm a `virtual-key-rankings` sheet/section is included with the correct columns.
4. Verify the "Export All" option includes virtual key rankings data.

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the dashboard tab bar showing the new Virtual Key Rankings tab._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Virtual key IDs and names are treated the same as other ranking dimension identifiers. No additional PII or secrets exposure beyond what already exists for user and customer rankings.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable