### PR TITLE
refactor: extract auto-resolve error messages as named constants and use exact-match comparison

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -20,6 +20,11 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+const (
+	ProviderAutoResolveErrorMessage = "could not auto resolve a provider for the request, please specify a provider explicitly"
+	ModelAutoResolveErrorMessage    = "could not auto resolve a model for the request, please specify a model explicitly"
+)
+
 // transientServerStatusCodes are upstream-side failures unrelated to the credential —
 // retried with the *same* key (a different credential gains nothing against a flaky
 // server). Distinct from perKeyFailureStatusCodes which trigger key rotation.
@@ -142,10 +147,10 @@ func validateRequestAfterPreRequestHooks(req *schemas.BifrostRequest) *schemas.B
 	}
 	provider, model, _ := req.GetRequestFields()
 	if provider == "" {
-		return newBifrostErrorFromMsg("could not auto resolve a provider for the request, please specify a provider explicitly")
+		return newBifrostErrorFromMsg(ProviderAutoResolveErrorMessage)
 	}
 	if isModelRequired(req.RequestType) && model == "" {
-		return newBifrostErrorFromMsg("could not auto resolve a model for the request, please specify a model explicitly")
+		return newBifrostErrorFromMsg(ModelAutoResolveErrorMessage)
 	}
 	return nil
 }

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
@@ -116,7 +117,9 @@ func SendBifrostError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError
 	} else if !bifrostErr.IsBifrostError {
 		ctx.SetStatusCode(fasthttp.StatusBadRequest)
 	} else {
-		if bifrostErr.Error != nil && strings.Contains(strings.ToLower(bifrostErr.Error.Message), "could not auto resolve a provider for the request") {
+		if bifrostErr.Error != nil &&
+			(bifrostErr.Error.Message == bifrost.ProviderAutoResolveErrorMessage ||
+				bifrostErr.Error.Message == bifrost.ModelAutoResolveErrorMessage) {
 			ctx.SetStatusCode(fasthttp.StatusBadRequest)
 		} else {
 			ctx.SetStatusCode(fasthttp.StatusInternalServerError)

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -205,7 +205,9 @@ func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.
 	} else if !bifrostErr.IsBifrostError {
 		ctx.SetStatusCode(fasthttp.StatusBadRequest)
 	} else {
-		if bifrostErr.Error != nil && strings.Contains(strings.ToLower(bifrostErr.Error.Message), "could not auto resolve a provider for the request") {
+		if bifrostErr.Error != nil &&
+			(bifrostErr.Error.Message == bifrost.ProviderAutoResolveErrorMessage ||
+				bifrostErr.Error.Message == bifrost.ModelAutoResolveErrorMessage) {
 			ctx.SetStatusCode(fasthttp.StatusBadRequest)
 		} else {
 			ctx.SetStatusCode(fasthttp.StatusInternalServerError)


### PR DESCRIPTION
## Summary

Auto-resolve error messages for provider and model were previously hardcoded inline strings, making them fragile to match against in HTTP error handling logic. This PR extracts those messages into exported constants and replaces substring matching with exact equality checks.

## Changes

- Extracted `ProviderAutoResolveErrorMessage` and `ModelAutoResolveErrorMessage` as exported constants in `core/utils.go`
- Replaced inline string literals in `validateRequestAfterPreRequestHooks` with the new constants
- Updated HTTP error status code logic in both `transports/bifrost-http/handlers/utils.go` and `transports/bifrost-http/integrations/utils.go` to use exact equality checks against the exported constants instead of case-insensitive substring matching, eliminating the risk of false positives

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger requests that omit a provider or model to confirm they still return `400 Bad Request`, and verify that unrelated internal errors still return `500 Internal Server Error`.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable