### PR TITLE
fixes datadog connector docs

### DIFF
--- a/docs/enterprise/datadog-connector.mdx
+++ b/docs/enterprise/datadog-connector.mdx
@@ -378,10 +378,10 @@ The plugin emits the following metrics to Datadog:
 
 | Metric | Type | Description | Tags |
 |--------|------|-------------|------|
-| `bifrost.requests.total` | Counter | Total LLM requests | provider, model, request_type |
-| `bifrost.success.total` | Counter | Successful requests | provider, model, request_type |
-| `bifrost.errors.total` | Counter | Failed requests | provider, model, request_type, reason |
-| `bifrost.latency.seconds` | Histogram | Request latency distribution | provider, model, request_type |
+| `bifrost.requests.total` | Counter | Total LLM requests | provider, model, method |
+| `bifrost.success.total` | Counter | Successful requests | provider, model, method |
+| `bifrost.errors.total` | Counter | Failed requests | provider, model, method, reason |
+| `bifrost.latency.seconds` | Histogram | Request latency distribution | provider, model, method |
 | `bifrost.tokens.input` | Counter | Input/prompt tokens consumed | provider, model |
 | `bifrost.tokens.output` | Counter | Output/completion tokens generated | provider, model |
 | `bifrost.tokens.total` | Counter | Total tokens (input + output) | provider, model |
@@ -411,9 +411,9 @@ The cost metric was renamed from `bifrost.cost.usd` to `bifrost.request.cost.usd
 All metrics include your configured `custom_tags` plus automatic tags for:
 - `provider` - LLM provider (openai, anthropic, etc.)
 - `model` - Model name
-- `request_type` - Type of request (chat, embedding, etc.)
-- `env` - Environment from configuration
+- `method` - Type of request (chat, embedding, etc.)
 - `bifrost_node` - Per-instance identity (`BIFROST_NODE_ID` if set, otherwise `hostname-pid`)
+- plus Bifrost-context tags when available (virtual key, selected key, team, customer, fallback index)
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the Datadog connector documentation to reflect the renaming of the `request_type` tag to `method` across all metrics, and documents the removal of the `env` automatic tag while adding context about Bifrost-context tags.

## Changes

- Renamed the `request_type` tag to `method` in the metrics table for `bifrost.requests.total`, `bifrost.success.total`, `bifrost.errors.total`, and `bifrost.latency.seconds`
- Removed `env` from the list of automatic tags included with all metrics
- Added documentation noting that Bifrost-context tags (virtual key, selected key, team, customer, fallback index) are included when available

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the documentation renders correctly and that the metrics table and tag descriptions accurately reflect the current behavior of the Datadog connector plugin.

## Breaking changes

- [x] Yes
- [ ] No

Users relying on the `request_type` tag in Datadog dashboards, monitors, or alerts will need to update their queries to use `method` instead. The `env` tag is no longer automatically included in metrics.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable