### PR TITLE
fix: bedrock signauture fix for minimax

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -4041,6 +4041,53 @@ func TestNovaReasoningEffortClamped(t *testing.T) {
 	}
 }
 
+// TestReasoningSignatureEchoedOnlyWhenNonEmpty verifies that an empty reasoning
+// signature is dropped before sending to Bedrock (MiniMax emits ""), while a real
+// signature is preserved (Anthropic requires it). Keyed on the value, not the model.
+func TestReasoningSignatureEchoedOnlyWhenNonEmpty(t *testing.T) {
+	cases := map[string]struct {
+		in   *string
+		want *string
+	}{
+		"empty signature dropped":  {in: schemas.Ptr(""), want: nil},
+		"nil signature dropped":    {in: nil, want: nil},
+		"real signature preserved": {in: schemas.Ptr("ErUBCkYI"), want: schemas.Ptr("ErUBCkYI")},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostChatRequest{
+				Model: "anthropic.claude-sonnet-4-5",
+				Input: []schemas.ChatMessage{
+					{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}},
+					{
+						Role:    schemas.ChatMessageRoleAssistant,
+						Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("ok")},
+						ChatAssistantMessage: &schemas.ChatAssistantMessage{
+							ReasoningDetails: []schemas.ChatReasoningDetails{
+								{Type: schemas.BifrostReasoningDetailsTypeText, Text: schemas.Ptr("thinking"), Signature: tc.in},
+							},
+						},
+					},
+				},
+			}
+
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			result, err := bedrock.ToBedrockChatCompletionRequest(ctx, bifrostReq)
+			require.NoError(t, err)
+
+			var got *string
+			for _, m := range result.Messages {
+				for _, b := range m.Content {
+					if b.ReasoningContent != nil && b.ReasoningContent.ReasoningText != nil {
+						got = b.ReasoningContent.ReasoningText.Signature
+					}
+				}
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // TestStandaloneCachePointBlockHandling tests that standalone cachePoint content blocks
 // (those with only cachePoint field and no type) are properly converted.
 func TestStandaloneCachePointBlockHandling(t *testing.T) {

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -4239,7 +4239,7 @@ func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage) []
 					ReasoningContent: &BedrockReasoningContent{
 						ReasoningText: &BedrockReasoningContentText{
 							Text:      block.Text,
-							Signature: block.Signature,
+							Signature: reasoningSignatureForBedrock(block.Signature),
 						},
 					},
 				}
@@ -4308,7 +4308,7 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 					bedrockBlock.ReasoningContent = &BedrockReasoningContent{
 						ReasoningText: &BedrockReasoningContentText{
 							Text:      block.Text,
-							Signature: block.Signature,
+							Signature: reasoningSignatureForBedrock(block.Signature),
 						},
 					}
 				}

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -791,6 +791,20 @@ func convertMessages(ctx context.Context, bifrostMessages []schemas.ChatMessage)
 	return messages, systemMessages, nil
 }
 
+// reasoningSignatureForBedrock returns sig only when it is a non-empty string.
+// A valid reasoning signature is a non-empty crypto token (Anthropic always emits
+// one, and Bedrock requires it on those reasoning blocks). Other families emit an
+// empty signature (MiniMax sends "") or none (Nova); echoing
+// reasoningContent.reasoningText.signature:"" back 400s with "This model doesn't
+// support the reasoningContent.reasoningText.signature field". Returning nil lets
+// omitempty drop the field (a non-nil *string to "" would still serialize as "").
+func reasoningSignatureForBedrock(sig *string) *string {
+	if sig == nil || *sig == "" {
+		return nil
+	}
+	return sig
+}
+
 // newBedrockCachePoint builds a default cache point, attaching the TTL only for the values
 // Bedrock accepts ("5m" | "1h"); anything else (e.g. Anthropic's "1m") is dropped to the default.
 func newBedrockCachePoint(ttl *string) *BedrockCachePoint {
@@ -856,7 +870,7 @@ func convertMessage(ctx context.Context, msg schemas.ChatMessage) (BedrockMessag
 					ReasoningContent: &BedrockReasoningContent{
 						ReasoningText: &BedrockReasoningContentText{
 							Text:      detail.Text,
-							Signature: detail.Signature,
+							Signature: reasoningSignatureForBedrock(detail.Signature),
 						},
 					},
 				})


### PR DESCRIPTION
## Summary

Fixes a `400` error from Bedrock when a reasoning block carries an empty signature string (`""`). Providers like MiniMax emit `signature: ""` while Nova emits none at all; echoing either back to Bedrock causes it to reject the request with `"This model doesn't support the reasoningContent.reasoningText.signature field"`. Anthropic, on the other hand, always emits a real crypto token and requires it to be present. The fix normalises the field so only non-empty signatures are forwarded.

## Changes

- Introduced `reasoningSignatureForBedrock(sig *string) *string` in `utils.go`, which returns `nil` for both `nil` and `""` inputs, allowing `omitempty` to drop the field during serialisation. A non-nil pointer to `""` would still serialise as an empty string, so returning `nil` is the correct approach.
- Applied `reasoningSignatureForBedrock` in three call sites across `utils.go` and `responses.go` where `ReasoningText.Signature` was previously assigned directly from the incoming value.
- Added `TestReasoningSignatureEchoedOnlyWhenNonEmpty` to cover the three cases: empty string dropped, nil dropped, and a real signature preserved end-to-end through `ToBedrockChatCompletionRequest`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... -run TestReasoningSignatureEchoedOnlyWhenNonEmpty -v
go test ./core/providers/bedrock/...
```

Expected: all tests pass, including the three new sub-cases (`empty signature dropped`, `nil signature dropped`, `real signature preserved`).

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The change only affects serialisation of an opaque signature token; no secrets or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable