### PR TITLE
fix(schemas): preserve extra_content on ChatAssistantMessageToolCall

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1438,12 +1438,17 @@ type ChatAssistantMessageAnnotationCitation struct {
 	Type       *string      `json:"type,omitempty"`
 }
 
-// ChatAssistantMessageToolCall represents a tool call in a message
+// ChatAssistantMessageToolCall represents a tool call in a message.
+// ExtraContent preserves provider-specific metadata (e.g. Gemini's
+// thought_signature for multi-turn continuation when extended thinking
+// is active). Stored as json.RawMessage so unknown nested fields are
+// forwarded verbatim through any proxy/gateway layer without loss.
 type ChatAssistantMessageToolCall struct {
-	Index    uint16                               `json:"index"`
-	Type     *string                              `json:"type,omitempty"`
-	ID       *string                              `json:"id,omitempty"`
-	Function ChatAssistantMessageToolCallFunction `json:"function"`
+	Index        uint16                               `json:"index"`
+	Type         *string                              `json:"type,omitempty"`
+	ID           *string                              `json:"id,omitempty"`
+	Function     ChatAssistantMessageToolCallFunction `json:"function"`
+	ExtraContent json.RawMessage                      `json:"extra_content,omitempty"`
 }
 
 // ChatAssistantMessageToolCallFunction represents a call to a function.

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -1,6 +1,7 @@
 package streaming
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -93,6 +94,10 @@ func deepCopyChatStreamDelta(original *schemas.ChatStreamResponseChoiceDelta) *s
 				copyName := *tc.Function.Name
 				copyTc.Function.Name = &copyName
 			}
+			// Deep copy ExtraContent (json.RawMessage is a []byte)
+			if len(tc.ExtraContent) > 0 {
+				copyTc.ExtraContent = append(json.RawMessage(nil), tc.ExtraContent...)
+			}
 			copy.ToolCalls[i] = copyTc
 		}
 	}
@@ -140,10 +145,11 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 
 	// Tool call argument builders keyed by delta index
 	type tcAccum struct {
-		id   *string
-		typ  *string
-		name *string
-		args strings.Builder
+		id           *string
+		typ          *string
+		name         *string
+		args         strings.Builder
+		extraContent json.RawMessage
 	}
 	var tcAccums map[uint16]*tcAccum
 
@@ -251,6 +257,10 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 			if args := deltaToolCall.Function.Arguments; args != "" {
 				acc.args.WriteString(args)
 			}
+			if len(deltaToolCall.ExtraContent) > 0 {
+				acc.extraContent = make(json.RawMessage, len(deltaToolCall.ExtraContent))
+				copy(acc.extraContent, deltaToolCall.ExtraContent)
+			}
 		}
 	}
 
@@ -333,7 +343,7 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 		toolCalls := make([]schemas.ChatAssistantMessageToolCall, 0, len(tcIndices))
 		for _, idx := range tcIndices {
 			acc := tcAccums[uint16(idx)]
-			toolCalls = append(toolCalls, schemas.ChatAssistantMessageToolCall{
+			tc := schemas.ChatAssistantMessageToolCall{
 				Index: uint16(idx),
 				ID:    acc.id,
 				Type:  acc.typ,
@@ -341,7 +351,11 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 					Name:      acc.name,
 					Arguments: acc.args.String(),
 				},
-			})
+			}
+			if len(acc.extraContent) > 0 {
+				tc.ExtraContent = acc.extraContent
+			}
+			toolCalls = append(toolCalls, tc)
 		}
 		completeMessage.ChatAssistantMessage.ToolCalls = toolCalls
 	}


### PR DESCRIPTION
# fix(schemas): preserve extra_content on ChatAssistantMessageToolCall

## Problem

Gemini multi-turn tool calls fail with a **bifrost 400** when the response stream passes through any proxy/gateway that uses the bifrost Go SDK's typed structs for deserialization:

```
gateway: bifrost: 400 Unable to submit request because function call
`default_api:activate_tools` in the 10. content block is missing a
`thought_signature`. Learn more: https://docs.cloud.google.com/vertex-ai/
generative-ai/docs/thought-signatures
```

### Root Cause

When Gemini has **extended thinking** enabled (`include_thoughts: true`), it returns a cryptographic continuation token called `thought_signature` on tool call objects in the streaming SSE response:

```json
{
  "choices": [{
    "delta": {
      "tool_calls": [{
        "id": "call_abc123",
        "function": {"name": "activate_tools", "arguments": "{}"},
        "extra_content": {
          "google": {
            "thought_signature": "<base64-url-encoded-signature>"
          }
        }
      }]
    }
  }]
}
```

This signature **must** be echoed back on the next turn's request. If it's missing, bifrost (acting as the Gemini gateway) rejects the request with HTTP 400.

The current `ChatAssistantMessageToolCall` struct in `core/schemas/chatcompletions.go`:

```go
type ChatAssistantMessageToolCall struct {
    Index    uint16                               `json:"index"`
    Type     *string                              `json:"type,omitempty"`
    ID       *string                              `json:"id,omitempty"`
    Function ChatAssistantMessageToolCallFunction `json:"function"`
    // NO extra_content field
}
```

Go's `json.Unmarshal` silently discards any JSON field that doesn't have a corresponding struct field. When a downstream consumer (e.g. a guardrail proxy) deserializes the SSE chunk into this struct and then re-serializes it, `extra_content` is permanently lost.

### Impact

- **All Gemini models with extended thinking** fail on multi-turn tool calls when the response passes through any Go service using this struct
- First turn succeeds; **second turn always gets 400**
- Affects `gemini-3.1-pro`, `gemini-3.1-pro-gsu`, and any model with `thinking_level` configured
- Services reading raw SSE bytes (no struct round-trip) are unaffected

### How thought_signature Works

1. **Turn 1 response** — bifrost/Gemini sends SSE chunks with `extra_content.google.thought_signature` on the tool call object
2. **Client captures it** — stores the signature keyed by tool call index
3. **Turn 2 request** — client echoes the signature back on `tool_calls[N].extra_content.google.thought_signature` in the outbound request body
4. **Bifrost validates** — rejects the request if the signature is missing or invalid

## Solution

Add `ExtraContent json.RawMessage` to `ChatAssistantMessageToolCall`:

```go
type ChatAssistantMessageToolCall struct {
    Index        uint16                               `json:"index"`
    Type         *string                              `json:"type,omitempty"`
    ID           *string                              `json:"id,omitempty"`
    Function     ChatAssistantMessageToolCallFunction `json:"function"`
    ExtraContent json.RawMessage                      `json:"extra_content,omitempty"`
}
```

### Why `json.RawMessage`

- **Provider-agnostic** — preserves any nested structure verbatim without needing to model every provider's schema (Gemini uses `{"google": {"thought_signature": "..."}}`, other providers may use different shapes)
- **Zero allocation when absent** — `omitempty` on `json.RawMessage` means the field is not marshaled when nil/empty
- **Backward compatible** — existing consumers that don't read `ExtraContent` are unaffected; the field simply passes through

### Why Not a Typed Struct

The `extra_content` field is intentionally opaque — different providers use different nested structures. A typed struct would require updating every time a provider adds a new field. `json.RawMessage` is the correct Go idiom for "preserve but don't interpret."

## Scope

This change affects the `ChatAssistantMessageToolCall` struct which is used in:
1. **Non-streaming responses** — `ChatAssistantMessage.ToolCalls` (line 1376)
2. **Streaming deltas** — `ChatStreamResponseChoiceDelta.ToolCalls` (line 1550)

Both paths are fixed by this single struct change since they share the same type.

## Testing

- `go build ./...` — passes
- `go test ./schemas/...` — passes (existing tests unaffected)
- Wire-level verification: a JSON payload with `extra_content` on a tool call now round-trips correctly through `json.Unmarshal` → `json.Marshal`

## Verification Steps

```go
input := `{"index":0,"type":"function","id":"call_1","function":{"name":"test","arguments":"{}"},"extra_content":{"google":{"thought_signature":"abc123"}}}`
var tc ChatAssistantMessageToolCall
json.Unmarshal([]byte(input), &tc)
output, _ := json.Marshal(tc)
// output contains extra_content — previously it was silently dropped
```

## Related

- [Gemini thought signatures documentation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures)
- Bifrost Vertex provider page confirms thinking support with `thoughtSignature` handling
- This fix unblocks any downstream consumer that uses the bifrost Go SDK for streaming SSE parsing (e.g. guardrail proxies, observability sidecars, gateway middleware)