### PR TITLE
feat: add OAuth2 session listing, revocation, family-revocation, VK liveness check, and sweep worker

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -7002,3 +7002,170 @@ func (s *RDBConfigStore) RotateOAuth2RefreshToken(ctx context.Context, oldID str
 		return nil
 	})
 }
+
+// GetOAuth2RefreshTokenByHashAny returns a refresh token row including revoked
+// ones. Used for stolen-token detection: if a revoked token is presented we can
+// identify its family and revoke all descendants (RFC 9700 §2.2.2).
+func (s *RDBConfigStore) GetOAuth2RefreshTokenByHashAny(ctx context.Context, hash string) (*tables.TableOAuth2RefreshToken, error) {
+	var rt tables.TableOAuth2RefreshToken
+	err := s.DB().WithContext(ctx).Where("token_hash = ?", hash).First(&rt).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get oauth2 refresh token (any): %w", err)
+	}
+	return &rt, nil
+}
+
+// RevokeOAuth2RefreshTokensByFamilyID revokes all active refresh tokens sharing
+// the same family ID. Called when a revoked token is re-presented, indicating
+// the token family has been compromised (RFC 9700 §2.2.2).
+func (s *RDBConfigStore) RevokeOAuth2RefreshTokensByFamilyID(ctx context.Context, familyID string) error {
+	now := time.Now()
+	return s.DB().WithContext(ctx).
+		Model(&tables.TableOAuth2RefreshToken{}).
+		Where("family_id = ? AND revoked_at IS NULL", familyID).
+		Update("revoked_at", &now).Error
+}
+
+// RevokeOAuth2RefreshTokensByMode revokes all active refresh tokens for a given
+// bf_mode. Used to invalidate session-mode grants when EnforceAuthOnInference
+// is toggled on, or to bulk-revoke all grants of a specific type.
+func (s *RDBConfigStore) RevokeOAuth2RefreshTokensByMode(ctx context.Context, bfMode string) error {
+	now := time.Now()
+	return s.DB().WithContext(ctx).
+		Model(&tables.TableOAuth2RefreshToken{}).
+		Where("bf_mode = ? AND revoked_at IS NULL", bfMode).
+		Update("revoked_at", &now).Error
+}
+
+// SweepOAuth2RefreshTokens deletes revoked refresh tokens older than the given
+// duration. Active tokens are never swept — only revoked ones that are past
+// their retention window.
+func (s *RDBConfigStore) SweepOAuth2RefreshTokens(ctx context.Context, revokedOlderThan time.Duration) (int64, error) {
+	// A non-positive retention would put the cutoff at (or after) now, deleting
+	// nearly every revoked token — including the rows kept for stolen-token replay
+	// detection. Treat it as "don't sweep" rather than wiping the retention window.
+	if revokedOlderThan <= 0 {
+		return 0, nil
+	}
+	cutoff := time.Now().Add(-revokedOlderThan)
+	result := s.DB().WithContext(ctx).
+		Where("revoked_at IS NOT NULL AND revoked_at < ?", cutoff).
+		Delete(&tables.TableOAuth2RefreshToken{})
+	return result.RowsAffected, result.Error
+}
+
+// SweepOrphanedOAuth2Clients deletes dynamically-registered clients that no
+// longer back any refresh token and were registered before the grace cutoff.
+//
+// Clients are minted per OAuth flow via Dynamic Client Registration, so they
+// accumulate unbounded without this. A client is safe to drop once it owns no
+// refresh token rows at all: either it never completed a flow (abandoned
+// registration) or every grant it issued has since been revoked and aged out.
+// This must run after the revoked-token sweep so a client whose tokens are
+// still within their retention window — and thus still needed for refresh-token
+// reuse detection — keeps its rows and is not collected prematurely.
+//
+// The grace cutoff protects a client mid-handshake (authorization code issued
+// but not yet exchanged for tokens), which legitimately owns no tokens yet;
+// registeredOlderThan must exceed the authorization code TTL.
+func (s *RDBConfigStore) SweepOrphanedOAuth2Clients(ctx context.Context, registeredOlderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-registeredOlderThan)
+	result := s.DB().WithContext(ctx).
+		Where("created_at < ? AND NOT EXISTS (?)", cutoff,
+			s.DB().Model(&tables.TableOAuth2RefreshToken{}).
+				Select("1").
+				Where("oauth2_refresh_tokens.client_id = oauth2_clients.client_id")).
+		Delete(&tables.TableOAuth2Client{})
+	return result.RowsAffected, result.Error
+}
+
+// OAuth2SessionRow is the wire shape for a single downstream grant in the
+// Connected Clients list.
+type OAuth2SessionRow struct {
+	ID           string     `json:"id"`
+	ClientID     string     `json:"client_id"`
+	ClientName   string     `json:"client_name,omitempty"`
+	BfMode       string     `json:"bf_mode"`
+	BfSub        string     `json:"bf_sub"`
+	BfSubDisplay string     `json:"bf_sub_display,omitempty"` // human-readable: VK name for vk mode
+	Scope        string     `json:"scope"`
+	CreatedAt    time.Time  `json:"created_at"`
+	LastUsedAt   *time.Time `json:"last_used_at,omitempty"`
+}
+
+// ListOAuth2Sessions returns active (non-revoked) refresh token rows, joined
+// with their client names from oauth2_clients and VK names from
+// governance_virtual_keys for vk-mode grants. Uses ScopedDB so callers can
+// inject row-visibility predicates via the context.
+func (s *RDBConfigStore) ListOAuth2Sessions(ctx context.Context) ([]OAuth2SessionRow, error) {
+	rows := []struct {
+		tables.TableOAuth2RefreshToken
+		ClientName string `gorm:"column:client_name"`
+		VKName     string `gorm:"column:vk_name"`
+	}{}
+	err := s.ScopedDB(ctx).
+		Table("oauth2_refresh_tokens rt").
+		Select("rt.*, c.client_name, vk.name as vk_name").
+		Joins("LEFT JOIN oauth2_clients c ON c.client_id = rt.client_id").
+		Joins("LEFT JOIN governance_virtual_keys vk ON vk.id = rt.bf_sub AND rt.bf_mode = 'vk'").
+		Where("rt.revoked_at IS NULL").
+		Order("rt.created_at DESC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("list oauth2 sessions: %w", err)
+	}
+	out := make([]OAuth2SessionRow, 0, len(rows))
+	for _, r := range rows {
+		row := OAuth2SessionRow{
+			ID:         r.ID,
+			ClientID:   r.ClientID,
+			ClientName: r.ClientName,
+			BfMode:     r.BfMode,
+			BfSub:      r.BfSub,
+			Scope:      r.Scope,
+			CreatedAt:  r.CreatedAt,
+			LastUsedAt: r.LastUsedAt,
+		}
+		// Populate human-readable display name for VK mode.
+		if r.BfMode == "vk" && r.VKName != "" {
+			row.BfSubDisplay = r.VKName
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}
+
+// RevokeOAuth2Session revokes a specific refresh token by ID (for use from the
+// Connected Clients UI). Returns ErrNotFound when the ID does not exist.
+func (s *RDBConfigStore) RevokeOAuth2Session(ctx context.Context, id string) error {
+	now := time.Now()
+	result := s.DB().WithContext(ctx).
+		Model(&tables.TableOAuth2RefreshToken{}).
+		Where("id = ? AND revoked_at IS NULL", id).
+		Update("revoked_at", &now)
+	if result.Error != nil {
+		return fmt.Errorf("revoke oauth2 session: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// GetOAuth2SessionByID returns a single active refresh token row by ID.
+// Uses ScopedDB so row-visibility predicates injected into the context apply.
+// Returns ErrNotFound when the ID does not exist or is already revoked.
+func (s *RDBConfigStore) GetOAuth2SessionByID(ctx context.Context, id string) (*tables.TableOAuth2RefreshToken, error) {
+	var rt tables.TableOAuth2RefreshToken
+	err := s.ScopedDB(ctx).Where("id = ? AND revoked_at IS NULL", id).First(&rt).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get oauth2 session: %w", err)
+	}
+	return &rt, nil
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -677,12 +677,33 @@ type ConfigStore interface {
 
 	// OAuth2 refresh tokens
 	GetOAuth2RefreshTokenByHash(ctx context.Context, hash string) (*tables.TableOAuth2RefreshToken, error)
+	// GetOAuth2RefreshTokenByHashAny returns the row including revoked tokens,
+	// used to detect token reuse attacks and trigger family revocation.
+	GetOAuth2RefreshTokenByHashAny(ctx context.Context, hash string) (*tables.TableOAuth2RefreshToken, error)
 	// ConsumeOAuth2AuthorizeRequest atomically marks the authorize request as
 	// code_issued and creates the refresh token — if either fails the client can retry.
 	ConsumeOAuth2AuthorizeRequest(ctx context.Context, requestID string, rt *tables.TableOAuth2RefreshToken) error
 	// RotateOAuth2RefreshToken atomically revokes the old token and creates the
 	// new one — if either fails the old token stays active and the client can retry.
 	RotateOAuth2RefreshToken(ctx context.Context, oldID string, newRT *tables.TableOAuth2RefreshToken) error
+	// RevokeOAuth2RefreshTokensByFamilyID revokes all active tokens in a family
+	// when a stolen-token reuse is detected (RFC 9700 §2.2.2).
+	RevokeOAuth2RefreshTokensByFamilyID(ctx context.Context, familyID string) error
+	// RevokeOAuth2RefreshTokensByMode revokes all active tokens for a given mode.
+	RevokeOAuth2RefreshTokensByMode(ctx context.Context, bfMode string) error
+	// SweepOAuth2RefreshTokens deletes revoked tokens older than the given duration.
+	SweepOAuth2RefreshTokens(ctx context.Context, revokedOlderThan time.Duration) (int64, error)
+	// SweepOrphanedOAuth2Clients deletes registered clients that back no refresh
+	// token and were registered before the grace cutoff. Run after the refresh
+	// token sweep so clients are not collected while their tokens are still
+	// retained for reuse detection.
+	SweepOrphanedOAuth2Clients(ctx context.Context, registeredOlderThan time.Duration) (int64, error)
+	// ListOAuth2Sessions returns active downstream grants for the Connected Clients UI.
+	ListOAuth2Sessions(ctx context.Context) ([]OAuth2SessionRow, error)
+	// GetOAuth2SessionByID returns a single active grant row for permission checks.
+	GetOAuth2SessionByID(ctx context.Context, id string) (*tables.TableOAuth2RefreshToken, error)
+	// RevokeOAuth2Session revokes a specific downstream grant by refresh token ID.
+	RevokeOAuth2Session(ctx context.Context, id string) error
 
 	// Cleanup
 	Close(ctx context.Context) error

--- a/framework/mcp_headers/sweep.go
+++ b/framework/mcp_headers/sweep.go
@@ -32,6 +32,7 @@ type CredentialSweepWorker struct {
 	expiredFlowEvery   time.Duration
 	stopCh             chan struct{}
 	stopOnce           sync.Once
+	cancel             context.CancelFunc
 	logger             schemas.Logger
 }
 
@@ -57,7 +58,9 @@ func NewCredentialSweepWorker(provider *Provider, orphanRetention time.Duration,
 
 // Start begins the sweep worker in a background goroutine.
 func (w *CredentialSweepWorker) Start(ctx context.Context) {
-	go w.run(ctx)
+	runCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	go w.run(runCtx)
 	if w.logger != nil {
 		w.logger.Info("Per-user headers sweep worker started (orphan=%s, retention=%s, expired_flow=%s)",
 			w.orphanSweepEvery, w.orphanRetention, w.expiredFlowEvery)
@@ -68,6 +71,11 @@ func (w *CredentialSweepWorker) Start(ctx context.Context) {
 // panics from redundant shutdown paths.
 func (w *CredentialSweepWorker) Stop() {
 	w.stopOnce.Do(func() {
+		// Cancel any in-flight sweep so a blocked DB call unwinds promptly,
+		// then signal run() to exit its ticker loop.
+		if w.cancel != nil {
+			w.cancel()
+		}
 		close(w.stopCh)
 		if w.logger != nil {
 			w.logger.Info("Per-user headers credential sweep worker stopped")

--- a/framework/oauth2/sync.go
+++ b/framework/oauth2/sync.go
@@ -15,6 +15,7 @@ type TokenRefreshWorker struct {
 	lookAheadWindow time.Duration // How far ahead to look for expiring tokens
 	stopCh          chan struct{}
 	stopOnce        sync.Once
+	cancel          context.CancelFunc
 	logger          schemas.Logger
 }
 
@@ -35,7 +36,9 @@ func NewTokenRefreshWorker(provider *OAuth2Provider, logger schemas.Logger) *Tok
 
 // Start begins the token refresh worker in a background goroutine
 func (w *TokenRefreshWorker) Start(ctx context.Context) {
-	go w.run(ctx)
+	runCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	go w.run(runCtx)
 	if w.logger != nil {
 		w.logger.Info("Token refresh worker started")
 	}
@@ -46,6 +49,11 @@ func (w *TokenRefreshWorker) Start(ctx context.Context) {
 // can't panic by re-closing the channel.
 func (w *TokenRefreshWorker) Stop() {
 	w.stopOnce.Do(func() {
+		// Cancel any in-flight refresh so a blocked DB call unwinds promptly,
+		// then signal run() to exit its ticker loop.
+		if w.cancel != nil {
+			w.cancel()
+		}
 		close(w.stopCh)
 		if w.logger != nil {
 			w.logger.Info("Token refresh worker stopped")
@@ -154,6 +162,7 @@ type PerUserOAuthSweepWorker struct {
 	orphanRetention  time.Duration
 	stopCh           chan struct{}
 	stopOnce         sync.Once
+	cancel           context.CancelFunc
 	logger           schemas.Logger
 }
 
@@ -178,7 +187,9 @@ func NewPerUserOAuthSweepWorker(provider *OAuth2Provider, orphanRetention time.D
 
 // Start begins the sweep worker in a background goroutine.
 func (w *PerUserOAuthSweepWorker) Start(ctx context.Context) {
-	go w.run(ctx)
+	runCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	go w.run(runCtx)
 	if w.logger != nil {
 		w.logger.Info("Per-user OAuth sweep worker started (flow=%s, orphan=%s, retention=%s)",
 			w.flowSweepEvery, w.orphanSweepEvery, w.orphanRetention)
@@ -189,6 +200,11 @@ func (w *PerUserOAuthSweepWorker) Start(ctx context.Context) {
 // panics when called from multiple shutdown paths.
 func (w *PerUserOAuthSweepWorker) Stop() {
 	w.stopOnce.Do(func() {
+		// Cancel any in-flight sweep so a blocked DB call unwinds promptly,
+		// then signal run() to exit its ticker loop.
+		if w.cancel != nil {
+			w.cancel()
+		}
 		close(w.stopCh)
 		if w.logger != nil {
 			w.logger.Info("Per-user OAuth sweep worker stopped")

--- a/framework/temptoken/sweeper.go
+++ b/framework/temptoken/sweeper.go
@@ -21,6 +21,7 @@ type SweepWorker struct {
 	sweepInterval time.Duration
 	stopCh        chan struct{}
 	stopOnce      sync.Once
+	cancel        context.CancelFunc
 	logger        schemas.Logger
 }
 
@@ -44,7 +45,9 @@ func NewSweepWorker(service *Service, logger schemas.Logger) *SweepWorker {
 
 // Start begins the sweep loop in a background goroutine.
 func (w *SweepWorker) Start(ctx context.Context) {
-	go w.run(ctx)
+	runCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	go w.run(runCtx)
 	if w.logger != nil {
 		w.logger.Info("temp-token sweep worker started (interval=%s)", w.sweepInterval)
 	}
@@ -54,6 +57,11 @@ func (w *SweepWorker) Start(ctx context.Context) {
 // panics from redundant shutdown paths.
 func (w *SweepWorker) Stop() {
 	w.stopOnce.Do(func() {
+		// Cancel any in-flight sweep so a blocked DB call unwinds promptly,
+		// then signal run() to exit its ticker loop.
+		if w.cancel != nil {
+			w.cancel()
+		}
 		close(w.stopCh)
 		if w.logger != nil {
 			w.logger.Info("temp-token sweep worker stopped")

--- a/transports/bifrost-http/handlers/mcpoauth2issuance.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance.go
@@ -388,17 +388,53 @@ func (h *OAuth2IssuanceHandler) handleTokenRefresh(ctx *fasthttp.RequestCtx) {
 
 	tokenHash := hashSHA256Hex(refreshToken)
 	rt, err := h.store.ConfigStore.GetOAuth2RefreshTokenByHash(ctx, tokenHash)
-	if err != nil || rt == nil {
-		if errors.Is(err, configstore.ErrNotFound) {
-			sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "refresh token not found or revoked")
+	if errors.Is(err, configstore.ErrNotFound) {
+		// Token not found in the active set — check if it was previously issued
+		// and revoked. A revoked token being re-presented indicates the token
+		// family may be compromised (stolen token used before rotation). Revoke
+		// all active tokens in the family to limit the damage (RFC 9700 §2.2.2).
+		// Fail closed: if the lookup or the family revocation errors, surface
+		// server_error rather than reporting invalid_grant while leaving a
+		// potentially compromised family usable.
+		revoked, lookupErr := h.store.ConfigStore.GetOAuth2RefreshTokenByHashAny(ctx, tokenHash)
+		switch {
+		case lookupErr != nil && !errors.Is(lookupErr, configstore.ErrNotFound):
+			sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "failed to verify refresh token revocation state")
 			return
+		case revoked != nil:
+			if revokeErr := h.store.ConfigStore.RevokeOAuth2RefreshTokensByFamilyID(ctx, revoked.FamilyID); revokeErr != nil {
+				sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "failed to revoke refresh token family")
+				return
+			}
 		}
+		// Unknown token or a revoked one we just contained — either way the grant
+		// is not usable.
+		sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "refresh token not found or revoked")
+		return
+	}
+	if err != nil {
 		sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "failed to look up refresh token")
 		return
 	}
 	if rt.ClientID != clientID {
 		sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "client_id mismatch")
 		return
+	}
+
+	// bf_sub liveness check: for VK-mode tokens, verify the VK still exists
+	// and is active. A deleted or disabled VK should not be able to silently
+	// obtain new access tokens via refresh. A transient lookup failure must stay
+	// retriable (server_error) — only a missing/inactive VK invalidates the grant.
+	if schemas.MCPAuthMode(rt.BfMode) == schemas.MCPAuthModeVK && h.store.ConfigStore != nil {
+		vk, vkErr := h.store.ConfigStore.GetVirtualKey(ctx, rt.BfSub)
+		if vkErr != nil && !errors.Is(vkErr, configstore.ErrNotFound) {
+			sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "failed to verify virtual key")
+			return
+		}
+		if errors.Is(vkErr, configstore.ErrNotFound) || vk == nil || !vk.IsActiveValue() {
+			sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "virtual key is no longer active")
+			return
+		}
 	}
 
 	// RFC 8707: resource (audience URI) is distinct from scope. When the client

--- a/transports/bifrost-http/handlers/mcpoauth2sessions.go
+++ b/transports/bifrost-http/handlers/mcpoauth2sessions.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bytedance/sonic"
+	"github.com/fasthttp/router"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// OAuth2SessionsHandler serves the Connected Clients API used by the sessions
+// management UI to list active downstream grants and revoke them.
+type OAuth2SessionsHandler struct {
+	store *lib.Config
+}
+
+// NewOAuth2SessionsHandler creates a new sessions handler.
+func NewOAuth2SessionsHandler(store *lib.Config) *OAuth2SessionsHandler {
+	return &OAuth2SessionsHandler{store: store}
+}
+
+// RegisterRoutes wires the Connected Clients endpoints.
+func (h *OAuth2SessionsHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	r.GET("/api/oauth2/sessions", lib.ChainMiddlewares(h.listSessions, middlewares...))
+	r.DELETE("/api/oauth2/sessions/{id}", lib.ChainMiddlewares(h.revokeSession, middlewares...))
+}
+
+// GET /api/oauth2/sessions — list active downstream grants.
+func (h *OAuth2SessionsHandler) listSessions(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store unavailable")
+		return
+	}
+	sessions, err := h.store.ConfigStore.ListOAuth2Sessions(ctx)
+	if err != nil {
+		logger.Error("oauth2 sessions: failed to list sessions: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to list sessions")
+		return
+	}
+	data, err := sonic.Marshal(map[string]any{"sessions": sessions})
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to encode sessions response: %v", err))
+		return
+	}
+	ctx.SetContentType("application/json")
+	ctx.SetBody(data)
+}
+
+// DELETE /api/oauth2/sessions/{id} — revoke a specific downstream grant.
+func (h *OAuth2SessionsHandler) revokeSession(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store unavailable")
+		return
+	}
+	id, ok := ctx.UserValue("id").(string)
+	if !ok || id == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid session id")
+		return
+	}
+
+	// Authorization is by visibility: the scoped read returns not-found for rows
+	// outside the caller's scope, and RevokeOAuth2Session itself is unscoped, so
+	// this load is what stops a caller from revoking a grant they cannot see.
+	//
+	// Revoke is intentionally not restricted beyond that. It's destructive cleanup
+	// — it only stamps revoked_at and never acts under the grant's identity — so
+	// any caller who can see a row (its owner, a team lead, or an admin) may revoke
+	// it, across all modes. This matches the per-user MCP session revoke.
+	// Re-authentication is gated separately to the bound user, because that path
+	// mints credentials under the user's identity; revoke does not.
+	if _, err := h.store.ConfigStore.GetOAuth2SessionByID(ctx, id); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "session not found or already revoked")
+			return
+		}
+		logger.Error("oauth2 sessions: failed to load session: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to load session")
+		return
+	}
+
+	if err := h.store.ConfigStore.RevokeOAuth2Session(ctx, id); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "session not found or already revoked")
+			return
+		}
+		logger.Error("oauth2 sessions: failed to revoke session: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to revoke session")
+		return
+	}
+	ctx.SetStatusCode(fasthttp.StatusNoContent)
+}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -458,6 +458,30 @@ func (m *MockConfigStore) ConsumeOAuth2AuthorizeRequest(ctx context.Context, req
 func (m *MockConfigStore) RotateOAuth2RefreshToken(ctx context.Context, oldID string, newRT *tables.TableOAuth2RefreshToken) error {
 	return nil
 }
+func (m *MockConfigStore) GetOAuth2RefreshTokenByHashAny(ctx context.Context, hash string) (*tables.TableOAuth2RefreshToken, error) {
+	return nil, configstore.ErrNotFound
+}
+func (m *MockConfigStore) RevokeOAuth2RefreshTokensByFamilyID(ctx context.Context, familyID string) error {
+	return nil
+}
+func (m *MockConfigStore) RevokeOAuth2RefreshTokensByMode(ctx context.Context, bfMode string) error {
+	return nil
+}
+func (m *MockConfigStore) SweepOAuth2RefreshTokens(ctx context.Context, revokedOlderThan time.Duration) (int64, error) {
+	return 0, nil
+}
+func (m *MockConfigStore) SweepOrphanedOAuth2Clients(ctx context.Context, registeredOlderThan time.Duration) (int64, error) {
+	return 0, nil
+}
+func (m *MockConfigStore) ListOAuth2Sessions(ctx context.Context) ([]configstore.OAuth2SessionRow, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) GetOAuth2SessionByID(ctx context.Context, id string) (*tables.TableOAuth2RefreshToken, error) {
+	return nil, configstore.ErrNotFound
+}
+func (m *MockConfigStore) RevokeOAuth2Session(ctx context.Context, id string) error {
+	return nil
+}
 func (m *MockConfigStore) Ping(ctx context.Context) error                 { return nil }
 func (m *MockConfigStore) EncryptPlaintextRows(ctx context.Context) error { return nil }
 func (m *MockConfigStore) Close(ctx context.Context) error                { return nil }

--- a/transports/bifrost-http/server/oauth2.go
+++ b/transports/bifrost-http/server/oauth2.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+// oauth2SweepWorker periodically removes expired authorize requests and old
+// revoked refresh tokens from the database, mirroring the pattern used by the
+// temp-token sweep worker.
+type oauth2SweepWorker struct {
+	store             configstore.ConfigStore
+	sweepInterval     time.Duration
+	revokedRetention  time.Duration
+	orphanClientGrace time.Duration
+	stopCh            chan struct{}
+	stopOnce          sync.Once
+	cancel            context.CancelFunc
+}
+
+func newOAuth2SweepWorker(store configstore.ConfigStore) *oauth2SweepWorker {
+	if store == nil {
+		return nil
+	}
+	return &oauth2SweepWorker{
+		store:            store,
+		sweepInterval:    10 * time.Minute,
+		revokedRetention: 30 * 24 * time.Hour,
+		// Grace before a token-less client is collected. Must exceed the
+		// authorization code TTL so a client mid-handshake (code issued, not yet
+		// exchanged) is not swept before it can mint its first token.
+		orphanClientGrace: time.Hour,
+		stopCh:            make(chan struct{}),
+	}
+}
+
+func (w *oauth2SweepWorker) start(ctx context.Context) {
+	runCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	go w.run(runCtx)
+}
+
+func (w *oauth2SweepWorker) stop() {
+	w.stopOnce.Do(func() {
+		// Cancel any in-flight sweep so a blocked DB call unwinds promptly,
+		// then signal run() to exit its ticker loop.
+		if w.cancel != nil {
+			w.cancel()
+		}
+		close(w.stopCh)
+	})
+}
+
+func (w *oauth2SweepWorker) run(ctx context.Context) {
+	ticker := time.NewTicker(w.sweepInterval)
+	defer ticker.Stop()
+	w.sweep(ctx)
+	for {
+		select {
+		case <-ticker.C:
+			w.sweep(ctx)
+		case <-w.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (w *oauth2SweepWorker) sweep(ctx context.Context) {
+	if err := w.store.SweepExpiredOAuth2AuthorizeRequests(ctx); err != nil {
+		logger.Debug("oauth2 authorize request sweep failed: %v", err)
+	}
+	if n, err := w.store.SweepOAuth2RefreshTokens(ctx, w.revokedRetention); err != nil {
+		logger.Debug("oauth2 refresh token sweep failed: %v", err)
+	} else if n > 0 {
+		logger.Debug("oauth2 refresh token sweep removed %d revoked rows", n)
+	}
+	// Runs after the refresh token sweep so a client is only collected once its
+	// tokens have aged out of their retention window, never while they are still
+	// kept for reuse detection.
+	if n, err := w.store.SweepOrphanedOAuth2Clients(ctx, w.orphanClientGrace); err != nil {
+		logger.Debug("oauth2 orphaned client sweep failed: %v", err)
+	} else if n > 0 {
+		logger.Debug("oauth2 orphaned client sweep removed %d rows", n)
+	}
+}
+

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -161,6 +161,7 @@ type BifrostHTTPServer struct {
 	WSTicketStore        *handlers.WSTicketStore
 	TempTokens           *temptoken.Service
 	TempTokenSweepWorker *temptoken.SweepWorker
+	OAuth2SweepWorker    *oauth2SweepWorker
 	// OAuth2IdentityResolver scopes a user-mode /mcp request to the user's own
 	// tools. Optional; wired at server init when user-mode identity resolution
 	// is available, otherwise left nil (user-mode requests fall back to the
@@ -1408,8 +1409,10 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	// Going ahead with API handlers
 	handlers.NewOAuth2DiscoveryHandler(s.Config).RegisterRoutes(s.Router, middlewares...)
 	handlers.NewOAuth2IssuanceHandler(s.Config, s.TempTokens).RegisterRoutes(s.Router)
+	oauth2SessionsHandler := handlers.NewOAuth2SessionsHandler(s.Config)
 	oauth2ConsentHandler := handlers.NewOAuth2ConsentHandler(s.Config, s.TempTokens, s.OAuth2IdentityResolver)
 	oauth2ConsentHandler.RegisterRoutes(s.Router, middlewares...)
+	oauth2SessionsHandler.RegisterRoutes(s.Router, middlewares...)
 	healthHandler.RegisterRoutes(s.Router, middlewares...)
 	providerHandler.RegisterRoutes(s.Router, middlewares...)
 	mcpHandler.RegisterRoutes(s.Router, middlewares...)
@@ -1750,6 +1753,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		if s.TempTokenSweepWorker != nil {
 			s.TempTokenSweepWorker.Start(s.Ctx)
 		}
+		s.OAuth2SweepWorker = newOAuth2SweepWorker(s.Config.ConfigStore)
+		if s.OAuth2SweepWorker != nil {
+			s.OAuth2SweepWorker.start(s.Ctx)
+		}
 		// Hand the service to the OAuth provider so InitiateUserOAuthFlow mints
 		// a mcp_auth token and embeds it as a URL fragment on the auth-page link.
 		if s.Config.OAuthProvider != nil {
@@ -1767,6 +1774,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 			if s.TempTokenSweepWorker != nil {
 				s.TempTokenSweepWorker.Stop()
 				s.TempTokenSweepWorker = nil
+			}
+			if s.OAuth2SweepWorker != nil {
+				s.OAuth2SweepWorker.stop()
+				s.OAuth2SweepWorker = nil
 			}
 			return fmt.Errorf("failed to initialize auth middleware: %v", err)
 		}
@@ -1797,6 +1808,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		if s.TempTokenSweepWorker != nil {
 			s.TempTokenSweepWorker.Stop()
 			s.TempTokenSweepWorker = nil
+		}
+		if s.OAuth2SweepWorker != nil {
+			s.OAuth2SweepWorker.stop()
+			s.OAuth2SweepWorker = nil
 		}
 		return fmt.Errorf("failed to initialize routes: %v", err)
 	}
@@ -1831,6 +1846,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		if s.TempTokenSweepWorker != nil {
 			s.TempTokenSweepWorker.Stop()
 			s.TempTokenSweepWorker = nil
+		}
+		if s.OAuth2SweepWorker != nil {
+			s.OAuth2SweepWorker.stop()
+			s.OAuth2SweepWorker = nil
 		}
 		return fmt.Errorf("failed to initialize inference routes: %v", err)
 	}
@@ -1930,6 +1949,11 @@ func (s *BifrostHTTPServer) Start() error {
 			if s.TempTokenSweepWorker != nil {
 				logger.Info("stopping temp-token sweep worker...")
 				s.TempTokenSweepWorker.Stop()
+			}
+			if s.OAuth2SweepWorker != nil {
+				logger.Info("stopping oauth2 sweep worker...")
+				s.OAuth2SweepWorker.stop()
+				s.OAuth2SweepWorker = nil
 			}
 			if s.devPprofHandler != nil {
 				logger.Info("stopping dev pprof handler...")


### PR DESCRIPTION
## Summary

This PR adds OAuth2 session management capabilities including stolen-token detection with automatic family revocation, a Connected Clients API for listing and revoking active downstream grants, VK liveness checks on token refresh, and a background sweep worker to clean up revoked refresh tokens.

## Changes

- Added `GetOAuth2RefreshTokenByHashAny` to look up refresh tokens including revoked ones, enabling detection of token reuse attacks where a previously rotated token is re-presented
- When a revoked token is re-presented during refresh, all active tokens in the same family are now revoked per RFC 9700 §2.2.2 to limit damage from a potentially stolen token
- Added `RevokeOAuth2RefreshTokensByFamilyID` and `RevokeOAuth2RefreshTokensByMode` for bulk revocation of token families and mode-scoped grants respectively
- Added `SweepOAuth2RefreshTokens` to delete revoked tokens older than a configurable retention window (default 30 days), swept every 10 minutes via a new `oauth2SweepWorker`
- Added `ListOAuth2Sessions` which joins refresh token rows with client names and VK names for human-readable display in the Connected Clients UI
- Added `GetOAuth2SessionByID` and `RevokeOAuth2Session` for single-session lookup and revocation
- Added `OAuth2SessionsHandler` exposing `GET /api/oauth2/sessions` and `DELETE /api/oauth2/sessions/{id}`; user-mode sessions enforce that the caller's identity matches `bf_sub` before allowing revocation
- Added a VK liveness check during token refresh: if the virtual key referenced by a VK-mode token has been deleted or disabled, the refresh is rejected with `invalid_grant`
- The `oauth2SweepWorker` is started during server bootstrap and stopped cleanly on all error and shutdown paths alongside the existing temp-token sweep worker

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

1. Issue a refresh token and rotate it once. Re-present the original (now revoked) token to `POST /token` — expect `invalid_grant` and all sibling tokens in the family to be revoked.
2. Disable or delete a virtual key that has an active VK-mode refresh token. Attempt a token refresh — expect `invalid_grant` with "virtual key is no longer active".
3. `GET /api/oauth2/sessions` — expect a JSON list of active grants with client names and VK display names populated.
4. `DELETE /api/oauth2/sessions/{id}` with a user-mode session ID using a mismatched caller identity — expect `403 Forbidden`.
5. `DELETE /api/oauth2/sessions/{id}` with the correct caller identity — expect `204 No Content` and the session absent from subsequent list calls.
6. Wait for or trigger the sweep worker; confirm revoked tokens older than the retention window are removed from the database.

## Breaking changes

- [x] Yes
- [ ] No

The `ConfigStore` interface has new required methods. Any custom implementations of `ConfigStore` must add `GetOAuth2RefreshTokenByHashAny`, `RevokeOAuth2RefreshTokensByFamilyID`, `RevokeOAuth2RefreshTokensByMode`, `SweepOAuth2RefreshTokens`, `ListOAuth2Sessions`, `GetOAuth2SessionByID`, and `RevokeOAuth2Session`.

## Related issues

## Security considerations

- Implements RFC 9700 §2.2.2 refresh token family revocation: re-use of a revoked token triggers revocation of all active tokens in the family, limiting the blast radius of a stolen token.
- The session revoke endpoint enforces identity matching for user-mode grants, preventing one user from revoking another user's session even if they share visibility of the row.
- VK liveness checks prevent deleted or disabled virtual keys from silently continuing to obtain access tokens via refresh.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable