### PR TITLE
docs alignments

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -831,36 +831,26 @@
               "changelogs/ent-v1.4.1",
               "changelogs/ent-v1.4.0",
               "changelogs/ent-v1.4.0-prerelease7",
-              {
-                "group": "April 2026",
-                "pages": [
-                  "changelogs/ent-v1.3.21",
-                  "changelogs/ent-v1.4.0-prerelease6",
-                  "changelogs/ent-v1.4.0-prerelease5",
-                  "changelogs/ent-v1.3.20",
-                  "changelogs/ent-v1.4.0-prerelease4",
-                  "changelogs/ent-v1.3.19",
-                  "changelogs/ent-v1.4.0-prerelease3",
-                  "changelogs/ent-v1.3.18",
-                  "changelogs/ent-v1.4.0-prerelease2",
-                  "changelogs/ent-v1.3.17",
-                  "changelogs/ent-v1.4.0-prerelease1"
-                ]
-              },
-              {
-                "group": "March 2026",
-                "pages": [
-                  "changelogs/ent-v1.3.16",
-                  "changelogs/ent-v1.3.15",
-                  "changelogs/ent-v1.3.14",
-                  "changelogs/ent-v1.3.13",
-                  "changelogs/ent-v1.3.12",
-                  "changelogs/ent-v1.3.11",
-                  "changelogs/ent-v1.3.10",
-                  "changelogs/ent-v1.3.9",
-                  "changelogs/ent-v1.3.8"
-                ]
-              }
+              "changelogs/ent-v1.3.21",
+              "changelogs/ent-v1.4.0-prerelease6",
+              "changelogs/ent-v1.4.0-prerelease5",
+              "changelogs/ent-v1.3.20",
+              "changelogs/ent-v1.4.0-prerelease4",
+              "changelogs/ent-v1.3.19",
+              "changelogs/ent-v1.4.0-prerelease3",
+              "changelogs/ent-v1.3.18",
+              "changelogs/ent-v1.4.0-prerelease2",
+              "changelogs/ent-v1.3.17",
+              "changelogs/ent-v1.4.0-prerelease1",
+              "changelogs/ent-v1.3.16",
+              "changelogs/ent-v1.3.15",
+              "changelogs/ent-v1.3.14",
+              "changelogs/ent-v1.3.13",
+              "changelogs/ent-v1.3.12",
+              "changelogs/ent-v1.3.11",
+              "changelogs/ent-v1.3.10",
+              "changelogs/ent-v1.3.9",
+              "changelogs/ent-v1.3.8"
             ]
           },
           {
@@ -870,15 +860,10 @@
               "changelogs/cli-v0.10.6",
               "changelogs/cli-v0.10.5",
               "changelogs/cli-v0.10.4",
-              {
-                "group": "March 2026",
-                "pages": [
-                  "changelogs/cli-v0.10.3",
-                  "changelogs/cli-v0.10.2",
-                  "changelogs/cli-v0.10.1",
-                  "changelogs/cli-v0.10.0"
-                ]
-              }
+              "changelogs/cli-v0.10.3",
+              "changelogs/cli-v0.10.2",
+              "changelogs/cli-v0.10.1",
+              "changelogs/cli-v0.10.0"
             ]
           },
           {


### PR DESCRIPTION
## Summary

Removes the month-based grouping from the Enterprise and CLI changelog navigation sections in the docs, flattening the entries into a single list.

## Changes

- Removed the "April 2026" and "March 2026" grouped sections from the Enterprise changelog navigation, replacing them with a flat list of the same changelog entries in the same order.
- Removed the "March 2026" grouped section from the CLI changelog navigation, similarly flattening those entries.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the changelog section of the docs and verify that the Enterprise and CLI changelog entries are displayed as a flat list without month groupings.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable