### PR TITLE
ui: add OAuth2 consent page and MCP server auth mode settings

### DIFF
--- a/ui/app/oauth/consent/layout.tsx
+++ b/ui/app/oauth/consent/layout.tsx
@@ -1,0 +1,40 @@
+import TempTokenScope from "@/components/tempTokenScope";
+import { ThemeProvider } from "@/components/themeProvider";
+import { ReduxProvider } from "@/lib/store";
+import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
+import { createFileRoute } from "@tanstack/react-router";
+import { Toaster } from "sonner";
+import OAuth2ConsentPage from "./page";
+
+// Public OAuth2 consent page — renders outside the dashboard chrome so
+// external users who arrive via `claude mcp add` can pick their identity
+// without needing a Bifrost dashboard account.
+//
+// tempTokenScoped: ClientLayout renders MinimalShell and skips the protected
+// config fetch when this flag is set. TempTokenScope extracts the `#t=…`
+// fragment minted by /oauth2/authorize and attaches it as
+// X-Bifrost-Temp-Token on every API call, letting the consent flow APIs
+// authenticate the anonymous visitor.
+//
+// ThemeProvider, ReduxProvider, NuqsAdapter and Toaster are provided here
+// directly because this route sits outside /workspace and does not inherit
+// them from ClientLayout.
+function RouteComponent() {
+	return (
+		<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+			<ReduxProvider>
+				<NuqsAdapter>
+					<Toaster closeButton />
+					<TempTokenScope name="oauth2_consent">
+						<OAuth2ConsentPage />
+					</TempTokenScope>
+				</NuqsAdapter>
+			</ReduxProvider>
+		</ThemeProvider>
+	);
+}
+
+export const Route = createFileRoute("/oauth/consent")({
+	staticData: { tempTokenScoped: true },
+	component: RouteComponent,
+});

--- a/ui/app/oauth/consent/page.tsx
+++ b/ui/app/oauth/consent/page.tsx
@@ -1,0 +1,376 @@
+import FullPageLoader from "@/components/fullPageLoader";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { toast } from "sonner";
+import {
+	getErrorMessage,
+	useGetOAuth2ConsentFlowQuery,
+	useIsAuthEnabledQuery,
+	useSubmitOAuth2ConsentFlowMutation,
+} from "@/lib/store";
+import {
+	getActiveTempToken,
+	setActiveTempToken,
+	setSuppressGlobal401,
+} from "@/lib/store/apis/tempToken";
+import {
+	Fingerprint,
+	KeyRound,
+	Loader2,
+	LogIn,
+	ShieldCheck,
+	UserRound,
+} from "lucide-react";
+import { useQueryState } from "nuqs";
+import React, { useEffect, useMemo, useState } from "react";
+
+export default function OAuth2ConsentPage() {
+	const [flowId] = useQueryState("flow");
+
+	if (!flowId) {
+		return (
+			<Shell>
+				<div className="text-center">
+					<h1 className="text-xl font-semibold">Missing flow identifier</h1>
+					<p className="text-muted-foreground mt-2 text-sm">
+						This URL is missing the{" "}
+						<code className="bg-muted rounded px-1 py-0.5 text-xs">flow</code>{" "}
+						query parameter. Restart the connection from your MCP client.
+					</p>
+				</div>
+			</Shell>
+		);
+	}
+
+	return <ConsentView flowId={flowId} />;
+}
+
+// isSafeRedirect rejects URLs whose scheme could execute script when assigned to
+// location.href (javascript:, data:, …) while allowing http(s) and any native
+// custom-scheme redirect a client may have registered.
+function isSafeRedirect(url: string): boolean {
+	try {
+		const proto = new URL(url, window.location.origin).protocol.toLowerCase();
+		return !["javascript:", "data:", "vbscript:", "blob:", "file:"].includes(proto);
+	} catch {
+		return false;
+	}
+}
+
+function ConsentView({ flowId }: { flowId: string }) {
+	const { data: flow, isLoading, isError, error } = useGetOAuth2ConsentFlowQuery(flowId);
+	const { data: authState } = useIsAuthEnabledQuery();
+	const [submitFlow, { isLoading: submitting }] = useSubmitOAuth2ConsentFlowMutation();
+	const [vkValue, setVkValue] = useState("");
+	const [selectedMode, setSelectedMode] = useState<"vk" | "session" | "user" | null>(null);
+
+	// Restore a temp token persisted across a login round-trip BEFORE sampling
+	// usingTempToken, so returning to consent after cancelling login (where the
+	// module-level token was already cleared) still surfaces the sign-in path.
+	const [usingTempToken] = useState(() => {
+		if (typeof sessionStorage !== "undefined") {
+			const stored = sessionStorage.getItem(`oauth2_consent_token_${flowId}`);
+			if (stored && !getActiveTempToken()) {
+				setActiveTempToken(stored);
+				setSuppressGlobal401(true);
+				sessionStorage.removeItem(`oauth2_consent_token_${flowId}`);
+			}
+		}
+		return getActiveTempToken() !== null;
+	});
+
+	const loginHref = useMemo(() => {
+		const returnPath = `/oauth/consent?flow=${encodeURIComponent(flowId)}`;
+		return `/login?goto=${encodeURIComponent(returnPath)}`;
+	}, [flowId]);
+
+	// Persist the active temp token so it can be restored after a login round-trip.
+	// Kept in an effect (not the memo above) so it runs exactly once per flowId —
+	// memo computations are not guaranteed to run in React 18 concurrent mode.
+	useEffect(() => {
+		if (typeof sessionStorage === "undefined") return;
+		const currentToken = getActiveTempToken();
+		if (currentToken) {
+			sessionStorage.setItem(`oauth2_consent_token_${flowId}`, currentToken);
+		}
+	}, [flowId]);
+
+	const showLoginOption =
+		usingTempToken &&
+		authState?.is_auth_enabled === true &&
+		authState.has_valid_token === false;
+
+	const handleSubmit = async (mode: "vk" | "session" | "user") => {
+		setSelectedMode(mode);
+		try {
+			const res = await submitFlow({
+				flowId,
+				body: { mode, value: mode === "vk" ? vkValue : undefined },
+			}).unwrap();
+			// Defence-in-depth: the server validates redirect_uri against the
+			// registered client, but never hand a javascript:/data: URL to
+			// location.href — it would execute in this origin. Block dangerous
+			// schemes while still allowing http(s) and native custom-scheme
+			// redirects that clients may register.
+			if (!isSafeRedirect(res.redirect_url)) {
+				toast.error("Authentication failed", { description: "Invalid redirect URL" });
+				setSelectedMode(null);
+				return;
+			}
+			window.location.href = res.redirect_url;
+		} catch (err) {
+			toast.error("Authentication failed", { description: getErrorMessage(err) });
+			setSelectedMode(null);
+		}
+	};
+
+	if (isLoading) return <FullPageLoader />;
+
+	if (isError || !flow) {
+		const status = (error as { status?: number } | undefined)?.status;
+		if (status === 401) return <InvalidLinkView />;
+		return (
+			<Shell>
+				<div className="text-center">
+					<h1 className="text-xl font-semibold">Link unavailable</h1>
+					<p className="text-muted-foreground mt-2 text-sm">
+						This authorization link may have expired or already been used.
+						Restart the connection from your MCP client to get a fresh link.
+					</p>
+				</div>
+			</Shell>
+		);
+	}
+
+	const hasUser = flow.available_modes.includes("user");
+	const hasVK = flow.available_modes.includes("vk");
+	const hasSession = flow.available_modes.includes("session");
+	const hasAnyMode = hasUser || hasVK || hasSession;
+	const clientName = flow.client_name || "MCP Client";
+
+	return (
+		<Shell>
+			{/* Header */}
+			<div className="mb-8 text-center">
+				<div className="bg-primary/10 mx-auto mb-4 flex size-14 items-center justify-center rounded-full">
+					<ShieldCheck className="text-primary size-7" />
+				</div>
+				<h1 className="text-xl font-semibold tracking-tight">
+					{clientName} wants to connect
+				</h1>
+				<p className="text-muted-foreground mt-1.5 text-sm">
+					Choose how you'd like to identify yourself to Bifrost
+				</p>
+			</div>
+
+			<div className="space-y-3">
+				{/* No mode available — nothing the user can act on here */}
+				{!hasAnyMode && (
+					<div
+						className="rounded-sm border p-4 text-center"
+						data-testid="oauth-consent-empty-state"
+					>
+						<p className="text-sm font-medium">
+							No authentication options available
+						</p>
+						<p className="text-muted-foreground mt-1 text-xs">
+							Restart the connection from your MCP client.
+						</p>
+					</div>
+				)}
+
+				{/* User mode — most prominent when logged in */}
+				{hasUser && flow.logged_in_user && (
+					<div className="rounded-sm border p-4">
+						<div className="flex items-center gap-3">
+							<div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-full">
+								<UserRound className="text-muted-foreground size-4" />
+							</div>
+							<div className="min-w-0 flex-1">
+								<p className="text-sm font-medium leading-tight">
+									{flow.logged_in_user.name || flow.logged_in_user.id}
+								</p>
+								<p className="text-muted-foreground text-xs">Signed-in account</p>
+							</div>
+						</div>
+						<Button
+							data-testid="oauth-consent-continue-user-btn"
+							className="mt-4 w-full"
+							onClick={() => handleSubmit("user")}
+							disabled={submitting}
+						>
+							{submitting && selectedMode === "user" ? (
+								<><Loader2 className="mr-2 size-4 animate-spin" />Connecting…</>
+							) : (
+								<>Continue as {flow.logged_in_user.name || flow.logged_in_user.id}</>
+							)}
+						</Button>
+					</div>
+				)}
+
+				{/* User mode — sign in prompt when not logged in */}
+				{hasUser && !flow.logged_in_user && showLoginOption && (
+					<div className="rounded-sm border p-4">
+						<div className="flex items-center gap-3">
+							<div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-full">
+								<UserRound className="text-muted-foreground size-4" />
+							</div>
+							<div>
+								<p className="text-sm font-medium">Sign in with your account</p>
+								<p className="text-muted-foreground text-xs">
+									Requires a Bifrost dashboard account
+								</p>
+							</div>
+						</div>
+						<Button asChild variant="outline" className="mt-4 w-full">
+							<a href={loginHref} data-testid="oauth-consent-signin-link">
+								<LogIn className="mr-2 size-4" />
+								Sign in to continue
+							</a>
+						</Button>
+					</div>
+				)}
+
+				{/* Divider between user and key options */}
+				{hasUser && (hasVK || hasSession) && (
+					<div className="relative">
+						<Separator />
+						<span className="bg-card text-muted-foreground absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 px-2 text-xs">
+							or
+						</span>
+					</div>
+				)}
+
+				{/* VK mode */}
+				{hasVK && (
+					<div className="rounded-sm border p-4">
+						<div className="mb-4 flex items-center gap-3">
+							<div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-full">
+								<KeyRound className="text-muted-foreground size-4" />
+							</div>
+							<div>
+								<p className="text-sm font-medium">Virtual key</p>
+								<p className="text-muted-foreground text-xs">
+									Use an API key from your Bifrost workspace
+								</p>
+							</div>
+						</div>
+						<Input
+							id="vk-input"
+							data-testid="oauth-consent-vk-input"
+							type="password"
+							placeholder="sk-bf-…"
+							value={vkValue}
+							onChange={(e) => setVkValue(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" && vkValue.trim()) {
+									void handleSubmit("vk");
+								}
+							}}
+							disabled={submitting}
+							className="mb-3"
+						/>
+						<Button
+							data-testid="oauth-consent-connect-vk-btn"
+							className="w-full"
+							onClick={() => handleSubmit("vk")}
+							disabled={submitting || !vkValue.trim()}
+						>
+							{submitting && selectedMode === "vk" ? (
+								<><Loader2 className="mr-2 size-4 animate-spin" />Connecting…</>
+							) : (
+								"Connect with key"
+							)}
+						</Button>
+						{hasUser && (
+							<p className="text-muted-foreground mt-2.5 text-xs">
+								If this key is linked to a user account, you'll be asked to sign
+								in to confirm your identity.
+							</p>
+						)}
+					</div>
+				)}
+
+				{hasVK && hasSession && (
+					<div className="relative">
+						<Separator />
+						<span className="bg-card text-muted-foreground absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 px-2 text-xs">
+							or
+						</span>
+					</div>
+				)}
+
+				{/* Session mode — de-emphasised, last */}
+				{hasSession && (
+					<Button
+						data-testid="oauth-consent-continue-session-btn"
+						variant="ghost"
+						className="text-muted-foreground hover:text-foreground w-full justify-start gap-3 px-4 py-3 h-auto"
+						onClick={() => handleSubmit("session")}
+						disabled={submitting}
+					>
+						<Fingerprint className="size-4 shrink-0" />
+						<div className="text-left">
+							<span className="block text-sm font-normal">
+								{submitting && selectedMode === "session"
+									? "Connecting…"
+									: "Continue without an identity"}
+							</span>
+							<span className="text-xs opacity-70">
+								Anonymous session - no account required
+							</span>
+						</div>
+					</Button>
+				)}
+			</div>
+
+			{/* Expiry */}
+			<p className="text-muted-foreground mt-6 text-center text-xs">
+				This link expires {formatExpiry(flow.expires_at)}
+			</p>
+		</Shell>
+	);
+}
+
+function formatExpiry(iso: string): string {
+	const ts = new Date(iso).getTime();
+	if (Number.isNaN(ts)) return "soon";
+	try {
+		const diffMs = ts - Date.now();
+		if (diffMs < 0) return "soon";
+		const mins = Math.floor(diffMs / 60_000);
+		if (mins < 1) return "in less than a minute";
+		if (mins === 1) return "in 1 minute";
+		return `in ${mins} minutes`;
+	} catch {
+		return "soon";
+	}
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+	return (
+		<div className="mx-auto flex min-h-screen w-full items-center justify-center p-4 sm:p-6">
+			<div className="bg-card w-full max-w-md rounded-sm border p-6 shadow-sm sm:p-8">
+				{children}
+			</div>
+		</div>
+	);
+}
+
+function InvalidLinkView() {
+	return (
+		<Shell>
+			<div className="text-center">
+				<h1 className="text-xl font-semibold tracking-tight">
+					This link is no longer valid
+				</h1>
+				<p className="text-muted-foreground mt-2 text-sm">
+					The authorization link has expired, been used already, or had its
+					token stripped. Restart the connection from your MCP client to get a
+					fresh link.
+				</p>
+			</div>
+		</Shell>
+	);
+}

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -28,11 +28,15 @@ export default function MCPView() {
 		mcp_tool_execution_timeout: string;
 		mcp_code_mode_binding_level: string;
 		mcp_tool_sync_interval: string;
+    oauth2_auth_code_ttl: string;
+    oauth2_access_token_ttl: string;
 	}>({
 		mcp_agent_depth: "10",
 		mcp_tool_execution_timeout: "30",
 		mcp_code_mode_binding_level: "server",
 		mcp_tool_sync_interval: "10",
+    oauth2_auth_code_ttl: "600",
+    oauth2_access_token_ttl: "600",
 	});
 
 	useEffect(() => {
@@ -43,6 +47,14 @@ export default function MCPView() {
 				mcp_tool_execution_timeout: config?.mcp_tool_execution_timeout?.toString() || "30",
 				mcp_code_mode_binding_level: config?.mcp_code_mode_binding_level || "server",
 				mcp_tool_sync_interval: config?.mcp_tool_sync_interval?.toString() || "10",
+        // Coerce a stored 0 (which the backend treats as "use default") to the
+        // displayed default so the inputs never show a confusing 0.
+        oauth2_auth_code_ttl: (
+          config?.oauth2_server_config?.auth_code_ttl || 600
+        ).toString(),
+        oauth2_access_token_ttl: (
+          config?.oauth2_server_config?.access_token_ttl || 600
+        ).toString(),
 			});
 		}
 	}, [config, bifrostConfig]);
@@ -50,6 +62,10 @@ export default function MCPView() {
 	const hasChanges = useMemo(() => {
 		if (!config) return false;
 		const clientURLChanged = !secretVarEquals(localConfig.mcp_external_client_url, config.mcp_external_client_url);
+    const issuerURLChanged = !secretVarEquals(
+      localConfig.oauth2_server_config?.issuer_url,
+      config.oauth2_server_config?.issuer_url,
+    );
 		return (
 			localConfig.mcp_agent_depth !== config.mcp_agent_depth ||
 			localConfig.mcp_tool_execution_timeout !== config.mcp_tool_execution_timeout ||
@@ -57,7 +73,14 @@ export default function MCPView() {
 			localConfig.mcp_tool_sync_interval !== (config.mcp_tool_sync_interval ?? 10) ||
 			localConfig.mcp_disable_auto_tool_inject !== (config.mcp_disable_auto_tool_inject ?? false) ||
 			localConfig.mcp_enable_temp_token_auth !== (config.mcp_enable_temp_token_auth ?? false) ||
-			clientURLChanged
+			clientURLChanged ||
+      (localConfig.mcp_server_auth_mode ?? "headers") !==
+        (config.mcp_server_auth_mode ?? "headers") ||
+      issuerURLChanged ||
+      (localConfig.oauth2_server_config?.auth_code_ttl ?? 600) !==
+        (config.oauth2_server_config?.auth_code_ttl ?? 600) ||
+      (localConfig.oauth2_server_config?.access_token_ttl ?? 600) !==
+        (config.oauth2_server_config?.access_token_ttl ?? 600)
 		);
 	}, [config, localConfig]);
 
@@ -116,6 +139,51 @@ export default function MCPView() {
 		setLocalConfig((prev) => ({ ...prev, mcp_external_client_url: value }));
 	}, []);
 
+  const handleAuthModeChange = useCallback((value: string) => {
+    if (value === "headers" || value === "both" || value === "oauth") {
+      setLocalConfig((prev) => ({
+        ...prev,
+        mcp_server_auth_mode: value,
+        // disable_vk_identity is oauth-only and its toggle is hidden outside oauth
+        // mode; clear it on the way out so a hidden-stale value can't be saved and
+        // rejected by the backend (400) on the next save.
+        oauth2_server_config:
+          value === "oauth"
+            ? prev.oauth2_server_config
+            : { ...prev.oauth2_server_config, disable_vk_identity: false },
+      }));
+    }
+  }, []);
+
+  const handleIssuerURLChange = useCallback((value: SecretVar) => {
+    setLocalConfig((prev) => ({
+      ...prev,
+      oauth2_server_config: { ...prev.oauth2_server_config, issuer_url: value },
+    }));
+  }, []);
+
+  const handleAuthCodeTTLChange = useCallback((value: string) => {
+    setLocalValues((prev) => ({ ...prev, oauth2_auth_code_ttl: value }));
+    const num = Number.parseInt(value);
+    if (!isNaN(num) && num >= 60) {
+      setLocalConfig((prev) => ({
+        ...prev,
+        oauth2_server_config: { ...prev.oauth2_server_config, auth_code_ttl: num },
+      }));
+    }
+  }, []);
+
+  const handleAccessTokenTTLChange = useCallback((value: string) => {
+    setLocalValues((prev) => ({ ...prev, oauth2_access_token_ttl: value }));
+    const num = Number.parseInt(value);
+    if (!isNaN(num) && num >= 60) {
+      setLocalConfig((prev) => ({
+        ...prev,
+        oauth2_server_config: { ...prev.oauth2_server_config, access_token_ttl: num },
+      }));
+    }
+  }, []);
+
 	const handleSave = useCallback(async () => {
 		try {
 			const agentDepth = Number.parseInt(localValues.mcp_agent_depth);
@@ -131,13 +199,54 @@ export default function MCPView() {
 				return;
 			}
 
+      // The TTL fields are only shown (and only relevant) in OAuth modes; the
+      // backend likewise validates oauth2_server_config only then. Guard the
+      // checks so a stale value can't dead-end the save after switching back to
+      // headers mode, where the fields are hidden and unfixable.
+      const oauthModeActive =
+        localConfig.mcp_server_auth_mode === "both" ||
+        localConfig.mcp_server_auth_mode === "oauth";
+
+      const authCodeTTL = Number.parseInt(localValues.oauth2_auth_code_ttl);
+      const accessTokenTTL = Number.parseInt(
+        localValues.oauth2_access_token_ttl,
+      );
+
+      if (oauthModeActive && (isNaN(authCodeTTL) || authCodeTTL < 60)) {
+        toast.error("Authorization code TTL must be at least 60 seconds.");
+        return;
+      }
+
+      if (oauthModeActive && (isNaN(accessTokenTTL) || accessTokenTTL < 60)) {
+        toast.error("Access token TTL must be at least 60 seconds.");
+        return;
+      }
+
 			if (!bifrostConfig) {
 				toast.error("Configuration not loaded. Please refresh and try again.");
 				return;
 			}
+
+      // The TTLs live in localValues (the text inputs) and only sync into
+      // localConfig when the field is edited, so a setup that never touches them
+      // (e.g. only toggling a switch or setting the issuer URL) would serialize
+      // oauth2_server_config with the TTLs omitted — which the Go side unmarshals
+      // back as 0. Write the validated values so the stored config always matches
+      // what the form shows.
+      const clientConfigToSave: CoreConfig = oauthModeActive
+        ? {
+            ...localConfig,
+            oauth2_server_config: {
+              ...localConfig.oauth2_server_config,
+              auth_code_ttl: authCodeTTL,
+              access_token_ttl: accessTokenTTL,
+            },
+          }
+        : localConfig;
+
 			await updateCoreConfig({
 				...bifrostConfig,
-				client_config: localConfig,
+				client_config: clientConfigToSave,
 			}).unwrap();
 			toast.success("MCP settings updated successfully.");
 		} catch (error) {
@@ -340,6 +449,168 @@ export default function MCPView() {
 									</p>
 								</AlertDescription>
 							</Alert>
+              {/* MCP Server Auth Mode */}
+              <div className="mt-4 space-y-2 border-t pt-4">
+                <label
+                  htmlFor="mcp-server-auth-mode"
+                  className="text-sm font-medium"
+                >
+                  MCP Server Authentication Mode
+                </label>
+                <p className="text-muted-foreground text-sm">
+                  Controls how inbound MCP clients (e.g. Claude Code, Cursor)
+                  authenticate to the <code className="text-xs">/mcp</code>{" "}
+                  endpoint.{" "}
+                  <b>headers</b> (default) - VK / api-key / session headers
+                  only, OAuth discovery disabled.{" "}
+                  <b>both</b> - accepts header credentials and Bifrost-issued
+                  JWTs; existing integrations are unaffected.{" "}
+                  <b>oauth</b> - JWTs only; VK and header access is disabled.
+                </p>
+                <Select
+                  value={localConfig.mcp_server_auth_mode ?? "headers"}
+                  onValueChange={handleAuthModeChange}
+                  disabled={!hasSettingsUpdateAccess}
+                >
+                  <SelectTrigger
+                    id="mcp-server-auth-mode"
+                    data-testid="mcp-server-auth-mode-select"
+                    className="w-40"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="headers">Headers</SelectItem>
+                    <SelectItem value="both">Both</SelectItem>
+                    <SelectItem value="oauth">OAuth</SelectItem>
+                  </SelectContent>
+                </Select>
+                {/* oauth: VK/header access disabled */}
+                {localConfig.mcp_server_auth_mode === "oauth" && (
+                  <Alert variant="warning">
+                    <AlertTriangle className="size-4" />
+                    <AlertTitle>VK / header MCP access will be disabled</AlertTitle>
+                    <AlertDescription>
+                      All existing MCP integrations that use a virtual key,
+                      api-key, or session header will stop working immediately.
+                      Clients must re-authenticate via the OAuth consent flow to
+                      obtain a JWT before they can connect.
+                    </AlertDescription>
+                  </Alert>
+                )}
+
+                {/* headers: warn if downgrading from oauth-enabled mode */}
+                {localConfig.mcp_server_auth_mode === "headers" &&
+                  (config?.mcp_server_auth_mode === "both" ||
+                    config?.mcp_server_auth_mode === "oauth") && (
+                  <Alert variant="warning">
+                    <AlertTriangle className="size-4" />
+                    <AlertTitle>OAuth discovery will be disabled</AlertTitle>
+                    <AlertDescription>
+                      All MCP clients that authenticated via the OAuth consent
+                      flow will lose access — their JWTs will be rejected and
+                      their refresh tokens will become unusable. They will need
+                      to reconfigure using a virtual key or api-key header.
+                    </AlertDescription>
+                  </Alert>
+                )}
+
+                {/* both: informational note about additive nature */}
+                {localConfig.mcp_server_auth_mode === "both" &&
+                  (config?.mcp_server_auth_mode ?? "headers") !== "both" && (
+                  <Alert>
+                    <AlertDescription>
+                      Existing VK / header integrations continue to work
+                      unchanged. New MCP clients can connect via OAuth - they'll
+                      be redirected to the consent page to pick an identity.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </div>
+
+              {/* OAuth2 AS Settings — only shown when auth mode is not headers */}
+              {(localConfig.mcp_server_auth_mode === "both" ||
+                localConfig.mcp_server_auth_mode === "oauth") && (
+                <div className="mt-4 space-y-4 border-t pt-4">
+                  <p className="text-sm font-medium">OAuth2 Server Settings</p>
+
+                  {/* Issuer URL */}
+                  <div className="space-y-1.5">
+                    <label
+                      htmlFor="oauth2-issuer-url"
+                      className="text-sm font-medium"
+                    >
+                      Issuer URL
+                    </label>
+                    <p className="text-muted-foreground text-sm">
+                      Stable public URL advertised in discovery documents and
+                      embedded as the <code className="text-xs">iss</code> claim
+                      in every JWT. Leave blank to derive it from the request{" "}
+                      <code className="text-xs">Host</code> header (sufficient
+                      for most deployments). Multi-host or reverse-proxy
+                      deployments might need this. Supports env var syntax (e.g.{" "}
+                      <code className="text-xs">env.BIFROST_ISSUER_URL</code>).
+                    </p>
+                    <SecretVarInput
+                      id="oauth2-issuer-url"
+                      data-testid="oauth2-issuer-url-input"
+                      placeholder="https://bifrost.example.com or env.BIFROST_ISSUER_URL"
+                      value={localConfig.oauth2_server_config?.issuer_url}
+                      onChange={handleIssuerURLChange}
+                      disabled={!hasSettingsUpdateAccess}
+                    />
+                  </div>
+
+                  {/* Token TTLs */}
+                  <div className="flex gap-6">
+                    <div className="space-y-1.5">
+                      <label
+                        htmlFor="oauth2-auth-code-ttl"
+                        className="text-sm font-medium"
+                      >
+                        Authorization code TTL (seconds)
+                      </label>
+                      <p className="text-muted-foreground text-xs">
+                        How long the one-time code is valid after the consent
+                        page redirects back to the MCP client (default: 600).
+                      </p>
+                      <Input
+                        id="oauth2-auth-code-ttl"
+                        data-testid="oauth2-auth-code-ttl-input"
+                        type="number"
+                        className="w-28"
+                        min="60"
+                        value={localValues.oauth2_auth_code_ttl}
+                        onChange={(e) => handleAuthCodeTTLChange(e.target.value)}
+                        disabled={!hasSettingsUpdateAccess}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <label
+                        htmlFor="oauth2-access-token-ttl"
+                        className="text-sm font-medium"
+                      >
+                        Access token TTL (seconds)
+                      </label>
+                      <p className="text-muted-foreground text-xs">
+                        Lifetime of issued JWT Bearer tokens. Clients silently
+                        refresh when expired (default: 600 = 10 min). Also bounds
+                        how long a revoked grant keeps working before it is cut off.
+                      </p>
+                      <Input
+                        id="oauth2-access-token-ttl"
+                        data-testid="oauth2-access-token-ttl-input"
+                        type="number"
+                        className="w-28"
+                        min="60"
+                        value={localValues.oauth2_access_token_ttl}
+                        onChange={(e) => handleAccessTokenTTLChange(e.target.value)}
+                        disabled={!hasSettingsUpdateAccess}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
 						</AccordionContent>
 					</AccordionItem>
 				</Accordion>

--- a/ui/lib/store/apis/index.ts
+++ b/ui/lib/store/apis/index.ts
@@ -11,6 +11,7 @@ export * from "./mcpApi";
 export * from "./mcpLogsApi";
 export * from "./mcpPerUserHeadersApi";
 export * from "./mcpSessionsApi";
+export * from "./oauth2ConsentApi";
 export * from "./pluginsApi";
 export * from "./providersApi";
 export * from "./promptsApi";

--- a/ui/lib/store/apis/oauth2ConsentApi.ts
+++ b/ui/lib/store/apis/oauth2ConsentApi.ts
@@ -1,0 +1,42 @@
+import { baseApi } from "./baseApi";
+
+export interface OAuth2ConsentFlowDetail {
+	client_name: string;
+	available_modes: Array<"vk" | "session" | "user">;
+	logged_in_user?: { id: string; name?: string };
+	expires_at: string;
+}
+
+export interface OAuth2ConsentSubmitRequest {
+	mode: "vk" | "session" | "user";
+	value?: string; // VK plaintext for mode=vk; absent for session/user
+}
+
+export interface OAuth2ConsentSubmitResponse {
+	redirect_url: string;
+}
+
+export const oauth2ConsentApi = baseApi.injectEndpoints({
+	endpoints: (builder) => ({
+		getOAuth2ConsentFlow: builder.query<OAuth2ConsentFlowDetail, string>({
+			query: (flowId) => ({
+				url: `/oauth2/consent/flows/${encodeURIComponent(flowId)}`,
+			}),
+		}),
+		submitOAuth2ConsentFlow: builder.mutation<
+			OAuth2ConsentSubmitResponse,
+			{ flowId: string; body: OAuth2ConsentSubmitRequest }
+		>({
+			query: ({ flowId, body }) => ({
+				url: `/oauth2/consent/flows/${encodeURIComponent(flowId)}`,
+				method: "PUT",
+				body,
+			}),
+		}),
+	}),
+});
+
+export const {
+	useGetOAuth2ConsentFlowQuery,
+	useSubmitOAuth2ConsentFlowMutation,
+} = oauth2ConsentApi;

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -581,6 +581,12 @@ export interface CoreConfig {
 	routing_chain_max_depth: number;
 	header_filter_config?: GlobalHeaderFilterConfig;
 	mcp_external_client_url?: SecretVar;
+	mcp_server_auth_mode?: "headers" | "both" | "oauth";
+	oauth2_server_config?: {
+		issuer_url?: SecretVar;
+		auth_code_ttl?: number;
+		access_token_ttl?: number;
+	};
 }
 
 export const DefaultCoreConfig: CoreConfig = {

--- a/ui/lib/utils/loginGoto.ts
+++ b/ui/lib/utils/loginGoto.ts
@@ -23,6 +23,10 @@ function isWorkspaceRoute(value: string): boolean {
 		value === DEFAULT_POST_LOGIN_PATH ||
 		value.startsWith(`${DEFAULT_POST_LOGIN_PATH}/`) ||
 		value.startsWith(`${DEFAULT_POST_LOGIN_PATH}?`) ||
-		value.startsWith(`${DEFAULT_POST_LOGIN_PATH}#`)
+		value.startsWith(`${DEFAULT_POST_LOGIN_PATH}#`) ||
+    value === "/oauth/consent" ||
+    value.startsWith("/oauth/consent?") ||
+    value.startsWith("/oauth/consent#") ||
+    value.startsWith("/oauth/consent/")
 	);
 }


### PR DESCRIPTION
## Summary

Adds an OAuth2 consent page and supporting configuration to allow MCP clients (e.g. `claude mcp add`) to authenticate via a browser-based OAuth flow. Anonymous visitors arrive at `/oauth/consent?flow=<id>` with a short-lived temp token embedded in the URL fragment, choose how they want to identify themselves (signed-in user, virtual key, or anonymous session), and are redirected back to the MCP client with an authorization code.

## Changes

- **`/oauth/consent` route** — New standalone page (`layout.tsx` + `page.tsx`) that renders outside the dashboard chrome. It wraps itself with `ThemeProvider`, `ReduxProvider`, `NuqsAdapter`, and `Toaster` directly since it does not inherit them from `ClientLayout`. `TempTokenScope` extracts the `#t=…` fragment and attaches it as `X-Bifrost-Temp-Token` on every API call so the consent APIs can authenticate the anonymous visitor.
- **Consent UI** — `ConsentView` fetches the flow details and presents up to three authentication options: continuing as the signed-in user, entering a virtual key, or proceeding anonymously. It preserves the temp token across the login redirect via `sessionStorage` so users who choose to sign in are returned to the correct flow.
- **`oauth2ConsentApi`** — New RTK Query endpoints (`GET` and `PUT` `/oauth2/consent/flows/:flowId`) for fetching flow details and submitting the chosen identity mode.
- **MCP Server Auth Mode setting** — The MCP config view gains a `mcp_server_auth_mode` selector (`headers` / `both` / `oauth`) with contextual warnings: switching to `oauth` disables VK/header access; downgrading back to `headers` revokes all existing OAuth JWTs. OAuth2 server settings (issuer URL, auth code TTL, access token TTL) are revealed when the mode is `both` or `oauth`.
- **`CoreConfig` types** — Added `mcp_server_auth_mode` and `oauth2_server_config` (issuer URL, auth code TTL, access token TTL) to the config type and dirty-check logic.
- **`loginGoto`** — `/oauth/consent` is now treated as a valid post-login redirect destination.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Start Bifrost with an MCP server configured.
2. Run `claude mcp add --transport sse <bifrost-url>/mcp` (or equivalent). The client should redirect to `/oauth/consent?flow=<id>#t=<token>`.
3. Verify the consent page loads without requiring a dashboard login.
4. Test each identity mode:
   - **User** — sign in via the login redirect and confirm you are returned to the consent page and redirected back to the MCP client.
   - **Virtual key** — enter a valid `sk-bf-…` key and confirm a successful redirect.
   - **Anonymous** — click "Continue without an identity" and confirm a successful redirect.
5. In the MCP config view, toggle `mcp_server_auth_mode` between `headers`, `both`, and `oauth` and verify the correct warnings appear and the OAuth2 server settings section shows/hides accordingly.

```sh
cd ui
pnpm i
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

Setting `mcp_server_auth_mode` to `oauth` disables virtual key and header-based MCP authentication immediately. All existing MCP integrations using VK, api-key, or session headers will stop working until clients re-authenticate via the OAuth consent flow. Setting the mode back to `headers` from `both` or `oauth` invalidates all previously issued OAuth JWTs and refresh tokens.

## Security considerations

- The temp token (`#t=…`) is passed in the URL fragment and never sent to the server by the browser directly; it is extracted client-side and attached as a custom header (`X-Bifrost-Temp-Token`), limiting exposure in server logs.
- `setSuppressGlobal401` is called when restoring a temp token from `sessionStorage` after a login redirect to prevent the global 401 handler from clearing the session prematurely during the consent flow.
- The consent page is intentionally accessible without a dashboard session; all authorization is enforced server-side via the flow ID and temp token.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable