### PR TITLE
feat: runway image operations

### DIFF
--- a/core/providers/runway/images.go
+++ b/core/providers/runway/images.go
@@ -1,0 +1,210 @@
+package runway
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToRunwayImageGenerationRequest converts a Bifrost image generation request to Runway's text_to_image format.
+func ToRunwayImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRequest) (*RunwayImageGenerationRequest, error) {
+	if bifrostReq.Input == nil {
+		return nil, fmt.Errorf("input is required")
+	}
+
+	// Field support varies by model; only attach what the target model accepts.
+	caps := runwayImageModelCapabilities(bifrostReq.Model)
+
+	request := &RunwayImageGenerationRequest{
+		Model:      bifrostReq.Model,
+		PromptText: bifrostReq.Input.Prompt,
+		Ratio:      defaultRunwayImageRatio(bifrostReq.Model),
+	}
+
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		if params.AspectRatio != nil && *params.AspectRatio != "" {
+			request.Ratio = *params.AspectRatio
+		} else if params.Size != nil && *params.Size != "" {
+			// convert 1920x1080 to 1920:1080
+			request.Ratio = strings.Replace(*params.Size, "x", ":", 1)
+		}
+
+		if caps.seed && params.Seed != nil {
+			request.Seed = params.Seed
+		}
+		if caps.outputCount && params.N != nil {
+			request.OutputCount = params.N
+		}
+		if caps.quality && params.Quality != nil {
+			request.Quality = params.Quality
+		}
+		if caps.background && params.Background != nil {
+			request.Background = params.Background
+		}
+		if caps.contentModeration && params.Moderation != nil && *params.Moderation != "" {
+			request.ContentModeration = &ContentModeration{PublicFigureThreshold: params.Moderation}
+		}
+
+		// Map input images to reference images (no tag unless provided via extra params)
+		for _, img := range params.InputImages {
+			sanitizedURL, err := schemas.SanitizeImageURL(img)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input image: %w", err)
+			}
+			request.ReferenceImages = append(request.ReferenceImages, ReferenceImage{URI: sanitizedURL})
+		}
+
+		if params.ExtraParams != nil {
+			request.ExtraParams = params.ExtraParams
+
+			// Explicit reference images (with tags for at-mention syntax) override input images
+			if refImagesVal := params.ExtraParams["reference_images"]; refImagesVal != nil {
+				if refImages, ok := refImagesVal.([]ReferenceImage); ok && refImages != nil {
+					delete(request.ExtraParams, "reference_images")
+					request.ReferenceImages = refImages
+				} else if refImages, err := schemas.ConvertViaJSON[[]ReferenceImage](refImagesVal); err == nil {
+					delete(request.ExtraParams, "reference_images")
+					request.ReferenceImages = refImages
+				}
+			}
+
+			// Content moderation: always remove from extra params (avoid leaking the
+			// snake_case key into the body), but only attach for models that support it.
+			if cmVal := params.ExtraParams["content_moderation"]; cmVal != nil {
+				delete(request.ExtraParams, "content_moderation")
+				if caps.contentModeration {
+					if cm, ok := cmVal.(*ContentModeration); ok && cm != nil {
+						request.ContentModeration = cm
+					} else if cm, err := schemas.ConvertViaJSON[ContentModeration](cmVal); err == nil {
+						request.ContentModeration = &cm
+					}
+				}
+			}
+		}
+	}
+
+	// Drop the per-reference subject for models that don't support character/object consistency.
+	if !caps.referenceSubject {
+		for i := range request.ReferenceImages {
+			request.ReferenceImages[i].Subject = ""
+		}
+	}
+
+	return request, nil
+}
+
+// ToRunwayImageEditRequest converts a Bifrost image edit request to Runway's text_to_image format.
+// Runway has no dedicated edit endpoint, so the input images are sent as reference images.
+func ToRunwayImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) (*RunwayImageGenerationRequest, error) {
+	if bifrostReq.Input == nil {
+		return nil, fmt.Errorf("input is required")
+	}
+
+	// Field support varies by model; only attach what the target model accepts.
+	caps := runwayImageModelCapabilities(bifrostReq.Model)
+
+	request := &RunwayImageGenerationRequest{
+		Model:      bifrostReq.Model,
+		PromptText: bifrostReq.Input.Prompt,
+		Ratio:      defaultRunwayImageRatio(bifrostReq.Model),
+	}
+
+	// Map edit input images (raw bytes) to reference images as data URIs.
+	for _, img := range bifrostReq.Input.Images {
+		if len(img.Image) == 0 {
+			continue
+		}
+		request.ReferenceImages = append(request.ReferenceImages, ReferenceImage{URI: providerUtils.FileBytesToBase64DataURL(img.Image)})
+	}
+
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		if params.Size != nil && *params.Size != "" {
+			// convert 1920x1080 to 1920:1080
+			request.Ratio = strings.Replace(*params.Size, "x", ":", 1)
+		}
+
+		if caps.seed && params.Seed != nil {
+			request.Seed = params.Seed
+		}
+		if caps.outputCount && params.N != nil {
+			request.OutputCount = params.N
+		}
+		if caps.quality && params.Quality != nil {
+			request.Quality = params.Quality
+		}
+		if caps.background && params.Background != nil {
+			request.Background = params.Background
+		}
+
+		if params.ExtraParams != nil {
+			request.ExtraParams = params.ExtraParams
+
+			// Explicit reference images (with tags/subject) are appended after the edit images.
+			if refImagesVal := params.ExtraParams["reference_images"]; refImagesVal != nil {
+				if refImages, ok := refImagesVal.([]ReferenceImage); ok && refImages != nil {
+					delete(request.ExtraParams, "reference_images")
+					request.ReferenceImages = append(request.ReferenceImages, refImages...)
+				} else if refImages, err := schemas.ConvertViaJSON[[]ReferenceImage](refImagesVal); err == nil {
+					delete(request.ExtraParams, "reference_images")
+					request.ReferenceImages = append(request.ReferenceImages, refImages...)
+				}
+			}
+
+			// Content moderation: always remove from extra params (avoid leaking the
+			// snake_case key into the body), but only attach for models that support it.
+			if cmVal := params.ExtraParams["content_moderation"]; cmVal != nil {
+				delete(request.ExtraParams, "content_moderation")
+				if caps.contentModeration {
+					if cm, ok := cmVal.(*ContentModeration); ok && cm != nil {
+						request.ContentModeration = cm
+					} else if cm, err := schemas.ConvertViaJSON[ContentModeration](cmVal); err == nil {
+						request.ContentModeration = &cm
+					}
+				}
+			}
+		}
+	}
+
+	// Drop the per-reference subject for models that don't support character/object consistency.
+	if !caps.referenceSubject {
+		for i := range request.ReferenceImages {
+			request.ReferenceImages[i].Subject = ""
+		}
+	}
+
+	return request, nil
+}
+
+// ToBifrostImageGenerationResponse converts Runway task details to Bifrost image generation response format.
+func ToBifrostImageGenerationResponse(taskDetails *RunwayTaskDetailsResponse) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	if taskDetails == nil {
+		return nil, providerUtils.NewBifrostOperationError("task details is nil", nil)
+	}
+
+	response := &schemas.BifrostImageGenerationResponse{
+		ID:   taskDetails.ID,
+		Data: []schemas.ImageData{},
+	}
+
+	if taskDetails.CreatedAt != "" {
+		if t, err := time.Parse(time.RFC3339, taskDetails.CreatedAt); err == nil {
+			response.Created = t.Unix()
+		}
+	}
+
+	for i, url := range taskDetails.Output {
+		response.Data = append(response.Data, schemas.ImageData{
+			URL:   url,
+			Index: i,
+		})
+	}
+
+	return response, nil
+}

--- a/core/providers/runway/images_test.go
+++ b/core/providers/runway/images_test.go
@@ -1,0 +1,261 @@
+package runway
+
+import (
+	"strings"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeImageReq(model, prompt string, params *schemas.ImageGenerationParameters) *schemas.BifrostImageGenerationRequest {
+	return &schemas.BifrostImageGenerationRequest{
+		Model:  model,
+		Input:  &schemas.ImageGenerationInput{Prompt: prompt},
+		Params: params,
+	}
+}
+
+func TestToRunwayImageGenerationRequest(t *testing.T) {
+	t.Run("defaults_ratio_when_unset", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", nil))
+		require.NoError(t, err)
+		assert.Equal(t, "gen4_image", result.Model)
+		assert.Equal(t, "a cat", result.PromptText)
+		assert.Equal(t, "1024:1024", result.Ratio)
+	})
+
+	t.Run("defaults_ratio_auto_for_gpt_image_2", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gpt_image_2", "a cat", nil))
+		require.NoError(t, err)
+		assert.Equal(t, "auto", result.Ratio)
+	})
+
+	t.Run("nil_input_errors", func(t *testing.T) {
+		_, err := ToRunwayImageGenerationRequest(&schemas.BifrostImageGenerationRequest{Model: "gen4_image"})
+		require.Error(t, err)
+	})
+
+	t.Run("aspect_ratio_takes_precedence_over_size", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			AspectRatio: schemas.Ptr("1080:1920"),
+			Size:        schemas.Ptr("1280x720"),
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1080:1920", result.Ratio)
+	})
+
+	t.Run("size_converted_to_ratio", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			Size: schemas.Ptr("1280x720"),
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1280:720", result.Ratio)
+	})
+
+	t.Run("seed_mapped", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			Seed: schemas.Ptr(42),
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, result.Seed)
+		assert.Equal(t, 42, *result.Seed)
+	})
+
+	t.Run("input_images_mapped_to_reference_images", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "@ref a cat", &schemas.ImageGenerationParameters{
+			InputImages: []string{"https://example.com/ref.jpg"},
+		}))
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 1)
+		assert.Equal(t, "https://example.com/ref.jpg", result.ReferenceImages[0].URI)
+		assert.Empty(t, result.ReferenceImages[0].Tag)
+	})
+
+	t.Run("explicit_reference_images_override_input_images", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "@logo a cat", &schemas.ImageGenerationParameters{
+			InputImages: []string{"https://example.com/input.jpg"},
+			ExtraParams: map[string]interface{}{
+				"reference_images": []ReferenceImage{{URI: "https://example.com/ref.jpg", Tag: "logo"}},
+			},
+		}))
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 1)
+		assert.Equal(t, "https://example.com/ref.jpg", result.ReferenceImages[0].URI)
+		assert.Equal(t, "logo", result.ReferenceImages[0].Tag)
+		assert.NotContains(t, result.ExtraParams, "reference_images")
+	})
+
+	t.Run("map_fallback_content_moderation", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			ExtraParams: map[string]interface{}{
+				"content_moderation": map[string]interface{}{"public_figure_threshold": "low"},
+			},
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, result.ContentModeration)
+		require.NotNil(t, result.ContentModeration.PublicFigureThreshold)
+		assert.Equal(t, "low", *result.ContentModeration.PublicFigureThreshold)
+		assert.NotContains(t, result.ExtraParams, "content_moderation")
+	})
+
+	t.Run("gpt_image_2_fields_attached", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gpt_image_2", "a cat", &schemas.ImageGenerationParameters{
+			N:          schemas.Ptr(3),
+			Quality:    schemas.Ptr("high"),
+			Background: schemas.Ptr("opaque"),
+			Seed:       schemas.Ptr(7),
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, result.OutputCount)
+		assert.Equal(t, 3, *result.OutputCount)
+		require.NotNil(t, result.Quality)
+		assert.Equal(t, "high", *result.Quality)
+		require.NotNil(t, result.Background)
+		assert.Equal(t, "opaque", *result.Background)
+		assert.Nil(t, result.Seed, "gpt_image_2 does not support seed")
+	})
+
+	t.Run("gen4_drops_unsupported_fields", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			N:          schemas.Ptr(3),
+			Quality:    schemas.Ptr("high"),
+			Background: schemas.Ptr("opaque"),
+			Seed:       schemas.Ptr(7),
+		}))
+		require.NoError(t, err)
+		assert.Nil(t, result.OutputCount, "gen4_image does not support outputCount")
+		assert.Nil(t, result.Quality, "gen4_image does not support quality")
+		assert.Nil(t, result.Background, "gen4_image does not support background")
+		require.NotNil(t, result.Seed)
+		assert.Equal(t, 7, *result.Seed)
+	})
+
+	t.Run("content_moderation_dropped_for_unsupported_model", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gpt_image_2", "a cat", &schemas.ImageGenerationParameters{
+			ExtraParams: map[string]interface{}{
+				"content_moderation": map[string]interface{}{"public_figure_threshold": "low"},
+			},
+		}))
+		require.NoError(t, err)
+		assert.Nil(t, result.ContentModeration, "gpt_image_2 does not support content moderation")
+		assert.NotContains(t, result.ExtraParams, "content_moderation", "key must not leak into body")
+	})
+
+	t.Run("reference_subject_kept_for_gemini_stripped_otherwise", func(t *testing.T) {
+		refImages := []ReferenceImage{{URI: "https://example.com/ref.jpg", Tag: "hero", Subject: "human"}}
+
+		gemini, err := ToRunwayImageGenerationRequest(makeImageReq("gemini_image3_pro", "@hero a cat", &schemas.ImageGenerationParameters{
+			ExtraParams: map[string]interface{}{"reference_images": refImages},
+		}))
+		require.NoError(t, err)
+		require.Len(t, gemini.ReferenceImages, 1)
+		assert.Equal(t, "human", gemini.ReferenceImages[0].Subject)
+
+		gen4, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "@hero a cat", &schemas.ImageGenerationParameters{
+			ExtraParams: map[string]interface{}{"reference_images": []ReferenceImage{{URI: "https://example.com/ref.jpg", Tag: "hero", Subject: "human"}}},
+		}))
+		require.NoError(t, err)
+		require.Len(t, gen4.ReferenceImages, 1)
+		assert.Empty(t, gen4.ReferenceImages[0].Subject, "non-gemini models must not send subject")
+	})
+}
+
+func makeImageEditReq(model, prompt string, images [][]byte, params *schemas.ImageEditParameters) *schemas.BifrostImageEditRequest {
+	imgs := make([]schemas.ImageInput, len(images))
+	for i, b := range images {
+		imgs[i] = schemas.ImageInput{Image: b}
+	}
+	return &schemas.BifrostImageEditRequest{
+		Model:  model,
+		Input:  &schemas.ImageEditInput{Images: imgs, Prompt: prompt},
+		Params: params,
+	}
+}
+
+func TestToRunwayImageEditRequest(t *testing.T) {
+	t.Run("nil_input_errors", func(t *testing.T) {
+		_, err := ToRunwayImageEditRequest(&schemas.BifrostImageEditRequest{Model: "gen4_image"})
+		require.Error(t, err)
+	})
+
+	t.Run("maps_image_bytes_to_data_uri_reference_images", func(t *testing.T) {
+		// minimal PNG header bytes so DetectContentType yields image/png
+		png := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "make it blue", [][]byte{png}, nil))
+		require.NoError(t, err)
+		assert.Equal(t, "make it blue", result.PromptText)
+		assert.Equal(t, "1024:1024", result.Ratio)
+		require.Len(t, result.ReferenceImages, 1)
+		assert.True(t, strings.HasPrefix(result.ReferenceImages[0].URI, "data:image/png;base64,"), "got %s", result.ReferenceImages[0].URI)
+	})
+
+	t.Run("skips_empty_images", func(t *testing.T) {
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "x", [][]byte{{}, {0x89, 0x50, 0x4E, 0x47}}, nil))
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 1)
+	})
+
+	t.Run("size_converted_to_ratio", func(t *testing.T) {
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "x", [][]byte{{0x89, 0x50}}, &schemas.ImageEditParameters{
+			Size: schemas.Ptr("1280x720"),
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1280:720", result.Ratio)
+	})
+
+	t.Run("explicit_reference_images_appended_after_edit_images", func(t *testing.T) {
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "@logo x", [][]byte{{0x89, 0x50}}, &schemas.ImageEditParameters{
+			ExtraParams: map[string]interface{}{
+				"reference_images": []ReferenceImage{{URI: "https://example.com/logo.png", Tag: "logo"}},
+			},
+		}))
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 2)
+		assert.True(t, strings.HasPrefix(result.ReferenceImages[0].URI, "data:"))
+		assert.Equal(t, "https://example.com/logo.png", result.ReferenceImages[1].URI)
+		assert.Equal(t, "logo", result.ReferenceImages[1].Tag)
+		assert.NotContains(t, result.ExtraParams, "reference_images")
+	})
+
+	t.Run("gen4_drops_unsupported_fields", func(t *testing.T) {
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "x", [][]byte{{0x89, 0x50}}, &schemas.ImageEditParameters{
+			N:          schemas.Ptr(3),
+			Quality:    schemas.Ptr("high"),
+			Background: schemas.Ptr("opaque"),
+			Seed:       schemas.Ptr(7),
+		}))
+		require.NoError(t, err)
+		assert.Nil(t, result.OutputCount)
+		assert.Nil(t, result.Quality)
+		assert.Nil(t, result.Background)
+		require.NotNil(t, result.Seed)
+		assert.Equal(t, 7, *result.Seed)
+	})
+}
+
+func TestToBifrostImageGenerationResponse(t *testing.T) {
+	t.Run("nil_task_details_errors", func(t *testing.T) {
+		_, err := ToBifrostImageGenerationResponse(nil)
+		require.NotNil(t, err)
+	})
+
+	t.Run("maps_output_urls", func(t *testing.T) {
+		taskDetails := &RunwayTaskDetailsResponse{
+			ID:        "task-123",
+			Status:    RunwayTaskStatusSucceeded,
+			CreatedAt: "2024-11-06T12:00:00Z",
+			Output:    []string{"https://example.com/0.png", "https://example.com/1.png"},
+		}
+		resp, err := ToBifrostImageGenerationResponse(taskDetails)
+		require.Nil(t, err)
+		assert.Equal(t, "task-123", resp.ID)
+		require.Len(t, resp.Data, 2)
+		assert.Equal(t, "https://example.com/0.png", resp.Data[0].URL)
+		assert.Equal(t, 0, resp.Data[0].Index)
+		assert.Equal(t, "https://example.com/1.png", resp.Data[1].URL)
+		assert.Equal(t, 1, resp.Data[1].Index)
+		assert.NotZero(t, resp.Created)
+	})
+}

--- a/core/providers/runway/runway.go
+++ b/core/providers/runway/runway.go
@@ -135,9 +135,169 @@ func (provider *RunwayProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.OCRRequest, provider.GetProviderKey())
 }
 
-// ImageGeneration is not supported by the Runway provider.
-func (provider *RunwayProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationRequest, provider.GetProviderKey())
+// ImageGeneration performs a text-to-image generation request to Runway's API.
+// Runway image generation is task-based: a task is created and then polled until it
+// reaches a terminal state, after which the generated image URLs are returned.
+func (provider *RunwayProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key, bifrostReq *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	// Convert Bifrost request to Runway format
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		bifrostReq,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToRunwayImageGenerationRequest(bifrostReq)
+		})
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	return provider.HandleRunwayImageTask(ctx, key, bifrostReq.Model, jsonData)
+}
+
+// HandleRunwayImageTask posts a prebuilt text_to_image body, polls the task to completion,
+// and builds the Bifrost image response. Shared by ImageGeneration and ImageEdit since both
+// use the same /v1/text_to_image endpoint and response shape.
+func (provider *RunwayProvider) HandleRunwayImageTask(ctx *schemas.BifrostContext, key schemas.Key, model string, jsonData []byte) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+
+	// Create HTTP request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/text_to_image"))
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	req.Header.Set("X-Runway-Version", "2024-11-06")
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	req.SetBody(jsonData)
+
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		return nil, providerUtils.EnrichError(ctx, parseRunwayError(resp), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
+	}
+
+	// Decode response body
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		rawErrBody := append([]byte(nil), resp.Body()...)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), jsonData, rawErrBody, sendBackRawRequest, sendBackRawResponse)
+	}
+
+	// Parse task creation response
+	var taskResp RunwayTaskCreationResponse
+	rawRequest, _, bifrostErr := providerUtils.HandleProviderResponse(body, &taskResp, jsonData, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Poll the task until it reaches a terminal state
+	taskDetails, rawResponse, bifrostErr := provider.pollRunwayTask(ctx, key, taskResp.ID, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse)
+	}
+
+	// Convert to Bifrost response
+	bifrostResp, bifrostErr := ToBifrostImageGenerationResponse(taskDetails)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	bifrostResp.Model = model
+	bifrostResp.ExtraFields.Latency = latency.Milliseconds()
+
+	if sendBackRawRequest {
+		bifrostResp.ExtraFields.RawRequest = rawRequest
+	}
+	if sendBackRawResponse {
+		bifrostResp.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResp, nil
+}
+
+// runwayImagePollingInterval is the interval between Runway task status polls for image generation.
+const runwayImagePollingInterval = 2 * time.Second
+
+// pollRunwayTask polls a Runway task until it reaches a terminal state or the context times out.
+func (provider *RunwayProvider) pollRunwayTask(ctx *schemas.BifrostContext, key schemas.Key, taskID string, sendBackRawResponse bool) (*RunwayTaskDetailsResponse, interface{}, *schemas.BifrostError) {
+	pollCtx, cancel := schemas.NewBifrostContextWithTimeout(ctx, time.Duration(provider.networkConfig.DefaultRequestTimeoutInSeconds)*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(runwayImagePollingInterval)
+	defer ticker.Stop()
+
+	for {
+		taskDetails, rawResponse, bifrostErr := provider.retrieveRunwayTask(pollCtx, key, taskID, sendBackRawResponse)
+		if bifrostErr != nil {
+			return nil, nil, bifrostErr
+		}
+
+		switch taskDetails.Status {
+		case RunwayTaskStatusSucceeded:
+			return taskDetails, rawResponse, nil
+		case RunwayTaskStatusFailed, RunwayTaskStatusCancelled:
+			return nil, nil, providerUtils.NewBifrostOperationError(fmt.Sprintf("runway task %s", taskDetails.Status), nil)
+		}
+
+		select {
+		case <-pollCtx.Done():
+			return nil, nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, fmt.Errorf("runway task polling timed out"))
+		case <-ticker.C:
+		}
+	}
+}
+
+// retrieveRunwayTask fetches the current state of a Runway task.
+func (provider *RunwayProvider) retrieveRunwayTask(ctx *schemas.BifrostContext, key schemas.Key, taskID string, sendBackRawResponse bool) (*RunwayTaskDetailsResponse, interface{}, *schemas.BifrostError) {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/tasks/"+taskID))
+	req.Header.SetMethod(http.MethodGet)
+	req.Header.Set("X-Runway-Version", "2024-11-06")
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, nil, bifrostErr
+	}
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		return nil, nil, parseRunwayError(resp)
+	}
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
+	}
+
+	var taskDetails RunwayTaskDetailsResponse
+	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &taskDetails, nil, false, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, nil, bifrostErr
+	}
+
+	return &taskDetails, rawResponse, nil
 }
 
 // ImageGenerationStream is not supported by the Runway provider.
@@ -145,9 +305,21 @@ func (provider *RunwayProvider) ImageGenerationStream(ctx *schemas.BifrostContex
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationStreamRequest, provider.GetProviderKey())
 }
 
-// ImageEdit is not supported by the Runway provider.
-func (provider *RunwayProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageEditRequest, provider.GetProviderKey())
+// ImageEdit performs an image edit request to Runway's API. Runway has no dedicated edit
+// endpoint, so the input images are passed as reference images to /v1/text_to_image.
+func (provider *RunwayProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, bifrostReq *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	// Convert Bifrost request to Runway format
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		bifrostReq,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToRunwayImageEditRequest(bifrostReq)
+		})
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	return provider.HandleRunwayImageTask(ctx, key, bifrostReq.Model, jsonData)
 }
 
 // ImageEditStream is not supported by the Runway provider.

--- a/core/providers/runway/runway_test.go
+++ b/core/providers/runway/runway_test.go
@@ -25,7 +25,11 @@ func TestRunway(t *testing.T) {
 	testConfig := llmtests.ComprehensiveTestConfig{
 		Provider:             schemas.Runway,
 		VideoGenerationModel: "gen4.5",
+		ImageGenerationModel: "gen4_image",
+		ImageEditModel:       "gen4_image",
 		Scenarios: llmtests.TestScenarios{
+			ImageGeneration: true,
+			ImageEdit:       true,
 			VideoGeneration: false, // disabled for now because of long running operations
 			VideoRetrieve:   false,
 			VideoRemix:      false,

--- a/core/providers/runway/types.go
+++ b/core/providers/runway/types.go
@@ -13,8 +13,9 @@ type Reference struct {
 }
 
 type ReferenceImage struct {
-	URI string `json:"uri"`
-	Tag string `json:"tag"`
+	URI     string `json:"uri"`
+	Tag     string `json:"tag,omitempty"`
+	Subject string `json:"subject,omitempty"` // "object" or "human" (gemini image models)
 }
 
 type PromptImageObject struct {
@@ -90,6 +91,23 @@ func (r *RunwayVideoGenerationRequest) GetExtraParams() map[string]interface{} {
 
 type ContentModeration struct {
 	PublicFigureThreshold *string `json:"public_figure_threshold,omitempty"`
+}
+
+type RunwayImageGenerationRequest struct {
+	Model             string                 `json:"model"`
+	PromptText        string                 `json:"promptText"`
+	Ratio             string                 `json:"ratio"`
+	Seed              *int                   `json:"seed,omitempty"`
+	ReferenceImages   []ReferenceImage       `json:"referenceImages,omitempty"`
+	Quality           *string                `json:"quality,omitempty"`     // gpt_image_2: "low", "medium", "high", "auto"
+	Background        *string                `json:"background,omitempty"`  // gpt_image_2: "opaque", "auto"
+	OutputCount       *int                   `json:"outputCount,omitempty"` // gpt_image_2 (1-10), gemini (1 or 4)
+	ContentModeration *ContentModeration     `json:"contentModeration,omitempty"`
+	ExtraParams       map[string]interface{} `json:"-"`
+}
+
+func (r *RunwayImageGenerationRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 type RunwayTaskCreationResponse struct {

--- a/core/providers/runway/utils.go
+++ b/core/providers/runway/utils.go
@@ -21,6 +21,44 @@ func getRunwayEndpoint(req *schemas.BifrostVideoGenerationRequest) string {
 	return "/v1/text_to_video"
 }
 
+// runwayImageModelCaps describes which optional fields a Runway image model accepts.
+type runwayImageModelCaps struct {
+	seed              bool
+	contentModeration bool
+	quality           bool
+	background        bool
+	outputCount       bool
+	referenceSubject  bool
+}
+
+// runwayImageModelCapabilities returns the supported optional fields for a Runway image model.
+// Unknown/custom models are treated permissively so new models work without code changes;
+// Runway validates the final combination.
+func runwayImageModelCapabilities(model string) runwayImageModelCaps {
+	switch model {
+	case "gen4_image", "gen4_image_turbo":
+		return runwayImageModelCaps{seed: true, contentModeration: true}
+	case "gpt_image_2":
+		return runwayImageModelCaps{quality: true, background: true, outputCount: true}
+	case "gemini_image3_pro", "gemini_image3.1_flash":
+		return runwayImageModelCaps{outputCount: true, referenceSubject: true}
+	case "gemini_2.5_flash":
+		return runwayImageModelCaps{}
+	default:
+		return runwayImageModelCaps{seed: true, contentModeration: true, quality: true, background: true, outputCount: true, referenceSubject: true}
+	}
+}
+
+// defaultRunwayImageRatio returns a sensible default ratio when the caller omits one.
+// Valid ratios differ per model, so the default is model-aware.
+func defaultRunwayImageRatio(model string) string {
+	if model == "gpt_image_2" {
+		return "auto"
+	}
+	// Valid for the gen4 family and every gemini image model.
+	return "1024:1024"
+}
+
 func isRunwayGenModel(model string) bool {
 	return strings.Contains(model, "gen")
 }


### PR DESCRIPTION
## Summary

Adds image generation and image editing support to the Runway provider. Runway has no dedicated image edit endpoint, so both operations are routed through the `/v1/text_to_image` endpoint, with edit input images passed as reference images. Since Runway's image API is task-based, a polling loop is introduced to wait for task completion before returning results.

## Changes

- Added `RunwayImageGenerationRequest` type with `GetExtraParams()` to support extra param merging during serialization.
- Added `ReferenceImage.Subject` field (omitempty) for Gemini image models that support character/object consistency via the `subject` tag.
- Introduced `ToRunwayImageGenerationRequest` and `ToRunwayImageEditRequest` converters in `images.go`, handling aspect ratio normalization (`1920x1080` → `1920:1080`), reference image mapping, content moderation, and per-model capability gating.
- Added `runwayImageModelCapabilities` to gate optional fields (`seed`, `quality`, `background`, `outputCount`, `contentModeration`, `referenceSubject`) per model, with an open-world default for unknown models so new Runway models work without code changes.
- Added `defaultRunwayImageRatio` to provide model-aware ratio defaults (`auto` for `gpt_image_2`, `1024:1024` for all others).
- Implemented `HandleRunwayImageTask`, `pollRunwayTask`, and `retrieveRunwayTask` in `runway.go` to create a task, poll it at 2-second intervals, and return the final image URLs once the task reaches a terminal state.
- `ImageGeneration` and `ImageEdit` provider methods now delegate to `HandleRunwayImageTask` instead of returning unsupported operation errors.
- Added comprehensive unit tests in `images_test.go` covering ratio defaults, field gating per model, reference image override behavior, content moderation handling, and data URI conversion for edit images.
- Enabled `ImageGeneration` and `ImageEdit` scenarios in `runway_test.go` integration tests using `gen4_image`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/runway/...
```

For integration testing, set a valid Runway API key and run:

```sh
go test ./core/providers/runway/... -run TestRunway -v
```

The `ImageGeneration` and `ImageEdit` scenarios use the `gen4_image` model. Note that `VideoGeneration`, `VideoRetrieve`, and `VideoRemix` remain disabled in the integration test suite due to long-running operations.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

API keys are passed via `Authorization: Bearer` headers and are never logged or included in raw request/response payloads unless explicitly opted into via `sendBackRawRequest`/`sendBackRawResponse` flags, consistent with the rest of the provider implementations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable