### PR TITLE
feat: add attribution columns (virtual key, routing rule, team, customer, user, business unit) to logs table with localStorage persistence

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -480,9 +480,17 @@ export default function LogsPage() {
 			latency: "Latency",
 			tokens: "Tokens",
 			cost: "Cost",
+			virtual_key: "Virtual Key",
+			routing_rule: "Routing Rule",
+			team: "Team",
+			customer: "Customer",
+			user: "User",
+			business_unit: "Business Unit",
 		}),
 		[],
 	);
+
+	const DEFAULT_HIDDEN_COLUMNS = useMemo(() => ["virtual_key", "routing_rule", "team", "customer", "user", "business_unit"], []);
 
 	const {
 		entries: columnEntries,
@@ -496,6 +504,8 @@ export default function LogsPage() {
 	} = useColumnConfig({
 		columnIds,
 		paramName: "cols",
+		storageKey: "bifrost.logs.cols",
+		defaultHidden: DEFAULT_HIDDEN_COLUMNS,
 		fixedColumns: hasDeleteAccess ? { right: ["actions"] } : undefined,
 	});
 

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -367,6 +367,49 @@ export const createColumns = (
 		},
 	];
 
+	const attributionCell = (value?: string | null) => (
+		<div className="max-w-[180px] truncate font-mono text-xs">{value || "-"}</div>
+	);
+
+	const attributionColumns: ColumnDef<LogEntry>[] = [
+		{
+			id: "virtual_key",
+			header: "Virtual Key",
+			size: 170,
+			cell: ({ row }) => attributionCell(row.original.virtual_key?.name ?? row.original.virtual_key_id),
+		},
+		{
+			id: "routing_rule",
+			header: "Routing Rule",
+			size: 170,
+			cell: ({ row }) => attributionCell(row.original.routing_rule?.name ?? row.original.routing_rule_id),
+		},
+		{
+			id: "team",
+			header: "Team",
+			size: 150,
+			cell: ({ row }) => attributionCell(row.original.team_name ?? row.original.team_id),
+		},
+		{
+			id: "customer",
+			header: "Customer",
+			size: 150,
+			cell: ({ row }) => attributionCell(row.original.customer_name ?? row.original.customer_id),
+		},
+		{
+			id: "user",
+			header: "User",
+			size: 150,
+			cell: ({ row }) => attributionCell(row.original.user_name ?? row.original.user_id),
+		},
+		{
+			id: "business_unit",
+			header: "Business Unit",
+			size: 150,
+			cell: ({ row }) => attributionCell(row.original.business_unit_name ?? row.original.business_unit_id),
+		},
+	];
+
 	const metadataColumns: ColumnDef<LogEntry>[] = metadataKeys.map((key) => ({
 		id: `metadata_${key}`,
 		header: key.charAt(0).toUpperCase() + key.slice(1),
@@ -395,5 +438,5 @@ export const createColumns = (
 			]
 		: [];
 
-	return [...baseColumns, ...metadataColumns, ...actionsColumn];
+	return [...baseColumns, ...attributionColumns, ...metadataColumns, ...actionsColumn];
 };

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -346,6 +346,8 @@ export default function MCPLogsPage() {
 	} = useColumnConfig({
 		columnIds,
 		paramName: "mcp_cols",
+		storageKey: "bifrost.mcp_logs.cols",
+		defaultHidden: ["virtual_key"],
 		fixedColumns: hasDeleteAccess ? { right: ["actions"] } : undefined,
 	});
 
@@ -356,6 +358,7 @@ export default function MCPLogsPage() {
 			server_label: "Server",
 			latency: "Latency",
 			cost: "Cost",
+			virtual_key: "Virtual Key",
 		}),
 		[],
 	);

--- a/ui/app/workspace/mcp-logs/views/columns.tsx
+++ b/ui/app/workspace/mcp-logs/views/columns.tsx
@@ -96,6 +96,15 @@ export const createMCPColumns = (
 			return <div className="font-mono text-sm">{isValidNumber ? `${cost.toFixed(4)}` : "N/A"}</div>;
 		},
 	},
+	{
+		id: "virtual_key",
+		header: "Virtual Key",
+		size: 170,
+		cell: ({ row }) => {
+			const value = row.original.virtual_key?.name ?? row.original.virtual_key_name ?? row.original.virtual_key_id;
+			return <div className="max-w-[180px] truncate font-mono text-xs">{value || "-"}</div>;
+		},
+	},
 	...(hasDeleteAccess
 		? [
 				{

--- a/ui/components/table/hooks/useColumnConfig.ts
+++ b/ui/components/table/hooks/useColumnConfig.ts
@@ -1,6 +1,6 @@
 import { ColumnPinningState, VisibilityState } from "@tanstack/react-table";
 import { parseAsString, useQueryState } from "nuqs";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 export interface ColumnConfigEntry {
 	id: string;
@@ -15,6 +15,13 @@ interface UseColumnConfigOptions {
 	paramName?: string;
 	/** Columns excluded from configuration (always visible, always in position) */
 	fixedColumns?: { left?: string[]; right?: string[] };
+	/**
+	 * localStorage key for persisting the config across sessions. When set, the
+	 * stored config seeds the table on load if the URL param is empty (URL wins).
+	 */
+	storageKey?: string;
+	/** Configurable column IDs that should be hidden by default (when not in URL/localStorage). */
+	defaultHidden?: string[];
 }
 
 // URL format: col1,col2:h,col3:l,col4:r
@@ -45,7 +52,18 @@ function deserialize(str: string): ColumnConfigEntry[] {
 	});
 }
 
-export function useColumnConfig({ columnIds, paramName = "cols", fixedColumns }: UseColumnConfigOptions) {
+function isSerializedConfigValid(str: string): boolean {
+	try {
+		return str.split(",").every((part) => {
+			const [rawId, flags = ""] = part.split(":");
+			return rawId !== "" && decodeURIComponent(rawId) !== "" && /^[hlr]*$/.test(flags) && !(flags.includes("l") && flags.includes("r"));
+		});
+	} catch {
+		return false;
+	}
+}
+
+export function useColumnConfig({ columnIds, paramName = "cols", fixedColumns, storageKey, defaultHidden }: UseColumnConfigOptions) {
 	const [raw, setRaw] = useQueryState(paramName, parseAsString.withDefault(""));
 
 	const fixedLeft = fixedColumns?.left ?? [];
@@ -53,6 +71,29 @@ export function useColumnConfig({ columnIds, paramName = "cols", fixedColumns }:
 	const fixedSet = useMemo(() => new Set([...fixedLeft, ...fixedRight]), [fixedLeft, fixedRight]);
 
 	const configurableIds = useMemo(() => columnIds.filter((id) => !fixedSet.has(id)), [columnIds, fixedSet]);
+
+	const defaultHiddenSet = useMemo(() => new Set(defaultHidden ?? []), [defaultHidden]);
+
+	// Seed from localStorage once on mount when the URL has no config (URL wins).
+	const hydratedRef = useRef(false);
+	useEffect(() => {
+		if (hydratedRef.current || !storageKey) return;
+		hydratedRef.current = true;
+		if (raw) return; // explicit URL config takes precedence
+		try {
+			const stored = localStorage.getItem(storageKey);
+			if (stored) {
+				if (isSerializedConfigValid(stored)) {
+					setRaw(stored);
+				} else {
+					localStorage.removeItem(storageKey);
+				}
+			}
+		} catch {
+			// localStorage unavailable (SSR, privacy mode) — keep default.
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	// Merge URL config with available columns (handles added/removed columns)
 	const entries = useMemo(() => {
@@ -71,12 +112,12 @@ export function useColumnConfig({ columnIds, paramName = "cols", fixedColumns }:
 		// New columns not yet in URL config
 		for (const id of configurableIds) {
 			if (!seen.has(id)) {
-				result.push({ id, visible: true, pinned: false });
+				result.push({ id, visible: !defaultHiddenSet.has(id), pinned: false });
 			}
 		}
 
 		return result;
-	}, [raw, configurableIds]);
+	}, [raw, configurableIds, defaultHiddenSet]);
 
 	// TanStack table state
 	const columnOrder = useMemo(() => [...fixedLeft, ...entries.map((e) => e.id), ...fixedRight], [entries, fixedLeft, fixedRight]);
@@ -101,8 +142,16 @@ export function useColumnConfig({ columnIds, paramName = "cols", fixedColumns }:
 		(newEntries: ColumnConfigEntry[]) => {
 			const serialized = serialize(newEntries);
 			setRaw(serialized || null);
+			if (storageKey) {
+				try {
+					if (serialized) localStorage.setItem(storageKey, serialized);
+					else localStorage.removeItem(storageKey);
+				} catch {
+					// localStorage unavailable — preference won't persist.
+				}
+			}
 		},
-		[setRaw],
+		[setRaw, storageKey],
 	);
 
 	const toggleVisibility = useCallback(
@@ -128,7 +177,14 @@ export function useColumnConfig({ columnIds, paramName = "cols", fixedColumns }:
 
 	const reset = useCallback(() => {
 		setRaw(null);
-	}, [setRaw]);
+		if (storageKey) {
+			try {
+				localStorage.removeItem(storageKey);
+			} catch {
+				// localStorage unavailable — nothing to clear.
+			}
+		}
+	}, [setRaw, storageKey]);
 
 	return {
 		entries,


### PR DESCRIPTION
## Summary

Adds attribution columns (Virtual Key, Routing Rule, Team, Customer, User, Business Unit) to the logs table, and a Virtual Key column to the MCP logs table. These columns are hidden by default to avoid cluttering the view but can be toggled on by users. Column visibility preferences are now persisted to `localStorage` so configurations survive page reloads and new sessions.

## Changes

- Added attribution columns (`virtual_key`, `routing_rule`, `team`, `customer`, `user`, `business_unit`) to the logs table, displaying the name when available and falling back to the ID.
- Added a `virtual_key` column to the MCP logs table.
- New columns are hidden by default via a `defaultHidden` option in `useColumnConfig`.
- Extended `useColumnConfig` with a `storageKey` option that persists column visibility/order to `localStorage`. On mount, if no URL config is present, the stored config is used to seed the table. URL params always take precedence over `localStorage`.
- `reset()` now also clears the `localStorage` entry when a `storageKey` is provided.
- Storage keys used: `bifrost.logs.cols` and `bifrost.mcp_logs.cols`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Logs page.
2. Confirm that the attribution columns (Virtual Key, Routing Rule, Team, Customer, User, Business Unit) are hidden by default.
3. Toggle one or more attribution columns visible using the column picker.
4. Reload the page — confirm the column visibility is restored from `localStorage` without needing a URL param.
5. Add a `cols` URL param manually — confirm it takes precedence over the stored `localStorage` value.
6. Click reset — confirm columns return to defaults and `localStorage` is cleared.
7. Repeat steps 2–6 on the MCP Logs page for the Virtual Key column.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots showing the new attribution columns in the column picker and table._

## Breaking changes

- [x] No

## Related issues

## Security considerations

Attribution data (team names, customer IDs, user IDs) is displayed in the logs table. Ensure that access controls on the logs API already restrict which records are returned to authorized users, as this change only surfaces data already present in log entries.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable