### PR TITLE
fix: deterministic MCP tool ordering for prompt cache stability

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: deterministic MCP tool ordering for prompt cache stability (closes #2347)

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -214,7 +215,15 @@ func (m *ToolsManager) GetAvailableTools(ctx *schemas.BifrostContext) []schemas.
 	// Track tool names to prevent duplicates
 	seenToolNames := make(map[string]bool)
 
-	for clientName, clientTools := range availableToolsPerClient {
+	// Sort client names for deterministic tool ordering
+	sortedClients := make([]string, 0, len(availableToolsPerClient))
+	for clientName := range availableToolsPerClient {
+		sortedClients = append(sortedClients, clientName)
+	}
+	slices.Sort(sortedClients)
+
+	for _, clientName := range sortedClients {
+		clientTools := availableToolsPerClient[clientName]
 		client := m.clientManager.GetClientByName(clientName)
 		if client == nil {
 			m.logger.Warn("%s Client %s not found, skipping", MCPLogPrefix, clientName)

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -71,10 +71,19 @@ func (m *MCPManager) GetToolPerClient(ctx context.Context) map[string][]schemas.
 
 	m.logger.Debug("%s GetToolPerClient: Total clients in manager: %d, Filter: %v", MCPLogPrefix, len(m.clientMap), includeClients)
 
-	tools := make(map[string][]schemas.ChatTool)
+	// Collect and sort client names for deterministic tool ordering
+	clientNames := make([]string, 0, len(m.clientMap))
+	clientsByName := make(map[string]*schemas.MCPClientState, len(m.clientMap))
 	for _, client := range m.clientMap {
-		// Use client name as the key (not ID)
-		clientName := client.ExecutionConfig.Name
+		name := client.ExecutionConfig.Name
+		clientNames = append(clientNames, name)
+		clientsByName[name] = client
+	}
+	slices.Sort(clientNames)
+
+	tools := make(map[string][]schemas.ChatTool)
+	for _, clientName := range clientNames {
+		client := clientsByName[clientName]
 		clientID := client.ExecutionConfig.ID
 
 		m.logger.Debug("%s Evaluating client %s (ID: %s) for tools", MCPLogPrefix, clientName, clientID)
@@ -91,12 +100,19 @@ func (m *MCPManager) GetToolPerClient(ctx context.Context) map[string][]schemas.
 			continue
 		}
 
-		// Add all tools from this client
+		// Collect and sort tool names for deterministic ordering
+		toolNames := make([]string, 0, len(client.ToolMap))
+		for toolName := range client.ToolMap {
+			toolNames = append(toolNames, toolName)
+		}
+		slices.Sort(toolNames)
+
 		// FILTERING HIERARCHY (restrictive, not permissive):
 		// 1. Client-level configuration (ToolsToExecute) - Global allow-list, most restrictive
 		// 2. Request context (MCPContextKeyIncludeTools) - Can only further narrow, not expand
 		// Context filtering CANNOT override client configuration - it can only be more restrictive.
-		for toolName, tool := range client.ToolMap {
+		for _, toolName := range toolNames {
+			tool := client.ToolMap[toolName]
 			// First check: Client configuration is the global allow-list
 			// If client config blocks a tool, it CANNOT be overridden by context
 			if shouldSkipToolForConfig(toolName, client.ExecutionConfig) {

--- a/core/schemas/orderedmap.go
+++ b/core/schemas/orderedmap.go
@@ -54,8 +54,7 @@ func NewOrderedMapFromPairs(pairs ...Pair) *OrderedMap {
 }
 
 // OrderedMapFromMap creates an OrderedMap from a plain map.
-// Key order is NOT guaranteed since Go maps have undefined iteration order.
-// Use this only when insertion order doesn't matter (e.g., for hashing).
+// Keys are sorted lexicographically to ensure deterministic ordering.
 func OrderedMapFromMap(m map[string]interface{}) *OrderedMap {
 	if m == nil {
 		return nil
@@ -68,6 +67,7 @@ func OrderedMapFromMap(m map[string]interface{}) *OrderedMap {
 		om.keys = append(om.keys, k)
 		om.values[k] = v
 	}
+	sort.Strings(om.keys)
 	return om
 }
 


### PR DESCRIPTION
## Summary

MCP tools are assembled from Go maps with undefined iteration order, causing the tool list to shuffle across requests. This breaks prefix-based prompt caching (~11x cost multiplier).

## Changes

- `core/mcp/utils.go` — Sort client names and tool names before iteration in `GetToolPerClient`
- `core/mcp/toolmanager.go` — Sort client names in `GetAvailableTools` before flattening
- `core/schemas/orderedmap.go` — Sort keys in `OrderedMapFromMap` so tool schema properties are deterministic

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## Breaking changes

- [x] No

## Related issues

Closes #2347

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable