### PR TITLE
[fix]: Bedrock stream errors use EventStream exceptions

### DIFF
--- a/transports/bifrost-http/integrations/bedrock.go
+++ b/transports/bifrost-http/integrations/bedrock.go
@@ -94,6 +94,7 @@ func createBedrockConverseStreamRouteConfig(pathPrefix string, handlerStore lib.
 			return bedrock.ToBedrockError(err)
 		},
 		StreamConfig: &StreamConfig{
+			ErrorConverter: bedrockStreamErrorConverter,
 			ResponsesStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesStreamResponse) (string, interface{}, error) {
 				bedrockEvent, err := bedrock.ToBedrockConverseStreamResponse(resp)
 				if err != nil {
@@ -154,6 +155,7 @@ func createBedrockInvokeWithResponseStreamRouteConfig(pathPrefix string, handler
 			return bedrock.ToBedrockError(err)
 		},
 		StreamConfig: &StreamConfig{
+			ErrorConverter: bedrockStreamErrorConverter,
 			TextStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostTextCompletionResponse) (string, interface{}, error) {
 				if resp == nil {
 					return "", nil, nil
@@ -176,6 +178,11 @@ func createBedrockInvokeWithResponseStreamRouteConfig(pathPrefix string, handler
 		},
 		PreCallback: bedrockPreCallback(handlerStore),
 	}
+}
+
+func bedrockStreamErrorConverter(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+	errorPayload := bedrock.ToBedrockError(err)
+	return newBedrockEventStreamException(errorPayload.Type, errorPayload.Message)
 }
 
 // createBedrockInvokeRouteConfig creates a route configuration for the Bedrock Invoke API endpoint

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -1,9 +1,14 @@
 package integrations
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/providers/bedrock"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/kvstore"
@@ -175,6 +180,7 @@ func Test_createBedrockConverseStreamRouteConfig(t *testing.T) {
 	assert.Equal(t, "POST", route.Method)
 	assert.Equal(t, RouteConfigTypeBedrock, route.Type)
 	assert.NotNil(t, route.StreamConfig)
+	assert.NotNil(t, route.StreamConfig.ErrorConverter)
 	assert.NotNil(t, route.StreamConfig.ResponsesStreamResponseConverter)
 
 	// Verify request instance type
@@ -207,6 +213,7 @@ func Test_createBedrockInvokeWithResponseStreamRouteConfig(t *testing.T) {
 	assert.Equal(t, "POST", route.Method)
 	assert.Equal(t, RouteConfigTypeBedrock, route.Type)
 	assert.NotNil(t, route.StreamConfig)
+	assert.NotNil(t, route.StreamConfig.ErrorConverter)
 	assert.NotNil(t, route.StreamConfig.TextStreamResponseConverter)
 	assert.NotNil(t, route.StreamConfig.ResponsesStreamResponseConverter)
 
@@ -214,6 +221,114 @@ func Test_createBedrockInvokeWithResponseStreamRouteConfig(t *testing.T) {
 	reqInstance := route.GetRequestTypeInstance(context.Background())
 	_, ok := reqInstance.(*bedrock.BedrockInvokeRequest)
 	assert.True(t, ok, "GetRequestTypeInstance should return *bedrock.BedrockInvokeRequest")
+}
+
+func Test_bedrockStreamErrorConverterEncodesEventStreamException(t *testing.T) {
+	errType := "PluginDenied"
+	statusCode := fasthttp.StatusForbidden
+	bifrostErr := &schemas.BifrostError{
+		Type:       &errType,
+		StatusCode: &statusCode,
+		Error: &schemas.ErrorField{
+			Message: "blocked by policy",
+		},
+	}
+
+	converted := bedrockStreamErrorConverter(nil, bifrostErr)
+	exception, ok := converted.(*bedrockEventStreamException)
+	require.True(t, ok)
+
+	reader := lib.NewSSEStreamReader()
+	require.True(t, sendBedrockEventStreamException(reader, eventstream.NewEncoder(), exception, bifrost.NewNoOpLogger()))
+	reader.Done()
+
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.False(t, bytes.HasPrefix(body, []byte("data: ")), "Bedrock streaming errors must not be plain SSE")
+
+	msg, err := eventstream.NewDecoder().Decode(bytes.NewReader(body), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "exception", eventStreamHeaderString(t, msg.Headers, ":message-type"))
+	assert.Equal(t, "PluginDenied", eventStreamHeaderString(t, msg.Headers, ":exception-type"))
+	assert.JSONEq(t, `{"message":"blocked by policy"}`, string(msg.Payload))
+	assert.False(t, strings.Contains(string(body), "data:"), "AWS EventStream bytes must not contain SSE framing")
+}
+
+func Test_toBedrockEventStreamExceptionAcceptsBedrockError(t *testing.T) {
+	exception, ok := toBedrockEventStreamException(&bedrock.BedrockError{
+		Type:    "ValidationException",
+		Message: "invalid request",
+	})
+	require.True(t, ok)
+
+	reader := lib.NewSSEStreamReader()
+	require.True(t, sendBedrockEventStreamException(reader, eventstream.NewEncoder(), exception, bifrost.NewNoOpLogger()))
+	reader.Done()
+
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.False(t, bytes.HasPrefix(body, []byte("data: ")), "Bedrock streaming errors must not be plain SSE")
+
+	msg, err := eventstream.NewDecoder().Decode(bytes.NewReader(body), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "exception", eventStreamHeaderString(t, msg.Headers, ":message-type"))
+	assert.Equal(t, "ValidationException", eventStreamHeaderString(t, msg.Headers, ":exception-type"))
+	assert.JSONEq(t, `{"message":"invalid request"}`, string(msg.Payload))
+}
+
+func Test_handleStreamingBedrockUnknownErrorResponseFallsBackToEventStreamException(t *testing.T) {
+	stream := make(chan *schemas.BifrostStreamChunk, 1)
+	statusCode := fasthttp.StatusInternalServerError
+	stream <- &schemas.BifrostStreamChunk{
+		BifrostError: &schemas.BifrostError{
+			StatusCode: &statusCode,
+			Error: &schemas.ErrorField{
+				Message: "plugin returned an unsupported error envelope",
+			},
+		},
+	}
+	close(stream)
+
+	router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, bifrost.NewNoOpLogger())
+	ctx := &fasthttp.RequestCtx{}
+	cancelCalled := false
+	router.handleStreaming(ctx, nil, RouteConfig{
+		Type: RouteConfigTypeBedrock,
+		StreamConfig: &StreamConfig{
+			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+				return map[string]interface{}{
+					"unexpected": "shape",
+				}
+			},
+		},
+	}, stream, func() {
+		cancelCalled = true
+	})
+
+	body, err := io.ReadAll(ctx.Response.BodyStream())
+	require.NoError(t, err)
+	require.NotEmpty(t, body)
+	require.False(t, bytes.HasPrefix(body, []byte("data: ")), "Bedrock fallback errors must not be plain SSE")
+
+	msg, err := eventstream.NewDecoder().Decode(bytes.NewReader(body), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "exception", eventStreamHeaderString(t, msg.Headers, ":message-type"))
+	assert.Equal(t, "InternalServerException", eventStreamHeaderString(t, msg.Headers, ":exception-type"))
+	assert.JSONEq(t, `{"message":"An error occurred while processing your request"}`, string(msg.Payload))
+	assert.False(t, cancelCalled, "fallback write should not cancel unless the client disconnects")
+}
+
+func eventStreamHeaderString(t *testing.T, headers eventstream.Headers, name string) string {
+	t.Helper()
+	for _, header := range headers {
+		if header.Name == name {
+			value, ok := header.Value.Get().(string)
+			require.True(t, ok, "%s header must be a string", name)
+			return value
+		}
+	}
+	t.Fatalf("missing EventStream header %s", name)
+	return ""
 }
 
 func Test_createBedrockRerankRouteConfig(t *testing.T) {

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2609,6 +2609,22 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 					// CUSTOM SSE FORMAT: The converter returned a complete SSE string
 					// This is used by providers like Anthropic that need custom event types
 					reader.Send([]byte(sseErrorString))
+				} else if config.Type == RouteConfigTypeBedrock && eventStreamEncoder != nil {
+					if bedrockException, ok := toBedrockEventStreamException(errorResponse); ok {
+						if !sendBedrockEventStreamException(reader, eventStreamEncoder, bedrockException, g.logger) {
+							cancel()
+						}
+						return
+					}
+					if bedrockEvent, ok := errorResponse.(*bedrock.BedrockStreamEvent); ok {
+						if !sendBedrockEventStream(reader, eventStreamEncoder, bedrockEvent, g.logger) {
+							cancel()
+						}
+						return
+					}
+					if !sendBedrockEventStreamException(reader, eventStreamEncoder, newBedrockEventStreamException("", ""), g.logger) {
+						cancel()
+					}
 				} else {
 					// STANDARD SSE FORMAT: The converter returned an object
 					errorJSON, err := sonic.Marshal(errorResponse)
@@ -2699,49 +2715,9 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 				if config.Type == RouteConfigTypeBedrock && eventStreamEncoder != nil {
 					// We need to cast to BedrockStreamEvent to determine event type and structure
 					if bedrockEvent, ok := convertedResponse.(*bedrock.BedrockStreamEvent); ok {
-						// Convert to sequence of specific Bedrock events
-						events := bedrockEvent.ToEncodedEvents()
-
-						// Send all collected events
-						for _, evt := range events {
-							jsonData, err := sonic.Marshal(evt.Payload)
-							if err != nil {
-								g.logger.Warn("Failed to marshal bedrock payload: %v", err)
-								continue
-							}
-
-							headers := eventstream.Headers{
-								{
-									Name:  ":content-type",
-									Value: eventstream.StringValue("application/json"),
-								},
-								{
-									Name:  ":event-type",
-									Value: eventstream.StringValue(evt.EventType),
-								},
-								{
-									Name:  ":message-type",
-									Value: eventstream.StringValue("event"),
-								},
-							}
-
-							message := eventstream.Message{
-								Headers: headers,
-								Payload: jsonData,
-							}
-
-							var msgBuf bytes.Buffer
-							if err := eventStreamEncoder.Encode(&msgBuf, message); err != nil {
-								g.logger.Warn("[Bedrock Stream] Failed to encode message: %v", err)
-								cancel()
-								return
-							}
-
-							if !reader.Send(msgBuf.Bytes()) {
-								g.logger.Warn("[Bedrock Stream] Client disconnected")
-								cancel()
-								return
-							}
+						if !sendBedrockEventStream(reader, eventStreamEncoder, bedrockEvent, g.logger) {
+							cancel()
+							return
 						}
 					}
 					// Continue to next chunk (we handled sending internally)
@@ -2803,6 +2779,123 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 			}
 		}
 	}()
+}
+
+type bedrockEventStreamException struct {
+	exceptionType string
+	payload       []byte
+}
+
+func toBedrockEventStreamException(errorResponse interface{}) (*bedrockEventStreamException, bool) {
+	switch response := errorResponse.(type) {
+	case *bedrockEventStreamException:
+		return response, true
+	case *bedrock.BedrockError:
+		return newBedrockEventStreamException(response.Type, response.Message), true
+	default:
+		return nil, false
+	}
+}
+
+func newBedrockEventStreamException(exceptionType, message string) *bedrockEventStreamException {
+	if message == "" {
+		message = "An error occurred while processing your request"
+	}
+	if exceptionType == "" {
+		exceptionType = "InternalServerException"
+	}
+
+	payloadJSON, err := sonic.Marshal(map[string]string{"message": message})
+	if err != nil {
+		payloadJSON = []byte(`{"message":"An error occurred while processing your request"}`)
+	}
+
+	return &bedrockEventStreamException{
+		exceptionType: exceptionType,
+		payload:       payloadJSON,
+	}
+}
+
+func sendBedrockEventStream(reader *lib.SSEStreamReader, encoder *eventstream.Encoder, bedrockEvent *bedrock.BedrockStreamEvent, logger schemas.Logger) bool {
+	// Convert to sequence of specific Bedrock events
+	events := bedrockEvent.ToEncodedEvents()
+
+	// Send all collected events
+	for _, evt := range events {
+		jsonData, err := sonic.Marshal(evt.Payload)
+		if err != nil {
+			logger.Warn("Failed to marshal bedrock payload: %v", err)
+			continue
+		}
+
+		headers := eventstream.Headers{
+			{
+				Name:  ":content-type",
+				Value: eventstream.StringValue("application/json"),
+			},
+			{
+				Name:  ":event-type",
+				Value: eventstream.StringValue(evt.EventType),
+			},
+			{
+				Name:  ":message-type",
+				Value: eventstream.StringValue("event"),
+			},
+		}
+
+		message := eventstream.Message{
+			Headers: headers,
+			Payload: jsonData,
+		}
+
+		var msgBuf bytes.Buffer
+		if err := encoder.Encode(&msgBuf, message); err != nil {
+			logger.Warn("[Bedrock Stream] Failed to encode message: %v", err)
+			return false
+		}
+
+		if !reader.Send(msgBuf.Bytes()) {
+			logger.Warn("[Bedrock Stream] Client disconnected")
+			return false
+		}
+	}
+
+	return true
+}
+
+func sendBedrockEventStreamException(reader *lib.SSEStreamReader, encoder *eventstream.Encoder, exception *bedrockEventStreamException, logger schemas.Logger) bool {
+	headers := eventstream.Headers{
+		{
+			Name:  ":content-type",
+			Value: eventstream.StringValue("application/json"),
+		},
+		{
+			Name:  ":exception-type",
+			Value: eventstream.StringValue(exception.exceptionType),
+		},
+		{
+			Name:  ":message-type",
+			Value: eventstream.StringValue("exception"),
+		},
+	}
+
+	message := eventstream.Message{
+		Headers: headers,
+		Payload: exception.payload,
+	}
+
+	var msgBuf bytes.Buffer
+	if err := encoder.Encode(&msgBuf, message); err != nil {
+		logger.Warn("[Bedrock Stream] Failed to encode exception: %v", err)
+		return false
+	}
+
+	if !reader.Send(msgBuf.Bytes()) {
+		logger.Warn("[Bedrock Stream] Client disconnected")
+		return false
+	}
+
+	return true
 }
 
 // extractPassthroughModel extracts the model from the passthrough request path and/or body.

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -9,6 +9,7 @@
 ## 🐞 Fixed
 
 - **Anthropic Streaming** — Fixed duplicate `message_start` event in the Anthropic stream (closes #4556)
+- **Bedrock Streaming** — Encode Bedrock stream errors as EventStream exceptions (#4545)
 - **Bedrock MiniMax** — Fixed Bedrock signature handling for MiniMax models
 - **Bedrock Nova** — Fixed Nova model handling on Bedrock
 - **Bedrock Batch** — Corrected model id in Bedrock batch requests


### PR DESCRIPTION
## Summary

Fixes #4545.

Bedrock streaming routes now serialize Bifrost stream errors as AWS EventStream exception frames instead of plain SSE `data:` events. This keeps `/bedrock/model/{modelId}/converse-stream` and `/bedrock/model/{modelId}/invoke-with-response-stream` wire-compatible when a plugin returns a `BifrostError` during streaming.

## Changes

- Add Bedrock streaming error converters for both Bedrock stream routes.
- Reuse the Bedrock EventStream encoder for stream errors and emit `:message-type: exception` frames.
- Add regression coverage that decodes the emitted bytes as AWS EventStream and verifies no SSE framing is present.
- Update the transports changelog.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## Verification

From `transports`:

```sh
go test ./bifrost-http/integrations -run 'Test_createBedrockConverseStreamRouteConfig|Test_createBedrockInvokeWithResponseStreamRouteConfig|Test_bedrockStreamErrorConverterEncodesEventStreamException|TestSendStreamError_BedrockErrorFormat|Test_createBedrockRouteConfigs$|TestSendStreamError_PropagatesProviderStatusCode|TestSendStreamError_OpenAIErrorFormat|TestSendStreamError_AnthropicErrorFormat|TestSendStreamError_ForwardsProviderHeaders' -count=1 -v
go test ./bifrost-http/integrations -run 'Test_handleStreaming|Test.*StreamError|Test.*Bedrock.*Stream' -count=1
```

Expected outcome: both commands pass.

Broader package command checked:

```sh
go test ./bifrost-http/integrations -count=1
```

Current outcome: this broader command fails on both this branch and a clean `dev` checkout with unrelated existing failures in `Test_createBedrockRerankRouteRequestConverter` and `TestCreateHandler_AnthropicRouteClears_UseRawRequestBody_WhenCatalogSelectsBedrock`.

## Screenshots/Recordings

Not applicable.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes #4545.

## Security considerations

No new auth surfaces, secrets, or PII handling. This only changes the wire framing used for Bedrock streaming error responses.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
