### PR TITLE
feat: adds github action scripts for migration cli

### DIFF
--- a/.github/workflows/release-bifrost-migration-cli.yml
+++ b/.github/workflows/release-bifrost-migration-cli.yml
@@ -1,0 +1,120 @@
+name: Release Migration CLI
+
+on:
+  push:
+    branches:
+      - main
+
+# Prevent concurrent runs
+concurrency:
+  group: release-bifrost-migration-cli
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      tag_exists: ${{ steps.check-tag.outputs.exists }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Get version from file
+        id: get-version
+        run: echo "version=$(cat scripts/bifrost-migration-cli/version)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check-tag
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+        run: |
+          if git rev-parse "bifrost-migration-cli/v${VERSION}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  test-bifrost-migration-cli:
+    needs: [check-version]
+    if: needs.check-version.outputs.tag_exists == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: "1.26.4"
+
+      - name: Run bifrost-migration-cli tests
+        working-directory: scripts/bifrost-migration-cli
+        env:
+          GOWORK: "off"
+        run: go test ./...
+
+  release-bifrost-migration-cli:
+    needs: [check-version, test-bifrost-migration-cli]
+    if: needs.check-version.outputs.tag_exists == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      success: ${{ steps.release.outputs.success }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: "1.26.4"
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Release Migration CLI
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: ./.github/workflows/scripts/release-bifrost-migration-cli.sh "${{ needs.check-version.outputs.version }}"

--- a/.github/workflows/scripts/build-bifrost-migration-cli-executables.sh
+++ b/.github/workflows/scripts/build-bifrost-migration-cli-executables.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cross-compile bifrost-migration-cli binaries for multiple platforms
+# Usage: ./build-bifrost-migration-cli-executables.sh <version>
+
+if [[ -z "${1:-}" ]]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+VERSION="$1"
+
+echo "🔨 Building bifrost-migration-cli executables with version: $VERSION"
+
+# Get the script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Clean and create dist directory
+rm -rf "$PROJECT_ROOT/dist"
+mkdir -p "$PROJECT_ROOT/dist"
+
+# Define platforms
+platforms=(
+  "darwin/amd64"
+  "darwin/arm64"
+  "linux/amd64"
+  "linux/arm64"
+  "windows/amd64"
+)
+
+MODULE_PATH="$PROJECT_ROOT/scripts/bifrost-migration-cli"
+COMMIT="${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo 'unknown')}"
+
+for platform in "${platforms[@]}"; do
+  IFS='/' read -r GOOS GOARCH <<< "$platform"
+
+  output_name="bifrost-migration-cli"
+  [[ "$GOOS" = "windows" ]] && output_name+='.exe'
+
+  echo "Building bifrost-migration-cli for $GOOS/$GOARCH..."
+  mkdir -p "$PROJECT_ROOT/dist/$GOOS/$GOARCH"
+
+  cd "$MODULE_PATH"
+
+  # bifrost-migration-cli has no CGO dependencies, so we can cross-compile without cross-compilers
+  env GOWORK=off CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+    go build -trimpath \
+    -ldflags "-s -w -buildid= -X main.version=v${VERSION} -X main.commit=${COMMIT}" \
+    -o "$PROJECT_ROOT/dist/$GOOS/$GOARCH/$output_name" .
+
+  # Generate SHA-256 checksum for the binary
+  (cd "$PROJECT_ROOT/dist/$GOOS/$GOARCH" && shasum -a 256 "$output_name" > "$output_name.sha256")
+  echo "  → checksum: $(cat "$PROJECT_ROOT/dist/$GOOS/$GOARCH/$output_name.sha256")"
+
+  cd "$PROJECT_ROOT"
+done
+
+echo "✅ All bifrost-migration-cli binaries built successfully"

--- a/.github/workflows/scripts/release-bifrost-migration-cli.sh
+++ b/.github/workflows/scripts/release-bifrost-migration-cli.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release bifrost-migration-cli component
+# Usage: ./release-bifrost-migration-cli.sh <version>
+
+# Get the absolute path of the script directory
+if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then
+  SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+fi
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
+
+# Validate input argument
+if [ "${1:-}" = "" ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+VERSION="$1"
+TAG_NAME="bifrost-migration-cli/v${VERSION}"
+
+echo "🚀 Releasing bifrost-migration-cli v$VERSION..."
+
+# Validate bifrost-migration-cli build
+echo "🔨 Validating bifrost-migration-cli build..."
+COMMIT="${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo 'unknown')}"
+(cd "$REPO_ROOT/scripts/bifrost-migration-cli" && GOWORK=off go build -ldflags "-X main.version=v${VERSION} -X main.commit=${COMMIT}" ./...)
+echo "✅ bifrost-migration-cli build validation successful"
+
+# Build bifrost-migration-cli executables
+echo "🔨 Building executables..."
+bash "$SCRIPT_DIR/build-bifrost-migration-cli-executables.sh" "$VERSION"
+
+# --- Preflight checks (no side effects) ---
+
+# Capturing changelog
+CHANGELOG_BODY=$(cat "$REPO_ROOT/scripts/bifrost-migration-cli/changelog.md")
+# Skip comments from changelog
+CHANGELOG_BODY=$(printf '%s\n' "$CHANGELOG_BODY" | sed '/<!--/,/-->/d')
+# If changelog is empty, return error
+if [ -z "$CHANGELOG_BODY" ]; then
+  echo "❌ Changelog is empty"
+  exit 1
+fi
+echo "📝 New changelog: $CHANGELOG_BODY"
+
+# Finding previous tag
+echo "🔍 Finding previous tag..."
+TAG_COUNT=$(git tag -l "bifrost-migration-cli/v*" | wc -l | tr -d ' ')
+if [[ "$TAG_COUNT" -eq 0 ]]; then
+  PREV_TAG=""
+else
+  PREV_TAG=$(git tag -l "bifrost-migration-cli/v*" | sort -V | tail -1)
+  if [[ "$PREV_TAG" == "$TAG_NAME" ]]; then
+    PREV_TAG=$(git tag -l "bifrost-migration-cli/v*" | sort -V | tail -2 | head -1)
+    [[ "$PREV_TAG" == "$TAG_NAME" ]] && PREV_TAG=""
+  fi
+fi
+echo "🔍 Previous tag: $PREV_TAG"
+
+# Get message of the tag and compare changelogs
+if [[ -n "$PREV_TAG" ]]; then
+  echo "🔍 Getting previous tag message..."
+  PREV_CHANGELOG=$(git tag -l --format='%(contents:body)' "$PREV_TAG")
+  echo "📝 Previous changelog body: $PREV_CHANGELOG"
+
+  # Checking if tag message is the same as the changelog
+  if [[ "$PREV_CHANGELOG" == "$CHANGELOG_BODY" ]]; then
+    echo "❌ Changelog is the same as the previous changelog"
+    exit 1
+  fi
+else
+  echo "ℹ️ No previous bifrost-migration-cli tag found. Skipping changelog comparison."
+fi
+
+# Verify GitHub token before any publish steps
+if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "Error: GH_TOKEN or GITHUB_TOKEN is not set. Please export one to authenticate the GitHub CLI."
+  exit 1
+fi
+
+# --- Publish steps (all checks passed) ---
+
+# Configure and upload to R2
+echo "📤 Uploading binaries..."
+bash "$SCRIPT_DIR/configure-r2.sh"
+bash "$SCRIPT_DIR/upload-bifrost-migration-cli-to-r2.sh" "$TAG_NAME"
+
+# Create and push tag
+if git rev-parse -q --verify "refs/tags/$TAG_NAME" >/dev/null; then
+  echo "ℹ️ Tag $TAG_NAME already exists. Reusing it."
+else
+  echo "🏷️ Creating tag: $TAG_NAME"
+  git tag "$TAG_NAME" -m "Release bifrost-migration-cli v$VERSION" -m "$CHANGELOG_BODY"
+  git push origin "$TAG_NAME"
+fi
+
+# Create GitHub release
+TITLE="Bifrost Migration CLI v$VERSION"
+
+# Mark prereleases when version contains a hyphen
+PRERELEASE_FLAG=""
+if [[ "$VERSION" == *-* ]]; then
+  PRERELEASE_FLAG="--prerelease"
+fi
+
+BODY="## Bifrost Migration CLI Release v$VERSION
+
+$CHANGELOG_BODY
+
+### Installation
+
+#### Binary Download
+\`\`\`bash
+npx @maximhq/bifrost-migration-cli --cli-version v$VERSION
+\`\`\`
+
+---
+_This release was automatically created._"
+
+if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+  echo "ℹ️ GitHub release $TAG_NAME already exists. Skipping."
+else
+  echo "🎉 Creating GitHub release for $TITLE..."
+  gh release create "$TAG_NAME" \
+    --title "$TITLE" \
+    --notes "$BODY" \
+    ${PRERELEASE_FLAG}
+fi
+
+echo "✅ Bifrost Migration CLI released successfully"
+
+# Print summary
+echo ""
+echo "📋 Release Summary:"
+echo "   🏷️  Tag: $TAG_NAME"
+echo "   🎉 GitHub release: Created"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "success=true" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/scripts/upload-bifrost-migration-cli-to-r2.sh
+++ b/.github/workflows/scripts/upload-bifrost-migration-cli-to-r2.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upload bifrost-migration-cli builds to R2 with retry logic
+# Usage: ./upload-bifrost-migration-cli-to-r2.sh <bifrost-migration-cli-version>
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <bifrost-migration-cli-version> (e.g., bifrost-migration-cli/v1.0.0)"
+  exit 1
+fi
+CLI_TAG="$1"
+# Validate tag format: must be bifrost-migration-cli/vX.Y.Z or bifrost-migration-cli/vX.Y.Z-prerelease
+if [[ ! "$CLI_TAG" =~ ^bifrost-migration-cli/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+  echo "❌ Invalid tag format: $CLI_TAG"
+  echo "   Expected format: bifrost-migration-cli/vX.Y.Z or bifrost-migration-cli/vX.Y.Z-prerelease (e.g., bifrost-migration-cli/v1.0.0, bifrost-migration-cli/v1.0.0-rc.1)"
+  exit 1
+fi
+if [[ ! -d "./dist" ]]; then
+  echo "❌ ./dist not found. Build artifacts must be present before upload."
+  exit 1
+fi
+: "${R2_ENDPOINT:?R2_ENDPOINT env var is required}"
+: "${R2_BUCKET:?R2_BUCKET env var is required}"
+
+# Strip 'bifrost-migration-cli/' prefix from version
+VERSION_ONLY=${CLI_TAG#bifrost-migration-cli/v}
+CLI_VERSION="v${VERSION_ONLY}"
+printf '%s' "$CLI_VERSION" > "./dist/version.txt"
+R2_ENDPOINT="$(echo "$R2_ENDPOINT" | tr -d '[:space:]')"
+
+echo "📤 Uploading bifrost-migration-cli binaries for version: $CLI_VERSION"
+
+# Function to upload with retry
+upload_with_retry() {
+  local source_path="$1"
+  local dest_path="$2"
+  local max_retries=3
+
+  for attempt in $(seq 1 $max_retries); do
+    echo "🔄 Attempt $attempt/$max_retries: Uploading to $dest_path"
+
+    if aws s3 sync "$source_path" "$dest_path" \
+       --endpoint-url "$R2_ENDPOINT" \
+       --profile "${R2_AWS_PROFILE:-R2}" \
+       --no-progress \
+       --delete; then
+      echo "✅ Upload successful to $dest_path"
+      return 0
+    else
+      echo "⚠️ Attempt $attempt failed"
+      if [ $attempt -lt $max_retries ]; then
+        delay=$((2 ** attempt))
+        echo "🕐 Waiting ${delay}s before retry..."
+        sleep $delay
+      fi
+    fi
+  done
+
+  echo "❌ All $max_retries attempts failed for $dest_path"
+  return 1
+}
+
+# Upload to versioned path
+if ! upload_with_retry "./dist/" "s3://$R2_BUCKET/bifrost-migration-cli/$CLI_VERSION/"; then
+  exit 1
+fi
+
+# Check if this is a prerelease version (semver: presence of a hyphen denotes pre-release)
+if [[ "$CLI_VERSION" == *-* ]]; then
+  echo "🔍 Detected prerelease version: $CLI_VERSION"
+  echo "⏭️ Skipping upload to latest/ for prerelease"
+else
+  echo "🔍 Detected stable release: $CLI_VERSION"
+
+  # Small delay between uploads (configurable; default 2s)
+  sleep "${INTER_UPLOAD_SLEEP_SECONDS:-2}"
+
+  # Upload to latest path
+  echo "📤 Uploading to latest/"
+  if ! upload_with_retry "./dist/" "s3://$R2_BUCKET/bifrost-migration-cli/latest/"; then
+    exit 1
+  fi
+fi
+
+echo "🎉 All bifrost-migration-cli binaries uploaded successfully to R2"


### PR DESCRIPTION
## Summary

Adds an automated CI/CD pipeline to build, test, and release the `bifrost-migration-cli` tool. When a push to `main` is detected and the version file contains a version that hasn't been tagged yet, the workflow runs tests, cross-compiles binaries for multiple platforms, uploads them to Cloudflare R2, and creates a GitHub release with a changelog-based release body.

## Changes

- Added a GitHub Actions workflow (`release-bifrost-migration-cli.yml`) that triggers on pushes to `main`, checks whether the current version has already been released by inspecting existing git tags, runs tests, and conditionally proceeds to release.
- Added `build-bifrost-migration-cli-executables.sh` to cross-compile the CLI for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`, and `windows/amd64` with trimmed binaries, embedded version/commit metadata, and SHA-256 checksums per binary.
- Added `release-bifrost-migration-cli.sh` to orchestrate the full release: build validation, changelog extraction and deduplication against the previous tag, R2 upload, git tagging, and GitHub release creation. Prerelease versions (those containing a hyphen) are flagged accordingly and skipped from the `latest/` R2 path.
- Added `upload-bifrost-migration-cli-to-r2.sh` to handle uploading build artifacts to R2 with retry logic (exponential backoff, up to 3 attempts). Stable releases are also mirrored to a `latest/` path; prereleases are not.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Bump the version in `scripts/bifrost-migration-cli/version` to a value that does not yet have a corresponding git tag, then push to `main`. The workflow should:

1. Detect the new version.
2. Run `go test ./...` inside `scripts/bifrost-migration-cli`.
3. Build binaries for all five target platforms.
4. Upload artifacts to R2 under the versioned path (and `latest/` for stable releases).
5. Create a git tag `bifrost-migration-cli/vX.Y.Z` and a corresponding GitHub release.

To validate locally:

```sh
cd scripts/bifrost-migration-cli
GOWORK=off go test ./...

# Build executables manually
bash .github/workflows/scripts/build-bifrost-migration-cli-executables.sh <version>
ls dist/
```

Required secrets: `GH_TOKEN`, `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- The `check-version` job uses `egress-policy: block` with only `github.com:443` allowed, minimizing the attack surface during tag inspection.
- Release and test jobs use `egress-policy: audit` to log outbound calls.
- `GH_TOKEN` and R2 credentials are consumed exclusively via GitHub Actions secrets and are never echoed to logs.
- All third-party actions are pinned to full commit SHAs.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable