### PR TITLE
extra header forwarding for mcp tools

### DIFF
--- a/core/internal/mcptests/extraheaders_test.go
+++ b/core/internal/mcptests/extraheaders_test.go
@@ -1,0 +1,386 @@
+package mcptests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	core "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/mcp"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// EXTRA-HEADER FORWARDING (wire-level) TESTS
+//
+// These tests assert the end-to-end contract that BifrostContextKeyMCPExtraHeaders
+// set during the plugin gate is forwarded to the upstream MCP server — on
+// bifrost-generated health-check probes (ping AND list_tools) as well as on a
+// normal caller tools/call — scoped by MCPClientConfig.AllowedExtraHeaders.
+//
+// They deliberately use a real streamable-HTTP transport (not the in-process
+// transport) because the per-request headers are injected by the transport
+// headerFunc registered in createHTTPConnection; the in-process transport has no
+// HTTP layer and would never exercise that path.
+// =============================================================================
+
+const (
+	allowedExtraHeader = "X-Allowed-Extra"
+	allowedExtraValue  = "reached-the-wire"
+	deniedExtraHeader  = "X-Denied-Extra"
+)
+
+// recordedRequest captures the JSON-RPC method and inbound headers of a single
+// HTTP request the upstream MCP server received.
+type recordedRequest struct {
+	method string // JSON-RPC method ("ping", "tools/list", "tools/call", ...); "" if not parseable
+	header http.Header
+}
+
+// headerRecorder is a thread-safe sink for inbound request headers, fronting the
+// mcp-go streamable HTTP handler.
+type headerRecorder struct {
+	mu   sync.Mutex
+	reqs []recordedRequest
+}
+
+func (hr *headerRecorder) add(method string, h http.Header) {
+	hr.mu.Lock()
+	defer hr.mu.Unlock()
+	hr.reqs = append(hr.reqs, recordedRequest{method: method, header: h.Clone()})
+}
+
+// valuesForMethod returns every value seen for headerName across recorded
+// requests whose JSON-RPC method matches.
+func (hr *headerRecorder) valuesForMethod(method, headerName string) []string {
+	hr.mu.Lock()
+	defer hr.mu.Unlock()
+	var out []string
+	for _, r := range hr.reqs {
+		if r.method == method {
+			if v := r.header.Get(headerName); v != "" {
+				out = append(out, v)
+			}
+		}
+	}
+	return out
+}
+
+// anyRequestHasHeader reports whether ANY recorded request (of any method)
+// carried headerName — used to prove a non-allowlisted header never escapes.
+func (hr *headerRecorder) anyRequestHasHeader(headerName string) bool {
+	hr.mu.Lock()
+	defer hr.mu.Unlock()
+	for _, r := range hr.reqs {
+		if r.header.Get(headerName) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// buildRecordingHTTPServer starts a streamable-HTTP MCP server (one "echo" tool)
+// behind an httptest server whose middleware records the JSON-RPC method and
+// inbound headers of every request. StreamableHTTPServer.ServeHTTP dispatches on
+// HTTP method only (it ignores the path), so delegating from a root-mounted
+// handler is sufficient.
+func buildRecordingHTTPServer(t *testing.T) (*httptest.Server, *headerRecorder) {
+	t.Helper()
+
+	s := server.NewMCPServer("test-http-headers", "1.0.0", server.WithToolCapabilities(true))
+	echoTool := mcpgo.NewTool("echo",
+		mcpgo.WithDescription("Echo tool"),
+		mcpgo.WithString("message", mcpgo.Required(), mcpgo.Description("message")),
+	)
+	s.AddTool(echoTool, func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		msg, _ := req.GetArguments()["message"].(string)
+		return mcpgo.NewToolResultText(msg), nil
+	})
+
+	streamable := server.NewStreamableHTTPServer(s)
+	rec := &headerRecorder{}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := ""
+		if r.Method == http.MethodPost && r.Body != nil {
+			if body, err := io.ReadAll(r.Body); err == nil {
+				var probe struct {
+					Method string `json:"method"`
+				}
+				_ = json.Unmarshal(body, &probe)
+				method = probe.Method
+				// Restore the consumed body for the streamable handler.
+				r.Body = io.NopCloser(bytes.NewReader(body))
+			}
+		}
+		rec.add(method, r.Header)
+		streamable.ServeHTTP(w, r)
+	})
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts, rec
+}
+
+// buildRecordingSSEServer starts an SSE MCP server (one "echo" tool) behind an
+// httptest server whose middleware records the JSON-RPC method and inbound
+// headers of every request. SSE splits the long-lived GET event stream from the
+// POST /message requests, so the JSON-RPC method is parsed from POST bodies only
+// (the GET stream records as method ""). The SSEServer must advertise an absolute
+// message endpoint back to the client, which is only known once httptest has
+// bound a port — hence sseSrv is wired after ts is created.
+func buildRecordingSSEServer(t *testing.T) (*httptest.Server, *headerRecorder) {
+	t.Helper()
+
+	s := server.NewMCPServer("test-sse-headers", "1.0.0", server.WithToolCapabilities(true))
+	echoTool := mcpgo.NewTool("echo",
+		mcpgo.WithDescription("Echo tool"),
+		mcpgo.WithString("message", mcpgo.Required(), mcpgo.Description("message")),
+	)
+	s.AddTool(echoTool, func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		msg, _ := req.GetArguments()["message"].(string)
+		return mcpgo.NewToolResultText(msg), nil
+	})
+
+	rec := &headerRecorder{}
+	var sseSrv *server.SSEServer
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := ""
+		if r.Method == http.MethodPost && r.Body != nil {
+			if body, err := io.ReadAll(r.Body); err == nil {
+				var probe struct {
+					Method string `json:"method"`
+				}
+				_ = json.Unmarshal(body, &probe)
+				method = probe.Method
+				// Restore the consumed body for the SSE handler.
+				r.Body = io.NopCloser(bytes.NewReader(body))
+			}
+		}
+		rec.add(method, r.Header)
+		sseSrv.ServeHTTP(w, r)
+	})
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	sseSrv = server.NewSSEServer(s, server.WithBaseURL(ts.URL))
+	return ts, rec
+}
+
+// extraHeaderInjectPlugin sets BifrostContextKeyMCPExtraHeaders on every MCP
+// request that flows through the generic gate (ping / list_tools / tools/call).
+// It injects one allowlisted and one non-allowlisted header so the tests can
+// prove both forwarding and AllowedExtraHeaders filtering at the wire.
+type extraHeaderInjectPlugin struct {
+	schemas.MCPPluginNoOpHooks
+}
+
+func (p *extraHeaderInjectPlugin) GetName() string { return "extraHeaderInjectPlugin" }
+func (p *extraHeaderInjectPlugin) Cleanup() error  { return nil }
+
+func (p *extraHeaderInjectPlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest) (*schemas.BifrostMCPRequest, *schemas.MCPPluginShortCircuit, error) {
+	ctx.SetValue(schemas.BifrostContextKeyMCPExtraHeaders, map[string][]string{
+		allowedExtraHeader: {allowedExtraValue},
+		deniedExtraHeader:  {"should-be-filtered"},
+	})
+	return req, nil, nil
+}
+
+// httpExtraHeaderConfig builds an HTTP MCP client config that allowlists only
+// allowedExtraHeader.
+func httpExtraHeaderConfig(clientName, serverURL string) *schemas.MCPClientConfig {
+	return &schemas.MCPClientConfig{
+		ID:                  clientName + "-id",
+		Name:                clientName,
+		ConnectionType:      schemas.MCPConnectionTypeHTTP,
+		ConnectionString:    schemas.NewEnvVar(serverURL),
+		ToolsToExecute:      []string{"*"},
+		AllowedExtraHeaders: schemas.WhiteList{allowedExtraHeader},
+	}
+}
+
+// sseExtraHeaderConfig builds an SSE MCP client config that allowlists only
+// allowedExtraHeader. The connection string targets the SSE event-stream
+// endpoint ("/sse"); the client learns the message endpoint from the stream.
+func sseExtraHeaderConfig(clientName, serverURL string) *schemas.MCPClientConfig {
+	return &schemas.MCPClientConfig{
+		ID:                  clientName + "-id",
+		Name:                clientName,
+		ConnectionType:      schemas.MCPConnectionTypeSSE,
+		ConnectionString:    schemas.NewEnvVar(serverURL + "/sse"),
+		ToolsToExecute:      []string{"*"},
+		AllowedExtraHeaders: schemas.WhiteList{allowedExtraHeader},
+	}
+}
+
+// TestExtraHeadersHealthCheckPingReachWire is the core regression for the bug:
+// a hook-set extra header must ride a bifrost-generated health-check ping onto
+// the wire (the library drops request.Header for ping, so this can only work via
+// the transport headerFunc).
+func TestExtraHeadersHealthCheckPingReachWire(t *testing.T) {
+	t.Parallel()
+
+	ts, rec := buildRecordingHTTPServer(t)
+	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{&extraHeaderInjectPlugin{}})
+
+	cfg := httpExtraHeaderConfig("hc_ping", ts.URL)
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
+
+	// Drive fast health-check pings (the AddClient-owned monitor ticks far too
+	// slowly for a test).
+	monitor := mcp.NewClientHealthMonitor(manager, cfg.ID, 10*time.Millisecond, true, core.NewDefaultLogger(schemas.LogLevelError))
+	monitor.Start()
+	defer monitor.Stop()
+
+	require.Eventually(t, func() bool {
+		return len(rec.valuesForMethod("ping", allowedExtraHeader)) > 0
+	}, 3*time.Second, 10*time.Millisecond, "allowlisted extra header should reach the upstream on a health-check ping")
+
+	vals := rec.valuesForMethod("ping", allowedExtraHeader)
+	require.NotEmpty(t, vals)
+	assert.Equal(t, allowedExtraValue, vals[0], "allowlisted header value should be forwarded verbatim")
+
+	assert.False(t, rec.anyRequestHasHeader(deniedExtraHeader), "non-allowlisted extra header must be filtered out everywhere")
+}
+
+// TestExtraHeadersHealthCheckListToolsReachWire covers the ping-unavailable
+// fallback where list_tools is the liveness probe.
+func TestExtraHeadersHealthCheckListToolsReachWire(t *testing.T) {
+	t.Parallel()
+
+	ts, rec := buildRecordingHTTPServer(t)
+	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{&extraHeaderInjectPlugin{}})
+
+	cfg := httpExtraHeaderConfig("hc_list", ts.URL)
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
+
+	// isPingAvailable=false → health check uses list_tools as the probe.
+	monitor := mcp.NewClientHealthMonitor(manager, cfg.ID, 10*time.Millisecond, false, core.NewDefaultLogger(schemas.LogLevelError))
+	monitor.Start()
+	defer monitor.Stop()
+
+	require.Eventually(t, func() bool {
+		return len(rec.valuesForMethod("tools/list", allowedExtraHeader)) > 0
+	}, 3*time.Second, 10*time.Millisecond, "allowlisted extra header should reach the upstream on a health-check list_tools probe")
+
+	assert.False(t, rec.anyRequestHasHeader(deniedExtraHeader), "non-allowlisted extra header must be filtered out everywhere")
+}
+
+// TestExtraHeadersToolCallReachWire guards the centralization change: removing
+// the per-call CallToolRequest.Header must NOT stop a normal tools/call from
+// forwarding allowlisted extras — they now ride the same transport headerFunc.
+func TestExtraHeadersToolCallReachWire(t *testing.T) {
+	t.Parallel()
+
+	ts, rec := buildRecordingHTTPServer(t)
+	manager, bf := setupBifrostWithPlugins(t, []schemas.MCPPlugin{&extraHeaderInjectPlugin{}})
+
+	cfg := httpExtraHeaderConfig("call_extra", ts.URL)
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
+
+	toolCall := schemas.ChatAssistantMessageToolCall{
+		ID: schemas.Ptr("call-1"),
+		Function: schemas.ChatAssistantMessageToolCallFunction{
+			Name:      schemas.Ptr("call_extra-echo"),
+			Arguments: `{"message":"hi"}`,
+		},
+	}
+	_, bErr := bf.ExecuteChatMCPTool(createTestContext(), &toolCall)
+	require.Nil(t, bErr, "echo tool call should succeed")
+
+	vals := rec.valuesForMethod("tools/call", allowedExtraHeader)
+	require.NotEmpty(t, vals, "allowlisted extra header should reach the upstream on a normal tools/call")
+	assert.Equal(t, allowedExtraValue, vals[0])
+
+	assert.False(t, rec.anyRequestHasHeader(deniedExtraHeader), "non-allowlisted extra header must be filtered out everywhere")
+}
+
+// TestExtraHeadersSSEHealthCheckPingReachWire is the SSE analogue of the ping
+// regression: createSSEConnection registers the same headerFunc, so a hook-set
+// extra header must ride a bifrost-generated health-check ping onto the wire.
+func TestExtraHeadersSSEHealthCheckPingReachWire(t *testing.T) {
+	t.Parallel()
+
+	ts, rec := buildRecordingSSEServer(t)
+	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{&extraHeaderInjectPlugin{}})
+
+	cfg := sseExtraHeaderConfig("sse_hc_ping", ts.URL)
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
+
+	monitor := mcp.NewClientHealthMonitor(manager, cfg.ID, 10*time.Millisecond, true, core.NewDefaultLogger(schemas.LogLevelError))
+	monitor.Start()
+	defer monitor.Stop()
+
+	require.Eventually(t, func() bool {
+		return len(rec.valuesForMethod("ping", allowedExtraHeader)) > 0
+	}, 3*time.Second, 10*time.Millisecond, "allowlisted extra header should reach the SSE upstream on a health-check ping")
+
+	vals := rec.valuesForMethod("ping", allowedExtraHeader)
+	require.NotEmpty(t, vals)
+	assert.Equal(t, allowedExtraValue, vals[0], "allowlisted header value should be forwarded verbatim")
+
+	assert.False(t, rec.anyRequestHasHeader(deniedExtraHeader), "non-allowlisted extra header must be filtered out everywhere")
+}
+
+// TestExtraHeadersSSEHealthCheckListToolsReachWire covers the SSE ping-unavailable
+// fallback where list_tools is the liveness probe.
+func TestExtraHeadersSSEHealthCheckListToolsReachWire(t *testing.T) {
+	t.Parallel()
+
+	ts, rec := buildRecordingSSEServer(t)
+	manager, _ := setupBifrostWithPlugins(t, []schemas.MCPPlugin{&extraHeaderInjectPlugin{}})
+
+	cfg := sseExtraHeaderConfig("sse_hc_list", ts.URL)
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
+
+	monitor := mcp.NewClientHealthMonitor(manager, cfg.ID, 10*time.Millisecond, false, core.NewDefaultLogger(schemas.LogLevelError))
+	monitor.Start()
+	defer monitor.Stop()
+
+	require.Eventually(t, func() bool {
+		return len(rec.valuesForMethod("tools/list", allowedExtraHeader)) > 0
+	}, 3*time.Second, 10*time.Millisecond, "allowlisted extra header should reach the SSE upstream on a health-check list_tools probe")
+
+	assert.False(t, rec.anyRequestHasHeader(deniedExtraHeader), "non-allowlisted extra header must be filtered out everywhere")
+}
+
+// TestExtraHeadersSSEToolCallReachWire guards the SSE side of the centralization
+// change: a normal tools/call must forward allowlisted extras via the transport
+// headerFunc.
+func TestExtraHeadersSSEToolCallReachWire(t *testing.T) {
+	t.Parallel()
+
+	ts, rec := buildRecordingSSEServer(t)
+	manager, bf := setupBifrostWithPlugins(t, []schemas.MCPPlugin{&extraHeaderInjectPlugin{}})
+
+	cfg := sseExtraHeaderConfig("sse_call_extra", ts.URL)
+	require.NoError(t, manager.AddClient(context.Background(), cfg))
+
+	toolCall := schemas.ChatAssistantMessageToolCall{
+		ID: schemas.Ptr("sse-call-1"),
+		Function: schemas.ChatAssistantMessageToolCallFunction{
+			Name:      schemas.Ptr("sse_call_extra-echo"),
+			Arguments: `{"message":"hi"}`,
+		},
+	}
+	_, bErr := bf.ExecuteChatMCPTool(createTestContext(), &toolCall)
+	require.Nil(t, bErr, "echo tool call should succeed")
+
+	vals := rec.valuesForMethod("tools/call", allowedExtraHeader)
+	require.NotEmpty(t, vals, "allowlisted extra header should reach the SSE upstream on a normal tools/call")
+	assert.Equal(t, allowedExtraValue, vals[0])
+
+	assert.False(t, rec.anyRequestHasHeader(deniedExtraHeader), "non-allowlisted extra header must be filtered out everywhere")
+}

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -100,7 +100,15 @@ func (m *MCPManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schem
 			targetURL = *preReq.ConnectionString
 		}
 
-		perUserOpts := []transport.StreamableHTTPCOption{transport.WithHTTPHeaders(finalHeaders)}
+		// finalHeaders (statics + per-user auth) are baked on; allowlisted per-request
+		// extras are injected via headerFunc so they reach tools/call now that the
+		// CallToolRequest.Header path has been centralized onto the transport.
+		perUserOpts := []transport.StreamableHTTPCOption{
+			transport.WithHTTPHeaders(finalHeaders),
+			transport.WithHTTPHeaderFunc(func(reqCtx context.Context) map[string]string {
+				return utils.FlattenHeaders(utils.ExtractFilteredExtras(reqCtx, config))
+			}),
+		}
 		perUserTLSClient, tlsErr := m.buildTLSHTTPClient(config.TLSConfig)
 		if tlsErr != nil {
 			return nil, fmt.Errorf("failed to build TLS HTTP client: %w", tlsErr)
@@ -1650,8 +1658,17 @@ func (m *MCPManager) createHTTPConnection(ctx context.Context, config *schemas.M
 		}
 	}
 
-	// Create StreamableHTTP transport
-	opts := []transport.StreamableHTTPCOption{transport.WithHTTPHeaders(headers)}
+	// Create StreamableHTTP transport. The static headers above are baked onto the
+	// transport once; per-request "extra" headers (BifrostContextKeyMCPExtraHeaders,
+	// allowlisted by AllowedExtraHeaders) are injected per outgoing request via the
+	// headerFunc, which runs for every method — including ping/list_tools, whose
+	// request.Header the mcp-go client otherwise drops.
+	opts := []transport.StreamableHTTPCOption{
+		transport.WithHTTPHeaders(headers),
+		transport.WithHTTPHeaderFunc(func(reqCtx context.Context) map[string]string {
+			return utils.FlattenHeaders(utils.ExtractFilteredExtras(reqCtx, config))
+		}),
+	}
 	httpClient, err := m.buildTLSHTTPClient(config.TLSConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build TLS HTTP client: %w", err)
@@ -1750,7 +1767,13 @@ func (m *MCPManager) createSSEConnection(ctx context.Context, config *schemas.MC
 		}
 	}
 
-	sseOpts := []transport.ClientOption{transport.WithHeaders(headers)}
+	// Per-request extra headers are injected via headerFunc; see createHTTPConnection.
+	sseOpts := []transport.ClientOption{
+		transport.WithHeaders(headers),
+		transport.WithHeaderFunc(func(reqCtx context.Context) map[string]string {
+			return utils.FlattenHeaders(utils.ExtractFilteredExtras(reqCtx, config))
+		}),
+	}
 	sseHTTPClient, err := m.buildTLSHTTPClient(config.TLSConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build TLS HTTP client: %w", err)

--- a/core/mcp/codemode/starlark/executecode.go
+++ b/core/mcp/codemode/starlark/executecode.go
@@ -478,11 +478,6 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 	}
 	defer release()
 
-	reqHeaders, err := s.credStore.RequestHeaders(nestedCtx, client.ExecutionConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	toolExecutionTimeout := s.getToolExecutionTimeout()
 
 	// Delegate to the canonical plugin gate. RunWithPluginPipeline owns the
@@ -519,6 +514,10 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 		toolCtx, cancel := context.WithTimeout(nestedCtx, toolExecutionTimeout)
 		defer cancel()
 
+		// Per-request extra headers (BifrostContextKeyMCPExtraHeaders) are injected
+		// uniformly by the transport headerFunc (see createHTTPConnection /
+		// createSSEConnection / AcquireClientConn), so no per-call Header is set here.
+		// Keeps nested codemode calls on the same single header path as the gateway.
 		callRequest := mcp.CallToolRequest{
 			Request: mcp.Request{
 				Method: string(mcp.MethodToolsCall),
@@ -527,7 +526,6 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 				Name:      effectiveToolName,
 				Arguments: effectiveArgs,
 			},
-			Header: reqHeaders,
 		}
 
 		toolResponse, callErr := conn.CallTool(toolCtx, callRequest)

--- a/core/mcp/pluginpipeline.go
+++ b/core/mcp/pluginpipeline.go
@@ -364,7 +364,11 @@ func (m *MCPManager) runListToolsWithHooks(ctx context.Context, conn *client.Cli
 	start := time.Now()
 
 	resp, bErr := m.RunWithPluginPipeline(gateCtx, req, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
-		detailed, opErr := retrieveExternalToolsDetailed(ctx, conn, clientName, m.logger)
+		// Use gateCtx (not the outer ctx) so values a PreMCPHook wrote during the
+		// gate — notably BifrostContextKeyMCPExtraHeaders — are visible to the wire
+		// call. BifrostContext.Value walks parent-ward only, so the outer ctx cannot
+		// see writes made to its gateCtx child.
+		detailed, opErr := retrieveExternalToolsDetailed(gateCtx, conn, clientName, m.logger)
 		if opErr != nil {
 			return nil, opErr
 		}
@@ -405,7 +409,9 @@ func (chm *ClientHealthMonitor) runPingWithHooks(ctx context.Context, conn *clie
 	gateCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 	start := time.Now()
 	_, bErr := chm.manager.RunWithPluginPipeline(gateCtx, req, func(preReq *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
-		if pingErr := conn.Ping(ctx); pingErr != nil {
+		// Use gateCtx so a PreMCPHook's context writes (e.g. BifrostContextKeyMCPExtraHeaders)
+		// reach the transport headerFunc on this ping. See runListToolsWithHooks for details.
+		if pingErr := conn.Ping(gateCtx); pingErr != nil {
 			return nil, pingErr
 		}
 		return &schemas.BifrostMCPResponse{

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -681,11 +681,10 @@ func (m *ToolsManager) executeToolInternal(
 
 	// The connection (shared persistent OR ephemeral per-call) is supplied by
 	// the caller via AcquireClientConn. Admin-level credentials live on the
-	// transport; per-call request carries filtered context-extras only.
-	reqHeaders, err := m.credStore.RequestHeaders(ctx, executionConfig)
-	if err != nil {
-		return nil, "", "", err
-	}
+	// transport; per-request filtered context-extras are injected uniformly by the
+	// transport headerFunc (see createHTTPConnection/createSSEConnection), so no
+	// per-call Header is set here — that keeps ping/list_tools and tools/call on a
+	// single header path.
 	callRequest := mcp.CallToolRequest{
 		Request: mcp.Request{
 			Method: string(mcp.MethodToolsCall),
@@ -694,7 +693,6 @@ func (m *ToolsManager) executeToolInternal(
 			Name:      originalMCPToolName,
 			Arguments: arguments,
 		},
-		Header: reqHeaders,
 	}
 
 	toolResponse, callErr := clientConn.CallTool(toolCtx, callRequest)

--- a/core/mcp/utils/utils.go
+++ b/core/mcp/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -167,7 +168,7 @@ func CanonicalizeHeaderMap(m map[string]string) map[string]string {
 // those live on the upstream transport via StaticConfigHeaders and apply
 // automatically to every message it carries. This function exists for the
 // per-message CredentialStore.RequestHeaders path on shared connections.
-func ExtractFilteredExtras(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) http.Header {
+func ExtractFilteredExtras(ctx context.Context, config *schemas.MCPClientConfig) http.Header {
 	headers := make(http.Header)
 	if ctx == nil || config == nil {
 		return headers


### PR DESCRIPTION
## Summary

Per-request extra headers set via `BifrostContextKeyMCPExtraHeaders` in a `PreMCPHook` were not reaching the upstream MCP server for health-check probes (`ping` and `tools/list`). The `mcp-go` client drops `request.Header` for these internally-generated calls, so headers injected at the `CallToolRequest` level were silently lost. This PR centralizes all per-request extra header injection onto the transport layer via `WithHTTPHeaderFunc` / `WithHeaderFunc`, ensuring headers flow on every outgoing message — including `ping`, `tools/list`, and `tools/call` — while still being filtered by `AllowedExtraHeaders`.

## Changes

- Registered a `headerFunc` on the `StreamableHTTP` and `SSE` transports (in `createHTTPConnection`, `createSSEConnection`, and `AcquireClientConn`) that reads `BifrostContextKeyMCPExtraHeaders` from the request context and injects only allowlisted headers per `MCPClientConfig.AllowedExtraHeaders`. This replaces the previous per-call `CallToolRequest.Header` approach.
- Removed `credStore.RequestHeaders` calls and `CallToolRequest.Header` assignments from `executeToolInternal` (tool manager) and `callMCPTool` (Starlark code mode), since header injection is now handled uniformly by the transport.
- Fixed `runListToolsWithHooks` and `runPingWithHooks` to pass `gateCtx` (the child context that carries `PreMCPHook` writes) instead of the outer `ctx` to the wire calls, so transport `headerFunc` can see values written during the plugin gate.
- Relaxed `ExtractFilteredExtras` to accept a plain `context.Context` instead of `*schemas.BifrostContext`, enabling it to be called from the transport `headerFunc` closure.
- Added end-to-end wire-level tests (`extraheaders_test.go`) using a real `httptest` streamable-HTTP server that records inbound headers per JSON-RPC method, covering: allowlisted headers reaching `ping`, `tools/list`, and `tools/call`; and non-allowlisted headers being filtered on all requests.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/internal/mcptests/... -run TestExtraHeaders -v
go test ./...
```

The three new tests validate:
- `TestExtraHeadersHealthCheckPingReachWire` — allowlisted header appears on `ping` probes; non-allowlisted header never appears on any request.
- `TestExtraHeadersHealthCheckListToolsReachWire` — same guarantee for `tools/list` health-check probes when ping is unavailable.
- `TestExtraHeadersToolCallReachWire` — allowlisted header appears on a normal `tools/call`; non-allowlisted header is filtered.

## Breaking changes

- [x] No

The `CallToolRequest.Header` field is no longer populated by Bifrost internals, but this is an internal implementation detail with no public API impact. Header forwarding behavior is preserved (and extended to health-check probes).

## Security considerations

`AllowedExtraHeaders` filtering is now enforced at the transport layer for all outgoing MCP requests. Non-allowlisted headers set by plugins are dropped before reaching the wire on every request type, including health-check probes that previously bypassed the per-call header path entirely.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable