### PR TITLE
fix: return `StatusBadRequest` for unresolvable provider errors instead of `StatusInternalServerError`

### DIFF
--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -116,7 +116,11 @@ func SendBifrostError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError
 	} else if !bifrostErr.IsBifrostError {
 		ctx.SetStatusCode(fasthttp.StatusBadRequest)
 	} else {
-		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		if bifrostErr.Error != nil && strings.Contains(strings.ToLower(bifrostErr.Error.Message), "could not auto resolve a provider for the request") {
+			ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		} else {
+			ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		}
 	}
 
 	ctx.SetContentType("application/json")

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -202,8 +202,14 @@ func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.
 
 	if bifrostErr.StatusCode != nil {
 		ctx.SetStatusCode(*bifrostErr.StatusCode)
+	} else if !bifrostErr.IsBifrostError {
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
 	} else {
-		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		if bifrostErr.Error != nil && strings.Contains(strings.ToLower(bifrostErr.Error.Message), "could not auto resolve a provider for the request") {
+			ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		} else {
+			ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		}
 	}
 	ctx.SetContentType("application/json")
 


### PR DESCRIPTION
## Summary

When Bifrost cannot auto-resolve a provider for a request, the HTTP transport was returning a `500 Internal Server Error`. This is misleading because the failure is caused by an invalid or incomplete client request, not an internal system fault. This PR corrects the status code to `400 Bad Request` for this specific error case.

## Changes

- In `transports/bifrost-http/handlers/utils.go`, the `SendBifrostError` function now checks if the error message contains `"could not auto resolve a provider for the request"` and returns `400` instead of `500`.
- In `transports/bifrost-http/integrations/utils.go`, the `sendError` method on `GenericRouter` applies the same logic, and also adds a missing `400` response for non-Bifrost errors (previously these fell through to `500`).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request to the Bifrost HTTP transport without a resolvable provider configured and verify the response status code is `400 Bad Request` rather than `500 Internal Server Error`.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This is a correctness fix for HTTP status codes returned to clients.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable