### PR TITLE
fixes buffering flow for bedrock

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -454,10 +454,13 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	req.Header.Set("Accept", "application/vnd.amazon.eventstream")
+	// Force identity encoding so Go's net/http transport does NOT auto-negotiate
+	// gzip. A gzip-compressed eventstream buffers upstream until the stream
+	// completes, collapsing TTFB to the total generation time (issue #4542).
+	req.Header.Set("Accept-Encoding", "identity")
 	if key.Value.GetValue() != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
 	} else {
-		req.Header.Set("Accept", "application/vnd.amazon.eventstream")
 		// Sign the request using either explicit credentials or IAM role authentication
 		if err := signAWSRequest(ctx, req, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService); err != nil {
 			return nil, err

--- a/core/providers/bedrock/streambuffering_test.go
+++ b/core/providers/bedrock/streambuffering_test.go
@@ -1,0 +1,161 @@
+package bedrock
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeEventStreamEvent encodes a well-formed AWS EventStream "event" frame
+// (":message-type" == "event") carrying the given JSON payload into w. Used to
+// emit normal streaming chunks (messageStart / contentBlockDelta) that the
+// Bedrock decode loop forwards to the response channel.
+func writeEventStreamEvent(t *testing.T, w io.Writer, eventType string, payload []byte) {
+	t.Helper()
+	enc := eventstream.NewEncoder()
+	headers := eventstream.Headers{
+		{Name: ":message-type", Value: eventstream.StringValue("event")},
+		{Name: ":event-type", Value: eventstream.StringValue(eventType)},
+		{Name: ":content-type", Value: eventstream.StringValue("application/json")},
+	}
+	require.NoError(t, enc.Encode(w, eventstream.Message{Headers: headers, Payload: payload}),
+		"failed to encode EventStream event frame")
+}
+
+// TestChatCompletionStream_StreamsIncrementally_NotBuffered reproduces issue #4542:
+// streaming Bedrock responses arrive in a single end-of-stream burst instead of
+// incrementally, because Go's net/http transport auto-negotiates gzip and the
+// gzip-compressed upstream buffers until the stream completes.
+//
+// The fake Bedrock server branches on the inbound Accept-Encoding:
+//   - gzip (Go's auto default, pre-fix): writes events into a gzip.Writer that is
+//     NOT flushed and blocks before Close, so the client receives nothing until the
+//     whole upstream stream finishes — TTFB == total generation time.
+//   - identity (post-fix): flushes the first event immediately, then blocks, so the
+//     client gets the first chunk well before the upstream completes.
+//
+// The test asserts the first chunk arrives before the upstream is released. It is
+// deterministic (channel-gated, no wall-clock sleeps): pre-fix the first read times
+// out; post-fix it succeeds.
+func TestChatCompletionStream_StreamsIncrementally_NotBuffered(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	closeRelease := func() { releaseOnce.Do(func() { close(release) }) }
+
+	roleStart := []byte(`{"role":"assistant"}`)
+	textDelta := []byte(`{"delta":{"text":"Hello"},"contentBlockIndex":0}`)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		acceptEncoding := r.Header.Get("Accept-Encoding")
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok, "test server ResponseWriter must support Flush")
+
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+		if strings.Contains(acceptEncoding, "gzip") {
+			w.Header().Set("Content-Encoding", "gzip")
+		}
+		w.WriteHeader(http.StatusOK)
+		// Flush headers immediately so makeStreamingRequest's client.Do returns and
+		// the decode goroutine begins reading the body. The body is what we withhold.
+		flusher.Flush()
+
+		if strings.Contains(acceptEncoding, "gzip") {
+			// Pre-fix path: Bedrock compresses the eventstream. gzip.Writer buffers
+			// small writes in memory and we never Flush, so no complete gzip block
+			// reaches the wire until Close(). We block before Close, so the client's
+			// (transparently decompressing) body Read starves — no chunk until the
+			// upstream stream completes. This is the issue #4542 symptom.
+			gz := gzip.NewWriter(w)
+			writeEventStreamEvent(t, gz, "messageStart", roleStart)
+			<-release // hold the entire (still-buffered) stream
+			writeEventStreamEvent(t, gz, "contentBlockDelta", textDelta)
+			_ = gz.Close()
+			flusher.Flush()
+			return
+		}
+
+		// Post-fix path: identity encoding, raw eventstream, flush per event.
+		writeEventStreamEvent(t, w, "messageStart", roleStart)
+		flusher.Flush()
+		<-release // first chunk already on the wire; hold the rest
+		writeEventStreamEvent(t, w, "contentBlockDelta", textDelta)
+		flusher.Flush()
+	}))
+	defer ts.Close()
+	// Must unblock the handler before ts.Close(), which waits for in-flight requests.
+	defer closeRelease()
+
+	provider := newTestProviderWithServer(t, ts)
+	ctx := testBedrockCtx()
+	key := testBedrockKey()
+
+	streamChan, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHookRunner, nil, key, testChatRequest())
+	require.Nil(t, bifrostErr, "stream setup should not error")
+	require.NotNil(t, streamChan)
+
+	// The first chunk MUST arrive while the upstream is still held open. If the
+	// response is buffered (issue #4542), nothing arrives until release is closed,
+	// so this read times out.
+	select {
+	case chunk, ok := <-streamChan:
+		require.True(t, ok, "stream closed before delivering any chunk")
+		require.NotNil(t, chunk)
+		require.Nil(t, chunk.BifrostError, "first chunk should be data, not an error: %+v", chunk.BifrostError)
+	case <-time.After(2 * time.Second):
+		t.Fatal("first chunk not received before upstream completed — response is buffered server-side (issue #4542)")
+	}
+
+	// Release the rest of the upstream and drain.
+	closeRelease()
+	for range streamChan {
+	}
+}
+
+// TestMakeStreamingRequest_SendsIdentityAcceptEncoding is the deterministic
+// mechanism guard for issue #4542: the Bedrock streaming request must send
+// Accept-Encoding: identity so Go's net/http transport does not auto-negotiate
+// gzip (which buffers the eventstream). Pre-fix, Go auto-adds "gzip".
+func TestMakeStreamingRequest_SendsIdentityAcceptEncoding(t *testing.T) {
+	var mu sync.Mutex
+	var gotAcceptEncoding string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAcceptEncoding = r.Header.Get("Accept-Encoding")
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		writeEventStreamEvent(t, w, "messageStart", []byte(`{"role":"assistant"}`))
+		writeEventStreamEvent(t, w, "contentBlockDelta", []byte(`{"delta":{"text":"Hi"},"contentBlockIndex":0}`))
+	}))
+	defer ts.Close()
+
+	provider := newTestProviderWithServer(t, ts)
+	ctx := testBedrockCtx()
+	key := testBedrockKey()
+
+	streamChan, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHookRunner, nil, key, testChatRequest())
+	require.Nil(t, bifrostErr)
+	require.NotNil(t, streamChan)
+	for range streamChan { // drain so the request fully completes
+	}
+
+	mu.Lock()
+	got := gotAcceptEncoding
+	mu.Unlock()
+	assert.Equal(t, "identity", got,
+		"Bedrock streaming request must send Accept-Encoding: identity to prevent net/http auto-gzip buffering (issue #4542)")
+}

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -344,6 +344,119 @@
               "path": ["bedrock", "model", "{{bedrockModel}}", "converse"]
             }
           }
+        },
+        {
+          "name": "POST /bedrock/model/{modelId}/converse-stream — streaming (incremental events)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Bedrock native streaming (converse-stream). Verifies the upstream is delivered",
+                  "// as a live AWS event stream with multiple incremental frames, guarding against the",
+                  "// server-side gzip buffering regression where all events arrive at once (issue #4542).",
+                  "if (pm.response.code >= 400) { return; }",
+                  "pm.test('Bedrock stream is an AWS event stream', function () {",
+                  "  var ct = pm.response.headers.get('content-type') || '';",
+                  "  pm.expect(ct, 'expected vnd.amazon.eventstream, got ' + ct).to.include('vnd.amazon.eventstream');",
+                  "});",
+                  "pm.test('Bedrock stream contains multiple incremental events', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  var deltas = (body.match(/contentBlockDelta/g) || []).length;",
+                  "  pm.expect(deltas, 'expected >= 2 contentBlockDelta frames, got ' + deltas).to.be.at.least(2);",
+                  "  pm.expect(body, 'expected a messageStop event terminating the stream').to.include('messageStop');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [{ \"text\": \"Write three short sentences about the Unix philosophy.\" }]\n    }\n  ],\n  \"inferenceConfig\": { \"maxTokens\": 512 }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/model/{{bedrockModel}}/converse-stream",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "bedrock",
+                "model",
+                "{{bedrockModel}}",
+                "converse-stream"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST /v1/chat/completions — bedrock streaming (SSE incremental deltas)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Bedrock streaming via the OpenAI-compatible SSE path (/v1/chat/completions).",
+                  "// Confirms chunked SSE delivery with multiple incremental content deltas and a",
+                  "// [DONE] terminator. Note: newman buffers the full response, so this validates",
+                  "// SSE framing/chunking, not wall-clock TTFB (that is covered by the Go unit test",
+                  "// TestChatCompletionStream_StreamsIncrementally_NotBuffered). Issue #4542.",
+                  "if (pm.response.code >= 400) { return; }",
+                  "pm.test('Bedrock SSE: content-type is text/event-stream', function () {",
+                  "  var ct = pm.response.headers.get('content-type') || '';",
+                  "  pm.expect(ct, 'expected SSE, got ' + ct).to.include('text/event-stream');",
+                  "});",
+                  "pm.test('Bedrock SSE: multiple data chunks with incremental content deltas', function () {",
+                  "  var lines = (pm.response.text() || '').split('\\n');",
+                  "  var chunks = 0, sawDelta = false, sawDone = false;",
+                  "  lines.forEach(function (l) {",
+                  "    if (l.indexOf('data: ') !== 0) { return; }",
+                  "    chunks++;",
+                  "    var p = l.slice(6).trim();",
+                  "    if (p === '[DONE]') { sawDone = true; return; }",
+                  "    try { var j = JSON.parse(p); var d = j.choices && j.choices[0] && j.choices[0].delta; if (d && typeof d.content === 'string' && d.content.length) { sawDelta = true; } } catch (e) {}",
+                  "  });",
+                  "  pm.expect(chunks, 'expected > 1 SSE data chunks, got ' + chunks).to.be.above(1);",
+                  "  pm.expect(sawDelta, 'expected at least one chunk with an incremental content delta').to.be.true;",
+                  "  pm.expect(sawDone, 'expected an SSE [DONE] terminator').to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/{{bedrockModel}}\",\n  \"stream\": true,\n  \"max_tokens\": 256,\n  \"messages\": [\n    { \"role\": \"user\", \"content\": \"Write three short sentences about the Unix philosophy.\" }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary

Fixes a streaming buffering issue (Closes #4542) where Bedrock streaming responses arrived in a single burst at the end of generation rather than incrementally. Go's `net/http` transport automatically negotiates gzip encoding, which causes the eventstream to be buffered until the stream completes, collapsing time-to-first-byte (TTFB) to the total generation time.

## Changes

- Added `Accept-Encoding: identity` header to all Bedrock streaming requests, preventing Go's `net/http` transport from auto-negotiating gzip compression on the eventstream connection
- Removed a duplicate `Accept` header set that was only applied to the IAM auth path
- Added `TestChatCompletionStream_StreamsIncrementally_NotBuffered`: a deterministic integration test using a channel-gated fake Bedrock server that verifies the first chunk arrives while the upstream is still held open (pre-fix this times out; post-fix it succeeds)
- Added `TestMakeStreamingRequest_SendsIdentityAcceptEncoding`: a guard test that asserts the outbound request carries `Accept-Encoding: identity` rather than Go's default `gzip`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... -v -run TestChatCompletionStream_StreamsIncrementally_NotBuffered
go test ./core/providers/bedrock/... -v -run TestMakeStreamingRequest_SendsIdentityAcceptEncoding
go test ./...
```

The buffering test is deterministic and channel-gated — no wall-clock sleeps. Pre-fix, `TestChatCompletionStream_StreamsIncrementally_NotBuffered` fails with a 2-second timeout; post-fix it passes immediately upon receiving the first flushed chunk.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

Closes #4542

## Security considerations

No security implications. The change only affects HTTP content-encoding negotiation for the Bedrock streaming endpoint.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable