### PR TITLE
fix: fix 403 errors for list models request

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -514,9 +514,20 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 
 				response, bifrostErr := bifrost.ListModelsRequest(providerCtx, providerRequest)
 				if bifrostErr != nil {
-					// Skip logging "no keys found" and "not supported" errors as they are expected when a provider is not configured
-					if !strings.Contains(bifrostErr.Error.Message, "no keys found") &&
-						!strings.Contains(bifrostErr.Error.Message, "not supported") {
+					// Some per-provider failures are expected when fanning out across all
+					// configured providers and must not be surfaced as a top-level error
+					errType := ""
+					if bifrostErr.Type != nil {
+						errType = *bifrostErr.Type
+					}
+					errMsg := ""
+					if bifrostErr.Error != nil {
+						errMsg = bifrostErr.Error.Message
+					}
+					isExpected := strings.Contains(errMsg, "no keys found") ||
+						strings.Contains(errMsg, "not supported") ||
+						errType == "provider_blocked"
+					if !isExpected {
 						providerErr = bifrostErr
 						bifrost.logger.Warn("failed to list models for provider %s: %s", providerKey, bifrostErr.GetErrorString())
 					}

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -272,7 +272,7 @@ func (r *BudgetResolver) EvaluateVirtualKeyRequest(ctx *schemas.BifrostContext, 
 		}
 	}
 	// 2. Check provider filtering
-	if requestType != schemas.MCPToolExecutionRequest && !r.isProviderAllowed(vk, provider) {
+	if requestType != schemas.MCPToolExecutionRequest && requestType != schemas.ListModelsRequest && !r.isProviderAllowed(vk, provider) {
 		return &EvaluationResult{
 			Decision:   DecisionProviderBlocked,
 			Reason:     fmt.Sprintf("Provider '%s' is not allowed for this virtual key", provider),

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -92,6 +92,34 @@ func TestBudgetResolver_EvaluateRequest_ProviderBlocked(t *testing.T) {
 	assertVirtualKeyFound(t, result)
 }
 
+// TestBudgetResolver_EvaluateRequest_ListModelsBypassesProviderBlock verifies that a VK
+// with a restricted provider allowlist does NOT block a ListModelsRequest for a provider
+// outside its allowlist. List-models fans out across all configured providers and is
+// filtered per-VK in the PostHook, so provider gating must be skipped here (resolver.go:275).
+func TestBudgetResolver_EvaluateRequest_ListModelsBypassesProviderBlock(t *testing.T) {
+	logger := NewMockLogger()
+
+	// Same Anthropic-only VK as TestBudgetResolver_EvaluateRequest_ProviderBlocked.
+	providerConfigs := []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("anthropic", []string{"claude-3-sonnet"}),
+	}
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", providerConfigs)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	ctx := &schemas.BifrostContext{}
+
+	// OpenAI is not in the allowlist, but ListModelsRequest must not be provider-blocked.
+	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ListModelsRequest, false)
+
+	assert.NotEqual(t, DecisionProviderBlocked, result.Decision, "ListModelsRequest must bypass provider allowlist gating")
+	assertDecision(t, DecisionAllow, result)
+}
+
 // TestBudgetResolver_EvaluateRequest_ModelBlocked tests model filtering
 func TestBudgetResolver_EvaluateRequest_ModelBlocked(t *testing.T) {
 	logger := NewMockLogger()


### PR DESCRIPTION
## Summary

When calling `ListAllModels` across all configured providers, certain per-provider failures are expected and should be silently skipped rather than surfaced as top-level errors. Previously, only `"no keys found"` and `"not supported"` message strings were suppressed. This PR extends that suppression to also cover `provider_blocked` and `model_blocked` error types, and fixes a potential nil pointer dereference when accessing `bifrostErr.Type` and `bifrostErr.Error`. Additionally, the governance resolver now skips provider-allowlist enforcement for `ListModelsRequest`, preventing blocked-provider errors from being incorrectly raised during model listing fan-out.

## Changes

- Extended the expected-error check in `ListAllModels` to include `provider_blocked` and `model_blocked` error types, so these are silently skipped during fan-out rather than logged as warnings or propagated as errors.
- Added nil guards for `bifrostErr.Type` and `bifrostErr.Error` before dereferencing, preventing potential panics.
- Exempted `ListModelsRequest` from provider-allowlist enforcement in `BudgetResolver.EvaluateVirtualKeyRequest`, consistent with the existing exemption for `MCPToolExecutionRequest`. This ensures that listing models across all providers does not trigger a `provider_blocked` decision for providers restricted by a virtual key's allowlist.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Plugins

## How to test

```sh
go test ./...
```

1. Configure a virtual key with a restricted provider allowlist.
2. Call the `ListAllModels` endpoint using that virtual key.
3. Verify that providers outside the allowlist are included in the model listing response without returning a `provider_blocked` error.
4. Verify that no spurious warnings are logged for expected per-provider failures (e.g., unconfigured providers, blocked providers).

## Breaking changes

- [x] No

## Related issues

## Security considerations

None. The change only affects model listing fan-out behavior and does not alter authentication, secret handling, or access control for inference requests.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable