### PR TITLE
fix: double message start event in anthropic stream closes #4556

### DIFF
--- a/core/providers/anthropic/advisor_test.go
+++ b/core/providers/anthropic/advisor_test.go
@@ -358,3 +358,105 @@ func TestAdvisorStream_RoundTrip(t *testing.T) {
 		t.Error("text block dropped")
 	}
 }
+
+// countPassthroughMessageStarts mirrors the transport passthrough converter
+// (transports/bifrost-http/integrations/anthropic.go): for each bifrost stream
+// response it forwards the raw upstream frame verbatim when present (except
+// ContentPartAdded), otherwise falls back to the normalized converter. Returns
+// how many message_start frames are emitted and the raw bytes of the forwarded one.
+func countPassthroughMessageStarts(ctx *schemas.BifrostContext, responses []*schemas.BifrostResponsesStreamResponse) (int, string) {
+	count := 0
+	forwarded := ""
+	for _, r := range responses {
+		if r.ExtraFields.RawResponse != nil && r.Type != schemas.ResponsesStreamResponseTypeContentPartAdded {
+			raw, _ := r.ExtraFields.RawResponse.(string)
+			if gjson.Get(raw, "type").String() == "message_start" {
+				count++
+				forwarded = raw
+			}
+			continue
+		}
+		for _, ev := range ToAnthropicResponsesStreamResponse(ctx, r) {
+			if ev.Type == AnthropicStreamEventTypeMessageStart {
+				count++
+			}
+		}
+	}
+	return count, forwarded
+}
+
+// TestResponsesStream_MessageStart_NoDuplicateOnPassthrough guards the fix for the
+// duplicate message_start emitted on the Anthropic passthrough responses_stream
+// path. A single upstream message_start expands inbound into [response.created,
+// response.in_progress]. The raw upstream frame must ride on response.created
+// (which maps back to message_start) so it is forwarded once with all upstream
+// fields intact; response.in_progress must carry no raw and convert to nil.
+// Attaching the raw to in_progress instead (the old "last chunk" rule) produced
+// two message_start frames: a lossy synthesized one from created plus the
+// raw-forwarded one from in_progress.
+func TestResponsesStream_MessageStart_NoDuplicateOnPassthrough(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+	const rawMessageStart = `{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-opus-4-8","content":[],"stop_reason":null,"usage":{"input_tokens":3450,"output_tokens":4,"service_tier":"standard","inference_geo":"not_available"}}}`
+
+	var chunk AnthropicStreamEvent
+	if err := sonic.Unmarshal([]byte(rawMessageStart), &chunk); err != nil {
+		t.Fatalf("unmarshal message_start: %v", err)
+	}
+
+	state := acquireAnthropicResponsesStreamState()
+	defer releaseAnthropicResponsesStreamState(state)
+
+	responses, bErr, _ := chunk.ToBifrostResponsesStream(ctx, 0, state)
+	if bErr != nil {
+		t.Fatalf("ToBifrostResponsesStream error: %v", bErr)
+	}
+
+	// Inbound must expand the single message_start into [created, in_progress].
+	if len(responses) != 2 {
+		t.Fatalf("expected 2 bifrost responses (created, in_progress), got %d", len(responses))
+	}
+	createdIdx := -1
+	for i, r := range responses {
+		if r.Type == schemas.ResponsesStreamResponseTypeCreated {
+			createdIdx = i
+		}
+	}
+	if createdIdx == -1 {
+		t.Fatal("expected a response.created in the message_start expansion")
+	}
+	// The fix attaches the raw to response.created; the old rule attached it to the
+	// last response (in_progress). Confirm they differ so the cases below exercise it.
+	if createdIdx == len(responses)-1 {
+		t.Fatal("response.created is last; raw attachment would not exercise the fix")
+	}
+
+	t.Run("raw on created emits one full message_start", func(t *testing.T) {
+		for _, r := range responses {
+			r.ExtraFields.RawResponse = nil
+		}
+		responses[createdIdx].ExtraFields.RawResponse = rawMessageStart
+
+		count, forwarded := countPassthroughMessageStarts(ctx, responses)
+		if count != 1 {
+			t.Fatalf("expected exactly 1 message_start, got %d", count)
+		}
+		// The surviving frame must be the verbatim upstream bytes, preserving
+		// service_tier/inference_geo that the synthesized frame drops.
+		if forwarded != rawMessageStart {
+			t.Errorf("forwarded message_start is not the verbatim upstream frame: %s", forwarded)
+		}
+	})
+
+	t.Run("raw on in_progress (old behavior) duplicates message_start", func(t *testing.T) {
+		for _, r := range responses {
+			r.ExtraFields.RawResponse = nil
+		}
+		responses[len(responses)-1].ExtraFields.RawResponse = rawMessageStart
+
+		count, _ := countPassthroughMessageStarts(ctx, responses)
+		if count != 2 {
+			t.Fatalf("expected the old last-chunk rule to duplicate message_start (2), got %d", count)
+		}
+	})
+}

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1330,6 +1330,16 @@ func HandleAnthropicResponsesStream(
 					responseChan, postHookSpanFinalizer)
 				continue
 			}
+			// Attach the upstream raw to exactly one bifrost response. Default to the last,
+			// but for the message_start expansion ([created, in_progress]) attach it to
+			// response.created
+			rawIdx := len(responses) - 1
+			for j, r := range responses {
+				if r != nil && r.Type == schemas.ResponsesStreamResponseTypeCreated {
+					rawIdx = j
+					break
+				}
+			}
 			// Handle each response in the slice
 			for i, response := range responses {
 				if response != nil {
@@ -1347,8 +1357,7 @@ func HandleAnthropicResponsesStream(
 					lastChunkTime = time.Now()
 					chunkIndex++
 
-					// Only add raw response to the last chunk of the incoming event
-					if providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse) && i == len(responses)-1 {
+					if providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse) && i == rawIdx {
 						response.ExtraFields.RawResponse = eventData
 					}
 


### PR DESCRIPTION
## Summary

Fixes a duplicate `message_start` event emitted on the Anthropic passthrough responses stream path. When a single upstream `message_start` is received, it expands into two bifrost responses: `response.created` and `response.in_progress`. The raw upstream frame was previously attached to the last chunk (`in_progress`), which caused the transport to emit two `message_start` frames — a lossy synthesized one from `created` and the raw-forwarded one from `in_progress`. The fix attaches the raw frame to `response.created` instead, ensuring exactly one `message_start` is forwarded with all upstream fields intact (including `service_tier` and `inference_geo`).

## Changes

- When attaching the upstream raw response to a bifrost response chunk, the default "last chunk" rule is now overridden for `message_start` expansions: the raw is attached to `response.created` rather than `response.in_progress`.
- Added `TestResponsesStream_MessageStart_NoDuplicateOnPassthrough` to explicitly guard this fix, verifying that the correct placement emits exactly one verbatim `message_start` and that the old placement produces the duplicate behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... -run TestResponsesStream_MessageStart_NoDuplicateOnPassthrough -v
```

Expected output: both subtests pass — `raw on created emits one full message_start` confirms a single verbatim frame, and `raw on in_progress (old behavior) duplicates message_start` confirms the old rule produced two frames.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable