### PR TITLE
adds vk related test in api harness

### DIFF
--- a/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
@@ -3259,6 +3259,171 @@
       ]
     },
     {
+      "name": "Governance - VK List Models Restriction",
+      "description": "Regression #2887 / PR #3187 (/v1/models) and #3094 (/api/models): a virtual key scoped to a subset of providers must restrict list-models output to ONLY those providers. The server has many providers configured; this VK allows only openai+anthropic, and both list-models endpoints must return only those providers and exclude the rest (mistral, gemini, groq).",
+      "item": [
+        {
+          "name": "Create VK (allow openai + anthropic only)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var ts = Date.now();",
+                  "var body = {",
+                  "  name: 'VK ListModels Restriction ' + ts,",
+                  "  is_active: true,",
+                  "  provider_configs: [",
+                  "    { provider: 'openai', weight: 1, allowed_models: ['*'], key_ids: ['*'] },",
+                  "    { provider: 'anthropic', weight: 1, allowed_models: ['*'], key_ids: ['*'] }",
+                  "  ]",
+                  "};",
+                  "pm.request.body.raw = JSON.stringify(body);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var code = pm.response.code;",
+                  "pm.test('Create VK returns 2xx', function () { pm.expect(code).to.be.within(200, 299); });",
+                  "if (code >= 200 && code <= 299) {",
+                  "  var json = pm.response.json();",
+                  "  var vk = json.virtual_key || json;",
+                  "  if (vk && vk.id) pm.collectionVariables.set('vkrestrict_id', vk.id);",
+                  "  if (vk && vk.value) pm.collectionVariables.set('vkrestrict_value', vk.value);",
+                  "  pm.test('Created VK value looks like a bifrost VK', function () { pm.expect(String(vk.value)).to.match(/^sk-bf-/); });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
+            "body": { "mode": "raw", "raw": "{}" },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys",
+              "host": [ "{{base_url}}" ],
+              "path": [ "api", "governance", "virtual-keys" ]
+            }
+          }
+        },
+        {
+          "name": "List Models via VK - /api/models (provider field)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var ALLOWED = ['openai', 'anthropic'];",
+                  "var DISALLOWED = ['mistral', 'gemini', 'groq'];",
+                  "pm.test('GET /api/models with VK returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "var models = (body && body.models) || [];",
+                  "var seen = {};",
+                  "models.forEach(function (m) { if (m && m.provider) seen[m.provider] = true; });",
+                  "var present = Object.keys(seen);",
+                  "ALLOWED.forEach(function (p) {",
+                  "  pm.test('/api/models includes allowed provider: ' + p, function () { pm.expect(present).to.include(p); });",
+                  "});",
+                  "DISALLOWED.forEach(function (p) {",
+                  "  pm.test('/api/models excludes disallowed provider: ' + p, function () { pm.expect(present).to.not.include(p); });",
+                  "});",
+                  "pm.test('/api/models contains only VK-allowed providers', function () {",
+                  "  var leaked = present.filter(function (p) { return ALLOWED.indexOf(p) === -1; });",
+                  "  pm.expect(leaked, 'leaked providers: ' + JSON.stringify(leaked)).to.eql([]);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [ { "key": "x-bf-vk", "value": "{{vkrestrict_value}}" } ],
+            "url": {
+              "raw": "{{base_url}}/api/models?limit=5000",
+              "host": [ "{{base_url}}" ],
+              "path": [ "api", "models" ],
+              "query": [ { "key": "limit", "value": "5000" } ]
+            }
+          }
+        },
+        {
+          "name": "List Models via VK - /v1/models (the #3187 flow)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var ALLOWED = ['openai', 'anthropic'];",
+                  "var DISALLOWED = ['mistral', 'gemini', 'groq'];",
+                  "pm.test('GET /v1/models with VK returns 200', function () { pm.response.to.have.status(200); });",
+                  "var body = pm.response.json();",
+                  "var data = (body && body.data) || [];",
+                  "var seen = {};",
+                  "data.forEach(function (m) {",
+                  "  var id = (m && m.id) ? String(m.id) : '';",
+                  "  var pfx = id.indexOf('/') >= 0 ? id.split('/')[0] : id;",
+                  "  if (pfx) seen[pfx] = true;",
+                  "});",
+                  "var present = Object.keys(seen);",
+                  "DISALLOWED.forEach(function (p) {",
+                  "  pm.test('/v1/models excludes disallowed provider: ' + p, function () { pm.expect(present).to.not.include(p); });",
+                  "});",
+                  "pm.test('/v1/models returns at least one allowed-provider model', function () {",
+                  "  var hasAllowed = present.some(function (p) { return ALLOWED.indexOf(p) >= 0; });",
+                  "  pm.expect(hasAllowed).to.be.true;",
+                  "});",
+                  "pm.test('/v1/models contains only VK-allowed providers', function () {",
+                  "  var leaked = present.filter(function (p) { return ALLOWED.indexOf(p) === -1; });",
+                  "  pm.expect(leaked, 'leaked providers: ' + JSON.stringify(leaked)).to.eql([]);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [ { "key": "x-bf-vk", "value": "{{vkrestrict_value}}" } ],
+            "url": {
+              "raw": "{{base_url}}/v1/models",
+              "host": [ "{{base_url}}" ],
+              "path": [ "v1", "models" ]
+            }
+          }
+        },
+        {
+          "name": "Teardown - Delete VK",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Delete VK returns 2xx', function () { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vkrestrict_id}}",
+              "host": [ "{{base_url}}" ],
+              "path": [ "api", "governance", "virtual-keys", "{{vkrestrict_id}}" ]
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "Governance - Routing Rules",
       "item": [
         {


### PR DESCRIPTION
## Summary

Adds an end-to-end regression test suite covering virtual key (VK) scoped model list restrictions. When a VK is configured to allow only a subset of providers, both the `/api/models` and `/v1/models` endpoints must return exclusively those providers — no leakage from other configured providers (e.g. mistral, gemini, groq).

## Changes

- Added a new Postman collection folder `Governance - VK List Models Restriction` that covers regression #2887 / PRs #3187 and #3094.
- The test flow creates a VK scoped to `openai` and `anthropic` only, then validates both list-models endpoints (`/api/models` and `/v1/models`) return only those providers and explicitly exclude `mistral`, `gemini`, and `groq`.
- A teardown step deletes the VK after the tests complete to keep the environment clean.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the Postman collection against a live Bifrost instance that has multiple providers configured (including openai, anthropic, mistral, gemini, and groq):

```sh
newman run tests/e2e/api/collections/bifrost-api-management.postman_collection.json \
  --folder "Governance - VK List Models Restriction" \
  --env-var "base_url=http://localhost:8080"
```

Expected outcome: all tests in the folder pass — allowed providers appear in both endpoints, disallowed providers do not.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2887
Related: #3187, #3094

## Security considerations

This test validates that VK-scoped provider restrictions are correctly enforced on model listing endpoints, preventing information leakage about providers a VK is not authorized to use.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable