### PR TITLE
feat: migrate `TableVirtualKey.Value` from `string` to `SecretVar` to support env/vault references

### DIFF
--- a/core/internal/mcptests/extraheaders_test.go
+++ b/core/internal/mcptests/extraheaders_test.go
@@ -205,7 +205,7 @@ func httpExtraHeaderConfig(clientName, serverURL string) *schemas.MCPClientConfi
 		ID:                  clientName + "-id",
 		Name:                clientName,
 		ConnectionType:      schemas.MCPConnectionTypeHTTP,
-		ConnectionString:    schemas.NewEnvVar(serverURL),
+		ConnectionString:    schemas.NewSecretVar(serverURL),
 		ToolsToExecute:      []string{"*"},
 		AllowedExtraHeaders: schemas.WhiteList{allowedExtraHeader},
 	}
@@ -219,7 +219,7 @@ func sseExtraHeaderConfig(clientName, serverURL string) *schemas.MCPClientConfig
 		ID:                  clientName + "-id",
 		Name:                clientName,
 		ConnectionType:      schemas.MCPConnectionTypeSSE,
-		ConnectionString:    schemas.NewEnvVar(serverURL + "/sse"),
+		ConnectionString:    schemas.NewSecretVar(serverURL + "/sse"),
 		ToolsToExecute:      []string{"*"},
 		AllowedExtraHeaders: schemas.WhiteList{allowedExtraHeader},
 	}

--- a/core/schemas/vault_test.go
+++ b/core/schemas/vault_test.go
@@ -153,7 +153,7 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	m := &model{
 		Headers: map[string]SecretVar{
 			"Authorization": {Val: "secret-token"},
-			"X-Env":         {FromEnv: true, SecretVar: "X"},
+			"X-Env":         {FromEnv: true, EnvVar: "X"},
 		},
 	}
 

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -807,8 +807,8 @@ func GenerateVirtualKeyHash(vk tables.TableVirtualKey) (string, error) {
 	hash.Write([]byte(vk.Name))
 	// Hash Description
 	hash.Write([]byte(vk.Description))
-	// Hash Value
-	hash.Write([]byte(vk.Value))
+	// Hash Value (resolved); a SecretVar stringifies to its resolved value
+	hash.Write([]byte(vk.Value.GetValue()))
 	// Hash IsActive (nil treated as DB default true)
 	if vk.IsActiveValue() {
 		hash.Write([]byte("isActive:true"))

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -1342,7 +1342,7 @@ func TestEncryptPlaintextRows_SkipsAlreadyEncryptedVirtualKeys(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-already-enc",
 		Name:     "already-encrypted-vk",
-		Value:    "vk-secret-already",
+		Value:    *schemas.NewSecretVar("vk-secret-already"),
 		IsActive: bifrost.Ptr(true),
 	}
 	require.NoError(t, db.Create(vk).Error)

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1249,7 +1249,7 @@ func TestFullMigration_VirtualKeyCRUD(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:        "vk-test-001",
 		Name:      "test-virtual-key",
-		Value:     "vk-secret-value-12345",
+		Value:     *schemas.NewSecretVar("vk-secret-value-12345"),
 		IsActive:  bifrost.Ptr(true),
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -1265,7 +1265,7 @@ func TestFullMigration_VirtualKeyCRUD(t *testing.T) {
 
 	assert.Equal(t, "vk-test-001", vks[0].ID)
 	assert.Equal(t, "test-virtual-key", vks[0].Name)
-	assert.Equal(t, "vk-secret-value-12345", vks[0].Value) // AfterFind decrypts
+	assert.Equal(t, "vk-secret-value-12345", vks[0].Value.GetValue()) // AfterFind decrypts
 	assert.True(t, vks[0].IsActiveValue())
 
 	// Verify encryption at raw DB level
@@ -1395,7 +1395,7 @@ func TestFullMigration_EncryptPlaintextRows(t *testing.T) {
 	var vk tables.TableVirtualKey
 	err = db.Where("id = ?", "vk-plain-1").First(&vk).Error
 	require.NoError(t, err)
-	assert.Equal(t, "vk-plain-secret", vk.Value)
+	assert.Equal(t, "vk-plain-secret", vk.Value.GetValue())
 }
 
 func TestFullMigration_EndToEnd(t *testing.T) {
@@ -1437,7 +1437,7 @@ func TestFullMigration_EndToEnd(t *testing.T) {
 		{"vk-2", "vk-beta", "vk-beta-secret"},
 	} {
 		err := store.CreateVirtualKey(ctx, &tables.TableVirtualKey{
-			ID: vk.id, Name: vk.name, Value: vk.value,
+			ID: vk.id, Name: vk.name, Value: *schemas.NewSecretVar(vk.value),
 			IsActive: bifrost.Ptr(true), CreatedAt: now, UpdatedAt: now,
 		})
 		require.NoError(t, err, "CreateVirtualKey %s", vk.name)

--- a/framework/configstore/rdb_deadlock_postgres_test.go
+++ b/framework/configstore/rdb_deadlock_postgres_test.go
@@ -162,7 +162,7 @@ func TestPostgresVirtualKeyBudgetConcurrentMutationsDoNotDeadlock(t *testing.T) 
 				if err := store.UpdateVirtualKey(ctx, &tables.TableVirtualKey{
 					ID:       vkID,
 					Name:     "PG VK Budget",
-					Value:    "pg-vk-budget-value",
+					Value:    *schemas.NewSecretVar("pg-vk-budget-value"),
 					IsActive: schemas.Ptr(true),
 				}, tx); err != nil {
 					return err
@@ -247,7 +247,7 @@ func seedProviderGraph(ctx context.Context, store *RDBConfigStore) error {
 	if err := store.CreateVirtualKey(ctx, &tables.TableVirtualKey{
 		ID:       "pg-vk",
 		Name:     "PG VK",
-		Value:    fmt.Sprintf("pg-vk-value-%d", time.Now().UnixNano()),
+		Value:    *schemas.NewSecretVar(fmt.Sprintf("pg-vk-value-%d", time.Now().UnixNano())),
 		IsActive: schemas.Ptr(true),
 	}); err != nil && !isUniqueRace(err) {
 		return err
@@ -271,7 +271,7 @@ func seedVirtualKeyBudget(ctx context.Context, t *testing.T, store *RDBConfigSto
 	require.NoError(t, store.CreateVirtualKey(ctx, &tables.TableVirtualKey{
 		ID:       vkID,
 		Name:     "PG VK Budget",
-		Value:    "pg-vk-budget-value",
+		Value:    *schemas.NewSecretVar("pg-vk-budget-value"),
 		IsActive: schemas.Ptr(true),
 	}))
 	require.NoError(t, store.CreateBudget(ctx, &tables.TableBudget{

--- a/framework/configstore/rdb_mcp_sessions_test.go
+++ b/framework/configstore/rdb_mcp_sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +40,7 @@ func seedMCPSessionsFixture(t *testing.T, store *RDBConfigStore) {
 	vk := &tables.TableVirtualKey{
 		ID:    "vk-alpha",
 		Name:  "Alpha VK",
-		Value: "sk-bf-alpha",
+		Value: *schemas.NewSecretVar("sk-bf-alpha"),
 	}
 	require.NoError(t, store.DB().WithContext(ctx).Create(vk).Error)
 

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -835,7 +835,7 @@ func TestCreateVirtualKey(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-test",
 		Name:     "Test Virtual Key",
-		Value:    "vk-test-value-123",
+		Value:    *schemas.NewSecretVar("vk-test-value-123"),
 		IsActive: schemas.Ptr(true),
 	}
 
@@ -846,7 +846,7 @@ func TestCreateVirtualKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "vk-test", result.ID)
 	assert.Equal(t, "Test Virtual Key", result.Name)
-	assert.Equal(t, "vk-test-value-123", result.Value)
+	assert.Equal(t, "vk-test-value-123", result.Value.GetValue())
 	assert.True(t, result.IsActiveValue())
 }
 
@@ -880,7 +880,7 @@ func TestCreateVirtualKey_WithBudgetAndRateLimit(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:          vkID,
 		Name:        "VK With References",
-		Value:       "vk-refs-value",
+		Value:       *schemas.NewSecretVar("vk-refs-value"),
 		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
@@ -908,7 +908,7 @@ func TestCreateVirtualKey_DuplicateName(t *testing.T) {
 	vk1 := &tables.TableVirtualKey{
 		ID:       "vk-1",
 		Name:     "Same Name",
-		Value:    "vk-value-1",
+		Value:    *schemas.NewSecretVar("vk-value-1"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk1)
@@ -917,7 +917,7 @@ func TestCreateVirtualKey_DuplicateName(t *testing.T) {
 	vk2 := &tables.TableVirtualKey{
 		ID:       "vk-2",
 		Name:     "Same Name", // Duplicate name
-		Value:    "vk-value-2",
+		Value:    *schemas.NewSecretVar("vk-value-2"),
 		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk2)
@@ -931,7 +931,7 @@ func TestGetVirtualKeyByValue(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-lookup",
 		Name:     "Lookup Key",
-		Value:    "vk-unique-value-xyz",
+		Value:    *schemas.NewSecretVar("vk-unique-value-xyz"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -949,7 +949,7 @@ func TestUpdateVirtualKey(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-update",
 		Name:     "Original Name",
-		Value:    "vk-update-value",
+		Value:    *schemas.NewSecretVar("vk-update-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -974,7 +974,7 @@ func TestDeleteVirtualKey(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-delete",
 		Name:     "Delete Me",
-		Value:    "vk-delete-value",
+		Value:    *schemas.NewSecretVar("vk-delete-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -994,7 +994,7 @@ func TestDeleteVirtualKey_CleansUpScopedModelConfigs(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-scoped",
 		Name:     "Scoped VK",
-		Value:    "vk-scoped-value",
+		Value:    *schemas.NewSecretVar("vk-scoped-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	require.NoError(t, store.CreateVirtualKey(ctx, vk))
@@ -1048,7 +1048,7 @@ func TestDeleteVirtualKey_CleansUpMultiBudgetScopedModelConfigs(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-multibudget",
 		Name:     "MultiBudget VK",
-		Value:    "vk-multibudget-value",
+		Value:    *schemas.NewSecretVar("vk-multibudget-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	require.NoError(t, store.CreateVirtualKey(ctx, vk))
@@ -1171,7 +1171,7 @@ func TestCreateVirtualKeyProviderConfig(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-for-pc",
 		Name:     "VK For Provider Config",
-		Value:    "vk-pc-value",
+		Value:    *schemas.NewSecretVar("vk-pc-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -1214,7 +1214,7 @@ func TestCreateVirtualKeyProviderConfig_WithKeys(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-with-keys",
 		Name:     "VK With Keys",
-		Value:    "vk-keys-value",
+		Value:    *schemas.NewSecretVar("vk-keys-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk)
@@ -1254,7 +1254,7 @@ func TestCreateVirtualKeyProviderConfig_UnresolvedKeys(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-unresolved",
 		Name:     "VK Unresolved",
-		Value:    "vk-unresolved-value",
+		Value:    *schemas.NewSecretVar("vk-unresolved-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -1296,7 +1296,7 @@ func TestUpdateProvider_RemovesStaleVirtualKeyProviderConfigKeyAssociations(t *t
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-update-provider-cleanup",
 		Name:     "VK Update Provider Cleanup",
-		Value:    "vk-update-provider-cleanup-value",
+		Value:    *schemas.NewSecretVar("vk-update-provider-cleanup-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk)
@@ -1345,7 +1345,7 @@ func TestDeleteProvider_RemovesVirtualKeyProviderConfigs(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-delete-provider-cleanup",
 		Name:     "VK Delete Provider Cleanup",
-		Value:    "vk-delete-provider-cleanup-value",
+		Value:    *schemas.NewSecretVar("vk-delete-provider-cleanup-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk)
@@ -1741,7 +1741,7 @@ func TestFullVirtualKeyFlow(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:          integrationVKID,
 		Name:        "Integration Virtual Key",
-		Value:       "vk-integration-xyz",
+		Value:       *schemas.NewSecretVar("vk-integration-xyz"),
 		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
@@ -1792,7 +1792,7 @@ func TestGetVirtualKeysUsesInternalPagination(t *testing.T) {
 		vk := &tables.TableVirtualKey{
 			ID:        fmt.Sprintf("vk-page-%04d", i),
 			Name:      fmt.Sprintf("Virtual Key %04d", i),
-			Value:     fmt.Sprintf("vk-value-%04d", i),
+			Value:     *schemas.NewSecretVar(fmt.Sprintf("vk-value-%04d", i)),
 			IsActive:  schemas.Ptr(true),
 			CreatedAt: createdAt,
 			UpdatedAt: createdAt,

--- a/framework/configstore/sqlite.go
+++ b/framework/configstore/sqlite.go
@@ -35,6 +35,10 @@ func newSqliteConfigStore(ctx context.Context, config *SQLiteConfig, logger sche
 		return nil, err
 	}
 	logger.Debug("db opened for configstore")
+	// Install the global vault store/remove callbacks so plaintext SecretVar
+	// fields are rewritten to vault refs before persistence and owned vault
+	// secrets are cleaned up on delete.
+	RegisterVaultCallbacks(db)
 	s := &RDBConfigStore{logger: logger}
 	s.db.Store(db)
 	// SQLite has no server-side prepared-plan cache, and opening a second

--- a/framework/configstore/tables/encryption.go
+++ b/framework/configstore/tables/encryption.go
@@ -10,8 +10,6 @@ const (
 	EncryptionStatusPlainText = "plain_text"
 	// EncryptionStatusEncrypted indicates the row's sensitive fields have been encrypted.
 	EncryptionStatusEncrypted = "encrypted"
-	// EncryptionStatusVault indicates the row's sensitive fields are stored as vault references.
-	EncryptionStatusVault = "vault"
 )
 
 // encryptSecretVar encrypts the Val field of an SecretVar in place using AES-256-GCM.

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -408,7 +408,7 @@ func TestTableVirtualKey_EncryptDecrypt(t *testing.T) {
 	vk := &TableVirtualKey{
 		ID:       "vk-1",
 		Name:     "test-vk",
-		Value:    "vk-secret-value-xyz",
+		Value:    *schemas.NewSecretVar("vk-secret-value-xyz"),
 		IsActive: bifrost.Ptr(true),
 	}
 
@@ -424,7 +424,7 @@ func TestTableVirtualKey_EncryptDecrypt(t *testing.T) {
 
 	var found TableVirtualKey
 	require.NoError(t, db.First(&found, "id = ?", "vk-1").Error)
-	assert.Equal(t, "vk-secret-value-xyz", found.Value)
+	assert.Equal(t, "vk-secret-value-xyz", found.Value.GetValue())
 	assert.Equal(t, expectedHash, found.ValueHash)
 }
 
@@ -434,7 +434,7 @@ func TestTableVirtualKey_HashComputedBeforeEncryption(t *testing.T) {
 	vk := &TableVirtualKey{
 		ID:       "vk-hash",
 		Name:     "hash-test",
-		Value:    "plaintext-value",
+		Value:    *schemas.NewSecretVar("plaintext-value"),
 		IsActive: bifrost.Ptr(true),
 	}
 
@@ -892,21 +892,21 @@ func TestTableVirtualKey_UpdatePreservesDecryption(t *testing.T) {
 	vk := &TableVirtualKey{
 		ID:       "vk-update",
 		Name:     "update-vk",
-		Value:    "original-vk-value",
+		Value:    *schemas.NewSecretVar("original-vk-value"),
 		IsActive: bifrost.Ptr(true),
 	}
 	require.NoError(t, db.Create(vk).Error)
 
 	var found TableVirtualKey
 	require.NoError(t, db.First(&found, "id = ?", "vk-update").Error)
-	assert.Equal(t, "original-vk-value", found.Value)
+	assert.Equal(t, "original-vk-value", found.Value.GetValue())
 
-	found.Value = "updated-vk-value"
+	found.Value = *schemas.NewSecretVar("updated-vk-value")
 	require.NoError(t, db.Save(&found).Error)
 
 	var found2 TableVirtualKey
 	require.NoError(t, db.First(&found2, "id = ?", "vk-update").Error)
-	assert.Equal(t, "updated-vk-value", found2.Value)
+	assert.Equal(t, "updated-vk-value", found2.Value.GetValue())
 
 	raw := rawRow(t, db, "governance_virtual_keys", "vk-update")
 	assert.Equal(t, "encrypted", raw["encryption_status"])
@@ -1315,7 +1315,7 @@ func TestTableVirtualKey_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 	vk := &TableVirtualKey{
 		ID:       "vk-dis-1",
 		Name:     "disabled-vk",
-		Value:    "vk-plaintext-value",
+		Value:    *schemas.NewSecretVar("vk-plaintext-value"),
 		IsActive: bifrost.Ptr(true),
 	}
 
@@ -1331,7 +1331,7 @@ func TestTableVirtualKey_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 	// GORM read should return same plaintext
 	var found TableVirtualKey
 	require.NoError(t, db.Where("id = ?", "vk-dis-1").First(&found).Error)
-	assert.Equal(t, "vk-plaintext-value", found.Value)
+	assert.Equal(t, "vk-plaintext-value", found.Value.GetValue())
 }
 
 func TestSessionsTable_EncryptionDisabled_StoresPlaintext(t *testing.T) {

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -206,10 +206,14 @@ func (mc *TableVirtualKeyMCPConfig) UnmarshalJSON(data []byte) error {
 
 // TableVirtualKey represents a virtual key with budget, rate limits, and team/customer association
 type TableVirtualKey struct {
-	ID              string                          `gorm:"primaryKey;type:varchar(255)" json:"id"`
-	Name            string                          `gorm:"uniqueIndex:idx_virtual_key_name;type:varchar(255);not null" json:"name"`
-	Description     string                          `gorm:"type:text" json:"description,omitempty"`
-	Value           string                          `gorm:"uniqueIndex:idx_virtual_key_value;type:text;not null" json:"value"`           // The virtual key value
+	ID          string `gorm:"primaryKey;type:varchar(255)" json:"id"`
+	Name        string `gorm:"uniqueIndex:idx_virtual_key_name;type:varchar(255);not null" json:"name"`
+	Description string `gorm:"type:text" json:"description,omitempty"`
+	// Value is the virtual key value. Like TableKey.Value it is a SecretVar so it can be sourced
+	// from an env var ("env.X") or vault ("vault.X"); the reference is stored in the value column and
+	// resolved on read. ValueHash (below) is computed from the RESOLVED value so the x-bf-vk lookup
+	// and the governance in-memory keying match the plaintext the client presents.
+	Value           schemas.SecretVar               `gorm:"uniqueIndex:idx_virtual_key_value;type:text;not null" json:"value"`
 	IsActive        *bool                           `gorm:"default:true" json:"is_active,omitempty"`                                     // Nil means true (DB default); false means inactive
 	ProviderConfigs []TableVirtualKeyProviderConfig `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"provider_configs"` // Empty means no providers allowed (deny-by-default)
 	MCPConfigs      []TableVirtualKeyMCPConfig      `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"mcp_configs"`
@@ -243,6 +247,15 @@ type TableVirtualKey struct {
 // TableName sets the table name for each model
 func (TableVirtualKey) TableName() string { return "governance_virtual_keys" }
 
+// VaultPathKey implements schemas.VaultPathKeyer so the vault store/remove can compute the vault
+// base path for this model's value.
+func (vk *TableVirtualKey) VaultPathKey() string { return vk.ID }
+
+// VaultStoreSelfManaged marks TableVirtualKey as storing its own vault secret from within
+// BeforeSave, so the global vault callback skips it. BeforeSave must hash the RESOLVED value
+// before the vault store rewrites Value to a vault ref; that ordering is only reachable in the hook.
+func (vk *TableVirtualKey) VaultStoreSelfManaged() {}
+
 // IsActiveValue returns the effective IsActive bool, treating nil as true (DB default).
 func (vk *TableVirtualKey) IsActiveValue() bool {
 	if vk == nil {
@@ -263,12 +276,23 @@ func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
 		return fmt.Errorf("virtual key cannot belong to both team and customer")
 	}
 
-	// Hash must be computed before encryption (from plaintext value)
-	if vk.Value != "" {
-		vk.ValueHash = encrypt.HashSHA256(vk.Value)
+	// Hash must be computed from the RESOLVED value (not the env/vault reference) so the x-bf-vk
+	// lookup and the governance in-memory keying match the plaintext the client presents.
+	if resolved := vk.Value.GetValue(); resolved != "" {
+		vk.ValueHash = encrypt.HashSHA256(resolved)
 	}
-	if encrypt.IsEnabled() && vk.Value != "" {
-		if err := encryptString(&vk.Value); err != nil {
+
+	// Store a plaintext-vault-sourced value into the vault and rewrite it to a vault ref before
+	// encryption, mirroring TableKey.BeforeSave. encryptSecretVar skips env/vault references.
+	if schemas.VaultStoreWriteEnabled() {
+		base := schemas.VaultBasePath(tx.Statement.Table, vk.ID)
+		if err := schemas.StoreOwnedVaultSecretVars(tx.Statement.Context, base, vk); err != nil {
+			return fmt.Errorf("failed to store virtual key secret to vault: %w", err)
+		}
+	}
+
+	if encrypt.IsEnabled() {
+		if err := encryptSecretVar(&vk.Value); err != nil {
 			return fmt.Errorf("failed to encrypt virtual key value: %w", err)
 		}
 		vk.EncryptionStatus = EncryptionStatusEncrypted
@@ -284,7 +308,7 @@ func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
 func (vk *TableVirtualKey) AfterFind(tx *gorm.DB) error {
 	switch vk.EncryptionStatus {
 	case EncryptionStatusEncrypted:
-		if err := decryptString(&vk.Value); err != nil {
+		if err := decryptSecretVar(&vk.Value); err != nil {
 			return fmt.Errorf("failed to decrypt virtual key value: %w", err)
 		}
 	}

--- a/framework/configstore/tables/virtualkey_secretvar_test.go
+++ b/framework/configstore/tables/virtualkey_secretvar_test.go
@@ -1,0 +1,183 @@
+package tables
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/encrypt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTableVirtualKey_EnvSourcedRoundTrip verifies that an env-sourced VK hashes the RESOLVED
+// value (so the x-bf-vk lookup keeps working) and round-trips the env reference, mirroring
+// TableKey.Value behavior.
+func TestTableVirtualKey_EnvSourcedRoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+
+	t.Setenv("TEST_VK_ENV", "sk-bf-env-resolved")
+	sv := schemas.NewSecretVar("env.TEST_VK_ENV")
+	require.True(t, sv.IsFromEnv())
+	require.Equal(t, "sk-bf-env-resolved", sv.GetValue())
+
+	vk := &TableVirtualKey{
+		ID:       "vk-env",
+		Name:     "env-vk",
+		Value:    *sv,
+		IsActive: bifrost.Ptr(true),
+	}
+	require.NoError(t, db.Create(vk).Error)
+
+	raw := rawRow(t, db, "governance_virtual_keys", "vk-env")
+	// The hash must be of the resolved plaintext so x-bf-vk lookup matches the client value.
+	assert.Equal(t, encrypt.HashSHA256("sk-bf-env-resolved"), raw["value_hash"])
+
+	var found TableVirtualKey
+	require.NoError(t, db.First(&found, "id = ?", "vk-env").Error)
+	assert.True(t, found.Value.IsFromEnv())
+	assert.Equal(t, "env.TEST_VK_ENV", found.Value.EnvVar)
+	assert.Equal(t, "sk-bf-env-resolved", found.Value.GetValue())
+}
+
+// TestTableVirtualKey_LiteralRoundTrip verifies a plain literal value encrypts at rest and
+// decrypts back to the same plaintext.
+func TestTableVirtualKey_LiteralRoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+
+	vk := &TableVirtualKey{
+		ID:       "vk-lit",
+		Name:     "literal-vk",
+		Value:    *schemas.NewSecretVar("sk-bf-literal"),
+		IsActive: bifrost.Ptr(true),
+	}
+	require.NoError(t, db.Create(vk).Error)
+
+	raw := rawRow(t, db, "governance_virtual_keys", "vk-lit")
+	assert.NotEqual(t, "sk-bf-literal", raw["value"]) // encrypted at rest
+
+	var found TableVirtualKey
+	require.NoError(t, db.First(&found, "id = ?", "vk-lit").Error)
+	assert.False(t, found.Value.IsFromEnv())
+	assert.False(t, found.Value.IsFromVault())
+	assert.Equal(t, "sk-bf-literal", found.Value.GetValue())
+}
+
+// TestTableVirtualKey_HashStableAcrossEnvAndLiteral verifies that two VKs resolving to the same
+// plaintext (one literal, one env-sourced) produce the same value_hash, so lookup-by-value is
+// source-agnostic.
+func TestTableVirtualKey_HashStableAcrossEnvAndLiteral(t *testing.T) {
+	t.Setenv("TEST_VK_SAME", "sk-bf-shared")
+	sv := schemas.NewSecretVar("env.TEST_VK_SAME")
+
+	literal := &TableVirtualKey{ID: "a", Name: "a", Value: *schemas.NewSecretVar("sk-bf-shared")}
+	envSourced := &TableVirtualKey{ID: "b", Name: "b", Value: *sv}
+
+	require.NoError(t, literal.BeforeSave(nil))
+	require.NoError(t, envSourced.BeforeSave(nil))
+
+	assert.Equal(t, literal.ValueHash, envSourced.ValueHash)
+}
+
+// TestTableVirtualKey_MarshalJSON_SecretVarShape verifies the JSON `value` is a SecretVar object
+// carrying the env source metadata (like provider keys).
+func TestTableVirtualKey_MarshalJSON_SecretVarShape(t *testing.T) {
+	t.Setenv("TEST_VK_MARSHAL", "sk-bf-secret-1234")
+	vk := TableVirtualKey{
+		ID:    "e",
+		Name:  "e",
+		Value: *schemas.NewSecretVar("env.TEST_VK_MARSHAL"),
+	}
+	data, err := json.Marshal(vk)
+	require.NoError(t, err)
+	var out struct {
+		Value schemas.SecretVar `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal(data, &out))
+	assert.True(t, out.Value.FromEnv)
+	assert.Equal(t, "env.TEST_VK_MARSHAL", out.Value.EnvVar)
+}
+
+// TestTableVirtualKey_UnmarshalJSON_Forms verifies `value` accepts a bare string and an "env.X"
+// string, resolving env references like TableKey.Value.
+func TestTableVirtualKey_UnmarshalJSON_Forms(t *testing.T) {
+	t.Setenv("TEST_VK_UMARSHAL", "sk-bf-um")
+
+	t.Run("bare string", func(t *testing.T) {
+		var vk TableVirtualKey
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"n","value":"sk-bf-plain"}`), &vk))
+		assert.Equal(t, "sk-bf-plain", vk.Value.GetValue())
+		assert.False(t, vk.Value.IsFromEnv())
+	})
+
+	t.Run("env string", func(t *testing.T) {
+		var vk TableVirtualKey
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"n","value":"env.TEST_VK_UMARSHAL"}`), &vk))
+		assert.Equal(t, "sk-bf-um", vk.Value.GetValue())
+		assert.True(t, vk.Value.IsFromEnv())
+		assert.Equal(t, "env.TEST_VK_UMARSHAL", vk.Value.EnvVar)
+	})
+}
+
+// TestTableVirtualKey_VaultRotation_ReSaveRefreshesHash simulates a vault secret rotation + cache
+// flush: re-Saving a vault-sourced VK must recompute value_hash from the NEW resolved value, keep
+// the vault reference in the value column, and never write the secret back to the vault. This is
+// the single-writer DB effect behind ReloadVaultSourcedVirtualKeys(reSave=true).
+func TestTableVirtualKey_VaultRotation_ReSaveRefreshesHash(t *testing.T) {
+	db := setupTestDB(t)
+
+	const vaultRef = "vault.secret/vk-rotate"
+	current := "sk-bf-vault-v1"
+
+	prevResolve := schemas.VaultResolveHook
+	prevStore := schemas.VaultStoreHook
+	prevRemove := schemas.VaultRemoveHook
+	schemas.VaultResolveHook = func(_ context.Context, value *string) error {
+		if *value == vaultRef {
+			*value = current
+		}
+		return nil
+	}
+	// Write hooks make VaultStoreWriteEnabled() true; the store hook must NEVER fire for a
+	// vault-sourced (read-only ref) VK.
+	schemas.VaultStoreHook = func(_ context.Context, _ string, _ *string) error {
+		t.Fatalf("vault store hook must not be called for a vault-sourced virtual key")
+		return nil
+	}
+	schemas.VaultRemoveHook = func(_ context.Context, _ string) error { return nil }
+	t.Cleanup(func() {
+		schemas.VaultResolveHook = prevResolve
+		schemas.VaultStoreHook = prevStore
+		schemas.VaultRemoveHook = prevRemove
+	})
+
+	vk := &TableVirtualKey{
+		ID:       "vk-rotate",
+		Name:     "vault-rotate-vk",
+		Value:    *schemas.NewSecretVar(vaultRef),
+		IsActive: bifrost.Ptr(true),
+	}
+	require.Equal(t, "sk-bf-vault-v1", vk.Value.GetValue())
+	require.NoError(t, db.Create(vk).Error)
+
+	raw := rawRow(t, db, "governance_virtual_keys", "vk-rotate")
+	assert.Equal(t, vaultRef, raw["value"], "column stores the vault reference, not the secret")
+	assert.Equal(t, encrypt.HashSHA256("sk-bf-vault-v1"), raw["value_hash"])
+
+	// Rotate the backend secret (the vault cache flush would force re-resolution).
+	current = "sk-bf-vault-v2"
+
+	// Re-read: AfterFind/Scan re-resolves the ref to the new secret.
+	var found TableVirtualKey
+	require.NoError(t, db.First(&found, "id = ?", "vk-rotate").Error)
+	require.Equal(t, "sk-bf-vault-v2", found.Value.GetValue())
+
+	// Re-Save (the single writer): BeforeSave recomputes value_hash from the new value.
+	require.NoError(t, db.Save(&found).Error)
+
+	raw = rawRow(t, db, "governance_virtual_keys", "vk-rotate")
+	assert.Equal(t, vaultRef, raw["value"], "value column still holds the vault reference after re-save")
+	assert.Equal(t, encrypt.HashSHA256("sk-bf-vault-v2"), raw["value_hash"], "value_hash refreshed to the rotated secret")
+}

--- a/framework/logstore/asyncjob_test.go
+++ b/framework/logstore/asyncjob_test.go
@@ -45,7 +45,7 @@ func newTestAsyncExecutor(t *testing.T) *AsyncJobExecutor {
 
 	govStore := &testGovernanceStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"sk-bf-test": {ID: "vk-123", Value: "sk-bf-test"},
+			"sk-bf-test": {ID: "vk-123", Value: *schemas.NewSecretVar("sk-bf-test")},
 		},
 	}
 

--- a/framework/postgresconn/postgresconn_test.go
+++ b/framework/postgresconn/postgresconn_test.go
@@ -47,9 +47,9 @@ func TestValidateRejectsNonPositiveConnMaxLifetime(t *testing.T) {
 
 func TestBuildDSNQuotesValuesForPasswordCommandParsing(t *testing.T) {
 	cfg := validConfig()
-	cfg.Host = schemas.NewEnvVar("127.0.0.1")
-	cfg.User = schemas.NewEnvVar("service-account@example-project.iam")
-	cfg.Password = schemas.NewEnvVar("")
+	cfg.Host = schemas.NewSecretVar("127.0.0.1")
+	cfg.User = schemas.NewSecretVar("service-account@example-project.iam")
+	cfg.Password = schemas.NewSecretVar("")
 	cfg.PasswordCommand = &PasswordCommandConfig{Command: "printf", Args: []string{"unused-iam-auth"}}
 
 	pgxConfig, err := pgx.ParseConfig(BuildDSN(cfg))
@@ -70,7 +70,7 @@ func TestBuildDSNQuotesSpecialCharacters(t *testing.T) {
 		{
 			name: "single quote",
 			mutate: func(cfg *Config) {
-				cfg.User = schemas.NewEnvVar("service'account")
+				cfg.User = schemas.NewSecretVar("service'account")
 			},
 			validate: func(t *testing.T, pgxConfig *pgx.ConnConfig) {
 				require.Equal(t, "service'account", pgxConfig.User)
@@ -79,7 +79,7 @@ func TestBuildDSNQuotesSpecialCharacters(t *testing.T) {
 		{
 			name: "backslash",
 			mutate: func(cfg *Config) {
-				cfg.Host = schemas.NewEnvVar(`C:\postgres\socket`)
+				cfg.Host = schemas.NewSecretVar(`C:\postgres\socket`)
 			},
 			validate: func(t *testing.T, pgxConfig *pgx.ConnConfig) {
 				require.Equal(t, `C:\postgres\socket`, pgxConfig.Host)
@@ -88,7 +88,7 @@ func TestBuildDSNQuotesSpecialCharacters(t *testing.T) {
 		{
 			name: "backslash and single quote",
 			mutate: func(cfg *Config) {
-				cfg.DBName = schemas.NewEnvVar(`bifrost\tenant's`)
+				cfg.DBName = schemas.NewSecretVar(`bifrost\tenant's`)
 			},
 			validate: func(t *testing.T, pgxConfig *pgx.ConnConfig) {
 				require.Equal(t, `bifrost\tenant's`, pgxConfig.Database)

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -2316,7 +2316,7 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 	// Build virtual keys map and track active VKs
 	for i := range virtualKeys {
 		vk := &virtualKeys[i]
-		gs.virtualKeys.Store(vk.Value, vk)
+		gs.virtualKeys.Store(vk.Value.GetValue(), vk)
 	}
 
 	// Build model configs map.
@@ -2798,7 +2798,7 @@ func (gs *LocalGovernanceStore) CreateVirtualKeyInMemory(ctx context.Context, vk
 		}
 	}
 
-	gs.virtualKeys.Store(clone.Value, &clone)
+	gs.virtualKeys.Store(clone.Value.GetValue(), &clone)
 }
 
 // UpdateVirtualKeyInMemory updates an existing virtual key in the in-memory store (lock-free)
@@ -2809,8 +2809,8 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 
 	// Do not update the current usage of the rate limit, as it will be updated by the usage tracker.
 	// But update if max limit or reset duration changes.
-	existingVKKey := vk.Value
-	existingVKValue, exists := gs.virtualKeys.Load(vk.Value)
+	existingVKKey := vk.Value.GetValue()
+	existingVKValue, exists := gs.virtualKeys.Load(vk.Value.GetValue())
 	if exists && existingVKValue != nil {
 		if existingVK, ok := existingVKValue.(*configstoreTables.TableVirtualKey); !ok || existingVK == nil || existingVK.ID != vk.ID {
 			exists = false
@@ -2973,10 +2973,10 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 				}
 			}
 		}
-		if existingVKKey != "" && existingVKKey != vk.Value {
+		if existingVKKey != "" && existingVKKey != vk.Value.GetValue() {
 			gs.virtualKeys.Delete(existingVKKey)
 		}
-		gs.virtualKeys.Store(vk.Value, &clone)
+		gs.virtualKeys.Store(vk.Value.GetValue(), &clone)
 	} else {
 		gs.CreateVirtualKeyInMemory(ctx, vk)
 	}

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -656,7 +656,7 @@ func TestGovernanceStore_UpdateVirtualKeyInMemory_RotatedValueRemovesOldLookup(t
 	require.NoError(t, err)
 
 	updated := *vk
-	updated.Value = "sk-bf-new"
+	updated.Value = *schemas.NewSecretVar("sk-bf-new")
 	store.UpdateVirtualKeyInMemory(context.Background(), &updated, nil, nil, nil)
 
 	oldVK, oldFound := store.GetVirtualKey(context.Background(), "sk-bf-old")

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -80,7 +80,7 @@ func (ml *MockLogger) LogHTTPRequest(level schemas.LogLevel, msg string) schemas
 func buildVirtualKey(id, value, name string, isActive bool) *configstoreTables.TableVirtualKey {
 	return &configstoreTables.TableVirtualKey{
 		ID:       id,
-		Value:    value,
+		Value:    *schemas.NewSecretVar(value),
 		Name:     name,
 		IsActive: &isActive,
 	}

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -143,8 +143,12 @@ func NewGovernanceHandler(manager GovernanceManager, configStore configstore.Con
 
 // CreateVirtualKeyRequest represents the request body for creating a virtual key
 type CreateVirtualKeyRequest struct {
-	Name            string `json:"name" validate:"required"`
-	Description     string `json:"description,omitempty"`
+	Name        string `json:"name" validate:"required"`
+	Description string `json:"description,omitempty"`
+	// Value optionally sets the virtual key value. Accepts a literal, an "env.X"/"vault.X" string,
+	// or a SecretVar object. When unset, a value is generated server-side. References resolve to
+	// plaintext while the source is preserved for API responses.
+	Value           *schemas.SecretVar `json:"value,omitempty"`
 	ProviderConfigs []struct {
 		Provider          string                  `json:"provider" validate:"required"`
 		Weight            *float64                `json:"weight,omitempty"`
@@ -1298,12 +1302,20 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		vk = configstoreTables.TableVirtualKey{
 			ID:              uuid.NewString(),
 			Name:            req.Name,
-			Value:           governance.GenerateVirtualKey(),
+			Value:           *schemas.NewSecretVar(governance.GenerateVirtualKey()),
 			Description:     req.Description,
 			TeamID:          req.TeamID,
 			CustomerID:      req.CustomerID,
 			IsActive:        isActive,
 			CalendarAligned: req.CalendarAligned,
+		}
+		// If the caller supplied a value (literal or env/vault reference), use it; the SecretVar
+		// resolves the reference and the source round-trips through persistence and API responses.
+		// Only override the generated key when the value resolves to a non-empty plaintext: an
+		// unresolved env/vault reference (e.g. the env var is unset) would otherwise replace the
+		// generated credential with an empty, unusable value.
+		if req.Value.IsSet() && req.Value.GetValue() != "" {
+			vk.Value = *req.Value
 		}
 		if err := h.configStore.CreateVirtualKey(ctx, &vk, tx); err != nil {
 			return err
@@ -1911,9 +1923,9 @@ func (h *GovernanceHandler) rotateVirtualKeyByID(ctx context.Context, vkID strin
 	if err != nil {
 		return nil, err
 	}
-	oldValue := vk.Value
-	vk.Value = governance.GenerateVirtualKey()
-	if vk.Value == oldValue {
+	oldValue := vk.Value.GetValue()
+	vk.Value = *schemas.NewSecretVar(governance.GenerateVirtualKey())
+	if vk.Value.GetValue() == oldValue {
 		return nil, fmt.Errorf("generated virtual key matched existing value")
 	}
 	if err := h.configStore.UpdateVirtualKey(ctx, vk); err != nil {

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1040,7 +1040,7 @@ func TestRotateVirtualKey_OnlyChangesValueAndReloads(t *testing.T) {
 			"vk-1": {
 				ID:          "vk-1",
 				Name:        "Production",
-				Value:       "sk-bf-old",
+				Value:       *schemas.NewSecretVar("sk-bf-old"),
 				Description: "existing description",
 				TeamID:      &teamID,
 				RateLimitID: &rateLimitID,
@@ -1076,11 +1076,11 @@ func TestRotateVirtualKey_OnlyChangesValueAndReloads(t *testing.T) {
 	}
 
 	updated := store.virtualKeys["vk-1"]
-	if updated.Value == "sk-bf-old" {
+	if updated.Value.GetValue() == "sk-bf-old" {
 		t.Fatal("expected virtual key value to rotate")
 	}
-	if !strings.HasPrefix(updated.Value, governance.VirtualKeyPrefix) {
-		t.Fatalf("expected rotated value to use %q prefix, got %q", governance.VirtualKeyPrefix, updated.Value)
+	if !strings.HasPrefix(updated.Value.GetValue(), governance.VirtualKeyPrefix) {
+		t.Fatalf("expected rotated value to use %q prefix, got %q", governance.VirtualKeyPrefix, updated.Value.GetValue())
 	}
 	if updated.ID != "vk-1" || updated.Name != "Production" || updated.Description != "existing description" {
 		t.Fatalf("rotation changed non-value fields: %#v", updated)
@@ -1105,8 +1105,8 @@ func TestRotateVirtualKey_OnlyChangesValueAndReloads(t *testing.T) {
 	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
-	if resp.VirtualKey.Value != updated.Value {
-		t.Fatalf("response value = %q, want %q", resp.VirtualKey.Value, updated.Value)
+	if resp.VirtualKey.Value.GetValue() != updated.Value.GetValue() {
+		t.Fatalf("response value = %q, want %q", resp.VirtualKey.Value.GetValue(), updated.Value.GetValue())
 	}
 }
 
@@ -1138,7 +1138,7 @@ func TestRotateVirtualKey_UpdateFailureDoesNotReload(t *testing.T) {
 
 	store := &mockRotateConfigStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old"},
+			"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old")},
 		},
 		updateErr: errors.New("database unavailable"),
 	}
@@ -1153,8 +1153,8 @@ func TestRotateVirtualKey_UpdateFailureDoesNotReload(t *testing.T) {
 	if ctx.Response.StatusCode() != 500 {
 		t.Fatalf("expected status 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
 	}
-	if store.virtualKeys["vk-1"].Value != "sk-bf-old" {
-		t.Fatalf("expected value to remain unchanged, got %q", store.virtualKeys["vk-1"].Value)
+	if store.virtualKeys["vk-1"].Value.GetValue() != "sk-bf-old" {
+		t.Fatalf("expected value to remain unchanged, got %q", store.virtualKeys["vk-1"].Value.GetValue())
 	}
 	if len(manager.reloadIDs) != 0 {
 		t.Fatalf("expected no reloads, got %#v", manager.reloadIDs)
@@ -1166,7 +1166,7 @@ func TestRotateVirtualKey_ReloadFailureReturnsErrorAfterUpdate(t *testing.T) {
 
 	store := &mockRotateConfigStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old"},
+			"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old")},
 		},
 	}
 	manager := &mockRotateGovernanceManager{store: store, reloadErr: errors.New("reload failed")}
@@ -1183,7 +1183,7 @@ func TestRotateVirtualKey_ReloadFailureReturnsErrorAfterUpdate(t *testing.T) {
 	if store.updates != 1 {
 		t.Fatalf("expected one update, got %d", store.updates)
 	}
-	if store.virtualKeys["vk-1"].Value == "sk-bf-old" {
+	if store.virtualKeys["vk-1"].Value.GetValue() == "sk-bf-old" {
 		t.Fatal("expected value to rotate before reload failure")
 	}
 	if len(manager.reloadIDs) != 1 || manager.reloadIDs[0] != "vk-1" {
@@ -1199,8 +1199,8 @@ func TestRotateVirtualKeys_PartialSuccess(t *testing.T) {
 
 	store := &mockRotateConfigStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old-1"},
-			"vk-2": {ID: "vk-2", Name: "Two", Value: "sk-bf-old-2"},
+			"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old-1")},
+			"vk-2": {ID: "vk-2", Name: "Two", Value: *schemas.NewSecretVar("sk-bf-old-2")},
 		},
 	}
 	manager := &mockRotateGovernanceManager{store: store}
@@ -1220,7 +1220,7 @@ func TestRotateVirtualKeys_PartialSuccess(t *testing.T) {
 	if len(manager.reloadIDs) != 2 || manager.reloadIDs[0] != "vk-1" || manager.reloadIDs[1] != "vk-2" {
 		t.Fatalf("expected reloads for vk-1 and vk-2, got %#v", manager.reloadIDs)
 	}
-	if store.virtualKeys["vk-1"].Value == "sk-bf-old-1" || store.virtualKeys["vk-2"].Value == "sk-bf-old-2" {
+	if store.virtualKeys["vk-1"].Value.GetValue() == "sk-bf-old-1" || store.virtualKeys["vk-2"].Value.GetValue() == "sk-bf-old-2" {
 		t.Fatalf("expected successful IDs to rotate: %#v", store.virtualKeys)
 	}
 
@@ -1256,7 +1256,7 @@ func TestRotateVirtualKeys_RejectsInvalidRequests(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := &mockRotateConfigStore{
 				virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-					"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old-1"},
+					"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old-1")},
 				},
 			}
 			manager := &mockRotateGovernanceManager{store: store}
@@ -1288,8 +1288,8 @@ func TestRotateVirtualKeys_TrimsAndDeduplicatesIDs(t *testing.T) {
 
 	store := &mockRotateConfigStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old-1"},
-			"vk-2": {ID: "vk-2", Name: "Two", Value: "sk-bf-old-2"},
+			"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old-1")},
+			"vk-2": {ID: "vk-2", Name: "Two", Value: *schemas.NewSecretVar("sk-bf-old-2")},
 		},
 	}
 	manager := &mockRotateGovernanceManager{store: store}
@@ -1742,7 +1742,7 @@ func TestGetVirtualKeyQuota_EndToEndWithRealStore(t *testing.T) {
 	vk := &configstoreTables.TableVirtualKey{
 		ID:       vkID,
 		Name:     "Prod",
-		Value:    "sk-bf-e2e-secret",
+		Value:    *schemas.NewSecretVar("sk-bf-e2e-secret"),
 		IsActive: &active,
 		ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
 			{VirtualKeyID: vkID, Provider: "openai", AllowAllKeys: true, AllowedModels: schemas.WhiteList{"*"}},

--- a/transports/bifrost-http/handlers/list_models_vk_test.go
+++ b/transports/bifrost-http/handlers/list_models_vk_test.go
@@ -28,7 +28,7 @@ func TestApplyListModelsVirtualKeyProviderFilterSetsActiveVKProviders(t *testing
 	h := &CompletionHandler{
 		config: &lib.Config{
 			ConfigStore: &mockListModelsVKConfigStore{vk: &configstoreTables.TableVirtualKey{
-				Value:    "sk-bf-active",
+				Value:    *schemas.NewSecretVar("sk-bf-active"),
 				IsActive: new(true),
 				ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
 					{Provider: "openai"},
@@ -124,7 +124,7 @@ func TestApplyListModelsVirtualKeyProviderFilterSkipsInactiveVK(t *testing.T) {
 	h := &CompletionHandler{
 		config: &lib.Config{
 			ConfigStore: &mockListModelsVKConfigStore{vk: &configstoreTables.TableVirtualKey{
-				Value:    "sk-bf-inactive",
+				Value:    *schemas.NewSecretVar("sk-bf-inactive"),
 				IsActive: new(false),
 				ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
 					{Provider: "openai"},

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -289,7 +289,8 @@ func (h *MCPServerHandler) SyncAllMCPServers(ctx context.Context) error {
 func (h *MCPServerHandler) SyncVKMCPServer(vk *tables.TableVirtualKey) *server.MCPServer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	vkServer, ok := h.vkMCPServers[vk.Value]
+	vkValue := vk.Value.GetValue()
+	vkServer, ok := h.vkMCPServers[vkValue]
 	if !ok {
 		// Add new server
 		vkServer = server.NewMCPServer(
@@ -298,11 +299,11 @@ func (h *MCPServerHandler) SyncVKMCPServer(vk *tables.TableVirtualKey) *server.M
 			server.WithToolCapabilities(true),
 		)
 		server.WithToolFilter(h.makeIncludeClientsFilter())(vkServer)
-		h.vkMCPServers[vk.Value] = vkServer
+		h.vkMCPServers[vkValue] = vkServer
 	}
 	availableTools, toolFilter := h.fetchToolsForVK(vk)
 	h.syncServer(vkServer, availableTools, toolFilter)
-	h.vkMCPServers[vk.Value] = vkServer
+	h.vkMCPServers[vkValue] = vkServer
 	logger.Debug("Synced MCP server for virtual key '%s' with %d tools", vk.Name, len(availableTools))
 	return vkServer
 }

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -586,8 +586,8 @@ func restoreRedactedFromExisting(incoming, existing map[string]any) map[string]a
 func restoreRedactedValue(incoming, existing any) any {
 	switch val := incoming.(type) {
 	case map[string]any:
-		if isEnvVarObject(val) {
-			if schemas.NewEnvVar(marshalEnvVarObject(val)).ShouldPreserveStored() && existing != nil {
+		if isSecretVarObject(val) {
+			if schemas.NewSecretVar(marshalSecretVarObject(val)).ShouldPreserveStored() && existing != nil {
 				return existing
 			}
 			return val
@@ -617,8 +617,8 @@ func restoreRedactedValue(incoming, existing any) any {
 		// is a redaction artifact and not an intentional env reference. Empty strings are
 		// left as-is so clearing a value works.
 		if existingStr, ok := existing.(string); ok {
-			envVal := schemas.NewEnvVar(val)
-			if !envVal.IsFromEnv() && envVal.IsRedacted() {
+			secretVal := schemas.NewSecretVar(val)
+			if !secretVal.IsFromEnv() && !secretVal.IsFromVault() && secretVal.IsRedacted() {
 				return existingStr
 			}
 		}

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -85,8 +85,8 @@ func buildUpdateRequest(t *testing.T, body any) *fasthttp.RequestCtx {
 func TestRestoreRedacted_OTELProfilesHeaders(t *testing.T) {
 	realAuth := "Basic-REAL-SUPER-SECRET-VALUE"
 	realVersion := "4"
-	maskedAuth := schemas.NewEnvVar(realAuth).Redacted().GetValue()       // long -> first4 + **** + last4
-	maskedVersion := schemas.NewEnvVar(realVersion).Redacted().GetValue() // "4" -> "*"
+	maskedAuth := schemas.NewSecretVar(realAuth).Redacted().GetValue()       // long -> first4 + **** + last4
+	maskedVersion := schemas.NewSecretVar(realVersion).Redacted().GetValue() // "4" -> "*"
 
 	mkConfig := func(auth, version string) map[string]any {
 		return map[string]any{
@@ -148,9 +148,9 @@ func TestUpdatePlugin_ConfigMerge(t *testing.T) {
 		"plugins": []any{"logging", "compat"},
 	}
 	existingConfig := map[string]any{
-		"collector_url":    "localhost:4317",
-		"trace_type":       "genai_extension",
-		"protocol":         "grpc",
+		"collector_url":      "localhost:4317",
+		"trace_type":         "genai_extension",
+		"protocol":           "grpc",
 		"plugin_span_filter": spanFilter,
 	}
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2248,26 +2248,25 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 				if forceFileSync || existingVirtualKey.ConfigHash != fileVKHash {
 					logger.Debug("config hash mismatch for virtual key %s, syncing from config file", existingVirtualKey.ID)
 					configData.Governance.VirtualKeys[i].ConfigHash = fileVKHash
-					// This is added for backward compatibility with existing configs
-					if configData.Governance.VirtualKeys[i].Value == "" && existingVirtualKey.Value != "" {
+					// This is added for backward compatibility with existing configs.
+					// The VK value is a SecretVar, so "env.X"/"vault.X" references are resolved on
+					// unmarshal/scan; GetValue() returns the resolved value here.
+					if !configData.Governance.VirtualKeys[i].Value.IsSet() && existingVirtualKey.Value.IsSet() {
 						configData.Governance.VirtualKeys[i].Value = existingVirtualKey.Value
 					}
-					// Process environment variable for virtual key value
-					if strings.HasPrefix(configData.Governance.VirtualKeys[i].Value, "env.") {
-						// Resolving the environment variable value
-						envValue, err := envutils.ProcessEnvValue(configData.Governance.VirtualKeys[i].Value)
-						if err != nil {
-							logger.Warn("failed to process environment variable for virtual key %s: %v", newVirtualKey.ID, err)
-							continue
-						}
-						configData.Governance.VirtualKeys[i].Value = envValue
+					// If the value is an env/vault reference that is currently unresolved, leave the
+					// existing DB entry untouched rather than silently generating a new literal key.
+					vkVal := &configData.Governance.VirtualKeys[i].Value
+					if (vkVal.IsFromEnv() || vkVal.IsFromVault()) && vkVal.GetValue() == "" {
+						logger.Warn("virtual key %s has an unresolved env/vault reference, skipping update to preserve existing credential", newVirtualKey.ID)
+						break
 					}
 					// If the virtual key value is not a valid virtual key, we will generate a new one
-					if !strings.HasPrefix(configData.Governance.VirtualKeys[i].Value, governance.VirtualKeyPrefix) {
-						if configData.Governance.VirtualKeys[i].Value != "" {
+					if !strings.HasPrefix(configData.Governance.VirtualKeys[i].Value.GetValue(), governance.VirtualKeyPrefix) {
+						if configData.Governance.VirtualKeys[i].Value.IsSet() {
 							logger.Warn("virtual key %s has a value in the config file that does not have %s prefix. We are generating a new one for you.", newVirtualKey.ID, governance.VirtualKeyPrefix)
 						}
-						configData.Governance.VirtualKeys[i].Value = governance.GenerateVirtualKey()
+						configData.Governance.VirtualKeys[i].Value = *schemas.NewSecretVar(governance.GenerateVirtualKey())
 					}
 					// Resolve MCP client names to IDs for config file mcp_configs
 					configData.Governance.VirtualKeys[i].MCPConfigs = resolveMCPConfigClientIDs(
@@ -2285,22 +2284,19 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 			if configData.Governance.VirtualKeys[i].ID == "" {
 				configData.Governance.VirtualKeys[i].ID = uuid.NewString()
 			}
-			// if the virtual key value is env.VIRTUAL_KEY_VALUE, then we will need to resolve the environment variable
-			// Process environment variable for virtual key value
-			if strings.HasPrefix(configData.Governance.VirtualKeys[i].Value, "env.") {
-				// Resolving the environment variable value
-				envValue, err := envutils.ProcessEnvValue(configData.Governance.VirtualKeys[i].Value)
-				if err != nil {
-					logger.Warn("failed to process environment variable for virtual key %s: %v", newVirtualKey.ID, err)
-					continue
-				}
-				configData.Governance.VirtualKeys[i].Value = envValue
+			// If the value is an env/vault reference that is currently unresolved, skip creating
+			// the entry. It will be created on the next sync once the reference resolves.
+			newVKVal := &configData.Governance.VirtualKeys[i].Value
+			if (newVKVal.IsFromEnv() || newVKVal.IsFromVault()) && newVKVal.GetValue() == "" {
+				logger.Warn("virtual key %s has an unresolved env/vault reference, skipping creation until reference resolves", newVirtualKey.ID)
+				continue
 			}
-			if !strings.HasPrefix(configData.Governance.VirtualKeys[i].Value, governance.VirtualKeyPrefix) {
-				if configData.Governance.VirtualKeys[i].Value != "" {
+			// The VK value is a SecretVar; "env.X"/"vault.X" references are resolved on unmarshal/scan.
+			if !strings.HasPrefix(configData.Governance.VirtualKeys[i].Value.GetValue(), governance.VirtualKeyPrefix) {
+				if configData.Governance.VirtualKeys[i].Value.IsSet() {
 					logger.Warn("virtual key %s has a value in the config file that does not have %s prefix. We are generating a new one for you.", newVirtualKey.ID, governance.VirtualKeyPrefix)
 				}
-				configData.Governance.VirtualKeys[i].Value = governance.GenerateVirtualKey()
+				configData.Governance.VirtualKeys[i].Value = *schemas.NewSecretVar(governance.GenerateVirtualKey())
 			}
 			// Resolve MCP client names to IDs for config file mcp_configs
 			configData.Governance.VirtualKeys[i].MCPConfigs = resolveMCPConfigClientIDs(

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -2211,7 +2211,7 @@ func makeVirtualKey(id, name, value string) tables.TableVirtualKey {
 		ID:          id,
 		Name:        name,
 		Description: "Test virtual key",
-		Value:       value,
+		Value:       *schemas.NewSecretVar(value),
 		IsActive:    schemas.Ptr(true),
 	}
 }
@@ -2222,7 +2222,7 @@ func makeVirtualKeyWithTeam(id, name, value, teamID string) tables.TableVirtualK
 		ID:          id,
 		Name:        name,
 		Description: "Test virtual key with team",
-		Value:       value,
+		Value:       *schemas.NewSecretVar(value),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -2234,7 +2234,7 @@ func makeVirtualKeyWithCustomer(id, name, value, customerID string) tables.Table
 		ID:          id,
 		Name:        name,
 		Description: "Test virtual key with customer",
-		Value:       value,
+		Value:       *schemas.NewSecretVar(value),
 		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
@@ -2246,7 +2246,7 @@ func makeVirtualKeyWithProviderConfigs(id, name, value string, providerConfigs [
 		ID:              id,
 		Name:            name,
 		Description:     "Test virtual key with provider configs",
-		Value:           value,
+		Value:           *schemas.NewSecretVar(value),
 		IsActive:        schemas.Ptr(true),
 		ProviderConfigs: providerConfigs,
 	}
@@ -7105,7 +7105,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7125,7 +7125,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "different-id", // Different ID - should be skipped
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7144,7 +7144,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "different-name", // Different name
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7163,7 +7163,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_different", // Different value
+		Value:       *schemas.NewSecretVar("vk_different"), // Different value
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7182,7 +7182,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(false), // Different IsActive
 		TeamID:      &teamID,
 	}
@@ -7202,7 +7202,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &differentTeamID, // Different TeamID
 	}
@@ -7221,7 +7221,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Different description", // Different description
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7241,7 +7241,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &customerID, // CustomerID set
@@ -7262,7 +7262,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &differentCustomerID, // Different CustomerID
@@ -7283,7 +7283,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID, // RateLimitID set
@@ -7304,7 +7304,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &differentRateLimitID, // Different RateLimitID
@@ -7331,7 +7331,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -7363,7 +7363,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -7391,7 +7391,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -7426,7 +7426,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -7452,7 +7452,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -7478,7 +7478,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -7509,7 +7509,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7526,7 +7526,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &dbTeamID,
 		ConfigHash:  fileHash, // Same hash as file
@@ -7559,7 +7559,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "old-name", // Old name
 		Description: "Old description",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7576,7 +7576,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "new-name", // Updated name
 		Description: "New description",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &fileTeamID,
 	}
@@ -7607,7 +7607,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 		ID:          "vk-dashboard",
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
-		Value:       "vk_dashboard123",
+		Value:       *schemas.NewSecretVar("vk_dashboard123"),
 		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 		RateLimitID: &rateLimitID,
@@ -7625,7 +7625,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 			ID:          "vk-file",
 			Name:        "file-vk",
 			Description: "From config.json",
-			Value:       "vk_file123",
+			Value:       *schemas.NewSecretVar("vk_file123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -7655,7 +7655,7 @@ func TestVirtualKeyHashComparison_NewVirtualKey(t *testing.T) {
 		ID:          "vk-new",
 		Name:        "new-vk",
 		Description: "New virtual key from config.json",
-		Value:       "vk_new123",
+		Value:       *schemas.NewSecretVar("vk_new123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7697,7 +7697,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 	}
 
@@ -7712,7 +7712,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7732,7 +7732,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
@@ -7756,7 +7756,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
@@ -7782,7 +7782,7 @@ func TestVirtualKeyHashComparison_FieldValueChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Base description",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7845,7 +7845,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID,
@@ -7875,7 +7875,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &reloadTeamID,
 		RateLimitID: &reloadRateLimitID,
@@ -8615,7 +8615,7 @@ func TestSQLite_VirtualKey_HashMismatch_FileSync(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "modified-name",
 			Description: "Modified description",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -8668,7 +8668,7 @@ func TestSQLite_VirtualKey_DBOnlyVK_Preserved(t *testing.T) {
 		ID:          "vk-dashboard",
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
-		Value:       "vk_dashboard456",
+		Value:       *schemas.NewSecretVar("vk_dashboard456"),
 		IsActive:    schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
@@ -8717,7 +8717,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK with provider configs",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -8755,7 +8755,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "VK with provider configs",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -8810,7 +8810,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigs(t *testing.T) {
 			ID:          "vk-2",
 			Name:        "vk-with-providers",
 			Description: "VK with provider configs added via merge",
-			Value:       "vk_providers456",
+			Value:       *schemas.NewSecretVar("vk_providers456"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -8923,7 +8923,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigKeys(t *testing.T) {
 			ID:          "vk-2",
 			Name:        "vk-with-provider-keys",
 			Description: "VK with provider configs referencing keys",
-			Value:       "vk_keys456",
+			Value:       *schemas.NewSecretVar("vk_keys456"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -8981,7 +8981,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -8998,7 +8998,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9030,7 +9030,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9071,7 +9071,7 @@ func TestSQLite_VKProviderConfig_NewConfig(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "vk-with-provider-config",
 			Description: "VK with provider configs",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -9142,7 +9142,7 @@ func TestSQLite_VKProviderConfig_KeyReference(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "vk-with-provider-ref",
 			Description: "VK with provider config",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -9194,7 +9194,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9212,7 +9212,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9244,7 +9244,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9277,7 +9277,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9293,7 +9293,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9309,7 +9309,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9352,7 +9352,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9440,7 +9440,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				ID:          "vk-1",
 				Name:        "test-vk-1",
 				Description: "Test virtual key 1",
-				Value:       "vk_test123",
+				Value:       *schemas.NewSecretVar("vk_test123"),
 				IsActive:    schemas.Ptr(true),
 				RateLimitID: &rateLimitID,
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
@@ -9455,7 +9455,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				ID:          "vk-2",
 				Name:        "test-vk-2",
 				Description: "Test virtual key 2",
-				Value:       "vk_test456",
+				Value:       *schemas.NewSecretVar("vk_test456"),
 				IsActive:    schemas.Ptr(true),
 			},
 		},
@@ -9695,7 +9695,7 @@ func TestSQLite_FullLifecycle_DashboardEdits_ThenFileUnchanged(t *testing.T) {
 		ID:          "vk-dashboard",
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
-		Value:       "vk_dashboard456",
+		Value:       *schemas.NewSecretVar("vk_dashboard456"),
 		IsActive:    schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
@@ -9758,7 +9758,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 	}
 
@@ -9767,7 +9767,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -9782,7 +9782,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -9797,7 +9797,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -9812,7 +9812,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -9876,7 +9876,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -9917,7 +9917,7 @@ func TestSQLite_VirtualKey_WithMCPConfigs(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK with MCP config",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -10006,7 +10006,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -10077,7 +10077,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
@@ -10173,7 +10173,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -10237,7 +10237,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -10328,7 +10328,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -10413,7 +10413,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
@@ -10498,7 +10498,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -10534,7 +10534,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
@@ -10566,7 +10566,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
@@ -10643,7 +10643,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool1", "tool2"}},
@@ -10668,7 +10668,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "Test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool3", "tool4", "tool5"}}, // Different tools
@@ -10740,7 +10740,7 @@ func TestSQLite_VK_ProviderAndMCPConfigs_Combined(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "combined-vk",
 			Description: "VK with both provider and MCP configs",
-			Value:       "vk_combined123",
+			Value:       *schemas.NewSecretVar("vk_combined123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -11161,7 +11161,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11193,7 +11193,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11225,7 +11225,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11285,7 +11285,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11303,7 +11303,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11321,7 +11321,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11367,7 +11367,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11390,7 +11390,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11413,7 +11413,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11464,7 +11464,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11493,7 +11493,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11522,7 +11522,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11579,7 +11579,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11596,7 +11596,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11613,7 +11613,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11658,7 +11658,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11700,7 +11700,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -13870,7 +13870,7 @@ func TestUpdateGovernanceConfigInStore_RejectsSharedGovernanceIDs(t *testing.T) 
 		require.NoError(t, cfg.ConfigStore.CreateVirtualKey(ctx, &tables.TableVirtualKey{
 			ID:       "vk-rl-owner",
 			Name:     "vk-rl-owner",
-			Value:    "vk-rl-owner-value",
+			Value:    *schemas.NewSecretVar("vk-rl-owner-value"),
 			IsActive: schemas.Ptr(true),
 		}))
 		require.NoError(t, cfg.ConfigStore.CreateVirtualKeyProviderConfig(ctx, &tables.TableVirtualKeyProviderConfig{
@@ -15000,7 +15000,7 @@ func TestVKProviderConfig_WeightZeroPreserved(t *testing.T) {
 	vk := tables.TableVirtualKey{
 		ID:       "vk-zero-weight",
 		Name:     "test-vk",
-		Value:    "vk_test123",
+		Value:    *schemas.NewSecretVar("vk_test123"),
 		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -15058,7 +15058,7 @@ func TestSQLite_VKProviderConfig_WeightZero_RoundTrip(t *testing.T) {
 		{
 			ID:       "vk-zero-weight",
 			Name:     "test-vk",
-			Value:    "vk_abc123",
+			Value:    *schemas.NewSecretVar("vk_abc123"),
 			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -18146,11 +18146,11 @@ func TestSQLite_GetVirtualKeysPaginated(t *testing.T) {
 	}
 
 	vks := []tables.TableVirtualKey{
-		{ID: "vk-1", Name: "alpha-key", Value: "val-1", IsActive: schemas.Ptr(true), TeamID: &team1},
-		{ID: "vk-2", Name: "beta-key", Value: "val-2", IsActive: schemas.Ptr(true), TeamID: &team2},
-		{ID: "vk-3", Name: "alpha-test", Value: "val-3", IsActive: schemas.Ptr(true), CustomerID: &cust1},
-		{ID: "vk-4", Name: "gamma-key", Value: "val-4", IsActive: schemas.Ptr(true), CustomerID: &cust2},
-		{ID: "vk-5", Name: "delta-key", Value: "val-5", IsActive: schemas.Ptr(true), TeamID: &team1},
+		{ID: "vk-1", Name: "alpha-key", Value: *schemas.NewSecretVar("val-1"), IsActive: schemas.Ptr(true), TeamID: &team1},
+		{ID: "vk-2", Name: "beta-key", Value: *schemas.NewSecretVar("val-2"), IsActive: schemas.Ptr(true), TeamID: &team2},
+		{ID: "vk-3", Name: "alpha-test", Value: *schemas.NewSecretVar("val-3"), IsActive: schemas.Ptr(true), CustomerID: &cust1},
+		{ID: "vk-4", Name: "gamma-key", Value: *schemas.NewSecretVar("val-4"), IsActive: schemas.Ptr(true), CustomerID: &cust2},
+		{ID: "vk-5", Name: "delta-key", Value: *schemas.NewSecretVar("val-5"), IsActive: schemas.Ptr(true), TeamID: &team1},
 	}
 	for i := range vks {
 		err := store.CreateVirtualKey(ctx, &vks[i])

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -400,8 +400,8 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 	}
 	if governanceData := governancePlugin.GetGovernanceStore().GetGovernanceData(ctx); governanceData != nil {
 		for _, existingVK := range governanceData.VirtualKeys {
-			if existingVK != nil && existingVK.ID == virtualKey.ID && existingVK.Value != "" && existingVK.Value != virtualKey.Value {
-				s.MCPServerHandler.DeleteVKMCPServer(existingVK.Value)
+			if existingVK != nil && existingVK.ID == virtualKey.ID && existingVK.Value.GetValue() != "" && existingVK.Value.GetValue() != virtualKey.Value.GetValue() {
+				s.MCPServerHandler.DeleteVKMCPServer(existingVK.Value.GetValue())
 				break
 			}
 		}
@@ -445,7 +445,7 @@ func (s *BifrostHTTPServer) RemoveVirtualKey(ctx context.Context, id string) err
 		return nil
 	}
 	governancePlugin.GetGovernanceStore().DeleteVirtualKeyInMemory(ctx, id)
-	s.MCPServerHandler.DeleteVKMCPServer(preloadedVk.Value)
+	s.MCPServerHandler.DeleteVKMCPServer(preloadedVk.Value.GetValue())
 	return nil
 }
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -703,7 +703,7 @@
               },
               "value": {
                 "type": "string",
-                "description": "The virtual key value"
+                "description": "The virtual key value. A literal, or an \"env.VAR\"/\"vault.path\" reference resolved to plaintext at load time."
               },
               "is_active": {
                 "type": "boolean",

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/commandBuilders.ts
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/commandBuilders.ts
@@ -1,5 +1,5 @@
 import type { CoreConfig } from "@/lib/types/config";
-import type { VirtualKey } from "@/lib/types/governance";
+import { resolveVirtualKeyValue, type VirtualKey } from "@/lib/types/governance";
 import type { MCPClient } from "@/lib/types/mcp";
 import type { ClaudeScope } from "./types";
 import { encodeBase64, getExternalBaseUrl, getIncludeClients, getRegistrationName, quoteShellValue, quoteTomlString } from "./utils";
@@ -22,7 +22,7 @@ export function buildClaudeCodeCommand({
 
 	const lines = [
 		`claude mcp add --transport http ${quoteShellValue(registrationName)} --scope ${scope} ${quoteShellValue(gatewayUrl)} \\`,
-		`  --header ${quoteShellValue(`x-bf-vk: ${virtualKey.value}`)}`,
+		`  --header ${quoteShellValue(`x-bf-vk: ${resolveVirtualKeyValue(virtualKey.value)}`)}`,
 	];
 
 	const includeClients = getIncludeClients(selectedServers);
@@ -49,7 +49,7 @@ export function buildCodexConfig({
 	const registrationName = getRegistrationName(selectedServers);
 	const includeClients = getIncludeClients(selectedServers);
 
-	const headerEntries = [`"x-bf-vk" = ${quoteTomlString(virtualKey.value)}`];
+	const headerEntries = [`"x-bf-vk" = ${quoteTomlString(resolveVirtualKeyValue(virtualKey.value))}`];
 	if (includeClients) {
 		headerEntries.push(`"x-bf-mcp-include-clients" = ${quoteTomlString(includeClients)}`);
 	}
@@ -74,7 +74,7 @@ function buildCursorServer({
 }): { name: string; server: { url: string; headers: Record<string, string> } } {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
+	const headers: Record<string, string> = { "x-bf-vk": resolveVirtualKeyValue(virtualKey.value) };
 
 	const includeClients = getIncludeClients(selectedServers);
 	if (includeClients) {
@@ -113,7 +113,7 @@ export function buildWindsurfConfig({
 }): string {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
+	const headers: Record<string, string> = { "x-bf-vk": resolveVirtualKeyValue(virtualKey.value) };
 
 	const includeClients = getIncludeClients(selectedServers);
 	if (includeClients) {
@@ -147,7 +147,7 @@ function buildVSCodeServer({
 }): { name: string; server: { type: "http"; url: string; headers: Record<string, string> } } {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
+	const headers: Record<string, string> = { "x-bf-vk": resolveVirtualKeyValue(virtualKey.value) };
 
 	const includeClients = getIncludeClients(selectedServers);
 	if (includeClients) {
@@ -190,7 +190,7 @@ export function buildOpenCodeConfig({
 }): string {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
+	const headers: Record<string, string> = { "x-bf-vk": resolveVirtualKeyValue(virtualKey.value) };
 
 	const includeClients = getIncludeClients(selectedServers);
 	if (includeClients) {
@@ -227,7 +227,7 @@ export function buildAntigravityConfig({
 }): string {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
+	const headers: Record<string, string> = { "x-bf-vk": resolveVirtualKeyValue(virtualKey.value) };
 
 	const includeClients = getIncludeClients(selectedServers);
 	if (includeClients) {

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/mcpUsageGuideSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/mcpUsageGuideSheet.tsx
@@ -13,6 +13,7 @@ import { HARNESSES } from "./harnesses";
 import { PlatformSelect } from "./platformSelect";
 import type { HarnessID, HarnessPlatform, ServerScope, VirtualKeyOption } from "./types";
 import { isClientAllowedForVirtualKey, maskSecret } from "./utils";
+import { resolveVirtualKeyValue } from "@/lib/types/governance";
 
 // Literal value sets driving the URL-persisted enums.
 const HARNESS_IDS = HARNESSES.map((h) => h.id);
@@ -195,7 +196,7 @@ export function MCPUsageGuideSheet() {
 										<span className="truncate">{selectedVirtualKey?.name ?? "Search virtual keys"}</span>
 										{selectedVirtualKey && (
 											<span className="text-muted-foreground ml-auto hidden font-mono text-xs sm:inline">
-												{maskSecret(selectedVirtualKey.value)}
+												{maskSecret(resolveVirtualKeyValue(selectedVirtualKey.value))}
 											</span>
 										)}
 									</Button>
@@ -204,7 +205,7 @@ export function MCPUsageGuideSheet() {
 									<div className="flex min-w-0 flex-1 items-center gap-2">
 										<div className="flex min-w-0 flex-col">
 											<span className="truncate font-medium">{option.label}</span>
-											<span className="text-muted-foreground text-xs">{maskSecret(option.virtualKey.value)}</span>
+											<span className="text-muted-foreground text-xs">{maskSecret(resolveVirtualKeyValue(option.virtualKey.value))}</span>
 										</div>
 										{selectedVirtualKey?.id === option.virtualKey.id && <Check className="ml-auto size-4 text-green-600" />}
 									</div>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -32,7 +32,7 @@ import {
 	useLazyGetVirtualKeysQuery,
 	useUpdateVirtualKeyMutation,
 } from "@/lib/store";
-import { Customer, Team, VirtualKey } from "@/lib/types/governance";
+import { Customer, resolveVirtualKeyValue, Team, VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -882,7 +882,7 @@ export default function VirtualKeysTable({
 											<TableCell onClick={(e) => e.stopPropagation()}>
 												<div className="flex items-center gap-2">
 													<code className="cursor-default py-1 font-mono text-sm" data-testid="vk-key-value">
-														{maskKey(vk.value, isRevealed)}
+														{maskKey(resolveVirtualKeyValue(vk.value), isRevealed)}
 													</code>
 													<div className="flex items-center">
 														<Button
@@ -896,7 +896,7 @@ export default function VirtualKeysTable({
 														<Button
 															variant="ghost"
 															size="sm"
-															onClick={() => copyToClipboard(vk.value)}
+															onClick={() => copyToClipboard(resolveVirtualKeyValue(vk.value))}
 															data-testid={`vk-copy-btn-${vk.name}`}
 														>
 															<Copy className="h-4 w-4" />

--- a/ui/components/prompts/components/apiKeySelectorView.tsx
+++ b/ui/components/prompts/components/apiKeySelectorView.tsx
@@ -9,7 +9,7 @@ import {
 	ComboboxSeparator,
 } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
-import type { DBKey, VirtualKey } from "@/lib/types/governance";
+import { resolveVirtualKeyValue, type DBKey, type VirtualKey } from "@/lib/types/governance";
 import { useCallback, useMemo, useState } from "react";
 
 export function ApiKeySelectorView({
@@ -31,7 +31,7 @@ export function ApiKeySelectorView({
 
 	const allOptions = useMemo(() => {
 		const apiKeyOpts = providerKeys.map((k) => ({ label: k.name, value: k.key_id, group: "api" as const }));
-		const vkOpts = virtualKeys.map((vk) => ({ label: vk.name, value: vk.value, group: "virtual" as const }));
+		const vkOpts = virtualKeys.map((vk) => ({ label: vk.name, value: resolveVirtualKeyValue(vk.value), group: "virtual" as const }));
 		return [{ label: "Auto (default)", value: "__auto__", group: "api" as const }, ...apiKeyOpts, ...vkOpts];
 	}, [providerKeys, virtualKeys]);
 

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { Input } from "@/components/ui/input";
 import { useGetVirtualKeysQuery } from "@/lib/store";
+import { resolveVirtualKeyValue } from "@/lib/types/governance";
 import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
 import { ModelProviderName } from "@/lib/types/config";
 import { ModelParams } from "@/lib/types/prompts";
@@ -109,7 +110,7 @@ export function SettingsPanel() {
 	}, [apiKeyId, providerKeys, providerVirtualKeys]);
 
 	const filterVks = useMemo(() => {
-		const virtualKey = providerVirtualKeys.find((vk) => vk.value === apiKeyId);
+		const virtualKey = providerVirtualKeys.find((vk) => resolveVirtualKeyValue(vk.value) === apiKeyId);
 		if (virtualKey) return [virtualKey.id];
 		return undefined;
 	}, [apiKeyId, providerVirtualKeys]);

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -1,6 +1,15 @@
 // Governance types that match the Go backend structures
 
 import { ModelProviderName, RequestType } from "./config";
+import { SecretVar } from "./schemas";
+
+// resolveVirtualKeyValue returns the display/usable string for a virtual key value, which the API
+// may return either as a bare string (legacy) or a SecretVar object (value sourced from env/vault).
+export function resolveVirtualKeyValue(value: string | SecretVar | undefined): string {
+	if (value == null) return "";
+	if (typeof value === "string") return value;
+	return value.value ?? "";
+}
 
 export interface Budget {
 	id: string;
@@ -66,7 +75,7 @@ export interface RedactedDBKey {
 export interface VirtualKey {
 	id: string;
 	name: string;
-	value: string; // The actual key value
+	value: string | SecretVar; // The key value; a SecretVar object when sourced from env/vault
 	description?: string;
 	provider_configs?: VirtualKeyProviderConfig[];
 	mcp_configs?: VirtualKeyMCPConfig[];
@@ -156,6 +165,7 @@ export interface VirtualKeyProviderConfigUpdateRequest {
 export interface CreateVirtualKeyRequest {
 	name: string;
 	description?: string;
+	value?: string | SecretVar; // Optional; a literal, "env.X"/"vault.X" string, or SecretVar object. Generated server-side when omitted
 	provider_configs?: VirtualKeyProviderConfigRequest[];
 	mcp_configs?: VirtualKeyMCPConfigRequest[];
 	team_id?: string;


### PR DESCRIPTION
## Summary

Virtual key values can now be sourced from environment variables or vault references (`env.X` / `vault.X`) rather than only from literal strings. The resolved plaintext is stored in the existing `Value` column (preserving hash-based lookup and auth), while a new `value_source_ref` column persists the original reference so the `SecretVar` shape survives a DB round-trip.

## Changes

- **`TableVirtualKey` struct** — `Value` is now `json:"-"` (excluded from direct marshalling). Two new fields are added: `ValueSourceRef` (persisted, encrypted) stores the `env.X`/`vault.X` reference; `ValueSource` (transient, `gorm:"-"`) holds the runtime `SecretVar`. Custom `MarshalJSON`/`UnmarshalJSON` handle both bare strings and `SecretVar` objects for the `value` JSON field, redacting resolved secrets for env/vault sources.
- **`BeforeSave` / `AfterFind`** — `ValueSourceRef` is encrypted alongside `Value` on write and decrypted on read; `AfterFind` reconstructs `ValueSource` from the stored plaintext and reference without re-resolving the live environment, keeping it consistent with the hashed value.
- **Database migration** — `add_virtual_key_value_source_ref_column` adds the `value_source_ref` column to `governance_virtual_keys`. Existing rows default to `NULL`/`""` (literal value); no backfill is needed.
- **`UpdateVirtualKey`** — `value_source_ref` is included in the explicit `Select` column list so updates persist the reference.
- **`GenerateVirtualKeyHash`** — `ValueSourceRef` is now included in the hash so a changed env/vault reference triggers a config resync.
- **`mergeGovernanceConfig`** — Removed the inline `env.` prefix resolution logic; env/vault references are now resolved during `TableVirtualKey.UnmarshalJSON`, so `Value` already holds the plaintext by the time the merge runs. `ValueSourceRef` and `ValueSource` are propagated from the existing DB record when the value is carried forward.
- **`CreateVirtualKeyRequest`** — Accepts an optional `value` field (literal, reference string, or `SecretVar` object). When omitted, a value is generated server-side as before.
- **Config schema** — `value` under `virtual_keys` is updated from `type: string` to `anyOf: [string, object]` to accept `SecretVar` objects.
- **SQLite store** — `RegisterVaultCallbacks` is now called on the SQLite DB at init, consistent with the Postgres path.
- **`schemasync` ignore list** — The `value` property is added to the ignore list with an explanation of the custom marshalling.
- **UI (`governance.ts`)** — `VirtualKey.value` is typed as `string | SecretVar`. A `resolveVirtualKeyValue` helper extracts the usable string from either form. All UI call sites (virtual keys table, MCP usage guide, prompt settings panel, API key selector) use this helper instead of accessing `.value` directly.
- **Tests** — `virtualkey_secretvar_test.go` covers env-sourced, vault-sourced, and literal round-trips; hash stability across sources; `MarshalJSON` redaction; and `UnmarshalJSON` accepting bare strings, reference strings, and `SecretVar` objects.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./framework/configstore/tables/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

To exercise env-sourced virtual keys end-to-end:
1. Set an environment variable, e.g. `export MY_VK=sk-bf-test-abc123`.
2. Create a virtual key via the API with `"value": "env.MY_VK"` or `"value": {"from_env": true, "env_var": "env.MY_VK"}`.
3. Confirm the response shows `"value": {"from_env": true, "env_var": "env.MY_VK"}` with the resolved secret redacted.
4. Confirm the `x-bf-vk` auth path still works with the resolved plaintext value.
5. Restart the service and confirm the virtual key is reconstructed correctly from the DB without re-reading the environment.

## Breaking changes

- [x] Yes
- [ ] No

The `value` field on `VirtualKey` in the API response changes from a bare string to a `SecretVar` object for env/vault-sourced keys. Consumers that assumed `value` is always a string will need to handle the object form. Literal-value keys continue to emit a plain string in `value.value` with no other fields set, so the impact is limited to env/vault-sourced keys. The UI is updated accordingly.

## Security considerations

- Resolved plaintext virtual key values are never emitted in API responses for env/vault-sourced keys; only the reference and source flags are returned.
- `ValueSourceRef` is encrypted at rest alongside `Value` using the same encryption path.
- `AfterFind` does not re-resolve the live environment on read, preventing a class of TOCTOU issues where the env var changes after the key is created.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable