### PR TITLE
chore: updated the default network config timings

### DIFF
--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -711,7 +711,7 @@ func (ma *MockAccount) AddProviderWithBaseURL(provider schemas.ModelProvider, co
 	ma.configs[provider] = &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
 			BaseURL:                        baseURL,
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 			MaxRetries:                     3,
 			RetryBackoffInitial:            500 * time.Millisecond,
 			RetryBackoffMax:                5 * time.Second,

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -547,7 +547,7 @@ func generateTestCACert(t *testing.T) string {
 func TestBedrockTransportHTTP2Config(t *testing.T) {
 	config := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 			MaxConnsPerHost:                5000,
 			EnforceHTTP2:                   true,
 		},
@@ -570,7 +570,7 @@ func TestBedrockTransportHTTP2Config(t *testing.T) {
 func TestBedrockTransportCustomMaxConns(t *testing.T) {
 	config := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 			MaxConnsPerHost:                50,
 		},
 	}
@@ -590,7 +590,7 @@ func TestBedrockTransportCustomMaxConns(t *testing.T) {
 func TestBedrockTransportDefaultMaxConns(t *testing.T) {
 	config := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 			// MaxConnsPerHost left as 0 — should default to 5000
 		},
 	}
@@ -612,7 +612,7 @@ func TestBedrockTransportDefaultMaxConns(t *testing.T) {
 func TestBedrockTransportTLSInsecureSkipVerify(t *testing.T) {
 	config := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 			InsecureSkipVerify:             true,
 			EnforceHTTP2:                   true,
 		},
@@ -636,7 +636,7 @@ func TestBedrockTransportTLSCACert(t *testing.T) {
 
 	config := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 			CACertPEM:                      schemas.NewEnvVar(testCACert),
 			EnforceHTTP2:                   true,
 		},
@@ -657,7 +657,7 @@ func TestBedrockTransportTLSCACert(t *testing.T) {
 func TestBedrockTransportDefaultTLS(t *testing.T) {
 	config := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 			// No TLS settings — should use system defaults
 		},
 	}
@@ -677,7 +677,7 @@ func TestBedrockTransportDefaultTLS(t *testing.T) {
 func TestBedrockTransportEnforceHTTP2(t *testing.T) {
 	config := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 			EnforceHTTP2:                   true,
 		},
 	}
@@ -696,7 +696,7 @@ func TestBedrockTransportEnforceHTTP2(t *testing.T) {
 func TestBedrockTransportEnforceHTTP2Disabled(t *testing.T) {
 	config := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 			EnforceHTTP2:                   false,
 		},
 	}

--- a/core/providers/fireworks/fireworks_test.go
+++ b/core/providers/fireworks/fireworks_test.go
@@ -431,7 +431,7 @@ func newTestFireworksProvider(t *testing.T, baseURL string) *fireworksprovider.F
 	provider, err := fireworksprovider.NewFireworksProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
 			BaseURL:                        baseURL,
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, bifrost.NewNoOpLogger())
 	if err != nil {

--- a/core/providers/mistral/ocr_test.go
+++ b/core/providers/mistral/ocr_test.go
@@ -605,7 +605,7 @@ func TestOCRWithMockServer(t *testing.T) {
 			provider := NewMistralProvider(&schemas.ProviderConfig{
 				NetworkConfig: schemas.NetworkConfig{
 					BaseURL:                        server.URL,
-					DefaultRequestTimeoutInSeconds: 30,
+					DefaultRequestTimeoutInSeconds: 300,
 				},
 			}, &testLogger{})
 
@@ -639,7 +639,7 @@ func TestOCRNilInput(t *testing.T) {
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
 			BaseURL:                        "https://api.mistral.ai",
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
 
@@ -686,7 +686,7 @@ func TestOCRRequestValidation(t *testing.T) {
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
 			BaseURL:                        server.URL,
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
 

--- a/core/providers/mistral/transcription_test.go
+++ b/core/providers/mistral/transcription_test.go
@@ -593,7 +593,7 @@ func TestTranscriptionWithMockServer(t *testing.T) {
 			provider := NewMistralProvider(&schemas.ProviderConfig{
 				NetworkConfig: schemas.NetworkConfig{
 					BaseURL:                        server.URL,
-					DefaultRequestTimeoutInSeconds: 30,
+					DefaultRequestTimeoutInSeconds: 300,
 				},
 			}, &testLogger{})
 
@@ -637,7 +637,7 @@ func TestTranscriptionNilInput(t *testing.T) {
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
 			BaseURL:                        "https://api.mistral.ai",
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
 
@@ -787,7 +787,7 @@ func TestTranscriptionStreamWithMockServer(t *testing.T) {
 			provider := NewMistralProvider(&schemas.ProviderConfig{
 				NetworkConfig: schemas.NetworkConfig{
 					BaseURL:                        server.URL,
-					DefaultRequestTimeoutInSeconds: 30,
+					DefaultRequestTimeoutInSeconds: 300,
 				},
 			}, &testLogger{})
 
@@ -842,7 +842,7 @@ func TestTranscriptionStreamNilInput(t *testing.T) {
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
 			BaseURL:                        "https://api.mistral.ai",
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
 
@@ -1272,7 +1272,7 @@ func TestTranscriptionStreamEdgeCases(t *testing.T) {
 			provider := NewMistralProvider(&schemas.ProviderConfig{
 				NetworkConfig: schemas.NetworkConfig{
 					BaseURL:                        server.URL,
-					DefaultRequestTimeoutInSeconds: 30,
+					DefaultRequestTimeoutInSeconds: 300,
 				},
 			}, &testLogger{})
 
@@ -1342,7 +1342,7 @@ func TestTranscriptionStreamContextCancellation(t *testing.T) {
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
 			BaseURL:                        server.URL,
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
 

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2217,7 +2217,7 @@ func SetupStreamCancellation(ctx *schemas.BifrostContext, bodyStream io.Reader, 
 // before bifrost considers the connection stalled and closes it. This protects
 // against providers that stop sending data but keep the TCP connection open
 // (e.g., Azure TPM throttling).
-const DefaultStreamIdleTimeout = 60 * time.Second
+const DefaultStreamIdleTimeout = 120 * time.Second
 
 // SetStreamIdleTimeoutIfEmpty sets the stream idle timeout on the context from
 // the provider's network config, but only if no valid timeout is already present.

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -13,12 +13,12 @@ const (
 	DefaultMaxRetries                 = 0
 	DefaultRetryBackoffInitial        = 500 * time.Millisecond
 	DefaultRetryBackoffMax            = 5 * time.Second
-	DefaultRequestTimeoutInSeconds    = 30
+	DefaultRequestTimeoutInSeconds    = 300
 	DefaultMaxConnDurationInSeconds   = 300 // 5 minutes — forces connection recycling to prevent stale connections from NAT/LB silent drops
 	DefaultBufferSize                 = 5000
 	DefaultConcurrency                = 1000
 	DefaultStreamBufferSize           = 256
-	DefaultStreamIdleTimeoutInSeconds = 60 // Idle timeout per stream chunk — if no data for this many seconds, bifrost closes the connection
+	DefaultStreamIdleTimeoutInSeconds = 120 // Idle timeout per stream chunk — if no data for this many seconds, bifrost closes the connection
 	DefaultMaxConnsPerHost            = 5000
 	MaxConnsPerHostUpperBound         = 10000
 	DefaultMaxIdleConnsPerHost        = 40
@@ -26,7 +26,7 @@ const (
 
 // Pre-defined errors for provider operations
 const (
-	ErrProviderRequestTimedOut      = "request timed out (default is 30 seconds). You can increase it by setting the default_request_timeout_in_seconds in the network_config or in UI - Providers > Provider Name > Network Config."
+	ErrProviderRequestTimedOut      = "request timed out (default is 300 seconds). You can increase it by setting the default_request_timeout_in_seconds in the network_config or in UI - Providers > Provider Name > Network Config."
 	ErrRequestCancelled             = "request cancelled by caller"
 	ErrRequestBodyConversion        = "failed to convert bifrost request to the expected provider request body"
 	ErrProviderRequestMarshal       = "failed to marshal request body to JSON"

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1135,7 +1135,7 @@ func TestNetworkConfig_TLSFieldsRoundTrip(t *testing.T) {
 // round-trips correctly through JSON marshaling.
 func TestNetworkConfig_StreamIdleTimeoutRoundTrip(t *testing.T) {
 	nc := NetworkConfig{
-		DefaultRequestTimeoutInSeconds: 30,
+		DefaultRequestTimeoutInSeconds: 300,
 		StreamIdleTimeoutInSeconds:     120,
 	}
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -14447,7 +14447,7 @@ func TestGenerateProviderHash_RuntimeVsMigrationParity(t *testing.T) {
 	t.Run("NetworkConfig_GORMRoundTrip", func(t *testing.T) {
 		networkConfig := &schemas.NetworkConfig{
 			BaseURL:                        "https://api.custom.com",
-			DefaultRequestTimeoutInSeconds: 30,
+			DefaultRequestTimeoutInSeconds: 300,
 		}
 
 		providerToSave := tables.TableProvider{

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2935,7 +2935,7 @@
           "type": "integer",
           "minimum": 5,
           "maximum": 3600,
-          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 60."
+          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 120."
         },
         "max_conns_per_host": {
           "type": "integer",
@@ -3004,7 +3004,7 @@
           "type": "integer",
           "minimum": 5,
           "maximum": 3600,
-          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 60."
+          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 120."
         },
         "max_conns_per_host": {
           "type": "integer",

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
+import { DefaultNetworkConfig } from "@/lib/constants/config";
 import { getErrorMessage, useCreateProviderMutation } from "@/lib/store";
 import { BaseProvider, ModelProviderName } from "@/lib/types/config";
 import { allowedRequestsSchema } from "@/lib/types/schemas";
@@ -102,7 +103,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 			network_config: {
 				base_url: data.base_url,
 				allow_private_network: data.allow_private_network ?? false,
-				default_request_timeout_in_seconds: 30,
+				default_request_timeout_in_seconds: DefaultNetworkConfig.default_request_timeout_in_seconds,
 				max_retries: 0,
 				retry_backoff_initial: 500,
 				retry_backoff_max: 5000,

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -104,7 +104,8 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				...provider.network_config,
 				base_url: data.network_config?.base_url || undefined,
 				extra_headers: data.network_config?.extra_headers || undefined,
-				default_request_timeout_in_seconds: data.network_config?.default_request_timeout_in_seconds ?? 30,
+				default_request_timeout_in_seconds:
+					data.network_config?.default_request_timeout_in_seconds ?? DefaultNetworkConfig.default_request_timeout_in_seconds,
 				max_retries: data.network_config?.max_retries ?? 0,
 				retry_backoff_initial: data.network_config?.retry_backoff_initial ?? 500,
 				retry_backoff_max: data.network_config?.retry_backoff_max ?? 10000,

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -83,13 +83,13 @@ export const isKeyRequiredByProvider: Record<ProviderName, boolean> = {
 
 export const DefaultNetworkConfig = {
 	base_url: "",
-	default_request_timeout_in_seconds: 30,
+	default_request_timeout_in_seconds: 300,
 	max_retries: 0,
 	retry_backoff_initial: 1000,
 	retry_backoff_max: 10000,
 	insecure_skip_verify: false,
 	ca_cert_pem: { value: "", env_var: "", from_env: false },
-	stream_idle_timeout_in_seconds: 60,
+	stream_idle_timeout_in_seconds: 120,
 	max_conns_per_host: 5000,
 	enforce_http2: false,
 	allow_private_network: false,


### PR DESCRIPTION
## Summary

Increases the default timeout values for network requests to reduce premature connection failures, particularly for slow or long-running requests and streaming connections.

## Changes

- Increased `default_request_timeout_in_seconds` from `30` to `300` seconds to better accommodate slower upstream providers or large payloads that exceed the previous short timeout.
- Increased `stream_idle_timeout_in_seconds` from `60` to `120` seconds to allow more time before idle streaming connections are terminated.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Verify that the new default values appear when creating or viewing a network configuration in the UI.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Confirm that requests to slow upstream providers no longer time out prematurely under the new defaults, and that streaming connections remain open for up to 120 seconds of idle time.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Longer timeouts may increase resource consumption if connections are held open by slow or unresponsive upstream services. Operators should ensure appropriate infrastructure-level timeouts are in place to mitigate potential abuse or resource exhaustion.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable