### PR TITLE
fixes go worspace setup for cost-accuracy and load-test

### DIFF
--- a/.github/workflows/scripts/cost-accuracy-test.sh
+++ b/.github/workflows/scripts/cost-accuracy-test.sh
@@ -2,6 +2,14 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# Setup Go workspace for CI (go.work is gitignored, must be regenerated) so the
+# build below resolves local core/framework/plugins instead of the published
+# versions pinned in transports/go.mod. Run with repo root as CWD because
+# setup-go-workspace.sh's `go work use ./core` paths are repo-root-relative; the
+# go.work file it writes at ${ROOT_DIR} is then auto-discovered by `go build`.
+( cd "${ROOT_DIR}" && source "${ROOT_DIR}/.github/workflows/scripts/setup-go-workspace.sh" )
+
 COMPOSE_FILE="${ROOT_DIR}/.github/workflows/configs/docker-compose.yml"
 COMPOSE_PROJECT="${COMPOSE_PROJECT:-bifrost-cost-accuracy}"
 BENCHMARK_DIR="${BENCHMARK_DIR:-${ROOT_DIR}/../bifrost-benchmarking}"

--- a/.github/workflows/scripts/load-test.sh
+++ b/.github/workflows/scripts/load-test.sh
@@ -20,6 +20,14 @@ set -Ee
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# Setup Go workspace for CI (go.work is gitignored, must be regenerated) so the
+# build below resolves local core/framework/plugins instead of the published
+# versions pinned in transports/go.mod. Run with repo root as CWD because
+# setup-go-workspace.sh's `go work use ./core` paths are repo-root-relative; the
+# go.work file it writes at ${REPO_ROOT} is then auto-discovered by `go build`.
+( cd "${REPO_ROOT}" && source "${SCRIPT_DIR}/setup-go-workspace.sh" )
+
 BIFROST_HTTP_DIR="${REPO_ROOT}/transports/bifrost-http"
 TRANSPORTS_DIR="${REPO_ROOT}/transports"
 WORK_DIR="${SCRIPT_DIR}"


### PR DESCRIPTION
## Summary

The `go.work` file is gitignored and must be regenerated in CI environments. Without it, builds in `cost-accuracy-test.sh` and `load-test.sh` resolve `core`, `framework`, and `plugins` from the published versions pinned in `transports/go.mod` rather than the local workspace copies. This PR ensures the Go workspace is initialized before any build steps run in those scripts.

## Changes

- Added a call to `setup-go-workspace.sh` at the start of both `cost-accuracy-test.sh` and `load-test.sh`, executed from the repo root so that the relative `go work use ./core` paths resolve correctly and the resulting `go.work` file is auto-discovered by subsequent `go build` invocations.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger the cost-accuracy and load-test CI workflows and confirm that the builds resolve local module versions rather than the published ones pinned in `transports/go.mod`.

```sh
# Manually verify workspace setup
cd <repo-root>
source .github/workflows/scripts/setup-go-workspace.sh
go build ./transports/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable