### PR TITLE
fix: resolve model names for feature gating

### DIFF
--- a/core/internal/llmtests/passthrough_api.go
+++ b/core/internal/llmtests/passthrough_api.go
@@ -87,7 +87,7 @@ func buildPassthroughChatReq(t *testing.T, provider schemas.ModelProvider, model
 		return passthroughChatReq{path: "/v1/messages", body: body}, true
 
 	case schemas.Gemini:
-		nativeReq, err := gemini.ToGeminiChatCompletionRequest(bfReq)
+		nativeReq, err := gemini.ToGeminiChatCompletionRequest(ctx, bfReq)
 		if err != nil {
 			return passthroughChatReq{}, false
 		}

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -446,7 +446,7 @@ func (provider *AnthropicProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 		// Feature gating keyed to schemas.Anthropic (not provider.GetProviderKey())
 		// so custom Anthropic aliases get the same feature lookup as the typed
 		// path above (line 445), keeping raw and typed behavior in lockstep.
-		sanitized, rawErr := StripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
+		sanitized, rawErr := StripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, schemas.ResolveCanonicalModel(ctx, request.Model))
 		if rawErr != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr)
 		}
@@ -539,7 +539,7 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		// Feature gating keyed to schemas.Anthropic (not provider.GetProviderKey())
 		// to keep raw and typed paths in lockstep on custom aliases — mirrors
 		// the typed path's hardcoded schemas.Anthropic at line 548.
-		sanitized, rawErr := StripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
+		sanitized, rawErr := StripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, schemas.ResolveCanonicalModel(ctx, request.Model))
 		if rawErr != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr)
 		}

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -248,6 +248,9 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		MaxTokens: providerUtils.GetMaxOutputTokensOrDefault(bifrostReq.Model, AnthropicDefaultMaxTokens),
 	}
 
+	// capModel is the canonical model string used only for capability/version
+	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
+
 	// Convert parameters
 	if bifrostReq.Params != nil {
 		anthropicReq.ExtraParams = bifrostReq.Params.ExtraParams
@@ -257,7 +260,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 
 		// Opus 4.7+ and the Fable/Mythos family reject temperature, top_p, and
 		// top_k with a 400 error.
-		if !IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+		if !IsAdaptiveOnlyThinkingModel(capModel) {
 			// Anthropic doesn't allow both temperature and top_p to be specified.
 			// If both are present, prefer temperature (more commonly used).
 			if bifrostReq.Params.Temperature != nil {
@@ -271,12 +274,12 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		// TopK — prefer the promoted neutral field; fall back to ExtraParams.
 		// Opus 4.7+ and the Fable/Mythos family reject top_k with a 400 error.
 		if bifrostReq.Params.TopK != nil {
-			if !IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+			if !IsAdaptiveOnlyThinkingModel(capModel) {
 				anthropicReq.TopK = bifrostReq.Params.TopK
 			}
 		} else if topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"]); ok {
 			delete(anthropicReq.ExtraParams, "top_k")
-			if !IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+			if !IsAdaptiveOnlyThinkingModel(capModel) {
 				anthropicReq.TopK = topK
 			}
 		}
@@ -458,7 +461,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 					continue
 				}
 				// Non-function tool: attempt server-tool reconstruction.
-				if converted, ok := convertServerToolToAnthropic(tool, bifrostReq.Model); ok {
+				if converted, ok := convertServerToolToAnthropic(tool, capModel); ok {
 					tools = append(tools, converted)
 				}
 			}
@@ -504,7 +507,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		// Convert reasoning
 		if bifrostReq.Params.Reasoning != nil {
 			if bifrostReq.Params.Reasoning.MaxTokens != nil {
-				if IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+				if IsAdaptiveOnlyThinkingModel(capModel) {
 					// Opus 4.7+ and Fable/Mythos: budget_tokens removed; adaptive thinking is the only thinking-on mode.
 					anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
 				} else {
@@ -524,11 +527,11 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 				}
 			} else if bifrostReq.Params.Reasoning.Effort != nil && *bifrostReq.Params.Reasoning.Effort != "none" {
 				effort := MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
-				if SupportsAdaptiveThinking(bifrostReq.Model) {
+				if SupportsAdaptiveThinking(capModel) {
 					// Opus 4.6+ and Opus 4.7+: adaptive thinking + native effort
 					anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
 					setEffortOnOutputConfig(anthropicReq, effort)
-				} else if SupportsNativeEffort(bifrostReq.Model) {
+				} else if SupportsNativeEffort(capModel) {
 					// Opus 4.5: native effort + budget_tokens thinking
 					setEffortOnOutputConfig(anthropicReq, effort)
 					budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(effort, MinimumReasoningMaxTokens, anthropicReq.MaxTokens)
@@ -550,7 +553,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 						BudgetTokens: schemas.Ptr(budgetTokens),
 					}
 				}
-			} else if !IsFableFamily(bifrostReq.Model) {
+			} else if !IsFableFamily(capModel) {
 				// Fable/Mythos reject thinking:{type:"disabled"} with a 400 —
 				// adaptive thinking is always on and cannot be disabled. Omit
 				// the thinking param entirely for that family; all other models
@@ -572,7 +575,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 			if anthropicReq.Thinking != nil && anthropicReq.Thinking.Type != "disabled" {
 				if bifrostReq.Params.Reasoning.Display != nil {
 					anthropicReq.Thinking.Display = bifrostReq.Params.Reasoning.Display
-				} else if IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+				} else if IsAdaptiveOnlyThinkingModel(capModel) {
 					anthropicReq.Thinking.Display = schemas.Ptr("summarized")
 				}
 			}
@@ -593,7 +596,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 	// system message and is emitted as role:"system" in the messages array
 	// (Anthropic API + Opus 4.8+ only).
 	seenConversation := false
-	midConvSystemSupported := SupportsMidConversationSystem(bifrostReq.Provider, bifrostReq.Model)
+	midConvSystemSupported := SupportsMidConversationSystem(bifrostReq.Provider, capModel)
 
 	i := 0
 	for i < len(messages) {
@@ -823,7 +826,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 	// Strip request- and tool-level fields the target Anthropic-family
 	// provider does not support. Fail-closed tool validation stays in
 	// ValidateToolsForProvider; this is strip-silently for additive fields.
-	stripUnsupportedAnthropicFields(anthropicReq, bifrostReq.Provider, bifrostReq.Model)
+	stripUnsupportedAnthropicFields(anthropicReq, bifrostReq.Provider, capModel)
 
 	return anthropicReq, nil
 }

--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -86,6 +86,9 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 		return nil, nil
 	}
 
+	// capModel is the canonical model used for capability gating in the raw-body
+	capModel := schemas.ResolveCanonicalModel(ctx, request.Model)
+
 	newErr := func(msg string, err error, reqBody []byte) *schemas.BifrostError {
 		return providerUtils.EnrichError(
 			ctx,
@@ -175,7 +178,7 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 			// request.Model is the alias-resolved model id; pass it so
 			// computer-use / text-editor / bash tools get normalized to the
 			// canonical {type, name} pair Anthropic expects for the model's generation.
-			jsonBody, err = RemapRawToolVersionsForProvider(jsonBody, cfg.Provider, request.Model)
+			jsonBody, err = RemapRawToolVersionsForProvider(jsonBody, cfg.Provider, capModel)
 			if err != nil {
 				return nil, newErr(err.Error(), nil, jsonBody)
 			}
@@ -188,7 +191,7 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 			}
 		}
 
-		jsonBody, err = StripUnsupportedFieldsFromRawBody(jsonBody, cfg.Provider, request.Model)
+		jsonBody, err = StripUnsupportedFieldsFromRawBody(jsonBody, cfg.Provider, capModel)
 		if err != nil {
 			return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
 		}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2612,6 +2612,9 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		MaxTokens: providerUtils.GetMaxOutputTokensOrDefault(bifrostReq.Model, AnthropicDefaultMaxTokens),
 	}
 
+	// capModel is the canonical model string used only for capability/version
+	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
+
 	// Convert basic parameters
 	if bifrostReq.Params != nil {
 		if bifrostReq.Params.MaxOutputTokens != nil {
@@ -2619,7 +2622,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		}
 		// Opus 4.7+ and the Fable/Mythos family reject temperature, top_p, and
 		// top_k with a 400 error.
-		if !IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+		if !IsAdaptiveOnlyThinkingModel(capModel) {
 			// Anthropic doesn't allow both temperature and top_p to be specified.
 			// If both are present, prefer temperature (more commonly used).
 			if bifrostReq.Params.Temperature != nil {
@@ -2690,7 +2693,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		}
 		if bifrostReq.Params.Reasoning != nil {
 			if bifrostReq.Params.Reasoning.MaxTokens != nil {
-				if IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+				if IsAdaptiveOnlyThinkingModel(capModel) {
 					// Opus 4.7+ and Fable/Mythos: budget_tokens removed; adaptive thinking is the only thinking-on mode.
 					anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
 					// Preserve a co-present effort — these models support
@@ -2718,11 +2721,11 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 					if *bifrostReq.Params.Reasoning.Effort != "none" {
 						effort := MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
 
-						if SupportsAdaptiveThinking(bifrostReq.Model) {
+						if SupportsAdaptiveThinking(capModel) {
 							// Opus 4.6+ and Opus 4.7+: adaptive thinking + native effort
 							anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
 							setEffortOnOutputConfig(anthropicReq, effort)
-						} else if SupportsNativeEffort(bifrostReq.Model) {
+						} else if SupportsNativeEffort(capModel) {
 							// Opus 4.5: native effort + budget_tokens thinking
 							setEffortOnOutputConfig(anthropicReq, effort)
 							budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(effort, MinimumReasoningMaxTokens, anthropicReq.MaxTokens)
@@ -2744,7 +2747,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 								BudgetTokens: schemas.Ptr(budgetTokens),
 							}
 						}
-					} else if !IsFableFamily(bifrostReq.Model) {
+					} else if !IsFableFamily(capModel) {
 						// Fable/Mythos reject thinking:{type:"disabled"} with a 400 —
 						// adaptive thinking is always on and cannot be disabled. Omit
 						// the thinking param entirely for that family; all other
@@ -2763,7 +2766,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 					} else {
 						anthropicReq.Thinking.Display = schemas.Ptr("summarized")
 					}
-				} else if IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+				} else if IsAdaptiveOnlyThinkingModel(capModel) {
 					anthropicReq.Thinking.Display = schemas.Ptr("summarized")
 				}
 			}
@@ -2826,13 +2829,13 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 			topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
 			if ok {
 				delete(anthropicReq.ExtraParams, "top_k")
-				if !IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+				if !IsAdaptiveOnlyThinkingModel(capModel) {
 					anthropicReq.TopK = topK
 				}
 			}
 			if speed, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["speed"]); ok {
 				delete(anthropicReq.ExtraParams, "speed")
-				if SupportsFastMode(bifrostReq.Model) {
+				if SupportsFastMode(capModel) {
 					anthropicReq.Speed = speed
 				}
 			}
@@ -2885,7 +2888,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 
 		// Convert tools
 		if bifrostReq.Params.Tools != nil {
-			anthropicTools, mcpServers := convertBifrostToolsToAnthropic(bifrostReq.Model, bifrostReq.Params.Tools, bifrostReq.Provider)
+			anthropicTools, mcpServers := convertBifrostToolsToAnthropic(capModel, bifrostReq.Params.Tools, bifrostReq.Provider)
 			if len(anthropicTools) > 0 {
 				if anthropicReq.Tools == nil {
 					anthropicReq.Tools = anthropicTools
@@ -2908,7 +2911,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 	}
 
 	if bifrostReq.Input != nil {
-		anthropicMessages, systemContent := ConvertBifrostMessagesToAnthropicMessages(ctx, bifrostReq.Input, true, bifrostReq.Provider, bifrostReq.Model)
+		anthropicMessages, systemContent := ConvertBifrostMessagesToAnthropicMessages(ctx, bifrostReq.Input, true, bifrostReq.Provider, capModel)
 
 		// Set system message if present
 		if systemContent != nil {

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1089,7 +1089,7 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 	// supports fast mode AND the model does (Opus 4.6 only per
 	// SupportsFastMode); otherwise sending the header guarantees a 400.
 	if req.Speed != nil {
-		if (!hasProvider || features.FastMode) && SupportsFastMode(req.Model) {
+		if (!hasProvider || features.FastMode) && SupportsFastMode(schemas.ResolveCanonicalModel(ctx, req.Model)) {
 			headers = appendUniqueHeader(headers, AnthropicFastModeBetaHeader)
 		}
 	}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -688,7 +688,7 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 			ctx,
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				reqBody := openai.ToOpenAIResponsesRequest(request)
+				reqBody := openai.ToOpenAIResponsesRequest(ctx, request)
 				return reqBody, nil
 			})
 	}
@@ -2751,7 +2751,7 @@ func (provider *AzureProvider) Compaction(ctx *schemas.BifrostContext, key schem
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return openai.ToOpenAICompactionRequest(request), nil
+			return openai.ToOpenAICompactionRequest(ctx, request), nil
 		})
 	if bifrostErr != nil {
 		return nil, bifrostErr

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -169,7 +169,7 @@ func (provider *BedrockProvider) responsesViaMantle(
 	maps.Copy(extraHeaders, provider.networkConfig.ExtraHeaders)
 	if key.Value.GetValue() == "" {
 		jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(ctx, request, func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return openai.ToOpenAIResponsesRequest(request), nil
+			return openai.ToOpenAIResponsesRequest(ctx, request), nil
 		})
 		if bifrostErr != nil {
 			return nil, bifrostErr
@@ -223,7 +223,7 @@ func (provider *BedrockProvider) responsesStreamViaMantle(
 	}
 
 	// SigV4: pre-build body to sign.
-	openaiReq := openai.ToOpenAIResponsesRequest(request)
+	openaiReq := openai.ToOpenAIResponsesRequest(ctx, request)
 	openaiReq.Stream = schemas.Ptr(true)
 
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(ctx, request, func() (providerUtils.RequestBodyWithExtraParams, error) {

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2138,6 +2138,9 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 		return nil, fmt.Errorf("bifrost request is nil")
 	}
 
+	// capModel is the canonical model used only for Anthropic capability gating
+	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
+
 	// Validate tools are supported by Bedrock
 	if bifrostReq.Params != nil && bifrostReq.Params.Tools != nil {
 		if toolErr := anthropic.ValidateToolsForProvider(bifrostReq.Params.Tools, schemas.Bedrock); toolErr != nil {
@@ -2219,7 +2222,7 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 					tokenBudget = anthropic.MinimumReasoningMaxTokens
 				}
 				if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
-					if anthropic.IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+					if anthropic.IsAdaptiveOnlyThinkingModel(capModel) {
 						bedrockReq.AdditionalModelRequestFields.Set("thinking", map[string]any{
 							"type": "adaptive",
 						})
@@ -2296,7 +2299,7 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 
 						bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", config)
 					} else if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
-						if anthropic.SupportsAdaptiveThinking(bifrostReq.Model) {
+						if anthropic.SupportsAdaptiveThinking(capModel) {
 							// Opus 4.6+: adaptive thinking + output_config.effort
 							effort := anthropic.MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
 							thinkingConfig := map[string]any{
@@ -2309,7 +2312,7 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 								} else {
 									thinkingConfig["display"] = "summarized"
 								}
-							} else if anthropic.IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+							} else if anthropic.IsAdaptiveOnlyThinkingModel(capModel) {
 								thinkingConfig["display"] = "summarized"
 							}
 							bedrockReq.AdditionalModelRequestFields.Set("thinking", thinkingConfig)
@@ -2351,7 +2354,7 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 					}
 				} else {
 					if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
-						if !anthropic.IsFableFamily(bifrostReq.Model) {
+						if !anthropic.IsFableFamily(capModel) {
 							// Fable/Mythos reject thinking:{type:"disabled"}; omit it
 							// entirely (adaptive thinking is always on for that family).
 							bedrockReq.AdditionalModelRequestFields.Set("thinking", map[string]any{

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -223,6 +223,9 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 	if bifrostReq.Params == nil {
 		return nil
 	}
+
+	// capModel is the canonical model used only for Anthropic capability gating
+	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
 	// Convert inference config
 	if inferenceConfig := convertInferenceConfig(bifrostReq.Params); inferenceConfig != nil {
 		bedrockReq.InferenceConfig = inferenceConfig
@@ -292,7 +295,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 				tokenBudget = anthropic.MinimumReasoningMaxTokens
 			}
 			if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
-				if anthropic.IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+				if anthropic.IsAdaptiveOnlyThinkingModel(capModel) {
 					bedrockReq.AdditionalModelRequestFields.Set("thinking", map[string]any{
 						"type": "adaptive",
 					})
@@ -392,7 +395,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 
 				bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", config)
 			} else if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
-				if anthropic.SupportsAdaptiveThinking(bifrostReq.Model) {
+				if anthropic.SupportsAdaptiveThinking(capModel) {
 					// Opus 4.6+: adaptive thinking + output_config.effort
 					effort := anthropic.MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
 					thinkingConfig := map[string]any{
@@ -400,7 +403,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 					}
 					if bifrostReq.Params.Reasoning.Display != nil {
 						thinkingConfig["display"] = *bifrostReq.Params.Reasoning.Display
-					} else if anthropic.IsAdaptiveOnlyThinkingModel(bifrostReq.Model) {
+					} else if anthropic.IsAdaptiveOnlyThinkingModel(capModel) {
 						thinkingConfig["display"] = "summarized"
 					}
 					bedrockReq.AdditionalModelRequestFields.Set("thinking", thinkingConfig)
@@ -419,7 +422,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 			}
 		} else {
 			if schemas.IsAnthropicModelFamily(ctx, bifrostReq.Model) {
-				if !anthropic.IsFableFamily(bifrostReq.Model) {
+				if !anthropic.IsFableFamily(capModel) {
 					bedrockReq.AdditionalModelRequestFields.Set("thinking", map[string]any{
 						"type": "disabled",
 					})

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ToGeminiChatCompletionRequest converts a BifrostChatRequest to Gemini's generation request format for chat completion
-func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*GeminiGenerationRequest, error) {
+func ToGeminiChatCompletionRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostChatRequest) (*GeminiGenerationRequest, error) {
 	if bifrostReq == nil {
 		return nil, nil
 	}
@@ -21,11 +21,14 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Gem
 		Model: bifrostReq.Model,
 	}
 
+	// Canonical model for capability gating only; wire model is untouched.
+	capModel := NormalizeModelName(schemas.ResolveCanonicalModel(ctx, bifrostReq.Model))
+
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
 		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 		var err error
-		geminiReq.GenerationConfig, err = convertParamsToGenerationConfig(bifrostReq.Params, []string{}, bifrostReq.Model)
+		geminiReq.GenerationConfig, err = convertParamsToGenerationConfig(bifrostReq.Params, []string{}, capModel)
 		if err != nil {
 			return nil, err
 		}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -288,7 +288,7 @@ func (provider *GeminiProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToGeminiChatCompletionRequest(request)
+			return ToGeminiChatCompletionRequest(ctx, request)
 		})
 	if err != nil {
 		return nil, err
@@ -344,7 +344,7 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			reqBody, err := ToGeminiChatCompletionRequest(request)
+			reqBody, err := ToGeminiChatCompletionRequest(ctx, request)
 			if err != nil {
 				return nil, err
 			}
@@ -657,7 +657,7 @@ func (provider *GeminiProvider) Responses(ctx *schemas.BifrostContext, key schem
 			ctx,
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				reqBody, err := ToGeminiResponsesRequest(request)
+				reqBody, err := ToGeminiResponsesRequest(ctx, request)
 				if err != nil {
 					return nil, err
 				}
@@ -845,7 +845,7 @@ func (provider *GeminiProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			reqBody, err := ToGeminiResponsesRequest(request)
+			reqBody, err := ToGeminiResponsesRequest(ctx, request)
 			if err != nil {
 				return nil, err
 			}
@@ -3915,7 +3915,7 @@ func (provider *GeminiProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 			ctx,
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				return ToGeminiResponsesRequest(request)
+				return ToGeminiResponsesRequest(ctx, request)
 			},
 		)
 		if bifrostErr != nil {

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -353,7 +353,7 @@ func TestThoughtSignatureInToolCalls(t *testing.T) {
 }
 
 func TestMissingThoughtSignatureUsesBypassSentinel(t *testing.T) {
-	result, err := gemini.ToGeminiChatCompletionRequest(&schemas.BifrostChatRequest{
+	result, err := gemini.ToGeminiChatCompletionRequest(nil, &schemas.BifrostChatRequest{
 		Model: "gemini-3.1-pro-preview",
 		Input: []schemas.ChatMessage{
 			{
@@ -395,7 +395,7 @@ func TestEmbeddedThoughtSignatureDoesNotUseBypassSentinel(t *testing.T) {
 	thoughtSig := base64.RawURLEncoding.EncodeToString([]byte{0x01, 0x02, 0x03})
 	callID := "call_1_ts_" + thoughtSig
 
-	result, err := gemini.ToGeminiChatCompletionRequest(&schemas.BifrostChatRequest{
+	result, err := gemini.ToGeminiChatCompletionRequest(nil, &schemas.BifrostChatRequest{
 		Model: "gemini-3.1-pro-preview",
 		Input: []schemas.ChatMessage{{
 			Role: schemas.ChatMessageRoleAssistant,
@@ -1143,7 +1143,7 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := gemini.ToGeminiChatCompletionRequest(tt.input)
+			result, err := gemini.ToGeminiChatCompletionRequest(nil, tt.input)
 			require.NoError(t, err)
 			require.NotNil(t, result, "Conversion should not return nil")
 			tt.validate(t, result)
@@ -1178,7 +1178,7 @@ func TestBifrostToGeminiToolConversion_PropertyOrdering(t *testing.T) {
 		},
 	}
 
-	result, err := gemini.ToGeminiChatCompletionRequest(input)
+	result, err := gemini.ToGeminiChatCompletionRequest(nil, input)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Tools, 1)
@@ -1227,7 +1227,7 @@ func TestBifrostToGeminiToolConversion_NestedPropertyOrdering(t *testing.T) {
 		},
 	}
 
-	result, err := gemini.ToGeminiChatCompletionRequest(input)
+	result, err := gemini.ToGeminiChatCompletionRequest(nil, input)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Tools, 1)
@@ -1468,7 +1468,7 @@ func TestStructuredOutputConversion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := gemini.ToGeminiChatCompletionRequest(tt.input)
+			result, err := gemini.ToGeminiChatCompletionRequest(nil, tt.input)
 			require.NoError(t, err)
 			require.NotNil(t, result, "Conversion should not return nil")
 			tt.validate(t, result)
@@ -1601,7 +1601,7 @@ func TestStructuredOutputWithToolsConflict(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := gemini.ToGeminiChatCompletionRequest(tt.input)
+			result, err := gemini.ToGeminiChatCompletionRequest(nil, tt.input)
 			require.NoError(t, err)
 			require.NotNil(t, result, "Conversion should not return nil")
 			tt.validate(t, result)
@@ -1737,7 +1737,7 @@ func TestResponsesStructuredOutputConversion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := gemini.ToGeminiResponsesRequest(tt.input)
+			result, err := gemini.ToGeminiResponsesRequest(nil, tt.input)
 			require.NoError(t, err)
 			require.NotNil(t, result, "Responses API conversion should not return nil")
 			tt.validate(t, result)
@@ -1789,7 +1789,7 @@ func TestServiceTierMappingChat(t *testing.T) {
 					ServiceTier: tt.inputTier,
 				},
 			}
-			result, err := gemini.ToGeminiChatCompletionRequest(req)
+			result, err := gemini.ToGeminiChatCompletionRequest(nil, req)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedGemini, result.ServiceTier)
 		})
@@ -1845,7 +1845,7 @@ func TestServiceTierMappingResponses(t *testing.T) {
 					ServiceTier: tt.inputTier,
 				},
 			}
-			result, err := gemini.ToGeminiResponsesRequest(req)
+			result, err := gemini.ToGeminiResponsesRequest(nil, req)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedGemini, result.ServiceTier)
 		})
@@ -2204,7 +2204,7 @@ func TestParallelFunctionCallingConversion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := gemini.ToGeminiChatCompletionRequest(tt.input)
+			result, err := gemini.ToGeminiChatCompletionRequest(nil, tt.input)
 			require.NoError(t, err)
 			require.NotNil(t, result, "Conversion should not return nil")
 			tt.validate(t, result)
@@ -2688,7 +2688,7 @@ func TestResponsesAPIParallelFunctionCalling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := gemini.ToGeminiResponsesRequest(tt.input)
+			result, err := gemini.ToGeminiResponsesRequest(nil, tt.input)
 			require.NoError(t, err)
 			require.NotNil(t, result, "Responses API conversion should not return nil")
 			tt.validate(t, result)
@@ -2977,7 +2977,7 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := gemini.ToGeminiResponsesRequest(tt.input)
+			result, err := gemini.ToGeminiResponsesRequest(nil, tt.input)
 			require.NoError(t, err)
 			require.NotNil(t, result, "Responses API conversion should not return nil")
 			tt.validate(t, result)
@@ -3351,7 +3351,7 @@ func TestGeminiToolInputKeyOrderPreservation(t *testing.T) {
 		},
 	}
 
-	result, err := gemini.ToGeminiChatCompletionRequest(bifrostReq)
+	result, err := gemini.ToGeminiChatCompletionRequest(nil, bifrostReq)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -3520,7 +3520,7 @@ func TestThinkingBudgetValidation_Chat(t *testing.T) {
 				},
 			}
 
-			result, err := gemini.ToGeminiChatCompletionRequest(req)
+			result, err := gemini.ToGeminiChatCompletionRequest(nil, req)
 
 			if tt.wantErr {
 				require.Error(t, err, "expected error for budget %d on model %s", tt.budget, tt.model)
@@ -3620,7 +3620,7 @@ func TestThinkingBudgetValidation_Responses(t *testing.T) {
 				},
 			}
 
-			result, err := gemini.ToGeminiResponsesRequest(req)
+			result, err := gemini.ToGeminiResponsesRequest(nil, req)
 
 			if tt.wantErr {
 				require.Error(t, err, "expected error for budget %d on model %s", tt.budget, tt.model)
@@ -3663,7 +3663,7 @@ func TestThinkingBudgetEffortUsesModelRange(t *testing.T) {
 				Reasoning: &schemas.ChatReasoning{Effort: &effort},
 			},
 		}
-		result, err := gemini.ToGeminiChatCompletionRequest(req)
+		result, err := gemini.ToGeminiChatCompletionRequest(nil, req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.NotNil(t, result.GenerationConfig.ThinkingConfig)
@@ -3680,7 +3680,7 @@ func TestThinkingBudgetEffortUsesModelRange(t *testing.T) {
 				Reasoning: &schemas.ChatReasoning{Effort: &effort},
 			},
 		}
-		result, err := gemini.ToGeminiChatCompletionRequest(req)
+		result, err := gemini.ToGeminiChatCompletionRequest(nil, req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.NotNil(t, result.GenerationConfig.ThinkingConfig)
@@ -3714,7 +3714,7 @@ func TestGenAIThinkingLevel_RoundTripPreservesLevelNotBudget(t *testing.T) {
 	assert.Equal(t, "minimal", *bifrostReq.Params.Reasoning.Effort)
 	assert.Nil(t, bifrostReq.Params.Reasoning.MaxTokens, "thinkingLevel must not populate reasoning max_tokens")
 
-	roundTrip, err := gemini.ToGeminiResponsesRequest(bifrostReq)
+	roundTrip, err := gemini.ToGeminiResponsesRequest(nil, bifrostReq)
 	require.NoError(t, err)
 	require.NotNil(t, roundTrip)
 	require.NotNil(t, roundTrip.GenerationConfig.ThinkingConfig)
@@ -3986,7 +3986,7 @@ func TestFunctionCallingConfigModeAny_RoundTrip(t *testing.T) {
 			require.NotNil(t, bifrostReq.Params)
 			require.NotNil(t, bifrostReq.Params.ToolChoice, "ToolChoice must be set")
 
-			roundTrip, err := gemini.ToGeminiResponsesRequest(bifrostReq)
+			roundTrip, err := gemini.ToGeminiResponsesRequest(nil, bifrostReq)
 			require.NoError(t, err)
 			require.NotNil(t, roundTrip)
 			require.NotNil(t, roundTrip.ToolConfig)
@@ -4061,7 +4061,7 @@ func TestMultimodalFunctionResponse_RoundTrip(t *testing.T) {
 	assert.True(t, hasImage, "Image block must be preserved")
 
 	// --- Bifrost -> Gemini: image must land back in functionResponse.parts ---
-	roundTrip, err := gemini.ToGeminiResponsesRequest(bifrostReq)
+	roundTrip, err := gemini.ToGeminiResponsesRequest(nil, bifrostReq)
 	require.NoError(t, err)
 	require.NotNil(t, roundTrip)
 
@@ -4114,7 +4114,7 @@ func TestMultimodalFunctionResponse_PreservesNonRefFields(t *testing.T) {
 	bifrostReq := geminiReq.ToBifrostResponsesRequest(bifrostCtx)
 	require.NotNil(t, bifrostReq)
 
-	roundTrip, err := gemini.ToGeminiResponsesRequest(bifrostReq)
+	roundTrip, err := gemini.ToGeminiResponsesRequest(nil, bifrostReq)
 	require.NoError(t, err)
 	require.NotNil(t, roundTrip)
 

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -76,7 +76,7 @@ func (request *GeminiGenerationRequest) ToBifrostResponsesRequest(ctx *schemas.B
 	return bifrostReq
 }
 
-func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*GeminiGenerationRequest, error) {
+func ToGeminiResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostResponsesRequest) (*GeminiGenerationRequest, error) {
 	if bifrostReq == nil {
 		return nil, nil
 	}
@@ -88,10 +88,13 @@ func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Gem
 		Model: bifrostReq.Model,
 	}
 
+	// Canonical model for capability gating only; wire model is untouched.
+	capModel := NormalizeModelName(schemas.ResolveCanonicalModel(ctx, bifrostReq.Model))
+
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
 		var err error
-		geminiReq.GenerationConfig, err = geminiReq.convertParamsToGenerationConfigResponses(bifrostReq.Params)
+		geminiReq.GenerationConfig, err = geminiReq.convertParamsToGenerationConfigResponses(bifrostReq.Params, capModel)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +119,7 @@ func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Gem
 
 	// Convert ResponsesInput messages to Gemini contents
 	if bifrostReq.Input != nil {
-		contents, systemInstruction, err := convertResponsesMessagesToGeminiContents(bifrostReq.Input, bifrostReq.Model, bifrostReq.Provider)
+		contents, systemInstruction, err := convertResponsesMessagesToGeminiContents(bifrostReq.Input, capModel, bifrostReq.Provider)
 		if err != nil {
 			return nil, err
 		}
@@ -2819,7 +2822,7 @@ func reconstructSchemaFromJSONSchema(jsonSchema *schemas.ResponsesTextConfigForm
 }
 
 // convertParamsToGenerationConfigResponses converts ChatParameters to GenerationConfig for Responses
-func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(params *schemas.ResponsesParameters) (GenerationConfig, error) {
+func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(params *schemas.ResponsesParameters, capModel string) (GenerationConfig, error) {
 	config := GenerationConfig{}
 
 	if params.Temperature != nil {
@@ -2832,14 +2835,14 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 		config.MaxOutputTokens = int32(*params.MaxOutputTokens)
 	}
 	// Only set ThinkingConfig if the model actually supports thinking
-	if params.Reasoning != nil && supportsThinkingConfig(r.Model) {
+	if params.Reasoning != nil && supportsThinkingConfig(capModel) {
 		config.ThinkingConfig = &GenerationConfigThinkingConfig{
 			IncludeThoughts: true,
 		}
 
 		hasMaxTokens := params.Reasoning.MaxTokens != nil
 		hasEffort := params.Reasoning.Effort != nil
-		supportsLevel := isGemini3Plus(r.Model) // Check if model is 3.0+
+		supportsLevel := isGemini3Plus(capModel) // Check if model is 3.0+
 
 		// PRIORITY RULE: If both max_tokens and effort are present, use ONLY max_tokens (budget)
 		// This ensures we send only thinkingBudget to Gemini, not thinkingLevel
@@ -2859,7 +2862,7 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 			case DynamicReasoningBudget: // Special case: -1 means dynamic budget
 				config.ThinkingConfig.ThinkingBudget = schemas.Ptr(int32(DynamicReasoningBudget))
 			default:
-				if err := validateThinkingBudget(r.Model, budget); err != nil {
+				if err := validateThinkingBudget(capModel, budget); err != nil {
 					return config, err
 				}
 				config.ThinkingConfig.ThinkingBudget = schemas.Ptr(int32(budget))
@@ -2868,13 +2871,13 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 			// User provided effort only (no max_tokens)
 			if supportsLevel {
 				// Gemini 3.0+ - use thinkingLevel (more native)
-				config.ThinkingConfig.ThinkingLevel = schemas.Ptr(effortToThinkingLevel(*params.Reasoning.Effort, r.Model))
+				config.ThinkingConfig.ThinkingLevel = schemas.Ptr(effortToThinkingLevel(*params.Reasoning.Effort, capModel))
 			} else {
-				maxTokens := providerUtils.GetMaxOutputTokensOrDefault(r.Model, DefaultCompletionMaxTokens)
+				maxTokens := providerUtils.GetMaxOutputTokensOrDefault(capModel, DefaultCompletionMaxTokens)
 				if config.MaxOutputTokens > 0 {
 					maxTokens = int(config.MaxOutputTokens)
 				}
-				budgetRange := getThinkingBudgetRange(r.Model, maxTokens)
+				budgetRange := getThinkingBudgetRange(capModel, maxTokens)
 				// Gemini < 3.0 - must convert effort to budget
 				budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(
 					*params.Reasoning.Effort,

--- a/core/providers/openai/advisor_filter_test.go
+++ b/core/providers/openai/advisor_filter_test.go
@@ -42,7 +42,7 @@ func TestToOpenAIResponsesRequest_DropsAdvisorTool(t *testing.T) {
 		},
 	}
 
-	result := ToOpenAIResponsesRequest(bifrostReq)
+	result := ToOpenAIResponsesRequest(nil, bifrostReq)
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -32,6 +32,9 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		Provider: bifrostReq.Provider,
 	}
 
+	// Canonical model for capability gating only; wire model (openaiReq.Model) is untouched.
+	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
+
 	if bifrostReq.Params != nil {
 		openaiReq.ChatParameters = *bifrostReq.Params
 		if openaiReq.ChatParameters.MaxCompletionTokens != nil && *openaiReq.ChatParameters.MaxCompletionTokens < MinMaxCompletionTokens {
@@ -57,23 +60,23 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 	}
 	switch bifrostReq.Provider {
 	case schemas.OpenAI, schemas.Azure:
-		openaiReq.normalizeReasoningEffort()
+		openaiReq.normalizeReasoningEffort(capModel)
 		return openaiReq
 	case schemas.XAI:
-		openaiReq.filterOpenAISpecificParameters()
-		openaiReq.applyXAICompatibility(bifrostReq.Model)
+		openaiReq.filterOpenAISpecificParameters(capModel)
+		openaiReq.applyXAICompatibility(capModel)
 		return openaiReq
 	case schemas.Gemini:
-		openaiReq.filterOpenAISpecificParameters()
+		openaiReq.filterOpenAISpecificParameters(capModel)
 		// Removing extra parameters that are not supported by Gemini
 		openaiReq.ServiceTier = nil
 		return openaiReq
 	case schemas.Mistral:
-		openaiReq.filterOpenAISpecificParameters()
+		openaiReq.filterOpenAISpecificParameters(capModel)
 		openaiReq.applyMistralCompatibility()
 		return openaiReq
 	case schemas.Vertex:
-		openaiReq.filterOpenAISpecificParameters()
+		openaiReq.filterOpenAISpecificParameters(capModel)
 
 		// Apply Mistral-specific transformations for Vertex Mistral models
 		if schemas.IsMistralModel(bifrostReq.Model) {
@@ -96,7 +99,7 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		}
 		// Fireworks supports predicted outputs; save before the filter strips them.
 		prediction := openaiReq.ChatParameters.Prediction
-		openaiReq.filterOpenAISpecificParameters()
+		openaiReq.filterOpenAISpecificParameters(capModel)
 		openaiReq.ChatParameters.Prediction = prediction
 		return openaiReq
 	default:
@@ -104,16 +107,16 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		if isCustomProvider, ok := ctx.Value(schemas.BifrostContextKeyIsCustomProvider).(bool); ok && isCustomProvider {
 			return openaiReq
 		}
-		openaiReq.filterOpenAISpecificParameters()
+		openaiReq.filterOpenAISpecificParameters(capModel)
 		return openaiReq
 	}
 }
 
 // Filter OpenAI Specific Parameters
-func (req *OpenAIChatRequest) filterOpenAISpecificParameters() {
+func (req *OpenAIChatRequest) filterOpenAISpecificParameters(capModel string) {
 	// Handle reasoning parameter: OpenAI uses effort-based reasoning
 	// Priority: effort (native) > max_tokens (estimated)
-	req.normalizeReasoningEffort()
+	req.normalizeReasoningEffort(capModel)
 
 	if req.ChatParameters.Prediction != nil {
 		req.ChatParameters.Prediction = nil
@@ -135,14 +138,14 @@ func (req *OpenAIChatRequest) filterOpenAISpecificParameters() {
 	}
 }
 
-func (req *OpenAIChatRequest) normalizeReasoningEffort() {
+func (req *OpenAIChatRequest) normalizeReasoningEffort(capModel string) {
 	if req.ChatParameters.Reasoning != nil {
 		reasoningCopy := *req.ChatParameters.Reasoning
 		req.ChatParameters.Reasoning = &reasoningCopy
 		if req.ChatParameters.Reasoning.Effort != nil {
 			// Native field is provided, use it (and clear max_tokens)
 			effort := *req.ChatParameters.Reasoning.Effort
-			req.ChatParameters.Reasoning.Effort = schemas.Ptr(normalizeOpenAIReasoningEffort(req.Model, effort))
+			req.ChatParameters.Reasoning.Effort = schemas.Ptr(normalizeOpenAIReasoningEffort(capModel, effort))
 			// Clear max_tokens since OpenAI doesn't use it
 			req.ChatParameters.Reasoning.MaxTokens = nil
 		} else if req.ChatParameters.Reasoning.MaxTokens != nil {

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -407,7 +407,7 @@ func TestOpenAIChatRequest_FilterOpenAISpecificParameters_NormalizesReasoningEff
 				},
 			}
 
-			req.filterOpenAISpecificParameters()
+			req.filterOpenAISpecificParameters(req.Model)
 
 			if req.Reasoning == nil || req.Reasoning.Effort == nil {
 				t.Fatal("expected reasoning effort to be set")

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1482,7 +1482,7 @@ func HandleOpenAIResponsesRequest(
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToOpenAIResponsesRequest(request), nil
+			return ToOpenAIResponsesRequest(ctx, request), nil
 		})
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1634,7 +1634,7 @@ func HandleOpenAIResponsesStreaming(
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			reqBody := ToOpenAIResponsesRequest(request)
+			reqBody := ToOpenAIResponsesRequest(ctx, request)
 			if reqBody != nil {
 				reqBody.Stream = schemas.Ptr(true)
 				if postRequestConverter != nil {
@@ -4131,7 +4131,7 @@ func HandleOpenAICompactionRequest(
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToOpenAICompactionRequest(request), nil
+			return ToOpenAICompactionRequest(ctx, request), nil
 		})
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -4243,7 +4243,7 @@ func HandleOpenAICountTokensRequest(
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToOpenAIResponsesRequest(request), nil
+			return ToOpenAIResponsesRequest(ctx, request), nil
 		})
 	if bifrostErr != nil {
 		return nil, bifrostErr

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -35,10 +35,13 @@ func (resp *OpenAIResponsesRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 }
 
 // ToOpenAIResponsesRequest converts a Bifrost responses request to OpenAI format
-func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *OpenAIResponsesRequest {
+func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostResponsesRequest) *OpenAIResponsesRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil {
 		return nil
 	}
+
+	// Canonical model for capability gating only; wire model is untouched.
+	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
 
 	var messages []schemas.ResponsesMessage
 	// OpenAI models (except for gpt-oss) do not support reasoning content blocks, so we need to convert them to summaries, if there are any
@@ -90,8 +93,8 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 		}
 
 		if message.ResponsesReasoning != nil {
-			isGptOss := strings.Contains(bifrostReq.Model, "gpt-oss")
-			isReasoning := isOpenAIReasoningModel(bifrostReq.Model)
+			isGptOss := strings.Contains(capModel, "gpt-oss")
+			isReasoning := isOpenAIReasoningModel(capModel)
 
 			// For non-gpt-oss models, skip reasoning-only messages that have content blocks but no summaries.
 			// For non-reasoning models (e.g., gpt-4o), also skip when EncryptedContent is present since
@@ -217,7 +220,7 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 			if req.ResponsesParameters.Reasoning.Effort != nil {
 				// Native field is provided, use it (and clear max_tokens)
 				effort := *req.ResponsesParameters.Reasoning.Effort
-				req.ResponsesParameters.Reasoning.Effort = schemas.Ptr(normalizeOpenAIReasoningEffort(req.Model, effort))
+				req.ResponsesParameters.Reasoning.Effort = schemas.Ptr(normalizeOpenAIReasoningEffort(capModel, effort))
 				// Clear max_tokens since OpenAI doesn't use it
 				req.ResponsesParameters.Reasoning.MaxTokens = nil
 			} else if req.ResponsesParameters.Reasoning.MaxTokens != nil {
@@ -241,8 +244,8 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 			// Handle xAI-specific parameter filtering
 			// Only grok-3-mini supports reasoning_effort
 			if bifrostReq.Provider == schemas.XAI &&
-				schemas.IsGrokReasoningModel(bifrostReq.Model) &&
-				!strings.Contains(bifrostReq.Model, "grok-3-mini") {
+				schemas.IsGrokReasoningModel(capModel) &&
+				!strings.Contains(capModel, "grok-3-mini") {
 				// Clear reasoning_effort for non-grok-3-mini xAI reasoning models
 				req.ResponsesParameters.Reasoning.Effort = nil
 			}
@@ -250,7 +253,7 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 			// Handle OpenAI-specific parameter filtering
 			// Only o1/o3 series models support reasoning.effort
 			// Regular models like gpt-4o, gpt-4, gpt-3.5-turbo don't support it
-			if bifrostReq.Provider == schemas.OpenAI && !isOpenAIReasoningModel(bifrostReq.Model) {
+			if bifrostReq.Provider == schemas.OpenAI && !isOpenAIReasoningModel(capModel) {
 				// Clear reasoning for non-reasoning OpenAI models to avoid API errors
 				req.ResponsesParameters.Reasoning = nil
 			}
@@ -258,9 +261,9 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 
 		// Strip top_p for OpenAI reasoning models (o1/o3 series) which reject it
 		// GPT-5.x accept top_p when reasoning.effort is "none" (defaults to "none" when omitted)
-		if isOpenAIReasoningModel(bifrostReq.Model) {
+		if isOpenAIReasoningModel(capModel) {
 			stripTopP := true
-			_, parsedModel := schemas.ParseModelString(bifrostReq.Model, schemas.OpenAI)
+			_, parsedModel := schemas.ParseModelString(capModel, schemas.OpenAI)
 			modelLower := strings.ToLower(parsedModel)
 			effort := ""
 			if req.ResponsesParameters.Reasoning != nil &&
@@ -421,7 +424,7 @@ type OpenAICompactionRequest struct {
 func (r *OpenAICompactionRequest) GetExtraParams() map[string]interface{} { return r.ExtraParams }
 
 // ToOpenAICompactionRequest converts a BifrostCompactionRequest to the OpenAI wire format.
-func ToOpenAICompactionRequest(req *schemas.BifrostCompactionRequest) *OpenAICompactionRequest {
+func ToOpenAICompactionRequest(ctx *schemas.BifrostContext, req *schemas.BifrostCompactionRequest) *OpenAICompactionRequest {
 	if req == nil {
 		return nil
 	}
@@ -437,7 +440,7 @@ func ToOpenAICompactionRequest(req *schemas.BifrostCompactionRequest) *OpenAICom
 	if len(req.Input) > 0 {
 		// Run through the same normalization as ToOpenAIResponsesRequest so reasoning
 		// role cleanup, compaction-content conversion, etc. are applied consistently.
-		normalized := ToOpenAIResponsesRequest(&schemas.BifrostResponsesRequest{
+		normalized := ToOpenAIResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
 			Provider: req.Provider,
 			Model:    req.Model,
 			Input:    req.Input,

--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -331,7 +331,7 @@ func TestToOpenAIResponsesRequest_FireworksPreservesNativeFields(t *testing.T) {
 		},
 	}
 
-	request := ToOpenAIResponsesRequest(bifrostReq)
+	request := ToOpenAIResponsesRequest(nil, bifrostReq)
 	if request == nil {
 		t.Fatal("expected non-nil request")
 	}

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -184,7 +184,7 @@ func TestToOpenAIResponsesRequest_ReasoningOnlyMessageSkip(t *testing.T) {
 				Input: []schemas.ResponsesMessage{tt.message},
 			}
 
-			result := ToOpenAIResponsesRequest(bifrostReq)
+			result := ToOpenAIResponsesRequest(nil, bifrostReq)
 
 			if result == nil {
 				t.Fatal("ToOpenAIResponsesRequest returned nil")
@@ -243,7 +243,7 @@ func TestToOpenAIResponsesRequest_ReasoningStringContent(t *testing.T) {
 			}},
 		}
 
-		result := ToOpenAIResponsesRequest(bifrostReq)
+		result := ToOpenAIResponsesRequest(nil, bifrostReq)
 		original := bifrostReq.Input[0].Content
 		if original == nil || original.ContentStr == nil || *original.ContentStr != "" {
 			t.Fatalf("expected input reasoning content string to remain unchanged, got %#v", original)
@@ -278,7 +278,7 @@ func TestToOpenAIResponsesRequest_ReasoningStringContent(t *testing.T) {
 			}},
 		}
 
-		result := ToOpenAIResponsesRequest(bifrostReq)
+		result := ToOpenAIResponsesRequest(nil, bifrostReq)
 		original := bifrostReq.Input[0].Content
 		if original == nil || original.ContentStr == nil || *original.ContentStr != "thinking" {
 			t.Fatalf("expected input reasoning content string to remain unchanged, got %#v", original)
@@ -422,7 +422,7 @@ func TestToOpenAIResponsesRequest_NormalizesReasoningEffort(t *testing.T) {
 			if provider == "" {
 				provider = schemas.OpenAI
 			}
-			req := ToOpenAIResponsesRequest(&schemas.BifrostResponsesRequest{
+			req := ToOpenAIResponsesRequest(nil, &schemas.BifrostResponsesRequest{
 				Provider: provider,
 				Model:    tt.model,
 				Input: []schemas.ResponsesMessage{{
@@ -543,7 +543,7 @@ func TestToOpenAIResponsesRequest_GPTOSS_SummaryToContentBlocks(t *testing.T) {
 				Input: []schemas.ResponsesMessage{tt.message},
 			}
 
-			result := ToOpenAIResponsesRequest(bifrostReq)
+			result := ToOpenAIResponsesRequest(nil, bifrostReq)
 
 			if result == nil {
 				t.Fatal("ToOpenAIResponsesRequest returned nil")
@@ -1678,7 +1678,7 @@ func TestToOpenAIResponsesRequest_ToolNormalization(t *testing.T) {
 		},
 	}
 
-	result := ToOpenAIResponsesRequest(bifrostReq)
+	result := ToOpenAIResponsesRequest(nil, bifrostReq)
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -1750,7 +1750,7 @@ func TestToOpenAIResponsesRequest_PreservesExplicitEmptyToolParameters(t *testin
 		},
 	}
 
-	result := ToOpenAIResponsesRequest(bifrostReq)
+	result := ToOpenAIResponsesRequest(nil, bifrostReq)
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
@@ -1876,7 +1876,7 @@ func TestToOpenAIResponsesRequest_PreservesNamespaceAndWebSearchFields(t *testin
 		},
 	}
 
-	result := ToOpenAIResponsesRequest(bifrostReq)
+	result := ToOpenAIResponsesRequest(nil, bifrostReq)
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -84,7 +84,7 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 	if buildErr != nil {
 		return nil, buildErr
 	}
-	stripped, err := anthropic.StripUnsupportedFieldsFromRawBody(jsonBody, schemas.Vertex, deployment)
+	stripped, err := anthropic.StripUnsupportedFieldsFromRawBody(jsonBody, schemas.Vertex, schemas.ResolveCanonicalModel(ctx, deployment))
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(err.Error(), nil)
 	}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -474,7 +474,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 					return nil, fmt.Errorf("failed to delete model field: %w", err)
 				}
 			} else if schemas.IsGeminiModelFamily(ctx, request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModelFamily(ctx, request.Model) {
-				reqBody, err := gemini.ToGeminiChatCompletionRequest(request)
+				reqBody, err := gemini.ToGeminiChatCompletionRequest(ctx, request)
 				if err != nil {
 					return nil, err
 				}
@@ -533,7 +533,8 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 
 	// Remap unsupported tool versions for Vertex (handles raw passthrough bodies)
 	if schemas.IsAnthropicModelFamily(ctx, request.Model) && jsonBody != nil {
-		remappedBody, remapErr := anthropic.RemapRawToolVersionsForProvider(jsonBody, schemas.Vertex, request.Model)
+		capModel := schemas.ResolveCanonicalModel(ctx, request.Model)
+		remappedBody, remapErr := anthropic.RemapRawToolVersionsForProvider(jsonBody, schemas.Vertex, capModel)
 		if remapErr != nil {
 			return nil, providerUtils.NewBifrostOperationError(remapErr.Error(), nil)
 		}
@@ -541,7 +542,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 
 		// Strip unsupported body fields for Vertex — covers both structured and raw passthrough paths.
 		var stripErr error
-		jsonBody, stripErr = anthropic.StripUnsupportedFieldsFromRawBody(jsonBody, schemas.Vertex, request.Model)
+		jsonBody, stripErr = anthropic.StripUnsupportedFieldsFromRawBody(jsonBody, schemas.Vertex, capModel)
 		if stripErr != nil {
 			return nil, providerUtils.NewBifrostOperationError(stripErr.Error(), nil)
 		}
@@ -813,15 +814,16 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 
 		// Remap unsupported tool versions for Vertex streaming (handles raw passthrough bodies)
 		if jsonData != nil {
+			capModel := schemas.ResolveCanonicalModel(ctx, request.Model)
 			var remapErr error
-			jsonData, remapErr = anthropic.RemapRawToolVersionsForProvider(jsonData, schemas.Vertex, request.Model)
+			jsonData, remapErr = anthropic.RemapRawToolVersionsForProvider(jsonData, schemas.Vertex, capModel)
 			if remapErr != nil {
 				return nil, providerUtils.NewBifrostOperationError(remapErr.Error(), nil)
 			}
 
 			// Strip unsupported body fields for Vertex — covers both structured and raw passthrough paths.
 			var stripErr error
-			jsonData, stripErr = anthropic.StripUnsupportedFieldsFromRawBody(jsonData, schemas.Vertex, request.Model)
+			jsonData, stripErr = anthropic.StripUnsupportedFieldsFromRawBody(jsonData, schemas.Vertex, capModel)
 			if stripErr != nil {
 				return nil, providerUtils.NewBifrostOperationError(stripErr.Error(), nil)
 			}
@@ -871,7 +873,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			ctx,
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				reqBody, err := gemini.ToGeminiChatCompletionRequest(request)
+				reqBody, err := gemini.ToGeminiChatCompletionRequest(ctx, request)
 				if err != nil {
 					return nil, err
 				}
@@ -1139,7 +1141,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 			ctx,
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				reqBody, err := gemini.ToGeminiResponsesRequest(request)
+				reqBody, err := gemini.ToGeminiResponsesRequest(ctx, request)
 				if err != nil {
 					return nil, err
 				}
@@ -1366,7 +1368,7 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			ctx,
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				reqBody, err := gemini.ToGeminiResponsesRequest(request)
+				reqBody, err := gemini.ToGeminiResponsesRequest(ctx, request)
 				if err != nil {
 					return nil, err
 				}
@@ -3984,7 +3986,7 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 			ctx,
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				return gemini.ToGeminiResponsesRequest(request)
+				return gemini.ToGeminiResponsesRequest(ctx, request)
 			},
 		)
 		if bifrostErr != nil {

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -408,6 +408,30 @@ func ResolveFamily(ctx *BifrostContext, fallbackModel string) ModelFamily {
 	return ""
 }
 
+// ResolveCanonicalModel returns the model string that capability/version gating
+// should run against for the current attempt, walking the alias hierarchy:
+// canonical ModelName → wire ModelID → fallbackModel.
+//
+// Precedence here means "first present tier wins" — a present ModelName is
+// authoritative and we do not fall through to ModelID on it. The ModelName tier
+// is what makes Claude-on-Azure work: there the wire ModelID is an opaque
+// deployment id, but the admin-configured ModelName carries the real
+// "claude-opus-4-8" string the substring checks need.
+//
+// When no alias is resolved in ctx, fallbackModel (typically request.Model) is
+// returned unchanged, preserving pre-refactor behavior.
+func ResolveCanonicalModel(ctx *BifrostContext, fallbackModel string) string {
+	if ra := GetResolvedAlias(ctx); ra != nil && ra.Config != nil {
+		if ra.Config.ModelName != nil && *ra.Config.ModelName != "" {
+			return *ra.Config.ModelName
+		}
+		if ra.Config.ModelID != "" {
+			return ra.Config.ModelID
+		}
+	}
+	return fallbackModel
+}
+
 // IsAnthropicModelFamily reports whether the current attempt resolves to the
 // Anthropic model family. Thin wrapper over ResolveFamily so provider code
 // reads uniformly at the many call sites that branch on Anthropic vs

--- a/core/schemas/account_test.go
+++ b/core/schemas/account_test.go
@@ -457,6 +457,114 @@ func TestResolveFamilyPrecedence(t *testing.T) {
 	}
 }
 
+func TestResolveCanonicalModelPrecedence(t *testing.T) {
+	// Helper to build a BifrostContext carrying a ResolvedAlias.
+	withAlias := func(ra *ResolvedAlias) *BifrostContext {
+		bc := NewBifrostContext(nil, NoDeadline)
+		if ra != nil {
+			bc.SetValue(BifrostContextKeyResolvedAlias, ra)
+		}
+		return bc
+	}
+
+	cases := []struct {
+		name     string
+		ra       *ResolvedAlias
+		fallback string
+		want     string
+	}{
+		{
+			name: "tier 1: explicit ModelName wins over ModelID",
+			ra: &ResolvedAlias{
+				Key: "best-claude",
+				Config: &AliasConfig{
+					ModelID:   "12345-azure-deployment",
+					ModelName: Ptr("claude-opus-4-8"),
+				},
+			},
+			fallback: "12345-azure-deployment",
+			want:     "claude-opus-4-8",
+		},
+		{
+			name: "tier 2: ModelID used when ModelName absent",
+			ra: &ResolvedAlias{
+				Key: "best-claude",
+				Config: &AliasConfig{
+					ModelID: "claude-opus-4-8-20251101",
+				},
+			},
+			fallback: "best-claude",
+			want:     "claude-opus-4-8-20251101",
+		},
+		{
+			name: "opaque ModelID is returned as-is when ModelName absent (legacy/passthrough alias)",
+			ra: &ResolvedAlias{
+				Key: "best-claude",
+				Config: &AliasConfig{
+					ModelID: "12345-azure-deployment",
+				},
+			},
+			fallback: "best-claude",
+			want:     "12345-azure-deployment",
+		},
+		{
+			name: "alias Key is NOT consulted — a Key that smells like a version must not leak into gating",
+			ra: &ResolvedAlias{
+				Key: "opus-4-8-fast", // intentionally version-looking; must be ignored
+				Config: &AliasConfig{
+					ModelID: "12345-azure-deployment",
+				},
+			},
+			fallback: "12345-azure-deployment",
+			want:     "12345-azure-deployment", // ModelID, never the Key
+		},
+		{
+			name: "ModelFamily is NOT consulted — present family must not change the resolved string",
+			ra: &ResolvedAlias{
+				Key: "x",
+				Config: &AliasConfig{
+					ModelID:     "claude-opus-4-8",
+					ModelFamily: Ptr(ModelFamilyAnthropic),
+				},
+			},
+			fallback: "x",
+			want:     "claude-opus-4-8",
+		},
+		{
+			name: "empty ModelName pointer is treated as absent (falls through to ModelID)",
+			ra: &ResolvedAlias{
+				Key: "x",
+				Config: &AliasConfig{
+					ModelID:   "claude-opus-4-8",
+					ModelName: Ptr(""),
+				},
+			},
+			fallback: "x",
+			want:     "claude-opus-4-8",
+		},
+		{
+			name:     "nil Config falls back to fallbackModel (defensive)",
+			ra:       &ResolvedAlias{Key: "x", Config: nil},
+			fallback: "claude-opus-4-8",
+			want:     "claude-opus-4-8",
+		},
+		{
+			name:     "no alias matched: fallbackModel returned verbatim — byte-identical to pre-refactor gating input",
+			ra:       nil,
+			fallback: "claude-opus-4-8",
+			want:     "claude-opus-4-8",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ResolveCanonicalModel(withAlias(c.ra), c.fallback)
+			if got != c.want {
+				t.Fatalf("ResolveCanonicalModel: got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
 func TestModelFamilyIsValid(t *testing.T) {
 	valid := []ModelFamily{
 		ModelFamilyAnthropic, ModelFamilyOpenAI, ModelFamilyMistral,


### PR DESCRIPTION
## Summary

Capability and version gating checks across the Anthropic and Bedrock providers were running against the raw wire model ID, which for deployments like Claude-on-Azure is an opaque deployment name rather than the real model string (e.g. `claude-opus-4-8`). This caused feature checks (`IsAdaptiveOnlyThinkingModel`, `SupportsAdaptiveThinking`, `IsFableFamily`, `SupportsFastMode`, etc.) to silently fall through to incorrect behavior for aliased models.

This PR introduces `ResolveCanonicalModel` to walk the alias hierarchy and return the correct model string for capability gating, then threads it through every affected call site.

## Changes

- Added `ResolveCanonicalModel(ctx, fallbackModel)` to `core/schemas/account.go`. It walks `ResolvedAlias.Config.ModelName` → `ResolvedAlias.Config.ModelID` → `fallbackModel`, returning the first non-empty tier. This preserves pre-existing behavior when no alias is resolved.
- All capability/version gating calls in `anthropic/chat.go`, `anthropic/responses.go`, `anthropic/requestbuilder.go`, `anthropic/anthropic.go`, `anthropic/utils.go`, `bedrock/responses.go`, and `bedrock/utils.go` now resolve a `capModel` once per function via `ResolveCanonicalModel` and pass that to the feature-check functions instead of the raw `request.Model` / `bifrostReq.Model`.
- The wire model field (`bifrostReq.Model`) is intentionally left unchanged everywhere it is used for routing, token limits, or the actual API request body — only the capability gating path is affected.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

To validate the fix end-to-end, configure an Azure-hosted Claude deployment where the deployment name differs from the canonical model string (e.g. deployment ID `my-opus-deployment`, `ModelName: claude-opus-4-8`). Send a request with `reasoning.max_tokens` set and confirm that adaptive thinking is correctly applied rather than falling back to `budget_tokens` mode. Repeat with `temperature` and verify it is stripped for Fable/Mythos family models resolved through an alias.

## Breaking changes

- [x] No

## Security considerations

None. This change only affects how model strings are resolved for feature gating; no auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable