### PR TITLE
test(alerting): add e2e coverage for alerting routes

### DIFF
--- a/tests/e2e/core/actions/navigation.ts
+++ b/tests/e2e/core/actions/navigation.ts
@@ -62,6 +62,30 @@ export async function goToPlugins(page: Page): Promise<void> {
 }
 
 /**
+ * Navigate to Alerting Channels page
+ */
+export async function goToAlertingChannels(page: Page): Promise<void> {
+  await page.goto('/workspace/alerting/channels')
+  await waitForNetworkIdle(page)
+}
+
+/**
+ * Navigate to Alerting Rules page
+ */
+export async function goToAlertingRules(page: Page): Promise<void> {
+  await page.goto('/workspace/alerting/rules')
+  await waitForNetworkIdle(page)
+}
+
+/**
+ * Navigate to Alerting History page
+ */
+export async function goToAlertingHistory(page: Page): Promise<void> {
+  await page.goto('/workspace/alerting/history')
+  await waitForNetworkIdle(page)
+}
+
+/**
  * Navigate to Config page
  */
 export async function goToConfig(page: Page): Promise<void> {

--- a/tests/e2e/core/pages/sidebar.page.ts
+++ b/tests/e2e/core/pages/sidebar.page.ts
@@ -12,6 +12,10 @@ export class SidebarPage extends BasePage {
   readonly mcpClientsLink: Locator
   readonly userGroupsLink: Locator
   readonly pluginsLink: Locator
+  readonly alertingButton: Locator
+  readonly alertingChannelsLink: Locator
+  readonly alertingRulesLink: Locator
+  readonly alertingHistoryLink: Locator
   readonly configLink: Locator
 
   constructor(page: Page) {
@@ -22,6 +26,14 @@ export class SidebarPage extends BasePage {
     this.mcpClientsLink = page.getByRole('link', { name: /mcp/i })
     this.userGroupsLink = page.getByRole('link', { name: /user groups/i })
     this.pluginsLink = page.getByRole('link', { name: /plugins/i })
+    this.alertingButton = page.getByTestId('sidebar-item-btn-alerting')
+    // Target by route-specific data-nav-url rather than the title-derived
+    // testid: the subitem slug "rules" also matches the Guardrails "Rules"
+    // subitem, so getByTestId('sidebar-subitem-link-rules') is ambiguous under
+    // Playwright strict mode when both submenus are expanded.
+    this.alertingChannelsLink = page.locator('[data-nav-url="/workspace/alerting/channels"]')
+    this.alertingRulesLink = page.locator('[data-nav-url="/workspace/alerting/rules"]')
+    this.alertingHistoryLink = page.locator('[data-nav-url="/workspace/alerting/history"]')
     this.configLink = page.getByRole('link', { name: /config/i })
   }
 
@@ -70,6 +82,44 @@ export class SidebarPage extends BasePage {
    */
   async goToPlugins(): Promise<void> {
     await this.pluginsLink.click()
+    await this.waitForPageLoad()
+  }
+
+  /**
+   * Ensure the Alerting submenu is expanded before clicking a subitem.
+   * The Alerting button toggles the submenu, so only click it when the
+   * target link is not already visible to avoid collapsing an open menu.
+   */
+  private async expandAlertingIfNeeded(targetLink: Locator): Promise<void> {
+    if (!(await targetLink.isVisible())) {
+      await this.alertingButton.click()
+    }
+  }
+
+  /**
+   * Navigate to Alerting Channels page
+   */
+  async goToAlertingChannels(): Promise<void> {
+    await this.expandAlertingIfNeeded(this.alertingChannelsLink)
+    await this.alertingChannelsLink.click()
+    await this.waitForPageLoad()
+  }
+
+  /**
+   * Navigate to Alerting Rules page
+   */
+  async goToAlertingRules(): Promise<void> {
+    await this.expandAlertingIfNeeded(this.alertingRulesLink)
+    await this.alertingRulesLink.click()
+    await this.waitForPageLoad()
+  }
+
+  /**
+   * Navigate to Alerting History page
+   */
+  async goToAlertingHistory(): Promise<void> {
+    await this.expandAlertingIfNeeded(this.alertingHistoryLink)
+    await this.alertingHistoryLink.click()
     await this.waitForPageLoad()
   }
 

--- a/tests/e2e/features/placeholders/placeholders.spec.ts
+++ b/tests/e2e/features/placeholders/placeholders.spec.ts
@@ -6,14 +6,36 @@ test.describe('Placeholder and Enterprise Pages', () => {
     await expect(page.getByText(/Prompt repository is coming soon/i)).toBeVisible({ timeout: 10000 })
   })
 
-  test('should load alert-channels page', async ({ page }) => {
-    await page.goto('/workspace/alert-channels')
+  test('should load alerting channels page', async ({ page }) => {
+    await page.goto('/workspace/alerting/channels')
     await page.waitForLoadState('networkidle')
-    await expect(page.getByText('Unlock alert channels for better observability')).toBeVisible()
+    await expect(page.getByText('Unlock alerting channels for proactive monitoring')).toBeVisible()
     const readMore = page.getByRole('button', { name: /Read more/i })
     await expect(readMore).toBeVisible()
     const [popup] = await Promise.all([page.waitForEvent('popup'), readMore.click()])
-    await expect(popup).toHaveURL(/^https:\/\/docs\.getbifrost\.ai\/enterprise\/alert-channels(\?|$)/)
+    await expect(popup).toHaveURL(/^https:\/\/docs\.getbifrost\.ai\/enterprise\/alerting\/alert-channels(\?|$)/)
+    await popup.close()
+  })
+
+  test('should load alerting rules page', async ({ page }) => {
+    await page.goto('/workspace/alerting/rules')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('Unlock alerting rules for proactive monitoring')).toBeVisible()
+    const readMore = page.getByRole('button', { name: /Read more/i })
+    await expect(readMore).toBeVisible()
+    const [popup] = await Promise.all([page.waitForEvent('popup'), readMore.click()])
+    await expect(popup).toHaveURL(/^https:\/\/docs\.getbifrost\.ai\/enterprise\/alerting\/alert-rules(\?|$)/)
+    await popup.close()
+  })
+
+  test('should load alerting history page', async ({ page }) => {
+    await page.goto('/workspace/alerting/history')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('Unlock alerting history for proactive monitoring')).toBeVisible()
+    const readMore = page.getByRole('button', { name: /Read more/i })
+    await expect(readMore).toBeVisible()
+    const [popup] = await Promise.all([page.waitForEvent('popup'), readMore.click()])
+    await expect(popup).toHaveURL(/^https:\/\/docs\.getbifrost\.ai\/enterprise\/alerting\/alert-history(\?|$)/)
     await popup.close()
   })
 


### PR DESCRIPTION
## Summary

Adds end-to-end coverage for the alerting routes: navigation/sidebar helpers and placeholder-route specs that exercise the alerting screens added lower in the stack.

## Changes

- `tests/e2e/core/actions/navigation.ts` and `tests/e2e/core/pages/sidebar.page.ts`: E2E navigation/sidebar helpers for the alerting routes.
- `tests/e2e/features/placeholders/placeholders.spec.ts`: extend placeholder coverage to the alerting routes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test:e2e || npm run test:e2e
```

Confirm the placeholder + sidebar navigation specs pass.

## Screenshots/Recordings

No application UI changes (tests only).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
