### PR TITLE
fix: fixes redaction setting in plugins config

### DIFF
--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -561,36 +561,71 @@ func (h *PluginsHandler) deletePlugin(ctx *fasthttp.RequestCtx) {
 	})
 }
 
-// restoreRedactedFromExisting walks the incoming config map and, for any field that
-// looks like an EnvVar object whose value ShouldPreserveStored (i.e. it is a redacted
-// placeholder like "***"), replaces the value with the corresponding field from the
-// existing DB config. This mirrors the mergeUpdatedKey pattern used by provider keys.
+// restoreRedactedFromExisting walks the incoming config map and, for any field whose
+// value is a redacted placeholder (a masked EnvVar object, or a masked plain string),
+// replaces it with the corresponding value from the existing DB
+// config so client-side redaction never overwrites real credentials. It descends into
+// nested maps AND slices (e.g. the OTEL `profiles` array), and handles header values that
+// are stored as plain strings rather than EnvVar objects. Mirrors the mergeUpdatedKey
+// pattern used by provider keys.
 func restoreRedactedFromExisting(incoming, existing map[string]any) map[string]any {
 	if len(incoming) == 0 {
 		return incoming
 	}
 	result := make(map[string]any, len(incoming))
 	for k, v := range incoming {
-		switch val := v.(type) {
-		case map[string]any:
-			if isEnvVarObject(val) {
-				ev := schemas.NewEnvVar(marshalEnvVarObject(val))
-				if ev.ShouldPreserveStored() {
-					if existingVal, ok := existing[k]; ok {
-						result[k] = existingVal
-						continue
-					}
-				}
-			} else if existingNested, ok := existing[k].(map[string]any); ok {
-				result[k] = restoreRedactedFromExisting(val, existingNested)
-				continue
-			}
-			result[k] = val
-		default:
-			result[k] = v
-		}
+		result[k] = restoreRedactedValue(v, existing[k])
 	}
 	return result
+}
+
+// restoreRedactedValue restores a single incoming value against its corresponding existing
+// value. It recurses through maps and slices, and treats both EnvVar-shaped objects and
+// plain redacted strings as placeholders to swap back to the stored original. Returns the
+// incoming value unchanged when it is not a redaction placeholder or has no stored match.
+func restoreRedactedValue(incoming, existing any) any {
+	switch val := incoming.(type) {
+	case map[string]any:
+		if isEnvVarObject(val) {
+			if schemas.NewEnvVar(marshalEnvVarObject(val)).ShouldPreserveStored() && existing != nil {
+				return existing
+			}
+			return val
+		}
+		if existingNested, ok := existing.(map[string]any); ok {
+			return restoreRedactedFromExisting(val, existingNested)
+		}
+		return val
+	case []any:
+		// Restore element-by-element against the existing slice (index-aligned). New
+		// elements beyond the existing length carry user-supplied values, so keep them.
+		existingSlice, ok := existing.([]any)
+		if !ok {
+			return val
+		}
+		out := make([]any, len(val))
+		for i, item := range val {
+			if i < len(existingSlice) {
+				out[i] = restoreRedactedValue(item, existingSlice[i])
+			} else {
+				out[i] = item
+			}
+		}
+		return out
+	case string:
+		// Plain-string secrets (e.g. OTEL headers): restore only when the incoming string
+		// is a redaction artifact and not an intentional env reference. Empty strings are
+		// left as-is so clearing a value works.
+		if existingStr, ok := existing.(string); ok {
+			envVal := schemas.NewEnvVar(val)
+			if !envVal.IsFromEnv() && envVal.IsRedacted() {
+				return existingStr
+			}
+		}
+		return val
+	default:
+		return incoming
+	}
 }
 
 // isEnvVarObject returns true if m has exactly the shape of a serialised EnvVar:

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -77,6 +77,69 @@ func buildUpdateRequest(t *testing.T, body any) *fasthttp.RequestCtx {
 // config over the existing DB config, preserving fields the caller did not send.
 // This is critical for the plugin_span_filter field: the OTEL config form in the
 // UI does not send plugin_span_filter, so it must survive a save without being wiped.
+// TestRestoreRedacted_OTELProfilesHeaders covers the two gaps that broke OTEL header
+// round-trips after the multi-profile change: (1) headers live inside the `profiles`
+// array (slice traversal), and (2) header values are plain redacted strings, not EnvVar
+// objects. Saving a config whose headers came back redacted must not overwrite the
+// stored credentials.
+func TestRestoreRedacted_OTELProfilesHeaders(t *testing.T) {
+	realAuth := "Basic-REAL-SUPER-SECRET-VALUE"
+	realVersion := "4"
+	maskedAuth := schemas.NewEnvVar(realAuth).Redacted().GetValue()       // long -> first4 + **** + last4
+	maskedVersion := schemas.NewEnvVar(realVersion).Redacted().GetValue() // "4" -> "*"
+
+	mkConfig := func(auth, version string) map[string]any {
+		return map[string]any{
+			"profiles": []any{
+				map[string]any{
+					"service_name": "langfuse",
+					"headers": map[string]any{
+						"Authorization":                auth,
+						"x-langfuse-ingestion-version": version,
+					},
+				},
+			},
+		}
+	}
+
+	existing := mkConfig(realAuth, realVersion)
+	incoming := mkConfig(maskedAuth, maskedVersion) // what the UI sends back after a redacted GET
+
+	got := restoreRedactedFromExisting(incoming, existing)
+	headers := got["profiles"].([]any)[0].(map[string]any)["headers"].(map[string]any)
+
+	if headers["Authorization"] != realAuth {
+		t.Errorf("Authorization not restored: got %q, want %q", headers["Authorization"], realAuth)
+	}
+	if headers["x-langfuse-ingestion-version"] != realVersion {
+		t.Errorf("version not restored: got %q, want %q", headers["x-langfuse-ingestion-version"], realVersion)
+	}
+
+	// A genuinely changed (non-redacted) header value must pass through untouched.
+	changed := mkConfig("Basic-A-BRAND-NEW-KEY-VALUE-1234", "3")
+	got2 := restoreRedactedFromExisting(changed, existing)
+	headers2 := got2["profiles"].([]any)[0].(map[string]any)["headers"].(map[string]any)
+	if headers2["Authorization"] != "Basic-A-BRAND-NEW-KEY-VALUE-1234" {
+		t.Errorf("new Authorization should pass through, got %q", headers2["Authorization"])
+	}
+	if headers2["x-langfuse-ingestion-version"] != "3" {
+		t.Errorf("new version should pass through, got %q", headers2["x-langfuse-ingestion-version"])
+	}
+
+	// An intentional env.* reference (e.g. credential rotation) must pass through.
+	// NewEnvVar parses the "env." prefix as FromEnv=true, which IsRedacted reports as
+	// redacted; the IsFromEnv guard must let it through rather than restoring the stored value.
+	rotated := mkConfig("env.NEW_TOKEN", "env.NEW_VERSION")
+	got3 := restoreRedactedFromExisting(rotated, existing)
+	headers3 := got3["profiles"].([]any)[0].(map[string]any)["headers"].(map[string]any)
+	if headers3["Authorization"] != "env.NEW_TOKEN" {
+		t.Errorf("env.* Authorization should pass through, got %q", headers3["Authorization"])
+	}
+	if headers3["x-langfuse-ingestion-version"] != "env.NEW_VERSION" {
+		t.Errorf("env.* version should pass through, got %q", headers3["x-langfuse-ingestion-version"])
+	}
+}
+
 func TestUpdatePlugin_ConfigMerge(t *testing.T) {
 	SetLogger(&mockLogger{})
 


### PR DESCRIPTION
## Summary

Fixes a bug where OTEL plugin headers were being overwritten with redacted placeholder values when saving a plugin configuration. After the multi-profile change, header values stored as plain strings inside the `profiles` array were not being restored from the database before saving, causing real credentials to be replaced with masked values like `****`.

## Changes

- Extracted `restoreRedactedValue` as a standalone recursive helper, replacing the inline logic in `restoreRedactedFromExisting`. This allows the restoration logic to descend into both nested maps and slices.
- Added slice traversal support (index-aligned) so that elements within arrays like the OTEL `profiles` array are individually checked and restored.
- Added plain-string redaction detection so that header values stored as raw strings (rather than `EnvVar` objects) are also restored from the existing DB config when they carry a redaction artifact. Empty strings are intentionally left as-is to allow clearing a value.
- Added `TestRestoreRedacted_OTELProfilesHeaders` to cover both failure modes: slice traversal and plain-string secret restoration. Also asserts that genuinely new (non-redacted) values pass through unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

Verify that saving an OTEL plugin configuration with multiple profiles, after a GET that returns redacted header values, does not overwrite the stored credentials in the database. Confirm that providing a genuinely new header value still persists correctly.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This fix ensures that redacted credential placeholders returned to the client are never written back over real secrets stored in the database. The restoration logic only replaces values that are confirmed redaction artifacts; empty strings and non-redacted values are always passed through as-is, preserving the ability to clear a credential intentionally.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable