### PR TITLE
fix: model id in bedrock batch request

### DIFF
--- a/core/providers/bedrock/batch.go
+++ b/core/providers/bedrock/batch.go
@@ -283,6 +283,11 @@ func ToBedrockBatchJobRetrieveResponse(resp *schemas.BifrostBatchRetrieveRespons
 		}
 	}
 
+	// Map the failure reason back to Bedrock's native message field.
+	if resp.Errors != nil && len(resp.Errors.Data) > 0 {
+		result.Message = resp.Errors.Data[0].Message
+	}
+
 	if resp.CreatedAt > 0 {
 		t := time.Unix(resp.CreatedAt, 0)
 		result.SubmitTime = &t

--- a/core/providers/bedrock/batch_test.go
+++ b/core/providers/bedrock/batch_test.go
@@ -1,0 +1,41 @@
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestToBedrockBatchJobRetrieveResponse_SurfacesFailureMessage verifies the
+// AWS job failure reason carried in the normalized Errors field is mapped back
+// to Bedrock's native message field, so callers can see why a job failed
+// without dropping to the AWS CLI.
+func TestToBedrockBatchJobRetrieveResponse_SurfacesFailureMessage(t *testing.T) {
+	const failure = "Batch job arn:... contains less records (1) than the required minimum of: 100"
+
+	resp := &schemas.BifrostBatchRetrieveResponse{
+		ID:     "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+		Status: schemas.BatchStatusFailed,
+		Errors: &schemas.BatchErrors{
+			Object: "list",
+			Data:   []schemas.BatchError{{Message: failure}},
+		},
+	}
+
+	out := ToBedrockBatchJobRetrieveResponse(resp)
+	assert.Equal(t, "Failed", out.Status)
+	assert.Equal(t, failure, out.Message)
+}
+
+// TestToBedrockBatchJobRetrieveResponse_NoErrors confirms the message stays
+// empty when there is no failure reason.
+func TestToBedrockBatchJobRetrieveResponse_NoErrors(t *testing.T) {
+	resp := &schemas.BifrostBatchRetrieveResponse{
+		ID:     "arn:aws:bedrock:us-east-1:123:model-invocation-job/abc",
+		Status: schemas.BatchStatusCompleted,
+	}
+
+	out := ToBedrockBatchJobRetrieveResponse(resp)
+	assert.Empty(t, out.Message)
+}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -3338,6 +3338,15 @@ func (provider *BedrockProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys
 			},
 		}
 
+		// Surface the AWS job message (e.g. a validation failure reason) so
+		// callers see why a job failed without dropping to the AWS CLI.
+		if bedrockResp.Message != "" {
+			result.Errors = &schemas.BatchErrors{
+				Object: "list",
+				Data:   []schemas.BatchError{{Message: bedrockResp.Message}},
+			}
+		}
+
 		if bedrockResp.InputDataConfig != nil {
 			result.InputFileID = bedrockResp.InputDataConfig.S3InputDataConfig.S3Uri
 		}

--- a/core/providers/bedrock/s3.go
+++ b/core/providers/bedrock/s3.go
@@ -92,24 +92,23 @@ func ConvertBedrockRequestsToJSONL(requests []schemas.BatchRequestItem, modelID 
 
 	// Iterate over the requests
 	for _, req := range requests {
-		// Build the Bedrock batch request format
+		// Build the Bedrock batch request format. modelId belongs at the job
+		// level, not inside modelInput, so the record only carries recordId and
+		// the raw model invocation body.
+		modelInput := map[string]interface{}{}
 		bedrockReq := map[string]interface{}{
-			"recordId": req.CustomID,
-			"modelInput": map[string]interface{}{
-				"modelId": *modelID,
-			},
+			"recordId":   req.CustomID,
+			"modelInput": modelInput,
 		}
 
 		// If the request has a body, use it as the model input parameters
 		if req.Body != nil {
-			modelInput := bedrockReq["modelInput"].(map[string]interface{})
 			for k, v := range req.Body {
-				if k != "model" { // Don't override modelId
+				if k != "model" { // model is set at the job level, not per-record
 					modelInput[k] = v
 				}
 			}
 		} else if req.Params != nil {
-			modelInput := bedrockReq["modelInput"].(map[string]interface{})
 			for k, v := range req.Params {
 				if k != "model" {
 					modelInput[k] = v

--- a/core/providers/bedrock/s3_test.go
+++ b/core/providers/bedrock/s3_test.go
@@ -1,0 +1,84 @@
+package bedrock
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConvertBedrockRequestsToJSONL_NoModelIDInModelInput guards against
+// regressing the Bedrock batch bug where modelId was injected into each
+// record's modelInput. Bedrock requires each JSONL line to be strictly
+// {recordId, modelInput} with modelId only at the job level, otherwise it
+// rejects records with "modelId: Extra inputs are not permitted".
+func TestConvertBedrockRequestsToJSONL_NoModelIDInModelInput(t *testing.T) {
+	modelID := "us.anthropic.claude-opus-4-6-v1"
+	requests := []schemas.BatchRequestItem{
+		{
+			CustomID: "item-00043",
+			Body: map[string]interface{}{
+				"anthropic_version": "bedrock-2023-05-31",
+				"max_tokens":        16,
+				"messages": []map[string]interface{}{
+					{"role": "user", "content": "Reply with the number 43."},
+				},
+				"model": modelID, // should be stripped, not leaked into modelInput
+			},
+		},
+		{
+			CustomID: "item-00044",
+			Params: map[string]interface{}{
+				"max_tokens": 8,
+				"model":      modelID,
+			},
+		},
+	}
+
+	data, err := ConvertBedrockRequestsToJSONL(requests, &modelID)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	require.Len(t, lines, 2)
+
+	for i, line := range lines {
+		var record struct {
+			RecordID   string                 `json:"recordId"`
+			ModelInput map[string]interface{} `json:"modelInput"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(line), &record), "line %d should be valid JSON", i)
+
+		assert.NotEmpty(t, record.RecordID, "recordId should be set")
+
+		// The core regression assertions: neither modelId nor model may appear
+		// inside modelInput.
+		_, hasModelID := record.ModelInput["modelId"]
+		assert.False(t, hasModelID, "modelInput must not contain modelId (line %d)", i)
+		_, hasModel := record.ModelInput["model"]
+		assert.False(t, hasModel, "modelInput must not contain model (line %d)", i)
+	}
+
+	// First record's body should be carried through verbatim (minus model).
+	var first struct {
+		ModelInput map[string]interface{} `json:"modelInput"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+	assert.Equal(t, "bedrock-2023-05-31", first.ModelInput["anthropic_version"])
+	assert.Contains(t, first.ModelInput, "messages")
+}
+
+// TestConvertBedrockRequestsToJSONL_RequiresModelID confirms the job-level
+// model is still mandatory.
+func TestConvertBedrockRequestsToJSONL_RequiresModelID(t *testing.T) {
+	requests := []schemas.BatchRequestItem{{CustomID: "item-1", Body: map[string]interface{}{"max_tokens": 16}}}
+
+	_, err := ConvertBedrockRequestsToJSONL(requests, nil)
+	assert.Error(t, err)
+
+	empty := ""
+	_, err = ConvertBedrockRequestsToJSONL(requests, &empty)
+	assert.Error(t, err)
+}

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -2876,6 +2876,11 @@ func (h *CompletionHandler) batchRetrieve(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, "batch_id is required")
 		return
 	}
+	// Decode percent-encoding so ARN ids (e.g. Bedrock job ARNs containing a
+	// slash sent as %2F) reach the provider raw, not double-encoded.
+	if decoded, err := url.PathUnescape(batchID); err == nil {
+		batchID = decoded
+	}
 
 	// Get provider from query parameters
 	provider := string(ctx.QueryArgs().Peek("provider"))
@@ -2922,6 +2927,11 @@ func (h *CompletionHandler) batchCancel(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, "batch_id is required")
 		return
 	}
+	// Decode percent-encoding so ARN ids (e.g. Bedrock job ARNs containing a
+	// slash sent as %2F) reach the provider raw, not double-encoded.
+	if decoded, err := url.PathUnescape(batchID); err == nil {
+		batchID = decoded
+	}
 
 	// Get provider from query parameters
 	provider := string(ctx.QueryArgs().Peek("provider"))
@@ -2967,6 +2977,11 @@ func (h *CompletionHandler) batchResults(ctx *fasthttp.RequestCtx) {
 	if batchID == "" {
 		SendError(ctx, fasthttp.StatusBadRequest, "batch_id is required")
 		return
+	}
+	// Decode percent-encoding so ARN ids (e.g. Bedrock job ARNs containing a
+	// slash sent as %2F) reach the provider raw, not double-encoded.
+	if decoded, err := url.PathUnescape(batchID); err == nil {
+		batchID = decoded
 	}
 
 	// Get provider from query parameters


### PR DESCRIPTION
## Summary

Fixes two Bedrock batch job bugs: `modelId` was incorrectly injected into each JSONL record's `modelInput` (causing Bedrock to reject records with "Extra inputs are not permitted"), and job failure reasons were silently dropped rather than surfaced to callers. Also fixes ARN-based batch IDs containing slashes being mangled by percent-encoding in the HTTP transport.

## Changes

- Removed `modelId` from per-record `modelInput` in JSONL generation — Bedrock requires `modelId` only at the job level, not inside individual records
- Mapped the AWS job `Message` field (e.g. validation failure reasons) into the normalized `Errors` field on `BifrostBatchRetrieveResponse`, and back again when converting to the Bedrock-native response shape
- Added `url.PathUnescape` decoding for `batch_id` in `batchRetrieve`, `batchCancel`, and `batchResults` HTTP handlers so Bedrock job ARNs containing `/` (sent as `%2F`) reach the provider unmodified
- Added unit tests covering the JSONL `modelId` regression, failure message surfacing, and the no-errors happy path

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... ./transports/bifrost-http/...
```

- Submit a Bedrock batch job with fewer than 100 records and confirm the failure reason (e.g. `"contains less records (1) than the required minimum of: 100"`) is returned in the `errors` field of the retrieve response.
- Call the retrieve/cancel/results endpoints with a URL-encoded ARN (`%2F` in place of `/`) and confirm the request reaches Bedrock without a "job not found" error.
- Inspect the generated JSONL and confirm no record's `modelInput` contains a `modelId` or `model` key.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The `url.PathUnescape` call only decodes the batch ID for internal use and does not expose any new surface.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable