### PR TITLE
docs(alerting): add alerting documentation

### DIFF
--- a/docs/deployment-guides/config-json.mdx
+++ b/docs/deployment-guides/config-json.mdx
@@ -404,6 +404,9 @@ Ready-to-use reference configurations from the [examples/configs](https://github
   <Card title="Governance" icon="shield-check" href="/deployment-guides/config-json/governance">
     Virtual keys, budgets, rate limits, routing rules, admin auth
   </Card>
+  <Card title="Alerting" icon="bell" href="/deployment-guides/config-json/alerting">
+    Alert channels, CEL rules, history retention, webhook network controls
+  </Card>
   <Card title="Guardrails" icon="shield-halved" href="/deployment-guides/config-json/guardrails">
     Content moderation providers and CEL-based rules (enterprise)
   </Card>

--- a/docs/deployment-guides/config-json/alerting.mdx
+++ b/docs/deployment-guides/config-json/alerting.mdx
@@ -1,0 +1,324 @@
+---
+title: "Alerting"
+description: "Configure Bifrost Enterprise alert channels, rules, evaluation frequency, history retention, and webhook network controls in config.json"
+icon: "bell"
+---
+
+<Note>
+Alerting is an **enterprise-only** feature and requires the enterprise Bifrost image.
+</Note>
+
+The `alerting` block lets you seed alert channels and CEL-based alert rules directly in `config.json`. Rules evaluate governance metrics, such as budget usage and rate limit usage, and send notifications to Slack, Microsoft Teams, PagerDuty, or generic webhooks.
+
+Use this page when you want alerting to be managed as code. For the UI workflow and runtime concepts, see [Alerting](/enterprise/alerting/overview), [Alert Rules](/enterprise/alerting/alert-rules), [Alert Channels](/enterprise/alerting/alert-channels), and [Alert History](/enterprise/alerting/alert-history).
+
+<Note>
+Alert rules reference governance scopes and budgets by ID. Define the referenced virtual keys, teams, customers, budgets, and rate limits under [`governance`](/deployment-guides/config-json/governance), or create them through the Web UI or API before the rule is evaluated.
+</Note>
+
+---
+
+## Quick example
+
+This example creates one Slack channel, one generic webhook channel, and two rules: one budget alert for a virtual key and one request-rate-limit alert for a team.
+
+```json
+{
+  "alerting": {
+    "history_retention_days": 365,
+    "evaluation_interval_seconds": 10,
+    "webhook_network": {
+      "allow_http": false,
+      "allow_private_network": false
+    },
+    "channels": [
+      {
+        "id": "slack-platform",
+        "name": "Platform Slack",
+        "type": "slack",
+        "enabled": true,
+        "config": {
+          "webhook_url": "env.SLACK_WEBHOOK_URL"
+        },
+        "cooldown_seconds": 60
+      },
+      {
+        "id": "ops-webhook",
+        "name": "Ops webhook",
+        "type": "webhook",
+        "enabled": true,
+        "config": {
+          "url": "env.ALERT_WEBHOOK_URL",
+          "headers": {
+            "X-Alert-Token": "env.ALERT_WEBHOOK_TOKEN"
+          }
+        }
+      }
+    ],
+    "rules": [
+      {
+        "id": "vk-budget-80",
+        "name": "Virtual key budget at 80%",
+        "enabled": true,
+        "scope_type": "virtual_key",
+        "scope_id": "vk-platform",
+        "cel_expression": "budget_usage_percent >= 80.0",
+        "channel_ids": ["slack-platform"],
+        "cooldown_seconds": 300
+      },
+      {
+        "id": "team-requests-90",
+        "name": "Team request limit at 90%",
+        "enabled": true,
+        "scope_type": "team",
+        "scope_id": "team-platform",
+        "cel_expression": "rate_limit_request_usage_percent >= 90.0",
+        "channel_ids": ["slack-platform", "ops-webhook"],
+        "notify_once_per_reset_cycle": true
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Top-level fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `history_retention_days` | integer | `365` | Days to retain alert history. Set `0` to disable retention pruning. |
+| `evaluation_interval_seconds` | integer | `60` | Seconds between rule evaluations. Use `5` to `10` for one-minute budget or rate-limit reset windows. |
+| `webhook_network` | object | See below | Outbound URL validation controls for webhook-based channels. |
+| `channels` | array | `[]` | Declarative notification destinations. |
+| `rules` | array | `[]` | Declarative CEL rules evaluated against governance metrics. |
+
+<Note>
+Alerting samples the current governance counters at this interval. Keep `evaluation_interval_seconds` comfortably below the shortest configured budget or rate-limit reset duration so a brief threshold breach is observed before governance resets the counter.
+</Note>
+
+### Webhook network controls
+
+```json
+{
+  "alerting": {
+    "webhook_network": {
+      "allow_http": false,
+      "allow_private_network": false
+    }
+  }
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `allow_http` | `false` | Allow Slack, Microsoft Teams, and generic webhook channels to use `http://` URLs. PagerDuty always uses its fixed HTTPS endpoint. |
+| `allow_private_network` | `false` | Allow webhook destinations on RFC1918 private networks. Link-local and unspecified addresses remain blocked. |
+
+<Warning>
+Keep both webhook network controls disabled for production unless you are intentionally sending alerts to trusted internal endpoints. Enabling them weakens TLS and SSRF protections.
+</Warning>
+
+---
+
+## Channels
+
+Each channel needs a stable `id`, a display `name`, a `type`, an `enabled` flag, and a type-specific `config`.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Stable channel ID. Rules reference this ID in `channel_ids`. |
+| `name` | Yes | Operator-facing channel name. |
+| `description` | No | Optional description. |
+| `type` | Yes | `slack`, `microsoft_teams`, `pagerduty`, or `webhook`. |
+| `enabled` | Yes | Whether this channel can receive notifications. |
+| `cooldown_seconds` | No | Minimum seconds between sends for this channel. Set `0` for no channel-level cooldown. |
+| `config` | Conditional | Required for every supported channel type. |
+
+### Channel config
+
+Credential and endpoint fields support `env.VAR_NAME` references. Bifrost resolves the value from the process environment at startup.
+
+| Channel type | Required config | Notes |
+|--------------|-----------------|-------|
+| `slack` | Exactly one of `webhook_url` or `url` | Slack incoming webhook URL. |
+| `microsoft_teams` | Exactly one of `webhook_url` or `url` | Teams incoming webhook or Workflows URL. |
+| `pagerduty` | Exactly one of `routing_key` or `integration_key` | PagerDuty Events API v2 integration key. |
+| `webhook` | Exactly one of `url` or `webhook_url` | Generic webhook URL. Optional `headers` values also support `env.VAR_NAME`. |
+
+<Note>
+For each alias pair, provide exactly one key. For example, use either `webhook_url` or `url` for Slack, not both.
+</Note>
+
+```json
+{
+  "alerting": {
+    "channels": [
+      {
+        "id": "teams-ops",
+        "name": "Ops Teams",
+        "type": "microsoft_teams",
+        "enabled": true,
+        "config": {
+          "webhook_url": "env.TEAMS_WEBHOOK_URL"
+        }
+      },
+      {
+        "id": "pagerduty-prod",
+        "name": "Production PagerDuty",
+        "type": "pagerduty",
+        "enabled": true,
+        "config": {
+          "routing_key": "env.PAGERDUTY_ROUTING_KEY"
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Rules
+
+Rules evaluate CEL expressions against governance metrics collected for a virtual key, team, or customer.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Stable rule ID. |
+| `name` | Yes | Operator-facing rule name. |
+| `description` | No | Optional description. |
+| `enabled` | Yes | Whether this rule is evaluated. |
+| `scope_type` | Yes | `virtual_key`, `team`, or `customer`. |
+| `scope_id` | Yes | ID of the scoped virtual key, team, or customer. |
+| `cel_expression` | Yes | CEL expression that evaluates to a boolean. |
+| `query` | No | Optional UI query-builder representation of `cel_expression`. |
+| `cooldown_seconds` | No | Minimum seconds between notifications for this rule. Default is `60`. Set `0` to disable rule-level cooldown. |
+| `notify_once_per_reset_cycle` | No | When `true`, notify at most once per matched budget or rate-limit reset cycle. |
+| `channel_ids` | Yes | One or more alert channel IDs. |
+| `target_type` | Conditional | Use `budget` with `target_id` to evaluate one specific budget. |
+| `target_id` | Conditional | Required when `target_type` is set. |
+
+### Scopes and targets
+
+Every rule must have a scope. A rule can either evaluate all budgets for that scope or target one budget explicitly.
+
+| Behavior | `target_type` | `target_id` |
+|----------|---------------|-------------|
+| Evaluate all budgets in the scope | Omit | Omit |
+| Evaluate one budget | `budget` | Budget ID |
+
+`target_type` and `target_id` must be provided together.
+
+### CEL examples
+
+```python
+# Any budget in the scope reaches 80%
+budget_usage_percent >= 80.0
+```
+
+```python
+# Absolute spend crosses $100
+budget_spent > 100.0
+```
+
+```python
+# Request rate limit reaches 90%
+rate_limit_request_usage_percent >= 90.0
+```
+
+```python
+# Either budget or token rate limit is exhausted
+budget_usage_percent >= 100.0 || rate_limit_token_usage_percent >= 100.0
+```
+
+For the complete variable list, see [Alerting CEL variables](/enterprise/alerting/overview#cel-variables).
+
+---
+
+## Specific budget example
+
+Use `target_type: "budget"` and `target_id` when a rule should evaluate one budget instead of every budget in the scope.
+
+```json
+{
+  "alerting": {
+    "rules": [
+      {
+        "id": "vk-platform-monthly-budget-90",
+        "name": "Platform monthly budget at 90%",
+        "enabled": true,
+        "scope_type": "virtual_key",
+        "scope_id": "vk-platform",
+        "target_type": "budget",
+        "target_id": "budget-platform-monthly",
+        "cel_expression": "budget_usage_percent >= 90.0",
+        "channel_ids": ["pagerduty-prod"],
+        "cooldown_seconds": 600
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Reset-cycle notifications
+
+Set `notify_once_per_reset_cycle` when you want one notification per budget or rate-limit reset window, instead of repeated sends based on a cooldown.
+
+```json
+{
+  "alerting": {
+    "rules": [
+      {
+        "id": "team-token-limit-cycle",
+        "name": "Team token limit per reset cycle",
+        "enabled": true,
+        "scope_type": "team",
+        "scope_id": "team-platform",
+        "cel_expression": "rate_limit_token_usage_percent >= 90.0",
+        "channel_ids": ["slack-platform"],
+        "notify_once_per_reset_cycle": true
+      }
+    ]
+  }
+}
+```
+
+This is useful for rate limits and recurring budgets because the same condition can remain true until the reset window rolls over.
+
+---
+
+## Clusters
+
+In a Bifrost Enterprise cluster, only the leader evaluates alert rules and writes alert history. Followers can serve inference traffic and update shared governance usage, but they do not dispatch duplicate alerts.
+
+No extra alerting configuration is required for cluster mode. Configure clustering separately under [`cluster_config`](/deployment-guides/config-json/cluster).
+
+---
+
+## Validation
+
+Add the schema URL to get editor autocomplete and validation:
+
+```json
+{
+  "$schema": "https://www.getbifrost.ai/schema"
+}
+```
+
+The schema validates the channel type, required channel config, rule scopes, required `channel_ids`, and the `target_type` / `target_id` pairing.
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Alerting overview" icon="bell" href="/enterprise/alerting/overview">
+    Learn how alert evaluation, cooldowns, history, and clustering work.
+  </Card>
+  <Card title="Governance config" icon="shield-check" href="/deployment-guides/config-json/governance">
+    Define the virtual keys, teams, customers, budgets, and rate limits that alert rules evaluate.
+  </Card>
+</CardGroup>

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -23,6 +23,7 @@ This page is a concise reference for every top-level key in `config.json`. Click
 | `client` | object | Worker pool, logging, CORS, auth enforcement, header filtering, MCP, compat shims | [Client](/deployment-guides/config-json/client) |
 | `providers` | object | LLM provider API keys, network settings, concurrency | [Providers](/deployment-guides/config-json/providers) |
 | `governance` | object | Admin auth, virtual keys, budgets, rate limits, routing rules, customers, teams | [Governance](/deployment-guides/config-json/governance) |
+| `alerting` | object | Alert channels, CEL-based rules, history retention, and webhook network controls *(enterprise only)* | [Alerting](/deployment-guides/config-json/alerting) |
 | `guardrails_config` | object | Content moderation providers and CEL-based rules *(enterprise only)* | [Guardrails](/deployment-guides/config-json/guardrails) |
 | `access_profiles` | array | Access profile templates for enterprise RBAC/governance controls *(enterprise only)* | [Enterprise Governance](/enterprise/advanced-governance) |
 | `cluster_config` | object | Cluster mode settings: gossip, peers, and auto-discovery backends *(enterprise only)* | [Cluster](/deployment-guides/config-json/cluster) |
@@ -142,6 +143,14 @@ Full documentation: [Governance](/deployment-guides/config-json/governance).
 Enterprise-only. Two sub-keys: `guardrail_providers` (array) and `guardrail_rules` (array).
 
 Full documentation: [Guardrails](/deployment-guides/config-json/guardrails).
+
+---
+
+## `alerting`
+
+Enterprise-only. Supports `channels` (array), `rules` (array), `history_retention_days`, `evaluation_interval_seconds`, and `webhook_network`.
+
+Full documentation: [Alerting](/deployment-guides/config-json/alerting).
 
 ---
 

--- a/docs/deployment-guides/helm.mdx
+++ b/docs/deployment-guides/helm.mdx
@@ -613,6 +613,9 @@ curl http://localhost:8080/health
   <Card title="Governance" icon="shield" href="/deployment-guides/helm/governance">
     Budgets, rate limits, virtual keys, routing rules
   </Card>
+  <Card title="Alerting" icon="bell" href="/deployment-guides/helm/alerting">
+    Alert channels, CEL rules, history retention, webhook network controls
+  </Card>
   <Card title="Cluster Mode" icon="network-wired" href="/deployment-guides/helm/cluster">
     Multi-replica HA, gossip, peer discovery
   </Card>

--- a/docs/deployment-guides/helm/alerting.mdx
+++ b/docs/deployment-guides/helm/alerting.mdx
@@ -1,0 +1,333 @@
+---
+title: "Alerting"
+description: "Configure Bifrost Enterprise alert channels, rules, history retention, and webhook network controls in Helm"
+icon: "bell"
+---
+
+<Note>
+Alerting is an **enterprise-only** feature and requires the enterprise Bifrost image.
+</Note>
+
+Helm renders `bifrost.alerting` into the generated `config.json` that Bifrost loads at startup. Use this page when you want alert channels and rules managed from values files.
+
+For the runtime behavior and UI workflow, see [Alerting](/enterprise/alerting/overview), [Alert Rules](/enterprise/alerting/alert-rules), [Alert Channels](/enterprise/alerting/alert-channels), and [Alert History](/enterprise/alerting/alert-history).
+
+<Note>
+Alert rules evaluate governance metrics. Define the referenced virtual keys, teams, customers, budgets, and rate limits under [`bifrost.governance`](/deployment-guides/helm/governance), or create them through the Web UI or API before the rule is evaluated.
+</Note>
+
+---
+
+## Quick example
+
+Create Kubernetes secrets for channel credentials and expose them as environment variables to the Bifrost pod:
+
+```bash
+kubectl create secret generic bifrost-alerting-secrets \
+  --from-literal=slack-webhook-url='https://hooks.slack.com/services/T000/B000/XXXX' \
+  --from-literal=teams-webhook-url='https://example.webhook.office.com/workflows/XXXX' \
+  --from-literal=pagerduty-routing-key='pd-routing-key' \
+  --from-literal=webhook-url='https://hooks.example.com/alerts' \
+  --from-literal=webhook-token='secret-token'
+```
+
+Reference those values from your Helm values file:
+
+```yaml
+env:
+  - name: SLACK_WEBHOOK_URL
+    valueFrom:
+      secretKeyRef:
+        name: bifrost-alerting-secrets
+        key: slack-webhook-url
+  - name: TEAMS_WEBHOOK_URL
+    valueFrom:
+      secretKeyRef:
+        name: bifrost-alerting-secrets
+        key: teams-webhook-url
+  - name: PAGERDUTY_ROUTING_KEY
+    valueFrom:
+      secretKeyRef:
+        name: bifrost-alerting-secrets
+        key: pagerduty-routing-key
+  - name: ALERT_WEBHOOK_URL
+    valueFrom:
+      secretKeyRef:
+        name: bifrost-alerting-secrets
+        key: webhook-url
+  - name: ALERT_WEBHOOK_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: bifrost-alerting-secrets
+        key: webhook-token
+
+bifrost:
+  alerting:
+    history_retention_days: 365
+    evaluation_interval_seconds: 10
+    webhook_network:
+      allow_http: false
+      allow_private_network: false
+
+    channels:
+      - id: "slack-platform"
+        name: "Platform Slack"
+        type: "slack"
+        enabled: true
+        config:
+          webhook_url: "env.SLACK_WEBHOOK_URL"
+        cooldown_seconds: 60
+
+      - id: "pagerduty-prod"
+        name: "Production PagerDuty"
+        type: "pagerduty"
+        enabled: true
+        config:
+          routing_key: "env.PAGERDUTY_ROUTING_KEY"
+
+      - id: "ops-webhook"
+        name: "Ops webhook"
+        type: "webhook"
+        enabled: true
+        config:
+          url: "env.ALERT_WEBHOOK_URL"
+          headers:
+            X-Alert-Token: "env.ALERT_WEBHOOK_TOKEN"
+
+    rules:
+      - id: "vk-budget-80"
+        name: "Virtual key budget at 80%"
+        enabled: true
+        scope_type: "virtual_key"
+        scope_id: "vk-platform"
+        cel_expression: "budget_usage_percent >= 80.0"
+        channel_ids: ["slack-platform"]
+        cooldown_seconds: 300
+
+      - id: "team-requests-90"
+        name: "Team request limit at 90%"
+        enabled: true
+        scope_type: "team"
+        scope_id: "team-platform"
+        cel_expression: "rate_limit_request_usage_percent >= 90.0"
+        channel_ids: ["slack-platform", "ops-webhook"]
+        notify_once_per_reset_cycle: true
+```
+
+Apply the values:
+
+```bash
+helm upgrade bifrost bifrost/bifrost --reuse-values -f alerting-values.yaml
+```
+
+---
+
+## Top-level fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `bifrost.alerting.history_retention_days` | integer | `365` | Days to retain alert history. Set `0` to disable retention pruning. |
+| `bifrost.alerting.evaluation_interval_seconds` | integer | `60` | Seconds between rule evaluations. Use `5` to `10` for one-minute budget or rate-limit reset windows. |
+| `bifrost.alerting.webhook_network` | object | See below | Outbound URL validation controls for webhook-based channels. |
+| `bifrost.alerting.channels` | array | `[]` | Declarative notification destinations. |
+| `bifrost.alerting.rules` | array | `[]` | Declarative CEL rules evaluated against governance metrics. |
+
+<Note>
+Alerting samples the current governance counters at this interval. Keep `evaluation_interval_seconds` comfortably below the shortest configured budget or rate-limit reset duration so a brief threshold breach is observed before governance resets the counter.
+</Note>
+
+### Webhook network controls
+
+```yaml
+bifrost:
+  alerting:
+    webhook_network:
+      allow_http: false
+      allow_private_network: false
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `allow_http` | `false` | Allow Slack, Microsoft Teams, and generic webhook channels to use `http://` URLs. PagerDuty always uses its fixed HTTPS endpoint. |
+| `allow_private_network` | `false` | Allow webhook destinations on RFC1918 private networks. Link-local and unspecified addresses remain blocked. |
+
+<Warning>
+Keep both webhook network controls disabled for production unless you are intentionally sending alerts to trusted internal endpoints. Enabling them weakens TLS and SSRF protections.
+</Warning>
+
+---
+
+## Channels
+
+Each channel needs a stable `id`, a display `name`, a `type`, an `enabled` flag, and a type-specific `config`.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Stable channel ID. Rules reference this ID in `channel_ids`. |
+| `name` | Yes | Operator-facing channel name. |
+| `description` | No | Optional description. |
+| `type` | Yes | `slack`, `microsoft_teams`, `pagerduty`, or `webhook`. |
+| `enabled` | Yes | Whether this channel can receive notifications. |
+| `cooldown_seconds` | No | Minimum seconds between sends for this channel. Set `0` for no channel-level cooldown. |
+| `config` | Conditional | Required for every supported channel type. |
+
+### Channel config
+
+Credential and endpoint fields support `env.VAR_NAME` references. Bifrost resolves the value from the pod environment at startup.
+
+| Channel type | Required config | Notes |
+|--------------|-----------------|-------|
+| `slack` | Exactly one of `webhook_url` or `url` | Slack incoming webhook URL. |
+| `microsoft_teams` | Exactly one of `webhook_url` or `url` | Teams incoming webhook or Workflows URL. |
+| `pagerduty` | Exactly one of `routing_key` or `integration_key` | PagerDuty Events API v2 integration key. |
+| `webhook` | Exactly one of `url` or `webhook_url` | Generic webhook URL. Optional `headers` values also support `env.VAR_NAME`. |
+
+<Note>
+For each alias pair, provide exactly one key. For example, use either `webhook_url` or `url` for Slack, not both.
+</Note>
+
+```yaml
+bifrost:
+  alerting:
+    channels:
+      - id: "teams-ops"
+        name: "Ops Teams"
+        type: "microsoft_teams"
+        enabled: true
+        config:
+          webhook_url: "env.TEAMS_WEBHOOK_URL"
+
+      - id: "pagerduty-prod"
+        name: "Production PagerDuty"
+        type: "pagerduty"
+        enabled: true
+        config:
+          routing_key: "env.PAGERDUTY_ROUTING_KEY"
+```
+
+---
+
+## Rules
+
+Rules evaluate CEL expressions against governance metrics collected for a virtual key, team, or customer.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Stable rule ID. |
+| `name` | Yes | Operator-facing rule name. |
+| `description` | No | Optional description. |
+| `enabled` | Yes | Whether this rule is evaluated. |
+| `scope_type` | Yes | `virtual_key`, `team`, or `customer`. |
+| `scope_id` | Yes | ID of the scoped virtual key, team, or customer. |
+| `cel_expression` | Yes | CEL expression that evaluates to a boolean. |
+| `query` | No | Optional UI query-builder representation of `cel_expression`. |
+| `cooldown_seconds` | No | Minimum seconds between notifications for this rule. Default is `60`. Set `0` to disable rule-level cooldown. |
+| `notify_once_per_reset_cycle` | No | When `true`, notify at most once per matched budget or rate-limit reset cycle. |
+| `channel_ids` | Yes | One or more alert channel IDs. |
+| `target_type` | Conditional | Use `budget` with `target_id` to evaluate one specific budget. |
+| `target_id` | Conditional | Required when `target_type` is set. |
+
+### Scopes and targets
+
+Every rule must have a scope. A rule can either evaluate all budgets for that scope or target one budget explicitly.
+
+| Behavior | `target_type` | `target_id` |
+|----------|---------------|-------------|
+| Evaluate all budgets in the scope | Omit | Omit |
+| Evaluate one budget | `budget` | Budget ID |
+
+`target_type` and `target_id` must be provided together.
+
+### CEL examples
+
+```python
+# Any budget in the scope reaches 80%
+budget_usage_percent >= 80.0
+```
+
+```python
+# Request rate limit reaches 90%
+rate_limit_request_usage_percent >= 90.0
+```
+
+```python
+# Either budget or token rate limit is exhausted
+budget_usage_percent >= 100.0 || rate_limit_token_usage_percent >= 100.0
+```
+
+For the complete variable list, see [Alerting CEL variables](/enterprise/alerting/overview#cel-variables).
+
+---
+
+## Specific budget example
+
+Use `target_type: "budget"` and `target_id` when a rule should evaluate one budget instead of every budget in the scope.
+
+```yaml
+bifrost:
+  alerting:
+    rules:
+      - id: "vk-platform-monthly-budget-90"
+        name: "Platform monthly budget at 90%"
+        enabled: true
+        scope_type: "virtual_key"
+        scope_id: "vk-platform"
+        target_type: "budget"
+        target_id: "budget-platform-monthly"
+        cel_expression: "budget_usage_percent >= 90.0"
+        channel_ids: ["pagerduty-prod"]
+        cooldown_seconds: 600
+```
+
+---
+
+## Reset-cycle notifications
+
+Set `notify_once_per_reset_cycle` when you want one notification per budget or rate-limit reset window, instead of repeated sends based on a cooldown.
+
+```yaml
+bifrost:
+  alerting:
+    rules:
+      - id: "team-token-limit-cycle"
+        name: "Team token limit per reset cycle"
+        enabled: true
+        scope_type: "team"
+        scope_id: "team-platform"
+        cel_expression: "rate_limit_token_usage_percent >= 90.0"
+        channel_ids: ["slack-platform"]
+        notify_once_per_reset_cycle: true
+```
+
+This is useful for rate limits and recurring budgets because the same condition can remain true until the reset window rolls over.
+
+---
+
+## Clusters
+
+In a Bifrost Enterprise cluster, only the leader evaluates alert rules and writes alert history. Followers can serve inference traffic and update shared governance usage, but they do not dispatch duplicate alerts.
+
+No extra alerting configuration is required for cluster mode. Configure clustering separately under [`bifrost.cluster`](/deployment-guides/helm/cluster).
+
+---
+
+## Validation
+
+The Helm values schema validates alerting configuration during template rendering and install or upgrade operations. It checks channel types, required channel config, exact-one alias pairs, required `channel_ids`, and the `target_type` / `target_id` pairing.
+
+```bash
+helm template bifrost bifrost/bifrost -f alerting-values.yaml >/tmp/bifrost-rendered.yaml
+```
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Alerting overview" icon="bell" href="/enterprise/alerting/overview">
+    Learn how alert evaluation, cooldowns, history, and clustering work.
+  </Card>
+  <Card title="Governance in Helm" icon="shield" href="/deployment-guides/helm/governance">
+    Define the virtual keys, teams, customers, budgets, and rate limits that alert rules evaluate.
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -318,6 +318,16 @@
                   }
                 ]
               },
+              {
+                "group": "Alerting",
+                "icon": "bell",
+                "pages": [
+                  "enterprise/alerting/overview",
+                  "enterprise/alerting/alert-rules",
+                  "enterprise/alerting/alert-channels",
+                  "enterprise/alerting/alert-history"
+                ]
+              },
               "enterprise/audit-logs",
               "enterprise/secret-management",
               "enterprise/log-exports",
@@ -558,6 +568,7 @@
                   "deployment-guides/helm/storage",
                   "deployment-guides/helm/plugins",
                   "deployment-guides/helm/governance",
+                  "deployment-guides/helm/alerting",
                   "deployment-guides/helm/guardrails",
                   "deployment-guides/helm/secret-management",
                   "deployment-guides/helm/cluster",
@@ -576,6 +587,7 @@
                   "deployment-guides/config-json/storage",
                   "deployment-guides/config-json/plugins",
                   "deployment-guides/config-json/governance",
+                  "deployment-guides/config-json/alerting",
                   "deployment-guides/config-json/cluster",
                   "deployment-guides/config-json/guardrails",
                   "deployment-guides/config-json/secret-management"

--- a/docs/enterprise/alerting/alert-channels.mdx
+++ b/docs/enterprise/alerting/alert-channels.mdx
@@ -1,0 +1,273 @@
+---
+title: "Alert Channels"
+description: "Configure where Bifrost Enterprise delivers alerts - Slack, Microsoft Teams, PagerDuty, or any HTTP webhook - with encrypted configuration, SSRF protection, and per-channel cooldowns."
+icon: "megaphone"
+keywords: ["alert channels", "slack", "microsoft teams", "pagerduty", "webhook", "notifications"]
+---
+
+## Overview
+
+An **alert channel** is a notification destination. When an [alert rule](/enterprise/alerting/alert-rules) triggers, Bifrost dispatches a notification to each channel attached to that rule. Channel configuration (URLs, keys, headers) is encrypted at rest.
+
+## Channel types
+
+| Type | `type` value | Required config key | Payload format |
+| --- | --- | --- | --- |
+| **Slack** | `slack` | `webhook_url` (or `url`) | Slack Block Kit message with header and message section. |
+| **Microsoft Teams** | `microsoft_teams` | `webhook_url` (or `url`) | Adaptive Card (28 KB payload limit). |
+| **PagerDuty** | `pagerduty` | `routing_key` (or `integration_key`) | PagerDuty Events API v2 event. |
+| **Webhook** | `webhook` | `url` (or `webhook_url`) | Generic JSON payload. |
+
+Every channel also accepts an optional `name`, an optional `description`, and an optional per-channel cooldown.
+
+---
+
+## Slack
+
+Create a Slack [incoming webhook](https://api.slack.com/messaging/webhooks) and provide its URL.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `webhook_url` | string | Yes | Slack incoming webhook URL (HTTPS). Also accepted as `url`. |
+
+```json
+{
+  "name": "Engineering Slack",
+  "type": "slack",
+  "config": {
+    "webhook_url": "https://hooks.slack.com/services/T000/B000/XXXX"
+  }
+}
+```
+
+Notifications are sent as Block Kit messages. Each message includes a header block showing the rule name and a section block containing the alert details in a markdown code block.
+
+---
+
+## Microsoft Teams
+
+Provide a Teams incoming webhook or Workflows URL.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `webhook_url` | string | Yes | Teams webhook URL (HTTPS). Also accepted as `url`. |
+
+```json
+{
+  "name": "Platform Teams",
+  "type": "microsoft_teams",
+  "config": {
+    "webhook_url": "https://prod-00.westus.logic.azure.com/workflows/XXXX"
+  }
+}
+```
+
+Notifications are sent as Adaptive Cards. Teams enforces a **28 KB** payload limit.
+
+---
+
+## PagerDuty
+
+Use a PagerDuty service integration key (routing key) from an Events API v2 integration.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `routing_key` | string | Yes | PagerDuty Events API v2 integration (routing) key. Also accepted as `integration_key`. |
+
+```json
+{
+  "name": "On-call",
+  "type": "pagerduty",
+  "config": {
+    "routing_key": "R0XXXXXXXXXXXXXXXXXXXXXXXX"
+  }
+}
+```
+
+Events are sent via the PagerDuty Events API v2 with `event_action: "trigger"`, severity `"warning"`, and a deduplication key derived from the rule ID, scope, and target so repeated triggers update the same incident. The source field is set to `"Bifrost Alerting"`.
+
+---
+
+## Webhook
+
+Send a generic JSON payload to any HTTPS endpoint.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `url` | string | Yes | Destination URL. HTTPS required unless `allow_http` is enabled in `webhook_network` config. Also accepted as `webhook_url`. |
+| `headers` | object | No | Additional HTTP headers to send. Sensitive headers are stripped (see [Security](#security)). |
+
+```json
+{
+  "name": "Internal webhook",
+  "type": "webhook",
+  "config": {
+    "url": "https://hooks.example.com/alerts",
+    "headers": {
+      "X-API-Key": "your-secret"
+    }
+  }
+}
+```
+
+### Webhook payload
+
+```json
+{
+  "event": "alert.triggered",
+  "timestamp": "2026-06-11T12:00:00Z",
+  "rule": { "id": "rule_123", "name": "Budget at 80%" },
+  "scope": { "type": "virtual_key", "id": "vk-abc" },
+  "cel_expression": "budget_usage_percent >= 80.0",
+  "input": {
+    "budget_usage_percent": 91.2,
+    "budget_spent": 456.0,
+    "budget_limit": 500.0,
+    "scope_type": "virtual_key",
+    "scope_id": "vk-abc",
+    "target_type": "budget",
+    "target_id": "budget-a"
+  },
+  "message": "Alert matched: Budget at 80%\nScope: virtual_key/vk-abc\nTarget: budget/budget-a\nExpression: budget_usage_percent >= 80.0\nValues: budget_limit=500, budget_spent=456, budget_usage_percent=91.2"
+}
+```
+
+---
+
+## Cooldowns
+
+Each channel can define an optional cooldown that applies on top of the rule's cooldown. When a channel is within its cooldown window, matched alerts that would have been delivered through that channel are recorded as `skipped` in [alert history](/enterprise/alerting/alert-history) with reason `"channel_cooldown"`.
+
+- A channel cooldown of `0` means no additional suppression beyond the rule cooldown.
+- The API accepts `cooldown_milliseconds`, which must be a multiple of 1000.
+- `config.json` accepts `cooldown_seconds`, a whole-second integer.
+
+---
+
+## Security
+
+All channels enforce network safety controls:
+
+- **HTTPS by default.** Slack, Microsoft Teams, and generic webhook channels require HTTPS unless `webhook_network.allow_http` is `true`. PagerDuty always uses its fixed HTTPS Events API endpoint.
+- **SSRF protection.** RFC1918 private-network destinations are blocked unless `webhook_network.allow_private_network` is `true`. Loopback destinations such as `localhost` are permitted for local development. Link-local and unspecified addresses remain blocked regardless of this setting.
+- **Header sanitization.** Sensitive outbound headers are stripped from webhook requests: `authorization`, `connection`, `content-length`, `cookie`, `host`, `proxy-authorization`, `set-cookie`, `te`, `trailer`, `transfer-encoding`, `upgrade`.
+
+<Warning>
+Enabling `allow_http` or `allow_private_network` weakens TLS or SSRF protections. Only enable these for trusted internal or air-gapped networks.
+</Warning>
+
+---
+
+## Creating a channel
+
+<Tabs group="setup-method">
+<Tab title="Web UI">
+
+1. Open **Alerting** in the Bifrost dashboard, go to the **Channels** tab, and click **Add Channel**.
+2. Enter a **Channel Name** and select a **Channel Type**.
+3. Provide the type-specific configuration (webhook URL, routing key, etc.).
+4. Optionally set a **Cooldown** and, for webhooks, **Custom Headers**.
+5. Click **Add Channel**.
+
+</Tab>
+<Tab title="API">
+
+All endpoints are under `/api/alerting/`.
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| `GET` | `/channels` | List channels (config redacted). |
+| `GET` | `/channels/{id}` | Get a channel by ID. |
+| `POST` | `/channels` | Create a channel. |
+| `PUT` | `/channels/{id}` | Update a channel. |
+| `DELETE` | `/channels/{id}` | Delete a channel and detach it from all rules. |
+
+```bash
+curl -X POST https://your-bifrost-gateway/api/alerting/channels \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Engineering Slack",
+    "type": "slack",
+    "config": { "webhook_url": "https://hooks.slack.com/services/T000/B000/XXXX" }
+  }'
+```
+
+To create a webhook with a per-channel cooldown:
+
+```bash
+curl -X POST https://your-bifrost-gateway/api/alerting/channels \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Custom Webhook",
+    "type": "webhook",
+    "config": {
+      "url": "https://hooks.example.com/alerts",
+      "headers": { "X-API-Key": "secret" }
+    },
+    "cooldown_milliseconds": 60000
+  }'
+```
+
+</Tab>
+<Tab title="config.json">
+<span id="configjson"></span>
+
+Channels can be declared statically in the `alerting` section of `config.json`. Changes are reconciled on gateway reload.
+
+```json
+{
+  "alerting": {
+    "channels": [
+      {
+        "id": "slack-prod",
+        "name": "Production Slack",
+        "type": "slack",
+        "enabled": true,
+        "config": {
+          "webhook_url": "https://hooks.slack.com/services/xxx"
+        },
+        "cooldown_seconds": 60
+      },
+      {
+        "id": "pagerduty-critical",
+        "name": "On-call PagerDuty",
+        "type": "pagerduty",
+        "enabled": true,
+        "config": {
+          "routing_key": "abc123..."
+        }
+      },
+      {
+        "id": "generic-webhook",
+        "name": "Custom Webhook",
+        "type": "webhook",
+        "enabled": true,
+        "config": {
+          "url": "https://my-service.example.com/alerts",
+          "headers": {
+            "X-Trace-ID": "value"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Alert Rules" icon="gavel" href="/enterprise/alerting/alert-rules">
+    Attach channels to rules and define trigger conditions.
+  </Card>
+  <Card title="Alert History" icon="clock-rotate-left" href="/enterprise/alerting/alert-history">
+    Review delivery outcomes for every channel.
+  </Card>
+</CardGroup>

--- a/docs/enterprise/alerting/alert-history.mdx
+++ b/docs/enterprise/alerting/alert-history.mdx
@@ -1,0 +1,144 @@
+---
+title: "Alert History"
+description: "Review delivered alert notifications, skipped alerts, and failed delivery attempts in Bifrost Enterprise."
+icon: "clock-rotate-left"
+keywords: ["alert history", "alert delivery", "notifications", "skipped alerts"]
+---
+
+## Overview
+
+Bifrost records every alert evaluation outcome in **alert history**. Each record captures the rule that was evaluated, the scope and target, the metric values at evaluation time, the delivery channel (if applicable), and the outcome status.
+
+Alert history is stored in the configured logs store. PostgreSQL and ClickHouse logs stores both support history writes, filtering, and recovery of alert state. With ClickHouse, Bifrost creates an `enterprise_alert_history` table with the configured `history_retention_days` TTL.
+
+Bifrost uses its shared key-value store for live rule cooldown, channel cooldown, and reset-cycle checks. After startup or a leadership change, the alerting engine bulk-loads only the latest relevant `sent` timestamps and reset-cycle identities from history before it can dispatch alerts. Normal evaluation sweeps do not query alert history for each rule or channel.
+
+With ClickHouse, a cold recovery performs an immediate read and a delayed second read before dispatch starts. This allows replicated ClickHouse tables time to converge and reduces duplicate notifications after failover.
+
+---
+
+## Alert history records
+
+Open **Alerting** in the Bifrost dashboard and select the **History** tab to review past alert activity.
+
+Each history record contains:
+
+| Field | Description |
+| --- | --- |
+| **Time** | When the evaluation was recorded. |
+| **Rule** | The rule that was evaluated. |
+| **Channel** | The channel that was notified, or empty for cooldown skips. |
+| **Scope** | The scope type and ID the rule applied to. |
+| **Target** | The budget target (`target_type` and `target_id`), if the rule targets one. |
+| **Status** | Delivery outcome: `sent`, `failed`, or `skipped`. |
+
+You can filter history by status, scope type, and channel type.
+
+---
+
+## Statuses
+
+Each history record has one of three statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `sent` | The alert was successfully delivered to the channel. |
+| `failed` | Delivery was attempted but failed (for example, network error or unsupported channel type). |
+| `skipped` | The rule matched but delivery was suppressed by a cooldown. |
+
+For skipped records, the `status_detail` field indicates the reason:
+
+- `"skipped due to rule cooldown"` - the rule-level cooldown was active.
+- `"skipped due to channel cooldown"` - the channel-level cooldown was active.
+
+For failed records, the `status_detail` field contains the error (for example, `"delivery failed"` or `"unsupported alert channel type: ..."`).
+
+---
+
+## Evaluation input
+
+Each history record stores the metric values that were evaluated. For a matched rule, this includes the specific values that caused the expression to evaluate to `true`. Example for a budget alert:
+
+```json
+{
+  "budget_usage_percent": 91.2,
+  "budget_spent": 456.0,
+  "budget_limit": 500.0,
+  "request_usage": 0,
+  "request_limit": 0,
+  "token_usage": 0,
+  "token_limit": 0,
+  "scope_type": "virtual_key",
+  "scope_id": "vk-abc",
+  "target_type": "budget",
+  "target_id": "budget-a"
+}
+```
+
+---
+
+## API
+
+The alert history API is available at `/api/alerting/history`.
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| `GET` | `/history` | Paginated history with filters. |
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `limit` | integer | Maximum records to return. Default `25`. |
+| `offset` | integer | Records to skip for pagination. Default `0`. |
+| `status` | string (comma-separated) | Filter by status: `sent`, `failed`, `skipped`. |
+| `scope_type` | string (comma-separated) | Filter by scope: `virtual_key`, `team`, `customer`. |
+| `channel_type` | string (comma-separated) | Filter by channel: `slack`, `microsoft_teams`, `pagerduty`, `webhook`. |
+
+```bash
+curl "https://your-bifrost-gateway/api/alerting/history?status=sent,failed&scope_type=virtual_key&limit=10" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+**Response:**
+
+The `id` is numeric with PostgreSQL and a UUID string with ClickHouse.
+
+```json
+{
+  "history": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "rule_id": "budget-80-percent",
+      "rule_name": "Budget at 80%",
+      "channel_id": "slack-prod",
+      "channel_name": "Production Slack",
+      "channel_type": "slack",
+      "scope_type": "virtual_key",
+      "scope_id": "vk-abc",
+      "target_type": "budget",
+      "target_id": "budget-a",
+      "cel_expression": "budget_usage_percent >= 80.0",
+      "status": "sent",
+      "status_detail": "",
+      "created_at": "2026-06-11T12:00:00Z"
+    }
+  ],
+  "total": 42,
+  "limit": 10,
+  "offset": 0
+}
+```
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Alert Rules" icon="gavel" href="/enterprise/alerting/alert-rules">
+    Tune conditions, scopes, and cooldowns based on what you see in history.
+  </Card>
+  <Card title="Alert Channels" icon="megaphone" href="/enterprise/alerting/alert-channels">
+    Reconfigure channels if you see delivery failures.
+  </Card>
+</CardGroup>

--- a/docs/enterprise/alerting/alert-rules.mdx
+++ b/docs/enterprise/alerting/alert-rules.mdx
@@ -1,0 +1,241 @@
+---
+title: "Alert Rules"
+description: "Define CEL-based alert rules in Bifrost Enterprise - scope them to virtual keys, teams, or customers, optionally target a specific budget, and send triggers to channels."
+icon: "gavel"
+keywords: ["alert rules", "cel", "conditions", "thresholds", "scope", "cooldown"]
+---
+
+## Overview
+
+An **alert rule** defines a CEL expression over governance metrics and the channels to notify when that expression evaluates to `true`. Rules are scoped to a governance entity (virtual key, team, or customer) and can optionally target a specific budget.
+
+## Anatomy of a rule
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | Human-readable rule name. |
+| `scope_type` | string | One of `virtual_key`, `team`, `customer`. |
+| `scope_id` | string | The ID of the scoped entity. Required. |
+| `cel_expression` | string | The CEL expression evaluated against governance metrics. Must evaluate to a boolean. |
+| `channel_ids` | array | One or more [channel](/enterprise/alerting/alert-channels) IDs to notify. |
+| `target_type` | string | Optional. Set to `"budget"` to target a specific budget. |
+| `target_id` | string | The ID of the target budget. Only valid when `target_type` is `"budget"`. |
+| `description` | string | Optional description of the rule. |
+| `enabled` | boolean | Whether the rule is active. Default `true`. |
+| `cooldown_milliseconds` | integer | Minimum milliseconds between notifications for the same rule, scope, and target. Must be a multiple of 1000 (whole seconds). API only; `config.json` uses `cooldown_seconds`. |
+
+---
+
+## CEL expressions
+
+Rules use [CEL](https://github.com/google/cel-spec) expressions evaluated against the [CEL variables](/enterprise/alerting/overview#cel-variables) populated from governance snapshots. Supported operators are `==`, `!=`, `>`, `<`, `>=`, and `<=`. Expressions can be combined using `&&` (and) and `||` (or).
+
+### Budget examples
+
+```python
+# Alert when any budget in the scope reaches 80% or more
+budget_usage_percent >= 80.0
+```
+
+```python
+# Alert when absolute spend crosses a threshold
+budget_spent > 1000.0
+```
+
+```python
+# Alert when a specific budget exceeds 50% AND spending is above $100
+budget_usage_percent > 50.0 && budget_spent > 100.0
+```
+
+### Rate limit examples
+
+```python
+# Alert when request rate limit usage reaches 80%
+rate_limit_request_usage_percent >= 80.0
+```
+
+```python
+# Alert when either request or token rate limit usage is above 90%
+rate_limit_request_usage_percent >= 90.0 || rate_limit_token_usage_percent >= 90.0
+```
+
+```python
+# Alert on absolute request count
+request_usage > 10000
+```
+
+### Compound examples
+
+```python
+# Alert on high budget usage AND high request volume
+budget_usage_percent > 80.0 && request_usage > 10000
+```
+
+```python
+# Alert on budget exhaustion OR rate limit exhaustion
+budget_usage_percent >= 100.0 || rate_limit_token_usage_percent >= 100.0
+```
+
+---
+
+## Scopes
+
+Rules must specify a scope type and a scope ID. The following scopes are supported:
+
+| Scope | Description |
+| --- | --- |
+| `virtual_key` | A virtual key. |
+| `team` | A team. |
+| `customer` | A customer. |
+
+The scope ID must be non-empty and identify an existing governance entity. The API validates that the referenced entity exists before creating or updating a rule.
+
+---
+
+## Budget targeting
+
+By default, a rule evaluates its CEL expression against every budget belonging to its scope. You can narrow evaluation to a specific budget by setting `target_type` to `"budget"` and `target_id` to the ID of the budget.
+
+| Behavior | `target_type` | `target_id` |
+| --- | --- | --- |
+| Evaluate all budgets in scope | Not set (or `null`) | Not set (or `null`) |
+| Evaluate a specific budget | `"budget"` | The budget's ID |
+
+When a target is set, only metrics for that specific budget are used. The budget usage percentage, absolute spend, and limit reflect that budget alone. Rate limit variables are still populated from the scope's active rate limits.
+
+---
+
+## Cooldowns
+
+The cooldown prevents alert storms by suppressing repeat notifications after a rule fires. The cooldown window is measured from the latest successful send for the same rule, scope, and target. Live checks use Bifrost's shared key-value store; alert history is the durable source used to rebuild that state after startup or leadership changes.
+
+- Default cooldown is 60 seconds. Set to `0` to disable suppression (every match produces a notification).
+- The API accepts `cooldown_milliseconds`, which must be a whole-second value (multiple of 1000).
+- `config.json` accepts `cooldown_seconds`, which is an integer in seconds.
+
+Channels can add their own [per-channel cooldown](/enterprise/alerting/alert-channels#cooldowns) on top of the rule cooldown.
+
+---
+
+## Creating a rule
+
+<Tabs group="setup-method">
+<Tab title="Web UI">
+
+1. Open **Alerting** in the Bifrost dashboard, go to the **Rules** tab, and click **Add Rule**.
+2. Enter a **Rule Name** and optional **Description**.
+3. Choose a **Scope Type** and select the **Scope** entity.
+4. Optionally set a **Target Type** of `budget` and select a specific budget.
+5. Build the **CEL Expression** using the rule builder.
+6. Select one or more **Notification Channels**.
+7. Optionally set a **Cooldown**.
+8. Click **Create Rule**.
+
+</Tab>
+<Tab title="API">
+
+All endpoints are under `/api/alerting/`.
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| `GET` | `/rules` | List all rules. |
+| `GET` | `/rules/{id}` | Get a rule by ID. |
+| `POST` | `/rules` | Create a rule. |
+| `PUT` | `/rules/{id}` | Update a rule. |
+| `DELETE` | `/rules/{id}` | Delete a rule. |
+
+Creating a rule validates that the name is set, the scope type is valid, the scope ID is non-empty, the referenced scope entity exists, the CEL expression compiles to a boolean, and at least one channel is attached.
+
+```bash
+curl -X POST https://your-bifrost-gateway/api/alerting/rules \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Budget at 80%",
+    "scope_type": "virtual_key",
+    "scope_id": "vk-123",
+    "cel_expression": "budget_usage_percent >= 80.0",
+    "channel_ids": ["slack-prod"],
+    "cooldown_milliseconds": 300000
+  }'
+```
+
+To target a specific budget:
+
+```bash
+curl -X POST https://your-bifrost-gateway/api/alerting/rules \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Budget A at 90%",
+    "scope_type": "virtual_key",
+    "scope_id": "vk-123",
+    "target_type": "budget",
+    "target_id": "budget-a",
+    "cel_expression": "budget_usage_percent >= 90.0",
+    "channel_ids": ["slack-prod"],
+    "cooldown_milliseconds": 300000
+  }'
+```
+
+</Tab>
+<Tab title="config.json">
+<span id="configjson"></span>
+
+Rules and channels can be declared statically in the `alerting` section of `config.json`. Changes are reconciled on gateway reload.
+
+```json
+{
+  "alerting": {
+    "rules": [
+      {
+        "id": "budget-80-percent",
+        "name": "Budget at 80%",
+        "description": "Alert when any budget exceeds 80%",
+        "enabled": true,
+        "scope_type": "virtual_key",
+        "scope_id": "vk-123",
+        "cel_expression": "budget_usage_percent >= 80.0",
+        "channel_ids": ["slack-prod"],
+        "cooldown_seconds": 300
+      },
+      {
+        "id": "rate-limit-alert",
+        "name": "Request rate limit at 80%",
+        "enabled": true,
+        "scope_type": "team",
+        "scope_id": "team-456",
+        "cel_expression": "rate_limit_request_usage_percent >= 80.0",
+        "channel_ids": ["slack-prod", "generic-webhook"]
+      },
+      {
+        "id": "specific-budget-alert",
+        "name": "Budget A at 90%",
+        "enabled": true,
+        "scope_type": "virtual_key",
+        "scope_id": "vk-123",
+        "target_type": "budget",
+        "target_id": "budget-a",
+        "cel_expression": "budget_usage_percent >= 90.0",
+        "channel_ids": ["pagerduty-critical"]
+      }
+    ]
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Alert Channels" icon="megaphone" href="/enterprise/alerting/alert-channels">
+    Configure the destinations a rule notifies.
+  </Card>
+  <Card title="Alert History" icon="clock-rotate-left" href="/enterprise/alerting/alert-history">
+    Review which rules fired and why.
+  </Card>
+</CardGroup>

--- a/docs/enterprise/alerting/overview.mdx
+++ b/docs/enterprise/alerting/overview.mdx
@@ -1,0 +1,166 @@
+---
+title: "Alerting"
+description: "Define CEL-based alert rules over governance metrics and dispatch notifications to Slack, Microsoft Teams, PagerDuty, and webhooks when budgets or rate limits cross your thresholds."
+icon: "bell"
+keywords: ["alerting", "alerts", "notifications", "monitoring", "slack", "pagerduty", "webhook", "cel", "budget", "rate limit"]
+---
+
+## Overview
+
+**Alerting** in Bifrost Enterprise evaluates [CEL](https://github.com/google/cel-spec) expressions against live governance metrics - budgets and rate limits - and dispatches notifications through [alert channels](/enterprise/alerting/alert-channels) when a threshold is crossed. Rules are scoped to virtual keys, teams, or customers and can optionally target a specific budget.
+
+Every evaluation and delivery attempt is recorded in [alert history](/enterprise/alerting/alert-history) so you can audit what fired, what was skipped by cooldowns, and what failed to deliver.
+
+### Key features
+
+| Feature | Description |
+| --- | --- |
+| **CEL-based rules** | Express conditions as CEL expressions over governance metrics, including compound conditions with `&&` and `\|\|`. |
+| **Governance scopes** | Scope rules to a specific virtual key, team, or customer. |
+| **Budget targeting** | Optionally target a specific budget ID so the rule only evaluates against that budget. |
+| **Multiple channels** | Notify Slack, Microsoft Teams, PagerDuty, or any HTTP webhook. |
+| **Periodic evaluation** | Rules are evaluated on a 60-second sweep against current governance snapshots. |
+| **Leader-aware** | In a cluster, only the leader evaluates and dispatches, avoiding duplicate alerts. |
+| **Cooldowns** | Per-rule and optional per-channel cooldowns prevent alert storms. |
+| **Alert history** | Every evaluation outcome is recorded with the rule, scope, metrics, and delivery status. |
+
+---
+
+## How it works
+
+Bifrost evaluates alert rules on a periodic sweep and dispatches notifications subject to cooldowns.
+
+<Steps>
+  <Step title="Governance snapshots are collected">
+    The alert engine reads the current governance state - budget consumption and rate limit usage - from the in-memory governance store. This includes per-budget spend versus its limit and per-rate-limit request and token usage versus their configured maximums.
+  </Step>
+  <Step title="Rules are evaluated">
+    Each enabled rule's CEL expression is evaluated against the governance metrics for its scope. If the rule has a `target_type` of `"budget"` and a specific `target_id`, only metrics for that budget are used. If no target is specified, the expression is evaluated against every budget in the scope.
+  </Step>
+  <Step title="Cooldowns are applied">
+    When a rule matches, its cooldown suppresses repeat notifications for the same rule, scope, and target. Bifrost checks compact successful-send state in the shared key-value store. Channels can define their own optional cooldown on top of the rule cooldown.
+  </Step>
+  <Step title="Notifications are dispatched">
+    The rule's channels are notified. Every outcome - `sent`, `failed`, or `skipped` - is written to [alert history](/enterprise/alerting/alert-history).
+  </Step>
+</Steps>
+
+---
+
+## CEL variables
+
+Each rule's CEL expression can reference the following variables, which are populated from the current governance snapshot:
+
+| Variable | Type | Meaning |
+| --- | --- | --- |
+| `budget_usage_percent` | `double` | Percentage of the budget consumed (`budget_spent / budget_limit * 100`). |
+| `budget_spent` | `double` | Absolute dollars spent against the budget. |
+| `budget_limit` | `double` | Budget maximum limit in dollars. |
+| `rate_limit_request_usage_percent` | `double` | Percentage of the request rate limit consumed. |
+| `request_usage` | `int` | Absolute request count consumed. |
+| `request_limit` | `int` | Request rate limit maximum. |
+| `rate_limit_token_usage_percent` | `double` | Percentage of the token rate limit consumed. |
+| `token_usage` | `int` | Absolute token count consumed. |
+| `token_limit` | `int` | Token rate limit maximum. |
+| `scope_type` | `string` | The rule's scope type (`virtual_key`, `team`, or `customer`). |
+| `scope_id` | `string` | The rule's scope ID. |
+| `target_type` | `string` | The target type (`"budget"`) if the rule targets a specific budget; empty string otherwise. |
+| `target_id` | `string` | The target budget ID if the rule targets a specific budget; empty string otherwise. |
+
+<Note>
+When a rule does not target a specific budget, the engine evaluates the expression once per budget in the scope. Each evaluation receives the `target_type` and `target_id` for that budget along with its `budget_spent` and `budget_limit`. Rate limit variables (`request_usage`, `token_usage`, and their limits) are populated from the scope's highest-utilization rate limits.
+</Note>
+
+Supported operators are `==`, `!=`, `>`, `<`, `>=`, and `<=`. See [Alert Rules](/enterprise/alerting/alert-rules) for CEL expression examples.
+
+---
+
+## Scopes
+
+Every rule must specify a scope type and a scope ID. The following scopes are supported:
+
+| Scope | Description |
+| --- | --- |
+| `virtual_key` | A specific virtual key. |
+| `team` | A specific team. |
+| `customer` | A specific customer. |
+
+A scope ID is required. There are no wildcard or global scopes.
+
+---
+
+## Budget targeting
+
+In addition to the scope, a rule can optionally target a specific governance object. The only supported target type is `"budget"`.
+
+| Behavior | `target_type` | `target_id` |
+| --- | --- | --- |
+| Evaluate all budgets in scope | Not set (or `null`) | Not set (or `null`) |
+| Evaluate a specific budget | `"budget"` | The budget's ID |
+
+When a target is set, only metrics for that specific budget are evaluated. Rate limit variables are still populated from the scope's active rate limits.
+
+---
+
+## Cooldowns
+
+Alerting uses a dual-layer cooldown system to prevent alert storms:
+
+- **Rule cooldown**: Suppresses repeat notifications for the same rule, scope, and target until the cooldown window elapses. Default is 60 seconds. The cooldown window is measured from the latest successful send for that rule and target.
+- **Channel cooldown**: An optional per-channel cooldown that suppresses a channel after it receives any alert. Default is 0 seconds (no suppression). Useful when one channel (such as PagerDuty) should be notified less frequently than another (such as Slack) for the same rule.
+
+Cooldowns are enforced from compact state in Bifrost's shared key-value store. Successful deliveries update that state before their [alert history](/enterprise/alerting/alert-history) row is appended. On startup, leadership changes, or relevant rule configuration changes, Bifrost rebuilds the required state with bounded aggregate reads from alert history.
+
+---
+
+## Clustering behavior
+
+When Bifrost runs as a [cluster](/enterprise/clustering), only the leader node evaluates rules and dispatches notifications. Successful-send state is shared through the cluster key-value store. A newly elected leader recovers and reconciles that state before its first scheduled dispatch. When a node loses leadership, its alerting engine stops until leadership is regained.
+
+No additional configuration is required; leader-aware alerting activates automatically in cluster mode.
+
+---
+
+## Configuration
+
+Webhook network behavior is configured through the `alerting` section of `config.json`. Channels and rules can also be managed via the Web UI or API.
+
+```json
+{
+  "alerting": {
+    "webhook_network": {
+      "allow_http": false,
+      "allow_private_network": false
+    }
+  }
+}
+```
+
+For declaring channels and rules statically in `config.json`, see the relevant pages: [Alert Rules](/enterprise/alerting/alert-rules#configjson) and [Alert Channels](/enterprise/alerting/alert-channels#configjson).
+
+### Configuration fields
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `webhook_network.allow_http` | boolean | `false` | When `true`, permits `http://` URLs for Slack, Microsoft Teams, and generic webhook channels. PagerDuty always uses its fixed HTTPS endpoint. |
+| `webhook_network.allow_private_network` | boolean | `false` | When `true`, permits webhook destinations on RFC1918 private networks. Link-local and unspecified addresses remain blocked. |
+
+<Warning>
+Leaving `webhook_network.allow_http` and `webhook_network.allow_private_network` at `false` is strongly recommended. Enabling these weakens SSRF and TLS protections. See [Alert Channels](/enterprise/alerting/alert-channels#security) for details.
+</Warning>
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Alert Channels" icon="megaphone" href="/enterprise/alerting/alert-channels">
+    Configure where alerts are delivered: Slack, Microsoft Teams, PagerDuty, and webhooks.
+  </Card>
+  <Card title="Alert Rules" icon="gavel" href="/enterprise/alerting/alert-rules">
+    Define the conditions, scopes, and channels that trigger alerts.
+  </Card>
+  <Card title="Alert History" icon="clock-rotate-left" href="/enterprise/alerting/alert-history">
+    Review delivered notifications, skipped alerts, and failed delivery attempts.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

Adds the enterprise alerting documentation: overview, alert rules (incl. health states), alert channels, and alert history. Standalone and dependency-free — it does not depend on any other PR in the alerting stack, so it can be reviewed and merged independently.

## Changes

- `docs/enterprise/alerting/overview.mdx`
- `docs/enterprise/alerting/alert-rules.mdx`
- `docs/enterprise/alerting/alert-channels.mdx`
- `docs/enterprise/alerting/alert-history.mdx`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
cd docs && npx mintlify dev
```

Confirm the four alerting pages render and links resolve.

## Screenshots/Recordings

No application UI changes (docs only).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
