### PR TITLE
adds bill accounting for failed requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1756,6 +1756,7 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		printf '  %-18s %s\n' "INCLUDE_SKIP=1"   "Run [SKIP]-tagged criss-cross cells (provider+modality pairs that return NewUnsupportedOperationError by design, e.g., anthropic embeddings, bedrock audio). Off by default."; \
 		printf '  %-18s %s\n' "PARALLEL=0"       "Disable per-provider parallelism (default: ON). When ON, forks one newman per provider (openai, anthropic, bedrock, gemini, vertex, azure) concurrently; reports merged into tmp/newman-report.json. The htmlextra report is only emitted in sequential mode (PARALLEL=0)."; \
 		printf '  %-18s %s\n' "SKIP_STREAM_CANCEL=1" "Skip the post-Newman stream-abort probes that verify server-side cancellation on client disconnect."; \
+		printf '  %-18s %s\n' "DB_VERIFY=0"      "Disable the dbverify reporter (ON by default). When on, [Costing]/[Accounting] requests assert the logs DB cost matches the getbifrost.ai/datasheet-computed cost (resolves DB from APP_DIR/config.json or BIFROST_LOGS_DB_URL); skips gracefully if no logs DB is reachable."; \
 		printf '  %-18s %s\n' "USE_INFISICAL=1" "Source secrets from Infisical CLI ('infisical export --path /local --format dotenv') instead of .env."; \
 		printf '  %-18s %s\n' "VERTEX_GCS_BUCKET" "Env-sourced (.env/Infisical): GCS bucket for Vertex file ops (forwarded to Newman as vertexGcsBucket)."; \
 		printf '  %-18s %s\n' "VERTEX_GCS_PREFIX" "Env-sourced: GCS object prefix for Vertex file ops (forwarded as vertexGcsPrefix)."; \
@@ -1805,6 +1806,27 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 	BASE_URL_VAL="$(or $(BASE_URL),http://localhost:8080)"; \
 	APP_DIR_VAL="$(or $(APP_DIR),tests/integrations/python)"; \
 	VIEWER_PORT_VAL="$(or $(VIEWER_PORT),8090)"; \
+	DBVERIFY_REPORTER=""; DBVERIFY_ARGS=""; DBVERIFY_READY=0; \
+	if [ "$(DB_VERIFY)" != "0" ]; then \
+		if [ -d tests/e2e/api/node_modules ] && npm --prefix tests/e2e/api ls --depth=0 >/dev/null 2>&1; then \
+			DBVERIFY_READY=1; \
+		else \
+			$(ECHO) "$(YELLOW)Installing dbverify reporter deps...$(NC)"; \
+			if (cd tests/e2e/api && npm install --silent); then \
+				DBVERIFY_READY=1; \
+			else \
+				$(ECHO) "$(YELLOW)dbverify dep install failed; cost checks disabled for this run (set DB_VERIFY=0 to silence)$(NC)"; \
+			fi; \
+		fi; \
+		if [ "$$DBVERIFY_READY" = "1" ]; then \
+			export NODE_PATH="$(CURDIR)/tests/e2e/api/node_modules$${NODE_PATH:+:$$NODE_PATH}"; \
+			DBVERIFY_REPORTER=",dbverify"; \
+			LOGS_DB_VAL="$${BIFROST_LOGS_DB_URL:-sqlite://$(CURDIR)/$$APP_DIR_VAL/logs.db}"; \
+			export BIFROST_LOGS_DB_URL="$$LOGS_DB_VAL"; \
+			DBVERIFY_ARGS="--reporter-dbverify-config $$APP_DIR_VAL/config.json"; \
+			$(ECHO) "$(CYAN)dbverify reporter enabled (logs DB: $$LOGS_DB_VAL). Set DB_VERIFY=0 to disable.$(NC)"; \
+		fi; \
+	fi; \
 	STARTED_BY_US=0; \
 	cleanup() { \
 		if [ -f tmp/harness-monitor.pid ]; then \
@@ -1931,7 +1953,7 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 					$${VERTEX_GCS_PREFIX:+--env-var "vertexGcsPrefix=$$VERTEX_GCS_PREFIX"} \
 					$(if $(ENV_FILE),--environment $(ENV_FILE),) \
 					$(if $(FOLDER),--folder "$(FOLDER)",) \
-					--reporters cli,json \
+					--reporters cli,json$$DBVERIFY_REPORTER $$DBVERIFY_ARGS \
 					--reporter-json-export "tmp/newman-report-$$p.json" 2>&1 | sed "s/^/[$$p] /" \
 			) > "tmp/newman-cli-$$p.log" 2>&1 & \
 			BG_PID=$$!; \
@@ -2014,7 +2036,7 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 				$${VERTEX_GCS_PREFIX:+--env-var "vertexGcsPrefix=$$VERTEX_GCS_PREFIX"} \
 				$(if $(ENV_FILE),--environment $(ENV_FILE),) \
 				$(if $(FOLDER),--folder "$(FOLDER)",) \
-				--reporters cli,json,htmlextra \
+				--reporters cli,json,htmlextra$$DBVERIFY_REPORTER $$DBVERIFY_ARGS \
 				--reporter-json-export tmp/newman-report.json \
 				--reporter-htmlextra-export tmp/newman-report.html \
 				--reporter-htmlextra-title "Bifrost Provider Harness" \
@@ -2038,7 +2060,7 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 				$${VERTEX_GCS_PREFIX:+--env-var "vertexGcsPrefix=$$VERTEX_GCS_PREFIX"} \
 				$(if $(ENV_FILE),--environment $(ENV_FILE),) \
 				$(if $(FOLDER),--folder "$(FOLDER)",) \
-				--reporters cli,json,htmlextra \
+				--reporters cli,json,htmlextra$$DBVERIFY_REPORTER $$DBVERIFY_ARGS \
 				--reporter-json-export tmp/newman-report.json \
 				--reporter-htmlextra-export tmp/newman-report.html \
 				--reporter-htmlextra-title "Bifrost Provider Harness" \

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3702,6 +3702,7 @@ func (bifrost *Bifrost) GetAvailableMCPTools(ctx *schemas.BifrostContext) []sche
 //	    ConnectionType: schemas.MCPConnectionTypeHTTP,
 //	    ConnectionString: &url,
 //	})
+//
 // ConnectConfiguredMCPClients dials the MCP clients supplied to Init. Construction
 // no longer auto-connects, so callers invoke this after all plugins are registered
 // (so every PreMCPConnectionHook participates in the connection). No-op if MCP is
@@ -6414,6 +6415,10 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			case <-req.Context.Done():
 				// Client no longer listening, log and continue
 				bifrost.logger.Debug("Client context cancelled while sending error response")
+				// The provider already produced this error (possibly after
+				// processing input tokens). tryRequest returned on ctx.Done and will
+				// never receive it, so bill/log it here. Non-streaming only.
+				bifrost.billAbandonedTerminal(req, nil, bifrostError)
 			case <-time.After(5 * time.Second):
 				// Timeout to prevent indefinite blocking
 				bifrost.logger.Warn("Timeout while sending error response, client may have disconnected")
@@ -6443,6 +6448,10 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				case <-req.Context.Done():
 					// Client no longer listening, log and continue
 					bifrost.logger.Debug("Client context cancelled while sending response")
+					// The provider already produced this non-streaming result
+					// (consuming tokens). tryRequest returned on ctx.Done and will never
+					// receive it, so bill/log it here.
+					bifrost.billAbandonedTerminal(req, result, nil)
 				case <-time.After(5 * time.Second):
 					// Timeout to prevent indefinite blocking
 					bifrost.logger.Warn("Timeout while sending response, client may have disconnected")
@@ -6452,6 +6461,32 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 	}
 
 	// bifrost.logger.Debug("worker for provider %s exiting...", provider.GetProviderKey())
+}
+
+// billAbandonedTerminal runs terminal post-LLM hooks for a NON-STREAMING request
+// whose client stopped waiting (tryRequest returned on ctx.Done) after the
+// provider had already produced a result or error. Without this, tokens the
+// provider consumed are never billed or logged (non-streaming
+// cancellation). Safety:
+//   - The channel rendezvous guarantees tryRequest did NOT also receive this
+//     value (a value cannot be both delivered and land in the no-receiver
+//     ctx.Done branch), so post-hooks never run twice for one call.
+//   - The governance tracker additionally dedupes on RequestID+attempt.
+//   - Streaming requests are excluded: their provider goroutine already runs
+//     terminal post-hooks via HandleStreamCancellation.
+func (bifrost *Bifrost) billAbandonedTerminal(req *ChannelMessage, result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) {
+	if req == nil || req.Context == nil || IsStreamRequestType(req.RequestType) {
+		return
+	}
+	pipeline := bifrost.getPluginPipeline()
+	defer bifrost.releasePluginPipeline(pipeline)
+	pluginCount := len(*bifrost.llmPlugins.Load())
+	if bifrostErr != nil {
+		_, _ = pipeline.RunPostLLMHooks(req.Context, nil, bifrostErr, pluginCount)
+	} else if result != nil {
+		_, _ = pipeline.RunPostLLMHooks(req.Context, result, nil, pluginCount)
+	}
+	drainAndAttachPluginLogs(req.Context)
 }
 
 // handleProviderRequest handles the request to the provider based on the request type

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -584,6 +584,20 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 	)
 }
 
+// normalizeCachedUsage folds the accumulated cached read/write token counts into
+// the top-level prompt and total counters. Anthropic reports these per-request
+// totals only after the full stream, so the streaming accumulator must apply the
+// same fold before billing - including on a mid-stream cancel/timeout. The += is
+// not idempotent; callers guard with a flag to apply it exactly once.
+func normalizeCachedUsage(usage *schemas.BifrostLLMUsage) {
+	if usage == nil || usage.PromptTokensDetails == nil {
+		return
+	}
+	cached := usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
+	usage.PromptTokens += cached
+	usage.TotalTokens += cached
+}
+
 // HandleAnthropicChatCompletionStreaming handles streaming for Anthropic-compatible APIs.
 // This shared function reduces code duplication between providers that use the same SSE event format.
 func HandleAnthropicChatCompletionStreaming(
@@ -722,6 +736,29 @@ func HandleAnthropicChatCompletionStreaming(
 		var finishReason *string
 
 		usage := &schemas.BifrostLLMUsage{}
+		// Register the accumulating usage handle so a mid-stream cancel/timeout
+		// can bill for tokens already processed Mutated in place below;
+		// the deferred HandleStreamCancellation/Timeout reads it from context.
+		ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, usage)
+
+		// Fold cached tokens into prompt/total exactly once at stream end. The EOF
+		// path calls normalizeUsage() after the loop; on a mid-stream cancel/timeout
+		// the deferred call below runs first (LIFO, registered after the cancellation
+		// handler at the top of the goroutine) so HandleStreamCancellation/Timeout
+		// bills the normalized totals.
+		usageNormalized := false
+		normalizeUsage := func() {
+			if usageNormalized {
+				return
+			}
+			usageNormalized = true
+			normalizeCachedUsage(usage)
+		}
+		defer func() {
+			if ctx.Err() != nil {
+				normalizeUsage()
+			}
+		}()
 
 		// Check for structured output tool name and track state
 		var structuredOutputToolName string
@@ -924,10 +961,7 @@ func HandleAnthropicChatCompletionStreaming(
 				break
 			}
 		}
-		if usage.PromptTokensDetails != nil {
-			usage.PromptTokens = usage.PromptTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
-			usage.TotalTokens = usage.TotalTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
-		}
+		normalizeUsage()
 		response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, modelName, 0)
 		if postResponseConverter != nil {
 			response = postResponseConverter(response)

--- a/core/providers/anthropic/cancelbilling_test.go
+++ b/core/providers/anthropic/cancelbilling_test.go
@@ -1,0 +1,45 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// normalizeCachedUsage must fold cached read/write tokens into the top-level
+// prompt + total counters, matching the per-request totals Anthropic reports
+// only at the end of a stream. This is the value billed when a stream is
+// cancelled mid-flight.
+func TestNormalizeCachedUsage_FoldsCacheIntoPromptAndTotal(t *testing.T) {
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      15,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedReadTokens:  3,
+			CachedWriteTokens: 7,
+		},
+	}
+	normalizeCachedUsage(usage)
+	if usage.PromptTokens != 20 {
+		t.Fatalf("PromptTokens = %d, want 20 (10 + 3 + 7)", usage.PromptTokens)
+	}
+	if usage.TotalTokens != 25 {
+		t.Fatalf("TotalTokens = %d, want 25 (15 + 3 + 7)", usage.TotalTokens)
+	}
+	if usage.CompletionTokens != 5 {
+		t.Fatalf("CompletionTokens = %d, want 5 (unchanged)", usage.CompletionTokens)
+	}
+}
+
+func TestNormalizeCachedUsage_NoCacheDetailsIsNoOp(t *testing.T) {
+	usage := &schemas.BifrostLLMUsage{PromptTokens: 10, TotalTokens: 15}
+	normalizeCachedUsage(usage)
+	if usage.PromptTokens != 10 || usage.TotalTokens != 15 {
+		t.Fatalf("unexpected mutation: prompt=%d total=%d", usage.PromptTokens, usage.TotalTokens)
+	}
+}
+
+func TestNormalizeCachedUsage_NilSafe(t *testing.T) {
+	normalizeCachedUsage(nil) // must not panic
+}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1145,6 +1145,18 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	return bifrostResponse, nil
 }
 
+// normalizeCachedUsage folds the accumulated cached read/write token counts into
+// PromptTokens. Bedrock reports TotalTokens directly on the stream, so only the
+// prompt counter needs the fold. The accumulator must apply it before billing -
+// including on a mid-stream cancel/timeout. The += is not idempotent; callers
+// guard with a flag to apply it exactly once.
+func normalizeCachedUsage(usage *schemas.BifrostLLMUsage) {
+	if usage == nil || usage.PromptTokensDetails == nil {
+		return
+	}
+	usage.PromptTokens += usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
+}
+
 // ChatCompletionStream performs a streaming chat completion request to Bedrock's API.
 // It formats the request, sends it to Bedrock, and processes the streaming response.
 // Returns a channel for streaming BifrostStreamChunk objects or an error if the request fails.
@@ -1202,6 +1214,28 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 
 		// Process AWS Event Stream format
 		usage := &schemas.BifrostLLMUsage{}
+		// Register the accumulating usage handle so a mid-stream
+		// cancel/timeout can bill for tokens the provider already processed.
+		ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, usage)
+
+		// Fold cached tokens into PromptTokens exactly once at stream end. The EOF
+		// path calls normalizeUsage() after the loop; on a mid-stream cancel/timeout
+		// the deferred call below runs first (LIFO, registered after the cancellation
+		// handler at the top of the goroutine) so HandleStreamCancellation/Timeout
+		// bills the normalized totals.
+		usageNormalized := false
+		normalizeUsage := func() {
+			if usageNormalized {
+				return
+			}
+			usageNormalized = true
+			normalizeCachedUsage(usage)
+		}
+		defer func() {
+			if ctx.Err() != nil {
+				normalizeUsage()
+			}
+		}()
 		var finishReason *string
 		chunkIndex := 0
 
@@ -1435,9 +1469,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 			}
 		}
 
-		if usage.PromptTokensDetails != nil {
-			usage.PromptTokens = usage.PromptTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
-		}
+		normalizeUsage()
 
 		// Send final response
 		response := providerUtils.CreateBifrostChatCompletionChunkResponse(id, usage, finishReason, chunkIndex, request.Model, 0)

--- a/core/providers/bedrock/cancelbilling_test.go
+++ b/core/providers/bedrock/cancelbilling_test.go
@@ -1,0 +1,41 @@
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// normalizeCachedUsage must fold cached read/write tokens into PromptTokens only.
+// Bedrock's stream reports TotalTokens directly, so the total must NOT be
+// re-summed here. This is the value billed when a stream is cancelled mid-flight.
+func TestNormalizeCachedUsage_FoldsCacheIntoPromptOnly(t *testing.T) {
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      18, // provider-reported, already includes cache
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedReadTokens:  3,
+			CachedWriteTokens: 7,
+		},
+	}
+	normalizeCachedUsage(usage)
+	if usage.PromptTokens != 20 {
+		t.Fatalf("PromptTokens = %d, want 20 (10 + 3 + 7)", usage.PromptTokens)
+	}
+	if usage.TotalTokens != 18 {
+		t.Fatalf("TotalTokens = %d, want 18 (provider-reported, unchanged)", usage.TotalTokens)
+	}
+}
+
+func TestNormalizeCachedUsage_NoCacheDetailsIsNoOp(t *testing.T) {
+	usage := &schemas.BifrostLLMUsage{PromptTokens: 10, TotalTokens: 15}
+	normalizeCachedUsage(usage)
+	if usage.PromptTokens != 10 || usage.TotalTokens != 15 {
+		t.Fatalf("unexpected mutation: prompt=%d total=%d", usage.PromptTokens, usage.TotalTokens)
+	}
+}
+
+func TestNormalizeCachedUsage_NilSafe(t *testing.T) {
+	normalizeCachedUsage(nil) // must not panic
+}

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -530,6 +530,13 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 
 		var responseID string
 
+		// Running usage handle so a cancel/timeout can bill for tokens
+		// already processed. Cohere only reports usage at message-end, so a true
+		// mid-stream cancel captures nothing (the API emits no incremental usage);
+		// this still bills correctly when usage has arrived before teardown.
+		streamUsage := &schemas.BifrostLLMUsage{}
+		ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, streamUsage)
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -572,6 +579,10 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			}
 			if response != nil {
 				response.ID = responseID
+				// keep the running usage handle current.
+				if response.Usage != nil {
+					*streamUsage = *response.Usage
+				}
 				response.ExtraFields = schemas.BifrostResponseExtraFields{
 					ChunkIndex: chunkIndex,
 					Latency:    time.Since(lastChunkTime).Milliseconds(),

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -519,6 +519,12 @@ func HandleGeminiChatCompletionStream(
 
 		streamState := NewGeminiStreamState()
 
+		// Running usage handle so a mid-stream cancel/timeout can bill for
+		// tokens already processed. Gemini's usageMetadata is cumulative, so the
+		// latest non-nil copy below is the running total.
+		streamUsage := &schemas.BifrostLLMUsage{}
+		ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, streamUsage)
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -587,6 +593,10 @@ func HandleGeminiChatCompletionStream(
 				response.ID = responseID
 				if modelName != "" {
 					response.Model = modelName
+				}
+				// keep the running usage handle current (cumulative).
+				if response.Usage != nil {
+					*streamUsage = *response.Usage
 				}
 				response.ExtraFields = schemas.BifrostResponseExtraFields{
 					ChunkIndex: chunkIndex,
@@ -1028,6 +1038,11 @@ func HandleGeminiResponsesStream(
 
 		var lastUsageMetadata *GenerateContentResponseUsageMetadata
 
+		// Running usage handle so a mid-stream cancel/timeout can bill for
+		// tokens already processed. Gemini's usageMetadata is cumulative.
+		streamUsage := &schemas.BifrostLLMUsage{}
+		ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, streamUsage)
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -1079,6 +1094,10 @@ func HandleGeminiResponsesStream(
 			// Track usage metadata from the latest chunk
 			if geminiResponse.UsageMetadata != nil {
 				lastUsageMetadata = geminiResponse.UsageMetadata
+				// keep the running usage handle current (cumulative).
+				if converted := ConvertGeminiUsageMetadataToChatUsage(lastUsageMetadata); converted != nil {
+					*streamUsage = *converted
+				}
 			}
 
 			// Convert to Bifrost responses stream response

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -569,6 +569,9 @@ func HandleOpenAITextCompletionStreaming(
 
 		chunkIndex := -1
 		usage := &schemas.BifrostLLMUsage{}
+		// Register the accumulating usage handle so a mid-stream
+		// cancel/timeout can bill for tokens the provider already processed.
+		ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, usage)
 
 		var finishReason *string
 		var messageID string
@@ -1113,6 +1116,9 @@ func HandleOpenAIChatCompletionStreaming(
 
 		chunkIndex := -1
 		usage := &schemas.BifrostLLMUsage{}
+		// Register the accumulating usage handle so a mid-stream
+		// cancel/timeout can bill for tokens the provider already processed.
+		ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, usage)
 
 		lastChunkTime := startTime
 

--- a/core/providers/utils/stream_test.go
+++ b/core/providers/utils/stream_test.go
@@ -229,6 +229,71 @@ func TestCheckFirstStreamChunk_CtxCancelUnblocksWrapper(t *testing.T) {
 	}
 }
 
+func TestAttachBilledUsageFromContext_KeepsUsageWithOnlyDetails(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	usage := &schemas.BifrostLLMUsage{
+		// top-level counters all zero, but cache details are present
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{CachedReadTokens: 5},
+	}
+	ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, usage)
+
+	bifrostErr := &schemas.BifrostError{}
+	attachBilledUsageFromContext(ctx, bifrostErr)
+
+	if bifrostErr.ExtraFields.BilledUsage == nil {
+		t.Fatal("BilledUsage should be attached when cache details are present")
+	}
+	if bifrostErr.ExtraFields.BilledUsage.PromptTokensDetails == nil ||
+		bifrostErr.ExtraFields.BilledUsage.PromptTokensDetails.CachedReadTokens != 5 {
+		t.Fatalf("cached read tokens not preserved: %+v", bifrostErr.ExtraFields.BilledUsage)
+	}
+}
+
+func TestAttachBilledUsageFromContext_CopiesUsage(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens: 10,
+		TotalTokens:  10,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedReadTokens: 3,
+			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens5m: 4,
+			},
+		},
+	}
+	ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, usage)
+
+	bifrostErr := &schemas.BifrostError{}
+	attachBilledUsageFromContext(ctx, bifrostErr)
+
+	// Mutating the original (top-level AND nested pointers) must not change the
+	// billed snapshot - BilledUsage is meant to be a fully decoupled record.
+	usage.PromptTokens = 999
+	usage.PromptTokensDetails.CachedReadTokens = 999
+	usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = 999
+
+	billed := bifrostErr.ExtraFields.BilledUsage
+	if billed.PromptTokens != 10 {
+		t.Fatalf("BilledUsage aliases the context handle: got %d, want 10", billed.PromptTokens)
+	}
+	if billed.PromptTokensDetails.CachedReadTokens != 3 {
+		t.Fatalf("BilledUsage aliases nested details: got %d, want 3", billed.PromptTokensDetails.CachedReadTokens)
+	}
+	if billed.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m != 4 {
+		t.Fatalf("BilledUsage aliases deeply-nested details: got %d, want 4", billed.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m)
+	}
+}
+
+func TestAttachBilledUsageFromContext_NoOpWhenEmpty(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, &schemas.BifrostLLMUsage{})
+	bifrostErr := &schemas.BifrostError{}
+	attachBilledUsageFromContext(ctx, bifrostErr)
+	if bifrostErr.ExtraFields.BilledUsage != nil {
+		t.Fatal("BilledUsage should stay nil when nothing measurable accumulated")
+	}
+}
+
 func TestCheckFirstStreamChunk_CodeOnlyError(t *testing.T) {
 	// Error with code but no message should be treated as an error
 	stream := make(chan *schemas.BifrostStreamChunk, 2)

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2408,8 +2408,57 @@ func HandleStreamCancellation(
 		cancelErr.ExtraFields.RawRequest = compactRawJSON(jsonBody)
 	}
 
+	// Bill for tokens the provider already processed before the client
+	// disconnected.
+	attachBilledUsageFromContext(ctx, cancelErr)
+
 	// Send through PostHook chain - this updates the log to "error" status
 	ProcessAndSendBifrostError(ctx, postHookRunner, cancelErr, responseChan, logger, postHookSpanFinalizer)
+}
+
+// attachBilledUsageFromContext copies a streaming provider's in-place
+// accumulated usage handle (BifrostContextKeyStreamAccumulatedUsage), if any,
+// onto the error's BilledUsage so downstream post-hooks (governance billing,
+// logging cost) can charge for tokens the provider already processed before the
+// stream was cancelled or timed out. No-op when nothing measurable was
+// accumulated, so failures that consumed no tokens bill nothing.
+func attachBilledUsageFromContext(ctx *schemas.BifrostContext, bifrostErr *schemas.BifrostError) {
+	if ctx == nil || bifrostErr == nil {
+		return
+	}
+	usage, ok := ctx.Value(schemas.BifrostContextKeyStreamAccumulatedUsage).(*schemas.BifrostLLMUsage)
+	if !ok || usage == nil {
+		return
+	}
+	if usage.PromptTokens == 0 &&
+		usage.CompletionTokens == 0 &&
+		usage.TotalTokens == 0 &&
+		usage.PromptTokensDetails == nil &&
+		usage.CompletionTokensDetails == nil &&
+		usage.Cost == nil {
+		return
+	}
+	// Snapshot the handle so the billed usage is fully decoupled from the
+	// in-context accumulator, which may still be mutated by the provider
+	// goroutine. A shallow copy leaves nested pointers aliased, so clone them too.
+	usageCopy := *usage
+	if usage.PromptTokensDetails != nil {
+		promptDetailsCopy := *usage.PromptTokensDetails
+		if usage.PromptTokensDetails.CachedWriteTokenDetails != nil {
+			cachedWriteDetailsCopy := *usage.PromptTokensDetails.CachedWriteTokenDetails
+			promptDetailsCopy.CachedWriteTokenDetails = &cachedWriteDetailsCopy
+		}
+		usageCopy.PromptTokensDetails = &promptDetailsCopy
+	}
+	if usage.CompletionTokensDetails != nil {
+		completionDetailsCopy := *usage.CompletionTokensDetails
+		usageCopy.CompletionTokensDetails = &completionDetailsCopy
+	}
+	if usage.Cost != nil {
+		costCopy := *usage.Cost
+		usageCopy.Cost = &costCopy
+	}
+	bifrostErr.ExtraFields.BilledUsage = &usageCopy
 }
 
 // HandleStreamTimeout should be called when a streaming goroutine exits
@@ -2446,6 +2495,9 @@ func HandleStreamTimeout(
 	if ShouldSendBackRawRequest(ctx, false) && len(jsonBody) > 0 {
 		timeoutErr.ExtraFields.RawRequest = compactRawJSON(jsonBody)
 	}
+
+	// Bill for tokens the provider already processed before the deadline.
+	attachBilledUsageFromContext(ctx, timeoutErr)
 
 	// Send through PostHook chain - this updates the log to "error" status
 	ProcessAndSendBifrostError(ctx, postHookRunner, timeoutErr, responseChan, logger, postHookSpanFinalizer)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -328,6 +328,7 @@ const (
 	BifrostContextKeyLargeResponseThreshold              BifrostContextKey = "bifrost-large-response-threshold"           // int64 (set by enterprise - DO NOT SET THIS MANUALLY)) threshold for response streaming
 	BifrostContextKeyLargePayloadPrefetchSize            BifrostContextKey = "bifrost-large-payload-prefetch-size"        // int (set by enterprise - DO NOT SET THIS MANUALLY)) prefetch buffer size for metadata extraction from large responses
 	BifrostContextKeyDeferredUsage                       BifrostContextKey = "bifrost-deferred-usage"                     // chan *BifrostLLMUsage (set by provider Phase B — delivers usage after response streaming completes)
+	BifrostContextKeyStreamAccumulatedUsage              BifrostContextKey = "bifrost-stream-accumulated-usage"           // *BifrostLLMUsage handle, set ONCE by a streaming provider and mutated in place as usage arrives; read on cancel/timeout to bill partial usage that the provider already consumed
 	BifrostContextKeyDeferredLargePayloadMetadata        BifrostContextKey = "bifrost-deferred-large-payload-metadata"    // <-chan *LargePayloadMetadata (set by enterprise Phase B request — delivers metadata after body streaming)
 	BifrostContextKeySSEReaderFactory                    BifrostContextKey = "bifrost-sse-reader-factory"                 // *providerUtils.SSEReaderFactory (set by enterprise — replaces default bufio.Scanner SSE readers with streaming readers)
 	BifrostContextKeySessionID                           BifrostContextKey = "bifrost-session-id"                         // string session ID for the request (session stickiness)
@@ -1866,4 +1867,12 @@ type BifrostErrorExtraFields struct {
 	DroppedCompatPluginParams []string              `json:"dropped_compat_plugin_params,omitempty"`
 	KeyStatuses               []KeyStatus           `json:"key_statuses,omitempty"`
 	MCPAuthRequired           *MCPAuthRequiredError `json:"mcp_auth_required,omitempty"` // Set when a per-user MCP tool requires the caller to complete an inline auth flow (OAuth or headers)
+	// BilledUsage carries provider-reported token usage that was consumed even
+	// though the request ultimately failed or was cancelled (e.g. a stream
+	// aborted mid-response, or a 5xx returned after input tokens were
+	// processed). Providers populate it on cancel/error paths so downstream
+	// post-LLM hooks (governance billing, logging cost) can charge for tokens
+	// the provider actually billed us for. Nil when the failure consumed no
+	// tokens (e.g. 401/403/429 before the model ran).
+	BilledUsage *BifrostLLMUsage `json:"billed_usage,omitempty"`
 }

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -33,6 +33,36 @@ func (s *Store) CalculateCost(result *schemas.BifrostResponse, scopes *LookupSco
 	return s.calculateBaseCost(result, lookupScopes)
 }
 
+// CalculateCostForUsage computes the dollar cost from a bare usage object plus
+// provider / model / request type, for cases where no full BifrostResponse
+// exists. The primary use is billing partial usage carried on a failed or
+// cancelled request via BifrostError.ExtraFields.BilledUsage: the
+// provider consumed tokens, so we must charge for them even though there is no
+// success response to read. It mirrors CalculateCost's compute path so success
+// and failure billing use identical rates. Returns 0 when usage is nil.
+func (s *Store) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *LookupScopes) float64 {
+	if usage == nil {
+		return 0
+	}
+
+	var lookupScopes LookupScopes
+	if scopes != nil {
+		lookupScopes = *scopes
+	}
+
+	// If the provider already computed cost, trust it (matches calculateBaseCost).
+	if usage.Cost != nil && usage.Cost.TotalCost > 0 {
+		return usage.Cost.TotalCost
+	}
+
+	return s.computeCostFromInput(
+		costInput{usage: usage},
+		schemas.RoutingInfo{Provider: provider, Model: model},
+		normalizeStreamRequestType(requestType),
+		lookupScopes,
+	)
+}
+
 // calculateCostWithCache handles cost calculation when semantic cache debug info is present.
 func (s *Store) calculateCostWithCache(result *schemas.BifrostResponse, cacheDebug *schemas.BifrostCacheDebug, scopes LookupScopes) float64 {
 	if cacheDebug.CacheHit {
@@ -128,6 +158,14 @@ func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes Lookup
 		requestType = normalizeStreamRequestType(requestType)
 	}
 
+	return s.computeCostFromInput(input, routingInfo, requestType, scopes)
+}
+
+// computeCostFromInput resolves pricing for the given routing info + request
+// type and routes the extracted usage to the appropriate per-modality compute
+// function. Shared by calculateBaseCost (response-driven) and
+// CalculateCostForUsage (bare-usage-driven, for failed/cancelled requests).
+func (s *Store) computeCostFromInput(input costInput, routingInfo schemas.RoutingInfo, requestType schemas.RequestType, scopes LookupScopes) float64 {
 	// When a pricing model override is set (e.g. container creates always look
 	// up "container"), it replaces the lookup hierarchy entirely. Build a
 	// synthetic RoutingInfo that reuses Provider but pins the model fields to

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -28,7 +28,7 @@ func chatPricing(input, output float64) configstoreTables.TableModelPricing {
 // testStoreWithPricing creates a catalog pre-loaded with the given pricing entries.
 func testStoreWithPricing(entries map[string]configstoreTables.TableModelPricing) *Store {
 	s := newTestStore()
-	
+
 	for k, v := range entries {
 		s.pricingData[k] = v
 	}
@@ -211,7 +211,7 @@ func TestComputeTextCost_FastMode_CacheBillsAtStandardRates(t *testing.T) {
 	p := chatPricing(0.000005, 0.000025)
 	p.InputCostPerTokenFast = bifrost.Ptr(0.00001)
 	p.OutputCostPerTokenFast = bifrost.Ptr(0.00005)
-	p.CacheReadInputTokenCost = bifrost.Ptr(0.0000005)     // standard read
+	p.CacheReadInputTokenCost = bifrost.Ptr(0.0000005)      // standard read
 	p.CacheCreationInputTokenCost = bifrost.Ptr(0.00000625) // standard 5m write
 
 	usage := &schemas.BifrostLLMUsage{
@@ -1958,7 +1958,7 @@ func TestCalculateCost_PriorityTier_EndToEnd(t *testing.T) {
 				TotalTokens:      1500,
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ChatCompletionRequest,
+				RequestType: schemas.ChatCompletionRequest,
 				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
@@ -1992,7 +1992,7 @@ func TestCalculateCost_NonPriorityServiceTier_UsesBaseRate(t *testing.T) {
 				TotalTokens:      1500,
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ChatCompletionRequest,
+				RequestType: schemas.ChatCompletionRequest,
 				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
@@ -2235,7 +2235,7 @@ func TestCalculateCost_FlexTier_EndToEnd(t *testing.T) {
 				TotalTokens:      1500,
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ChatCompletionRequest,
+				RequestType: schemas.ChatCompletionRequest,
 				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
@@ -2261,7 +2261,7 @@ func TestCalculateCost_FlexTier_FallsBackToBaseWhenNoFlexRate(t *testing.T) {
 				TotalTokens:      1500,
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ChatCompletionRequest,
+				RequestType: schemas.ChatCompletionRequest,
 				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
 			},
 		},
@@ -2518,7 +2518,7 @@ func TestCalculateCost_ResponsesWithCodeInterpreter(t *testing.T) {
 				{Type: &ciType},
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:            schemas.ResponsesRequest,
+				RequestType: schemas.ResponsesRequest,
 				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4.1"),
 			},
 		},
@@ -2798,4 +2798,41 @@ func TestCalculateCost_BackCompat_PartialRoutingInfo_NoFallback(t *testing.T) {
 
 	cost := s.CalculateCost(resp, nil)
 	assert.Equal(t, 0.0, cost)
+}
+
+// TestCalculateCostForUsage_MatchesCalculateCost verifies the cost-from-usage helper:
+// billing a bare usage object (the failure/cancel path) yields exactly the same
+// cost as billing a full BifrostResponse carrying that usage (the success path),
+// so failed-but-token-consuming requests are charged at identical rates.
+func TestCalculateCostForUsage_MatchesCalculateCost(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
+	})
+
+	usage := &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500}
+
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Usage: usage,
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-4o"),
+			},
+		},
+	}
+
+	respCost := s.CalculateCost(resp, nil)
+	usageCost := s.CalculateCostForUsage(usage, schemas.OpenAI, "gpt-4o", schemas.ChatCompletionRequest, nil)
+
+	assert.Greater(t, respCost, 0.0, "response cost should be positive")
+	assert.Equal(t, respCost, usageCost, "bare-usage cost must equal full-response cost")
+}
+
+// TestCalculateCostForUsage_NilUsageIsZero verifies the helper bills nothing
+// when there is no usage (e.g. a failure that consumed no tokens).
+func TestCalculateCostForUsage_NilUsageIsZero(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
+	})
+	assert.Equal(t, 0.0, s.CalculateCostForUsage(nil, schemas.OpenAI, "gpt-4o", schemas.ChatCompletionRequest, nil))
 }

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -629,3 +629,16 @@ func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
 		done:      make(chan struct{}),
 	}
 }
+
+// NewTestCatalogWithDatasheet wraps a caller-provided datasheet.Store (e.g. one
+// loaded from a local testdata pricing file via datasheet.New(...) +
+// LoadFromURLIntoMemory) in a ModelCatalog, so tests in other packages can
+// exercise real pricing/cost computation without reaching the network.
+func NewTestCatalogWithDatasheet(ds *datasheet.Store) *ModelCatalog {
+	return &ModelCatalog{
+		datasheet: ds,
+		live:      live.New(nil),
+		keyconf:   keyconfig.New(nil),
+		done:      make(chan struct{}),
+	}
+}

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -42,6 +42,13 @@ func (mc *ModelCatalog) CalculateCost(result *schemas.BifrostResponse, scopes *P
 	return mc.datasheet.CalculateCost(result, (*datasheet.LookupScopes)(scopes))
 }
 
+// CalculateCostForUsage computes the dollar cost from a bare usage object when
+// no full BifrostResponse is available — used to bill partial usage carried on
+// a failed/cancelled request (BifrostError.ExtraFields.BilledUsage).
+func (mc *ModelCatalog) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, provider schemas.ModelProvider, model string, requestType schemas.RequestType, scopes *PricingLookupScopes) float64 {
+	return mc.datasheet.CalculateCostForUsage(usage, provider, model, requestType, (*datasheet.LookupScopes)(scopes))
+}
+
 // UpsertModelPricingAttributes writes additional_attributes for every row
 // matching (model, provider) and reloads the pricing cache.
 func (mc *ModelCatalog) UpsertModelPricingAttributes(ctx context.Context, model string, provider schemas.ModelProvider, attrs map[string]string) (int64, error) {

--- a/plugins/governance/accounting_test.go
+++ b/plugins/governance/accounting_test.go
@@ -1,0 +1,200 @@
+package governance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// accountingFixture wires a tracker over a single virtual key that carries both
+// a budget (for cost accumulation) and a rate limit (for request/token counts),
+// so accounting assertions can read all three dimensions.
+type accountingFixture struct {
+	store   GovernanceStore
+	tracker *UsageTracker
+}
+
+func newAccountingFixture(t *testing.T) *accountingFixture {
+	t.Helper()
+	logger := NewMockLogger()
+
+	budget := buildBudgetWithUsage("budget1", 1_000_000.0, 0.0, "1d")
+	rl := buildRateLimit("rl1", 1_000_000_000, 1_000_000)
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-acct", "Acct VK", budget)
+	vk.RateLimit = rl
+	rlID := rl.ID
+	vk.RateLimitID = &rlID
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*budget},
+		RateLimits:  []configstoreTables.TableRateLimit{*rl},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	tracker := NewUsageTracker(context.Background(), store, resolver, nil, logger)
+	t.Cleanup(func() { _ = tracker.Cleanup() })
+
+	return &accountingFixture{store: store, tracker: tracker}
+}
+
+func (f *accountingFixture) apply(updates ...*UsageUpdate) {
+	for _, u := range updates {
+		f.tracker.UpdateUsage(context.Background(), u)
+	}
+	// Let async processing settle.
+	time.Sleep(250 * time.Millisecond)
+}
+
+func (f *accountingFixture) cost() float64 {
+	return f.store.GetGovernanceData(context.Background()).Budgets["budget1"].CurrentUsage
+}
+
+func (f *accountingFixture) requests() int64 {
+	return f.store.GetGovernanceData(context.Background()).RateLimits["rl1"].RequestCurrentUsage
+}
+
+func (f *accountingFixture) tokens() int64 {
+	return f.store.GetGovernanceData(context.Background()).RateLimits["rl1"].TokenCurrentUsage
+}
+
+// acctUpdate builds a terminal (non-streaming) usage update for accounting tests.
+func acctUpdate(requestID string, attempt int, success bool, cost float64, tokens int64) *UsageUpdate {
+	return &UsageUpdate{
+		VirtualKey:    "sk-bf-acct",
+		Provider:      schemas.OpenAI,
+		Model:         "gpt-4",
+		Success:       success,
+		TokensUsed:    tokens,
+		Cost:          cost,
+		RequestID:     requestID,
+		AttemptNumber: attempt,
+		HasUsageData:  tokens > 0 || cost > 0,
+	}
+}
+
+// TestAccounting_CumulativeCostAcrossRequests: distinct successful requests each
+// add to the budget — the budget is a running total, not a per-request value.
+func TestAccounting_CumulativeCostAcrossRequests(t *testing.T) {
+	f := newAccountingFixture(t)
+
+	f.apply(
+		acctUpdate("req-1", 0, true, 10.0, 100),
+		acctUpdate("req-2", 0, true, 10.0, 100),
+		acctUpdate("req-3", 0, true, 10.0, 100),
+	)
+
+	assert.Equal(t, 30.0, f.cost(), "cost must accumulate across requests")
+	assert.Equal(t, int64(3), f.requests(), "each successful request counts once")
+	assert.Equal(t, int64(300), f.tokens(), "tokens must accumulate across requests")
+}
+
+// TestAccounting_StreamingChunksAccumulate: a streaming request reports token
+// deltas on intermediate chunks and cost on the final chunk; the request counts
+// exactly once and totals are correct.
+func TestAccounting_StreamingChunksAccumulate(t *testing.T) {
+	f := newAccountingFixture(t)
+
+	nonFinal := &UsageUpdate{
+		VirtualKey: "sk-bf-acct", Provider: schemas.OpenAI, Model: "gpt-4",
+		Success: true, TokensUsed: 50, Cost: 0.0, RequestID: "req-s", AttemptNumber: 0,
+		IsStreaming: true, IsFinalChunk: false, HasUsageData: true,
+	}
+	final := &UsageUpdate{
+		VirtualKey: "sk-bf-acct", Provider: schemas.OpenAI, Model: "gpt-4",
+		Success: true, TokensUsed: 0, Cost: 12.5, RequestID: "req-s", AttemptNumber: 0,
+		IsStreaming: true, IsFinalChunk: true, HasUsageData: true,
+	}
+	f.apply(nonFinal, final)
+
+	assert.Equal(t, 12.5, f.cost(), "final-chunk cost is billed once")
+	assert.Equal(t, int64(1), f.requests(), "streaming request counts once (final chunk only)")
+	assert.Equal(t, int64(50), f.tokens(), "token delta from the non-final chunk is counted")
+}
+
+// TestAccounting_FailedStreamingBilledOnceAndAccumulates: cancelled/failed
+// streaming requests that consumed tokens are billed (cost accumulates) but do
+// NOT increment the request counter.
+func TestAccounting_FailedStreamingBilledOnceAndAccumulates(t *testing.T) {
+	f := newAccountingFixture(t)
+
+	mk := func(reqID string) *UsageUpdate {
+		return &UsageUpdate{
+			VirtualKey: "sk-bf-acct", Provider: schemas.OpenAI, Model: "gpt-4",
+			Success: false, TokensUsed: 200, Cost: 8.0, RequestID: reqID, AttemptNumber: 0,
+			IsStreaming: true, IsFinalChunk: true, HasUsageData: true,
+		}
+	}
+	f.apply(mk("req-f1"), mk("req-f2"))
+
+	assert.Equal(t, 16.0, f.cost(), "partial cost from failed streams accumulates")
+	assert.Equal(t, int64(0), f.requests(), "failed requests do not increment request count")
+	assert.Equal(t, int64(400), f.tokens(), "consumed tokens are still counted")
+}
+
+// TestAccounting_RetryAttemptsEachBilledAndSummed: each physical attempt under
+// one logical RequestID that consumed tokens bills separately; the budget is the
+// sum across attempts.
+func TestAccounting_RetryAttemptsEachBilledAndSummed(t *testing.T) {
+	f := newAccountingFixture(t)
+
+	f.apply(
+		acctUpdate("req-retry", 0, false, 5.0, 100),
+		acctUpdate("req-retry", 1, false, 5.0, 100),
+		acctUpdate("req-retry", 2, false, 5.0, 100),
+	)
+
+	assert.Equal(t, 15.0, f.cost(), "each token-consuming attempt bills; budget is the sum")
+	assert.Equal(t, int64(0), f.requests(), "failed attempts do not count as requests")
+	assert.Equal(t, int64(300), f.tokens(), "tokens accumulate across attempts")
+}
+
+// TestAccounting_FailedAttemptThenSuccessfulRetry: a failed attempt that
+// consumed partial tokens plus a successful retry both bill (cost sums), but only
+// the successful attempt increments the request counter.
+func TestAccounting_FailedAttemptThenSuccessfulRetry(t *testing.T) {
+	f := newAccountingFixture(t)
+
+	f.apply(
+		acctUpdate("req-mix", 0, false, 4.0, 100), // failed attempt, partial usage
+		acctUpdate("req-mix", 1, true, 6.0, 150),  // successful retry
+	)
+
+	assert.Equal(t, 10.0, f.cost(), "failed-attempt cost + successful-retry cost both bill")
+	assert.Equal(t, int64(1), f.requests(), "only the successful attempt counts as a request")
+	assert.Equal(t, int64(250), f.tokens(), "tokens from both attempts accumulate")
+}
+
+// TestAccounting_NoDoubleBillSuccessVsCancelTerminal: when both a success
+// terminal and a cancellation terminal fire for the SAME physical call
+// (RequestID+attempt), the budget is charged exactly once.
+func TestAccounting_NoDoubleBillSuccessVsCancelTerminal(t *testing.T) {
+	f := newAccountingFixture(t)
+
+	success := acctUpdate("req-race", 0, true, 10.0, 100)
+	cancel := acctUpdate("req-race", 0, false, 10.0, 100) // duplicate settlement of the same call
+	f.apply(success, cancel)
+
+	assert.Equal(t, 10.0, f.cost(), "same physical call must bill exactly once")
+	assert.Equal(t, int64(1), f.requests(), "request counted once (the successful settlement)")
+	assert.Equal(t, int64(100), f.tokens(), "tokens counted once")
+}
+
+// TestAccounting_ZeroCostFailureNotBilled: a failure that consumed nothing
+// (e.g. 401/403/429 before the model ran) must not touch any counter.
+func TestAccounting_ZeroCostFailureNotBilled(t *testing.T) {
+	f := newAccountingFixture(t)
+
+	f.apply(acctUpdate("req-z", 0, false, 0.0, 0))
+
+	assert.Equal(t, 0.0, f.cost(), "no-usage failure bills no cost")
+	assert.Equal(t, int64(0), f.requests(), "no-usage failure counts no request")
+	assert.Equal(t, int64(0), f.tokens(), "no-usage failure counts no tokens")
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1347,11 +1347,23 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 			ctx.SetValue(schemas.BifrostContextKeyGovernanceRateLimitIDs, rateLimitIDs)
 		}
 
+		// Attempt number distinguishes physical provider calls within one
+		// logical request so each token-consuming attempt bills exactly once.
+		// Set by core on every retry iteration.
+		attemptNumber := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
+
 		p.wg.Add(1)
 		go func() {
 			defer p.wg.Done()
+			// Recover so a billing panic (e.g. an unexpected nil deref) can never
+			// crash the process and lose in-memory counters.
+			defer func() {
+				if r := recover(); r != nil {
+					p.logger.Error("recovered from panic in governance postHookWorker: %v", r)
+				}
+			}()
 			// Use the requested model for usage tracking
-			p.postHookWorker(result, provider, requestedModel, requestType, effectiveVK, requestID, userID, isFinalChunk, pricingScopes)
+			p.postHookWorker(result, err, provider, requestedModel, requestType, effectiveVK, requestID, userID, isFinalChunk, attemptNumber, pricingScopes)
 		}()
 	}
 
@@ -1603,9 +1615,10 @@ func (p *GovernancePlugin) Cleanup() error {
 //   - isBatch: Whether the request is a batch request
 //   - isFinalChunk: Whether the request is the final chunk
 //   - pricingScopes: Prebuilt pricing lookup scopes using governance VK ID (nil if not applicable)
-func (p *GovernancePlugin) postHookWorker(result *schemas.BifrostResponse, provider schemas.ModelProvider, model string, requestType schemas.RequestType, virtualKey, requestID, userID string, isFinalChunk bool, pricingScopes *modelcatalog.PricingLookupScopes) {
+func (p *GovernancePlugin) postHookWorker(result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError, provider schemas.ModelProvider, model string, requestType schemas.RequestType, virtualKey, requestID, userID string, isFinalChunk bool, attemptNumber int, pricingScopes *modelcatalog.PricingLookupScopes) {
 	// Determine if request was successful
 	success := (result != nil)
+	billedReason := "success"
 
 	// Streaming detection
 	isStreaming := bifrost.IsStreamRequestType(requestType)
@@ -1616,6 +1629,17 @@ func (p *GovernancePlugin) postHookWorker(result *schemas.BifrostResponse, provi
 			cost = p.modelCatalog.CalculateCost(result, pricingScopes)
 		}
 		tokensUsed := 0
+		// The request failed/was cancelled but the provider still
+		// processed tokens (carried on BifrostError.ExtraFields.BilledUsage).
+		// Bill those tokens — Anthropic charges us for them regardless.
+		if result == nil && bifrostErr != nil && bifrostErr.ExtraFields.BilledUsage != nil {
+			billedUsage := bifrostErr.ExtraFields.BilledUsage
+			tokensUsed = billedUsage.TotalTokens
+			billedReason = "partial_usage_on_error"
+			if p.modelCatalog != nil {
+				cost = p.modelCatalog.CalculateCostForUsage(billedUsage, provider, model, requestType, pricingScopes)
+			}
+		}
 		if result != nil {
 			switch {
 			case result.TextCompletionResponse != nil && result.TextCompletionResponse.Usage != nil:
@@ -1645,17 +1669,19 @@ func (p *GovernancePlugin) postHookWorker(result *schemas.BifrostResponse, provi
 
 		// Create usage update for tracker (business logic)
 		usageUpdate := &UsageUpdate{
-			VirtualKey:   virtualKey,
-			Provider:     provider,
-			Model:        model,
-			Success:      success,
-			TokensUsed:   int64(tokensUsed),
-			Cost:         cost,
-			RequestID:    requestID,
-			UserID:       userID,
-			IsStreaming:  isStreaming,
-			IsFinalChunk: isFinalChunk,
-			HasUsageData: tokensUsed > 0 || cost > 0,
+			VirtualKey:    virtualKey,
+			Provider:      provider,
+			Model:         model,
+			Success:       success,
+			TokensUsed:    int64(tokensUsed),
+			Cost:          cost,
+			RequestID:     requestID,
+			UserID:        userID,
+			IsStreaming:   isStreaming,
+			IsFinalChunk:  isFinalChunk,
+			HasUsageData:  tokensUsed > 0 || cost > 0,
+			AttemptNumber: attemptNumber,
+			BilledReason:  billedReason,
 		}
 
 		// Queue usage update asynchronously using tracker

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -28,6 +28,16 @@ type UsageUpdate struct {
 	IsStreaming  bool `json:"is_streaming"`   // Whether this is a streaming response
 	IsFinalChunk bool `json:"is_final_chunk"` // Whether this is the final chunk
 	HasUsageData bool `json:"has_usage_data"` // Whether this chunk contains usage data
+
+	// AttemptNumber distinguishes physical provider calls within one logical
+	// request (the retry loop reuses RequestID across attempts). Billing is
+	// deduped on RequestID+AttemptNumber so each token-consuming attempt bills
+	// at most once while distinct attempts each bill.
+	AttemptNumber int `json:"attempt_number,omitempty"`
+	// BilledReason is auditing metadata only ("success" | "partial_usage_on_error"):
+	// it makes it possible to assert we never bill both a success and a failure
+	// for the same physical call. Not used for dedup.
+	BilledReason string `json:"billed_reason,omitempty"`
 }
 
 // UsageTracker manages VK-level usage tracking and budget management
@@ -43,10 +53,22 @@ type UsageTracker struct {
 	resetTicker   *time.Ticker
 	done          chan struct{}
 	wg            sync.WaitGroup
+
+	// billed is the idempotency set: it records the
+	// RequestID+AttemptNumber keys already billed, so a physical provider call
+	// is billed at most once even when both the core ctx.Done() client-return
+	// path and the provider goroutine's terminal post-hook fire for it. Bounded
+	// by a TTL sweep on the existing resetWorker tick (no extra goroutine).
+	billedMu sync.Mutex
+	billed   map[string]time.Time
 }
 
 const (
 	workerInterval = 10 * time.Second
+	// billedEntryTTL bounds the idempotency set. It must comfortably exceed the
+	// lifetime of a single logical request (max retries × backoff + stream idle
+	// timeout); 5 minutes is well beyond any real request.
+	billedEntryTTL = 5 * time.Minute
 )
 
 // NewUsageTracker creates a new usage tracker for the hierarchical budget system
@@ -57,6 +79,7 @@ func NewUsageTracker(ctx context.Context, store GovernanceStore, resolver *Budge
 		configStore: configStore,
 		logger:      logger,
 		done:        make(chan struct{}),
+		billed:      make(map[string]time.Time),
 	}
 
 	// Start background workers for business logic
@@ -68,15 +91,35 @@ func NewUsageTracker(ctx context.Context, store GovernanceStore, resolver *Budge
 
 // UpdateUsage queues a usage update for async processing (main business entry point)
 func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
-	// Only process successful requests for usage tracking
-	if !update.Success {
-		t.logger.Debug("Request was not successful, skipping usage update")
+	// Bill for tokens the provider actually processed, even when the
+	// request ultimately failed or was cancelled. A failed request is only
+	// skipped when it consumed nothing (e.g. 401/403/429 before the model ran).
+	hasUsage := update.TokensUsed > 0 || update.Cost > 0
+	if !update.Success && !hasUsage {
+		t.logger.Debug("Request was not successful and consumed no tokens, skipping usage update")
 		return
 	}
 
-	// Streaming optimization: only process certain updates based on streaming status
+	// Idempotency: each physical provider call (RequestID + attempt) settles its
+	// billing at most once. Only TERMINAL settlements are deduped — a streaming
+	// request legitimately calls UpdateUsage multiple times per attempt (token
+	// deltas on intermediate chunks, request count + cost on the final chunk),
+	// and those must all be applied. The dedup specifically guards against the
+	// success-terminal vs cancellation-terminal race for one physical call.
+	// Empty RequestID (e.g. SDK-direct callers) is never deduped, preserving
+	// prior behavior.
+	isTerminal := !update.IsStreaming || update.IsFinalChunk
+	if isTerminal && !t.tryClaimBilling(update) {
+		t.logger.Debug("Usage already billed for request %s attempt %d, skipping", update.RequestID, update.AttemptNumber)
+		return
+	}
+
+	// Streaming optimization: only process certain updates based on streaming status.
+	// Request COUNT only increments for successful requests — a failed-but-billed
+	// request adds cost+tokens but must not inflate success/rate-limit request
+	// counts.
 	shouldUpdateTokens := !update.IsStreaming || (update.IsStreaming && update.HasUsageData)
-	shouldUpdateRequests := !update.IsStreaming || (update.IsStreaming && update.IsFinalChunk)
+	shouldUpdateRequests := update.Success && (!update.IsStreaming || (update.IsStreaming && update.IsFinalChunk))
 	shouldUpdateBudget := !update.IsStreaming || (update.IsStreaming && update.HasUsageData)
 
 	// 1. Update rate limit usage for both provider-level and model-level
@@ -215,6 +258,42 @@ func (t *UsageTracker) resetExpiredCounters(ctx context.Context) {
 	}
 	if err := t.store.DumpBudgets(ctx, nil); err != nil {
 		t.logger.Error("failed to dump budgets to database: %v", err)
+	}
+
+	// ==== PART 4: Sweep expired billing-idempotency keys ====
+	t.sweepBilled()
+}
+
+// tryClaimBilling records that the physical provider call identified by
+// (RequestID, AttemptNumber) is being billed and returns true if this is the
+// first claim. Subsequent calls for the same key return false so the same
+// physical call is never billed twice An empty RequestID is treated as
+// non-dedupable (always returns true) to preserve behavior for SDK-direct
+// callers that carry no request id.
+func (t *UsageTracker) tryClaimBilling(update *UsageUpdate) bool {
+	if update.RequestID == "" {
+		return true
+	}
+	key := fmt.Sprintf("%s:%d", update.RequestID, update.AttemptNumber)
+	t.billedMu.Lock()
+	defer t.billedMu.Unlock()
+	if _, seen := t.billed[key]; seen {
+		return false
+	}
+	t.billed[key] = time.Now()
+	return true
+}
+
+// sweepBilled drops idempotency keys older than billedEntryTTL, bounding the
+// map to roughly the requests seen within the TTL window.
+func (t *UsageTracker) sweepBilled() {
+	cutoff := time.Now().Add(-billedEntryTTL)
+	t.billedMu.Lock()
+	defer t.billedMu.Unlock()
+	for k, at := range t.billed {
+		if at.Before(cutoff) {
+			delete(t.billed, k)
+		}
 	}
 }
 

--- a/plugins/governance/tracker_test.go
+++ b/plugins/governance/tracker_test.go
@@ -12,8 +12,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestUsageTracker_UpdateUsage_FailedRequest tests usage tracking for a failed request
-func TestUsageTracker_UpdateUsage_FailedRequest(t *testing.T) {
+// TestUsageTracker_FailedRequestWithUsage_IsBilled verifies the fix:
+// a request that failed (Success=false) but still consumed provider tokens
+// (Cost/TokensUsed > 0, e.g. a cancelled mid-stream or a 5xx after input
+// processing) MUST update the budget. Anthropic bills for tokens it processed
+// regardless of whether Bifrost classified the request as successful.
+func TestUsageTracker_FailedRequestWithUsage_IsBilled(t *testing.T) {
+	logger := NewMockLogger()
+
+	budget := buildBudgetWithUsage("budget1", 1000.0, 0.0, "1d")
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", budget)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	tracker := NewUsageTracker(context.Background(), store, resolver, nil, logger)
+	defer tracker.Cleanup()
+
+	update := &UsageUpdate{
+		VirtualKey:   "sk-bf-test",
+		Provider:     schemas.OpenAI,
+		Model:        "gpt-4",
+		Success:      false, // Failed/cancelled request...
+		TokensUsed:   100,
+		Cost:         25.5, // ...that nonetheless consumed provider tokens.
+		RequestID:    "req-123",
+		HasUsageData: true,
+	}
+
+	tracker.UpdateUsage(context.Background(), update)
+
+	// Give time for async processing
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify budget WAS updated - retrieve from store
+	budgets := store.GetGovernanceData(context.Background()).Budgets
+	updatedBudget, exists := budgets["budget1"]
+	require.True(t, exists)
+	require.NotNil(t, updatedBudget)
+
+	assert.Equal(t, 25.5, updatedBudget.CurrentUsage,
+		"Failed request that consumed tokens should still bill the budget")
+}
+
+// TestUsageTracker_FailedRequestNoUsage_IsSkipped verifies the inverse: a
+// request that failed WITHOUT consuming any tokens (e.g. 401/403/429 before the
+// model ran) carries no usage and must NOT bill anything.
+func TestUsageTracker_FailedRequestNoUsage_IsSkipped(t *testing.T) {
 	logger := NewMockLogger()
 
 	budget := buildBudgetWithUsage("budget1", 1000.0, 0.0, "1d")
@@ -33,10 +82,10 @@ func TestUsageTracker_UpdateUsage_FailedRequest(t *testing.T) {
 		VirtualKey: "sk-bf-test",
 		Provider:   schemas.OpenAI,
 		Model:      "gpt-4",
-		Success:    false, // Failed request
-		TokensUsed: 100,
-		Cost:       25.5,
-		RequestID:  "req-123",
+		Success:    false, // Failed before the model ran...
+		TokensUsed: 0,
+		Cost:       0.0, // ...so no tokens were consumed.
+		RequestID:  "req-456",
 	}
 
 	tracker.UpdateUsage(context.Background(), update)
@@ -44,13 +93,13 @@ func TestUsageTracker_UpdateUsage_FailedRequest(t *testing.T) {
 	// Give time for async processing
 	time.Sleep(200 * time.Millisecond)
 
-	// Verify budget was NOT updated - retrieve from store
 	budgets := store.GetGovernanceData(context.Background()).Budgets
 	updatedBudget, exists := budgets["budget1"]
 	require.True(t, exists)
 	require.NotNil(t, updatedBudget)
 
-	assert.Equal(t, 0.0, updatedBudget.CurrentUsage, "Failed request should not update budget")
+	assert.Equal(t, 0.0, updatedBudget.CurrentUsage,
+		"Failed request with no usage should not bill anything")
 }
 
 // TestUsageTracker_UpdateUsage_VirtualKeyNotFound tests handling of missing VK
@@ -149,6 +198,97 @@ func TestUsageTracker_UpdateUsage_StreamingOptimization(t *testing.T) {
 
 	// Request counter should be updated on final chunk
 	assert.Equal(t, int64(1), updatedRateLimit.RequestCurrentUsage, "Request should be incremented on final chunk")
+}
+
+// TestUsageTracker_Idempotency_SameAttemptBilledOnce verifies the billing dedup:
+// the same physical provider call (RequestID + AttemptNumber) settling twice —
+// e.g. both the core ctx.Done() return path and the provider goroutine's
+// terminal post-hook — bills the budget only once.
+func TestUsageTracker_Idempotency_SameAttemptBilledOnce(t *testing.T) {
+	logger := NewMockLogger()
+
+	budget := buildBudgetWithUsage("budget1", 1000.0, 0.0, "1d")
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", budget)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	tracker := NewUsageTracker(context.Background(), store, resolver, nil, logger)
+	defer tracker.Cleanup()
+
+	mk := func() *UsageUpdate {
+		return &UsageUpdate{
+			VirtualKey:    "sk-bf-test",
+			Provider:      schemas.OpenAI,
+			Model:         "gpt-4",
+			Success:       false,
+			TokensUsed:    100,
+			Cost:          10.0,
+			RequestID:     "req-dup",
+			AttemptNumber: 0,
+			HasUsageData:  true,
+		}
+	}
+
+	tracker.UpdateUsage(context.Background(), mk())
+	tracker.UpdateUsage(context.Background(), mk()) // duplicate settlement
+	time.Sleep(200 * time.Millisecond)
+
+	budgets := store.GetGovernanceData(context.Background()).Budgets
+	updatedBudget := budgets["budget1"]
+	require.NotNil(t, updatedBudget)
+	assert.Equal(t, 10.0, updatedBudget.CurrentUsage,
+		"Same RequestID+attempt must bill exactly once")
+}
+
+// TestUsageTracker_Idempotency_DifferentAttemptsBothBilled verifies that two
+// distinct physical provider calls under one logical RequestID (e.g. a failed
+// attempt that consumed partial tokens, then a successful retry) each bill —
+// the dedup key includes the attempt number so legitimate per-attempt charges
+// are not suppressed.
+func TestUsageTracker_Idempotency_DifferentAttemptsBothBilled(t *testing.T) {
+	logger := NewMockLogger()
+
+	budget := buildBudgetWithUsage("budget1", 1000.0, 0.0, "1d")
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", budget)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	tracker := NewUsageTracker(context.Background(), store, resolver, nil, logger)
+	defer tracker.Cleanup()
+
+	mk := func(attempt int, success bool, cost float64) *UsageUpdate {
+		return &UsageUpdate{
+			VirtualKey:    "sk-bf-test",
+			Provider:      schemas.OpenAI,
+			Model:         "gpt-4",
+			Success:       success,
+			TokensUsed:    100,
+			Cost:          cost,
+			RequestID:     "req-retry",
+			AttemptNumber: attempt,
+			HasUsageData:  true,
+		}
+	}
+
+	tracker.UpdateUsage(context.Background(), mk(0, false, 4.0)) // failed attempt, partial usage
+	tracker.UpdateUsage(context.Background(), mk(1, true, 6.0))  // successful retry
+	time.Sleep(200 * time.Millisecond)
+
+	budgets := store.GetGovernanceData(context.Background()).Budgets
+	updatedBudget := budgets["budget1"]
+	require.NotNil(t, updatedBudget)
+	assert.Equal(t, 10.0, updatedBudget.CurrentUsage,
+		"Distinct attempts under one RequestID must each bill")
 }
 
 // TestUsageTracker_Cleanup tests cleanup of the usage tracker

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -163,6 +163,30 @@ func applyMCPGovernanceFieldsToEntry(ctx *schemas.BifrostContext, entry *logstor
 }
 
 // scheduleDeferredUsageUpdate schedules a deferred usage update for the request.
+// applyErrorBillingFromBilledUsage backfills a failed/cancelled request's log
+// entry from the usage the provider already processed before the failure
+// (carried on BifrostError.ExtraFields.BilledUsage). Token usage is only filled
+// when stream accumulation didn't already capture it, but cost is (re)computed
+// whenever it is still missing - independent of whether tokens were already
+// parsed, since a streaming error can populate usage without a cost.
+func (p *LoggerPlugin) applyErrorBillingFromBilledUsage(ctx *schemas.BifrostContext, entry *logstore.Log, billed *schemas.BifrostLLMUsage, requestType schemas.RequestType) {
+	if billed == nil {
+		return
+	}
+	if entry.TokenUsageParsed == nil {
+		entry.TokenUsageParsed = billed
+		entry.PromptTokens = billed.PromptTokens
+		entry.CompletionTokens = billed.CompletionTokens
+		entry.TotalTokens = billed.TotalTokens
+	}
+	if entry.Cost == nil && p.pricingManager != nil {
+		pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(entry.Provider))
+		if cost := p.pricingManager.CalculateCostForUsage(billed, schemas.ModelProvider(entry.Provider), entry.Model, requestType, pricingScopes); cost > 0 {
+			entry.Cost = &cost
+		}
+	}
+}
+
 func (p *LoggerPlugin) scheduleDeferredUsageUpdate(ctx *schemas.BifrostContext, requestID string, usageAlreadyPresent bool) {
 	if usageAlreadyPresent || ctx == nil {
 		return
@@ -1044,6 +1068,11 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				}
 			}
 		}
+		// The request failed/was cancelled but the provider still
+		// processed tokens (carried on BilledUsage). Record cost + tokens so the
+		// logs DB reflects what we were actually billed, mirroring the governance
+		// budget.
+		p.applyErrorBillingFromBilledUsage(ctx, entry, bifrostErr.ExtraFields.BilledUsage, requestType)
 		applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
 		p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))
 		p.scheduleDeferredUsageUpdate(ctx, requestID, entry.TokenUsageParsed != nil)

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
 )
 
 type testLogger struct{}
@@ -180,6 +182,181 @@ func TestPostLLMHookStreamingErrorPreservesHeaderMetadata(t *testing.T) {
 	}
 	if got := logEntry.MetadataParsed["environment"]; got != "staging" {
 		t.Fatalf("expected dimension metadata staging, got %#v", got)
+	}
+}
+
+// TestPostLLMHookCancelledStreamLogsCost verifies #3357 at the logging layer: a
+// streaming request cancelled mid-flight (result==nil) whose error carries the
+// partial usage the provider already processed (BifrostError.ExtraFields.BilledUsage)
+// must produce a log row with status="error", the consumed tokens, AND an
+// accurate cost computed from the datasheet rates.
+func TestPostLLMHookCancelledStreamLogsCost(t *testing.T) {
+	store := newTestStore(t)
+
+	// Pricing manager loaded from the committed datasheet testdata via an
+	// offline file:// URL (no network).
+	abs, err := filepath.Abs("../../framework/modelcatalog/datasheet/testdata/pricing.json")
+	if err != nil {
+		t.Fatalf("resolve testdata path: %v", err)
+	}
+	ds := datasheet.New(nil, testLogger{}, datasheet.Config{URL: "file://" + abs})
+	if err := ds.LoadFromURLIntoMemory(context.Background()); err != nil {
+		t.Fatalf("load pricing datasheet: %v", err)
+	}
+	pricingManager := modelcatalog.NewTestCatalogWithDatasheet(ds)
+
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, pricingManager, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, "req-cancel-cost")
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionStreamRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o",
+			Params:   &schemas.ChatParameters{},
+		},
+	}
+	if _, _, err = plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook() error = %v", err)
+	}
+
+	const promptTokens, completionTokens = 100, 50
+	statusCode := 499 // client closed request (mid-stream cancel)
+	bifrostErr := &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error:          &schemas.ErrorField{Message: "client disconnected"},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType:            schemas.ChatCompletionStreamRequest,
+			Provider:               schemas.OpenAI,
+			OriginalModelRequested: "gpt-4o",
+			ResolvedModelUsed:      "gpt-4o",
+			// Provider processed these tokens before the client disconnected.
+			BilledUsage: &schemas.BifrostLLMUsage{
+				PromptTokens:     promptTokens,
+				CompletionTokens: completionTokens,
+				TotalTokens:      promptTokens + completionTokens,
+			},
+		},
+	}
+	if _, _, err = plugin.PostLLMHook(ctx, nil, bifrostErr); err != nil {
+		t.Fatalf("PostLLMHook() error = %v", err)
+	}
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	entry, err := store.FindByID(context.Background(), "req-cancel-cost")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if entry.Status != "error" {
+		t.Fatalf("expected error status, got %q", entry.Status)
+	}
+	if entry.TokenUsageParsed == nil {
+		t.Fatalf("expected token usage recorded from BilledUsage on the cancel path")
+	}
+	if entry.TotalTokens != promptTokens+completionTokens {
+		t.Fatalf("expected total_tokens %d, got %d", promptTokens+completionTokens, entry.TotalTokens)
+	}
+	if entry.Cost == nil {
+		t.Fatalf("expected a cost to be logged for a cancelled request that consumed tokens (#3357)")
+	}
+	// gpt-4o testdata rates: input 2.5e-6/token, output 1e-5/token.
+	want := float64(promptTokens)*2.5e-6 + float64(completionTokens)*1e-5
+	if diff := *entry.Cost - want; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("logged cost %v does not match datasheet-computed cost %v", *entry.Cost, want)
+	}
+}
+
+// newTestPricingManager builds a ModelCatalog backed by the committed pricing
+// testdata via an offline file:// URL (no network).
+func newTestPricingManager(t *testing.T) *modelcatalog.ModelCatalog {
+	t.Helper()
+	abs, err := filepath.Abs("../../framework/modelcatalog/datasheet/testdata/pricing.json")
+	if err != nil {
+		t.Fatalf("resolve testdata path: %v", err)
+	}
+	ds := datasheet.New(nil, testLogger{}, datasheet.Config{URL: "file://" + abs})
+	if err := ds.LoadFromURLIntoMemory(context.Background()); err != nil {
+		t.Fatalf("load pricing datasheet: %v", err)
+	}
+	return modelcatalog.NewTestCatalogWithDatasheet(ds)
+}
+
+// TestApplyErrorBillingFromBilledUsage_ComputesCostWhenTokensAlreadyParsed guards
+// the case where stream accumulation already captured token usage on a failed
+// request but no cost was computed: cost must still be backfilled, and the
+// already-parsed token counters must be left untouched (not double-applied).
+func TestApplyErrorBillingFromBilledUsage_ComputesCostWhenTokensAlreadyParsed(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, newTestPricingManager(t), nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	const promptTokens, completionTokens = 100, 50
+	entry := &logstore.Log{
+		Provider:         string(schemas.OpenAI),
+		Model:            "gpt-4o",
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+		TokenUsageParsed: &schemas.BifrostLLMUsage{
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      promptTokens + completionTokens,
+		},
+	}
+	billed := entry.TokenUsageParsed
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	plugin.applyErrorBillingFromBilledUsage(ctx, entry, billed, schemas.ChatCompletionStreamRequest)
+
+	if entry.Cost == nil {
+		t.Fatal("expected cost to be computed even though token usage was already parsed")
+	}
+	// gpt-4o testdata rates: input 2.5e-6/token, output 1e-5/token.
+	want := float64(promptTokens)*2.5e-6 + float64(completionTokens)*1e-5
+	if diff := *entry.Cost - want; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("cost %v does not match datasheet-computed %v", *entry.Cost, want)
+	}
+	if entry.PromptTokens != promptTokens || entry.TotalTokens != promptTokens+completionTokens {
+		t.Fatalf("token counters mutated: prompt=%d total=%d", entry.PromptTokens, entry.TotalTokens)
+	}
+}
+
+// TestApplyErrorBillingFromBilledUsage_FillsTokensAndCostWhenUnparsed pins the
+// original behaviour: when no usage was captured yet, both tokens and cost are
+// backfilled from BilledUsage.
+func TestApplyErrorBillingFromBilledUsage_FillsTokensAndCostWhenUnparsed(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, newTestPricingManager(t), nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	const promptTokens, completionTokens = 100, 50
+	entry := &logstore.Log{Provider: string(schemas.OpenAI), Model: "gpt-4o"}
+	billed := &schemas.BifrostLLMUsage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	plugin.applyErrorBillingFromBilledUsage(ctx, entry, billed, schemas.ChatCompletionStreamRequest)
+
+	if entry.TokenUsageParsed == nil || entry.TotalTokens != promptTokens+completionTokens {
+		t.Fatalf("expected tokens backfilled, got %+v", entry.TokenUsageParsed)
+	}
+	if entry.Cost == nil {
+		t.Fatal("expected cost computed on the unparsed path")
 	}
 }
 

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -7550,6 +7550,734 @@
           ]
         }
       ]
+    },
+    {
+      "name": "15. Costing — Failed/Cancelled Requests",
+      "description": "Asserts that a request which FAILED or was CANCELLED but still consumed provider tokens is billed (logs DB cost>0 && total_tokens>0). Each request pins a unique `x-request-id` and sets `x-bf-expect-cost: true`, which the newman-reporter-dbverify reporter uses to look up the log row and verify cost. Pre-fix these FAIL (cost is 0 on failed requests); post-fix they PASS. Streaming mid-flight cancellation is driven deterministically by runners/run-stream-cancellation.mjs (Postman cannot abort a stream mid-response).",
+      "item": [
+        {
+          "name": "[Costing] Streaming chat cancelled mid-flight records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-request-id", "value": "costing-stream-chat-{{$guid}}" },
+              { "key": "x-bf-expect-cost", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{model}}\",\n  \"messages\": [{\"role\": \"user\", \"content\": \"Count slowly from 1 to 200, one number per line.\"}],\n  \"stream\": true,\n  \"max_tokens\": 2048\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/v1/chat/completions", "host": ["{{baseUrl}}"], "path": ["v1", "chat", "completions"] }
+          },
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "// Stream returns 200 (headers sent) then is cancelled mid-response by",
+              "// runners/run-stream-cancellation.mjs. The cost assertion is performed by",
+              "// the dbverify reporter against the logs row keyed on x-request-id.",
+              "pm.test('[Costing] stream started (200) before cancellation', function () {",
+              "  pm.expect(pm.response.code).to.equal(200);",
+              "});"
+            ] } }
+          ]
+        },
+        {
+          "name": "[Costing] Non-streaming chat failure records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-request-id", "value": "costing-nonstream-chat-{{$guid}}" },
+              { "key": "x-bf-expect-cost", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{model}}\",\n  \"messages\": [{\"role\": \"user\", \"content\": \"Write a long essay about distributed systems.\"}],\n  \"max_tokens\": 1024\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/v1/chat/completions", "host": ["{{baseUrl}}"], "path": ["v1", "chat", "completions"] }
+          },
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "// A non-streaming request that fails AFTER the provider processed input",
+              "// tokens (timeout / 5xx after input) must still be billed. The dbverify",
+              "// reporter verifies logs cost>0 && total_tokens>0 for x-request-id.",
+              "pm.test('[Costing] non-stream request reached the provider', function () {",
+              "  pm.expect(pm.response.code).to.not.equal(404);",
+              "});"
+            ] } }
+          ]
+        },
+        {
+          "name": "[Costing] Embeddings failure records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-request-id", "value": "costing-embeddings-{{$guid}}" },
+              { "key": "x-bf-expect-cost", "value": "true" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{embedding_model}}\",\n  \"input\": \"costing probe embedding input\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/v1/embeddings", "host": ["{{baseUrl}}"], "path": ["v1", "embeddings"] }
+          },
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "// 'Other' request type: embeddings. A failure after input processing must",
+              "// still record cost. Verified by the dbverify reporter via x-request-id.",
+              "pm.test('[Costing] embeddings request reached the provider', function () {",
+              "  pm.expect(pm.response.code).to.not.equal(404);",
+              "});"
+            ] } }
+          ]
+        },
+        {
+          "name": "[Costing] Transcription failure records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "x-request-id", "value": "costing-transcription-{{$guid}}" },
+              { "key": "x-bf-expect-cost", "value": "true" }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "model", "value": "{{transcription_model}}", "type": "text" },
+                { "key": "file", "src": "fixtures/sample.mp3", "type": "file" }
+              ]
+            },
+            "url": { "raw": "{{baseUrl}}/v1/audio/transcriptions", "host": ["{{baseUrl}}"], "path": ["v1", "audio", "transcriptions"] }
+          },
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "// 'Other' request type: audio transcription. A failure after the audio was",
+              "// processed must still record cost. Verified by the dbverify reporter.",
+              "pm.test('[Costing] transcription request reached the provider', function () {",
+              "  pm.expect(pm.response.code).to.not.equal(404);",
+              "});"
+            ] } }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "16. Accounting (cost recording across providers)",
+      "description": "Criss-cross of providers x {non-streaming, streaming} chat requests that each pin a unique x-request-id and set x-bf-expect-cost. The dbverify reporter asserts the logs DB recorded cost>0 && total_tokens>0 per request, guarding against accounting regressions. Failed-streaming, retry-attempt, cumulative-sum and no-double-bill semantics are covered by Go unit tests (plugins/governance/accounting_test.go).",
+      "item": [
+        {
+          "name": "[Accounting] openai non-streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-openai-nonstreaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-4o-mini\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] openai nonstreaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] openai streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-openai-streaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-4o-mini\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512,\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] openai streaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] anthropic non-streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-anthropic-nonstreaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-haiku-4-5\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] anthropic nonstreaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] anthropic streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-anthropic-streaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-haiku-4-5\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512,\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] anthropic streaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] bedrock non-streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-bedrock-nonstreaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/us.amazon.nova-lite-v1:0\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] bedrock nonstreaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] bedrock streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-bedrock-streaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/us.amazon.nova-lite-v1:0\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512,\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] bedrock streaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] gemini non-streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-gemini-nonstreaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] gemini nonstreaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] gemini streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-gemini-streaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512,\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] gemini streaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] vertex non-streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-vertex-nonstreaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vertex/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] vertex nonstreaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] vertex streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-vertex-streaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vertex/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512,\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] vertex streaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] azure non-streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-azure-nonstreaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"azure/{{azureDeployment}}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] azure nonstreaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "[Accounting] azure streaming records cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "acct-azure-streaming"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"azure/{{azureDeployment}}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with a short sentence about the number seven.\"\n    }\n  ],\n  \"max_tokens\": 512,\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Cost recording is verified against the logs DB by the dbverify reporter",
+                  "// (cost>0 && total_tokens>0 for this x-request-id). This request asserts the",
+                  "// gateway accepted and routed it.",
+                  "pm.test(`[Accounting] azure streaming reached the provider`, function () {",
+                  "  pm.expect(pm.response.code).to.not.equal(404);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/e2e/api/lib/pricing.js
+++ b/tests/e2e/api/lib/pricing.js
@@ -1,0 +1,42 @@
+// Shared pricing-datasheet entry resolver, used by both the newman dbverify
+// reporter and the stream-cancellation runner. Kept in one place so the provider
+// alias normalization can never drift between the two consumers again.
+//
+// Datasheet keys are model ids — bare ("gpt-4o", "claude-haiku-4-5") or prefixed
+// ("anthropic.claude-...", "azure/gpt-..."). We try a few normalizations and
+// return null when there's no confident match so callers skip cost-accuracy.
+//
+// Bifrost provider names → datasheet (LiteLLM) provider names. The datasheet keys
+// Vertex-hosted Gemini under the bare model id with provider "vertex_ai" (vs the
+// AI-Studio variant "gemini/<model>" with provider "gemini"), so a Bifrost
+// "vertex" row would otherwise fail the provider guard below.
+const PRICING_PROVIDER_ALIASES = { vertex: 'vertex_ai' };
+
+function normalizePricingProvider(p) {
+  if (!p) return '';
+  const lp = String(p).toLowerCase();
+  return PRICING_PROVIDER_ALIASES[lp] || lp;
+}
+
+function resolvePricingEntry(sheet, model, provider) {
+  if (!sheet || !model) return null;
+  const m = String(model);
+  const bare = m.includes('/') ? m.split('/').pop() : m;
+  // Datasheet keys are lowercase-prefixed (litellm style), so lower-case the
+  // provider before building the prefixed candidate to avoid case-only misses.
+  const lowerProvider = provider ? String(provider).toLowerCase() : '';
+  const np = normalizePricingProvider(provider);
+  const candidates = [m, bare,
+    lowerProvider ? `${lowerProvider}/${bare}` : null,
+    np && np !== lowerProvider ? `${np}/${bare}` : null,
+  ].filter(Boolean);
+  for (const key of candidates) {
+    const e = sheet[key];
+    if (e && (!e.provider || !np || normalizePricingProvider(e.provider) === np)) {
+      return e;
+    }
+  }
+  return null;
+}
+
+module.exports = { PRICING_PROVIDER_ALIASES, normalizePricingProvider, resolvePricingEntry };

--- a/tests/e2e/api/lib/pricing.test.js
+++ b/tests/e2e/api/lib/pricing.test.js
@@ -1,0 +1,56 @@
+// Unit tests for the shared pricing-entry resolver. Run directly: `node pricing.test.js`.
+// No test framework needed (the tests/e2e/api dir has no test runner configured).
+const assert = require('node:assert');
+const { resolvePricingEntry, normalizePricingProvider } = require('./pricing');
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ok - ${name}`);
+}
+
+// The regression this de-duplication fixes: Bifrost reports provider "vertex",
+// but the datasheet keys Vertex-hosted Gemini under "vertex_ai". Without alias
+// normalization the lookup fails. (The runner's old copy lacked this.)
+test('resolves vertex model against vertex_ai datasheet key', () => {
+  const sheet = {
+    'vertex_ai/gemini-2.5-flash': { provider: 'vertex_ai', input_cost_per_token: 1 },
+  };
+  const entry = resolvePricingEntry(sheet, 'gemini-2.5-flash', 'vertex');
+  assert.ok(entry, 'expected a pricing entry for vertex → vertex_ai');
+  assert.strictEqual(entry.input_cost_per_token, 1);
+});
+
+test('resolves a plain bare-model key with matching provider', () => {
+  const sheet = { 'gpt-4o': { provider: 'openai', input_cost_per_token: 2.5e-6 } };
+  const entry = resolvePricingEntry(sheet, 'gpt-4o', 'openai');
+  assert.ok(entry);
+  assert.strictEqual(entry.input_cost_per_token, 2.5e-6);
+});
+
+// Datasheet keys are lowercase-prefixed (litellm style). Provider casing from
+// callers must not cause a false miss against an only-prefixed key.
+test('resolves prefixed key when provider casing differs (OpenAI → openai/<model>)', () => {
+  const sheet = { 'openai/gpt-4o': { provider: 'openai', input_cost_per_token: 5 } };
+  const entry = resolvePricingEntry(sheet, 'gpt-4o', 'OpenAI');
+  assert.ok(entry, 'expected case-insensitive prefixed match');
+  assert.strictEqual(entry.input_cost_per_token, 5);
+});
+
+test('returns null when model is missing', () => {
+  assert.strictEqual(resolvePricingEntry({}, null, 'openai'), null);
+});
+
+test('does not match when provider guard disagrees', () => {
+  const sheet = { 'gpt-4o': { provider: 'azure' } };
+  assert.strictEqual(resolvePricingEntry(sheet, 'gpt-4o', 'openai'), null);
+});
+
+test('normalizePricingProvider maps vertex → vertex_ai, passes others through', () => {
+  assert.strictEqual(normalizePricingProvider('vertex'), 'vertex_ai');
+  assert.strictEqual(normalizePricingProvider('OpenAI'), 'openai');
+  assert.strictEqual(normalizePricingProvider(''), '');
+});
+
+console.log(`\npricing.test.js: ${passed} passed`);

--- a/tests/e2e/api/newman-reporter-dbverify/index.js
+++ b/tests/e2e/api/newman-reporter-dbverify/index.js
@@ -582,6 +582,166 @@ async function runMultiTableVerification(db, method, mapping, body, name) {
   return { name, result: 'PASS', detail: `${tableNames} verified` };
 }
 
+// ─── Costing assertion ────────────────────────────────────────────────
+
+/** Read a request header value (newman SDK HeaderList) defensively. */
+function getHeader(request, key) {
+  try {
+    if (request && request.headers && typeof request.headers.get === 'function') {
+      return request.headers.get(key);
+    }
+  } catch (_) { /* ignore */ }
+  return undefined;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ─── Datasheet pricing (cost-accuracy recompute) ──────────────────────────────
+// Authoritative pricing source — the same datasheet Bifrost itself syncs from
+// (framework/modelcatalog/datasheet/store.go DefaultURL). Override via env.
+const PRICING_URL = process.env.BIFROST_PRICING_URL || 'https://getbifrost.ai/datasheet';
+let _datasheetPromise; // fetched at most once per run
+
+function fetchJSON(url) {
+  return new Promise((resolve, reject) => {
+    const lib = url.startsWith('https:') ? require('https') : require('http');
+    const req = lib.get(url, { timeout: 15000 }, (res) => {
+      if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume();
+        reject(new Error(`HTTP ${res.statusCode} fetching ${url}`));
+        return;
+      }
+      let buf = '';
+      res.setEncoding('utf8');
+      res.on('data', (c) => { buf += c; });
+      res.on('end', () => { try { resolve(JSON.parse(buf)); } catch (e) { reject(e); } });
+    });
+    req.on('timeout', () => req.destroy(new Error('datasheet fetch timeout')));
+    req.on('error', reject);
+  });
+}
+
+// Lazily fetch the datasheet once; on failure resolve null so cost-accuracy is
+// skipped (presence check still runs).
+function loadDatasheet() {
+  if (!_datasheetPromise) {
+    _datasheetPromise = fetchJSON(PRICING_URL).catch((e) => {
+      console.warn(`[dbverify] could not fetch pricing datasheet (${PRICING_URL}): ${e.message}; cost-accuracy checks skipped`);
+      return null;
+    });
+  }
+  return _datasheetPromise;
+}
+
+// Datasheet entry resolver + provider alias normalization live in the shared
+// lib so this reporter and runners/run-stream-cancellation.mjs can't drift.
+const { resolvePricingEntry } = require('../lib/pricing');
+
+// Recompute expected base-tier cost, mirroring datasheet/cost.go computeTextCost:
+// nonCachedPrompt×input + cachedRead×cacheRead + cachedWrite×cacheCreation + completion×output.
+function expectedCostFromDatasheet(entry, row) {
+  const input = entry.input_cost_per_token || 0;
+  const output = entry.output_cost_per_token || 0;
+  const cacheReadRate = entry.cache_read_input_token_cost || 0;
+  const cacheWriteRate = entry.cache_creation_input_token_cost || 0;
+
+  const prompt = Number(row.prompt_tokens || 0);
+  const completion = Number(row.completion_tokens || 0);
+  let cachedRead = Number(row.cached_read_tokens || 0);
+  let cachedWrite = 0;
+  if (row.token_usage) {
+    try {
+      const d = JSON.parse(row.token_usage)?.prompt_tokens_details;
+      if (d) {
+        if (cachedRead === 0 && d.cached_read_tokens) cachedRead = Number(d.cached_read_tokens);
+        if (d.cached_write_tokens) cachedWrite = Number(d.cached_write_tokens);
+      }
+    } catch (_) { /* ignore malformed usage blob */ }
+  }
+  // Clamp exactly like cost.go.
+  cachedRead = Math.min(cachedRead, prompt);
+  cachedWrite = Math.min(cachedWrite, Math.max(0, prompt - cachedRead));
+  const nonCachedPrompt = Math.max(0, prompt - cachedRead - cachedWrite);
+  return nonCachedPrompt * input + cachedRead * cacheReadRate + cachedWrite * cacheWriteRate + completion * output;
+}
+
+/**
+ * Verify that a failed/cancelled request still recorded cost + tokens.
+ * The logs row is written asynchronously by the logging plugin (and usage may
+ * arrive via the deferred-usage channel), so we poll with backoff. The logs
+ * table is keyed by request id (Log.ID == BifrostContextKeyRequestID), which
+ * the Costing requests pin via the `x-request-id` header.
+ */
+async function verifyCostingRequest(db, reqId, name, results, silent) {
+  const delays = [200, 500, 1000, 2000]; // ~3.7s total, covers async write + deferred usage
+  const sql = 'SELECT cost, prompt_tokens, completion_tokens, total_tokens, cached_read_tokens, token_usage, model, provider, status FROM logs WHERE id = $1';
+  let row = null;
+  for (let i = 0; i < delays.length; i++) {
+    await sleep(delays[i]);
+    try {
+      const { rows } = await db.query(sql, [reqId]);
+      if (rows && rows.length > 0) {
+        row = rows[0];
+        const cost = Number(row.cost || 0);
+        const tokens = Number(row.total_tokens || 0);
+        if (cost > 0 && tokens > 0) break; // both landed; stop early (matches the final assertion)
+      }
+    } catch (e) {
+      results.push({ name, result: 'FAIL', detail: `Costing query error: ${e.message}` });
+      return;
+    }
+  }
+  if (!row) {
+    results.push({ name, result: 'FAIL', detail: `No log row found for request_id=${reqId}` });
+    return;
+  }
+
+  // 1) Presence: a failed/cancelled request that consumed tokens must record cost+tokens.
+  const cost = Number(row.cost || 0);
+  const tokens = Number(row.total_tokens || 0);
+  if (!(cost > 0 && tokens > 0)) {
+    results.push({ name, result: 'FAIL', detail: `[Costing] status=${row.status} cost=$${cost} total_tokens=${tokens} — expected cost>0 && tokens>0` });
+    if (!silent) console.log(`[dbverify] costing ${reqId}: FAIL (presence) cost=$${cost} tokens=${tokens}`);
+    return;
+  }
+
+  // 2) Accuracy: recompute the expected cost from the datasheet and compare.
+  let result = 'PASS';
+  let note = '';
+  let expectedStr = 'n/a';
+  const sheet = await loadDatasheet();
+  const entry = resolvePricingEntry(sheet, row.model, row.provider);
+  if (!sheet) {
+    note = 'accuracy SKIPPED: datasheet unavailable';
+  } else if (!entry) {
+    note = `accuracy SKIPPED: no datasheet entry for ${row.provider}/${row.model}`;
+  } else if (tokens > 128000) {
+    note = 'accuracy SKIPPED: tiered pricing not modelled';
+  } else {
+    const expected = expectedCostFromDatasheet(entry, row);
+    expectedStr = `$${expected}`;
+    const tol = Math.max(1e-9, 1e-4 * expected);
+    if (Math.abs(cost - expected) <= tol) {
+      note = 'accurate';
+    } else {
+      result = 'FAIL';
+      note = `INACCURATE (|logged-expected|>${tol})`;
+    }
+  }
+  const detail = `[Costing] status=${row.status} model=${row.provider}/${row.model} prompt=${row.prompt_tokens} completion=${row.completion_tokens} total=${tokens} logged=$${cost} expected=${expectedStr} — ${note}`;
+  results.push({ name, result, detail });
+  // Surface the actual log entry's cost next to the datasheet-computed expected
+  // cost, so the comparison is visible in the run logs.
+  if (!silent) {
+    console.log(`[dbverify] ── cost check (${result}) ─ ${reqId}`);
+    console.log(`[dbverify]     model      : ${row.provider}/${row.model}`);
+    console.log(`[dbverify]     tokens     : prompt=${row.prompt_tokens} completion=${row.completion_tokens} total=${tokens} cachedRead=${row.cached_read_tokens || 0}`);
+    console.log(`[dbverify]     logged $   : ${cost}    (logs DB row)`);
+    console.log(`[dbverify]     expected $ : ${expectedStr}    (recomputed from getbifrost.ai/datasheet)`);
+    console.log(`[dbverify]     verdict    : ${result}${note ? ' — ' + note : ''}`);
+  }
+}
+
 /**
  * Process a single request's DB verification (immediate or from queue).
  * Handles bulk DELETE, tracks promises, pushes results.
@@ -700,7 +860,9 @@ module.exports = function (newman, options) {
     || path.resolve(process.cwd(), 'config.json');
 
   // Main DB (config_store)
-  let dbUrl = (options && options['db-url']) || process.env.BIFROST_DB_URL || null;
+  // newman/commander camelCases multi-word reporter flags, so --reporter-dbverify-db-url
+  // arrives as options.dbUrl, not options['db-url']. Accept both spellings.
+  let dbUrl = (options && (options['db-url'] || options['dbUrl'])) || process.env.BIFROST_DB_URL || null;
   if (!dbUrl) {
     dbUrl = dbUrlFromBifrostConfig(configPath);
     if (dbUrl && !silent) console.log(`[dbverify] Auto-detected main DB from config: ${configPath}`);
@@ -710,7 +872,7 @@ module.exports = function (newman, options) {
   }
 
   // Logs DB (logs_store)
-  let logsDbUrl = (options && options['logs-db-url']) || process.env.BIFROST_LOGS_DB_URL || null;
+  let logsDbUrl = (options && (options['logs-db-url'] || options['logsDbUrl'])) || process.env.BIFROST_LOGS_DB_URL || null;
   if (!logsDbUrl) {
     logsDbUrl = logsDbUrlFromBifrostConfig(configPath);
     if (logsDbUrl && !silent) console.log(`[dbverify] Auto-detected logs DB from config: ${configPath}`);
@@ -721,6 +883,11 @@ module.exports = function (newman, options) {
   const pendingVerifications = [];
   const earlyMainDbQueue  = [];
   const earlyLogsDbQueue  = [];
+  const earlyCostingQueue = [];
+  // DB connection chains; awaited in `done` before pendingVerifications so the
+  // queue-draining .then() callbacks (which push deferred verifications) are
+  // guaranteed to have run before we wait on them.
+  const connectionPromises = [];
   let   db         = null;
   let   logsDb     = null;
   let   dbReady    = false;
@@ -737,12 +904,21 @@ module.exports = function (newman, options) {
     }
   }
 
+  // Costing verifications deferred while the logs DB connection was still
+  // resolving. Run once connected so a fast first request can't silently SKIP.
+  function drainCostingQueue(activeLogsDb) {
+    while (earlyCostingQueue.length > 0) {
+      const item = earlyCostingQueue.shift();
+      pendingVerifications.push(verifyCostingRequest(activeLogsDb, item.reqId, item.name, results, silent));
+    }
+  }
+
   newman.on('start', function (err) {
     if (err) return;
 
     if (dbUrl) {
       const safeUrl = dbUrl.replace(/:([^:@]+)@/, ':***@');
-      createDbClient(dbUrl)
+      connectionPromises.push(createDbClient(dbUrl)
         .then((client) => {
           db      = client;
           dbReady = !!client;
@@ -754,24 +930,29 @@ module.exports = function (newman, options) {
           console.warn(`[dbverify] Main DB not reachable, skipping DB checks: ${e.message}`);
           earlyMainDbQueue.forEach((item) => results.push({ name: item.name, result: 'SKIP', detail: 'Main DB not connected' }));
           earlyMainDbQueue.length = 0;
-        });
+        }));
     }
 
     if (logsDbUrl) {
       const safeLogsUrl = logsDbUrl.replace(/:([^:@]+)@/, ':***@');
-      createDbClient(logsDbUrl)
+      connectionPromises.push(createDbClient(logsDbUrl)
         .then((client) => {
           logsDb      = client;
           logsDbReady = !!client;
           if (logsDbReady && !silent) console.log(`[dbverify] Connected to logs DB (${detectDbType(logsDbUrl)}): ${safeLogsUrl}`);
-          if (logsDbReady && logsDb) drainQueue(earlyLogsDbQueue, logsDb);
+          if (logsDbReady && logsDb) {
+            drainQueue(earlyLogsDbQueue, logsDb);
+            drainCostingQueue(logsDb);
+          }
         })
         .catch((e) => {
           logsDbReady = false;
           console.warn(`[dbverify] Logs DB not reachable, skipping logs DB checks: ${e.message}`);
           earlyLogsDbQueue.forEach((item) => results.push({ name: item.name, result: 'SKIP', detail: 'Logs DB not connected' }));
           earlyLogsDbQueue.length = 0;
-        });
+          earlyCostingQueue.forEach((item) => results.push({ name: item.name, result: 'SKIP', detail: 'Logs DB not connected (costing check)' }));
+          earlyCostingQueue.length = 0;
+        }));
     }
   });
 
@@ -782,6 +963,31 @@ module.exports = function (newman, options) {
     const request    = args.request;
     const name       = (args.item && args.item.name) || 'Unknown Request';
     const statusCode = response && response.code;
+
+    // Costing requests assert that a failed/cancelled request still
+    // recorded cost + tokens. This MUST run before the 2xx-skip below, because
+    // failed requests (4xx/5xx) are exactly the case under test.
+    const expectCost = getHeader(request, 'x-bf-expect-cost');
+    if (expectCost && /^(1|true|yes)$/i.test(String(expectCost))) {
+      const reqId = getHeader(request, 'x-request-id');
+      if (!reqId) {
+        results.push({ name, result: 'FAIL', detail: 'x-bf-expect-cost set but no x-request-id header to locate the log row' });
+        return;
+      }
+      if (!logsDbReady || !logsDb) {
+        if (!logsDbUrl) {
+          // No logs DB configured at all — nothing to verify against.
+          results.push({ name, result: 'SKIP', detail: 'Logs DB not configured (costing check)' });
+          return;
+        }
+        // Configured but the async connection hasn't resolved yet. Defer instead
+        // of SKIP so a fast first request can't silently hide a billing regression.
+        earlyCostingQueue.push({ reqId, name });
+        return;
+      }
+      pendingVerifications.push(verifyCostingRequest(logsDb, reqId, name, results, silent));
+      return;
+    }
 
     if (!statusCode || statusCode < 200 || statusCode > 299) {
       results.push({ name, result: 'SKIP', detail: `HTTP ${statusCode || '?'} (non-2xx)` });
@@ -828,10 +1034,15 @@ module.exports = function (newman, options) {
   });
 
   newman.on('done', function () {
-    Promise.allSettled(pendingVerifications).then(() => {
-      if (db)     db.close();
-      if (logsDb) logsDb.close();
-      if (results.length > 0) printSummary(results, dbType);
-    });
+    // Await the DB connections first so deferred (queued) verifications are
+    // drained into pendingVerifications before we wait on it; otherwise a fast
+    // run could print the summary before late-arriving costing checks settle.
+    Promise.allSettled(connectionPromises)
+      .then(() => Promise.allSettled(pendingVerifications))
+      .then(() => {
+        if (db)     db.close();
+        if (logsDb) logsDb.close();
+        if (results.length > 0) printSummary(results, dbType);
+      });
   });
 };

--- a/tests/e2e/api/runners/run-stream-cancellation.mjs
+++ b/tests/e2e/api/runners/run-stream-cancellation.mjs
@@ -2,7 +2,14 @@
 // Exercises Bifrost's server-side stream cancellation path by opening a stream,
 // reading the first bytes, then aborting the downstream request.
 
-import { writeFileSync } from "node:fs";
+import { writeFileSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+// Shared with newman-reporter-dbverify so provider alias normalization stays in sync.
+const { resolvePricingEntry } = require("../lib/pricing");
 
 const args = Object.fromEntries(
   process.argv.slice(2).reduce((acc, cur, i, arr) => {
@@ -20,8 +27,117 @@ const providerFilter = (args.provider || "").toLowerCase();
 const out = args.out || "tmp/stream-cancel-report.json";
 const readTimeoutMs = Number(args["read-timeout-ms"] || 20000);
 const abortAfterBytes = Number(args["abort-after-bytes"] || 1);
+// Non-streaming cancellation: abort this many ms after dispatch (before the full
+// response can return) to force a client-disconnect on a non-streaming request,
+// exercising the non-streaming client-disconnect billing path (#3357).
+const nonStreamAbortMs = Number(args["nonstream-abort-ms"] || 300);
+// Cost verification: after aborting a stream mid-flight, confirm the logs DB row
+// for that request carries a cost (#3357). Needs a logs DB. Skip with --no-cost-check.
+const skipCostCheck = args["no-cost-check"] === "true";
+const logsDbUrlArg = args["logs-db-url"] || process.env.BIFROST_LOGS_DB_URL || "";
+const configPathArg = args["config"] || process.env.BIFROST_CONFIG_PATH || "config.json";
+const pricingUrl = args["pricing-url"] || process.env.BIFROST_PRICING_URL || "https://getbifrost.ai/datasheet";
+// Providers that emit usage in the FIRST stream event → a cancel-after-first-byte
+// deterministically has billable usage, so cost MUST be > 0. Only native Anthropic
+// qualifies: its message_start event carries input_tokens + cache tokens immediately
+// (https://platform.claude.com/docs/en/api/messages-streaming).
+// Everyone else delivers usage only in a terminal event, so an early cancel may
+// legitimately have none — for those we require only that the error row exists.
+// Notably Bedrock (Converse) is NOT early-usage: per the ConverseStream response
+// schema the `usage` field lives solely in the terminal `metadata`
+// (ConverseStreamMetadataEvent), after messageStop — messageStart carries only role
+// (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html).
+// So a Bedrock stream cancelled before metadata has nothing to bill, same as the
+// OpenAI family — the fix still bills Bedrock whenever metadata arrives before failure.
+const EARLY_USAGE_PROVIDERS = new Set(["anthropic"]);
 
-const cases = [
+// ─── logs DB + datasheet helpers (cost verification) ──────────────────────────
+function resolveLogsDbUrl() {
+  if (logsDbUrlArg) return logsDbUrlArg;
+  try {
+    const cfg = JSON.parse(readFileSync(configPathArg, "utf8"));
+    const ls = cfg.logs_store;
+    if (!ls || !ls.enabled) return "";
+    if (ls.type === "sqlite") {
+      const p = ls.config && ls.config.path;
+      if (!p || typeof p !== "string") return "";
+      const abs = path.isAbsolute(p) ? p : path.resolve(path.dirname(configPathArg), p);
+      return "sqlite://" + abs;
+    }
+    if (ls.type === "postgres") {
+      const c = ls.config || {};
+      const host = c.host || "localhost", port = c.port || "5432", user = c.user || "bifrost";
+      const pass = c.password || "", db = c.db_name || "bifrost", ssl = c.ssl_mode || "disable";
+      return `postgresql://${user}:${encodeURIComponent(pass)}@${host}:${port}/${db}?sslmode=${ssl}`;
+    }
+  } catch (_) { /* no config / unreadable → skip */ }
+  return "";
+}
+
+async function connectLogsDb(url) {
+  if (/^postgres/i.test(url)) {
+    const pg = require("pg");
+    const client = new pg.Client({ connectionString: url });
+    await client.connect();
+    return { query: async (sql, p) => (await client.query(sql, p)).rows, close: () => client.end().catch(() => {}) };
+  }
+  const Database = require("better-sqlite3");
+  const sdb = new Database(url.replace(/^sqlite:\/\//i, ""), { readonly: true });
+  return { query: async (sql, p) => sdb.prepare(sql.replace(/\$\d+/g, "?")).all(...p), close: () => { try { sdb.close(); } catch (_) {} } };
+}
+
+async function pollLogRow(db, id) {
+  const sql = "SELECT cost, prompt_tokens, completion_tokens, total_tokens, cached_read_tokens, token_usage, model, provider, status FROM logs WHERE id = $1";
+  let last = null;
+  for (const ms of [300, 700, 1200, 2000]) {
+    await new Promise((r) => setTimeout(r, ms));
+    const rows = await db.query(sql, [id]);
+    if (rows && rows.length) { last = rows[0]; if (last.cost != null && Number(last.cost) > 0) return last; }
+  }
+  return last;
+}
+
+
+function expectedCost(entry, row) {
+  const input = entry.input_cost_per_token || 0, output = entry.output_cost_per_token || 0;
+  const cr = entry.cache_read_input_token_cost || 0, cw = entry.cache_creation_input_token_cost || 0;
+  const prompt = Number(row.prompt_tokens || 0), completion = Number(row.completion_tokens || 0);
+  let cachedRead = Number(row.cached_read_tokens || 0), cachedWrite = 0;
+  if (row.token_usage) {
+    try {
+      const d = JSON.parse(row.token_usage)?.prompt_tokens_details;
+      if (d) { if (cachedRead === 0 && d.cached_read_tokens) cachedRead = Number(d.cached_read_tokens); if (d.cached_write_tokens) cachedWrite = Number(d.cached_write_tokens); }
+    } catch (_) { /* ignore */ }
+  }
+  cachedRead = Math.min(cachedRead, prompt);
+  cachedWrite = Math.min(cachedWrite, Math.max(0, prompt - cachedRead));
+  const nonCached = Math.max(0, prompt - cachedRead - cachedWrite);
+  return nonCached * input + cachedRead * cr + cachedWrite * cw + completion * output;
+}
+
+// A streaming cancel is always logged status=error; a non-streaming cancel may finish
+// server-side and log success — accept either for non-stream.
+function statusIsCancelOutcome(status, nonStream) {
+  if (nonStream) return status === "error" || status === "success";
+  return status === "error";
+}
+
+// Compare the logged cost against the datasheet-recomputed cost. Returns
+// {verdict, detail, fail}; accuracy is skipped (PASS) when no datasheet entry resolves
+// or the request is tiered (>128k tokens).
+function costAccuracyVerdict(sheet, row, cost, tokens, kind) {
+  const entry = resolvePricingEntry(sheet, row.model, row.provider);
+  if (entry && tokens <= 128000) {
+    const exp = expectedCost(entry, row), tol = Math.max(1e-9, 1e-4 * exp);
+    if (Math.abs(cost - exp) > tol) {
+      return { verdict: "FAIL", detail: `${kind} inaccurate logged=$${cost} expected=$${exp}`, fail: true };
+    }
+    return { verdict: "PASS", detail: `${kind} cost=$${cost} accurate (expected=$${exp})`, fail: false };
+  }
+  return { verdict: "PASS", detail: `${kind} cost=$${cost} (accuracy skipped: no datasheet entry / tiered)`, fail: false };
+}
+
+const streamCases = [
   {
     provider: "openai",
     name: "openai/gpt-4o-mini chat stream",
@@ -83,7 +199,22 @@ const cases = [
       stream: true,
     },
   },
-].filter((c) => !providerFilter || c.provider === providerFilter);
+];
+
+// Derive a non-streaming cancellation case per provider: same model, stream:false,
+// aborted shortly after dispatch (before the response returns). A higher max_tokens
+// makes generation last long enough that the abort lands while the request is still
+// in flight, producing a real client-disconnect on a non-streaming call.
+const nonStreamCases = streamCases.map((c) => ({
+  provider: c.provider,
+  name: `${c.body.model} non-stream cancel`,
+  path: c.path,
+  nonStream: true,
+  body: { ...c.body, stream: false, max_tokens: Math.max(Number(c.body.max_tokens) || 0, 1024) },
+}));
+
+const cases = [...streamCases, ...nonStreamCases]
+  .filter((c) => !providerFilter || c.provider === providerFilter);
 
 const resolveVariables = (value) => {
   if (typeof value === "string") {
@@ -96,15 +227,68 @@ const resolveVariables = (value) => {
   return value;
 };
 
+// Non-streaming cancel: dispatch the request, then abort the socket before the full
+// response returns. If the response comes back before the abort fires, the request
+// completed and we couldn't induce a cancellation → flagged racedToCompletion (SKIP).
+async function runNonStreamCase(testCase) {
+  const controller = new AbortController();
+  const requestId = `nonstream-cancel-${testCase.provider}-${crypto.randomUUID()}`;
+  const timer = setTimeout(
+    () => controller.abort(new Error("intentional non-stream abort before response")),
+    nonStreamAbortMs,
+  );
+  try {
+    const response = await fetch(`${baseUrl}${testCase.path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": requestId,
+        "x-bf-expect-cost": "1",
+      },
+      body: JSON.stringify(resolveVariables(testCase.body)),
+      signal: controller.signal,
+    });
+    // Reaching here means the response returned before our abort fired.
+    clearTimeout(timer);
+    await response.text().catch(() => {});
+    return {
+      ...testCase,
+      requestId,
+      ok: true,
+      status: response.status,
+      aborted: false,
+      racedToCompletion: true,
+      error: "response returned before abort (could not induce cancellation)",
+    };
+  } catch (err) {
+    return {
+      ...testCase,
+      requestId,
+      ok: controller.signal.aborted,
+      aborted: controller.signal.aborted,
+      error: err?.message || String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function runCase(testCase) {
+  if (testCase.nonStream) return runNonStreamCase(testCase);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error("stream read timeout")), readTimeoutMs);
   let bytesRead = 0;
+  // Pin a known request id so the cost-verification pass can locate the log row.
+  const requestId = `stream-cancel-${testCase.provider}-${crypto.randomUUID()}`;
 
   try {
     const response = await fetch(`${baseUrl}${testCase.path}`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": requestId,
+        "x-bf-expect-cost": "1",
+      },
       body: JSON.stringify(resolveVariables(testCase.body)),
       signal: controller.signal,
     });
@@ -145,6 +329,7 @@ async function runCase(testCase) {
 
     return {
       ...testCase,
+      requestId,
       ok: bytesRead > 0,
       status: response.status,
       contentType,
@@ -155,6 +340,7 @@ async function runCase(testCase) {
   } catch (err) {
     return {
       ...testCase,
+      requestId,
       ok: false,
       bytesRead,
       aborted: controller.signal.aborted,
@@ -186,11 +372,74 @@ const report = {
   results,
 };
 
+// ─── Cost verification: a cancelled stream's log row must still carry cost (#3357) ───
+let costFailures = 0;
+if (skipCostCheck) {
+  console.error("[stream-cancel] cost verification skipped (--no-cost-check)");
+} else {
+  const logsUrl = resolveLogsDbUrl();
+  if (!logsUrl) {
+    console.error("[stream-cancel] no logs DB configured (set BIFROST_LOGS_DB_URL or a config.json logs_store); skipping cost verification");
+  } else {
+    let db = null;
+    try { db = await connectLogsDb(logsUrl); }
+    catch (e) { console.error(`[stream-cancel] could not connect to logs DB: ${e.message}; skipping cost verification`); }
+    if (db) {
+      let sheet = null;
+      try { const resp = await fetch(pricingUrl); sheet = resp.ok ? await resp.json() : null; }
+      catch (_) { sheet = null; }
+      if (!sheet) console.error(`[stream-cancel] pricing datasheet (${pricingUrl}) unavailable; cost-accuracy checks skipped`);
+      for (const r of results) {
+        const kind = r.nonStream ? "non-stream" : "stream";
+        if (r.racedToCompletion) { r.costCheck = "SKIP"; r.costDetail = "request completed before abort could fire"; console.error(`[stream-cancel] cost ${r.provider} (${kind}): SKIP — ${r.costDetail}`); continue; }
+        if (!r.aborted || !r.requestId) { r.costCheck = "SKIP"; continue; }
+        const row = await pollLogRow(db, r.requestId);
+        if (!row) {
+          r.costCheck = "FAIL"; r.costDetail = `no log row for ${r.requestId}`; costFailures++;
+        } else if (!statusIsCancelOutcome(row.status, r.nonStream)) {
+          // A streaming cancel is always logged status=error. A non-streaming cancel may
+          // instead finish the upstream call server-side and log success — either way it
+          // must be billed, so we accept both for non-stream and key the cost rules off
+          // the provider, not the status.
+          r.costCheck = "FAIL"; r.costDetail = `status=${row.status}, unexpected for ${kind} cancel`; costFailures++;
+        } else {
+          const cost = Number(row.cost || 0), tokens = Number(row.total_tokens || 0);
+          // Strict cost-presence only where usage is deterministically available at the
+          // moment of cancel: native Anthropic streaming (input tokens in message_start).
+          // Non-streaming cancel billing is provider/timing-dependent (the upstream call
+          // may or may not have completed), so we report it but don't hard-require it.
+          if (!r.nonStream && EARLY_USAGE_PROVIDERS.has(r.provider)) {
+            if (!(cost > 0 && tokens > 0)) {
+              r.costCheck = "FAIL"; r.costDetail = `cancelled ${r.provider} ${kind} logged no cost (cost=$${cost} tokens=${tokens})`; costFailures++;
+            } else {
+              const v = costAccuracyVerdict(sheet, row, cost, tokens, kind);
+              if (v.fail) costFailures++;
+              r.costDetail = v.detail; r.costCheck = v.verdict;
+            }
+          } else {
+            // Presence not required. If a cost WAS recorded, still verify its accuracy.
+            if (cost > 0 && tokens > 0) {
+              const v = costAccuracyVerdict(sheet, row, cost, tokens, kind);
+              if (v.fail) costFailures++;
+              r.costDetail = v.detail; r.costCheck = v.verdict;
+            } else {
+              r.costCheck = "PASS"; r.costDetail = `status=${row.status} cost=$${cost} (cost-presence not required for ${r.provider} ${kind})`;
+            }
+          }
+        }
+        console.error(`[stream-cancel] cost ${r.provider} (${kind}): ${r.costCheck}${r.costDetail ? " — " + r.costDetail : ""}`);
+      }
+      await db.close();
+    }
+  }
+}
+report.costFailures = costFailures;
+
 writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
 
-if (report.failed > 0) {
-  console.error(`[stream-cancel] ${report.failed}/${report.total} case(s) failed; report: ${out}`);
+if (report.failed > 0 || costFailures > 0) {
+  console.error(`[stream-cancel] ${report.failed}/${report.total} stream case(s) failed, ${costFailures} cost check(s) failed; report: ${out}`);
   process.exit(1);
 }
 
-console.error(`[stream-cancel] all ${report.total} case(s) passed; report: ${out}`);
+console.error(`[stream-cancel] all ${report.total} case(s) passed (incl. cost checks); report: ${out}`);


### PR DESCRIPTION
## Summary

Providers (Anthropic, OpenAI, Gemini, Cohere, Bedrock) bill for tokens they process regardless of whether the client receives the response. Previously, if a streaming request was cancelled mid-flight or a non-streaming request timed out after the provider had already consumed input tokens, Bifrost recorded zero cost and zero tokens — silently under-billing. This PR closes that gap by propagating partial/full usage from failed and cancelled requests through the post-LLM hook pipeline so governance budgets and logging reflect what the provider actually charged. Closes #3357

## Changes

- **Streaming providers** (`anthropic`, `openai`, `gemini`, `cohere`, `bedrock`) now register an in-place `*BifrostLLMUsage` handle on the context (`BifrostContextKeyStreamAccumulatedUsage`) at the start of each stream. The handle is mutated as usage chunks arrive, so `HandleStreamCancellation` and `HandleStreamTimeout` in `providers/utils` can read the latest accumulated usage and attach it to the `BifrostError.ExtraFields.BilledUsage` field before running post-hooks.
- **Non-streaming cancellation** (`core/bifrost.go`) — when `requestWorker` detects that the client context was cancelled after the provider had already returned a result or error (the `ctx.Done` branch of the response-send select), it now calls `billAbandonedTerminal`, which runs terminal post-LLM hooks for that result/error. A channel rendezvous guarantee ensures `tryRequest` cannot also receive the same value, so hooks never fire twice for one call.
- **`BifrostError.ExtraFields.BilledUsage`** (`schemas/bifrost.go`) — new optional field carrying provider-reported token usage on failed/cancelled requests. Nil when the failure consumed no tokens (e.g. 401/403/429 before the model ran).
- **`BifrostContextKeyStreamAccumulatedUsage`** (`schemas/bifrost.go`) — new context key for the streaming usage handle.
- **Governance plugin** (`plugins/governance/main.go`, `tracker.go`) — `postHookWorker` now accepts the `BifrostError` and bills `BilledUsage` when present on a failed request. `UpdateUsage` no longer skips all failed requests; it skips only those with zero tokens and zero cost. A billing idempotency set (`RequestID + AttemptNumber`) prevents the same physical provider call from being billed twice when both the core cancellation path and the provider goroutine's terminal hook fire. The idempotency map is swept on the existing reset-worker tick using a 5-minute TTL. Request counts are only incremented for successful requests.
- **Logging plugin** (`plugins/logging/main.go`) — fills `TokenUsageParsed`, `PromptTokens`, `CompletionTokens`, `TotalTokens`, and `Cost` from `BilledUsage` on error entries when stream accumulation did not already capture usage.
- **Model catalog** (`framework/modelcatalog`, `datasheet/cost.go`) — new `CalculateCostForUsage` helper computes cost from a bare `BifrostLLMUsage` object (provider + model + request type) using the same pricing path as `CalculateCost`, so success and failure billing use identical rates. `calculateBaseCost` is refactored to share a `computeCostFromInput` helper with the new function.
- **E2E test collection** (`tests/e2e/api/collections/provider-harness.json`) — new "Costing — Failed/Cancelled Requests" folder with four cases (streaming chat, non-streaming chat, embeddings, transcription) that pin `x-request-id` and `x-bf-expect-cost: true`.
- **Newman DB-verify reporter** (`newman-reporter-dbverify/index.js`) — new `verifyCostingRequest` function polls the logs table with exponential backoff and asserts `cost > 0 && total_tokens > 0` for the pinned request ID, covering the async write + deferred usage path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/...
go test ./plugins/governance/...
go test ./framework/modelcatalog/...
```

Key unit tests added:

- `TestCalculateCostForUsage_MatchesCalculateCost` — bare-usage cost equals full-response cost for the same tokens.
- `TestCalculateCostForUsage_NilUsageIsZero` — nil usage bills nothing.
- `TestUsageTracker_FailedRequestWithUsage_IsBilled` — a failed request that consumed tokens updates the budget.
- `TestUsageTracker_FailedRequestNoUsage_IsSkipped` — a failed request with no tokens does not update the budget.
- `TestUsageTracker_Idempotency_SameAttemptBilledOnce` — duplicate settlement for the same `RequestID + AttemptNumber` bills exactly once.
- `TestUsageTracker_Idempotency_DifferentAttemptsBothBilled` — distinct attempts under one `RequestID` each bill independently.

For streaming cancellation, use `tests/e2e/api/runners/run-stream-cancellation.mjs` to abort a stream mid-response and verify the logs row for `costing-stream-chat` shows `cost > 0` and `total_tokens > 0`.

## Breaking changes

- [x] No

`BifrostError.ExtraFields.BilledUsage` is a new optional JSON field (`omitempty`). Existing consumers that ignore unknown fields are unaffected. The governance `UsageUpdate` struct gains `AttemptNumber` and `BilledReason` fields, also `omitempty`.

## Security considerations

No new auth surfaces, secrets, or PII handling. The billing idempotency map is in-process and bounded by TTL sweep; it does not persist across restarts, which is acceptable since in-flight requests do not survive a restart.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable