### PR TITLE
ui: add OAuth Grants page and `identity` exact-match filter for MCP sessions

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6457,6 +6457,16 @@ func applyMCPSessionFilters(query *gorm.DB, params MCPSessionsFilterParams, t mc
 	if len(params.MCPClientIDs) > 0 {
 		query = query.Where(t.table+".mcp_client_id IN ?", params.MCPClientIDs)
 	}
+	if params.Identity != "" {
+		// Exact match against whichever identity column carries the value for this
+		// row's mode. Parenthesized explicitly so the OR group ANDs cleanly with the
+		// filters above — GORM does not wrap raw-string conditions in parentheses, so
+		// without the parens the trailing ORs would escape the AND chain.
+		query = query.Where(
+			"("+t.table+".user_id = ? OR "+t.table+".virtual_key_id = ? OR "+t.table+".session_id = ?)",
+			params.Identity, params.Identity, params.Identity,
+		)
+	}
 	if params.Search != "" {
 		needle := "%" + strings.ToLower(params.Search) + "%"
 		query = query.

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -127,6 +127,12 @@ type MCPSessionsFilterParams struct {
 	Statuses     []string
 	AuthModes    []string // matched against auth_mode (tokens, credentials) or flow_mode (sessions, flows)
 	MCPClientIDs []string
+	// Identity exact-matches a single resolved identity value against any of
+	// the row's identity columns (user_id, virtual_key_id, session_id). Unlike
+	// Search it is not a substring match — it pins the list to exactly one
+	// user, virtual key, or session. Typically paired with AuthModes to scope
+	// to that identity's rows for a known mode.
+	Identity string
 	// MatchedUserIDs is an optional set of user_ids that should be treated
 	// as a positive search hit alongside Search. Callers that maintain a
 	// user directory (display names, emails) resolve the search string

--- a/transports/bifrost-http/handlers/mcpsessions.go
+++ b/transports/bifrost-http/handlers/mcpsessions.go
@@ -125,6 +125,10 @@ func parseMCPSessionsListQuery(ctx *fasthttp.RequestCtx) (mcpSessionsListQuery, 
 	q := mcpSessionsListQuery{Limit: mcpSessionsDefaultLimit}
 	args := ctx.QueryArgs()
 	q.Filters.Search = strings.TrimSpace(string(args.Peek("q")))
+	// Identity is an exact-match SQL key (bf_sub), unlike the fuzzy Search term —
+	// pass it through verbatim so identities with significant leading/trailing
+	// whitespace still resolve.
+	q.Filters.Identity = string(args.Peek("identity"))
 	q.Filters.Statuses = parseCommaSeparated(string(args.Peek("status")))
 	q.Filters.AuthModes = parseCommaSeparated(string(args.Peek("auth_mode")))
 	q.Filters.MCPClientIDs = parseCommaSeparated(string(args.Peek("mcp_client_id")))

--- a/ui/app/workspace/mcp-sessions/page.tsx
+++ b/ui/app/workspace/mcp-sessions/page.tsx
@@ -18,12 +18,14 @@ export default function MCPSessionsPage() {
 			status: parseAsArrayOf(parseAsString).withDefault([]),
 			auth_mode: parseAsArrayOf(parseAsString).withDefault([]),
 			mcp_client_id: parseAsArrayOf(parseAsString).withDefault([]),
+			identity: parseAsString.withDefault(""),
 			offset: parseAsInteger.withDefault(0),
 		},
 		{ history: "push" },
 	);
 
 	const debouncedSearch = useDebouncedValue(urlState.q, 300);
+	const normalizedIdentity = urlState.identity.trim();
 
 	const { data, isLoading, isFetching, isError, error } = useGetMCPSessionsQuery({
 		q: debouncedSearch || undefined,
@@ -31,6 +33,7 @@ export default function MCPSessionsPage() {
 		status: urlState.status.length ? (urlState.status as MCPSessionStatus[]) : undefined,
 		auth_mode: urlState.auth_mode.length ? (urlState.auth_mode as AuthMode[]) : undefined,
 		mcp_client_id: urlState.mcp_client_id.length ? urlState.mcp_client_id : undefined,
+		identity: normalizedIdentity || undefined,
 		limit: PAGE_SIZE,
 		offset: urlState.offset,
 	});
@@ -46,9 +49,7 @@ export default function MCPSessionsPage() {
 		});
 	}, [totalCount, urlState.offset, data, setUrlState]);
 
-	if (isLoading) {
-		return <FullPageLoader />;
-	}
+	if (isLoading) return <FullPageLoader />;
 
 	if (isError) {
 		return (
@@ -65,14 +66,15 @@ export default function MCPSessionsPage() {
 		urlState.kind.length > 0 ||
 		urlState.status.length > 0 ||
 		urlState.auth_mode.length > 0 ||
-		urlState.mcp_client_id.length > 0;
+		urlState.mcp_client_id.length > 0 ||
+		!!normalizedIdentity;
 
 	const handleSearchChange = (value: string) => setUrlState({ q: value || null, offset: 0 });
 	const handleKindChange = (value: string[]) => setUrlState({ kind: value.length ? value : null, offset: 0 });
 	const handleStatusChange = (value: string[]) => setUrlState({ status: value.length ? value : null, offset: 0 });
 	const handleAuthModeChange = (value: string[]) => setUrlState({ auth_mode: value.length ? value : null, offset: 0 });
 	const handleOffsetChange = (offset: number) => setUrlState({ offset });
-	const handleClearFilters = () => setUrlState({ q: null, kind: null, status: null, auth_mode: null, mcp_client_id: null, offset: 0 });
+	const handleClearFilters = () => setUrlState({ q: null, kind: null, status: null, auth_mode: null, mcp_client_id: null, identity: null, offset: 0 });
 
 	return (
 		<div className="mx-auto w-full max-w-7xl">

--- a/ui/app/workspace/oauth-grants/layout.tsx
+++ b/ui/app/workspace/oauth-grants/layout.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import OAuthGrantsPage from "./page";
+
+export const Route = createFileRoute("/workspace/oauth-grants")({
+	component: OAuthGrantsPage,
+});

--- a/ui/app/workspace/oauth-grants/page.tsx
+++ b/ui/app/workspace/oauth-grants/page.tsx
@@ -1,0 +1,121 @@
+import { getErrorMessage, useGetOAuth2GrantsQuery, useRevokeOAuth2GrantMutation } from "@/lib/store";
+import type { OAuth2GrantRow } from "@/lib/store/apis/oauth2SessionsApi";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import GrantsFilterBar from "./views/grantsFilterBar";
+import GrantsTable from "./views/grantsTable";
+import RevokeGrantDialog from "./views/revokeGrantDialog";
+
+const PAGE_SIZE = 50;
+
+export default function OAuthGrantsPage() {
+	const { data, isLoading, isFetching, isError, error } = useGetOAuth2GrantsQuery();
+	const [revokeGrant, { isLoading: revoking }] = useRevokeOAuth2GrantMutation();
+
+	const [search, setSearch] = useState("");
+	const [modeFilter, setModeFilter] = useState<string[]>([]);
+	const [offset, setOffset] = useState(0);
+	const [pendingDelete, setPendingDelete] = useState<OAuth2GrantRow | null>(null);
+	const [pendingActionRowId, setPendingActionRowId] = useState<string | null>(null);
+
+	const allGrants = data?.sessions ?? [];
+	const filtered = allGrants.filter((g) => {
+		const matchesMode = modeFilter.length === 0 || modeFilter.includes(g.bf_mode);
+		const q = search.toLowerCase();
+		const matchesSearch =
+			!q ||
+			g.client_name?.toLowerCase().includes(q) ||
+			g.client_id.toLowerCase().includes(q) ||
+			(g.bf_sub_display ?? g.bf_sub).toLowerCase().includes(q);
+		return matchesMode && matchesSearch;
+	});
+	const totalCount = filtered.length;
+	const page = filtered.slice(offset, offset + PAGE_SIZE);
+	const hasActiveFilters = !!search || modeFilter.length > 0;
+
+	// Snap the offset back into range when the filtered count shrinks (e.g. a
+	// revoke removes the last row on the last page). Without this the page goes
+	// blank with the paginator and clear-filters affordances both hidden.
+	useEffect(() => {
+		if (totalCount === 0) {
+			if (offset !== 0) setOffset(0);
+			return;
+		}
+		const maxOffset = Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE;
+		if (offset > maxOffset) setOffset(maxOffset);
+	}, [offset, totalCount]);
+
+	const clearFilters = () => {
+		setSearch("");
+		setModeFilter([]);
+		setOffset(0);
+	};
+
+	const confirmRevoke = async () => {
+		if (!pendingDelete) return;
+		const row = pendingDelete;
+		setPendingDelete(null);
+		setPendingActionRowId(row.id);
+		try {
+			await revokeGrant(row.id).unwrap();
+			toast.success("Grant revoked");
+		} catch (err) {
+			toast.error("Failed to revoke grant", { description: getErrorMessage(err) });
+		} finally {
+			setPendingActionRowId(null);
+		}
+	};
+
+	return (
+		<div className="mx-auto w-full max-w-7xl space-y-4">
+			<RevokeGrantDialog
+				open={pendingDelete !== null}
+				onOpenChange={(open) => !open && setPendingDelete(null)}
+				onConfirm={confirmRevoke}
+			/>
+
+			<div className="flex items-center justify-between gap-4">
+				<div>
+					<h2 className="text-lg font-semibold tracking-tight">OAuth Grants</h2>
+					<p className="text-muted-foreground text-sm">
+						Active downstream OAuth grants issued to MCP clients that connected
+						via the OAuth consent flow.
+					</p>
+				</div>
+			</div>
+
+			<GrantsFilterBar
+				search={search}
+				onSearchChange={(value) => { setSearch(value); setOffset(0); }}
+				modeFilter={modeFilter}
+				onModeChange={(value) => { setModeFilter(value); setOffset(0); }}
+				hasActiveFilters={hasActiveFilters}
+				onClearFilters={clearFilters}
+			/>
+
+			{isLoading ? (
+				<div className="flex items-center justify-center py-16">
+					<Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+				</div>
+			) : isError ? (
+				<div className="rounded-lg border border-destructive bg-destructive/10 p-6 text-sm text-destructive">
+					Failed to load OAuth grants: {getErrorMessage(error)}
+				</div>
+			) : (
+				<GrantsTable
+					rows={page}
+					totalCount={totalCount}
+					offset={offset}
+					pageSize={PAGE_SIZE}
+					onOffsetChange={setOffset}
+					isFetching={isFetching}
+					hasActiveFilters={hasActiveFilters}
+					revoking={revoking}
+					pendingActionRowId={pendingActionRowId}
+					onRevoke={setPendingDelete}
+				/>
+			)}
+		</div>
+	);
+}

--- a/ui/app/workspace/oauth-grants/views/grantActions.tsx
+++ b/ui/app/workspace/oauth-grants/views/grantActions.tsx
@@ -1,0 +1,61 @@
+// Per-row actions menu for an OAuth grant: a dropdown exposing "View auth
+// sessions" (deep-link into MCP sessions pre-filtered to this grant's exact
+// identity) and a destructive "Revoke" action. The revoke confirmation itself
+// is owned by the page via onRevoke.
+
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
+import type { OAuth2GrantRow } from "@/lib/store/apis/oauth2SessionsApi";
+import { Link } from "@tanstack/react-router";
+import { ExternalLink, Loader2, MoreHorizontal, Trash2 } from "lucide-react";
+
+interface GrantActionsProps {
+	row: OAuth2GrantRow;
+	revoking: boolean;
+	isPendingRow: boolean;
+	onRevoke: () => void;
+}
+
+export default function GrantActions({ row, revoking, isPendingRow, onRevoke }: GrantActionsProps) {
+	const busy = revoking;
+	// Link to Auth Sessions pre-filtered to this grant's exact identity: the
+	// mode plus the identity filter, which exact-matches bf_sub against the
+	// session's user_id / virtual key id / session id, so the user lands on
+	// just this identity's sessions.
+	const authSessionsUrl = `/workspace/mcp-sessions?auth_mode=${row.bf_mode}&identity=${encodeURIComponent(row.bf_sub)}`;
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button data-testid="oauth-grants-actions-trigger" variant="ghost" size="icon" className="h-8 w-8" aria-label="Grant actions" disabled={busy}>
+					{busy && isPendingRow ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				{(row.bf_mode === "user" || row.bf_mode === "vk" || row.bf_mode === "session") && (
+					<DropdownMenuItem asChild className="cursor-pointer">
+						<Link to={authSessionsUrl} data-testid="oauth-grants-view-sessions-link">
+							<ExternalLink className="h-4 w-4" />
+							View auth sessions
+						</Link>
+					</DropdownMenuItem>
+				)}
+				<DropdownMenuItem
+					data-testid="oauth-grants-revoke-action"
+					variant="destructive"
+					className="cursor-pointer"
+					disabled={busy}
+					onSelect={(e) => { e.preventDefault(); onRevoke(); }}
+				>
+					<Trash2 className="h-4 w-4" />
+					Revoke
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/ui/app/workspace/oauth-grants/views/grantsFilterBar.tsx
+++ b/ui/app/workspace/oauth-grants/views/grantsFilterBar.tsx
@@ -1,0 +1,65 @@
+// Filter row above the grants table: free-text search (client / identity) and
+// a multi-select on the grant's identity mode (user / vk / session), plus a
+// clear-filters affordance shown only when something is active.
+
+import { Button } from "@/components/ui/button";
+import { ComboboxSelect } from "@/components/ui/combobox";
+import { Input } from "@/components/ui/input";
+import { Fingerprint, KeyRound, Search, UserRound, X } from "lucide-react";
+
+const MODE_OPTIONS = [
+	{ label: "User", value: "user", icon: <UserRound className="size-3.5" /> },
+	{ label: "Virtual key", value: "vk", icon: <KeyRound className="size-3.5" /> },
+	{ label: "Session", value: "session", icon: <Fingerprint className="size-3.5" /> },
+];
+
+interface GrantsFilterBarProps {
+	search: string;
+	onSearchChange: (value: string) => void;
+	modeFilter: string[];
+	onModeChange: (value: string[]) => void;
+	hasActiveFilters: boolean;
+	onClearFilters: () => void;
+}
+
+export default function GrantsFilterBar({
+	search,
+	onSearchChange,
+	modeFilter,
+	onModeChange,
+	hasActiveFilters,
+	onClearFilters,
+}: GrantsFilterBarProps) {
+	return (
+		<div className="flex shrink-0 flex-wrap items-center gap-3">
+			<div className="relative max-w-sm flex-1 min-w-[200px]">
+				<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+				<Input
+					data-testid="oauth-grants-search-input"
+					aria-label="Search grants"
+					placeholder="Search client, identity..."
+					value={search}
+					onChange={(e) => onSearchChange(e.target.value)}
+					className="pl-9"
+				/>
+			</div>
+			<ComboboxSelect
+				data-testid="oauth-grants-mode-filter"
+				multiple
+				disableSearch
+				compactTrigger
+				options={MODE_OPTIONS}
+				value={modeFilter}
+				onValueChange={onModeChange}
+				placeholder="All identities"
+				className="h-9 w-[180px]"
+			/>
+			{hasActiveFilters && (
+				<Button data-testid="oauth-grants-clear-filters-btn" variant="ghost" size="sm" onClick={onClearFilters} className="h-9">
+					<X className="h-4 w-4" />
+					Clear filters
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/ui/app/workspace/oauth-grants/views/grantsTable.tsx
+++ b/ui/app/workspace/oauth-grants/views/grantsTable.tsx
@@ -1,0 +1,241 @@
+// Results table for OAuth grants: one row per active downstream grant, with the
+// bound identity, an approximate access-token expiry, created/last-used relative
+// times, and a per-row actions menu. Owns the empty state and pagination; the
+// page passes in the current page slice plus filter/revoke state.
+
+import { Button } from "@/components/ui/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import type { OAuth2GrantRow } from "@/lib/store/apis/oauth2SessionsApi";
+import {
+	ChevronLeft,
+	ChevronRight,
+	Fingerprint,
+	Info,
+	KeyRound,
+	ShieldCheck,
+	UserRound,
+} from "lucide-react";
+import GrantActions from "./grantActions";
+
+interface GrantsTableProps {
+	rows: OAuth2GrantRow[];
+	totalCount: number;
+	offset: number;
+	pageSize: number;
+	onOffsetChange: (offset: number) => void;
+	isFetching: boolean;
+	hasActiveFilters: boolean;
+	revoking: boolean;
+	pendingActionRowId: string | null;
+	onRevoke: (row: OAuth2GrantRow) => void;
+}
+
+export default function GrantsTable({
+	rows,
+	totalCount,
+	offset,
+	pageSize,
+	onOffsetChange,
+	isFetching,
+	hasActiveFilters,
+	revoking,
+	pendingActionRowId,
+	onRevoke,
+}: GrantsTableProps) {
+	return (
+		<>
+			<div className={`overflow-auto rounded-sm border ${isFetching ? "opacity-70 transition-opacity" : ""}`}>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Client</TableHead>
+							<TableHead>
+								<HeaderWithTooltip
+									label="Bound to"
+									tooltip="The identity this grant is tied to: an end user (via SSO), a virtual key (shared by anyone using that VK), or an anonymous session. This determines which upstream per-user OAuth sessions are reachable under this grant."
+								/>
+							</TableHead>
+							<TableHead>
+								<HeaderWithTooltip
+									label="Access token expiry"
+									tooltip="When the current JWT access token expires. MCP clients silently refresh using the refresh token, so an active grant past its expiry will mint a new token automatically on the next request."
+								/>
+							</TableHead>
+							<TableHead>Created</TableHead>
+							<TableHead>
+								<HeaderWithTooltip
+									label="Last used"
+									tooltip="When this grant last refreshed its access token. MCP clients refresh as their token nears expiry, so this tracks the grant's most recent activity. Grants that have not refreshed since they were authorized fall back to when they were created."
+								/>
+							</TableHead>
+							<TableHead className={`bg-muted relative sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`} />
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{rows.length === 0 ? (
+							<TableRow>
+								<TableCell colSpan={6} className="h-24 text-center">
+									{hasActiveFilters ? (
+										<div className="text-muted-foreground text-sm">
+											No grants match these filters.
+										</div>
+									) : (
+										<EmptyGrantsState />
+									)}
+								</TableCell>
+							</TableRow>
+						) : (
+							rows.map((row) => (
+								<TableRow key={row.id} className="group">
+									<TableCell className="font-medium">
+										{row.client_name || row.client_id}
+									</TableCell>
+									<TableCell>
+										<BindingCell row={row} />
+									</TableCell>
+									<TableCell className="text-muted-foreground text-sm">
+										<AccessTokenExpiry row={row} />
+									</TableCell>
+									<TableCell className="text-muted-foreground text-sm">
+										{formatRelativePast(row.created_at)}
+									</TableCell>
+									<TableCell className="text-muted-foreground text-sm">
+										{formatRelativePast(row.last_used_at || row.created_at)}
+									</TableCell>
+									<TableCell
+										className={`relative group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+									>
+										<GrantActions
+											row={row}
+											revoking={revoking}
+											isPendingRow={pendingActionRowId === row.id}
+											onRevoke={() => onRevoke(row)}
+										/>
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			{totalCount > pageSize && (
+				<div className="flex items-center justify-between gap-4">
+					<p className="text-muted-foreground text-sm">
+						Showing {offset + 1}&#8211;{Math.min(offset + pageSize, totalCount)} of {totalCount}
+					</p>
+					<div className="flex items-center gap-2">
+						<Button data-testid="oauth-grants-prev-page-btn" variant="outline" size="sm" disabled={offset === 0}
+							onClick={() => onOffsetChange(Math.max(0, offset - pageSize))}>
+							<ChevronLeft className="h-4 w-4" />
+							Previous
+						</Button>
+						<Button data-testid="oauth-grants-next-page-btn" variant="outline" size="sm" disabled={offset + pageSize >= totalCount}
+							onClick={() => onOffsetChange(offset + pageSize)}>
+							Next
+							<ChevronRight className="h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			)}
+		</>
+	);
+}
+
+function BindingCell({ row }: { row: OAuth2GrantRow }) {
+	const display = row.bf_sub_display || row.bf_sub;
+	if (row.bf_mode === "user") {
+		return (
+			<span className="inline-flex items-center gap-2">
+				<UserRound className="text-muted-foreground size-3.5 shrink-0" />
+				<span className="text-sm">{display}</span>
+			</span>
+		);
+	}
+	if (row.bf_mode === "vk") {
+		return (
+			<span className="inline-flex items-center gap-2">
+				<KeyRound className="text-muted-foreground size-3.5 shrink-0" />
+				<span className="text-sm">{display}</span>
+			</span>
+		);
+	}
+	return (
+		<span className="inline-flex items-center gap-2">
+			<Fingerprint className="text-muted-foreground size-3.5 shrink-0" />
+			<span className="font-mono text-sm">{display}</span>
+		</span>
+	);
+}
+
+function AccessTokenExpiry({ row }: { row: OAuth2GrantRow }) {
+	// Access token TTL is 10 min (600s default). Access tokens are stateless JWTs
+	// not stored server-side, so we approximate expiry from the grant's last
+	// activity (last_used_at, falling back to created_at). Anchoring to created_at
+	// alone would read as expired for any grant that has silently refreshed.
+	const baseMs = new Date(row.last_used_at ?? row.created_at).getTime();
+	if (!Number.isFinite(baseMs)) {
+		return <span className="text-muted-foreground">Unknown</span>;
+	}
+	const expiryMs = baseMs + 600_000; // 10 min default
+	const diffMs = expiryMs - Date.now();
+	if (diffMs < 0) {
+		return <span className="text-muted-foreground">Refreshes on next use</span>;
+	}
+	const mins = Math.ceil(diffMs / 60_000);
+	return <span>in {mins} min</span>;
+}
+
+function HeaderWithTooltip({ label, tooltip }: { label: string; tooltip: string }) {
+	return (
+		<TooltipProvider delayDuration={150}>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span className="inline-flex cursor-help items-center gap-2">
+						{label}
+						<Info className="text-muted-foreground size-3" />
+					</span>
+				</TooltipTrigger>
+				<TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}
+
+function EmptyGrantsState() {
+	return (
+		<div className="flex flex-col items-center gap-3 py-4">
+			<p className="text-muted-foreground text-sm">
+				No grants yet. Grants appear here when an MCP client connects via the OAuth
+				consent flow. (Authentication Mode needs to be set to "oauth" or "both" for grants to be issued.)
+			</p>
+		</div>
+	);
+}
+
+function formatRelativePast(iso: string): string {
+	try {
+		const ts = new Date(iso).getTime();
+		if (!Number.isFinite(ts)) return iso;
+		const diffMs = Date.now() - ts;
+		if (diffMs < 0) return "just now";
+		const mins = Math.floor(diffMs / 60_000);
+		if (mins < 1) return "just now";
+		if (mins < 60) return `${mins}m ago`;
+		const hrs = Math.floor(mins / 60);
+		if (hrs < 24) return `${hrs}h ago`;
+		const days = Math.floor(hrs / 24);
+		return `${days}d ago`;
+	} catch {
+		return iso;
+	}
+}

--- a/ui/app/workspace/oauth-grants/views/revokeGrantDialog.tsx
+++ b/ui/app/workspace/oauth-grants/views/revokeGrantDialog.tsx
@@ -1,0 +1,51 @@
+// Confirmation dialog for revoking an OAuth grant. Open/confirm are driven by
+// the page; the copy explains that the refresh token stops rotating immediately
+// while the current short-lived access token keeps working until it expires.
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+
+interface RevokeGrantDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+}
+
+export default function RevokeGrantDialog({ open, onOpenChange, onConfirm }: RevokeGrantDialogProps) {
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Revoke this OAuth grant?</AlertDialogTitle>
+					<AlertDialogDescription>
+						The refresh token for this grant stops rotating right away, so the
+						MCP client can no longer renew its access. Its current access token
+						is a short-lived JWT that keeps working on the{" "}
+						<code className="rounded bg-muted px-1 py-0.5 text-xs">/mcp</code>{" "}
+						endpoint until it expires (default 10 minutes), after which the client
+						is fully cut off and must reconnect via the OAuth consent flow.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel data-testid="oauth-grants-revoke-cancel-btn">
+						Cancel
+					</AlertDialogCancel>
+					<AlertDialogAction
+						data-testid="oauth-grants-revoke-confirm-btn"
+						onClick={onConfirm}
+					>
+						Revoke
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -730,6 +730,13 @@ export default function AppSidebar() {
 						hasAccess: hasMCPGatewayAccess,
 					},
 					{
+						title: "OAuth Grants",
+						url: "/workspace/oauth-grants",
+						icon: ShieldCheck,
+						description: "Downstream OAuth grants",
+						hasAccess: hasMCPGatewayAccess,
+					},
+					{
 						title: "MCP Settings",
 						url: "/workspace/mcp-settings",
 						icon: Settings,

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -191,6 +191,7 @@ export const baseApi = createApi({
 		"FeatureFlags",
 		"ComplexityAnalyzerConfig",
 		"Skills",
+		"OAuth2Grants",
 		"CircuitBreakerPolicies",
 		"CircuitBreakerState",
 	],

--- a/ui/lib/store/apis/index.ts
+++ b/ui/lib/store/apis/index.ts
@@ -12,6 +12,7 @@ export * from "./mcpLogsApi";
 export * from "./mcpPerUserHeadersApi";
 export * from "./mcpSessionsApi";
 export * from "./oauth2ConsentApi";
+export * from "./oauth2SessionsApi";
 export * from "./pluginsApi";
 export * from "./providersApi";
 export * from "./promptsApi";

--- a/ui/lib/store/apis/mcpSessionsApi.ts
+++ b/ui/lib/store/apis/mcpSessionsApi.ts
@@ -19,6 +19,7 @@ function buildMCPSessionsListParams(params?: MCPSessionsQueryParams) {
 	if (!params) return {};
 	const out: Record<string, string | number> = {};
 	if (params.q) out.q = params.q;
+	if (params.identity) out.identity = params.identity;
 	if (params.kind?.length) out.kind = [...params.kind].sort().join(",");
 	if (params.status?.length) out.status = [...params.status].sort().join(",");
 	if (params.auth_mode?.length) out.auth_mode = [...params.auth_mode].sort().join(",");

--- a/ui/lib/store/apis/oauth2SessionsApi.ts
+++ b/ui/lib/store/apis/oauth2SessionsApi.ts
@@ -1,0 +1,32 @@
+import { baseApi } from "./baseApi";
+
+export interface OAuth2GrantRow {
+	id: string;
+	client_id: string;
+	client_name?: string;
+	bf_mode: "user" | "vk" | "session";
+	bf_sub: string;
+	bf_sub_display?: string; // human-readable: VK name for vk mode
+	scope: string;
+	created_at: string;
+	last_used_at?: string | null;
+}
+
+export interface OAuth2GrantsListResponse {
+	sessions: OAuth2GrantRow[];
+}
+
+export const oauth2SessionsApi = baseApi.injectEndpoints({
+	endpoints: (builder) => ({
+		getOAuth2Grants: builder.query<OAuth2GrantsListResponse, void>({
+			query: () => ({ url: "/oauth2/sessions" }),
+			providesTags: ["OAuth2Grants"],
+		}),
+		revokeOAuth2Grant: builder.mutation<void, string>({
+			query: (id) => ({ url: `/oauth2/sessions/${id}`, method: "DELETE" }),
+			invalidatesTags: ["OAuth2Grants"],
+		}),
+	}),
+});
+
+export const { useGetOAuth2GrantsQuery, useRevokeOAuth2GrantMutation } = oauth2SessionsApi;

--- a/ui/lib/types/mcpSessions.ts
+++ b/ui/lib/types/mcpSessions.ts
@@ -90,6 +90,9 @@ export interface MCPSessionsListResponse {
 // missing as "no filter" for that field.
 export interface MCPSessionsQueryParams {
 	q?: string;
+	// Exact-match filter pinning the list to a single identity (user_id,
+	// virtual key id, or session id). Distinct from the fuzzy `q` search.
+	identity?: string;
 	kind?: MCPSessionKind[];
 	status?: MCPSessionStatus[];
 	auth_mode?: AuthMode[];


### PR DESCRIPTION
## Summary

Adds an **OAuth Grants** management page to the UI and introduces an `identity` exact-match filter for MCP sessions. Together these allow operators to view all active downstream OAuth grants issued to MCP clients and drill through from a grant directly to the auth sessions belonging to that specific identity.

## Changes

- Added `Identity` field to `MCPSessionsFilterParams` in the config store, which exact-matches against `user_id`, `virtual_key_id`, or `session_id` columns (ANDed with any other active filters).
- Exposed the `identity` query parameter in the HTTP handler so callers can pass it via the API.
- Added `identity` to the MCP sessions URL state and query params in the UI, included it in the "has active filters" check, and wired it into `handleClearFilters`.
- Created `oauth2SessionsApi.ts` with `getOAuth2Grants` and `revokeOAuth2Grant` endpoints, registered the `OAuth2Grants` cache tag in `baseApi`, and exported the new API from the store index.
- Built the `OAuthGrantsPage` component with client-side search and mode filtering, a paginated table showing client name, bound identity (user/virtual key/anonymous session), access token expiry, created time, and last used time, and per-row actions to revoke a grant or navigate to MCP sessions pre-filtered to that identity via `auth_mode` + `identity` query params.
- Added the OAuth Grants route and sidebar entry under the MCP Gateway section.

The `identity` filter is intentionally an exact match (not a substring) so that linking from a grant to its sessions produces a precise, unambiguous result rather than a fuzzy hit list.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Start the gateway with at least one MCP client connected via the OAuth consent flow.
2. Navigate to **OAuth Grants** in the sidebar — the table should list active grants with client name, bound identity, expiry, and timestamps.
3. Use the search box and identity-mode filter to narrow results; verify the Clear filters button resets both.
4. Open the row actions menu on a user or virtual-key grant and click **View auth sessions** — confirm the MCP Sessions page opens filtered to that exact identity and auth mode.
5. Click **Revoke** on a grant, confirm the dialog, and verify the grant disappears from the list and a success toast appears.
6. On the MCP Sessions page, manually append `&identity=<some-id>` to the URL and confirm only sessions matching that exact identity are returned.

```sh
go test ./framework/configstore/...

cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots of the OAuth Grants page and the MCP Sessions identity filter._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

_Link related issues here._

## Security considerations

Revocation stops refresh token rotation immediately; the current short-lived JWT access token (≤10 min TTL) remains valid until it expires naturally. This is documented in the revocation confirmation dialog so operators understand the brief window before full cutoff.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable