### PR TITLE
fix: nova bedrock fixes

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -4008,6 +4008,39 @@ func TestNovaReasoningConfigUsesReasoningConfigField(t *testing.T) {
 	assert.False(t, hasThinking, "Nova models should NOT use thinking field")
 }
 
+// TestNovaReasoningEffortClamped verifies efforts above Nova's enum (xhigh/max)
+// are clamped to "high" so Nova doesn't 400 on an invalid maxReasoningEffort.
+func TestNovaReasoningEffortClamped(t *testing.T) {
+	cases := map[string]string{
+		"xhigh":   "high",
+		"max":     "high",
+		"high":    "high",
+		"medium":  "medium",
+		"minimal": "low",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostChatRequest{
+				Model: "amazon.nova-pro-v1",
+				Input: []schemas.ChatMessage{
+					{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+				},
+				Params: &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr(in)}},
+			}
+
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			result, err := bedrock.ToBedrockChatCompletionRequest(ctx, bifrostReq)
+			require.NoError(t, err)
+
+			cfg, ok := result.AdditionalModelRequestFields.Get("reasoningConfig")
+			require.True(t, ok, "expected reasoningConfig")
+			cfgMap, ok := cfg.(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, want, cfgMap["maxReasoningEffort"], "effort %q should map to %q", in, want)
+		})
+	}
+}
+
 // TestStandaloneCachePointBlockHandling tests that standalone cachePoint content blocks
 // (those with only cachePoint field and no type) are properly converted.
 func TestStandaloneCachePointBlockHandling(t *testing.T) {

--- a/core/providers/bedrock/cache_points_test.go
+++ b/core/providers/bedrock/cache_points_test.go
@@ -158,3 +158,75 @@ func TestStripCachePoints_EmptyRequest(t *testing.T) {
 		t.Errorf("expected empty request to remain empty, got %+v", req)
 	}
 }
+
+func cachePointTTL(ttl BedrockCacheWriteTTL) *BedrockCachePoint {
+	return &BedrockCachePoint{Type: BedrockCachePointTypeDefault, TTL: schemas.Ptr(string(ttl))}
+}
+
+// TestDowngradeExtendedCacheTTL — 1h cache TTLs across messages, nested tool
+// results, system, and tools are dropped to default; 5m and unset TTLs are
+// untouched and the cache points themselves are preserved.
+func TestDowngradeExtendedCacheTTL(t *testing.T) {
+	req := &BedrockConverseRequest{
+		Messages: []BedrockMessage{
+			{
+				Role: BedrockMessageRoleUser,
+				Content: []BedrockContentBlock{
+					{Text: schemas.Ptr("hello"), CachePoint: cachePointTTL(BedrockCacheWriteTTL1h)},
+					{Text: schemas.Ptr("world"), CachePoint: cachePointTTL(BedrockCacheWriteTTL5m)},
+					{
+						ToolResult: &BedrockToolResult{
+							ToolUseID: "call_1",
+							Content: []BedrockContentBlock{
+								{Text: schemas.Ptr("tr"), CachePoint: cachePointTTL(BedrockCacheWriteTTL1h)},
+							},
+						},
+					},
+				},
+			},
+		},
+		System:     []BedrockSystemMessage{{Text: schemas.Ptr("sys"), CachePoint: cachePointTTL(BedrockCacheWriteTTL1h)}},
+		ToolConfig: &BedrockToolConfig{Tools: []BedrockTool{{ToolSpec: &BedrockToolSpec{Name: "t"}, CachePoint: cachePointTTL(BedrockCacheWriteTTL1h)}}},
+	}
+
+	downgradeExtendedCacheTTLInBedrockRequest(req)
+
+	blocks := req.Messages[0].Content
+	if cp := blocks[0].CachePoint; cp == nil || cp.TTL != nil {
+		t.Errorf("expected 1h message cache point downgraded to nil TTL, got %+v", cp)
+	}
+	if cp := blocks[1].CachePoint; cp == nil || cp.TTL == nil || *cp.TTL != string(BedrockCacheWriteTTL5m) {
+		t.Errorf("expected 5m cache point preserved, got %+v", cp)
+	}
+	if cp := blocks[2].ToolResult.Content[0].CachePoint; cp == nil || cp.TTL != nil {
+		t.Errorf("expected nested 1h tool-result cache point downgraded, got %+v", cp)
+	}
+	if cp := req.System[0].CachePoint; cp == nil || cp.TTL != nil {
+		t.Errorf("expected 1h system cache point downgraded, got %+v", cp)
+	}
+	if cp := req.ToolConfig.Tools[0].CachePoint; cp == nil || cp.TTL != nil {
+		t.Errorf("expected 1h tool cache point downgraded, got %+v", cp)
+	}
+}
+
+// TestDowngradeExtendedCacheTTL_NilSafe — no panic on nil tool config / cache points.
+func TestDowngradeExtendedCacheTTL_NilSafe(t *testing.T) {
+	req := &BedrockConverseRequest{
+		Messages: []BedrockMessage{{Role: BedrockMessageRoleUser, Content: []BedrockContentBlock{{Text: schemas.Ptr("hi")}}}},
+	}
+	downgradeExtendedCacheTTLInBedrockRequest(req)
+}
+
+// TestBedrockModelSupportsExtendedCacheTTL — only Anthropic models support 1h TTL.
+func TestBedrockModelSupportsExtendedCacheTTL(t *testing.T) {
+	cases := map[string]bool{
+		"anthropic.claude-sonnet-4-5": true,
+		"amazon.nova-pro-v1:0":        false,
+		"minimax.minimax-m2.5":        false,
+	}
+	for model, want := range cases {
+		if got := schemas.BedrockModelSupportsExtendedCacheTTL(model); got != want {
+			t.Errorf("BedrockModelSupportsExtendedCacheTTL(%q) = %v, want %v", model, got, want)
+		}
+	}
+}

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -64,8 +64,12 @@ func ToBedrockChatCompletionRequest(ctx *schemas.BifrostContext, bifrostReq *sch
 	// Ensure tool config is present when needed
 	ensureChatToolConfigForConversation(ctx, bifrostReq, bedrockReq)
 
-	if !schemas.BedrockModelSupportsCachePoints(bifrostReq.Model) {
+	// capModel is the canonical model used for capability gating (resolves aliases).
+	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
+	if !schemas.BedrockModelSupportsCachePoints(capModel) {
 		stripCachePointsFromBedrockRequest(bedrockReq)
+	} else if !schemas.BedrockModelSupportsExtendedCacheTTL(capModel) {
+		downgradeExtendedCacheTTLInBedrockRequest(bedrockReq)
 	}
 
 	return bedrockReq, nil

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2277,8 +2277,10 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 						effort := *bifrostReq.Params.Reasoning.Effort
 						typeStr := "enabled"
 						switch effort {
-						case "high":
-							// for nova models we need to unset these fields at high effort
+						case "high", "xhigh", "max":
+							// Nova's maxReasoningEffort enum tops out at "high"; clamp
+							// xhigh/max and unset these fields at high effort.
+							effort = "high"
 							inferenceConfig.MaxTokens = nil
 							inferenceConfig.Temperature = nil
 							inferenceConfig.TopP = nil
@@ -2539,8 +2541,10 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 	// Ensure tool config is present when tool content exists (similar to Chat Completions)
 	ensureResponsesToolConfigForConversation(ctx, bifrostReq, bedrockReq)
 
-	if !schemas.BedrockModelSupportsCachePoints(bifrostReq.Model) {
+	if !schemas.BedrockModelSupportsCachePoints(capModel) {
 		stripCachePointsFromBedrockRequest(bedrockReq)
+	} else if !schemas.BedrockModelSupportsExtendedCacheTTL(capModel) {
+		downgradeExtendedCacheTTLInBedrockRequest(bedrockReq)
 	}
 
 	return bedrockReq, nil

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -374,7 +374,9 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 				effort := *bifrostReq.Params.Reasoning.Effort
 				typeStr := "enabled"
 				switch effort {
-				case "high":
+				case "high", "xhigh", "max":
+					// Nova's maxReasoningEffort enum tops out at "high"; clamp xhigh/max.
+					effort = "high"
 					if bedrockReq.InferenceConfig != nil {
 						bedrockReq.InferenceConfig.MaxTokens = nil
 						bedrockReq.InferenceConfig.Temperature = nil
@@ -2337,5 +2339,35 @@ func stripCachePointsFromBedrockRequest(req *BedrockConverseRequest) {
 			}
 		}
 		req.ToolConfig.Tools = req.ToolConfig.Tools[:nt]
+	}
+}
+
+// downgradeExtendedCacheTTLInBedrockRequest drops the 1h (extended) cache TTL to
+// the default for models that support cache points but not extended TTL (e.g. Nova),
+// which otherwise 400 with "Extended TTL prompt caching is only supported for
+// Anthropic models". Only 1h TTLs are touched; cache points themselves are kept.
+func downgradeExtendedCacheTTLInBedrockRequest(req *BedrockConverseRequest) {
+	downgrade := func(cp *BedrockCachePoint) {
+		if cp != nil && cp.TTL != nil && *cp.TTL == string(BedrockCacheWriteTTL1h) {
+			cp.TTL = nil
+		}
+	}
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content {
+			downgrade(req.Messages[i].Content[j].CachePoint)
+			if req.Messages[i].Content[j].ToolResult != nil {
+				for k := range req.Messages[i].Content[j].ToolResult.Content {
+					downgrade(req.Messages[i].Content[j].ToolResult.Content[k].CachePoint)
+				}
+			}
+		}
+	}
+	for i := range req.System {
+		downgrade(req.System[i].CachePoint)
+	}
+	if req.ToolConfig != nil {
+		for i := range req.ToolConfig.Tools {
+			downgrade(req.ToolConfig.Tools[i].CachePoint)
+		}
 	}
 }

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1400,6 +1400,14 @@ func BedrockModelSupportsCachePoints(model string) bool {
 	return IsAnthropicModel(model) || IsNovaModel(model)
 }
 
+// BedrockModelSupportsExtendedCacheTTL reports whether the Bedrock model supports
+// the 1h (extended) prompt-caching TTL. This is Anthropic-only; other cache-point
+// models (e.g. Nova) support caching but only the default 5m TTL and 400 with
+// "Extended TTL prompt caching is only supported for Anthropic models".
+func BedrockModelSupportsExtendedCacheTTL(model string) bool {
+	return IsAnthropicModel(model)
+}
+
 // IsMistralModel checks if the model is a Mistral or Codestral model.
 func IsMistralModel(model string) bool {
 	return strings.Contains(model, "mistral") || strings.Contains(model, "codestral")


### PR DESCRIPTION
## Summary

Nova models support prompt-cache points but only the default 5-minute TTL. Sending a 1-hour (extended) TTL to Nova causes a 400 error: *"Extended TTL prompt caching is only supported for Anthropic models"*. Similarly, Nova's `maxReasoningEffort` enum tops out at `"high"`, so passing `"xhigh"` or `"max"` also results in a 400. This PR adds automatic clamping/downgrading for both cases so requests targeting Nova (and other non-Anthropic cache-point models) succeed without requiring callers to know about these model-specific constraints.

## Changes

- Added `BedrockModelSupportsExtendedCacheTTL` to `core/schemas/utils.go`, which returns `true` only for Anthropic models.
- Added `downgradeExtendedCacheTTLInBedrockRequest` in `core/providers/bedrock/utils.go`, which strips the `1h` TTL from all cache points (messages, nested tool results, system blocks, and tools) while leaving the cache points themselves and any `5m` TTLs intact.
- Wired the downgrade into both `ToBedrockChatCompletionRequest` (`chat.go`) and `ToBedrockResponsesRequest` (`responses.go`): models that support cache points but not extended TTL now have their `1h` TTLs silently downgraded rather than stripped entirely.
- Both `chat.go` and `responses.go` now resolve the canonical model via `schemas.ResolveCanonicalModel` before capability gating, ensuring aliases are handled consistently.
- Clamped `"xhigh"` and `"max"` reasoning effort values to `"high"` in both `utils.go` (chat) and `responses.go` (responses) for Nova models, matching Nova's supported enum.
- Added tests covering effort clamping (`TestNovaReasoningEffortClamped`), TTL downgrade behavior (`TestDowngradeExtendedCacheTTL`), nil-safety (`TestDowngradeExtendedCacheTTL_NilSafe`), and the `BedrockModelSupportsExtendedCacheTTL` helper (`TestBedrockModelSupportsExtendedCacheTTL`).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... ./core/schemas/...
```

Key test cases to verify:
- `TestNovaReasoningEffortClamped` — confirms `"xhigh"` and `"max"` map to `"high"`, `"medium"` stays `"medium"`, and `"minimal"` maps to `"low"` for Nova.
- `TestDowngradeExtendedCacheTTL` — confirms `1h` TTLs are dropped to nil across all block types while `5m` TTLs are preserved.
- `TestDowngradeExtendedCacheTTL_NilSafe` — confirms no panic when tool config or cache points are absent.
- `TestBedrockModelSupportsExtendedCacheTTL` — confirms Anthropic models return `true` and Nova/other models return `false`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Changes are limited to request transformation logic with no impact on auth, secrets, or PII handling.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable