### PR TITLE
feat(alerting): add enterprise fallback views

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/alert-channels/alertChannelsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/alert-channels/alertChannelsView.tsx
@@ -1,16 +1,12 @@
-import { Siren } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import AlertingPlaceholderView from "./alertingPlaceholderView";
 
 export default function AlertChannelsView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<Siren className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock alert channels for better observability"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/alert-channels"
-			/>
-		</div>
+		<AlertingPlaceholderView
+			title="Unlock alerting channels for proactive monitoring"
+			description="This feature is a part of the Bifrost enterprise license. Configure Slack, PagerDuty, OpsGenie, and webhook alerts to stay ahead of budget and performance issues."
+			readmeLink="https://docs.getbifrost.ai/enterprise/alerting/alert-channels"
+			testIdPrefix="alert-channels"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/alert-channels/alertHistoryView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/alert-channels/alertHistoryView.tsx
@@ -5,6 +5,7 @@ export default function AlertHistoryView() {
 		<AlertingPlaceholderView
 			title="Unlock alerting history for proactive monitoring"
 			description="This feature is a part of the Bifrost enterprise license. Review alert delivery outcomes, failures, and resolution events in one place."
+			readmeLink="https://docs.getbifrost.ai/enterprise/alerting/alert-history"
 			testIdPrefix="alert-history"
 		/>
 	);

--- a/ui/app/_fallbacks/enterprise/components/alert-channels/alertRulesView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/alert-channels/alertRulesView.tsx
@@ -5,6 +5,7 @@ export default function AlertRulesView() {
 		<AlertingPlaceholderView
 			title="Unlock alerting rules for proactive monitoring"
 			description="This feature is a part of the Bifrost enterprise license. Define alerting rules to catch budget, latency, and degradation issues before they become incidents."
+			readmeLink="https://docs.getbifrost.ai/enterprise/alerting/alert-rules"
 			testIdPrefix="alert-rules"
 		/>
 	);

--- a/ui/app/_fallbacks/enterprise/components/alert-channels/alertingPlaceholderView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/alert-channels/alertingPlaceholderView.tsx
@@ -5,9 +5,16 @@ type AlertingPlaceholderViewProps = {
 	title: string;
 	description: string;
 	testIdPrefix: string;
+	/** Docs page this placeholder links to. Defaults to the alerting overview. */
+	readmeLink?: string;
 };
 
-export default function AlertingPlaceholderView({ title, description, testIdPrefix }: AlertingPlaceholderViewProps) {
+export default function AlertingPlaceholderView({
+	title,
+	description,
+	testIdPrefix,
+	readmeLink = "https://docs.getbifrost.ai/enterprise/alerting/overview",
+}: AlertingPlaceholderViewProps) {
 	return (
 		<div className="h-full w-full">
 			<ContactUsView
@@ -15,7 +22,7 @@ export default function AlertingPlaceholderView({ title, description, testIdPref
 				icon={<Bell className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
 				title={title}
 				description={description}
-				readmeLink="https://docs.getbifrost.ai/enterprise/alerting"
+				readmeLink={readmeLink}
 				testIdPrefix={testIdPrefix}
 			/>
 		</div>


### PR DESCRIPTION
## Summary

Adds the open-source enterprise *fallback* views for the alerting screens. In the OSS build these render placeholder/upsell content where the enterprise alerting UI would otherwise mount, so the routes added in the previous PR resolve cleanly without the enterprise bundle.

## Changes

- `ui/app/_fallbacks/enterprise/components/alert-channels/alertingPlaceholderView.tsx`: shared placeholder shell for alerting screens.
- `ui/app/_fallbacks/enterprise/components/alert-channels/{alertChannelsView,alertHistoryView,alertRulesView}.tsx`: per-screen fallbacks wired to the placeholder.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

In an OSS build, visit `/workspace/alerting/{rules,channels,history}` and confirm the fallback placeholder views render in place of the enterprise UI.

## Screenshots/Recordings

UI changes (fallback placeholder views). Screenshots to be attached on submit.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None — static placeholder views, no data access.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
