### PR TITLE
feat: adds group traces by sessions to config json and helm

### DIFF
--- a/docs/enterprise/datadog-connector.mdx
+++ b/docs/enterprise/datadog-connector.mdx
@@ -77,6 +77,7 @@ Datadog officially supports agentless submission for [LLM Observability](https:/
 | `enable_metrics` | `bool` | No | `true` | Enable metrics emission |
 | `enable_traces` | `bool` | No | `true` | Enable APM traces |
 | `enable_llm_obs` | `bool` | No | `true` | Enable LLM Observability |
+| `group_traces_by_session` | `bool` | No | `false` | Group requests sharing the same `x-bf-session-id` into one APM trace (agent mode only). See [Grouping APM Traces by Session](#grouping-apm-traces-by-session) |
 | `agentless` | `bool` | No | `false` | Use agentless mode (direct API) |
 | `api_key` | `string` | Agentless only | - | Datadog API key (supports `env.VAR_NAME`) |
 | `site` | `string` | No | `datadoghq.com` | Datadog site/region |
@@ -339,6 +340,30 @@ curl -X POST https://your-bifrost-gateway/v1/chat/completions \
 ```
 
 Sessions appear in Datadog LLM Observability, allowing you to trace entire conversation flows.
+
+### Grouping APM Traces by Session
+
+By default, every request is its own APM trace, so a multi-turn conversation appears as many separate traces in the APM trace view. (Cross-trace grouping normally lives in [LLM Observability sessions](#session-tracking), a separate product from APM.) Enable `group_traces_by_session` to instead group every request sharing the same `x-bf-session-id` into a **single APM trace**, where each request renders as a top-level sibling span:
+
+```json
+{
+  "group_traces_by_session": true
+}
+```
+
+```bash
+# Both requests below land in the same APM trace
+curl ... -H "x-bf-session-id: user-123-session-456" -d '{...}'
+curl ... -H "x-bf-session-id: user-123-session-456" -d '{...}'
+```
+
+Bifrost derives a stable Datadog trace ID from the `x-bf-session-id` value, so all requests carrying that header resolve to the same trace.
+
+<Note>
+  - **Agent mode only.** APM spans are emitted only in agent mode. In agentless mode the plugin emits LLM Observability spans only, which already group via [session tracking](#session-tracking).
+  - **W3C traceparent takes precedence.** If a request carries an inbound [`traceparent`](#w3c-distributed-tracing) header, it stays on that distributed trace and is not regrouped by session.
+  - **APM traces are not built for long-lived sessions.** Datadog has practical limits on spans-per-trace and trace-assembly windows; very long sessions may render with large time gaps or be truncated. For long conversations, prefer LLM Observability sessions.
+</Note>
 
 ### W3C Distributed Tracing
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1040,6 +1040,10 @@
                       "type": "boolean",
                       "description": "Enable Datadog LLM Observability (default: true)"
                     },
+                    "group_traces_by_session": {
+                      "type": "boolean",
+                      "description": "Group requests sharing the same x-bf-session-id header into a single APM trace, with each request as a top-level sibling span. Agent mode only; an inbound W3C traceparent takes precedence (default: false)"
+                    },
                     "disable_content_logging": {
                       "type": "boolean",
                       "description": "When true, sensitive content (prompts, completions, embeddings) is excluded from traces (default: false)"

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -581,6 +581,7 @@ bifrost:
         # ml_app: ""                  # ML app name for LLM Observability (defaults to service_name)
         # enable_metrics: true
         # enable_llm_obs: true
+        # group_traces_by_session: false  # Group requests sharing x-bf-session-id into one APM trace (agent mode only)
         # disable_content_logging: false
         # request_headers: []         # Header name patterns (exact or wildcard like "x-custom-*")
         # Agentless mode (direct to Datadog API, no local agent):

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1952,6 +1952,11 @@
                       "description": "Enable LLM Observability (default: true)",
                       "default": true
                     },
+                    "group_traces_by_session": {
+                      "type": "boolean",
+                      "description": "Group requests sharing the same x-bf-session-id header into a single APM trace, with each request as a top-level sibling span. Agent mode only; an inbound W3C traceparent takes precedence (default: false)",
+                      "default": false
+                    },
                     "disable_content_logging": {
                       "type": "boolean",
                       "description": "Disable logging of message content to Datadog (default: false)",


### PR DESCRIPTION
## Summary

Adds a new `group_traces_by_session` option to the Datadog connector that consolidates all requests sharing the same `x-bf-session-id` header into a single APM trace, rather than producing one trace per request. This makes multi-turn conversations visible as a unified trace in Datadog APM.

## Changes

- Added `group_traces_by_session` boolean config field (default: `false`) to the Datadog connector. When enabled, Bifrost derives a stable Datadog trace ID from the `x-bf-session-id` value so all requests carrying that header resolve to the same APM trace, with each request rendered as a top-level sibling span.
- Documented the feature in the Datadog connector docs, including constraints: agent mode only, inbound W3C `traceparent` headers take precedence over session grouping, and Datadog's practical span-per-trace limits make this unsuitable for very long sessions.
- Added the field to `transports/config.schema.json` and `helm-charts/bifrost/values.schema.json` with appropriate descriptions and defaults.
- Added a commented-out example entry in `helm-charts/bifrost/values.yaml`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Configure the Datadog connector with `group_traces_by_session: true` and `agentless: false` (agent mode).
2. Send multiple requests to the Bifrost gateway with the same `x-bf-session-id` header value.
3. Verify in Datadog APM that all requests appear as sibling spans within a single trace, identified by the session ID.
4. Send a request with an inbound `traceparent` header alongside `x-bf-session-id` and confirm it remains on the distributed trace rather than being regrouped by session.
5. Confirm that with `group_traces_by_session: false` (default), each request produces its own independent APM trace.

```sh
# Both requests should land in the same APM trace
curl ... -H "x-bf-session-id: user-123-session-456" -d '{...}'
curl ... -H "x-bf-session-id: user-123-session-456" -d '{...}'
```

**New config option:**

| Field | Type | Default | Description |
|---|---|---|---|
| `group_traces_by_session` | `bool` | `false` | Group requests sharing the same `x-bf-session-id` into one APM trace (agent mode only) |

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `x-bf-session-id` header value is hashed to derive a Datadog trace ID. No session content or PII is exposed through this mechanism beyond what is already present in APM spans.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable