### PR TITLE
datadog docs fixes

### DIFF
--- a/docs/enterprise/datadog-connector.mdx
+++ b/docs/enterprise/datadog-connector.mdx
@@ -44,13 +44,16 @@ The agent handles batching, retries, and provides lower latency. This is the rec
 
 ### Agentless Mode
 
-In agentless mode, the plugin sends data directly to Datadog's intake APIs:
+In agentless mode, the plugin sends data directly to Datadog's intake APIs (`{site}` is your configured Datadog site, e.g. `datadoghq.com`):
 
-- **APM Traces** → `https://trace.agent.{site}`
-- **LLM Observability** → Direct API submission
-- **Metrics** → Datadog Metrics API
+- **LLM Observability** → `https://api.{site}/api/intake/llm-obs/v1/trace/spans`
+- **Metrics** → `https://api.{site}` Metrics API (series to `/api/v2/series`, distributions to `/api/v1/distribution_points`)
 
 This mode requires an API key but simplifies deployment by eliminating the need for a local agent. Ideal for serverless environments, Kubernetes pods, or quick testing.
+
+<Note>
+Datadog officially supports agentless submission for [LLM Observability](https://docs.datadoghq.com/llm_observability/instrumentation/api/) and [metrics](https://docs.datadoghq.com/api/latest/metrics/), but **not** for general APM tracing - the [dd-trace-go setup](https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/go/) assumes a running Agent (or the serverless extension). The plugin points the tracer at the public trace intake so APM spans are still emitted, but if you need fully-supported APM, run the Datadog Agent (agent mode). LLM Observability and metrics are unaffected.
+</Note>
 
 ---
 
@@ -132,7 +135,7 @@ env:
 
 Configure the Datadog plugin through the Bifrost UI:
 
-1. Navigate to **Settings** → **Plugins**
+1. Navigate to **Plugins**
 2. Enable the **Datadog** plugin
 3. Configure the required fields based on your deployment mode
 
@@ -292,6 +295,7 @@ The plugin supports all Datadog regional sites. Set the `site` field to match yo
 | AP1 | Asia Pacific (Japan) | `ap1.datadoghq.com` |
 | AP2 | Asia Pacific (Australia) | `ap2.datadoghq.com` |
 | US1-FED | US Government | `ddog-gov.com` |
+| US2-FED | US Government | `us2.ddog-gov.com` |
 
 <Note>
 Ensure your API key corresponds to the selected site. API keys from one region will not work with another.
@@ -424,7 +428,7 @@ Each APM trace includes comprehensive LLM operation metadata:
 ### Span Attributes
 
 - **Span Name** - Based on request type (`genai.chat`, `genai.embedding`, etc.)
-- **Service Info** - `service.name`, `service.version`, `env`
+- **Service Info** - `service.name`, `service.version`, `env` (Datadog's [unified service tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/): `service`, `version`, `env`)
 - **Provider & Model** - `gen_ai.provider.name`, `gen_ai.request.model`
 
 ### Request Parameters


### PR DESCRIPTION
## Summary

Improves the accuracy and completeness of the Datadog connector documentation, clarifying agentless mode endpoint URLs, APM support limitations, and adding missing configuration details.

## Changes

- Replaced vague agentless mode endpoint descriptions with exact URLs for LLM Observability (`https://api.{site}/api/intake/llm-obs/v1/trace/spans`) and Metrics API (`/api/v2/series`, `/api/v1/distribution_points`)
- Added a `<Note>` block clarifying that Datadog officially supports agentless submission for LLM Observability and metrics, but **not** for general APM tracing — and that users requiring fully-supported APM should run the Datadog Agent
- Added the missing `US2-FED` (`us2.ddog-gov.com`) regional site to the supported sites table
- Updated the UI navigation path from **Settings → Plugins** to **Plugins**
- Added a reference to Datadog's [unified service tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/) for `service`, `version`, and `env` span attributes

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation to confirm:
- Agentless mode endpoint URLs are accurate and match Datadog's public API references
- The APM agentless limitation note renders correctly as a `<Note>` block
- The `US2-FED` site entry appears in the regional sites table
- The unified service tagging link resolves correctly

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Documentation-only change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable