### PR TITLE
feat: add consolidated `GET /api/logs/dashboard` endpoint

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -965,6 +965,8 @@ paths:
     $ref: './paths/management/logging.yaml#/logs-filterdata'
   /api/logs/rankings:
     $ref: './paths/management/logging.yaml#/logs-rankings'
+  /api/logs/dashboard:
+    $ref: './paths/management/logging.yaml#/logs-dashboard'
   /api/logs/recalculate-cost:
     $ref: './paths/management/logging.yaml#/logs-recalculate-cost'
 

--- a/docs/openapi/paths/management/logging.yaml
+++ b/docs/openapi/paths/management/logging.yaml
@@ -359,14 +359,20 @@ logs-histogram:
     parameters:
       - $ref: '#/_histogram-parameters/providers'
       - $ref: '#/_histogram-parameters/models'
+      - $ref: '#/_histogram-parameters/aliases'
       - $ref: '#/_histogram-parameters/status'
       - $ref: '#/_histogram-parameters/objects'
       - $ref: '#/_histogram-parameters/selected_key_ids'
       - $ref: '#/_histogram-parameters/virtual_key_ids'
+      - $ref: '#/_histogram-parameters/team_ids'
+      - $ref: '#/_histogram-parameters/customer_ids'
+      - $ref: '#/_histogram-parameters/user_ids'
+      - $ref: '#/_histogram-parameters/business_unit_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
+      - $ref: '#/_histogram-parameters/period'
       - $ref: '#/_histogram-parameters/min_latency'
       - $ref: '#/_histogram-parameters/max_latency'
       - $ref: '#/_histogram-parameters/min_tokens'
@@ -374,6 +380,10 @@ logs-histogram:
       - $ref: '#/_histogram-parameters/min_cost'
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
+      - $ref: '#/_histogram-parameters/stop_reasons'
+      - $ref: '#/_histogram-parameters/cache_hit_types'
+      - $ref: '#/_histogram-parameters/parent_request_id'
+      - $ref: '#/_histogram-parameters/metadata_key'
       - $ref: '#/_histogram-parameters/content_search'
     security:
       - ManagementBearerAuth: []
@@ -683,6 +693,12 @@ _histogram-parameters:
     description: Comma-separated list of models to filter by
     schema:
       type: string
+  aliases:
+    name: aliases
+    in: query
+    description: Comma-separated list of model aliases to filter by
+    schema:
+      type: string
   status:
     name: status
     in: query
@@ -705,6 +721,30 @@ _histogram-parameters:
     name: virtual_key_ids
     in: query
     description: Comma-separated list of virtual key IDs to filter by
+    schema:
+      type: string
+  team_ids:
+    name: team_ids
+    in: query
+    description: Comma-separated list of team IDs to filter by
+    schema:
+      type: string
+  customer_ids:
+    name: customer_ids
+    in: query
+    description: Comma-separated list of customer IDs to filter by
+    schema:
+      type: string
+  user_ids:
+    name: user_ids
+    in: query
+    description: Comma-separated list of user IDs to filter by
+    schema:
+      type: string
+  business_unit_ids:
+    name: business_unit_ids
+    in: query
+    description: Comma-separated list of business unit IDs to filter by
     schema:
       type: string
   routing_rule_ids:
@@ -733,6 +773,12 @@ _histogram-parameters:
     schema:
       type: string
       format: date-time
+  period:
+    name: period
+    in: query
+    description: Relative time period filter
+    schema:
+      type: string
   min_latency:
     name: min_latency
     in: query
@@ -775,6 +821,30 @@ _histogram-parameters:
     description: Only show logs with missing cost
     schema:
       type: boolean
+  stop_reasons:
+    name: stop_reasons
+    in: query
+    description: Comma-separated list of stop reasons to filter by
+    schema:
+      type: string
+  cache_hit_types:
+    name: cache_hit_types
+    in: query
+    description: Comma-separated list of cache hit types to filter by
+    schema:
+      type: string
+  parent_request_id:
+    name: parent_request_id
+    in: query
+    description: Parent request ID to filter by
+    schema:
+      type: string
+  metadata_key:
+    name: metadata_<key>
+    in: query
+    description: Metadata filter where <key> is the metadata key to match
+    schema:
+      type: string
   content_search:
     name: content_search
     in: query
@@ -1155,14 +1225,20 @@ logs-rankings:
     parameters:
       - $ref: '#/_histogram-parameters/providers'
       - $ref: '#/_histogram-parameters/models'
+      - $ref: '#/_histogram-parameters/aliases'
       - $ref: '#/_histogram-parameters/status'
       - $ref: '#/_histogram-parameters/objects'
       - $ref: '#/_histogram-parameters/selected_key_ids'
       - $ref: '#/_histogram-parameters/virtual_key_ids'
+      - $ref: '#/_histogram-parameters/team_ids'
+      - $ref: '#/_histogram-parameters/customer_ids'
+      - $ref: '#/_histogram-parameters/user_ids'
+      - $ref: '#/_histogram-parameters/business_unit_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
+      - $ref: '#/_histogram-parameters/period'
       - $ref: '#/_histogram-parameters/min_latency'
       - $ref: '#/_histogram-parameters/max_latency'
       - $ref: '#/_histogram-parameters/min_tokens'
@@ -1170,6 +1246,10 @@ logs-rankings:
       - $ref: '#/_histogram-parameters/min_cost'
       - $ref: '#/_histogram-parameters/max_cost'
       - $ref: '#/_histogram-parameters/missing_cost_only'
+      - $ref: '#/_histogram-parameters/stop_reasons'
+      - $ref: '#/_histogram-parameters/cache_hit_types'
+      - $ref: '#/_histogram-parameters/parent_request_id'
+      - $ref: '#/_histogram-parameters/metadata_key'
       - $ref: '#/_histogram-parameters/content_search'
     security:
       - ManagementBearerAuth: []
@@ -1180,6 +1260,78 @@ logs-rankings:
           application/json:
             schema:
               $ref: '../../schemas/management/logging.yaml#/ModelRankingResult'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+logs-dashboard:
+  get:
+    operationId: getDashboard
+    summary: Get consolidated dashboard data
+    description: |
+      Returns every metric shown on the workspace dashboard in a single
+      response: overview totals and histograms, provider usage, model rankings,
+      dimension rankings (team, user, virtual key, customer, business unit), and
+      MCP usage. Intended for external integrations that want the full dashboard
+      in one call rather than orchestrating the individual endpoints.
+
+      Accepts the same LLM filter parameters as the histogram and rankings
+      endpoints, plus the MCP filter parameters (`tool_names`, `server_labels`)
+      which apply to the `mcp` section. Filters are applied once and every
+      section is computed against the same time window and bucket size. The
+      request fails as a whole if any section cannot be computed, so the payload
+      is always complete.
+    tags:
+      - Logging
+    parameters:
+      - $ref: '#/_histogram-parameters/providers'
+      - $ref: '#/_histogram-parameters/models'
+      - $ref: '#/_histogram-parameters/aliases'
+      - $ref: '#/_histogram-parameters/status'
+      - $ref: '#/_histogram-parameters/objects'
+      - $ref: '#/_histogram-parameters/selected_key_ids'
+      - $ref: '#/_histogram-parameters/virtual_key_ids'
+      - $ref: '#/_histogram-parameters/team_ids'
+      - $ref: '#/_histogram-parameters/customer_ids'
+      - $ref: '#/_histogram-parameters/user_ids'
+      - $ref: '#/_histogram-parameters/business_unit_ids'
+      - $ref: '#/_histogram-parameters/routing_rule_ids'
+      - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/start_time'
+      - $ref: '#/_histogram-parameters/end_time'
+      - $ref: '#/_histogram-parameters/period'
+      - $ref: '#/_histogram-parameters/min_latency'
+      - $ref: '#/_histogram-parameters/max_latency'
+      - $ref: '#/_histogram-parameters/min_tokens'
+      - $ref: '#/_histogram-parameters/max_tokens'
+      - $ref: '#/_histogram-parameters/min_cost'
+      - $ref: '#/_histogram-parameters/max_cost'
+      - $ref: '#/_histogram-parameters/missing_cost_only'
+      - $ref: '#/_histogram-parameters/stop_reasons'
+      - $ref: '#/_histogram-parameters/cache_hit_types'
+      - $ref: '#/_histogram-parameters/parent_request_id'
+      - $ref: '#/_histogram-parameters/metadata_key'
+      - $ref: '#/_histogram-parameters/content_search'
+      - name: tool_names
+        in: query
+        description: Comma-separated list of MCP tool names to filter the MCP section by
+        schema:
+          type: string
+      - name: server_labels
+        in: query
+        description: Comma-separated list of MCP server labels to filter the MCP section by
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Dashboard data retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/logging.yaml#/DashboardResult'
       '400':
         $ref: '../../openapi.yaml#/components/responses/BadRequest'
       '500':

--- a/docs/openapi/schemas/management/logging.yaml
+++ b/docs/openapi/schemas/management/logging.yaml
@@ -1177,3 +1177,168 @@ MCPTopToolsResult:
       type: array
       items:
         $ref: '#/MCPTopToolResult'
+
+RankingDimension:
+  type: string
+  description: Entity used to group dimension rankings
+  enum:
+    - team
+    - customer
+    - business_unit
+    - user
+    - virtual_key
+
+DimensionRankingEntry:
+  type: object
+  description: Aggregated usage for a single dimension value (team, user, virtual key, etc.)
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    total_requests:
+      type: integer
+      format: int64
+    total_tokens:
+      type: integer
+      format: int64
+    total_cost:
+      type: number
+
+DimensionRankingTrend:
+  type: object
+  description: Percentage change versus the previous comparable period
+  properties:
+    has_previous_period:
+      type: boolean
+    requests_trend:
+      type: number
+    tokens_trend:
+      type: number
+    cost_trend:
+      type: number
+
+DimensionRankingWithTrend:
+  allOf:
+    - $ref: '#/DimensionRankingEntry'
+    - type: object
+      properties:
+        trend:
+          $ref: '#/DimensionRankingTrend'
+
+DimensionRankingResult:
+  type: object
+  description: Dimension values ranked by usage with trend comparison
+  properties:
+    rankings:
+      type: array
+      items:
+        $ref: '#/DimensionRankingWithTrend'
+    dimension:
+      $ref: '#/RankingDimension'
+    total_actual_requests:
+      type: integer
+      format: int64
+      description: |
+        Distinct request count over the attributed population. Only set for
+        fan-out dimensions (team, customer, business_unit) on Postgres.
+    total_attributed_requests:
+      type: integer
+      format: int64
+      description: |
+        Requests credited to every dimension value they touch; the sum can
+        exceed the real request count. Only set for fan-out dimensions.
+
+DashboardMeta:
+  type: object
+  description: Parameters the dashboard data was computed with
+  properties:
+    generated_at:
+      type: string
+      format: date-time
+      description: UTC time the response was assembled
+    bucket_size_seconds:
+      type: integer
+      format: int64
+      description: Width of every histogram bucket, derived from the time range
+    start_time:
+      type: string
+      format: date-time
+      description: Resolved start of the queried range
+    end_time:
+      type: string
+      format: date-time
+      description: Resolved end of the queried range
+
+DashboardOverview:
+  type: object
+  description: Overview tab metrics
+  properties:
+    stats:
+      $ref: '#/LogStats'
+    requests:
+      $ref: '#/HistogramResult'
+    tokens:
+      $ref: '#/TokenHistogramResult'
+    cost:
+      $ref: '#/CostHistogramResult'
+    models:
+      $ref: '#/ModelHistogramResult'
+    latency:
+      $ref: '#/LatencyHistogramResult'
+
+DashboardProviderUsage:
+  type: object
+  description: Provider Usage tab metrics
+  properties:
+    cost:
+      $ref: '#/ProviderCostHistogramResult'
+    tokens:
+      $ref: '#/ProviderTokenHistogramResult'
+    latency:
+      $ref: '#/ProviderLatencyHistogramResult'
+
+DashboardModelRankings:
+  type: object
+  description: Model Rankings tab data
+  properties:
+    rankings:
+      $ref: '#/ModelRankingResult'
+    histogram:
+      $ref: '#/ModelHistogramResult'
+
+DashboardMCP:
+  type: object
+  description: MCP usage tab metrics
+  properties:
+    volume:
+      $ref: '#/MCPHistogramResult'
+    cost:
+      $ref: '#/MCPCostHistogramResult'
+    top_tools:
+      $ref: '#/MCPTopToolsResult'
+
+DashboardResult:
+  type: object
+  description: |
+    Consolidated payload containing every metric shown on the workspace
+    dashboard. Each section mirrors the response of its dedicated endpoint, so
+    consumers can integrate a single call instead of orchestrating many.
+  properties:
+    meta:
+      $ref: '#/DashboardMeta'
+    overview:
+      $ref: '#/DashboardOverview'
+    provider_usage:
+      $ref: '#/DashboardProviderUsage'
+    model_rankings:
+      $ref: '#/DashboardModelRankings'
+    dimension_rankings:
+      type: object
+      description: |
+        Ranking tables keyed by dimension (`team`, `user`, `virtual_key`,
+        `customer`, `business_unit`); each value is that dimension's rankings.
+      additionalProperties:
+        $ref: '#/DimensionRankingResult'
+    mcp:
+      $ref: '#/DashboardMCP'

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1707,6 +1707,65 @@ type DimensionRankingResult struct {
 	TotalAttributedRequests int64 `json:"total_attributed_requests,omitempty"`
 }
 
+// ==================== CONSOLIDATED DASHBOARD RESULT ====================
+// The types below back the GET /api/logs/dashboard endpoint, which returns
+// every metric shown on the /workspace/dashboard page in a single response.
+// Each section reuses the same struct returned by its dedicated endpoint, so
+// the consolidated payload stays byte-for-byte consistent with the per-tab
+// endpoints. This is a stable, public-facing contract: add fields, do not
+// rename or remove existing ones.
+
+// DashboardMeta describes the parameters the dashboard data was computed with,
+// so consumers can interpret the buckets and rankings without re-deriving them.
+type DashboardMeta struct {
+	GeneratedAt       time.Time  `json:"generated_at"`         // UTC time the response was assembled
+	BucketSizeSeconds int64      `json:"bucket_size_seconds"`  // Width of every histogram bucket, derived from the time range
+	StartTime         *time.Time `json:"start_time,omitempty"` // Resolved start of the queried range (from start_time/end_time or period)
+	EndTime           *time.Time `json:"end_time,omitempty"`   // Resolved end of the queried range
+}
+
+// DashboardOverview holds the Overview tab metrics.
+type DashboardOverview struct {
+	Stats    *SearchStats            `json:"stats"`    // Totals + success/cache rates
+	Requests *HistogramResult        `json:"requests"` // Request volume over time
+	Tokens   *TokenHistogramResult   `json:"tokens"`   // Token usage over time
+	Cost     *CostHistogramResult    `json:"cost"`     // Cost over time, broken down by model
+	Models   *ModelHistogramResult   `json:"models"`   // Per-model usage over time
+	Latency  *LatencyHistogramResult `json:"latency"`  // Latency percentiles over time
+}
+
+// DashboardProviderUsage holds the Provider Usage tab metrics.
+type DashboardProviderUsage struct {
+	Cost    *ProviderCostHistogramResult    `json:"cost"`
+	Tokens  *ProviderTokenHistogramResult   `json:"tokens"`
+	Latency *ProviderLatencyHistogramResult `json:"latency"`
+}
+
+// DashboardModelRankings holds the Model Rankings tab data.
+type DashboardModelRankings struct {
+	Rankings  *ModelRankingResult   `json:"rankings"`  // Ranked table with trends
+	Histogram *ModelHistogramResult `json:"histogram"` // Backs the "Top Models" stacked bar chart
+}
+
+// DashboardMCP holds the MCP usage tab metrics.
+type DashboardMCP struct {
+	Volume   *MCPHistogramResult     `json:"volume"`    // Tool call volume over time
+	Cost     *MCPCostHistogramResult `json:"cost"`      // MCP cost over time
+	TopTools *MCPTopToolsResult      `json:"top_tools"` // Top tools by call count
+}
+
+// DashboardResult is the full consolidated payload for GET /api/logs/dashboard.
+// DimensionRankings is keyed by RankingDimension ("team", "user", "virtual_key",
+// "customer", "business_unit"); each value is that dimension's ranking table.
+type DashboardResult struct {
+	Meta              DashboardMeta                      `json:"meta"`
+	Overview          DashboardOverview                  `json:"overview"`
+	ProviderUsage     DashboardProviderUsage             `json:"provider_usage"`
+	ModelRankings     DashboardModelRankings             `json:"model_rankings"`
+	DimensionRankings map[string]*DimensionRankingResult `json:"dimension_rankings"`
+	MCP               DashboardMCP                       `json:"mcp"`
+}
+
 // NodeUsageCursor identifies the last log row included in a node usage scan.
 // The initial scan uses Timestamp + LogID because each ghost has a timestamp
 // lower bound. Once rows written with IncNumber are seen, subsequent scans use

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -242,6 +242,8 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.GET("/api/logs/filterdata", lib.ChainMiddlewares(h.getAvailableFilterData, middlewares...))
 	r.GET("/api/logs/rankings", lib.ChainMiddlewares(h.getModelRankings, middlewares...))
 	r.GET("/api/logs/rankings/by-dimension", lib.ChainMiddlewares(h.getDimensionRankings, middlewares...))
+	// Consolidated, public-facing dashboard payload (all of the above in one call)
+	r.GET("/api/logs/dashboard", lib.ChainMiddlewares(h.getDashboard, middlewares...))
 	r.DELETE("/api/logs", lib.ChainMiddlewares(h.deleteLogs, middlewares...))
 	r.POST("/api/logs/recalculate-cost", lib.ChainMiddlewares(h.recalculateLogCosts, middlewares...))
 
@@ -1104,6 +1106,196 @@ func (h *LoggingHandler) getDimensionRankings(ctx *fasthttp.RequestCtx) {
 	if err != nil {
 		logger.Error("failed to get dimension rankings: %v", err)
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Dimension rankings calculation failed: %v", err))
+		return
+	}
+
+	SendJSON(ctx, result)
+}
+
+// dashboardRankingDimensions is the fixed set of dimensions returned in the
+// consolidated dashboard payload, mirroring the dimension-ranking tabs on the
+// /workspace/dashboard page (Team, User, Virtual Key, Customer, Business Unit).
+var dashboardRankingDimensions = []logstore.RankingDimension{
+	logstore.RankingDimensionTeam,
+	logstore.RankingDimensionUser,
+	logstore.RankingDimensionVirtualKey,
+	logstore.RankingDimensionCustomer,
+	logstore.RankingDimensionBusinessUnit,
+}
+
+const dashboardMCPTopToolsLimit = 10
+
+// getDashboard handles GET /api/logs/dashboard - returns every metric shown on
+// the /workspace/dashboard page in a single consolidated, public-facing payload.
+//
+// It accepts the same filter query parameters as the individual histogram and
+// rankings endpoints (period OR start_time/end_time, providers, models, status,
+// virtual_key_ids, team_ids, etc., plus metadata_<key> filters) and the MCP
+// filter params (tool_names, server_labels). Filters are parsed once and the
+// histogram bucket size is derived once from the resolved time range, so every
+// section is computed against an identical window. All sub-queries run
+// concurrently; if any fails the whole request fails, so consumers always get a
+// complete payload or a clear error, never partial data.
+func (h *LoggingHandler) getDashboard(ctx *fasthttp.RequestCtx) {
+	filters := parseHistogramFilters(ctx)
+	bucketSizeSeconds := calculateBucketSize(filters.StartTime, filters.EndTime)
+
+	mcpFilters, err := parseMCPHistogramFilters(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	result := &logstore.DashboardResult{
+		Meta: logstore.DashboardMeta{
+			GeneratedAt:       time.Now().UTC(),
+			BucketSizeSeconds: bucketSizeSeconds,
+			StartTime:         filters.StartTime,
+			EndTime:           filters.EndTime,
+		},
+		DimensionRankings: make(map[string]*logstore.DimensionRankingResult, len(dashboardRankingDimensions)),
+	}
+
+	// dimensionResults is written concurrently (one goroutine per dimension),
+	// so guard the map; the other sections each write a distinct field.
+	var dimMu sync.Mutex
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	// ---- Overview ----
+	g.Go(func() error {
+		stats, err := h.logManager.GetStats(gCtx, filters)
+		if err != nil {
+			return fmt.Errorf("stats: %w", err)
+		}
+		result.Overview.Stats = stats
+		return nil
+	})
+	g.Go(func() error {
+		res, err := h.logManager.GetHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("request histogram: %w", err)
+		}
+		result.Overview.Requests = res
+		return nil
+	})
+	g.Go(func() error {
+		res, err := h.logManager.GetTokenHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("token histogram: %w", err)
+		}
+		result.Overview.Tokens = res
+		return nil
+	})
+	g.Go(func() error {
+		res, err := h.logManager.GetCostHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("cost histogram: %w", err)
+		}
+		result.Overview.Cost = res
+		return nil
+	})
+	g.Go(func() error {
+		res, err := h.logManager.GetLatencyHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("latency histogram: %w", err)
+		}
+		result.Overview.Latency = res
+		return nil
+	})
+
+	// modelHistogram backs both the Overview "Model Usage" card and the Model
+	// Rankings "Top Models" chart; compute it once and share the pointer.
+	g.Go(func() error {
+		res, err := h.logManager.GetModelHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("model histogram: %w", err)
+		}
+		result.Overview.Models = res
+		result.ModelRankings.Histogram = res
+		return nil
+	})
+
+	// ---- Provider Usage ----
+	g.Go(func() error {
+		res, err := h.logManager.GetProviderCostHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("provider cost histogram: %w", err)
+		}
+		result.ProviderUsage.Cost = res
+		return nil
+	})
+	g.Go(func() error {
+		res, err := h.logManager.GetProviderTokenHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("provider token histogram: %w", err)
+		}
+		result.ProviderUsage.Tokens = res
+		return nil
+	})
+	g.Go(func() error {
+		res, err := h.logManager.GetProviderLatencyHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("provider latency histogram: %w", err)
+		}
+		result.ProviderUsage.Latency = res
+		return nil
+	})
+
+	// ---- Model Rankings table ----
+	g.Go(func() error {
+		res, err := h.logManager.GetModelRankings(gCtx, filters)
+		if err != nil {
+			return fmt.Errorf("model rankings: %w", err)
+		}
+		result.ModelRankings.Rankings = res
+		return nil
+	})
+
+	// ---- Dimension Rankings (one query per dimension) ----
+	for _, dim := range dashboardRankingDimensions {
+		dim := dim
+		g.Go(func() error {
+			res, err := h.logManager.GetDimensionRankings(gCtx, filters, dim)
+			if err != nil {
+				return fmt.Errorf("%s rankings: %w", dim, err)
+			}
+			dimMu.Lock()
+			result.DimensionRankings[string(dim)] = res
+			dimMu.Unlock()
+			return nil
+		})
+	}
+
+	// ---- MCP usage ----
+	g.Go(func() error {
+		res, err := h.logManager.GetMCPHistogram(gCtx, *mcpFilters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("mcp histogram: %w", err)
+		}
+		result.MCP.Volume = res
+		return nil
+	})
+	g.Go(func() error {
+		res, err := h.logManager.GetMCPCostHistogram(gCtx, *mcpFilters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("mcp cost histogram: %w", err)
+		}
+		result.MCP.Cost = res
+		return nil
+	})
+	g.Go(func() error {
+		res, err := h.logManager.GetMCPTopTools(gCtx, *mcpFilters, dashboardMCPTopToolsLimit)
+		if err != nil {
+			return fmt.Errorf("mcp top tools: %w", err)
+		}
+		result.MCP.TopTools = res
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		logger.Error("failed to build dashboard data: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Dashboard data calculation failed: %v", err))
 		return
 	}
 

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -2,9 +2,15 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"net"
 	"testing"
 
+	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/queryscope"
+	loggingplugin "github.com/maximhq/bifrost/plugins/logging"
+	"github.com/valyala/fasthttp"
 	"gorm.io/gorm"
 )
 
@@ -37,3 +43,243 @@ func TestShouldUseFilterDataCacheRejectsScopedContext(t *testing.T) {
 		t.Fatal("expected scoped request to bypass filterdata cache")
 	}
 }
+
+func TestGetDashboard(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		failStats  bool
+		wantStatus int
+		assert     func(t *testing.T, mgr *dashboardLogManager, body []byte)
+	}{
+		{
+			name:       "success includes all sections",
+			query:      "providers=openai&models=gpt-4&tool_names=calculator&server_labels=primary",
+			wantStatus: fasthttp.StatusOK,
+			assert: func(t *testing.T, mgr *dashboardLogManager, body []byte) {
+				t.Helper()
+				var payload map[string]json.RawMessage
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatalf("decode dashboard response: %v", err)
+				}
+				for _, key := range []string{"meta", "overview", "provider_usage", "model_rankings", "dimension_rankings", "mcp"} {
+					if _, ok := payload[key]; !ok {
+						t.Fatalf("expected top-level key %q in response", key)
+					}
+				}
+				var response logstore.DashboardResult
+				if err := json.Unmarshal(body, &response); err != nil {
+					t.Fatalf("decode dashboard result: %v", err)
+				}
+				if response.Overview.Models == nil || response.ModelRankings.Histogram == nil {
+					t.Fatal("expected shared model histogram to populate both sections")
+				}
+				if len(response.DimensionRankings) != len(dashboardRankingDimensions) {
+					t.Fatalf("expected %d dimension rankings, got %d", len(dashboardRankingDimensions), len(response.DimensionRankings))
+				}
+				if got := mgr.lastLLMFilters.Providers; len(got) != 1 || got[0] != "openai" {
+					t.Fatalf("expected LLM providers filter, got %#v", got)
+				}
+				if got := mgr.lastMCPFilters.ToolNames; len(got) != 1 || got[0] != "calculator" {
+					t.Fatalf("expected MCP tool_names filter, got %#v", got)
+				}
+			},
+		},
+		{
+			name:       "sub-query error returns no partial dashboard",
+			failStats:  true,
+			wantStatus: fasthttp.StatusInternalServerError,
+			assert: func(t *testing.T, mgr *dashboardLogManager, body []byte) {
+				t.Helper()
+				if json.Valid(body) {
+					var payload map[string]json.RawMessage
+					if err := json.Unmarshal(body, &payload); err == nil {
+						if _, ok := payload["overview"]; ok {
+							t.Fatalf("expected error payload, got partial dashboard: %s", string(body))
+						}
+					}
+				}
+			},
+		},
+		{
+			name:       "MCP filters are isolated from LLM filters",
+			query:      "providers=openai&models=gpt-4&tool_names=calculator,clock&server_labels=primary&virtual_key_ids=vk-llm",
+			wantStatus: fasthttp.StatusOK,
+			assert: func(t *testing.T, mgr *dashboardLogManager, body []byte) {
+				t.Helper()
+				if len(mgr.lastLLMFilters.Providers) != 1 || mgr.lastLLMFilters.Providers[0] != "openai" {
+					t.Fatalf("expected LLM providers filter, got %#v", mgr.lastLLMFilters.Providers)
+				}
+				if len(mgr.lastMCPFilters.ToolNames) != 2 {
+					t.Fatalf("expected MCP tool filters, got %#v", mgr.lastMCPFilters.ToolNames)
+				}
+				if mgr.lastLLMFilters.ContentSearch == "calculator" {
+					t.Fatal("MCP tool_names leaked into LLM filters")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetLogger(&mockLogger{})
+
+			mgr := &dashboardLogManager{failStats: tt.failStats}
+			h := &LoggingHandler{logManager: mgr}
+			var req fasthttp.Request
+			uri := "/api/logs/dashboard"
+			if tt.query != "" {
+				uri += "?" + tt.query
+			}
+			req.SetRequestURI(uri)
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+
+			h.getDashboard(ctx)
+
+			if got := ctx.Response.StatusCode(); got != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, got, string(ctx.Response.Body()))
+			}
+			if tt.assert != nil {
+				tt.assert(t, mgr, ctx.Response.Body())
+			}
+		})
+	}
+}
+
+type dashboardLogManager struct {
+	failStats      bool
+	lastLLMFilters logstore.SearchFilters
+	lastMCPFilters logstore.MCPToolLogSearchFilters
+}
+
+func (m *dashboardLogManager) GetLog(ctx context.Context, id string) (*logstore.Log, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) Search(ctx context.Context, filters *logstore.SearchFilters, pagination *logstore.PaginationOptions) (*logstore.SearchResult, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetSessionLogs(ctx context.Context, sessionID string, pagination *logstore.PaginationOptions) (*logstore.SessionDetailResult, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetSessionSummary(ctx context.Context, sessionID string) (*logstore.SessionSummaryResult, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetStats(ctx context.Context, filters *logstore.SearchFilters) (*logstore.SearchStats, error) {
+	m.lastLLMFilters = *filters
+	if m.failStats {
+		return nil, errors.New("stats failed")
+	}
+	return &logstore.SearchStats{}, nil
+}
+func (m *dashboardLogManager) GetHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.HistogramResult, error) {
+	return &logstore.HistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetTokenHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.TokenHistogramResult, error) {
+	return &logstore.TokenHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetCostHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.CostHistogramResult, error) {
+	return &logstore.CostHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetModelHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ModelHistogramResult, error) {
+	return &logstore.ModelHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetLatencyHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.LatencyHistogramResult, error) {
+	return &logstore.LatencyHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetProviderCostHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ProviderCostHistogramResult, error) {
+	return &logstore.ProviderCostHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetProviderTokenHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ProviderTokenHistogramResult, error) {
+	return &logstore.ProviderTokenHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetProviderLatencyHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ProviderLatencyHistogramResult, error) {
+	return &logstore.ProviderLatencyHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetModelRankings(ctx context.Context, filters *logstore.SearchFilters) (*logstore.ModelRankingResult, error) {
+	return &logstore.ModelRankingResult{}, nil
+}
+func (m *dashboardLogManager) GetDimensionRankings(ctx context.Context, filters *logstore.SearchFilters, dimension logstore.RankingDimension) (*logstore.DimensionRankingResult, error) {
+	return &logstore.DimensionRankingResult{Dimension: dimension}, nil
+}
+func (m *dashboardLogManager) GetDroppedRequests(ctx context.Context) int64 { return 0 }
+func (m *dashboardLogManager) GetAvailableModels(ctx context.Context, limit int, query string) ([]string, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableAliases(ctx context.Context, limit int, query string) ([]string, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableSelectedKeys(ctx context.Context, limit int, query string) ([]loggingplugin.KeyPair, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableVirtualKeys(ctx context.Context, limit int, query string) ([]loggingplugin.KeyPair, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableRoutingRules(ctx context.Context, limit int, query string) ([]loggingplugin.KeyPair, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableRoutingEngines(ctx context.Context, limit int, query string) ([]string, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableStopReasons(ctx context.Context, limit int, query string) ([]string, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableTeams(ctx context.Context, limit int, query string) ([]loggingplugin.KeyPair, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableCustomers(ctx context.Context, limit int, query string) ([]loggingplugin.KeyPair, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableUsers(ctx context.Context, limit int, query string) ([]loggingplugin.KeyPair, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableBusinessUnits(ctx context.Context, limit int, query string) ([]loggingplugin.KeyPair, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableMetadataKeys(ctx context.Context, limit int, query string) (map[string][]string, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetDimensionCostHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64, dimension logstore.HistogramDimension) (*logstore.DimensionCostHistogramResult, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetDimensionTokenHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64, dimension logstore.HistogramDimension) (*logstore.DimensionTokenHistogramResult, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetDimensionLatencyHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64, dimension logstore.HistogramDimension) (*logstore.DimensionLatencyHistogramResult, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) DeleteLog(ctx context.Context, id string) error     { return nil }
+func (m *dashboardLogManager) DeleteLogs(ctx context.Context, ids []string) error { return nil }
+func (m *dashboardLogManager) RecalculateCosts(ctx context.Context, filters *logstore.SearchFilters, limit int) (*loggingplugin.RecalculateCostResult, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) SearchMCPToolLogs(ctx context.Context, filters *logstore.MCPToolLogSearchFilters, pagination *logstore.PaginationOptions) (*logstore.MCPToolLogSearchResult, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetMCPToolLogStats(ctx context.Context, filters *logstore.MCPToolLogSearchFilters) (*logstore.MCPToolLogStats, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableToolNames(ctx context.Context, limit int, query string) ([]string, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableServerLabels(ctx context.Context, limit int, query string) ([]string, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) ([]loggingplugin.KeyPair, error) {
+	return nil, nil
+}
+func (m *dashboardLogManager) GetMCPHistogram(ctx context.Context, filters logstore.MCPToolLogSearchFilters, bucketSizeSeconds int64) (*logstore.MCPHistogramResult, error) {
+	m.lastMCPFilters = filters
+	return &logstore.MCPHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetMCPCostHistogram(ctx context.Context, filters logstore.MCPToolLogSearchFilters, bucketSizeSeconds int64) (*logstore.MCPCostHistogramResult, error) {
+	return &logstore.MCPCostHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetMCPTopTools(ctx context.Context, filters logstore.MCPToolLogSearchFilters, limit int) (*logstore.MCPTopToolsResult, error) {
+	return &logstore.MCPTopToolsResult{}, nil
+}
+func (m *dashboardLogManager) DeleteMCPToolLogs(ctx context.Context, ids []string) error { return nil }


### PR DESCRIPTION
## Summary

Adds a new `GET /api/logs/dashboard` endpoint that returns every metric shown on the workspace dashboard in a single consolidated response. This eliminates the need for external integrations to orchestrate multiple individual endpoints to reconstruct the full dashboard state.

## Changes

- Registered `GET /api/logs/dashboard` route in the HTTP handler alongside the existing logging endpoints.
- Implemented `getDashboard` handler that parses LLM filter parameters once, derives a single bucket size from the resolved time range, and fans out all sub-queries concurrently using an `errgroup`. If any sub-query fails, the entire request fails — consumers always receive a complete payload or a clear error, never partial data.
- The model histogram is computed once and shared between the Overview "Model Usage" card and the Model Rankings "Top Models" chart to avoid a redundant query.
- Dimension rankings for all five dimensions (`team`, `user`, `virtual_key`, `customer`, `business_unit`) are fetched concurrently with mutex-guarded writes into the result map.
- MCP-specific filters (`tool_names`, `server_labels`) are accepted alongside the standard LLM filters and applied exclusively to the `mcp` section.
- Added `DashboardResult`, `DashboardMeta`, `DashboardOverview`, `DashboardProviderUsage`, `DashboardModelRankings`, and `DashboardMCP` structs in `framework/logstore/tables.go` to back the new endpoint. Each section reuses existing result types to stay byte-for-byte consistent with the per-tab endpoints.
- Added corresponding OpenAPI schema definitions and the `logs-dashboard` path entry in the API spec.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./...

# Start the server and issue a request against the new endpoint
curl -H "Authorization: Bearer <token>" \
  "http://localhost:8080/api/logs/dashboard?start_time=2024-01-01T00:00:00Z&end_time=2024-01-08T00:00:00Z"

# Verify the response contains all top-level keys:
# meta, overview, provider_usage, model_rankings, dimension_rankings, mcp

# Verify dimension_rankings contains all five dimensions:
# team, user, virtual_key, customer, business_unit

# Verify MCP filters are applied correctly
curl -H "Authorization: Bearer <token>" \
  "http://localhost:8080/api/logs/dashboard?tool_names=my_tool&server_labels=my_server"
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The endpoint is protected by `ManagementBearerAuth` (same as all other `/api/logs/*` endpoints). No new auth surface is introduced. The endpoint does not expose any data not already available through the individual dashboard endpoints.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable