### PR TITLE
feat(mcp): add per-MCP-server tool execution timeout

### DIFF
--- a/core/internal/mcptests/per_server_timeout_test.go
+++ b/core/internal/mcptests/per_server_timeout_test.go
@@ -78,12 +78,19 @@ func TestPerServerTimeout_OverridesGlobal(t *testing.T) {
 
 	start := time.Now()
 	toolCall := makeDelayToolCall(clientName, 3.0)
-	_, _ = bf.ExecuteChatMCPTool(ctx, &toolCall)
+	result, bifrostErr := bf.ExecuteChatMCPTool(ctx, &toolCall)
 	elapsed := time.Since(start)
 
 	assert.Less(t, elapsed, 2500*time.Millisecond,
 		"per-server timeout (1s) should fire before the 3s tool delay; got %v", elapsed)
-	t.Logf("elapsed: %v (expected < 2.5s)", elapsed)
+	// Timeout surfaces either as a BifrostError or as an error message in the result content.
+	if bifrostErr != nil && bifrostErr.Error != nil {
+		t.Logf("elapsed: %v, error: %s", elapsed, bifrostErr.Error.Message)
+	} else if result != nil {
+		t.Logf("elapsed: %v, timeout returned in result", elapsed)
+	} else {
+		t.Errorf("expected either a bifrost error or a result indicating timeout, got both nil")
+	}
 }
 
 // TestPerServerTimeout_AllowsLongerThanGlobal verifies that when the per-server
@@ -150,10 +157,17 @@ func TestPerServerTimeout_FallsBackToGlobal(t *testing.T) {
 
 	start := time.Now()
 	toolCall := makeDelayToolCall(clientName, 5.0) // 5s delay
-	_, _ = bf.ExecuteChatMCPTool(ctx, &toolCall)
+	result, bifrostErr := bf.ExecuteChatMCPTool(ctx, &toolCall)
 	elapsed := time.Since(start)
 
 	assert.Less(t, elapsed, 2*time.Second,
 		"context deadline should cancel the tool (per-server=0 falls back to global); got %v", elapsed)
-	t.Logf("elapsed: %v (expected < 2s)", elapsed)
+	// Cancellation surfaces either as a BifrostError or as an error message in the result content.
+	if bifrostErr != nil && bifrostErr.Error != nil {
+		t.Logf("elapsed: %v, error: %s", elapsed, bifrostErr.Error.Message)
+	} else if result != nil {
+		t.Logf("elapsed: %v, cancellation returned in result", elapsed)
+	} else {
+		t.Errorf("expected either a bifrost error or a result indicating cancellation, got both nil")
+	}
 }

--- a/core/internal/mcptests/per_server_timeout_test.go
+++ b/core/internal/mcptests/per_server_timeout_test.go
@@ -1,0 +1,159 @@
+package mcptests
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildPerServerDelayServer creates an InProcess MCP server with a delay tool
+// that respects context cancellation so per-server timeouts are observable.
+func buildPerServerDelayServer(t *testing.T) *server.MCPServer {
+	t.Helper()
+	s := server.NewMCPServer("delay-server", "1.0.0", server.WithToolCapabilities(true))
+	delayTool := mcpgo.NewTool("delay",
+		mcpgo.WithDescription("Sleeps for the given number of seconds, respects context cancellation"),
+		mcpgo.WithNumber("seconds", mcpgo.Required(), mcpgo.Description("seconds to sleep")),
+	)
+	s.AddTool(delayTool, func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		seconds, _ := req.GetArguments()["seconds"].(float64)
+		timer := time.NewTimer(time.Duration(seconds * float64(time.Second)))
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			return mcpgo.NewToolResultText("ok"), nil
+		case <-ctx.Done():
+			return mcpgo.NewToolResultError("timed out"), nil
+		}
+	})
+	return s
+}
+
+// makeDelayToolCall builds a ChatAssistantMessageToolCall for the delay tool on the named client.
+func makeDelayToolCall(clientName string, seconds float64) schemas.ChatAssistantMessageToolCall {
+	args, _ := json.Marshal(map[string]interface{}{"seconds": seconds})
+	toolName := clientName + "-delay"
+	return schemas.ChatAssistantMessageToolCall{
+		ID:   schemas.Ptr("call-delay"),
+		Type: schemas.Ptr("function"),
+		Function: schemas.ChatAssistantMessageToolCallFunction{
+			Name:      &toolName,
+			Arguments: string(args),
+		},
+	}
+}
+
+// TestPerServerTimeout_OverridesGlobal verifies that a per-server ToolExecutionTimeout
+// fires before the global timeout and before the tool naturally finishes.
+// Setup: per-server = 1s, tool delay = 3s, context = 10s.
+// Expected: call returns in < 2.5s (per-server timeout fires at ~1s).
+func TestPerServerTimeout_OverridesGlobal(t *testing.T) {
+	t.Parallel()
+
+	clientName := "tsoverride"
+	cfg := &schemas.MCPClientConfig{
+		ID:                   clientName + "-id",
+		Name:                 clientName,
+		ConnectionType:       schemas.MCPConnectionTypeInProcess,
+		InProcessServer:      buildPerServerDelayServer(t),
+		ToolsToExecute:       []string{"*"},
+		ToolExecutionTimeout: 1 * time.Second,
+	}
+
+	manager := setupMCPManager(t)
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
+
+	bf := setupBifrost(t)
+	bf.SetMCPManager(manager)
+
+	ctx, cancel := createTestContextWithTimeout(10 * time.Second)
+	defer cancel()
+
+	start := time.Now()
+	toolCall := makeDelayToolCall(clientName, 3.0)
+	_, _ = bf.ExecuteChatMCPTool(ctx, &toolCall)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 2500*time.Millisecond,
+		"per-server timeout (1s) should fire before the 3s tool delay; got %v", elapsed)
+	t.Logf("elapsed: %v (expected < 2.5s)", elapsed)
+}
+
+// TestPerServerTimeout_AllowsLongerThanGlobal verifies that when the per-server
+// timeout is longer than the tool's execution time the tool completes successfully.
+// Setup: per-server = 3s, tool delay = 2s, context = 10s.
+// Expected: call succeeds with no error.
+func TestPerServerTimeout_AllowsLongerThanGlobal(t *testing.T) {
+	t.Parallel()
+
+	clientName := "tsallowslong"
+	cfg := &schemas.MCPClientConfig{
+		ID:                   clientName + "-id",
+		Name:                 clientName,
+		ConnectionType:       schemas.MCPConnectionTypeInProcess,
+		InProcessServer:      buildPerServerDelayServer(t),
+		ToolsToExecute:       []string{"*"},
+		ToolExecutionTimeout: 3 * time.Second,
+	}
+
+	manager := setupMCPManager(t)
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
+
+	bf := setupBifrost(t)
+	bf.SetMCPManager(manager)
+
+	ctx, cancel := createTestContextWithTimeout(10 * time.Second)
+	defer cancel()
+
+	toolCall := makeDelayToolCall(clientName, 2.0) // 2s delay < 3s timeout → must succeed
+	result, bifrostErr := bf.ExecuteChatMCPTool(ctx, &toolCall)
+
+	require.Nil(t, bifrostErr, "tool should succeed when delay < per-server timeout")
+	assert.NotNil(t, result, "should have a result")
+}
+
+// TestPerServerTimeout_FallsBackToGlobal verifies that a client with
+// ToolExecutionTimeout = 0 falls back to the global timeout / context deadline.
+// A short context (500 ms) is used to make the timeout observable without
+// depending on the manager's exact configured global value.
+// Setup: per-server = 0 (use global), tool delay = 5s, context = 500ms.
+// Expected: call returns well under 2s (context fires).
+func TestPerServerTimeout_FallsBackToGlobal(t *testing.T) {
+	t.Parallel()
+
+	clientName := "tsfallback"
+	cfg := &schemas.MCPClientConfig{
+		ID:                   clientName + "-id",
+		Name:                 clientName,
+		ConnectionType:       schemas.MCPConnectionTypeInProcess,
+		InProcessServer:      buildPerServerDelayServer(t),
+		ToolsToExecute:       []string{"*"},
+		ToolExecutionTimeout: 0, // 0 = use global
+	}
+
+	manager := setupMCPManager(t)
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
+
+	bf := setupBifrost(t)
+	bf.SetMCPManager(manager)
+
+	// Short context deadline — demonstrates that global/context applies when per-server = 0.
+	ctx, cancel := createTestContextWithTimeout(500 * time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	toolCall := makeDelayToolCall(clientName, 5.0) // 5s delay
+	_, _ = bf.ExecuteChatMCPTool(ctx, &toolCall)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 2*time.Second,
+		"context deadline should cancel the tool (per-server=0 falls back to global); got %v", elapsed)
+	t.Logf("elapsed: %v (expected < 2s)", elapsed)
+}

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -982,6 +982,7 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 		AllowedExtraHeaders:   slices.Clone(updatedConfig.AllowedExtraHeaders),
 		IsPingAvailable:       updatedConfig.IsPingAvailable,
 		ToolSyncInterval:      updatedConfig.ToolSyncInterval,
+		ToolExecutionTimeout:  updatedConfig.ToolExecutionTimeout,
 		AllowOnAllVirtualKeys: updatedConfig.AllowOnAllVirtualKeys,
 		Disabled:              updatedConfig.Disabled,
 		TLSConfig:             updatedConfig.TLSConfig,

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -683,8 +683,12 @@ func (m *ToolsManager) executeToolInternal(
 	sanitizedToolName := stripClientPrefix(toolName, executionConfig.Name)
 	originalMCPToolName := getOriginalToolName(sanitizedToolName, toolNameMapping)
 
-	// Create timeout context for tool execution
+	// Create timeout context for tool execution.
+	// Per-server timeout (executionConfig.ToolExecutionTimeout) takes precedence over the global.
 	toolExecutionTimeout := m.toolExecutionTimeout.Load().(time.Duration)
+	if executionConfig != nil && executionConfig.ToolExecutionTimeout > 0 {
+		toolExecutionTimeout = executionConfig.ToolExecutionTimeout
+	}
 	toolCtx, cancel := context.WithTimeout(ctx, toolExecutionTimeout)
 	defer cancel()
 

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -352,36 +352,11 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 			c.ToolSyncInterval = dur
 		}
 		if aux.ToolExecutionTimeout != nil {
-			raw := *aux.ToolExecutionTimeout
-			// string like "30s" — parse as Go duration
-			if len(raw) > 0 && raw[0] == '"' {
-				var s string
-				if err := json.Unmarshal(raw, &s); err != nil {
-					return fmt.Errorf("invalid tool_execution_timeout: %w", err)
-				}
-				dur, err := time.ParseDuration(s)
-				if err != nil {
-					return fmt.Errorf("invalid tool_execution_timeout %q: %w", s, err)
-				}
-				if dur < 0 {
-					return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %v", dur)
-				}
-				c.ToolExecutionTimeout = dur
-			} else {
-				// bare integer — treat as seconds
-				var n int64
-				if err := json.Unmarshal(raw, &n); err != nil {
-					return fmt.Errorf("invalid tool_execution_timeout: expected a duration string (e.g. \"30s\") or integer seconds: %w", err)
-				}
-				if n < 0 {
-					return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %d", n)
-				}
-				const maxTimeoutSeconds = math.MaxInt64 / int64(time.Second)
-				if n > maxTimeoutSeconds {
-					return fmt.Errorf("invalid tool_execution_timeout: value %d seconds overflows duration (max %d)", n, maxTimeoutSeconds)
-				}
-				c.ToolExecutionTimeout = time.Duration(n) * time.Second
+			dur, err := parseToolExecutionTimeoutField(*aux.ToolExecutionTimeout)
+			if err != nil {
+				return err
 			}
+			c.ToolExecutionTimeout = dur
 		}
 		return nil
 	}
@@ -405,36 +380,45 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 		c.ToolSyncInterval = dur
 	}
 	if auxStr.ToolExecutionTimeout != nil {
-		raw := *auxStr.ToolExecutionTimeout
-		if len(raw) > 0 && raw[0] == '"' {
-			var s string
-			if err := json.Unmarshal(raw, &s); err != nil {
-				return fmt.Errorf("invalid tool_execution_timeout: %w", err)
-			}
-			dur, err := time.ParseDuration(s)
-			if err != nil {
-				return fmt.Errorf("invalid tool_execution_timeout %q: %w", s, err)
-			}
-			if dur < 0 {
-				return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %v", dur)
-			}
-			c.ToolExecutionTimeout = dur
-		} else {
-			var n int64
-			if err := json.Unmarshal(raw, &n); err != nil {
-				return fmt.Errorf("invalid tool_execution_timeout: expected a duration string (e.g. \"30s\") or integer seconds: %w", err)
-			}
-			if n < 0 {
-				return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %d", n)
-			}
-			const maxTimeoutSeconds = math.MaxInt64 / int64(time.Second)
-			if n > maxTimeoutSeconds {
-				return fmt.Errorf("invalid tool_execution_timeout: value %d seconds overflows duration (max %d)", n, maxTimeoutSeconds)
-			}
-			c.ToolExecutionTimeout = time.Duration(n) * time.Second
+		dur, err := parseToolExecutionTimeoutField(*auxStr.ToolExecutionTimeout)
+		if err != nil {
+			return err
 		}
+		c.ToolExecutionTimeout = dur
 	}
 	return nil
+}
+
+// parseToolExecutionTimeoutField parses a tool_execution_timeout JSON value.
+// Accepts a Go duration string (e.g. "30s") or a bare integer treated as seconds.
+// Rejects negative values and integers that would overflow time.Duration.
+func parseToolExecutionTimeoutField(raw json.RawMessage) (time.Duration, error) {
+	if len(raw) > 0 && raw[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return 0, fmt.Errorf("invalid tool_execution_timeout: %w", err)
+		}
+		dur, err := time.ParseDuration(s)
+		if err != nil {
+			return 0, fmt.Errorf("invalid tool_execution_timeout %q: %w", s, err)
+		}
+		if dur < 0 {
+			return 0, fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %v", dur)
+		}
+		return dur, nil
+	}
+	var n int64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0, fmt.Errorf("invalid tool_execution_timeout: expected a duration string (e.g. \"30s\") or integer seconds: %w", err)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %d", n)
+	}
+	const maxTimeoutSeconds = math.MaxInt64 / int64(time.Second)
+	if n > maxTimeoutSeconds {
+		return 0, fmt.Errorf("invalid tool_execution_timeout: value %d seconds overflows duration (max %d)", n, maxTimeoutSeconds)
+	}
+	return time.Duration(n) * time.Second, nil
 }
 
 // MarshalJSON emits tool_execution_timeout as a duration string so it round-trips

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"net/http"
 	"strconv"
@@ -375,6 +376,10 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 				if n < 0 {
 					return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %d", n)
 				}
+				const maxTimeoutSeconds = math.MaxInt64 / int64(time.Second)
+				if n > maxTimeoutSeconds {
+					return fmt.Errorf("invalid tool_execution_timeout: value %d seconds overflows duration (max %d)", n, maxTimeoutSeconds)
+				}
 				c.ToolExecutionTimeout = time.Duration(n) * time.Second
 			}
 		}
@@ -382,9 +387,11 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	// Allow Go duration strings while keeping numeric tokens as json.Number.
+	// ToolExecutionTimeout uses *json.RawMessage (not *string) so that integer
+	// values like 60 remain valid even when tool_sync_interval is a string.
 	auxStr := &struct {
-		ToolSyncInterval     *string `json:"tool_sync_interval,omitempty"`
-		ToolExecutionTimeout *string `json:"tool_execution_timeout,omitempty"`
+		ToolSyncInterval     *string          `json:"tool_sync_interval,omitempty"`
+		ToolExecutionTimeout *json.RawMessage `json:"tool_execution_timeout,omitempty"`
 		*alias
 	}{alias: (*alias)(c)}
 	if err := json.Unmarshal(data, auxStr); err != nil {
@@ -398,16 +405,52 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 		c.ToolSyncInterval = dur
 	}
 	if auxStr.ToolExecutionTimeout != nil {
-		dur, err := parseFlexibleDurationField(*auxStr.ToolExecutionTimeout, "tool_execution_timeout")
-		if err != nil {
-			return err
+		raw := *auxStr.ToolExecutionTimeout
+		if len(raw) > 0 && raw[0] == '"' {
+			var s string
+			if err := json.Unmarshal(raw, &s); err != nil {
+				return fmt.Errorf("invalid tool_execution_timeout: %w", err)
+			}
+			dur, err := time.ParseDuration(s)
+			if err != nil {
+				return fmt.Errorf("invalid tool_execution_timeout %q: %w", s, err)
+			}
+			if dur < 0 {
+				return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %v", dur)
+			}
+			c.ToolExecutionTimeout = dur
+		} else {
+			var n int64
+			if err := json.Unmarshal(raw, &n); err != nil {
+				return fmt.Errorf("invalid tool_execution_timeout: expected a duration string (e.g. \"30s\") or integer seconds: %w", err)
+			}
+			if n < 0 {
+				return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %d", n)
+			}
+			const maxTimeoutSeconds = math.MaxInt64 / int64(time.Second)
+			if n > maxTimeoutSeconds {
+				return fmt.Errorf("invalid tool_execution_timeout: value %d seconds overflows duration (max %d)", n, maxTimeoutSeconds)
+			}
+			c.ToolExecutionTimeout = time.Duration(n) * time.Second
 		}
-		if dur < 0 {
-			return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %v", dur)
-		}
-		c.ToolExecutionTimeout = dur
 	}
 	return nil
+}
+
+// MarshalJSON emits tool_execution_timeout as a duration string so it round-trips
+// correctly — default time.Duration marshaling emits nanoseconds, but UnmarshalJSON
+// treats bare integers as seconds.
+func (c MCPClientConfig) MarshalJSON() ([]byte, error) {
+	type alias MCPClientConfig
+	type shadow struct {
+		ToolExecutionTimeout string `json:"tool_execution_timeout,omitempty"`
+		*alias
+	}
+	s := shadow{alias: (*alias)(&c)}
+	if c.ToolExecutionTimeout > 0 {
+		s.ToolExecutionTimeout = c.ToolExecutionTimeout.String()
+	}
+	return json.Marshal(s)
 }
 
 func parseFlexibleDurationField(v any, fieldName string) (time.Duration, error) {

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -362,12 +362,18 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 				if err != nil {
 					return fmt.Errorf("invalid tool_execution_timeout %q: %w", s, err)
 				}
+				if dur < 0 {
+					return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %v", dur)
+				}
 				c.ToolExecutionTimeout = dur
 			} else {
-				// bare integer — treat as seconds 
+				// bare integer — treat as seconds
 				var n int64
 				if err := json.Unmarshal(raw, &n); err != nil {
 					return fmt.Errorf("invalid tool_execution_timeout: expected a duration string (e.g. \"30s\") or integer seconds: %w", err)
+				}
+				if n < 0 {
+					return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %d", n)
 				}
 				c.ToolExecutionTimeout = time.Duration(n) * time.Second
 			}
@@ -395,6 +401,9 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 		dur, err := parseFlexibleDurationField(*auxStr.ToolExecutionTimeout, "tool_execution_timeout")
 		if err != nil {
 			return err
+		}
+		if dur < 0 {
+			return fmt.Errorf("invalid tool_execution_timeout: value must be >= 0, got %v", dur)
 		}
 		c.ToolExecutionTimeout = dur
 	}

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -313,9 +313,10 @@ type MCPClientConfig struct {
 	// - nil/omitted => treated as [] (no tools)
 	// - ["tool1", "tool2"] => auto-execute only the specified tools
 	// Note: If a tool is in ToolsToAutoExecute but not in ToolsToExecute, it will be skipped.
-	IsPingAvailable       *bool              `json:"is_ping_available,omitempty"`  // Whether the MCP server supports ping for health checks (nil/true = ping; false = listTools). Defaults to true.
-	ToolSyncInterval      time.Duration      `json:"tool_sync_interval,omitempty"` // Per-client override for tool sync interval (0 = use global, negative = disabled)
-	ToolPricing           map[string]float64 `json:"tool_pricing,omitempty"`       // Tool pricing for each tool (cost per execution)
+	IsPingAvailable       *bool              `json:"is_ping_available,omitempty"`       // Whether the MCP server supports ping for health checks (nil/true = ping; false = listTools). Defaults to true.
+	ToolSyncInterval      time.Duration      `json:"tool_sync_interval,omitempty"`      // Per-client override for tool sync interval (0 = use global, negative = disabled)
+	ToolExecutionTimeout  time.Duration      `json:"tool_execution_timeout,omitempty"`  // Per-client override for tool execution timeout (0 = use global from tool_manager_config)
+	ToolPricing           map[string]float64 `json:"tool_pricing,omitempty"`            // Tool pricing for each tool (cost per execution)
 	Disabled              bool               `json:"disabled"`                     // Whether the client is intentionally disabled (stops connection and workers)
 	ConfigHash            string             `json:"-"`                            // Config hash for reconciliation (not serialized)
 	AllowOnAllVirtualKeys bool               `json:"allow_on_all_virtual_keys"`    // Whether to allow the MCP client to run on all virtual keys
@@ -325,12 +326,14 @@ type MCPClientConfig struct {
 	DiscoveredToolNameMapping map[string]string   `json:"-"` // Mapping from sanitized tool names to original MCP names
 }
 
-// UnmarshalJSON supports Go duration strings (e.g. "10m") for tool_sync_interval.
-// Numeric values remain supported for backward compatibility (treated as raw nanoseconds).
+// UnmarshalJSON supports Go duration strings (e.g. "10m") for tool_sync_interval and
+// tool_execution_timeout. Numeric values are treated as raw nanoseconds for tool_sync_interval
+// and as seconds for tool_execution_timeout (matching tool_manager_config behaviour).
 func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 	type alias MCPClientConfig
 	aux := &struct {
-		ToolSyncInterval *json.Number `json:"tool_sync_interval,omitempty"`
+		ToolSyncInterval     *json.Number     `json:"tool_sync_interval,omitempty"`
+		ToolExecutionTimeout *json.RawMessage `json:"tool_execution_timeout,omitempty"`
 		*alias
 	}{alias: (*alias)(c)}
 
@@ -340,33 +343,61 @@ func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
 		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 			return errors.New("trailing JSON data")
 		}
-		if aux.ToolSyncInterval == nil {
-			return nil
+		if aux.ToolSyncInterval != nil {
+			dur, parseErr := parseFlexibleDurationField(*aux.ToolSyncInterval, "tool_sync_interval")
+			if parseErr != nil {
+				return parseErr
+			}
+			c.ToolSyncInterval = dur
 		}
-		dur, parseErr := parseFlexibleDurationField(*aux.ToolSyncInterval, "tool_sync_interval")
-		if parseErr != nil {
-			return parseErr
+		if aux.ToolExecutionTimeout != nil {
+			raw := *aux.ToolExecutionTimeout
+			// string like "30s" — parse as Go duration
+			if len(raw) > 0 && raw[0] == '"' {
+				var s string
+				if err := json.Unmarshal(raw, &s); err != nil {
+					return fmt.Errorf("invalid tool_execution_timeout: %w", err)
+				}
+				dur, err := time.ParseDuration(s)
+				if err != nil {
+					return fmt.Errorf("invalid tool_execution_timeout %q: %w", s, err)
+				}
+				c.ToolExecutionTimeout = dur
+			} else {
+				// bare integer — treat as seconds 
+				var n int64
+				if err := json.Unmarshal(raw, &n); err != nil {
+					return fmt.Errorf("invalid tool_execution_timeout: expected a duration string (e.g. \"30s\") or integer seconds: %w", err)
+				}
+				c.ToolExecutionTimeout = time.Duration(n) * time.Second
+			}
 		}
-		c.ToolSyncInterval = dur
 		return nil
 	}
 
 	// Allow Go duration strings while keeping numeric tokens as json.Number.
 	auxStr := &struct {
-		ToolSyncInterval *string `json:"tool_sync_interval,omitempty"`
+		ToolSyncInterval     *string `json:"tool_sync_interval,omitempty"`
+		ToolExecutionTimeout *string `json:"tool_execution_timeout,omitempty"`
 		*alias
 	}{alias: (*alias)(c)}
 	if err := json.Unmarshal(data, auxStr); err != nil {
 		return err
 	}
-	if auxStr.ToolSyncInterval == nil {
-		return nil
+	if auxStr.ToolSyncInterval != nil {
+		dur, err := parseFlexibleDurationField(*auxStr.ToolSyncInterval, "tool_sync_interval")
+		if err != nil {
+			return err
+		}
+		c.ToolSyncInterval = dur
 	}
-	dur, err := parseFlexibleDurationField(*auxStr.ToolSyncInterval, "tool_sync_interval")
-	if err != nil {
-		return err
+	if auxStr.ToolExecutionTimeout != nil {
+		dur, err := parseFlexibleDurationField(*auxStr.ToolExecutionTimeout, "tool_execution_timeout")
+		if err != nil {
+			return err
+		}
+		c.ToolExecutionTimeout = dur
 	}
-	c.ToolSyncInterval = dur
 	return nil
 }
 

--- a/core/schemas/mcp_json_test.go
+++ b/core/schemas/mcp_json_test.go
@@ -102,3 +102,19 @@ func TestMCPClientConfigUnmarshalToolExecutionTimeoutInvalidString(t *testing.T)
 	}
 }
 
+func TestMCPClientConfigUnmarshalToolExecutionTimeoutNegativeInteger(t *testing.T) {
+	raw := []byte(`{"name":"demo","connection_type":"http","tool_execution_timeout":-30}`)
+	var cfg MCPClientConfig
+	if err := sonic.Unmarshal(raw, &cfg); err == nil {
+		t.Fatal("expected unmarshal error for negative timeout, got nil")
+	}
+}
+
+func TestMCPClientConfigUnmarshalToolExecutionTimeoutNegativeString(t *testing.T) {
+	raw := []byte(`{"name":"demo","connection_type":"http","tool_execution_timeout":"-30s"}`)
+	var cfg MCPClientConfig
+	if err := sonic.Unmarshal(raw, &cfg); err == nil {
+		t.Fatal("expected unmarshal error for negative duration string, got nil")
+	}
+}
+

--- a/core/schemas/mcp_json_test.go
+++ b/core/schemas/mcp_json_test.go
@@ -94,6 +94,17 @@ func TestMCPClientConfigUnmarshalToolExecutionTimeoutNotSet(t *testing.T) {
 	}
 }
 
+func TestMCPClientConfigUnmarshalToolExecutionTimeoutExplicitZero(t *testing.T) {
+	raw := []byte(`{"name":"demo","connection_type":"http","tool_execution_timeout":0}`)
+	var cfg MCPClientConfig
+	if err := sonic.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if cfg.ToolExecutionTimeout != 0 {
+		t.Fatalf("expected 0 (use global), got %v", cfg.ToolExecutionTimeout)
+	}
+}
+
 func TestMCPClientConfigUnmarshalToolExecutionTimeoutInvalidString(t *testing.T) {
 	raw := []byte(`{"name":"demo","connection_type":"http","tool_execution_timeout":"not-a-duration"}`)
 	var cfg MCPClientConfig

--- a/core/schemas/mcp_json_test.go
+++ b/core/schemas/mcp_json_test.go
@@ -61,3 +61,44 @@ func TestMCPConfigUnmarshalToolSyncIntervalRejectsFractionalNumber(t *testing.T)
 	}
 }
 
+func TestMCPClientConfigUnmarshalToolExecutionTimeoutString(t *testing.T) {
+	raw := []byte(`{"name":"demo","connection_type":"http","tool_execution_timeout":"45s"}`)
+	var cfg MCPClientConfig
+	if err := sonic.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if cfg.ToolExecutionTimeout != 45*time.Second {
+		t.Fatalf("expected 45s, got %v", cfg.ToolExecutionTimeout)
+	}
+}
+
+func TestMCPClientConfigUnmarshalToolExecutionTimeoutInteger(t *testing.T) {
+	raw := []byte(`{"name":"demo","connection_type":"http","tool_execution_timeout":60}`)
+	var cfg MCPClientConfig
+	if err := sonic.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if cfg.ToolExecutionTimeout != 60*time.Second {
+		t.Fatalf("expected 60s, got %v", cfg.ToolExecutionTimeout)
+	}
+}
+
+func TestMCPClientConfigUnmarshalToolExecutionTimeoutNotSet(t *testing.T) {
+	raw := []byte(`{"name":"demo","connection_type":"http"}`)
+	var cfg MCPClientConfig
+	if err := sonic.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if cfg.ToolExecutionTimeout != 0 {
+		t.Fatalf("expected 0 (use global), got %v", cfg.ToolExecutionTimeout)
+	}
+}
+
+func TestMCPClientConfigUnmarshalToolExecutionTimeoutInvalidString(t *testing.T) {
+	raw := []byte(`{"name":"demo","connection_type":"http","tool_execution_timeout":"not-a-duration"}`)
+	var cfg MCPClientConfig
+	if err := sonic.Unmarshal(raw, &cfg); err == nil {
+		t.Fatal("expected unmarshal error for invalid duration, got nil")
+	}
+}
+

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -10280,23 +10280,11 @@ func migrationAddMCPClientToolExecutionTimeoutColumn(ctx context.Context, db *go
 		ID: migrationName,
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if !migrator.HasColumn(&tables.TableMCPClient{}, "tool_execution_timeout") {
-				logger.Info("[configstore] %s: adding column tool_execution_timeout to TableMCPClient", migrationName)
-				if err := migrator.AddColumn(&tables.TableMCPClient{}, "tool_execution_timeout"); err != nil {
-					return err
-				}
-			}
-			return nil
+			return addColumnIfNotExists(tx, logger, &tables.TableMCPClient{}, "tool_execution_timeout")
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column tool_execution_timeout from TableMCPClient", migrationName)
-			if err := migrator.DropColumn(&tables.TableMCPClient{}, "tool_execution_timeout"); err != nil {
-				return err
-			}
-			return nil
+			return dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "tool_execution_timeout")
 		},
 	}})
 	if err := m.Migrate(); err != nil {

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -434,6 +434,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_dump_errors_in_console_logs_column"}, run: migrationAddDumpErrorsInConsoleLogsColumn},
 	{IDs: []string{"add_bedrock_mantle_key_columns"}, run: migrationAddBedrockMantleKeyColumns},
 	{IDs: []string{"add_model_pricing_is_deprecated_column"}, run: migrationAddModelPricingIsDeprecatedColumn},
+	{IDs: []string{"add_mcp_client_tool_execution_timeout_column"}, run: migrationAddMCPClientToolExecutionTimeoutColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -10267,6 +10268,39 @@ func migrationAddOAuth2IssuanceTables(ctx context.Context, db *gorm.DB, logger s
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running db migration %s: %w", migrationName, err)
+	}
+	return nil
+}
+
+func migrationAddMCPClientToolExecutionTimeoutColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_mcp_client_tool_execution_timeout_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&tables.TableMCPClient{}, "tool_execution_timeout") {
+				logger.Info("[configstore] %s: adding column tool_execution_timeout to TableMCPClient", migrationName)
+				if err := migrator.AddColumn(&tables.TableMCPClient{}, "tool_execution_timeout"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			logger.Info("[configstore] %s: dropping column tool_execution_timeout from TableMCPClient", migrationName)
+			if err := migrator.DropColumn(&tables.TableMCPClient{}, "tool_execution_timeout"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %w", migrationName, err)
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -129,10 +130,7 @@ func toolExecutionTimeoutDurationToStoredSeconds(timeout time.Duration) (int, er
 	if timeout < 0 {
 		return 0, fmt.Errorf("tool_execution_timeout must be non-negative, got %q", timeout.String())
 	}
-	if timeout%time.Second != 0 {
-		return 0, fmt.Errorf("tool_execution_timeout must be a whole number of seconds, got %q", timeout.String())
-	}
-	return int(timeout / time.Second), nil
+	return int(math.Ceil(timeout.Seconds())), nil
 }
 
 func toolSyncIntervalDurationToStoredSeconds(interval time.Duration) (int, error) {

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -126,11 +126,8 @@ func lockBudgetOwner(ctx context.Context, txDB *gorm.DB, budget tables.TableBudg
 	return nil
 }
 
-func toolExecutionTimeoutDurationToStoredSeconds(timeout time.Duration) (int, error) {
-	if timeout < 0 {
-		return 0, fmt.Errorf("tool_execution_timeout must be non-negative, got %q", timeout.String())
-	}
-	return int(math.Ceil(timeout.Seconds())), nil
+func toolExecutionTimeoutDurationToStoredSeconds(timeout time.Duration) int {
+	return int(math.Ceil(timeout.Seconds()))
 }
 
 func toolSyncIntervalDurationToStoredSeconds(interval time.Duration) (int, error) {
@@ -2038,10 +2035,7 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 		if err != nil {
 			return err
 		}
-		toolExecutionTimeoutSec, err := toolExecutionTimeoutDurationToStoredSeconds(clientConfigCopy.ToolExecutionTimeout)
-		if err != nil {
-			return err
-		}
+		toolExecutionTimeoutSec := toolExecutionTimeoutDurationToStoredSeconds(clientConfigCopy.ToolExecutionTimeout)
 		dbClient := tables.TableMCPClient{
 			ClientID:              clientConfigCopy.ID,
 			Name:                  clientConfigCopy.Name,

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -125,6 +125,16 @@ func lockBudgetOwner(ctx context.Context, txDB *gorm.DB, budget tables.TableBudg
 	return nil
 }
 
+func toolExecutionTimeoutDurationToStoredSeconds(timeout time.Duration) (int, error) {
+	if timeout < 0 {
+		return 0, fmt.Errorf("tool_execution_timeout must be non-negative, got %q", timeout.String())
+	}
+	if timeout%time.Second != 0 {
+		return 0, fmt.Errorf("tool_execution_timeout must be a whole number of seconds, got %q", timeout.String())
+	}
+	return int(timeout / time.Second), nil
+}
+
 func toolSyncIntervalDurationToStoredSeconds(interval time.Duration) (int, error) {
 	if interval < 0 {
 		return 0, fmt.Errorf("tool_sync_interval must be non-negative, got %q", interval.String())
@@ -1525,6 +1535,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 					AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
 					IsPingAvailable:           dbClient.IsPingAvailable,
 					ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
+					ToolExecutionTimeout:      time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
 					ToolPricing:               dbClient.ToolPricing,
 					AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
 					Disabled:                  dbClient.Disabled,
@@ -1567,6 +1578,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
 			IsPingAvailable:           dbClient.IsPingAvailable,
 			ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
+			ToolExecutionTimeout:      time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
 			AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
 			Disabled:                  dbClient.Disabled,
 			ToolPricing:               dbClient.ToolPricing,
@@ -1989,6 +2001,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 		AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
 		IsPingAvailable:           dbClient.IsPingAvailable,
 		ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
+		ToolExecutionTimeout:      time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
 		AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
 		Disabled:                  dbClient.Disabled,
 		ToolPricing:               dbClient.ToolPricing,
@@ -2027,6 +2040,10 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 		if err != nil {
 			return err
 		}
+		toolExecutionTimeoutSec, err := toolExecutionTimeoutDurationToStoredSeconds(clientConfigCopy.ToolExecutionTimeout)
+		if err != nil {
+			return err
+		}
 		dbClient := tables.TableMCPClient{
 			ClientID:              clientConfigCopy.ID,
 			Name:                  clientConfigCopy.Name,
@@ -2043,6 +2060,7 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 			AllowedExtraHeaders:   clientConfigCopy.AllowedExtraHeaders,
 			IsPingAvailable:       clientConfigCopy.IsPingAvailable,
 			ToolSyncInterval:      toolSyncIntervalSec,
+			ToolExecutionTimeout:  toolExecutionTimeoutSec,
 			AllowOnAllVirtualKeys: clientConfigCopy.AllowOnAllVirtualKeys,
 			// DiscoveredTools has json:"-" so deepCopy loses it; use original clientConfig
 			DiscoveredTools:           clientConfig.DiscoveredTools,
@@ -2192,6 +2210,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			"allowed_extra_headers_json": string(allowedExtraHeadersJSON),
 			"tool_pricing_json":          string(toolPricingJSON),
 			"tool_sync_interval":         clientConfigCopy.ToolSyncInterval,
+			"tool_execution_timeout":     clientConfigCopy.ToolExecutionTimeout,
 			"allow_on_all_virtual_keys":  clientConfigCopy.AllowOnAllVirtualKeys,
 			"disabled":                   clientConfigCopy.Disabled,
 			"updated_at":                 time.Now(),

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2199,6 +2199,10 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 
 		// Update only editable fields using a map to avoid updating connection info
 		// Connection info (ConnectionType, ConnectionString, StdioConfig) is read-only and should not be modified via API
+		if clientConfigCopy.ToolExecutionTimeout < 0 {
+			return fmt.Errorf("tool_execution_timeout must be non-negative, got %d", clientConfigCopy.ToolExecutionTimeout)
+		}
+
 		updates := map[string]interface{}{
 			"name":                       clientConfigCopy.Name,
 			"is_code_mode_client":        clientConfigCopy.IsCodeModeClient,

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -28,6 +28,7 @@ type TableMCPClient struct {
 	IsPingAvailable         *bool              `gorm:"default:true" json:"is_ping_available,omitempty"` // Whether the MCP server supports ping for health checks
 	ToolPricingJSON         string             `gorm:"type:text" json:"-"`                              // JSON serialized map[string]float64
 	ToolSyncInterval        int                `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in seconds (0 = use global, negative = disabled)
+	ToolExecutionTimeout    int                `gorm:"default:0" json:"tool_execution_timeout"`         // Per-client tool execution timeout in seconds (0 = use global from tool_manager_config)
 
 	// Per-user OAuth: discovered tools persisted so they survive restart
 	DiscoveredToolsJSON string `gorm:"type:text" json:"-"` // JSON serialized map[string]schemas.ChatTool

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -1099,6 +1099,10 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 	resolvedToolExecutionTimeout := existingConfig.ToolExecutionTimeout
 	if req.ToolExecutionTimeout != nil {
+		if *req.ToolExecutionTimeout < 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "tool_execution_timeout must be >= 0")
+			return
+		}
 		resolvedToolExecutionTimeout = time.Duration(*req.ToolExecutionTimeout) * time.Second
 	}
 

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -443,6 +443,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			AllowedExtraHeaders:   dbClient.AllowedExtraHeaders,
 			IsPingAvailable:       &isPingAvailable,
 			ToolSyncInterval:      time.Duration(dbClient.ToolSyncInterval) * time.Second,
+			ToolExecutionTimeout:  time.Duration(dbClient.ToolExecutionTimeout) * time.Second,
 			ToolPricing:           dbClient.ToolPricing,
 			AllowOnAllVirtualKeys: dbClient.AllowOnAllVirtualKeys,
 			Disabled:              dbClient.Disabled,
@@ -576,6 +577,7 @@ type MCPClientUpdateRequest struct {
 	IsCodeModeClient      *bool                        `json:"is_code_mode_client,omitempty"`
 	IsPingAvailable       *bool                        `json:"is_ping_available,omitempty"`
 	ToolSyncInterval      *int                         `json:"tool_sync_interval,omitempty"`
+	ToolExecutionTimeout  *int                         `json:"tool_execution_timeout,omitempty"`
 	Headers               map[string]schemas.SecretVar `json:"headers,omitempty"`
 	AllowedExtraHeaders   *schemas.WhiteList           `json:"allowed_extra_headers,omitempty"`
 	ToolPricing           map[string]float64           `json:"tool_pricing,omitempty"`
@@ -1095,6 +1097,10 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	if req.ToolSyncInterval != nil {
 		resolvedToolSyncInterval = time.Duration(*req.ToolSyncInterval) * time.Minute
 	}
+	resolvedToolExecutionTimeout := existingConfig.ToolExecutionTimeout
+	if req.ToolExecutionTimeout != nil {
+		resolvedToolExecutionTimeout = time.Duration(*req.ToolExecutionTimeout) * time.Second
+	}
 
 	// Resolve tools_to_execute and tools_to_auto_execute.
 	resolvedToolsToExecute := existingConfig.ToolsToExecute
@@ -1265,6 +1271,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		IsPingAvailable:       isPingAvailable,
 		ToolPricing:           toolPricing,
 		ToolSyncInterval:      int(resolvedToolSyncInterval / time.Second),
+		ToolExecutionTimeout:  int(resolvedToolExecutionTimeout / time.Second),
 		AuthType:              string(existingConfig.AuthType),
 		OauthConfigID:         existingConfig.OauthConfigID,
 		AllowOnAllVirtualKeys: allowOnAllVKs,
@@ -1328,6 +1335,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		OauthConfigID:         existingConfig.OauthConfigID,
 		IsPingAvailable:       isPingAvailable,
 		ToolSyncInterval:      toolSyncInterval,
+		ToolExecutionTimeout:  resolvedToolExecutionTimeout,
 		ToolPricing:           toolPricing,
 		AllowOnAllVirtualKeys: allowOnAllVKs,
 		Disabled:              disabled,

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1823,6 +1823,12 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 			clientConfig.ToolSyncInterval.String(),
 		)
 	}
+	if clientConfig.ToolExecutionTimeout < 0 {
+		return configstoreTables.TableMCPClient{}, fmt.Errorf(
+			"tool_execution_timeout must be >= 0, got %q",
+			clientConfig.ToolExecutionTimeout.String(),
+		)
+	}
 	authType := string(clientConfig.AuthType)
 	if authType == "" {
 		authType = string(schemas.MCPAuthTypeHeaders)

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1823,12 +1823,6 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 			clientConfig.ToolSyncInterval.String(),
 		)
 	}
-	if clientConfig.ToolExecutionTimeout%time.Second != 0 {
-		return configstoreTables.TableMCPClient{}, fmt.Errorf(
-			"tool_execution_timeout must be a whole number of seconds, got %q",
-			clientConfig.ToolExecutionTimeout.String(),
-		)
-	}
 	authType := string(clientConfig.AuthType)
 	if authType == "" {
 		authType = string(schemas.MCPAuthTypeHeaders)
@@ -1848,7 +1842,7 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
 		IsPingAvailable:           clientConfig.IsPingAvailable,
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
-		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
+		ToolExecutionTimeout:      int(math.Ceil(clientConfig.ToolExecutionTimeout.Seconds())),
 		ToolPricing:               clientConfig.ToolPricing,
 		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
 		Disabled:                  clientConfig.Disabled,

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1823,6 +1823,12 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 			clientConfig.ToolSyncInterval.String(),
 		)
 	}
+	if clientConfig.ToolExecutionTimeout%time.Second != 0 {
+		return configstoreTables.TableMCPClient{}, fmt.Errorf(
+			"tool_execution_timeout must be a whole number of seconds, got %q",
+			clientConfig.ToolExecutionTimeout.String(),
+		)
+	}
 	authType := string(clientConfig.AuthType)
 	if authType == "" {
 		authType = string(schemas.MCPAuthTypeHeaders)
@@ -1842,6 +1848,7 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
 		IsPingAvailable:           clientConfig.IsPingAvailable,
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
+		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
 		ToolPricing:               clientConfig.ToolPricing,
 		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
 		Disabled:                  clientConfig.Disabled,
@@ -5838,6 +5845,7 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 	c.MCPConfig.ClientConfigs[configIndex].ToolPricing = updatedConfig.ToolPricing
 	c.MCPConfig.ClientConfigs[configIndex].IsPingAvailable = updatedConfig.IsPingAvailable
 	c.MCPConfig.ClientConfigs[configIndex].ToolSyncInterval = updatedConfig.ToolSyncInterval
+	c.MCPConfig.ClientConfigs[configIndex].ToolExecutionTimeout = updatedConfig.ToolExecutionTimeout
 	c.MCPConfig.ClientConfigs[configIndex].AllowOnAllVirtualKeys = updatedConfig.AllowOnAllVirtualKeys
 	c.MCPConfig.ClientConfigs[configIndex].Disabled = updatedConfig.Disabled
 	c.MCPConfig.ClientConfigs[configIndex].PerUserHeaderKeys = updatedConfig.PerUserHeaderKeys

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4079,6 +4079,19 @@
             }
           ]
         },
+        "tool_execution_timeout": {
+          "description": "Per-client override for tool execution timeout. Accepts a Go duration string (e.g. '30s', '2m') or a bare integer treated as seconds. When set, overrides the global tool_manager_config.tool_execution_timeout for this MCP server only. Omit or set to 0 to use the global default.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(?:\\d+(?:\\.\\d+)?(?:ns|us|µs|ms|s|m|h))+$"
+            },
+            {
+              "type": "integer",
+              "minimum": 0
+            }
+          ]
+        },
         "allowed_extra_headers": {
           "type": "array",
           "items": {

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -60,6 +60,28 @@ function toolSyncIntervalToMinutes(v: number | undefined | null): number {
 	return n;
 }
 
+/** API sends tool_execution_timeout as a Go duration string e.g. "30s". Normalize to whole seconds for form. */
+function toolExecutionTimeoutToSeconds(v: string | number | undefined | null): number {
+	if (v === undefined || v === null || v === "") return 0;
+	if (typeof v === "number") return v;
+	// Parse Go duration string: "30s", "1m30s", "2h", etc.
+	let total = 0;
+	const re = /(\d+(?:\.\d+)?)(ns|us|µs|ms|s|m|h)/g;
+	let match;
+	while ((match = re.exec(v)) !== null) {
+		const n = parseFloat(match[1]);
+		switch (match[2]) {
+			case "ns": total += n / 1e9; break;
+			case "us": case "µs": total += n / 1e6; break;
+			case "ms": total += n / 1e3; break;
+			case "s": total += n; break;
+			case "m": total += n * 60; break;
+			case "h": total += n * 3600; break;
+		}
+	}
+	return Math.round(total);
+}
+
 export default function MCPClientSheet({
 	mcpClient,
 	onClose,
@@ -191,6 +213,7 @@ export default function MCPClientSheet({
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
+				tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
@@ -219,6 +242,7 @@ export default function MCPClientSheet({
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
+				tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
@@ -282,6 +306,7 @@ export default function MCPClientSheet({
 					tools_to_auto_execute: data.tools_to_auto_execute,
 					tool_pricing: data.tool_pricing,
 					tool_sync_interval: data.tool_sync_interval ?? 0,
+					tool_execution_timeout: data.tool_execution_timeout ?? 0,
 					allowed_extra_headers: data.allowed_extra_headers,
 					oauth_config: shouldRotateOAuthCredentials
 						? {
@@ -761,6 +786,51 @@ export default function MCPClientSheet({
 																field.onChange(val);
 															}}
 															min="-1"
+														/>
+													</FormControl>
+												</FormItem>
+											);
+										}}
+									/>
+									<FormField
+										control={form.control}
+										name="tool_execution_timeout"
+										render={({ field }) => {
+											const isUsingGlobal = field.value === undefined || field.value === null || field.value === 0;
+											return (
+												<FormItem className="flex items-center justify-between rounded-lg border px-4 py-2">
+													<div className="flex flex-col items-start gap-0.5">
+														<div className="flex items-start gap-2">
+															<div>
+																<FormLabel>Tool Execution Timeout (seconds)</FormLabel>
+															</div>
+															<TooltipProvider>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																	</TooltipTrigger>
+																	<TooltipContent className="max-w-xs">
+																		<p>
+																			Override the global tool execution timeout for this server. Leave empty or set to 0 to use
+																			the global setting.
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															</TooltipProvider>
+														</div>
+														<div>{isUsingGlobal && <p className="text-muted-foreground text-xs">Using global setting</p>}</div>
+													</div>
+													<FormControl>
+														<Input
+															type="number"
+															className={`w-24 ${isUsingGlobal ? "text-muted-foreground" : ""}`}
+															placeholder="0"
+															value={field.value === 0 || field.value === undefined ? "" : String(field.value)}
+															onChange={(e) => {
+																const val = e.target.value === "" ? undefined : parseInt(e.target.value);
+																field.onChange(val);
+															}}
+															min="0"
 														/>
 													</FormControl>
 												</FormItem>

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -827,10 +827,16 @@ export default function MCPClientSheet({
 															placeholder="0"
 															value={field.value === 0 || field.value === undefined ? "" : String(field.value)}
 															onChange={(e) => {
-																const val = e.target.value === "" ? undefined : parseInt(e.target.value);
-																field.onChange(val);
+																if (e.target.value === "") {
+																	field.onChange(undefined);
+																	return;
+																}
+																const n = Number(e.target.value);
+																field.onChange(Number.isInteger(n) ? n : Math.trunc(n));
 															}}
 															min="0"
+															step="1"
+															data-testid="mcp-tool-execution-timeout"
 														/>
 													</FormControl>
 												</FormItem>

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -79,7 +79,7 @@ function toolExecutionTimeoutToSeconds(v: string | number | undefined | null): n
 			case "h": total += n * 3600; break;
 		}
 	}
-	return Math.round(total);
+	return Math.ceil(total);
 }
 
 export default function MCPClientSheet({
@@ -832,7 +832,8 @@ export default function MCPClientSheet({
 																	return;
 																}
 																const n = Number(e.target.value);
-																field.onChange(Number.isInteger(n) ? n : Math.trunc(n));
+																if (!Number.isInteger(n)) return;
+																field.onChange(n);
 															}}
 															min="0"
 															step="1"

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -68,6 +68,7 @@ export interface MCPClientConfig {
 	is_ping_available?: boolean;
 	tool_pricing?: Record<string, number>;
 	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
+	tool_execution_timeout?: string | number; // Per-client tool execution timeout; API returns string e.g. "30s", UI sends integer seconds (0 = use global)
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
 	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this
 	disabled?: boolean; // When true, connection/workers are shut down; tools are unavailable until re-enabled
@@ -147,6 +148,7 @@ export interface UpdateMCPClientRequest {
 	is_ping_available?: boolean;
 	tool_pricing?: Record<string, number>;
 	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
+	tool_execution_timeout?: number; // Per-client tool execution timeout in seconds (0 = use global)
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
 	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this
 	disabled?: boolean; // Set to true to shut down connection/workers; false to reconnect

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1124,6 +1124,7 @@ export const mcpClientUpdateSchema = z.object({
 		),
 	tool_pricing: z.record(z.string(), z.number().min(0, "Cost must be non-negative")).optional(),
 	tool_sync_interval: z.number().optional(), // -1 = disabled, 0 = use global, >0 = custom interval in minutes
+	tool_execution_timeout: z.number().min(0).optional(), // 0 = use global, >0 = per-server timeout in seconds
 	allowed_extra_headers: z
 		.array(z.string())
 		.optional()

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1124,7 +1124,7 @@ export const mcpClientUpdateSchema = z.object({
 		),
 	tool_pricing: z.record(z.string(), z.number().min(0, "Cost must be non-negative")).optional(),
 	tool_sync_interval: z.number().optional(), // -1 = disabled, 0 = use global, >0 = custom interval in minutes
-	tool_execution_timeout: z.number().min(0).optional(), // 0 = use global, >0 = per-server timeout in seconds
+	tool_execution_timeout: z.number().int().min(0).optional(), // 0 = use global, >0 = per-server timeout in seconds
 	allowed_extra_headers: z
 		.array(z.string())
 		.optional()


### PR DESCRIPTION
## Summary

Adds a per-MCP-server `tool_execution_timeout` field to `MCPClientConfig`, allowing each MCP server to declare its own tool execution timeout instead of sharing the single global value from `tool_manager_config`. When set, it overrides the global for that server only. Omitting it (or setting `0`) falls back to the global default.

## Changes

- Added `ToolExecutionTimeout time.Duration` to `MCPClientConfig` in `core/schemas/mcp.go`
- Updated `MCPClientConfig.UnmarshalJSON` to parse the new field — accepts a Go duration string (e.g. `"30s"`, `"2m"`) or a bare integer treated as seconds, matching the behaviour of `tool_manager_config.tool_execution_timeout`
- Updated `executeToolInternal` in `core/mcp/toolmanager.go` to check `executionConfig.ToolExecutionTimeout` before falling back to the global timeout
- Added `tool_execution_timeout` to the `mcp_client_config` definition in `transports/config.schema.json` for IDE autocomplete/validation
- Added DB column `tool_execution_timeout` to `config_mcp_clients` with migration `add_mcp_client_tool_execution_timeout_column`
- Added UI field "Tool Execution Timeout (seconds)" in the MCP client sheet, following the same pattern as `tool_sync_interval`
- Added `tool_execution_timeout` to the update request handler in `transports/bifrost-http/handlers/mcp.go` with negative value validation
- Added 8 unit tests in `core/schemas/mcp_json_test.go` covering: duration string, bare integer, field not set, explicit zero, invalid string, negative integer, and negative string
- Added 3 integration tests in `core/internal/mcptests/per_server_timeout_test.go` covering: per-server timeout overrides global, per-server timeout allows tool to complete, and zero timeout falls back to global

**Design decision:** Bare integers are treated as **seconds** (not nanoseconds) to match `tool_manager_config.tool_execution_timeout` behaviour and to be practical for timeout values. This intentionally differs from `tool_sync_interval`, which treats bare integers as nanoseconds following Go's `time.Duration` convention.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Run the schema unit tests
cd core
go test ./schemas/... -run TestMCPClientConfigUnmarshalToolExecutionTimeout -v

# Run the integration tests
go test ./internal/mcptests/ -run TestPerServerTimeout -v
```

To test end-to-end via config file, add `tool_execution_timeout` to a server in your `config.json`:

```json
{
  "client_configs": [
    {
      "name": "myslowserver",
      "connection_type": "http",
      "connection_string": "http://localhost:8080",
      "tool_execution_timeout": "5s"
    }
  ]
}
```

Tools on `myslowserver` will now time out after 5 seconds regardless of the global timeout. Other servers continue to use the global default.

You can also set the timeout via the UI — open the MCP client sheet and set "Tool Execution Timeout (seconds)". The value is stored in Postgres and survives restarts.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4446

## Security considerations

None — this is a timeout configuration field only. No auth, secrets, or PII involved.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
