### PR TITLE
fix: show remaining minutes and seconds in `secondsToHumanReadable`

### DIFF
--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -35,11 +35,19 @@ const secondsToHumanReadable = (seconds: number) => {
 	}
 	if (seconds < 3600) {
 		const minutes = Math.floor(seconds / 60);
-		return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+		const remainingSeconds = seconds % 60;
+		const parts: string[] = [`${minutes} ${minutes === 1 ? "minute" : "minutes"}`];
+		if (remainingSeconds > 0) parts.push(`${remainingSeconds} ${remainingSeconds === 1 ? "second" : "seconds"}`);
+		return parts.join(" ");
 	}
 	if (seconds < 86400) {
 		const hours = Math.floor(seconds / 3600);
-		return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+		const minutes = Math.floor((seconds % 3600) / 60);
+		const remainingSeconds = seconds % 60;
+		const parts: string[] = [`${hours} ${hours === 1 ? "hour" : "hours"}`];
+		if (minutes > 0) parts.push(`${minutes} ${minutes === 1 ? "minute" : "minutes"}`);
+		if (remainingSeconds > 0) parts.push(`${remainingSeconds} ${remainingSeconds === 1 ? "second" : "seconds"}`);
+		return parts.join(" ");
 	}
 	// For >= 1 day, only show non-zero components
 	const days = Math.floor(seconds / 86400);


### PR DESCRIPTION
## Summary

The `secondsToHumanReadable` function previously truncated sub-unit remainders when displaying durations in the minutes and hours ranges. For example, 90 seconds would display as "1 minute" instead of "1 minute 30 seconds". This PR fixes that by including remaining minutes and seconds as additional components in the output.

## Changes

- For durations in the minutes range (60s–3599s), remaining seconds are now appended if non-zero.
- For durations in the hours range (3600s–86399s), remaining minutes and seconds are now appended if non-zero.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify that timeout or interval values displayed in the network provider form show full precision. For example, a value of 90 seconds should render as "1 minute 30 seconds", and 3661 seconds should render as "1 hour 1 minute 1 second".

## Screenshots/Recordings

Before: `90s → "1 minute"`
After: `90s → "1 minute 30 seconds"`

Before: `3661s → "1 hour"`
After: `3661s → "1 hour 1 minute 1 second"`

## Breaking changes

- [ ] Yes
- [x] No

## Related issues
https://github.com/maximhq/bifrost/issues/3573

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable