### PR TITLE
feat: add JWT Bearer authentication path for `/mcp` with session validation and context injection

### DIFF
--- a/core/mcp/credstore/per_user_headers.go
+++ b/core/mcp/credstore/per_user_headers.go
@@ -88,6 +88,11 @@ func (r *perUserHeadersResolver) buildAuthRequiredError(ctx *schemas.BifrostCont
 		// can't accidentally start flow rows with empty identity columns.
 		return fmt.Errorf("per-user headers auth-required flow requires an identity")
 	}
+	// No identity gate here (see per_user_oauth.go for the rationale). For
+	// user-mode flows the submission is verified at the cookie-bearing UI step
+	// (flowSubmit → canAccessUserFlow requires the dashboard user to match
+	// flow.UserID, and user-mode flows mint no shareable temp token); the flow
+	// row created here grants nothing on its own.
 	initiation, err := r.provider.InitiateUserSubmissionFlow(ctx, mode, identity, config.ID, baseURL)
 	if err != nil {
 		return fmt.Errorf("failed to initiate per-user headers submission flow for %s: %w", config.Name, err)

--- a/core/mcp/credstore/per_user_oauth.go
+++ b/core/mcp/credstore/per_user_oauth.go
@@ -57,6 +57,13 @@ func (r *perUserOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, co
 		if redirectURI == "" {
 			return nil, fmt.Errorf("per-user OAuth requires a redirect URI but none is available in context")
 		}
+		// No identity gate here. A user-mode caller (e.g. an MCP client presenting
+		// only a Bearer JWT) carries no dashboard session at tool-call time. The
+		// flow row records the caller's identity (flow.UserID = bf_sub); the binding
+		// is verified at the cookie-bearing UI step (flowStart → canAccessUserFlow)
+		// before the upstream authorize URL — which carries the single-use state — is
+		// ever revealed, and the callback binds the token to the flow's recorded
+		// identity. So initiating the flow here grants nothing on its own.
 		flowInitiation, sessionID, flowErr := r.provider.InitiateUserOAuthFlow(ctx, *config.OauthConfigID, config.ID, redirectURI, mode)
 		if flowErr != nil {
 			return nil, fmt.Errorf("failed to initiate per-user OAuth flow for %s: %w", config.Name, flowErr)

--- a/transports/bifrost-http/handlers/mcpoauth2jwt.go
+++ b/transports/bifrost-http/handlers/mcpoauth2jwt.go
@@ -1,0 +1,142 @@
+package handlers
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/maximhq/bifrost/core/schemas"
+	configtables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// jwtMCPClaims are the custom claims embedded in Bifrost-issued /mcp JWTs.
+type jwtMCPClaims struct {
+	jwt.RegisteredClaims
+	BfMode string `json:"bf_mode"` // user | vk | session
+	Scope  string `json:"scope"`
+}
+
+// extractBearerJWT returns the raw JWT string from an Authorization: Bearer
+// header when the token looks like a JWT (starts with "eyJ"). Returns empty
+// string when the header is absent or the token is a VK (starts with "sk-bf-").
+func extractBearerJWT(ctx *fasthttp.RequestCtx) string {
+	auth := strings.TrimSpace(string(ctx.Request.Header.Peek("Authorization")))
+	if auth == "" {
+		return ""
+	}
+	if !strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+		return ""
+	}
+	token := strings.TrimSpace(auth[7:])
+	// JWTs are base64url-encoded JSON starting with '{', which encodes to "eyJ".
+	// VKs start with the "sk-bf-" prefix. Anything not starting with "eyJ" is
+	// treated as a non-JWT credential and left to the VK path.
+	if !strings.HasPrefix(token, "eyJ") {
+		return ""
+	}
+	return token
+}
+
+// verifyMCPJWT parses and verifies a Bifrost-issued JWT for the /mcp endpoint.
+// It validates the RS256 signature using the active signing key, checks the
+// audience matches the canonical /mcp resource URL (RFC 8707), and returns
+// the verified claims.
+func verifyMCPJWT(ctx *fasthttp.RequestCtx, rawToken string, store *lib.Config) (*jwtMCPClaims, error) {
+	if store.ConfigStore == nil {
+		return nil, fmt.Errorf("config store unavailable")
+	}
+
+	signingKey, err := store.ConfigStore.GetOAuth2SigningKey(ctx)
+	if err != nil || signingKey == nil {
+		return nil, fmt.Errorf("signing key unavailable")
+	}
+
+	privKey, err := parseRSAPrivateKeyPEM(signingKey.PrivateKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signing key: %w", err)
+	}
+	pubKey := &privKey.PublicKey
+
+	// Pin the issuer to this instance: the kid + signature checks only prove the
+	// token was signed by our key, so a different authorization server sharing
+	// the same keypair would otherwise pass. Issuance stamps iss from the same
+	// oauth2IssuerURL, so the two always agree.
+	issuer := oauth2IssuerURL(ctx, store)
+
+	claims := &jwtMCPClaims{}
+	tok, err := jwt.ParseWithClaims(rawToken, claims, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		if kid, _ := t.Header["kid"].(string); kid != signingKey.KID {
+			return nil, fmt.Errorf("unknown key id %q", kid)
+		}
+		return pubKey, nil
+	}, jwt.WithExpirationRequired(), jwt.WithIssuedAt(), jwt.WithIssuer(issuer),
+		// Accept exactly the algorithm we issue. The SigningMethodRSA type
+		// assertion above admits the whole RS family (RS256/384/512); pin to
+		// RS256 so verification matches issuance.
+		jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}))
+	if err != nil {
+		return nil, fmt.Errorf("invalid token: %w", err)
+	}
+	if !tok.Valid {
+		return nil, fmt.Errorf("token is not valid")
+	}
+	// WithIssuedAt only validates iat when present; require it, since every
+	// token we issue stamps one.
+	if claims.IssuedAt == nil {
+		return nil, fmt.Errorf("token missing iat claim")
+	}
+
+	// RFC 8707: the token must have been issued for this specific resource.
+	resource := oauth2MCPResourceURL(ctx, store)
+	aud, err := claims.GetAudience()
+	if err != nil || !slices.Contains(aud, resource) {
+		return nil, fmt.Errorf("token audience does not match this resource")
+	}
+
+	return claims, nil
+}
+
+// injectJWTContext sets the identity context keys from verified JWT claims,
+// mirroring what header auth sets today so everything downstream (governance,
+// per-user upstream OAuth, tool-group filtering) works unchanged.
+//
+// bf_mode=user    → BifrostContextKeyUserID
+// bf_mode=vk      → BifrostContextKeyVirtualKey (governance derives the VK row ID from it)
+// bf_mode=session → BifrostContextKeyMCPSessionID
+func injectJWTContext(bifrostCtx *schemas.BifrostContext, claims *jwtMCPClaims, vk *configtables.TableVirtualKey) error {
+	sub := claims.Subject
+	if sub == "" {
+		return fmt.Errorf("JWT missing sub claim")
+	}
+	switch schemas.MCPAuthMode(claims.BfMode) {
+	case schemas.MCPAuthModeUser:
+		bifrostCtx.SetValue(schemas.BifrostContextKeyUserID, sub)
+	case schemas.MCPAuthModeVK:
+		if vk == nil {
+			return fmt.Errorf("VK not provided for vk-mode JWT injection")
+		}
+		// Set the VK value only. Governance's PreMCPConnectionHook resolves it to
+		// the VK row ID (BifrostContextKeyGovernanceVirtualKeyID) on the connect
+		// path before the per-user credential resolver needs it — the same way the
+		// x-bf-vk header path does, which never stamps the row ID at ingress either.
+		bifrostCtx.SetValue(schemas.BifrostContextKeyVirtualKey, vk.Value)
+	case schemas.MCPAuthModeSession:
+		bifrostCtx.SetValue(schemas.BifrostContextKeyMCPSessionID, sub)
+	default:
+		return fmt.Errorf("unknown bf_mode %q in JWT", claims.BfMode)
+	}
+	return nil
+}
+
+// wwwAuthenticateValue returns the WWW-Authenticate header value pointing at
+// the /mcp resource metadata endpoint, per RFC 9728 §5.
+func wwwAuthenticateValue(ctx *fasthttp.RequestCtx, store *lib.Config) string {
+	base := oauth2IssuerURL(ctx, store)
+	return fmt.Sprintf(`Bearer resource_metadata="%s/.well-known/oauth-protected-resource/mcp"`, base)
+}

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -42,11 +42,15 @@ type MCPServerHandler struct {
 	globalMCPServer *server.MCPServer
 	vkMCPServers    map[string]*server.MCPServer // Map of vk value -> mcp server
 	config          *lib.Config
-	mu              sync.RWMutex
+	// identityResolver scopes a user-mode /mcp request to the user's own tools by
+	// resolving a representative virtual key. Optional: when nil, user-mode
+	// requests fall back to the global server.
+	identityResolver OAuth2IdentityResolver
+	mu               sync.RWMutex
 }
 
 // NewMCPServerHandler creates a new MCP server handler instance
-func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MCPToolManager) (*MCPServerHandler, error) {
+func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MCPToolManager, identityResolver OAuth2IdentityResolver) (*MCPServerHandler, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
@@ -62,10 +66,11 @@ func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MC
 	)
 
 	handler := &MCPServerHandler{
-		toolManager:     toolManager,
-		globalMCPServer: globalMCPServer,
-		config:          config,
-		vkMCPServers:    make(map[string]*server.MCPServer),
+		toolManager:      toolManager,
+		globalMCPServer:  globalMCPServer,
+		config:           config,
+		vkMCPServers:     make(map[string]*server.MCPServer),
+		identityResolver: identityResolver,
 	}
 
 	// Register per-request tool filter so x-bf-mcp-include-clients and x-bf-mcp-include-tools are respected on tools/list
@@ -81,32 +86,34 @@ func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MC
 	return handler, nil
 }
 
-// RegisterRoutes registers the MCP server route
+// RegisterRoutes registers the MCP server routes.
 func (h *MCPServerHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
 	// MCP server endpoint - supports both POST (JSON-RPC) and GET (SSE)
 	r.POST("/mcp", lib.ChainMiddlewares(h.handleMCPServer, middlewares...))
 	r.GET("/mcp", lib.ChainMiddlewares(h.handleMCPServerSSE, middlewares...))
-	// Bifrost is NOT an OAuth authorization server — auth is via the
-	// x-bf-vk / x-bf-mcp-session-id headers or upstream SSO. Claude Code's
-	// MCP client may proactively POST `/register` (RFC 7591 DCR) on
-	// `claude mcp add` and log "SDK auth failed: ..." when the probe fails,
-	// even though the underlying `/mcp` connection works fine. That warning
-	// is a known Claude Code bug — see
-	// https://github.com/anthropics/claude-code/issues/46640 — and is safe
-	// to ignore. We intentionally do NOT implement an OAuth stub.
 }
 
 func (h *MCPServerHandler) handleMCPServer(ctx *fasthttp.RequestCtx) {
-	mcpServer, err := h.getMCPServerForRequest(ctx)
+	authResult, err := h.getMCPServerForRequest(ctx)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusUnauthorized, err.Error())
 		return
 	}
 
-	// Convert context
 	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
 	bifrostCtx.SetValue(schemas.BifrostContextKeyIsMCPGateway, true)
 	defer cancel()
+
+	// Inject JWT identity into BifrostContext so downstream resolvers
+	// (per-user OAuth, governance, tool-group filtering) see the same context
+	// keys as header-based auth paths.
+	if authResult.jwtClaims != nil {
+		if injErr := injectJWTContext(bifrostCtx, authResult.jwtClaims, authResult.jwtVK); injErr != nil {
+			SendError(ctx, fasthttp.StatusUnauthorized, injErr.Error())
+			return
+		}
+	}
+	mcpServer := authResult.mcpServer
 
 	// Use mcp-go server to handle the request
 	// HandleMessage processes JSON-RPC messages and returns appropriate responses
@@ -132,12 +139,11 @@ func (h *MCPServerHandler) handleMCPServer(ctx *fasthttp.RequestCtx) {
 
 // handleMCPServerSSE handles GET requests for MCP Server-Sent Events streaming
 func (h *MCPServerHandler) handleMCPServerSSE(ctx *fasthttp.RequestCtx) {
-	_, err := h.getMCPServerForRequest(ctx)
+	authResult, err := h.getMCPServerForRequest(ctx)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusUnauthorized, err.Error())
 		return
 	}
-
 	// Signal to transport-plugin and tracing middlewares that this is a streaming
 	// response. Without this, fasthttpResponseToHTTPResponse calls ctx.Response.Body()
 	// during post-hook processing, which materializes the SSE body stream and
@@ -165,6 +171,14 @@ func (h *MCPServerHandler) handleMCPServerSSE(ctx *fasthttp.RequestCtx) {
 	// Convert context
 	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
 	bifrostCtx.SetValue(schemas.BifrostContextKeyIsMCPGateway, true)
+
+	if authResult.jwtClaims != nil {
+		if injErr := injectJWTContext(bifrostCtx, authResult.jwtClaims, authResult.jwtVK); injErr != nil {
+			cancel()
+			SendError(ctx, fasthttp.StatusUnauthorized, injErr.Error())
+			return
+		}
+	}
 
 	// Use SSEStreamReader to bypass fasthttp's internal pipe batching
 	reader := lib.NewSSEStreamReader()
@@ -546,33 +560,199 @@ func (h *MCPServerHandler) makeIncludeClientsFilter() server.ToolFilterFunc {
 
 // Utility methods
 
-func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*server.MCPServer, error) {
+// mcpAuthResult carries the outcome of /mcp request authentication.
+type mcpAuthResult struct {
+	mcpServer *server.MCPServer
+	jwtClaims *jwtMCPClaims           // non-nil when authenticated via JWT
+	jwtVK     *tables.TableVirtualKey // non-nil when jwt bf_mode=vk
+}
+
+// getMCPServerForRequest authenticates the /mcp request and returns the
+// appropriate scoped MCP server alongside any JWT claims that must be injected
+// into the BifrostContext after it is created.
+//
+// Authentication priority:
+//  1. JWT Bearer token (when MCPServerAuthMode is both or oauth)
+//  2. VK / header credentials (when MCPServerAuthMode is headers or both)
+//  3. Anonymous access (when EnforceAuthOnInference is false)
+//
+// When MCPServerAuthMode is oauth (strict), header credentials are rejected.
+func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mcpAuthResult, error) {
 	h.config.Mu.RLock()
-	enforceVK := h.config.ClientConfig.EnforceAuthOnInference
+	enforceAuth := h.config.ClientConfig.EnforceAuthOnInference
+	authMode := h.config.ClientConfig.MCPServerAuthMode
 	h.config.Mu.RUnlock()
 
+	discoveryEnabled := authMode == tables.MCPServerAuthModeBoth || authMode == tables.MCPServerAuthModeOAuth
+
+	// --- JWT path ---
+	if rawJWT := extractBearerJWT(ctx); rawJWT != "" && discoveryEnabled {
+		// An OAuth token is the sole identity for the request. Reject when a
+		// header-based virtual key (x-bf-vk / x-api-key / Bearer vk) is also
+		// presented: mixing credential sources is ambiguous, and for user- and
+		// session-mode tokens — which carry no virtual key — a stray header VK
+		// would otherwise leak onto the context and be attributed to the request.
+		if headerVK := getVKFromRequest(ctx); headerVK != "" {
+			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+			return nil, fmt.Errorf("conflicting credentials: an OAuth token and a virtual key header were both provided; send only the OAuth token")
+		}
+
+		claims, err := verifyMCPJWT(ctx, rawJWT, h.config)
+		if err != nil {
+			if discoveryEnabled {
+				ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+			}
+			// Forward verifyMCPJWT's error verbatim: it already labels a genuine
+			// token failure ("invalid token: ...") precisely, while its config
+			// faults ("signing key unavailable", ...) must not be mislabeled as
+			// the client's token being bad.
+			return nil, err
+		}
+
+		// For user-mode JWTs, if a dashboard session is present on the request
+		// (BifrostContextKeyUserID, set by the auth middleware) it must match
+		// bf_sub — a mismatch means the session and the token disagree on
+		// identity. Its absence is not fatal: the JWT itself proves identity, and
+		// initiating a new upstream per-user flow is verified later at the
+		// session-bearing UI step (flowStart → canAccessUserFlow).
+		if schemas.MCPAuthMode(claims.BfMode) == schemas.MCPAuthModeUser {
+			sessionUserID, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string)
+			if sessionUserID != "" && sessionUserID != claims.Subject {
+				ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+				return nil, fmt.Errorf("session user does not match the authenticated token")
+			}
+		}
+
+		// Session-mode tokens carry no verified identity. When the operator
+		// requires authentication (EnforceAuthOnInference=true), session-mode
+		// JWT requests are rejected — the session itself is not deleted, but
+		// this endpoint becomes inaccessible until the client re-authenticates
+		// with a VK or user-mode token.
+		if schemas.MCPAuthMode(claims.BfMode) == schemas.MCPAuthModeSession && enforceAuth {
+			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+			return nil, fmt.Errorf("authentication required; session-mode tokens are not accepted when authentication is enforced - re-authenticate with a virtual key or user identity")
+		}
+
+		res := &mcpAuthResult{jwtClaims: claims}
+
+		// For vk mode, look up the VK by ID to get the scoped server and value.
+		if schemas.MCPAuthMode(claims.BfMode) == schemas.MCPAuthModeVK {
+			// Live virtual-key identity cutoff: when virtual-key identity has been
+			// disabled, reject vk-mode tokens at request time rather than waiting
+			// for the access token to expire and its refresh to be denied. The
+			// DisableVKIdentity flag is read first so the common (flag-off) path
+			// stays a single lock-guarded bool — IsUserModeAvailable is consulted
+			// only when the flag is set. Gated identically to the refresh cutoff and
+			// the consent flow's availableModes so it can never fire where vk is
+			// still an offered authentication path.
+			if oauth2ServerCfg(h.config).DisableVKIdentity &&
+				h.identityResolver != nil && h.identityResolver.IsUserModeAvailable() {
+				ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+				return nil, fmt.Errorf("virtual-key identity is no longer accepted; re-authenticate")
+			}
+			if h.config.ConfigStore == nil {
+				return nil, fmt.Errorf("virtual key not found")
+			}
+			vk, err := h.config.ConfigStore.GetVirtualKey(ctx, claims.Subject)
+			if err != nil || vk == nil {
+				return nil, fmt.Errorf("virtual key not found or inactive")
+			}
+			if !vk.IsActiveValue() {
+				return nil, fmt.Errorf("virtual key is inactive")
+			}
+			res.jwtVK = vk
+			vkServer, serverErr := h.ensureVKMCPServerByValue(ctx, vk.Value)
+			if serverErr != nil {
+				return nil, serverErr
+			}
+			res.mcpServer = vkServer
+		} else if scopedServer, scopedErr := h.userScopedServer(ctx, claims); scopedErr != nil {
+			return nil, scopedErr
+		} else if scopedServer != nil {
+			res.mcpServer = scopedServer
+		} else {
+			res.mcpServer = h.globalMCPServer
+		}
+		return res, nil
+	}
+
+	// --- oauth strict mode: reject non-JWT requests ---
+	if authMode == tables.MCPServerAuthModeOAuth {
+		ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+		return nil, fmt.Errorf("this server requires OAuth JWT authentication; header credentials are not accepted in oauth mode")
+	}
+
+	// --- VK / header credential path ---
 	vk := getVKFromRequest(ctx)
 
 	// EnforceAuth=false: anonymous access to the global (un-scoped) MCP server
 	// is allowed in dev mode. EnforceAuth=true: VK header is mandatory.
-	if !enforceVK && vk == "" {
-		return h.globalMCPServer, nil
+	if !enforceAuth && vk == "" {
+		// Anonymous access allowed in dev mode.
+		return &mcpAuthResult{mcpServer: h.globalMCPServer}, nil
 	}
 
 	if vk == "" {
+		if discoveryEnabled {
+			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+		}
 		return nil, fmt.Errorf("virtual key required to access mcp server; set one of x-bf-vk, Authorization: Bearer <vk>, or x-api-key in your MCP client config")
 	}
 
-	// Fast path: a per-VK server already exists in the cache.
-	h.mu.RLock()
-	vkServer, ok := h.vkMCPServers[vk]
-	h.mu.RUnlock()
-	if ok {
-		return vkServer, nil
+	vkServer, err := h.ensureVKMCPServerByValue(ctx, vk)
+	if err != nil {
+		return nil, err
 	}
+	return &mcpAuthResult{mcpServer: vkServer}, nil
+}
 
+// userScopedServer returns a per-VK MCP server scoped to a user-mode token's
+// own tools, or nil (with nil error) when no scoping applies — no resolver, a
+// non-user-mode token, or a user with no virtual key — so the caller falls back
+// to the global server.
+//
+// User-mode tokens carry a user identity but no virtual key of their own. The
+// resolver maps the user to a representative virtual key (any one of the user's
+// equivalent keys), letting this reuse the per-VK scoped server instead of
+// serving the global (unscoped) one. Session-mode tokens have no identity to
+// scope by and return nil here.
+func (h *MCPServerHandler) userScopedServer(ctx *fasthttp.RequestCtx, claims *jwtMCPClaims) (*server.MCPServer, error) {
+	if h.identityResolver == nil || h.config.ConfigStore == nil {
+		return nil, nil
+	}
+	if schemas.MCPAuthMode(claims.BfMode) != schemas.MCPAuthModeUser {
+		return nil, nil
+	}
+	vkID, err := h.identityResolver.ResolveUserVirtualKey(ctx, claims.Subject)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve virtual key for user: %w", err)
+	}
+	if vkID == "" {
+		return nil, nil
+	}
+	// Mirror the vk-mode branch: resolve the representative VK by ID to get its
+	// value and active state, then reuse the shared per-VK server cache.
+	vk, err := h.config.ConfigStore.GetVirtualKey(ctx, vkID)
+	if err != nil || vk == nil {
+		return nil, fmt.Errorf("virtual key not found or inactive")
+	}
+	if !vk.IsActiveValue() {
+		return nil, fmt.Errorf("virtual key is inactive")
+	}
+	return h.ensureVKMCPServerByValue(ctx, vk.Value)
+}
+
+// ensureVKMCPServerByValue returns the per-VK server from cache or creates it.
+func (h *MCPServerHandler) ensureVKMCPServerByValue(ctx context.Context, vkValue string) (*server.MCPServer, error) {
+	h.mu.RLock()
+	s, ok := h.vkMCPServers[vkValue]
+	h.mu.RUnlock()
+	// Fast path: a per-VK server already exists in the cache.
+	if ok {
+		return s, nil
+	}
 	// Slow path: build the per-VK server lazily on first use.
-	return h.ensureVKMCPServer(ctx, vk)
+	return h.ensureVKMCPServer(ctx, vkValue)
 }
 
 // ensureVKMCPServer lazily builds and caches the MCP server for a virtual key on
@@ -587,6 +767,12 @@ func (h *MCPServerHandler) ensureVKMCPServer(ctx context.Context, vkValue string
 	vk, err := h.config.ConfigStore.GetVirtualKeyByValue(ctx, vkValue)
 	if err != nil || vk == nil {
 		return nil, fmt.Errorf("virtual key not found")
+	}
+	// GetVirtualKeyByValue does not filter inactive keys, so fail closed here:
+	// a deactivated key must not yield (or cache) a usable MCP server. This is
+	// the single chokepoint for both the header path and the JWT vk path.
+	if !vk.IsActiveValue() {
+		return nil, fmt.Errorf("virtual key is inactive")
 	}
 	// SyncVKMCPServer creates (or refreshes) and caches the server under the
 	// handler write lock, returning the live server so a concurrent

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1331,7 +1331,7 @@ func (s *BifrostHTTPServer) RegisterInferenceRoutes(ctx context.Context, middlew
 	inferenceHandler := handlers.NewInferenceHandler(s.Client, s.Config)
 	s.IntegrationHandler = handlers.NewIntegrationHandler(s.Client, s.Config, wsResponsesHandler, wsRealtimeHandler, webrtcRealtimeHandler, realtimeClientSecretsHandler)
 	mcpInferenceHandler := handlers.NewMCPInferenceHandler(s.Client, s.Config)
-	mcpServerHandler, err := handlers.NewMCPServerHandler(ctx, s.Config, s)
+	mcpServerHandler, err := handlers.NewMCPServerHandler(ctx, s.Config, s, s.OAuth2IdentityResolver)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mcp server handler: %v", err)
 	}


### PR DESCRIPTION
## Summary

This PR adds JWT Bearer token authentication to the `/mcp` endpoint, enabling Bifrost-issued JWTs to be used as a first-class authentication mechanism alongside existing VK/header credentials. It also introduces a session validation gate that prevents per-user upstream flows (OAuth and header submission) from being initiated unless the caller's identity has been actively verified for the current request.

## Changes

- Added `extractBearerJWT` to detect and extract JWT Bearer tokens from the `Authorization` header, distinguishing them from VK credentials by the `eyJ` prefix.
- Added `verifyMCPJWT` to validate RS256-signed JWTs against the active signing key, enforcing expiry, issued-at, key ID, and RFC 8707 audience checks against the `/mcp` resource URL.
- Added `injectJWTContext` to translate verified JWT claims (`bf_mode=user|vk|session`) into the same `BifrostContext` keys that header-based auth sets, ensuring downstream resolvers (governance, per-user OAuth, tool-group filtering) work without modification.
- Introduced `mcpAuthResult` to carry the authenticated MCP server, JWT claims, and resolved VK out of `getMCPServerForRequest`, replacing the previous single return value.
- Refactored `getMCPServerForRequest` to implement a prioritized auth flow: JWT → oauth-strict rejection → VK/header → anonymous dev mode. In `oauth` strict mode, non-JWT requests are rejected with a `WWW-Authenticate` header per RFC 9728.
- Added `BifrostContextKeyOAuth2JWTAuthenticated` and `BifrostContextKeyOAuth2JWTSessionValidated` context keys. The session-validated key is set only when a user-mode JWT's `sub` is confirmed against an active dashboard session.
- Added a session validation gate in both `per_user_oauth.go` and `per_user_headers.go`: when a request is JWT-authenticated in user mode, upstream flows cannot be initiated unless `BifrostContextKeyOAuth2JWTSessionValidated` is present.
- Extracted `ensureVKMCPServerByValue` to allow VK server lookup by value from both the header path and the JWT VK path.
- Removed the stale comment block about Bifrost not being an OAuth authorization server.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

- Send a request to `/mcp` with a valid Bifrost-issued JWT in `Authorization: Bearer <token>` and confirm the appropriate context keys are set and the correct scoped server is used.
- Send a request with `bf_mode=user` JWT and no active dashboard session; confirm a `401` is returned with a message indicating no active session.
- Send a request with `bf_mode=user` JWT and a mismatched session user; confirm rejection.
- Configure `MCPServerAuthMode=oauth` and send a request with a VK header; confirm rejection with a `WWW-Authenticate` header.
- Attempt to initiate a per-user OAuth or header submission flow with a user-mode JWT that has not been session-validated; confirm the flow is blocked.
- Confirm anonymous dev-mode access (`EnforceAuthOnInference=false`, no credentials) still works.

## Breaking changes

- [x] Yes
- [ ] No

`getMCPServerForRequest` now returns `*mcpAuthResult` instead of `*server.MCPServer`. Any code calling this method directly must be updated. When `MCPServerAuthMode` is set to `oauth`, header-based credentials are no longer accepted at the `/mcp` endpoint.

## Security considerations

- JWT verification enforces RS256 signature, expiry, issued-at, key ID, and RFC 8707 audience binding to the `/mcp` resource URL, preventing token reuse across resources.
- User-mode JWTs require an active dashboard session whose user ID matches `bf_sub`, preventing replay of valid tokens after session expiry.
- The session validation gate on per-user upstream flows ensures that even a structurally valid JWT cannot trigger credential submission flows without a confirmed live session.
- `WWW-Authenticate` headers are emitted on auth failures in discovery-enabled modes, per RFC 9728.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable