### PR TITLE
fix: add no-op `PreRequestHook` to `OtelPlugin` for plugin interface compliance

### DIFF
--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -547,6 +547,11 @@ func (p *OtelPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, r
 	return chunk, nil
 }
 
+// PreRequestHook implements schemas.LLMPlugin (no-op — required for plugin indexing).
+func (p *OtelPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
 // PreLLMHook is a no-op - tracing is handled via the Inject method.
 // The OTEL plugin receives completed traces from TracingMiddleware.
 func (p *OtelPlugin) PreLLMHook(_ *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {


### PR DESCRIPTION
## Summary

The `OtelPlugin` was missing a `PreRequestHook` method required to satisfy the `schemas.LLMPlugin` interface for plugin indexing. This adds a no-op implementation to ensure the plugin is correctly registered and indexed.

## Changes

- Added a no-op `PreRequestHook` method to `OtelPlugin` to fulfill the `schemas.LLMPlugin` interface contract. The method returns `nil` immediately, as the OTEL plugin handles tracing through `TracingMiddleware` rather than at the pre-request stage.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that the OTEL plugin compiles and is correctly indexed without any interface satisfaction errors.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None. This is a no-op method addition with no behavioral changes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable