### PR TITLE
feat: auto-detect ChatGPT subscription tokens and route to chatgpt.com

### DIFF
--- a/core/providers/openai/chatgpt_passthrough.go
+++ b/core/providers/openai/chatgpt_passthrough.go
@@ -1,0 +1,57 @@
+package openai
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const (
+	chatGPTAccountIDKey = "chatgpt_account_id"
+	openAIAuthClaim     = "https://api.openai.com/auth"
+
+	// ChatGPTCodexURL is the full upstream URL for ChatGPT subscription token requests.
+	ChatGPTCodexURL = "https://chatgpt.com/backend-api/codex/responses"
+)
+
+// ParseChatGPTJWT parses a raw bearer token, checks for the ChatGPT subscription
+// JWT claim, and returns the chatgpt_account_id. No signature verification is
+// Returns ("", false) for any non-ChatGPT or malformed token.
+func ParseChatGPTJWT(token string) (accountID string, ok bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", false
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", false
+	}
+
+	// Extract the nested claim: {"https://api.openai.com/auth": {"chatgpt_account_id": "..."}}
+	var claims map[string]interface{}
+	if err := sonic.Unmarshal(payload, &claims); err != nil {
+		return "", false
+	}
+
+	authClaim, ok := claims[openAIAuthClaim].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+
+	accountID, ok = authClaim[chatGPTAccountIDKey].(string)
+	if !ok || accountID == "" {
+		return "", false
+	}
+
+	return accountID, true
+}
+
+// IsChatGPTPassthrough reports whether the current request was auto-detected
+// as a ChatGPT subscription token and should be routed to chatgpt.com.
+func IsChatGPTPassthrough(ctx *schemas.BifrostContext) bool {
+	v, _ := ctx.Value(schemas.BifrostContextKeyChatGPTPassthrough).(bool)
+	return v
+}

--- a/core/providers/openai/chatgpt_passthrough.go
+++ b/core/providers/openai/chatgpt_passthrough.go
@@ -18,6 +18,7 @@ const (
 
 // ParseChatGPTJWT parses a raw bearer token, checks for the ChatGPT subscription
 // JWT claim, and returns the chatgpt_account_id. No signature verification is
+// performed — the token is used only as a routing hint.
 // Returns ("", false) for any non-ChatGPT or malformed token.
 func ParseChatGPTJWT(token string) (accountID string, ok bool) {
 	parts := strings.Split(token, ".")

--- a/core/providers/openai/chatgpt_passthrough_test.go
+++ b/core/providers/openai/chatgpt_passthrough_test.go
@@ -1,0 +1,90 @@
+package openai
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+)
+
+// makeTestJWT builds a syntactically valid JWT with arbitrary header/payload JSON.
+// The signature segment is a fixed placeholder — ParseChatGPTJWT never verifies it.
+func makeTestJWT(payloadJSON string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
+	return fmt.Sprintf("%s.%s.fakesig", header, payload)
+}
+
+func TestParseChatGPTJWT(t *testing.T) {
+	validAccountID := "9dce4683-94cd-4aeb-ade4-4ecce82ebac5"
+
+	tests := []struct {
+		name      string
+		token     string
+		wantID    string
+		wantOK    bool
+	}{
+		{
+			name: "valid ChatGPT JWT returns account ID",
+			token: makeTestJWT(fmt.Sprintf(
+				`{"aud":["https://api.openai.com/v1"],"https://api.openai.com/auth":{"chatgpt_account_id":%q}}`,
+				validAccountID,
+			)),
+			wantID: validAccountID,
+			wantOK: true,
+		},
+		{
+			name: "JWT missing chatgpt_account_id claim returns false",
+			token: makeTestJWT(`{"aud":["https://api.openai.com/v1"],"sub":"user-abc"}`),
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name: "JWT with https://api.openai.com/auth but no chatgpt_account_id returns false",
+			token: makeTestJWT(`{"https://api.openai.com/auth":{"other_field":"value"}}`),
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "not a JWT (sk- API key) returns false",
+			token:  "sk-proj-abcdefghijklmnopqrstuvwxyz",
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "empty string returns false",
+			token:  "",
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "only two segments returns false",
+			token:  "header.payload",
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "invalid base64 in payload returns false",
+			token:  "header.!!!invalid!!!.sig",
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "payload is valid base64 but not JSON returns false",
+			token:  fmt.Sprintf("header.%s.sig", base64.RawURLEncoding.EncodeToString([]byte("not-json"))),
+			wantID: "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotOK := ParseChatGPTJWT(tt.token)
+			if gotOK != tt.wantOK {
+				t.Errorf("ParseChatGPTJWT() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotID != tt.wantID {
+				t.Errorf("ParseChatGPTJWT() accountID = %q, want %q", gotID, tt.wantID)
+			}
+		})
+	}
+}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1445,22 +1445,17 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return nil, err
 	}
 
-	if provider.disableStore || IsChatGPTPassthrough(ctx) {
+	if provider.disableStore {
 		if request.Params == nil {
 			request.Params = &schemas.ResponsesParameters{}
 		}
 		request.Params.Store = schemas.Ptr(false)
 	}
 
-	url := provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesRequest)
-	if IsChatGPTPassthrough(ctx) {
-		url = ChatGPTCodexURL
-	}
-
 	return HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		url,
+		provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesRequest),
 		request,
 		BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -1629,25 +1624,24 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
 		return nil, err
 	}
-	if provider.disableStore || IsChatGPTPassthrough(ctx) {
+	var authHeader map[string]string
+	if key.Value.GetValue() != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
+	}
+	if provider.disableStore {
 		if request.Params == nil {
 			request.Params = &schemas.ResponsesParameters{}
 		}
 		request.Params.Store = schemas.Ptr(false)
 	}
 
-	streamURL := provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesStreamRequest)
-	if IsChatGPTPassthrough(ctx) {
-		streamURL = ChatGPTCodexURL
-	}
-
 	// Use shared streaming logic
 	return HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamingClient,
-		streamURL,
+		provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesStreamRequest),
 		request,
-		BearerAuthHeader(key),
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1432,7 +1432,7 @@ func HandleOpenAIChatCompletionStreaming(
 
 // Responses performs a responses request to the OpenAI API.
 func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
-	if provider.shouldFallbackResponsesToChat(schemas.ResponsesRequest, schemas.ChatCompletionRequest) {
+	if !IsChatGPTPassthrough(ctx) && provider.shouldFallbackResponsesToChat(schemas.ResponsesRequest, schemas.ChatCompletionRequest) {
 		chatResponse, err := provider.ChatCompletion(ctx, key, request.ToChatRequest())
 		if err != nil {
 			return nil, err
@@ -1620,7 +1620,7 @@ func HandleOpenAIResponsesRequest(
 
 // ResponsesStream performs a streaming responses request to the OpenAI API.
 func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	if provider.shouldFallbackResponsesToChat(schemas.ResponsesStreamRequest, schemas.ChatCompletionStreamRequest) {
+	if !IsChatGPTPassthrough(ctx) && provider.shouldFallbackResponsesToChat(schemas.ResponsesStreamRequest, schemas.ChatCompletionStreamRequest) {
 		ctx.SetValue(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
 		return provider.ChatCompletionStream(ctx, postHookRunner, postHookSpanFinalizer, key, request.ToChatRequest())
 	}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1445,7 +1445,7 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return nil, err
 	}
 
-	if provider.disableStore {
+	if provider.disableStore || IsChatGPTPassthrough(ctx) {
 		if request.Params == nil {
 			request.Params = &schemas.ResponsesParameters{}
 		}
@@ -1624,7 +1624,7 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
 		return nil, err
 	}
-	if provider.disableStore {
+	if provider.disableStore || IsChatGPTPassthrough(ctx) {
 		if request.Params == nil {
 			request.Params = &schemas.ResponsesParameters{}
 		}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1445,7 +1445,7 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return nil, err
 	}
 
-	if provider.disableStore {
+	if provider.disableStore || IsChatGPTPassthrough(ctx) {
 		if request.Params == nil {
 			request.Params = &schemas.ResponsesParameters{}
 		}
@@ -1628,7 +1628,7 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	if key.Value.GetValue() != "" {
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
 	}
-	if provider.disableStore {
+	if provider.disableStore || IsChatGPTPassthrough(ctx) {
 		if request.Params == nil {
 			request.Params = &schemas.ResponsesParameters{}
 		}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1440,9 +1440,10 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return chatResponse.ToBifrostResponsesResponse(), nil
 	}
 
-	// Check if chat completion is allowed for this provider
-	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
-		return nil, err
+	if !IsChatGPTPassthrough(ctx) {
+		if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
+			return nil, err
+		}
 	}
 
 	if provider.disableStore || IsChatGPTPassthrough(ctx) {
@@ -1620,9 +1621,10 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		return provider.ChatCompletionStream(ctx, postHookRunner, postHookSpanFinalizer, key, request.ToChatRequest())
 	}
 
-	// Check if chat completion stream is allowed for this provider
-	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
-		return nil, err
+	if !IsChatGPTPassthrough(ctx) {
+		if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
+			return nil, err
+		}
 	}
 	var authHeader map[string]string
 	if key.Value.GetValue() != "" {

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1452,10 +1452,15 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		request.Params.Store = schemas.Ptr(false)
 	}
 
+	url := provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesRequest)
+	if IsChatGPTPassthrough(ctx) {
+		url = ChatGPTCodexURL
+	}
+
 	return HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesRequest),
+		url,
 		request,
 		BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -1631,11 +1636,16 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		request.Params.Store = schemas.Ptr(false)
 	}
 
+	streamURL := provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesStreamRequest)
+	if IsChatGPTPassthrough(ctx) {
+		streamURL = ChatGPTCodexURL
+	}
+
 	// Use shared streaming logic
 	return HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesStreamRequest),
+		streamURL,
 		request,
 		BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -361,6 +361,11 @@ const (
 	BifrostContextKeyConnectionClosed                    BifrostContextKey = "connection_closed"
 	BifrostContextKeyTempTokenScope                      BifrostContextKey = "bifrost-temp-token-scope"       // string (set by auth middleware when a temp token authorized the request - names the scope from the temptoken registry)
 	BifrostContextKeyTempTokenResourceID                 BifrostContextKey = "bifrost-temp-token-resource-id" // string (set by auth middleware alongside the scope - the resource_id the token is bound to, e.g. an OAuth flow ID for mcp_auth)
+
+	// ChatGPT subscription token auto-detection. Set by the OpenAI transport pre-hook
+	// when the incoming bearer JWT contains the chatgpt_account_id claim. The provider
+	// uses this to reroute to chatgpt.com/backend-api/codex/responses.
+	BifrostContextKeyChatGPTPassthrough BifrostContextKey = "bifrost-chatgpt-passthrough" // bool
 )
 
 const (

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -764,7 +764,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 						existing, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
 						headers := make(map[string][]string, len(existing)+1)
 						for k, v := range existing {
-							headers[k] = v
+							if !strings.EqualFold(k, "authorization") {
+								headers[k] = v
+							}
 						}
 						headers["Authorization"] = []string{"Bearer " + token}
 						bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, headers)

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -761,6 +761,8 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 					if _, ok := openai.ParseChatGPTJWT(token); ok {
 						bifrostCtx.SetValue(schemas.BifrostContextKeyChatGPTPassthrough, true)
 						bifrostCtx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
+						bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+						bifrostCtx.SetValue(schemas.BifrostContextKeyURLPath, openai.ChatGPTCodexURL)
 						existing, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
 						headers := make(map[string][]string, len(existing)+1)
 						for k, v := range existing {

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -756,15 +756,18 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				if isAzureSDKRequest(ctx) {
 					bifrostCtx.SetValue(schemas.BifrostContextKeyIsAzureUserAgent, true)
 				}
-				if authHeader := string(ctx.Request.Header.Peek("Authorization")); strings.HasPrefix(authHeader, "Bearer ") {
-					token := strings.TrimPrefix(authHeader, "Bearer ")
+				if authHeader := string(ctx.Request.Header.Peek("Authorization")); strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+					token := authHeader[7:]
 					if _, ok := openai.ParseChatGPTJWT(token); ok {
 						bifrostCtx.SetValue(schemas.BifrostContextKeyChatGPTPassthrough, true)
 						bifrostCtx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
-						bifrostCtx.SetValue(schemas.BifrostContextKeyURLPath, openai.ChatGPTCodexURL)
-						bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
-							"Authorization": {"Bearer " + token},
-						})
+						existing, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+						headers := make(map[string][]string, len(existing)+1)
+						for k, v := range existing {
+							headers[k] = v
+						}
+						headers["Authorization"] = []string{"Bearer " + token}
+						bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, headers)
 					}
 				}
 				return nil

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -756,6 +756,17 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				if isAzureSDKRequest(ctx) {
 					bifrostCtx.SetValue(schemas.BifrostContextKeyIsAzureUserAgent, true)
 				}
+				if authHeader := string(ctx.Request.Header.Peek("Authorization")); strings.HasPrefix(authHeader, "Bearer ") {
+					token := strings.TrimPrefix(authHeader, "Bearer ")
+					if _, ok := openai.ParseChatGPTJWT(token); ok {
+						bifrostCtx.SetValue(schemas.BifrostContextKeyChatGPTPassthrough, true)
+						bifrostCtx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
+						bifrostCtx.SetValue(schemas.BifrostContextKeyURLPath, openai.ChatGPTCodexURL)
+						bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+							"Authorization": {"Bearer " + token},
+						})
+					}
+				}
 				return nil
 			},
 		})


### PR DESCRIPTION
## Summary

When a user logs into Codex CLI using their ChatGPT subscription (`codex login` with ChatGPT OAuth), the resulting bearer token is a JWT containing a `chatgpt_account_id` claim. Sending this token to `api.openai.com/v1/responses` returns 401 because it is a subscription token, not an API key.

This PR auto-detects that token in Bifrost's `/v1/responses` pre-hook and transparently reroutes the request to `chatgpt.com/backend-api/codex/responses` — the endpoint that actually accepts it. No config change or URL change is required from the user.

## Changes

- **`core/providers/openai/chatgpt_passthrough.go`** — new file with `ParseChatGPTJWT` (decodes the JWT payload and checks for the `chatgpt_account_id` claim under `https://api.openai.com/auth`) and `IsChatGPTPassthrough` (reads the detection flag from context)
- **`core/schemas/bifrost.go`** — adds `BifrostContextKeyChatGPTPassthrough` context key (bool) set by the pre-hook and read by the provider
- **`transports/bifrost-http/integrations/openai.go`** — pre-hook for `POST /v1/responses` that calls `ParseChatGPTJWT` on the incoming bearer token; if detected, sets the URL override to `chatgpt.com/backend-api/codex/responses`, skips Bifrost key selection, and forwards the original bearer token
- **`core/providers/openai/openai.go`** — `Responses()` and `ResponsesStream()` force `store: false` when `IsChatGPTPassthrough` is true (required by the chatgpt.com backend)
- **`core/providers/openai/chatgpt_passthrough_test.go`** — unit tests for `ParseChatGPTJWT` covering valid JWT, missing claim, malformed tokens, non-JWT API keys, and edge cases

> Design decision: JWT signature is intentionally not verified — the token is used only as a routing hint. The upstream chatgpt.com endpoint validates it for real.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

**Unit tests:**

```sh
cd core
go test ./providers/openai/ -run TestParseChatGPTJWT -v
```



## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4459

## Security considerations

- The JWT is decoded (base64) but **not signature-verified** — it is used only as a routing hint. The chatgpt.com backend performs real authentication with the token.
- No credentials are stored or logged; the bearer token passes through in-memory only.
- `BifrostContextKeySkipKeySelection` is set so Bifrost does not attempt to inject a stored API key over the user's token.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
