### PR TITLE
`fix: add --target commit SHA to Helm chart GitHub release creation`

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -105,6 +105,7 @@ jobs:
           cd helm-charts
           gh release create "helm-chart-v${{ steps.chart-version.outputs.version }}" \
             bifrost-${{ steps.chart-version.outputs.version }}.tgz \
+            --target ${{ github.sha }} \
             --title "Helm Chart v${{ steps.chart-version.outputs.version }}" \
             --notes "Helm chart release for Bifrost v${{ steps.chart-version.outputs.version }}"
         env:


### PR DESCRIPTION
## Summary

The Helm release GitHub Actions workflow was not pinning releases to the correct commit, which could cause the release to be associated with the wrong ref. This fix ensures the GitHub release is created targeting the exact commit SHA that triggered the workflow.

## Changes

- Added `--target ${{ github.sha }}` to the `gh release create` command so the Helm chart release is explicitly tied to the triggering commit SHA rather than defaulting to the branch HEAD

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger the Helm release workflow and verify the resulting GitHub release points to the correct commit SHA.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable