### PR TITLE
feat: add `skillsRegistry`, `allowDirectKeys`, `mcpExternalClientUrl`, `blacklisted_models`, `allow_private_network`, and deployment `strategy` to Bifrost Helm chart

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -319,6 +319,12 @@ false
 {{- if .Values.bifrost.client.routingChainMaxDepth }}
 {{- $_ := set $client "routing_chain_max_depth" .Values.bifrost.client.routingChainMaxDepth }}
 {{- end }}
+{{- if hasKey .Values.bifrost.client "allowDirectKeys" }}
+{{- $_ := set $client "allow_direct_keys" .Values.bifrost.client.allowDirectKeys }}
+{{- end }}
+{{- if .Values.bifrost.client.mcpExternalClientUrl }}
+{{- $_ := set $client "mcp_external_client_url" .Values.bifrost.client.mcpExternalClientUrl }}
+{{- end }}
 {{- $_ := set $config "client" $client }}
 {{- end }}
 {{- /* Server */ -}}
@@ -406,6 +412,9 @@ false
 {{- end }}
 {{- if $providerConfig.network_config.beta_header_overrides }}
 {{- $_ := set $networkConfig "beta_header_overrides" $providerConfig.network_config.beta_header_overrides }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "allow_private_network" }}
+{{- $_ := set $networkConfig "allow_private_network" $providerConfig.network_config.allow_private_network }}
 {{- end }}
 {{- $_ := set $providerCopy "network_config" $networkConfig }}
 {{- end }}
@@ -696,6 +705,10 @@ false
 {{- if or $guardrails.guardrail_rules $guardrails.guardrail_providers }}
 {{- $_ := set $config "guardrails_config" $guardrails }}
 {{- end }}
+{{- end }}
+{{- /* Skills Registry */ -}}
+{{- if .Values.bifrost.skillsRegistry }}
+{{- $_ := set $config "skills_registry" .Values.bifrost.skillsRegistry }}
 {{- end }}
 {{- /* Access Profiles (Enterprise) */ -}}
 {{- if .Values.bifrost.accessProfiles }}

--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "bifrost.serverSelectorLabels" . | nindent 6 }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -270,6 +270,10 @@
     "affinity": {
       "type": "object"
     },
+    "strategy": {
+      "type": "object",
+      "description": "Deployment update strategy. Applies to the Deployment only (not the StatefulSet). Empty uses the Kubernetes default. Rendered verbatim into spec.strategy."
+    },
     "bifrost": {
       "type": "object",
       "description": "Bifrost application configuration",
@@ -529,6 +533,15 @@
               "minimum": 1,
               "description": "Maximum depth for routing rule chain evaluation",
               "default": 10
+            },
+            "allowDirectKeys": {
+              "type": "boolean",
+              "description": "Allow callers to bypass the registered key pool by supplying x-bf-direct-key: true with an Authorization header carrying the provider key. Maps to client.allow_direct_keys.",
+              "default": false
+            },
+            "mcpExternalClientUrl": {
+              "type": "string",
+              "description": "Public base URL Bifrost uses as the redirect_uri when acting as an OAuth client to upstream MCP servers. Maps to client.mcp_external_client_url."
             }
           },
           "additionalProperties": false
@@ -3011,6 +3024,111 @@
           },
           "additionalProperties": false
         },
+        "skillsRegistry": {
+          "type": "object",
+          "description": "Declarative Skills Repository definitions reconciled from config.json. Rendered verbatim into skills_registry.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether config-defined skills should be reconciled at startup"
+            },
+            "skills": {
+              "type": "array",
+              "description": "Skills to create or update from config.json",
+              "items": {
+                "type": "object",
+                "required": ["name", "description", "skill_md_body", "version"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "license": {
+                    "type": "string"
+                  },
+                  "compatibility": {
+                    "type": "string"
+                  },
+                  "allowed_tools": {
+                    "type": "string"
+                  },
+                  "extra_frontmatter": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "skill_md_body": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["path", "source_type"],
+                      "properties": {
+                        "path": {
+                          "type": "string"
+                        },
+                        "source_type": {
+                          "type": "string",
+                          "enum": ["text", "url", "dataurl"]
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "content": {
+                          "type": "string"
+                        },
+                        "dataurl": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "source_type": {
+                              "const": "url"
+                            }
+                          },
+                          "required": ["url"]
+                        },
+                        {
+                          "properties": {
+                            "source_type": {
+                              "const": "text"
+                            }
+                          },
+                          "required": ["content"]
+                        },
+                        {
+                          "properties": {
+                            "source_type": {
+                              "const": "dataurl"
+                            }
+                          },
+                          "required": ["dataurl"]
+                        }
+                      ]
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "accessProfiles": {
           "type": "array",
           "description": "Enterprise access profile templates rendered as top-level access_profiles in config.json",
@@ -5112,6 +5230,13 @@
         "allowed_models": {
           "type": "array",
           "description": "Allowed models for this provider config. Use [\"*\"] to allow all models; empty array denies all (deny-by-default).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blacklisted_models": {
+          "type": "array",
+          "description": "Models blocked for this provider config even if matched by allowed_models. Use [\"*\"] to block all.",
           "items": {
             "type": "string"
           }

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -170,6 +170,17 @@ tolerations: []
 
 affinity: {}
 
+# Deployment rolling update strategy. Applies to the Deployment only (not the
+# StatefulSet used for sqlite-with-persistence). Rendered verbatim into spec.strategy.
+# Empty ({}) uses the Kubernetes default (RollingUpdate, maxSurge 25%, maxUnavailable 25%).
+# For HA gateway deployments, surge-only rollouts avoid dropping capacity:
+# strategy:
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxSurge: 100%
+#     maxUnavailable: 0%
+strategy: {}
+
 # Graceful shutdown configuration for long-lived connections (SSE streaming)
 # When a pod is terminated (e.g. during HPA scale-down), active streaming connections
 # are severed abruptly. This causes clients to lose their SSE stream mid-response.
@@ -282,6 +293,8 @@ bifrost:
     # hideDeletedVirtualKeysInFilters: false  # Omit deleted virtual keys from logs/MCP filter data
     # whitelistedRoutes: []           # Routes that bypass auth middleware
     # routingChainMaxDepth: 10        # Maximum depth for routing rule chain evaluation
+    # allowDirectKeys: false          # Allow callers to bypass the key pool via x-bf-direct-key + Authorization header
+    # mcpExternalClientUrl: ""        # Public base URL used as redirect_uri when Bifrost is an OAuth client to MCP servers
 
   # Server configuration
   server:
@@ -704,6 +717,7 @@ bifrost:
       #     - provider: "openai"
       #       weight: 1.0
       #       allowed_models: ["gpt-4o"]
+      #       blacklisted_models: []   # Models blocked even if matched by allowed_models; ["*"] blocks all
       #       rate_limit_id: ""
       #       keys:
       #         - key_id: "uuid-of-key"
@@ -941,6 +955,27 @@ bifrost:
       #   enabled: true
       #   timeout: 30        # Timeout in seconds for provider execution (default: 30)
       #   config: {}
+
+  # Declarative Skills Repository. Rendered verbatim as top-level `skills_registry`
+  # in config.json and reconciled at startup when enabled.
+  # skillsRegistry:
+  #   enabled: true
+  #   skills:
+  #     - name: "my-skill"
+  #       description: "What this skill does"
+  #       version: "1.0.0"
+  #       skill_md_body: "# My Skill\n\nInstructions..."
+  #       # license: "MIT"
+  #       # compatibility: ">=1.0.0"
+  #       # allowed_tools: "Read,Write"
+  #       # metadata: {}
+  #       # extra_frontmatter: {}
+  #       # files:
+  #       #   - path: "reference.md"
+  #       #     source_type: "text"   # text | url | dataurl
+  #       #     content: "..."          # required when source_type=text
+  #       #     # url: "https://..."    # required when source_type=url
+  #       #     # dataurl: "data:..."   # required when source_type=dataurl
 
   # Access profiles (enterprise): seed RBAC access profile templates from Helm.
   # This is rendered directly as top-level `access_profiles` in config.json.


### PR DESCRIPTION
## Summary

Extends the Bifrost Helm chart with several new configuration surface areas: a declarative Skills Registry, two new client-level options (`allowDirectKeys` and `mcpExternalClientUrl`), a `blacklisted_models` field for provider configs, `allow_private_network` support in network configs, and a configurable Deployment update strategy.

## Changes

- Added `strategy` field to `values.yaml` and `deployment.yaml` so operators can override the Kubernetes Deployment rollout strategy (e.g. surge-only rollouts for HA gateway deployments).
- Added `bifrost.client.allowDirectKeys` to permit callers to bypass the registered key pool via `x-bf-direct-key` + `Authorization` header, mapping to `client.allow_direct_keys`.
- Added `bifrost.client.mcpExternalClientUrl` to set the public base URL Bifrost uses as `redirect_uri` when acting as an OAuth client to upstream MCP servers, mapping to `client.mcp_external_client_url`.
- Added `allow_private_network` to provider `network_config` handling in `_helpers.tpl`, using `hasKey` to allow explicit `false` values to be set.
- Added `blacklisted_models` to the provider config schema, allowing specific models to be blocked even when matched by `allowed_models` (use `["*"]` to block all).
- Added `bifrost.skillsRegistry` as a declarative Skills Repository block rendered verbatim as `skills_registry` in `config.json`, reconciled at startup when enabled. Supports skill definitions with name, description, version, markdown body, optional metadata, and file attachments with `text`, `url`, or `dataurl` source types.
- Updated `values.schema.json` with full JSON Schema definitions and descriptions for all new fields.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Render the Helm chart and verify new fields appear in the generated config
helm template bifrost ./helm-charts/bifrost \
  --set bifrost.client.allowDirectKeys=true \
  --set bifrost.client.mcpExternalClientUrl="https://example.com" \
  --set bifrost.skillsRegistry.enabled=true \
  --set strategy.type=RollingUpdate

# Validate the chart against the schema
helm lint ./helm-charts/bifrost

# Verify allow_private_network renders correctly for a provider network_config
helm template bifrost ./helm-charts/bifrost -f <values-with-allow_private_network.yaml>
```

New configuration fields:

| Field | Description |
|---|---|
| `strategy` | Deployment update strategy rendered verbatim into `spec.strategy` |
| `bifrost.client.allowDirectKeys` | Allows bypassing the key pool via `x-bf-direct-key` header |
| `bifrost.client.mcpExternalClientUrl` | Public base URL used as `redirect_uri` for MCP OAuth flows |
| `bifrost.skillsRegistry` | Declarative skills reconciled at startup |
| `network_config.allow_private_network` | Permits connections to private network addresses for a provider |
| `blacklisted_models` | Models blocked for a provider config even if matched by `allowed_models` |

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`allowDirectKeys` permits callers to supply raw provider keys directly via the `Authorization` header, bypassing the managed key pool. This should only be enabled in trusted environments where callers are already authenticated and authorized, as it exposes provider credentials to the request path.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable