### PR TITLE
tests: add MCP auth mode e2e collection and Newman runner for headers/both/oauth

### DIFF
--- a/examples/mcps/http-no-ping-server/main.go
+++ b/examples/mcps/http-no-ping-server/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -51,8 +52,13 @@ func main() {
 	// Create HTTP server using StreamableHTTP transport
 	httpServer := server.NewStreamableHTTPServer(mcpServer)
 
-	port := 3001
-	addr := fmt.Sprintf("localhost:%d", port)
+	// Port defaults to 3001 but can be overridden via MCP_SERVER_PORT so multiple
+	// instances (or a test harness facing a port conflict) can bind elsewhere.
+	port := "3001"
+	if p := os.Getenv("MCP_SERVER_PORT"); p != "" {
+		port = p
+	}
+	addr := fmt.Sprintf("localhost:%s", port)
 
 	log.Printf("MCP server listening on http://%s/", addr)
 	log.Printf("Note: This server does NOT support ping. Use is_ping_available=false in Bifrost config.")

--- a/tests/e2e/api/collections/bifrost-v1-mcp-auth.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-v1-mcp-auth.postman_collection.json
@@ -1,0 +1,388 @@
+{
+  "info": {
+    "name": "Bifrost V1 - MCP Auth",
+    "description": "Validates inbound /mcp authentication across the three server auth modes (headers | both | oauth), driven by the auth_mode env-var set per boot config. The runner boots a fresh server per mode with two pre-seeded virtual keys (one active, one inactive) and an upstream MCP client. Core guarantees: (1) in headers mode every virtual-key credential connects exactly as before and the OAuth discovery surface is invisible (404); (2) both mode keeps every header-credential outcome identical and only ADDS JWT acceptance + discovery; (3) oauth mode rejects header credentials outright; (4) an inactive virtual key never connects, in any mode; (5) discovery documents are spec-shaped when served.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "base_url", "value": "http://localhost:8090", "type": "string" },
+    { "key": "auth_mode", "value": "headers", "type": "string" },
+    { "key": "vk_value", "value": "sk-bf-mcp-test-key", "type": "string" },
+    { "key": "vk_inactive_value", "value": "sk-bf-mcp-inactive-key", "type": "string" },
+    { "key": "mcp_issuer", "value": "http://localhost:8090", "type": "string" }
+  ],
+  "item": [
+    {
+      "name": "Discovery gating",
+      "item": [
+        {
+          "name": "Protected resource metadata",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var mode = String(pm.variables.get('auth_mode') || '');",
+                  "var code = pm.response.code;",
+                  "if (mode === 'headers') {",
+                  "  pm.test('PRM is hidden in headers mode (404)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.equal(404);",
+                  "  });",
+                  "  return;",
+                  "}",
+                  "pm.test('PRM is served (200)', function () { pm.expect(code).to.equal(200); });",
+                  "var b = pm.response.json();",
+                  "var issuer = pm.variables.get('mcp_issuer');",
+                  "pm.test('resource is the /mcp URL (RFC 9728)', function () {",
+                  "  pm.expect(b.resource).to.equal(issuer + '/mcp');",
+                  "});",
+                  "pm.test('authorization_servers lists this issuer', function () {",
+                  "  pm.expect(b.authorization_servers).to.include(issuer);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/.well-known/oauth-protected-resource",
+              "host": ["{{base_url}}"],
+              "path": [".well-known", "oauth-protected-resource"]
+            }
+          }
+        },
+        {
+          "name": "Authorization server metadata",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var mode = String(pm.variables.get('auth_mode') || '');",
+                  "var code = pm.response.code;",
+                  "if (mode === 'headers') {",
+                  "  pm.test('AS metadata is hidden in headers mode (404)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.equal(404);",
+                  "  });",
+                  "  return;",
+                  "}",
+                  "pm.test('AS metadata is served (200)', function () { pm.expect(code).to.equal(200); });",
+                  "var b = pm.response.json();",
+                  "var issuer = pm.variables.get('mcp_issuer');",
+                  "pm.test('issuer + endpoints are present', function () {",
+                  "  pm.expect(b.issuer).to.equal(issuer);",
+                  "  pm.expect(b.authorization_endpoint).to.equal(issuer + '/oauth2/authorize');",
+                  "  pm.expect(b.token_endpoint).to.equal(issuer + '/oauth2/token');",
+                  "  pm.expect(b.registration_endpoint).to.equal(issuer + '/oauth2/register');",
+                  "  pm.expect(b.jwks_uri).to.equal(issuer + '/.well-known/jwks.json');",
+                  "});",
+                  "pm.test('advertises code grant, PKCE S256, public clients', function () {",
+                  "  pm.expect(b.response_types_supported).to.include('code');",
+                  "  pm.expect(b.grant_types_supported).to.include('authorization_code');",
+                  "  pm.expect(b.grant_types_supported).to.include('refresh_token');",
+                  "  pm.expect(b.code_challenge_methods_supported).to.include('S256');",
+                  "  pm.expect(b.token_endpoint_auth_methods_supported).to.include('none');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/.well-known/oauth-authorization-server",
+              "host": ["{{base_url}}"],
+              "path": [".well-known", "oauth-authorization-server"]
+            }
+          }
+        },
+        {
+          "name": "JWKS",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var mode = String(pm.variables.get('auth_mode') || '');",
+                  "var code = pm.response.code;",
+                  "if (mode === 'headers') {",
+                  "  pm.test('JWKS is hidden in headers mode (404)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.equal(404);",
+                  "  });",
+                  "  return;",
+                  "}",
+                  "pm.test('JWKS is served (200)', function () { pm.expect(code).to.equal(200); });",
+                  "var b = pm.response.json();",
+                  "pm.test('exposes one RS256 signing key', function () {",
+                  "  pm.expect(b.keys).to.be.an('array').with.lengthOf(1);",
+                  "  var k = b.keys[0];",
+                  "  pm.expect(k.kty).to.equal('RSA');",
+                  "  pm.expect(k.alg).to.equal('RS256');",
+                  "  pm.expect(k.use).to.equal('sig');",
+                  "  pm.expect(k.kid).to.be.a('string').and.not.empty;",
+                  "  pm.expect(k.n).to.be.a('string').and.not.empty;",
+                  "  pm.expect(k.e).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/.well-known/jwks.json",
+              "host": ["{{base_url}}"],
+              "path": [".well-known", "jwks.json"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "MCP connect matrix",
+      "description": "POST a JSON-RPC initialize to /mcp with each credential. The auth gate runs on every /mcp request, so initialize alone proves accept/reject. Accepted is asserted as 'not 401'; rejected is asserted as exactly 401 (with WWW-Authenticate where discovery is enabled).",
+      "item": [
+        {
+          "name": "Virtual key via x-bf-vk",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var mode = String(pm.variables.get('auth_mode') || '');",
+                  "var code = pm.response.code;",
+                  "if (mode === 'oauth') {",
+                  "  pm.test('header VK is rejected in oauth-strict mode (401)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.equal(401);",
+                  "  });",
+                  "  pm.test('401 advertises the protected-resource metadata', function () {",
+                  "    pm.expect(pm.response.headers.get('WWW-Authenticate')).to.be.a('string');",
+                  "  });",
+                  "} else {",
+                  "  pm.test('header VK connects (not 401) — unchanged legacy behavior', function () {",
+                  "    pm.expect(code, pm.response.text()).to.not.equal(401);",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Accept", "value": "application/json, text/event-stream" },
+              { "key": "x-bf-vk", "value": "{{vk_value}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"newman-mcp-auth\",\"version\":\"1.0.0\"}}}"
+            },
+            "url": { "raw": "{{base_url}}/mcp", "host": ["{{base_url}}"], "path": ["mcp"] }
+          }
+        },
+        {
+          "name": "Virtual key via Authorization Bearer",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var mode = String(pm.variables.get('auth_mode') || '');",
+                  "var code = pm.response.code;",
+                  "if (mode === 'oauth') {",
+                  "  pm.test('Bearer VK is rejected in oauth-strict mode (401)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.equal(401);",
+                  "  });",
+                  "} else {",
+                  "  pm.test('Bearer VK connects (not 401) — unchanged legacy behavior', function () {",
+                  "    pm.expect(code, pm.response.text()).to.not.equal(401);",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Accept", "value": "application/json, text/event-stream" },
+              { "key": "Authorization", "value": "Bearer {{vk_value}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"newman-mcp-auth\",\"version\":\"1.0.0\"}}}"
+            },
+            "url": { "raw": "{{base_url}}/mcp", "host": ["{{base_url}}"], "path": ["mcp"] }
+          }
+        },
+        {
+          "name": "Virtual key via x-api-key",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var mode = String(pm.variables.get('auth_mode') || '');",
+                  "var code = pm.response.code;",
+                  "if (mode === 'oauth') {",
+                  "  pm.test('x-api-key VK is rejected in oauth-strict mode (401)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.equal(401);",
+                  "  });",
+                  "} else {",
+                  "  pm.test('x-api-key VK connects (not 401) — unchanged legacy behavior', function () {",
+                  "    pm.expect(code, pm.response.text()).to.not.equal(401);",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Accept", "value": "application/json, text/event-stream" },
+              { "key": "x-api-key", "value": "{{vk_value}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"newman-mcp-auth\",\"version\":\"1.0.0\"}}}"
+            },
+            "url": { "raw": "{{base_url}}/mcp", "host": ["{{base_url}}"], "path": ["mcp"] }
+          }
+        },
+        {
+          "name": "No credentials (anonymous)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// enforce_auth_on_inference is off in the boot config, so anonymous /mcp",
+                  "// access falls back to the global server in headers/both. oauth-strict",
+                  "// still requires a JWT.",
+                  "var mode = String(pm.variables.get('auth_mode') || '');",
+                  "var code = pm.response.code;",
+                  "if (mode === 'oauth') {",
+                  "  pm.test('anonymous is rejected in oauth-strict mode (401)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.equal(401);",
+                  "  });",
+                  "  pm.test('401 advertises the protected-resource metadata', function () {",
+                  "    pm.expect(pm.response.headers.get('WWW-Authenticate')).to.be.a('string');",
+                  "  });",
+                  "} else {",
+                  "  pm.test('anonymous connects when auth is not enforced (not 401)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.not.equal(401);",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Accept", "value": "application/json, text/event-stream" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"newman-mcp-auth\",\"version\":\"1.0.0\"}}}"
+            },
+            "url": { "raw": "{{base_url}}/mcp", "host": ["{{base_url}}"], "path": ["mcp"] }
+          }
+        },
+        {
+          "name": "Inactive virtual key via x-bf-vk",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// A deactivated key must never connect, in any mode: headers/both reject",
+                  "// it at the shared key-lookup chokepoint, oauth-strict rejects the header",
+                  "// credential outright.",
+                  "var code = pm.response.code;",
+                  "pm.test('inactive virtual key is rejected (401)', function () {",
+                  "  pm.expect(code, pm.response.text()).to.equal(401);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Accept", "value": "application/json, text/event-stream" },
+              { "key": "x-bf-vk", "value": "{{vk_inactive_value}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"newman-mcp-auth\",\"version\":\"1.0.0\"}}}"
+            },
+            "url": { "raw": "{{base_url}}/mcp", "host": ["{{base_url}}"], "path": ["mcp"] }
+          }
+        },
+        {
+          "name": "Opaque bearer token (not a Bifrost JWT)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// A JWT-shaped bearer that is not a real issued token. In headers mode the",
+                  "// JWT path is off, so this is not treated as a credential and falls back to",
+                  "// anonymous (auth not enforced). In both/oauth the token is verified and",
+                  "// fails, yielding 401 with WWW-Authenticate.",
+                  "var mode = String(pm.variables.get('auth_mode') || '');",
+                  "var code = pm.response.code;",
+                  "if (mode === 'headers') {",
+                  "  pm.test('JWT-shaped bearer is ignored in headers mode (not 401)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.not.equal(401);",
+                  "  });",
+                  "} else {",
+                  "  pm.test('invalid JWT is rejected (401)', function () {",
+                  "    pm.expect(code, pm.response.text()).to.equal(401);",
+                  "  });",
+                  "  pm.test('401 advertises the protected-resource metadata', function () {",
+                  "    pm.expect(pm.response.headers.get('WWW-Authenticate')).to.be.a('string');",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Accept", "value": "application/json, text/event-stream" },
+              { "key": "Authorization", "value": "Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJmYWtlIn0.bm90LWEtcmVhbC1zaWduYXR1cmU" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"newman-mcp-auth\",\"version\":\"1.0.0\"}}}"
+            },
+            "url": { "raw": "{{base_url}}/mcp", "host": ["{{base_url}}"], "path": ["mcp"] }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/api/runners/individual/run-newman-mcp-auth-tests.sh
+++ b/tests/e2e/api/runners/individual/run-newman-mcp-auth-tests.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+
+# Bifrost MCP Auth Newman Test Runner
+#
+# Boots a fresh Bifrost server (sqlite, pre-seeded virtual keys + an upstream MCP
+# client) once per inbound /mcp authentication mode:
+#   - client.mcp_server_auth_mode = headers   (default; header credentials only, discovery off)
+#   - client.mcp_server_auth_mode = both      (header credentials AND issued JWTs, discovery on)
+#   - client.mcp_server_auth_mode = oauth     (issued JWTs only, header credentials rejected)
+# and runs collections/bifrost-v1-mcp-auth.postman_collection.json against each.
+#
+# The collection's test scripts branch on the auth_mode env var, so a single
+# collection encodes the full accept/reject matrix. The central guarantee: in
+# headers mode every existing virtual-key path connects exactly as before and the
+# OAuth surface is invisible (discovery 404s); enabling both only ADDS JWT
+# acceptance without changing any header-credential outcome.
+#
+# An upstream MCP server (examples/mcps/http-no-ping-server on port 3001) is built
+# and started by this runner so /mcp exposes real tools. It is pre-seeded as an
+# MCP client in each boot config, so it is connected before the server reports
+# ready — no post-boot registration race.
+#
+# Requires a built bifrost-http binary; this runner boots its own servers (each
+# mode needs a different boot config, so the shared e2e server is not reused).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPO_ROOT="$(cd "$API_DIR/../../.." && pwd)"
+cd "$API_DIR"
+
+COLLECTION="collections/bifrost-v1-mcp-auth.postman_collection.json"
+REPORT_DIR="newman-reports/mcp-auth"
+VK_VALUE="sk-bf-mcp-test-key"
+VK_INACTIVE_VALUE="sk-bf-mcp-inactive-key"
+MCP_UPSTREAM_DIR="$REPO_ROOT/examples/mcps/http-no-ping-server"
+MCP_UPSTREAM_PORT="3001"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+BIFROST_BINARY=""
+PORT="8090"
+REPORTERS="cli"
+VERBOSE=""
+BAIL=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --binary) BIFROST_BINARY="$2"; shift 2 ;;
+        --port) PORT="$2"; shift 2 ;;
+        --mcp-port) MCP_UPSTREAM_PORT="$2"; shift 2 ;;
+        --html) REPORTERS="${REPORTERS},html"; shift ;;
+        --json) REPORTERS="${REPORTERS},json"; shift ;;
+        --verbose) VERBOSE="--verbose"; shift ;;
+        --bail) BAIL="--bail"; shift ;;
+        --help)
+            echo "Usage: $0 --binary <path-to-bifrost-http> [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --binary <path>   Path to a built bifrost-http binary (required)"
+            echo "  --port <port>     Port to boot each server on (default: 8090)"
+            echo "  --mcp-port <port> Port for the upstream MCP test server (default: 3001)"
+            echo "  --html            Generate HTML report"
+            echo "  --json            Generate JSON report"
+            echo "  --verbose         Show detailed Newman output"
+            echo "  --bail            Stop on first failure"
+            echo "  --help            Show this help message"
+            exit 0 ;;
+        *) echo -e "${RED}Unknown option: $1${NC}"; exit 1 ;;
+    esac
+done
+
+echo -e "${GREEN}==============================================${NC}"
+echo -e "${GREEN}Bifrost MCP Auth Test Runner${NC}"
+echo -e "${GREEN}==============================================${NC}"
+echo ""
+
+if ! command -v newman &>/dev/null; then
+    echo -e "${RED}Error: Newman is not installed${NC}"
+    echo "Install it with: npm install -g newman"
+    exit 1
+fi
+if [ -z "$BIFROST_BINARY" ] || [ ! -x "$BIFROST_BINARY" ]; then
+    echo -e "${RED}Error: --binary must point to an executable bifrost-http binary${NC}"
+    exit 1
+fi
+if [ ! -f "$COLLECTION" ]; then
+    echo -e "${RED}Error: Collection file not found: $COLLECTION${NC}"
+    exit 1
+fi
+
+mkdir -p "$REPORT_DIR"
+
+# Tracks the running servers + temp dirs so the trap can always clean up.
+CURRENT_PID=""
+CURRENT_DIR=""
+MCP_UPSTREAM_PID=""
+MCP_UPSTREAM_TMP=""
+OVERALL_EXIT=0
+
+cleanup() {
+    if [ -n "$CURRENT_PID" ] && kill -0 "$CURRENT_PID" 2>/dev/null; then
+        kill "$CURRENT_PID" 2>/dev/null || true
+        wait "$CURRENT_PID" 2>/dev/null || true
+    fi
+    [ -n "$CURRENT_DIR" ] && rm -rf "$CURRENT_DIR"
+    [ -n "$MCP_UPSTREAM_TMP" ] && rm -rf "$MCP_UPSTREAM_TMP"
+    if [ -n "$MCP_UPSTREAM_PID" ] && kill -0 "$MCP_UPSTREAM_PID" 2>/dev/null; then
+        kill "$MCP_UPSTREAM_PID" 2>/dev/null || true
+        wait "$MCP_UPSTREAM_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# Build and start the upstream MCP server so /mcp has real tools to expose.
+start_upstream_mcp() {
+    if [ ! -d "$MCP_UPSTREAM_DIR" ]; then
+        echo -e "${RED}Error: upstream MCP server source not found: $MCP_UPSTREAM_DIR${NC}"
+        exit 1
+    fi
+    # Fail fast with a clear message if the chosen port is already taken, rather
+    # than letting the server fail to bind and surfacing as a readiness timeout.
+    if (command -v nc &>/dev/null && nc -z 127.0.0.1 "$MCP_UPSTREAM_PORT" 2>/dev/null) \
+       || (echo >/dev/tcp/127.0.0.1/"$MCP_UPSTREAM_PORT") 2>/dev/null; then
+        echo -e "${RED}Error: port $MCP_UPSTREAM_PORT is already in use; pass --mcp-port <port> to use another${NC}"
+        exit 1
+    fi
+    echo -e "${YELLOW}Building upstream MCP server...${NC}"
+    # Build into a temp dir (cleaned up on exit) so no binary is left in the
+    # example's source tree. GOWORK=off: the example has its own module and is
+    # not part of the repo workspace, so building it in-workspace would fail.
+    MCP_UPSTREAM_TMP="$(mktemp -d)"
+    ( cd "$MCP_UPSTREAM_DIR" && GOWORK=off go build -o "$MCP_UPSTREAM_TMP/http-no-ping-server" . ) || {
+        echo -e "${RED}Error: failed to build upstream MCP server${NC}"; exit 1; }
+    MCP_SERVER_PORT="$MCP_UPSTREAM_PORT" "$MCP_UPSTREAM_TMP/http-no-ping-server" > "$API_DIR/$REPORT_DIR/upstream-mcp.log" 2>&1 &
+    MCP_UPSTREAM_PID=$!
+    local waited=0
+    while [ $waited -lt 20 ]; do
+        if (command -v nc &>/dev/null && nc -z 127.0.0.1 "$MCP_UPSTREAM_PORT" 2>/dev/null) \
+           || (echo >/dev/tcp/127.0.0.1/"$MCP_UPSTREAM_PORT") 2>/dev/null; then
+            echo -e "${GREEN}Upstream MCP server ready on :$MCP_UPSTREAM_PORT${NC}"
+            return
+        fi
+        if ! kill -0 "$MCP_UPSTREAM_PID" 2>/dev/null; then
+            echo -e "${RED}Upstream MCP server exited during startup${NC}"
+            cat "$API_DIR/$REPORT_DIR/upstream-mcp.log"
+            exit 1
+        fi
+        sleep 0.5; waited=$((waited + 1))
+    done
+    echo -e "${RED}Upstream MCP server did not become ready${NC}"; exit 1
+}
+
+# write_config <dir> <mode headers|both|oauth>
+write_config() {
+    local dir="$1" mode="$2"
+    local oauth_block=""
+    # Discovery + JWT issuance only apply in both/oauth. A stable issuer_url keeps
+    # discovery docs and minted-token claims deterministic across the collection.
+    if [ "$mode" != "headers" ]; then
+        oauth_block="\"oauth2_server_config\": { \"issuer_url\": \"http://localhost:$PORT\", \"auth_code_ttl\": 600, \"access_token_ttl\": 600 },"
+    fi
+    cat > "$dir/config.json" <<EOF
+{
+  "\$schema": "https://www.getbifrost.ai/schema",
+  "client": {
+    "drop_excess_requests": false,
+    "initial_pool_size": 50,
+    "allowed_origins": ["*"],
+    "enable_logging": false,
+    "enforce_auth_on_inference": false,
+    "mcp_server_auth_mode": "$mode",
+    $oauth_block
+    "max_request_body_size_mb": 100
+  },
+  "config_store": { "enabled": true, "type": "sqlite", "config": { "path": "$dir/config.db" } },
+  "logs_store": { "enabled": false },
+  "providers": {
+    "openai": {
+      "keys": [{ "name": "mcp-dummy", "value": "sk-mcp-dummy", "weight": 1 }],
+      "network_config": { "base_url": "http://127.0.0.1:1", "default_request_timeout_in_seconds": 5 }
+    }
+  },
+  "governance": {
+    "virtual_keys": [
+      {
+        "name": "MCP Test VK", "id": "vk-mcp", "value": "$VK_VALUE", "is_active": true,
+        "provider_configs": [{ "provider": "openai", "allowed_models": ["*"], "key_ids": ["*"], "weight": 1.0 }]
+      },
+      {
+        "name": "MCP Inactive VK", "id": "vk-mcp-inactive", "value": "$VK_INACTIVE_VALUE", "is_active": false,
+        "provider_configs": [{ "provider": "openai", "allowed_models": ["*"], "key_ids": ["*"], "weight": 1.0 }]
+      }
+    ]
+  },
+  "mcp": {
+    "client_configs": [
+      {
+        "client_id": "test-mcp",
+        "name": "Test MCP",
+        "connection_type": "http",
+        "connection_string": "http://localhost:$MCP_UPSTREAM_PORT/",
+        "auth_type": "none",
+        "is_ping_available": false
+      }
+    ]
+  }
+}
+EOF
+}
+
+# run_mode <mode headers|both|oauth>
+run_mode() {
+    local mode="$1"
+    echo -e "${GREEN}----------------------------------------------${NC}"
+    echo -e "${GREEN}MCP server auth mode: ${YELLOW}${mode}${NC}"
+    echo -e "${GREEN}----------------------------------------------${NC}"
+
+    CURRENT_DIR="$(mktemp -d)"
+    write_config "$CURRENT_DIR" "$mode"
+    local server_log="$CURRENT_DIR/server.log"
+
+    "$BIFROST_BINARY" --app-dir "$CURRENT_DIR" --port "$PORT" --log-level info > "$server_log" 2>&1 &
+    CURRENT_PID=$!
+
+    local elapsed=0
+    while [ $elapsed -lt 60 ]; do
+        grep -q "successfully started bifrost" "$server_log" 2>/dev/null && break
+        if ! kill -0 "$CURRENT_PID" 2>/dev/null; then
+            echo -e "${RED}   Server exited before becoming ready${NC}"; cat "$server_log"
+            OVERALL_EXIT=1; CURRENT_PID=""; rm -rf "$CURRENT_DIR"; CURRENT_DIR=""; return
+        fi
+        sleep 1; elapsed=$((elapsed + 1))
+    done
+    if [ $elapsed -ge 60 ]; then
+        echo -e "${RED}   Server did not start within 60s${NC}"; cat "$server_log"; OVERALL_EXIT=1
+    else
+        local report_prefix="${REPORT_DIR}/${mode}"
+        local cmd=(newman run "$COLLECTION"
+            --env-var "base_url=http://localhost:$PORT"
+            --env-var "auth_mode=$mode"
+            --env-var "vk_value=$VK_VALUE"
+            --env-var "vk_inactive_value=$VK_INACTIVE_VALUE"
+            --env-var "mcp_issuer=http://localhost:$PORT"
+            --timeout-script 60000 --timeout 120000
+            -r "$REPORTERS")
+        [[ "$REPORTERS" == *"html"* ]] && cmd+=(--reporter-html-export "${report_prefix}.html")
+        [[ "$REPORTERS" == *"json"* ]] && cmd+=(--reporter-json-export "${report_prefix}.json")
+        [ -n "$VERBOSE" ] && cmd+=("$VERBOSE")
+        [ -n "$BAIL" ] && cmd+=("$BAIL")
+
+        set +e
+        "${cmd[@]}"
+        local code=$?
+        set -e
+        [ $code -ne 0 ] && OVERALL_EXIT=1
+    fi
+
+    if [ -n "$CURRENT_PID" ] && kill -0 "$CURRENT_PID" 2>/dev/null; then
+        kill "$CURRENT_PID" 2>/dev/null || true
+        wait "$CURRENT_PID" 2>/dev/null || true
+    fi
+    CURRENT_PID=""
+    rm -rf "$CURRENT_DIR"; CURRENT_DIR=""
+    echo ""
+}
+
+start_upstream_mcp
+run_mode "headers"
+run_mode "both"
+run_mode "oauth"
+
+echo ""
+if [ $OVERALL_EXIT -eq 0 ]; then
+    echo -e "${GREEN}✓ All MCP auth modes passed!${NC}"
+else
+    echo -e "${RED}✗ Some MCP auth mode checks failed${NC}"
+fi
+if [[ "$REPORTERS" == *"html"* ]] || [[ "$REPORTERS" == *"json"* ]]; then
+    echo ""
+    echo -e "Reports saved to: ${YELLOW}$REPORT_DIR${NC}"
+    ls -lh "$REPORT_DIR" 2>/dev/null | tail -n +2
+fi
+
+exit $OVERALL_EXIT


### PR DESCRIPTION
## Summary

Adds an end-to-end Newman test suite that validates inbound `/mcp` authentication across all three server auth modes (`headers`, `both`, `oauth`). This ensures that enabling OAuth support does not regress existing virtual-key authentication behavior, and that each mode enforces exactly the access guarantees it is supposed to.

## Changes

- Added `bifrost-v1-mcp-auth.postman_collection.json` — a Postman collection with two test groups:
  - **Discovery gating**: verifies that `/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`, and `/.well-known/jwks.json` return 404 in `headers` mode and well-formed spec-compliant responses in `both`/`oauth` modes.
  - **MCP connect matrix**: exercises six credential scenarios (`x-bf-vk`, `Authorization: Bearer <vk>`, `x-api-key`, anonymous, inactive virtual key, and an invalid JWT) against each mode. A single collection encodes the full accept/reject matrix by branching on the `auth_mode` environment variable.

- Added `run-newman-mcp-auth-tests.sh` — a shell runner that:
  - Builds and starts the upstream `http-no-ping-server` MCP example so `/mcp` exposes real tools.
  - Boots a fresh Bifrost server per auth mode with a pre-seeded SQLite config containing one active and one inactive virtual key.
  - Runs the collection against each mode in sequence (`headers` → `both` → `oauth`) and aggregates pass/fail.
  - Supports `--html`, `--json`, `--verbose`, `--bail`, and `--port` flags for flexible CI integration.

Core guarantees validated:
1. In `headers` mode, all virtual-key credential paths connect exactly as before and the OAuth discovery surface is invisible (404).
2. In `both` mode, header-credential outcomes are unchanged and JWT acceptance is added.
3. In `oauth` mode, header credentials are rejected outright with a `WWW-Authenticate` response.
4. An inactive virtual key is rejected in every mode.
5. Discovery documents are spec-shaped when served.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Build the binary first, then run the test runner:

```sh
# Build the binary
go build -o bifrost-http ./cmd/bifrost-http

# Run the MCP auth e2e suite
cd tests/e2e/api
bash runners/individual/run-newman-mcp-auth-tests.sh \
  --binary ../../../bifrost-http \
  --port 8090

# Optional: generate HTML and JSON reports
bash runners/individual/run-newman-mcp-auth-tests.sh \
  --binary ../../../bifrost-http \
  --html --json
```

Newman must be installed (`npm install -g newman`). The runner will build the upstream MCP server from `examples/mcps/http-no-ping-server` automatically.

Expected outcome: all three modes pass with `✓ All MCP auth modes passed!`.

## Breaking changes

- [x] No

## Related issues

## Security considerations

The test suite exercises the authentication boundary for the `/mcp` endpoint, including rejection of inactive credentials, invalid JWTs, and header-based credentials in strict OAuth mode. No secrets or PII are introduced; all keys used are test fixtures scoped to the local test server.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable