### PR TITLE
feat(alerting): add UI routes, sidebar nav, and shared components

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/alert-channels/alertHistoryView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/alert-channels/alertHistoryView.tsx
@@ -1,0 +1,11 @@
+import AlertingPlaceholderView from "./alertingPlaceholderView";
+
+export default function AlertHistoryView() {
+	return (
+		<AlertingPlaceholderView
+			title="Unlock alerting history for proactive monitoring"
+			description="This feature is a part of the Bifrost enterprise license. Review alert delivery outcomes, failures, and resolution events in one place."
+			testIdPrefix="alert-history"
+		/>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/components/alert-channels/alertRulesView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/alert-channels/alertRulesView.tsx
@@ -1,0 +1,11 @@
+import AlertingPlaceholderView from "./alertingPlaceholderView";
+
+export default function AlertRulesView() {
+	return (
+		<AlertingPlaceholderView
+			title="Unlock alerting rules for proactive monitoring"
+			description="This feature is a part of the Bifrost enterprise license. Define alerting rules to catch budget, latency, and degradation issues before they become incidents."
+			testIdPrefix="alert-rules"
+		/>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/components/alert-channels/alertingPlaceholderView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/alert-channels/alertingPlaceholderView.tsx
@@ -1,0 +1,23 @@
+import { Bell } from "lucide-react";
+import ContactUsView from "../views/contactUsView";
+
+type AlertingPlaceholderViewProps = {
+	title: string;
+	description: string;
+	testIdPrefix: string;
+};
+
+export default function AlertingPlaceholderView({ title, description, testIdPrefix }: AlertingPlaceholderViewProps) {
+	return (
+		<div className="h-full w-full">
+			<ContactUsView
+				className="mx-auto min-h-[80vh]"
+				icon={<Bell className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+				title={title}
+				description={description}
+				readmeLink="https://docs.getbifrost.ai/enterprise/alerting"
+				testIdPrefix={testIdPrefix}
+			/>
+		</div>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -34,6 +34,7 @@ export enum RbacResource {
   Inference = "Inference",
   Metrics = "Metrics",
   FeatureFlags = "FeatureFlags",
+  AlertRules = "AlertRules",
 }
 
 // RBAC Operation Names (must match backend definitions)

--- a/ui/app/workspace/alert-channels/layout.tsx
+++ b/ui/app/workspace/alert-channels/layout.tsx
@@ -1,6 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router";
-import AlertChannelsPage from "./page";
-
-export const Route = createFileRoute("/workspace/alert-channels")({
-	component: AlertChannelsPage,
-});

--- a/ui/app/workspace/alerting/channels/layout.tsx
+++ b/ui/app/workspace/alerting/channels/layout.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import AlertChannelsPage from "./page";
+
+function RouteComponent() {
+	const hasAlertingAccess = useRbac(RbacResource.AlertRules, RbacOperation.View);
+	if (!hasAlertingAccess) {
+		return <NoPermissionView entity="alerting" />;
+	}
+	return <AlertChannelsPage />;
+}
+
+export const Route = createFileRoute("/workspace/alerting/channels")({
+	component: RouteComponent,
+});

--- a/ui/app/workspace/alerting/channels/page.tsx
+++ b/ui/app/workspace/alerting/channels/page.tsx
@@ -1,9 +1,5 @@
 import AlertChannelsView from "@enterprise/components/alert-channels/alertChannelsView";
 
 export default function AlertChannelsPage() {
-	return (
-		<div className="mx-auto w-full max-w-7xl">
-			<AlertChannelsView />
-		</div>
-	);
+	return <AlertChannelsView />;
 }

--- a/ui/app/workspace/alerting/history/layout.tsx
+++ b/ui/app/workspace/alerting/history/layout.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import AlertHistoryPage from "./page";
+
+function RouteComponent() {
+	const hasAlertingAccess = useRbac(RbacResource.AlertRules, RbacOperation.View);
+	if (!hasAlertingAccess) {
+		return <NoPermissionView entity="alerting" />;
+	}
+	return <AlertHistoryPage />;
+}
+
+export const Route = createFileRoute("/workspace/alerting/history")({
+	component: RouteComponent,
+});

--- a/ui/app/workspace/alerting/history/page.tsx
+++ b/ui/app/workspace/alerting/history/page.tsx
@@ -1,0 +1,5 @@
+import AlertHistoryView from "@enterprise/components/alert-channels/alertHistoryView";
+
+export default function AlertHistoryPage() {
+	return <AlertHistoryView />;
+}

--- a/ui/app/workspace/alerting/layout.tsx
+++ b/ui/app/workspace/alerting/layout.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+
+function RouteComponent() {
+	const hasAlertingAccess = useRbac(RbacResource.AlertRules, RbacOperation.View);
+
+	if (!hasAlertingAccess) {
+		return <NoPermissionView entity="alerting" />;
+	}
+
+	return <div className="flex h-full flex-col">{<Outlet />}</div>;
+}
+
+export const Route = createFileRoute("/workspace/alerting")({
+	beforeLoad: ({ location }) => {
+		if (location.pathname === "/workspace/alerting" || location.pathname === "/workspace/alerting/") {
+			throw redirect({ to: "/workspace/alerting/channels", replace: true });
+		}
+	},
+	component: RouteComponent,
+});

--- a/ui/app/workspace/alerting/rules/layout.tsx
+++ b/ui/app/workspace/alerting/rules/layout.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import AlertRulesPage from "./page";
+
+function RouteComponent() {
+	const hasAlertingAccess = useRbac(RbacResource.AlertRules, RbacOperation.View);
+	if (!hasAlertingAccess) {
+		return <NoPermissionView entity="alerting" />;
+	}
+	return <AlertRulesPage />;
+}
+
+export const Route = createFileRoute("/workspace/alerting/rules")({
+	component: RouteComponent,
+});

--- a/ui/app/workspace/alerting/rules/page.tsx
+++ b/ui/app/workspace/alerting/rules/page.tsx
@@ -1,0 +1,5 @@
+import AlertRulesView from "@enterprise/components/alert-channels/alertRulesView";
+
+export default function AlertRulesPage() {
+	return <AlertRulesView />;
+}

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -1,5 +1,6 @@
 import {
 	ArrowUpRight,
+	Bell,
 	BookOpenText,
 	BookUser,
 	Boxes,
@@ -14,12 +15,15 @@ import {
 	Flag,
 	FlaskConical,
 	FolderGit,
+	Gavel,
 	Globe,
+	History,
 	KeyRound,
 	Landmark,
 	LayoutGrid,
 	LogOut,
 	Logs,
+	Megaphone,
 	Network,
 	PanelLeftClose,
 	PanelLeftOpen,
@@ -319,7 +323,12 @@ const SidebarItemView = ({
 	let menuButton: React.ReactNode;
 	if (hasSubItems) {
 		menuButton = (
-			<SidebarMenuButton tooltip={isSidebarCollapsed ? undefined : item.title} className={buttonClassName} onClick={handleClick}>
+			<SidebarMenuButton
+				tooltip={isSidebarCollapsed ? undefined : item.title}
+				className={buttonClassName}
+				onClick={handleClick}
+				data-testid={`sidebar-item-btn-${slug(item.title)}`}
+			>
 				{innerContent}
 			</SidebarMenuButton>
 		);
@@ -463,12 +472,21 @@ const SidebarItemView = ({
 						return (
 							<SidebarMenuSubItem key={subItem.title}>
 								{subItem.hasAccess === false ? (
-									<SidebarMenuSubButton data-nav-url={subItemHref} className={subItemClassName}>
+									<SidebarMenuSubButton
+										data-nav-url={subItemHref}
+										data-testid={`sidebar-subitem-disabled-${slug(subItem.title)}`}
+										className={subItemClassName}
+									>
 										{subInner}
 									</SidebarMenuSubButton>
 								) : (
 									<SidebarMenuSubButton asChild className={subItemClassName}>
-										<Link to={subItemHref as any} preload="intent" data-nav-url={subItemHref}>
+										<Link
+											to={subItemHref as any}
+											preload="intent"
+											data-nav-url={subItemHref}
+											data-testid={`sidebar-subitem-link-${slug(subItem.title)}`}
+										>
 											{subInner}
 										</Link>
 									</SidebarMenuSubButton>
@@ -542,6 +560,9 @@ export default function AppSidebar() {
 	});
 	const hasLogsAccess = useRbac(RbacResource.Logs, RbacOperation.View);
 	const hasObservabilityAccess = useRbac(RbacResource.Observability, RbacOperation.View);
+	// Alerting is gated on the same resource the alerting route layouts use
+	// (AlertRules), so sidebar visibility matches page access.
+	const hasAlertingAccess = useRbac(RbacResource.AlertRules, RbacOperation.View);
 	const hasDashboardAccess = useRbac(RbacResource.Dashboard, RbacOperation.View);
 	const hasModelProvidersAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
 	const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
@@ -735,6 +756,36 @@ export default function AppSidebar() {
 				icon: Puzzle,
 				description: "Manage custom plugins",
 				hasAccess: hasPluginsAccess,
+			},
+			{
+				title: "Alerting",
+				url: "/workspace/alerting",
+				icon: Bell,
+				description: "Manage alert channels, rules, and history",
+				hasAccess: hasAlertingAccess,
+				subItems: [
+					{
+						title: "Channels",
+						url: "/workspace/alerting/channels",
+						icon: Megaphone,
+						description: "Configure notification channels",
+						hasAccess: hasAlertingAccess,
+					},
+					{
+						title: "Rules",
+						url: "/workspace/alerting/rules",
+						icon: Gavel,
+						description: "Define alerting rules",
+						hasAccess: hasAlertingAccess,
+					},
+					{
+						title: "History",
+						url: "/workspace/alerting/history",
+						icon: History,
+						description: "Review alert delivery history",
+						hasAccess: hasAlertingAccess,
+					},
+				],
 			},
 			{
 				title: "Governance",
@@ -961,6 +1012,7 @@ export default function AppSidebar() {
 			hasLogsAccess,
 			hasAPIKeyAccess,
 			hasObservabilityAccess,
+			hasAlertingAccess,
 			hasDashboardAccess,
 			hasModelProvidersAccess,
 			hasMCPGatewayAccess,

--- a/ui/components/ui/icons.tsx
+++ b/ui/components/ui/icons.tsx
@@ -692,6 +692,192 @@ export const Icons = {
 			/>
 		</svg>
 	),
+	microsoftTeamsIcon: (props: IconProps) => {
+		// Per-instance prefix so multiple teamsIcon renders don't share gradient
+		// ids (a hardcoded id would make every instance resolve url(#…) to the
+		// first instance's <defs>, mis-rendering the gradients).
+		const gid = React.useId();
+		return (
+		<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="4 4 36 38" width="24" height="24" {...props}>
+			<path
+				fill={`url(#${gid}-teamsIconGradientA)`}
+				d="M21.9999 20h12c3.3137 0 6 2.6863 6 6v10c0 3.3137-2.6863 6-6 6s-6-2.6863-6-6V26c0-3.3137-2.6863-6-6-6"
+			/>
+			<path
+				fill={`url(#${gid}-teamsIconGradientB)`}
+				d="M7.99988 24c0-3.3137 2.68632-6 6.00002-6h8c3.3137 0 6 2.6863 6 6v12c0 3.3137 2.6863 6 6 6l-16.0001-.0001c-5.5228 0-9.99992-4.4771-9.99992-10z"
+			/>
+			<path
+				fill={`url(#${gid}-teamsIconGradientC)`}
+				fillOpacity=".7"
+				d="M7.99988 24c0-3.3137 2.68632-6 6.00002-6h8c3.3137 0 6 2.6863 6 6v12c0 3.3137 2.6863 6 6 6l-16.0001-.0001c-5.5228 0-9.99992-4.4771-9.99992-10z"
+			/>
+			<path
+				fill={`url(#${gid}-teamsIconGradientD)`}
+				fillOpacity=".7"
+				d="M7.99988 24c0-3.3137 2.68632-6 6.00002-6h8c3.3137 0 6 2.6863 6 6v12c0 3.3137 2.6863 6 6 6l-16.0001-.0001c-5.5228 0-9.99992-4.4771-9.99992-10z"
+			/>
+			<path fill={`url(#${gid}-teamsIconGradientE)`} d="M32.9999 18c2.7614 0 5-2.2386 5-5s-2.2386-5-5-5-5 2.2386-5 5 2.2386 5 5 5" />
+			<path
+				fill={`url(#${gid}-teamsIconGradientF)`}
+				fillOpacity=".46"
+				d="M32.9999 18c2.7614 0 5-2.2386 5-5s-2.2386-5-5-5-5 2.2386-5 5 2.2386 5 5 5"
+			/>
+			<path
+				fill={`url(#${gid}-teamsIconGradientG)`}
+				fillOpacity=".4"
+				d="M32.9999 18c2.7614 0 5-2.2386 5-5s-2.2386-5-5-5-5 2.2386-5 5 2.2386 5 5 5"
+			/>
+			<path
+				fill={`url(#${gid}-teamsIconGradientH)`}
+				d="M17.9999 16c3.3137 0 6-2.6863 6-6 0-3.31371-2.6863-6-6-6s-6 2.68629-6 6c0 3.3137 2.6863 6 6 6"
+			/>
+			<path
+				fill={`url(#${gid}-teamsIconGradientI)`}
+				fillOpacity=".6"
+				d="M17.9999 16c3.3137 0 6-2.6863 6-6 0-3.31371-2.6863-6-6-6s-6 2.68629-6 6c0 3.3137 2.6863 6 6 6"
+			/>
+			<path
+				fill={`url(#${gid}-teamsIconGradientJ)`}
+				fillOpacity=".5"
+				d="M17.9999 16c3.3137 0 6-2.6863 6-6 0-3.31371-2.6863-6-6-6s-6 2.68629-6 6c0 3.3137 2.6863 6 6 6"
+			/>
+			<rect width="16" height="16" x="4" y="23" fill={`url(#${gid}-teamsIconGradientK)`} rx="3.25" />
+			<rect width="16" height="16" x="4" y="23" fill={`url(#${gid}-teamsIconGradientL)`} fillOpacity=".7" rx="3.25" />
+			<path fill="#fff" d="M15.4792 28.1054h-2.4471v7.466h-2.0648v-7.466H8.52014v-1.6768h6.95906z" />
+			<defs>
+				<radialGradient
+					id={`${gid}-teamsIconGradientA`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="matrix(13.4784 0 0 33.2694 39.7967 22.1739)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#a98aff" />
+					<stop offset=".14" stopColor="#8c75ff" />
+					<stop offset=".565" stopColor="#5f50e2" />
+					<stop offset=".9" stopColor="#3c2cb8" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientB`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="rotate(68.1539 -7.71566095 14.71355834)scale(32.752 33.1231)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#85c2ff" />
+					<stop offset=".69" stopColor="#7588ff" />
+					<stop offset="1" stopColor="#6459fe" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientD`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="rotate(113.326 8.09285255 17.64474501)scale(19.2186 15.4273)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#bd96ff" />
+					<stop offset=".686685" stopColor="#bd96ff" stopOpacity="0" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientE`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="matrix(0 -10 12.6216 0 32.9999 11.5714)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop offset=".268201" stopColor="#6868f7" />
+					<stop offset="1" stopColor="#3923b1" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientF`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="rotate(40.0516 -.03068196 44.8729095)scale(7.14629 10.3363)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop offset=".270711" stopColor="#a1d3ff" />
+					<stop offset=".813393" stopColor="#a1d3ff" stopOpacity="0" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientG`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="rotate(-41.6581 32.11799918 -43.41948423)scale(8.51275 20.8824)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#e3acfd" />
+					<stop offset=".816041" stopColor="#9fa2ff" stopOpacity="0" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientH`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="matrix(0 -12 15.146 0 17.9999 8.28571)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop offset=".268201" stopColor="#8282ff" />
+					<stop offset="1" stopColor="#3923b1" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientI`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="rotate(40.0516 -3.15465147 21.41641466)scale(8.57554 12.4035)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop offset=".270711" stopColor="#a1d3ff" />
+					<stop offset=".813393" stopColor="#a1d3ff" stopOpacity="0" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientJ`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="rotate(-41.6581 20.38180375 -26.51566158)scale(10.2153 25.0589)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#e3acfd" />
+					<stop offset=".816041" stopColor="#9fa2ff" stopOpacity="0" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientK`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="rotate(45 -25.76345597 16.32842712)scale(22.6274)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop offset=".046875" stopColor="#688eff" />
+					<stop offset=".946875" stopColor="#230f94" />
+				</radialGradient>
+				<radialGradient
+					id={`${gid}-teamsIconGradientL`}
+					cx="0"
+					cy="0"
+					r="1"
+					gradientTransform="matrix(0 11.2 -13.0702 0 12 32.6)"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop offset=".570647" stopColor="#6965f6" stopOpacity="0" />
+					<stop offset="1" stopColor="#8f8fff" />
+				</radialGradient>
+				<linearGradient id={`${gid}-teamsIconGradientC`} x1="20.5936" x2="20.5936" y1="18" y2="42" gradientUnits="userSpaceOnUse">
+					<stop offset=".801159" stopColor="#6864f6" stopOpacity="0" />
+					<stop offset="1" stopColor="#5149de" />
+				</linearGradient>
+			</defs>
+		</svg>
+		);
+	},
 };
 
 export const SdkIcons = {

--- a/ui/components/ui/keyValueEditor.tsx
+++ b/ui/components/ui/keyValueEditor.tsx
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface KeyValuePair {
+	id: number;
+	key: string;
+	value: string;
+}
+
+function recordsEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+	const aEntries = Object.entries(a);
+	const bEntries = Object.entries(b);
+	if (aEntries.length !== bEntries.length) {
+		return false;
+	}
+	return aEntries.every(([aKey, aValue], index) => {
+		const [bKey, bValue] = bEntries[index] ?? [];
+		return aKey === bKey && aValue === bValue;
+	});
+}
+
+type FieldErrors = Record<number, string>;
+
+function validatePairs(pairs: KeyValuePair[]): { record: Record<string, string>; keyErrors: FieldErrors } {
+	const record: Record<string, string> = {};
+	const keys = new Map<string, number[]>();
+
+	for (const pair of pairs) {
+		const key = pair.key.trim();
+		if (!key) {
+			continue;
+		}
+		record[key] = pair.value;
+		const ids = keys.get(key);
+		if (ids) {
+			ids.push(pair.id);
+		} else {
+			keys.set(key, [pair.id]);
+		}
+	}
+
+	const keyErrors: FieldErrors = {};
+	for (const ids of keys.values()) {
+		if (ids.length < 2) {
+			continue;
+		}
+		for (const id of ids) {
+			keyErrors[id] = "Duplicate key";
+		}
+	}
+
+	return { record, keyErrors };
+}
+
+interface KeyValueEditorProps {
+	value: Record<string, string>;
+	onChange: (value: Record<string, string>) => void;
+	label?: string;
+	description?: string;
+	keyPlaceholder?: string;
+	valuePlaceholder?: string;
+}
+
+// KeyValueEditor provides a reusable key-value pair editor for custom blocks.
+// Pairs use stable IDs to avoid React key-mismatch bugs on reorder/remove.
+export function KeyValueEditor({
+	value,
+	onChange,
+	label = "Custom Blocks",
+	description = "Add custom key-value pairs",
+	keyPlaceholder = "Key",
+	valuePlaceholder = "Value",
+}: KeyValueEditorProps) {
+	const nextId = useRef(0);
+
+	// Persisted key -> id map so a given key keeps the same stable React key
+	// across external value syncs (reorder / add / remove from the parent).
+	const idMapRef = useRef<Map<string, number>>(new Map());
+
+	const buildPairs = useCallback((record: Record<string, string>): KeyValuePair[] => {
+		return Object.entries(record).map(([key, val]) => {
+			let id = idMapRef.current.get(key);
+			if (id === undefined) {
+				id = nextId.current++;
+				idMapRef.current.set(key, id);
+			}
+			return { id, key, value: val };
+		});
+	}, []);
+
+	const [pairs, setPairs] = useState<KeyValuePair[]>(() => buildPairs(value));
+	const [keyErrors, setKeyErrors] = useState<FieldErrors>({});
+	const isFirstRender = useRef(true);
+	const suppressOnChange = useRef(false);
+	// Last record we emitted to (or received from) the parent. Used to ignore
+	// the parent echoing our own onChange back as a new object reference, which
+	// would otherwise drop an in-progress empty row and regenerate IDs.
+	const lastSyncedRef = useRef<Record<string, string>>(value);
+	const onChangeRef = useRef(onChange);
+	onChangeRef.current = onChange;
+
+	useEffect(() => {
+		// Skip syncing when the incoming value matches what we last emitted/saw.
+		if (recordsEqual(value, lastSyncedRef.current)) {
+			return;
+		}
+
+		lastSyncedRef.current = value;
+		suppressOnChange.current = true;
+		setPairs(buildPairs(value));
+	}, [value, buildPairs]);
+
+	useEffect(() => {
+		const validation = validatePairs(pairs);
+		setKeyErrors(validation.keyErrors);
+
+		if (Object.keys(validation.keyErrors).length > 0) {
+			return;
+		}
+
+		if (isFirstRender.current) {
+			isFirstRender.current = false;
+			return;
+		}
+		if (suppressOnChange.current) {
+			suppressOnChange.current = false;
+			return;
+		}
+		const record = validation.record;
+		lastSyncedRef.current = record;
+		onChangeRef.current(record);
+	}, [pairs]);
+
+	const addPair = useCallback(() => {
+		setPairs((prev) => {
+			const id = nextId.current++;
+			return [...prev, { id, key: "", value: "" }];
+		});
+	}, []);
+
+	const removePair = useCallback((index: number) => {
+		setPairs((prev) => {
+			const removed = prev[index];
+			if (removed && removed.key.trim()) {
+				idMapRef.current.delete(removed.key.trim());
+			}
+			return prev.filter((_, i) => i !== index);
+		});
+	}, []);
+
+	const updatePair = useCallback((index: number, field: "key" | "value", newValue: string) => {
+		setPairs((prev) =>
+			prev.map((pair, i) => {
+				if (i !== index) {
+					return pair;
+				}
+
+				if (field === "key") {
+					const oldKey = pair.key.trim();
+					const nextKey = newValue.trim();
+
+					if (oldKey) {
+						idMapRef.current.delete(oldKey);
+					}
+
+					if (nextKey) {
+						idMapRef.current.set(nextKey, pair.id);
+					}
+				}
+
+				return { ...pair, [field]: newValue };
+			}),
+		);
+	}, []);
+
+	return (
+		<div className="rounded-md border p-4">
+			<div className="mb-3 flex items-center justify-between">
+				<div>
+					<h4 className="text-sm font-medium">{label}</h4>
+					{description && <p className="text-muted-foreground text-xs">{description}</p>}
+				</div>
+				<Button type="button" variant="outline" size="sm" onClick={addPair} data-testid="key-value-editor-add-button">
+					<Plus className="mr-1 h-3 w-3" />
+					Add
+				</Button>
+			</div>
+
+			{pairs.length === 0 && (
+				<p className="text-muted-foreground py-2 text-center text-xs">No entries defined. Click Add to create one.</p>
+			)}
+
+			{pairs.map((pair, index) => (
+				<div key={pair.id} className="mb-2 flex items-center gap-2">
+					<div className="flex-1">
+						{index === 0 && (
+							<Label className="text-xs" htmlFor={`key-value-editor-key-${pair.id}`}>
+								Key
+							</Label>
+						)}
+						<Input
+							id={`key-value-editor-key-${pair.id}`}
+							placeholder={keyPlaceholder}
+							value={pair.key}
+							aria-label={`Key ${index + 1}`}
+							aria-invalid={Boolean(keyErrors[pair.id])}
+							aria-describedby={keyErrors[pair.id] ? `key-value-editor-key-error-${pair.id}` : undefined}
+							onChange={(e) => updatePair(index, "key", e.target.value)}
+							data-testid={`key-value-editor-key-input-${pair.id}`}
+						/>
+						{keyErrors[pair.id] && (
+							<p id={`key-value-editor-key-error-${pair.id}`} className="text-destructive mt-1 text-xs">
+								{keyErrors[pair.id]}
+							</p>
+						)}
+					</div>
+
+					<div className="flex-[2]">
+						{index === 0 && (
+							<Label className="text-xs" htmlFor={`key-value-editor-value-${pair.id}`}>
+								Value
+							</Label>
+						)}
+						<Input
+							id={`key-value-editor-value-${pair.id}`}
+							placeholder={valuePlaceholder}
+							value={pair.value}
+							aria-label={`Value ${index + 1}`}
+							onChange={(e) => updatePair(index, "value", e.target.value)}
+							data-testid={`key-value-editor-value-input-${pair.id}`}
+						/>
+					</div>
+
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon"
+						className={index === 0 ? "mt-5" : "mt-0"}
+						onClick={() => removePair(index)}
+						aria-label={`Remove key-value pair ${index + 1}`}
+						title="Remove entry"
+						data-testid={`key-value-editor-delete-button-${pair.id}`}
+					>
+						<Trash2 className="h-4 w-4" />
+					</Button>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/ui/components/ui/multiSelect.tsx
+++ b/ui/components/ui/multiSelect.tsx
@@ -251,6 +251,23 @@ interface MultiSelectProps
 	 * Optional, defaults to false.
 	 */
 	closeOnSelect?: boolean;
+
+	/**
+	 * Optional action rendered as a row pinned to the bottom of the dropdown,
+	 * below the option list (e.g. "Create new channel..."). When provided, the
+	 * popover closes before the handler runs so a sheet/dialog can open cleanly.
+	 * Opt-in: when omitted, no footer row is rendered and behavior is unchanged.
+	 */
+	footerAction?: {
+		/** Label text shown in the action row. */
+		label: string;
+		/** Invoked when the action row is selected. The popover is closed first. */
+		onSelect: () => void;
+		/** Optional leading icon for the action row. */
+		icon?: React.ComponentType<{ className?: string }>;
+		/** Optional test id for the action row. */
+		testId?: string;
+	};
 }
 
 /**
@@ -307,6 +324,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
 			deduplicateOptions = false,
 			resetOnDefaultValueChange = true,
 			closeOnSelect = false,
+			footerAction,
 			...props
 		},
 		ref,
@@ -982,6 +1000,21 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
 										)}
 									</div>
 								</CommandGroup>
+								{footerAction && (
+									<CommandGroup className="bg-popover sticky bottom-0 z-10 border-t">
+										<CommandItem
+											onSelect={() => {
+												setIsPopoverOpen(false);
+												footerAction.onSelect();
+											}}
+											data-testid={footerAction.testId}
+											className="text-muted-foreground data-[selected=true]:text-foreground cursor-pointer gap-2"
+										>
+											{footerAction.icon ? <footerAction.icon className="h-4 w-4" /> : null}
+											<span>{footerAction.label}</span>
+										</CommandItem>
+									</CommandGroup>
+								)}
 							</CommandList>
 						</Command>
 					</PopoverContent>


### PR DESCRIPTION
## Summary

Adds the open-source UI foundation for alerting: the `/workspace/alerting` route group (rules, channels, history), sidebar navigation, and the shared UI components the alerting screens reuse. Builds on the config/governance base in the previous PR.

## Changes

- New route group `ui/app/workspace/alerting/**` with `layout.tsx` and `rules/`, `channels/`, `history/` pages.
- Renames the legacy `ui/app/workspace/alert-channels/page.tsx` into `ui/app/workspace/alerting/channels/page.tsx` and removes the old `alert-channels/layout.tsx`.
- Shared components: `ui/components/ui/{icons,keyValueEditor,multi-select}.tsx` (Slack/PagerDuty/Teams icons, key-value editor, multi-select) and sidebar nav entry in `ui/components/sidebar.tsx`.
- `ui/lib/store/apis/baseApi.ts`: base API wiring used by alerting data fetching.
- `ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx`: register the `AlertRules` RBAC resource (single-line addition) used to gate the nav/routes.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Navigate to `/workspace/alerting` and confirm the Rules, Channels, and History routes render and the sidebar entry appears (gated on the `AlertRules` RBAC resource).

## Screenshots/Recordings

UI changes (new alerting nav + route shells). Screenshots to be attached on submit.

## Breaking changes

- [ ] Yes
- [x] No

The old `/workspace/alert-channels` page path is replaced by `/workspace/alerting/channels`.

## Related issues

N/A

## Security considerations

Alerting nav and routes are gated on the `AlertRules` RBAC resource.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
