### PR TITLE
feat: show inline error for 409 errors

### DIFF
--- a/ui/app/workspace/governance/views/customerSheet.tsx
+++ b/ui/app/workspace/governance/views/customerSheet.tsx
@@ -66,6 +66,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		...createInitialState(customer),
 		isDirty: false,
 	});
+	const [nameError, setNameError] = useState<string | null>(null);
 
 	const [showCalendarAlignWarning, setShowCalendarAlignWarning] = useState(false);
 
@@ -82,6 +83,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 			const init = createInitialState(customer);
 			setInitialState(init);
 			setFormData({ ...init, isDirty: false });
+			setNameError(null);
 		}
 	}, [open, customer]);
 
@@ -177,6 +179,9 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 	);
 
 	const updateField = <K extends keyof CustomerFormData>(field: K, value: CustomerFormData[K]) => {
+		if (field === "name") {
+			setNameError(null);
+		}
 		setFormData((prev) => ({ ...prev, [field]: value }));
 	};
 
@@ -244,7 +249,11 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 
 			onOpenChange(false);
 			onSuccess?.();
-		} catch (error) {
+		} catch (error: any) {
+			if (error?.status === 409) {
+				setNameError(getErrorMessage(error));
+				return;
+			}
 			toast.error(getErrorMessage(error));
 		}
 	};
@@ -285,6 +294,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 										maxLength={50}
 										onChange={(e) => updateField("name", e.target.value)}
 									/>
+									{nameError && <p className="text-destructive text-sm">{nameError}</p>}
 									<p className="text-muted-foreground text-sm">This name will be used to identify the customer account.</p>
 								</div>
 							</div>

--- a/ui/app/workspace/governance/views/teamSheet.tsx
+++ b/ui/app/workspace/governance/views/teamSheet.tsx
@@ -127,11 +127,13 @@ export default function TeamSheet({
     ...initialState,
     isDirty: false,
   });
+  const [nameError, setNameError] = useState<string | null>(null);
 
   useEffect(() => {
     const nextInitial = createInitialState(team);
     setInitialState(nextInitial);
     setFormData({ ...nextInitial, isDirty: false });
+    setNameError(null);
     setShowCalendarAlignWarning(false);
   }, [team]);
 
@@ -290,6 +292,9 @@ export default function TeamSheet({
     field: K,
     value: TeamFormData[K],
   ) => {
+    if (field === "name") {
+      setNameError(null);
+    }
     setFormData((prev) => ({ ...prev, [field]: value }));
   };
 
@@ -381,7 +386,11 @@ export default function TeamSheet({
       }
 
       onSave();
-    } catch (error) {
+    } catch (error: any) {
+      if (error?.status === 409) {
+        setNameError(getErrorMessage(error));
+        return;
+      }
       toast.error(getErrorMessage(error));
     }
   };
@@ -422,6 +431,7 @@ export default function TeamSheet({
                   onChange={(e) => updateField("name", e.target.value)}
                   data-testid="team-name-input"
                 />
+                {nameError && <p className="text-destructive text-sm">{nameError}</p>}
               </div>
 
               {/* Customer Assignment */}

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
@@ -345,6 +345,10 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 			onClose();
 		} catch (error) {
 			setIsLoading(false);
+			if ((error as any)?.status === 409) {
+				setError("name", { message: getErrorMessage(error) });
+				return;
+			}
 			toast({
 				title: "Error",
 				description: getErrorMessage(error),
@@ -863,6 +867,10 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 							variant: "destructive",
 						});
 					}}
+					onConflict={(error) => {
+						setOauthFlow(null);
+						setError("name", { message: error });
+					}}
 					authorizeUrl={oauthFlow.authorizeUrl}
 					oauthConfigId={oauthFlow.oauthConfigId}
 					mcpClientId={oauthFlow.mcpClientId}
@@ -888,6 +896,10 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 					}}
 					onError={() => {
 						/* error toast handled by the dialog itself */
+					}}
+					onConflict={(error) => {
+						setHeadersFlow(null);
+						setError("name", { message: error });
 					}}
 					payload={headersFlow.payload}
 					perUserHeaderKeys={perUserHeaderKeys}

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -296,6 +296,10 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			}
 		} catch (error) {
 			setIsLoading(false);
+			if ((error as any)?.status === 409) {
+				setError("name", { message: getErrorMessage(error) });
+				return;
+			}
 			toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
 		}
 	};
@@ -925,6 +929,10 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					onError={(error) => {
 						toast({ title: "OAuth Error", description: error, variant: "destructive" });
 					}}
+					onConflict={(error) => {
+						setOauthFlow(null);
+						setError("name", { message: error });
+					}}
 					authorizeUrl={oauthFlow.authorizeUrl}
 					oauthConfigId={oauthFlow.oauthConfigId}
 					mcpClientId={oauthFlow.mcpClientId}
@@ -951,6 +959,10 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					}}
 					onError={() => {
 						/* error toast handled by the dialog itself */
+					}}
+					onConflict={(error) => {
+						setHeadersFlow(null);
+						setError("name", { message: error });
 					}}
 					payload={headersFlow.payload}
 					perUserHeaderKeys={perUserHeaderKeys}

--- a/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
@@ -20,6 +20,7 @@ interface MCPHeadersAuthorizerProps {
 	onClose: () => void;
 	onSuccess: () => void;
 	onError: (error: string) => void;
+	onConflict?: (error: string) => void;
 	// Full payload the parent has already assembled. The dialog adds
 	// user_headers (collected inline) and POSTs once.
 	payload: CreateMCPClientRequest;
@@ -34,6 +35,7 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 	onClose,
 	onSuccess,
 	onError,
+	onConflict,
 	payload,
 	perUserHeaderKeys,
 }) => {
@@ -70,6 +72,12 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 		} catch (err) {
 			if (cancelledRef.current) return;
 			const errMsg = getErrorMessage(err);
+			if ((err as any)?.status === 409) {
+				setStatus("input");
+				setErrorMessage(null);
+				onConflict?.(errMsg);
+				return;
+			}
 			setStatus("failed");
 			setErrorMessage(errMsg);
 			onError(errMsg);

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -11,6 +11,7 @@ interface OAuth2AuthorizerProps {
 	onClose: () => void;
 	onSuccess: () => void;
 	onError: (error: string) => void;
+	onConflict?: (error: string) => void;
 	authorizeUrl: string;
 	oauthConfigId: string;
 	mcpClientId: string;
@@ -111,6 +112,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	onClose,
 	onSuccess,
 	onError,
+	onConflict,
 	authorizeUrl,
 	oauthConfigId,
 	isPerUserOauth,
@@ -152,11 +154,18 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		} catch (error) {
 			if (cancelledRef.current) return;
 			const errMsg = getErrorMessage(error);
+			if ((error as any)?.status === 409 && onConflict) {
+				setStatus(isPerUserOauth ? "confirm" : "polling");
+				setErrorMessage(null);
+				isCompletingRef.current = false;
+				onConflict(errMsg);
+				return;
+			}
 			setStatus("failed");
 			setErrorMessage(errMsg);
 			onError(errMsg);
 		}
-	}, [oauthConfigId, completeOAuth, onSuccess, onError]);
+	}, [oauthConfigId, completeOAuth, onSuccess, onError, onConflict, isPerUserOauth]);
 
 	const handleOAuthFailed = useCallback(
 		(reason: string) => {

--- a/ui/app/workspace/providers/views/providerKeyForm.tsx
+++ b/ui/app/workspace/providers/views/providerKeyForm.tsx
@@ -113,6 +113,10 @@ export default function ProviderKeyForm({ provider, keyId, onCancel, onSave }: P
 				onSave();
 			})
 			.catch((err) => {
+				if (err?.status === 409) {
+					form.setError("key.name", { message: getErrorMessage(err) });
+					return;
+				}
 				toast.error(isEditing ? "Error updating key" : "Error creating key", {
 					description: getErrorMessage(err),
 				});

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -971,7 +971,11 @@ export default function VirtualKeySheet({
       }
 
       onSave();
-    } catch (error) {
+    } catch (error: any) {
+      if (error?.status === 409) {
+        form.setError("name", { message: getErrorMessage(error) });
+        return;
+      }
       toast.error(getErrorMessage(error));
     }
   };


### PR DESCRIPTION
## Summary

When a user attempts to create or rename a resource with a name that already exists, the server returns a `409 Conflict` response. Previously, this was displayed as a generic toast notification. This PR surfaces the conflict error inline, directly beneath the name field, so users immediately understand what went wrong and can correct it without dismissing a toast.

## Changes

- 409 conflict errors on save are now caught and displayed as inline field-level validation messages on the name input, rather than toast notifications, across customer sheets, team sheets, virtual key sheets, provider key forms, MCP client forms, and MCP library install sheets.
- `OAuth2Authorizer` and `MCPHeadersAuthorizer` now accept an optional `onConflict` callback so that conflict errors surfaced during OAuth and headers-based authorization flows can be propagated back to the parent form and shown inline on the name field.
- The name error state is cleared whenever the user edits the name field or the sheet/form is reset, preventing stale error messages from persisting.

## Type of change

- [x] Bug fix

## Affected areas

- [x] UI (React)

## How to test

1. Create a customer, team, virtual key, provider key, or MCP client with a given name.
2. Attempt to create a second resource with the same name.
3. Verify that instead of a toast, an inline error message appears directly below the name field indicating the conflict.
4. Edit the name field and verify the inline error clears immediately.
5. Close and reopen the form and verify no stale error is shown.

## Screenshots/Recordings

Before: Duplicate name errors appeared as a dismissible toast notification.  
After: Duplicate name errors appear inline beneath the name input field.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable