### PR TITLE
feat(routing-rules): added context length routing rule variable

### DIFF
--- a/docs/providers/provider-routing.mdx
+++ b/docs/providers/provider-routing.mdx
@@ -1469,6 +1469,9 @@ customer_id                // Customer ID
 budget_used                // Budget usage %
 tokens_used                // Token rate limit usage %
 request                    // Request rate limit usage %
+
+// Request size
+context_length             // Input context length in tokens
 ```
 
 ### Examples
@@ -1489,6 +1492,12 @@ budget_used > 85                 // → groq/llama-2 (cheaper)
 
 ```cel
 team_name == "ml-research"       // → anthropic/claude-3-opus
+```
+
+#### Route long-context requests
+
+```cel
+context_length > 32000           // → vertex/gemini-2.5-pro
 ```
 
 #### Complex multi-condition routing
@@ -1522,9 +1531,10 @@ Within each scope, rules are sorted by **priority** (ascending: 0 before 10).
 | **Fallback Chains**    | Define multiple fallback providers for automatic failover              |
 | **Priority Ordering**  | Lower priority evaluated first within same scope                       |
 | **Capacity Awareness** | Access real-time budget and rate limit usage percentages               |
+| **Context Awareness**  | Route by request input context length using provider-native counts where available |
 
 <Info>
-For complexity-based routing driven by request content, see [Complexity Router](/features/governance/complexity-router). It adds a `complexity_tier` CEL variable that lets routing rules steer SIMPLE, MEDIUM, COMPLEX, and REASONING requests to different models.
+For complexity-based routing driven by request content, see [Complexity Router](/features/governance/complexity-router). It adds a `complexity_tier` CEL variable that lets routing rules steer SIMPLE, MEDIUM, COMPLEX, and REASONING requests to different models. For context-length routing, Bifrost uses provider-native token counting when supported and falls back to `ceil(serialized_request_bytes / 4)` when exact counting is unavailable.
 </Info>
 
 ### Integration with Governance

--- a/docs/providers/routing-rules.mdx
+++ b/docs/providers/routing-rules.mdx
@@ -116,6 +116,24 @@ tokens_used < 50           // Route to fast provider when below 50% token limit
 request > 90               // Switch providers when request limit near max
 ```
 
+#### Request Context Length
+
+```cel
+context_length   // Input context length for the request, in tokens
+```
+
+Bifrost uses provider-native token counting when the configured provider supports it. If exact counting is unavailable, it falls back to an estimated token count using `ceil(serialized_request_bytes / 4)`.
+
+<Note>
+`context_length` is computed only for routing rules that reference it. If it cannot be computed for a request, it is treated as **unknown** by the evaluator - the rule does not match and evaluation falls through.
+</Note>
+
+**Examples:**
+```cel
+context_length > 32000                       // Route long-context requests
+context_length >= 8192 && team_name == "ai"  // Long-context routing scoped to a team
+```
+
 #### Complexity Routing
 
 ```cel

--- a/plugins/governance/contextlength.go
+++ b/plugins/governance/contextlength.go
@@ -1,0 +1,118 @@
+package governance
+
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const estimatedContextBytesPerToken int64 = 4
+
+// computeContextLength returns the request input context length in tokens.
+// It uses Bifrost's provider-native CountTokensRequest path when available and
+// falls back to a local byte-size estimate for providers without support.
+func (p *GovernancePlugin) computeContextLength(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (int64, bool) {
+	countReq, estimateBytes, ok := buildContextLengthCountRequest(req)
+	if !ok {
+		if p.logger != nil {
+			p.logger.Debug("[Governance] Context length skipped: unsupported request type")
+		}
+		ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, schemas.LogLevelInfo, "Context length skipped: no supported input detected")
+		return 0, false
+	}
+
+	if p.countTokensRequestExecutor != nil && countReq != nil && countReq.Provider != "" && countReq.Model != "" {
+		countCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		defer countCtx.Cancel()
+		countCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
+
+		resp, err := p.countTokensRequestExecutor(countCtx, countReq)
+		if err == nil && resp != nil {
+			inputTokens := resp.InputTokens
+			if inputTokens == 0 && resp.TotalTokens != nil {
+				inputTokens = *resp.TotalTokens
+			}
+			ctx.AppendRoutingEngineLog(
+				schemas.RoutingEngineRoutingRule,
+				schemas.LogLevelInfo,
+				fmt.Sprintf("Context length: %d tokens (provider count)", inputTokens),
+			)
+			return int64(inputTokens), true
+		}
+		if p.logger != nil && err != nil {
+			p.logger.Debug("[Governance] Context length provider count failed, falling back to estimate: %v", err)
+		}
+	}
+
+	estimate := estimateContextTokens(estimateBytes)
+	ctx.AppendRoutingEngineLog(
+		schemas.RoutingEngineRoutingRule,
+		schemas.LogLevelInfo,
+		fmt.Sprintf("Context length: %d tokens (estimated from %d bytes)", estimate, estimateBytes),
+	)
+	return estimate, true
+}
+
+func buildContextLengthCountRequest(req *schemas.BifrostRequest) (*schemas.BifrostResponsesRequest, int64, bool) {
+	if req == nil {
+		return nil, 0, false
+	}
+
+	var countReq *schemas.BifrostResponsesRequest
+	var rawRequestBody []byte
+
+	switch {
+	case req.ResponsesRequest != nil:
+		copyReq := *req.ResponsesRequest
+		copyReq.Fallbacks = nil
+		countReq = &copyReq
+		rawRequestBody = copyReq.RawRequestBody
+	case req.ChatRequest != nil:
+		countReq = req.ChatRequest.ToResponsesRequest()
+		countReq.Fallbacks = nil
+		rawRequestBody = req.ChatRequest.RawRequestBody
+	case req.TextCompletionRequest != nil:
+		chatReq := req.TextCompletionRequest.ToBifrostChatRequest()
+		if chatReq != nil {
+			countReq = chatReq.ToResponsesRequest()
+			countReq.Fallbacks = nil
+		}
+		rawRequestBody = req.TextCompletionRequest.RawRequestBody
+	case req.CountTokensRequest != nil:
+		copyReq := *req.CountTokensRequest
+		copyReq.Fallbacks = nil
+		countReq = &copyReq
+		rawRequestBody = copyReq.RawRequestBody
+	default:
+		return nil, 0, false
+	}
+
+	if countReq != nil && countReq.Input != nil {
+		provider, model, _ := req.GetRequestFields()
+		countReq.Provider = provider
+		countReq.Model = model
+		estimateBytes, ok := serializedRequestBytes(countReq)
+		return countReq, estimateBytes, ok
+	}
+
+	if len(rawRequestBody) > 0 {
+		return nil, int64(len(rawRequestBody)), true
+	}
+
+	return nil, 0, false
+}
+
+func serializedRequestBytes(req *schemas.BifrostResponsesRequest) (int64, bool) {
+	body, err := schemas.Marshal(req)
+	if err != nil {
+		return 0, false
+	}
+	return int64(len(body)), true
+}
+
+func estimateContextTokens(byteLen int64) int64 {
+	if byteLen <= 0 {
+		return 0
+	}
+	return (byteLen + estimatedContextBytesPerToken - 1) / estimatedContextBytesPerToken
+}

--- a/plugins/governance/contextlength_test.go
+++ b/plugins/governance/contextlength_test.go
@@ -1,0 +1,292 @@
+package governance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCELExpressionReferencesContextLengthIdentifierOnly(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		expected   bool
+	}{
+		{
+			name:       "direct identifier",
+			expression: `context_length >= 8192`,
+			expected:   true,
+		},
+		{
+			name:       "identifier in compound expression",
+			expression: `context_length > 32000 && team_name == "research"`,
+			expected:   true,
+		},
+		{
+			name:       "string literal only",
+			expression: `model == "context_length"`,
+			expected:   false,
+		},
+		{
+			name:       "unrelated identifier containing name",
+			expression: `max_context_length == 128000`,
+			expected:   false,
+		},
+		{
+			name:       "map key string",
+			expression: `headers["context_length"] == "large"`,
+			expected:   false,
+		},
+		{
+			name:       "field selection",
+			expression: `metadata.context_length == 8192`,
+			expected:   false,
+		},
+		{
+			name:       "comprehension local shadows identifier",
+			expression: `[100].exists(context_length, context_length > 10)`,
+			expected:   false,
+		},
+		{
+			name:       "comprehension references outer identifier",
+			expression: `[100].exists(limit, context_length > limit)`,
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, celExpressionReferencesIdentifier(tt.expression, "context_length"))
+		})
+	}
+}
+
+func TestEvaluateCELExpression_ContextLengthUnknown(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		budgetUsed float64
+		expected   bool
+	}{
+		{
+			name:       "less than depends on unavailable context length",
+			expression: `context_length < 2048`,
+			expected:   false,
+		},
+		{
+			name:       "not equals depends on unavailable context length",
+			expression: `context_length != 2048`,
+			expected:   false,
+		},
+		{
+			name:       "or short-circuits when non-context side is true",
+			expression: `budget_used > 90.0 || context_length < 2048`,
+			budgetUsed: 95.0,
+			expected:   true,
+		},
+		{
+			name:       "or is no match when only unavailable context can decide",
+			expression: `budget_used > 90.0 || context_length < 2048`,
+			budgetUsed: 40.0,
+			expected:   false,
+		},
+	}
+
+	env, err := createCELEnvironment()
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expression)
+			require.NoError(t, issues.Err())
+
+			program, err := env.Program(ast, cel.EvalOptions(cel.OptPartialEval))
+			require.NoError(t, err)
+
+			variables := contextLengthRoutingVariables()
+			variables["budget_used"] = tt.budgetUsed
+			delete(variables, "context_length")
+
+			matched, err := evaluateCELExpression(program, variables, cel.AttributePattern("context_length"))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, matched)
+		})
+	}
+}
+
+func TestEvaluateRoutingRules_ContextLengthMatches(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewLocalGovernanceStore(ctx, NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	rule := contextLengthRoutingRule("context-length-large", `context_length >= 8192`)
+	require.NoError(t, store.UpdateRoutingRuleInMemory(ctx, rule))
+
+	engine, err := NewRoutingEngine(store, NewMockLogger(), schemas.Ptr(10))
+	require.NoError(t, err)
+
+	computeCalls := 0
+	decision, err := engine.EvaluateRoutingRules(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &RoutingContext{
+		Provider:    schemas.OpenAI,
+		Model:       "gpt-4o",
+		RequestType: "chat_completion",
+		computeContextLength: func() (int64, bool) {
+			computeCalls++
+			return 9000, true
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+
+	assert.Equal(t, 1, computeCalls)
+	assert.Equal(t, "anthropic", decision.Provider)
+	assert.Equal(t, "claude-3-5-sonnet", decision.Model)
+}
+
+func TestEvaluateRoutingRules_ContextLengthUnavailableDoesNotMatch(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewLocalGovernanceStore(ctx, NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	rule := contextLengthRoutingRule("context-length-unavailable", `context_length < 2048`)
+	require.NoError(t, store.UpdateRoutingRuleInMemory(ctx, rule))
+
+	engine, err := NewRoutingEngine(store, NewMockLogger(), schemas.Ptr(10))
+	require.NoError(t, err)
+
+	computeCalls := 0
+	decision, err := engine.EvaluateRoutingRules(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &RoutingContext{
+		Provider:    schemas.OpenAI,
+		Model:       "gpt-4o",
+		RequestType: "chat_completion",
+		computeContextLength: func() (int64, bool) {
+			computeCalls++
+			return 0, false
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Nil(t, decision)
+	assert.Equal(t, 1, computeCalls)
+}
+
+func TestEvaluateRoutingRules_ContextLengthLiteralDoesNotCompute(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewLocalGovernanceStore(ctx, NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	rule := contextLengthRoutingRule("context-length-literal", `model == "context_length"`)
+	require.NoError(t, store.UpdateRoutingRuleInMemory(ctx, rule))
+
+	engine, err := NewRoutingEngine(store, NewMockLogger(), schemas.Ptr(10))
+	require.NoError(t, err)
+
+	computeCalls := 0
+	decision, err := engine.EvaluateRoutingRules(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &RoutingContext{
+		Provider:    schemas.OpenAI,
+		Model:       "context_length",
+		RequestType: "chat_completion",
+		computeContextLength: func() (int64, bool) {
+			computeCalls++
+			return 9000, true
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+
+	assert.Equal(t, 0, computeCalls)
+	assert.Equal(t, "anthropic", decision.Provider)
+	assert.Equal(t, "claude-3-5-sonnet", decision.Model)
+}
+
+func TestComputeContextLengthUsesExecutorWithChildContext(t *testing.T) {
+	parentCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	prompt := "Explain vector clocks in one paragraph."
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o",
+			Input: []schemas.ChatMessage{
+				{
+					Role:    schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{ContentStr: &prompt},
+				},
+			},
+			Fallbacks: []schemas.Fallback{{Provider: schemas.Anthropic, Model: "claude-3-5-sonnet"}},
+		},
+	}
+
+	plugin := &GovernancePlugin{logger: NewMockLogger()}
+	plugin.SetCountTokensRequestExecutor(func(ctx *schemas.BifrostContext, countReq *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+		skipPipeline, _ := ctx.Value(schemas.BifrostContextKeySkipPluginPipeline).(bool)
+		assert.True(t, skipPipeline)
+		assert.Equal(t, schemas.OpenAI, countReq.Provider)
+		assert.Equal(t, "gpt-4o", countReq.Model)
+		assert.Len(t, countReq.Input, 1)
+		assert.Empty(t, countReq.Fallbacks)
+		return &schemas.BifrostCountTokensResponse{InputTokens: 123}, nil
+	})
+
+	contextLength, ok := plugin.computeContextLength(parentCtx, req)
+	require.True(t, ok)
+	assert.Equal(t, int64(123), contextLength)
+
+	parentSkipPipeline, _ := parentCtx.Value(schemas.BifrostContextKeySkipPluginPipeline).(bool)
+	assert.False(t, parentSkipPipeline)
+}
+
+func TestComputeContextLengthFallsBackToByteEstimate(t *testing.T) {
+	parentCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	prompt := "Summarize the current routing plan."
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o",
+			Input: []schemas.ChatMessage{
+				{
+					Role:    schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{ContentStr: &prompt},
+				},
+			},
+		},
+	}
+
+	_, estimateBytes, ok := buildContextLengthCountRequest(req)
+	require.True(t, ok)
+
+	plugin := &GovernancePlugin{logger: NewMockLogger()}
+	contextLength, ok := plugin.computeContextLength(parentCtx, req)
+	require.True(t, ok)
+	assert.Equal(t, estimateContextTokens(estimateBytes), contextLength)
+	assert.Greater(t, contextLength, int64(0))
+}
+
+func contextLengthRoutingVariables() map[string]interface{} {
+	variables := complexityRoutingVariables()
+	variables["context_length"] = int64(0)
+	return variables
+}
+
+func contextLengthRoutingRule(id string, expression string) *configstoreTables.TableRoutingRule {
+	provider := "anthropic"
+	model := "claude-3-5-sonnet"
+	return &configstoreTables.TableRoutingRule{
+		ID:            id,
+		Name:          id,
+		Enabled:       boolPtr(true),
+		CelExpression: expression,
+		Scope:         "global",
+		Priority:      1,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: &provider, Model: &model, Weight: 1.0},
+		},
+	}
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -47,6 +47,10 @@ type InMemoryStore interface {
 	GetMCPClientsAllowingAllVirtualKeys() map[string]string // clientID → clientName
 }
 
+// CountTokensRequestExecutor invokes Bifrost's provider-native count-token path.
+// It mirrors the signature of bifrost.Client.CountTokensRequest.
+type CountTokensRequestExecutor func(ctx *schemas.BifrostContext, req *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError)
+
 type BaseGovernancePlugin interface {
 	GetName() string
 	EvaluateGovernanceRequest(ctx *schemas.BifrostContext, evaluationRequest *EvaluationRequest, requestType schemas.RequestType) (*EvaluationResult, *schemas.BifrostError)
@@ -80,7 +84,8 @@ type GovernancePlugin struct {
 	logger       schemas.Logger
 
 	// Transport dependencies
-	inMemoryStore InMemoryStore
+	inMemoryStore              InMemoryStore
+	countTokensRequestExecutor CountTokensRequestExecutor
 
 	cfgMutex sync.RWMutex
 
@@ -340,6 +345,13 @@ func InitFromStore(
 // GetName returns the name of the plugin
 func (p *GovernancePlugin) GetName() string {
 	return PluginName
+}
+
+// SetCountTokensRequestExecutor wires up the function routing rules use to
+// compute provider-native context_length values. When unset, routing falls back
+// to local byte-size estimation.
+func (p *GovernancePlugin) SetCountTokensRequestExecutor(executor CountTokensRequestExecutor) {
+	p.countTokensRequestExecutor = executor
 }
 
 // ReloadComplexityAnalyzerConfig swaps the analyzer used by complexity_tier routing.
@@ -726,6 +738,10 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		}
 	}
 
+	computeContextLength := func() (int64, bool) {
+		return p.computeContextLength(ctx, req)
+	}
+
 	routingCtx := &RoutingContext{
 		VirtualKey:               virtualKey,
 		Provider:                 provider,
@@ -735,6 +751,7 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		QueryParams:              queryParams,
 		BudgetAndRateLimitStatus: p.store.GetBudgetAndRateLimitStatus(ctx, model, provider, virtualKey, nil, nil, nil),
 		computeComplexity:        computeComplexity,
+		computeContextLength:     computeContextLength,
 	}
 
 	p.logger.Debug("[PreRequestHook] Built routing context: provider=%s, model=%s, requestType=%s, vk=%v",

--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -46,6 +46,7 @@ type RoutingContext struct {
 	QueryParams              map[string]string                   // Query parameters for dynamic routing
 	BudgetAndRateLimitStatus *BudgetAndRateLimitStatus           // Budget and rate limit status by provider/model
 	computeComplexity        func() *complexity.ComplexityResult // Lazy complexity computation; called at most once when a rule references "complexity_tier"
+	computeContextLength     func() (int64, bool)                // Lazy context-length computation; called at most once when a rule references "context_length"
 }
 
 type RoutingEngine struct {
@@ -126,7 +127,9 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 
 	var finalDecision *RoutingDecision
 	var complexityResult *complexity.ComplexityResult
+	var contextLengthResult *int64
 	computeComplexity := routingCtx.computeComplexity
+	computeContextLength := routingCtx.computeContextLength
 
 	for chainStep := 0; ; chainStep++ {
 		// TERMINATION 4: Chain exceeded configured max depth.
@@ -157,6 +160,9 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 		}
 		if complexityResult != nil {
 			variables["complexity_tier"] = complexityResult.Tier
+		}
+		if contextLengthResult != nil {
+			variables["context_length"] = *contextLengthResult
 		}
 
 		re.logger.Debug("[RoutingEngine] Chain Step: %d", chainStep)
@@ -189,6 +195,7 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 				re.logger.Debug("[RoutingEngine] Evaluating rule: name=%s, expression=%s", rule.Name, rule.CelExpression)
 
 				referencesComplexity := celExpressionReferencesIdentifier(rule.CelExpression, "complexity_tier")
+				referencesContextLength := celExpressionReferencesIdentifier(rule.CelExpression, "context_length")
 
 				// Lazy complexity: compute only when a rule references complexity and it hasn't been computed yet
 				if complexityResult == nil && computeComplexity != nil && referencesComplexity {
@@ -198,6 +205,13 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 						variables["complexity_tier"] = complexityResult.Tier
 					}
 				}
+				if contextLengthResult == nil && computeContextLength != nil && referencesContextLength {
+					if contextLength, ok := computeContextLength(); ok {
+						contextLengthResult = &contextLength
+						variables["context_length"] = contextLength
+					}
+					computeContextLength = nil // compute at most once
+				}
 
 				program, err := re.store.GetRoutingProgram(ctx, rule)
 				if err != nil {
@@ -206,12 +220,15 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 					continue
 				}
 
-				var unknowns []*cel.AttributePatternType
+				var unknownVariables []string
 				if referencesComplexity && complexityResult == nil {
-					unknowns = append(unknowns, cel.AttributePattern("complexity_tier"))
+					unknownVariables = append(unknownVariables, "complexity_tier")
+				}
+				if referencesContextLength && contextLengthResult == nil {
+					unknownVariables = append(unknownVariables, "context_length")
 				}
 
-				matched, err := evaluateCELExpression(program, variables, unknowns...)
+				matched, err := evaluateCELExpressionWithUnknowns(program, variables, unknownVariables...)
 				if err != nil {
 					re.logger.Warn("[RoutingEngine] Failed to evaluate rule %s: %v", rule.Name, err)
 					ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, schemas.LogLevelError, fmt.Sprintf("Rule '%s' skipped: eval error: %v", rule.Name, err))
@@ -433,6 +450,25 @@ func evaluateCELExpression(program cel.Program, variables map[string]any, unknow
 	return matched, nil
 }
 
+func evaluateCELExpressionWithUnknowns(program cel.Program, variables map[string]any, unknownVariableNames ...string) (bool, error) {
+	if len(unknownVariableNames) == 0 {
+		return evaluateCELExpression(program, variables)
+	}
+
+	evalVariables := make(map[string]any, len(variables))
+	for k, v := range variables {
+		evalVariables[k] = v
+	}
+
+	unknowns := make([]*cel.AttributePatternType, 0, len(unknownVariableNames))
+	for _, name := range unknownVariableNames {
+		delete(evalVariables, name)
+		unknowns = append(unknowns, cel.AttributePattern(name))
+	}
+
+	return evaluateCELExpression(program, evalVariables, unknowns...)
+}
+
 // extractRoutingVariables builds a map of CEL variables from routing context
 // This map is used to evaluate CEL expressions in routing rules
 func extractRoutingVariables(ctx *RoutingContext) (map[string]interface{}, error) {
@@ -518,6 +554,7 @@ func extractRoutingVariables(ctx *RoutingContext) (map[string]interface{}, error
 	// actually references complexity_tier. If complexity is unavailable, it is
 	// evaluated as a CEL unknown so negative predicates do not accidentally match.
 	variables["complexity_tier"] = ""
+	variables["context_length"] = int64(0)
 
 	return variables, nil
 }
@@ -545,6 +582,7 @@ func buildNoMatchContext(expr string, variables map[string]any) string {
 		fmt.Sprintf("budget_used=%.1f%%", variables["budget_used"]),
 		fmt.Sprintf("tokens_used=%.1f%%", variables["tokens_used"]),
 		fmt.Sprintf("request=%.1f%%", variables["request"]),
+		fmt.Sprintf("context_length=%d", variables["context_length"]),
 	}
 	for _, mapName := range []string{"headers", "params"} {
 		keys := extractMapKeysFromCEL(expr, mapName)
@@ -621,6 +659,7 @@ func createCELEnvironment() (*cel.Env, error) {
 		cel.Variable("tokens_used", cel.DoubleType),
 		cel.Variable("request", cel.DoubleType),
 		cel.Variable("budget_used", cel.DoubleType),
+		cel.Variable("context_length", cel.IntType),
 
 		// Complexity tier. When analysis is unavailable, evaluation marks this
 		// variable as CEL unknown so complexity-dependent predicates do not match.

--- a/plugins/governance/routingcomplexity_test.go
+++ b/plugins/governance/routingcomplexity_test.go
@@ -364,6 +364,7 @@ func complexityRoutingVariables() map[string]interface{} {
 		"tokens_used":      0.0,
 		"request":          0.0,
 		"budget_used":      0.0,
+		"context_length":   int64(0),
 		"complexity_tier":  "",
 	}
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -61,6 +61,10 @@ var enterprisePlugins = []string{
 	"kafka",
 }
 
+type countTokensRequestExecutorPlugin interface {
+	SetCountTokensRequestExecutor(governance.CountTokensRequestExecutor)
+}
+
 // ServerCallbacks is a interface that defines the callbacks for the server.
 type ServerCallbacks interface {
 	// Plugins callbacks
@@ -1273,6 +1277,9 @@ func (s *BifrostHTTPServer) ReloadPlugin(ctx context.Context, name string, path 
 	if semanticCachePlugin, ok := plugin.(*semanticcache.Plugin); ok {
 		semanticCachePlugin.SetEmbeddingRequestExecutor(s.Client.EmbeddingRequest)
 	}
+	if governancePlugin, ok := plugin.(countTokensRequestExecutorPlugin); ok && s.Client != nil {
+		governancePlugin.SetCountTokensRequestExecutor(s.Client.CountTokensRequest)
+	}
 	return s.SyncLoadedPlugin(ctx, name, plugin, placement, order)
 }
 
@@ -1803,6 +1810,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	semanticCachePlugin, err := lib.FindPluginAs[*semanticcache.Plugin](s.Config, semanticcache.PluginName)
 	if err == nil && semanticCachePlugin != nil {
 		semanticCachePlugin.SetEmbeddingRequestExecutor(s.Client.EmbeddingRequest)
+	}
+	governancePlugin, err := lib.FindPluginAs[countTokensRequestExecutorPlugin](s.Config, s.getGovernancePluginName())
+	if err == nil && governancePlugin != nil {
+		governancePlugin.SetCountTokensRequestExecutor(s.Client.CountTokensRequest)
 	}
 
 	// Register routes

--- a/ui/lib/config/celFieldsRouting.ts
+++ b/ui/lib/config/celFieldsRouting.ts
@@ -113,6 +113,16 @@ export const baseRoutingFields: CELFieldDefinition[] = [
 		description: "Check budget usage as percentage. Checked against max of model and provider configs.",
 	},
 	{
+		name: "context_length",
+		label: "Context Length",
+		placeholder: "e.g., 8192",
+		inputType: "text",
+		valueEditorType: "number",
+		operators: ["=", "!=", ">", "<", ">=", "<="],
+		defaultOperator: ">=",
+		description: "Route based on the input context length of the request in tokens.",
+	},
+	{
 		name: "complexity_tier",
 		label: "Complexity Tier",
 		placeholder: "Select complexity tier",

--- a/ui/lib/utils/celConverterRouting.ts
+++ b/ui/lib/utils/celConverterRouting.ts
@@ -224,6 +224,15 @@ function convertRuleToCEL(rule: RuleType): string {
 		}
 	}
 
+	if (field === "context_length") {
+		const thresholdValue = String(value).trim();
+		if (thresholdValue) {
+			const numValue = parseFloat(thresholdValue);
+			const actualValue = !isNaN(numValue) ? numValue.toString() : thresholdValue;
+			return `${field} ${celOperator} ${actualValue}`;
+		}
+	}
+
 	// Handle other keyValue fields (headers, params) for other operators
 	if (isKeyValueField) {
 		const keyValuePair = parseKeyValue(String(value));


### PR DESCRIPTION
## Summary

Adds `context_length` as a CEL routing variable that exposes the input token count of a request to routing rules. This enables routing long-context requests to models with larger context windows (e.g., directing requests over 32k tokens to Gemini 2.5 Pro or Claude) without manual intervention.

## Changes

- Introduced `computeContextLength` in `contextlength.go` that uses provider-native token counting via `CountTokensRequestExecutor` when available, falling back to `ceil(serialized_request_bytes / 4)` when exact counting is unavailable.
- Added `context_length` as a typed `int64` CEL variable in the routing engine environment, populated lazily — computed only when a routing rule's expression references the `context_length` identifier (not string literals or field selections).
- When `context_length` cannot be computed for a request, it is treated as a CEL unknown so rules depending on it fall through rather than accidentally matching.
- Refactored unknown-variable handling into `evaluateCELExpressionWithUnknowns` to cleanly support both `complexity_tier` and `context_length` unknowns without duplicating attribute pattern logic.
- Wired `SetCountTokensRequestExecutor` into the HTTP server bootstrap and plugin reload paths, mirroring the existing pattern used for the semantic cache embedding executor.
- Added `context_length` field definition and CEL converter support to the UI routing rule builder.
- Updated routing rule and provider routing documentation with the new variable, fallback behavior explanation, and a long-context routing example.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/governance/...

# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
```

To validate end-to-end:
1. Configure a routing rule with `context_length > 32000` targeting a long-context model.
2. Send a chat request with a prompt exceeding 32k tokens.
3. Confirm the request is routed to the configured target.
4. Send a short request and confirm it falls through to the default provider.
5. Disable or omit a `CountTokensRequestExecutor` and confirm the byte-estimate fallback is used (check routing engine logs for `estimated from N bytes`).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `CountTokensRequestExecutor` is invoked in a child context with `BifrostContextKeySkipPluginPipeline` set to `true` to prevent recursive plugin pipeline execution during token counting. The parent context is not mutated.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable