### PR TITLE
fix: lazy load markdown imports at all places to reduce bundle size

### DIFF
--- a/ui/app/workspace/skills-repo/components/shared.tsx
+++ b/ui/app/workspace/skills-repo/components/shared.tsx
@@ -7,7 +7,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { ScrollArea, ScrollBar } from "@/components/ui/scrollArea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Markdown } from "@/components/ui/markdown";
+import { lazy, Suspense, type ComponentProps } from "react";
 import { Tree, type BaseNodeData, type TreeNode } from "@/components/ui/treeView";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { SkillFileEntry } from "@/lib/types/skills";
@@ -38,6 +38,9 @@ import {
 import { useState, useMemo } from "react";
 import { formatYamlRecord } from "./helpers";
 import { FilePreviewPane, getFileServeUrl } from "./filePreview";
+
+const LazyMarkdown = lazy(() => import("@/components/ui/markdown").then((m) => ({ default: m.Markdown })));
+const Markdown = (props: ComponentProps<typeof LazyMarkdown>) => <Suspense fallback={null}><LazyMarkdown {...props} /></Suspense>;
 
 // Sentinel used as the "selected file" value for the SKILL.md body node.
 export const SKILLMD_KEY = "__skillmd__";

--- a/ui/app/workspace/skills-repo/forms/skillEditForm.tsx
+++ b/ui/app/workspace/skills-repo/forms/skillEditForm.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea, ScrollBar } from "@/components/ui/scrollArea";
 import { Textarea } from "@/components/ui/textarea";
-import { Markdown } from "@/components/ui/markdown";
+import { lazy, Suspense, type ComponentProps } from "react";
 import { CodeEditor, type CompletionItem } from "@/components/ui/codeEditor";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { validateVersionBump } from "@/lib/validators/skills";
@@ -38,6 +38,9 @@ import { FormSection } from "../components/shared";
 import { FilePreviewPane } from "../components/filePreview";
 import { FileManagerSection } from "../components/fileManagerView";
 import { MetadataTableEditor } from "../components/metadataEditorTableView";
+
+const LazyMarkdown = lazy(() => import("@/components/ui/markdown").then((m) => ({ default: m.Markdown })));
+const Markdown = (props: ComponentProps<typeof LazyMarkdown>) => <Suspense fallback={null}><LazyMarkdown {...props} /></Suspense>;
 
 export function SkillEditView({
   form,

--- a/ui/components/prompts/components/messagesView/assistantMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/assistantMessageView.tsx
@@ -2,11 +2,13 @@ import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Message, SerializedMessage } from "@/lib/message";
 import { InfoIcon, PencilIcon, XIcon } from "lucide-react";
-import { Markdown } from "@/components/ui/markdown";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ComponentProps } from "react";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
 import { isJson } from "@/lib/utils/validation";
 import { CodeEditor } from "@/components/ui/codeEditor";
+
+const LazyMarkdown = lazy(() => import("@/components/ui/markdown").then((m) => ({ default: m.Markdown })));
+const Markdown = (props: ComponentProps<typeof LazyMarkdown>) => <Suspense fallback={null}><LazyMarkdown {...props} /></Suspense>;
 
 /**
  * Renders the assistant message UI including role switcher, usage tooltip, edit/delete controls, and editable or view-only content.

--- a/ui/components/prompts/components/messagesView/systemMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/systemMessageView.tsx
@@ -1,12 +1,14 @@
 import { CodeEditor } from "@/components/ui/codeEditor";
 import { RichTextarea } from "@/components/ui/custom/richTextarea";
-import { Markdown } from "@/components/ui/markdown";
 import { Message, SerializedMessage } from "@/lib/message";
 import { JINJA_VAR_HIGHLIGHT_PATTERNS, JINJA_VAR_REGEX } from "@/lib/message/constant";
 import { isJson } from "@/lib/utils/validation";
 import { PencilIcon, XIcon } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ComponentProps } from "react";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
+
+const LazyMarkdown = lazy(() => import("@/components/ui/markdown").then((m) => ({ default: m.Markdown })));
+const Markdown = (props: ComponentProps<typeof LazyMarkdown>) => <Suspense fallback={null}><LazyMarkdown {...props} /></Suspense>;
 
 /**
  * Renders an editable system message block that supports role switching, rich-text editing, JSON editing with buffered changes, Jinja variable highlighting, and optional removal.

--- a/ui/components/prompts/components/messagesView/userMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/userMessageView.tsx
@@ -1,14 +1,16 @@
 import { CodeEditor } from "@/components/ui/codeEditor";
 import { RichTextarea } from "@/components/ui/custom/richTextarea";
-import { Markdown } from "@/components/ui/markdown";
 import { Message, SerializedMessage, type MessageContent } from "@/lib/message";
 import { JINJA_VAR_HIGHLIGHT_PATTERNS, JINJA_VAR_REGEX } from "@/lib/message/constant";
 import { isJson } from "@/lib/utils/validation";
 import { Paperclip, PencilIcon, XIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ComponentProps } from "react";
 import { fileToAttachment } from "../../utils/attachment";
 import { AttachmentDisplay } from "./attachmentViews";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
+
+const LazyMarkdown = lazy(() => import("@/components/ui/markdown").then((m) => ({ default: m.Markdown })));
+const Markdown = (props: ComponentProps<typeof LazyMarkdown>) => <Suspense fallback={null}><LazyMarkdown {...props} /></Suspense>;
 
 /**
  * Render an interactive user message block that supports viewing and editing content, role switching, file attachments (via picker or drag-and-drop), and special handling for JSON and Jinja-variable content.

--- a/ui/components/prompts/sheets/commitVersionSheet.tsx
+++ b/ui/components/prompts/sheets/commitVersionSheet.tsx
@@ -5,14 +5,16 @@ import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scrollArea";
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Message, MessageType } from "@/lib/message";
-import { Markdown } from "@/components/ui/markdown";
 import { getErrorMessage } from "@/lib/store";
 import { useCommitSessionMutation } from "@/lib/store/apis/promptsApi";
 import { PromptSession, PromptSessionMessage } from "@/lib/types/prompts";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type ComponentProps } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+
+const LazyMarkdown = lazy(() => import("@/components/ui/markdown").then((m) => ({ default: m.Markdown })));
+const Markdown = (props: ComponentProps<typeof LazyMarkdown>) => <Suspense fallback={null}><LazyMarkdown {...props} /></Suspense>;
 
 interface CommitVersionFormData {
 	commitMessage: string;


### PR DESCRIPTION
## Summary

The `Markdown` component is now lazy-loaded across all call sites to defer
loading its dependencies until the component is actually rendered, reducing the
initial bundle size.

## Changes

- Replaced direct imports of `Markdown` from `@/components/ui/markdown` with a
  lazy-loaded wrapper using React's `lazy` and `Suspense` in the following
  files:
  - `ui/app/workspace/skills-repo/components/shared.tsx`
  - `ui/app/workspace/skills-repo/forms/skillEditForm.tsx`
  - `ui/components/prompts/components/messagesView/assistantMessageView.tsx`
  - `ui/components/prompts/components/messagesView/systemMessageView.tsx`
  - `ui/components/prompts/components/messagesView/userMessageView.tsx`
  - `ui/components/prompts/sheets/commitVersionSheet.tsx`
- Each file defines a `LazyMarkdown` via `React.lazy` and wraps it in a local
  `Markdown` convenience component with a `null` fallback, preserving the
  existing usage API without requiring changes at call sites.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Verify that the built bundle no longer includes the Markdown component in the
initial chunk, and that Markdown content still renders correctly in the skills
repo, prompt message views, and commit version sheet.

## Screenshots/Recordings

No visual changes expected; rendering behavior is identical.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

