### PR TITLE
fix: anthropic cache diagnostics

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -351,6 +351,33 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 			anthropicReq.CacheControl = bifrostReq.Params.CacheControl
 		}
 
+		// Diagnostics — cache diagnostics opt-in (Anthropic API only). Promote
+		// the raw/typed form from ExtraParams onto the typed field so it is
+		// always serialized (parity with cache_control), not gated behind the
+		// ExtraParams passthrough flag.
+		if dVal := bifrostReq.Params.ExtraParams["diagnostics"]; dVal != nil {
+			parsed := false
+			switch v := dVal.(type) {
+			case *AnthropicDiagnostics:
+				anthropicReq.Diagnostics = v
+				parsed = true
+			case AnthropicDiagnostics:
+				anthropicReq.Diagnostics = &v
+				parsed = true
+			default:
+				if data, err := providerUtils.MarshalSorted(v); err == nil {
+					var d AnthropicDiagnostics
+					if sonic.Unmarshal(data, &d) == nil {
+						anthropicReq.Diagnostics = &d
+						parsed = true
+					}
+				}
+			}
+			if parsed {
+				delete(anthropicReq.ExtraParams, "diagnostics")
+			}
+		}
+
 		// TaskBudget — maps onto output_config.task_budget. If an OutputConfig
 		// already exists (e.g. from structured outputs), attach the budget to
 		// it; otherwise create one.
@@ -990,6 +1017,12 @@ func (response *AnthropicMessageResponse) ToBifrostChatResponse(ctx *schemas.Bif
 		}
 	}
 
+	// Forward cache diagnostics (cache-diagnosis-2026-04-07) — top-level on the
+	// message, not under usage.
+	if response.Diagnostics != nil {
+		bifrostResponse.Diagnostics = response.Diagnostics
+	}
+
 	return bifrostResponse
 }
 
@@ -1039,6 +1072,11 @@ func ToAnthropicChatResponse(bifrostResp *schemas.BifrostChatResponse) *Anthropi
 		if bifrostResp.Speed != nil {
 			anthropicResp.Usage.Speed = bifrostResp.Speed
 		}
+	}
+
+	// Forward cache diagnostics (cache-diagnosis-2026-04-07) — top-level, not under usage.
+	if bifrostResp.Diagnostics != nil {
+		anthropicResp.Diagnostics = bifrostResp.Diagnostics
 	}
 
 	// Convert choices to content
@@ -1156,6 +1194,10 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 						},
 					},
 				},
+			}
+			// Cache diagnostics arrives on message_start (cache-diagnosis-2026-04-07).
+			if chunk.Message.Diagnostics != nil {
+				streamResponse.Diagnostics = chunk.Message.Diagnostics
 			}
 			return streamResponse, nil, false
 		}
@@ -1443,6 +1485,10 @@ func ToAnthropicChatStreamResponse(bifrostResp *schemas.BifrostChatResponse) str
 			}
 
 			streamMessage.Content = content
+			// Cache diagnostics arrives on message_start (cache-diagnosis-2026-04-07).
+			if bifrostResp.Diagnostics != nil {
+				streamMessage.Diagnostics = bifrostResp.Diagnostics
+			}
 			streamResp.Message = streamMessage
 		}
 	}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -298,6 +298,10 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				if state.Model != nil {
 					response.Model = *state.Model
 				}
+				// Forward cache diagnostics from message_start (cache-diagnosis-2026-04-07).
+				if chunk.Message.Diagnostics != nil {
+					response.Diagnostics = chunk.Message.Diagnostics
+				}
 				// Forward input usage from message_start so clients see cache metrics early
 				if chunk.Message.Usage != nil {
 					response.Usage = &schemas.ResponsesResponseUsage{
@@ -1649,6 +1653,10 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			} else if bifrostResp.ExtraFields.OriginalModelRequested != "" {
 				streamMessage.Model = bifrostResp.ExtraFields.OriginalModelRequested
 			}
+			// Cache diagnostics arrives on message_start (cache-diagnosis-2026-04-07).
+			if bifrostResp.Response.Diagnostics != nil {
+				streamMessage.Diagnostics = bifrostResp.Response.Diagnostics
+			}
 			streamResp.Message = streamMessage
 		}
 	case schemas.ResponsesStreamResponseTypeInProgress:
@@ -2433,6 +2441,9 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 	if req.CacheControl != nil {
 		params.ExtraParams["cache_control"] = req.CacheControl
 	}
+	if req.Diagnostics != nil {
+		params.ExtraParams["diagnostics"] = req.Diagnostics
+	}
 	if req.TopK != nil {
 		params.ExtraParams["top_k"] = *req.TopK
 	}
@@ -2790,6 +2801,28 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 					delete(anthropicReq.ExtraParams, "cache_control")
 				}
 			}
+			if diagnosticsRaw, exists := anthropicReq.ExtraParams["diagnostics"]; exists {
+				parsed := false
+				switch v := diagnosticsRaw.(type) {
+				case *AnthropicDiagnostics:
+					anthropicReq.Diagnostics = v
+					parsed = true
+				case AnthropicDiagnostics:
+					anthropicReq.Diagnostics = &v
+					parsed = true
+				default:
+					if data, err := providerUtils.MarshalSorted(v); err == nil {
+						var d AnthropicDiagnostics
+						if sonic.Unmarshal(data, &d) == nil {
+							anthropicReq.Diagnostics = &d
+							parsed = true
+						}
+					}
+				}
+				if parsed {
+					delete(anthropicReq.ExtraParams, "diagnostics")
+				}
+			}
 			topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
 			if ok {
 				delete(anthropicReq.ExtraParams, "top_k")
@@ -3075,6 +3108,11 @@ func (response *AnthropicMessageResponse) ToBifrostResponsesResponse(ctx *schema
 		bifrostResp.Speed = response.Usage.Speed
 	}
 
+	// Forward cache diagnostics (cache-diagnosis-2026-04-07) to the client.
+	if response.Diagnostics != nil {
+		bifrostResp.Diagnostics = response.Diagnostics
+	}
+
 	return bifrostResp
 }
 
@@ -3142,6 +3180,10 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 			anthropicResp.Usage = &AnthropicUsage{}
 		}
 		anthropicResp.Usage.Speed = bifrostResp.Speed
+	}
+
+	if bifrostResp.Diagnostics != nil {
+		anthropicResp.Diagnostics = bifrostResp.Diagnostics
 	}
 
 	return anthropicResp

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -60,6 +60,8 @@ const (
 	AnthropicTaskBudgetsBetaHeader = "task-budgets-2026-03-13"
 	// AnthropicAdvisorBetaHeader is required for the advisor_20260301 server tool. Anthropic API only.
 	AnthropicAdvisorBetaHeader = "advisor-tool-2026-03-01"
+	// AnthropicCacheDiagnosisBetaHeader is required for cache diagnostics (diagnostics.previous_message_id). Anthropic API only.
+	AnthropicCacheDiagnosisBetaHeader = "cache-diagnosis-2026-04-07"
 	// AnthropicEagerInputStreamingBetaHeader is required for eager_input_streaming
 	// on custom tools (streams input_json_delta before full args are determined).
 	// Per Table 20: GA on Anthropic/Bedrock/Vertex, Beta on Azure.
@@ -83,6 +85,7 @@ const (
 	AnthropicSkillsBetaHeaderPrefix              = "skills-"
 	AnthropicContext1MBetaHeaderPrefix           = "context-1m-"
 	AnthropicFastModeBetaHeaderPrefix            = "fast-mode-"
+	AnthropicCacheDiagnosisBetaHeaderPrefix      = "cache-diagnosis-"
 	AnthropicRedactThinkingBetaHeaderPrefix      = "redact-thinking-"
 	AnthropicTaskBudgetsBetaHeaderPrefix         = "task-budgets-"
 	AnthropicEagerInputStreamingBetaHeaderPrefix = "fine-grained-tool-streaming-"
@@ -140,7 +143,7 @@ type ProviderFeatureSupport struct {
 	FileSearch             bool // file_search server tool (OpenAI-only)
 	ImageGeneration        bool // image_generation server tool (OpenAI-only)
 	ServiceTier            bool // service_tier request field — strip when false (Vertex uses headers instead)
-	Diagnostics            bool // diagnostics request field — undocumented Claude Code session-continuity field (diagnostics.previous_message_id); not in the public Messages API reference, so treated as Claude API only and stripped elsewhere (fail-closed). Azure rejects it; Bedrock/Vertex undocumented.
+	Diagnostics            bool // diagnostics request field — cache diagnostics (cache-diagnosis-2026-04-07 beta, diagnostics.previous_message_id). Claude API only per docs ("not supported on Amazon Bedrock or Vertex AI"); stripped elsewhere fail-closed. Azure rejects it.
 }
 
 // ProviderFeatures maps each provider to its supported Anthropic features.
@@ -159,7 +162,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		FastMode: true, RedactThinking: true, TaskBudgets: true,
 		InferenceGeo: true, EagerInputStreaming: true, AdvisorTool: true,
 		ServiceTier: true,
-		Diagnostics: true, // Claude Code talks to the direct API and sends diagnostics.previous_message_id; only this provider keeps it.
+		Diagnostics: true, // cache-diagnosis-2026-04-07 — Claude API only; only this provider keeps diagnostics.previous_message_id.
 	},
 	// Google Vertex AI — cite: A (overview table) and V-platform.
 	// Notably NOT supported: MCP (MCP-excl), Skills/container.skills,
@@ -372,6 +375,7 @@ type AnthropicMessageRequest struct {
 	InferenceGeo      *string                `json:"inference_geo,omitempty"` // the geographic region for inference processing. If not specified, the workspace's default_inference_geo is used.
 	ContextManagement *ContextManagement     `json:"context_management,omitempty"`
 	Container         *AnthropicContainer    `json:"container,omitempty"` // string id OR object with skills[]; skills require skills-2025-10-02 beta
+	Diagnostics       *AnthropicDiagnostics  `json:"diagnostics,omitempty"`   // cache diagnostics opt-in; requires cache-diagnosis-2026-04-07 beta (Anthropic API only)
 
 	// Extra params for advanced use cases
 	ExtraParams map[string]interface{} `json:"-"`
@@ -395,6 +399,14 @@ func (req *AnthropicMessageRequest) GetExtraParams() map[string]interface{} {
 
 type AnthropicMetaData struct {
 	UserID *string `json:"user_id"`
+}
+
+// AnthropicDiagnostics is the request-side cache diagnostics opt-in
+// (cache-diagnosis-2026-04-07 beta). PreviousMessageID is the prior response id
+// to compare prompt prefixes against; it is sent as JSON null on the first turn
+// to opt in, so previous_message_id is never omitted.
+type AnthropicDiagnostics struct {
+	PreviousMessageID *string `json:"previous_message_id"`
 }
 
 type AnthropicThinking struct {
@@ -649,6 +661,7 @@ var anthropicMessageRequestKnownFields = map[string]bool{
 	"inference_geo":      true,
 	"context_management": true,
 	"container":          true,
+	"diagnostics":        true,
 	"extra_params":       true,
 	"fallbacks":          true,
 }
@@ -1523,6 +1536,10 @@ type AnthropicMessageResponse struct {
 	StopReason   AnthropicStopReason     `json:"stop_reason,omitempty"`
 	StopSequence *string                 `json:"stop_sequence,omitempty"`
 	Usage        *AnthropicUsage         `json:"usage,omitempty"`
+	// Diagnostics is the cache-diagnosis response payload (cache-diagnosis-2026-04-07).
+	// omitempty when absent; a present-but-null value (no divergence) is conveyed by a
+	// non-nil pointer with a nil CacheMissReason — see schemas.CacheDiagnostics.
+	Diagnostics *schemas.CacheDiagnostics `json:"diagnostics,omitempty"`
 }
 
 // AnthropicTextResponse represents the response structure from Anthropic's text completion API

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1105,6 +1105,12 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			headers = appendUniqueHeader(headers, AnthropicStructuredOutputsBetaHeader)
 		}
 	}
+	// Check for cache diagnostics (diagnostics opt-in present)
+	if req.Diagnostics != nil {
+		if !hasProvider || features.Diagnostics {
+			headers = appendUniqueHeader(headers, AnthropicCacheDiagnosisBetaHeader)
+		}
+	}
 	// Check for cache control with scope in system message (only if not already found)
 	if !hasCachingScope && req.System != nil && req.System.ContentBlocks != nil {
 		for _, block := range req.System.ContentBlocks {
@@ -1184,6 +1190,7 @@ var betaHeaderPrefixKnown = []string{
 	AnthropicTaskBudgetsBetaHeaderPrefix,
 	AnthropicEagerInputStreamingBetaHeaderPrefix,
 	AnthropicAdvisorBetaHeaderPrefix,
+	AnthropicCacheDiagnosisBetaHeaderPrefix,
 }
 
 // betaHeaderPrefixExists checks if any header in existing shares a known prefix with newHeader.
@@ -1501,6 +1508,7 @@ var betaHeaderPrefixToFeature = map[string]func(ProviderFeatureSupport) bool{
 	AnthropicTaskBudgetsBetaHeaderPrefix:         func(f ProviderFeatureSupport) bool { return f.TaskBudgets },
 	AnthropicEagerInputStreamingBetaHeaderPrefix: func(f ProviderFeatureSupport) bool { return f.EagerInputStreaming },
 	AnthropicAdvisorBetaHeaderPrefix:             func(f ProviderFeatureSupport) bool { return f.AdvisorTool },
+	AnthropicCacheDiagnosisBetaHeaderPrefix:      func(f ProviderFeatureSupport) bool { return f.Diagnostics },
 }
 
 // MergeBetaHeaders collects anthropic-beta values from provider ExtraHeaders and

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/tidwall/gjson"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -1528,9 +1529,9 @@ func TestNetworkConfigBetaOverridesFlow(t *testing.T) {
 
 func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 	t.Run("diagnostics_gated_via_feature_map", func(t *testing.T) {
-		// diagnostics is an undocumented Claude Code session-continuity field
-		// (diagnostics.previous_message_id). Only Anthropic direct keeps it;
-		// every other provider strips it fail-closed via Diagnostics=false.
+		// diagnostics enables cache diagnostics (cache-diagnosis-2026-04-07,
+		// diagnostics.previous_message_id) — Claude API only. Only Anthropic direct
+		// keeps it; every other provider strips it fail-closed via Diagnostics=false.
 		const body = `{"model":"claude-opus-4-7","diagnostics":{"previous_message_id":null}}`
 		// Anthropic keeps it.
 		result, err := StripUnsupportedFieldsFromRawBody([]byte(body), schemas.Anthropic, "claude-opus-4-7")
@@ -2755,6 +2756,166 @@ func TestAddMissingBetaHeadersToContext_TaskBudgets(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestAddMissingBetaHeadersToContext_CacheDiagnostics(t *testing.T) {
+	tests := []struct {
+		name            string
+		provider        schemas.ModelProvider
+		req             *AnthropicMessageRequest
+		expectHeaders   []string
+		unexpectHeaders []string
+	}{
+		{
+			name:          "Anthropic gets cache-diagnosis header when diagnostics set",
+			provider:      schemas.Anthropic,
+			req:           &AnthropicMessageRequest{Diagnostics: &AnthropicDiagnostics{}},
+			expectHeaders: []string{AnthropicCacheDiagnosisBetaHeader},
+		},
+		{
+			name:            "Bedrock does not get cache-diagnosis header (Diagnostics=false)",
+			provider:        schemas.Bedrock,
+			req:             &AnthropicMessageRequest{Diagnostics: &AnthropicDiagnostics{}},
+			unexpectHeaders: []string{AnthropicCacheDiagnosisBetaHeader},
+		},
+		{
+			name:            "Vertex does not get cache-diagnosis header (Diagnostics=false)",
+			provider:        schemas.Vertex,
+			req:             &AnthropicMessageRequest{Diagnostics: &AnthropicDiagnostics{}},
+			unexpectHeaders: []string{AnthropicCacheDiagnosisBetaHeader},
+		},
+		{
+			name:            "Azure does not get cache-diagnosis header (Diagnostics=false)",
+			provider:        schemas.Azure,
+			req:             &AnthropicMessageRequest{Diagnostics: &AnthropicDiagnostics{}},
+			unexpectHeaders: []string{AnthropicCacheDiagnosisBetaHeader},
+		},
+		{
+			name:            "no cache-diagnosis header when diagnostics is nil",
+			provider:        schemas.Anthropic,
+			req:             &AnthropicMessageRequest{},
+			unexpectHeaders: []string{AnthropicCacheDiagnosisBetaHeader},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+			AddMissingBetaHeadersToContext(ctx, tt.req, tt.provider)
+
+			var headers []string
+			if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
+				headers = extraHeaders[AnthropicBetaHeader]
+			}
+
+			for _, expected := range tt.expectHeaders {
+				if !slices.Contains(headers, expected) {
+					t.Errorf("expected header %q not found in %v", expected, headers)
+				}
+			}
+			for _, unexpected := range tt.unexpectHeaders {
+				if slices.Contains(headers, unexpected) {
+					t.Errorf("unexpected header %q found in %v", unexpected, headers)
+				}
+			}
+		})
+	}
+}
+
+func TestDiagnostics_ResponsesRequestRoundTrip(t *testing.T) {
+	// The diagnostics opt-in must survive the AnthropicMessageRequest -> Bifrost
+	// -> AnthropicMessageRequest round-trip as a typed field (parity with
+	// cache_control), not get dropped into ungated ExtraParams.
+	prev := "msg_prev_123"
+	cases := []struct {
+		name string
+		diag *AnthropicDiagnostics
+		want string // expected previous_message_id raw JSON
+	}{
+		{"with_previous_id", &AnthropicDiagnostics{PreviousMessageID: &prev}, `"msg_prev_123"`},
+		{"first_turn_null", &AnthropicDiagnostics{}, `null`}, // opt-in: previous_message_id must serialize as null, not be omitted
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &AnthropicMessageRequest{Model: "claude-opus-4-8", MaxTokens: 1024, Diagnostics: tc.diag}
+			bifrostReq := req.ToBifrostResponsesRequest(nil)
+			if bifrostReq == nil || bifrostReq.Params == nil {
+				t.Fatal("ToBifrostResponsesRequest returned nil")
+			}
+			back, err := ToAnthropicResponsesRequest(nil, bifrostReq)
+			if err != nil {
+				t.Fatalf("ToAnthropicResponsesRequest: %v", err)
+			}
+			if back.Diagnostics == nil {
+				t.Fatal("diagnostics dropped on round-trip")
+			}
+			out, err := sonic.Marshal(back)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got := gjson.GetBytes(out, "diagnostics.previous_message_id")
+			if !got.Exists() {
+				t.Fatalf("diagnostics.previous_message_id missing from %s", string(out))
+			}
+			if got.Raw != tc.want {
+				t.Errorf("previous_message_id = %s, want %s", got.Raw, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiagnostics_ResponseRoundTrip(t *testing.T) {
+	const raw = `{"id":"msg_1","type":"message","role":"assistant","model":"claude-opus-4-8",` +
+		`"content":[{"type":"text","text":"hi"}],` +
+		`"diagnostics":{"cache_miss_reason":{"type":"system_changed","cache_missed_input_tokens":41850}}}`
+	var resp AnthropicMessageResponse
+	if err := sonic.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Diagnostics == nil || resp.Diagnostics.CacheMissReason == nil {
+		t.Fatal("diagnostics not parsed onto AnthropicMessageResponse")
+	}
+	if resp.Diagnostics.CacheMissReason.Type != "system_changed" {
+		t.Errorf("type = %q, want system_changed", resp.Diagnostics.CacheMissReason.Type)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	bifrostResp := resp.ToBifrostResponsesResponse(ctx)
+	if bifrostResp == nil || bifrostResp.Diagnostics == nil {
+		t.Fatal("diagnostics dropped in ToBifrostResponsesResponse")
+	}
+	back := ToAnthropicResponsesResponse(ctx, bifrostResp)
+	if back == nil || back.Diagnostics == nil || back.Diagnostics.CacheMissReason == nil {
+		t.Fatal("diagnostics dropped in ToAnthropicResponsesResponse")
+	}
+	if got := back.Diagnostics.CacheMissReason.CacheMissedInputTokens; got == nil || *got != 41850 {
+		t.Errorf("cache_missed_input_tokens not preserved: %+v", back.Diagnostics.CacheMissReason)
+	}
+}
+
+func TestDiagnostics_ChatResponseRoundTrip(t *testing.T) {
+	// Chat path promotes the diagnostics opt-in on the request, so the response
+	// payload must round-trip too rather than be silently dropped.
+	const raw = `{"id":"msg_1","type":"message","role":"assistant","model":"claude-opus-4-8",` +
+		`"content":[{"type":"text","text":"hi"}],` +
+		`"diagnostics":{"cache_miss_reason":{"type":"tools_changed","cache_missed_input_tokens":128}}}`
+	var resp AnthropicMessageResponse
+	if err := sonic.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	bifrostResp := resp.ToBifrostChatResponse(ctx)
+	if bifrostResp == nil || bifrostResp.Diagnostics == nil {
+		t.Fatal("diagnostics dropped in ToBifrostChatResponse")
+	}
+	back := ToAnthropicChatResponse(bifrostResp)
+	if back == nil || back.Diagnostics == nil || back.Diagnostics.CacheMissReason == nil {
+		t.Fatal("diagnostics dropped in ToAnthropicChatResponse")
+	}
+	if back.Diagnostics.CacheMissReason.Type != "tools_changed" {
+		t.Errorf("type = %q, want tools_changed", back.Diagnostics.CacheMissReason.Type)
 	}
 }
 

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -41,6 +41,7 @@ type BifrostChatResponse struct {
 	Object            string                     `json:"object"` // "chat.completion" or "chat.completion.chunk"
 	ServiceTier       *BifrostServiceTier        `json:"service_tier,omitempty"`
 	Speed             *string                    `json:"speed,omitempty"` // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
+	Diagnostics       *CacheDiagnostics          `json:"diagnostics,omitempty"` // Anthropic cache diagnostics (cache-diagnosis-2026-04-07); first prompt-cache prefix divergence point
 	SystemFingerprint string                     `json:"system_fingerprint"`
 	Usage             *BifrostLLMUsage           `json:"usage"`
 	ExtraFields       BifrostResponseExtraFields `json:"extra_fields"`

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -130,6 +130,7 @@ type BifrostResponsesResponse struct {
 	SafetyIdentifier     *string                             `json:"safety_identifier"` // Safety identifier
 	ServiceTier          *BifrostServiceTier                 `json:"service_tier"`
 	Speed                *string                             `json:"speed,omitempty"` // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
+	Diagnostics          *CacheDiagnostics                   `json:"diagnostics,omitempty"` // Anthropic cache diagnostics (cache-diagnosis-2026-04-07); first prompt-cache prefix divergence point
 	Status               *string                             `json:"status,omitempty"` // completed, failed, in_progress, cancelled, queued, or incomplete
 	StreamOptions        *ResponsesStreamOptions             `json:"stream_options,omitempty"`
 	StopReason           *string                             `json:"stop_reason,omitempty"` // Not in OpenAI's spec, but sent by other providers
@@ -149,6 +150,22 @@ type BifrostResponsesResponse struct {
 	SearchResults []SearchResult `json:"search_results,omitempty"`
 	Videos        []VideoResult  `json:"videos,omitempty"`
 	Citations     []string       `json:"citations,omitempty"`
+}
+
+// CacheDiagnostics is the Anthropic cache-diagnosis response payload
+// (cache-diagnosis-2026-04-07 beta). CacheMissReason is null while the comparison
+// is still pending and, when set, identifies the first prompt-cache prefix
+// divergence point. A nil *CacheDiagnostics means no divergence / not requested.
+type CacheDiagnostics struct {
+	CacheMissReason *CacheMissReason `json:"cache_miss_reason"`
+}
+
+// CacheMissReason identifies the first cache-prefix divergence point. The
+// *_changed types also carry CacheMissedInputTokens; previous_message_not_found
+// and unavailable do not.
+type CacheMissReason struct {
+	Type                   string `json:"type"`
+	CacheMissedInputTokens *int   `json:"cache_missed_input_tokens,omitempty"`
 }
 
 // UnmarshalJSON handles providers that return created_at/completed_at as floats (e.g. Bedrock mantle).


### PR DESCRIPTION
## Summary

Adds first-class support for Anthropic's `cache-diagnosis-2026-04-07` beta feature, which allows clients to opt in to cache diagnostics and receive information about the first prompt-cache prefix divergence point in a response. Previously, the `diagnostics` field was treated as an undocumented Claude Code session-continuity field; it is now a documented beta capability with proper typed structs, beta header injection, and round-trip serialization support.

## Changes

- Introduced `AnthropicDiagnostics` (request-side opt-in) and `CacheDiagnostics` / `CacheMissReason` (response-side payload) types.
- Added `AnthropicCacheDiagnosisBetaHeader` and `AnthropicCacheDiagnosisBetaHeaderPrefix` constants; wired them into the beta header injection, deduplication, and feature-gate maps so the header is automatically added when `Diagnostics` is set and the provider supports it.
- Promoted `diagnostics` from an untyped `ExtraParams` passthrough to a typed field on `AnthropicMessageRequest`, mirroring the existing `cache_control` pattern, so it is always serialized correctly (including `previous_message_id: null` on the first turn).
- Forwarded `Diagnostics` through the full request/response pipeline for both streaming (`message_start`) and non-streaming paths.
- Added `Diagnostics` to `BifrostResponsesResponse` so cache diagnostics are surfaced to clients.
- Updated `ProviderFeatureSupport.Diagnostics` comment to reflect the now-documented beta status; Bedrock and Vertex remain gated out (fail-closed).
- Added tests covering beta header injection per provider, request round-trip serialization (including null `previous_message_id`), and response round-trip preservation of `cache_miss_reason`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... -run TestAddMissingBetaHeadersToContext_CacheDiagnostics
go test ./core/providers/anthropic/... -run TestDiagnostics_ResponsesRequestRoundTrip
go test ./core/providers/anthropic/... -run TestDiagnostics_ResponseRoundTrip
go test ./core/providers/anthropic/... -run TestStripUnsupportedFieldsFromRawBody
go test ./...
```

To validate end-to-end, send a request to the Anthropic API with `diagnostics: { previous_message_id: null }` in `extra_params`. The response should include a `diagnostics` object, and the `cache-diagnosis-2026-04-07` beta header should be present in the outbound request. Bedrock and Vertex requests with the same payload should have the `diagnostics` field stripped.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. The `diagnostics` field is gated to Anthropic direct only; it is stripped fail-closed for all other providers, preventing accidental leakage of session-continuity metadata to providers that do not support or document the field.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable