### PR TITLE
changelogs and api e2e improvements

### DIFF
--- a/docs/changelogs/ent-v1.4.10.mdx
+++ b/docs/changelogs/ent-v1.4.10.mdx
@@ -1,0 +1,459 @@
+---
+title: "v1.4.10"
+description: "Enterprise v1.4.10 changelog - 2026-06-16"
+---
+
+<Update label="Bifrost Enterprise" description="v1.4.10">
+
+<Warning>
+  **Breaking changes in v1.4.0.** See the [v1.4.0 Migration
+  Guide](/enterprise/migration-guides/v1.4.0) for full before/after examples, automatic migration
+  details, and a step-by-step checklist before upgrading.
+</Warning>
+
+
+## Changelog
+
+A platform and reliability release on `transports/v1.5.14`. The headline work is a new **skills repository** - a full dashboard, config-based registry, and management/serving APIs, wired with enterprise RBAC so skills are governed like the rest of the workspace. This release also hardens **config-as-source-of-truth sync** with a deterministic file-wins path, aligns **SCIM provisioning** with the OIDC default-access-profile behavior, and overhauls **migration cataloguing and logging** across Postgres and SQLite.
+
+## ✨ Features
+
+- **Skills Repository (OSS)** - New skills repository with a dashboard UI (security warnings, navigation and access state), a config-based registry, and management plus serving APIs.
+- **Skills Repository RBAC (enterprise)** - `SkillsRepository` is now a first-class enterprise RBAC resource with `Create`/`View`/`Update`/`Delete` operations, default role grants (Admin and Developer full CRUD, Viewer view-only), `/api/skills/*` route mapping with public `/api/skills/serve/*`, and an idempotent seed migration for existing installs.
+- **OpenCode Gateway Providers (OSS)** - Added support for OpenCode gateway providers (Go, Zen).
+- **Advisor Tool Compatibility (OSS)** - Added advisor tool compatibility for Claude.
+- **Environment Label Banner (OSS)** - Added an environment label banner to the sidebar so the active environment is visible at a glance.
+- **Datadog Plugin Host/Port (OSS + enterprise)** - Datadog Agent and DogStatsD endpoints now accept separate `host` and `port` fields (each supporting env var references), enabling Kubernetes downward-API host injection, with a clear precedence order over the combined `addr` field.
+- **Postgres Password Command (OSS)** - Added support for sourcing the Postgres password from a command.
+- **Deterministic Config File-Wins Sync (OSS + enterprise)** - When `source_of_truth=config.json`, plugins, governance entities, and client config now force file-wins sync. A new `forceFileSync` flag on every reconcile function (guardrails, access profiles, roles, business units, MCP tool groups) bypasses hash-match preservation so config.json always wins for its declared resource types, preventing DB drift from manual edits.
+
+## 🐞 Fixed
+
+- **Inference Auth via Virtual Key (OSS)** - Inference authentication is now delegated entirely to the governance plugin (the authoritative virtual-key validator). VK-authenticated inference requests no longer return `401 Unauthorized` when dashboard password auth is enabled, and admin-password auth is now exclusive to dashboard/API routes.
+- **SCIM Default Access Profile (enterprise)** - The role's default access profile is now always auto-assigned during SCIM provisioning, even when the user's role does not change, aligning SCIM behavior with the OIDC login flow. The assignment is idempotent, so repeated syncs do not create duplicates.
+- **Migration Cataloguing and Logging (enterprise)** - Migration flows now use an explicit logger for consistent output, pending migrations are handled correctly for SQLite as well as Postgres, and duplicate migration runs were eliminated.
+- **MCP Library Cleanup (OSS)** - Custom MCP library entries are now hard-deleted and remote ones tombstoned.
+- **Skills API Response Bloat (OSS)** - Cleared backend response bloat on skills APIs and adjusted the orphan-cleanup grace period.
+- **Bedrock Tool Result Order (OSS)** - Preserved `tool_result` order to match parallel `tool_use` blocks.
+- **Bedrock Cache TTL (OSS)** - Set TTL in Bedrock cache points.
+- **Gemini/Vertex Batch Conversion (OSS)** - Fixed request conversion for Gemini/Vertex batch requests.
+- **Routing-Pinned Key ID (OSS)** - Commit the routing-pinned key ID to the reserved `BifrostContextKeyAPIKeyID` after `PreRequestHook` unblock.
+- **Responses `max_output_tokens` (OSS)** - Preserved `max_output_tokens` on Responses requests.
+- **VK Provider Blacklist Migration (OSS)** - Run the VK provider blacklist migration before backfill.
+- **Ranking Trends Accuracy (OSS)** - Stopped double-counting the boundary hour in matview ranking trends and gated ranking readers on the fresh-aggregate matview window.
+- **Logstore Migrations (OSS)** - Fixed duplicate migration runs for the logstore and added logging across all migrations.
+- **MCP Usage Guide Button (OSS)** - Fixed styling of the "Connect agent" trigger button in the MCP usage guide.
+
+## 📀 Base OSS version
+
+`transports/v1.5.14`
+
+## 🔌 If you are compiling plugin against this release - use following deps
+
+```
+module github.com/maximhq/bifrost-enterprise
+
+go 1.26.4
+
+require (
+	cloud.google.com/go/bigquery v1.74.0
+	cloud.google.com/go/pubsub/v2 v2.4.0
+	cloud.google.com/go/secretmanager v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/DataDog/datadog-go/v5 v5.6.0
+	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/aws/aws-sdk-go-v2 v1.41.12
+	github.com/aws/aws-sdk-go-v2/config v1.32.11
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.6
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.2
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
+	github.com/bytedance/sonic v1.15.1
+	github.com/coreos/go-oidc/v3 v3.12.0
+	github.com/fasthttp/router v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/cel-go v0.28.1
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/consul/api v1.28.2
+	github.com/hashicorp/memberlist v0.5.4
+	github.com/hashicorp/vault/api v1.23.0
+	github.com/maximhq/bifrost/core v1.5.20
+	github.com/maximhq/bifrost/framework v1.3.20
+	github.com/maximhq/bifrost/plugins/governance v1.5.20
+	github.com/maximhq/bifrost/plugins/logging v1.5.20
+	github.com/maximhq/bifrost/plugins/prompts v1.0.20
+	github.com/maximhq/bifrost/plugins/semanticcache v1.5.20
+	github.com/maximhq/bifrost/transports v1.5.14
+	github.com/nakabonne/tstorage v0.3.6
+	github.com/segmentio/kafka-go v0.4.47
+	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.42.0
+	github.com/tetratelabs/wazero v1.11.0
+	github.com/valyala/fasthttp v1.71.0
+	github.com/zricethezav/gitleaks/v8 v8.30.1
+	go.etcd.io/etcd/client/v3 v3.6.6
+	golang.org/x/crypto v0.52.0
+	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
+	google.golang.org/api v0.282.0
+	google.golang.org/grpc v1.81.1
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+	k8s.io/api v0.34.1
+	k8s.io/apimachinery v0.34.1
+	k8s.io/client-go v0.34.1
+)
+
+require (
+	cel.dev/expr v0.25.1 // indirect
+	cloud.google.com/go v0.123.0 // indirect
+	cloud.google.com/go/auth v0.20.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/iam v1.7.0 // indirect
+	cloud.google.com/go/monitoring v1.24.3 // indirect
+	cloud.google.com/go/storage v1.61.3 // indirect
+	dario.cat/mergo v1.0.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/BobuSumisu/aho-corasick v1.0.3 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/proto v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.73.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/log v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.71.0 // indirect
+	github.com/DataDog/go-libddwaf/v4 v4.6.1 // indirect
+	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633 // indirect
+	github.com/DataDog/go-sqllexer v0.1.8 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
+	github.com/DataDog/sketches-go v1.4.7 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.3.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/STARRY-S/zip v0.2.1 // indirect
+	github.com/andybalholm/brotli v1.2.1 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/apache/arrow/go/v15 v15.0.2 // indirect
+	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/armon/go-metrics v0.4.1 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
+	github.com/aws/smithy-go v1.27.1 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bodgit/plumbing v1.3.0 // indirect
+	github.com/bodgit/sevenzip v1.6.0 // indirect
+	github.com/bodgit/windows v1.0.1 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.1 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charmbracelet/lipgloss v0.5.0 // indirect
+	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
+	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
+	github.com/containerd/errdefs v1.0.0 // indirect
+	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/containerd/log v0.1.0 // indirect
+	github.com/containerd/platforms v0.2.1 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-connections v0.6.0 // indirect
+	github.com/docker/go-units v0.5.0 // indirect
+	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/ebitengine/purego v0.10.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
+	github.com/fasthttp/websocket v1.5.12 // indirect
+	github.com/fatih/color v1.18.0 // indirect
+	github.com/fatih/semgroup v1.2.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
+	github.com/gitleaks/go-gitdiff v0.9.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/go-openapi/analysis v0.24.2 // indirect
+	github.com/go-openapi/errors v0.22.5 // indirect
+	github.com/go-openapi/jsonpointer v0.22.4 // indirect
+	github.com/go-openapi/jsonreference v0.21.4 // indirect
+	github.com/go-openapi/loads v0.23.2 // indirect
+	github.com/go-openapi/runtime v0.29.2 // indirect
+	github.com/go-openapi/spec v0.22.2 // indirect
+	github.com/go-openapi/strfmt v0.25.0 // indirect
+	github.com/go-openapi/swag v0.25.4 // indirect
+	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
+	github.com/go-openapi/swag/conv v0.25.4 // indirect
+	github.com/go-openapi/swag/fileutils v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonname v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonutils v0.25.4 // indirect
+	github.com/go-openapi/swag/loading v0.25.4 // indirect
+	github.com/go-openapi/swag/mangling v0.25.4 // indirect
+	github.com/go-openapi/swag/netutils v0.25.4 // indirect
+	github.com/go-openapi/swag/stringutils v0.25.4 // indirect
+	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
+	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
+	github.com/go-openapi/validate v0.25.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.1.3 // indirect
+	github.com/google/flatbuffers v23.5.26+incompatible // indirect
+	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
+	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/h2non/filetype v1.1.3 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-hclog v1.6.3 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-metrics v0.5.4 // indirect
+	github.com/hashicorp/go-msgpack/v2 v2.1.5 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
+	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
+	github.com/hashicorp/serf v0.10.1 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/jaswdr/faker/v2 v2.8.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
+	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mailru/easyjson v0.9.1 // indirect
+	github.com/mark3labs/mcp-go v0.43.2 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mattn/go-sqlite3 v1.14.32 // indirect
+	github.com/maximhq/bifrost/plugins/compat v0.1.18 // indirect
+	github.com/maximhq/bifrost/plugins/maxim v1.6.19 // indirect
+	github.com/maximhq/bifrost/plugins/mocker v1.5.19 // indirect
+	github.com/maximhq/bifrost/plugins/modelcatalogresolver v1.0.0 // indirect
+	github.com/maximhq/bifrost/plugins/otel v1.2.19 // indirect
+	github.com/maximhq/bifrost/plugins/telemetry v1.5.19 // indirect
+	github.com/maximhq/maxim-go v0.2.1 // indirect
+	github.com/mholt/archives v0.1.2 // indirect
+	github.com/miekg/dns v1.1.68 // indirect
+	github.com/minio/minlz v1.0.0 // indirect
+	github.com/minio/simdjson-go v0.4.5 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/go-archive v0.2.0 // indirect
+	github.com/moby/moby/api v1.54.1 // indirect
+	github.com/moby/moby/client v0.4.0 // indirect
+	github.com/moby/patternmatcher v0.6.1 // indirect
+	github.com/moby/sys/sequential v0.6.0 // indirect
+	github.com/moby/sys/user v0.4.0 // indirect
+	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/moby/term v0.5.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nwaples/rardecode/v2 v2.2.2 // indirect
+	github.com/oapi-codegen/runtime v1.1.1 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/outcaste-io/ristretto v0.2.3 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.21 // indirect
+	github.com/pinecone-io/go-pinecone/v5 v5.3.0 // indirect
+	github.com/pion/datachannel v1.6.0 // indirect
+	github.com/pion/dtls/v3 v3.1.2 // indirect
+	github.com/pion/ice/v4 v4.2.1 // indirect
+	github.com/pion/interceptor v0.1.44 // indirect
+	github.com/pion/logging v0.2.4 // indirect
+	github.com/pion/mdns/v2 v2.1.0 // indirect
+	github.com/pion/randutil v0.1.0 // indirect
+	github.com/pion/rtcp v1.2.16 // indirect
+	github.com/pion/rtp v1.10.1 // indirect
+	github.com/pion/sctp v1.9.2 // indirect
+	github.com/pion/sdp/v3 v3.0.18 // indirect
+	github.com/pion/srtp/v3 v3.0.10 // indirect
+	github.com/pion/stun/v3 v3.1.1 // indirect
+	github.com/pion/transport/v4 v4.0.1 // indirect
+	github.com/pion/turn/v4 v4.1.4 // indirect
+	github.com/pion/webrtc/v4 v4.2.9 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.67.5 // indirect
+	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
+	github.com/qdrant/go-client v1.16.2 // indirect
+	github.com/redis/go-redis/v9 v9.17.2 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rs/zerolog v1.34.0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/sagikazarmark/locafero v0.7.0 // indirect
+	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 // indirect
+	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	github.com/secure-systems-lab/go-securesystemslib v0.9.0 // indirect
+	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/sorairolake/lzip-go v0.3.5 // indirect
+	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
+	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/spf13/viper v1.19.0 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/theckman/httpforwarded v0.4.0 // indirect
+	github.com/therootcompany/xz v1.0.1 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
+	github.com/tinylib/msgp v1.3.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.16 // indirect
+	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/wasilibs/go-re2 v1.9.0 // indirect
+	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
+	github.com/weaviate/weaviate v1.36.5 // indirect
+	github.com/weaviate/weaviate-go-client/v5 v5.7.1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	github.com/wlynxg/anet v0.0.5 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	github.com/zeebo/xxh3 v1.0.2 // indirect
+	go.einride.tech/aip v0.83.0 // indirect
+	go.etcd.io/etcd/api/v3 v3.6.6 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.6.6 // indirect
+	go.mongodb.org/mongo-driver v1.17.6 // indirect
+	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/component v1.39.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.39.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.133.0 // indirect
+	go.opentelemetry.io/collector/pdata v1.39.0 // indirect
+	go.opentelemetry.io/contrib/bridges/otelzap v0.12.0 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.42.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
+	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
+	go.opentelemetry.io/otel/log v0.14.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.starlark.net v0.0.0-20260102030733-3fee463870c9 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.3 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
+	golang.org/x/arch v0.23.0 // indirect
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
+	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
+	golang.org/x/term v0.43.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/tools v0.44.0 // indirect
+	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
+	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/postgres v1.6.0 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
+)
+```
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -814,6 +814,7 @@
             "item": "Enterprise",
             "icon": "building",
             "pages": [
+              "changelogs/ent-v1.4.10",
               "changelogs/ent-v1.4.9",
               "changelogs/ent-v1.4.8",
               "changelogs/ent-v1.4.7",

--- a/tests/e2e/api/runners/add-auth-header.mjs
+++ b/tests/e2e/api/runners/add-auth-header.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const [, , sourcePath, outPath] = process.argv;
+
+if (!sourcePath || !outPath) {
+  console.error("Usage: add-auth-header.mjs <source-collection> <out-collection>");
+  process.exit(1);
+}
+
+const collection = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
+const authScript = [
+  "const adminAuthHeader = pm.variables.get('admin_auth_header') || pm.environment.get('admin_auth_header');",
+  "if (adminAuthHeader) {",
+  "  pm.request.headers.upsert({ key: 'Authorization', value: adminAuthHeader });",
+  "}",
+];
+
+collection.event = Array.isArray(collection.event) ? collection.event : [];
+collection.event.push({
+  listen: "prerequest",
+  script: {
+    type: "text/javascript",
+    exec: authScript,
+  },
+});
+
+fs.writeFileSync(outPath, `${JSON.stringify(collection, null, 2)}\n`);

--- a/tests/e2e/api/runners/run-newman-api-tests.sh
+++ b/tests/e2e/api/runners/run-newman-api-tests.sh
@@ -66,6 +66,10 @@ DB_CONFIG_PATH=""
 SEED_ENV_PATH="${BIFROST_E2E_SEED_ENV:-}"
 EXPECTED_PATH="${BIFROST_E2E_SEED_EXPECTED:-}"
 EXTRA_COLLECTIONS=()
+BASE_URL="${BIFROST_E2E_BASE_URL:-${BIFROST_BASE_URL:-http://localhost:8080}}"
+ADMIN_USERNAME="${BIFROST_E2E_ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD="${BIFROST_E2E_ADMIN_PASSWORD:-bifrost-e2e-admin-password}"
+ADMIN_AUTH_HEADER="Bearer $(printf '%s:%s' "$ADMIN_USERNAME" "$ADMIN_PASSWORD" | base64 | tr -d '\n')"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -222,8 +226,10 @@ fi
 
 echo -e "Configuration:"
 echo -e "  Collection: ${YELLOW}$COLLECTION${NC}"
+echo -e "  Base URL:   ${YELLOW}$BASE_URL${NC}"
 echo -e "  Reports:    ${YELLOW}$REPORT_DIR${NC}"
 echo -e "  Verbose:    ${YELLOW}$([ -n "$VERBOSE" ] && echo "enabled" || echo "disabled")${NC}"
+echo -e "  Auth Pass:  ${YELLOW}enabled (username: $ADMIN_USERNAME)${NC}"
 if [ ${#EXTRA_COLLECTIONS[@]} -gt 0 ]; then
     echo -e "  Extensions: ${YELLOW}${EXTRA_COLLECTIONS[*]}${NC}"
 fi
@@ -267,6 +273,7 @@ fi
 HTTP_SERVER_DIR="$BIFROST_ROOT/examples/mcps/http-no-ping-server"
 HTTP_SERVER_BIN="$HTTP_SERVER_DIR/http-server"
 HTTP_SERVER_PID=""
+AUTH_ENABLED_BY_RUN=""
 
 start_http_mcp_server() {
     # Skip if something is already listening on 3001
@@ -312,8 +319,20 @@ stop_http_mcp_server() {
     fi
 }
 
-# Register teardown so the server is stopped even if the script exits early
-trap stop_http_mcp_server EXIT
+cleanup() {
+    if [ "$AUTH_ENABLED_BY_RUN" = "1" ]; then
+        echo "Restoring dashboard auth to disabled..."
+        BIFROST_E2E_AUTH_HEADER="$ADMIN_AUTH_HEADER" \
+        BIFROST_E2E_BASE_URL="$BASE_URL" \
+        BIFROST_E2E_ADMIN_USERNAME="$ADMIN_USERNAME" \
+        BIFROST_E2E_ADMIN_PASSWORD="$ADMIN_PASSWORD" \
+            node "$SCRIPT_DIR/set-auth-config.mjs" disable >/dev/null 2>&1 || true
+    fi
+    stop_http_mcp_server
+}
+
+# Register teardown so auth and the server are restored even if the script exits early
+trap cleanup EXIT
 
 echo "Setting up MCP test servers..."
 start_http_mcp_server
@@ -350,8 +369,10 @@ if [ -n "$DB_VERIFY" ]; then
     export NODE_PATH="$API_DIR/node_modules${NODE_PATH:+:$NODE_PATH}"
 fi
 
-# Build Newman command
-cmd=(newman run "$COLLECTION" --timeout-script 120000 --timeout 900000 -r "$REPORTERS")
+# Build shared Newman arguments. The collection and reporter export paths are
+# supplied per pass so the unauthenticated and authenticated runs keep separate
+# reports while using identical environment/config inputs.
+newman_args=(--timeout-script 120000 --timeout 900000 -r "$REPORTERS" --env-var "base_url=$BASE_URL")
 
 # Parsed seed env entries live here, not in the runner's shell namespace.
 # Decoupling the data keyspace from the script's own variables (PATH, COLLECTION,
@@ -392,7 +413,7 @@ add_env_var_if_set() {
     local name="$1"
     local value="${seed_env_values[$name]:-}"
     if [ -n "$value" ]; then
-        cmd+=(--env-var "$name=$value")
+        newman_args+=(--env-var "$name=$value")
     fi
 }
 
@@ -423,33 +444,39 @@ if [ -n "$EXPECTED_PATH" ]; then
         exit 1
     fi
     EXPECTED_JSON="$(node -e 'const fs=require("fs"); const p=process.argv[1]; process.stdout.write(JSON.stringify(JSON.parse(fs.readFileSync(p,"utf8"))));' "$EXPECTED_PATH")"
-    cmd+=(--env-var "e2e_seed_expected=$EXPECTED_JSON")
+    newman_args+=(--env-var "e2e_seed_expected=$EXPECTED_JSON")
 fi
 
 # Override plugin_path with resolved absolute path so Create Plugin / Get Plugin use the built .so
 # env-var takes precedence over collection variables in Newman's resolution order
 if [ -n "$PLUGIN_PATH_ABS" ]; then
-    cmd+=(--env-var "plugin_path=$PLUGIN_PATH_ABS")
-fi
-
-if [[ "$REPORTERS" == *"htmlextra"* ]]; then
-    cmd+=(--reporter-htmlextra-export "$REPORT_DIR/report.html")
-    cmd+=(--reporter-htmlextra-title "Bifrost API Management & Health")
-    cmd+=(--reporter-htmlextra-darkTheme)
-fi
-
-if [[ "$REPORTERS" == *"json"* ]]; then
-    cmd+=(--reporter-json-export "$REPORT_DIR/report.json")
+    newman_args+=(--env-var "plugin_path=$PLUGIN_PATH_ABS")
 fi
 
 if [ -n "$DB_VERIFY" ]; then
-    [ -n "$DB_URL" ]      && cmd+=(--reporter-dbverify-db-url "$DB_URL")
-    [ -n "$LOGS_DB_URL" ] && cmd+=(--reporter-dbverify-logs-db-url "$LOGS_DB_URL")
-    [ -n "$DB_CONFIG_PATH" ] && cmd+=(--reporter-dbverify-config "$DB_CONFIG_PATH")
+    [ -n "$DB_URL" ]      && newman_args+=(--reporter-dbverify-db-url "$DB_URL")
+    [ -n "$LOGS_DB_URL" ] && newman_args+=(--reporter-dbverify-logs-db-url "$LOGS_DB_URL")
+    [ -n "$DB_CONFIG_PATH" ] && newman_args+=(--reporter-dbverify-config "$DB_CONFIG_PATH")
 fi
 
-[ -n "$VERBOSE" ] && cmd+=("$VERBOSE")
-[ -n "$BAIL" ] && cmd+=("$BAIL")
+[ -n "$VERBOSE" ] && newman_args+=("$VERBOSE")
+[ -n "$BAIL" ] && newman_args+=("$BAIL")
+
+build_newman_cmd() {
+    local collection_path="$1"
+    local report_suffix="$2"
+    cmd=(newman run "$collection_path" "${newman_args[@]}")
+
+    if [[ "$REPORTERS" == *"htmlextra"* ]]; then
+        cmd+=(--reporter-htmlextra-export "$REPORT_DIR/report${report_suffix}.html")
+        cmd+=(--reporter-htmlextra-title "Bifrost API Management & Health${report_suffix}")
+        cmd+=(--reporter-htmlextra-darkTheme)
+    fi
+
+    if [[ "$REPORTERS" == *"json"* ]]; then
+        cmd+=(--reporter-json-export "$REPORT_DIR/report${report_suffix}.json")
+    fi
+}
 
 # Run Newman and save output to log file while displaying to console (using tee)
 LOG_FILE="$LOG_DIR/api-management.log"
@@ -461,10 +488,86 @@ else
     echo "[setup] plugin_path not resolved (build may have failed)" | tee "$LOG_FILE"
 fi
 
-set +e
-"${cmd[@]}" 2>&1 | tee -a "$LOG_FILE"
-EXIT_CODE=${PIPESTATUS[0]}
-set -e
+run_newman_pass() {
+    local label="$1"
+    local collection_path="$2"
+    local report_suffix="$3"
+    local with_auth="$4"
+
+    echo "" | tee -a "$LOG_FILE"
+    echo -e "${GREEN}${label}${NC}" | tee -a "$LOG_FILE"
+
+    build_newman_cmd "$collection_path" "$report_suffix"
+    if [ "$with_auth" = "1" ]; then
+        cmd+=(--env-var "admin_auth_header=$ADMIN_AUTH_HEADER")
+        cmd+=(--env-var "admin_username=$ADMIN_USERNAME")
+        cmd+=(--env-var "admin_password=$ADMIN_PASSWORD")
+    fi
+
+    set +e
+    "${cmd[@]}" 2>&1 | tee -a "$LOG_FILE"
+    local pass_exit=${PIPESTATUS[0]}
+    set -e
+    return $pass_exit
+}
+
+run_newman_pass "Running unauthenticated API management tests..." "$COLLECTION" "" ""
+EXIT_CODE=$?
+
+AUTH_COLLECTION="$REPORT_DIR/api-management-auth.postman_collection.json"
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "" | tee -a "$LOG_FILE"
+    echo -e "${GREEN}Enabling dashboard auth for authenticated API management tests...${NC}" | tee -a "$LOG_FILE"
+    set +e
+    BIFROST_E2E_BASE_URL="$BASE_URL" \
+    BIFROST_E2E_ADMIN_USERNAME="$ADMIN_USERNAME" \
+    BIFROST_E2E_ADMIN_PASSWORD="$ADMIN_PASSWORD" \
+        node "$SCRIPT_DIR/set-auth-config.mjs" enable 2>&1 | tee -a "$LOG_FILE"
+    AUTH_SETUP_EXIT=${PIPESTATUS[0]}
+    set -e
+    if [ $AUTH_SETUP_EXIT -ne 0 ]; then
+        EXIT_CODE=$AUTH_SETUP_EXIT
+    else
+        AUTH_ENABLED_BY_RUN="1"
+        node "$SCRIPT_DIR/add-auth-header.mjs" "$COLLECTION" "$AUTH_COLLECTION"
+        run_newman_pass "Running authenticated API management tests..." "$AUTH_COLLECTION" "-auth" "1"
+        EXIT_CODE=$?
+    fi
+fi
+
+if [ $EXIT_CODE -eq 0 ] && [ "${BIFROST_E2E_SKIP_OBSERVABILITY:-0}" != "1" ]; then
+    echo "" | tee -a "$LOG_FILE"
+    echo -e "${GREEN}Running authenticated local OTEL and Prometheus observability checks...${NC}" | tee -a "$LOG_FILE"
+    set +e
+    BIFROST_E2E_BASE_URL="$BASE_URL" \
+    BIFROST_E2E_AUTH_HEADER="$ADMIN_AUTH_HEADER" \
+        node "$SCRIPT_DIR/run-observability-local.mjs" 2>&1 | tee -a "$LOG_FILE"
+    OBS_EXIT_CODE=${PIPESTATUS[0]}
+    set -e
+    if [ $OBS_EXIT_CODE -ne 0 ]; then
+        EXIT_CODE=$OBS_EXIT_CODE
+    fi
+elif [ $EXIT_CODE -eq 0 ]; then
+    echo "" | tee -a "$LOG_FILE"
+    echo -e "${YELLOW}Skipping local OTEL and Prometheus observability checks (BIFROST_E2E_SKIP_OBSERVABILITY=1).${NC}" | tee -a "$LOG_FILE"
+fi
+
+if [ "$AUTH_ENABLED_BY_RUN" = "1" ]; then
+    echo "" | tee -a "$LOG_FILE"
+    echo -e "${GREEN}Restoring dashboard auth to disabled...${NC}" | tee -a "$LOG_FILE"
+    set +e
+    BIFROST_E2E_AUTH_HEADER="$ADMIN_AUTH_HEADER" \
+    BIFROST_E2E_BASE_URL="$BASE_URL" \
+    BIFROST_E2E_ADMIN_USERNAME="$ADMIN_USERNAME" \
+    BIFROST_E2E_ADMIN_PASSWORD="$ADMIN_PASSWORD" \
+        node "$SCRIPT_DIR/set-auth-config.mjs" disable 2>&1 | tee -a "$LOG_FILE"
+    AUTH_RESTORE_EXIT=${PIPESTATUS[0]}
+    set -e
+    AUTH_ENABLED_BY_RUN=""
+    if [ $EXIT_CODE -eq 0 ] && [ $AUTH_RESTORE_EXIT -ne 0 ]; then
+        EXIT_CODE=$AUTH_RESTORE_EXIT
+    fi
+fi
 
 echo ""
 if [ $EXIT_CODE -eq 0 ]; then
@@ -480,6 +583,7 @@ if [[ "$REPORTERS" == *"htmlextra"* ]] || [[ "$REPORTERS" == *"json"* ]]; then
 fi
 if [[ "$REPORTERS" == *"htmlextra"* ]]; then
     echo -e "HTML report: ${YELLOW}$REPORT_DIR/report.html${NC}"
+    [ -f "$REPORT_DIR/report-auth.html" ] && echo -e "Auth HTML report: ${YELLOW}$REPORT_DIR/report-auth.html${NC}"
 fi
 echo -e "Log saved to: ${YELLOW}$LOG_FILE${NC}"
 

--- a/tests/e2e/api/runners/run-observability-local.mjs
+++ b/tests/e2e/api/runners/run-observability-local.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+
+import http from "node:http";
+
+const baseURL = (process.env.BIFROST_E2E_BASE_URL || process.env.BIFROST_BASE_URL || "http://localhost:8080").replace(/\/+$/, "");
+const adminAuthHeader = process.env.BIFROST_E2E_AUTH_HEADER || "";
+const providerName = `otel-e2e-${process.pid}-${Date.now()}`;
+const modelName = "hello-world";
+const requestedModel = `${providerName}/${modelName}`;
+const requestID = `otel-e2e-request-${process.pid}-${Date.now()}`;
+
+const state = {
+  otelTraceRequests: [],
+  otelMetricRequests: [],
+  mockRequests: [],
+};
+
+function listen(server, host = "127.0.0.1") {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, host, () => {
+      server.off("error", reject);
+      resolve(server.address().port);
+    });
+  });
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function createOtelReceiver() {
+  return http.createServer(async (req, res) => {
+    const body = await readBody(req);
+    if (req.method === "POST" && req.url === "/v1/traces") {
+      state.otelTraceRequests.push({
+        headers: req.headers,
+        bytes: body.length,
+        body,
+      });
+      res.writeHead(200, { "content-type": "application/x-protobuf" });
+      res.end("");
+      return;
+    }
+    if (req.method === "POST" && req.url === "/v1/metrics") {
+      state.otelMetricRequests.push({
+        headers: req.headers,
+        bytes: body.length,
+        body,
+      });
+      res.writeHead(200, { "content-type": "application/x-protobuf" });
+      res.end("");
+      return;
+    }
+    res.writeHead(404);
+    res.end("not found");
+  });
+}
+
+function createOpenAIMock() {
+  return http.createServer(async (req, res) => {
+    const body = await readBody(req);
+    if (req.method === "POST" && req.url === "/v1/chat/completions") {
+      state.mockRequests.push({
+        headers: req.headers,
+        body: body.toString("utf8"),
+      });
+      const now = Math.floor(Date.now() / 1000);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({
+        id: `chatcmpl-${now}`,
+        object: "chat.completion",
+        created: now,
+        model: modelName,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "hello world",
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: {
+          prompt_tokens: 2,
+          completion_tokens: 2,
+          total_tokens: 4,
+        },
+      }));
+      return;
+    }
+    res.writeHead(404);
+    res.end("not found");
+  });
+}
+
+async function request(method, path, body, headers = {}) {
+  const requestHeaders = adminAuthHeader ? { Authorization: adminAuthHeader, ...headers } : { ...headers };
+  if (body !== undefined && requestHeaders["content-type"] === undefined && requestHeaders["Content-Type"] === undefined) {
+    requestHeaders["content-type"] = "application/json";
+  }
+  const res = await fetch(`${baseURL}${path}`, {
+    method,
+    headers: Object.keys(requestHeaders).length === 0 ? undefined : requestHeaders,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      json = null;
+    }
+  }
+  return { ok: res.ok, status: res.status, text, json };
+}
+
+async function mustRequest(method, path, body, headers = {}) {
+  const res = await request(method, path, body, headers);
+  if (!res.ok) {
+    throw new Error(`${method} ${path} failed with ${res.status}: ${res.text}`);
+  }
+  return res;
+}
+
+async function getPlugin(name) {
+  const res = await request("GET", `/api/plugins/${encodeURIComponent(name)}`);
+  if (res.status === 404) {
+    return null;
+  }
+  if (!res.ok) {
+    throw new Error(`GET /api/plugins/${name} failed with ${res.status}: ${res.text}`);
+  }
+  return res.json?.plugin ?? res.json ?? null;
+}
+
+function pluginUpdatePayload(plugin) {
+  return {
+    enabled: Boolean(plugin.enabled),
+    path: plugin.path ?? null,
+    config: plugin.config ?? {},
+    placement: plugin.placement ?? undefined,
+    order: plugin.order ?? undefined,
+  };
+}
+
+async function enableBuiltinPlugin(name, config) {
+  await mustRequest("PUT", `/api/plugins/${encodeURIComponent(name)}`, {
+    enabled: true,
+    path: null,
+    config,
+  });
+}
+
+async function addLocalProvider(mockPort) {
+  await mustRequest("POST", "/api/providers", {
+    provider: providerName,
+    custom_provider_config: {
+      base_provider_type: "openai",
+      is_key_less: true,
+      allowed_requests: {
+        chat_completion: true,
+      },
+    },
+    network_config: {
+      base_url: `http://127.0.0.1:${mockPort}`,
+      allow_private_network: true,
+      default_request_timeout_in_seconds: 10,
+      max_retries: 0,
+      retry_backoff_initial: 500,
+      retry_backoff_max: 5000,
+    },
+    concurrency_and_buffer_size: {
+      concurrency: 10,
+      buffer_size: 100,
+    },
+    keys: [],
+  });
+}
+
+async function chatHelloWorld() {
+  const res = await mustRequest("POST", "/v1/chat/completions", {
+    model: requestedModel,
+    messages: [
+      { role: "user", content: "hello world" },
+    ],
+  }, {
+    "x-request-id": requestID,
+  });
+  const content = res.json?.choices?.[0]?.message?.content;
+  if (content !== "hello world") {
+    throw new Error(`unexpected chat response content: ${JSON.stringify(content)}`);
+  }
+}
+
+async function poll(name, timeoutMs, fn) {
+  const started = Date.now();
+  let lastError;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const result = await fn();
+      if (result) {
+        return result;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  if (lastError) {
+    throw new Error(`${name} timed out: ${lastError.message}`);
+  }
+  throw new Error(`${name} timed out`);
+}
+
+async function assertOtelReceived() {
+  const entry = await poll("OTEL trace receiver", 20000, () => state.otelTraceRequests.find((item) => item.bytes > 0));
+  assertBufferContainsAll("OTEL trace export", entry.body, [
+    "bifrost-e2e",
+    providerName,
+    modelName,
+    requestID,
+    "gen_ai.provider.name",
+    "gen_ai.request.model",
+    "gen_ai.request_id",
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.output_tokens",
+    "gen_ai.usage.total_tokens",
+  ]);
+}
+
+async function assertOtelMetricsReceived() {
+  const entry = await poll("OTEL metrics receiver", 30000, () => state.otelMetricRequests.find((item) => item.bytes > 0));
+  assertBufferContainsAll("OTEL metrics export", entry.body, [
+    "bifrost-e2e",
+    "bifrost_upstream_requests_total",
+    "bifrost_success_requests_total",
+    "bifrost_input_tokens_total",
+    "bifrost_output_tokens_total",
+    "bifrost_upstream_latency_seconds",
+    "bifrost_request_retries",
+    "provider",
+    providerName,
+    "model",
+    requestedModel,
+    "method",
+    "chat_completion",
+  ]);
+}
+
+function assertBufferContainsAll(name, body, values) {
+  for (const value of values) {
+    if (!body.includes(Buffer.from(value))) {
+      throw new Error(`${name} is missing ${JSON.stringify(value)}`);
+    }
+  }
+}
+
+function findPrometheusSample(metrics, metricName, labels) {
+  const prefix = `${metricName}{`;
+  return metrics
+    .split("\n")
+    .find((line) => line.startsWith(prefix) &&
+      Object.entries(labels).every(([key, value]) => line.includes(`${key}="${value}"`)));
+}
+
+function parsePrometheusValue(line) {
+  const raw = line?.trim().split(/\s+/).at(-1);
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`invalid Prometheus sample value in line: ${line}`);
+  }
+  return value;
+}
+
+async function assertPrometheusScrape() {
+  const metrics = await poll("Prometheus scrape", 20000, async () => {
+    const res = await request("GET", "/metrics");
+    if (!res.ok) {
+      throw new Error(`GET /metrics failed with ${res.status}: ${res.text}`);
+    }
+    const hasLLMSuccessMetric = res.text
+      .split("\n")
+      .some((line) => line.startsWith("bifrost_success_requests_total{") &&
+        line.includes(`provider="${providerName}"`) &&
+        (line.includes(`model="${modelName}"`) || line.includes(`model="${requestedModel}"`)));
+    if (hasLLMSuccessMetric) {
+      return res.text;
+    }
+    return null;
+  });
+
+  const labels = { provider: providerName, model: requestedModel, method: "chat_completion" };
+  const successLine = findPrometheusSample(metrics, "bifrost_success_requests_total", labels);
+  const upstreamLine = findPrometheusSample(metrics, "bifrost_upstream_requests_total", labels);
+  const inputLine = findPrometheusSample(metrics, "bifrost_input_tokens_total", labels);
+  const outputLine = findPrometheusSample(metrics, "bifrost_output_tokens_total", labels);
+
+  if (!successLine || parsePrometheusValue(successLine) < 1) {
+    throw new Error("Prometheus scrape is missing bifrost_success_requests_total for the LLM call");
+  }
+  if (!upstreamLine || parsePrometheusValue(upstreamLine) < 1) {
+    throw new Error("Prometheus scrape is missing bifrost_upstream_requests_total for the LLM call");
+  }
+  if (!inputLine || parsePrometheusValue(inputLine) < 2) {
+    throw new Error("Prometheus scrape is missing input token count for the LLM call");
+  }
+  if (!outputLine || parsePrometheusValue(outputLine) < 2) {
+    throw new Error("Prometheus scrape is missing output token count for the LLM call");
+  }
+
+  return metrics;
+}
+
+async function assertLoggingTrace() {
+  const log = await poll("logging trace API", 30000, async () => {
+    const res = await request("GET", `/api/logs/${encodeURIComponent(requestID)}`);
+    if (res.status === 404) {
+      return null;
+    }
+    if (!res.ok) {
+      throw new Error(`GET /api/logs/${requestID} failed with ${res.status}: ${res.text}`);
+    }
+    return res.json;
+  });
+
+  if (log.id !== requestID) {
+    throw new Error(`logging trace API returned unexpected id: ${JSON.stringify(log.id)}`);
+  }
+  if (log.status !== "success") {
+    throw new Error(`logging trace API returned unexpected status: ${JSON.stringify(log.status)}`);
+  }
+  if (log.provider !== providerName) {
+    throw new Error(`logging trace API returned unexpected provider: ${JSON.stringify(log.provider)}`);
+  }
+  if (log.model !== modelName && log.model !== requestedModel) {
+    throw new Error(`logging trace API returned unexpected model: ${JSON.stringify(log.model)}`);
+  }
+  if (log.object !== "chat_completion" && log.object !== "chat.completion") {
+    throw new Error(`logging trace API returned unexpected object: ${JSON.stringify(log.object)}`);
+  }
+  if (!log.token_usage || log.token_usage.prompt_tokens !== 2 || log.token_usage.completion_tokens !== 2 || log.token_usage.total_tokens !== 4) {
+    throw new Error(`logging trace API returned incomplete token usage: ${JSON.stringify(log.token_usage)}`);
+  }
+  if (!Array.isArray(log.input_history) || log.input_history.length !== 1 || log.input_history[0]?.role !== "user" || log.input_history[0]?.content !== "hello world") {
+    throw new Error(`logging trace API returned incomplete input history: ${JSON.stringify(log.input_history)}`);
+  }
+  if (!log.output_message || log.output_message.role !== "assistant" || log.output_message.content !== "hello world") {
+    throw new Error(`logging trace API returned incomplete output message: ${JSON.stringify(log.output_message)}`);
+  }
+  if (typeof log.latency !== "number" || log.latency < 0) {
+    throw new Error(`logging trace API returned invalid latency: ${JSON.stringify(log.latency)}`);
+  }
+
+  return log;
+}
+
+function assertMockProviderRequest() {
+  if (state.mockRequests.length !== 1) {
+    throw new Error(`expected exactly one mock provider request, got ${state.mockRequests.length}`);
+  }
+  let body;
+  try {
+    body = JSON.parse(state.mockRequests[0].body);
+  } catch (err) {
+    throw new Error(`mock provider request body is not JSON: ${err.message}`);
+  }
+  if (body.model !== requestedModel && body.model !== modelName) {
+    throw new Error(`mock provider received unexpected model: ${JSON.stringify(body.model)}`);
+  }
+  if (!Array.isArray(body.messages) || body.messages.length !== 1 || body.messages[0]?.role !== "user" || body.messages[0]?.content !== "hello world") {
+    throw new Error(`mock provider received incomplete messages: ${JSON.stringify(body.messages)}`);
+  }
+}
+
+async function main() {
+  console.log("Running local observability API check...");
+  console.log(`  Bifrost: ${baseURL}`);
+  if (adminAuthHeader) {
+    console.log("  Auth:    Bearer admin credentials");
+  }
+
+  const originalOtel = await getPlugin("otel");
+  const originalTelemetry = await getPlugin("telemetry");
+
+  const otelReceiver = createOtelReceiver();
+  const openaiMock = createOpenAIMock();
+  const otelPort = await listen(otelReceiver);
+  const mockPort = await listen(openaiMock);
+
+  let cleanupError = null;
+  try {
+    console.log(`  OTEL trace receiver:   http://127.0.0.1:${otelPort}/v1/traces`);
+    console.log(`  OTEL metrics receiver: http://127.0.0.1:${otelPort}/v1/metrics`);
+    console.log(`  Mock provider:  http://127.0.0.1:${mockPort}`);
+
+    await enableBuiltinPlugin("telemetry", { metrics_enabled: true });
+    await enableBuiltinPlugin("otel", {
+      profiles: [
+        {
+          enabled: true,
+          service_name: "bifrost-e2e",
+          collector_url: `http://127.0.0.1:${otelPort}/v1/traces`,
+          trace_type: "genai_extension",
+          protocol: "http",
+          insecure: true,
+          metrics_enabled: true,
+          metrics_endpoint: `http://127.0.0.1:${otelPort}/v1/metrics`,
+          metrics_push_interval: 1,
+          disable_content_logging: true,
+        },
+      ],
+    });
+
+    await addLocalProvider(mockPort);
+    await chatHelloWorld();
+
+    assertMockProviderRequest();
+
+    await assertOtelReceived();
+    await assertOtelMetricsReceived();
+    await assertPrometheusScrape();
+    await assertLoggingTrace();
+
+    console.log(`  OTEL trace exports received: ${state.otelTraceRequests.length}`);
+    console.log(`  OTEL metric exports received: ${state.otelMetricRequests.length}`);
+    console.log(`  Prometheus scrape includes provider="${providerName}" model="${requestedModel}"`);
+    console.log(`  Logging trace API returned id="${requestID}"`);
+    console.log("Local observability API check passed.");
+  } finally {
+    try {
+      await request("DELETE", `/api/providers/${encodeURIComponent(providerName)}`);
+      if (originalOtel) {
+        await request("PUT", "/api/plugins/otel", pluginUpdatePayload(originalOtel));
+      } else {
+        await request("DELETE", "/api/plugins/otel");
+      }
+      if (originalTelemetry) {
+        await request("PUT", "/api/plugins/telemetry", pluginUpdatePayload(originalTelemetry));
+      }
+    } catch (err) {
+      cleanupError = err;
+    }
+    await Promise.all([close(otelReceiver), close(openaiMock)]);
+    if (cleanupError) {
+      console.warn(`WARNING: observability cleanup failed: ${cleanupError.message}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(`Local observability API check failed: ${err.message}`);
+  process.exit(1);
+});

--- a/tests/e2e/api/runners/set-auth-config.mjs
+++ b/tests/e2e/api/runners/set-auth-config.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+const baseURL = (process.env.BIFROST_E2E_BASE_URL || process.env.BIFROST_BASE_URL || "http://localhost:8080").replace(/\/+$/, "");
+const mode = process.argv[2];
+const username = process.env.BIFROST_E2E_ADMIN_USERNAME || "admin";
+const password = process.env.BIFROST_E2E_ADMIN_PASSWORD || "bifrost-e2e-admin-password";
+const authHeader = process.env.BIFROST_E2E_AUTH_HEADER || "";
+
+if (mode !== "enable" && mode !== "disable") {
+  console.error("Usage: set-auth-config.mjs <enable|disable>");
+  process.exit(1);
+}
+
+async function request(method, path, body) {
+  const headers = { "content-type": "application/json" };
+  if (authHeader) {
+    headers.Authorization = authHeader;
+  }
+  const res = await fetch(`${baseURL}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      json = null;
+    }
+  }
+  if (!res.ok) {
+    throw new Error(`${method} ${path} failed with ${res.status}: ${text}`);
+  }
+  return json;
+}
+
+const current = await request("GET", "/api/config");
+await request("PUT", "/api/config", {
+  client_config: current.client_config,
+  framework_config: current.framework_config,
+  auth_config: mode === "enable"
+    ? {
+        is_enabled: true,
+        admin_username: username,
+        admin_password: password,
+      }
+    : {
+        is_enabled: false,
+        admin_username: username,
+        admin_password: "<redacted>",
+      },
+});
+
+console.log(`Auth ${mode}d at ${baseURL}`);


### PR DESCRIPTION
## Summary

Adds the Enterprise v1.4.10 changelog and extends the E2E API test runner with a two-pass authenticated/unauthenticated Newman execution flow, a new local observability check, and supporting helper scripts.

## Changes

- Added `docs/changelogs/ent-v1.4.10.mdx` documenting the v1.4.10 release (Skills Repository, RBAC, SCIM fixes, config file-wins sync, migration cataloguing, and all associated bug fixes) and registered it in `docs/docs.json`.
- Refactored `run-newman-api-tests.sh` to split Newman execution into two sequential passes: an unauthenticated pass using the original collection, followed by an authenticated pass against a copy of the collection that has an `Authorization` pre-request script injected. Dashboard auth is enabled before the authenticated pass and reliably restored (via both explicit teardown and an `EXIT` trap) regardless of test outcome.
- Added `add-auth-header.mjs` — a small Node script that injects a collection-level pre-request script into a Postman collection JSON file so every request in the authenticated pass carries the admin `Authorization` header.
- Added `set-auth-config.mjs` — a Node script that enables or disables dashboard auth on a running Bifrost instance via `PUT /api/config`, driven by `BIFROST_E2E_BASE_URL`, `BIFROST_E2E_ADMIN_USERNAME`, `BIFROST_E2E_ADMIN_PASSWORD`, and `BIFROST_E2E_AUTH_HEADER` environment variables.
- Added `run-observability-local.mjs` — a self-contained Node script that spins up a local OTLP HTTP receiver and an OpenAI-compatible mock provider, registers them with Bifrost, fires a chat completion, then asserts that OTEL traces, OTEL metrics, Prometheus scrape output, and the logging trace API all reflect the request correctly. This check runs automatically after the authenticated Newman pass unless `BIFROST_E2E_SKIP_OBSERVABILITY=1` is set.
- Separate HTML and JSON reports are now generated for each Newman pass (`report.html` / `report-auth.html`, `report.json` / `report-auth.json`).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
# Run the full E2E suite against a local Bifrost instance
cd tests/e2e/api
BIFROST_E2E_BASE_URL=http://localhost:8080 \
BIFROST_E2E_ADMIN_USERNAME=admin \
BIFROST_E2E_ADMIN_PASSWORD=bifrost-e2e-admin-password \
  ./runners/run-newman-api-tests.sh --collection ./collections/api-management.postman_collection.json

# Skip the observability check if OTEL/Prometheus are not configured locally
BIFROST_E2E_SKIP_OBSERVABILITY=1 ./runners/run-newman-api-tests.sh ...
```

Expected outcomes:
- Unauthenticated Newman pass completes and produces `report.html` / `report.json`.
- Dashboard auth is enabled, authenticated pass completes and produces `report-auth.html` / `report-auth.json`.
- Observability check asserts OTEL traces, OTEL metrics, Prometheus samples, and logging trace API all contain the expected values.
- Dashboard auth is restored to disabled on exit in all cases.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Admin credentials (`BIFROST_E2E_ADMIN_USERNAME` / `BIFROST_E2E_ADMIN_PASSWORD`) are passed only via environment variables and are never written to the collection JSON on disk. The `Authorization` header is injected at runtime into an in-memory copy of the collection. The `set-auth-config.mjs` disable path redacts the password field in the config payload.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable