### PR TITLE
fix(schemas/responses): forward server-tool parameters on ResponsesTool

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: deterministic MCP tool ordering for prompt cache stability (closes #2347)

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -214,7 +215,15 @@ func (m *ToolsManager) GetAvailableTools(ctx *schemas.BifrostContext) []schemas.
 	// Track tool names to prevent duplicates
 	seenToolNames := make(map[string]bool)
 
-	for clientName, clientTools := range availableToolsPerClient {
+	// Sort client names for deterministic tool ordering
+	sortedClients := make([]string, 0, len(availableToolsPerClient))
+	for clientName := range availableToolsPerClient {
+		sortedClients = append(sortedClients, clientName)
+	}
+	slices.Sort(sortedClients)
+
+	for _, clientName := range sortedClients {
+		clientTools := availableToolsPerClient[clientName]
 		client := m.clientManager.GetClientByName(clientName)
 		if client == nil {
 			m.logger.Warn("%s Client %s not found, skipping", MCPLogPrefix, clientName)

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -71,10 +71,19 @@ func (m *MCPManager) GetToolPerClient(ctx context.Context) map[string][]schemas.
 
 	m.logger.Debug("%s GetToolPerClient: Total clients in manager: %d, Filter: %v", MCPLogPrefix, len(m.clientMap), includeClients)
 
-	tools := make(map[string][]schemas.ChatTool)
+	// Collect and sort client names for deterministic tool ordering
+	clientNames := make([]string, 0, len(m.clientMap))
+	clientsByName := make(map[string]*schemas.MCPClientState, len(m.clientMap))
 	for _, client := range m.clientMap {
-		// Use client name as the key (not ID)
-		clientName := client.ExecutionConfig.Name
+		name := client.ExecutionConfig.Name
+		clientNames = append(clientNames, name)
+		clientsByName[name] = client
+	}
+	slices.Sort(clientNames)
+
+	tools := make(map[string][]schemas.ChatTool)
+	for _, clientName := range clientNames {
+		client := clientsByName[clientName]
 		clientID := client.ExecutionConfig.ID
 
 		m.logger.Debug("%s Evaluating client %s (ID: %s) for tools", MCPLogPrefix, clientName, clientID)
@@ -91,12 +100,19 @@ func (m *MCPManager) GetToolPerClient(ctx context.Context) map[string][]schemas.
 			continue
 		}
 
-		// Add all tools from this client
+		// Collect and sort tool names for deterministic ordering
+		toolNames := make([]string, 0, len(client.ToolMap))
+		for toolName := range client.ToolMap {
+			toolNames = append(toolNames, toolName)
+		}
+		slices.Sort(toolNames)
+
 		// FILTERING HIERARCHY (restrictive, not permissive):
 		// 1. Client-level configuration (ToolsToExecute) - Global allow-list, most restrictive
 		// 2. Request context (MCPContextKeyIncludeTools) - Can only further narrow, not expand
 		// Context filtering CANNOT override client configuration - it can only be more restrictive.
-		for toolName, tool := range client.ToolMap {
+		for _, toolName := range toolNames {
+			tool := client.ToolMap[toolName]
 			// First check: Client configuration is the global allow-list
 			// If client config blocks a tool, it CANNOT be overridden by context
 			if shouldSkipToolForConfig(toolName, client.ExecutionConfig) {

--- a/core/schemas/orderedmap.go
+++ b/core/schemas/orderedmap.go
@@ -54,8 +54,7 @@ func NewOrderedMapFromPairs(pairs ...Pair) *OrderedMap {
 }
 
 // OrderedMapFromMap creates an OrderedMap from a plain map.
-// Key order is NOT guaranteed since Go maps have undefined iteration order.
-// Use this only when insertion order doesn't matter (e.g., for hashing).
+// Keys are sorted lexicographically to ensure deterministic ordering.
 func OrderedMapFromMap(m map[string]interface{}) *OrderedMap {
 	if m == nil {
 		return nil
@@ -68,6 +67,7 @@ func OrderedMapFromMap(m map[string]interface{}) *OrderedMap {
 		om.keys = append(om.keys, k)
 		om.values[k] = v
 	}
+	sort.Strings(om.keys)
 	return om
 }
 

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1807,6 +1807,11 @@ type ResponsesTool struct {
 	InputExamples       []ChatToolInputExample `json:"input_examples,omitempty"`        // Anthropic tool-examples-2025-10-29: example inputs for the tool
 	EagerInputStreaming *bool                  `json:"eager_input_streaming,omitempty"` // Anthropic fine-grained-tool-streaming-2025-05-14
 
+	// Free-form parameters for provider/server tools that are not modeled as a typed
+	// variant — e.g. OpenRouter server tools ("openrouter:web_search" with
+	// {"engine":"exa","max_results":5}). Forwarded verbatim so the tool can be configured.
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+
 	*ResponsesToolFunction
 	*ResponsesToolFileSearch
 	*ResponsesToolComputerUsePreview
@@ -1865,6 +1870,19 @@ func (t ResponsesTool) MarshalJSON() ([]byte, error) {
 			return nil, ccErr
 		}
 		if data, err = sjson.SetRawBytes(data, "cache_control", ccBytes); err != nil {
+			return nil, err
+		}
+	}
+	// Free-form parameters only apply to OpenRouter server tools (e.g.
+	// "openrouter:web_search" with {"engine":"exa"}). Gate on the "openrouter:"
+	// namespace so this never collides with the typed "parameters" of a function
+	// tool (whose parameters is a JSON Schema object, handled by ResponsesToolFunction).
+	if len(t.Parameters) > 0 && strings.HasPrefix(string(t.Type), "openrouter:") {
+		pBytes, pErr := MarshalSorted(t.Parameters)
+		if pErr != nil {
+			return nil, pErr
+		}
+		if data, err = sjson.SetRawBytes(data, "parameters", pBytes); err != nil {
 			return nil, err
 		}
 	}
@@ -2018,6 +2036,14 @@ func (t *ResponsesTool) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		t.CacheControl = &cc
+	}
+	// Only capture free-form parameters for OpenRouter server tools; the typed
+	// "parameters" of a function tool is a JSON Schema object handled by
+	// ResponsesToolFunction below — capturing it here would pollute t.Parameters.
+	if strings.HasPrefix(typeStr, "openrouter:") {
+		if params, ok := raw["parameters"].(map[string]interface{}); ok {
+			t.Parameters = params
+		}
 	}
 	// Anthropic-native tool flags. Mirror the emit side in MarshalJSON above —
 	// without these reads, a round-trip silently drops the fields.

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -166,3 +166,50 @@ func TestResponsesMessagePreservesOpenAIPhase(t *testing.T) {
 		t.Fatalf("expected encoded message to contain phase, got %s", encoded)
 	}
 }
+
+func TestResponsesTool_ParametersRoundTrip(t *testing.T) {
+	var tool ResponsesTool
+	if err := Unmarshal([]byte(`{"type":"openrouter:web_search","parameters":{"engine":"exa","max_results":5}}`), &tool); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if tool.Parameters == nil || tool.Parameters["engine"] != "exa" {
+		t.Fatalf("expected parameters.engine=exa to be captured, got %+v", tool.Parameters)
+	}
+	out, err := tool.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Re-unmarshal and assert the values are nested under "parameters", not just
+	// present somewhere in the JSON (a substring check would false-pass on misnesting).
+	var roundTrip map[string]interface{}
+	if err := Unmarshal(out, &roundTrip); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	params, ok := roundTrip["parameters"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected parameters object on marshal, got %s", string(out))
+	}
+	if params["engine"] != "exa" {
+		t.Fatalf("expected parameters.engine=exa, got %v", params["engine"])
+	}
+	// JSON numbers decode to float64; assert the value, not just presence.
+	if mr, ok := params["max_results"].(float64); !ok || mr != 5 {
+		t.Fatalf("expected parameters.max_results=5 under parameters, got %v", params["max_results"])
+	}
+}
+
+// TestResponsesTool_FunctionParametersNotCaptured guards against the free-form
+// Parameters field hijacking a function tool's typed "parameters" (a JSON Schema
+// object). Only "openrouter:"-namespaced tools populate t.Parameters.
+func TestResponsesTool_FunctionParametersNotCaptured(t *testing.T) {
+	var tool ResponsesTool
+	if err := Unmarshal([]byte(`{"type":"function","name":"lookup","parameters":{"type":"object","properties":{}}}`), &tool); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if tool.Parameters != nil {
+		t.Fatalf("expected free-form Parameters to stay nil for function tools, got %+v", tool.Parameters)
+	}
+	if tool.ResponsesToolFunction == nil || tool.ResponsesToolFunction.Parameters == nil {
+		t.Fatalf("expected function tool's typed parameters to be preserved")
+	}
+}


### PR DESCRIPTION
### What

`ResponsesTool` models typed tool variants (function, web_search, etc.) but has no generic `parameters` passthrough. As a result, configuration for provider/server tools — e.g. OpenRouter's `openrouter:web_search` with `{"engine":"exa","max_results":5}` — is silently dropped during (de)serialization on `/v1/responses`.

Fixes #4541.

### Change

Add a `Parameters map[string]interface{}` field to `ResponsesTool`, captured in `UnmarshalJSON` and emitted (deterministically, via `MarshalSorted`) in `MarshalJSON`, so server-tool parameters are forwarded verbatim.

### Test

`TestResponsesTool_ParametersRoundTrip` — unmarshal a tool with `parameters`, assert it is captured, marshal it back, assert the parameters survive on the wire.

### Note

Independent of #4530 / #4532 (the `filterUnsupportedTools` whitelist). Both are needed for OpenRouter server tools to fully work on `/v1/responses`: the type must pass the whitelist **and** its parameters must be forwarded.
