### PR TITLE
fix: standardize pagination UI and fix scrolling layout across table views

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/page.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/page.tsx
@@ -2,7 +2,7 @@ import ScopedPricingOverridesView from "@/app/workspace/custom-pricing/overrides
 
 export default function ScopedPricingOverridesPage() {
 	return (
-		<div className="mx-auto w-full max-w-7xl">
+		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
 			<ScopedPricingOverridesView />
 		</div>
 	);

--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
@@ -295,8 +296,8 @@ export default function ScopedPricingOverridesView() {
 	}
 
 	return (
-		<div className="space-y-4">
-			<div className="flex items-center justify-between gap-4">
+		<div className="flex flex-col overflow-y-auto">
+			<div className="flex items-center justify-between gap-4 mb-4">
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">Pricing Overrides</h2>
 					<p className="text-muted-foreground text-sm">
@@ -310,7 +311,7 @@ export default function ScopedPricingOverridesView() {
 			</div>
 
 			{/* Search */}
-			<div className="relative max-w-sm">
+			<div className="relative max-w-sm mb-4">
 				<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 				<Input
 					aria-label="Search pricing overrides by name"
@@ -322,21 +323,21 @@ export default function ScopedPricingOverridesView() {
 				/>
 			</div>
 
-			<div className="overflow-hidden rounded-sm border">
+			<div className="overflow-hidden rounded-sm border mb-2">
 				{isLoading ? (
 					<div className="p-4 text-sm">Loading overrides...</div>
 				) : error ? (
 					<div className="p-4 text-sm text-red-500">Failed to load pricing overrides. Please try refreshing the page.</div>
 				) : (
-					<Table>
-						<TableHeader>
+					<Table containerClassName="h-full overflow-auto">
+						<TableHeader className="sticky top-0 bg-muted z-10">
 							<TableRow className="bg-muted/50">
 								<TableHead className="font-semibold">Name</TableHead>
 								<TableHead className="font-semibold">Scope</TableHead>
 								<TableHead className="font-semibold">Provider</TableHead>
 								<TableHead className="font-semibold">Key</TableHead>
 								<TableHead className="font-semibold">Model</TableHead>
-								<TableHead className="w-[100px] text-right font-semibold">Actions</TableHead>
+								<TableHead className={`bg-muted sticky right-0 z-30 w-[50px] text-right font-semibold ${PIN_SHADOW_RIGHT}`}>Actions</TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>
@@ -348,7 +349,7 @@ export default function ScopedPricingOverridesView() {
 								</TableRow>
 							) : (
 								rows.map((row) => (
-									<TableRow key={row.id} className="hover:bg-muted/50 cursor-pointer transition-colors">
+									<TableRow key={row.id} className="group hover:bg-muted/50 cursor-pointer transition-colors">
 										<TableCell>{row.name || "-"}</TableCell>
 										<TableCell>
 											<Badge variant="secondary">{scopeLabel(row, virtualKeyMap)}</Badge>
@@ -367,8 +368,11 @@ export default function ScopedPricingOverridesView() {
 										</TableCell>
 										<TableCell>{keyLabel(row, providerKeyLabelMap)}</TableCell>
 										<TableCell>{row.pattern}</TableCell>
-										<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
-											<div className="flex items-center justify-end">
+										<TableCell
+											className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+											onClick={(e) => e.stopPropagation()}
+										>
+											<div className="flex items-center justify-center">
 												<PricingOverrideActionsMenu
 													row={row}
 													onEdit={openEditDrawer}
@@ -386,30 +390,38 @@ export default function ScopedPricingOverridesView() {
 
 			{/* Pagination */}
 			{totalCount > 0 && (
-				<div className="flex items-center justify-between px-2">
-					<p className="text-muted-foreground text-sm">
-						Showing {offset + 1}-{Math.min(offset + PAGE_SIZE, totalCount)} of {totalCount}
-					</p>
-					<div className="flex gap-2">
+				<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+					<div className="text-muted-foreground flex items-center gap-2">
+						{(offset + 1).toLocaleString()}-{Math.min(offset + PAGE_SIZE, totalCount).toLocaleString()} of {totalCount.toLocaleString()} entries
+					</div>
+
+					<div className="flex items-center gap-2">
 						<Button
-							variant="outline"
+							variant="ghost"
 							size="sm"
-							disabled={offset === 0}
 							onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+							disabled={offset === 0}
 							data-testid="pricing-overrides-pagination-prev-btn"
+							aria-label="Previous page"
 						>
-							<ChevronLeft className="mr-1 h-4 w-4" />
-							Previous
+							<ChevronLeft className="size-3" />
 						</Button>
+
+						<div className="flex items-center gap-1">
+							<span>Page</span>
+							<span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
+							<span>of {Math.ceil(totalCount / PAGE_SIZE)}</span>
+						</div>
+
 						<Button
-							variant="outline"
+							variant="ghost"
 							size="sm"
-							disabled={offset + PAGE_SIZE >= totalCount}
 							onClick={() => setOffset(offset + PAGE_SIZE)}
+							disabled={offset + PAGE_SIZE >= totalCount}
 							data-testid="pricing-overrides-pagination-next-btn"
+							aria-label="Next page"
 						>
-							Next
-							<ChevronRight className="ml-1 h-4 w-4" />
+							<ChevronRight className="size-3" />
 						</Button>
 					</div>
 				</div>

--- a/ui/app/workspace/model-limits/page.tsx
+++ b/ui/app/workspace/model-limits/page.tsx
@@ -1,5 +1,7 @@
 import ModelLimitsView from "./views/modelLimitsView";
 
 export default function ModelLimitsPage() {
-	return <ModelLimitsView />;
+	return (<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<ModelLimitsView />
+	</div>);
 }

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -13,28 +13,29 @@ import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationLabels, supportsCalendarAlignment } from "@/lib/constants/governance";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import { getModelLimitScope, getModelLimitScopes } from "@/lib/registries/modelLimitScopes";
 import { getErrorMessage, useDeleteModelConfigMutation } from "@/lib/store";
-import { ModelConfig } from "@/lib/types/governance";
 import { ModelProvider } from "@/lib/types/config";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { ModelConfig } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
+import { getScopeLabel } from "@/lib/utils/labels";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { ArrowUpRight, ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
 import { ModelLimitsEmptyState } from "./modelLimitsEmptyState";
-import { getScopeLabel } from "@/lib/utils/labels";
-import { getModelLimitScope, getModelLimitScopes } from "@/lib/registries/modelLimitScopes";
 // Side-effect import: pull in downstream scope registrations (enterprise
 // "user" deep-link, etc.). No-op for OSS builds.
 import "@enterprise/lib/registrations/modelLimitScopes";
+import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import { useNavigate } from "@tanstack/react-router";
 
 // Helper to format reset duration for display
@@ -123,6 +124,7 @@ interface ModelLimitsTableProps {
 	offset: number;
 	limit: number;
 	onOffsetChange: (offset: number) => void;
+	isLoading?: boolean;
 }
 
 export default function ModelLimitsTable({
@@ -139,6 +141,7 @@ export default function ModelLimitsTable({
 	offset,
 	limit,
 	onOffsetChange,
+	isLoading = false,
 }: ModelLimitsTableProps) {
 	const navigate = useNavigate();
 	const [showModelLimitSheet, setShowModelLimitSheet] = useState(false);
@@ -188,8 +191,10 @@ export default function ModelLimitsTable({
 
 	const hasActiveFilters = debouncedSearch || scope || provider;
 
-	// True empty state: no model limits at all (not just filtered to zero)
-	if (totalCount === 0 && !hasActiveFilters) {
+	// True empty state: no model limits at all (not just filtered to zero).
+	// Suppress while the initial load is in flight so we don't flash the empty
+	// state before the API responds.
+	if (totalCount === 0 && !hasActiveFilters && !isLoading) {
 		return (
 			<>
 				{showModelLimitSheet && (
@@ -230,8 +235,8 @@ export default function ModelLimitsTable({
 				</AlertDialogContent>
 			</AlertDialog>
 
-			<div className="space-y-4">
-				<div className="flex items-center justify-between">
+			<div className="flex flex-col overflow-y-auto">
+				<div className="flex items-center justify-between mb-4">
 					<div>
 						<h1 className="text-lg font-semibold">Model Limits</h1>
 						<p className="text-muted-foreground text-sm">
@@ -245,7 +250,7 @@ export default function ModelLimitsTable({
 				</div>
 
 				{/* Toolbar: Search + Filters */}
-				<div className="flex flex-wrap items-center gap-3">
+				<div className="flex flex-wrap items-center gap-3 mb-4">
 					<div className="relative min-w-[220px] flex-1">
 						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 						<Input
@@ -301,9 +306,9 @@ export default function ModelLimitsTable({
 					)}
 				</div>
 
-				<div className="rounded-sm border" data-testid="model-limits-table">
-					<Table>
-						<TableHeader>
+				<div className="rounded-sm border mb-2 overflow-hidden" data-testid="model-limits-table">
+					<Table containerClassName="h-full overflow-auto">
+						<TableHeader className="sticky top-0 bg-muted z-10">
 							<TableRow className="hover:bg-transparent">
 								<TableHead className="font-medium">Model</TableHead>
 								<TableHead className="font-medium">Provider</TableHead>
@@ -311,14 +316,16 @@ export default function ModelLimitsTable({
 								<TableHead className="font-medium">Scope Target</TableHead>
 								<TableHead className="font-medium">Budget</TableHead>
 								<TableHead className="font-medium">Rate Limit</TableHead>
-								<TableHead className="w-[100px]"></TableHead>
+								<TableHead className={`bg-muted sticky right-0 z-30 w-[50px] text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>
 							{modelConfigs.length === 0 ? (
 								<TableRow>
 									<TableCell colSpan={7} className="h-24 text-center">
-										<span className="text-muted-foreground text-sm">No matching model limits found.</span>
+										<span className="text-muted-foreground text-sm">
+											{isLoading ? "Loading model limits..." : "No matching model limits found."}
+										</span>
 									</TableCell>
 								</TableRow>
 							) : (
@@ -503,8 +510,14 @@ export default function ModelLimitsTable({
 													<span className="text-muted-foreground text-sm">-</span>
 												)}
 											</TableCell>
-											<TableCell onClick={(e) => e.stopPropagation()}>
-												<div className="flex items-center justify-end">
+											<TableCell
+												className={cn(
+													"group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right",
+													PIN_SHADOW_RIGHT,
+												)}
+												onClick={(e) => e.stopPropagation()}
+											>
+												<div className="flex items-center justify-center">
 													<ModelLimitActionsMenu
 														config={config}
 														hasUpdateAccess={hasUpdateAccess}
@@ -524,30 +537,38 @@ export default function ModelLimitsTable({
 
 				{/* Pagination */}
 				{totalCount > 0 && (
-					<div className="flex items-center justify-between px-2">
-						<p className="text-muted-foreground text-sm">
-							Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
-						</p>
-						<div className="flex gap-2">
+					<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+						<div className="text-muted-foreground flex items-center gap-2">
+							{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()} entries
+						</div>
+
+						<div className="flex items-center gap-2">
 							<Button
-								variant="outline"
+								variant="ghost"
 								size="sm"
-								disabled={offset === 0}
 								onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+								disabled={offset === 0}
 								data-testid="model-limits-pagination-prev-btn"
+								aria-label="Previous page"
 							>
-								<ChevronLeft className="mr-1 h-4 w-4" />
-								Previous
+								<ChevronLeft className="size-3" />
 							</Button>
+
+							<div className="flex items-center gap-1">
+								<span>Page</span>
+								<span>{Math.floor(offset / limit) + 1}</span>
+								<span>of {Math.ceil(totalCount / limit)}</span>
+							</div>
+
 							<Button
-								variant="outline"
+								variant="ghost"
 								size="sm"
-								disabled={offset + limit >= totalCount}
 								onClick={() => onOffsetChange(offset + limit)}
+								disabled={offset + limit >= totalCount}
 								data-testid="model-limits-pagination-next-btn"
+								aria-label="Next page"
 							>
-								Next
-								<ChevronRight className="ml-1 h-4 w-4" />
+								<ChevronRight className="size-3" />
 							</Button>
 						</div>
 					</div>

--- a/ui/app/workspace/model-limits/views/modelLimitsView.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsView.tsx
@@ -1,5 +1,5 @@
-import { getErrorMessage, useGetModelConfigsQuery, useGetProvidersQuery } from "@/lib/store";
 import { useDebouncedValue } from "@/hooks/useDebounce";
+import { getErrorMessage, useGetModelConfigsQuery, useGetProvidersQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -25,7 +25,7 @@ export default function ModelLimitsView() {
 
 	const { data: providers } = useGetProvidersQuery();
 
-	const { data: modelConfigsData, error: modelConfigsError } = useGetModelConfigsQuery(
+	const { data: modelConfigsData, error: modelConfigsError, isLoading: isModelConfigsLoading } = useGetModelConfigsQuery(
 		{
 			limit: PAGE_SIZE,
 			offset,
@@ -55,22 +55,21 @@ export default function ModelLimitsView() {
 	}, [modelConfigsError]);
 
 	return (
-		<div className="mx-auto w-full max-w-7xl">
-			<ModelLimitsTable
-				modelConfigs={modelConfigsData?.model_configs || []}
-				totalCount={modelConfigsData?.total_count || 0}
-				providers={providers ?? []}
-				search={search}
-				debouncedSearch={debouncedSearch}
-				onSearchChange={setSearch}
-				scope={scope}
-				onScopeChange={setScope}
-				provider={provider}
-				onProviderChange={setProvider}
-				offset={offset}
-				limit={PAGE_SIZE}
-				onOffsetChange={setOffset}
-			/>
-		</div>
+		<ModelLimitsTable
+			modelConfigs={modelConfigsData?.model_configs || []}
+			totalCount={modelConfigsData?.total_count || 0}
+			providers={providers ?? []}
+			search={search}
+			debouncedSearch={debouncedSearch}
+			onSearchChange={setSearch}
+			scope={scope}
+			onScopeChange={setScope}
+			provider={provider}
+			onProviderChange={setProvider}
+			offset={offset}
+			limit={PAGE_SIZE}
+			onOffsetChange={setOffset}
+			isLoading={isModelConfigsLoading}
+		/>
 	);
 }

--- a/ui/app/workspace/routing-rules/page.tsx
+++ b/ui/app/workspace/routing-rules/page.tsx
@@ -7,7 +7,7 @@ import { RoutingRulesView } from "./views/routingRulesView";
 
 export default function RoutingRulesPage() {
 	return (
-		<div className="mx-auto w-full max-w-7xl">
+		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
 			<RoutingRulesView />
 		</div>
 	);

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -19,6 +19,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { getErrorMessage } from "@/lib/store";
@@ -173,7 +174,7 @@ export function RoutingRulesTable({
 	return (
 		<>
 			{/* Toolbar: Search */}
-			<div className="flex items-center gap-3">
+			<div className="flex items-center gap-3 mb-4">
 				<div className="relative max-w-sm flex-1">
 					<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
 					<Input
@@ -187,9 +188,9 @@ export function RoutingRulesTable({
 				</div>
 			</div>
 
-			<div className="overflow-hidden rounded-sm border">
-				<Table>
-					<TableHeader>
+			<div className="overflow-hidden rounded-sm border mb-2">
+				<Table containerClassName="h-full overflow-auto">
+					<TableHeader className="sticky top-0 bg-muted z-10">
 						<TableRow className="bg-muted/50">
 							<TableHead className="font-semibold">Name</TableHead>
 							<TableHead className="font-semibold">Targets</TableHead>
@@ -197,7 +198,7 @@ export function RoutingRulesTable({
 							<TableHead className="text-right font-semibold">Priority</TableHead>
 							<TableHead className="font-semibold">Expression</TableHead>
 							<TableHead className="font-semibold">Status</TableHead>
-							<TableHead className="text-right font-semibold">Actions</TableHead>
+							<TableHead className={`bg-muted sticky right-0 z-30 w-[50px] text-right font-semibold ${PIN_SHADOW_RIGHT}`}>Actions</TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
@@ -209,7 +210,7 @@ export function RoutingRulesTable({
 							</TableRow>
 						) : (
 							sortedRules.map((rule) => (
-								<TableRow key={rule.id} className="hover:bg-muted/50 cursor-pointer transition-colors" onClick={() => onRowClick(rule)}>
+								<TableRow key={rule.id} className="group hover:bg-muted/50 cursor-pointer transition-colors" onClick={() => onRowClick(rule)}>
 									<TableCell className="font-medium">
 										<div className="flex flex-col gap-1">
 											<span className="max-w-xs truncate">{rule.name}</span>
@@ -257,8 +258,11 @@ export function RoutingRulesTable({
 											}}
 										/>
 									</TableCell>
-									<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
-										<div className="flex items-center justify-end">
+									<TableCell
+										className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+										onClick={(e) => e.stopPropagation()}
+									>
+										<div className="flex items-center justify-center">
 											<RoutingRuleActionsMenu
 												rule={rule}
 												canUpdate={canUpdate}
@@ -277,30 +281,38 @@ export function RoutingRulesTable({
 
 			{/* Pagination */}
 			{totalCount > 0 && (
-				<div className="flex items-center justify-between px-2">
-					<p className="text-muted-foreground text-sm">
-						Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
-					</p>
-					<div className="flex gap-2">
+				<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+					<div className="text-muted-foreground flex items-center gap-2">
+						{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()} entries
+					</div>
+
+					<div className="flex items-center gap-2">
 						<Button
-							variant="outline"
+							variant="ghost"
 							size="sm"
-							disabled={offset === 0}
 							onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+							disabled={offset === 0}
 							data-testid="routing-rules-pagination-prev-btn"
+							aria-label="Previous page"
 						>
-							<ChevronLeft className="mr-1 h-4 w-4" />
-							Previous
+							<ChevronLeft className="size-3" />
 						</Button>
+
+						<div className="flex items-center gap-1">
+							<span>Page</span>
+							<span>{Math.floor(offset / limit) + 1}</span>
+							<span>of {Math.ceil(totalCount / limit)}</span>
+						</div>
+
 						<Button
-							variant="outline"
+							variant="ghost"
 							size="sm"
-							disabled={offset + limit >= totalCount}
 							onClick={() => onOffsetChange(offset + limit)}
+							disabled={offset + limit >= totalCount}
 							data-testid="routing-rules-pagination-next-btn"
+							aria-label="Next page"
 						>
-							Next
-							<ChevronRight className="ml-1 h-4 w-4" />
+							<ChevronRight className="size-3" />
 						</Button>
 					</div>
 				</div>

--- a/ui/app/workspace/routing-rules/views/routingRulesView.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesView.tsx
@@ -3,13 +3,13 @@
  * Main orchestrator component for routing rules management
  */
 
-import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Button } from "@/components/ui/button";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { useGetRoutingRulesQuery } from "@/lib/store/apis/routingRulesApi";
 import { RoutingRule } from "@/lib/types/routingRules";
-import { GitBranch, Plus } from "lucide-react";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
+import { GitBranch, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { RoutingRuleInfoSheet } from "./routingRuleInfoSheet";
 import { RoutingRuleSheet } from "./routingRuleSheet";
@@ -113,9 +113,9 @@ export function RoutingRulesView() {
 	}
 
 	return (
-		<div className="space-y-4">
+		<div className="flex flex-col overflow-y-auto">
 			{/* Header */}
-			<div className="flex items-center justify-between">
+			<div className="flex items-center justify-between mb-4">
 				<div>
 					<h1 className="text-foreground text-lg font-semibold">Routing Rules</h1>
 					<p className="text-muted-foreground text-sm">Manage CEL-based routing rules for intelligent request routing across providers</p>


### PR DESCRIPTION
## Summary

Standardizes the pagination UI across the Model Limits, Routing Rules, and Custom Pricing Overrides table views, and fixes a layout issue on the Model Limits page that caused it to overflow rather than fit within the viewport.

## Changes

- Replaced "Previous/Next" labeled outline buttons with icon-only ghost buttons (`ChevronLeft`/`ChevronRight`) and added `aria-label` attributes for accessibility
- Added a "Page X of Y" indicator between the navigation buttons
- Changed the entry count display from `"Showing X-Y of Z"` to `"X-Y of Z entries"` with locale-formatted numbers
- Added a `data-testid="pagination"` attribute to the pagination container across all three views for consistency
- Wrapped the Model Limits page in a full-height flex container to prevent overflow and enable proper scroll containment within the table
- Made the table header sticky with a background so it remains visible while scrolling
- Added an `isLoading` prop to `ModelLimitsTable` to suppress the empty state flash before the initial API response arrives, and to show a "Loading model limits..." message in the table body during load

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the Model Limits, Routing Rules, and Custom Pricing Overrides pages with enough records to trigger pagination and verify:

1. The pagination controls show icon-only previous/next buttons with a "Page X of Y" label between them.
2. Entry counts are locale-formatted (e.g., `1,000`).
3. The Model Limits page does not overflow the viewport; the table scrolls internally with a sticky header.
4. On initial page load, the empty state is not briefly flashed before data arrives; instead, "Loading model limits..." is shown in the table body.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before/after screenshots of the pagination controls and Model Limits layout recommended.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable