### PR TITLE
feat: overhaul skills repo UI with resizable panels, file-aware markdown links, breadcrumb nav, and version popover

### DIFF
--- a/ui/app/workspace/skills-repo/components/fileManagerView.tsx
+++ b/ui/app/workspace/skills-repo/components/fileManagerView.tsx
@@ -30,6 +30,7 @@ import { Tree, type BaseNodeData, type TreeNode } from "@/components/ui/treeView
 import { getErrorMessage } from "@/lib/store/apis/baseApi";
 import { useUploadSkillFileMutation } from "@/lib/store/apis/skillsApi";
 import { SkillFileEntry } from "@/lib/types/skills";
+import { cn } from "@/lib/utils";
 import { validateFilePath, validateFilename, validateSkillFileSize, validateSourceType } from "@/lib/validators/skills";
 import {
 	AlertCircle,
@@ -46,9 +47,8 @@ import {
 	X,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
-import { formatFileSize } from "./helpers";
-import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import { formatFileSize } from "./helpers";
 
 const FILE_SOURCE_OPTIONS = [
 	{ value: "text", label: "Via text", shortLabel: "Text" },
@@ -445,6 +445,8 @@ export function FileManagerSection({
 	bodySelected,
 	onSelectBody,
 	hasBodyError,
+	searchQuery: controlledSearchQuery,
+	onSearchChange,
 }: {
 	files: SkillFileEntry[];
 	onAddFile: (entry: SkillFileEntry) => void;
@@ -460,6 +462,10 @@ export function FileManagerSection({
 	onSelectBody?: () => void;
 	// When true, the SKILL.md label renders red to indicate missing body.
 	hasBodyError?: boolean;
+	// When provided, the search input is rendered by the parent and its value is
+	// controlled from there; the internal search bar is hidden.
+	searchQuery?: string;
+	onSearchChange?: (value: string) => void;
 }) {
 	const [uploadSkillFile] = useUploadSkillFileMutation();
 	const folderUploadInputRef = useRef<HTMLInputElement | null>(null);
@@ -476,7 +482,10 @@ export function FileManagerSection({
 	const [editingFileOriginal, setEditingFileOriginal] = useState<{
 		path: string;
 	} | null>(null);
-	const [searchQuery, setSearchQuery] = useState("");
+	const [internalSearchQuery, setInternalSearchQuery] = useState("");
+	const isSearchControlled = onSearchChange != null;
+	const searchQuery = isSearchControlled ? (controlledSearchQuery ?? "") : internalSearchQuery;
+	const setSearchQuery = isSearchControlled ? onSearchChange : setInternalSearchQuery;
 	const [addingFile, setAddingFile] = useState<{
 		folderPath: string;
 		sourceType: string;
@@ -505,6 +514,18 @@ export function FileManagerSection({
 		});
 	}, [files]);
 
+	// Expand all folders while searching so matching results stay visible.
+	useEffect(() => {
+		if (!searchQuery.trim()) return;
+		setExpandedNodes((prev) => {
+			const next: Record<string, boolean> = { ...prev, root: true };
+			folders.forEach((f) => {
+				next[f] = true;
+			});
+			return next;
+		});
+	}, [searchQuery, folders]);
+
 	const expandFolder = (folderPath: string) => {
 		const normalizedFolderPath = folderPath === "root" ? "" : folderPath;
 		const ancestors = normalizedFolderPath.split("/").filter(Boolean);
@@ -518,6 +539,23 @@ export function FileManagerSection({
 			return next;
 		});
 	};
+
+	// When selection is driven externally (e.g. a markdown link opens a file), the file
+	// can be buried in a collapsed folder. Expand its ancestors so the row is visible.
+	const selectedPath = selectedIndex != null ? files[selectedIndex]?.path : undefined;
+	useEffect(() => {
+		if (!selectedPath) return;
+		const ancestors = getFolderAncestors(selectedPath);
+		if (ancestors.length === 0) return;
+		setExpandedNodes((prev) => {
+			if (ancestors.every((folder) => prev[folder])) return prev;
+			const next: Record<string, boolean> = { ...prev, root: true };
+			ancestors.forEach((folder) => {
+				next[folder] = true;
+			});
+			return next;
+		});
+	}, [selectedPath]);
 
 	const isFolderUploading = folderUploadState !== null;
 
@@ -1066,11 +1104,11 @@ export function FileManagerSection({
 						onKeyDown={
 							!isRenaming && onSelectFile
 								? (e) => {
-										if (e.key === "Enter" || e.key === " ") {
-											e.preventDefault();
-											onSelectFile(index);
-										}
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault();
+										onSelectFile(index);
 									}
+								}
 								: undefined
 						}
 						role={!isRenaming && onSelectFile ? "button" : undefined}
@@ -1206,8 +1244,8 @@ export function FileManagerSection({
 		const folderMoveTargets = isRoot
 			? []
 			: availableFolderPaths.filter(
-					(folderPath) => folderPath !== item.path && !folderPath.startsWith(`${item.path}/`) && folderPath !== dirname(item.path),
-				);
+				(folderPath) => folderPath !== item.path && !folderPath.startsWith(`${item.path}/`) && folderPath !== dirname(item.path),
+			);
 
 		return (
 			<div
@@ -1423,33 +1461,24 @@ export function FileManagerSection({
 					{folderUploadError}
 				</div>
 			)}
-			<div className="mb-2">
-				<Input
-					value={searchQuery}
-					onChange={(e) => {
-						setSearchQuery(e.target.value);
-						if (e.target.value.trim()) {
-							// Expand all folders when searching so results are visible
-							setExpandedNodes((prev) => {
-								const next: Record<string, boolean> = { ...prev, root: true };
-								folders.forEach((f) => {
-									next[f] = true;
-								});
-								return next;
-							});
-						}
-					}}
-					placeholder="Search files..."
-					className="h-7 font-mono text-xs"
-					aria-label="Search files"
-				/>
-			</div>
-			<div className="min-w-max pr-2">
+			{!isSearchControlled && (
+				<div className="mb-2">
+					<Input
+						value={searchQuery}
+						onChange={(e) => setSearchQuery(e.target.value)}
+						placeholder="Search files..."
+						className="h-7 text-xs"
+						aria-label="Search files"
+					/>
+				</div>
+			)}
+			<div className="min-w-0 pr-2">
 				<Tree
 					data={treeData}
 					renderItem={renderItem}
 					indentSize={22}
 					levelsToExpandByDefault={1}
+					fitContainer
 					states={{ expandedNodes, setExpandedNodes }}
 				/>
 			</div>

--- a/ui/app/workspace/skills-repo/components/filePreview.tsx
+++ b/ui/app/workspace/skills-repo/components/filePreview.tsx
@@ -237,7 +237,7 @@ export function FilePreview({
     const textContent = source.inlineText ?? fetchedText ?? "";
 
     return (
-      <ScrollArea className="h-full">
+      <ScrollArea className="h-full" bidirectionalScroll>
         <pre className="p-4 font-mono text-xs leading-5 whitespace-pre-wrap">
           {textContent || "(empty)"}
         </pre>

--- a/ui/app/workspace/skills-repo/components/shared.tsx
+++ b/ui/app/workspace/skills-repo/components/shared.tsx
@@ -4,24 +4,25 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
-import { ScrollArea, ScrollBar } from "@/components/ui/scrollArea";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
+import { ScrollArea } from "@/components/ui/scrollArea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { lazy, Suspense, type ComponentProps } from "react";
 import { Tree, type BaseNodeData, type TreeNode } from "@/components/ui/treeView";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { SkillFileEntry } from "@/lib/types/skills";
-import { getApiBaseUrl } from "@/lib/utils/port";
 import { cn } from "@/lib/utils";
+import { getApiBaseUrl } from "@/lib/utils/port";
 import {
-	Check,
-	Bot,
 	BookOpen,
+	Bot,
+	Check,
 	ChevronDown,
 	ChevronRight,
 	ChevronsDownUp,
 	ChevronsUpDown,
-	ArrowLeft,
 	Copy,
 	Download,
 	ExternalLink,
@@ -29,15 +30,15 @@ import {
 	Folder,
 	FolderOpen,
 	Hammer,
+	Info,
 	MoreHorizontal,
-	PanelLeftClose,
-	PanelLeftOpen,
 	Scale,
+	Search,
 	X,
 } from "lucide-react";
-import { useState, useMemo } from "react";
-import { formatYamlRecord } from "./helpers";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ComponentProps } from "react";
 import { FilePreviewPane, getFileServeUrl } from "./filePreview";
+import { formatYamlRecord } from "./helpers";
 
 const LazyMarkdown = lazy(() => import("@/components/ui/markdown").then((m) => ({ default: m.Markdown })));
 const Markdown = (props: ComponentProps<typeof LazyMarkdown>) => <Suspense fallback={null}><LazyMarkdown {...props} /></Suspense>;
@@ -82,6 +83,60 @@ export function HeaderMetaItem({
 	);
 }
 
+// ---------- ClampedDescription ----------
+
+/** Shows the description clamped to 3 lines with a Show more/less toggle when it overflows. */
+function ClampedDescription({ description }: { description: string }) {
+	const [expanded, setExpanded] = useState(false);
+	const [isOverflowing, setIsOverflowing] = useState(false);
+	const textRef = useRef<HTMLParagraphElement>(null);
+
+	useEffect(() => {
+		// Only measure while collapsed — once expanded the clamp is removed so the
+		// element always fits, which would otherwise reset isOverflowing to false.
+		if (expanded) return;
+		const el = textRef.current;
+		if (!el) return;
+		const check = () => setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
+		check();
+		const observer = new ResizeObserver(check);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [description, expanded]);
+
+	if (!description) return null;
+
+	return (
+		<div className="relative max-w-3xl">
+			<p
+				ref={textRef}
+				className={cn("text-muted-foreground text-xs", !expanded && "line-clamp-3")}
+			>
+				{description}
+				{expanded && isOverflowing && (
+					<button
+						type="button"
+						onClick={() => setExpanded(false)}
+						className="ml-1 cursor-pointer text-xs font-medium text-blue-600 transition-colors hover:underline dark:text-blue-400"
+					>
+						Show less
+					</button>
+				)}
+			</p>
+			{!expanded && isOverflowing && (
+				<button
+					type="button"
+					onClick={() => setExpanded(true)}
+					className="bg-card absolute right-0 bottom-0 cursor-pointer pl-8 pr-4 text-xs font-medium text-blue-600 transition-colors hover:underline dark:text-blue-400"
+				>
+					<span className="from-card pointer-events-none absolute top-0 right-full h-full w-8 bg-gradient-to-l to-transparent" />
+					Show more
+				</button>
+			)}
+		</div>
+	);
+}
+
 // ---------- SkillHeader ----------
 
 export function SkillHeader({
@@ -119,50 +174,66 @@ export function SkillHeader({
 
 	return (
 		<>
-			<div className={cn("flex flex-col items-start gap-2 bg-white dark:bg-card w-full", sticky && "sticky top-0 z-30 py-4")}>
-				<div className="flex w-full flex-row items-center gap-2">
-					<div className="flex flex-row items-center gap-2 align-middle">
-						{onBack && (
-							<Button variant="ghost" size="sm" className="h-8 w-8 shrink-0 p-0" onClick={onBack} aria-label="Go back">
-								<ArrowLeft className="h-4 w-4" />
-							</Button>
-						)}
-						<h2 className="min-w-0 truncate text-xl font-semibold tracking-tight">{name}</h2>
-						<Badge variant="secondary" className="shrink-0 font-mono text-xs" role="status">
-							v{version}
-						</Badge>
-						{composedSkillMd && (
-							<Button
-								variant="link"
-								size="sm"
-								className="h-auto shrink-0 px-1 py-0 text-xs text-blue-600 dark:text-blue-400"
-								onClick={() => setShowRawDialog(true)}
-							>
-								View raw SKILL.md
-							</Button>
-						)}
-					</div>
-					<div className="ml-auto flex flex-row items-center align-middle">
-						{decorators}
-						{(actions || downloadSkillName) && (
-							<div className="ml-auto flex shrink-0 items-center gap-1.5">
-								{downloadSkillName && (
-									<Button variant="outline" size="sm" asChild>
-										<a href={`${getApiBaseUrl()}/skills/serve/${encodeURIComponent(downloadSkillName)}/download.zip`} download>
-											Download ZIP
-										</a>
-									</Button>
-								)}
-								{actions}
-							</div>
-						)}
-					</div>
+			<div className={cn("flex w-full flex-row items-center gap-2 bg-card relative", sticky && "sticky top-0 z-30 py-4")}>
+				<div className="flex flex-row items-center gap-2 align-middle h-5">
+					{onBack ? (
+						<nav aria-label="Breadcrumb" className="min-w-0">
+							<ol className="text-muted-foreground flex items-center gap-1.5 text-sm">
+								<li>
+									<button
+										type="button"
+										data-testid="skill-back-btn"
+										onClick={onBack}
+										className="hover:text-foreground cursor-pointer transition-colors"
+									>
+										Skills
+									</button>
+								</li>
+								<li aria-hidden="true" className="text-muted-foreground/60">
+									/
+								</li>
+								<li aria-current="page" className="text-foreground truncate font-medium">
+									{name}
+								</li>
+							</ol>
+						</nav>
+					) : (
+						<h2 className="truncate text-xl font-semibold">{name}</h2>
+					)}
+					<Badge variant="secondary" className="shrink-0 font-mono text-xs" role="status">
+						v{version}
+					</Badge>
+					{composedSkillMd && (
+						<Button
+							variant="link"
+							size="sm"
+							className="h-auto shrink-0 px-1 py-0 text-xs text-blue-600 dark:text-blue-400"
+							onClick={() => setShowRawDialog(true)}
+						>
+							View raw SKILL.md
+						</Button>
+					)}
+				</div>
+				<div className="ml-auto flex flex-row items-center align-middle absolute right-0 top-4">
+					{decorators}
+					{(actions || downloadSkillName) && (
+						<div className="ml-auto flex shrink-0 items-center gap-1.5">
+							{downloadSkillName && (
+								<Button variant="outline" size="sm" asChild>
+									<a href={`${getApiBaseUrl()}/skills/serve/${encodeURIComponent(downloadSkillName)}/download.zip`} download>
+										Download ZIP
+									</a>
+								</Button>
+							)}
+							{actions}
+						</div>
+					)}
 				</div>
 			</div>
 			<div className="w-full">
-				<p className="text-muted-foreground max-w-3xl text-xs">{description}</p>
+				<ClampedDescription description={description} />
 				<TooltipProvider>
-					<div className="mt-3 flex flex-wrap items-center gap-2 pb-2">
+					<div className="mt-4 flex flex-wrap items-center gap-2 pb-2">
 						<HeaderMetaItem label="License" value={license} missingText="No license defined" icon={Scale} />
 						<HeaderMetaItem label="Compatibility" value={compatibility} missingText="No compatibility defined" icon={Bot} />
 						<HeaderMetaItem label="Allowed tools" value={allowedTools} missingText="No allowed tools defined" icon={Hammer} />
@@ -171,7 +242,7 @@ export function SkillHeader({
 			</div>
 			{composedSkillMd && (
 				<Dialog open={showRawDialog} onOpenChange={setShowRawDialog}>
-					<DialogContent showCloseButton={false} className="w-full max-w-full border-0 p-0 sm:w-4/5 sm:max-w-4xl md:w-1/2 md:max-w-3xl">
+					<DialogContent showCloseButton={false} className="w-full h-[90vh] border-0 p-0 sm:w-[85vw] sm:max-w-[85vw] md:w-[75vw] md:max-w-[75vw]">
 						<DialogHeader className="sr-only">
 							<DialogTitle>Raw SKILL.md</DialogTitle>
 						</DialogHeader>
@@ -180,19 +251,19 @@ export function SkillHeader({
 								<Button
 									variant="ghost"
 									size="icon"
-									className="bg-background/70 text-muted-foreground hover:bg-background/90 hover:text-foreground h-8 w-8 rounded-sm"
+									className="bg-background/70 text-muted-foreground hover:bg-card hover:text-foreground h-8 w-8 rounded-sm"
 									onClick={() => copyRawSkillMd(composedSkillMd)}
 									aria-label={copiedRawSkillMd ? "Raw SKILL.md copied" : "Copy raw SKILL.md"}
 								>
 									{copiedRawSkillMd ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
 								</Button>
-								<DialogClose className="text-muted-foreground hover:bg-background/80 hover:text-foreground cursor-pointer rounded-sm p-1.5 transition-colors">
+								<DialogClose className="text-muted-foreground hover:bg-card hover:text-foreground cursor-pointer rounded-sm h-8 w-8 flex justify-center items-center transition-colors">
 									<X className="h-4 w-4" />
 									<span className="sr-only">Close</span>
 								</DialogClose>
 							</div>
-							<ScrollArea className="h-screen" viewportClassName="bg-muted">
-								<pre className="bg-muted min-h-96 p-5 pr-24 font-mono text-xs leading-5 whitespace-pre-wrap">{composedSkillMd}</pre>
+							<ScrollArea className="h-full" viewportClassName="bg-muted">
+								<pre className="bg-muted p-5 pr-24 font-mono text-xs leading-5 whitespace-pre-wrap">{composedSkillMd}</pre>
 							</ScrollArea>
 						</div>
 					</DialogContent>
@@ -216,11 +287,24 @@ export function FormSection({
 	helperText?: React.ReactNode;
 }) {
 	return (
-		<section className={cn("flex flex-col gap-3", className)}>
-			<div className="flex items-baseline gap-2 pb-1">
-				<h2 className="text-foreground text-base font-semibold tracking-tight">{title}</h2>
+		<section className={cn("flex flex-col gap-2", className)}>
+			<div className="flex items-center gap-1.5">
+				<Label>{title}</Label>
 				{optional && <span className="text-muted-foreground text-xs">optional</span>}
-				{helperText && <span className="text-muted-foreground text-xs">{helperText}</span>}
+				{helperText && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								className="text-muted-foreground hover:text-foreground inline-flex h-4 w-4 items-center justify-center"
+								aria-label={`About ${title}`}
+							>
+								<Info className="h-3.5 w-3.5" aria-hidden="true" />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent className="max-w-xs text-xs">{helperText}</TooltipContent>
+					</Tooltip>
+				)}
 			</div>
 			{children}
 		</section>
@@ -254,8 +338,8 @@ export function ReadOnlyMetadataTable({ value, className }: { value: Record<stri
 				<div className="text-muted-foreground flex-1 divide-y overflow-y-auto">
 					{entries.map(([key, item]) => (
 						<div key={key} className="grid grid-cols-2 gap-3 px-3 py-2.5 text-sm">
-							<p className="min-w-0 truncate font-mono text-xs">{key}</p>
-							<p className="min-w-0 font-mono text-xs leading-5 break-words">{String(item)}</p>
+							<p className="truncate font-mono text-xs">{key}</p>
+							<p className="font-mono text-xs leading-5 break-words">{String(item)}</p>
 						</div>
 					))}
 				</div>
@@ -265,8 +349,57 @@ export function ReadOnlyMetadataTable({ value, className }: { value: Record<stri
 }
 // ---------- ReadOnlySkillBody ----------
 
-export function ReadOnlySkillBody({ body }: { body: string }) {
-	const [activeTab, setActiveTab] = useState("rendered");
+// Resolve a relative markdown link (e.g. "./tui/activity.go", "../foo.md") to a
+// known skill file path so it can be opened in the sidebar instead of navigated.
+function resolveSkillFilePath(href: string, files: SkillFileEntry[]): string | null {
+	if (!href) return null;
+	// Ignore anchors and protocol-ish links (mailto:, //example.com, etc.).
+	if (href.startsWith("#") || href.startsWith("//") || /^[a-z][a-z0-9+.-]*:/i.test(href)) return null;
+
+	// Strip query/hash and any leading "./".
+	const cleaned = href.split(/[?#]/)[0].replace(/^\.\//, "");
+	if (!cleaned) return null;
+
+	const normalize = (p: string) => p.replace(/^\.?\//, "").replace(/^\/+/, "");
+	const target = normalize(cleaned);
+
+	// Exact match on the full path first.
+	const exact = files.find((f) => normalize(f.path) === target);
+	if (exact) return exact.path;
+
+	// Fall back to matching by trailing path segments (handles "../" prefixes).
+	const targetTail = target.replace(/^(\.\.\/)+/, "");
+	const byTail = files.find((f) => {
+		const fp = normalize(f.path);
+		return fp === targetTail || fp.endsWith(`/${targetTail}`);
+	});
+	if (byTail) return byTail.path;
+
+	// Last resort: match on the bare filename if unambiguous.
+	const fileName = target.split("/").pop();
+	if (fileName) {
+		const matches = files.filter((f) => normalize(f.path).split("/").pop() === fileName);
+		if (matches.length === 1) return matches[0].path;
+	}
+
+	return null;
+}
+
+// Renders SKILL.md markdown with skill-aware links: relative links that resolve to
+// a sibling file open it via onSelectFile, external links route through a confirm
+// dialog instead of navigating away. Shared by the read-only view and the edit-form
+// preview so both behave identically.
+export function SkillMarkdown({
+	content,
+	files = [],
+	onSelectFile,
+	className,
+}: {
+	content: string;
+	files?: SkillFileEntry[];
+	onSelectFile?: (path: string) => void;
+	className?: string;
+}) {
 	const [externalLink, setExternalLink] = useState<{
 		href: string;
 		label: string;
@@ -274,28 +407,46 @@ export function ReadOnlySkillBody({ body }: { body: string }) {
 
 	const markdownComponents = {
 		a: ({ href, children, ...props }: React.ComponentProps<"a">) => {
-			const isExternal = Boolean(href && /^https?:\/\//i.test(href));
+			const isExternal = Boolean(href && (href.startsWith("//") || /^https?:\/\//i.test(href)));
 			const label = typeof children === "string" ? children : href || "external link";
 
-			if (!isExternal || !href) {
+			if (isExternal && href) {
 				return (
-					<a href={href} {...props}>
+					<a
+						href={href}
+						{...props}
+						onClick={(event) => {
+							props.onClick?.(event);
+							if (event.defaultPrevented) return;
+							event.preventDefault();
+							setExternalLink({ href, label });
+						}}
+					>
 						{children}
 					</a>
 				);
 			}
 
+			// Internal/relative link: resolve to a sibling file and select it in the
+			// sidebar instead of letting the browser navigate to a broken path.
+			const matchedPath = href ? resolveSkillFilePath(href, files) : null;
+
+			// Resolvable file link: render as a primary-styled button (matching the
+			// markdown preview's link treatment) that selects the file in the sidebar.
+			if (matchedPath && onSelectFile) {
+				return (
+					<button
+						type="button"
+						className="wrap-anywhere cursor-pointer appearance-none text-left font-medium text-primary underline"
+						onClick={() => onSelectFile(matchedPath)}
+					>
+						{children}
+					</button>
+				);
+			}
+
 			return (
-				<a
-					href={href}
-					{...props}
-					onClick={(event) => {
-						props.onClick?.(event);
-						if (event.defaultPrevented) return;
-						event.preventDefault();
-						setExternalLink({ href, label });
-					}}
-				>
+				<a href={href} {...props}>
 					{children}
 				</a>
 			);
@@ -303,33 +454,8 @@ export function ReadOnlySkillBody({ body }: { body: string }) {
 	};
 
 	return (
-		<FormSection title="SKILL.md Body" className="flex min-h-0 flex-1 flex-col">
-			<Tabs defaultValue="rendered" onValueChange={setActiveTab} className="flex min-h-0 w-full flex-1 flex-col">
-				<div className={cn("relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-sm border")}>
-					<div className="absolute top-3 right-3 z-10 flex items-center gap-1.5">
-						<TabsList className="bg-muted h-8 shadow-sm backdrop-blur">
-							<TabsTrigger value="rendered" className="h-6 px-2.5 text-xs">
-								Rendered
-							</TabsTrigger>
-							<TabsTrigger value="raw" className="h-6 px-2.5 text-xs">
-								Raw
-							</TabsTrigger>
-						</TabsList>
-					</div>
-					<TabsContent value="rendered" className="m-0 flex-1 overflow-y-auto">
-						<div className="min-w-0 p-4">
-							<Markdown
-								content={body || ""}
-								className="max-w-full text-sm break-words [&_*]:max-w-full [&_*]:break-words [&_a]:break-all [&_code]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:whitespace-pre-wrap [&_table]:table-fixed"
-								components={markdownComponents}
-							/>
-						</div>
-					</TabsContent>
-					<TabsContent value="raw" className="m-0 flex-1 overflow-y-auto">
-						<pre className="min-h-full p-4 font-mono text-xs leading-5 whitespace-pre-wrap">{body || "(empty)"}</pre>
-					</TabsContent>
-				</div>
-			</Tabs>
+		<>
+			<Markdown content={content || ""} className={className} components={markdownComponents} />
 
 			<Dialog open={externalLink != null} onOpenChange={(open) => !open && setExternalLink(null)}>
 				<DialogContent>
@@ -337,7 +463,7 @@ export function ReadOnlySkillBody({ body }: { body: string }) {
 						<DialogTitle>Open external link?</DialogTitle>
 						<DialogDescription>This link opens outside Bifrost in a new browser tab.</DialogDescription>
 					</DialogHeader>
-					<div className="bg-muted/40 min-w-0 rounded-sm border px-3 py-2">
+					<div className="bg-muted/40 rounded-sm border px-3 py-2">
 						<p className="truncate text-sm font-medium">{externalLink?.label}</p>
 						<p className="text-muted-foreground truncate font-mono text-xs">{externalLink?.href}</p>
 					</div>
@@ -358,7 +484,54 @@ export function ReadOnlySkillBody({ body }: { body: string }) {
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
-		</FormSection>
+		</>
+	);
+}
+
+export function ReadOnlySkillBody({
+	body,
+	files = [],
+	onSelectFile,
+}: {
+	body: string;
+	files?: SkillFileEntry[];
+	onSelectFile?: (path: string) => void;
+}) {
+	const [activeTab, setActiveTab] = useState("preview");
+
+	return (
+		<Tabs
+			defaultValue="preview"
+			onValueChange={setActiveTab}
+			className="flex min-h-0 w-full flex-1 flex-col gap-2"
+		>
+			<div className="flex items-center justify-between gap-2">
+				<h2 className="text-foreground text-base font-semibold leading-[normal]">SKILL.md Body</h2>
+				<TabsList className="bg-muted h-8">
+					<TabsTrigger value="preview" className="h-6 px-2.5 text-xs">
+						Preview
+					</TabsTrigger>
+					<TabsTrigger value="raw" className="h-6 px-2.5 text-xs">
+						Raw
+					</TabsTrigger>
+				</TabsList>
+			</div>
+			<div className={cn("flex min-h-0 flex-1 flex-col overflow-hidden rounded-sm border")}>
+				<TabsContent value="preview" className="m-0 flex-1 overflow-y-auto">
+					<div className="p-4">
+						<SkillMarkdown
+							content={body}
+							files={files}
+							onSelectFile={onSelectFile}
+							className="max-w-full text-sm break-words [&_*]:max-w-full [&_*]:break-words [&_a]:break-all [&_code]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:whitespace-pre-wrap [&_table]:table-fixed"
+						/>
+					</div>
+				</TabsContent>
+				<TabsContent value="raw" className="m-0 flex-1 overflow-y-auto">
+					<pre className="min-h-full p-4 font-mono text-xs leading-5 whitespace-pre-wrap">{body || "(empty)"}</pre>
+				</TabsContent>
+			</div>
+		</Tabs>
 	);
 }
 
@@ -422,6 +595,7 @@ export function ReadOnlyFileTree({
 	bare = false,
 	selectedPath,
 	onSelectPath,
+	searchQuery = "",
 }: {
 	skillName: string;
 	files: SkillFileEntry[];
@@ -434,7 +608,14 @@ export function ReadOnlyFileTree({
 	// is reported as SKILLMD_KEY.
 	selectedPath?: string;
 	onSelectPath?: (path: string) => void;
+	// Filters the tree to files whose path matches (case-insensitive substring).
+	searchQuery?: string;
 }) {
+	const query = searchQuery.trim().toLowerCase();
+	const filteredFiles = useMemo(
+		() => (query ? files.filter((f) => f.path.toLowerCase().includes(query)) : files),
+		[files, query],
+	);
 	const treeData = useMemo((): TreeNode<FileTreeNodeData>[] => {
 		interface FolderBucket {
 			files: SkillFileEntry[];
@@ -442,7 +623,7 @@ export function ReadOnlyFileTree({
 		}
 		const rootBucket: FolderBucket = { files: [], subfolders: {} };
 
-		for (const file of files) {
+		for (const file of filteredFiles) {
 			const segments = file.path.split("/").filter(Boolean);
 			if (segments.length === 0) continue;
 			segments.pop();
@@ -495,10 +676,35 @@ export function ReadOnlyFileTree({
 					type: "root",
 					childCount: Object.keys(rootBucket.subfolders).length + rootBucket.files.length,
 				},
-				children: [{ data: { id: "skillmd", name: "SKILL.md", type: "skillmd" } }, ...bucketToNodes(rootBucket, "")],
+				children: [
+					...(query ? [] : [{ data: { id: "skillmd", name: "SKILL.md", type: "skillmd" as const } }]),
+					...bucketToNodes(rootBucket, ""),
+				],
 			},
 		];
-	}, [skillName, files]);
+	}, [skillName, filteredFiles, query]);
+
+	// Own the expansion state so we can programmatically reveal a file selected from
+	// outside the tree (e.g. a markdown link), expanding its ancestor folders.
+	const [expandedNodes, setExpandedNodes] = useState<Record<string, boolean>>({});
+
+	useEffect(() => {
+		if (!selectedPath || selectedPath === SKILLMD_KEY) return;
+		const segments = selectedPath.split("/").filter(Boolean);
+		segments.pop(); // drop the file name, keep folder ancestors
+		if (segments.length === 0) return;
+		setExpandedNodes((prev) => {
+			const next: Record<string, boolean> = { ...prev, root: true };
+			let path = "";
+			for (const segment of segments) {
+				path = path ? `${path}/${segment}` : segment;
+				next[`folder-${path}`] = true;
+			}
+			// Skip the state update if every ancestor is already expanded.
+			const changed = Object.keys(next).some((id) => next[id] !== prev[id]);
+			return changed ? next : prev;
+		});
+	}, [selectedPath]);
 
 	const downloadUrl = `${getApiBaseUrl()}/skills/serve/${encodeURIComponent(skillName)}/download.zip`;
 
@@ -506,8 +712,10 @@ export function ReadOnlyFileTree({
 		<TooltipProvider>
 			<Tree<FileTreeNodeData>
 				data={treeData}
-				levelsToExpandByDefault={1}
+				levelsToExpandByDefault={query ? 99 : 1}
+				states={{ expandedNodes, setExpandedNodes }}
 				indentSize={28}
+				fitContainer
 				renderItem={({ item, isExpanded, hasChildren, onToggle, onExpandAll, onCollapseAll, isAllExpanded, isAllCollapsed }) => {
 					const isFolder = item.type === "root" || item.type === "folder";
 					const isSkillMd = item.type === "skillmd";
@@ -673,8 +881,8 @@ export function SkillReadOnlyContent({
 	const hasFrontmatter = extraFrontmatter && Object.keys(extraFrontmatter).length > 0;
 
 	return (
-		<div className={cn("flex min-h-0 w-full gap-3", className)}>
-			<div className="flex w-72 shrink-0 flex-col gap-2">
+		<ResizablePanelGroup direction="horizontal" className={cn("min-h-0 w-full", className)}>
+			<ResizablePanel defaultSize="28%" minSize="18%" maxSize="50%" className="flex min-h-0 flex-col gap-2">
 				{/* Metadata & Frontmatter buttons */}
 				{(hasMetadata || hasFrontmatter) && (
 					<div className="flex gap-1.5">
@@ -717,10 +925,12 @@ export function SkillReadOnlyContent({
 					selectedPath={selected === METADATA_KEY || selected === FRONTMATTER_KEY ? undefined : selected}
 					onSelectPath={setSelected}
 				/>
-			</div>
+			</ResizablePanel>
+
+			<ResizableHandle className="mx-1.5 bg-transparent" />
 
 			{/* Right: content pane */}
-			<div className="flex grow flex-col overflow-auto">
+			<ResizablePanel defaultSize="72%" minSize="30%" className="flex min-h-0 flex-col overflow-auto">
 				{selected === METADATA_KEY && metadata ? (
 					<ReadOnlyMetadataTable value={metadata} />
 				) : selected === FRONTMATTER_KEY && extraFrontmatter ? (
@@ -728,14 +938,12 @@ export function SkillReadOnlyContent({
 				) : selectedFile ? (
 					<FilePreviewPane file={selectedFile} skillName={skillName} mode="view" />
 				) : (
-					<ReadOnlySkillBody body={skillMdBody} />
+					<ReadOnlySkillBody body={skillMdBody} files={files} onSelectFile={setSelected} />
 				)}
-			</div>
-		</div>
+			</ResizablePanel>
+		</ResizablePanelGroup>
 	);
 }
-
-const FILES_COLLAPSE_STORAGE_KEY = "skill-files-sidebar-collapsed";
 
 function SkillFilesSidebar({
 	skillName,
@@ -750,54 +958,22 @@ function SkillFilesSidebar({
 	selectedPath?: string;
 	onSelectPath?: (path: string) => void;
 }) {
-	const [collapsed, setCollapsed] = useState(() => {
-		if (typeof window === "undefined") return false;
-		return window.localStorage.getItem(FILES_COLLAPSE_STORAGE_KEY) === "true";
-	});
-
-	const toggleCollapsed = () => {
-		setCollapsed((prev) => {
-			const next = !prev;
-			if (typeof window !== "undefined") {
-				window.localStorage.setItem(FILES_COLLAPSE_STORAGE_KEY, String(next));
-			}
-			return next;
-		});
-	};
-
-	// Collapsed: thin rail with a vertical "Files" label — the whole rail expands on click
-	if (collapsed) {
-		return (
-			<button
-				type="button"
-				data-testid="skill-files-sidebar-show-btn"
-				onClick={toggleCollapsed}
-				className="bg-card group flex h-full w-10 shrink-0 cursor-pointer flex-col items-center gap-3 rounded-md border py-4 text-sm font-medium"
-				title="Show files"
-				aria-label="Show files"
-			>
-				<PanelLeftOpen className="text-muted-foreground group-hover:text-foreground size-4 transition-colors" />
-				<span className="rotate-180 select-none [writing-mode:vertical-rl]">Files</span>
-			</button>
-		);
-	}
+	const [searchQuery, setSearchQuery] = useState("");
 
 	return (
-		<div className="bg-card flex h-full w-72 shrink-0 flex-col rounded-md border">
-			{/* Header */}
-			<div className="flex h-11 items-center justify-between border-b pr-2 pl-4">
-				<span className="text-sm font-semibold">Files</span>
-				<Button
-					variant="ghost"
-					size="icon"
-					data-testid="skill-files-sidebar-hide-btn"
-					className="size-7"
-					onClick={toggleCollapsed}
-					title="Hide files"
-					aria-label="Hide files"
-				>
-					<PanelLeftClose className="size-4" />
-				</Button>
+		<div className="bg-card flex h-full w-full min-w-0 flex-col rounded-md border">
+			{/* Header: search */}
+			<div className="flex h-9 items-center border-b">
+				<div className="relative grow">
+					<Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+					<Input
+						placeholder="Search files..."
+						value={searchQuery}
+						onChange={(e) => setSearchQuery(e.target.value)}
+						data-testid="sidebar-search"
+						className="h-9 border-none pl-8 shadow-none focus-visible:ring-0"
+					/>
+				</div>
 			</div>
 
 			{/* Scrollable tree */}
@@ -810,6 +986,7 @@ function SkillFilesSidebar({
 						composedSkillMd={composedSkillMd}
 						selectedPath={selectedPath}
 						onSelectPath={onSelectPath}
+						searchQuery={searchQuery}
 					/>
 				</div>
 			</ScrollArea>

--- a/ui/app/workspace/skills-repo/components/skillDetailsView.tsx
+++ b/ui/app/workspace/skills-repo/components/skillDetailsView.tsx
@@ -13,6 +13,7 @@ import {
 import FullPageLoader from "@/components/fullPageLoader";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { SplitButton } from "@/components/ui/splitButton";
 import { useGetSkillQuery, useUpdateSkillMutation, useDeleteSkillMutation } from "@/lib/store/apis/skillsApi";
 import { getErrorMessage } from "@/lib/store/apis/baseApi";
 import { SkillFile, SkillVersionSummary } from "@/lib/types/skills";
@@ -26,7 +27,7 @@ import { type SkillFormState, composeFrontmatter, useSkillForm } from "./helpers
 import { SkillHeader } from "./shared";
 import { SkillFormFields } from "../forms/skillEditFormFields";
 import { SkillEditView } from "../forms/skillEditForm";
-import { SkillVersionsPopover } from "../dialogs/skillVersionDialog";
+import { SkillVersionsList } from "../dialogs/skillVersionDialog";
 import { VersionDetailDialog } from "../dialogs/versionDetailsDialog";
 
 // ---------- SkillDetailView ----------
@@ -50,6 +51,7 @@ export function SkillDetailView({
 	const [deleteSkill, { isLoading: isDeleting }] = useDeleteSkillMutation();
 
 	const [selectedVersion, setSelectedVersion] = useState<SkillVersionSummary | null>(null);
+	const [versionsOpen, setVersionsOpen] = useState(false);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
 	const form = useSkillForm();
@@ -171,6 +173,7 @@ export function SkillDetailView({
 					onSave={handleSave}
 					onCancel={handleCancelEdit}
 					onBack={handleCancelEdit}
+					onNavigateToList={onBack}
 					isSaving={isUpdating}
 				/>
 			) : (
@@ -201,13 +204,41 @@ export function SkillDetailView({
 						onBack={onBack}
 						actions={
 							<>
-								<SkillVersionsPopover skillId={skillId} servingVersion={skill.latest_version} onSelectVersion={setSelectedVersion} />
-								{hasEditAccess && (
-									<Button size="sm" data-testid="skill-add-version-btn" onClick={() => setIsEditing(true)}>
-										<Plus className="h-3.5 w-3.5" />
-										Add New Version
-									</Button>
-								)}
+								<SplitButton
+									onClick={() => setIsEditing(true)}
+									variant="outline"
+									disabledCheck
+									dropdownTrigger={{
+										className: "bg-transparent",
+										dataTestId: "skill-versions-popover-trigger",
+										"aria-label": `Versions for ${skill.name}`,
+									}}
+									button={{
+										dataTestId: "skill-add-version-btn",
+										className: "bg-transparent",
+										disabled: !hasEditAccess,
+									}}
+									dropdownContent={{
+										align: "end",
+										className: "w-72 p-0",
+										open: versionsOpen,
+										onOpenChange: setVersionsOpen,
+										children: (
+											<SkillVersionsList
+												skillId={skillId}
+												servingVersion={skill.latest_version}
+												open={versionsOpen}
+												onSelectVersion={(v) => {
+													setSelectedVersion(v);
+													setVersionsOpen(false);
+												}}
+											/>
+										),
+									}}
+								>
+									<Plus className="h-3.5 w-3.5" />
+									Add New Version
+								</SplitButton>
 								<DropdownMenu>
 									<DropdownMenuTrigger asChild>
 										<Button variant="ghost" size="icon" className="h-8 w-8" aria-label={`Actions for ${skill.name}`}>

--- a/ui/app/workspace/skills-repo/components/skillListView.tsx
+++ b/ui/app/workspace/skills-repo/components/skillListView.tsx
@@ -1,158 +1,133 @@
 "use client";
 
+import FullPageLoader from "@/components/fullPageLoader";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
-import FullPageLoader from "@/components/fullPageLoader";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdownMenu";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
-  useListSkillsQuery,
-  useDeleteSkillMutation,
-  useGetAllSkillsVersionQuery,
-  useBumpAllSkillsVersionMutation,
-} from "@/lib/store/apis/skillsApi";
-import { getErrorMessage } from "@/lib/store/apis/baseApi";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useGetCoreConfigQuery } from "@/lib/store";
-import { getApiBaseUrl } from "@/lib/utils/port";
+import { getErrorMessage } from "@/lib/store/apis/baseApi";
+import {
+	useBumpAllSkillsVersionMutation,
+	useDeleteSkillMutation,
+	useGetAllSkillsVersionQuery,
+	useListSkillsQuery,
+} from "@/lib/store/apis/skillsApi";
+import { AllSkillsVersionBump, SkillListItem } from "@/lib/types/skills";
 import { cn } from "@/lib/utils";
-import { SkillListItem, AllSkillsVersionBump } from "@/lib/types/skills";
+import { getApiBaseUrl } from "@/lib/utils/port";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import {
-  ArrowDown,
-  ArrowUp,
-  ArrowUpDown,
-  Check,
-  Clipboard,
-  Info,
-  Download,
-  Loader2,
-  ChevronLeft,
-  ChevronRight,
-  FileText,
-  MoreHorizontal,
-  Package,
-  Plus,
-  Search,
-  Trash2,
-  ChevronDown,
-  ArrowUpRight,
-  BookOpenText,
+	ArrowDown,
+	ArrowUp,
+	ArrowUpDown,
+	ArrowUpRight,
+	BookOpenText,
+	Check,
+	ChevronDown,
+	ChevronLeft,
+	ChevronRight,
+	Clipboard,
+	Download,
+	FileText,
+	Info,
+	Loader2,
+	MoreHorizontal,
+	Package,
+	Plus,
+	Search,
+	Trash2,
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { PAGE_SIZE, formatDateShort, useDebouncedValue } from "./helpers";
 
-const SKILLS_REPOSITORY_DOCS_URL =
-  "https://docs.getbifrost.ai/features/skills-repository";
+const SKILLS_REPOSITORY_DOCS_URL = "https://docs.getbifrost.ai/features/skills-repository";
 
 // ---------- MarketplacePopover ----------
 
 function MarketplacePopover() {
-  const [copiedKey, setCopiedKey] = useState<string | null>(null);
-  const [open, setOpen] = useState(false);
-  const marketplaceBaseUrl = getApiBaseUrl();
+	const [copiedKey, setCopiedKey] = useState<string | null>(null);
+	const [open, setOpen] = useState(false);
+	const marketplaceBaseUrl = getApiBaseUrl();
 
-  const items = [
-    {
-      key: "claude",
-      label: "Claude Code",
-      command: `claude plugin marketplace add ${marketplaceBaseUrl}/skills/serve/claude-code/.claude-plugin/marketplace.json`,
-    },
-    {
-      key: "codex",
-      label: "Codex",
-      command: `codex plugin marketplace add ${marketplaceBaseUrl}/skills/serve/codex`,
-    },
-  ];
+	const items = [
+		{
+			key: "claude",
+			label: "Claude Code",
+			command: `claude plugin marketplace add ${marketplaceBaseUrl}/skills/serve/claude-code/.claude-plugin/marketplace.json`,
+		},
+		{
+			key: "codex",
+			label: "Codex",
+			command: `codex plugin marketplace add ${marketplaceBaseUrl}/skills/serve/codex`,
+		},
+	];
 
-  const handleCopy = (key: string, text: string) => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        setCopiedKey(key);
-        setOpen(false);
-        toast.success("Copied to clipboard");
-        setTimeout(() => setCopiedKey(null), 2000);
-      })
-      .catch(() => {
-        toast.error("Failed to copy to clipboard");
-      });
-  };
+	const handleCopy = (key: string, text: string) => {
+		navigator.clipboard
+			.writeText(text)
+			.then(() => {
+				setCopiedKey(key);
+				setOpen(false);
+				toast.success("Copied to clipboard");
+				setTimeout(() => setCopiedKey(null), 2000);
+			})
+			.catch(() => {
+				toast.error("Failed to copy to clipboard");
+			});
+	};
 
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button variant="outline" size="sm">
-          <Package className="h-3.5 w-3.5" />
-          Register as Marketplace
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-auto max-w-md p-0">
-        <div className="px-3 py-2 border-b">
-          <p className="text-xs font-medium text-muted-foreground">
-            Copy CLI command to register this repository
-          </p>
-        </div>
-        <div className="py-1">
-          {items.map((item) => (
-            <button
-              key={item.key}
-              data-testid={`skill-copy-marketplace-${item.key}`}
-              className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-muted/50 transition-colors cursor-pointer"
-              aria-label={`Copy ${item.label} command`}
-              onClick={() => handleCopy(item.key, item.command)}
-            >
-              <div className="min-w-0 flex-1">
-                <p className="text-xs font-medium">{item.label}</p>
-                <p className="text-xs font-mono text-muted-foreground truncate mt-0.5">
-                  {item.command}
-                </p>
-              </div>
-              {copiedKey === item.key ? (
-                <Check className="h-3.5 w-3.5 shrink-0 text-green-500" />
-              ) : (
-                <Clipboard className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              )}
-            </button>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button variant="outline" size="sm">
+					<Package className="h-3.5 w-3.5" />
+					Register as Marketplace
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="end" className="w-auto max-w-md p-0">
+				<div className="border-b px-3 py-2">
+					<p className="text-muted-foreground text-xs font-medium">Copy CLI command to register this repository</p>
+				</div>
+				<div className="py-1">
+					{items.map((item) => (
+						<button
+							key={item.key}
+							data-testid={`skill-copy-marketplace-${item.key}`}
+							className="hover:bg-muted/50 flex w-full cursor-pointer items-center gap-3 px-3 py-2 text-left transition-colors"
+							aria-label={`Copy ${item.label} command`}
+							onClick={() => handleCopy(item.key, item.command)}
+						>
+							<div className="min-w-0 flex-1">
+								<p className="text-xs font-medium">{item.label}</p>
+								<p className="text-muted-foreground mt-0.5 truncate font-mono text-xs">{item.command}</p>
+							</div>
+							{copiedKey === item.key ? (
+								<Check className="h-3.5 w-3.5 shrink-0 text-green-500" />
+							) : (
+								<Clipboard className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+							)}
+						</button>
+					))}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
 }
 
 // ---------- SortableHeader ----------
@@ -161,637 +136,543 @@ type SortColumn = "name" | "updated_at";
 type SortOrder = "asc" | "desc";
 
 function SortableHeader({
-  column,
-  label,
-  sortBy,
-  order,
-  onToggle,
+	column,
+	label,
+	sortBy,
+	order,
+	onToggle,
 }: {
-  column: SortColumn;
-  label: string;
-  sortBy: SortColumn | null;
-  order: SortOrder;
-  onToggle: (column: SortColumn) => void;
+	column: SortColumn;
+	label: string;
+	sortBy: SortColumn | null;
+	order: SortOrder;
+	onToggle: (column: SortColumn) => void;
 }) {
-  const isActive = sortBy === column;
-  let Icon = ArrowUpDown;
-  if (isActive && order === "desc") Icon = ArrowDown;
-  else if (isActive) Icon = ArrowUp;
-  return (
-    <Button
-      variant="ghost"
-      onClick={() => onToggle(column)}
-      className="!px-0"
-      data-testid={`skill-sort-${column}`}
-      aria-label={`Sort by ${label}`}
-    >
-      {label}
-      <Icon className={cn("h-4 w-4", isActive && "text-foreground")} />
-    </Button>
-  );
+	const isActive = sortBy === column;
+	let Icon = ArrowUpDown;
+	if (isActive && order === "desc") Icon = ArrowDown;
+	else if (isActive) Icon = ArrowUp;
+	return (
+		<Button
+			variant="ghost"
+			onClick={() => onToggle(column)}
+			className="!px-0"
+			data-testid={`skill-sort-${column}`}
+			aria-label={`Sort by ${label}`}
+		>
+			{label}
+			<Icon className={cn("h-4 w-4", isActive && "text-foreground")} />
+		</Button>
+	);
 }
 
 // ---------- SkillActionsMenu ----------
 
 function SkillActionsMenu({
-  skill,
-  hasEditAccess,
-  hasDeleteAccess,
-  isDeleting,
-  onEdit,
-  onDelete,
+	skill,
+	hasEditAccess,
+	hasDeleteAccess,
+	isDeleting,
+	onEdit,
+	onDelete,
 }: {
-  skill: SkillListItem;
-  hasEditAccess: boolean;
-  hasDeleteAccess: boolean;
-  isDeleting: boolean;
-  onEdit: (id: string) => void;
-  onDelete: (id: string) => Promise<void>;
+	skill: SkillListItem;
+	hasEditAccess: boolean;
+	hasDeleteAccess: boolean;
+	isDeleting: boolean;
+	onEdit: (id: string) => void;
+	onDelete: (id: string) => Promise<void>;
 }) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [isDownloading, setIsDownloading] = useState(false);
+	const [isOpen, setIsOpen] = useState(false);
+	const [deleteOpen, setDeleteOpen] = useState(false);
+	const [isDownloading, setIsDownloading] = useState(false);
 
-  const handleDownload = async () => {
-    setIsDownloading(true);
-    let url: string | undefined;
-    try {
-      const res = await fetch(
-        `${getApiBaseUrl()}/skills/serve/${encodeURIComponent(skill.name)}/download.zip`,
-      );
-      if (!res.ok) throw new Error("Download failed");
-      const blob = await res.blob();
-      url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = `${skill.name}.zip`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    } catch {
-      toast.error("Failed to download skill");
-    } finally {
-      if (url) URL.revokeObjectURL(url);
-      setIsDownloading(false);
-    }
-  };
+	const handleDownload = async () => {
+		setIsDownloading(true);
+		let url: string | undefined;
+		try {
+			const res = await fetch(`${getApiBaseUrl()}/skills/serve/${encodeURIComponent(skill.name)}/download.zip`);
+			if (!res.ok) throw new Error("Download failed");
+			const blob = await res.blob();
+			url = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = `${skill.name}.zip`;
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
+		} catch {
+			toast.error("Failed to download skill");
+		} finally {
+			if (url) URL.revokeObjectURL(url);
+			setIsDownloading(false);
+		}
+	};
 
-  return (
-    <>
-      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            data-testid={`skill-actions-menu-${skill.name}`}
-            aria-label={`Actions for ${skill.name}`}
-          >
-            <MoreHorizontal className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            className="cursor-pointer"
-            data-testid={`skill-download-btn-${skill.name}`}
-            disabled={isDownloading}
-            onSelect={(e) => {
-              e.preventDefault();
-              handleDownload();
-              setIsOpen(false);
-            }}
-          >
-            {isDownloading ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Download className="h-4 w-4" />
-            )}
-            {isDownloading ? "Downloading..." : "Download ZIP"}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            variant="destructive"
-            className="cursor-pointer"
-            data-testid={`skill-delete-btn-${skill.name}`}
-            disabled={!hasDeleteAccess || isDeleting}
-            onSelect={(e) => {
-              e.preventDefault();
-              setDeleteOpen(true);
-              setIsOpen(false);
-            }}
-          >
-            <Trash2 className="h-4 w-4" />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+	return (
+		<>
+			<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+				<DropdownMenuTrigger asChild>
+					<Button
+						variant="ghost"
+						size="icon"
+						className="h-8 w-8"
+						data-testid={`skill-actions-menu-${skill.name}`}
+						aria-label={`Actions for ${skill.name}`}
+					>
+						<MoreHorizontal className="h-4 w-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuItem
+						className="cursor-pointer"
+						data-testid={`skill-download-btn-${skill.name}`}
+						disabled={isDownloading}
+						onSelect={(e) => {
+							e.preventDefault();
+							handleDownload();
+							setIsOpen(false);
+						}}
+					>
+						{isDownloading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+						{isDownloading ? "Downloading..." : "Download ZIP"}
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						variant="destructive"
+						className="cursor-pointer"
+						data-testid={`skill-delete-btn-${skill.name}`}
+						disabled={!hasDeleteAccess || isDeleting}
+						onSelect={(e) => {
+							e.preventDefault();
+							setDeleteOpen(true);
+							setIsOpen(false);
+						}}
+					>
+						<Trash2 className="h-4 w-4" />
+						Delete
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
 
-      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete {skill.name}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action cannot be undone. The skill, its files, and version
-              history will be permanently deleted.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              data-testid="skill-delete-confirm-btn"
-              onClick={() => onDelete(skill.id)}
-              disabled={isDeleting}
-            >
-              {isDeleting ? (
-                <>
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" /> Deleting...
-                </>
-              ) : (
-                "Delete skill"
-              )}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
-  );
+			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete {skill.name}?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone. The skill, its files, and version history will be permanently deleted.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction data-testid="skill-delete-confirm-btn" onClick={() => onDelete(skill.id)} disabled={isDeleting}>
+							{isDeleting ? (
+								<>
+									<Loader2 className="h-3.5 w-3.5 animate-spin" /> Deleting...
+								</>
+							) : (
+								"Delete skill"
+							)}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
+	);
 }
 
 // ---------- SkillsListView ----------
 
 export function SkillsListView({
-  onSelectSkill,
-  onCreateNew,
+	onSelectSkill,
+	onCreateNew,
 }: {
-  onSelectSkill: (id: string, edit?: boolean) => void;
-  onCreateNew: () => void;
+	onSelectSkill: (id: string, edit?: boolean) => void;
+	onCreateNew: () => void;
 }) {
-  const hasCreateAccess = useRbac(
-    RbacResource.SkillsRepository,
-    RbacOperation.Create,
-  );
-  const hasEditAccess = useRbac(
-    RbacResource.SkillsRepository,
-    RbacOperation.Update,
-  );
-  const hasDeleteAccess = useRbac(
-    RbacResource.SkillsRepository,
-    RbacOperation.Delete,
-  );
-  const { data: bifrostConfig } = useGetCoreConfigQuery({});
-  const isGitAvailable = bifrostConfig?.is_git_available ?? false;
-  const [deleteSkill, { isLoading: isDeleting }] = useDeleteSkillMutation();
-  const { data: allSkillsVersionData, refetch: refetchAllSkillsVersion } =
-    useGetAllSkillsVersionQuery();
-  const [bumpAllSkillsVersion, { isLoading: isBumpingAllSkillsVersion }] =
-    useBumpAllSkillsVersionMutation();
+	const hasCreateAccess = useRbac(RbacResource.SkillsRepository, RbacOperation.Create);
+	const hasEditAccess = useRbac(RbacResource.SkillsRepository, RbacOperation.Update);
+	const hasDeleteAccess = useRbac(RbacResource.SkillsRepository, RbacOperation.Delete);
+	const { data: bifrostConfig } = useGetCoreConfigQuery({});
+	const isGitAvailable = bifrostConfig?.is_git_available ?? false;
+	const [deleteSkill, { isLoading: isDeleting }] = useDeleteSkillMutation();
+	const { data: allSkillsVersionData, refetch: refetchAllSkillsVersion } = useGetAllSkillsVersionQuery();
+	const [bumpAllSkillsVersion, { isLoading: isBumpingAllSkillsVersion }] = useBumpAllSkillsVersionMutation();
 
-  const [isDownloadingAll, setIsDownloadingAll] = useState(false);
-  const [search, setSearch] = useState("");
-  const debouncedSearch = useDebouncedValue(search, 300);
-  const [offset, setOffset] = useState(0);
-  const [sortBy, setSortBy] = useState<SortColumn | null>(null);
-  const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
+	const [isDownloadingAll, setIsDownloadingAll] = useState(false);
+	const [search, setSearch] = useState("");
+	const debouncedSearch = useDebouncedValue(search, 300);
+	const [offset, setOffset] = useState(0);
+	const [sortBy, setSortBy] = useState<SortColumn | null>(null);
+	const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
 
-  const { data, isLoading, isFetching, isError, refetch } = useListSkillsQuery({
-    limit: PAGE_SIZE,
-    offset,
-    search: debouncedSearch || undefined,
-    sort_by: sortBy || undefined,
-    order: sortBy ? sortOrder : undefined,
-  });
+	const { data, isLoading, isFetching, isError, refetch } = useListSkillsQuery({
+		limit: PAGE_SIZE,
+		offset,
+		search: debouncedSearch || undefined,
+		sort_by: sortBy || undefined,
+		order: sortBy ? sortOrder : undefined,
+	});
 
-  const skills = data?.skills || [];
-  const total = data?.total || 0;
+	const skills = data?.skills || [];
+	const total = data?.total || 0;
+	const isSearchSettling = search !== debouncedSearch;
 
-  const toggleSort = (column: SortColumn) => {
-    setOffset(0);
-    if (sortBy === column) {
-      if (sortOrder === "asc") {
-        setSortOrder("desc");
-      } else {
-        setSortBy(null);
-        setSortOrder("asc");
-      }
-    } else {
-      setSortBy(column);
-      setSortOrder("asc");
-    }
-  };
+	const toggleSort = (column: SortColumn) => {
+		setOffset(0);
+		if (sortBy === column) {
+			if (sortOrder === "asc") {
+				setSortOrder("desc");
+			} else {
+				setSortBy(null);
+				setSortOrder("asc");
+			}
+		} else {
+			setSortBy(column);
+			setSortOrder("asc");
+		}
+	};
 
-  const handleDeleteSkill = async (id: string) => {
-    try {
-      await deleteSkill(id).unwrap();
-      toast.success("Skill deleted");
-    } catch (err: unknown) {
-      toast.error("Failed to delete skill", {
-        description: getErrorMessage(err),
-      });
-    }
-  };
+	const handleDeleteSkill = async (id: string) => {
+		try {
+			await deleteSkill(id).unwrap();
+			toast.success("Skill deleted");
+		} catch (err: unknown) {
+			toast.error("Failed to delete skill", {
+				description: getErrorMessage(err),
+			});
+		}
+	};
 
-  const handleBumpAllSkillsVersion = async (bump: AllSkillsVersionBump) => {
-    try {
-      const result = await bumpAllSkillsVersion({ bump }).unwrap();
-      toast.success(`All-skills version bumped to ${result.version}`);
-      refetchAllSkillsVersion();
-    } catch (err: unknown) {
-      toast.error("Failed to bump all-skills version", {
-        description: getErrorMessage(err),
-      });
-    }
-  };
+	const handleBumpAllSkillsVersion = async (bump: AllSkillsVersionBump) => {
+		try {
+			const result = await bumpAllSkillsVersion({ bump }).unwrap();
+			toast.success(`All-skills version bumped to ${result.version}`);
+			refetchAllSkillsVersion();
+		} catch (err: unknown) {
+			toast.error("Failed to bump all-skills version", {
+				description: getErrorMessage(err),
+			});
+		}
+	};
 
-  if (isLoading) {
-    return <FullPageLoader />;
-  }
+	if (isLoading) {
+		return <FullPageLoader />;
+	}
 
-  if (isError) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-3 py-20">
-        <p className="text-muted-foreground text-sm">Failed to load skills</p>
-        <Button variant="outline" size="sm" onClick={refetch}>
-          Retry
-        </Button>
-      </div>
-    );
-  }
+	if (isError) {
+		return (
+			<div className="flex flex-col items-center justify-center gap-3 py-20">
+				<p className="text-muted-foreground text-sm">Failed to load skills</p>
+				<Button variant="outline" size="sm" onClick={refetch}>
+					Retry
+				</Button>
+			</div>
+		);
+	}
 
-  // True empty state: no skills at all (not just filtered to zero)
-  if (total === 0 && !search && !isFetching) {
-    return (
-      <div
-        className="flex h-full w-full flex-col items-center justify-center gap-4 py-16 text-center"
-        data-testid="skills-repo-empty-state"
-      >
-        <div className="text-muted-foreground">
-          <BookOpenText className="h-24 w-24" strokeWidth={1} />
-        </div>
-        <div className="flex flex-col gap-1">
-          <h1 className="text-muted-foreground text-xl font-medium">
-            Create, version, and share Agent Skills from Bifrost
-          </h1>
-          <div className="text-muted-foreground mx-auto mt-2 max-w-xl text-sm font-normal">
-            Manage SKILL.md instructions and supporting files in one place,
-            publish immutable versions, and expose them as installable plugins
-            for Claude Code, Codex, and other skill-aware clients.
-          </div>
-          <div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-            <Button
-              variant="outline"
-              aria-label="Read more about skills (opens in new tab)"
-              data-testid="skills-button-read-more"
-              onClick={() => {
-                window.open(
-                  `${SKILLS_REPOSITORY_DOCS_URL}?utm_source=bfd`,
-                  "_blank",
-                  "noopener,noreferrer",
-                );
-              }}
-            >
-              Read more{" "}
-              <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-            </Button>
-            {hasCreateAccess && (
-              <Button
-                aria-label="Create your first skill"
-                data-testid="skill-create-btn"
-                onClick={onCreateNew}
-              >
-                Create Skill
-              </Button>
-            )}
-          </div>
-        </div>
-      </div>
-    );
-  }
+	// True empty state: no skills at all (not just filtered to zero)
+	if (total === 0 && !search && !debouncedSearch && !isFetching) {
+		return (
+			<div className="flex h-full w-full flex-col items-center justify-center gap-4 text-center" data-testid="skills-repo-empty-state">
+				<div className="text-muted-foreground">
+					<BookOpenText className="h-24 w-24" strokeWidth={1} />
+				</div>
+				<div className="flex flex-col gap-1">
+					<h1 className="text-muted-foreground text-xl font-medium">Create, version, and share Agent Skills from Bifrost</h1>
+					<div className="text-muted-foreground mx-auto mt-2 max-w-xl text-sm font-normal">
+						Manage SKILL.md instructions and supporting files in one place, publish immutable versions, and expose them as installable
+						plugins for Claude Code, Codex, and other skill-aware clients.
+					</div>
+					<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
+						<Button
+							variant="outline"
+							aria-label="Read more about skills (opens in new tab)"
+							data-testid="skills-button-read-more"
+							onClick={() => {
+								window.open(`${SKILLS_REPOSITORY_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
+							}}
+						>
+							Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
+						</Button>
+						{hasCreateAccess && (
+							<Button aria-label="Create your first skill" data-testid="skill-create-btn" onClick={onCreateNew}>
+								Create Skill
+							</Button>
+						)}
+					</div>
+				</div>
+			</div>
+		);
+	}
 
-  return (
-    <div className="w-full flex-1 flex flex-col">
-      {/* Header */}
-      <div className="flex shrink-0 items-center justify-between mb-4">
-        <div>
-          <div className="flex items-center gap-2">
-            <h2 className="text-lg font-semibold">Skills Repository</h2>
-            <Badge aria-label="Skills Repository is in beta">Beta</Badge>
-          </div>
-          <p className="text-muted-foreground text-sm">
-            Manage Agent Skills for distribution to AI coding assistants
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {isGitAvailable ? (
-            <MarketplacePopover />
-          ) : (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span tabIndex={0}>
-                  <Button variant="outline" size="sm" disabled>
-                    <Package className="h-3.5 w-3.5" />
-                    Register as Marketplace
-                  </Button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                <p className="max-w-xs text-xs">
-                  Git is not available on the server. Install git and restart
-                  Bifrost to enable marketplace registration for Claude Code and
-                  Codex.
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          )}
-          <Button
-            variant="outline"
-            size="sm"
-            data-testid="skill-download-all-btn"
-            onClick={async () => {
-              setIsDownloadingAll(true);
-              try {
-                const res = await fetch(
-                  `${getApiBaseUrl()}/skills/serve/all/download.zip`,
-                );
-                if (!res.ok) throw new Error("Download failed");
-                const blob = await res.blob();
-                const url = URL.createObjectURL(blob);
-                const link = document.createElement("a");
-                link.href = url;
-                link.download = "all-skills.zip";
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-                URL.revokeObjectURL(url);
-              } catch {
-                toast.error("Failed to download skills");
-              } finally {
-                setIsDownloadingAll(false);
-              }
-            }}
-            disabled={!skills?.length || isDownloadingAll}
-          >
-            {isDownloadingAll ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Download className="h-4 w-4" />
-            )}
-            {isDownloadingAll ? "Downloading..." : "Download All Skills"}
-          </Button>
-          {hasCreateAccess && (
-            <Button
-              data-testid="skill-create-btn"
-              onClick={onCreateNew}
-              size="sm"
-            >
-              <Plus className="h-4 w-4" />
-              New Skill
-            </Button>
-          )}
-        </div>
-      </div>
+	return (
+		<div className="flex w-full flex-1 flex-col">
+			{/* Header */}
+			<div className="mb-4 flex shrink-0 items-center justify-between">
+				<div>
+					<div className="flex items-center gap-2">
+						<h2 className="text-lg font-semibold">Skills Repository</h2>
+						<Badge aria-label="Skills Repository is in beta">Beta</Badge>
+					</div>
+					<p className="text-muted-foreground text-sm">Manage Agent Skills for distribution to AI coding assistants</p>
+				</div>
+				<div className="flex items-center gap-2">
+					{isGitAvailable ? (
+						<MarketplacePopover />
+					) : (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span tabIndex={0}>
+									<Button variant="outline" size="sm" disabled>
+										<Package className="h-3.5 w-3.5" />
+										Register as Marketplace
+									</Button>
+								</span>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">
+								<p className="max-w-xs text-xs">
+									Git is not available on the server. Install git and restart Bifrost to enable marketplace registration for Claude Code and
+									Codex.
+								</p>
+							</TooltipContent>
+						</Tooltip>
+					)}
+					<Button
+						variant="outline"
+						size="sm"
+						data-testid="skill-download-all-btn"
+						onClick={async () => {
+							setIsDownloadingAll(true);
+							try {
+								const res = await fetch(`${getApiBaseUrl()}/skills/serve/all/download.zip`);
+								if (!res.ok) throw new Error("Download failed");
+								const blob = await res.blob();
+								const url = URL.createObjectURL(blob);
+								const link = document.createElement("a");
+								link.href = url;
+								link.download = "all-skills.zip";
+								document.body.appendChild(link);
+								link.click();
+								document.body.removeChild(link);
+								URL.revokeObjectURL(url);
+							} catch {
+								toast.error("Failed to download skills");
+							} finally {
+								setIsDownloadingAll(false);
+							}
+						}}
+						disabled={!skills?.length || isDownloadingAll}
+					>
+						{isDownloadingAll ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+						{isDownloadingAll ? "Downloading..." : "Download All Skills"}
+					</Button>
+					{hasCreateAccess && (
+						<Button data-testid="skill-create-btn" onClick={onCreateNew} size="sm">
+							<Plus className="h-4 w-4" />
+							New Skill
+						</Button>
+					)}
+				</div>
+			</div>
 
-      {/* Search + All-skills version */}
-      <div className="flex items-center gap-3 mb-4">
-        <div className="relative max-w-sm flex-1">
-          <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-          <Input
-            data-testid="skill-search-input"
-            aria-label="Search skills by name"
-            placeholder="Search skills..."
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-              setOffset(0);
-            }}
-            className="pl-9"
-          />
-        </div>
-        <div className="flex items-center gap-2 text-xs">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="max-w-xs text-xs">
-              When registered as a marketplace, an "all-skills" plugin is
-              available that installs every skill in this repository at once.
-              Its version bumps automatically on changes; use the dropdown to
-              bump manually if needed.
-            </TooltipContent>
-          </Tooltip>
-          <span className="text-muted-foreground whitespace-nowrap">
-            all-skills version
-          </span>
-          {hasEditAccess ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  data-testid="skill-bump-version-btn"
-                  disabled={isBumpingAllSkillsVersion}
-                  className="cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <Badge
-                    variant="secondary"
-                    className="font-mono text-xs hover:bg-muted transition-colors"
-                  >
-                    {isBumpingAllSkillsVersion ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : (
-                      <>
-                        {allSkillsVersionData?.version ?? "0.0.0"}
-                        <ChevronDown className="h-3 w-3" />
-                      </>
-                    )}
-                  </Badge>
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {(["patch", "minor", "major"] as AllSkillsVersionBump[]).map(
-                  (bump) => (
-                    <DropdownMenuItem
-                      key={bump}
-                      className="cursor-pointer capitalize"
-                      disabled={isBumpingAllSkillsVersion}
-                      onSelect={() => handleBumpAllSkillsVersion(bump)}
-                    >
-                      Bump {bump}
-                    </DropdownMenuItem>
-                  ),
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <Badge variant="secondary" className="font-mono text-xs">
-              {allSkillsVersionData?.version ?? "0.0.0"}
-            </Badge>
-          )}
-        </div>
-      </div>
+			{/* Search + All-skills version */}
+			<div className="mb-4 flex items-center gap-3">
+				<div className="relative max-w-sm flex-1">
+					<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+					<Input
+						data-testid="skill-search-input"
+						aria-label="Search skills by name"
+						placeholder="Search skills..."
+						value={search}
+						onChange={(e) => {
+							setSearch(e.target.value);
+							setOffset(0);
+						}}
+						className="h-8 pl-9"
+					/>
+				</div>
+				<div className="flex items-center gap-2 text-xs">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Info className="text-muted-foreground h-3.5 w-3.5 cursor-help" />
+						</TooltipTrigger>
+						<TooltipContent side="bottom" className="max-w-xs text-xs">
+							When registered as a marketplace, an "all-skills" plugin is available that installs every skill in this repository at once.
+							Its version bumps automatically on changes; use the dropdown to bump manually if needed.
+						</TooltipContent>
+					</Tooltip>
+					<span className="text-muted-foreground whitespace-nowrap">all-skills version</span>
+					{hasEditAccess ? (
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<button
+									data-testid="skill-bump-version-btn"
+									disabled={isBumpingAllSkillsVersion}
+									className="cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+								>
+									<Badge variant="secondary" className="hover:bg-muted font-mono text-xs transition-colors">
+										{isBumpingAllSkillsVersion ? (
+											<Loader2 className="h-3 w-3 animate-spin" />
+										) : (
+											<>
+												{allSkillsVersionData?.version ?? "0.0.0"}
+												<ChevronDown className="h-3 w-3" />
+											</>
+										)}
+									</Badge>
+								</button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								{(["patch", "minor", "major"] as AllSkillsVersionBump[]).map((bump) => (
+									<DropdownMenuItem
+										key={bump}
+										className="cursor-pointer capitalize"
+										disabled={isBumpingAllSkillsVersion}
+										onSelect={() => handleBumpAllSkillsVersion(bump)}
+									>
+										Bump {bump}
+									</DropdownMenuItem>
+								))}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					) : (
+						<Badge variant="secondary" className="font-mono text-xs">
+							{allSkillsVersionData?.version ?? "0.0.0"}
+						</Badge>
+					)}
+				</div>
+			</div>
 
-      {/* Table */}
-      <div className="grow overflow-hidden rounded-sm border">
-        <Table
-          containerClassName="h-full overflow-auto"
-          className="w-full table-fixed"
-        >
-          <TableHeader className="bg-muted sticky top-0 z-20">
-            <TableRow className="hover:bg-transparent">
-              <TableHead className="w-60">
-                <SortableHeader
-                  column="name"
-                  label="Name"
-                  sortBy={sortBy}
-                  order={sortOrder}
-                  onToggle={toggleSort}
-                />
-              </TableHead>
-              <TableHead>Description</TableHead>
-              <TableHead className="w-36">Version</TableHead>
-              <TableHead className="w-36">Files</TableHead>
-              <TableHead className="w-44">
-                <SortableHeader
-                  column="updated_at"
-                  label="Updated"
-                  sortBy={sortBy}
-                  order={sortOrder}
-                  onToggle={toggleSort}
-                />
-              </TableHead>
-              <TableHead
-                className={`bg-muted sticky right-0 z-30 w-14 text-right ${PIN_SHADOW_RIGHT}`}
-              >
-                <span className="sr-only">Actions</span>
-              </TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {skills.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center py-12">
-                  <div className="flex flex-col items-center gap-2">
-                    <FileText className="h-8 w-8 text-muted-foreground" />
-                    <p className="text-muted-foreground text-sm">
-                      {search
-                        ? "No skills match your search"
-                        : "No skills created yet"}
-                    </p>
-                    {!search && hasCreateAccess && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={onCreateNew}
-                        className="mt-2"
-                      >
-                        <Plus className="h-3.5 w-3.5" />
-                        Create your first skill
-                      </Button>
-                    )}
-                  </div>
-                </TableCell>
-              </TableRow>
-            ) : (
-              skills.map((skill) => {
-                const fileCount = skill.file_count ?? 0;
+			{/* Table */}
+			<div className="mb-2 grow overflow-hidden rounded-sm border">
+				<Table containerClassName="h-full overflow-auto" className="w-full table-fixed">
+					<TableHeader className="bg-muted sticky top-0 z-20">
+						<TableRow className="hover:bg-transparent">
+							<TableHead className="w-60">
+								<SortableHeader column="name" label="Name" sortBy={sortBy} order={sortOrder} onToggle={toggleSort} />
+							</TableHead>
+							<TableHead>Description</TableHead>
+							<TableHead className="w-36">Version</TableHead>
+							<TableHead className="w-36">Files</TableHead>
+							<TableHead className="w-44">
+								<SortableHeader column="updated_at" label="Updated" sortBy={sortBy} order={sortOrder} onToggle={toggleSort} />
+							</TableHead>
+							<TableHead className={`bg-muted sticky right-0 z-30 w-14 text-right ${PIN_SHADOW_RIGHT}`}>
+								<span className="sr-only">Actions</span>
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{skills.length === 0 && !isSearchSettling && !isFetching ? (
+							<TableRow>
+								<TableCell colSpan={6} className="py-12 text-center">
+									<div className="flex flex-col items-center gap-2">
+										<FileText className="text-muted-foreground h-8 w-8" />
+										<p className="text-muted-foreground text-sm">{search ? "No skills match your search" : "No skills created yet"}</p>
+										{!search && hasCreateAccess && (
+											<Button variant="outline" size="sm" onClick={onCreateNew} className="mt-2">
+												<Plus className="h-3.5 w-3.5" />
+												Create your first skill
+											</Button>
+										)}
+									</div>
+								</TableCell>
+							</TableRow>
+						) : (
+							skills.map((skill) => {
+								const fileCount = skill.file_count ?? 0;
 
-                return (
-                  <TableRow
-                    key={skill.id}
-                    data-testid={`skill-row-${skill.name}`}
-                    className="group hover:bg-muted/50 cursor-pointer transition-colors"
-                    tabIndex={0}
-                    onClick={() => onSelectSkill(skill.id)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        onSelectSkill(skill.id);
-                      }
-                    }}
-                  >
-                    <TableCell className="w-60 max-w-60 overflow-hidden font-medium font-mono text-sm">
-                      <div className="max-w-full truncate" title={skill.name}>
-                        {skill.name}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground overflow-hidden text-sm">
-                      <div className="truncate" title={skill.description}>
-                        {skill.description}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <Badge
-                        variant="secondary"
-                        className="font-mono text-xs px-2.5 py-1"
-                      >
-                        {skill.latest_version}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <span className="text-muted-foreground text-xs">
-                        <span className="font-mono text-foreground">
-                          {fileCount}
-                        </span>{" "}
-                        files
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
-                      {formatDateShort(skill.updated_at)}
-                    </TableCell>
-                    <TableCell
-                      className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <SkillActionsMenu
-                        skill={skill}
-                        hasEditAccess={hasEditAccess}
-                        hasDeleteAccess={hasDeleteAccess}
-                        isDeleting={isDeleting}
-                        onEdit={(id) => onSelectSkill(id, true)}
-                        onDelete={handleDeleteSkill}
-                      />
-                    </TableCell>
-                  </TableRow>
-                );
-              })
-            )}
-          </TableBody>
-        </Table>
-      </div>
+								return (
+									<TableRow
+										key={skill.id}
+										data-testid={`skill-row-${skill.name}`}
+										className="group hover:bg-muted/50 cursor-pointer transition-colors"
+										tabIndex={0}
+										onClick={() => onSelectSkill(skill.id)}
+										onKeyDown={(e) => {
+											if (e.key === "Enter" || e.key === " ") {
+												e.preventDefault();
+												onSelectSkill(skill.id);
+											}
+										}}
+									>
+										<TableCell className="w-60 max-w-60 overflow-hidden text-sm font-medium">
+											<div className="max-w-full truncate" title={skill.name}>
+												{skill.name}
+											</div>
+										</TableCell>
+										<TableCell className="text-muted-foreground overflow-hidden text-sm">
+											<div className="truncate" title={skill.description}>
+												{skill.description}
+											</div>
+										</TableCell>
+										<TableCell>
+											<Badge variant="secondary" className="px-2.5 py-1 text-xs">
+												{skill.latest_version}
+											</Badge>
+										</TableCell>
+										<TableCell>
+											<span className="text-muted-foreground text-xs">
+												<span className="text-foreground">{fileCount}</span> files
+											</span>
+										</TableCell>
+										<TableCell className="text-muted-foreground text-sm">{formatDateShort(skill.updated_at)}</TableCell>
+										<TableCell
+											className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+											onClick={(e) => e.stopPropagation()}
+										>
+											<SkillActionsMenu
+												skill={skill}
+												hasEditAccess={hasEditAccess}
+												hasDeleteAccess={hasDeleteAccess}
+												isDeleting={isDeleting}
+												onEdit={(id) => onSelectSkill(id, true)}
+												onDelete={handleDeleteSkill}
+											/>
+										</TableCell>
+									</TableRow>
+								);
+							})
+						)}
+					</TableBody>
+				</Table>
+			</div>
 
-      {/* Pagination */}
-      {total > 0 && (
-        <div className="flex shrink-0 items-center justify-between text-xs">
-          <div className="text-muted-foreground flex items-center gap-2">
-            {(offset + 1).toLocaleString()}-
-            {Math.min(offset + PAGE_SIZE, total).toLocaleString()} of{" "}
-            {total.toLocaleString()} entries
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              data-testid="skill-pagination-prev"
-              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-              disabled={offset === 0 || isFetching}
-              aria-label="Previous page"
-            >
-              <ChevronLeft className="size-3" />
-            </Button>
-            <div className="flex items-center gap-1">
-              <span>Page</span>
-              <span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
-              <span>of {Math.ceil(total / PAGE_SIZE)}</span>
-            </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              data-testid="skill-pagination-next"
-              onClick={() => setOffset(offset + PAGE_SIZE)}
-              disabled={offset + PAGE_SIZE >= total || isFetching}
-              aria-label="Next page"
-            >
-              <ChevronRight className="size-3" />
-            </Button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+			{/* Pagination */}
+			{total > 0 && (
+				<div className="flex shrink-0 items-center justify-between text-xs">
+					<div className="text-muted-foreground flex items-center gap-2">
+						{(offset + 1).toLocaleString()}-{Math.min(offset + PAGE_SIZE, total).toLocaleString()} of {total.toLocaleString()} entries
+					</div>
+					<div className="flex items-center gap-2">
+						<Button
+							variant="ghost"
+							size="sm"
+							data-testid="skill-pagination-prev"
+							onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+							disabled={offset === 0 || isFetching}
+							aria-label="Previous page"
+						>
+							<ChevronLeft className="size-3" />
+						</Button>
+						<div className="flex items-center gap-1">
+							<span>Page</span>
+							<span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
+							<span>of {Math.ceil(total / PAGE_SIZE)}</span>
+						</div>
+						<Button
+							variant="ghost"
+							size="sm"
+							data-testid="skill-pagination-next"
+							onClick={() => setOffset(offset + PAGE_SIZE)}
+							disabled={offset + PAGE_SIZE >= total || isFetching}
+							aria-label="Next page"
+						>
+							<ChevronRight className="size-3" />
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
 }

--- a/ui/app/workspace/skills-repo/dialogs/skillVersionDialog.tsx
+++ b/ui/app/workspace/skills-repo/dialogs/skillVersionDialog.tsx
@@ -2,12 +2,11 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { ScrollArea } from "@/components/ui/scrollArea";
 import { useListSkillVersionsQuery } from "@/lib/store/apis/skillsApi";
 import { SkillVersionSummary } from "@/lib/types/skills";
-import { ChevronDown, Loader2, Search } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { formatDate, useDebouncedValue } from "../components/helpers";
 
@@ -40,10 +39,10 @@ export function SkillVersionsPopover({
 
 	// Reset the accumulator whenever the search term changes so a new query
 	// starts from page 0 instead of appending onto stale results.
-useEffect(() => {
-    setOffset(0);
-    setAccumulated([]);
-}, [debouncedSearch, skillId]);
+	useEffect(() => {
+		setOffset(0);
+		setAccumulated([]);
+	}, [debouncedSearch, skillId]);
 
 	// Append each fetched page. RTK Query replaces `data` per arg combo, so we
 	// accumulate here; dedupe by id guards against effect re-runs on the same page.
@@ -84,73 +83,138 @@ useEffect(() => {
 					<ChevronDown className="h-3.5 w-3.5" />
 				</Button>
 			</PopoverTrigger>
-			<PopoverContent align="end" className="w-80 p-0">
-				<div className="border-b p-2">
-					<div className="relative">
-						<Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
-						<Input
-							data-testid="skill-versions-search-input"
-							aria-label="Search versions"
-							placeholder="Search versions..."
-							value={search}
-							onChange={(e) => setSearch(e.target.value)}
-							className="h-8 pl-8 text-sm"
-						/>
-					</div>
-				</div>
-				<ScrollArea className="h-72">
-					<div className="p-1">
-						{accumulated.map((v) => {
-							const isServing = v.version === servingVersion;
-							return (
-								<button
-									key={v.id}
-									type="button"
-									data-testid="skill-version-option"
-									onClick={() => {
-										onSelectVersion(v);
-										setOpen(false);
-									}}
-									className="hover:bg-muted/60 flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-left transition-colors"
-								>
-									<span className="flex items-center gap-2">
-										<span className="font-mono text-sm font-medium">{v.version}</span>
-										{isServing && (
-											<Badge
-												variant="secondary"
-												className="bg-emerald-100 text-xs text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
-											>
-												Serving
-											</Badge>
-										)}
-									</span>
-									<span className="text-muted-foreground shrink-0 text-xs">{formatDate(v.created_at)}</span>
-								</button>
-							);
-						})}
-
-						{isFetching && (
-							<div className="text-muted-foreground flex items-center justify-center gap-2 py-3 text-xs">
-								<Loader2 className="h-3.5 w-3.5 animate-spin" />
-								Loading...
-							</div>
-						)}
-
-						{isError && !isFetching && accumulated.length === 0 && (
-							<div className="text-muted-foreground py-6 text-center text-xs">Failed to load versions</div>
-						)}
-
-						{!isError && !isFetching && accumulated.length === 0 && (
-							<div className="text-muted-foreground py-6 text-center text-xs">
-								{debouncedSearch ? "No versions match your search" : "No versions yet"}
-							</div>
-						)}
-
-						{/* Sentinel observed to trigger the next page fetch */}
-						{hasMore && <div ref={sentinelRef} className="h-px" />}
-					</div>
-				</ScrollArea>
+			<PopoverContent align="end" className="w-72 p-0">
+				<SkillVersionsList
+					skillId={skillId}
+					servingVersion={servingVersion}
+					open={open}
+					onSelectVersion={(v) => {
+						onSelectVersion(v);
+						setOpen(false);
+					}}
+				/>
 			</PopoverContent>
 		</Popover>
+	);
+}
+
+/**
+ * The searchable, infinitely-scrolling list of skill versions. Extracted so it can
+ * be rendered either inside the standalone popover or inside a SplitButton dropdown.
+ * `open` gates the query so versions are only fetched while the container is open.
+ */
+export function SkillVersionsList({
+	skillId,
+	servingVersion,
+	open,
+	onSelectVersion,
+}: {
+	skillId: string;
+	servingVersion: string;
+	open: boolean;
+	onSelectVersion: (version: SkillVersionSummary) => void;
+}) {
+	const [search, setSearch] = useState("");
+	const debouncedSearch = useDebouncedValue(search, 300);
+	const [offset, setOffset] = useState(0);
+	const [accumulated, setAccumulated] = useState<SkillVersionSummary[]>([]);
+
+	const { data, isFetching, isError } = useListSkillVersionsQuery(
+		{
+			id: skillId,
+			limit: PAGE_SIZE,
+			offset,
+			search: debouncedSearch || undefined,
+		},
+		{ skip: !open },
+	);
+
+	// Reset the accumulator whenever the search term changes so a new query
+	// starts from page 0 instead of appending onto stale results.
+	useEffect(() => {
+		setOffset(0);
+		setAccumulated([]);
+	}, [debouncedSearch, skillId]);
+
+	// Append each fetched page. RTK Query replaces `data` per arg combo, so we
+	// accumulate here; dedupe by id guards against effect re-runs on the same page.
+	useEffect(() => {
+		if (!data) return;
+		setAccumulated((prev) => {
+			if (offset === 0) return data.versions;
+			const seen = new Set(prev.map((v) => v.id));
+			return [...prev, ...data.versions.filter((v) => !seen.has(v.id))];
+		});
+	}, [data, offset]);
+
+	const total = data?.total ?? 0;
+	const hasMore = accumulated.length < total;
+
+	// Infinite scroll: bump the offset when the bottom sentinel scrolls into view.
+	const sentinelRef = useRef<HTMLDivElement | null>(null);
+	useEffect(() => {
+		const node = sentinelRef.current;
+		if (!node || !open || !hasMore || isFetching) return;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting) {
+					setOffset((o) => o + PAGE_SIZE);
+				}
+			},
+			{ threshold: 1 },
+		);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, [open, hasMore, isFetching]);
+
+	return (
+		<Command shouldFilter={false}>
+			<CommandInput
+				data-testid="skill-versions-search-input"
+				placeholder="Search versions..."
+				value={search}
+				onValueChange={setSearch}
+				isLoading={isFetching}
+			/>
+			<CommandList>
+				{!isFetching && accumulated.length === 0 && (
+					<CommandEmpty>{debouncedSearch ? "No versions match your search" : "No versions yet"}</CommandEmpty>
+				)}
+				<CommandGroup>
+					{accumulated.map((v) => {
+						const isServing = v.version === servingVersion;
+						return (
+							<CommandItem
+								key={v.id}
+								value={`${v.id}-${v.version}`}
+								data-testid="skill-version-option"
+								onSelect={() => onSelectVersion(v)}
+								className="flex items-center justify-between gap-2 cursor-pointer"
+							>
+								<span className="flex items-center gap-2">
+									<span className="text-sm font-medium">{v.version}</span>
+									{isServing && (
+										<Badge
+											variant="secondary"
+											className="bg-emerald-100 text-xs h-auto py-0 px-1.5"
+										>
+											Serving
+										</Badge>
+									)}
+								</span>
+								<span className="text-muted-foreground shrink-0 text-xs">{formatDate(v.created_at)}</span>
+							</CommandItem>
+						);
+					})}
+
+					{isError && !isFetching && accumulated.length === 0 && (
+						<div className="text-muted-foreground py-6 text-center text-xs">Failed to load versions</div>
+					)}
+
+					{/* Sentinel observed to trigger the next page fetch */}
+					{hasMore && <div ref={sentinelRef} className="h-px" />}
+				</CommandGroup>
+			</CommandList>
+		</Command>
 	);
 }

--- a/ui/app/workspace/skills-repo/dialogs/versionDetailsDialog.tsx
+++ b/ui/app/workspace/skills-repo/dialogs/versionDetailsDialog.tsx
@@ -3,11 +3,11 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { useGetSkillQuery, useShiftSkillVersionMutation } from "@/lib/store/apis/skillsApi";
 import { getErrorMessage } from "@/lib/store/apis/baseApi";
-import { getApiBaseUrl } from "@/lib/utils/port";
+import { useGetSkillQuery, useShiftSkillVersionMutation } from "@/lib/store/apis/skillsApi";
 import type { SkillFile, SkillFileEntry } from "@/lib/types/skills";
-import { Loader2, RefreshCw, Download, X } from "lucide-react";
+import { getApiBaseUrl } from "@/lib/utils/port";
+import { Download, Loader2, RefreshCw, X } from "lucide-react";
 import { toast } from "sonner";
 import { composeFrontmatter } from "../components/helpers";
 import { SkillHeader, SkillReadOnlyContent } from "../components/shared";
@@ -38,30 +38,30 @@ export function VersionDetailDialog({
 
 	const composedSkillMd = skill
 		? composeFrontmatter({
-				name: skill.name,
-				description: skill.description,
-				license: skill.license || "",
-				compatibility: skill.compatibility || "",
-				allowed_tools: skill.allowed_tools || "",
-				extra_frontmatter_json: skill.extra_frontmatter ? JSON.stringify(skill.extra_frontmatter) : "",
-				metadata_json: skill.metadata ? JSON.stringify(skill.metadata) : "",
-			}) +
-			"\n\n" +
-			skill.skill_md_body
+			name: skill.name,
+			description: skill.description,
+			license: skill.license || "",
+			compatibility: skill.compatibility || "",
+			allowed_tools: skill.allowed_tools || "",
+			extra_frontmatter_json: skill.extra_frontmatter ? JSON.stringify(skill.extra_frontmatter) : "",
+			metadata_json: skill.metadata ? JSON.stringify(skill.metadata) : "",
+		}) +
+		"\n\n" +
+		skill.skill_md_body
 		: "";
 
 	const fileEntries: SkillFileEntry[] = skill?.files
 		? skill.files.map((f: SkillFile) => ({
-				path: f.path,
-				source_type: f.source_type,
-				content: f.content,
-				source_url: f.source_url,
-				dataurl: f.dataurl,
-				storage_key: f.storage_key,
-				blob_id: f.blob_id,
-				mime_type: f.mime_type,
-				file_size_bytes: f.file_size_bytes,
-			}))
+			path: f.path,
+			source_type: f.source_type,
+			content: f.content,
+			source_url: f.source_url,
+			dataurl: f.dataurl,
+			storage_key: f.storage_key,
+			blob_id: f.blob_id,
+			mime_type: f.mime_type,
+			file_size_bytes: f.file_size_bytes,
+		}))
 		: [];
 
 	const downloadUrl = skill
@@ -163,7 +163,7 @@ export function VersionDetailDialog({
 								/>
 							</div>
 
-							<div className="min-h-0 flex-1 px-6 pb-6">
+							<div className="min-h-0 flex-1 px-6 pb-6 flex">
 								<SkillReadOnlyContent
 									skillName={skill.name}
 									skillMdBody={skill.skill_md_body}

--- a/ui/app/workspace/skills-repo/forms/skillEditForm.tsx
+++ b/ui/app/workspace/skills-repo/forms/skillEditForm.tsx
@@ -1,858 +1,822 @@
 "use client";
 
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { CodeEditor, type CompletionItem } from "@/components/ui/codeEditor";
+import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { ScrollArea, ScrollBar } from "@/components/ui/scrollArea";
 import { Textarea } from "@/components/ui/textarea";
-import { lazy, Suspense, type ComponentProps } from "react";
-import { CodeEditor, type CompletionItem } from "@/components/ui/codeEditor";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-import { validateVersionBump } from "@/lib/validators/skills";
-import { cn } from "@/lib/utils";
 import type { SkillFileEntry } from "@/lib/types/skills";
-import {
-  AlertTriangle,
-  ArrowLeft,
-  Check,
-  Copy,
-  Eye,
-  Loader2,
-  Plus,
-  Save,
-  X,
-} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { validateSkillForm, validateVersionBump } from "@/lib/validators/skills";
+import { AlertTriangle, Check, Copy, Eye, Info, Loader2, Plus, Save, Search, Settings2, X } from "lucide-react";
 import { useRef, useState } from "react";
-import {
-  type SkillFormReturn,
-  composeFrontmatter,
-} from "../components/helpers";
-import { FormSection } from "../components/shared";
-import { FilePreviewPane } from "../components/filePreview";
 import { FileManagerSection } from "../components/fileManagerView";
+import { FilePreviewPane } from "../components/filePreview";
+import { composeFrontmatter, type SkillFormReturn } from "../components/helpers";
 import { MetadataTableEditor } from "../components/metadataEditorTableView";
-
-const LazyMarkdown = lazy(() => import("@/components/ui/markdown").then((m) => ({ default: m.Markdown })));
-const Markdown = (props: ComponentProps<typeof LazyMarkdown>) => <Suspense fallback={null}><LazyMarkdown {...props} /></Suspense>;
+import { FormSection, SkillMarkdown } from "../components/shared";
 
 export function SkillEditView({
-  form,
-  skillName,
-  previousVersion,
-  onSave,
-  onCancel,
-  onBack,
-  isSaving,
-  mode = "edit",
+	form,
+	skillName,
+	previousVersion,
+	onSave,
+	onCancel,
+	onBack,
+	onNavigateToList,
+	isSaving,
+	mode = "edit",
 }: {
-  form: SkillFormReturn;
-  skillName?: string;
-  previousVersion?: string;
-  onSave: (serve: boolean) => void;
-  onCancel: () => void;
-  onBack: () => void;
-  isSaving: boolean;
-  mode?: "edit" | "create";
+	form: SkillFormReturn;
+	skillName?: string;
+	previousVersion?: string;
+	onSave: (serve: boolean) => void;
+	onCancel: () => void;
+	onBack: () => void;
+	/** Navigate all the way back to the skills list (the "Skills" breadcrumb crumb). Falls back to onBack. */
+	onNavigateToList?: () => void;
+	isSaving: boolean;
+	mode?: "edit" | "create";
 }) {
-  const isCreate = mode === "create";
-  const [bodyTab, setBodyTab] = useState<"edit" | "preview">("edit");
-  const [showPreviewDialog, setShowPreviewDialog] = useState(false);
-  // Two-pane workspace selection: null = SKILL.md body, otherwise a file index.
-  const [selectedFileIndex, setSelectedFileIndex] = useState<number | null>(
-    null,
-  );
-  const [selectedDetailsPane, setSelectedDetailsPane] = useState<
-    "details" | "metadata" | "frontmatter" | null
-  >("details");
-  const selectedFile =
-    selectedFileIndex != null ? (form.files[selectedFileIndex] ?? null) : null;
+	const isCreate = mode === "create";
+	const [bodyTab, setBodyTab] = useState<"edit" | "preview">("edit");
+	const [showPreviewDialog, setShowPreviewDialog] = useState(false);
+	const [fileSearchQuery, setFileSearchQuery] = useState("");
+	// Two-pane workspace selection: null = SKILL.md body, otherwise a file index.
+	const [selectedFileIndex, setSelectedFileIndex] = useState<number | null>(null);
+	const [selectedDetailsPane, setSelectedDetailsPane] = useState<"details" | null>("details");
+	const selectedFile = selectedFileIndex != null ? (form.files[selectedFileIndex] ?? null) : null;
 
-  // The version is asked for in a dialog at save time (not in the form).
-  const [versionDialog, setVersionDialog] = useState<{ serve: boolean } | null>(
-    null,
-  );
+	// The version is asked for in a popover anchored to the Save button (not in the form).
+	const [versionPopover, setVersionPopover] = useState<{
+		serve: boolean;
+	} | null>(null);
 
-  // Lets the file editor commit any buffered ("Save file") content before a version save.
-  const flushFileEditRef = useRef<(() => void) | null>(null);
+	// Lets the file editor commit any buffered ("Save file") content before a version save.
+	const flushFileEditRef = useRef<(() => void) | null>(null);
 
-  const openVersionDialog = (serve: boolean) => {
-    flushFileEditRef.current?.();
-    // Suggest a patch bump for edits when the version still equals the previous one.
-    if (!isCreate && previousVersion) {
-      const match = previousVersion.match(/^(\d+)\.(\d+)\.(\d+)$/);
-      if (match && (form.version === previousVersion || !form.version.trim())) {
-        const suggested = `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
-        form.setVersion(suggested);
-        form.validateField("version", suggested);
-      }
-    }
-    setVersionDialog({ serve });
-  };
+	// Which pane each validatable field lives in, so a failed save can surface
+	// the error instead of silently blocking from another tab.
+	const focusFieldError = (field: string): boolean => {
+		switch (field) {
+			case "description":
+			case "metadata":
+			case "extra_frontmatter":
+				setSelectedDetailsPane("details");
+				setSelectedFileIndex(null);
+				return true;
+			case "skill_md_body":
+				setSelectedDetailsPane(null);
+				setSelectedFileIndex(null);
+				return true;
+			// "name" renders in the always-visible header (create mode); "version" is
+			// handled in its own dialog — neither needs pane navigation.
+			default:
+				return false;
+		}
+	};
 
-  // Closing the dialog restores a valid version so a half-typed value can't
-  // leave the footer Save buttons stuck disabled via form.hasErrors.
-  const closeVersionDialog = () => {
-    if (form.errors.version) {
-      const restore = !isCreate && previousVersion ? previousVersion : "1.0.0";
-      form.setVersion(restore);
-      form.validateField("version", restore);
-    }
-    setVersionDialog(null);
-  };
-  const { copy: copyPreviewContent, copied: copiedPreviewContent } =
-    useCopyToClipboard({
-      successMessage: "Copied raw SKILL.md",
-      errorMessage: "Failed to copy raw SKILL.md",
-    });
+	const openVersionPopover = (serve: boolean) => {
+		flushFileEditRef.current?.();
+		// Validate up front so an error hiding in another pane navigates into view
+		// rather than leaving the user staring at a Save button that does nothing.
+		const errors = validateSkillForm({
+			name: form.name,
+			description: form.description,
+			version: form.version,
+			skill_md_body: form.skillMdBody,
+			extra_frontmatter_json: form.extraFrontmatterJson || undefined,
+			metadata_json: form.metadataJson || undefined,
+		});
+		if (errors.length > 0) {
+			// Reuse the form's validators to populate inline errors in each pane.
+			form.validateField("name", form.name);
+			form.validateField("description", form.description);
+			form.validateField("extra_frontmatter", form.extraFrontmatterJson);
+			form.validateField("metadata", form.metadataJson);
+			// Navigate to the first error that maps to a pane; the inline error in
+			// that pane tells the user what to fix.
+			errors.find((e) => focusFieldError(e.field));
+			return;
+		}
+		// Suggest a patch bump for edits when the version still equals the previous one.
+		if (!isCreate && previousVersion) {
+			const match = previousVersion.match(/^(\d+)\.(\d+)\.(\d+)$/);
+			if (match && (form.version === previousVersion || !form.version.trim())) {
+				const suggested = `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
+				form.setVersion(suggested);
+				form.validateField("version", suggested);
+			}
+		}
+		setVersionPopover({ serve });
+	};
 
-  const previewContent =
-    composeFrontmatter({
-      name: form.name,
-      description: form.description,
-      license: form.license,
-      compatibility: form.compatibility,
-      allowed_tools: form.allowedTools,
-      extra_frontmatter_json: form.extraFrontmatterJson,
-      metadata_json: form.metadataJson,
-    }) +
-    "\n\n" +
-    form.skillMdBody;
+	// Closing the popover restores a valid version so a half-typed value can't
+	// make the next save attempt fail validation before the popover reopens.
+	const closeVersionPopover = () => {
+		if (form.errors.version) {
+			const restore = !isCreate && previousVersion ? previousVersion : "1.0.0";
+			form.setVersion(restore);
+			form.validateField("version", restore);
+		}
+		setVersionPopover(null);
+	};
+	const { copy: copyPreviewContent, copied: copiedPreviewContent } = useCopyToClipboard({
+		successMessage: "Copied raw SKILL.md",
+		errorMessage: "Failed to copy raw SKILL.md",
+	});
 
-  const filePathCompletions = buildFilePathCompletions(form.files);
+	const previewContent =
+		composeFrontmatter({
+			name: form.name,
+			description: form.description,
+			license: form.license,
+			compatibility: form.compatibility,
+			allowed_tools: form.allowedTools,
+			extra_frontmatter_json: form.extraFrontmatterJson,
+			metadata_json: form.metadataJson,
+		}) +
+		"\n\n" +
+		form.skillMdBody;
 
-  const descriptionLength = form.description.length;
-  let descriptionLimitColor = "text-muted-foreground";
-  if (descriptionLength > 1024) {
-    descriptionLimitColor = "text-destructive";
-  } else if (descriptionLength > 900) {
-    descriptionLimitColor = "text-yellow-600 dark:text-yellow-500";
-  }
+	const filePathCompletions = buildFilePathCompletions(form.files);
 
-  return (
-    <div className="animate-in fade-in flex h-full min-h-0 flex-col duration-200 overflow-hidden">
-      <div className="shrink-0 overflow-y-auto px-4">
-        {/* Top bar with back button integrated */}
-        <div className="dark:bg-card flex items-center gap-3 bg-white py-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            data-testid="skill-back-btn"
-            onClick={onBack}
-            aria-label="Go back"
-          >
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-          <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
-            <span>{isCreate ? "Creating" : "Editing"}</span>
-            <span className="text-foreground truncate font-mono">
-              {isCreate ? form.name || "<new-skill>" : skillName}
-            </span>
-          </div>
-        </div>
+	const descriptionLength = form.description.length;
+	let descriptionLimitColor = "text-muted-foreground";
+	if (descriptionLength > 1024) {
+		descriptionLimitColor = "text-destructive";
+	} else if (descriptionLength > 900) {
+		descriptionLimitColor = "text-yellow-600 dark:text-yellow-500";
+	}
 
-        <div className="mb-6 flex gap-3 rounded-sm border border-amber-500/40 bg-amber-50/80 p-3 text-sm text-amber-900 dark:border-amber-400/30 dark:bg-amber-950/40 dark:text-amber-200">
-          <AlertTriangle
-            className="mt-0.5 h-4 w-4 shrink-0"
-            aria-hidden="true"
-          />
-          <p>
-            Files added to a skill can be downloaded from marketplace URLs
-            without logging in. Anyone who can reach this Bifrost server can
-            request them directly, so do not upload secrets, credentials,
-            private code, or other sensitive files.
-          </p>
-        </div>
+	return (
+		<div className="flex h-full min-h-0 flex-col overflow-hidden">
+			<div className="shrink-0 overflow-y-auto px-4">
+				{/* Breadcrumb */}
+				<nav aria-label="Breadcrumb" className="py-4">
+					<ol className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-sm">
+						<li>
+							<button
+								type="button"
+								data-testid="skill-back-btn"
+								onClick={onNavigateToList ?? onBack}
+								className="hover:text-foreground cursor-pointer transition-colors"
+							>
+								Skills
+							</button>
+						</li>
+						<li aria-hidden="true" className="text-muted-foreground/60">
+							/
+						</li>
+						{isCreate ? (
+							<li aria-current="page" className="text-foreground min-w-0 truncate font-medium">
+								{form.name || "<new-skill>"}
+							</li>
+						) : (
+							<>
+								<li className="min-w-0 truncate">
+									<button
+										type="button"
+										data-testid="skill-view-btn"
+										onClick={onBack}
+										className="hover:text-foreground min-w-0 cursor-pointer truncate transition-colors"
+									>
+										{skillName}
+									</button>
+								</li>
+								<li aria-hidden="true" className="text-muted-foreground/60">
+									/
+								</li>
+								<li aria-current="page" className="text-foreground font-medium">
+									new
+								</li>
+							</>
+						)}
+					</ol>
+				</nav>
 
-        {/* Edit sections */}
-        <div className="flex flex-col gap-8">
-          {isCreate && (
-            <FormSection title="Name">
-              <Input
-                data-testid="skill-name-input"
-                value={form.name}
-                onChange={(e) => {
-                  form.setName(e.target.value);
-                  form.validateField("name", e.target.value);
-                }}
-                placeholder="my-skill-name"
-                className={cn(
-                  "font-mono",
-                  form.errors.name && "border-destructive",
-                )}
-              />
-              {form.errors.name && (
-                <p className="text-destructive text-xs" role="alert">
-                  {form.errors.name}
-                </p>
-              )}
-              <p className="text-muted-foreground text-xs">
-                Lowercase letters, numbers, and hyphens only.{" "}
-                <span className="font-bold">
-                  Cannot be changed after creation.
-                </span>
-              </p>
-            </FormSection>
-          )}
+				<Alert variant="info">
+					<AlertTriangle aria-hidden="true" />
+					<AlertDescription>
+						Files added to a skill can be downloaded from marketplace URLs without logging in. Anyone who can reach this Bifrost server can
+						request them directly, so do not upload secrets, credentials, private code, or other sensitive files.
+					</AlertDescription>
+				</Alert>
 
-          {/* Details now render in the right pane, selected from above the file tree. */}
-        </div>
-      </div>
+				{/* Edit sections */}
+				{isCreate && (
+					<div className="flex flex-col gap-8 pt-4">
+						<section className="flex flex-col gap-2">
+							<div className="flex items-center gap-1.5">
+								<h2 className="text-foreground text-base leading-[normal] font-semibold">Name</h2>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<button
+											type="button"
+											className="text-muted-foreground hover:text-foreground inline-flex h-4 w-4 items-center justify-center"
+											aria-label="Skill names cannot be changed after creation"
+										>
+											<Info className="h-3.5 w-3.5" aria-hidden="true" />
+										</button>
+									</TooltipTrigger>
+									<TooltipContent className="max-w-xs text-xs">Name cannot be changed after creation.</TooltipContent>
+								</Tooltip>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Input
+									data-testid="skill-name-input"
+									value={form.name}
+									onChange={(e) => {
+										form.setName(e.target.value);
+										form.validateField("name", e.target.value);
+									}}
+									placeholder="my-skill-name"
+									className={cn(form.errors.name && "border-destructive")}
+								/>
+								{form.errors.name && (
+									<p className="text-destructive text-xs" role="alert">
+										{form.errors.name}
+									</p>
+								)}
+							</div>
+						</section>
+					</div>
+				)}
 
-      {/* Files + SKILL.md two-pane workspace */}
-      <div className="min-h-0 flex-1 px-4 pt-4 pb-2">
-        <div className="flex h-full min-h-0 gap-3">
-          {/* Left: files panel */}
-          <div className="bg-card flex min-h-0 w-72 shrink-0 flex-col gap-2">
-            <div className="grid gap-1.5">
-              <div className="grid grid-cols-2 gap-1.5">
-                {[
-                  ["details", "Details"],
-                  ["metadata", "Metadata"],
-                ].map(([pane, label]) => (
-                  <button
-                    key={pane}
-                    type="button"
-                    data-testid={`skill-${pane}-pane-btn`}
-                    onClick={() => {
-                      setSelectedDetailsPane(pane as "details" | "metadata");
-                      setSelectedFileIndex(null);
-                    }}
-                    className={cn(
-                      "rounded-md border px-3 py-2 text-left text-xs font-medium transition-colors",
-                      selectedDetailsPane === pane
-                        ? "border-primary/20 bg-primary/10 text-primary hover:bg-primary/10"
-                        : "bg-card hover:bg-muted",
-                    )}
-                  >
-                    {label}
-                  </button>
-                ))}
-              </div>
-              <button
-                type="button"
-                data-testid="skill-frontmatter-pane-btn"
-                onClick={() => {
-                  setSelectedDetailsPane("frontmatter");
-                  setSelectedFileIndex(null);
-                }}
-                className={cn(
-                  "rounded-md border px-3 py-2 text-left text-xs font-medium transition-colors",
-                  selectedDetailsPane === "frontmatter"
-                    ? "border-primary/20 bg-primary/10 text-primary hover:bg-primary/10"
-                    : "bg-card hover:bg-muted",
-                )}
-              >
-                Extra Frontmatter
-              </button>
-            </div>
-            <div className="bg-card flex min-h-0 flex-1 flex-col rounded-md border">
-              <div className="flex py-2 items-center border-b px-3">
-                <span className="text-sm font-semibold">Files</span>
-              </div>
-              <ScrollArea
-                className="min-h-0 flex-1 p-1"
-                viewportClassName="overflow-x-auto"
-              >
-                <FileManagerSection
-                  files={form.files}
-                  onAddFile={form.addFile}
-                  onRemoveFile={form.removeFile}
-                  onUpdateFile={form.updateFile}
-                  readOnly={false}
-                  selectedIndex={
-                    selectedDetailsPane == null ? selectedFileIndex : null
-                  }
-                  onSelectFile={(index) => {
-                    setSelectedDetailsPane(null);
-                    setSelectedFileIndex(index);
-                  }}
-                  bodySelected={
-                    selectedFile == null && selectedDetailsPane == null
-                  }
-                  hasBodyError={!form.skillMdBody.trim()}
-                  onSelectBody={() => {
-                    setSelectedDetailsPane(null);
-                    setSelectedFileIndex(null);
-                  }}
-                />
-                <ScrollBar orientation="horizontal" />
-              </ScrollArea>
-            </div>
-          </div>
+				{/* Details now render in the right pane, selected from above the file tree. */}
+			</div>
 
-          {/* Right: editor for the selected item */}
-          <div className="flex min-h-0 grow flex-col overflow-auto">
-            {selectedDetailsPane === "details" ? (
-              <DetailsEditorPane
-                form={form}
-                descriptionLength={descriptionLength}
-                descriptionLimitColor={descriptionLimitColor}
-              />
-            ) : selectedDetailsPane === "metadata" ? (
-              <MetadataEditorPane form={form} />
-            ) : selectedDetailsPane === "frontmatter" ? (
-              <ExtraFrontmatterEditorPane form={form} />
-            ) : selectedFile ? (
-              <FilePreviewPane
-                key={selectedFile.path}
-                file={selectedFile}
-                skillName={skillName ?? form.name ?? ""}
-                mode="edit"
-                registerFlush={(flush) => {
-                  flushFileEditRef.current = flush;
-                }}
-                onFileUpdate={(updates) => {
-                  if (selectedFileIndex == null) return;
-                  form.updateFile(selectedFileIndex, updates);
-                }}
-                onContentChange={(editedText) => {
-                  if (selectedFileIndex == null) return;
-                  if (selectedFile.source_type === "dataurl") {
-                    // Re-encode edited text as a data URI; drop old storage refs
-                    // so the backend creates a new blob for the new version.
-                    const dataurl = `data:${selectedFile.mime_type || "text/plain"};base64,${btoa(unescape(encodeURIComponent(editedText)))}`;
-                    form.updateFile(selectedFileIndex, {
-                      dataurl,
-                      blob_id: undefined,
-                      storage_key: undefined,
-                    });
-                  } else {
-                    // text source: submit raw content; drop old storage refs.
-                    form.updateFile(selectedFileIndex, {
-                      content: editedText,
-                      blob_id: undefined,
-                      storage_key: undefined,
-                    });
-                  }
-                }}
-              />
-            ) : (
-              <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-sm border">
-                <div
-                  className="flex h-9 shrink-0 items-center gap-1 border-b px-2"
-                  role="tablist"
-                  aria-label="Body editor tabs"
-                >
-                  <button
-                    type="button"
-                    className={cn(
-                      "px-3 py-1 text-xs rounded-sm transition-colors cursor-pointer",
-                      bodyTab === "edit"
-                        ? "bg-muted font-medium"
-                        : "text-muted-foreground hover:text-foreground",
-                    )}
-                    data-testid="skill-body-tab-edit"
-                    onClick={() => setBodyTab("edit")}
-                    role="tab"
-                    aria-selected={bodyTab === "edit"}
-                  >
-                    Edit
-                  </button>
-                  <button
-                    type="button"
-                    className={cn(
-                      "px-3 py-1 text-xs rounded-sm transition-colors cursor-pointer",
-                      bodyTab === "preview"
-                        ? "bg-muted font-medium"
-                        : "text-muted-foreground hover:text-foreground",
-                    )}
-                    data-testid="skill-body-tab-preview"
-                    onClick={() => setBodyTab("preview")}
-                    role="tab"
-                    aria-selected={bodyTab === "preview"}
-                  >
-                    Preview
-                  </button>
-                  <span className="text-muted-foreground ml-auto pr-1 text-xs">
-                    Use <code className="font-mono">@</code> to reference files
-                  </span>
-                </div>
-                <div className="min-h-0 grow overflow-y-auto">
-                  {bodyTab === "edit" ? (
-                    <CodeEditor
-                      className="z-0 w-full"
-                      code={form.skillMdBody}
-                      lang="markdown"
-                      onChange={(value: string) => form.setSkillMdBody(value)}
-                      height="100%"
-                      wrap
-                      customCompletions={filePathCompletions}
-                      options={{
-                        showVerticalScrollbar: true,
-                        scrollBeyondLastLine: false,
-                        lineNumbers: "on",
-                        alwaysConsumeMouseWheel: false,
-                        quickSuggestions: false,
-                      }}
-                    />
-                  ) : (
-                    <div className="p-4">
-                      <Markdown
-                        content={form.skillMdBody || ""}
-                        className="text-sm"
-                      />
-                    </div>
-                  )}
-                </div>
-                {(form.errors.skill_md_body || form.bodyWarning) && (
-                  <div className="shrink-0 border-t px-3 py-1.5">
-                    {form.errors.skill_md_body && (
-                      <p className="text-destructive text-xs" role="alert">
-                        {form.errors.skill_md_body}
-                      </p>
-                    )}
-                    {form.bodyWarning && (
-                      <p
-                        className="text-xs text-yellow-600 dark:text-yellow-500"
-                        role="status"
-                      >
-                        {form.bodyWarning}
-                      </p>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+			{/* Files + SKILL.md two-pane workspace */}
+			<div className="min-h-0 flex-1 px-4 pt-4">
+				<ResizablePanelGroup direction="horizontal" className="h-full min-h-0">
+					{/* Left: files panel */}
+					<ResizablePanel defaultSize="28%" minSize="18%" maxSize="50%" className="bg-card flex min-h-0 flex-col gap-2">
+						<p className="text-muted-foreground/70 px-1 text-[10px] font-semibold tracking-wider uppercase">Details</p>
+						<button
+							type="button"
+							data-testid="skill-details-pane-btn"
+							onClick={() => {
+								setSelectedDetailsPane("details");
+								setSelectedFileIndex(null);
+							}}
+							className={cn(
+								"flex items-center gap-2 rounded-md border px-3 py-2 text-left text-xs font-medium transition-colors",
+								selectedDetailsPane === "details"
+									? "border-primary/20 bg-primary/10 text-primary hover:bg-primary/10"
+									: "bg-card hover:bg-muted",
+							)}
+						>
+							<Settings2 className="h-3.5 w-3.5 shrink-0" />
+							Skill Metadata
+						</button>
+						<p className="text-muted-foreground/70 mt-2 px-1 text-[10px] font-semibold tracking-wider uppercase">Files</p>
+						<div className="bg-card flex min-h-0 flex-1 flex-col rounded-md border">
+							<div className="flex h-9 items-center border-b">
+								<div className="relative grow">
+									<Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+									<Input
+										placeholder="Search files..."
+										value={fileSearchQuery}
+										onChange={(e) => setFileSearchQuery(e.target.value)}
+										data-testid="sidebar-search"
+										className="h-9 border-none pl-8"
+									/>
+								</div>
+							</div>
+							<ScrollArea className="min-h-0 flex-1 p-1" viewportClassName="overflow-x-auto">
+								<FileManagerSection
+									files={form.files}
+									onAddFile={form.addFile}
+									onRemoveFile={form.removeFile}
+									onUpdateFile={form.updateFile}
+									readOnly={false}
+									selectedIndex={selectedDetailsPane == null ? selectedFileIndex : null}
+									onSelectFile={(index) => {
+										setSelectedDetailsPane(null);
+										setSelectedFileIndex(index);
+									}}
+									bodySelected={selectedFile == null && selectedDetailsPane == null}
+									hasBodyError={!form.skillMdBody.trim()}
+									onSelectBody={() => {
+										setSelectedDetailsPane(null);
+										setSelectedFileIndex(null);
+									}}
+									searchQuery={fileSearchQuery}
+									onSearchChange={setFileSearchQuery}
+								/>
+								<ScrollBar orientation="horizontal" />
+							</ScrollArea>
+						</div>
+					</ResizablePanel>
 
-      <div className="dark:bg-card/95 sticky bottom-0 z-20 mt-4 flex items-center justify-end gap-2 border-t bg-white/95 px-1 py-3 backdrop-blur">
-        <Button
-          variant="ghost"
-          size="sm"
-          data-testid="skill-cancel-btn"
-          onClick={onCancel}
-          className="text-muted-foreground hover:bg-transparent hover:text-red-600 dark:hover:text-red-400"
-        >
-          Cancel
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          data-testid="skill-preview-btn"
-          onClick={() => setShowPreviewDialog(true)}
-        >
-          <Eye className="h-3.5 w-3.5" />
-          Preview Raw SKILL.md
-        </Button>
-        {isCreate ? (
-          <Button
-            size="sm"
-            data-testid="skill-create-save-btn"
-            onClick={() => openVersionDialog(true)}
-            disabled={isSaving || form.hasErrors}
-          >
-            {isSaving ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Plus className="h-3.5 w-3.5" />
-            )}
-            {isSaving ? "Creating..." : "Create Skill"}
-          </Button>
-        ) : (
-          <>
-            <Button
-              variant="outline"
-              size="sm"
-              data-testid="skill-save-btn"
-              onClick={() => openVersionDialog(false)}
-              disabled={isSaving || form.hasErrors}
-            >
-              {isSaving ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Save className="h-3.5 w-3.5" />
-              )}
-              {isSaving ? "Saving..." : "Save"}
-            </Button>
-            <Button
-              size="sm"
-              data-testid="skill-save-serve-btn"
-              onClick={() => openVersionDialog(true)}
-              disabled={isSaving || form.hasErrors}
-            >
-              {isSaving ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Save className="h-3.5 w-3.5" />
-              )}
-              {isSaving ? "Saving..." : "Save & Serve"}
-            </Button>
-          </>
-        )}
-      </div>
+					<ResizableHandle className="mx-1.5 bg-transparent" />
 
-      {/* Preview SKILL.md Dialog */}
-      <Dialog open={showPreviewDialog} onOpenChange={setShowPreviewDialog}>
-        <DialogContent
-          showCloseButton={false}
-          className="border-0 p-0 shadow-none sm:w-4/5 sm:max-w-4xl md:w-1/2 md:max-w-3xl"
-        >
-          <DialogHeader className="sr-only">
-            <DialogTitle>SKILL.md Preview</DialogTitle>
-          </DialogHeader>
-          <div className="bg-muted relative overflow-hidden rounded-sm border shadow-lg">
-            <div className="absolute top-3 right-3 z-10 flex items-center gap-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                data-testid="skill-preview-copy-btn"
-                className="bg-background/70 text-muted-foreground hover:bg-background/90 hover:text-foreground h-8 w-8 rounded-sm"
-                onClick={() => copyPreviewContent(previewContent)}
-                aria-label={
-                  copiedPreviewContent
-                    ? "Raw SKILL.md copied"
-                    : "Copy raw SKILL.md"
-                }
-              >
-                {copiedPreviewContent ? (
-                  <Check className="h-4 w-4" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
-              </Button>
-              <DialogClose className="text-muted-foreground hover:bg-background/80 hover:text-foreground cursor-pointer rounded-sm p-1.5 transition-colors">
-                <X className="h-4 w-4" />
-                <span className="sr-only">Close</span>
-              </DialogClose>
-            </div>
-            <ScrollArea className="h-dvh" viewportClassName="bg-muted">
-              <pre className="bg-muted min-h-96 p-5 pr-24 font-mono text-xs leading-5 whitespace-pre-wrap">
-                {previewContent}
-              </pre>
-            </ScrollArea>
-          </div>
-        </DialogContent>
-      </Dialog>
+					{/* Right: editor for the selected item */}
+					<ResizablePanel defaultSize="72%" minSize="30%" className="flex min-h-0 flex-col overflow-auto">
+						{selectedDetailsPane === "details" ? (
+							<DetailsEditorPane form={form} descriptionLength={descriptionLength} descriptionLimitColor={descriptionLimitColor} />
+						) : selectedFile ? (
+							<FilePreviewPane
+								key={selectedFile.path}
+								file={selectedFile}
+								skillName={skillName ?? form.name ?? ""}
+								mode="edit"
+								registerFlush={(flush) => {
+									flushFileEditRef.current = flush;
+								}}
+								onFileUpdate={(updates) => {
+									if (selectedFileIndex == null) return;
+									form.updateFile(selectedFileIndex, updates);
+								}}
+								onContentChange={(editedText) => {
+									if (selectedFileIndex == null) return;
+									if (selectedFile.source_type === "dataurl") {
+										// Re-encode edited text as a data URI; drop old storage refs
+										// so the backend creates a new blob for the new version.
+										const dataurl = `data:${selectedFile.mime_type || "text/plain"};base64,${btoa(unescape(encodeURIComponent(editedText)))}`;
+										form.updateFile(selectedFileIndex, {
+											dataurl,
+											blob_id: undefined,
+											storage_key: undefined,
+										});
+									} else {
+										// text source: submit raw content; drop old storage refs.
+										form.updateFile(selectedFileIndex, {
+											content: editedText,
+											blob_id: undefined,
+											storage_key: undefined,
+										});
+									}
+								}}
+							/>
+						) : (
+							<div className="flex h-full min-h-0 flex-col overflow-hidden rounded-sm border">
+								<div className="flex h-9 shrink-0 items-center gap-1 border-b px-2" role="tablist" aria-label="Body editor tabs">
+									<button
+										type="button"
+										className={cn(
+											"px-3 py-1 text-xs rounded-sm transition-colors cursor-pointer",
+											bodyTab === "edit" ? "bg-muted font-medium" : "text-muted-foreground hover:text-foreground",
+										)}
+										data-testid="skill-body-tab-edit"
+										onClick={() => setBodyTab("edit")}
+										role="tab"
+										aria-selected={bodyTab === "edit"}
+									>
+										Edit
+									</button>
+									<button
+										type="button"
+										className={cn(
+											"px-3 py-1 text-xs rounded-sm transition-colors cursor-pointer",
+											bodyTab === "preview" ? "bg-muted font-medium" : "text-muted-foreground hover:text-foreground",
+										)}
+										data-testid="skill-body-tab-preview"
+										onClick={() => setBodyTab("preview")}
+										role="tab"
+										aria-selected={bodyTab === "preview"}
+									>
+										Preview
+									</button>
+									<span className="text-muted-foreground ml-auto pr-1 text-xs">
+										Use <code className="font-mono">@</code> to reference files
+									</span>
+								</div>
+								<div className="min-h-0 grow overflow-y-auto">
+									{bodyTab === "edit" ? (
+										<CodeEditor
+											className="z-0 w-full"
+											code={form.skillMdBody}
+											lang="markdown"
+											onChange={(value: string) => form.setSkillMdBody(value)}
+											height="100%"
+											wrap
+											customCompletions={filePathCompletions}
+											options={{
+												showVerticalScrollbar: true,
+												scrollBeyondLastLine: false,
+												lineNumbers: "on",
+												alwaysConsumeMouseWheel: false,
+												quickSuggestions: false,
+											}}
+										/>
+									) : (
+										<div className="p-4">
+											<SkillMarkdown
+												content={form.skillMdBody}
+												files={form.files}
+												onSelectFile={(path) => {
+													const index = form.files.findIndex((f) => f.path === path);
+													if (index === -1) return;
+													setSelectedDetailsPane(null);
+													setSelectedFileIndex(index);
+												}}
+												className="text-sm"
+											/>
+										</div>
+									)}
+								</div>
+								{(form.errors.skill_md_body || form.bodyWarning) && (
+									<div className="shrink-0 border-t px-3 py-1.5">
+										{form.errors.skill_md_body && (
+											<p className="text-destructive text-xs" role="alert">
+												{form.errors.skill_md_body}
+											</p>
+										)}
+										{form.bodyWarning && (
+											<p className="text-xs text-yellow-600 dark:text-yellow-500" role="status">
+												{form.bodyWarning}
+											</p>
+										)}
+									</div>
+								)}
+							</div>
+						)}
+					</ResizablePanel>
+				</ResizablePanelGroup>
+			</div>
 
-      {/* Version dialog — asked for at save time */}
-      <Dialog
-        open={versionDialog != null}
-        onOpenChange={(open) => !open && closeVersionDialog()}
-      >
-        <DialogContent className="sm:max-w-sm">
-          <DialogHeader>
-            <DialogTitle>
-              {isCreate ? "Create skill" : "Save new version"}
-            </DialogTitle>
-          </DialogHeader>
-          <VersionDialogBody
-            form={form}
-            isCreate={isCreate}
-            previousVersion={previousVersion}
-            isSaving={isSaving}
-            serve={versionDialog?.serve ?? false}
-            onClose={closeVersionDialog}
-            onSave={(serve) => {
-              setVersionDialog(null);
-              onSave(serve);
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-    </div>
-  );
+			{/* Dims the page behind the version popover so it reads as a focused step, like a dialog. */}
+			{versionPopover != null && (
+				<div className="animate-in fade-in-0 fixed inset-0 z-50 bg-black/50" onClick={closeVersionPopover} aria-hidden />
+			)}
+
+			<div className="dark:bg-card/95 sticky bottom-0 z-20 mt-4 flex items-center justify-end gap-2 border-t bg-white/95 px-1 py-3 backdrop-blur">
+				<Button
+					variant="ghost"
+					size="sm"
+					data-testid="skill-cancel-btn"
+					onClick={onCancel}
+					className="text-muted-foreground hover:bg-transparent hover:text-red-600 dark:hover:text-red-400"
+				>
+					Cancel
+				</Button>
+				<Button variant="outline" size="sm" data-testid="skill-preview-btn" onClick={() => setShowPreviewDialog(true)}>
+					<Eye className="h-3.5 w-3.5" />
+					Preview Raw SKILL.md
+				</Button>
+				{isCreate ? (
+					<Popover open={versionPopover != null} onOpenChange={(open) => !open && closeVersionPopover()}>
+						<PopoverAnchor asChild>
+							<Button size="sm" data-testid="skill-create-save-btn" onClick={() => openVersionPopover(true)} disabled={isSaving}>
+								{isSaving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
+								{isSaving ? "Creating..." : "Create Skill"}
+							</Button>
+						</PopoverAnchor>
+						<PopoverContent align="end" className="w-max">
+							<VersionPopoverBody
+								form={form}
+								isCreate={isCreate}
+								previousVersion={previousVersion}
+								isSaving={isSaving}
+								serve={versionPopover?.serve ?? false}
+								onClose={closeVersionPopover}
+								onSave={(serve) => {
+									setVersionPopover(null);
+									onSave(serve);
+								}}
+							/>
+						</PopoverContent>
+					</Popover>
+				) : (
+					<>
+						<Popover open={versionPopover?.serve === false} onOpenChange={(open) => !open && closeVersionPopover()}>
+							<PopoverAnchor asChild>
+								<Button
+									variant="outline"
+									size="sm"
+									data-testid="skill-save-btn"
+									onClick={() => openVersionPopover(false)}
+									disabled={isSaving}
+								>
+									{isSaving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+									{isSaving ? "Saving..." : "Save"}
+								</Button>
+							</PopoverAnchor>
+							<PopoverContent align="end" className="w-max">
+								<VersionPopoverBody
+									form={form}
+									isCreate={isCreate}
+									previousVersion={previousVersion}
+									isSaving={isSaving}
+									serve={false}
+									onClose={closeVersionPopover}
+									onSave={(serve) => {
+										setVersionPopover(null);
+										onSave(serve);
+									}}
+								/>
+							</PopoverContent>
+						</Popover>
+						<Popover open={versionPopover?.serve === true} onOpenChange={(open) => !open && closeVersionPopover()}>
+							<PopoverAnchor asChild>
+								<Button size="sm" data-testid="skill-save-serve-btn" onClick={() => openVersionPopover(true)} disabled={isSaving}>
+									{isSaving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+									{isSaving ? "Saving..." : "Save & Serve"}
+								</Button>
+							</PopoverAnchor>
+							<PopoverContent align="end" className="w-max">
+								<VersionPopoverBody
+									form={form}
+									isCreate={isCreate}
+									previousVersion={previousVersion}
+									isSaving={isSaving}
+									serve={true}
+									onClose={closeVersionPopover}
+									onSave={(serve) => {
+										setVersionPopover(null);
+										onSave(serve);
+									}}
+								/>
+							</PopoverContent>
+						</Popover>
+					</>
+				)}
+			</div>
+
+			{/* Preview SKILL.md Dialog */}
+			<Dialog open={showPreviewDialog} onOpenChange={setShowPreviewDialog}>
+				<DialogContent
+					showCloseButton={false}
+					className="h-[90vh] w-full border-0 p-0 sm:w-[85vw] sm:max-w-[85vw] md:w-[75vw] md:max-w-[75vw]"
+				>
+					<DialogHeader className="sr-only">
+						<DialogTitle>SKILL.md Preview</DialogTitle>
+					</DialogHeader>
+					<div className="bg-muted relative overflow-hidden rounded-sm border shadow-lg">
+						<div className="absolute top-3 right-3 z-10 flex items-center gap-1">
+							<Button
+								variant="ghost"
+								size="icon"
+								data-testid="skill-preview-copy-btn"
+								className="bg-background/70 text-muted-foreground hover:bg-background/90 hover:text-foreground h-8 w-8 rounded-sm"
+								onClick={() => copyPreviewContent(previewContent)}
+								aria-label={copiedPreviewContent ? "Raw SKILL.md copied" : "Copy raw SKILL.md"}
+							>
+								{copiedPreviewContent ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+							</Button>
+							<DialogClose className="text-muted-foreground hover:bg-background/80 hover:text-foreground cursor-pointer rounded-sm p-1.5 transition-colors">
+								<X className="h-4 w-4" />
+								<span className="sr-only">Close</span>
+							</DialogClose>
+						</div>
+						<ScrollArea className="h-dvh" viewportClassName="bg-muted">
+							<pre className="bg-muted min-h-96 p-5 pr-24 font-mono text-xs leading-5 whitespace-pre-wrap">{previewContent}</pre>
+						</ScrollArea>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
 }
 
 /** Build autocomplete items for referencing skill files with @[name](path) syntax. */
 function buildFilePathCompletions(files: SkillFileEntry[]): CompletionItem[] {
-  const completions: CompletionItem[] = [];
-  const folderPaths = new Set<string>();
+	const completions: CompletionItem[] = [];
+	const folderPaths = new Set<string>();
 
-  for (const file of files) {
-    if (!file.path) continue;
-    const pathParts = file.path.split("/").filter(Boolean);
-    const fileName = pathParts.at(-1) ?? file.path;
-    const rootRelativePath = `./${file.path}`;
+	for (const file of files) {
+		if (!file.path) continue;
+		const pathParts = file.path.split("/").filter(Boolean);
+		const fileName = pathParts.at(-1) ?? file.path;
+		const rootRelativePath = `./${file.path}`;
 
-    for (let i = 0; i < pathParts.length - 1; i++) {
-      folderPaths.add(pathParts.slice(0, i + 1).join("/"));
-    }
+		for (let i = 0; i < pathParts.length - 1; i++) {
+			folderPaths.add(pathParts.slice(0, i + 1).join("/"));
+		}
 
-    completions.push({
-      label: fileName,
-      insertText: `@[${fileName}](${rootRelativePath})`,
-      type: "object" as const,
-      description: rootRelativePath,
-      documentation: `Full path: ${rootRelativePath}`,
-    });
-  }
+		completions.push({
+			label: fileName,
+			insertText: `@[${fileName}](${rootRelativePath})`,
+			type: "object" as const,
+			description: rootRelativePath,
+			documentation: `Full path: ${rootRelativePath}`,
+		});
+	}
 
-  for (const folderPath of folderPaths) {
-    const folderName =
-      folderPath.split("/").filter(Boolean).pop() ?? folderPath;
-    const rootRelativePath = `./${folderPath}/`;
-    completions.push({
-      label: folderName,
-      insertText: `@[${folderName}](${rootRelativePath})`,
-      type: "folder" as const,
-      description: rootRelativePath,
-      documentation: `Full path: ${rootRelativePath}`,
-    });
-  }
+	for (const folderPath of folderPaths) {
+		const folderName = folderPath.split("/").filter(Boolean).pop() ?? folderPath;
+		const rootRelativePath = `./${folderPath}/`;
+		completions.push({
+			label: folderName,
+			insertText: `@[${folderName}](${rootRelativePath})`,
+			type: "folder" as const,
+			description: rootRelativePath,
+			documentation: `Full path: ${rootRelativePath}`,
+		});
+	}
 
-  return completions.sort(
-    (a, b) => a.description?.localeCompare(b.description ?? "") ?? 0,
-  );
+	return completions.sort((a, b) => a.description?.localeCompare(b.description ?? "") ?? 0);
 }
 
 function DetailsEditorPane({
-  form,
-  descriptionLength,
-  descriptionLimitColor,
+	form,
+	descriptionLength,
+	descriptionLimitColor,
 }: {
-  form: SkillFormReturn;
-  descriptionLength: number;
-  descriptionLimitColor: string;
+	form: SkillFormReturn;
+	descriptionLength: number;
+	descriptionLimitColor: string;
 }) {
-  return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <div className="flex h-9 shrink-0 items-center gap-2 px-1">
-        <span className="text-sm font-semibold">Details</span>
-        <span className="text-muted-foreground text-xs">
-          Edit the skill description and spec fields
-        </span>
-      </div>
-      <ScrollArea className="min-h-0 flex-1 rounded-sm border">
-        <div className="flex flex-col gap-8 p-4">
-          <FormSection title="Description">
-            <div className="flex flex-col gap-2">
-              <Textarea
-                data-testid="skill-description-input"
-                value={form.description}
-                onChange={(e) => {
-                  form.setDescription(e.target.value);
-                  form.validateField("description", e.target.value);
-                }}
-                placeholder="What does this skill do?"
-                rows={3}
-                className={
-                  form.errors.description ? "border-destructive" : undefined
-                }
-              />
-              <div className="flex justify-between">
-                <span
-                  className={`text-xs tabular-nums transition-colors ${descriptionLimitColor}`}
-                >
-                  {descriptionLength}/1024
-                </span>
-                {form.errors.description ? (
-                  <p className="text-destructive text-xs" role="alert">
-                    {form.errors.description}
-                  </p>
-                ) : (
-                  <span />
-                )}
-              </div>
-            </div>
-          </FormSection>
+	return (
+		<div className="flex h-full min-h-0 flex-col overflow-hidden">
+			<ScrollArea className="min-h-0 flex-1 rounded-sm border">
+				<div className="flex flex-col gap-8 p-4">
+					<FormSection title="Description">
+						<div className="flex flex-col gap-2">
+							<Textarea
+								data-testid="skill-description-input"
+								value={form.description}
+								onChange={(e) => {
+									form.setDescription(e.target.value);
+									form.validateField("description", e.target.value);
+								}}
+								placeholder="What does this skill do?"
+								rows={3}
+								className={form.errors.description ? "border-destructive" : undefined}
+							/>
+							{form.errors.description ? (
+								<p className="text-destructive text-xs" role="alert">
+									{form.errors.description}
+								</p>
+							) : null}
+							<p className={cn("text-right text-xs", descriptionLimitColor)}>{descriptionLength}/1024</p>
+						</div>
+					</FormSection>
 
-          <FormSection title="Spec Fields">
-            <div className="grid grid-cols-3 gap-4">
-              <div className="flex flex-col gap-1.5">
-                <Label className="text-muted-foreground text-xs">License</Label>
-                <Input
-                  data-testid="skill-license-input"
-                  value={form.license}
-                  onChange={(e) => form.setLicense(e.target.value)}
-                  placeholder="MIT (optional)"
-                  className="text-sm"
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label className="text-muted-foreground text-xs">
-                  Compatibility
-                </Label>
-                <Input
-                  data-testid="skill-compatibility-input"
-                  value={form.compatibility}
-                  onChange={(e) => form.setCompatibility(e.target.value)}
-                  placeholder="Claude Code, Codex (optional)"
-                  className="text-sm"
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label className="text-muted-foreground text-xs">
-                  Allowed Tools
-                </Label>
-                <Input
-                  data-testid="skill-allowed-tools-input"
-                  value={form.allowedTools}
-                  onChange={(e) => form.setAllowedTools(e.target.value)}
-                  placeholder="Bash Read Grep (optional)"
-                  className="text-sm"
-                />
-              </div>
-            </div>
-          </FormSection>
-        </div>
-      </ScrollArea>
-    </div>
-  );
-}
+					<FormSection title="Spec Fields">
+						<div className="grid grid-cols-3 gap-4">
+							<div className="flex flex-col gap-1">
+								<Label className="text-muted-foreground text-xs">License</Label>
+								<Input
+									data-testid="skill-license-input"
+									value={form.license}
+									onChange={(e) => form.setLicense(e.target.value)}
+									placeholder="MIT (optional)"
+									className="h-8 text-sm"
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Label className="text-muted-foreground text-xs">Compatibility</Label>
+								<Input
+									data-testid="skill-compatibility-input"
+									value={form.compatibility}
+									onChange={(e) => form.setCompatibility(e.target.value)}
+									placeholder="Claude Code, Codex (optional)"
+									className="h-8 text-sm"
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Label className="text-muted-foreground text-xs">Allowed Tools</Label>
+								<Input
+									data-testid="skill-allowed-tools-input"
+									value={form.allowedTools}
+									onChange={(e) => form.setAllowedTools(e.target.value)}
+									placeholder="Bash Read Grep (optional)"
+									className="h-8 text-sm"
+								/>
+							</div>
+						</div>
+					</FormSection>
 
-function MetadataEditorPane({ form }: { form: SkillFormReturn }) {
-  return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <div className="flex h-9 shrink-0 items-center gap-2 px-1">
-        <span className="text-sm font-semibold">Metadata</span>
-        <span className="text-muted-foreground text-xs">
-          Flat key-value pairs nested under{" "}
-          <code className="font-mono">metadata:</code> in SKILL.md
-        </span>
-      </div>
-      <ScrollArea className="min-h-0 flex-1 rounded-sm border">
-        <div className="p-3">
-          <MetadataTableEditor
-            metadataJson={form.metadataJson}
-            onChange={(json) => {
-              form.setMetadataJson(json);
-              form.validateField("metadata", json);
-            }}
-            error={form.errors.metadata}
-          />
-        </div>
-      </ScrollArea>
-    </div>
-  );
-}
+					<FormSection
+						title="Metadata"
+						helperText={
+							<>
+								Flat key-value pairs nested under <code className="font-mono">metadata:</code> in SKILL.md
+							</>
+						}
+					>
+						<MetadataTableEditor
+							metadataJson={form.metadataJson}
+							onChange={(json) => {
+								form.setMetadataJson(json);
+								form.validateField("metadata", json);
+							}}
+							error={form.errors.metadata}
+						/>
+					</FormSection>
 
-function ExtraFrontmatterEditorPane({ form }: { form: SkillFormReturn }) {
-  return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <div className="flex h-9 shrink-0 items-center gap-2 px-1">
-        <span className="text-sm font-semibold">Extra Frontmatter</span>
-        <span className="text-muted-foreground text-xs">
-          Valid JSON merged into the SKILL.md YAML frontmatter
-        </span>
-      </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-2 rounded-sm border p-3">
-        <div className="min-h-0 flex-1 overflow-hidden">
-          <CodeEditor
-            className="z-0 w-full"
-            code={form.extraFrontmatterJson}
-            lang="json"
-            onChange={(value: string) => {
-              form.setExtraFrontmatterJson(value);
-              form.validateField("extra_frontmatter", value);
-            }}
-            height="100%"
-            wrap
-            options={{
-              showVerticalScrollbar: true,
-              scrollBeyondLastLine: false,
-              lineNumbers: "on",
-              alwaysConsumeMouseWheel: false,
-            }}
-          />
-        </div>
-        {form.errors.extra_frontmatter && (
-          <p className="text-destructive shrink-0 text-xs" role="alert">
-            {form.errors.extra_frontmatter}
-          </p>
-        )}
-      </div>
-    </div>
-  );
+					<FormSection title="Extra Frontmatter" helperText="Valid JSON merged into the SKILL.md YAML frontmatter">
+						<div className="flex flex-col gap-2">
+							<div className="h-64 overflow-hidden rounded-sm border">
+								<CodeEditor
+									className="z-0 w-full py-2"
+									code={form.extraFrontmatterJson}
+									lang="json"
+									onChange={(value: string) => {
+										form.setExtraFrontmatterJson(value);
+										form.validateField("extra_frontmatter", value);
+									}}
+									height="100%"
+									wrap
+									options={{
+										showVerticalScrollbar: true,
+										scrollBeyondLastLine: false,
+										lineNumbers: "off",
+										alwaysConsumeMouseWheel: false,
+										showIndentLines: false,
+									}}
+								/>
+							</div>
+							{form.errors.extra_frontmatter && (
+								<p className="text-destructive text-xs" role="alert">
+									{form.errors.extra_frontmatter}
+								</p>
+							)}
+						</div>
+					</FormSection>
+				</div>
+			</ScrollArea>
+		</div>
+	);
 }
 
 /** The version input + confirm/cancel inside the version dialog. */
-function VersionDialogBody({
-  form,
-  isCreate,
-  previousVersion,
-  isSaving,
-  serve,
-  onClose,
-  onSave,
+function VersionPopoverBody({
+	form,
+	isCreate,
+	previousVersion,
+	isSaving,
+	serve,
+	onClose,
+	onSave,
 }: {
-  form: SkillFormReturn;
-  isCreate: boolean;
-  previousVersion?: string;
-  isSaving: boolean;
-  serve: boolean;
-  onClose: () => void;
-  onSave: (serve: boolean) => void;
+	form: SkillFormReturn;
+	isCreate: boolean;
+	previousVersion?: string;
+	isSaving: boolean;
+	serve: boolean;
+	onClose: () => void;
+	onSave: (serve: boolean) => void;
 }) {
-  const bumpError =
-    !isCreate && previousVersion
-      ? validateVersionBump(form.version, previousVersion)
-      : null;
-  const versionError = form.errors.version || bumpError;
-  const canSave = !!form.version.trim() && !versionError && !isSaving;
+	const bumpError = !isCreate && previousVersion ? validateVersionBump(form.version, previousVersion) : null;
+	const versionError = form.errors.version || bumpError;
+	const canSave = !!form.version.trim() && !versionError && !isSaving;
 
-  const submit = () => {
-    if (!canSave) return;
-    onSave(serve);
-  };
+	const submit = () => {
+		if (!canSave) return;
+		onSave(serve);
+	};
 
-  return (
-    <>
-      <div className="flex flex-col gap-1.5">
-        <Label className="text-muted-foreground text-xs">Version</Label>
-        <div className="flex items-center gap-2">
-          {!isCreate && previousVersion && (
-            <>
-              <span className="text-muted-foreground font-mono text-sm">
-                {previousVersion}
-              </span>
-              <span className="text-muted-foreground/50">→</span>
-            </>
-          )}
-          <Input
-            autoFocus
-            data-testid="skill-version-input"
-            value={form.version}
-            onChange={(e) => {
-              form.setVersion(e.target.value);
-              form.validateField("version", e.target.value);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                submit();
-              }
-            }}
-            placeholder="1.0.0"
-            className={cn(
-              "max-w-44 font-mono text-sm",
-              versionError && "border-destructive",
-            )}
-          />
-        </div>
-        {versionError ? (
-          <p className="text-destructive text-xs" role="alert">
-            {versionError}
-          </p>
-        ) : (
-          !isCreate && (
-            <p className="text-muted-foreground text-xs">
-              Bump major (2.x.x), minor (1.1.x), or patch (1.0.1).
-            </p>
-          )
-        )}
-      </div>
-      <div className="mt-4 flex justify-end gap-2">
-        <Button variant="ghost" size="sm" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button
-          size="sm"
-          data-testid="skill-version-confirm-btn"
-          disabled={!canSave}
-          onClick={submit}
-        >
-          {isCreate ? "Create" : serve ? "Save & Serve" : "Save"}
-        </Button>
-      </div>
-    </>
-  );
+	return (
+		<>
+			<div className="mb-3 flex flex-col gap-0.5">
+				<p className="text-sm font-medium">{isCreate ? "Create skill" : "Save new version"}</p>
+				<p className="text-muted-foreground text-xs">
+					{isCreate ? "Set the initial version for this skill." : "Choose a new version number for these changes."}
+				</p>
+			</div>
+			<div className="flex flex-col gap-1.5">
+				<Label className="text-muted-foreground text-xs">Version</Label>
+				<div className="flex items-center gap-2">
+					{!isCreate && previousVersion && (
+						<>
+							<span className="text-muted-foreground font-mono text-sm">{previousVersion}</span>
+							<span className="text-muted-foreground/50">→</span>
+						</>
+					)}
+					<Input
+						autoFocus
+						data-testid="skill-version-input"
+						value={form.version}
+						onChange={(e) => {
+							form.setVersion(e.target.value);
+							form.validateField("version", e.target.value);
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								submit();
+							}
+						}}
+						placeholder="1.0.0"
+						className={cn("max-w-44 font-mono text-sm", versionError && "border-destructive")}
+					/>
+				</div>
+				{versionError ? (
+					<p className="text-destructive text-xs" role="alert">
+						{versionError}
+					</p>
+				) : (
+					!isCreate && <p className="text-muted-foreground text-xs">Bump major (2.x.x), minor (1.1.x), or patch (1.0.1).</p>
+				)}
+			</div>
+			<div className="mt-4 flex justify-end gap-2">
+				<Button variant="ghost" size="sm" onClick={onClose}>
+					Cancel
+				</Button>
+				<Button size="sm" data-testid="skill-version-confirm-btn" disabled={!canSave} onClick={submit}>
+					{isCreate ? "Create" : serve ? "Save & Serve" : "Save"}
+				</Button>
+			</div>
+		</>
+	);
 }

--- a/ui/app/workspace/skills-repo/page.tsx
+++ b/ui/app/workspace/skills-repo/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQueryStates, parseAsBoolean, parseAsString } from "nuqs";
+import { parseAsBoolean, parseAsString, useQueryStates } from "nuqs";
 import { SkillCreateView } from "./components/skillCreatorView";
 import { SkillDetailView } from "./components/skillDetailsView";
 import { SkillsListView } from "./components/skillListView";
@@ -50,7 +50,7 @@ export default function SkillsRepoPage() {
 
 	// List view
 	return (
-		<div className="no-padding-parent flex w-full flex-col p-4">
+		<div className="no-padding-parent flex w-full flex-col p-4 h-[calc(100dvh_-_16px)]">
 			<SkillsListView onSelectSkill={handleSelectSkill} onCreateNew={() => setUrlState({ create: true, skillId: null, edit: false })} />
 		</div>
 	);

--- a/ui/components/ui/command.tsx
+++ b/ui/components/ui/command.tsx
@@ -1,5 +1,5 @@
 import { Command as CommandPrimitive } from "cmdk";
-import { SearchIcon } from "lucide-react";
+import { Loader2Icon, SearchIcon } from "lucide-react";
 import * as React from "react";
 
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -43,10 +43,10 @@ function CommandDialog({
 	);
 }
 
-function CommandInput({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Input>) {
+function CommandInput({ className, isLoading, ...props }: React.ComponentProps<typeof CommandPrimitive.Input> & { isLoading?: boolean }) {
 	return (
 		<div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
-			<SearchIcon className="size-4 shrink-0 opacity-50" />
+			{isLoading ? <Loader2Icon className="size-4 shrink-0 opacity-50 animate-spin" /> : <SearchIcon className="size-4 shrink-0 opacity-50" />}
 			<CommandPrimitive.Input
 				data-slot="command-input"
 				className={cn(

--- a/ui/components/ui/resizable.tsx
+++ b/ui/components/ui/resizable.tsx
@@ -36,7 +36,7 @@ function ResizableHandle({
 		<Separator
 			data-slot="resizable-handle"
 			className={cn(
-				"bg-border focus-visible:ring-ring group/resizable-handle relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+				"bg-border focus-visible:ring-ring group/resizable-handle relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90 focus-visible:ring-0",
 				className,
 			)}
 			{...props}

--- a/ui/components/ui/scrollArea.tsx
+++ b/ui/components/ui/scrollArea.tsx
@@ -1,14 +1,15 @@
-import * as React from "react";
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
 function ScrollArea({
 	className,
 	viewportClassName,
+	bidirectionalScroll,
 	children,
 	...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & { viewportClassName?: string }) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & { viewportClassName?: string, bidirectionalScroll?: boolean }) {
 	return (
 		<ScrollAreaPrimitive.Root data-slot="scroll-area" className={cn("relative", className)} {...props}>
 			<ScrollAreaPrimitive.Viewport
@@ -20,7 +21,7 @@ function ScrollArea({
 			>
 				{children}
 			</ScrollAreaPrimitive.Viewport>
-			<ScrollBar />
+			{bidirectionalScroll ? <><ScrollBar orientation="horizontal" /><ScrollBar orientation="vertical" /></> : <ScrollBar />}
 			<ScrollAreaPrimitive.Corner />
 		</ScrollAreaPrimitive.Root>
 	);

--- a/ui/components/ui/treeView.tsx
+++ b/ui/components/ui/treeView.tsx
@@ -33,6 +33,12 @@ export interface TreeProps<T extends BaseNodeData> {
 	lineColor?: string;
 	lineWidth?: number;
 	levelsToExpandByDefault?: number;
+	/**
+	 * When true, rows fill the container width and long labels truncate instead of
+	 * growing the tree (and the parent) horizontally. Defaults to false, where the
+	 * tree expands to its widest content (enabling horizontal scroll).
+	 */
+	fitContainer?: boolean;
 	/** External expansion state control — parent can manage expandedNodes directly */
 	states?: {
 		expandedNodes: Record<string, boolean>;
@@ -83,6 +89,7 @@ function TreeNodeComponent<T extends BaseNodeData>({
 	onCollapseAll,
 	isAllExpanded,
 	isAllCollapsed,
+	fitContainer,
 }: {
 	node: TreeNode<T>;
 	level: number;
@@ -97,12 +104,14 @@ function TreeNodeComponent<T extends BaseNodeData>({
 	onCollapseAll: () => void;
 	isAllExpanded: boolean;
 	isAllCollapsed: boolean;
+	fitContainer: boolean;
 }) {
 	const hasChildren = Boolean(node.children?.length);
 	const isExpanded = expandedNodes[node.data.id] ?? false;
+	const widthClass = fitContainer ? "min-w-0" : "min-w-max";
 
 	return (
-		<div className="relative min-w-max">
+		<div className={cn("relative", widthClass)}>
 			{/* Vertical line from parent — spans the full node height (row + children) for sibling continuation */}
 			{level > 0 && !isLast && (
 				<div
@@ -118,7 +127,7 @@ function TreeNodeComponent<T extends BaseNodeData>({
 			)}
 
 			{/* Row wrapper — horizontal line positions relative to just this row */}
-			<div className="relative min-w-max">
+			<div className={cn("relative", widthClass)}>
 				{/* Vertical line stub for last child — only goes to row center */}
 				{level > 0 && isLast && (
 					<div
@@ -148,7 +157,7 @@ function TreeNodeComponent<T extends BaseNodeData>({
 				)}
 
 				{/* Node content */}
-				<div className="relative min-w-max" style={{ paddingLeft: `${level * indentSize}px` }}>
+				<div className={cn("relative", widthClass)} style={{ paddingLeft: `${level * indentSize}px` }}>
 					<div className="py-0.5">
 						{renderItem({
 							item: node.data,
@@ -167,7 +176,7 @@ function TreeNodeComponent<T extends BaseNodeData>({
 
 			{/* Children */}
 			{isExpanded && node.children && (
-				<div className="relative min-w-max">
+				<div className={cn("relative", widthClass)}>
 					{node.children.map((child, idx) => (
 						<TreeNodeComponent
 							key={child.data.id}
@@ -184,6 +193,7 @@ function TreeNodeComponent<T extends BaseNodeData>({
 							onCollapseAll={onCollapseAll}
 							isAllExpanded={isAllExpanded}
 							isAllCollapsed={isAllCollapsed}
+							fitContainer={fitContainer}
 						/>
 					))}
 				</div>
@@ -202,6 +212,7 @@ export function Tree<T extends BaseNodeData>({
 	lineColor = "var(--border)",
 	lineWidth = 1,
 	levelsToExpandByDefault,
+	fitContainer = false,
 	states,
 }: TreeProps<T>) {
 	const [localExpandedNodes, localSetExpandedNodes] = useState<Record<string, boolean>>(() =>
@@ -274,7 +285,7 @@ export function Tree<T extends BaseNodeData>({
 	}, [dataFingerprint, levelsToExpandByDefault]);
 
 	return (
-		<div className={cn("min-w-max", className)}>
+		<div className={cn(fitContainer ? "min-w-0" : "min-w-max", className)}>
 			{data.map((node, idx) => (
 				<TreeNodeComponent
 					key={node.data.id}
@@ -291,6 +302,7 @@ export function Tree<T extends BaseNodeData>({
 					onCollapseAll={handleCollapseAll}
 					isAllExpanded={isAllExpanded}
 					isAllCollapsed={isAllCollapsed}
+					fitContainer={fitContainer}
 				/>
 			))}
 		</div>


### PR DESCRIPTION
## Summary

Overhauls the Skills Repo UI with a resizable two-pane layout, smarter file tree navigation, and a more polished editing experience. The primary goals are to make the file sidebar and content pane resizable, allow markdown links in SKILL.md to open sibling files directly in the sidebar, and consolidate the version-save flow into an inline popover instead of a modal dialog.

## Changes

- **Resizable panels**: The read-only skill view and the edit form both now use `ResizablePanelGroup`/`ResizablePanel` instead of fixed-width sidebars, letting users adjust the split between the file tree and content pane.
- **`SkillMarkdown` component**: Extracted a shared `SkillMarkdown` component that resolves relative markdown links (e.g. `./tui/activity.go`) to known skill files and opens them in the sidebar via `onSelectFile`, rather than navigating the browser. External links still route through a confirmation dialog.
- **Controlled search in `FileManagerSection`**: Added `searchQuery`/`onSearchChange` props so a parent can own the search state and render the input outside the component (e.g. in the sidebar header). The internal search bar is hidden when the parent controls it.
- **Auto-expand on selection and search**: The file tree now automatically expands ancestor folders when a file is selected externally (e.g. via a markdown link) and expands all folders while a search query is active.
- **`fitContainer` prop on `Tree`**: Added a `fitContainer` boolean that switches tree rows from `min-w-max` (horizontal scroll) to `min-w-0` (truncate to container), used in the sidebar panels.
- **Version save popover**: Replaced the version-save `Dialog` with a `Popover` anchored to the Save button, with a backdrop overlay. Pre-save validation now navigates to the pane containing the first error rather than silently blocking.
- **`SkillVersionsList` extracted**: The searchable, infinitely-scrolling version list is now a standalone component reusable in both the standalone `SkillVersionsPopover` and the new `SplitButton` dropdown on the detail view. The list uses `Command`/`CommandInput` instead of a plain `Input` + `ScrollArea`.
- **Details pane consolidation**: The separate Metadata and Extra Frontmatter panes in the edit form are merged into the single Details pane as `FormSection` entries, reducing navigation steps.
- **Breadcrumb navigation**: Both the edit form and the read-only header now render a breadcrumb (`Skills / <name> / new`) instead of a plain back arrow button.
- **`ClampedDescription`**: Long skill descriptions in the header are clamped to 3 lines with a Show more/less toggle, measured via `ResizeObserver`.
- **`FormSection` helper text as tooltip**: Helper text on `FormSection` is now shown in a tooltip triggered by an info icon instead of inline text.
- **`ScrollArea` bidirectional scroll**: Added a `bidirectionalScroll` prop that renders both horizontal and vertical `ScrollBar` components; used in the file preview pane.
- **`CommandInput` loading state**: `CommandInput` accepts an `isLoading` prop that swaps the search icon for a spinner.
- **`ResizableHandle` focus ring removed**: Suppressed the focus ring on the resize handle to avoid visual noise.
- **Skills list page height fix**: The list page container now uses `h-[calc(100dvh_-_16px)]` so the table fills the viewport correctly.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
```

1. Open the Skills Repo page and verify the list fills the viewport without extra padding.
2. Open a skill's detail view — confirm the file tree and content pane are resizable by dragging the handle.
3. In SKILL.md preview, click a relative link (e.g. `./somefile.go`) and confirm the file opens in the sidebar without a browser navigation.
4. Click an external `https://` link and confirm the confirmation dialog appears.
5. In the edit form, type a search query in the sidebar search box and confirm all matching folders expand automatically.
6. Click Save / Save & Serve and confirm the version popover appears anchored to the button with a backdrop, and that validation errors navigate to the correct pane.
7. Open the versions dropdown on the detail view and confirm the `Command`-based search and infinite scroll work correctly.
8. Verify a long skill description clamps to 3 lines with a "Show more" button.

## Screenshots/Recordings

_Before/after screenshots recommended for the resizable layout, breadcrumb, and version popover._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No new auth surfaces or secret handling introduced. The existing warning about not uploading sensitive files to skill packages is preserved in the edit form.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable