### PR TITLE
fix: remove effect that cleared selected IDs on visibility change

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -362,14 +362,6 @@ export default function VirtualKeysTable({
 	const allVisibleSelected = visibleIds.length > 0 && selectedVisibleIds.length === visibleIds.length;
 	const someVisibleSelected = selectedVisibleIds.length > 0 && selectedVisibleIds.length < visibleIds.length;
 
-	useEffect(() => {
-		setSelectedIds((prev) => {
-			const visible = new Set(visibleIds);
-			const next = new Set([...prev].filter((id) => visible.has(id)));
-			return next.size === prev.size ? prev : next;
-		});
-	}, [visibleIds]);
-
 	const toggleSelectAllVisible = (checked: boolean) => {
 		setSelectedIds((prev) => {
 			const next = new Set(prev);


### PR DESCRIPTION
## Summary

Removes a `useEffect` that was automatically deselecting virtual keys when they scrolled out of view or were filtered out of the visible list. This allows selections to persist across filter/pagination changes.

## Changes

- Removed the `useEffect` that filtered `selectedIds` down to only currently visible IDs whenever `visibleIds` changed. This effect caused selections to be silently dropped when a user filtered the table or navigated pages, leading to unexpected loss of selection state.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Virtual Keys table.
2. Select one or more keys.
3. Apply a filter or change the page such that the selected keys are no longer visible.
4. Clear the filter or return to the original page.
5. Verify that the previously selected keys are still selected.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable