### PR TITLE
signin with bifrost in cli

### DIFF
--- a/cli/changelog.md
+++ b/cli/changelog.md
@@ -1,12 +1,13 @@
 - feat: adds an interactive tab command popup invoked by the `Ctrl+B` prefix — lists every open tab plus a trailing "New tab" action row, supports arrow keys / `h`/`j`/`k`/`l` navigation, `Enter` to switch or open a tab, number keys (`1`–`9`) for direct jumps, and `Esc`/`Ctrl+B` to resume
-- feat: adds `Ctrl+G` as a tmux-safe alternate prefix key, giving users a one-press tab selector inside tmux sessions that already consume `Ctrl+B`
+- feat: adds `Ctrl+T` as a tmux-safe alternate prefix key, giving users a one-press tab selector inside tmux sessions that already consume `Ctrl+B` without colliding with Claude Code's `Ctrl+G` shortcut
 - feat: adds a Home-screen Ctrl+C quit confirmation — when no tabs are open, the first `Ctrl+C` shows a centered "Quit Bifrost?" prompt and the second press exits, preventing accidental termination
 - feat: adds an interactive summary screen with arrow-key navigation across actionable rows (launch, base URL, virtual key, worktree, harness, model, dashboard, docs, issues, repo, quit) plus inline editing of base URL and virtual key without leaving the summary
+- feat: adds a "Sign in with Bifrost" CLI setup flow after Base URL entry, with browser handover, assigned virtual-key selection, sign-out from the Ready screen, and manual virtual-key entry as a fallback
 - feat: masks the virtual key input with `*` characters in the chooser to avoid leaking credentials on shared screens
 - feat: adds a Home-styled mandatory update prompt — when a new Bifrost CLI version is available, a centered confirmation popup is shown before the chooser opens, and declining keeps the user on Home instead of blocking startup
 - feat: keeps the CLI running after a harness session ends — the tab manager now loops back to the chooser instead of exiting, so closing the last tab returns to Home rather than terminating Bifrost
 - improvement: model chooser `Esc` now clears the active filter, manual-entry selection, and any error message on first press before exiting the phase, matching common picker behavior
 - improvement: model chooser treats manual model names (typed into the filter) as a distinct selectable row, with arrow-key wrap-around between the filtered list and the manual entry
 - improvement: hides the Bifrost logo when re-entering the harness/model/worktree phases from the summary, giving editing flows more vertical space
-- fix: tab command-mode key handling now correctly distinguishes `Enter` (activate the selected row) from `Esc`/prefix (resume the active tab), and recognises both `Ctrl+B` and `Ctrl+G` as the dismiss key
+- fix: tab command-mode key handling now correctly distinguishes `Enter` (activate the selected row) from `Esc`/prefix (resume the active tab), and recognises both `Ctrl+B` and `Ctrl+T` as the dismiss key
 - fix: arrow-key escape sequences are now mapped to the existing `h`/`j`/`k`/`l` navigation in the command overlay, so users can navigate the tab popup with cursor keys

--- a/cli/internal/apis/models.go
+++ b/cli/internal/apis/models.go
@@ -2,10 +2,15 @@ package apis
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"os/exec"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -22,16 +27,32 @@ type listModelsResp struct {
 	Data []Model `json:"data"`
 }
 
+// VirtualKey represents a virtual key returned by the CLI handover API.
+type VirtualKey struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Key   string `json:"key,omitempty"`
+}
+
+type listVirtualKeysResp struct {
+	VirtualKeys []VirtualKey `json:"virtual_keys"`
+	Keys        []VirtualKey `json:"keys"`
+	Data        []VirtualKey `json:"data"`
+}
+
 // Client wraps HTTP calls to the Bifrost gateway API used by the CLI setup
 // flow.
 type Client struct {
-	http *http.Client
+	http    *http.Client
+	openURL func(string) error
 }
 
 // NewClient creates a Bifrost API client with a default HTTP timeout.
 func NewClient() *Client {
 	return &Client{
-		http: &http.Client{Timeout: 20 * time.Second},
+		http:    &http.Client{Timeout: 20 * time.Second},
+		openURL: openBrowser,
 	}
 }
 
@@ -106,4 +127,202 @@ func (c *Client) ListModels(ctx context.Context, baseURL, virtualKey string) ([]
 	}
 	sort.Strings(models)
 	return models, nil
+}
+
+// SignInWithBifrost opens the Bifrost browser handover flow, waits for a
+// session token callback, then returns virtual keys assigned to that session.
+func (c *Client) SignInWithBifrost(ctx context.Context, baseURL string) ([]VirtualKey, error) {
+	sessionID, err := c.startCLIHandover(ctx, baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return c.ListVirtualKeys(ctx, baseURL, sessionID)
+}
+
+// ListVirtualKeys fetches virtual keys assigned to the authenticated CLI
+// handover session.
+func (c *Client) ListVirtualKeys(ctx context.Context, baseURL, sessionID string) ([]VirtualKey, error) {
+	endpoint, err := BuildEndpoint(baseURL, "/api/cli/virtual-keys")
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build virtual keys request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(sessionID))
+	req.Header.Set("x-bf-cli-session-id", strings.TrimSpace(sessionID))
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request CLI virtual keys: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("/api/cli/virtual-keys status %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+
+	const maxVirtualKeysResponseBytes = 1 << 20 // 1 MiB
+	b, err := io.ReadAll(io.LimitReader(resp.Body, maxVirtualKeysResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read virtual keys response: %w", err)
+	}
+
+	var parsed listVirtualKeysResp
+	if err := sonic.Unmarshal(b, &parsed); err != nil {
+		return nil, fmt.Errorf("parse virtual keys response: %w", err)
+	}
+	keys := parsed.VirtualKeys
+	if len(keys) == 0 {
+		keys = parsed.Keys
+	}
+	if len(keys) == 0 {
+		keys = parsed.Data
+	}
+
+	out := make([]VirtualKey, 0, len(keys))
+	for _, key := range keys {
+		key.ID = strings.TrimSpace(key.ID)
+		key.Name = strings.TrimSpace(key.Name)
+		key.Value = strings.TrimSpace(key.Value)
+		if key.Value == "" {
+			key.Value = strings.TrimSpace(key.Key)
+		}
+		if key.Value == "" {
+			continue
+		}
+		out = append(out, key)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Name == out[j].Name {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+func (c *Client) startCLIHandover(ctx context.Context, baseURL string) (string, error) {
+	state, err := randomState()
+	if err != nil {
+		return "", err
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("start local callback listener: %w", err)
+	}
+	defer listener.Close()
+
+	callbackURL := "http://" + listener.Addr().String() + "/callback"
+	handoverURL, err := BuildEndpoint(baseURL, "/cli/handover")
+	if err != nil {
+		return "", err
+	}
+	u, err := url.Parse(handoverURL)
+	if err != nil {
+		return "", fmt.Errorf("build handover url: %w", err)
+	}
+	q := u.Query()
+	q.Set("redirect_uri", callbackURL)
+	q.Set("state", state)
+	u.RawQuery = q.Encode()
+
+	resultCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	server := &http.Server{
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/callback" {
+				http.NotFound(w, r)
+				return
+			}
+			if got := r.URL.Query().Get("state"); got != state {
+				http.Error(w, "invalid state", http.StatusBadRequest)
+				select {
+				case errCh <- fmt.Errorf("handover callback state mismatch"):
+				default:
+				}
+				return
+			}
+			sessionID := firstNonEmpty(
+				r.URL.Query().Get("session_id"),
+				r.URL.Query().Get("session"),
+				r.URL.Query().Get("token"),
+			)
+			if sessionID == "" {
+				http.Error(w, "missing session_id", http.StatusBadRequest)
+				select {
+				case errCh <- fmt.Errorf("handover callback did not include session_id"):
+				default:
+				}
+				return
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = io.WriteString(w, "<!doctype html><title>Bifrost CLI</title><p>Sign in complete. You can return to the Bifrost CLI.</p>")
+			select {
+			case resultCh <- sessionID:
+			default:
+			}
+		}),
+	}
+
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}
+	}()
+	defer server.Close()
+
+	openURL := c.openURL
+	if openURL == nil {
+		openURL = openBrowser
+	}
+	if err := openURL(u.String()); err != nil {
+		return "", fmt.Errorf("open handover URL: %w", err)
+	}
+
+	select {
+	case sessionID := <-resultCh:
+		return strings.TrimSpace(sessionID), nil
+	case err := <-errCh:
+		return "", err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func randomState() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate handover state: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func openBrowser(rawURL string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", rawURL)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL)
+	default:
+		cmd = exec.Command("xdg-open", rawURL)
+	}
+	return cmd.Start()
 }

--- a/cli/internal/apis/models_test.go
+++ b/cli/internal/apis/models_test.go
@@ -1,0 +1,88 @@
+package apis
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestListVirtualKeysParsesAssignedKeys(t *testing.T) {
+	var gotAuth string
+	var gotSession string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/cli/virtual-keys" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		gotSession = r.Header.Get("x-bf-cli-session-id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"virtual_keys":[{"id":"vk_2","name":"Support","key":"sk-support"},{"id":"vk_1","name":"Engineering","value":"sk-eng"}]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	keys, err := client.ListVirtualKeys(context.Background(), server.URL, "session-123")
+	if err != nil {
+		t.Fatalf("ListVirtualKeys returned error: %v", err)
+	}
+
+	if gotAuth != "Bearer session-123" || gotSession != "session-123" {
+		t.Fatalf("unexpected auth headers Authorization=%q x-bf-cli-session-id=%q", gotAuth, gotSession)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected two keys, got %d", len(keys))
+	}
+	if keys[0].Name != "Engineering" || keys[0].Value != "sk-eng" {
+		t.Fatalf("expected sorted Engineering key first, got %#v", keys[0])
+	}
+	if keys[1].Name != "Support" || keys[1].Value != "sk-support" {
+		t.Fatalf("expected key fallback to be used, got %#v", keys[1])
+	}
+}
+
+func TestSignInWithBifrostHandoverCallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/cli/virtual-keys" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("x-bf-cli-session-id"); got != "session-abc" {
+			t.Fatalf("expected callback session to be used, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"virtual_keys":[{"id":"vk_1","name":"Engineering","value":"sk-eng"}]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient()
+	client.openURL = func(rawURL string) error {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			return err
+		}
+		if u.Path != "/cli/handover" {
+			t.Fatalf("expected handover URL, got %q", u.Path)
+		}
+		callback := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+		if callback == "" || state == "" {
+			t.Fatalf("expected redirect_uri and state in handover URL: %q", rawURL)
+		}
+		go func() {
+			resp, err := http.Get(callback + "?session_id=session-abc&state=" + url.QueryEscape(state))
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	keys, err := client.SignInWithBifrost(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("SignInWithBifrost returned error: %v", err)
+	}
+	if len(keys) != 1 || keys[0].Value != "sk-eng" {
+		t.Fatalf("unexpected keys: %#v", keys)
+	}
+}

--- a/cli/internal/app/app.go
+++ b/cli/internal/app/app.go
@@ -147,7 +147,26 @@ func (a *App) Run(ctx context.Context) error {
 				Harnesses:     harnesses,
 				TabBarLine:    tabBarLine,
 				FetchModels:   a.apiClient.ListModels,
-				Input:         stdinReader,
+				SignIn: func(ctx context.Context, baseURL string) ([]tui.VirtualKeyOption, error) {
+					keys, err := a.apiClient.SignInWithBifrost(ctx, baseURL)
+					if err != nil {
+						return nil, err
+					}
+					options := make([]tui.VirtualKeyOption, 0, len(keys))
+					for _, key := range keys {
+						options = append(options, tui.VirtualKeyOption{
+							ID:    key.ID,
+							Name:  key.Name,
+							Value: key.Value,
+						})
+					}
+					return options, nil
+				},
+				SignOut: func() error {
+					vk = ""
+					return secrets.SetVirtualKey(activeProfile.ID, "")
+				},
+				Input: stdinReader,
 				Notify: func(message string, isError bool) {
 					level := runtime.TabNoticeInfo
 					if isError {

--- a/cli/internal/runtime/tabmgr.go
+++ b/cli/internal/runtime/tabmgr.go
@@ -507,9 +507,10 @@ func (tm *TabManager) readPTY(tab *Tab) {
 // output is frozen and bifrost enters tab mode.
 const prefix = 0x02
 
-// tmuxSafePrefix is an alternate prefix key: Ctrl+G (0x07). tmux consumes
-// Ctrl+B by default, so this gives users a one-press tab selector inside tmux.
-const tmuxSafePrefix = 0x07
+// tmuxSafePrefix is an alternate prefix key: Ctrl+T (0x14). tmux consumes
+// Ctrl+B by default, so this gives users a one-press tab selector inside tmux
+// without colliding with Claude Code's Ctrl+G shortcut.
+const tmuxSafePrefix = 0x14
 
 // inputLoop is the main event loop that reads stdin and dispatches to tabs or hotkeys.
 //
@@ -518,7 +519,7 @@ const tmuxSafePrefix = 0x07
 //	Ctrl+1…9    — jump to tab N
 //	Ctrl+Tab    — cycle to next tab
 //	Ctrl+B      — toggle tab command mode
-//	Ctrl+G      — toggle tab command mode; useful inside tmux
+//	Ctrl+T      — toggle tab command mode; useful inside tmux
 //
 // Keybindings while in tab command mode (^B prefix):
 //
@@ -528,7 +529,7 @@ const tmuxSafePrefix = 0x07
 //	H/L or J/K      — move left/right
 //	1…9             — jump to tab N
 //	U               — update bifrost (if available)
-//	Esc/Enter/Ctrl+B/Ctrl+G — resume the active tab
+//	Esc/Enter/Ctrl+B/Ctrl+T — resume the active tab
 func (tm *TabManager) inputLoop(ctx context.Context, newTabFn NewTabFunc, termState *term.State) error {
 	pending := make([]byte, 0, 4096)
 
@@ -606,6 +607,7 @@ func (tm *TabManager) inputLoop(ctx context.Context, newTabFn NewTabFunc, termSt
 
 			// Ctrl+1..9 — jump to tab (works in any mode)
 			if idx := parseCtrlDigit(token); idx >= 0 {
+				tm.clearNotice()
 				if tm.isCommandMode() {
 					tm.exitCommandMode()
 				}
@@ -615,6 +617,7 @@ func (tm *TabManager) inputLoop(ctx context.Context, newTabFn NewTabFunc, termSt
 
 			// Ctrl+Tab — cycle to next tab (works in any mode)
 			if isCtrlTab(token) {
+				tm.clearNotice()
 				if tm.isCommandMode() {
 					tm.exitCommandMode()
 				}
@@ -643,6 +646,7 @@ func (tm *TabManager) inputLoop(ctx context.Context, newTabFn NewTabFunc, termSt
 			// because a child process enabled the kitty protocol.
 			if isCSIu(token) {
 				if decoded := decodeCSIu(token); decoded != nil {
+					tm.clearNotice()
 					if tm.handleActiveCtrlC(decoded) {
 						continue
 					}
@@ -652,8 +656,10 @@ func (tm *TabManager) inputLoop(ctx context.Context, newTabFn NewTabFunc, termSt
 			}
 
 			if tm.handleActiveCtrlC(token) {
+				tm.clearNotice()
 				continue
 			}
+			tm.clearNotice()
 			tm.forwardToActive(token)
 		}
 	}
@@ -799,7 +805,7 @@ func containsStandaloneBEL(data []byte, state *belParserState) bool {
 }
 
 // isPrefixSequence reports whether a CSI sequence encodes a bifrost prefix key
-// (Ctrl+B or the tmux-safe Ctrl+G) under the kitty keyboard protocol (CSI u) or
+// (Ctrl+B or the tmux-safe Ctrl+T) under the kitty keyboard protocol (CSI u) or
 // xterm modifyOtherKeys (CSI 27 ~), so it triggers command mode just like the
 // raw single-byte prefix.
 func isPrefixSequence(seq []byte) bool {
@@ -844,11 +850,11 @@ func isReleaseEvent(modField string) bool {
 }
 
 // isPrefixKeyCode reports whether a CSI codepoint field encodes one of the
-// bifrost prefix keys: Ctrl+B (b/B, 98/66) or the tmux-safe Ctrl+G (g/G,
-// 103/71). Used so CSI-encoded prefixes (kitty protocol / modifyOtherKeys)
+// bifrost prefix keys: Ctrl+B (b/B, 98/66) or the tmux-safe Ctrl+T (t/T,
+// 116/84). Used so CSI-encoded prefixes (kitty protocol / modifyOtherKeys)
 // are recognized the same way as their raw single-byte forms.
 func isPrefixKeyCode(s string) bool {
-	return s == "98" || s == "66" || s == "103" || s == "71"
+	return s == "98" || s == "66" || s == "116" || s == "84"
 }
 
 // parseCtrlDigit checks if a CSI sequence is Ctrl+1..9 and returns the
@@ -1425,6 +1431,27 @@ func (tm *TabManager) clearNoticeAndResume() {
 	}
 }
 
+func isNoticeDismissKey(b byte) bool {
+	return b == ' ' || b == 0x1b || b == prefix || b == tmuxSafePrefix
+}
+
+func (tm *TabManager) clearStickyErrorForAction(b byte) bool {
+	if !tm.hasStickyErrorNotice() {
+		return false
+	}
+
+	tm.clearNotice()
+	if isNoticeDismissKey(b) {
+		if tm.hasTabs() {
+			tm.enterCommandMode()
+		} else {
+			tm.drawTabBar()
+		}
+		return true
+	}
+	return false
+}
+
 func (tm *TabManager) hasTabs() bool {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
@@ -1464,16 +1491,16 @@ func (tm *TabManager) exitCommandMode() {
 }
 
 func (tm *TabManager) handleCommandKey(ctx context.Context, newTabFn NewTabFunc, termState *term.State, b byte) error {
+	if tm.clearStickyErrorForAction(b) {
+		return nil
+	}
+
 	switch {
 	case b == 0x03:
 		if tm.handleHomeCtrlC() {
 			tm.signalClose()
 		}
 	case b == ' ':
-		if tm.hasStickyErrorNotice() {
-			tm.clearNoticeAndStayInCommandMode()
-			return nil
-		}
 		tm.clearNoticeAndResume()
 	case b == 0x1b || b == prefix || b == tmuxSafePrefix:
 		tm.mu.Lock()
@@ -1487,12 +1514,6 @@ func (tm *TabManager) handleCommandKey(ctx context.Context, newTabFn NewTabFunc,
 			return nil
 		}
 		tm.mu.Unlock()
-		if tm.hasStickyErrorNotice() {
-			if b == 0x1b {
-				tm.clearNoticeAndStayInCommandMode()
-			}
-			return nil
-		}
 		if !tm.hasTabs() {
 			if b == 0x1b {
 				return tm.openNewTab(ctx, newTabFn, termState)
@@ -1502,9 +1523,6 @@ func (tm *TabManager) handleCommandKey(ctx context.Context, newTabFn NewTabFunc,
 		}
 		tm.exitCommandMode()
 	case b == '\r' || b == '\n':
-		if tm.hasStickyErrorNotice() {
-			return nil
-		}
 		if !tm.hasTabs() {
 			return tm.openNewTab(ctx, newTabFn, termState)
 		}
@@ -1759,6 +1777,7 @@ func (tm *TabManager) handleTabBarMouseEvent(ev mouseEvent) bool {
 		return false
 	}
 
+	tm.clearNotice()
 	if commandMode {
 		tm.switchTabAndResume(idx)
 	} else {
@@ -3032,14 +3051,15 @@ func normalizedVersionLabel(version string) string {
 	return "v" + version
 }
 
-// tabModeHintLabel returns the tab-mode shortcut shown in the bottom bar.
-// Inside tmux, Ctrl+B is normally tmux's own prefix, so Bifrost advertises
-// Ctrl+G as the one-press shortcut.
+// tabModeHintLabel returns the tab-mode shortcut shown in the bottom bar. In
+// regular terminals it advertises both prefixes so Ctrl+T remains discoverable.
+// Inside tmux, Ctrl+B is normally tmux's own prefix, so Bifrost advertises only
+// Ctrl+T as the one-press shortcut.
 func tabModeHintLabel() string {
 	if strings.TrimSpace(os.Getenv("TMUX")) != "" {
-		return "^G"
+		return "^T"
 	}
-	return "^B"
+	return "^B/^T"
 }
 
 // truncateCells trims a plain ASCII status string to fit in the requested cell

--- a/cli/internal/runtime/tabmgr_test.go
+++ b/cli/internal/runtime/tabmgr_test.go
@@ -296,21 +296,29 @@ func TestBuildTabBarStringKeepsVersionVisibleWhenCommandHintIsLong(t *testing.T)
 	}
 }
 
-func TestNextInputTokenTreatsCtrlGAsTabModePrefix(t *testing.T) {
+func TestNextInputTokenTreatsCtrlTAsTabModePrefix(t *testing.T) {
 	t.Parallel()
 
 	token, consumed, isPrefix, complete := nextInputToken([]byte{tmuxSafePrefix})
 
 	if !complete || !isPrefix || consumed != 1 || len(token) != 1 || token[0] != tmuxSafePrefix {
-		t.Fatalf("expected ctrl+g to be parsed as tab-mode prefix, token=%q consumed=%d isPrefix=%v complete=%v", token, consumed, isPrefix, complete)
+		t.Fatalf("expected ctrl+t to be parsed as tab-mode prefix, token=%q consumed=%d isPrefix=%v complete=%v", token, consumed, isPrefix, complete)
 	}
 }
 
-func TestTabModeHintLabelUsesCtrlGInsideTmux(t *testing.T) {
+func TestTabModeHintLabelUsesCtrlTInsideTmux(t *testing.T) {
 	t.Setenv("TMUX", "/tmp/tmux-501/default,123,0")
 
-	if got := tabModeHintLabel(); got != "^G" {
-		t.Fatalf("expected tmux tab mode hint to use ^G, got %q", got)
+	if got := tabModeHintLabel(); got != "^T" {
+		t.Fatalf("expected tmux tab mode hint to use ^T, got %q", got)
+	}
+}
+
+func TestTabModeHintLabelShowsBothPrefixesOutsideTmux(t *testing.T) {
+	t.Setenv("TMUX", "")
+
+	if got := tabModeHintLabel(); got != "^B/^T" {
+		t.Fatalf("expected regular tab mode hint to show both prefixes, got %q", got)
 	}
 }
 
@@ -452,7 +460,7 @@ func TestHandleCommandKeyEscapeClearsStickyErrorAndStaysInCommandMode(t *testing
 	}
 }
 
-func TestHandleCommandKeyEnterDoesNotResumeWhileStickyErrorIsShown(t *testing.T) {
+func TestHandleCommandKeyDismissKeyClearsStickyErrorAndStaysInCommandMode(t *testing.T) {
 	t.Parallel()
 
 	tm := &TabManager{
@@ -466,13 +474,41 @@ func TestHandleCommandKeyEnterDoesNotResumeWhileStickyErrorIsShown(t *testing.T)
 		tabs:         []*Tab{{id: 1, label: "Codex"}},
 	}
 
-	tm.handleCommandKey(nil, nil, nil, '\r')
+	tm.handleCommandKey(nil, nil, nil, tmuxSafePrefix)
 
 	if !tm.commandMode {
-		t.Fatal("expected sticky error to keep tab manager in command mode")
+		t.Fatal("expected dismiss key to keep tab manager in command mode after clearing sticky error")
 	}
-	if tm.noticeText != "oops" {
-		t.Fatalf("expected enter to leave sticky error untouched, got %q", tm.noticeText)
+	if tm.noticeText != "" {
+		t.Fatalf("expected dismiss key to clear sticky error notice, got %q", tm.noticeText)
+	}
+}
+
+func TestHandleCommandKeyActionClearsStickyErrorAndContinues(t *testing.T) {
+	t.Parallel()
+
+	tm := &TabManager{
+		stdout:       io.Discard,
+		rows:         24,
+		cols:         80,
+		commandMode:  true,
+		commandIdx:   0,
+		noticeText:   "oops",
+		noticeLevel:  TabNoticeError,
+		noticeSticky: true,
+		tabs: []*Tab{
+			{id: 1, label: "Codex"},
+			{id: 2, label: "Claude Code"},
+		},
+	}
+
+	tm.handleCommandKey(nil, nil, nil, 'l')
+
+	if tm.noticeText != "" {
+		t.Fatalf("expected action to clear sticky error notice, got %q", tm.noticeText)
+	}
+	if tm.commandIdx != 1 {
+		t.Fatalf("expected action to continue after clearing sticky error, commandIdx=%d", tm.commandIdx)
 	}
 }
 
@@ -639,16 +675,16 @@ func TestIsPrefixSequenceSupportsColonSuffix(t *testing.T) {
 		t.Fatal("expected ctrl+b repeat event to be recognized")
 	}
 
-	// Ctrl+G is the tmux-safe alternate prefix and must be recognized in its
-	// CSI-encoded forms too, not just as the raw 0x07 byte.
-	if !isPrefixSequence([]byte("\x1b[103;5:1u")) {
-		t.Fatal("expected ctrl+g press event (CSI u, tmux-safe prefix) to be recognized")
+	// Ctrl+T is the tmux-safe alternate prefix and must be recognized in its
+	// CSI-encoded forms too, not just as the raw 0x14 byte.
+	if !isPrefixSequence([]byte("\x1b[116;5:1u")) {
+		t.Fatal("expected ctrl+t press event (CSI u, tmux-safe prefix) to be recognized")
 	}
-	if isPrefixSequence([]byte("\x1b[103;5:3u")) {
-		t.Fatal("expected ctrl+g release event to be rejected")
+	if isPrefixSequence([]byte("\x1b[116;5:3u")) {
+		t.Fatal("expected ctrl+t release event to be rejected")
 	}
-	if !isPrefixSequence([]byte("\x1b[27;5;103~")) {
-		t.Fatal("expected ctrl+g modifyOtherKeys (CSI 27 ~) to be recognized")
+	if !isPrefixSequence([]byte("\x1b[27;5;116~")) {
+		t.Fatal("expected ctrl+t modifyOtherKeys (CSI 27 ~) to be recognized")
 	}
 }
 

--- a/cli/internal/ui/tui/chooser.go
+++ b/cli/internal/ui/tui/chooser.go
@@ -48,6 +48,8 @@ type ChooserConfig struct {
 	ReservedRows  int           // rows reserved by the tab bar; subtracted from the available height
 	TabBarLine    func() string // returns the current tab bar content; rendered as the last line
 	FetchModels   func(ctx context.Context, baseURL, virtualKey string) ([]string, error)
+	SignIn        func(ctx context.Context, baseURL string) ([]VirtualKeyOption, error)
+	SignOut       func() error
 	Notify        func(message string, isError bool)
 	Input         io.Reader // optional stdin override; when nil, os.Stdin is used
 }
@@ -65,23 +67,35 @@ type ChooserResult struct {
 	Worktree        string
 }
 
+// VirtualKeyOption is a virtual key selectable from the Bifrost CLI handover flow.
+type VirtualKeyOption struct {
+	ID    string
+	Name  string
+	Value string
+}
+
 type chooserPhase int
 
 const (
 	phaseBaseURL chooserPhase = iota
+	phaseAuthMethod
 	phaseVirtualKey
+	phaseVirtualKeySelect
 	phaseHarness
 	phaseModel
 	phaseWorktree
 	phaseSummary
+	phaseConfig
 )
 
 type summaryAction int
 
 const (
 	summaryActionLaunch summaryAction = iota
+	summaryActionConfig
 	summaryActionBaseURL
 	summaryActionVirtualKey
+	summaryActionSignOut
 	summaryActionWorktree
 	summaryActionHarness
 	summaryActionModel
@@ -89,12 +103,18 @@ const (
 	summaryActionDocs
 	summaryActionIssues
 	summaryActionRepo
+	summaryActionBack
 	summaryActionQuit
 )
 
 type modelsMsg struct {
 	models []string
 	err    error
+}
+
+type signInMsg struct {
+	keys []VirtualKeyOption
+	err  error
 }
 
 type warmupDoneMsg struct{}
@@ -118,6 +138,9 @@ type chooserModel struct {
 	worktreeInput textInput.Model
 
 	harnessIdx          int
+	authMethodIdx       int
+	vkOptionIdx         int
+	vkOptions           []VirtualKeyOption
 	modelIdx            int
 	models              []string
 	modelManualSelected bool
@@ -125,6 +148,7 @@ type chooserModel struct {
 	filterInput textInput.Model
 	filtered    []int // indices into models
 	loading     bool
+	signingIn   bool
 	loadErr     string
 
 	summaryIdx          int
@@ -230,11 +254,17 @@ func newChooserModel(cfg ChooserConfig) chooserModel {
 		plainLayout:   prefersPlainChooserLayout(),
 	}
 
-	if strings.TrimSpace(cfg.BaseURL) != "" {
+	if strings.TrimSpace(cfg.BaseURL) != "" && strings.TrimSpace(cfg.VirtualKey) != "" {
 		m.phase = phaseHarness
 		m.baseInput.Blur()
+	} else if strings.TrimSpace(cfg.BaseURL) != "" {
+		m.phase = phaseAuthMethod
+		m.baseInput.Blur()
 	}
-	if strings.TrimSpace(cfg.Harness) != "" && strings.TrimSpace(cfg.Model) != "" && strings.TrimSpace(cfg.BaseURL) != "" {
+	if strings.TrimSpace(cfg.Harness) != "" &&
+		strings.TrimSpace(cfg.Model) != "" &&
+		strings.TrimSpace(cfg.BaseURL) != "" &&
+		(strings.TrimSpace(cfg.VirtualKey) != "" || cfg.SignIn == nil) {
 		m.phase = phaseSummary
 		m.models = []string{strings.TrimSpace(cfg.Model)}
 		m.modelIdx = 0
@@ -296,7 +326,9 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		canTriggerUpdate := strings.TrimSpace(m.cfg.UpdateVersion) != "" &&
 			m.phase != phaseBaseURL &&
+			m.phase != phaseAuthMethod &&
 			m.phase != phaseVirtualKey &&
+			m.phase != phaseVirtualKeySelect &&
 			m.phase != phaseModel &&
 			m.phase != phaseWorktree
 		if canTriggerUpdate && (s == "y" || s == "Y") {
@@ -322,8 +354,7 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.phase = phaseSummary
 					return m, nil
 				}
-				m.phase = phaseVirtualKey
-				m.vkInput.Focus()
+				m.phase = phaseAuthMethod
 				return m, nil
 			}
 			if s == "esc" && m.returnToSummary {
@@ -335,6 +366,67 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var cmd tea.Cmd
 			m.baseInput, cmd = m.baseInput.Update(msg)
 			return m, cmd
+
+		case phaseAuthMethod:
+			if m.signingIn {
+				if s == "esc" {
+					m.signingIn = false
+					m.loadErr = ""
+					if m.returnToSummary {
+						m.phase = phaseSummary
+					}
+					return m, nil
+				}
+				return m, nil
+			}
+			if s == "up" || s == "k" || s == "down" || s == "j" {
+				if s == "up" || s == "k" {
+					if m.authMethodIdx > 0 {
+						m.authMethodIdx--
+					} else {
+						m.authMethodIdx = len(authMethodOptions()) - 1
+					}
+				} else {
+					if m.authMethodIdx < len(authMethodOptions())-1 {
+						m.authMethodIdx++
+					} else {
+						m.authMethodIdx = 0
+					}
+				}
+				return m, nil
+			}
+			if s == "enter" {
+				if m.authMethodIdx == 0 {
+					m.signingIn = true
+					m.loadErr = ""
+					return m, m.signInCmd()
+				}
+				if m.authMethodIdx == 2 {
+					m.phase = phaseBaseURL
+					m.returnToSummary = false
+					m.baseInput.Focus()
+					return m, nil
+				}
+				if m.authMethodIdx == 3 {
+					m.quit = true
+					return m, tea.Quit
+				}
+				m.phase = phaseVirtualKey
+				m.vkInput.Focus()
+				return m, nil
+			}
+			if s == "esc" {
+				if m.returnToSummary {
+					if strings.TrimSpace(m.vkInput.Value()) != "" {
+						m.returnToSummary = false
+						m.phase = phaseSummary
+					}
+					return m, nil
+				}
+				m.phase = phaseBaseURL
+				m.baseInput.Focus()
+				return m, nil
+			}
 
 		case phaseVirtualKey:
 			if s == "enter" {
@@ -354,8 +446,8 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.phase = phaseSummary
 					return m, nil
 				}
-				m.phase = phaseBaseURL
-				m.baseInput.Focus()
+				m.phase = phaseAuthMethod
+				m.vkInput.Blur()
 				return m, nil
 			}
 			if s == "f1" {
@@ -369,6 +461,48 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var cmd tea.Cmd
 			m.vkInput, cmd = m.vkInput.Update(msg)
 			return m, cmd
+
+		case phaseVirtualKeySelect:
+			if s == "up" || s == "k" {
+				if m.vkOptionIdx > 0 {
+					m.vkOptionIdx--
+				} else {
+					m.vkOptionIdx = len(m.vkOptions)
+				}
+				return m, nil
+			}
+			if s == "down" || s == "j" {
+				if m.vkOptionIdx < len(m.vkOptions) {
+					m.vkOptionIdx++
+				} else {
+					m.vkOptionIdx = 0
+				}
+				return m, nil
+			}
+			if s == "enter" {
+				if m.vkOptionIdx >= 0 && m.vkOptionIdx < len(m.vkOptions) {
+					m.vkInput.SetValue(m.vkOptions[m.vkOptionIdx].Value)
+					if m.returnToSummary {
+						m.returnToSummary = false
+						m.phase = phaseSummary
+						return m, nil
+					}
+					m.phase = phaseHarness
+					return m, nil
+				}
+				m.phase = phaseVirtualKey
+				m.vkInput.Focus()
+				return m, nil
+			}
+			if s == "esc" {
+				if m.returnToSummary {
+					m.returnToSummary = false
+					m.phase = phaseSummary
+					return m, nil
+				}
+				m.phase = phaseAuthMethod
+				return m, nil
+			}
 
 		case phaseHarness:
 			if s == "up" || s == "k" {
@@ -408,8 +542,7 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.phase = phaseSummary
 					return m, nil
 				}
-				m.phase = phaseVirtualKey
-				m.vkInput.Focus()
+				m.phase = phaseAuthMethod
 				return m, nil
 			}
 
@@ -537,7 +670,7 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.worktreeInput, cmd = m.worktreeInput.Update(msg)
 			return m, cmd
 
-		case phaseSummary:
+		case phaseSummary, phaseConfig:
 			if m.summaryEditing {
 				switch s {
 				case "enter":
@@ -598,7 +731,16 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch s {
 			case "enter":
 				return m.performSummaryAction(m.currentSummaryAction())
+			case "c":
+				if m.phase == phaseSummary {
+					m.phase = phaseConfig
+					m.summaryIdx = 0
+					return m, nil
+				}
 			case "u":
+				if m.phase != phaseConfig {
+					return m, nil
+				}
 				m.summaryIdx = m.summaryIndexForAction(summaryActionBaseURL)
 				m.summaryEditing = true
 				m.summaryEditAction = summaryActionBaseURL
@@ -606,13 +748,17 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.baseInput.Focus()
 				return m, nil
 			case "v":
+				if m.phase != phaseConfig {
+					return m, nil
+				}
 				m.summaryIdx = m.summaryIndexForAction(summaryActionVirtualKey)
-				m.summaryEditing = true
-				m.summaryEditAction = summaryActionVirtualKey
-				m.summaryEditOriginal = m.vkInput.Value()
-				m.vkInput.Focus()
+				m.phase = phaseAuthMethod
+				m.returnToSummary = true
 				return m, nil
 			case "w":
+				if m.phase != phaseConfig {
+					return m, nil
+				}
 				if m.currentHarness().SupportsWorktree {
 					m.phase = phaseWorktree
 					m.returnToSummary = true
@@ -620,10 +766,16 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 			case "h":
+				if m.phase != phaseConfig {
+					return m, nil
+				}
 				m.phase = phaseHarness
 				m.returnToSummary = true
 				return m, nil
 			case "m":
+				if m.phase != phaseConfig {
+					return m, nil
+				}
 				if !m.currentHarness().SupportsModelOverride {
 					m.notify(m.currentHarness().Label+" manages its own model selection", true)
 					return m, nil
@@ -652,6 +804,11 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.notify("opened GitHub repo", false)
 				return m, nil
 			case "esc":
+				if m.phase == phaseConfig {
+					m.phase = phaseSummary
+					m.summaryIdx = m.summaryIndexForAction(summaryActionConfig)
+					return m, nil
+				}
 				m.quit = true
 				return m, tea.Quit
 			}
@@ -675,6 +832,33 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.modelManualSelected = false
 		m.filterInput.SetValue("")
 		m.filterInput.Focus()
+
+	case signInMsg:
+		m.signingIn = false
+		if msg.err != nil {
+			m.loadErr = msg.err.Error()
+			m.notify(m.loadErr, true)
+			return m, nil
+		}
+		m.vkOptions = msg.keys
+		m.vkOptionIdx = 0
+		if len(m.vkOptions) == 0 {
+			m.loadErr = "no virtual keys assigned to this Bifrost account"
+			m.notify(m.loadErr, true)
+			return m, nil
+		}
+		if len(m.vkOptions) == 1 {
+			m.vkInput.SetValue(m.vkOptions[0].Value)
+			m.notify("signed in with Bifrost", false)
+			if m.returnToSummary {
+				m.returnToSummary = false
+				m.phase = phaseSummary
+				return m, nil
+			}
+			m.phase = phaseHarness
+			return m, nil
+		}
+		m.phase = phaseVirtualKeySelect
 	}
 
 	return m, nil
@@ -698,7 +882,7 @@ func (m chooserModel) View() string {
 		h = 24
 	}
 
-	hideLogo := m.returnToSummary && (m.phase == phaseHarness || m.phase == phaseModel || m.phase == phaseWorktree)
+	hideLogo := m.returnToSummary && (m.phase == phaseVirtualKeySelect || m.phase == phaseHarness || m.phase == phaseModel || m.phase == phaseWorktree)
 	logoBlock := ""
 	if !hideLogo {
 		logoBlock = logoColor.Render(logo.Render(w))
@@ -737,6 +921,24 @@ func (m chooserModel) View() string {
 			footer = hint.Render("enter: continue  ctrl+c: quit")
 		}
 
+	case phaseAuthMethod:
+		title = accent.Render("Home")
+		if m.signingIn {
+			body.WriteString(hint.Render("opening browser for Bifrost sign in..."))
+			footer = hint.Render("waiting for browser sign in")
+		} else {
+			for i, option := range authMethodOptions() {
+				cursor := "  "
+				style := label
+				if i == m.authMethodIdx {
+					cursor = accent.Render("> ")
+					style = lipgloss.NewStyle().Bold(true)
+				}
+				body.WriteString(cursor + style.Render(option) + "\n")
+			}
+			footer = hint.Render("up/down: move  enter: select")
+		}
+
 	case phaseVirtualKey:
 		title = accent.Render("Virtual Key") + label.Render(" (optional)")
 		body.WriteString(m.vkInput.View())
@@ -744,6 +946,34 @@ func (m chooserModel) View() string {
 			footer = hint.Render("enter: update  esc: cancel  f1: open dashboard")
 		} else {
 			footer = hint.Render("enter: continue  esc: back  f1: open dashboard")
+		}
+
+	case phaseVirtualKeySelect:
+		title = accent.Render("Choose Virtual Key")
+		for i, key := range m.vkOptions {
+			cursor := "  "
+			style := label
+			if i == m.vkOptionIdx {
+				cursor = accent.Render("> ")
+				style = lipgloss.NewStyle().Bold(true)
+			}
+			body.WriteString(cursor + style.Render(virtualKeyOptionLabel(key)) + "\n")
+		}
+		cursor := "  "
+		style := label
+		if m.vkOptionIdx == len(m.vkOptions) {
+			cursor = accent.Render("> ")
+			style = lipgloss.NewStyle().Bold(true)
+		}
+		body.WriteString(cursor + style.Render("Add virtual key manually") + "\n")
+		if m.returnToSummary {
+			footer = hint.Render("up/down: move  enter: select  esc: cancel")
+			bodyStr := body.String()
+			body.Reset()
+			body.WriteString(renderChooserPopup("Choose Virtual Key", bodyStr, w))
+			title = accent.Render("Bifrost CLI")
+		} else {
+			footer = hint.Render("up/down: move  enter: select  esc: back")
 		}
 
 	case phaseHarness:
@@ -815,13 +1045,43 @@ func (m chooserModel) View() string {
 	case phaseSummary:
 		ho := m.currentHarness()
 		baseURL := strings.TrimSpace(m.baseInput.Value())
+
+		title = accent.Render("Ready to launch")
+		renderSummaryLine := func(action summaryAction, name, value string) {
+			cursor := "  "
+			nameStyle := label
+			valueStyle := lipgloss.NewStyle()
+			if action == m.currentSummaryAction() {
+				cursor = accent.Render("> ")
+				nameStyle = lipgloss.NewStyle().Bold(true)
+				valueStyle = lipgloss.NewStyle().Bold(true)
+			}
+			body.WriteString(cursor + nameStyle.Render(fmt.Sprintf("%-12s", name)) + " " + valueStyle.Render(value) + "\n")
+		}
+		renderSummaryLine(summaryActionLaunch, "Start", ho.Label)
+		renderSummaryLine(summaryActionConfig, "CLI Config", "Base URL, virtual key, harness, model")
+		renderSummaryLine(summaryActionDashboard, "Dashboard", baseURL)
+		renderSummaryLine(summaryActionDocs, "Docs", docsURL)
+		renderSummaryLine(summaryActionIssues, "Report issue", issuesURL)
+		renderSummaryLine(summaryActionRepo, "Star", repoURL)
+		renderSummaryLine(summaryActionQuit, "Exit", "Bifrost CLI")
+
+		if m.summaryEditing {
+			footer = hint.Render("editing  enter: save  esc: cancel")
+		} else {
+			footer = hint.Render("up/down: move  enter: select  shortcuts: c/d/r/i/s/q")
+		}
+
+	case phaseConfig:
+		ho := m.currentHarness()
+		baseURL := strings.TrimSpace(m.baseInput.Value())
 		model := m.currentModel()
 		harnessStr := ho.Label
 		if ho.Version != "" {
 			harnessStr += " (" + ho.Version + ")"
 		}
 
-		title = accent.Render("Ready to launch")
+		title = accent.Render("CLI Config")
 		renderSummaryLine := func(action summaryAction, name, value string) {
 			cursor := "  "
 			nameStyle := label
@@ -853,11 +1113,14 @@ func (m chooserModel) View() string {
 			body.WriteString(label.Render("               ") + " " + warnStyle.Render("⚠ Gemini function calling is not compatible with") + "\n")
 			body.WriteString(label.Render("               ") + " " + warnStyle.Render("  Claude Code and may not work as intended") + "\n")
 		}
-		vkValue := maskVirtualKey(strings.TrimSpace(m.vkInput.Value()))
+		vkValue := summaryVirtualKeyValue(strings.TrimSpace(m.vkInput.Value()), m.cfg.SignIn != nil)
 		if m.summaryEditing && m.currentSummaryAction() == summaryActionVirtualKey {
 			vkValue = m.vkInput.View()
 		}
 		renderSummaryLine(summaryActionVirtualKey, "Virtual Key", vkValue)
+		if strings.TrimSpace(m.vkInput.Value()) != "" {
+			renderSummaryLine(summaryActionSignOut, "Sign out", "from CLI")
+		}
 		if ho.SupportsWorktree {
 			wtState := "no"
 			if wt := strings.TrimSpace(m.worktreeInput.Value()); wt != "" {
@@ -865,18 +1128,12 @@ func (m chooserModel) View() string {
 			}
 			renderSummaryLine(summaryActionWorktree, "Worktree", wtState)
 		}
-		body.WriteString("\n")
-		renderSummaryLine(summaryActionLaunch, "Start", ho.Label)
-		renderSummaryLine(summaryActionDashboard, "Dashboard", baseURL)
-		renderSummaryLine(summaryActionDocs, "Docs", docsURL)
-		renderSummaryLine(summaryActionIssues, "Report issue", issuesURL)
-		renderSummaryLine(summaryActionRepo, "Star", repoURL)
-		renderSummaryLine(summaryActionQuit, "Exit", "Bifrost CLI")
+		renderSummaryLine(summaryActionBack, "Back", "Ready")
 
 		if m.summaryEditing {
 			footer = hint.Render("editing  enter: save  esc: cancel")
 		} else {
-			footer = hint.Render("up/down: move  enter: select  shortcuts: u/v/h/m/d/r/i/s/q")
+			footer = hint.Render("up/down: move  enter: select  shortcuts: u/v/h/m/w/esc")
 		}
 	}
 
@@ -1007,6 +1264,33 @@ func maskVirtualKey(value string) string {
 	return string(runes[:2]) + strings.Repeat("*", len(runes)-5) + string(runes[len(runes)-3:])
 }
 
+func summaryVirtualKeyValue(value string, canSignIn bool) string {
+	value = strings.TrimSpace(value)
+	if value == "" && canSignIn {
+		return "Sign in with Bifrost"
+	}
+	return maskVirtualKey(value)
+}
+
+func authMethodOptions() []string {
+	return []string{"Sign in with Bifrost", "Add virtual key manually", "Change Base URL", "Exit Bifrost CLI"}
+}
+
+func virtualKeyOptionLabel(key VirtualKeyOption) string {
+	name := strings.TrimSpace(key.Name)
+	id := strings.TrimSpace(key.ID)
+	switch {
+	case name != "" && id != "":
+		return name + " (" + id + ")"
+	case name != "":
+		return name
+	case id != "":
+		return id
+	default:
+		return maskVirtualKey(key.Value)
+	}
+}
+
 // renderChooserPopup wraps chooser content in a bordered box so summary actions
 // can open as overlays instead of visually replacing the Ready screen.
 func renderChooserPopup(title, content string, width int) string {
@@ -1046,27 +1330,34 @@ func (m *chooserModel) notify(message string, isError bool) {
 // rendered, so arrow navigation follows the visible sequence.
 func (m chooserModel) summaryActions() []summaryAction {
 	ho := m.currentHarness()
+	if m.phase == phaseConfig {
+		actions := []summaryAction{
+			summaryActionBaseURL,
+			summaryActionHarness,
+		}
+		if ho.SupportsModelOverride {
+			actions = append(actions, summaryActionModel)
+		}
+		actions = append(actions, summaryActionVirtualKey)
+		if strings.TrimSpace(m.vkInput.Value()) != "" {
+			actions = append(actions, summaryActionSignOut)
+		}
+		if ho.SupportsWorktree {
+			actions = append(actions, summaryActionWorktree)
+		}
+		actions = append(actions, summaryActionBack)
+		return actions
+	}
+
 	actions := []summaryAction{
-		summaryActionBaseURL,
-		summaryActionHarness,
-	}
-	if ho.SupportsModelOverride {
-		actions = append(actions, summaryActionModel)
-	}
-	actions = append(actions,
-		summaryActionVirtualKey,
-	)
-	if ho.SupportsWorktree {
-		actions = append(actions, summaryActionWorktree)
-	}
-	actions = append(actions,
 		summaryActionLaunch,
+		summaryActionConfig,
 		summaryActionDashboard,
 		summaryActionDocs,
 		summaryActionIssues,
 		summaryActionRepo,
 		summaryActionQuit,
-	)
+	}
 	return actions
 }
 
@@ -1101,6 +1392,10 @@ func (m chooserModel) performSummaryAction(action summaryAction) (tea.Model, tea
 	case summaryActionLaunch:
 		m.done = true
 		return m, tea.Quit
+	case summaryActionConfig:
+		m.phase = phaseConfig
+		m.summaryIdx = 0
+		return m, nil
 	case summaryActionBaseURL:
 		m.summaryEditing = true
 		m.summaryEditAction = summaryActionBaseURL
@@ -1108,10 +1403,24 @@ func (m chooserModel) performSummaryAction(action summaryAction) (tea.Model, tea
 		m.baseInput.Focus()
 		return m, nil
 	case summaryActionVirtualKey:
-		m.summaryEditing = true
-		m.summaryEditAction = summaryActionVirtualKey
-		m.summaryEditOriginal = m.vkInput.Value()
-		m.vkInput.Focus()
+		m.phase = phaseAuthMethod
+		m.returnToSummary = true
+		return m, nil
+	case summaryActionSignOut:
+		m.vkInput.SetValue("")
+		m.phase = phaseAuthMethod
+		m.returnToSummary = true
+		if m.cfg.SignOut != nil {
+			if err := m.cfg.SignOut(); err != nil {
+				m.notify(err.Error(), true)
+				return m, nil
+			}
+		}
+		m.notify("signed out from CLI", false)
+		return m, nil
+	case summaryActionBack:
+		m.phase = phaseSummary
+		m.summaryIdx = m.summaryIndexForAction(summaryActionConfig)
 		return m, nil
 	case summaryActionWorktree:
 		if m.currentHarness().SupportsWorktree {
@@ -1434,5 +1743,20 @@ func (m chooserModel) fetchModelsCmd() tea.Cmd {
 		defer cancel()
 		models, err := fetch(ctx, baseURL, vk)
 		return modelsMsg{models: models, err: err}
+	}
+}
+
+// signInCmd returns a tea.Cmd that runs the browser-based Bifrost handover flow.
+func (m chooserModel) signInCmd() tea.Cmd {
+	baseURL := strings.TrimSpace(m.baseInput.Value())
+	signIn := m.cfg.SignIn
+	return func() tea.Msg {
+		if signIn == nil {
+			return signInMsg{err: fmt.Errorf("Bifrost sign in is not configured")}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		keys, err := signIn(ctx, baseURL)
+		return signInMsg{keys: keys, err: err}
 	}
 }

--- a/cli/internal/ui/tui/chooser_test.go
+++ b/cli/internal/ui/tui/chooser_test.go
@@ -87,8 +87,21 @@ func TestChooserSummaryArrowEnterOpensSelectedOption(t *testing.T) {
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	got := next.(chooserModel)
-	if got.phase != phaseSummary || !got.summaryEditing {
-		t.Fatalf("expected enter on first summary row to edit base URL inline, phase=%v summaryEditing=%v", got.phase, got.summaryEditing)
+	if got.phase != phaseSummary || !got.done {
+		t.Fatalf("expected enter on Start row to launch, phase=%v done=%v", got.phase, got.done)
+	}
+
+	m.summaryIdx = m.summaryIndexForAction(summaryActionConfig)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got = next.(chooserModel)
+	if got.phase != phaseConfig {
+		t.Fatalf("expected CLI Config row to open config, phase=%v", got.phase)
+	}
+
+	next, _ = got.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got = next.(chooserModel)
+	if got.phase != phaseConfig || !got.summaryEditing {
+		t.Fatalf("expected enter on first config row to edit base URL inline, phase=%v summaryEditing=%v", got.phase, got.summaryEditing)
 	}
 
 	next, _ = got.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("-edited")})
@@ -117,6 +130,7 @@ func TestChooserSummaryArrowEnterOpensSelectedOption(t *testing.T) {
 			return []string{"gpt-4o-mini"}, nil
 		},
 	})
+	m.phase = phaseConfig
 	for i := 0; i < 2; i++ {
 		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
 		m = next.(chooserModel)
@@ -244,11 +258,35 @@ func TestChooserSummaryUsesActionLabels(t *testing.T) {
 	if !strings.Contains(view, "Start") || !strings.Contains(view, "Codex CLI") {
 		t.Fatalf("expected summary to show Start <harness>, got %q", view)
 	}
+	if !strings.Contains(view, "CLI Config") || !strings.Contains(view, "Base URL, virtual key, harness, model") {
+		t.Fatalf("expected summary to show CLI Config action, got %q", view)
+	}
 	if !strings.Contains(view, "Exit") || !strings.Contains(view, "Bifrost CLI") {
 		t.Fatalf("expected summary to show Exit Bifrost CLI, got %q", view)
 	}
-	if strings.Contains(view, "start Codex CLI") || strings.Contains(view, "Quit") {
+	if strings.Contains(view, "Base URL     http://localhost:8080") || strings.Contains(view, "Virtual Key") || strings.Contains(view, "start Codex CLI") || strings.Contains(view, "Quit") {
 		t.Fatalf("did not expect old launch/quit labels, got %q", view)
+	}
+}
+
+func TestChooserWithSignInStartsAtAuthMethodWhenVirtualKeyMissing(t *testing.T) {
+	m := newChooserModel(ChooserConfig{
+		BaseURL: "http://localhost:8080",
+		Harness: "codex",
+		Model:   "gpt-4o-mini",
+		Harnesses: []HarnessOption{{
+			ID:                    "codex",
+			Label:                 "Codex CLI",
+			Installed:             true,
+			SupportsModelOverride: true,
+		}},
+		SignIn: func(ctx context.Context, baseURL string) ([]VirtualKeyOption, error) {
+			return nil, nil
+		},
+	})
+
+	if m.phase != phaseAuthMethod {
+		t.Fatalf("expected auth method phase when sign-in is available and no virtual key is saved, got %v", m.phase)
 	}
 }
 
@@ -265,6 +303,7 @@ func TestChooserSummaryMasksVirtualKeyAfterSave(t *testing.T) {
 			SupportsModelOverride: true,
 		}},
 	})
+	m.phase = phaseConfig
 
 	view := m.View()
 	if !strings.Contains(view, "sk*******xyz") {
@@ -273,9 +312,107 @@ func TestChooserSummaryMasksVirtualKeyAfterSave(t *testing.T) {
 	if strings.Contains(view, "sk-abcdefxyz") {
 		t.Fatalf("expected summary not to show full virtual key after save, got %q", view)
 	}
+	if !strings.Contains(view, "Sign out") || !strings.Contains(view, "from CLI") {
+		t.Fatalf("expected signed-in summary to show sign out action, got %q", view)
+	}
 }
 
-func TestChooserSummaryVirtualKeyVisibleWhileEditing(t *testing.T) {
+func TestChooserShowsOnlyAuthOptionsWhenVirtualKeyMissing(t *testing.T) {
+	m := newChooserModel(ChooserConfig{
+		BaseURL: "http://localhost:8080",
+		Harness: "codex",
+		Model:   "gpt-4o-mini",
+		Harnesses: []HarnessOption{{
+			ID:                    "codex",
+			Label:                 "Codex CLI",
+			Installed:             true,
+			SupportsModelOverride: true,
+		}},
+		SignIn: func(ctx context.Context, baseURL string) ([]VirtualKeyOption, error) {
+			return nil, nil
+		},
+	})
+
+	view := m.View()
+	for _, want := range []string{"Home", "Sign in with Bifrost", "Add virtual key manually", "Change Base URL", "Exit Bifrost CLI"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected unsigned chooser to show %q, got %q", want, view)
+		}
+	}
+	if strings.Contains(view, "Ready to launch") || strings.Contains(view, "Start") || strings.Contains(view, "Sign out") || strings.Contains(view, "╭") {
+		t.Fatalf("did not expect full summary while virtual key is missing, got %q", view)
+	}
+}
+
+func TestChooserSummarySignOutClearsVirtualKey(t *testing.T) {
+	cleared := false
+	m := newChooserModel(ChooserConfig{
+		BaseURL:    "http://localhost:8080",
+		VirtualKey: "sk-abcdefxyz",
+		Harness:    "codex",
+		Model:      "gpt-4o-mini",
+		Harnesses: []HarnessOption{{
+			ID:                    "codex",
+			Label:                 "Codex CLI",
+			Installed:             true,
+			SupportsModelOverride: true,
+		}},
+		SignOut: func() error {
+			cleared = true
+			return nil
+		},
+	})
+	m.phase = phaseConfig
+	m.summaryIdx = m.summaryIndexForAction(summaryActionSignOut)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(chooserModel)
+	if got.vkInput.Value() != "" {
+		t.Fatalf("expected sign out to clear virtual key, got %q", got.vkInput.Value())
+	}
+	if got.phase != phaseAuthMethod || !got.returnToSummary {
+		t.Fatalf("expected sign out to show auth options before returning to summary, phase=%v returnToSummary=%v", got.phase, got.returnToSummary)
+	}
+	if !cleared {
+		t.Fatal("expected sign out to clear persisted virtual key data")
+	}
+}
+
+func TestChooserAuthMethodExitQuits(t *testing.T) {
+	m := newChooserModel(ChooserConfig{
+		BaseURL: "http://localhost:8080",
+		SignIn: func(ctx context.Context, baseURL string) ([]VirtualKeyOption, error) {
+			return nil, nil
+		},
+	})
+	m.phase = phaseAuthMethod
+	m.authMethodIdx = 3
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(chooserModel)
+	if !got.quit {
+		t.Fatal("expected auth method exit option to quit")
+	}
+}
+
+func TestChooserAuthMethodCanChangeBaseURL(t *testing.T) {
+	m := newChooserModel(ChooserConfig{
+		BaseURL: "http://localhost:8080",
+		SignIn: func(ctx context.Context, baseURL string) ([]VirtualKeyOption, error) {
+			return nil, nil
+		},
+	})
+	m.phase = phaseAuthMethod
+	m.authMethodIdx = 2
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(chooserModel)
+	if got.phase != phaseBaseURL {
+		t.Fatalf("expected change base URL to open base URL phase, got %v", got.phase)
+	}
+}
+
+func TestChooserSummaryVirtualKeyOpensConnectOptions(t *testing.T) {
 	m := newChooserModel(ChooserConfig{
 		BaseURL:    "http://localhost:8080",
 		VirtualKey: "sk-abcdefxyz",
@@ -288,23 +425,66 @@ func TestChooserSummaryVirtualKeyVisibleWhileEditing(t *testing.T) {
 			SupportsModelOverride: true,
 		}},
 	})
+	m.phase = phaseConfig
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
 	got := next.(chooserModel)
-	if !got.summaryEditing || got.summaryEditAction != summaryActionVirtualKey {
-		t.Fatalf("expected v to edit virtual key, editing=%v action=%v", got.summaryEditing, got.summaryEditAction)
+	if got.phase != phaseAuthMethod || !got.returnToSummary {
+		t.Fatalf("expected v to open connect options, phase=%v returnToSummary=%v", got.phase, got.returnToSummary)
 	}
 
 	view := got.View()
-	if !strings.Contains(view, "sk-abcdefxyz") {
-		t.Fatalf("expected full virtual key to be visible while editing, got %q", view)
+	if !strings.Contains(view, "Sign in with Bifrost") || !strings.Contains(view, "Add virtual key manually") {
+		t.Fatalf("expected virtual key connect options, got %q", view)
+	}
+}
+
+func TestChooserSignInWithBifrostSingleVirtualKey(t *testing.T) {
+	m := newChooserModel(ChooserConfig{
+		BaseURL: "http://localhost:8080",
+		SignIn: func(ctx context.Context, baseURL string) ([]VirtualKeyOption, error) {
+			if baseURL != "http://localhost:8080" {
+				t.Fatalf("unexpected baseURL %q", baseURL)
+			}
+			return []VirtualKeyOption{{ID: "vk_1", Name: "Engineering", Value: "sk-bf-123"}}, nil
+		},
+	})
+	m.phase = phaseAuthMethod
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(chooserModel)
+	if !got.signingIn || cmd == nil {
+		t.Fatalf("expected sign-in command to start, signingIn=%v cmdNil=%v", got.signingIn, cmd == nil)
 	}
 
+	msg := cmd().(signInMsg)
+	next, _ = got.Update(msg)
+	got = next.(chooserModel)
+	if got.phase != phaseHarness || got.vkInput.Value() != "sk-bf-123" {
+		t.Fatalf("expected single key to be selected, phase=%v vk=%q", got.phase, got.vkInput.Value())
+	}
+}
+
+func TestChooserSignInWithBifrostMultipleVirtualKeys(t *testing.T) {
+	m := newChooserModel(ChooserConfig{
+		BaseURL: "http://localhost:8080",
+	})
+
+	next, _ := m.Update(signInMsg{keys: []VirtualKeyOption{
+		{ID: "vk_1", Name: "Engineering", Value: "sk-bf-eng"},
+		{ID: "vk_2", Name: "Support", Value: "sk-bf-support"},
+	}})
+	got := next.(chooserModel)
+	if got.phase != phaseVirtualKeySelect {
+		t.Fatalf("expected key picker, phase=%v", got.phase)
+	}
+
+	next, _ = got.Update(tea.KeyMsg{Type: tea.KeyDown})
+	got = next.(chooserModel)
 	next, _ = got.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	got = next.(chooserModel)
-	view = got.View()
-	if !strings.Contains(view, "sk*******xyz") || strings.Contains(view, "sk-abcdefxyz") {
-		t.Fatalf("expected saved virtual key to be masked, got %q", view)
+	if got.phase != phaseHarness || got.vkInput.Value() != "sk-bf-support" {
+		t.Fatalf("expected selected key, phase=%v vk=%q", got.phase, got.vkInput.Value())
 	}
 }
 

--- a/docs/changelogs/cli-v0.10.5.mdx
+++ b/docs/changelogs/cli-v0.10.5.mdx
@@ -9,17 +9,17 @@ description: "v0.10.5 changelog - 2026-05-31"
 ## v0.10.5
 
 - feat: adds an interactive tab command popup invoked by the `Ctrl+B` prefix — lists every open tab plus a trailing "New tab" action row, supports arrow keys / `h`/`j`/`k`/`l` navigation, `Enter` to switch or open a tab, number keys (`1`–`9`) for direct jumps, and `Esc`/`Ctrl+B` to resume
-- feat: adds `Ctrl+G` as a tmux-safe alternate prefix key, giving users a one-press tab selector inside tmux sessions that already consume `Ctrl+B`
+- feat: adds `Ctrl+T` as a tmux-safe alternate prefix key, giving users a one-press tab selector inside tmux sessions that already consume `Ctrl+B` without colliding with Claude Code's `Ctrl+G` shortcut
 - feat: adds a Home-screen Ctrl+C quit confirmation — when no tabs are open, the first `Ctrl+C` shows a centered "Quit Bifrost?" prompt and the second press exits, preventing accidental termination
 - feat: adds an interactive summary screen with arrow-key navigation across actionable rows (launch, base URL, virtual key, worktree, harness, model, dashboard, docs, issues, repo, quit) plus inline editing of base URL and virtual key without leaving the summary
+- feat: adds a "Sign in with Bifrost" CLI setup flow after Base URL entry, with browser handover, assigned virtual-key selection, sign-out from the Ready screen, and manual virtual-key entry as a fallback
 - feat: masks the virtual key input with `*` characters in the chooser to avoid leaking credentials on shared screens
 - feat: adds a Home-styled mandatory update prompt — when a new Bifrost CLI version is available, a centered confirmation popup is shown before the chooser opens, and declining keeps the user on Home instead of blocking startup
 - feat: keeps the CLI running after a harness session ends — the tab manager now loops back to the chooser instead of exiting, so closing the last tab returns to Home rather than terminating Bifrost
 - improvement: model chooser `Esc` now clears the active filter, manual-entry selection, and any error message on first press before exiting the phase, matching common picker behavior
 - improvement: model chooser treats manual model names (typed into the filter) as a distinct selectable row, with arrow-key wrap-around between the filtered list and the manual entry
 - improvement: hides the Bifrost logo when re-entering the harness/model/worktree phases from the summary, giving editing flows more vertical space
-- fix: tab command-mode key handling now correctly distinguishes `Enter` (activate the selected row) from `Esc`/prefix (resume the active tab), and recognises both `Ctrl+B` and `Ctrl+G` as the dismiss key
+- fix: tab command-mode key handling now correctly distinguishes `Enter` (activate the selected row) from `Esc`/prefix (resume the active tab), and recognises both `Ctrl+B` and `Ctrl+T` as the dismiss key
 - fix: arrow-key escape sequences are now mapped to the existing `h`/`j`/`k`/`l` navigation in the command overlay, so users can navigate the tab popup with cursor keys
 
 </Update>
-


### PR DESCRIPTION
## Summary

Introduces a "Sign in with Bifrost" browser-based authentication flow into the CLI setup experience, and replaces `Ctrl+G` with `Ctrl+T` as the tmux-safe alternate prefix key to avoid colliding with Claude Code's existing `Ctrl+G` shortcut.

## Changes

- **`Ctrl+G` → `Ctrl+T`**: The tmux-safe alternate prefix key is changed from `Ctrl+G` (0x07) to `Ctrl+T` (0x14) to avoid conflicting with Claude Code. The tab-bar hint outside tmux now shows `^B/^T` so both shortcuts remain discoverable. CSI-encoded key recognition (`isPrefixKeyCode`) is updated accordingly (codes 103/71 → 116/84).
- **Browser-based sign-in flow**: After entering a Base URL, users without a saved virtual key are now routed to an `authMethod` phase offering "Sign in with Bifrost", "Add virtual key manually", "Change Base URL", and "Exit". Selecting sign-in opens a local HTTP callback server, generates a CSRF state token, launches the browser to `/cli/handover`, and waits for the session token to be returned via redirect.
- **Virtual key selection**: When sign-in returns multiple virtual keys, a new `phaseVirtualKeySelect` picker lets users choose one by name. A single key is auto-selected. A "Add virtual key manually" fallback row is always present at the bottom.
- **Sign-out action**: The CLI Config screen shows a "Sign out" row when a virtual key is active. Selecting it clears the in-memory and persisted virtual key and returns to the auth method screen.
- **Restructured summary screen**: The Ready screen now shows a high-level action list (Start, CLI Config, Dashboard, Docs, Report issue, Star, Exit). CLI Config opens a separate `phaseConfig` screen containing Base URL, harness, model, virtual key, sign-out, worktree, and Back rows. Keyboard shortcuts (`u`, `v`, `h`, `m`, `w`) are gated to `phaseConfig` only.
- **Sticky error dismissal refactor**: `clearStickyErrorForAction` consolidates the previously scattered sticky-error guard logic. Dismiss keys (`Space`, `Esc`, `Ctrl+B`, `Ctrl+T`) clear the notice and re-enter command mode; any other key clears the notice and continues with the action.
- **`apis.Client` additions**: `SignInWithBifrost`, `ListVirtualKeys`, and `startCLIHandover` are added to the API client. `openURL` is injectable for testing. `VirtualKey` and `listVirtualKeysResp` types are introduced, with response field fallback (`virtual_keys` → `keys` → `data`, `value` → `key`).
- **Tab bar mouse click clears notice**: `handleTabBarMouseEvent` now calls `clearNotice()` before switching tabs.
- **Logo hidden for `phaseVirtualKeySelect`**: Consistent with harness/model/worktree editing flows.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
go test ./cli/internal/apis/... ./cli/internal/runtime/... ./cli/internal/ui/tui/...
```

1. Launch the CLI without a saved virtual key — confirm the auth method screen appears after Base URL entry with four options.
2. Select "Sign in with Bifrost" — confirm the browser opens to `/cli/handover` and the CLI waits.
3. Complete sign-in in the browser — confirm the CLI receives the session token, fetches virtual keys, and either auto-selects (single key) or shows the picker (multiple keys).
4. From the Ready screen, open CLI Config and select "Sign out" — confirm the virtual key is cleared and the auth method screen is shown.
5. Inside tmux, confirm `Ctrl+T` opens the tab popup and `Ctrl+G` is passed through to the active tab unmodified.
6. Outside tmux, confirm the tab bar hint reads `^B/^T`.

## Breaking changes

- [x] Yes
- [ ] No

`Ctrl+G` no longer acts as the Bifrost tab-mode prefix. Users who relied on `Ctrl+G` inside tmux must switch to `Ctrl+T`.

## Security considerations

- The browser handover flow uses a 16-byte random hex CSRF state token to prevent open-redirect token injection.
- The local callback server binds only to `127.0.0.1` on an OS-assigned ephemeral port.
- The session token is transmitted only over localhost and then sent to the configured Bifrost base URL over whatever scheme the user has configured (HTTPS recommended in production).
- Virtual key values continue to be masked with `*` characters in all summary views.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)