### PR TITLE
fix: move anthropic raw request body check to core

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5938,6 +5938,24 @@ func executeRequestWithRetries[T any](
 	return result, bifrostError
 }
 
+// clearAnthropicPassthroughForNonNativeProvider disables Anthropic raw-body passthrough when a
+// request from the Anthropic-format integration resolves to a provider that doesn't speak the
+// Anthropic Messages API natively (e.g. Bedrock), forcing that provider to convert the request
+// itself. Gated on the final resolved provider so it fires regardless of how the provider was
+// picked (prefix, catalog, key alias, governance) and re-runs per attempt for fallbacks. No-op
+// for Anthropic/Vertex/Azure providers and for non-Anthropic integrations.
+func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, baseProvider schemas.ModelProvider) {
+	if integrationType, _ := ctx.Value(schemas.BifrostContextKeyIntegrationType).(string); integrationType != "anthropic" {
+		return
+	}
+	if baseProvider == schemas.Anthropic || baseProvider == schemas.Vertex || baseProvider == schemas.Azure {
+		return
+	}
+	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
+	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, false)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, false)
+}
+
 // requestWorker handles incoming requests from the queue for a specific provider.
 // It manages retries, error handling, and response processing.
 func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas.ProviderConfig, pq *ProviderQueue, waitGroup *sync.WaitGroup) {
@@ -5988,6 +6006,9 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			baseProvider = cfg.BaseProviderType
 		}
 		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
+
+		// Disable Anthropic raw-body passthrough when this attempt's provider isn't Anthropic-native (e.g. Bedrock).
+		clearAnthropicPassthroughForNonNativeProvider(req.Context, baseProvider)
 
 		// Determine whether this provider attempt should capture raw payloads.
 		//

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -2826,3 +2826,52 @@ func TestRunPreRequestHooks_CommitsRoutingPinnedKey(t *testing.T) {
 		}
 	})
 }
+
+// TestClearAnthropicPassthroughForNonNativeProvider verifies that Anthropic raw-body
+// passthrough flags are cleared only when an Anthropic-integration request resolves to a
+// provider that doesn't speak the Anthropic Messages API natively (e.g. Bedrock). This
+// guards the fix for Claude-via-Bedrock tool calls breaking when the model is routed to
+// Bedrock through a key alias (so the catalog-time guard never fires).
+func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
+	flagKeys := []schemas.BifrostContextKey{
+		schemas.BifrostContextKeyUseRawRequestBody,
+		schemas.BifrostContextKeySendBackRawResponse,
+		schemas.BifrostContextKeyPassthroughOverridesPresent,
+	}
+
+	tests := []struct {
+		name            string
+		integrationType string
+		baseProvider    schemas.ModelProvider
+		wantCleared     bool
+	}{
+		{"anthropic integration to bedrock clears", "anthropic", schemas.Bedrock, true},
+		{"anthropic integration to anthropic preserved", "anthropic", schemas.Anthropic, false},
+		{"anthropic integration to vertex preserved", "anthropic", schemas.Vertex, false},
+		{"anthropic integration to azure preserved", "anthropic", schemas.Azure, false},
+		{"non-anthropic integration to bedrock preserved", "openai", schemas.Bedrock, false},
+		{"no integration type to bedrock preserved", "", schemas.Bedrock, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			if tt.integrationType != "" {
+				ctx.SetValue(schemas.BifrostContextKeyIntegrationType, tt.integrationType)
+			}
+			for _, k := range flagKeys {
+				ctx.SetValue(k, true)
+			}
+
+			clearAnthropicPassthroughForNonNativeProvider(ctx, tt.baseProvider)
+
+			for _, k := range flagKeys {
+				got, _ := ctx.Value(k).(bool)
+				want := !tt.wantCleared // flags start true; cleared means false
+				if got != want {
+					t.Errorf("flag %v = %v, want %v", k, got, want)
+				}
+			}
+		})
+	}
+}

--- a/plugins/modelcatalogresolver/main.go
+++ b/plugins/modelcatalogresolver/main.go
@@ -224,19 +224,6 @@ func ResolveProviderFromCatalog(ctx *schemas.BifrostContext, catalog *modelcatal
 			if slices.Contains(providers, preferred) {
 				selected = preferred
 			}
-
-			// For Anthropic-type routes, raw request body passthrough is only valid for
-			// providers that speak the Anthropic Messages API natively. When the model
-			// catalog falls back to a provider that doesn't (e.g. Bedrock), clear the
-			// flag so the provider performs its own format conversion.
-			if integrationType == "anthropic" &&
-				selected != schemas.Anthropic &&
-				selected != schemas.Vertex &&
-				selected != schemas.Azure {
-				ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
-				ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, false)
-				ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, false)
-			}
 		}
 	}
 	return selected, providers


### PR DESCRIPTION
## Summary

When an Anthropic-integration request is routed to a non-native Anthropic provider (e.g. Bedrock via a key alias), the raw-body passthrough flags must be cleared so the provider performs its own format conversion. Previously, this guard only fired during catalog resolution, meaning it was silently skipped when the provider was selected through a key alias, prefix, or governance rule — causing tool calls to break when Claude was routed to Bedrock outside of catalog resolution.

## Changes

- Introduced `clearAnthropicPassthroughForNonNativeProvider` in `core/bifrost.go`, which clears `BifrostContextKeyUseRawRequestBody`, `BifrostContextKeySendBackRawResponse`, and `BifrostContextKeyPassthroughOverridesPresent` whenever an Anthropic-integration request resolves to a provider that isn't Anthropic, Vertex, or Azure.
- This function is now called per attempt inside `requestWorker`, after the final provider is resolved, ensuring it fires regardless of how the provider was selected and re-runs correctly on fallback attempts.
- Removed the equivalent inline guard from `modelcatalogresolver/main.go` since the new per-attempt call in `requestWorker` covers all routing paths, making the catalog-level check redundant.
- Added `TestClearAnthropicPassthroughForNonNativeProvider` covering Bedrock, Anthropic, Vertex, Azure, and non-Anthropic integration types to verify the flags are cleared only in the correct case.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/... ./plugins/modelcatalogresolver/...
```

To validate end-to-end: configure a model with a key alias that routes to Bedrock, send a Claude tool-call request through the Anthropic integration, and confirm the request is correctly converted by Bedrock rather than passed through as a raw Anthropic body.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

## Security considerations

No security implications. This change only affects internal context flag management for request routing.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable