### PR TITLE
fix: run governance on cc oauth requests when vk is present

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1260,16 +1260,19 @@ func (p *GovernancePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *sche
 //   - *schemas.LLMPluginShortCircuit: The plugin short circuit if the request is not allowed
 //   - error: Any error that occurred during processing
 func (p *GovernancePlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
-	// If its skip key selection - in that case we need to skip virtual key selection too
-	if bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipKeySelection) {
+	// Extract virtual key using utility functions
+	virtualKeyValue := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyVirtualKey)
+
+	// SkipKeySelection (e.g. Claude Code OAuth/max mode) bypasses governance only when no VK
+	// was supplied, preserving keyless OAuth users; with a VK present, run full governance.
+	if bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipKeySelection) &&
+		virtualKeyValue == "" {
 		return req, nil, nil
 	}
 	// Validate required headers are present
 	if headerErr := p.validateRequiredHeaders(ctx); headerErr != nil {
 		return req, &schemas.LLMPluginShortCircuit{Error: headerErr}, nil
 	}
-	// Extract governance headers and virtual key using utility functions
-	virtualKeyValue := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyVirtualKey)
 	// Extract user ID for enterprise user-level governance
 	userID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID)
 	// Getting provider and mode from the request

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -1576,6 +1576,69 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyChecksPass(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
+// TestPreLLMHook_SkipKeySelection covers the OAuth/max-mode bypass condition: governance is
+// skipped only when SkipKeySelection is set AND no virtual key is present (keyless OAuth users),
+// while a SkipKeySelection request that carries a VK is fully governed.
+func TestPreLLMHook_SkipKeySelection(t *testing.T) {
+	logger := NewMockLogger()
+	// Valid VK whose budget is already exceeded, so enforcement is observable when it runs.
+	vkBudget := buildBudgetWithUsage("vk-budget1", 100.0, 100.1, "1h")
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", vkBudget)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*vkBudget},
+	}, nil)
+	require.NoError(t, err)
+
+	// IsVkMandatory=true so the keyless control case (no skip, no VK) is rejected — this is what
+	// proves the skip+no-VK case bypasses rather than merely passing checks.
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(true)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		skipKeySelection   bool
+		virtualKey         string
+		expectShortCircuit bool
+		msgContains        string
+	}{
+		{name: "skip + no VK bypasses governance (keyless OAuth)", skipKeySelection: true, virtualKey: "", expectShortCircuit: false},
+		{name: "no skip + no VK is enforced (VK required)", skipKeySelection: false, virtualKey: "", expectShortCircuit: true, msgContains: "virtual key is required"},
+		{name: "skip + valid VK is enforced (budget exceeded)", skipKeySelection: true, virtualKey: "sk-bf-test", expectShortCircuit: true, msgContains: "budget exceeded"},
+		{name: "skip + unknown VK is enforced (not found)", skipKeySelection: true, virtualKey: "sk-bf-unknown", expectShortCircuit: true, msgContains: "not found"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-1")
+			if tc.virtualKey != "" {
+				parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyVirtualKey, tc.virtualKey)
+			}
+			ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+			if tc.skipKeySelection {
+				ctx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
+			}
+			req := &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{
+					Provider: schemas.OpenAI,
+					Model:    "gpt-4",
+				},
+			}
+
+			result, shortCircuit, err := plugin.PreLLMHook(ctx, req)
+			assert.NoError(t, err)
+			if tc.expectShortCircuit {
+				require.NotNil(t, shortCircuit, "expected governance to short-circuit")
+				assert.Contains(t, shortCircuit.Error.Error.Message, tc.msgContains)
+			} else {
+				assert.Nil(t, shortCircuit, "expected governance to be bypassed")
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
 func TestPreLLMHook_ModelProviderPass_VirtualKeyNotFound(t *testing.T) {
 	logger := NewMockLogger()
 	// Model/provider checks pass (no limits)


### PR DESCRIPTION
## Summary

When `SkipKeySelection` is set (e.g. Claude Code OAuth/max mode), governance was being bypassed entirely — even for requests that included a virtual key. This meant users supplying a virtual key alongside an OAuth flow were not subject to governance controls.

## Changes

- `PreLLMHook` now only skips governance when `SkipKeySelection` is true **and** no virtual key is present. If a virtual key is supplied, full governance runs regardless of the skip flag.
- Moved the `virtualKeyValue` extraction to before the `SkipKeySelection` check so it can be used in the condition, removing the need for a second extraction later in the function.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Send a request with `SkipKeySelection` set and **no** virtual key — governance should be bypassed as before.
2. Send a request with `SkipKeySelection` set and a **valid virtual key** — governance should run and enforce policies.
3. Send a request with `SkipKeySelection` set and an **invalid/unauthorized virtual key** — governance should reject the request.

```sh
go test ./plugins/governance/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This fix closes a governance bypass where OAuth users who also supplied a virtual key could circumvent access controls. Requests with a virtual key now always go through full governance validation, regardless of the `SkipKeySelection` flag.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable