### PR TITLE
fix(anthropic): keep mid-conversation system inline for custom Anthropic-base providers (GLM, Kimi, ...) to preserve prompt cache

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: deterministic MCP tool ordering for prompt cache stability (closes #2347)

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -214,7 +215,15 @@ func (m *ToolsManager) GetAvailableTools(ctx *schemas.BifrostContext) []schemas.
 	// Track tool names to prevent duplicates
 	seenToolNames := make(map[string]bool)
 
-	for clientName, clientTools := range availableToolsPerClient {
+	// Sort client names for deterministic tool ordering
+	sortedClients := make([]string, 0, len(availableToolsPerClient))
+	for clientName := range availableToolsPerClient {
+		sortedClients = append(sortedClients, clientName)
+	}
+	slices.Sort(sortedClients)
+
+	for _, clientName := range sortedClients {
+		clientTools := availableToolsPerClient[clientName]
 		client := m.clientManager.GetClientByName(clientName)
 		if client == nil {
 			m.logger.Warn("%s Client %s not found, skipping", MCPLogPrefix, clientName)

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -71,10 +71,19 @@ func (m *MCPManager) GetToolPerClient(ctx context.Context) map[string][]schemas.
 
 	m.logger.Debug("%s GetToolPerClient: Total clients in manager: %d, Filter: %v", MCPLogPrefix, len(m.clientMap), includeClients)
 
-	tools := make(map[string][]schemas.ChatTool)
+	// Collect and sort client names for deterministic tool ordering
+	clientNames := make([]string, 0, len(m.clientMap))
+	clientsByName := make(map[string]*schemas.MCPClientState, len(m.clientMap))
 	for _, client := range m.clientMap {
-		// Use client name as the key (not ID)
-		clientName := client.ExecutionConfig.Name
+		name := client.ExecutionConfig.Name
+		clientNames = append(clientNames, name)
+		clientsByName[name] = client
+	}
+	slices.Sort(clientNames)
+
+	tools := make(map[string][]schemas.ChatTool)
+	for _, clientName := range clientNames {
+		client := clientsByName[clientName]
 		clientID := client.ExecutionConfig.ID
 
 		m.logger.Debug("%s Evaluating client %s (ID: %s) for tools", MCPLogPrefix, clientName, clientID)
@@ -91,12 +100,19 @@ func (m *MCPManager) GetToolPerClient(ctx context.Context) map[string][]schemas.
 			continue
 		}
 
-		// Add all tools from this client
+		// Collect and sort tool names for deterministic ordering
+		toolNames := make([]string, 0, len(client.ToolMap))
+		for toolName := range client.ToolMap {
+			toolNames = append(toolNames, toolName)
+		}
+		slices.Sort(toolNames)
+
 		// FILTERING HIERARCHY (restrictive, not permissive):
 		// 1. Client-level configuration (ToolsToExecute) - Global allow-list, most restrictive
 		// 2. Request context (MCPContextKeyIncludeTools) - Can only further narrow, not expand
 		// Context filtering CANNOT override client configuration - it can only be more restrictive.
-		for toolName, tool := range client.ToolMap {
+		for _, toolName := range toolNames {
+			tool := client.ToolMap[toolName]
 			// First check: Client configuration is the global allow-list
 			// If client config blocks a tool, it CANNOT be overridden by context
 			if shouldSkipToolForConfig(toolName, client.ExecutionConfig) {

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -840,13 +840,31 @@ func appendToSystemContent(existing *AnthropicContent, newContent AnthropicConte
 
 // SupportsMidConversationSystem returns true if the provider+model combination
 // supports role:"system" entries inside the messages array (mid-conversation
-// system messages). Available on the Anthropic API only — not on Bedrock or
-// Vertex. Supported on Claude Opus 4.8+ and the Claude Fable/Mythos family
-// (Fable post-dates Opus 4.8; the public doc lists Opus 4.8 but Fable supports
-// it as well). No beta header is required.
+// system messages). On Bifrost's built-in providers this is an Anthropic-API
+// feature only (not Bedrock or Vertex), supported on Claude Opus 4.8+ and the
+// Claude Fable/Mythos family (Fable post-dates Opus 4.8; the public doc lists
+// Opus 4.8 but Fable supports it as well). No beta header is required.
+//
+// It is also enabled for any CUSTOM provider (a provider key that is not one of
+// Bifrost's built-in providers) reaching this Anthropic converter. Such a
+// provider exists because the operator set base_provider_type to an
+// Anthropic-compatible base and pointed it at a self-hosted engine (sglang,
+// vLLM, TGI, llama.cpp, ...). Such engines are typically prefix/radix KV-cache
+// based and generally render role:"system" inline at any position via their
+// chat template, so keeping Claude Code's per-turn reminders inline -- rather
+// than hoisting them into the leading system block -- tends to preserve the
+// prefix cache instead of forking it every turn. Built-in non-Anthropic
+// providers (Bedrock, Vertex, Azure, ...) are unaffected: their keys are
+// standard, so they skip the custom-provider branch and are then rejected by
+// the provider != Anthropic guard below, keeping their historical behavior.
 //
 // Source: https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages
 func SupportsMidConversationSystem(provider schemas.ModelProvider, model string) bool {
+	// Custom provider reaching the Anthropic converter => operator chose an
+	// Anthropic-compatible base for a self-hosted engine; assume inline support.
+	if provider != "" && !schemas.IsStandardProvider(provider) {
+		return true
+	}
 	if provider != schemas.Anthropic {
 		return false
 	}

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -2390,6 +2390,26 @@ func TestSupportsMidConversationSystem(t *testing.T) {
 		// Not supported off the Anthropic provider, even for Fable.
 		{schemas.Bedrock, "claude-fable-5", false},
 		{schemas.Vertex, "claude-fable-5", false},
+		// Supported: any CUSTOM provider key (not a built-in provider) reaching
+		// the Anthropic converter -- it exists only because the operator chose an
+		// Anthropic-compatible base for a self-hosted engine (sglang/vLLM/TGI),
+		// which renders role:"system" inline. Holds regardless of model name, so
+		// it covers GLM, Kimi, and any other self-hosted Anthropic-compatible
+		// model. Keeping the reminder inline preserves the engine's prefix cache.
+		{schemas.ModelProvider("amd_qre_001"), "glm-5", true},
+		{schemas.ModelProvider("amd_qre_001"), "GLM-5", true},
+		{schemas.ModelProvider("virtuaireason"), "Kimi-K2.7-Code", true},
+		{schemas.ModelProvider("some-custom-key"), "qwen3-coder", true},
+		// Branch ordering: the custom-provider check runs BEFORE the model gate,
+		// so a custom key returns true even for a model name the standard model
+		// gate would reject (claude-opus-4-7 is false on a built-in provider).
+		// This pins the short-circuit; reordering the guards would silently break
+		// custom engines for any non-opus-4.8/Fable model name.
+		{schemas.ModelProvider("some-custom-key"), "claude-opus-4-7", true},
+		// Built-in non-Anthropic providers stay on historical behavior even for
+		// a self-hosted model name (their keys are standard).
+		{schemas.SGL, "glm-5", false},
+		{schemas.OpenAI, "glm-5", false},
 		// Defensive cases.
 		{schemas.Anthropic, "", false},
 		{"", "claude-opus-4-8", false},

--- a/core/schemas/orderedmap.go
+++ b/core/schemas/orderedmap.go
@@ -54,8 +54,7 @@ func NewOrderedMapFromPairs(pairs ...Pair) *OrderedMap {
 }
 
 // OrderedMapFromMap creates an OrderedMap from a plain map.
-// Key order is NOT guaranteed since Go maps have undefined iteration order.
-// Use this only when insertion order doesn't matter (e.g., for hashing).
+// Keys are sorted lexicographically to ensure deterministic ordering.
 func OrderedMapFromMap(m map[string]interface{}) *OrderedMap {
 	if m == nil {
 		return nil
@@ -68,6 +67,7 @@ func OrderedMapFromMap(m map[string]interface{}) *OrderedMap {
 		om.keys = append(om.keys, k)
 		om.values[k] = v
 	}
+	sort.Strings(om.keys)
 	return om
 }
 

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -81,11 +81,35 @@ func UnregisterKnownProvider(provider ModelProvider) {
 	delete(knownProviders, string(provider))
 }
 
-// IsKnownProvider checks if a provider string is known.
+// IsKnownProvider checks if a provider string is known. This set is dynamic: it
+// includes custom providers registered at runtime via RegisterKnownProvider. For
+// a built-in-only check (excludes custom keys) use IsStandardProvider.
 func IsKnownProvider(provider string) bool {
 	knownProvidersMu.RLock()
 	defer knownProvidersMu.RUnlock()
 	return knownProviders[provider]
+}
+
+// standardProvidersSet is a set of the built-in (non-custom) provider keys,
+// built once from StandardProviders at package init time. Unlike knownProviders
+// it is never updated with custom provider keys, so it answers "is this a
+// built-in provider" rather than "is this a recognized provider".
+var standardProvidersSet = func() map[ModelProvider]struct{} {
+	m := make(map[ModelProvider]struct{}, len(StandardProviders))
+	for _, p := range StandardProviders {
+		m[p] = struct{}{}
+	}
+	return m
+}()
+
+// IsStandardProvider reports whether provider is one of Bifrost's built-in
+// providers. A custom provider's key (e.g. an operator-chosen name pointed at a
+// self-hosted Anthropic-compatible engine via base_provider_type) is NOT a
+// standard provider, even though its base type is. The empty provider ("") is
+// not standard and returns false.
+func IsStandardProvider(provider ModelProvider) bool {
+	_, ok := standardProvidersSet[provider]
+	return ok
 }
 
 // ParseModelString extracts provider and model from a model string.

--- a/core/schemas/utils_test.go
+++ b/core/schemas/utils_test.go
@@ -1,0 +1,34 @@
+package schemas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsStandardProvider verifies that IsStandardProvider reflects exactly the
+// built-in StandardProviders set and, unlike IsKnownProvider, never counts a
+// custom provider registered at runtime as standard.
+func TestIsStandardProvider(t *testing.T) {
+	// Every built-in provider is standard. Guards against the set being
+	// shadowed or cleared.
+	for _, p := range StandardProviders {
+		assert.Truef(t, IsStandardProvider(p), "built-in provider %q should be standard", p)
+	}
+
+	// The empty provider is not standard.
+	assert.False(t, IsStandardProvider(""), "empty provider should not be standard")
+
+	// An arbitrary custom key is not standard.
+	assert.False(t, IsStandardProvider("amd_qre_001"), "custom key should not be standard")
+
+	// Crux of the design: a custom provider registered at runtime becomes a
+	// KNOWN provider but must NOT become a STANDARD provider. This is what lets
+	// the mid-conversation-system gate treat custom Anthropic-base providers as
+	// custom even after they are registered for model-string parsing.
+	const customKey ModelProvider = "is-standard-provider-test-custom"
+	RegisterKnownProvider(customKey)
+	defer UnregisterKnownProvider(customKey)
+	assert.True(t, IsKnownProvider(string(customKey)), "registered custom provider should be known")
+	assert.False(t, IsStandardProvider(customKey), "registered custom provider must not be standard")
+}

--- a/core/utils.go
+++ b/core/utils.go
@@ -342,18 +342,10 @@ func IsSupportedBaseProvider(providerKey schemas.ModelProvider) bool {
 	return ok
 }
 
-var standardProvidersSet = func() map[schemas.ModelProvider]struct{} {
-	m := make(map[schemas.ModelProvider]struct{}, len(schemas.StandardProviders))
-	for _, p := range schemas.StandardProviders {
-		m[p] = struct{}{}
-	}
-	return m
-}()
-
 // IsStandardProvider reports whether providerKey is a built-in (non-custom) provider.
+// Forwards to schemas.IsStandardProvider so the built-in set has a single source of truth.
 func IsStandardProvider(providerKey schemas.ModelProvider) bool {
-	_, ok := standardProvidersSet[providerKey]
-	return ok
+	return schemas.IsStandardProvider(providerKey)
 }
 
 // IsStreamRequestType returns true if the given request type is a stream request.


### PR DESCRIPTION
## Summary

Fixes #4592. Keeps mid-conversation `role:system` messages **inline** for **any custom Anthropic-base provider**, instead of hoisting them into the top-level `system` block.

This is the custom-provider sibling of #4534 (Bedrock). A custom provider whose key is not one of Bifrost's built-in providers reaches the Anthropic converter only because the operator set `base_provider_type: anthropic` and pointed it at a self-hosted Anthropic-compatible engine (sglang, vLLM, TGI, llama.cpp). The gate `SupportsMidConversationSystem` returned `false` for these (the custom key is not `schemas.Anthropic`, and the served model -- `glm-5`, `Kimi-K2`, ... -- is neither opus-4.8 nor Fable), so Claude Code's per-turn reminders were hoisted every turn, forking the engine's prefix/radix cache and stranding the cacheable tail (tools + history).

This covers GLM, Kimi, and any other self-hosted Anthropic-compatible model in one rule rather than per-model special-casing.

## Changes

- `SupportsMidConversationSystem`: a non-standard (custom) provider key reaching the Anthropic converter now returns `true` -- the operator chose an Anthropic-compatible base, whose engines render `role:system` inline. Built-in providers (Bedrock, Vertex, Azure, standard SGL/OpenAI) fall through to the existing model-based opus-4.8/Fable gate, so their behavior is unchanged.
- New `schemas.IsStandardProvider` (built from `StandardProviders`) so the gate can distinguish a custom provider key from a built-in one without an import cycle.

## Type: Bug fix · Affected: Core (Go), Providers

## How to test

`go test ./core/providers/anthropic/ -run "TestSupportsMidConversationSystem|MidConversation"` -- `TestSupportsMidConversationSystem` adds: custom keys (GLM under `amd_qre_001`, Kimi under `virtuaireason`, a generic custom key) return `true` regardless of model; built-in `schemas.SGL`/`schemas.OpenAI` with a self-hosted model name still return `false`; existing Anthropic/opus-4.8/Fable/Bedrock/Vertex cases unchanged.

## Evidence

#4592 has the full root-cause and the natural-experiment data: on identical Claude Code traffic, the "task tools haven't been used" reminder lands in the top-level `system` block 98% of the time on the unpatched custom-provider path vs 0% on Bedrock after #4534 (where it lands inline as a `user` turn 100% of the time, sustaining ~98% cached-read).

## Notes for reviewers

- The signal is "provider key is not a built-in provider" -- i.e. a custom provider configured with an Anthropic base. Happy to rework this into an explicit per-custom-provider `supports_mid_conversation_system` config flag (default on) if you'd prefer an operator-visible opt-out for a backend whose chat template cannot render mid-stream system.
- Inverse policy to #4276: hoisting is correct only for engines that cannot render `role:system` inline; this gate keeps it inline for those that can. Glad to coordinate the two so they don't regress each other.