### PR TITLE
refactor: unify SecretVar secret source into typed `ref`,`SecretType` fields, replacing `FromEnv`, `EnvVar`, `FromVault`, `VaultRef`

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -344,7 +344,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		return client
 	case schemas.HTTPProxy:
 		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.Ref())
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.GetSecretRef())
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -370,7 +370,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		dialFunc = fasthttpproxy.FasthttpHTTPDialer(proxyURL)
 	case schemas.Socks5Proxy:
 		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.Ref())
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.GetSecretRef())
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -409,7 +409,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 
 	// Configure custom CA certificate if provided
 	if proxyConfig.CACertPEM != nil && proxyConfig.CACertPEM.IsFromSecret() && proxyConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.Ref())
+		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.GetSecretRef())
 		getLogger().Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client
@@ -452,7 +452,7 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
 	if networkConfig.CACertPEM != nil && networkConfig.CACertPEM.IsFromSecret() && networkConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.Ref())
+		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.GetSecretRef())
 		logger.Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -343,8 +343,12 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 	case schemas.NoProxy:
 		return client
 	case schemas.HTTPProxy:
-		if proxyConfig.URL != nil && proxyConfig.URL.IsFromEnv() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.EnvVar)
+		if proxyConfig.URL != nil && (proxyConfig.URL.IsFromEnv() || proxyConfig.URL.IsFromVault()) && proxyConfig.URL.GetValue() == "" {
+			ref := proxyConfig.URL.EnvVar
+			if proxyConfig.URL.IsFromVault() {
+				ref = proxyConfig.URL.VaultRef
+			}
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", ref)
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -369,8 +373,12 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		}
 		dialFunc = fasthttpproxy.FasthttpHTTPDialer(proxyURL)
 	case schemas.Socks5Proxy:
-		if proxyConfig.URL != nil && proxyConfig.URL.IsFromEnv() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.EnvVar)
+		if proxyConfig.URL != nil && (proxyConfig.URL.IsFromEnv() || proxyConfig.URL.IsFromVault()) && proxyConfig.URL.GetValue() == "" {
+			ref := proxyConfig.URL.EnvVar
+			if proxyConfig.URL.IsFromVault() {
+				ref = proxyConfig.URL.VaultRef
+			}
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", ref)
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -408,8 +416,12 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 	}
 
 	// Configure custom CA certificate if provided
-	if proxyConfig.CACertPEM != nil && proxyConfig.CACertPEM.IsFromEnv() && proxyConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.EnvVar)
+	if proxyConfig.CACertPEM != nil && (proxyConfig.CACertPEM.IsFromEnv() || proxyConfig.CACertPEM.IsFromVault()) && proxyConfig.CACertPEM.GetValue() == "" {
+		ref := proxyConfig.CACertPEM.EnvVar
+		if proxyConfig.CACertPEM.IsFromVault() {
+			ref = proxyConfig.CACertPEM.VaultRef
+		}
+		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", ref)
 		getLogger().Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client
@@ -451,8 +463,12 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 // ConfigureTLS applies TLS settings from NetworkConfig to the fasthttp client.
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
-	if networkConfig.CACertPEM != nil && networkConfig.CACertPEM.IsFromEnv() && networkConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.EnvVar)
+	if networkConfig.CACertPEM != nil && (networkConfig.CACertPEM.IsFromEnv() || networkConfig.CACertPEM.IsFromVault()) && networkConfig.CACertPEM.GetValue() == "" {
+		ref := networkConfig.CACertPEM.EnvVar
+		if networkConfig.CACertPEM.IsFromVault() {
+			ref = networkConfig.CACertPEM.VaultRef
+		}
+		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", ref)
 		logger.Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -343,12 +343,8 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 	case schemas.NoProxy:
 		return client
 	case schemas.HTTPProxy:
-		if proxyConfig.URL != nil && (proxyConfig.URL.IsFromEnv() || proxyConfig.URL.IsFromVault()) && proxyConfig.URL.GetValue() == "" {
-			ref := proxyConfig.URL.EnvVar
-			if proxyConfig.URL.IsFromVault() {
-				ref = proxyConfig.URL.VaultRef
-			}
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", ref)
+		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.SecretRef)
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -373,12 +369,8 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		}
 		dialFunc = fasthttpproxy.FasthttpHTTPDialer(proxyURL)
 	case schemas.Socks5Proxy:
-		if proxyConfig.URL != nil && (proxyConfig.URL.IsFromEnv() || proxyConfig.URL.IsFromVault()) && proxyConfig.URL.GetValue() == "" {
-			ref := proxyConfig.URL.EnvVar
-			if proxyConfig.URL.IsFromVault() {
-				ref = proxyConfig.URL.VaultRef
-			}
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", ref)
+		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.SecretRef)
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -416,12 +408,8 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 	}
 
 	// Configure custom CA certificate if provided
-	if proxyConfig.CACertPEM != nil && (proxyConfig.CACertPEM.IsFromEnv() || proxyConfig.CACertPEM.IsFromVault()) && proxyConfig.CACertPEM.GetValue() == "" {
-		ref := proxyConfig.CACertPEM.EnvVar
-		if proxyConfig.CACertPEM.IsFromVault() {
-			ref = proxyConfig.CACertPEM.VaultRef
-		}
-		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", ref)
+	if proxyConfig.CACertPEM != nil && proxyConfig.CACertPEM.IsFromSecret() && proxyConfig.CACertPEM.GetValue() == "" {
+		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.SecretRef)
 		getLogger().Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client
@@ -463,12 +451,8 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 // ConfigureTLS applies TLS settings from NetworkConfig to the fasthttp client.
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
-	if networkConfig.CACertPEM != nil && (networkConfig.CACertPEM.IsFromEnv() || networkConfig.CACertPEM.IsFromVault()) && networkConfig.CACertPEM.GetValue() == "" {
-		ref := networkConfig.CACertPEM.EnvVar
-		if networkConfig.CACertPEM.IsFromVault() {
-			ref = networkConfig.CACertPEM.VaultRef
-		}
-		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", ref)
+	if networkConfig.CACertPEM != nil && networkConfig.CACertPEM.IsFromSecret() && networkConfig.CACertPEM.GetValue() == "" {
+		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.SecretRef)
 		logger.Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -344,7 +344,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		return client
 	case schemas.HTTPProxy:
 		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.SecretRef)
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.Ref())
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -370,7 +370,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		dialFunc = fasthttpproxy.FasthttpHTTPDialer(proxyURL)
 	case schemas.Socks5Proxy:
 		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.SecretRef)
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.Ref())
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -409,7 +409,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 
 	// Configure custom CA certificate if provided
 	if proxyConfig.CACertPEM != nil && proxyConfig.CACertPEM.IsFromSecret() && proxyConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.SecretRef)
+		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.Ref())
 		getLogger().Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client
@@ -452,7 +452,7 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
 	if networkConfig.CACertPEM != nil && networkConfig.CACertPEM.IsFromSecret() && networkConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.SecretRef)
+		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.Ref())
 		logger.Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -344,7 +344,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		return client
 	case schemas.HTTPProxy:
 		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.GetSecretRef())
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.GetRawRef())
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -370,7 +370,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		dialFunc = fasthttpproxy.FasthttpHTTPDialer(proxyURL)
 	case schemas.Socks5Proxy:
 		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.GetSecretRef())
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.GetRawRef())
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -409,7 +409,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 
 	// Configure custom CA certificate if provided
 	if proxyConfig.CACertPEM != nil && proxyConfig.CACertPEM.IsFromSecret() && proxyConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.GetSecretRef())
+		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.GetRawRef())
 		getLogger().Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client
@@ -452,7 +452,7 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
 	if networkConfig.CACertPEM != nil && networkConfig.CACertPEM.IsFromSecret() && networkConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.GetSecretRef())
+		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.GetRawRef())
 		logger.Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client

--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -10,18 +10,37 @@ import (
 	"github.com/bytedance/sonic"
 )
 
+// SecretType identifies the source of a SecretVar's value.
+type SecretType string
+
+const (
+	SecretTypePlainText SecretType = "plain_text"
+	SecretTypeEnv       SecretType = "env"
+	SecretTypeVault     SecretType = "vault"
+)
+
 // SecretVar is a wrapper around a value that can be sourced from an environment variable
 // or an external vault (e.g. AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault).
 // Three reference forms are accepted: plain text, "env.VAR_NAME", and "vault.path/to/secret".
 type SecretVar struct {
 	Val        string `json:"value"`
-	secretRef  string
-	fromSecret bool
+	ref        string
+	SecretType SecretType `json:"type,omitempty"`
+}
+
+// inferSecretType returns the SecretType implied by a reference string prefix.
+func inferSecretType(ref string) SecretType {
+	if strings.HasPrefix(ref, "vault.") {
+		return SecretTypeVault
+	}
+	if strings.HasPrefix(ref, "env.") {
+		return SecretTypeEnv
+	}
+	return SecretTypePlainText
 }
 
 // NewSecretVar creates a new SecretVar from a string.
 func NewSecretVar(value string) *SecretVar {
-	// Use strconv.Unquote to properly handle JSON string escape sequences
 	val := value
 	if unquoted, err := strconv.Unquote(value); err == nil {
 		val = unquoted
@@ -31,57 +50,57 @@ func NewSecretVar(value string) *SecretVar {
 		valueNode, _ := sonic.Get([]byte(val), "value")
 		if valueNode.Exists() {
 			type secretVarCompat struct {
-				Val        string `json:"value"`
-				SecretRef  string `json:"secret_ref"`
-				FromSecret bool   `json:"from_secret"`
-				// backward compat: env_var/from_env (shipped)
+				Val        string     `json:"value"`
+				Ref        string     `json:"ref"`
+				SecretType SecretType `json:"type"`
+				// shipped backward compat: env_var/from_env
 				EnvVar  string `json:"env_var"`
 				FromEnv bool   `json:"from_env"`
 			}
 			var raw secretVarCompat
 			if err := sonic.Unmarshal([]byte(value), &raw); err == nil {
 				e := &SecretVar{Val: raw.Val}
-				// New format
-				if raw.SecretRef != "" || raw.FromSecret {
-					e.secretRef = raw.SecretRef
-					e.fromSecret = raw.FromSecret
-				} else {
-					// Backward compat: env (shipped — must keep working)
-					if raw.FromEnv && raw.EnvVar != "" {
-						ref := raw.EnvVar
-						if !strings.HasPrefix(ref, "env.") {
-							ref = "env." + ref
-						}
-						e.secretRef = ref
-						e.fromSecret = true
-						if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
-							e.Val = envValue
-						} else {
-							e.Val = ""
-						}
-						return e
+				if raw.SecretType != "" {
+					// New format: explicit type field
+					e.ref = raw.Ref
+					e.SecretType = raw.SecretType
+				} else if raw.Ref != "" {
+					// Has ref but no type — infer from prefix
+					e.ref = raw.Ref
+					e.SecretType = inferSecretType(raw.Ref)
+				} else if raw.FromEnv && raw.EnvVar != "" {
+					// Backward compat: from_env/env_var
+					ref := raw.EnvVar
+					if !strings.HasPrefix(ref, "env.") {
+						ref = "env." + ref
 					}
-					// Legacy format: value == env_var == "env.XXX"
-					if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
-						e.secretRef = raw.EnvVar
-						e.fromSecret = true
+					e.ref = ref
+					e.SecretType = SecretTypeEnv
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
+						e.Val = envValue
+					} else {
 						e.Val = ""
-						if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
-							e.Val = envValue
-						}
-						return e
 					}
-				}
-				// Resolve vault reference
-				if e.fromSecret && strings.HasPrefix(e.secretRef, "vault.") {
+					return e
+				} else if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
+					// Legacy format: value == env_var == "env.XXX"
+					e.ref = raw.EnvVar
+					e.SecretType = SecretTypeEnv
 					e.Val = ""
-					if vaultValue, ok := LookupVault(e.secretRef); ok {
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
+						e.Val = envValue
+					}
+					return e
+				}
+				// Resolve references
+				if e.SecretType == SecretTypeVault {
+					e.Val = ""
+					if vaultValue, ok := LookupVault(e.ref); ok {
 						e.Val = vaultValue
 					}
 				}
-				// Resolve env reference
-				if e.fromSecret && strings.HasPrefix(e.secretRef, "env.") {
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.secretRef, "env.")); ok {
+				if e.SecretType == SecretTypeEnv {
+					if envValue, ok := os.LookupEnv(e.EnvKey()); ok {
 						e.Val = envValue
 					} else {
 						e.Val = ""
@@ -92,41 +111,57 @@ func NewSecretVar(value string) *SecretVar {
 		}
 	}
 	if strings.HasPrefix(val, "vault.") {
-		e := &SecretVar{
-			secretRef:  val,
-			fromSecret: true,
-		}
+		e := &SecretVar{ref: val, SecretType: SecretTypeVault}
 		if vaultValue, ok := LookupVault(val); ok {
 			e.Val = vaultValue
 		}
 		return e
 	}
 	if envKey, ok := strings.CutPrefix(val, "env."); ok {
+		e := &SecretVar{ref: val, SecretType: SecretTypeEnv}
 		if envValue, ok := os.LookupEnv(envKey); ok {
-			return &SecretVar{
-				Val:        envValue,
-				secretRef:  val,
-				fromSecret: true,
-			}
+			e.Val = envValue
 		}
-		return &SecretVar{
-			Val:        "",
-			secretRef:  val,
-			fromSecret: true,
-		}
+		return e
 	}
-	return &SecretVar{
-		Val: val,
-	}
+	return &SecretVar{Val: val}
 }
 
-// Ref returns the secret reference string (e.g. "env.MY_VAR" or "vault.path/to/secret").
+// GetRawRef returns the full secret reference string including prefix
+// (e.g. "env.MY_VAR" or "vault.path/to/secret").
 // Returns an empty string for plain-value SecretVars.
-func (e *SecretVar) GetSecretRef() string {
+func (e *SecretVar) GetRawRef() string {
 	if e == nil {
 		return ""
 	}
-	return e.secretRef
+	return e.ref
+}
+
+// GetRef returns the secret reference without its type prefix.
+// For env secrets it strips "env." (returning "MY_VAR"), for vault it strips "vault."
+// (returning "path/to/secret"), and for plain values it returns the ref as-is.
+func (e *SecretVar) GetRef() string {
+	if e == nil {
+		return ""
+	}
+	switch e.SecretType {
+	case SecretTypeEnv:
+		return strings.TrimPrefix(e.ref, "env.")
+	case SecretTypeVault:
+		return strings.TrimPrefix(e.ref, "vault.")
+	}
+	return e.ref
+}
+
+// Type returns the SecretType of this SecretVar.
+func (e *SecretVar) Type() SecretType {
+	if e == nil {
+		return SecretTypePlainText
+	}
+	if e.SecretType == "" {
+		return SecretTypePlainText
+	}
+	return e.SecretType
 }
 
 // IsFromSecret returns true if the value is sourced from an external secret (env var or vault).
@@ -134,7 +169,7 @@ func (e *SecretVar) IsFromSecret() bool {
 	if e == nil {
 		return false
 	}
-	return e.fromSecret
+	return e.SecretType == SecretTypeEnv || e.SecretType == SecretTypeVault
 }
 
 // IsFromVault returns true if the value is sourced from a vault path.
@@ -142,7 +177,33 @@ func (e *SecretVar) IsFromVault() bool {
 	if e == nil {
 		return false
 	}
-	return e.fromSecret && strings.HasPrefix(e.secretRef, "vault.")
+	return e.SecretType == SecretTypeVault
+}
+
+// VaultPath returns the vault path without the "vault." prefix.
+// Returns an empty string if the SecretVar is not vault-backed.
+func (e *SecretVar) VaultPath() string {
+	if e == nil || e.SecretType != SecretTypeVault {
+		return ""
+	}
+	return strings.TrimPrefix(e.ref, "vault.")
+}
+
+// EnvKey returns the environment variable name without the "env." prefix.
+// Returns an empty string if the SecretVar is not env-backed.
+func (e *SecretVar) EnvKey() string {
+	if e == nil || e.SecretType != SecretTypeEnv {
+		return ""
+	}
+	return strings.TrimPrefix(e.ref, "env.")
+}
+
+// IsFromEnv returns true if the value is sourced from an environment variable.
+func (e *SecretVar) IsFromEnv() bool {
+	if e == nil {
+		return false
+	}
+	return e.SecretType == SecretTypeEnv
 }
 
 // IsRedacted returns true if the value is redacted.
@@ -150,11 +211,11 @@ func (e *SecretVar) IsRedacted() bool {
 	if e == nil {
 		return false
 	}
-	if e.Val == "" && !e.fromSecret {
+	if e.Val == "" && !e.IsFromSecret() {
 		return false
 	}
 	// Secret references (env/vault) are treated as redacted — the real value is external
-	if e.fromSecret {
+	if e.IsFromSecret() {
 		return true
 	}
 	if len(e.Val) <= 8 {
@@ -187,8 +248,8 @@ func (e *SecretVar) Equals(other *SecretVar) bool {
 		return false
 	}
 	return e.Val == other.Val &&
-		e.secretRef == other.secretRef &&
-		e.fromSecret == other.fromSecret
+		e.ref == other.ref &&
+		e.SecretType == other.SecretType
 }
 
 // Redacted returns a new SecretVar with the value redacted.
@@ -197,65 +258,38 @@ func (e *SecretVar) Redacted() *SecretVar {
 		return nil
 	}
 	if e.Val == "" {
-		return &SecretVar{
-			Val:        "",
-			secretRef:  e.secretRef,
-			fromSecret: e.fromSecret,
-		}
+		return &SecretVar{Val: "", ref: e.ref, SecretType: e.SecretType}
 	}
-	// If key is 8 characters or less, just return all asterisks
 	if len(e.Val) <= 8 {
-		return &SecretVar{
-			Val:        strings.Repeat("*", len(e.Val)),
-			secretRef:  e.secretRef,
-			fromSecret: e.fromSecret,
-		}
+		return &SecretVar{Val: strings.Repeat("*", len(e.Val)), ref: e.ref, SecretType: e.SecretType}
 	}
-	// Show first 4 and last 4 characters, replace middle with asterisks
 	prefix := e.Val[:4]
 	suffix := e.Val[len(e.Val)-4:]
 	middle := strings.Repeat("*", 24)
-
-	return &SecretVar{
-		Val:        prefix + middle + suffix,
-		secretRef:  e.secretRef,
-		fromSecret: e.fromSecret,
-	}
+	return &SecretVar{Val: prefix + middle + suffix, ref: e.ref, SecretType: e.SecretType}
 }
 
 // FullyRedacted returns a copy of the SecretVar with Val replaced by a fixed placeholder
 // so no substring of the original value is exposed. Use for API responses where
-// Redacted is unsafe (e.g. literal proxy passwords). secretRef and fromSecret are
+// Redacted is unsafe (e.g. literal proxy passwords). secretRef and secretType are
 // preserved so references remain visible.
 func (e *SecretVar) FullyRedacted() *SecretVar {
 	if e == nil {
 		return nil
 	}
 	if e.Val == "" {
-		return &SecretVar{
-			Val:        "",
-			secretRef:  e.secretRef,
-			fromSecret: e.fromSecret,
-		}
+		return &SecretVar{Val: "", ref: e.ref, SecretType: e.SecretType}
 	}
-	return &SecretVar{
-		Val:        "<REDACTED>",
-		secretRef:  e.secretRef,
-		fromSecret: e.fromSecret,
-	}
+	return &SecretVar{Val: "<REDACTED>", ref: e.ref, SecretType: e.SecretType}
 }
 
-// MarshalJSON serializes the SecretVar, emitting secret_ref and from_secret fields.
+// MarshalJSON serializes the SecretVar, emitting ref and type fields.
 func (e SecretVar) MarshalJSON() ([]byte, error) {
 	return Marshal(struct {
-		Val        string `json:"value"`
-		SecretRef  string `json:"secret_ref,omitempty"`
-		FromSecret bool   `json:"from_secret,omitempty"`
-	}{
-		Val:        e.Val,
-		SecretRef:  e.secretRef,
-		FromSecret: e.fromSecret,
-	})
+		Val        string     `json:"value"`
+		Ref        string     `json:"ref,omitempty"`
+		SecretType SecretType `json:"type,omitempty"`
+	}{Val: e.Val, Ref: e.ref, SecretType: e.SecretType})
 }
 
 // UnmarshalJSON unmarshals the value from JSON.
@@ -268,29 +302,32 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 		valueNode, _ := sonic.Get(data, "value")
 		if valueNode.Exists() {
 			type secretVarCompat struct {
-				Val        string `json:"value"`
-				SecretRef  string `json:"secret_ref"`
-				FromSecret bool   `json:"from_secret"`
-				// backward compat: env_var/from_env (shipped)
+				Val        string     `json:"value"`
+				Ref        string     `json:"ref"`
+				SecretType SecretType `json:"type"`
+				// shipped backward compat: env_var/from_env
 				EnvVar  string `json:"env_var"`
 				FromEnv bool   `json:"from_env"`
 			}
 			var raw secretVarCompat
 			if err := sonic.Unmarshal(data, &raw); err == nil {
 				e.Val = raw.Val
-
-				// New format
-				if raw.SecretRef != "" || raw.FromSecret {
-					e.secretRef = raw.SecretRef
-					e.fromSecret = raw.FromSecret
+				if raw.SecretType != "" {
+					// New format: explicit type field
+					e.ref = raw.Ref
+					e.SecretType = raw.SecretType
+				} else if raw.Ref != "" {
+					// Has ref but no type — infer from prefix
+					e.ref = raw.Ref
+					e.SecretType = inferSecretType(raw.Ref)
 				} else if raw.FromEnv && raw.EnvVar != "" {
-					// Backward compat: env
+					// Backward compat: from_env/env_var
 					ref := raw.EnvVar
 					if !strings.HasPrefix(ref, "env.") {
 						ref = "env." + ref
 					}
-					e.secretRef = ref
-					e.fromSecret = true
+					e.ref = ref
+					e.SecretType = SecretTypeEnv
 					if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
 						e.Val = envValue
 					} else {
@@ -298,25 +335,24 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 					}
 					return nil
 				} else if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
-					// Old format: value == env_var == "env.XXX"
-					e.secretRef = raw.EnvVar
-					e.fromSecret = true
+					// Legacy format: value == env_var == "env.XXX"
+					e.ref = raw.EnvVar
+					e.SecretType = SecretTypeEnv
 					e.Val = ""
 					if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
 						e.Val = envValue
 					}
 					return nil
 				}
-
 				// Resolve references
-				if e.fromSecret && strings.HasPrefix(e.secretRef, "vault.") {
+				if e.SecretType == SecretTypeVault {
 					e.Val = ""
-					if vaultValue, ok := LookupVault(e.secretRef); ok {
+					if vaultValue, ok := LookupVault(e.ref); ok {
 						e.Val = vaultValue
 					}
 				}
-				if e.fromSecret && strings.HasPrefix(e.secretRef, "env.") {
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.secretRef, "env.")); ok {
+				if e.SecretType == SecretTypeEnv {
+					if envValue, ok := os.LookupEnv(e.EnvKey()); ok {
 						e.Val = envValue
 					} else {
 						e.Val = ""
@@ -328,8 +364,8 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 	}
 	// Plain string forms
 	if strings.HasPrefix(val, "vault.") {
-		e.secretRef = val
-		e.fromSecret = true
+		e.ref = val
+		e.SecretType = SecretTypeVault
 		e.Val = ""
 		if vaultValue, ok := LookupVault(val); ok {
 			e.Val = vaultValue
@@ -337,8 +373,8 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	if envKey, ok := strings.CutPrefix(val, "env."); ok {
-		e.secretRef = val
-		e.fromSecret = true
+		e.ref = val
+		e.SecretType = SecretTypeEnv
 		if envValue, ok := os.LookupEnv(envKey); ok {
 			e.Val = envValue
 		} else {
@@ -347,8 +383,8 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	e.Val = val
-	e.secretRef = ""
-	e.fromSecret = false
+	e.ref = ""
+	e.SecretType = SecretTypePlainText
 	return nil
 }
 
@@ -364,27 +400,27 @@ func (e *SecretVar) String() string {
 func (e *SecretVar) Scan(value any) error {
 	if value == nil {
 		e.Val = ""
-		e.secretRef = ""
-		e.fromSecret = false
+		e.ref = ""
+		e.SecretType = SecretTypePlainText
 		return nil
 	}
 	switch v := value.(type) {
 	case []byte:
 		return e.Scan(string(v))
 	case string:
-		val := strings.Trim(v, "\"")
-		if strings.HasPrefix(val, "vault.") {
+		// Check raw value first — quoted strings (e.g. `"vault.x"`) are literals, not refs.
+		if strings.HasPrefix(v, "vault.") {
 			e.Val = ""
-			e.secretRef = val
-			e.fromSecret = true
-			if vaultValue, ok := LookupVault(val); ok {
+			e.ref = v
+			e.SecretType = SecretTypeVault
+			if vaultValue, ok := LookupVault(v); ok {
 				e.Val = vaultValue
 			}
 			return nil
 		}
-		if envKey, ok := strings.CutPrefix(val, "env."); ok {
-			e.secretRef = val
-			e.fromSecret = true
+		if envKey, ok := strings.CutPrefix(v, "env."); ok {
+			e.ref = v
+			e.SecretType = SecretTypeEnv
 			if envValue, ok := os.LookupEnv(envKey); ok {
 				e.Val = envValue
 			} else {
@@ -393,8 +429,8 @@ func (e *SecretVar) Scan(value any) error {
 			return nil
 		}
 		e.Val = strings.Trim(v, "\"")
-		e.secretRef = ""
-		e.fromSecret = false
+		e.ref = ""
+		e.SecretType = SecretTypePlainText
 		return nil
 	}
 	return fmt.Errorf("failed to scan value: %v", value)
@@ -402,10 +438,10 @@ func (e *SecretVar) Scan(value any) error {
 
 // Value implements driver.Valuer for database storage.
 // It stores the secret reference (e.g., "env.API_KEY" or "vault.path/to/secret") if
-// fromSecret is true, otherwise the raw value.
+// the type is env or vault, otherwise the raw value.
 func (e SecretVar) Value() (driver.Value, error) {
-	if e.fromSecret {
-		return e.secretRef, nil
+	if e.IsFromSecret() {
+		return e.ref, nil
 	}
 	return e.Val, nil
 }
@@ -418,7 +454,7 @@ func (e *SecretVar) ShouldPreserveStored() bool {
 	if e == nil {
 		return true
 	}
-	if e.fromSecret {
+	if e.IsFromSecret() {
 		return false
 	}
 	return e.GetValue() == "" || e.IsRedacted()
@@ -431,8 +467,8 @@ func (e *SecretVar) IsSet() bool {
 	if e == nil {
 		return false
 	}
-	if e.fromSecret {
-		return e.secretRef != ""
+	if e.IsFromSecret() {
+		return e.ref != ""
 	}
 	return e.Val != ""
 }

--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -15,8 +15,8 @@ import (
 // Three reference forms are accepted: plain text, "env.VAR_NAME", and "vault.path/to/secret".
 type SecretVar struct {
 	Val        string `json:"value"`
-	SecretRef  string `json:"secret_ref,omitempty"`
-	FromSecret bool   `json:"from_secret,omitempty"`
+	secretRef  string
+	fromSecret bool
 }
 
 // NewSecretVar creates a new SecretVar from a string.
@@ -45,8 +45,8 @@ func NewSecretVar(value string) *SecretVar {
 				e := &SecretVar{Val: raw.Val}
 				// New format
 				if raw.SecretRef != "" || raw.FromSecret {
-					e.SecretRef = raw.SecretRef
-					e.FromSecret = raw.FromSecret
+					e.secretRef = raw.SecretRef
+					e.fromSecret = raw.FromSecret
 				} else {
 					// Backward compat: env (shipped — must keep working)
 					if raw.FromEnv && raw.EnvVar != "" {
@@ -54,8 +54,8 @@ func NewSecretVar(value string) *SecretVar {
 						if !strings.HasPrefix(ref, "env.") {
 							ref = "env." + ref
 						}
-						e.SecretRef = ref
-						e.FromSecret = true
+						e.secretRef = ref
+						e.fromSecret = true
 						if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
 							e.Val = envValue
 						} else {
@@ -65,8 +65,8 @@ func NewSecretVar(value string) *SecretVar {
 					}
 					// Legacy format: value == env_var == "env.XXX"
 					if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
-						e.SecretRef = raw.EnvVar
-						e.FromSecret = true
+						e.secretRef = raw.EnvVar
+						e.fromSecret = true
 						e.Val = ""
 						if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
 							e.Val = envValue
@@ -75,15 +75,15 @@ func NewSecretVar(value string) *SecretVar {
 					}
 				}
 				// Resolve vault reference
-				if e.FromSecret && strings.HasPrefix(e.SecretRef, "vault.") {
+				if e.fromSecret && strings.HasPrefix(e.secretRef, "vault.") {
 					e.Val = ""
-					if vaultValue, ok := LookupVault(e.SecretRef); ok {
+					if vaultValue, ok := LookupVault(e.secretRef); ok {
 						e.Val = vaultValue
 					}
 				}
 				// Resolve env reference
-				if e.FromSecret && strings.HasPrefix(e.SecretRef, "env.") {
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.SecretRef, "env.")); ok {
+				if e.fromSecret && strings.HasPrefix(e.secretRef, "env.") {
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.secretRef, "env.")); ok {
 						e.Val = envValue
 					} else {
 						e.Val = ""
@@ -95,8 +95,8 @@ func NewSecretVar(value string) *SecretVar {
 	}
 	if strings.HasPrefix(val, "vault.") {
 		e := &SecretVar{
-			SecretRef:  val,
-			FromSecret: true,
+			secretRef:  val,
+			fromSecret: true,
 		}
 		if vaultValue, ok := LookupVault(val); ok {
 			e.Val = vaultValue
@@ -107,14 +107,14 @@ func NewSecretVar(value string) *SecretVar {
 		if envValue, ok := os.LookupEnv(envKey); ok {
 			return &SecretVar{
 				Val:        envValue,
-				SecretRef:  val,
-				FromSecret: true,
+				secretRef:  val,
+				fromSecret: true,
 			}
 		}
 		return &SecretVar{
 			Val:        "",
-			SecretRef:  val,
-			FromSecret: true,
+			secretRef:  val,
+			fromSecret: true,
 		}
 	}
 	return &SecretVar{
@@ -122,12 +122,21 @@ func NewSecretVar(value string) *SecretVar {
 	}
 }
 
+// Ref returns the secret reference string (e.g. "env.MY_VAR" or "vault.path/to/secret").
+// Returns an empty string for plain-value SecretVars.
+func (e *SecretVar) Ref() string {
+	if e == nil {
+		return ""
+	}
+	return e.secretRef
+}
+
 // IsFromSecret returns true if the value is sourced from an external secret (env var or vault).
 func (e *SecretVar) IsFromSecret() bool {
 	if e == nil {
 		return false
 	}
-	return e.FromSecret
+	return e.fromSecret
 }
 
 // IsFromVault returns true if the value is sourced from a vault path.
@@ -135,7 +144,7 @@ func (e *SecretVar) IsFromVault() bool {
 	if e == nil {
 		return false
 	}
-	return e.FromSecret && strings.HasPrefix(e.SecretRef, "vault.")
+	return e.fromSecret && strings.HasPrefix(e.secretRef, "vault.")
 }
 
 // IsRedacted returns true if the value is redacted.
@@ -143,11 +152,11 @@ func (e *SecretVar) IsRedacted() bool {
 	if e == nil {
 		return false
 	}
-	if e.Val == "" && !e.FromSecret {
+	if e.Val == "" && !e.fromSecret {
 		return false
 	}
 	// Secret references (env/vault) are treated as redacted — the real value is external
-	if e.FromSecret {
+	if e.fromSecret {
 		return true
 	}
 	if len(e.Val) <= 8 {
@@ -180,8 +189,8 @@ func (e *SecretVar) Equals(other *SecretVar) bool {
 		return false
 	}
 	return e.Val == other.Val &&
-		e.SecretRef == other.SecretRef &&
-		e.FromSecret == other.FromSecret
+		e.secretRef == other.secretRef &&
+		e.fromSecret == other.fromSecret
 }
 
 // Redacted returns a new SecretVar with the value redacted.
@@ -192,16 +201,16 @@ func (e *SecretVar) Redacted() *SecretVar {
 	if e.Val == "" {
 		return &SecretVar{
 			Val:        "",
-			SecretRef:  e.SecretRef,
-			FromSecret: e.FromSecret,
+			secretRef:  e.secretRef,
+			fromSecret: e.fromSecret,
 		}
 	}
 	// If key is 8 characters or less, just return all asterisks
 	if len(e.Val) <= 8 {
 		return &SecretVar{
 			Val:        strings.Repeat("*", len(e.Val)),
-			SecretRef:  e.SecretRef,
-			FromSecret: e.FromSecret,
+			secretRef:  e.secretRef,
+			fromSecret: e.fromSecret,
 		}
 	}
 	// Show first 4 and last 4 characters, replace middle with asterisks
@@ -211,14 +220,14 @@ func (e *SecretVar) Redacted() *SecretVar {
 
 	return &SecretVar{
 		Val:        prefix + middle + suffix,
-		SecretRef:  e.SecretRef,
-		FromSecret: e.FromSecret,
+		secretRef:  e.secretRef,
+		fromSecret: e.fromSecret,
 	}
 }
 
 // FullyRedacted returns a copy of the SecretVar with Val replaced by a fixed placeholder
 // so no substring of the original value is exposed. Use for API responses where
-// Redacted is unsafe (e.g. literal proxy passwords). SecretRef and FromSecret are
+// Redacted is unsafe (e.g. literal proxy passwords). secretRef and fromSecret are
 // preserved so references remain visible.
 func (e *SecretVar) FullyRedacted() *SecretVar {
 	if e == nil {
@@ -227,15 +236,28 @@ func (e *SecretVar) FullyRedacted() *SecretVar {
 	if e.Val == "" {
 		return &SecretVar{
 			Val:        "",
-			SecretRef:  e.SecretRef,
-			FromSecret: e.FromSecret,
+			secretRef:  e.secretRef,
+			fromSecret: e.fromSecret,
 		}
 	}
 	return &SecretVar{
 		Val:        "<REDACTED>",
-		SecretRef:  e.SecretRef,
-		FromSecret: e.FromSecret,
+		secretRef:  e.secretRef,
+		fromSecret: e.fromSecret,
 	}
+}
+
+// MarshalJSON serializes the SecretVar, emitting secret_ref and from_secret fields.
+func (e SecretVar) MarshalJSON() ([]byte, error) {
+	return Marshal(struct {
+		Val        string `json:"value"`
+		SecretRef  string `json:"secret_ref,omitempty"`
+		FromSecret bool   `json:"from_secret,omitempty"`
+	}{
+		Val:        e.Val,
+		SecretRef:  e.secretRef,
+		FromSecret: e.fromSecret,
+	})
 }
 
 // UnmarshalJSON unmarshals the value from JSON.
@@ -263,16 +285,16 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 
 				// New format
 				if raw.SecretRef != "" || raw.FromSecret {
-					e.SecretRef = raw.SecretRef
-					e.FromSecret = raw.FromSecret
+					e.secretRef = raw.SecretRef
+					e.fromSecret = raw.FromSecret
 				} else if raw.FromEnv && raw.EnvVar != "" {
 					// Backward compat: env
 					ref := raw.EnvVar
 					if !strings.HasPrefix(ref, "env.") {
 						ref = "env." + ref
 					}
-					e.SecretRef = ref
-					e.FromSecret = true
+					e.secretRef = ref
+					e.fromSecret = true
 					if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
 						e.Val = envValue
 					} else {
@@ -281,8 +303,8 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 					return nil
 				} else if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
 					// Old format: value == env_var == "env.XXX"
-					e.SecretRef = raw.EnvVar
-					e.FromSecret = true
+					e.secretRef = raw.EnvVar
+					e.fromSecret = true
 					e.Val = ""
 					if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
 						e.Val = envValue
@@ -291,14 +313,14 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 				}
 
 				// Resolve references
-				if e.FromSecret && strings.HasPrefix(e.SecretRef, "vault.") {
+				if e.fromSecret && strings.HasPrefix(e.secretRef, "vault.") {
 					e.Val = ""
-					if vaultValue, ok := LookupVault(e.SecretRef); ok {
+					if vaultValue, ok := LookupVault(e.secretRef); ok {
 						e.Val = vaultValue
 					}
 				}
-				if e.FromSecret && strings.HasPrefix(e.SecretRef, "env.") {
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.SecretRef, "env.")); ok {
+				if e.fromSecret && strings.HasPrefix(e.secretRef, "env.") {
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.secretRef, "env.")); ok {
 						e.Val = envValue
 					} else {
 						e.Val = ""
@@ -310,8 +332,8 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 	}
 	// Plain string forms
 	if strings.HasPrefix(val, "vault.") {
-		e.SecretRef = val
-		e.FromSecret = true
+		e.secretRef = val
+		e.fromSecret = true
 		e.Val = ""
 		if vaultValue, ok := LookupVault(val); ok {
 			e.Val = vaultValue
@@ -319,8 +341,8 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	if envKey, ok := strings.CutPrefix(val, "env."); ok {
-		e.SecretRef = val
-		e.FromSecret = true
+		e.secretRef = val
+		e.fromSecret = true
 		if envValue, ok := os.LookupEnv(envKey); ok {
 			e.Val = envValue
 		} else {
@@ -329,8 +351,8 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	e.Val = val
-	e.SecretRef = ""
-	e.FromSecret = false
+	e.secretRef = ""
+	e.fromSecret = false
 	return nil
 }
 
@@ -346,26 +368,27 @@ func (e *SecretVar) String() string {
 func (e *SecretVar) Scan(value any) error {
 	if value == nil {
 		e.Val = ""
-		e.SecretRef = ""
-		e.FromSecret = false
+		e.secretRef = ""
+		e.fromSecret = false
 		return nil
 	}
 	switch v := value.(type) {
 	case []byte:
 		return e.Scan(string(v))
 	case string:
-		if strings.HasPrefix(v, "vault.") {
+		val := strings.Trim(v, "\"")
+		if strings.HasPrefix(val, "vault.") {
 			e.Val = ""
-			e.SecretRef = v
-			e.FromSecret = true
-			if vaultValue, ok := LookupVault(v); ok {
+			e.secretRef = val
+			e.fromSecret = true
+			if vaultValue, ok := LookupVault(val); ok {
 				e.Val = vaultValue
 			}
 			return nil
 		}
-		if envKey, ok := strings.CutPrefix(v, "env."); ok {
-			e.SecretRef = v
-			e.FromSecret = true
+		if envKey, ok := strings.CutPrefix(val, "env."); ok {
+			e.secretRef = val
+			e.fromSecret = true
 			if envValue, ok := os.LookupEnv(envKey); ok {
 				e.Val = envValue
 			} else {
@@ -374,8 +397,8 @@ func (e *SecretVar) Scan(value any) error {
 			return nil
 		}
 		e.Val = strings.Trim(v, "\"")
-		e.SecretRef = ""
-		e.FromSecret = false
+		e.secretRef = ""
+		e.fromSecret = false
 		return nil
 	}
 	return fmt.Errorf("failed to scan value: %v", value)
@@ -383,10 +406,10 @@ func (e *SecretVar) Scan(value any) error {
 
 // Value implements driver.Valuer for database storage.
 // It stores the secret reference (e.g., "env.API_KEY" or "vault.path/to/secret") if
-// FromSecret is true, otherwise the raw value.
+// fromSecret is true, otherwise the raw value.
 func (e SecretVar) Value() (driver.Value, error) {
-	if e.FromSecret {
-		return e.SecretRef, nil
+	if e.fromSecret {
+		return e.secretRef, nil
 	}
 	return e.Val, nil
 }
@@ -399,7 +422,7 @@ func (e *SecretVar) ShouldPreserveStored() bool {
 	if e == nil {
 		return true
 	}
-	if e.FromSecret {
+	if e.fromSecret {
 		return false
 	}
 	return e.GetValue() == "" || e.IsRedacted()
@@ -412,8 +435,8 @@ func (e *SecretVar) IsSet() bool {
 	if e == nil {
 		return false
 	}
-	if e.FromSecret {
-		return e.SecretRef != ""
+	if e.fromSecret {
+		return e.secretRef != ""
 	}
 	return e.Val != ""
 }

--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -29,9 +29,7 @@ func NewSecretVar(value string) *SecretVar {
 	// If it's a valid JSON object following the SecretVar schema, unmarshal it
 	if sonic.Valid([]byte(value)) {
 		valueNode, _ := sonic.Get([]byte(val), "value")
-		envNode, _ := sonic.Get([]byte(val), "env_var")
-		secretRefNode, _ := sonic.Get([]byte(val), "secret_ref")
-		if valueNode.Exists() && (envNode.Exists() || secretRefNode.Exists()) {
+		if valueNode.Exists() {
 			type secretVarCompat struct {
 				Val        string `json:"value"`
 				SecretRef  string `json:"secret_ref"`
@@ -124,7 +122,7 @@ func NewSecretVar(value string) *SecretVar {
 
 // Ref returns the secret reference string (e.g. "env.MY_VAR" or "vault.path/to/secret").
 // Returns an empty string for plain-value SecretVars.
-func (e *SecretVar) Ref() string {
+func (e *SecretVar) GetSecretRef() string {
 	if e == nil {
 		return ""
 	}
@@ -268,9 +266,7 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 	}
 	if sonic.Valid(data) {
 		valueNode, _ := sonic.Get(data, "value")
-		envNode, _ := sonic.Get(data, "env_var")
-		secretRefNode, _ := sonic.Get(data, "secret_ref")
-		if valueNode.Exists() && (envNode.Exists() || secretRefNode.Exists()) {
+		if valueNode.Exists() {
 			type secretVarCompat struct {
 				Val        string `json:"value"`
 				SecretRef  string `json:"secret_ref"`

--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -14,65 +14,79 @@ import (
 // or an external vault (e.g. AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault).
 // Three reference forms are accepted: plain text, "env.VAR_NAME", and "vault.path/to/secret".
 type SecretVar struct {
-	Val       string `json:"value"`
-	EnvVar    string `json:"env_var"`
-	FromEnv   bool   `json:"from_env"`
-	VaultRef  string `json:"vault_var,omitempty"`
-	FromVault bool   `json:"from_vault,omitempty"`
+	Val        string `json:"value"`
+	SecretRef  string `json:"secret_ref,omitempty"`
+	FromSecret bool   `json:"from_secret,omitempty"`
 }
 
-// NewSecretVar creates a new EnvValue from a string.
+// NewSecretVar creates a new SecretVar from a string.
 func NewSecretVar(value string) *SecretVar {
-	// Cleanup string if required
 	// Use strconv.Unquote to properly handle JSON string escape sequences
-	// This converts "\"{\\\"key\\\":\\\"value\\\"}\"" to "{\"key\":\"value\"}"
 	val := value
 	if unquoted, err := strconv.Unquote(value); err == nil {
 		val = unquoted
 	}
-	// Here we will need to check if the incoming data is a valid JSON object
-	// If it's a valid JSON object and follows the SecretVar schema, then we will unmarshal it into an SecretVar object
+	// If it's a valid JSON object following the SecretVar schema, unmarshal it
 	if sonic.Valid([]byte(value)) {
 		valueNode, _ := sonic.Get([]byte(val), "value")
 		envNode, _ := sonic.Get([]byte(val), "env_var")
-		if valueNode.Exists() && envNode.Exists() {
-			// Use a type alias to avoid infinite recursion (alias doesn't inherit methods)
-			type secretVarAlias SecretVar
-			var secretVar secretVarAlias
-			if err := sonic.Unmarshal([]byte(value), &secretVar); err == nil {
-				e := &SecretVar{
-					Val:       secretVar.Val,
-					FromEnv:   secretVar.FromEnv,
-					EnvVar: secretVar.EnvVar,
-					FromVault: secretVar.FromVault,
-					VaultRef:  secretVar.VaultRef,
-				}
-				// Explicit vault reference: {from_vault: true, vault_var: "vault.path"}
-				if e.FromVault && e.VaultRef != "" {
-					if !strings.HasPrefix(e.VaultRef, "vault.") {
-						e.VaultRef = "vault." + e.VaultRef
+		secretRefNode, _ := sonic.Get([]byte(val), "secret_ref")
+		if valueNode.Exists() && (envNode.Exists() || secretRefNode.Exists()) {
+			type secretVarCompat struct {
+				Val        string `json:"value"`
+				SecretRef  string `json:"secret_ref"`
+				FromSecret bool   `json:"from_secret"`
+				// backward compat: env_var/from_env (shipped)
+				EnvVar  string `json:"env_var"`
+				FromEnv bool   `json:"from_env"`
+			}
+			var raw secretVarCompat
+			if err := sonic.Unmarshal([]byte(value), &raw); err == nil {
+				e := &SecretVar{Val: raw.Val}
+				// New format
+				if raw.SecretRef != "" || raw.FromSecret {
+					e.SecretRef = raw.SecretRef
+					e.FromSecret = raw.FromSecret
+				} else {
+					// Backward compat: env (shipped — must keep working)
+					if raw.FromEnv && raw.EnvVar != "" {
+						ref := raw.EnvVar
+						if !strings.HasPrefix(ref, "env.") {
+							ref = "env." + ref
+						}
+						e.SecretRef = ref
+						e.FromSecret = true
+						if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
+							e.Val = envValue
+						} else {
+							e.Val = ""
+						}
+						return e
 					}
-					e.Val = e.VaultRef
-					if vaultValue, ok := LookupVault(e.VaultRef); ok {
+					// Legacy format: value == env_var == "env.XXX"
+					if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
+						e.SecretRef = raw.EnvVar
+						e.FromSecret = true
+						e.Val = ""
+						if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
+							e.Val = envValue
+						}
+						return e
+					}
+				}
+				// Resolve vault reference
+				if e.FromSecret && strings.HasPrefix(e.SecretRef, "vault.") {
+					e.Val = ""
+					if vaultValue, ok := LookupVault(e.SecretRef); ok {
 						e.Val = vaultValue
 					}
-					return e
 				}
-				// Old format: value == env_var == "env.XXX"
-				if strings.HasPrefix(e.Val, "env.") && e.Val == e.EnvVar {
-					e.Val = ""
-					// Load the environment variable value
-					envValue, ok := os.LookupEnv(strings.TrimPrefix(e.EnvVar, "env."))
-					if ok {
+				// Resolve env reference
+				if e.FromSecret && strings.HasPrefix(e.SecretRef, "env.") {
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.SecretRef, "env.")); ok {
 						e.Val = envValue
-					}
-					e.FromEnv = true
-				}
-				// New format: value is empty, from_env=true, env_var holds the reference
-				if e.Val == "" && e.FromEnv && strings.HasPrefix(e.EnvVar, "env.") {
-					e.FromEnv = true
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.EnvVar, "env.")); ok {
-						e.Val = envValue
+					} else {
+						e.Val = ""
 					}
 				}
 				return e
@@ -81,11 +95,10 @@ func NewSecretVar(value string) *SecretVar {
 	}
 	if strings.HasPrefix(val, "vault.") {
 		e := &SecretVar{
-			Val:       val,
-			VaultRef:  val,
-			FromVault: true,
+			SecretRef:  val,
+			FromSecret: true,
 		}
-		if vaultValue, ok := LookupVault(e.VaultRef); ok {
+		if vaultValue, ok := LookupVault(val); ok {
 			e.Val = vaultValue
 		}
 		return e
@@ -93,30 +106,36 @@ func NewSecretVar(value string) *SecretVar {
 	if envKey, ok := strings.CutPrefix(val, "env."); ok {
 		if envValue, ok := os.LookupEnv(envKey); ok {
 			return &SecretVar{
-				Val:       envValue,
-				FromEnv:   true,
-				EnvVar: val,
+				Val:        envValue,
+				SecretRef:  val,
+				FromSecret: true,
 			}
 		}
 		return &SecretVar{
-			Val:       "",
-			FromEnv:   true,
-			EnvVar: val,
+			Val:        "",
+			SecretRef:  val,
+			FromSecret: true,
 		}
 	}
 	return &SecretVar{
-		Val:       val,
-		FromEnv:   false,
-		EnvVar: "",
+		Val: val,
 	}
 }
 
-// IsFromVault returns true if the value is sourced from an external vault.
+// IsFromSecret returns true if the value is sourced from an external secret (env var or vault).
+func (e *SecretVar) IsFromSecret() bool {
+	if e == nil {
+		return false
+	}
+	return e.FromSecret
+}
+
+// IsFromVault returns true if the value is sourced from a vault path.
 func (e *SecretVar) IsFromVault() bool {
 	if e == nil {
 		return false
 	}
-	return e.FromVault
+	return e.FromSecret && strings.HasPrefix(e.SecretRef, "vault.")
 }
 
 // IsRedacted returns true if the value is redacted.
@@ -124,11 +143,11 @@ func (e *SecretVar) IsRedacted() bool {
 	if e == nil {
 		return false
 	}
-	if e.Val == "" && !e.FromEnv && !e.FromVault {
+	if e.Val == "" && !e.FromSecret {
 		return false
 	}
-	// Vault and env references are treated as redacted (the real value is external)
-	if e.FromEnv || e.FromVault {
+	// Secret references (env/vault) are treated as redacted — the real value is external
+	if e.FromSecret {
 		return true
 	}
 	if len(e.Val) <= 8 {
@@ -152,7 +171,7 @@ func (e *SecretVar) IsRedacted() bool {
 	return false
 }
 
-// Equals checks if two SecretKeys are equal.
+// Equals checks if two SecretVars are equal.
 func (e *SecretVar) Equals(other *SecretVar) bool {
 	if e == nil && other == nil {
 		return true
@@ -161,34 +180,28 @@ func (e *SecretVar) Equals(other *SecretVar) bool {
 		return false
 	}
 	return e.Val == other.Val &&
-		e.EnvVar == other.EnvVar &&
-		e.FromEnv == other.FromEnv &&
-		e.VaultRef == other.VaultRef &&
-		e.FromVault == other.FromVault
+		e.SecretRef == other.SecretRef &&
+		e.FromSecret == other.FromSecret
 }
 
-// Redacted returns a new SecretKey with the value redacted.
+// Redacted returns a new SecretVar with the value redacted.
 func (e *SecretVar) Redacted() *SecretVar {
 	if e == nil {
 		return nil
 	}
 	if e.Val == "" {
 		return &SecretVar{
-			Val:       "",
-			FromEnv:   e.FromEnv,
-			EnvVar: e.EnvVar,
-			FromVault: e.FromVault,
-			VaultRef:  e.VaultRef,
+			Val:        "",
+			SecretRef:  e.SecretRef,
+			FromSecret: e.FromSecret,
 		}
 	}
 	// If key is 8 characters or less, just return all asterisks
 	if len(e.Val) <= 8 {
 		return &SecretVar{
-			Val:       strings.Repeat("*", len(e.Val)),
-			FromEnv:   e.FromEnv,
-			EnvVar: e.EnvVar,
-			FromVault: e.FromVault,
-			VaultRef:  e.VaultRef,
+			Val:        strings.Repeat("*", len(e.Val)),
+			SecretRef:  e.SecretRef,
+			FromSecret: e.FromSecret,
 		}
 	}
 	// Show first 4 and last 4 characters, replace middle with asterisks
@@ -197,126 +210,127 @@ func (e *SecretVar) Redacted() *SecretVar {
 	middle := strings.Repeat("*", 24)
 
 	return &SecretVar{
-		Val:       prefix + middle + suffix,
-		FromEnv:   e.FromEnv,
-		EnvVar: e.EnvVar,
-		FromVault: e.FromVault,
-		VaultRef:  e.VaultRef,
+		Val:        prefix + middle + suffix,
+		SecretRef:  e.SecretRef,
+		FromSecret: e.FromSecret,
 	}
 }
 
 // FullyRedacted returns a copy of the SecretVar with Val replaced by a fixed placeholder
 // so no substring of the original value is exposed. Use for API responses where
-// Redacted is unsafe (e.g. literal proxy passwords). FromEnv/SecretVar and
-// FromVault/VaultRef are preserved so references remain visible.
+// Redacted is unsafe (e.g. literal proxy passwords). SecretRef and FromSecret are
+// preserved so references remain visible.
 func (e *SecretVar) FullyRedacted() *SecretVar {
 	if e == nil {
 		return nil
 	}
 	if e.Val == "" {
 		return &SecretVar{
-			Val:       "",
-			FromEnv:   e.FromEnv,
-			EnvVar: e.EnvVar,
-			FromVault: e.FromVault,
-			VaultRef:  e.VaultRef,
+			Val:        "",
+			SecretRef:  e.SecretRef,
+			FromSecret: e.FromSecret,
 		}
 	}
 	return &SecretVar{
-		Val:       "<REDACTED>",
-		FromEnv:   e.FromEnv,
-		EnvVar: e.EnvVar,
-		FromVault: e.FromVault,
-		VaultRef:  e.VaultRef,
+		Val:        "<REDACTED>",
+		SecretRef:  e.SecretRef,
+		FromSecret: e.FromSecret,
 	}
 }
 
 // UnmarshalJSON unmarshals the value from JSON.
 func (e *SecretVar) UnmarshalJSON(data []byte) error {
 	val := string(data)
-	// Cleanup string if required
-	// Use strconv.Unquote to properly handle JSON string escape sequences
-	// This converts "\"{\\\"key\\\":\\\"value\\\"}\"" to "{\"key\":\"value\"}"
 	if unquoted, err := strconv.Unquote(val); err == nil {
 		val = unquoted
 	}
-	// Check if the incoming data is a valid JSON object matching the SecretVar schema.
 	if sonic.Valid(data) {
 		valueNode, _ := sonic.Get(data, "value")
 		envNode, _ := sonic.Get(data, "env_var")
-		if valueNode.Exists() && envNode.Exists() {
-			// Use a type alias to avoid infinite recursion (alias doesn't inherit methods)
-			type secretVarAlias SecretVar
-			var secretVar secretVarAlias
-			if err := sonic.Unmarshal(data, &secretVar); err == nil {
-				e.Val = secretVar.Val
-				e.FromEnv = secretVar.FromEnv
-				e.EnvVar = secretVar.EnvVar
-				e.FromVault = secretVar.FromVault
-				e.VaultRef = secretVar.VaultRef
+		secretRefNode, _ := sonic.Get(data, "secret_ref")
+		if valueNode.Exists() && (envNode.Exists() || secretRefNode.Exists()) {
+			type secretVarCompat struct {
+				Val        string `json:"value"`
+				SecretRef  string `json:"secret_ref"`
+				FromSecret bool   `json:"from_secret"`
+				// backward compat: env_var/from_env (shipped)
+				EnvVar  string `json:"env_var"`
+				FromEnv bool   `json:"from_env"`
+			}
+			var raw secretVarCompat
+			if err := sonic.Unmarshal(data, &raw); err == nil {
+				e.Val = raw.Val
 
-				// Explicit vault reference: {from_vault: true, vault_var: "vault.path"}
-				if e.FromVault && e.VaultRef != "" {
-					if !strings.HasPrefix(e.VaultRef, "vault.") {
-						e.VaultRef = "vault." + e.VaultRef
+				// New format
+				if raw.SecretRef != "" || raw.FromSecret {
+					e.SecretRef = raw.SecretRef
+					e.FromSecret = raw.FromSecret
+				} else if raw.FromEnv && raw.EnvVar != "" {
+					// Backward compat: env
+					ref := raw.EnvVar
+					if !strings.HasPrefix(ref, "env.") {
+						ref = "env." + ref
 					}
-					e.Val = e.VaultRef
-					if vaultValue, ok := LookupVault(e.VaultRef); ok {
-						e.Val = vaultValue
+					e.SecretRef = ref
+					e.FromSecret = true
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
+						e.Val = envValue
+					} else {
+						e.Val = ""
+					}
+					return nil
+				} else if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
+					// Old format: value == env_var == "env.XXX"
+					e.SecretRef = raw.EnvVar
+					e.FromSecret = true
+					e.Val = ""
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
+						e.Val = envValue
 					}
 					return nil
 				}
-				// Old format: value == env_var == "env.XXX"
-				if strings.HasPrefix(e.Val, "env.") && e.Val == e.EnvVar {
+
+				// Resolve references
+				if e.FromSecret && strings.HasPrefix(e.SecretRef, "vault.") {
 					e.Val = ""
-					envValue, ok := os.LookupEnv(strings.TrimPrefix(e.EnvVar, "env."))
-					if ok {
-						e.Val = envValue
+					if vaultValue, ok := LookupVault(e.SecretRef); ok {
+						e.Val = vaultValue
 					}
-					e.FromEnv = true
 				}
-				// New format: value is empty, from_env=true, env_var holds the reference
-				if e.Val == "" && e.FromEnv && strings.HasPrefix(e.EnvVar, "env.") {
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.EnvVar, "env.")); ok {
+				if e.FromSecret && strings.HasPrefix(e.SecretRef, "env.") {
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.SecretRef, "env.")); ok {
 						e.Val = envValue
+					} else {
+						e.Val = ""
 					}
 				}
 				return nil
 			}
-			// Else the value is JSON, so we will treat this as a normal value
 		}
 	}
-	// Plain string forms: "vault.path/to/secret", "env.VAR", or literal value
+	// Plain string forms
 	if strings.HasPrefix(val, "vault.") {
-		e.VaultRef = val
-		e.FromVault = true
-		e.Val = val
-		e.FromEnv = false
-		e.EnvVar = ""
+		e.SecretRef = val
+		e.FromSecret = true
+		e.Val = ""
 		if vaultValue, ok := LookupVault(val); ok {
 			e.Val = vaultValue
 		}
 		return nil
 	}
 	if envKey, ok := strings.CutPrefix(val, "env."); ok {
+		e.SecretRef = val
+		e.FromSecret = true
 		if envValue, ok := os.LookupEnv(envKey); ok {
 			e.Val = envValue
-			e.FromEnv = true
-			e.EnvVar = val
-			return nil
+		} else {
+			e.Val = ""
 		}
-		e.Val = ""
-		e.FromEnv = true
-		e.EnvVar = val
-		e.FromVault = false
-		e.VaultRef = ""
 		return nil
 	}
 	e.Val = val
-	e.FromEnv = false
-	e.EnvVar = ""
-	e.FromVault = false
-	e.VaultRef = ""
+	e.SecretRef = ""
+	e.FromSecret = false
 	return nil
 }
 
@@ -332,108 +346,74 @@ func (e *SecretVar) String() string {
 func (e *SecretVar) Scan(value any) error {
 	if value == nil {
 		e.Val = ""
-		e.FromEnv = false
-		e.EnvVar = ""
-		e.FromVault = false
-		e.VaultRef = ""
+		e.SecretRef = ""
+		e.FromSecret = false
 		return nil
 	}
 	switch v := value.(type) {
 	case []byte:
 		return e.Scan(string(v))
 	case string:
-		// Cleanup string if required
-		// The string may have "\"env.TEST\"", "env.TEST" or "env.TEST\"", we need to clean it up to "env.TEST"
-		val := strings.Trim(v, "\"")
-		// Vault reference: keep the reference in Val so the AfterFind GORM hook
-		// (resolveVaultSecretVar) can resolve it via ResolveString(&e.Val). VaultRef
-		// preserves the original path so it survives resolution and can be surfaced
-		// in API responses and re-stored correctly on writes.
-		if strings.HasPrefix(val, "vault.") {
-			e.Val = val
-			e.VaultRef = val
-			e.FromVault = true
-			e.FromEnv = false
-			e.EnvVar = ""
-			if vaultValue, ok := LookupVault(val); ok {
+		if strings.HasPrefix(v, "vault.") {
+			e.Val = ""
+			e.SecretRef = v
+			e.FromSecret = true
+			if vaultValue, ok := LookupVault(v); ok {
 				e.Val = vaultValue
 			}
 			return nil
 		}
-		if envKey, ok := strings.CutPrefix(val, "env."); ok {
+		if envKey, ok := strings.CutPrefix(v, "env."); ok {
+			e.SecretRef = v
+			e.FromSecret = true
 			if envValue, ok := os.LookupEnv(envKey); ok {
 				e.Val = envValue
-				e.FromEnv = true
-				e.EnvVar = val
-				e.FromVault = false
-				e.VaultRef = ""
-				return nil
+			} else {
+				e.Val = ""
 			}
-			e.Val = ""
-			e.FromEnv = true
-			e.EnvVar = val
-			e.FromVault = false
-			e.VaultRef = ""
 			return nil
 		}
-		e.Val = val
-		e.FromEnv = false
-		e.EnvVar = ""
-		e.FromVault = false
-		e.VaultRef = ""
+		e.Val = strings.Trim(v, "\"")
+		e.SecretRef = ""
+		e.FromSecret = false
 		return nil
 	}
 	return fmt.Errorf("failed to scan value: %v", value)
 }
 
 // Value implements driver.Valuer for database storage.
-// It stores the vault reference (e.g., "vault.path/to/secret") if FromVault is true,
-// the env reference (e.g., "env.API_KEY") if FromEnv is true, otherwise the raw value.
+// It stores the secret reference (e.g., "env.API_KEY" or "vault.path/to/secret") if
+// FromSecret is true, otherwise the raw value.
 func (e SecretVar) Value() (driver.Value, error) {
-	if e.FromVault {
-		return e.VaultRef, nil
-	}
-	if e.FromEnv {
-		return e.EnvVar, nil
+	if e.FromSecret {
+		return e.SecretRef, nil
 	}
 	return e.Val, nil
 }
 
-// IsFromEnv returns true if the value is sourced from an environment variable.
-func (e *SecretVar) IsFromEnv() bool {
-	if e == nil {
-		return false
-	}
-	return e.FromEnv
-}
-
 // ShouldPreserveStored returns true when the SecretVar is a client-side placeholder
 // that should not overwrite the stored credential. Returns true for a nil receiver,
-// an empty non-env/non-vault value, or a redacted non-env/non-vault value. Returns
-// false for env/vault references (always intentional) and plain non-empty values.
+// an empty non-secret value, or a redacted non-secret value. Returns false for secret
+// references (always intentional) and plain non-empty values.
 func (e *SecretVar) ShouldPreserveStored() bool {
 	if e == nil {
 		return true
 	}
-	if e.IsFromEnv() || e.IsFromVault() {
+	if e.FromSecret {
 		return false
 	}
 	return e.GetValue() == "" || e.IsRedacted()
 }
 
-// IsSet returns true if the SecretVar has a resolved value or an environment variable
-// or vault reference. This should be used instead of GetValue() != "" when checking
-// whether a field was configured, because references may have an empty Val before
-// resolution (e.g., when the env var is not set in the current environment).
+// IsSet returns true if the SecretVar has a resolved value or a secret reference.
+// Use instead of GetValue() != "" when checking whether a field was configured,
+// because references may have an empty Val before resolution.
 func (e *SecretVar) IsSet() bool {
 	if e == nil {
 		return false
 	}
-	if e.IsFromVault() {
-		return e.VaultRef != ""
-	}
-	if e.IsFromEnv() {
-		return e.EnvVar != ""
+	if e.FromSecret {
+		return e.SecretRef != ""
 	}
 	return e.Val != ""
 }

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -54,8 +54,8 @@ func TestSecretVar_UnmarshalJSON_DoubleEscapedJSON(t *testing.T) {
 			if secretVar.Val != tt.expected {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expected, secretVar.Val)
 			}
-			if secretVar.FromSecret {
-				t.Errorf("Expected FromSecret=false, got FromSecret=true")
+			if secretVar.IsFromSecret() {
+				t.Errorf("Expected IsFromSecret()=false, got true")
 			}
 		})
 	}
@@ -98,11 +98,11 @@ func TestSecretVar_UnmarshalJSON_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.SecretRef != tt.expectedSecretRef {
-				t.Errorf("Expected SecretRef=%q, got SecretRef=%q", tt.expectedSecretRef, secretVar.SecretRef)
+			if secretVar.Ref() != tt.expectedSecretRef {
+				t.Errorf("Expected Ref()=%q, got %q", tt.expectedSecretRef, secretVar.Ref())
 			}
-			if secretVar.FromSecret != tt.expectedFromSecret {
-				t.Errorf("Expected FromSecret=%v, got FromSecret=%v", tt.expectedFromSecret, secretVar.FromSecret)
+			if secretVar.IsFromSecret() != tt.expectedFromSecret {
+				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
 			}
 		})
 	}
@@ -121,17 +121,16 @@ func TestSecretVar_UnmarshalJSON_BackwardCompat(t *testing.T) {
 		if err != nil {
 			t.Fatalf("UnmarshalJSON failed: %v", err)
 		}
-		if secretVar.SecretRef != "env.MY_KEY" {
-			t.Errorf("Expected SecretRef=%q, got %q", "env.MY_KEY", secretVar.SecretRef)
+		if secretVar.Ref() != "env.MY_KEY" {
+			t.Errorf("Expected Ref()=%q, got %q", "env.MY_KEY", secretVar.Ref())
 		}
-		if !secretVar.FromSecret {
-			t.Error("Expected FromSecret=true, got false")
+		if !secretVar.IsFromSecret() {
+			t.Error("Expected IsFromSecret()=true, got false")
 		}
 		if secretVar.Val != "resolved-value" {
 			t.Errorf("Expected Val=%q, got %q", "resolved-value", secretVar.Val)
 		}
 	})
-
 }
 
 func TestNewSecretVar_DoubleEscapedJSON(t *testing.T) {
@@ -180,28 +179,28 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 		name               string
 		input              string
 		expectedVal        string
-		expectedSecretRef  string
+		expectedRef        string
 		expectedFromSecret bool
 	}{
 		{
 			name:               "env var reference with value present",
 			input:              "env.TEST_NEW_ENVVAR_KEY",
 			expectedVal:        "resolved-value",
-			expectedSecretRef:  "env.TEST_NEW_ENVVAR_KEY",
+			expectedRef:        "env.TEST_NEW_ENVVAR_KEY",
 			expectedFromSecret: true,
 		},
 		{
 			name:               "env var reference with quotes",
 			input:              `"env.TEST_NEW_ENVVAR_KEY"`,
 			expectedVal:        "resolved-value",
-			expectedSecretRef:  "env.TEST_NEW_ENVVAR_KEY",
+			expectedRef:        "env.TEST_NEW_ENVVAR_KEY",
 			expectedFromSecret: true,
 		},
 		{
 			name:               "env var reference missing",
 			input:              "env.MISSING_VAR",
 			expectedVal:        "",
-			expectedSecretRef:  "env.MISSING_VAR",
+			expectedRef:        "env.MISSING_VAR",
 			expectedFromSecret: true,
 		},
 	}
@@ -212,11 +211,11 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.SecretRef != tt.expectedSecretRef {
-				t.Errorf("Expected SecretRef=%q, got SecretRef=%q", tt.expectedSecretRef, secretVar.SecretRef)
+			if secretVar.Ref() != tt.expectedRef {
+				t.Errorf("Expected Ref()=%q, got %q", tt.expectedRef, secretVar.Ref())
 			}
-			if secretVar.FromSecret != tt.expectedFromSecret {
-				t.Errorf("Expected FromSecret=%v, got FromSecret=%v", tt.expectedFromSecret, secretVar.FromSecret)
+			if secretVar.IsFromSecret() != tt.expectedFromSecret {
+				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
 			}
 		})
 	}
@@ -280,16 +279,16 @@ func TestSecretVar_MixedConfigParsing(t *testing.T) {
 	if config.ProjectID.Val != "env-project-id" {
 		t.Errorf("Expected ProjectID=%q, got %q", "env-project-id", config.ProjectID.Val)
 	}
-	if !config.ProjectID.FromSecret {
-		t.Errorf("Expected ProjectID.FromSecret=true")
+	if !config.ProjectID.IsFromSecret() {
+		t.Error("Expected ProjectID.IsFromSecret()=true")
 	}
 
 	expectedCreds := `{"type":"service_account","key":"value"}`
 	if config.Credentials.Val != expectedCreds {
 		t.Errorf("Expected Credentials=%q, got %q", expectedCreds, config.Credentials.Val)
 	}
-	if config.Credentials.FromSecret {
-		t.Errorf("Expected Credentials.FromSecret=false")
+	if config.Credentials.IsFromSecret() {
+		t.Error("Expected Credentials.IsFromSecret()=false")
 	}
 }
 
@@ -320,8 +319,8 @@ func TestSecretVar_Equals(t *testing.T) {
 		},
 		{
 			name:     "equal values",
-			a:        &SecretVar{Val: "test", SecretRef: "env.TEST", FromSecret: true},
-			b:        &SecretVar{Val: "test", SecretRef: "env.TEST", FromSecret: true},
+			a:        NewSecretVarFromRef("env.TEST", "test"),
+			b:        NewSecretVarFromRef("env.TEST", "test"),
 			expected: true,
 		},
 		{
@@ -384,11 +383,11 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 	})
 
 	tests := []struct {
-		name               string
-		input              SecretVar
-		wantVal            string
-		wantFromSecret     bool
-		wantSecretRef      string
+		name           string
+		input          SecretVar
+		wantVal        string
+		wantFromSecret bool
+		wantRef        string
 	}{
 		{
 			name:           "empty value",
@@ -404,10 +403,10 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 		},
 		{
 			name:           "resolved env password preserves reference metadata",
-			input:          SecretVar{Val: "resolved-secret", FromSecret: true, SecretRef: "env.PROXY_PASS"},
+			input:          *NewSecretVarFromRef("env.PROXY_PASS", "resolved-secret"),
 			wantVal:        "<REDACTED>",
 			wantFromSecret: true,
-			wantSecretRef:  "env.PROXY_PASS",
+			wantRef:        "env.PROXY_PASS",
 		},
 	}
 
@@ -417,11 +416,11 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 			if result.Val != tt.wantVal {
 				t.Errorf("Val: want %q, got %q", tt.wantVal, result.Val)
 			}
-			if result.FromSecret != tt.wantFromSecret {
-				t.Errorf("FromSecret: want %v, got %v", tt.wantFromSecret, result.FromSecret)
+			if result.IsFromSecret() != tt.wantFromSecret {
+				t.Errorf("IsFromSecret(): want %v, got %v", tt.wantFromSecret, result.IsFromSecret())
 			}
-			if result.SecretRef != tt.wantSecretRef {
-				t.Errorf("SecretRef: want %q, got %q", tt.wantSecretRef, result.SecretRef)
+			if result.Ref() != tt.wantRef {
+				t.Errorf("Ref(): want %q, got %q", tt.wantRef, result.Ref())
 			}
 		})
 	}
@@ -440,7 +439,7 @@ func TestSecretVar_IsRedacted(t *testing.T) {
 		},
 		{
 			name:     "from secret",
-			input:    SecretVar{Val: "test", FromSecret: true, SecretRef: "env.KEY"},
+			input:    *NewSecretVarFromRef("env.KEY", "test"),
 			expected: true,
 		},
 		{
@@ -501,28 +500,23 @@ func TestSecretVar_IsSet(t *testing.T) {
 		},
 		{
 			name:     "env reference not yet resolved",
-			input:    &SecretVar{SecretRef: "env.MISSING", FromSecret: true},
+			input:    NewSecretVarFromRef("env.MISSING", ""),
 			expected: true,
 		},
 		{
 			name:     "env reference resolved",
-			input:    &SecretVar{Val: "resolved-secret", SecretRef: "env.X", FromSecret: true},
+			input:    NewSecretVarFromRef("env.X", "resolved-secret"),
 			expected: true,
 		},
 		{
-			name:     "FromSecret true but no reference and no value",
-			input:    &SecretVar{FromSecret: true},
+			name:     "fromSecret true but no reference and no value",
+			input:    NewSecretVarFromRef("", ""),
 			expected: false,
 		},
 		{
 			name:     "vault reference set",
-			input:    &SecretVar{SecretRef: "vault.bifrost/key", FromSecret: true, Val: "vault.bifrost/key"},
+			input:    NewSecretVarFromRef("vault.bifrost/key", "vault.bifrost/key"),
 			expected: true,
-		},
-		{
-			name:     "FromSecret true but empty SecretRef",
-			input:    &SecretVar{FromSecret: true, SecretRef: ""},
-			expected: false,
 		},
 	}
 
@@ -537,17 +531,17 @@ func TestSecretVar_IsSet(t *testing.T) {
 
 func TestSecretVar_Scan_VaultRef(t *testing.T) {
 	tests := []struct {
-		name               string
-		input              string
-		wantVal            string
-		wantSecretRef      string
-		wantFromSecret     bool
+		name           string
+		input          string
+		wantVal        string
+		wantRef        string
+		wantFromSecret bool
 	}{
 		{
 			name:           "plain vault reference",
 			input:          "vault.bifrost/providers/openai/key",
 			wantVal:        "",
-			wantSecretRef:  "vault.bifrost/providers/openai/key",
+			wantRef:        "vault.bifrost/providers/openai/key",
 			wantFromSecret: true,
 		},
 		{
@@ -558,7 +552,7 @@ func TestSecretVar_Scan_VaultRef(t *testing.T) {
 		{
 			name:           "env reference",
 			input:          "env.MY_VAR",
-			wantSecretRef:  "env.MY_VAR",
+			wantRef:        "env.MY_VAR",
 			wantFromSecret: true,
 		},
 		{
@@ -574,13 +568,11 @@ func TestSecretVar_Scan_VaultRef(t *testing.T) {
 			if err := e.Scan(tt.input); err != nil {
 				t.Fatalf("Scan() error: %v", err)
 			}
-			if tt.wantFromSecret {
-				if !e.FromSecret {
-					t.Errorf("FromSecret = false, want true")
-				}
-				if e.SecretRef != tt.wantSecretRef {
-					t.Errorf("SecretRef = %q, want %q", e.SecretRef, tt.wantSecretRef)
-				}
+			if e.IsFromSecret() != tt.wantFromSecret {
+				t.Errorf("IsFromSecret() = %v, want %v", e.IsFromSecret(), tt.wantFromSecret)
+			}
+			if tt.wantFromSecret && e.Ref() != tt.wantRef {
+				t.Errorf("Ref() = %q, want %q", e.Ref(), tt.wantRef)
 			}
 			if tt.wantVal != "" && e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -594,21 +586,21 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 		name           string
 		input          string
 		wantVal        string
-		wantSecretRef  string
+		wantRef        string
 		wantFromSecret bool
 	}{
 		{
 			name:           "new format: secret_ref/from_secret",
 			input:          `{"value":"vault.bifrost/key","secret_ref":"vault.bifrost/key","from_secret":true}`,
 			wantVal:        "",
-			wantSecretRef:  "vault.bifrost/key",
+			wantRef:        "vault.bifrost/key",
 			wantFromSecret: true,
 		},
 		{
 			name:           "plain string vault reference",
 			input:          `"vault.myproject/secret"`,
 			wantVal:        "",
-			wantSecretRef:  "vault.myproject/secret",
+			wantRef:        "vault.myproject/secret",
 			wantFromSecret: true,
 		},
 	}
@@ -619,11 +611,11 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 			if err := json.Unmarshal([]byte(tt.input), &e); err != nil {
 				t.Fatalf("UnmarshalJSON() error: %v", err)
 			}
-			if e.FromSecret != tt.wantFromSecret {
-				t.Errorf("FromSecret = %v, want %v", e.FromSecret, tt.wantFromSecret)
+			if e.IsFromSecret() != tt.wantFromSecret {
+				t.Errorf("IsFromSecret() = %v, want %v", e.IsFromSecret(), tt.wantFromSecret)
 			}
-			if e.SecretRef != tt.wantSecretRef {
-				t.Errorf("SecretRef = %q, want %q", e.SecretRef, tt.wantSecretRef)
+			if e.Ref() != tt.wantRef {
+				t.Errorf("Ref() = %q, want %q", e.Ref(), tt.wantRef)
 			}
 			if e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -633,11 +625,7 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 }
 
 func TestSecretVar_Value_VaultRef(t *testing.T) {
-	e := &SecretVar{
-		Val:        "actual-secret",
-		SecretRef:  "vault.bifrost/key",
-		FromSecret: true,
-	}
+	e := NewSecretVarFromRef("vault.bifrost/key", "actual-secret")
 	got, err := e.Value()
 	if err != nil {
 		t.Fatalf("Value() error: %v", err)
@@ -648,27 +636,23 @@ func TestSecretVar_Value_VaultRef(t *testing.T) {
 }
 
 func TestSecretVar_Redacted_VaultRef(t *testing.T) {
-	e := &SecretVar{
-		Val:        "actual-secret-value",
-		SecretRef:  "vault.bifrost/key",
-		FromSecret: true,
-	}
+	e := NewSecretVarFromRef("vault.bifrost/key", "actual-secret-value")
 	r := e.Redacted()
 	wantVal := "actu************************alue"
 	if r.Val != wantVal {
 		t.Errorf("Redacted().Val = %q, want %q", r.Val, wantVal)
 	}
-	if !r.FromSecret {
-		t.Errorf("Redacted().FromSecret = false, want true")
+	if !r.IsFromSecret() {
+		t.Error("Redacted().IsFromSecret() = false, want true")
 	}
-	if r.SecretRef != "vault.bifrost/key" {
-		t.Errorf("Redacted().SecretRef = %q, want %q", r.SecretRef, "vault.bifrost/key")
+	if r.Ref() != "vault.bifrost/key" {
+		t.Errorf("Redacted().Ref() = %q, want %q", r.Ref(), "vault.bifrost/key")
 	}
 }
 
 func TestSecretVar_IsSet_VaultRef(t *testing.T) {
-	set := &SecretVar{SecretRef: "vault.bifrost/key", FromSecret: true, Val: "vault.bifrost/key"}
-	unset := &SecretVar{FromSecret: true}
+	set := NewSecretVarFromRef("vault.bifrost/key", "vault.bifrost/key")
+	unset := NewSecretVarFromRef("", "")
 	if !set.IsSet() {
 		t.Error("IsSet() = false for vault ref, want true")
 	}
@@ -679,13 +663,49 @@ func TestSecretVar_IsSet_VaultRef(t *testing.T) {
 
 func TestNewSecretVar_VaultRef(t *testing.T) {
 	e := NewSecretVar("vault.bifrost/mykey")
-	if !e.FromSecret {
-		t.Error("FromSecret = false, want true")
+	if !e.IsFromVault() {
+		t.Error("IsFromVault() = false, want true")
 	}
-	if e.SecretRef != "vault.bifrost/mykey" {
-		t.Errorf("SecretRef = %q, want %q", e.SecretRef, "vault.bifrost/mykey")
+	if e.Ref() != "vault.bifrost/mykey" {
+		t.Errorf("Ref() = %q, want %q", e.Ref(), "vault.bifrost/mykey")
 	}
 	if e.Val != "" {
 		t.Errorf("Val = %q, want empty string when vault lookup fails", e.Val)
+	}
+}
+
+func TestSecretVar_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input SecretVar
+		want  string
+	}{
+		{
+			name:  "plain value",
+			input: SecretVar{Val: "my-api-key"},
+			want:  `{"value":"my-api-key"}`,
+		},
+		{
+			name:  "env reference",
+			input: *NewSecretVarFromRef("env.MY_KEY", "resolved"),
+			want:  `{"value":"resolved","secret_ref":"env.MY_KEY","from_secret":true}`,
+		},
+		{
+			name:  "vault reference",
+			input: *NewSecretVarFromRef("vault.path/to/secret", ""),
+			want:  `{"value":"","secret_ref":"vault.path/to/secret","from_secret":true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("MarshalJSON() error: %v", err)
+			}
+			if string(b) != tt.want {
+				t.Errorf("MarshalJSON() = %s, want %s", b, tt.want)
+			}
+		})
 	}
 }

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -98,8 +98,8 @@ func TestSecretVar_UnmarshalJSON_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.Ref() != tt.expectedSecretRef {
-				t.Errorf("Expected Ref()=%q, got %q", tt.expectedSecretRef, secretVar.Ref())
+			if secretVar.GetSecretRef() != tt.expectedSecretRef {
+				t.Errorf("Expected Ref()=%q, got %q", tt.expectedSecretRef, secretVar.GetSecretRef())
 			}
 			if secretVar.IsFromSecret() != tt.expectedFromSecret {
 				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
@@ -121,8 +121,8 @@ func TestSecretVar_UnmarshalJSON_BackwardCompat(t *testing.T) {
 		if err != nil {
 			t.Fatalf("UnmarshalJSON failed: %v", err)
 		}
-		if secretVar.Ref() != "env.MY_KEY" {
-			t.Errorf("Expected Ref()=%q, got %q", "env.MY_KEY", secretVar.Ref())
+		if secretVar.GetSecretRef() != "env.MY_KEY" {
+			t.Errorf("Expected Ref()=%q, got %q", "env.MY_KEY", secretVar.GetSecretRef())
 		}
 		if !secretVar.IsFromSecret() {
 			t.Error("Expected IsFromSecret()=true, got false")
@@ -211,8 +211,8 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.Ref() != tt.expectedRef {
-				t.Errorf("Expected Ref()=%q, got %q", tt.expectedRef, secretVar.Ref())
+			if secretVar.GetSecretRef() != tt.expectedRef {
+				t.Errorf("Expected Ref()=%q, got %q", tt.expectedRef, secretVar.GetSecretRef())
 			}
 			if secretVar.IsFromSecret() != tt.expectedFromSecret {
 				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
@@ -319,8 +319,8 @@ func TestSecretVar_Equals(t *testing.T) {
 		},
 		{
 			name:     "equal values",
-			a:        NewSecretVarFromRef("env.TEST", "test"),
-			b:        NewSecretVarFromRef("env.TEST", "test"),
+			a:        &SecretVar{Val: "test", secretRef: "env.TEST", fromSecret: true},
+			b:        &SecretVar{Val: "test", secretRef: "env.TEST", fromSecret: true},
 			expected: true,
 		},
 		{
@@ -403,7 +403,7 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 		},
 		{
 			name:           "resolved env password preserves reference metadata",
-			input:          *NewSecretVarFromRef("env.PROXY_PASS", "resolved-secret"),
+			input:          SecretVar{Val: "resolved-secret", secretRef: "env.PROXY_PASS", fromSecret: true},
 			wantVal:        "<REDACTED>",
 			wantFromSecret: true,
 			wantRef:        "env.PROXY_PASS",
@@ -419,8 +419,8 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 			if result.IsFromSecret() != tt.wantFromSecret {
 				t.Errorf("IsFromSecret(): want %v, got %v", tt.wantFromSecret, result.IsFromSecret())
 			}
-			if result.Ref() != tt.wantRef {
-				t.Errorf("Ref(): want %q, got %q", tt.wantRef, result.Ref())
+			if result.GetSecretRef() != tt.wantRef {
+				t.Errorf("Ref(): want %q, got %q", tt.wantRef, result.GetSecretRef())
 			}
 		})
 	}
@@ -439,7 +439,7 @@ func TestSecretVar_IsRedacted(t *testing.T) {
 		},
 		{
 			name:     "from secret",
-			input:    *NewSecretVarFromRef("env.KEY", "test"),
+			input:    SecretVar{Val: "test", secretRef: "env.KEY", fromSecret: true},
 			expected: true,
 		},
 		{
@@ -500,22 +500,22 @@ func TestSecretVar_IsSet(t *testing.T) {
 		},
 		{
 			name:     "env reference not yet resolved",
-			input:    NewSecretVarFromRef("env.MISSING", ""),
+			input:    &SecretVar{secretRef: "env.MISSING", fromSecret: true},
 			expected: true,
 		},
 		{
 			name:     "env reference resolved",
-			input:    NewSecretVarFromRef("env.X", "resolved-secret"),
+			input:    &SecretVar{Val: "resolved-secret", secretRef: "env.X", fromSecret: true},
 			expected: true,
 		},
 		{
 			name:     "fromSecret true but no reference and no value",
-			input:    NewSecretVarFromRef("", ""),
+			input:    &SecretVar{fromSecret: true},
 			expected: false,
 		},
 		{
 			name:     "vault reference set",
-			input:    NewSecretVarFromRef("vault.bifrost/key", "vault.bifrost/key"),
+			input:    &SecretVar{Val: "vault.bifrost/key", secretRef: "vault.bifrost/key", fromSecret: true},
 			expected: true,
 		},
 	}
@@ -571,8 +571,8 @@ func TestSecretVar_Scan_VaultRef(t *testing.T) {
 			if e.IsFromSecret() != tt.wantFromSecret {
 				t.Errorf("IsFromSecret() = %v, want %v", e.IsFromSecret(), tt.wantFromSecret)
 			}
-			if tt.wantFromSecret && e.Ref() != tt.wantRef {
-				t.Errorf("Ref() = %q, want %q", e.Ref(), tt.wantRef)
+			if tt.wantFromSecret && e.GetSecretRef() != tt.wantRef {
+				t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), tt.wantRef)
 			}
 			if tt.wantVal != "" && e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -614,8 +614,8 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 			if e.IsFromSecret() != tt.wantFromSecret {
 				t.Errorf("IsFromSecret() = %v, want %v", e.IsFromSecret(), tt.wantFromSecret)
 			}
-			if e.Ref() != tt.wantRef {
-				t.Errorf("Ref() = %q, want %q", e.Ref(), tt.wantRef)
+			if e.GetSecretRef() != tt.wantRef {
+				t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), tt.wantRef)
 			}
 			if e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -625,7 +625,7 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 }
 
 func TestSecretVar_Value_VaultRef(t *testing.T) {
-	e := NewSecretVarFromRef("vault.bifrost/key", "actual-secret")
+	e := &SecretVar{Val: "actual-secret", secretRef: "vault.bifrost/key", fromSecret: true}
 	got, err := e.Value()
 	if err != nil {
 		t.Fatalf("Value() error: %v", err)
@@ -636,7 +636,7 @@ func TestSecretVar_Value_VaultRef(t *testing.T) {
 }
 
 func TestSecretVar_Redacted_VaultRef(t *testing.T) {
-	e := NewSecretVarFromRef("vault.bifrost/key", "actual-secret-value")
+	e := &SecretVar{Val: "actual-secret-value", secretRef: "vault.bifrost/key", fromSecret: true}
 	r := e.Redacted()
 	wantVal := "actu************************alue"
 	if r.Val != wantVal {
@@ -645,14 +645,14 @@ func TestSecretVar_Redacted_VaultRef(t *testing.T) {
 	if !r.IsFromSecret() {
 		t.Error("Redacted().IsFromSecret() = false, want true")
 	}
-	if r.Ref() != "vault.bifrost/key" {
-		t.Errorf("Redacted().Ref() = %q, want %q", r.Ref(), "vault.bifrost/key")
+	if r.GetSecretRef() != "vault.bifrost/key" {
+		t.Errorf("Redacted().GetSecretRef() = %q, want %q", r.GetSecretRef(), "vault.bifrost/key")
 	}
 }
 
 func TestSecretVar_IsSet_VaultRef(t *testing.T) {
-	set := NewSecretVarFromRef("vault.bifrost/key", "vault.bifrost/key")
-	unset := NewSecretVarFromRef("", "")
+	set := &SecretVar{Val: "vault.bifrost/key", secretRef: "vault.bifrost/key", fromSecret: true}
+	unset := &SecretVar{fromSecret: true}
 	if !set.IsSet() {
 		t.Error("IsSet() = false for vault ref, want true")
 	}
@@ -666,8 +666,8 @@ func TestNewSecretVar_VaultRef(t *testing.T) {
 	if !e.IsFromVault() {
 		t.Error("IsFromVault() = false, want true")
 	}
-	if e.Ref() != "vault.bifrost/mykey" {
-		t.Errorf("Ref() = %q, want %q", e.Ref(), "vault.bifrost/mykey")
+	if e.GetSecretRef() != "vault.bifrost/mykey" {
+		t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), "vault.bifrost/mykey")
 	}
 	if e.Val != "" {
 		t.Errorf("Val = %q, want empty string when vault lookup fails", e.Val)
@@ -687,12 +687,12 @@ func TestSecretVar_MarshalJSON(t *testing.T) {
 		},
 		{
 			name:  "env reference",
-			input: *NewSecretVarFromRef("env.MY_KEY", "resolved"),
+			input: SecretVar{Val: "resolved", secretRef: "env.MY_KEY", fromSecret: true},
 			want:  `{"value":"resolved","secret_ref":"env.MY_KEY","from_secret":true}`,
 		},
 		{
 			name:  "vault reference",
-			input: *NewSecretVarFromRef("vault.path/to/secret", ""),
+			input: SecretVar{secretRef: "vault.path/to/secret", fromSecret: true},
 			want:  `{"value":"","secret_ref":"vault.path/to/secret","from_secret":true}`,
 		},
 	}

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -54,38 +54,37 @@ func TestSecretVar_UnmarshalJSON_DoubleEscapedJSON(t *testing.T) {
 			if secretVar.Val != tt.expected {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expected, secretVar.Val)
 			}
-			if secretVar.FromEnv {
-				t.Errorf("Expected FromEnv=false, got FromEnv=true")
+			if secretVar.FromSecret {
+				t.Errorf("Expected FromSecret=false, got FromSecret=true")
 			}
 		})
 	}
 }
 
 func TestSecretVar_UnmarshalJSON_SecretVarReference(t *testing.T) {
-	// Set up test environment variable
 	os.Setenv("TEST_API_KEY", "actual-api-key-value")
 	defer os.Unsetenv("TEST_API_KEY")
 
 	tests := []struct {
-		name            string
-		input           string
-		expectedVal     string
-		expectedEnvVar  string
-		expectedFromEnv bool
+		name               string
+		input              string
+		expectedVal        string
+		expectedSecretRef  string
+		expectedFromSecret bool
 	}{
 		{
-			name:            "env var reference with value present",
-			input:           `"env.TEST_API_KEY"`,
-			expectedVal:     "actual-api-key-value",
-			expectedEnvVar:  "env.TEST_API_KEY",
-			expectedFromEnv: true,
+			name:               "env var reference with value present",
+			input:              `"env.TEST_API_KEY"`,
+			expectedVal:        "actual-api-key-value",
+			expectedSecretRef:  "env.TEST_API_KEY",
+			expectedFromSecret: true,
 		},
 		{
-			name:            "env var reference with missing value",
-			input:           `"env.NONEXISTENT_VAR"`,
-			expectedVal:     "",
-			expectedEnvVar:  "env.NONEXISTENT_VAR",
-			expectedFromEnv: true,
+			name:               "env var reference with missing value",
+			input:              `"env.NONEXISTENT_VAR"`,
+			expectedVal:        "",
+			expectedSecretRef:  "env.NONEXISTENT_VAR",
+			expectedFromSecret: true,
 		},
 	}
 
@@ -99,34 +98,40 @@ func TestSecretVar_UnmarshalJSON_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.EnvVar != tt.expectedEnvVar {
-				t.Errorf("Expected SecretVar=%q, got SecretVar=%q", tt.expectedEnvVar, secretVar.EnvVar)
+			if secretVar.SecretRef != tt.expectedSecretRef {
+				t.Errorf("Expected SecretRef=%q, got SecretRef=%q", tt.expectedSecretRef, secretVar.SecretRef)
 			}
-			if secretVar.FromEnv != tt.expectedFromEnv {
-				t.Errorf("Expected FromEnv=%v, got FromEnv=%v", tt.expectedFromEnv, secretVar.FromEnv)
+			if secretVar.FromSecret != tt.expectedFromSecret {
+				t.Errorf("Expected FromSecret=%v, got FromSecret=%v", tt.expectedFromSecret, secretVar.FromSecret)
 			}
 		})
 	}
 }
 
-func TestSecretVar_UnmarshalJSON_FullStructure(t *testing.T) {
-	// Test when the input is already an SecretVar JSON object
-	input := `{"value":"my-api-key","env_var":"env.MY_KEY","from_env":true}`
+// TestSecretVar_UnmarshalJSON_BackwardCompat verifies that the old env_var/from_env JSON
+// format (shipped in previous versions) still deserializes correctly to the new fields.
+func TestSecretVar_UnmarshalJSON_BackwardCompat(t *testing.T) {
+	os.Setenv("MY_KEY", "resolved-value")
+	defer os.Unsetenv("MY_KEY")
 
-	var secretVar SecretVar
-	err := secretVar.UnmarshalJSON([]byte(input))
-	if err != nil {
-		t.Fatalf("UnmarshalJSON failed: %v", err)
-	}
-	if secretVar.Val != "my-api-key" {
-		t.Errorf("Expected Val=%q, got Val=%q", "my-api-key", secretVar.Val)
-	}
-	if secretVar.EnvVar != "env.MY_KEY" {
-		t.Errorf("Expected SecretVar=%q, got SecretVar=%q", "env.MY_KEY", secretVar.EnvVar)
-	}
-	if !secretVar.FromEnv {
-		t.Errorf("Expected FromEnv=true, got FromEnv=false")
-	}
+	t.Run("old env_var/from_env format", func(t *testing.T) {
+		input := `{"value":"my-api-key","env_var":"env.MY_KEY","from_env":true}`
+		var secretVar SecretVar
+		err := secretVar.UnmarshalJSON([]byte(input))
+		if err != nil {
+			t.Fatalf("UnmarshalJSON failed: %v", err)
+		}
+		if secretVar.SecretRef != "env.MY_KEY" {
+			t.Errorf("Expected SecretRef=%q, got %q", "env.MY_KEY", secretVar.SecretRef)
+		}
+		if !secretVar.FromSecret {
+			t.Error("Expected FromSecret=true, got false")
+		}
+		if secretVar.Val != "resolved-value" {
+			t.Errorf("Expected Val=%q, got %q", "resolved-value", secretVar.Val)
+		}
+	})
+
 }
 
 func TestNewSecretVar_DoubleEscapedJSON(t *testing.T) {
@@ -168,37 +173,36 @@ func TestNewSecretVar_DoubleEscapedJSON(t *testing.T) {
 }
 
 func TestNewSecretVar_SecretVarReference(t *testing.T) {
-	// Set up test environment variable
 	os.Setenv("TEST_NEW_ENVVAR_KEY", "resolved-value")
 	defer os.Unsetenv("TEST_NEW_ENVVAR_KEY")
 
 	tests := []struct {
-		name            string
-		input           string
-		expectedVal     string
-		expectedEnvVar  string
-		expectedFromEnv bool
+		name               string
+		input              string
+		expectedVal        string
+		expectedSecretRef  string
+		expectedFromSecret bool
 	}{
 		{
-			name:            "env var reference with value present",
-			input:           "env.TEST_NEW_ENVVAR_KEY",
-			expectedVal:     "resolved-value",
-			expectedEnvVar:  "env.TEST_NEW_ENVVAR_KEY",
-			expectedFromEnv: true,
+			name:               "env var reference with value present",
+			input:              "env.TEST_NEW_ENVVAR_KEY",
+			expectedVal:        "resolved-value",
+			expectedSecretRef:  "env.TEST_NEW_ENVVAR_KEY",
+			expectedFromSecret: true,
 		},
 		{
-			name:            "env var reference with quotes",
-			input:           `"env.TEST_NEW_ENVVAR_KEY"`,
-			expectedVal:     "resolved-value",
-			expectedEnvVar:  "env.TEST_NEW_ENVVAR_KEY",
-			expectedFromEnv: true,
+			name:               "env var reference with quotes",
+			input:              `"env.TEST_NEW_ENVVAR_KEY"`,
+			expectedVal:        "resolved-value",
+			expectedSecretRef:  "env.TEST_NEW_ENVVAR_KEY",
+			expectedFromSecret: true,
 		},
 		{
-			name:            "env var reference missing",
-			input:           "env.MISSING_VAR",
-			expectedVal:     "",
-			expectedEnvVar:  "env.MISSING_VAR",
-			expectedFromEnv: true,
+			name:               "env var reference missing",
+			input:              "env.MISSING_VAR",
+			expectedVal:        "",
+			expectedSecretRef:  "env.MISSING_VAR",
+			expectedFromSecret: true,
 		},
 	}
 
@@ -208,11 +212,11 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.EnvVar != tt.expectedEnvVar {
-				t.Errorf("Expected SecretVar=%q, got SecretVar=%q", tt.expectedEnvVar, secretVar.EnvVar)
+			if secretVar.SecretRef != tt.expectedSecretRef {
+				t.Errorf("Expected SecretRef=%q, got SecretRef=%q", tt.expectedSecretRef, secretVar.SecretRef)
 			}
-			if secretVar.FromEnv != tt.expectedFromEnv {
-				t.Errorf("Expected FromEnv=%v, got FromEnv=%v", tt.expectedFromEnv, secretVar.FromEnv)
+			if secretVar.FromSecret != tt.expectedFromSecret {
+				t.Errorf("Expected FromSecret=%v, got FromSecret=%v", tt.expectedFromSecret, secretVar.FromSecret)
 			}
 		})
 	}
@@ -221,7 +225,6 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 // TestSecretVar_RealWorldVertexCredentials tests the actual use case that triggered
 // the double-escaping bug: Vertex AI service account credentials
 func TestSecretVar_RealWorldVertexCredentials(t *testing.T) {
-	// This simulates what happens when parsing config.json with embedded service account JSON
 	type VertexKeyConfig struct {
 		ProjectID       SecretVar `json:"project_id"`
 		Region          SecretVar `json:"region"`
@@ -240,13 +243,10 @@ func TestSecretVar_RealWorldVertexCredentials(t *testing.T) {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
 
-	// Verify auth_credentials is properly unescaped
 	expectedAuthCreds := `{"type":"service_account","project_id":"my-project","private_key_id":"abc123","private_key":"-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----\n","client_email":"test@my-project.iam.gserviceaccount.com"}`
 	if config.AuthCredentials.Val != expectedAuthCreds {
 		t.Errorf("AuthCredentials not properly unescaped.\nExpected: %s\nGot: %s", expectedAuthCreds, config.AuthCredentials.Val)
 	}
-
-	// Verify simple string fields work correctly
 	if config.ProjectID.Val != "my-project" {
 		t.Errorf("Expected ProjectID=%q, got %q", "my-project", config.ProjectID.Val)
 	}
@@ -277,21 +277,19 @@ func TestSecretVar_MixedConfigParsing(t *testing.T) {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
 
-	// Verify env var reference is resolved
 	if config.ProjectID.Val != "env-project-id" {
 		t.Errorf("Expected ProjectID=%q, got %q", "env-project-id", config.ProjectID.Val)
 	}
-	if !config.ProjectID.FromEnv {
-		t.Errorf("Expected ProjectID.FromEnv=true")
+	if !config.ProjectID.FromSecret {
+		t.Errorf("Expected ProjectID.FromSecret=true")
 	}
 
-	// Verify JSON credentials are properly unescaped
 	expectedCreds := `{"type":"service_account","key":"value"}`
 	if config.Credentials.Val != expectedCreds {
 		t.Errorf("Expected Credentials=%q, got %q", expectedCreds, config.Credentials.Val)
 	}
-	if config.Credentials.FromEnv {
-		t.Errorf("Expected Credentials.FromEnv=false")
+	if config.Credentials.FromSecret {
+		t.Errorf("Expected Credentials.FromSecret=false")
 	}
 }
 
@@ -322,8 +320,8 @@ func TestSecretVar_Equals(t *testing.T) {
 		},
 		{
 			name:     "equal values",
-			a:        &SecretVar{Val: "test", EnvVar: "env.TEST", FromEnv: true},
-			b:        &SecretVar{Val: "test", EnvVar: "env.TEST", FromEnv: true},
+			a:        &SecretVar{Val: "test", SecretRef: "env.TEST", FromSecret: true},
+			b:        &SecretVar{Val: "test", SecretRef: "env.TEST", FromSecret: true},
 			expected: true,
 		},
 		{
@@ -386,30 +384,30 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 	})
 
 	tests := []struct {
-		name        string
-		input       SecretVar
-		wantVal     string
-		wantFromEnv bool
-		wantEnvVar  string
+		name               string
+		input              SecretVar
+		wantVal            string
+		wantFromSecret     bool
+		wantSecretRef      string
 	}{
 		{
-			name:        "empty value",
-			input:       SecretVar{Val: ""},
-			wantVal:     "",
-			wantFromEnv: false,
+			name:           "empty value",
+			input:          SecretVar{Val: ""},
+			wantVal:        "",
+			wantFromSecret: false,
 		},
 		{
-			name:        "long literal never leaks prefix or suffix",
-			input:       SecretVar{Val: "mysecretpassword", FromEnv: false},
-			wantVal:     "<REDACTED>",
-			wantFromEnv: false,
+			name:           "long literal never leaks prefix or suffix",
+			input:          SecretVar{Val: "mysecretpassword"},
+			wantVal:        "<REDACTED>",
+			wantFromSecret: false,
 		},
 		{
-			name:        "resolved env password preserves reference metadata",
-			input:       SecretVar{Val: "resolved-secret", FromEnv: true, EnvVar: "env.PROXY_PASS"},
-			wantVal:     "<REDACTED>",
-			wantFromEnv: true,
-			wantEnvVar:  "env.PROXY_PASS",
+			name:           "resolved env password preserves reference metadata",
+			input:          SecretVar{Val: "resolved-secret", FromSecret: true, SecretRef: "env.PROXY_PASS"},
+			wantVal:        "<REDACTED>",
+			wantFromSecret: true,
+			wantSecretRef:  "env.PROXY_PASS",
 		},
 	}
 
@@ -419,11 +417,11 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 			if result.Val != tt.wantVal {
 				t.Errorf("Val: want %q, got %q", tt.wantVal, result.Val)
 			}
-			if result.FromEnv != tt.wantFromEnv {
-				t.Errorf("FromEnv: want %v, got %v", tt.wantFromEnv, result.FromEnv)
+			if result.FromSecret != tt.wantFromSecret {
+				t.Errorf("FromSecret: want %v, got %v", tt.wantFromSecret, result.FromSecret)
 			}
-			if result.EnvVar != tt.wantEnvVar {
-				t.Errorf("EnvVar: want %q, got %q", tt.wantEnvVar, result.EnvVar)
+			if result.SecretRef != tt.wantSecretRef {
+				t.Errorf("SecretRef: want %q, got %q", tt.wantSecretRef, result.SecretRef)
 			}
 		})
 	}
@@ -436,13 +434,13 @@ func TestSecretVar_IsRedacted(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "empty not from env",
-			input:    SecretVar{Val: "", FromEnv: false},
+			name:     "empty not from secret",
+			input:    SecretVar{Val: ""},
 			expected: false,
 		},
 		{
-			name:     "from env",
-			input:    SecretVar{Val: "test", FromEnv: true},
+			name:     "from secret",
+			input:    SecretVar{Val: "test", FromSecret: true, SecretRef: "env.KEY"},
 			expected: true,
 		},
 		{
@@ -478,9 +476,8 @@ func TestSecretVar_IsRedacted(t *testing.T) {
 }
 
 // TestSecretVar_IsSet verifies the semantic difference between GetValue() != "" and IsSet().
-// IsSet() must return true when the SecretVar references an env var (regardless of whether
-// that env var has been resolved to a non-empty Val). This is the property that the
-// BeforeSave hooks rely on so env var references survive persistence.
+// IsSet() must return true when the SecretVar references an env var or vault secret
+// (regardless of whether the reference has been resolved to a non-empty Val).
 func TestSecretVar_IsSet(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -488,7 +485,7 @@ func TestSecretVar_IsSet(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "nil envvar",
+			name:     "nil",
 			input:    nil,
 			expected: false,
 		},
@@ -503,28 +500,28 @@ func TestSecretVar_IsSet(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "only SecretVar reference set (env not resolved on this server)",
-			input:    &SecretVar{EnvVar: "env.MISSING", FromEnv: true},
+			name:     "env reference not yet resolved",
+			input:    &SecretVar{SecretRef: "env.MISSING", FromSecret: true},
 			expected: true,
 		},
 		{
-			name:     "Val and SecretVar both set (env was resolved)",
-			input:    &SecretVar{Val: "resolved-secret", EnvVar: "env.X", FromEnv: true},
+			name:     "env reference resolved",
+			input:    &SecretVar{Val: "resolved-secret", SecretRef: "env.X", FromSecret: true},
 			expected: true,
 		},
 		{
-			name:     "FromEnv true but no reference and no value",
-			input:    &SecretVar{FromEnv: true},
+			name:     "FromSecret true but no reference and no value",
+			input:    &SecretVar{FromSecret: true},
 			expected: false,
 		},
 		{
 			name:     "vault reference set",
-			input:    &SecretVar{VaultRef: "vault.bifrost/key", FromVault: true, Val: "vault.bifrost/key"},
+			input:    &SecretVar{SecretRef: "vault.bifrost/key", FromSecret: true, Val: "vault.bifrost/key"},
 			expected: true,
 		},
 		{
-			name:     "FromVault true but no reference",
-			input:    &SecretVar{FromVault: true},
+			name:     "FromSecret true but empty SecretRef",
+			input:    &SecretVar{FromSecret: true, SecretRef: ""},
 			expected: false,
 		},
 	}
@@ -540,31 +537,29 @@ func TestSecretVar_IsSet(t *testing.T) {
 
 func TestSecretVar_Scan_VaultRef(t *testing.T) {
 	tests := []struct {
-		name              string
-		input             string
-		wantVal           string
-		wantVaultRef      string
-		wantFromVault     bool
-		wantFromEnv       bool
+		name               string
+		input              string
+		wantVal            string
+		wantSecretRef      string
+		wantFromSecret     bool
 	}{
 		{
-			name:          "plain vault reference",
-			input:         "vault.bifrost/providers/openai/key",
-			wantVal:       "vault.bifrost/providers/openai/key",
-			wantVaultRef:  "vault.bifrost/providers/openai/key",
-			wantFromVault: true,
+			name:           "plain vault reference",
+			input:          "vault.bifrost/providers/openai/key",
+			wantVal:        "",
+			wantSecretRef:  "vault.bifrost/providers/openai/key",
+			wantFromSecret: true,
 		},
 		{
-			name:          "vault reference with quoted wrapping",
-			input:         `"vault.myproject/secret"`,
-			wantVal:       "vault.myproject/secret",
-			wantVaultRef:  "vault.myproject/secret",
-			wantFromVault: true,
+			name:    "quoted vault string is treated as literal, not a vault ref",
+			input:   `"vault.myproject/secret"`,
+			wantVal: "vault.myproject/secret",
 		},
 		{
-			name:        "env reference still works",
-			input:       "env.MY_VAR",
-			wantFromEnv: true,
+			name:           "env reference",
+			input:          "env.MY_VAR",
+			wantSecretRef:  "env.MY_VAR",
+			wantFromSecret: true,
 		},
 		{
 			name:    "plain string unaffected",
@@ -579,21 +574,15 @@ func TestSecretVar_Scan_VaultRef(t *testing.T) {
 			if err := e.Scan(tt.input); err != nil {
 				t.Fatalf("Scan() error: %v", err)
 			}
-			if tt.wantFromVault {
-				if !e.FromVault {
-					t.Errorf("FromVault = false, want true")
+			if tt.wantFromSecret {
+				if !e.FromSecret {
+					t.Errorf("FromSecret = false, want true")
 				}
-				if e.VaultRef != tt.wantVaultRef {
-					t.Errorf("VaultRef = %q, want %q", e.VaultRef, tt.wantVaultRef)
-				}
-				if e.Val != tt.wantVal {
-					t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
+				if e.SecretRef != tt.wantSecretRef {
+					t.Errorf("SecretRef = %q, want %q", e.SecretRef, tt.wantSecretRef)
 				}
 			}
-			if tt.wantFromEnv && !e.FromEnv {
-				t.Errorf("FromEnv = false, want true")
-			}
-			if !tt.wantFromVault && !tt.wantFromEnv && e.Val != tt.wantVal {
+			if tt.wantVal != "" && e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
 			}
 		})
@@ -602,32 +591,25 @@ func TestSecretVar_Scan_VaultRef(t *testing.T) {
 
 func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         string
-		wantVal       string
-		wantVaultRef  string
-		wantFromVault bool
+		name           string
+		input          string
+		wantVal        string
+		wantSecretRef  string
+		wantFromSecret bool
 	}{
 		{
-			name:          "struct form with from_vault",
-			input:         `{"value":"","env_var":"","from_env":false,"vault_var":"vault.bifrost/key","from_vault":true}`,
-			wantVal:       "vault.bifrost/key",
-			wantVaultRef:  "vault.bifrost/key",
-			wantFromVault: true,
+			name:           "new format: secret_ref/from_secret",
+			input:          `{"value":"vault.bifrost/key","secret_ref":"vault.bifrost/key","from_secret":true}`,
+			wantVal:        "",
+			wantSecretRef:  "vault.bifrost/key",
+			wantFromSecret: true,
 		},
 		{
-			name:          "struct form vault_var without vault. prefix — prefix auto-added",
-			input:         `{"value":"","env_var":"","from_env":false,"vault_var":"bifrost/key","from_vault":true}`,
-			wantVal:       "vault.bifrost/key",
-			wantVaultRef:  "vault.bifrost/key",
-			wantFromVault: true,
-		},
-		{
-			name:          "plain string vault reference",
-			input:         `"vault.myproject/secret"`,
-			wantVal:       "vault.myproject/secret",
-			wantVaultRef:  "vault.myproject/secret",
-			wantFromVault: true,
+			name:           "plain string vault reference",
+			input:          `"vault.myproject/secret"`,
+			wantVal:        "",
+			wantSecretRef:  "vault.myproject/secret",
+			wantFromSecret: true,
 		},
 	}
 
@@ -637,11 +619,11 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 			if err := json.Unmarshal([]byte(tt.input), &e); err != nil {
 				t.Fatalf("UnmarshalJSON() error: %v", err)
 			}
-			if e.FromVault != tt.wantFromVault {
-				t.Errorf("FromVault = %v, want %v", e.FromVault, tt.wantFromVault)
+			if e.FromSecret != tt.wantFromSecret {
+				t.Errorf("FromSecret = %v, want %v", e.FromSecret, tt.wantFromSecret)
 			}
-			if e.VaultRef != tt.wantVaultRef {
-				t.Errorf("VaultRef = %q, want %q", e.VaultRef, tt.wantVaultRef)
+			if e.SecretRef != tt.wantSecretRef {
+				t.Errorf("SecretRef = %q, want %q", e.SecretRef, tt.wantSecretRef)
 			}
 			if e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -652,9 +634,9 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 
 func TestSecretVar_Value_VaultRef(t *testing.T) {
 	e := &SecretVar{
-		Val:       "actual-secret",
-		VaultRef:  "vault.bifrost/key",
-		FromVault: true,
+		Val:        "actual-secret",
+		SecretRef:  "vault.bifrost/key",
+		FromSecret: true,
 	}
 	got, err := e.Value()
 	if err != nil {
@@ -667,26 +649,26 @@ func TestSecretVar_Value_VaultRef(t *testing.T) {
 
 func TestSecretVar_Redacted_VaultRef(t *testing.T) {
 	e := &SecretVar{
-		Val:       "actual-secret-value",
-		VaultRef:  "vault.bifrost/key",
-		FromVault: true,
+		Val:        "actual-secret-value",
+		SecretRef:  "vault.bifrost/key",
+		FromSecret: true,
 	}
 	r := e.Redacted()
 	wantVal := "actu************************alue"
 	if r.Val != wantVal {
 		t.Errorf("Redacted().Val = %q, want %q", r.Val, wantVal)
 	}
-	if !r.FromVault {
-		t.Errorf("Redacted().FromVault = false, want true")
+	if !r.FromSecret {
+		t.Errorf("Redacted().FromSecret = false, want true")
 	}
-	if r.VaultRef != "vault.bifrost/key" {
-		t.Errorf("Redacted().VaultRef = %q, want %q", r.VaultRef, "vault.bifrost/key")
+	if r.SecretRef != "vault.bifrost/key" {
+		t.Errorf("Redacted().SecretRef = %q, want %q", r.SecretRef, "vault.bifrost/key")
 	}
 }
 
 func TestSecretVar_IsSet_VaultRef(t *testing.T) {
-	set := &SecretVar{VaultRef: "vault.bifrost/key", FromVault: true, Val: "vault.bifrost/key"}
-	unset := &SecretVar{FromVault: true}
+	set := &SecretVar{SecretRef: "vault.bifrost/key", FromSecret: true, Val: "vault.bifrost/key"}
+	unset := &SecretVar{FromSecret: true}
 	if !set.IsSet() {
 		t.Error("IsSet() = false for vault ref, want true")
 	}
@@ -697,14 +679,13 @@ func TestSecretVar_IsSet_VaultRef(t *testing.T) {
 
 func TestNewSecretVar_VaultRef(t *testing.T) {
 	e := NewSecretVar("vault.bifrost/mykey")
-	if !e.FromVault {
-		t.Error("FromVault = false, want true")
+	if !e.FromSecret {
+		t.Error("FromSecret = false, want true")
 	}
-	if e.VaultRef != "vault.bifrost/mykey" {
-		t.Errorf("VaultRef = %q, want %q", e.VaultRef, "vault.bifrost/mykey")
+	if e.SecretRef != "vault.bifrost/mykey" {
+		t.Errorf("SecretRef = %q, want %q", e.SecretRef, "vault.bifrost/mykey")
 	}
-	if e.Val != "vault.bifrost/mykey" {
-		t.Errorf("Val = %q, want %q", e.Val, "vault.bifrost/mykey")
+	if e.Val != "" {
+		t.Errorf("Val = %q, want empty string when vault lookup fails", e.Val)
 	}
 }
-

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -69,21 +69,21 @@ func TestSecretVar_UnmarshalJSON_SecretVarReference(t *testing.T) {
 		name               string
 		input              string
 		expectedVal        string
-		expectedSecretRef  string
+		expectedRef        string
 		expectedFromSecret bool
 	}{
 		{
 			name:               "env var reference with value present",
 			input:              `"env.TEST_API_KEY"`,
 			expectedVal:        "actual-api-key-value",
-			expectedSecretRef:  "env.TEST_API_KEY",
+			expectedRef:        "env.TEST_API_KEY",
 			expectedFromSecret: true,
 		},
 		{
 			name:               "env var reference with missing value",
 			input:              `"env.NONEXISTENT_VAR"`,
 			expectedVal:        "",
-			expectedSecretRef:  "env.NONEXISTENT_VAR",
+			expectedRef:        "env.NONEXISTENT_VAR",
 			expectedFromSecret: true,
 		},
 	}
@@ -98,8 +98,8 @@ func TestSecretVar_UnmarshalJSON_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.GetSecretRef() != tt.expectedSecretRef {
-				t.Errorf("Expected Ref()=%q, got %q", tt.expectedSecretRef, secretVar.GetSecretRef())
+			if secretVar.GetRawRef() != tt.expectedRef {
+				t.Errorf("Expected Ref()=%q, got %q", tt.expectedRef, secretVar.GetRawRef())
 			}
 			if secretVar.IsFromSecret() != tt.expectedFromSecret {
 				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
@@ -121,8 +121,8 @@ func TestSecretVar_UnmarshalJSON_BackwardCompat(t *testing.T) {
 		if err != nil {
 			t.Fatalf("UnmarshalJSON failed: %v", err)
 		}
-		if secretVar.GetSecretRef() != "env.MY_KEY" {
-			t.Errorf("Expected Ref()=%q, got %q", "env.MY_KEY", secretVar.GetSecretRef())
+		if secretVar.GetRawRef() != "env.MY_KEY" {
+			t.Errorf("Expected Ref()=%q, got %q", "env.MY_KEY", secretVar.GetRawRef())
 		}
 		if !secretVar.IsFromSecret() {
 			t.Error("Expected IsFromSecret()=true, got false")
@@ -211,8 +211,8 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.GetSecretRef() != tt.expectedRef {
-				t.Errorf("Expected Ref()=%q, got %q", tt.expectedRef, secretVar.GetSecretRef())
+			if secretVar.GetRawRef() != tt.expectedRef {
+				t.Errorf("Expected Ref()=%q, got %q", tt.expectedRef, secretVar.GetRawRef())
 			}
 			if secretVar.IsFromSecret() != tt.expectedFromSecret {
 				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
@@ -319,8 +319,8 @@ func TestSecretVar_Equals(t *testing.T) {
 		},
 		{
 			name:     "equal values",
-			a:        &SecretVar{Val: "test", secretRef: "env.TEST", fromSecret: true},
-			b:        &SecretVar{Val: "test", secretRef: "env.TEST", fromSecret: true},
+			a:        &SecretVar{Val: "test", ref: "env.TEST", SecretType: SecretTypeEnv},
+			b:        &SecretVar{Val: "test", ref: "env.TEST", SecretType: SecretTypeEnv},
 			expected: true,
 		},
 		{
@@ -403,7 +403,7 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 		},
 		{
 			name:           "resolved env password preserves reference metadata",
-			input:          SecretVar{Val: "resolved-secret", secretRef: "env.PROXY_PASS", fromSecret: true},
+			input:          SecretVar{Val: "resolved-secret", ref: "env.PROXY_PASS", SecretType: SecretTypeEnv},
 			wantVal:        "<REDACTED>",
 			wantFromSecret: true,
 			wantRef:        "env.PROXY_PASS",
@@ -419,8 +419,8 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 			if result.IsFromSecret() != tt.wantFromSecret {
 				t.Errorf("IsFromSecret(): want %v, got %v", tt.wantFromSecret, result.IsFromSecret())
 			}
-			if result.GetSecretRef() != tt.wantRef {
-				t.Errorf("Ref(): want %q, got %q", tt.wantRef, result.GetSecretRef())
+			if result.GetRawRef() != tt.wantRef {
+				t.Errorf("Ref(): want %q, got %q", tt.wantRef, result.GetRawRef())
 			}
 		})
 	}
@@ -439,7 +439,7 @@ func TestSecretVar_IsRedacted(t *testing.T) {
 		},
 		{
 			name:     "from secret",
-			input:    SecretVar{Val: "test", secretRef: "env.KEY", fromSecret: true},
+			input:    SecretVar{Val: "test", ref: "env.KEY", SecretType: SecretTypeEnv},
 			expected: true,
 		},
 		{
@@ -500,22 +500,22 @@ func TestSecretVar_IsSet(t *testing.T) {
 		},
 		{
 			name:     "env reference not yet resolved",
-			input:    &SecretVar{secretRef: "env.MISSING", fromSecret: true},
+			input:    &SecretVar{ref: "env.MISSING", SecretType: SecretTypeEnv},
 			expected: true,
 		},
 		{
 			name:     "env reference resolved",
-			input:    &SecretVar{Val: "resolved-secret", secretRef: "env.X", fromSecret: true},
+			input:    &SecretVar{Val: "resolved-secret", ref: "env.X", SecretType: SecretTypeEnv},
 			expected: true,
 		},
 		{
-			name:     "fromSecret true but no reference and no value",
-			input:    &SecretVar{fromSecret: true},
+			name:     "secret type set but no reference and no value",
+			input:    &SecretVar{SecretType: SecretTypeEnv},
 			expected: false,
 		},
 		{
 			name:     "vault reference set",
-			input:    &SecretVar{Val: "vault.bifrost/key", secretRef: "vault.bifrost/key", fromSecret: true},
+			input:    &SecretVar{Val: "vault.bifrost/key", ref: "vault.bifrost/key", SecretType: SecretTypeVault},
 			expected: true,
 		},
 	}
@@ -571,8 +571,8 @@ func TestSecretVar_Scan_VaultRef(t *testing.T) {
 			if e.IsFromSecret() != tt.wantFromSecret {
 				t.Errorf("IsFromSecret() = %v, want %v", e.IsFromSecret(), tt.wantFromSecret)
 			}
-			if tt.wantFromSecret && e.GetSecretRef() != tt.wantRef {
-				t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), tt.wantRef)
+			if tt.wantFromSecret && e.GetRawRef() != tt.wantRef {
+				t.Errorf("Ref() = %q, want %q", e.GetRawRef(), tt.wantRef)
 			}
 			if tt.wantVal != "" && e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -590,8 +590,8 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 		wantFromSecret bool
 	}{
 		{
-			name:           "new format: secret_ref/from_secret",
-			input:          `{"value":"vault.bifrost/key","secret_ref":"vault.bifrost/key","from_secret":true}`,
+			name:           "new format: type field",
+			input:          `{"value":"","ref":"vault.bifrost/key","type":"vault"}`,
 			wantVal:        "",
 			wantRef:        "vault.bifrost/key",
 			wantFromSecret: true,
@@ -614,8 +614,8 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 			if e.IsFromSecret() != tt.wantFromSecret {
 				t.Errorf("IsFromSecret() = %v, want %v", e.IsFromSecret(), tt.wantFromSecret)
 			}
-			if e.GetSecretRef() != tt.wantRef {
-				t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), tt.wantRef)
+			if e.GetRawRef() != tt.wantRef {
+				t.Errorf("Ref() = %q, want %q", e.GetRawRef(), tt.wantRef)
 			}
 			if e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -625,7 +625,7 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 }
 
 func TestSecretVar_Value_VaultRef(t *testing.T) {
-	e := &SecretVar{Val: "actual-secret", secretRef: "vault.bifrost/key", fromSecret: true}
+	e := &SecretVar{Val: "actual-secret", ref: "vault.bifrost/key", SecretType: SecretTypeVault}
 	got, err := e.Value()
 	if err != nil {
 		t.Fatalf("Value() error: %v", err)
@@ -636,7 +636,7 @@ func TestSecretVar_Value_VaultRef(t *testing.T) {
 }
 
 func TestSecretVar_Redacted_VaultRef(t *testing.T) {
-	e := &SecretVar{Val: "actual-secret-value", secretRef: "vault.bifrost/key", fromSecret: true}
+	e := &SecretVar{Val: "actual-secret-value", ref: "vault.bifrost/key", SecretType: SecretTypeVault}
 	r := e.Redacted()
 	wantVal := "actu************************alue"
 	if r.Val != wantVal {
@@ -645,14 +645,14 @@ func TestSecretVar_Redacted_VaultRef(t *testing.T) {
 	if !r.IsFromSecret() {
 		t.Error("Redacted().IsFromSecret() = false, want true")
 	}
-	if r.GetSecretRef() != "vault.bifrost/key" {
-		t.Errorf("Redacted().GetSecretRef() = %q, want %q", r.GetSecretRef(), "vault.bifrost/key")
+	if r.GetRawRef() != "vault.bifrost/key" {
+		t.Errorf("Redacted().GetRawRef() = %q, want %q", r.GetRawRef(), "vault.bifrost/key")
 	}
 }
 
 func TestSecretVar_IsSet_VaultRef(t *testing.T) {
-	set := &SecretVar{Val: "vault.bifrost/key", secretRef: "vault.bifrost/key", fromSecret: true}
-	unset := &SecretVar{fromSecret: true}
+	set := &SecretVar{Val: "vault.bifrost/key", ref: "vault.bifrost/key", SecretType: SecretTypeVault}
+	unset := &SecretVar{SecretType: SecretTypeVault}
 	if !set.IsSet() {
 		t.Error("IsSet() = false for vault ref, want true")
 	}
@@ -666,8 +666,8 @@ func TestNewSecretVar_VaultRef(t *testing.T) {
 	if !e.IsFromVault() {
 		t.Error("IsFromVault() = false, want true")
 	}
-	if e.GetSecretRef() != "vault.bifrost/mykey" {
-		t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), "vault.bifrost/mykey")
+	if e.GetRawRef() != "vault.bifrost/mykey" {
+		t.Errorf("Ref() = %q, want %q", e.GetRawRef(), "vault.bifrost/mykey")
 	}
 	if e.Val != "" {
 		t.Errorf("Val = %q, want empty string when vault lookup fails", e.Val)
@@ -687,13 +687,13 @@ func TestSecretVar_MarshalJSON(t *testing.T) {
 		},
 		{
 			name:  "env reference",
-			input: SecretVar{Val: "resolved", secretRef: "env.MY_KEY", fromSecret: true},
-			want:  `{"value":"resolved","secret_ref":"env.MY_KEY","from_secret":true}`,
+			input: SecretVar{Val: "resolved", ref: "env.MY_KEY", SecretType: SecretTypeEnv},
+			want:  `{"value":"resolved","ref":"env.MY_KEY","type":"env"}`,
 		},
 		{
 			name:  "vault reference",
-			input: SecretVar{secretRef: "vault.path/to/secret", fromSecret: true},
-			want:  `{"value":"","secret_ref":"vault.path/to/secret","from_secret":true}`,
+			input: SecretVar{ref: "vault.path/to/secret", SecretType: SecretTypeVault},
+			want:  `{"value":"","ref":"vault.path/to/secret","type":"vault"}`,
 		},
 	}
 

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -38,7 +38,7 @@ func SecretVarAsString(e *SecretVar) string {
 		return ""
 	}
 	if e.IsFromSecret() {
-		return e.SecretRef
+		return e.secretRef
 	}
 	return e.GetValue()
 }

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -38,7 +38,7 @@ func SecretVarAsString(e *SecretVar) string {
 		return ""
 	}
 	if e.IsFromSecret() {
-		return e.secretRef
+		return e.ref
 	}
 	return e.GetValue()
 }

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -37,11 +37,8 @@ func SecretVarAsString(e *SecretVar) string {
 	if e == nil {
 		return ""
 	}
-	if e.IsFromEnv() {
-		return e.EnvVar
-	}
-	if e.IsFromVault() {
-		return e.VaultRef
+	if e.IsFromSecret() {
+		return e.SecretRef
 	}
 	return e.GetValue()
 }

--- a/core/schemas/vault.go
+++ b/core/schemas/vault.go
@@ -119,10 +119,10 @@ func RemoveOwnedVaultSecretVars(ctx context.Context, ownedPrefix string, model i
 // vault-backed, non-fragment reference under ownedPrefix. Fragment refs (#key)
 // point at shared, externally-managed secrets and are never auto-deleted.
 func removeOwnedVaultSecretVar(ctx context.Context, ownedPrefix string, field *SecretVar) {
-	if field == nil || !strings.HasPrefix(field.SecretRef, "vault.") || field.SecretRef == "" {
+	if field == nil || !strings.HasPrefix(field.secretRef, "vault.") || field.secretRef == "" {
 		return
 	}
-	path := strings.TrimPrefix(field.SecretRef, "vault.")
+	path := strings.TrimPrefix(field.secretRef, "vault.")
 	if strings.IndexByte(path, '#') >= 0 {
 		return
 	}
@@ -145,8 +145,8 @@ func StoreVaultSecretVar(ctx context.Context, path string, e *SecretVar) error {
 	if err := VaultStoreHook(ctx, path, &e.Val); err != nil {
 		return err
 	}
-	e.SecretRef = "vault." + path
-	e.FromSecret = true
+	e.secretRef = "vault." + path
+	e.fromSecret = true
 	return nil
 }
 

--- a/core/schemas/vault.go
+++ b/core/schemas/vault.go
@@ -119,10 +119,10 @@ func RemoveOwnedVaultSecretVars(ctx context.Context, ownedPrefix string, model i
 // vault-backed, non-fragment reference under ownedPrefix. Fragment refs (#key)
 // point at shared, externally-managed secrets and are never auto-deleted.
 func removeOwnedVaultSecretVar(ctx context.Context, ownedPrefix string, field *SecretVar) {
-	if field == nil || !field.IsFromVault() || field.VaultRef == "" {
+	if field == nil || !strings.HasPrefix(field.SecretRef, "vault.") || field.SecretRef == "" {
 		return
 	}
-	path := strings.TrimPrefix(field.VaultRef, "vault.")
+	path := strings.TrimPrefix(field.SecretRef, "vault.")
 	if strings.IndexByte(path, '#') >= 0 {
 		return
 	}
@@ -139,14 +139,14 @@ func StoreVaultSecretVar(ctx context.Context, path string, e *SecretVar) error {
 	if VaultStoreHook == nil || e == nil {
 		return nil
 	}
-	if e.IsFromEnv() || e.IsFromVault() || e.Val == "" || e.IsRedacted() {
+	if e.IsFromSecret() || e.Val == "" || e.IsRedacted() {
 		return nil
 	}
 	if err := VaultStoreHook(ctx, path, &e.Val); err != nil {
 		return err
 	}
-	e.VaultRef = e.Val
-	e.FromVault = true
+	e.SecretRef = "vault." + path
+	e.FromSecret = true
 	return nil
 }
 

--- a/core/schemas/vault.go
+++ b/core/schemas/vault.go
@@ -119,10 +119,10 @@ func RemoveOwnedVaultSecretVars(ctx context.Context, ownedPrefix string, model i
 // vault-backed, non-fragment reference under ownedPrefix. Fragment refs (#key)
 // point at shared, externally-managed secrets and are never auto-deleted.
 func removeOwnedVaultSecretVar(ctx context.Context, ownedPrefix string, field *SecretVar) {
-	if field == nil || !strings.HasPrefix(field.secretRef, "vault.") || field.secretRef == "" {
+	path := field.GetRef()
+	if path == "" {
 		return
 	}
-	path := strings.TrimPrefix(field.secretRef, "vault.")
 	if strings.IndexByte(path, '#') >= 0 {
 		return
 	}
@@ -145,8 +145,8 @@ func StoreVaultSecretVar(ctx context.Context, path string, e *SecretVar) error {
 	if err := VaultStoreHook(ctx, path, &e.Val); err != nil {
 		return err
 	}
-	e.secretRef = "vault." + path
-	e.fromSecret = true
+	e.ref = "vault." + path
+	e.SecretType = SecretTypeVault
 	return nil
 }
 

--- a/core/schemas/vault_test.go
+++ b/core/schemas/vault_test.go
@@ -31,11 +31,11 @@ func TestStoreVaultSecretVar_StoresPlaintext(t *testing.T) {
 	if got := stored["bifrost/tbl/id/value"]; got != "secret-key" {
 		t.Errorf("stored plaintext = %q, want %q", got, "secret-key")
 	}
-	if !e.FromSecret {
-		t.Error("FromSecret should be true after store")
+	if !e.IsFromVault() {
+		t.Error("IsFromVault() should be true after store")
 	}
-	if e.SecretRef != "vault.bifrost/tbl/id/value" {
-		t.Errorf("SecretRef = %q, want %q", e.SecretRef, "vault.bifrost/tbl/id/value")
+	if e.Ref() != "vault.bifrost/tbl/id/value" {
+		t.Errorf("Ref() = %q, want %q", e.Ref(), "vault.bifrost/tbl/id/value")
 	}
 	if e.Val != "vault.bifrost/tbl/id/value" {
 		t.Errorf("Val = %q, want rewritten to vault ref", e.Val)
@@ -48,8 +48,8 @@ func TestStoreVaultSecretVar_NoOps(t *testing.T) {
 		e    *SecretVar
 	}{
 		{"nil", nil},
-		{"env-sourced", &SecretVar{FromSecret: true, SecretRef: "env.MY_VAR"}},
-		{"already-vault", &SecretVar{FromSecret: true, SecretRef: "vault.some/path", Val: "vault.some/path"}},
+		{"env-sourced", NewSecretVarFromRef("env.MY_VAR", "")},
+		{"already-vault", NewSecretVarFromRef("vault.some/path", "vault.some/path")},
 		{"empty", &SecretVar{Val: ""}},
 	}
 	for _, tc := range cases {
@@ -74,8 +74,8 @@ func TestStoreVaultSecretVar_NoHookNoOp(t *testing.T) {
 	if err := StoreVaultSecretVar(context.Background(), "p", e); err != nil {
 		t.Fatalf("StoreVaultSecretVar: %v", err)
 	}
-	if e.FromSecret || e.SecretRef != "" || e.Val != "secret" {
-		t.Errorf("expected no mutation when hook nil, got %+v", e)
+	if e.IsFromSecret() || e.Ref() != "" || e.Val != "secret" {
+		t.Errorf("expected no mutation when hook nil, got val=%q ref=%q fromSecret=%v", e.Val, e.Ref(), e.IsFromSecret())
 	}
 }
 
@@ -93,8 +93,8 @@ func TestRemoveOwnedVaultSecretVars_SkipsFragmentRefs(t *testing.T) {
 		Fragment SecretVar `gorm:"column:fragment"`
 	}
 	m := &model{
-		Normal:   SecretVar{FromSecret: true, SecretRef: "vault.bifrost/m/1/normal", Val: "vault.bifrost/m/1/normal"},
-		Fragment: SecretVar{FromSecret: true, SecretRef: "vault.external/db#apiKey", Val: "vault.external/db#apiKey"},
+		Normal:   *NewSecretVarFromRef("vault.bifrost/m/1/normal", "vault.bifrost/m/1/normal"),
+		Fragment: *NewSecretVarFromRef("vault.external/db#apiKey", "vault.external/db#apiKey"),
 	}
 
 	RemoveOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m)
@@ -119,7 +119,7 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 		Plain:    SecretVar{Val: "p1"},
 		Ptr:      &SecretVar{Val: "p2"},
 		Snake:    SecretVar{Val: "p3"},
-		EnvBased: SecretVar{FromSecret: true, SecretRef: "env.X"},
+		EnvBased: *NewSecretVarFromRef("env.X", ""),
 	}
 
 	if err := StoreOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m); err != nil {
@@ -139,8 +139,8 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 			t.Errorf("stored[%q] = %q, want %q", path, stored[path], val)
 		}
 	}
-	if !m.Plain.FromSecret || !m.Ptr.FromSecret || !m.Snake.FromSecret {
-		t.Error("SecretVar fields should be marked FromSecret after store")
+	if !m.Plain.IsFromVault() || !m.Ptr.IsFromVault() || !m.Snake.IsFromVault() {
+		t.Error("SecretVar fields should be vault-backed after store")
 	}
 }
 
@@ -153,7 +153,7 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	m := &model{
 		Headers: map[string]SecretVar{
 			"Authorization": {Val: "secret-token"},
-			"X-Env":         {FromSecret: true, SecretRef: "env.X"},
+			"X-Env":         *NewSecretVarFromRef("env.X", ""),
 		},
 	}
 
@@ -168,11 +168,10 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 		t.Errorf("stored Authorization = %q, want %q", got, "secret-token")
 	}
 	auth := m.Headers["Authorization"]
-	if !auth.FromSecret || auth.SecretRef != "vault.bifrost/m/1/headers/Authorization" {
-		t.Errorf("map entry not converted to ref: %+v", auth)
+	if !auth.IsFromVault() || auth.Ref() != "vault.bifrost/m/1/headers/Authorization" {
+		t.Errorf("map entry not converted to vault ref: val=%q ref=%q fromVault=%v", auth.Val, auth.Ref(), auth.IsFromVault())
 	}
-	if env := m.Headers["X-Env"]; env.FromSecret && env.SecretRef == "env.X" {
-		// still FromSecret=true (it was env-sourced), but it should NOT have been vault-stored
+	if env := m.Headers["X-Env"]; env.IsFromSecret() && env.Ref() == "env.X" {
 		if stored["bifrost/m/1/headers/X-Env"] != "" {
 			t.Error("env-sourced header should not be vault-stored")
 		}
@@ -193,8 +192,8 @@ func TestRemoveOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	}
 	m := &model{
 		Headers: map[string]SecretVar{
-			"Owned":    {FromSecret: true, SecretRef: "vault.bifrost/m/1/headers/Owned", Val: "vault.bifrost/m/1/headers/Owned"},
-			"External": {FromSecret: true, SecretRef: "vault.external/db#key", Val: "vault.external/db#key"},
+			"Owned":    *NewSecretVarFromRef("vault.bifrost/m/1/headers/Owned", "vault.bifrost/m/1/headers/Owned"),
+			"External": *NewSecretVarFromRef("vault.external/db#key", "vault.external/db#key"),
 		},
 	}
 

--- a/core/schemas/vault_test.go
+++ b/core/schemas/vault_test.go
@@ -34,8 +34,8 @@ func TestStoreVaultSecretVar_StoresPlaintext(t *testing.T) {
 	if !e.IsFromVault() {
 		t.Error("IsFromVault() should be true after store")
 	}
-	if e.Ref() != "vault.bifrost/tbl/id/value" {
-		t.Errorf("Ref() = %q, want %q", e.Ref(), "vault.bifrost/tbl/id/value")
+	if e.GetSecretRef() != "vault.bifrost/tbl/id/value" {
+		t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), "vault.bifrost/tbl/id/value")
 	}
 	if e.Val != "vault.bifrost/tbl/id/value" {
 		t.Errorf("Val = %q, want rewritten to vault ref", e.Val)
@@ -48,8 +48,8 @@ func TestStoreVaultSecretVar_NoOps(t *testing.T) {
 		e    *SecretVar
 	}{
 		{"nil", nil},
-		{"env-sourced", NewSecretVarFromRef("env.MY_VAR", "")},
-		{"already-vault", NewSecretVarFromRef("vault.some/path", "vault.some/path")},
+		{"env-sourced", &SecretVar{secretRef: "env.MY_VAR", fromSecret: true}},
+		{"already-vault", &SecretVar{Val: "vault.some/path", secretRef: "vault.some/path", fromSecret: true}},
 		{"empty", &SecretVar{Val: ""}},
 	}
 	for _, tc := range cases {
@@ -74,8 +74,8 @@ func TestStoreVaultSecretVar_NoHookNoOp(t *testing.T) {
 	if err := StoreVaultSecretVar(context.Background(), "p", e); err != nil {
 		t.Fatalf("StoreVaultSecretVar: %v", err)
 	}
-	if e.IsFromSecret() || e.Ref() != "" || e.Val != "secret" {
-		t.Errorf("expected no mutation when hook nil, got val=%q ref=%q fromSecret=%v", e.Val, e.Ref(), e.IsFromSecret())
+	if e.IsFromSecret() || e.GetSecretRef() != "" || e.Val != "secret" {
+		t.Errorf("expected no mutation when hook nil, got val=%q ref=%q fromSecret=%v", e.Val, e.GetSecretRef(), e.IsFromSecret())
 	}
 }
 
@@ -93,8 +93,8 @@ func TestRemoveOwnedVaultSecretVars_SkipsFragmentRefs(t *testing.T) {
 		Fragment SecretVar `gorm:"column:fragment"`
 	}
 	m := &model{
-		Normal:   *NewSecretVarFromRef("vault.bifrost/m/1/normal", "vault.bifrost/m/1/normal"),
-		Fragment: *NewSecretVarFromRef("vault.external/db#apiKey", "vault.external/db#apiKey"),
+		Normal:   SecretVar{Val: "vault.bifrost/m/1/normal", secretRef: "vault.bifrost/m/1/normal", fromSecret: true},
+		Fragment: SecretVar{Val: "vault.external/db#apiKey", secretRef: "vault.external/db#apiKey", fromSecret: true},
 	}
 
 	RemoveOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m)
@@ -119,7 +119,7 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 		Plain:    SecretVar{Val: "p1"},
 		Ptr:      &SecretVar{Val: "p2"},
 		Snake:    SecretVar{Val: "p3"},
-		EnvBased: *NewSecretVarFromRef("env.X", ""),
+		EnvBased: SecretVar{secretRef: "env.X", fromSecret: true},
 	}
 
 	if err := StoreOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m); err != nil {
@@ -153,7 +153,7 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	m := &model{
 		Headers: map[string]SecretVar{
 			"Authorization": {Val: "secret-token"},
-			"X-Env":         *NewSecretVarFromRef("env.X", ""),
+			"X-Env":         SecretVar{secretRef: "env.X", fromSecret: true},
 		},
 	}
 
@@ -168,10 +168,10 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 		t.Errorf("stored Authorization = %q, want %q", got, "secret-token")
 	}
 	auth := m.Headers["Authorization"]
-	if !auth.IsFromVault() || auth.Ref() != "vault.bifrost/m/1/headers/Authorization" {
-		t.Errorf("map entry not converted to vault ref: val=%q ref=%q fromVault=%v", auth.Val, auth.Ref(), auth.IsFromVault())
+	if !auth.IsFromVault() || auth.GetSecretRef() != "vault.bifrost/m/1/headers/Authorization" {
+		t.Errorf("map entry not converted to vault ref: val=%q ref=%q fromVault=%v", auth.Val, auth.GetSecretRef(), auth.IsFromVault())
 	}
-	if env := m.Headers["X-Env"]; env.IsFromSecret() && env.Ref() == "env.X" {
+	if env := m.Headers["X-Env"]; env.IsFromSecret() && env.GetSecretRef() == "env.X" {
 		if stored["bifrost/m/1/headers/X-Env"] != "" {
 			t.Error("env-sourced header should not be vault-stored")
 		}
@@ -192,8 +192,8 @@ func TestRemoveOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	}
 	m := &model{
 		Headers: map[string]SecretVar{
-			"Owned":    *NewSecretVarFromRef("vault.bifrost/m/1/headers/Owned", "vault.bifrost/m/1/headers/Owned"),
-			"External": *NewSecretVarFromRef("vault.external/db#key", "vault.external/db#key"),
+			"Owned":    SecretVar{Val: "vault.bifrost/m/1/headers/Owned", secretRef: "vault.bifrost/m/1/headers/Owned", fromSecret: true},
+			"External": SecretVar{Val: "vault.external/db#key", secretRef: "vault.external/db#key", fromSecret: true},
 		},
 	}
 

--- a/core/schemas/vault_test.go
+++ b/core/schemas/vault_test.go
@@ -31,11 +31,11 @@ func TestStoreVaultSecretVar_StoresPlaintext(t *testing.T) {
 	if got := stored["bifrost/tbl/id/value"]; got != "secret-key" {
 		t.Errorf("stored plaintext = %q, want %q", got, "secret-key")
 	}
-	if !e.FromVault {
-		t.Error("FromVault should be true after store")
+	if !e.FromSecret {
+		t.Error("FromSecret should be true after store")
 	}
-	if e.VaultRef != "vault.bifrost/tbl/id/value" {
-		t.Errorf("VaultRef = %q, want %q", e.VaultRef, "vault.bifrost/tbl/id/value")
+	if e.SecretRef != "vault.bifrost/tbl/id/value" {
+		t.Errorf("SecretRef = %q, want %q", e.SecretRef, "vault.bifrost/tbl/id/value")
 	}
 	if e.Val != "vault.bifrost/tbl/id/value" {
 		t.Errorf("Val = %q, want rewritten to vault ref", e.Val)
@@ -48,8 +48,8 @@ func TestStoreVaultSecretVar_NoOps(t *testing.T) {
 		e    *SecretVar
 	}{
 		{"nil", nil},
-		{"env-sourced", &SecretVar{FromEnv: true, EnvVar: "MY_VAR"}},
-		{"already-vault", &SecretVar{FromVault: true, VaultRef: "vault.some/path", Val: "vault.some/path"}},
+		{"env-sourced", &SecretVar{FromSecret: true, SecretRef: "env.MY_VAR"}},
+		{"already-vault", &SecretVar{FromSecret: true, SecretRef: "vault.some/path", Val: "vault.some/path"}},
 		{"empty", &SecretVar{Val: ""}},
 	}
 	for _, tc := range cases {
@@ -74,7 +74,7 @@ func TestStoreVaultSecretVar_NoHookNoOp(t *testing.T) {
 	if err := StoreVaultSecretVar(context.Background(), "p", e); err != nil {
 		t.Fatalf("StoreVaultSecretVar: %v", err)
 	}
-	if e.FromVault || e.VaultRef != "" || e.Val != "secret" {
+	if e.FromSecret || e.SecretRef != "" || e.Val != "secret" {
 		t.Errorf("expected no mutation when hook nil, got %+v", e)
 	}
 }
@@ -93,8 +93,8 @@ func TestRemoveOwnedVaultSecretVars_SkipsFragmentRefs(t *testing.T) {
 		Fragment SecretVar `gorm:"column:fragment"`
 	}
 	m := &model{
-		Normal:   SecretVar{FromVault: true, VaultRef: "vault.bifrost/m/1/normal", Val: "vault.bifrost/m/1/normal"},
-		Fragment: SecretVar{FromVault: true, VaultRef: "vault.external/db#apiKey", Val: "vault.external/db#apiKey"},
+		Normal:   SecretVar{FromSecret: true, SecretRef: "vault.bifrost/m/1/normal", Val: "vault.bifrost/m/1/normal"},
+		Fragment: SecretVar{FromSecret: true, SecretRef: "vault.external/db#apiKey", Val: "vault.external/db#apiKey"},
 	}
 
 	RemoveOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m)
@@ -119,7 +119,7 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 		Plain:    SecretVar{Val: "p1"},
 		Ptr:      &SecretVar{Val: "p2"},
 		Snake:    SecretVar{Val: "p3"},
-		EnvBased: SecretVar{FromEnv: true, EnvVar: "X"},
+		EnvBased: SecretVar{FromSecret: true, SecretRef: "env.X"},
 	}
 
 	if err := StoreOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m); err != nil {
@@ -139,8 +139,8 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 			t.Errorf("stored[%q] = %q, want %q", path, stored[path], val)
 		}
 	}
-	if !m.Plain.FromVault || !m.Ptr.FromVault || !m.Snake.FromVault {
-		t.Error("SecretVar fields should be marked FromVault after store")
+	if !m.Plain.FromSecret || !m.Ptr.FromSecret || !m.Snake.FromSecret {
+		t.Error("SecretVar fields should be marked FromSecret after store")
 	}
 }
 
@@ -153,7 +153,7 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	m := &model{
 		Headers: map[string]SecretVar{
 			"Authorization": {Val: "secret-token"},
-			"X-Env":         {FromEnv: true, EnvVar: "X"},
+			"X-Env":         {FromSecret: true, SecretRef: "env.X"},
 		},
 	}
 
@@ -168,11 +168,14 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 		t.Errorf("stored Authorization = %q, want %q", got, "secret-token")
 	}
 	auth := m.Headers["Authorization"]
-	if !auth.FromVault || auth.VaultRef != "vault.bifrost/m/1/headers/Authorization" {
+	if !auth.FromSecret || auth.SecretRef != "vault.bifrost/m/1/headers/Authorization" {
 		t.Errorf("map entry not converted to ref: %+v", auth)
 	}
-	if env := m.Headers["X-Env"]; env.FromVault {
-		t.Error("env-sourced header should not be vault-stored")
+	if env := m.Headers["X-Env"]; env.FromSecret && env.SecretRef == "env.X" {
+		// still FromSecret=true (it was env-sourced), but it should NOT have been vault-stored
+		if stored["bifrost/m/1/headers/X-Env"] != "" {
+			t.Error("env-sourced header should not be vault-stored")
+		}
 	}
 }
 
@@ -190,8 +193,8 @@ func TestRemoveOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	}
 	m := &model{
 		Headers: map[string]SecretVar{
-			"Owned":    {FromVault: true, VaultRef: "vault.bifrost/m/1/headers/Owned", Val: "vault.bifrost/m/1/headers/Owned"},
-			"External": {FromVault: true, VaultRef: "vault.external/db#key", Val: "vault.external/db#key"},
+			"Owned":    {FromSecret: true, SecretRef: "vault.bifrost/m/1/headers/Owned", Val: "vault.bifrost/m/1/headers/Owned"},
+			"External": {FromSecret: true, SecretRef: "vault.external/db#key", Val: "vault.external/db#key"},
 		},
 	}
 

--- a/core/schemas/vault_test.go
+++ b/core/schemas/vault_test.go
@@ -34,8 +34,8 @@ func TestStoreVaultSecretVar_StoresPlaintext(t *testing.T) {
 	if !e.IsFromVault() {
 		t.Error("IsFromVault() should be true after store")
 	}
-	if e.GetSecretRef() != "vault.bifrost/tbl/id/value" {
-		t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), "vault.bifrost/tbl/id/value")
+	if e.GetRawRef() != "vault.bifrost/tbl/id/value" {
+		t.Errorf("Ref() = %q, want %q", e.GetRawRef(), "vault.bifrost/tbl/id/value")
 	}
 	if e.Val != "vault.bifrost/tbl/id/value" {
 		t.Errorf("Val = %q, want rewritten to vault ref", e.Val)
@@ -48,8 +48,8 @@ func TestStoreVaultSecretVar_NoOps(t *testing.T) {
 		e    *SecretVar
 	}{
 		{"nil", nil},
-		{"env-sourced", &SecretVar{secretRef: "env.MY_VAR", fromSecret: true}},
-		{"already-vault", &SecretVar{Val: "vault.some/path", secretRef: "vault.some/path", fromSecret: true}},
+		{"env-sourced", &SecretVar{ref: "env.MY_VAR", SecretType: SecretTypeEnv}},
+		{"already-vault", &SecretVar{Val: "vault.some/path", ref: "vault.some/path", SecretType: SecretTypeVault}},
 		{"empty", &SecretVar{Val: ""}},
 	}
 	for _, tc := range cases {
@@ -74,8 +74,8 @@ func TestStoreVaultSecretVar_NoHookNoOp(t *testing.T) {
 	if err := StoreVaultSecretVar(context.Background(), "p", e); err != nil {
 		t.Fatalf("StoreVaultSecretVar: %v", err)
 	}
-	if e.IsFromSecret() || e.GetSecretRef() != "" || e.Val != "secret" {
-		t.Errorf("expected no mutation when hook nil, got val=%q ref=%q fromSecret=%v", e.Val, e.GetSecretRef(), e.IsFromSecret())
+	if e.IsFromSecret() || e.GetRawRef() != "" || e.Val != "secret" {
+		t.Errorf("expected no mutation when hook nil, got val=%q ref=%q fromSecret=%v", e.Val, e.GetRawRef(), e.IsFromSecret())
 	}
 }
 
@@ -93,8 +93,8 @@ func TestRemoveOwnedVaultSecretVars_SkipsFragmentRefs(t *testing.T) {
 		Fragment SecretVar `gorm:"column:fragment"`
 	}
 	m := &model{
-		Normal:   SecretVar{Val: "vault.bifrost/m/1/normal", secretRef: "vault.bifrost/m/1/normal", fromSecret: true},
-		Fragment: SecretVar{Val: "vault.external/db#apiKey", secretRef: "vault.external/db#apiKey", fromSecret: true},
+		Normal:   SecretVar{Val: "vault.bifrost/m/1/normal", ref: "vault.bifrost/m/1/normal", SecretType: SecretTypeVault},
+		Fragment: SecretVar{Val: "vault.external/db#apiKey", ref: "vault.external/db#apiKey", SecretType: SecretTypeVault},
 	}
 
 	RemoveOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m)
@@ -119,7 +119,7 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 		Plain:    SecretVar{Val: "p1"},
 		Ptr:      &SecretVar{Val: "p2"},
 		Snake:    SecretVar{Val: "p3"},
-		EnvBased: SecretVar{secretRef: "env.X", fromSecret: true},
+		EnvBased: SecretVar{ref: "env.X", SecretType: SecretTypeEnv},
 	}
 
 	if err := StoreOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m); err != nil {
@@ -153,7 +153,7 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	m := &model{
 		Headers: map[string]SecretVar{
 			"Authorization": {Val: "secret-token"},
-			"X-Env":         SecretVar{secretRef: "env.X", fromSecret: true},
+			"X-Env":         SecretVar{ref: "env.X", SecretType: SecretTypeEnv},
 		},
 	}
 
@@ -168,10 +168,10 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 		t.Errorf("stored Authorization = %q, want %q", got, "secret-token")
 	}
 	auth := m.Headers["Authorization"]
-	if !auth.IsFromVault() || auth.GetSecretRef() != "vault.bifrost/m/1/headers/Authorization" {
-		t.Errorf("map entry not converted to vault ref: val=%q ref=%q fromVault=%v", auth.Val, auth.GetSecretRef(), auth.IsFromVault())
+	if !auth.IsFromVault() || auth.GetRawRef() != "vault.bifrost/m/1/headers/Authorization" {
+		t.Errorf("map entry not converted to vault ref: val=%q ref=%q fromVault=%v", auth.Val, auth.GetRawRef(), auth.IsFromVault())
 	}
-	if env := m.Headers["X-Env"]; env.IsFromSecret() && env.GetSecretRef() == "env.X" {
+	if env := m.Headers["X-Env"]; env.IsFromSecret() && env.GetRawRef() == "env.X" {
 		if stored["bifrost/m/1/headers/X-Env"] != "" {
 			t.Error("env-sourced header should not be vault-stored")
 		}
@@ -192,8 +192,8 @@ func TestRemoveOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	}
 	m := &model{
 		Headers: map[string]SecretVar{
-			"Owned":    SecretVar{Val: "vault.bifrost/m/1/headers/Owned", secretRef: "vault.bifrost/m/1/headers/Owned", fromSecret: true},
-			"External": SecretVar{Val: "vault.external/db#key", secretRef: "vault.external/db#key", fromSecret: true},
+			"Owned":    SecretVar{Val: "vault.bifrost/m/1/headers/Owned", ref: "vault.bifrost/m/1/headers/Owned", SecretType: SecretTypeVault},
+			"External": SecretVar{Val: "vault.external/db#key", ref: "vault.external/db#key", SecretType: SecretTypeVault},
 		},
 	}
 

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -360,7 +360,7 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 
 	if c.MCPExternalClientURL.IsSet() {
 		if c.MCPExternalClientURL.IsFromSecret() {
-			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.SecretRef))
+			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.Ref()))
 		} else {
 			hash.Write([]byte("externalClientURL:val:" + c.MCPExternalClientURL.GetValue()))
 		}
@@ -652,7 +652,7 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	hash.Write([]byte(key.Name))
 	// Hash Value (prefix with source type to prevent collisions between ref and literal)
 	if key.Value.IsFromSecret() {
-		hash.Write([]byte("ref:" + key.Value.SecretRef))
+		hash.Write([]byte("ref:" + key.Value.Ref()))
 	} else {
 		hash.Write([]byte("val:" + key.Value.Val))
 	}
@@ -1326,7 +1326,7 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 	// Hash ConnectionString
 	if m.ConnectionString != nil {
 		if m.ConnectionString.IsFromSecret() {
-			hash.Write([]byte(m.ConnectionString.SecretRef))
+			hash.Write([]byte(m.ConnectionString.Ref()))
 		} else {
 			hash.Write([]byte(m.ConnectionString.Val))
 		}
@@ -1372,7 +1372,7 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 		for _, k := range keys {
 			val := m.Headers[k]
 			if val.IsFromSecret() {
-				hash.Write([]byte(k + ":ref:" + val.SecretRef))
+				hash.Write([]byte(k + ":ref:" + val.Ref()))
 			} else {
 				hash.Write([]byte(k + ":val:" + val.Val))
 			}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -360,7 +360,7 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 
 	if c.MCPExternalClientURL.IsSet() {
 		if c.MCPExternalClientURL.IsFromSecret() {
-			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.Ref()))
+			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.GetSecretRef()))
 		} else {
 			hash.Write([]byte("externalClientURL:val:" + c.MCPExternalClientURL.GetValue()))
 		}
@@ -652,7 +652,7 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	hash.Write([]byte(key.Name))
 	// Hash Value (prefix with source type to prevent collisions between ref and literal)
 	if key.Value.IsFromSecret() {
-		hash.Write([]byte("ref:" + key.Value.Ref()))
+		hash.Write([]byte("ref:" + key.Value.GetSecretRef()))
 	} else {
 		hash.Write([]byte("val:" + key.Value.Val))
 	}
@@ -1326,7 +1326,7 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 	// Hash ConnectionString
 	if m.ConnectionString != nil {
 		if m.ConnectionString.IsFromSecret() {
-			hash.Write([]byte(m.ConnectionString.Ref()))
+			hash.Write([]byte(m.ConnectionString.GetSecretRef()))
 		} else {
 			hash.Write([]byte(m.ConnectionString.Val))
 		}
@@ -1372,7 +1372,7 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 		for _, k := range keys {
 			val := m.Headers[k]
 			if val.IsFromSecret() {
-				hash.Write([]byte(k + ":ref:" + val.Ref()))
+				hash.Write([]byte(k + ":ref:" + val.GetSecretRef()))
 			} else {
 				hash.Write([]byte(k + ":val:" + val.Val))
 			}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -30,7 +30,7 @@ const (
 
 // EnvKeyInfo stores information about a key sourced from environment
 type EnvKeyInfo struct {
-	SecretVar     string                // The environment variable name (without env. prefix)
+	SecretVar  string                // The environment variable name (without env. prefix)
 	Provider   schemas.ModelProvider // The provider this key belongs to (empty for core/mcp configs)
 	KeyType    EnvKeyType            // Type of key (e.g., "api_key", "azure_config", "vertex_config", "bedrock_config", "connection_string", "mcp_header")
 	ConfigPath string                // Path in config where this env var is used
@@ -97,7 +97,7 @@ type ClientConfig struct {
 	WhitelistedRoutes                     []string                         `json:"whitelisted_routes,omitempty"`         // Routes that bypass auth middleware
 	HideDeletedVirtualKeysInFilters       bool                             `json:"hide_deleted_virtual_keys_in_filters"` // Hide deleted virtual keys from logs/MCP filter data
 	RoutingChainMaxDepth                  int                              `json:"routing_chain_max_depth"`              // Maximum depth for routing rule chain evaluation (default: 10)
-	MCPExternalClientURL                  *schemas.SecretVar                  `json:"mcp_external_client_url,omitempty"`    // Public base URL used as redirect_uri when Bifrost acts as an OAuth client to upstream MCP servers. Supports env var syntax ("env.MY_VAR")
+	MCPExternalClientURL                  *schemas.SecretVar               `json:"mcp_external_client_url,omitempty"`    // Public base URL used as redirect_uri when Bifrost acts as an OAuth client to upstream MCP servers. Supports env var syntax ("env.MY_VAR")
 	ConfigHash                            string                           `json:"-"`                                    // Config hash for reconciliation (not serialized)
 }
 
@@ -360,7 +360,7 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 
 	if c.MCPExternalClientURL.IsSet() {
 		if c.MCPExternalClientURL.IsFromSecret() {
-			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.GetSecretRef()))
+			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.GetRawRef()))
 		} else {
 			hash.Write([]byte("externalClientURL:val:" + c.MCPExternalClientURL.GetValue()))
 		}
@@ -652,7 +652,7 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	hash.Write([]byte(key.Name))
 	// Hash Value (prefix with source type to prevent collisions between ref and literal)
 	if key.Value.IsFromSecret() {
-		hash.Write([]byte("ref:" + key.Value.GetSecretRef()))
+		hash.Write([]byte("ref:" + key.Value.GetRawRef()))
 	} else {
 		hash.Write([]byte("val:" + key.Value.Val))
 	}
@@ -1326,7 +1326,7 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 	// Hash ConnectionString
 	if m.ConnectionString != nil {
 		if m.ConnectionString.IsFromSecret() {
-			hash.Write([]byte(m.ConnectionString.GetSecretRef()))
+			hash.Write([]byte(m.ConnectionString.GetRawRef()))
 		} else {
 			hash.Write([]byte(m.ConnectionString.Val))
 		}
@@ -1372,7 +1372,7 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 		for _, k := range keys {
 			val := m.Headers[k]
 			if val.IsFromSecret() {
-				hash.Write([]byte(k + ":ref:" + val.GetSecretRef()))
+				hash.Write([]byte(k + ":ref:" + val.GetRawRef()))
 			} else {
 				hash.Write([]byte(k + ":val:" + val.Val))
 			}
@@ -1486,7 +1486,7 @@ func GenerateFrameworkConfigHash(pricingURL *string, modelParametersURL *string,
 type AuthConfig struct {
 	AdminUserName *schemas.SecretVar `json:"admin_username"`
 	AdminPassword *schemas.SecretVar `json:"admin_password"`
-	IsEnabled     bool            `json:"is_enabled"`
+	IsEnabled     bool               `json:"is_enabled"`
 }
 
 // ConfigMap maps provider names to their configurations.

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -359,10 +359,8 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 	}
 
 	if c.MCPExternalClientURL.IsSet() {
-		if c.MCPExternalClientURL.IsFromEnv() {
-			hash.Write([]byte("externalClientURL:env:" + c.MCPExternalClientURL.EnvVar))
-		} else if c.MCPExternalClientURL.IsFromVault() {
-			hash.Write([]byte("externalClientURL:vault:" + c.MCPExternalClientURL.VaultRef))
+		if c.MCPExternalClientURL.IsFromSecret() {
+			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.SecretRef))
 		} else {
 			hash.Write([]byte("externalClientURL:val:" + c.MCPExternalClientURL.GetValue()))
 		}
@@ -395,7 +393,7 @@ func (c *ClientConfig) GenerateClientConfigHashWithToolManager(tm *schemas.MCPTo
 // Redacted returns a copy of ClientConfig with any env-backed SecretVar fields masked.
 func (c *ClientConfig) Redacted() ClientConfig {
 	out := *c
-	if c.MCPExternalClientURL != nil && (c.MCPExternalClientURL.IsFromEnv() || c.MCPExternalClientURL.IsFromVault()) {
+	if c.MCPExternalClientURL != nil && c.MCPExternalClientURL.IsFromSecret() {
 		out.MCPExternalClientURL = c.MCPExternalClientURL.Redacted()
 	}
 	return out
@@ -483,7 +481,7 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		// Redact Azure key config if present
 		if key.AzureKeyConfig != nil {
 			azureConfig := &schemas.AzureKeyConfig{}
-			if key.AzureKeyConfig.Endpoint.IsFromEnv() || key.AzureKeyConfig.Endpoint.IsFromVault() {
+			if key.AzureKeyConfig.Endpoint.IsFromSecret() {
 				azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.Redacted()
 			} else {
 				azureConfig.Endpoint = key.AzureKeyConfig.Endpoint
@@ -652,11 +650,9 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	hash := sha256.New()
 	// Hash Name
 	hash.Write([]byte(key.Name))
-	// Hash Value (prefix with source type to prevent collisions between env and literal)
-	if key.Value.IsFromEnv() {
-		hash.Write([]byte("env:" + key.Value.EnvVar))
-	} else if key.Value.IsFromVault() {
-		hash.Write([]byte("vault:" + key.Value.VaultRef))
+	// Hash Value (prefix with source type to prevent collisions between ref and literal)
+	if key.Value.IsFromSecret() {
+		hash.Write([]byte("ref:" + key.Value.SecretRef))
 	} else {
 		hash.Write([]byte("val:" + key.Value.Val))
 	}
@@ -1329,10 +1325,8 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 
 	// Hash ConnectionString
 	if m.ConnectionString != nil {
-		if m.ConnectionString.IsFromEnv() {
-			hash.Write([]byte(m.ConnectionString.EnvVar))
-		} else if m.ConnectionString.IsFromVault() {
-			hash.Write([]byte(m.ConnectionString.VaultRef))
+		if m.ConnectionString.IsFromSecret() {
+			hash.Write([]byte(m.ConnectionString.SecretRef))
 		} else {
 			hash.Write([]byte(m.ConnectionString.Val))
 		}
@@ -1377,8 +1371,8 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 		sort.Strings(keys)
 		for _, k := range keys {
 			val := m.Headers[k]
-			if val.FromEnv {
-				hash.Write([]byte(k + ":env:" + val.EnvVar))
+			if val.IsFromSecret() {
+				hash.Write([]byte(k + ":ref:" + val.SecretRef))
 			} else {
 				hash.Write([]byte(k + ":val:" + val.Val))
 			}

--- a/framework/configstore/clientconfig_redaction_test.go
+++ b/framework/configstore/clientconfig_redaction_test.go
@@ -42,17 +42,17 @@ func TestProviderConfig_Redacted_AutoMasksEnvBackedFields(t *testing.T) {
 	require.NoError(t, err)
 
 	var out struct {
-		Value     string `json:"value"`
-		SecretRef string `json:"secret_ref"`
-		FromSecret bool  `json:"from_secret"`
+		Value      string `json:"value"`
+		Ref        string `json:"ref"`
+		SecretType string `json:"type"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
 	assert.NotContains(t, out.Value, "secret-resource",
 		"resolved env value leaked through Endpoint JSON output: %q", out.Value)
-	assert.Equal(t, "env.MY_AZURE_ENDPOINT_SECRET", out.SecretRef,
+	assert.Equal(t, "env.MY_AZURE_ENDPOINT_SECRET", out.Ref,
 		"secret ref must be preserved so the UI can show it")
-	assert.True(t, out.FromSecret, "from_secret flag must be preserved")
+	assert.Equal(t, "env", out.SecretType, "type field must be preserved")
 }
 
 // TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields verifies that the
@@ -80,13 +80,13 @@ func TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields(t *testing.T) {
 
 	var out struct {
 		Value      string `json:"value"`
-		FromSecret bool   `json:"from_secret"`
+		SecretType string `json:"type"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
 	assert.Equal(t, "https://foo.openai.azure.com", out.Value,
 		"plain Endpoint was incorrectly redacted")
-	assert.False(t, out.FromSecret)
+	assert.Empty(t, out.SecretType)
 }
 
 // TestProviderConfig_Redacted_PreservesSecretVarReferenceForVertex verifies that
@@ -117,15 +117,15 @@ func TestProviderConfig_Redacted_PreservesSecretVarReferenceForVertex(t *testing
 
 	var out struct {
 		Value      string `json:"value"`
-		SecretRef  string `json:"secret_ref"`
-		FromSecret bool   `json:"from_secret"`
+		Ref        string `json:"ref"`
+		SecretType string `json:"type"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
 	assert.NotContains(t, out.Value, "super-secret-project",
 		"resolved Vertex ProjectID env value leaked: %q", out.Value)
-	assert.Equal(t, "env.MY_VERTEX_PROJECT_ID_SECRET", out.SecretRef)
-	assert.True(t, out.FromSecret)
+	assert.Equal(t, "env.MY_VERTEX_PROJECT_ID_SECRET", out.Ref)
+	assert.Equal(t, "env", out.SecretType)
 }
 
 // TestProviderConfig_Redacted_DoesNotMutateOriginal ensures Redacted() does not

--- a/framework/configstore/clientconfig_redaction_test.go
+++ b/framework/configstore/clientconfig_redaction_test.go
@@ -17,7 +17,7 @@ func TestProviderConfig_Redacted_AutoMasksEnvBackedFields(t *testing.T) {
 	t.Setenv("MY_AZURE_ENDPOINT_SECRET", "https://secret-resource.openai.azure.com")
 
 	endpoint := schemas.NewSecretVar("env.MY_AZURE_ENDPOINT_SECRET")
-	require.True(t, endpoint.IsFromEnv(), "setup: Endpoint should be FromEnv")
+	require.True(t, endpoint.IsFromSecret(), "setup: Endpoint should be FromSecret")
 	require.Equal(t, "https://secret-resource.openai.azure.com", endpoint.GetValue(),
 		"setup: Endpoint should be resolved")
 
@@ -42,17 +42,17 @@ func TestProviderConfig_Redacted_AutoMasksEnvBackedFields(t *testing.T) {
 	require.NoError(t, err)
 
 	var out struct {
-		Value   string `json:"value"`
-		EnvVar  string `json:"env_var"`
-		FromEnv bool   `json:"from_env"`
+		Value     string `json:"value"`
+		SecretRef string `json:"secret_ref"`
+		FromSecret bool  `json:"from_secret"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
 	assert.NotContains(t, out.Value, "secret-resource",
 		"resolved env value leaked through Endpoint JSON output: %q", out.Value)
-	assert.Equal(t, "env.MY_AZURE_ENDPOINT_SECRET", out.EnvVar,
-		"env var reference must be preserved so the UI can show it")
-	assert.True(t, out.FromEnv, "from_env flag must be preserved")
+	assert.Equal(t, "env.MY_AZURE_ENDPOINT_SECRET", out.SecretRef,
+		"secret ref must be preserved so the UI can show it")
+	assert.True(t, out.FromSecret, "from_secret flag must be preserved")
 }
 
 // TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields verifies that the
@@ -79,14 +79,14 @@ func TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields(t *testing.T) {
 	require.NoError(t, err)
 
 	var out struct {
-		Value   string `json:"value"`
-		FromEnv bool   `json:"from_env"`
+		Value      string `json:"value"`
+		FromSecret bool   `json:"from_secret"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
 	assert.Equal(t, "https://foo.openai.azure.com", out.Value,
 		"plain Endpoint was incorrectly redacted")
-	assert.False(t, out.FromEnv)
+	assert.False(t, out.FromSecret)
 }
 
 // TestProviderConfig_Redacted_PreservesSecretVarReferenceForVertex verifies that
@@ -116,16 +116,16 @@ func TestProviderConfig_Redacted_PreservesSecretVarReferenceForVertex(t *testing
 	require.NoError(t, err)
 
 	var out struct {
-		Value   string `json:"value"`
-		EnvVar  string `json:"env_var"`
-		FromEnv bool   `json:"from_env"`
+		Value      string `json:"value"`
+		SecretRef  string `json:"secret_ref"`
+		FromSecret bool   `json:"from_secret"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
 	assert.NotContains(t, out.Value, "super-secret-project",
 		"resolved Vertex ProjectID env value leaked: %q", out.Value)
-	assert.Equal(t, "env.MY_VERTEX_PROJECT_ID_SECRET", out.EnvVar)
-	assert.True(t, out.FromEnv)
+	assert.Equal(t, "env.MY_VERTEX_PROJECT_ID_SECRET", out.SecretRef)
+	assert.True(t, out.FromSecret)
 }
 
 // TestProviderConfig_Redacted_DoesNotMutateOriginal ensures Redacted() does not

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -428,7 +428,7 @@ func TestEncryptPlaintextVirtualKeys_EncryptsAndDecryptsCorrectly(t *testing.T) 
 	// GORM hooks should decrypt on read
 	var found tables.TableVirtualKey
 	require.NoError(t, db.Where("id = ?", "vk-batch-1").First(&found).Error)
-	assert.Equal(t, "vk-batch-secret", found.Value)
+	assert.Equal(t, "vk-batch-secret", found.Value.GetValue())
 }
 
 func TestEncryptPlaintextOAuthConfigs_EncryptsAndDecryptsCorrectly(t *testing.T) {
@@ -986,11 +986,11 @@ func TestBeforeSave_SecretVarBackedFields_NotEncrypted(t *testing.T) {
 	}
 
 	// Verify the SecretVars resolved correctly and are marked as FromEnv
-	require.True(t, azureCfg.Endpoint.IsFromEnv())
+	require.True(t, azureCfg.Endpoint.IsFromSecret())
 	require.Equal(t, "https://env-resource.openai.azure.com", azureCfg.Endpoint.GetValue())
-	require.True(t, azureCfg.ClientSecret.IsFromEnv())
-	require.True(t, vertexCfg.AuthCredentials.IsFromEnv())
-	require.True(t, bedrockCfg.AccessKey.IsFromEnv())
+	require.True(t, azureCfg.ClientSecret.IsFromSecret())
+	require.True(t, vertexCfg.AuthCredentials.IsFromSecret())
+	require.True(t, bedrockCfg.AccessKey.IsFromSecret())
 
 	key := &tables.TableKey{
 		Name:             "env-backed-key",
@@ -1016,53 +1016,53 @@ func TestBeforeSave_SecretVarBackedFields_NotEncrypted(t *testing.T) {
 
 	// The shared config structs must NOT be mutated
 	assert.Equal(t, "https://env-resource.openai.azure.com", azureCfg.Endpoint.GetValue())
-	assert.True(t, azureCfg.Endpoint.IsFromEnv())
+	assert.True(t, azureCfg.Endpoint.IsFromSecret())
 	assert.Equal(t, "env-azure-client-secret", azureCfg.ClientSecret.GetValue())
-	assert.True(t, azureCfg.ClientSecret.IsFromEnv())
+	assert.True(t, azureCfg.ClientSecret.IsFromSecret())
 	assert.Equal(t, "env-vertex-creds-json", vertexCfg.AuthCredentials.GetValue())
-	assert.True(t, vertexCfg.AuthCredentials.IsFromEnv())
+	assert.True(t, vertexCfg.AuthCredentials.IsFromSecret())
 	assert.Equal(t, "env-AKIA-ACCESS", bedrockCfg.AccessKey.GetValue())
-	assert.True(t, bedrockCfg.AccessKey.IsFromEnv())
+	assert.True(t, bedrockCfg.AccessKey.IsFromSecret())
 	assert.Equal(t, "env-bedrock-secret", bedrockCfg.SecretKey.GetValue())
-	assert.True(t, bedrockCfg.SecretKey.IsFromEnv())
+	assert.True(t, bedrockCfg.SecretKey.IsFromSecret())
 	assert.Equal(t, "env-bedrock-session", bedrockCfg.SessionToken.GetValue())
-	assert.True(t, bedrockCfg.SessionToken.IsFromEnv())
+	assert.True(t, bedrockCfg.SessionToken.IsFromSecret())
 
 	// GORM round-trip: AfterFind should reconstruct env-backed SecretVars correctly
 	var found tables.TableKey
 	require.NoError(t, db.Where("name = ?", "env-backed-key").First(&found).Error)
 	assert.Equal(t, "sk-azure-from-env", found.Value.GetValue())
-	assert.True(t, found.Value.IsFromEnv())
+	assert.True(t, found.Value.IsFromSecret())
 
 	require.NotNil(t, found.AzureKeyConfig)
 	assert.Equal(t, "https://env-resource.openai.azure.com", found.AzureKeyConfig.Endpoint.GetValue())
-	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromSecret())
 	assert.Equal(t, "env-azure-client-secret", found.AzureKeyConfig.ClientSecret.GetValue())
-	assert.True(t, found.AzureKeyConfig.ClientSecret.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.ClientSecret.IsFromSecret())
 	assert.Equal(t, "env-azure-client-id", found.AzureKeyConfig.ClientID.GetValue())
-	assert.True(t, found.AzureKeyConfig.ClientID.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.ClientID.IsFromSecret())
 	assert.Equal(t, "env-azure-tenant-id", found.AzureKeyConfig.TenantID.GetValue())
-	assert.True(t, found.AzureKeyConfig.TenantID.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.TenantID.IsFromSecret())
 
 	require.NotNil(t, found.VertexKeyConfig)
 	assert.Equal(t, "env-vertex-project", found.VertexKeyConfig.ProjectID.GetValue())
-	assert.True(t, found.VertexKeyConfig.ProjectID.IsFromEnv())
+	assert.True(t, found.VertexKeyConfig.ProjectID.IsFromSecret())
 	assert.Equal(t, "env-us-central1", found.VertexKeyConfig.Region.GetValue())
-	assert.True(t, found.VertexKeyConfig.Region.IsFromEnv())
+	assert.True(t, found.VertexKeyConfig.Region.IsFromSecret())
 	assert.Equal(t, "env-vertex-creds-json", found.VertexKeyConfig.AuthCredentials.GetValue())
-	assert.True(t, found.VertexKeyConfig.AuthCredentials.IsFromEnv())
+	assert.True(t, found.VertexKeyConfig.AuthCredentials.IsFromSecret())
 
 	require.NotNil(t, found.BedrockKeyConfig)
 	assert.Equal(t, "env-AKIA-ACCESS", found.BedrockKeyConfig.AccessKey.GetValue())
-	assert.True(t, found.BedrockKeyConfig.AccessKey.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.AccessKey.IsFromSecret())
 	assert.Equal(t, "env-bedrock-secret", found.BedrockKeyConfig.SecretKey.GetValue())
-	assert.True(t, found.BedrockKeyConfig.SecretKey.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.SecretKey.IsFromSecret())
 	assert.Equal(t, "env-bedrock-session", found.BedrockKeyConfig.SessionToken.GetValue())
-	assert.True(t, found.BedrockKeyConfig.SessionToken.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.SessionToken.IsFromSecret())
 	assert.Equal(t, "env-us-east-1", found.BedrockKeyConfig.Region.GetValue())
-	assert.True(t, found.BedrockKeyConfig.Region.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.Region.IsFromSecret())
 	assert.Equal(t, "arn:aws:iam::env:role/test", found.BedrockKeyConfig.ARN.GetValue())
-	assert.True(t, found.BedrockKeyConfig.ARN.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.ARN.IsFromSecret())
 }
 
 func TestEncryptPlaintextKeys_SecretVarBackedFields_SurviveStartupPass(t *testing.T) {
@@ -1101,16 +1101,16 @@ func TestEncryptPlaintextKeys_SecretVarBackedFields_SurviveStartupPass(t *testin
 	var found tables.TableKey
 	require.NoError(t, db.Where("name = ?", "env-startup-key").First(&found).Error)
 	assert.Equal(t, "sk-startup-env-key", found.Value.GetValue())
-	assert.True(t, found.Value.IsFromEnv())
+	assert.True(t, found.Value.IsFromSecret())
 	require.NotNil(t, found.AzureKeyConfig)
 	assert.Equal(t, "https://startup.openai.azure.com", found.AzureKeyConfig.Endpoint.GetValue())
-	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromSecret())
 	require.NotNil(t, found.VertexKeyConfig)
 	assert.Equal(t, "startup-vertex-creds", found.VertexKeyConfig.AuthCredentials.GetValue())
-	assert.True(t, found.VertexKeyConfig.AuthCredentials.IsFromEnv())
+	assert.True(t, found.VertexKeyConfig.AuthCredentials.IsFromSecret())
 	require.NotNil(t, found.BedrockKeyConfig)
 	assert.Equal(t, "AKIA-STARTUP", found.BedrockKeyConfig.AccessKey.GetValue())
-	assert.True(t, found.BedrockKeyConfig.AccessKey.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.AccessKey.IsFromSecret())
 }
 
 // ============================================================================
@@ -1306,7 +1306,7 @@ func TestEncryptPlaintextMCPClients_SecretVarConnectionStringSurvivesStartup(t *
 	var found tables.TableMCPClient
 	require.NoError(t, db.Where("client_id = ?", "mcp-env-startup").First(&found).Error)
 	assert.Equal(t, "https://mcp-env.example.com/sse", found.ConnectionString.GetValue())
-	assert.True(t, found.ConnectionString.IsFromEnv())
+	assert.True(t, found.ConnectionString.IsFromSecret())
 }
 
 // ============================================================================

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2044,7 +2044,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if clientConfigCopy.Headers != nil {
 			for key, value := range clientConfigCopy.Headers {
 				if value.IsFromSecret() {
-					headersToSerialize[key] = value.Ref()
+					headersToSerialize[key] = value.GetSecretRef()
 				} else {
 					headersToSerialize[key] = value.GetValue()
 				}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2044,7 +2044,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if clientConfigCopy.Headers != nil {
 			for key, value := range clientConfigCopy.Headers {
 				if value.IsFromSecret() {
-					headersToSerialize[key] = value.SecretRef
+					headersToSerialize[key] = value.Ref()
 				} else {
 					headersToSerialize[key] = value.GetValue()
 				}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2043,10 +2043,8 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		headersToSerialize := make(map[string]string)
 		if clientConfigCopy.Headers != nil {
 			for key, value := range clientConfigCopy.Headers {
-				if value.IsFromEnv() {
-					headersToSerialize[key] = value.EnvVar
-				} else if value.IsFromVault() {
-					headersToSerialize[key] = value.VaultRef
+				if value.IsFromSecret() {
+					headersToSerialize[key] = value.SecretRef
 				} else {
 					headersToSerialize[key] = value.GetValue()
 				}
@@ -2165,7 +2163,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if clientConfigCopy.ConfigHash != "" {
 			connectionStringToPersist := clientConfigCopy.ConnectionString
 			if encrypt.IsEnabled() && connectionStringToPersist != nil &&
-				!connectionStringToPersist.IsFromEnv() && !connectionStringToPersist.IsFromVault() && connectionStringToPersist.GetValue() != "" {
+				!connectionStringToPersist.IsFromSecret() && connectionStringToPersist.GetValue() != "" {
 				// Mirror TableMCPClient.BeforeSave behavior for map-based Updates.
 				cs := *connectionStringToPersist
 				encryptedConnString, encErr := encrypt.Encrypt(cs.Val)

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2044,7 +2044,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if clientConfigCopy.Headers != nil {
 			for key, value := range clientConfigCopy.Headers {
 				if value.IsFromSecret() {
-					headersToSerialize[key] = value.GetSecretRef()
+					headersToSerialize[key] = value.GetRawRef()
 				} else {
 					headersToSerialize[key] = value.GetValue()
 				}

--- a/framework/configstore/tables/encryption.go
+++ b/framework/configstore/tables/encryption.go
@@ -15,7 +15,7 @@ const (
 // encryptSecretVar encrypts the Val field of an SecretVar in place using AES-256-GCM.
 // It is a no-op if the field is nil, references an environment variable or vault, or has an empty value.
 func encryptSecretVar(field *schemas.SecretVar) error {
-	if field == nil || field.IsFromEnv() || field.IsFromVault() || field.GetValue() == "" {
+	if field == nil || field.IsFromSecret() || field.GetValue() == "" {
 		return nil
 	}
 	encrypted, err := encrypt.Encrypt(field.Val)
@@ -29,7 +29,7 @@ func encryptSecretVar(field *schemas.SecretVar) error {
 // decryptSecretVar decrypts the Val field of an SecretVar in place using AES-256-GCM.
 // It is a no-op if the field is nil, references an environment variable or vault, or has an empty value.
 func decryptSecretVar(field *schemas.SecretVar) error {
-	if field == nil || field.IsFromEnv() || field.IsFromVault() || field.GetValue() == "" {
+	if field == nil || field.IsFromSecret() || field.GetValue() == "" {
 		return nil
 	}
 	decrypted, err := encrypt.Decrypt(field.Val)

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -1739,7 +1739,7 @@ func TestTableKey_VertexUnresolvedSecretVar_RoundTrip(t *testing.T) {
 
 	// VertexKeyConfig must NOT be wiped — this was the original bug.
 	require.NotNil(t, found.VertexKeyConfig, "VertexKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_VERTEX_PROJECT_ID_FOR_TEST", found.VertexKeyConfig.ProjectID.GetSecretRef(),
+	assert.Equal(t, "env.FAKE_VERTEX_PROJECT_ID_FOR_TEST", found.VertexKeyConfig.ProjectID.GetRawRef(),
 		"env var reference for ProjectID lost on round-trip")
 	assert.True(t, found.VertexKeyConfig.ProjectID.IsFromSecret(),
 		"FromEnv flag for ProjectID lost on round-trip")
@@ -1772,7 +1772,7 @@ func TestTableKey_AzureUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.AzureKeyConfig, "AzureKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_AZURE_ENDPOINT_FOR_TEST", found.AzureKeyConfig.Endpoint.GetSecretRef(),
+	assert.Equal(t, "env.FAKE_AZURE_ENDPOINT_FOR_TEST", found.AzureKeyConfig.Endpoint.GetRawRef(),
 		"env var reference for Endpoint lost on round-trip")
 	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromSecret(),
 		"FromEnv flag for Endpoint lost on round-trip")
@@ -1805,9 +1805,9 @@ func TestTableKey_BedrockUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.BedrockKeyConfig, "BedrockKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_AWS_ACCESS_KEY_FOR_TEST", found.BedrockKeyConfig.AccessKey.GetSecretRef(),
+	assert.Equal(t, "env.FAKE_AWS_ACCESS_KEY_FOR_TEST", found.BedrockKeyConfig.AccessKey.GetRawRef(),
 		"env var reference for AccessKey lost on round-trip")
-	assert.Equal(t, "env.FAKE_AWS_SECRET_KEY_FOR_TEST", found.BedrockKeyConfig.SecretKey.GetSecretRef(),
+	assert.Equal(t, "env.FAKE_AWS_SECRET_KEY_FOR_TEST", found.BedrockKeyConfig.SecretKey.GetRawRef(),
 		"env var reference for SecretKey lost on round-trip")
 	require.NotNil(t, found.BedrockKeyConfig.Region)
 	assert.Equal(t, "us-west-2", found.BedrockKeyConfig.Region.GetValue())
@@ -1837,7 +1837,7 @@ func TestTableKey_OllamaUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.OllamaKeyConfig, "OllamaKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_OLLAMA_URL_FOR_TEST", found.OllamaKeyConfig.URL.GetSecretRef())
+	assert.Equal(t, "env.FAKE_OLLAMA_URL_FOR_TEST", found.OllamaKeyConfig.URL.GetRawRef())
 	assert.True(t, found.OllamaKeyConfig.URL.IsFromSecret())
 }
 
@@ -1863,7 +1863,7 @@ func TestTableKey_SGLUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.SGLKeyConfig, "SGLKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_SGL_URL_FOR_TEST", found.SGLKeyConfig.URL.GetSecretRef())
+	assert.Equal(t, "env.FAKE_SGL_URL_FOR_TEST", found.SGLKeyConfig.URL.GetRawRef())
 	assert.True(t, found.SGLKeyConfig.URL.IsFromSecret())
 }
 

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -249,7 +249,7 @@ func TestTableKey_SecretVarNotEncrypted(t *testing.T) {
 	var found TableKey
 	require.NoError(t, db.First(&found, key.ID).Error)
 	// The value should be readable (either the env var value or empty if not set)
-	assert.True(t, found.Value.IsFromEnv())
+	assert.True(t, found.Value.IsFromSecret())
 }
 
 // ============================================================================
@@ -350,7 +350,7 @@ func TestTableMCPClient_SecretVarConnectionString_NotEncrypted(t *testing.T) {
 
 	var found TableMCPClient
 	require.NoError(t, db.First(&found, client.ID).Error)
-	assert.True(t, found.ConnectionString.IsFromEnv())
+	assert.True(t, found.ConnectionString.IsFromSecret())
 }
 
 // ============================================================================
@@ -735,7 +735,7 @@ func TestEncryptSecretVar_EnvRefIsNoop(t *testing.T) {
 	require.NoError(t, encryptSecretVar(ev))
 	// Value should not change — env var references are never encrypted
 	assert.Equal(t, originalVal, ev.Val)
-	assert.True(t, ev.IsFromEnv())
+	assert.True(t, ev.IsFromSecret())
 }
 
 func TestDecryptSecretVar_NilIsNoop(t *testing.T) {
@@ -1726,12 +1726,8 @@ func TestTableKey_VertexUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "vertex-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		VertexKeyConfig: &schemas.VertexKeyConfig{
-			ProjectID: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_VERTEX_PROJECT_ID_FOR_TEST",
-				FromEnv: true,
-			},
-			Region: *schemas.NewSecretVar("us-central1"),
+			ProjectID: *schemas.NewSecretVar("env.FAKE_VERTEX_PROJECT_ID_FOR_TEST"),
+			Region:    *schemas.NewSecretVar("us-central1"),
 		},
 	}
 
@@ -1743,9 +1739,9 @@ func TestTableKey_VertexUnresolvedSecretVar_RoundTrip(t *testing.T) {
 
 	// VertexKeyConfig must NOT be wiped — this was the original bug.
 	require.NotNil(t, found.VertexKeyConfig, "VertexKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_VERTEX_PROJECT_ID_FOR_TEST", found.VertexKeyConfig.ProjectID.EnvVar,
+	assert.Equal(t, "env.FAKE_VERTEX_PROJECT_ID_FOR_TEST", found.VertexKeyConfig.ProjectID.GetSecretRef(),
 		"env var reference for ProjectID lost on round-trip")
-	assert.True(t, found.VertexKeyConfig.ProjectID.FromEnv,
+	assert.True(t, found.VertexKeyConfig.ProjectID.IsFromSecret(),
 		"FromEnv flag for ProjectID lost on round-trip")
 	assert.Equal(t, "us-central1", found.VertexKeyConfig.Region.GetValue(),
 		"Plain Region value should survive round-trip unchanged")
@@ -1766,11 +1762,7 @@ func TestTableKey_AzureUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "azure-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_AZURE_ENDPOINT_FOR_TEST",
-				FromEnv: true,
-			},
+			Endpoint: *schemas.NewSecretVar("env.FAKE_AZURE_ENDPOINT_FOR_TEST"),
 		},
 	}
 
@@ -1780,9 +1772,9 @@ func TestTableKey_AzureUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.AzureKeyConfig, "AzureKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_AZURE_ENDPOINT_FOR_TEST", found.AzureKeyConfig.Endpoint.EnvVar,
+	assert.Equal(t, "env.FAKE_AZURE_ENDPOINT_FOR_TEST", found.AzureKeyConfig.Endpoint.GetSecretRef(),
 		"env var reference for Endpoint lost on round-trip")
-	assert.True(t, found.AzureKeyConfig.Endpoint.FromEnv,
+	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromSecret(),
 		"FromEnv flag for Endpoint lost on round-trip")
 }
 
@@ -1801,17 +1793,9 @@ func TestTableKey_BedrockUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "bedrock-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		BedrockKeyConfig: &schemas.BedrockKeyConfig{
-			AccessKey: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_AWS_ACCESS_KEY_FOR_TEST",
-				FromEnv: true,
-			},
-			SecretKey: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_AWS_SECRET_KEY_FOR_TEST",
-				FromEnv: true,
-			},
-			Region: schemas.NewSecretVar("us-west-2"),
+			AccessKey: *schemas.NewSecretVar("env.FAKE_AWS_ACCESS_KEY_FOR_TEST"),
+			SecretKey: *schemas.NewSecretVar("env.FAKE_AWS_SECRET_KEY_FOR_TEST"),
+			Region:    schemas.NewSecretVar("us-west-2"),
 		},
 	}
 
@@ -1821,9 +1805,9 @@ func TestTableKey_BedrockUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.BedrockKeyConfig, "BedrockKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_AWS_ACCESS_KEY_FOR_TEST", found.BedrockKeyConfig.AccessKey.EnvVar,
+	assert.Equal(t, "env.FAKE_AWS_ACCESS_KEY_FOR_TEST", found.BedrockKeyConfig.AccessKey.GetSecretRef(),
 		"env var reference for AccessKey lost on round-trip")
-	assert.Equal(t, "env.FAKE_AWS_SECRET_KEY_FOR_TEST", found.BedrockKeyConfig.SecretKey.EnvVar,
+	assert.Equal(t, "env.FAKE_AWS_SECRET_KEY_FOR_TEST", found.BedrockKeyConfig.SecretKey.GetSecretRef(),
 		"env var reference for SecretKey lost on round-trip")
 	require.NotNil(t, found.BedrockKeyConfig.Region)
 	assert.Equal(t, "us-west-2", found.BedrockKeyConfig.Region.GetValue())
@@ -1843,11 +1827,7 @@ func TestTableKey_OllamaUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "ollama-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		OllamaKeyConfig: &schemas.OllamaKeyConfig{
-			URL: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_OLLAMA_URL_FOR_TEST",
-				FromEnv: true,
-			},
+			URL: *schemas.NewSecretVar("env.FAKE_OLLAMA_URL_FOR_TEST"),
 		},
 	}
 
@@ -1857,8 +1837,8 @@ func TestTableKey_OllamaUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.OllamaKeyConfig, "OllamaKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_OLLAMA_URL_FOR_TEST", found.OllamaKeyConfig.URL.EnvVar)
-	assert.True(t, found.OllamaKeyConfig.URL.FromEnv)
+	assert.Equal(t, "env.FAKE_OLLAMA_URL_FOR_TEST", found.OllamaKeyConfig.URL.GetSecretRef())
+	assert.True(t, found.OllamaKeyConfig.URL.IsFromSecret())
 }
 
 func TestTableKey_SGLUnresolvedSecretVar_RoundTrip(t *testing.T) {
@@ -1873,11 +1853,7 @@ func TestTableKey_SGLUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "sgl-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		SGLKeyConfig: &schemas.SGLKeyConfig{
-			URL: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_SGL_URL_FOR_TEST",
-				FromEnv: true,
-			},
+			URL: *schemas.NewSecretVar("env.FAKE_SGL_URL_FOR_TEST"),
 		},
 	}
 
@@ -1887,8 +1863,8 @@ func TestTableKey_SGLUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.SGLKeyConfig, "SGLKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_SGL_URL_FOR_TEST", found.SGLKeyConfig.URL.EnvVar)
-	assert.True(t, found.SGLKeyConfig.URL.FromEnv)
+	assert.Equal(t, "env.FAKE_SGL_URL_FOR_TEST", found.SGLKeyConfig.URL.GetSecretRef())
+	assert.True(t, found.SGLKeyConfig.URL.IsFromSecret())
 }
 
 // TestTableKey_VertexPlainValue_RoundTrip is a sanity check ensuring that plain
@@ -1916,7 +1892,7 @@ func TestTableKey_VertexPlainValue_RoundTrip(t *testing.T) {
 
 	require.NotNil(t, found.VertexKeyConfig)
 	assert.Equal(t, "my-gcp-project", found.VertexKeyConfig.ProjectID.GetValue())
-	assert.False(t, found.VertexKeyConfig.ProjectID.FromEnv)
+	assert.False(t, found.VertexKeyConfig.ProjectID.IsFromSecret())
 	assert.Equal(t, "us-central1", found.VertexKeyConfig.Region.GetValue())
 }
 

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -13,21 +13,21 @@ import (
 
 // TableMCPClient represents an MCP client configuration in the database
 type TableMCPClient struct {
-	ID                      uint            `gorm:"primaryKey;autoIncrement" json:"id"` // ID is used as the internal primary key and is also accessed by public methods, so it must be present.
-	ClientID                string          `gorm:"type:varchar(255);uniqueIndex;not null" json:"client_id"`
-	Name                    string          `gorm:"type:varchar(255);uniqueIndex;not null" json:"name"`
-	IsCodeModeClient        bool            `gorm:"default:false" json:"is_code_mode_client"`         // Whether the client is a code mode client
-	ConnectionType          string          `gorm:"type:varchar(20);not null" json:"connection_type"` // schemas.MCPConnectionType
+	ID                      uint               `gorm:"primaryKey;autoIncrement" json:"id"` // ID is used as the internal primary key and is also accessed by public methods, so it must be present.
+	ClientID                string             `gorm:"type:varchar(255);uniqueIndex;not null" json:"client_id"`
+	Name                    string             `gorm:"type:varchar(255);uniqueIndex;not null" json:"name"`
+	IsCodeModeClient        bool               `gorm:"default:false" json:"is_code_mode_client"`         // Whether the client is a code mode client
+	ConnectionType          string             `gorm:"type:varchar(20);not null" json:"connection_type"` // schemas.MCPConnectionType
 	ConnectionString        *schemas.SecretVar `gorm:"type:text" json:"connection_string,omitempty"`
-	StdioConfigJSON         *string         `gorm:"type:text" json:"-"`                              // JSON serialized schemas.MCPStdioConfig
-	TLSConfigJSON           *string         `gorm:"type:text" json:"-"`                              // JSON serialized schemas.MCPTLSConfig
-	ToolsToExecuteJSON      string          `gorm:"type:text" json:"-"`                              // JSON serialized []string
-	ToolsToAutoExecuteJSON  string          `gorm:"type:text" json:"-"`                              // JSON serialized []string
-	HeadersJSON             string          `gorm:"type:text" json:"-"`                              // JSON serialized map[string]string
-	AllowedExtraHeadersJSON string          `gorm:"type:text" json:"-"`                              // JSON serialized []string
-	IsPingAvailable         *bool           `gorm:"default:true" json:"is_ping_available,omitempty"` // Whether the MCP server supports ping for health checks
-	ToolPricingJSON         string          `gorm:"type:text" json:"-"`                              // JSON serialized map[string]float64
-	ToolSyncInterval        int             `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in seconds (0 = use global, negative = disabled)
+	StdioConfigJSON         *string            `gorm:"type:text" json:"-"`                              // JSON serialized schemas.MCPStdioConfig
+	TLSConfigJSON           *string            `gorm:"type:text" json:"-"`                              // JSON serialized schemas.MCPTLSConfig
+	ToolsToExecuteJSON      string             `gorm:"type:text" json:"-"`                              // JSON serialized []string
+	ToolsToAutoExecuteJSON  string             `gorm:"type:text" json:"-"`                              // JSON serialized []string
+	HeadersJSON             string             `gorm:"type:text" json:"-"`                              // JSON serialized map[string]string
+	AllowedExtraHeadersJSON string             `gorm:"type:text" json:"-"`                              // JSON serialized []string
+	IsPingAvailable         *bool              `gorm:"default:true" json:"is_ping_available,omitempty"` // Whether the MCP server supports ping for health checks
+	ToolPricingJSON         string             `gorm:"type:text" json:"-"`                              // JSON serialized map[string]float64
+	ToolSyncInterval        int                `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in seconds (0 = use global, negative = disabled)
 
 	// Per-user OAuth: discovered tools persisted so they survive restart
 	DiscoveredToolsJSON string `gorm:"type:text" json:"-"` // JSON serialized map[string]schemas.ChatTool
@@ -57,16 +57,16 @@ type TableMCPClient struct {
 	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
 
 	// Virtual fields for runtime use (not stored in DB)
-	StdioConfig               *schemas.MCPStdioConfig     `gorm:"-" json:"stdio_config,omitempty"`
-	TLSConfig                 *schemas.MCPTLSConfig       `gorm:"-" json:"tls_config,omitempty"`
-	ToolsToExecute            schemas.WhiteList           `gorm:"-" json:"tools_to_execute"`
-	ToolsToAutoExecute        schemas.WhiteList           `gorm:"-" json:"tools_to_auto_execute"`
-	Headers                   map[string]schemas.SecretVar   `gorm:"-" json:"headers"`
-	AllowedExtraHeaders       schemas.WhiteList           `gorm:"-" json:"allowed_extra_headers"`
-	ToolPricing               map[string]float64          `gorm:"-" json:"tool_pricing"`
-	DiscoveredTools           map[string]schemas.ChatTool `gorm:"-" json:"-"`
-	DiscoveredToolNameMapping map[string]string           `gorm:"-" json:"-"`
-	PerUserHeaderKeys         []string                    `gorm:"-" json:"per_user_header_keys"`
+	StdioConfig               *schemas.MCPStdioConfig      `gorm:"-" json:"stdio_config,omitempty"`
+	TLSConfig                 *schemas.MCPTLSConfig        `gorm:"-" json:"tls_config,omitempty"`
+	ToolsToExecute            schemas.WhiteList            `gorm:"-" json:"tools_to_execute"`
+	ToolsToAutoExecute        schemas.WhiteList            `gorm:"-" json:"tools_to_auto_execute"`
+	Headers                   map[string]schemas.SecretVar `gorm:"-" json:"headers"`
+	AllowedExtraHeaders       schemas.WhiteList            `gorm:"-" json:"allowed_extra_headers"`
+	ToolPricing               map[string]float64           `gorm:"-" json:"tool_pricing"`
+	DiscoveredTools           map[string]schemas.ChatTool  `gorm:"-" json:"-"`
+	DiscoveredToolNameMapping map[string]string            `gorm:"-" json:"-"`
+	PerUserHeaderKeys         []string                     `gorm:"-" json:"per_user_header_keys"`
 }
 
 // TableName sets the table name for each model
@@ -128,7 +128,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		headersToSerialize := make(map[string]string, len(c.Headers))
 		for key, value := range c.Headers {
 			if value.IsFromSecret() {
-				headersToSerialize[key] = value.GetSecretRef()
+				headersToSerialize[key] = value.GetRawRef()
 			} else {
 				headersToSerialize[key] = value.GetValue()
 			}

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -128,7 +128,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		headersToSerialize := make(map[string]string, len(c.Headers))
 		for key, value := range c.Headers {
 			if value.IsFromSecret() {
-				headersToSerialize[key] = value.Ref()
+				headersToSerialize[key] = value.GetSecretRef()
 			} else {
 				headersToSerialize[key] = value.GetValue()
 			}

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -127,10 +127,8 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 	if c.Headers != nil {
 		headersToSerialize := make(map[string]string, len(c.Headers))
 		for key, value := range c.Headers {
-			if value.IsFromEnv() {
-				headersToSerialize[key] = value.EnvVar
-			} else if value.IsFromVault() {
-				headersToSerialize[key] = value.VaultRef
+			if value.IsFromSecret() {
+				headersToSerialize[key] = value.SecretRef
 			} else {
 				headersToSerialize[key] = value.GetValue()
 			}
@@ -197,7 +195,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 	// Always set EncryptionStatus when encryption is enabled so the startup
 	// batch pass does not re-process this row indefinitely.
 	if encrypt.IsEnabled() {
-		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && !c.ConnectionString.IsFromVault() && c.ConnectionString.GetValue() != "" {
+		if c.ConnectionString != nil && !c.ConnectionString.IsFromSecret() && c.ConnectionString.GetValue() != "" {
 			// Copy to avoid encrypting the shared ConnectionString through the pointer
 			cs := *c.ConnectionString
 			enc, err := encrypt.Encrypt(cs.Val)
@@ -231,7 +229,7 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 			}
 			c.HeadersJSON = decrypted
 		}
-		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && !c.ConnectionString.IsFromVault() && c.ConnectionString.GetValue() != "" {
+		if c.ConnectionString != nil && !c.ConnectionString.IsFromSecret() && c.ConnectionString.GetValue() != "" {
 			decrypted, err := encrypt.Decrypt(c.ConnectionString.Val)
 			if err != nil {
 				return fmt.Errorf("failed to decrypt mcp connection string: %w", err)

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -128,7 +128,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		headersToSerialize := make(map[string]string, len(c.Headers))
 		for key, value := range c.Headers {
 			if value.IsFromSecret() {
-				headersToSerialize[key] = value.SecretRef
+				headersToSerialize[key] = value.Ref()
 			} else {
 				headersToSerialize[key] = value.GetValue()
 			}

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -48,7 +48,7 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 
 	if encrypt.IsEnabled() {
 		encrypted := false
-		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && !c.ClientSecret.IsFromVault() && c.ClientSecret.Val != "" {
+		if c.ClientSecret != nil && !c.ClientSecret.IsFromSecret() && c.ClientSecret.Val != "" {
 			if err := encryptString(&c.ClientSecret.Val); err != nil {
 				return fmt.Errorf("failed to encrypt oauth client secret: %w", err)
 			}
@@ -71,7 +71,7 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 func (c *TableOauthConfig) AfterFind(tx *gorm.DB) error {
 	switch c.EncryptionStatus {
 	case EncryptionStatusEncrypted:
-		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && !c.ClientSecret.IsFromVault() && c.ClientSecret.Val != "" {
+		if c.ClientSecret != nil && !c.ClientSecret.IsFromSecret() && c.ClientSecret.Val != "" {
 			if err := decryptString(&c.ClientSecret.Val); err != nil {
 				return fmt.Errorf("failed to decrypt oauth client secret: %w", err)
 			}

--- a/framework/configstore/tables/virtualkey_secretvar_test.go
+++ b/framework/configstore/tables/virtualkey_secretvar_test.go
@@ -38,7 +38,7 @@ func TestTableVirtualKey_EnvSourcedRoundTrip(t *testing.T) {
 	var found TableVirtualKey
 	require.NoError(t, db.First(&found, "id = ?", "vk-env").Error)
 	assert.True(t, found.Value.IsFromSecret())
-	assert.Equal(t, "env.TEST_VK_ENV", found.Value.GetSecretRef())
+	assert.Equal(t, "env.TEST_VK_ENV", found.Value.GetRawRef())
 	assert.Equal(t, "sk-bf-env-resolved", found.Value.GetValue())
 }
 
@@ -97,7 +97,7 @@ func TestTableVirtualKey_MarshalJSON_SecretVarShape(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 	assert.True(t, out.Value.IsFromSecret())
-	assert.Equal(t, "env.TEST_VK_MARSHAL", out.Value.GetSecretRef())
+	assert.Equal(t, "env.TEST_VK_MARSHAL", out.Value.GetRawRef())
 }
 
 // TestTableVirtualKey_UnmarshalJSON_Forms verifies `value` accepts a bare string and an "env.X"
@@ -117,7 +117,7 @@ func TestTableVirtualKey_UnmarshalJSON_Forms(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(`{"name":"n","value":"env.TEST_VK_UMARSHAL"}`), &vk))
 		assert.Equal(t, "sk-bf-um", vk.Value.GetValue())
 		assert.True(t, vk.Value.IsFromSecret())
-		assert.Equal(t, "env.TEST_VK_UMARSHAL", vk.Value.GetSecretRef())
+		assert.Equal(t, "env.TEST_VK_UMARSHAL", vk.Value.GetRawRef())
 	})
 }
 

--- a/framework/configstore/tables/virtualkey_secretvar_test.go
+++ b/framework/configstore/tables/virtualkey_secretvar_test.go
@@ -20,7 +20,7 @@ func TestTableVirtualKey_EnvSourcedRoundTrip(t *testing.T) {
 
 	t.Setenv("TEST_VK_ENV", "sk-bf-env-resolved")
 	sv := schemas.NewSecretVar("env.TEST_VK_ENV")
-	require.True(t, sv.IsFromEnv())
+	require.True(t, sv.IsFromSecret())
 	require.Equal(t, "sk-bf-env-resolved", sv.GetValue())
 
 	vk := &TableVirtualKey{
@@ -37,8 +37,8 @@ func TestTableVirtualKey_EnvSourcedRoundTrip(t *testing.T) {
 
 	var found TableVirtualKey
 	require.NoError(t, db.First(&found, "id = ?", "vk-env").Error)
-	assert.True(t, found.Value.IsFromEnv())
-	assert.Equal(t, "env.TEST_VK_ENV", found.Value.EnvVar)
+	assert.True(t, found.Value.IsFromSecret())
+	assert.Equal(t, "env.TEST_VK_ENV", found.Value.GetSecretRef())
 	assert.Equal(t, "sk-bf-env-resolved", found.Value.GetValue())
 }
 
@@ -60,7 +60,7 @@ func TestTableVirtualKey_LiteralRoundTrip(t *testing.T) {
 
 	var found TableVirtualKey
 	require.NoError(t, db.First(&found, "id = ?", "vk-lit").Error)
-	assert.False(t, found.Value.IsFromEnv())
+	assert.False(t, found.Value.IsFromSecret())
 	assert.False(t, found.Value.IsFromVault())
 	assert.Equal(t, "sk-bf-literal", found.Value.GetValue())
 }
@@ -96,8 +96,8 @@ func TestTableVirtualKey_MarshalJSON_SecretVarShape(t *testing.T) {
 		Value schemas.SecretVar `json:"value"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
-	assert.True(t, out.Value.FromEnv)
-	assert.Equal(t, "env.TEST_VK_MARSHAL", out.Value.EnvVar)
+	assert.True(t, out.Value.IsFromSecret())
+	assert.Equal(t, "env.TEST_VK_MARSHAL", out.Value.GetSecretRef())
 }
 
 // TestTableVirtualKey_UnmarshalJSON_Forms verifies `value` accepts a bare string and an "env.X"
@@ -109,15 +109,15 @@ func TestTableVirtualKey_UnmarshalJSON_Forms(t *testing.T) {
 		var vk TableVirtualKey
 		require.NoError(t, json.Unmarshal([]byte(`{"name":"n","value":"sk-bf-plain"}`), &vk))
 		assert.Equal(t, "sk-bf-plain", vk.Value.GetValue())
-		assert.False(t, vk.Value.IsFromEnv())
+		assert.False(t, vk.Value.IsFromSecret())
 	})
 
 	t.Run("env string", func(t *testing.T) {
 		var vk TableVirtualKey
 		require.NoError(t, json.Unmarshal([]byte(`{"name":"n","value":"env.TEST_VK_UMARSHAL"}`), &vk))
 		assert.Equal(t, "sk-bf-um", vk.Value.GetValue())
-		assert.True(t, vk.Value.IsFromEnv())
-		assert.Equal(t, "env.TEST_VK_UMARSHAL", vk.Value.EnvVar)
+		assert.True(t, vk.Value.IsFromSecret())
+		assert.Equal(t, "env.TEST_VK_UMARSHAL", vk.Value.GetSecretRef())
 	})
 }
 

--- a/framework/configstore/vault_callbacks_test.go
+++ b/framework/configstore/vault_callbacks_test.go
@@ -131,7 +131,7 @@ func TestVaultCallbacks_SelfManagedStoresPlaintext(t *testing.T) {
 			var row tables.TableKey
 			require.NoError(t, db.First(&row, "key_id = ?", keyID).Error)
 			require.NotNil(t, row.BedrockSecretKey)
-			require.Equal(t, "vault."+secretPath, row.BedrockSecretKey.Val, "column should store vault ref")
+			require.Equal(t, "vault."+secretPath, row.BedrockSecretKey.GetRawRef(), "column should store vault ref")
 		})
 	}
 }

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -295,7 +295,7 @@ func redactHeaderValue(v string) string {
 // consumers can tell the value exists without leaking env content. Unresolved env
 // references keep an empty Val, while preserving env_var for round-trip edits.
 func hideResolvedEnvValue(v *schemas.SecretVar) *schemas.SecretVar {
-	if v == nil || (!v.IsFromEnv() && !v.IsFromVault()) {
+	if v == nil || !v.IsFromSecret() {
 		return v
 	}
 	return v.Redacted()

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -128,7 +128,7 @@ func (c *Config) Redacted() *Config {
 // For env var references it zeroes out the resolved Val so the actual env content is
 // not leaked in API responses, while keeping the env_var name for round-trip edits.
 func hideResolvedEnvValue(v *schemas.SecretVar) *schemas.SecretVar {
-	if v == nil || (!v.IsFromEnv() && !v.IsFromVault()) {
+	if v == nil || !v.IsFromSecret() {
 		return v
 	}
 	return v.Redacted()

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -702,12 +702,20 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			}
 
 			// Validate env variables are set if referenced
-			if payload.AuthConfig.AdminUserName.IsFromEnv() && payload.AuthConfig.AdminUserName.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("environment variable %s is not set", payload.AuthConfig.AdminUserName.EnvVar))
+			if (payload.AuthConfig.AdminUserName.IsFromEnv() || payload.AuthConfig.AdminUserName.IsFromVault()) && payload.AuthConfig.AdminUserName.GetValue() == "" {
+				ref := payload.AuthConfig.AdminUserName.EnvVar
+				if payload.AuthConfig.AdminUserName.IsFromVault() {
+					ref = payload.AuthConfig.AdminUserName.VaultRef
+				}
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", ref))
 				return
 			}
-			if payload.AuthConfig.AdminPassword.IsFromEnv() && payload.AuthConfig.AdminPassword.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("environment variable %s is not set", payload.AuthConfig.AdminPassword.EnvVar))
+			if (payload.AuthConfig.AdminPassword.IsFromEnv() || payload.AuthConfig.AdminPassword.IsFromVault()) && payload.AuthConfig.AdminPassword.GetValue() == "" {
+				ref := payload.AuthConfig.AdminPassword.EnvVar
+				if payload.AuthConfig.AdminPassword.IsFromVault() {
+					ref = payload.AuthConfig.AdminPassword.VaultRef
+				}
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", ref))
 				return
 			}
 

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -666,11 +666,10 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			}
 		} else {
 			// Compare with existing config using value comparison (not pointer comparison)
-			// Password is considered changed only if it's NOT redacted and has a value
-			// (IsRedacted() returns true for <redacted>, asterisk patterns, and env var references)
+			// Password is considered changed when it was intentionally submitted —
+			// ShouldPreserveStored() returns false for both plain values and secret refs.
 			passwordChanged := payload.AuthConfig.AdminPassword != nil &&
-				!payload.AuthConfig.AdminPassword.IsRedacted() &&
-				payload.AuthConfig.AdminPassword.GetValue() != ""
+				!payload.AuthConfig.AdminPassword.ShouldPreserveStored()
 			usernameChanged := payload.AuthConfig.AdminUserName != nil &&
 				!payload.AuthConfig.AdminUserName.Equals(authConfig.AdminUserName)
 			if payload.AuthConfig.IsEnabled != authConfig.IsEnabled ||
@@ -691,11 +690,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 
 			// Validate env variables are set if referenced
 			if payload.AuthConfig.AdminUserName.IsFromSecret() && payload.AuthConfig.AdminUserName.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.GetSecretRef()))
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.GetRawRef()))
 				return
 			}
 			if payload.AuthConfig.AdminPassword.IsFromSecret() && payload.AuthConfig.AdminPassword.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.GetSecretRef()))
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.GetRawRef()))
 				return
 			}
 

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -137,11 +137,7 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 			// If not from env, show <redacted> as the value
 			var passwordSecretVar *schemas.SecretVar
 			if authConfig.AdminPassword != nil && authConfig.AdminPassword.IsFromSecret() {
-				passwordSecretVar = &schemas.SecretVar{
-					Val:        "<redacted>",
-					SecretRef:  authConfig.AdminPassword.SecretRef,
-					FromSecret: true,
-				}
+				passwordSecretVar = authConfig.AdminPassword.FullyRedacted()
 			} else {
 				passwordSecretVar = &schemas.SecretVar{
 					Val: "<redacted>",
@@ -695,11 +691,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 
 			// Validate env variables are set if referenced
 			if payload.AuthConfig.AdminUserName.IsFromSecret() && payload.AuthConfig.AdminUserName.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.SecretRef))
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.Ref()))
 				return
 			}
 			if payload.AuthConfig.AdminPassword.IsFromSecret() && payload.AuthConfig.AdminPassword.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.SecretRef))
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.Ref()))
 				return
 			}
 
@@ -726,10 +722,12 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 						return
 					}
 					// Preserve env/vault reference metadata when storing hashed password
-					payload.AuthConfig.AdminPassword = &schemas.SecretVar{
-						Val:        hashedPassword,
-						SecretRef:  payload.AuthConfig.AdminPassword.SecretRef,
-						FromSecret: payload.AuthConfig.AdminPassword.IsFromSecret(),
+					if payload.AuthConfig.AdminPassword.IsFromSecret() {
+						sv := *payload.AuthConfig.AdminPassword
+						sv.Val = hashedPassword
+						payload.AuthConfig.AdminPassword = &sv
+					} else {
+						payload.AuthConfig.AdminPassword = &schemas.SecretVar{Val: hashedPassword}
 					}
 				}
 			}

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -691,11 +691,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 
 			// Validate env variables are set if referenced
 			if payload.AuthConfig.AdminUserName.IsFromSecret() && payload.AuthConfig.AdminUserName.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.Ref()))
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.GetSecretRef()))
 				return
 			}
 			if payload.AuthConfig.AdminPassword.IsFromSecret() && payload.AuthConfig.AdminPassword.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.Ref()))
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.GetSecretRef()))
 				return
 			}
 

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -136,23 +136,15 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 			// If from env, preserve env_var reference but clear value
 			// If not from env, show <redacted> as the value
 			var passwordSecretVar *schemas.SecretVar
-			if authConfig.AdminPassword != nil && authConfig.AdminPassword.IsFromEnv() {
+			if authConfig.AdminPassword != nil && authConfig.AdminPassword.IsFromSecret() {
 				passwordSecretVar = &schemas.SecretVar{
-					Val:     "",
-					EnvVar:  authConfig.AdminPassword.EnvVar,
-					FromEnv: true,
-				}
-			} else if authConfig.AdminPassword != nil && authConfig.AdminPassword.IsFromVault() {
-				passwordSecretVar = &schemas.SecretVar{
-					Val:       "",
-					FromVault: true,
-					VaultRef:  authConfig.AdminPassword.VaultRef,
+					Val:        "<redacted>",
+					SecretRef:  authConfig.AdminPassword.SecretRef,
+					FromSecret: true,
 				}
 			} else {
 				passwordSecretVar = &schemas.SecretVar{
-					Val:     "<redacted>",
-					EnvVar:  "",
-					FromEnv: false,
+					Val: "<redacted>",
 				}
 			}
 			mapConfig["auth_config"] = map[string]any{
@@ -163,15 +155,15 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 		} else {
 			// No auth config exists yet, return default empty SecretVar values
 			mapConfig["auth_config"] = map[string]any{
-				"admin_username": &schemas.SecretVar{Val: "", EnvVar: "", FromEnv: false},
-				"admin_password": &schemas.SecretVar{Val: "", EnvVar: "", FromEnv: false},
+				"admin_username": &schemas.SecretVar{},
+				"admin_password": &schemas.SecretVar{},
 				"is_enabled":     false,
 			}
 		}
 	} else {
 		mapConfig["auth_config"] = map[string]any{
-			"admin_username": &schemas.SecretVar{Val: "", EnvVar: "", FromEnv: false},
-			"admin_password": &schemas.SecretVar{Val: "", EnvVar: "", FromEnv: false},
+			"admin_username": &schemas.SecretVar{},
+			"admin_password": &schemas.SecretVar{},
 			"is_enabled":     false,
 		}
 	}
@@ -702,20 +694,12 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			}
 
 			// Validate env variables are set if referenced
-			if (payload.AuthConfig.AdminUserName.IsFromEnv() || payload.AuthConfig.AdminUserName.IsFromVault()) && payload.AuthConfig.AdminUserName.GetValue() == "" {
-				ref := payload.AuthConfig.AdminUserName.EnvVar
-				if payload.AuthConfig.AdminUserName.IsFromVault() {
-					ref = payload.AuthConfig.AdminUserName.VaultRef
-				}
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", ref))
+			if payload.AuthConfig.AdminUserName.IsFromSecret() && payload.AuthConfig.AdminUserName.GetValue() == "" {
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.SecretRef))
 				return
 			}
-			if (payload.AuthConfig.AdminPassword.IsFromEnv() || payload.AuthConfig.AdminPassword.IsFromVault()) && payload.AuthConfig.AdminPassword.GetValue() == "" {
-				ref := payload.AuthConfig.AdminPassword.EnvVar
-				if payload.AuthConfig.AdminPassword.IsFromVault() {
-					ref = payload.AuthConfig.AdminPassword.VaultRef
-				}
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", ref))
+			if payload.AuthConfig.AdminPassword.IsFromSecret() && payload.AuthConfig.AdminPassword.GetValue() == "" {
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.SecretRef))
 				return
 			}
 
@@ -725,7 +709,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			}
 			// Fetching current Auth config
 			if payload.AuthConfig.AdminUserName.GetValue() != "" {
-				if payload.AuthConfig.AdminPassword.IsRedacted() {
+				if payload.AuthConfig.AdminPassword.ShouldPreserveStored() {
 					if authConfig == nil || authConfig.AdminPassword.GetValue() == "" {
 						SendError(ctx, fasthttp.StatusBadRequest, "auth password must be provided")
 						return
@@ -743,11 +727,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 					}
 					// Preserve env/vault reference metadata when storing hashed password
 					payload.AuthConfig.AdminPassword = &schemas.SecretVar{
-						Val:       hashedPassword,
-						FromEnv:   payload.AuthConfig.AdminPassword.IsFromEnv(),
-						EnvVar:    payload.AuthConfig.AdminPassword.EnvVar,
-						FromVault: payload.AuthConfig.AdminPassword.IsFromVault(),
-						VaultRef:  payload.AuthConfig.AdminPassword.VaultRef,
+						Val:        hashedPassword,
+						SecretRef:  payload.AuthConfig.AdminPassword.SecretRef,
+						FromSecret: payload.AuthConfig.AdminPassword.IsFromSecret(),
 					}
 				}
 			}
@@ -760,7 +742,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			}
 		} else if authConfig != nil {
 			// Auth is being disabled but there's an existing config - preserve credentials and update disabled state
-			if payload.AuthConfig.AdminPassword == nil || payload.AuthConfig.AdminPassword.IsRedacted() || payload.AuthConfig.AdminPassword.GetValue() == "" {
+			if payload.AuthConfig.AdminPassword.ShouldPreserveStored() {
 				payload.AuthConfig.AdminPassword = authConfig.AdminPassword
 			}
 			if payload.AuthConfig.AdminUserName == nil || payload.AuthConfig.AdminUserName.GetValue() == "" {

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -618,7 +618,7 @@ func restoreRedactedValue(incoming, existing any) any {
 		// left as-is so clearing a value works.
 		if existingStr, ok := existing.(string); ok {
 			secretVal := schemas.NewSecretVar(val)
-			if !secretVal.IsFromEnv() && !secretVal.IsFromVault() && secretVal.IsRedacted() {
+			if !secretVal.IsFromSecret() && secretVal.IsRedacted() {
 				return existingStr
 			}
 		}
@@ -632,15 +632,27 @@ func restoreRedactedValue(incoming, existing any) any {
 // keys "value", "env_var", and "from_env".
 func isSecretVarObject(m map[string]any) bool {
 	_, hasValue := m["value"]
-	_, hasSecretVar := m["env_var"]
+	_, hasSecretRef := m["secret_ref"]
+	_, hasFromSecret := m["from_secret"]
+	// also accept legacy env_var/from_env keys for backward compat
+	_, hasEnvVar := m["env_var"]
 	_, hasFromEnv := m["from_env"]
-	return hasValue && hasSecretVar && hasFromEnv
+	return hasValue && ((hasSecretRef && hasFromSecret) || (hasEnvVar && hasFromEnv))
 }
 
-// marshalSecretVarObject serialises an SecretVar-shaped map back to the JSON string that
+// marshalSecretVarObject serialises a SecretVar-shaped map back to the JSON string that
 // schemas.NewSecretVar expects so we can call ShouldPreserveStored on it.
 func marshalSecretVarObject(m map[string]any) string {
 	value, _ := m["value"].(string)
+	// new format
+	if secretRef, ok := m["secret_ref"].(string); ok {
+		fromSecret, _ := m["from_secret"].(bool)
+		if fromSecret {
+			return fmt.Sprintf(`{"value":%q,"secret_ref":%q,"from_secret":true}`, value, secretRef)
+		}
+		return fmt.Sprintf(`{"value":%q}`, value)
+	}
+	// backward compat: old env_var/from_env format
 	secretVar, _ := m["env_var"].(string)
 	fromEnv, _ := m["from_env"].(bool)
 	if fromEnv {

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -628,27 +628,25 @@ func restoreRedactedValue(incoming, existing any) any {
 	}
 }
 
-// isSecretVarObject returns true if m has exactly the shape of a serialised SecretVar:
-// keys "value", "env_var", and "from_env".
+// isSecretVarObject returns true if m has the shape of a serialised SecretVar.
 func isSecretVarObject(m map[string]any) bool {
 	_, hasValue := m["value"]
-	_, hasSecretRef := m["secret_ref"]
-	_, hasFromSecret := m["from_secret"]
-	// also accept legacy env_var/from_env keys for backward compat
+	_, hasSecretRef := m["ref"]
+	_, hasType := m["type"]
+	// shipped backward compat: env_var/from_env
 	_, hasEnvVar := m["env_var"]
 	_, hasFromEnv := m["from_env"]
-	return hasValue && ((hasSecretRef && hasFromSecret) || (hasEnvVar && hasFromEnv))
+	return hasValue && ((hasSecretRef && hasType) || (hasEnvVar && hasFromEnv))
 }
 
 // marshalSecretVarObject serialises a SecretVar-shaped map back to the JSON string that
 // schemas.NewSecretVar expects so we can call ShouldPreserveStored on it.
 func marshalSecretVarObject(m map[string]any) string {
 	value, _ := m["value"].(string)
-	// new format
-	if secretRef, ok := m["secret_ref"].(string); ok {
-		fromSecret, _ := m["from_secret"].(bool)
-		if fromSecret {
-			return fmt.Sprintf(`{"value":%q,"secret_ref":%q,"from_secret":true}`, value, secretRef)
+	if secretRef, ok := m["ref"].(string); ok {
+		secretType, _ := m["type"].(string)
+		if secretType != "" {
+			return fmt.Sprintf(`{"value":%q,"ref":%q,"type":%q}`, value, secretRef, secretType)
 		}
 		return fmt.Sprintf(`{"value":%q}`, value)
 	}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3693,10 +3693,10 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 	}
 	// Fail-closed: if env/vault reference is unresolved, don't persist empty credentials.
 	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && authConfig.AdminUserName.IsFromSecret() {
-		logger.Warn("username set with external reference but value is empty: %s", authConfig.AdminUserName.Ref())
+		logger.Warn("username set with external reference but value is empty: %s", authConfig.AdminUserName.GetSecretRef())
 	}
 	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && authConfig.AdminPassword.IsFromSecret() {
-		logger.Warn("password set with external reference but value is empty: %s", authConfig.AdminPassword.Ref())
+		logger.Warn("password set with external reference but value is empty: %s", authConfig.AdminPassword.GetSecretRef())
 	}
 	if authConfig.AdminPassword == nil || authConfig.AdminUserName == nil {
 		logger.Warn("auth config is missing admin_username or admin_password, skipping auth config processing")

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2257,7 +2257,7 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 					// If the value is an env/vault reference that is currently unresolved, leave the
 					// existing DB entry untouched rather than silently generating a new literal key.
 					vkVal := &configData.Governance.VirtualKeys[i].Value
-					if (vkVal.IsFromEnv() || vkVal.IsFromVault()) && vkVal.GetValue() == "" {
+					if vkVal.IsFromSecret() && vkVal.GetValue() == "" {
 						logger.Warn("virtual key %s has an unresolved env/vault reference, skipping update to preserve existing credential", newVirtualKey.ID)
 						break
 					}
@@ -2287,7 +2287,7 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 			// If the value is an env/vault reference that is currently unresolved, skip creating
 			// the entry. It will be created on the next sync once the reference resolves.
 			newVKVal := &configData.Governance.VirtualKeys[i].Value
-			if (newVKVal.IsFromEnv() || newVKVal.IsFromVault()) && newVKVal.GetValue() == "" {
+			if newVKVal.IsFromSecret() && newVKVal.GetValue() == "" {
 				logger.Warn("virtual key %s has an unresolved env/vault reference, skipping creation until reference resolves", newVirtualKey.ID)
 				continue
 			}
@@ -3644,9 +3644,9 @@ func preserveSecretVar(source *schemas.SecretVar, value string) *schemas.SecretV
 		return schemas.NewSecretVar(value)
 	}
 	return &schemas.SecretVar{
-		Val:     value,
-		EnvVar:  source.EnvVar,
-		FromEnv: source.FromEnv,
+		Val:        value,
+		SecretRef:  source.SecretRef,
+		FromSecret: source.IsFromSecret(),
 	}
 }
 
@@ -3690,20 +3690,20 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 	if authConfig == nil {
 		return
 	}
-	// File config present: warn about empty env/vault references but continue processing
-	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && (authConfig.AdminUserName.IsFromEnv() || authConfig.AdminUserName.IsFromVault()) {
-		ref := authConfig.AdminUserName.EnvVar
-		if authConfig.AdminUserName.IsFromVault() {
-			ref = authConfig.AdminUserName.VaultRef
+	// Fail-closed: if env/vault reference is unresolved, don't persist empty credentials.
+	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && authConfig.AdminUserName.IsFromSecret() {
+		logger.Warn("username set with external reference but value is empty: %s — skipping auth config", authConfig.AdminUserName.SecretRef)
+		if dbAuthConfig != nil {
+			config.GovernanceConfig.AuthConfig = dbAuthConfig
 		}
-		logger.Warn("username set with external reference but value is empty: %s", ref)
+		return
 	}
-	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && (authConfig.AdminPassword.IsFromEnv() || authConfig.AdminPassword.IsFromVault()) {
-		ref := authConfig.AdminPassword.EnvVar
-		if authConfig.AdminPassword.IsFromVault() {
-			ref = authConfig.AdminPassword.VaultRef
+	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && authConfig.AdminPassword.IsFromSecret() {
+		logger.Warn("password set with external reference but value is empty: %s — skipping auth config", authConfig.AdminPassword.SecretRef)
+		if dbAuthConfig != nil {
+			config.GovernanceConfig.AuthConfig = dbAuthConfig
 		}
-		logger.Warn("password set with external reference but value is empty: %s", ref)
+		return
 	}
 	if authConfig.AdminPassword == nil || authConfig.AdminUserName == nil {
 		logger.Warn("auth config is missing admin_username or admin_password, skipping auth config processing")

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -164,7 +164,7 @@ type ConfigData struct {
 	Server        *ServerConfig             `json:"server,omitempty"`
 	SourceOfTruth string                    `json:"source_of_truth,omitempty"`
 	Client        *configstore.ClientConfig `json:"client"`
-	EncryptionKey *schemas.SecretVar           `json:"encryption_key"`
+	EncryptionKey *schemas.SecretVar        `json:"encryption_key"`
 	// Deprecated: Use GovernanceConfig.AuthConfig instead
 	AuthConfig        *configstore.AuthConfig               `json:"auth_config,omitempty"`
 	Providers         map[string]configstore.ProviderConfig `json:"providers"`
@@ -378,7 +378,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 		FrameworkConfig   json.RawMessage                       `json:"framework,omitempty"`
 		Server            *ServerConfig                         `json:"server,omitempty"`
 		Client            *configstore.ClientConfig             `json:"client"`
-		EncryptionKey     *schemas.SecretVar                       `json:"encryption_key"`
+		EncryptionKey     *schemas.SecretVar                    `json:"encryption_key"`
 		AuthConfig        *configstore.AuthConfig               `json:"auth_config,omitempty"`
 		Providers         map[string]configstore.ProviderConfig `json:"providers"`
 		MCP               *schemas.MCPConfig                    `json:"mcp,omitempty"`
@@ -3693,10 +3693,10 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 	}
 	// Fail-closed: if env/vault reference is unresolved, don't persist empty credentials.
 	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && authConfig.AdminUserName.IsFromSecret() {
-		logger.Warn("username set with external reference but value is empty: %s", authConfig.AdminUserName.GetSecretRef())
+		logger.Warn("username set with external reference but value is empty: %s", authConfig.AdminUserName.GetRawRef())
 	}
 	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && authConfig.AdminPassword.IsFromSecret() {
-		logger.Warn("password set with external reference but value is empty: %s", authConfig.AdminPassword.GetSecretRef())
+		logger.Warn("password set with external reference but value is empty: %s", authConfig.AdminPassword.GetRawRef())
 	}
 	if authConfig.AdminPassword == nil || authConfig.AdminUserName == nil {
 		logger.Warn("auth config is missing admin_username or admin_password, skipping auth config processing")

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3643,11 +3643,12 @@ func preserveSecretVar(source *schemas.SecretVar, value string) *schemas.SecretV
 	if source == nil {
 		return schemas.NewSecretVar(value)
 	}
-	return &schemas.SecretVar{
-		Val:        value,
-		SecretRef:  source.SecretRef,
-		FromSecret: source.IsFromSecret(),
+	if source.IsFromSecret() {
+		sv := *source
+		sv.Val = value
+		return &sv
 	}
+	return &schemas.SecretVar{Val: value}
 }
 
 // loadAuthConfig loads auth config from file.
@@ -3692,18 +3693,10 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 	}
 	// Fail-closed: if env/vault reference is unresolved, don't persist empty credentials.
 	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && authConfig.AdminUserName.IsFromSecret() {
-		logger.Warn("username set with external reference but value is empty: %s — skipping auth config", authConfig.AdminUserName.SecretRef)
-		if dbAuthConfig != nil {
-			config.GovernanceConfig.AuthConfig = dbAuthConfig
-		}
-		return
+		logger.Warn("username set with external reference but value is empty: %s", authConfig.AdminUserName.Ref())
 	}
 	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && authConfig.AdminPassword.IsFromSecret() {
-		logger.Warn("password set with external reference but value is empty: %s — skipping auth config", authConfig.AdminPassword.SecretRef)
-		if dbAuthConfig != nil {
-			config.GovernanceConfig.AuthConfig = dbAuthConfig
-		}
-		return
+		logger.Warn("password set with external reference but value is empty: %s", authConfig.AdminPassword.Ref())
 	}
 	if authConfig.AdminPassword == nil || authConfig.AdminUserName == nil {
 		logger.Warn("auth config is missing admin_username or admin_password, skipping auth config processing")

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3690,12 +3690,20 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 	if authConfig == nil {
 		return
 	}
-	// File config present: warn about empty env vars but continue processing
-	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && authConfig.AdminUserName.IsFromEnv() {
-		logger.Warn("username set with env var but value is empty: %s", authConfig.AdminUserName.EnvVar)
+	// File config present: warn about empty env/vault references but continue processing
+	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && (authConfig.AdminUserName.IsFromEnv() || authConfig.AdminUserName.IsFromVault()) {
+		ref := authConfig.AdminUserName.EnvVar
+		if authConfig.AdminUserName.IsFromVault() {
+			ref = authConfig.AdminUserName.VaultRef
+		}
+		logger.Warn("username set with external reference but value is empty: %s", ref)
 	}
-	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && authConfig.AdminPassword.IsFromEnv() {
-		logger.Warn("password set with env var but value is empty: %s", authConfig.AdminPassword.EnvVar)
+	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && (authConfig.AdminPassword.IsFromEnv() || authConfig.AdminPassword.IsFromVault()) {
+		ref := authConfig.AdminPassword.EnvVar
+		if authConfig.AdminPassword.IsFromVault() {
+			ref = authConfig.AdminPassword.VaultRef
+		}
+		logger.Warn("password set with external reference but value is empty: %s", ref)
 	}
 	if authConfig.AdminPassword == nil || authConfig.AdminUserName == nil {
 		logger.Warn("auth config is missing admin_username or admin_password, skipping auth config processing")

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -4536,8 +4536,8 @@ func TestProviderHashComparison_ProviderChangedKeysUnchanged(t *testing.T) {
 		ID:     "key-1",
 		Name:   "openai-key",
 		Value:  *schemas.NewSecretVar("sk-original-123"), // SAME
-		Models: []string{"gpt-4", "gpt-3.5-turbo"},    // SAME
-		Weight: 1.5,                                   // SAME
+		Models: []string{"gpt-4", "gpt-3.5-turbo"},       // SAME
+		Weight: 1.5,                                      // SAME
 	}
 	sameKeyHash, _ := configstore.GenerateKeyHash(sameKey)
 
@@ -4634,7 +4634,7 @@ func TestProviderHashComparison_KeysChangedProviderUnchanged(t *testing.T) {
 	changedKey := schemas.Key{
 		ID:     "key-1",
 		Name:   "openai-key",
-		Value:  *schemas.NewSecretVar("sk-new-456"),         // CHANGED!
+		Value:  *schemas.NewSecretVar("sk-new-456"),      // CHANGED!
 		Models: []string{"gpt-4", "gpt-3.5-turbo", "o1"}, // CHANGED!
 		Weight: 2.0,                                      // CHANGED!
 	}
@@ -4735,8 +4735,8 @@ func TestProviderHashComparison_BothChangedIndependently(t *testing.T) {
 		ID:     "key-1",
 		Name:   "openai-key",
 		Value:  *schemas.NewSecretVar("sk-new-456"), // CHANGED
-		Models: []string{"gpt-4", "o1"},          // CHANGED
-		Weight: 2.0,                              // CHANGED
+		Models: []string{"gpt-4", "o1"},             // CHANGED
+		Weight: 2.0,                                 // CHANGED
 	}
 	changedKeyHash, _ := configstore.GenerateKeyHash(changedKey)
 
@@ -4817,8 +4817,8 @@ func TestProviderHashComparison_NeitherChanged(t *testing.T) {
 		ID:     "key-1",
 		Name:   "openai-key",
 		Value:  *schemas.NewSecretVar("sk-original-123"), // SAME
-		Models: []string{"gpt-4"},                     // SAME
-		Weight: 1.0,                                   // SAME
+		Models: []string{"gpt-4"},                        // SAME
+		Weight: 1.0,                                      // SAME
 	}
 	sameKeyHash, _ := configstore.GenerateKeyHash(sameKey)
 
@@ -4887,8 +4887,8 @@ func TestKeyLevelSync_ProviderHashMatch_SingleKeyChanged(t *testing.T) {
 		ID:     "key-1",
 		Name:   "openai-key",
 		Value:  *schemas.NewSecretVar("sk-new-value"), // CHANGED
-		Models: []string{"gpt-4", "gpt-4-turbo"},   // CHANGED
-		Weight: 2.0,                                // CHANGED
+		Models: []string{"gpt-4", "gpt-4-turbo"},      // CHANGED
+		Weight: 2.0,                                   // CHANGED
 	}
 	fileKeyHash, _ := configstore.GenerateKeyHash(fileKey)
 
@@ -5000,8 +5000,8 @@ func TestKeyLevelSync_ProviderHashMatch_NewKeyInFile(t *testing.T) {
 		ID:     "key-1",
 		Name:   "openai-key-1",
 		Value:  *schemas.NewSecretVar("sk-key-1"), // SAME
-		Models: []string{"gpt-4"},              // SAME
-		Weight: 1.0,                            // SAME
+		Models: []string{"gpt-4"},                 // SAME
+		Weight: 1.0,                               // SAME
 	}
 	newFileKey := schemas.Key{
 		ID:     "key-2",
@@ -5129,8 +5129,8 @@ func TestKeyLevelSync_ProviderHashMatch_KeyOnlyInDB(t *testing.T) {
 		ID:     "key-1",
 		Name:   "openai-key-1",
 		Value:  *schemas.NewSecretVar("sk-key-1"), // SAME
-		Models: []string{"gpt-4"},              // SAME
-		Weight: 1.0,                            // SAME
+		Models: []string{"gpt-4"},                 // SAME
+		Weight: 1.0,                               // SAME
 	}
 
 	fileConfig := configstore.ProviderConfig{
@@ -5254,15 +5254,15 @@ func TestKeyLevelSync_ProviderHashMatch_MixedScenario(t *testing.T) {
 		ID:     "key-unchanged",
 		Name:   "unchanged-key",
 		Value:  *schemas.NewSecretVar("sk-unchanged"), // SAME
-		Models: []string{"gpt-4"},                  // SAME
-		Weight: 1.0,                                // SAME
+		Models: []string{"gpt-4"},                     // SAME
+		Weight: 1.0,                                   // SAME
 	}
 	fileChangedKey := schemas.Key{
 		ID:     "key-changed",
 		Name:   "changed-key",
 		Value:  *schemas.NewSecretVar("sk-NEW-value"), // CHANGED
-		Models: []string{"gpt-4", "gpt-4-turbo"},   // CHANGED
-		Weight: 2.0,                                // CHANGED
+		Models: []string{"gpt-4", "gpt-4-turbo"},      // CHANGED
+		Weight: 2.0,                                   // CHANGED
 	}
 	newFileKey := schemas.Key{
 		ID:     "key-new",
@@ -17703,7 +17703,7 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 		// Verify username was resolved from env
 		require.Equal(t, "envadmin", storedAuth.AdminUserName.GetValue(), "username should be resolved from env variable")
 		require.True(t, storedAuth.AdminUserName.IsFromSecret(), "username should be marked as from env")
-		require.Equal(t, "env.TEST_ADMIN_USERNAME", storedAuth.AdminUserName.GetSecretRef(), "env var reference should be preserved")
+		require.Equal(t, "env.TEST_ADMIN_USERNAME", storedAuth.AdminUserName.GetRawRef(), "env var reference should be preserved")
 
 		// Verify password was hashed
 		require.True(t, isBcryptHash(storedAuth.AdminPassword.GetValue()), "password should be hashed")
@@ -17737,7 +17737,7 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 
 		// Verify env var reference is preserved after hashing
 		require.True(t, storedAuth.AdminPassword.IsFromSecret(), "password should still be marked as from env after hashing")
-		require.Equal(t, "env.TEST_ADMIN_PASSWORD", storedAuth.AdminPassword.GetSecretRef(), "password env var reference should be preserved")
+		require.Equal(t, "env.TEST_ADMIN_PASSWORD", storedAuth.AdminPassword.GetRawRef(), "password env var reference should be preserved")
 	})
 
 	t.Run("both username and password from env variables", func(t *testing.T) {
@@ -17773,7 +17773,7 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 
 		// Verify env var reference is preserved after hashing
 		require.True(t, storedAuth.AdminPassword.IsFromSecret(), "password should still be marked as from env after hashing")
-		require.Equal(t, "env.TEST_ADMIN_PASS", storedAuth.AdminPassword.GetSecretRef(), "password env var reference should be preserved")
+		require.Equal(t, "env.TEST_ADMIN_PASS", storedAuth.AdminPassword.GetRawRef(), "password env var reference should be preserved")
 	})
 
 	t.Run("env variable not set results in empty value", func(t *testing.T) {
@@ -17799,12 +17799,12 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 		// Verify username is empty but env var reference is preserved
 		require.Equal(t, "", storedAuth.AdminUserName.GetValue(), "username should be empty when env var not set")
 		require.True(t, storedAuth.AdminUserName.IsFromSecret(), "username should be marked as from env")
-		require.Equal(t, "env.NONEXISTENT_USERNAME", storedAuth.AdminUserName.GetSecretRef(), "env var reference should be preserved")
+		require.Equal(t, "env.NONEXISTENT_USERNAME", storedAuth.AdminUserName.GetRawRef(), "env var reference should be preserved")
 
 		// Verify password is empty (not hashed since empty)
 		require.Equal(t, "", storedAuth.AdminPassword.GetValue(), "password should be empty when env var not set")
 		require.True(t, storedAuth.AdminPassword.IsFromSecret(), "password should be marked as from env")
-		require.Equal(t, "env.NONEXISTENT_PASSWORD", storedAuth.AdminPassword.GetSecretRef(), "env var reference should be preserved")
+		require.Equal(t, "env.NONEXISTENT_PASSWORD", storedAuth.AdminPassword.GetRawRef(), "env var reference should be preserved")
 	})
 
 	t.Run("password change flushes existing sessions", func(t *testing.T) {

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -17702,8 +17702,8 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 
 		// Verify username was resolved from env
 		require.Equal(t, "envadmin", storedAuth.AdminUserName.GetValue(), "username should be resolved from env variable")
-		require.True(t, storedAuth.AdminUserName.IsFromEnv(), "username should be marked as from env")
-		require.Equal(t, "env.TEST_ADMIN_USERNAME", storedAuth.AdminUserName.EnvVar, "env var reference should be preserved")
+		require.True(t, storedAuth.AdminUserName.IsFromSecret(), "username should be marked as from env")
+		require.Equal(t, "env.TEST_ADMIN_USERNAME", storedAuth.AdminUserName.GetSecretRef(), "env var reference should be preserved")
 
 		// Verify password was hashed
 		require.True(t, isBcryptHash(storedAuth.AdminPassword.GetValue()), "password should be hashed")
@@ -17736,8 +17736,8 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 		require.True(t, match, "hashed password should match the env variable value")
 
 		// Verify env var reference is preserved after hashing
-		require.True(t, storedAuth.AdminPassword.IsFromEnv(), "password should still be marked as from env after hashing")
-		require.Equal(t, "env.TEST_ADMIN_PASSWORD", storedAuth.AdminPassword.EnvVar, "password env var reference should be preserved")
+		require.True(t, storedAuth.AdminPassword.IsFromSecret(), "password should still be marked as from env after hashing")
+		require.Equal(t, "env.TEST_ADMIN_PASSWORD", storedAuth.AdminPassword.GetSecretRef(), "password env var reference should be preserved")
 	})
 
 	t.Run("both username and password from env variables", func(t *testing.T) {
@@ -17763,7 +17763,7 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 
 		// Verify username was resolved from env
 		require.Equal(t, "envuser", storedAuth.AdminUserName.GetValue(), "username should be resolved from env variable")
-		require.True(t, storedAuth.AdminUserName.IsFromEnv(), "username should be marked as from env")
+		require.True(t, storedAuth.AdminUserName.IsFromSecret(), "username should be marked as from env")
 
 		// Verify password was resolved from env and hashed
 		require.True(t, isBcryptHash(storedAuth.AdminPassword.GetValue()), "password should be a bcrypt hash")
@@ -17772,8 +17772,8 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 		require.True(t, match, "hashed password should match the env variable value")
 
 		// Verify env var reference is preserved after hashing
-		require.True(t, storedAuth.AdminPassword.IsFromEnv(), "password should still be marked as from env after hashing")
-		require.Equal(t, "env.TEST_ADMIN_PASS", storedAuth.AdminPassword.EnvVar, "password env var reference should be preserved")
+		require.True(t, storedAuth.AdminPassword.IsFromSecret(), "password should still be marked as from env after hashing")
+		require.Equal(t, "env.TEST_ADMIN_PASS", storedAuth.AdminPassword.GetSecretRef(), "password env var reference should be preserved")
 	})
 
 	t.Run("env variable not set results in empty value", func(t *testing.T) {
@@ -17798,13 +17798,13 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 
 		// Verify username is empty but env var reference is preserved
 		require.Equal(t, "", storedAuth.AdminUserName.GetValue(), "username should be empty when env var not set")
-		require.True(t, storedAuth.AdminUserName.IsFromEnv(), "username should be marked as from env")
-		require.Equal(t, "env.NONEXISTENT_USERNAME", storedAuth.AdminUserName.EnvVar, "env var reference should be preserved")
+		require.True(t, storedAuth.AdminUserName.IsFromSecret(), "username should be marked as from env")
+		require.Equal(t, "env.NONEXISTENT_USERNAME", storedAuth.AdminUserName.GetSecretRef(), "env var reference should be preserved")
 
 		// Verify password is empty (not hashed since empty)
 		require.Equal(t, "", storedAuth.AdminPassword.GetValue(), "password should be empty when env var not set")
-		require.True(t, storedAuth.AdminPassword.IsFromEnv(), "password should be marked as from env")
-		require.Equal(t, "env.NONEXISTENT_PASSWORD", storedAuth.AdminPassword.EnvVar, "env var reference should be preserved")
+		require.True(t, storedAuth.AdminPassword.IsFromSecret(), "password should be marked as from env")
+		require.Equal(t, "env.NONEXISTENT_PASSWORD", storedAuth.AdminPassword.GetSecretRef(), "env var reference should be preserved")
 	})
 
 	t.Run("password change flushes existing sessions", func(t *testing.T) {

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -532,7 +532,7 @@ func TestConvertToBifrostContext_DirectKey_EnvPrefixNotResolved(t *testing.T) {
 	if key.Value.GetValue() != "env.SOME_SECRET" {
 		t.Errorf("direct key value = %q, want literal %q (must not resolve env vars)", key.Value.GetValue(), "env.SOME_SECRET")
 	}
-	if key.Value.IsFromEnv() {
-		t.Error("direct key must not be marked as from-env")
+	if key.Value.IsFromSecret() {
+		t.Error("direct key must not be marked as from-secret")
 	}
 }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -265,8 +265,8 @@
               "type": "object",
               "properties": {
                 "value": { "type": "string" },
-                "secret_ref": { "type": "string" },
-                "from_secret": { "type": "boolean" },
+                "ref": { "type": "string" },
+                "type": { "type": "string", "enum": ["plain_text", "env", "vault"] },
                 "env_var": { "type": "string" },
                 "from_env": { "type": "boolean" }
               },

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -265,6 +265,8 @@
               "type": "object",
               "properties": {
                 "value": { "type": "string" },
+                "secret_ref": { "type": "string" },
+                "from_secret": { "type": "boolean" },
                 "env_var": { "type": "string" },
                 "from_env": { "type": "boolean" }
               },

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -30,8 +30,8 @@ import { toast } from "sonner";
 
 const secretVarEquals = (a?: SecretVar, b?: SecretVar) =>
   (a?.value ?? "") === (b?.value ?? "") &&
-  (a?.secret_ref ?? "") === (b?.secret_ref ?? "") &&
-  (a?.from_secret ?? false) === (b?.from_secret ?? false);
+  (a?.ref ?? "") === (b?.ref ?? "") &&
+  (a?.type ?? "plain_text") === (b?.type ?? "plain_text");
 
 export default function MCPView() {
   const hasSettingsUpdateAccess = useRbac(

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -30,10 +30,8 @@ import { toast } from "sonner";
 
 const secretVarEquals = (a?: SecretVar, b?: SecretVar) =>
   (a?.value ?? "") === (b?.value ?? "") &&
-  (a?.env_var ?? "") === (b?.env_var ?? "") &&
-  (a?.from_env ?? false) === (b?.from_env ?? false) &&
-  (a?.vault_var ?? "") === (b?.vault_var ?? "") &&
-  (a?.from_vault ?? false) === (b?.from_vault ?? false);
+  (a?.secret_ref ?? "") === (b?.secret_ref ?? "") &&
+  (a?.from_secret ?? false) === (b?.from_secret ?? false);
 
 export default function MCPView() {
   const hasSettingsUpdateAccess = useRbac(

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -39,8 +39,8 @@ export default function SecurityView() {
 	});
 
 	const [authConfig, setAuthConfig] = useState<AuthConfig>({
-		admin_username: { value: "", env_var: "", from_env: false },
-		admin_password: { value: "", env_var: "", from_env: false },
+		admin_username: { value: "", secret_ref: "", from_secret: false },
+		admin_password: { value: "", secret_ref: "", from_secret: false },
 		is_enabled: false,
 	});
 
@@ -71,12 +71,12 @@ export default function SecurityView() {
 
 		const usernameChanged =
 			authConfig.admin_username?.value !== bifrostConfig?.auth_config?.admin_username?.value ||
-			authConfig.admin_username?.env_var !== bifrostConfig?.auth_config?.admin_username?.env_var ||
-			authConfig.admin_username?.from_env !== bifrostConfig?.auth_config?.admin_username?.from_env;
+			authConfig.admin_username?.secret_ref !== bifrostConfig?.auth_config?.admin_username?.secret_ref ||
+			authConfig.admin_username?.from_secret !== bifrostConfig?.auth_config?.admin_username?.from_secret;
 		const passwordChanged =
 			authConfig.admin_password?.value !== bifrostConfig?.auth_config?.admin_password?.value ||
-			authConfig.admin_password?.env_var !== bifrostConfig?.auth_config?.admin_password?.env_var ||
-			authConfig.admin_password?.from_env !== bifrostConfig?.auth_config?.admin_password?.from_env;
+			authConfig.admin_password?.secret_ref !== bifrostConfig?.auth_config?.admin_password?.secret_ref ||
+			authConfig.admin_password?.from_secret !== bifrostConfig?.auth_config?.admin_password?.from_secret;
 		const authChanged = showPasswordSection
 			? authConfig.is_enabled !== bifrostConfig?.auth_config?.is_enabled || usernameChanged || passwordChanged
 			: false;
@@ -153,8 +153,8 @@ export default function SecurityView() {
 				);
 				return;
 			}
-			const hasUsername = authConfig.admin_username?.value || authConfig.admin_username?.env_var;
-			const hasPassword = authConfig.admin_password?.value || authConfig.admin_password?.env_var;
+			const hasUsername = authConfig.admin_username?.value || authConfig.admin_username?.secret_ref;
+			const hasPassword = authConfig.admin_password?.value || authConfig.admin_password?.secret_ref;
 			await updateCoreConfig({
 				...bifrostConfig!,
 				client_config: localConfig,

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -39,8 +39,8 @@ export default function SecurityView() {
 	});
 
 	const [authConfig, setAuthConfig] = useState<AuthConfig>({
-		admin_username: { value: "", secret_ref: "", from_secret: false },
-		admin_password: { value: "", secret_ref: "", from_secret: false },
+		admin_username: { value: "", ref: "" },
+		admin_password: { value: "", ref: "" },
 		is_enabled: false,
 	});
 
@@ -71,12 +71,12 @@ export default function SecurityView() {
 
 		const usernameChanged =
 			authConfig.admin_username?.value !== bifrostConfig?.auth_config?.admin_username?.value ||
-			authConfig.admin_username?.secret_ref !== bifrostConfig?.auth_config?.admin_username?.secret_ref ||
-			authConfig.admin_username?.from_secret !== bifrostConfig?.auth_config?.admin_username?.from_secret;
+			authConfig.admin_username?.ref !== bifrostConfig?.auth_config?.admin_username?.ref ||
+			authConfig.admin_username?.type !== bifrostConfig?.auth_config?.admin_username?.type;
 		const passwordChanged =
 			authConfig.admin_password?.value !== bifrostConfig?.auth_config?.admin_password?.value ||
-			authConfig.admin_password?.secret_ref !== bifrostConfig?.auth_config?.admin_password?.secret_ref ||
-			authConfig.admin_password?.from_secret !== bifrostConfig?.auth_config?.admin_password?.from_secret;
+			authConfig.admin_password?.ref !== bifrostConfig?.auth_config?.admin_password?.ref ||
+			authConfig.admin_password?.type !== bifrostConfig?.auth_config?.admin_password?.type;
 		const authChanged = showPasswordSection
 			? authConfig.is_enabled !== bifrostConfig?.auth_config?.is_enabled || usernameChanged || passwordChanged
 			: false;
@@ -153,8 +153,8 @@ export default function SecurityView() {
 				);
 				return;
 			}
-			const hasUsername = authConfig.admin_username?.value || authConfig.admin_username?.secret_ref;
-			const hasPassword = authConfig.admin_password?.value || authConfig.admin_password?.secret_ref;
+			const hasUsername = authConfig.admin_username?.value || authConfig.admin_username?.ref;
+			const hasPassword = authConfig.admin_password?.value || authConfig.admin_password?.ref;
 			await updateCoreConfig({
 				...bifrostConfig!,
 				client_config: localConfig,

--- a/ui/app/workspace/mcp-registry/library/page.tsx
+++ b/ui/app/workspace/mcp-registry/library/page.tsx
@@ -120,7 +120,7 @@ export default function MCPLibraryPage() {
 				.filter((server) =>
 					clients.some((client) => {
 						const connectionString = client.config.connection_string;
-						const connectionUrl = connectionString?.from_secret ? connectionString.secret_ref : connectionString?.value;
+						const connectionUrl = (connectionString?.type === "env" || connectionString?.type === "vault") ? connectionString.ref : connectionString?.value;
 						return (
 							(server.connection_url && connectionUrl === server.connection_url) ||
 							client.config.name.toLowerCase() === sanitizeServerName(server.name).toLowerCase()

--- a/ui/app/workspace/mcp-registry/library/page.tsx
+++ b/ui/app/workspace/mcp-registry/library/page.tsx
@@ -120,7 +120,7 @@ export default function MCPLibraryPage() {
 				.filter((server) =>
 					clients.some((client) => {
 						const connectionString = client.config.connection_string;
-						const connectionUrl = connectionString?.from_env ? connectionString.env_var : connectionString?.value;
+						const connectionUrl = connectionString?.from_secret ? connectionString.secret_ref : connectionString?.value;
 						return (
 							(server.connection_url && connectionUrl === server.connection_url) ||
 							client.config.name.toLowerCase() === sanitizeServerName(server.name).toLowerCase()

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
@@ -31,13 +31,13 @@ interface MCPLibraryInstallSheetProps {
 	onInstalled: () => void;
 }
 
-const emptySecretVar: SecretVar = { value: "", env_var: "", from_env: false };
+const emptySecretVar: SecretVar = { value: "", secret_ref: "", from_secret: false };
 
 /** Strips empty TLS config so we don't send `{}` to the server. */
 function buildTLSConfigPayload(tls: MCPTLSConfig | undefined): MCPTLSConfig | undefined {
 	if (!tls) return undefined;
 	const hasSkipVerify = tls.insecure_skip_verify === true;
-	const hasCACert = tls.ca_cert_pem?.value || tls.ca_cert_pem?.from_env;
+	const hasCACert = tls.ca_cert_pem?.value?.trim() || tls.ca_cert_pem?.secret_ref?.trim();
 	if (!hasSkipVerify && !hasCACert) return undefined;
 	return { insecure_skip_verify: tls.insecure_skip_verify, ca_cert_pem: hasCACert ? tls.ca_cert_pem : undefined };
 }
@@ -65,10 +65,10 @@ function buildInitialValues(server: MCPLibraryEntry): CreateMCPClientRequest {
 		is_code_mode_client: false,
 		is_ping_available: true,
 		connection_type: server.connection_type || "http",
-		connection_string: isStdio ? undefined : server.connection_url ? { value: server.connection_url, env_var: "", from_env: false } : emptySecretVar,
+		connection_string: isStdio ? undefined : server.connection_url ? { value: server.connection_url, secret_ref: "", from_secret: false } : emptySecretVar,
 		stdio_config: isStdio && server.stdio_config ? server.stdio_config : undefined,
 		auth_type: authType,
-		headers: authType === "headers" ? { Authorization: { value: "", env_var: "", from_env: false } } : undefined,
+		headers: authType === "headers" ? { Authorization: { value: "", secret_ref: "", from_secret: false } } : undefined,
 	};
 }
 
@@ -180,7 +180,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 		}
 		setValue("auth_type", authScope === "per_user" ? "per_user_headers" : "headers");
 		setValue("oauth_config", undefined);
-		setValue("headers", { Authorization: { value: "", env_var: "", from_env: false } });
+		setValue("headers", { Authorization: { value: "", secret_ref: "", from_secret: false } });
 	};
 
 	const applyAuthScope = (scope: "shared" | "per_user") => {
@@ -218,7 +218,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 	const headersValidationError = useMemo(() => {
 		if ((authType !== "headers" && authType !== "per_user_headers") || !headers) return null;
 		for (const [key, secretVar] of Object.entries(headers)) {
-			if (!secretVar.value && !secretVar.env_var) {
+			if (!secretVar.value && !secretVar.secret_ref) {
 				return `Header "${key}" must have a value`;
 			}
 		}
@@ -288,7 +288,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 		const payload: CreateMCPClientRequest = {
 			...data,
 			connection_type: server.connection_type || "http",
-			connection_string: isStdio ? undefined : { value: connectionUrl, env_var: "", from_env: false },
+			connection_string: isStdio ? undefined : { value: connectionUrl, secret_ref: "", from_secret: false },
 			stdio_config: stdioConfig,
 			is_code_mode_client: false,
 			is_ping_available: true,
@@ -298,7 +298,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 					? {
 						client_id: data.oauth_config?.client_id ?? emptySecretVar,
 						client_secret:
-							data.oauth_config?.client_secret?.value || data.oauth_config?.client_secret?.from_env
+							data.oauth_config?.client_secret?.value?.trim() || data.oauth_config?.client_secret?.secret_ref?.trim()
 								? data.oauth_config.client_secret
 								: undefined,
 						authorize_url: data.oauth_config?.authorize_url || undefined,

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
@@ -31,13 +31,13 @@ interface MCPLibraryInstallSheetProps {
 	onInstalled: () => void;
 }
 
-const emptySecretVar: SecretVar = { value: "", secret_ref: "", from_secret: false };
+const emptySecretVar: SecretVar = { value: "", ref: "" };
 
 /** Strips empty TLS config so we don't send `{}` to the server. */
 function buildTLSConfigPayload(tls: MCPTLSConfig | undefined): MCPTLSConfig | undefined {
 	if (!tls) return undefined;
 	const hasSkipVerify = tls.insecure_skip_verify === true;
-	const hasCACert = tls.ca_cert_pem?.value?.trim() || tls.ca_cert_pem?.secret_ref?.trim();
+	const hasCACert = tls.ca_cert_pem?.value?.trim() || tls.ca_cert_pem?.ref?.trim();
 	if (!hasSkipVerify && !hasCACert) return undefined;
 	return { insecure_skip_verify: tls.insecure_skip_verify, ca_cert_pem: hasCACert ? tls.ca_cert_pem : undefined };
 }
@@ -65,10 +65,10 @@ function buildInitialValues(server: MCPLibraryEntry): CreateMCPClientRequest {
 		is_code_mode_client: false,
 		is_ping_available: true,
 		connection_type: server.connection_type || "http",
-		connection_string: isStdio ? undefined : server.connection_url ? { value: server.connection_url, secret_ref: "", from_secret: false } : emptySecretVar,
+		connection_string: isStdio ? undefined : server.connection_url ? { value: server.connection_url, ref: "" } : emptySecretVar,
 		stdio_config: isStdio && server.stdio_config ? server.stdio_config : undefined,
 		auth_type: authType,
-		headers: authType === "headers" ? { Authorization: { value: "", secret_ref: "", from_secret: false } } : undefined,
+		headers: authType === "headers" ? { Authorization: { value: "", ref: "" } } : undefined,
 	};
 }
 
@@ -180,7 +180,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 		}
 		setValue("auth_type", authScope === "per_user" ? "per_user_headers" : "headers");
 		setValue("oauth_config", undefined);
-		setValue("headers", { Authorization: { value: "", secret_ref: "", from_secret: false } });
+		setValue("headers", { Authorization: { value: "", ref: "" } });
 	};
 
 	const applyAuthScope = (scope: "shared" | "per_user") => {
@@ -218,7 +218,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 	const headersValidationError = useMemo(() => {
 		if ((authType !== "headers" && authType !== "per_user_headers") || !headers) return null;
 		for (const [key, secretVar] of Object.entries(headers)) {
-			if (!secretVar.value && !secretVar.secret_ref) {
+			if (!secretVar.value && !secretVar.ref) {
 				return `Header "${key}" must have a value`;
 			}
 		}
@@ -288,7 +288,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 		const payload: CreateMCPClientRequest = {
 			...data,
 			connection_type: server.connection_type || "http",
-			connection_string: isStdio ? undefined : { value: connectionUrl, secret_ref: "", from_secret: false },
+			connection_string: isStdio ? undefined : { value: connectionUrl, ref: "" },
 			stdio_config: stdioConfig,
 			is_code_mode_client: false,
 			is_ping_available: true,
@@ -298,7 +298,7 @@ export function MCPLibraryInstallSheet({ server, open, onClose, onInstalled }: M
 					? {
 						client_id: data.oauth_config?.client_id ?? emptySecretVar,
 						client_secret:
-							data.oauth_config?.client_secret?.value?.trim() || data.oauth_config?.client_secret?.secret_ref?.trim()
+							data.oauth_config?.client_secret?.value?.trim() || data.oauth_config?.client_secret?.ref?.trim()
 								? data.oauth_config.client_secret
 								: undefined,
 						authorize_url: data.oauth_config?.authorize_url || undefined,

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -33,13 +33,13 @@ const emptyStdioConfig: MCPStdioConfig = {
 	envs: [],
 };
 
-const emptySecretVar: SecretVar = { value: "", secret_ref: "", from_secret: false };
+const emptySecretVar: SecretVar = { value: "", ref: "" };
 
 /** Strips empty TLS config so we don't send `{}` to the server. */
 function buildTLSConfigPayload(tls: MCPTLSConfig | undefined): MCPTLSConfig | undefined {
 	if (!tls) return undefined;
 	const hasSkipVerify = tls.insecure_skip_verify === true;
-	const hasCACert = tls.ca_cert_pem?.value || tls.ca_cert_pem?.from_secret;
+	const hasCACert = tls.ca_cert_pem?.value || (tls.ca_cert_pem?.type === "env" || tls.ca_cert_pem?.type === "vault");
 	if (!hasSkipVerify && !hasCACert) return undefined;
 	return { insecure_skip_verify: tls.insecure_skip_verify, ca_cert_pem: hasCACert ? tls.ca_cert_pem : undefined };
 }
@@ -139,7 +139,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		headers
 	) {
 		for (const [key, secretVar] of Object.entries(headers)) {
-			if (!secretVar.value && !secretVar.secret_ref) {
+			if (!secretVar.value && !secretVar.ref) {
 				headersValidationError = `Header "${key}" must have a value`;
 				break;
 			}
@@ -166,13 +166,15 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		let hasErrors = false;
 
 		if (connectionType === "http" || connectionType === "sse") {
-			const connVal = data.connection_string?.value || "";
-			if (!connVal.trim()) {
+			const connVal = data.connection_string?.value?.trim() || "";
+			const connRef = data.connection_string?.ref?.trim() || "";
+			const isSecret = data.connection_string?.type === "env" || data.connection_string?.type === "vault";
+			if (!connVal && !connRef) {
 				setError("connection_string", { message: "Connection URL is required" });
 				hasErrors = true;
-			} else if (!/^((https?:\/\/.+)|(env\.[A-Z_]+))$/.test(connVal)) {
+			} else if (!isSecret && connVal && !/^https?:\/\/.+/.test(connVal)) {
 				setError("connection_string", {
-					message: "Connection URL must start with http://, https://, or be an environment variable (env.VAR_NAME)",
+					message: "Connection URL must start with http:// or https://",
 				});
 				hasErrors = true;
 			}
@@ -245,7 +247,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					? {
 						client_id: data.oauth_config?.client_id ?? emptySecretVar,
 						client_secret:
-							data.oauth_config?.client_secret?.value || data.oauth_config?.client_secret?.from_secret
+							data.oauth_config?.client_secret?.value || (data.oauth_config?.client_secret?.type === "env" || data.oauth_config?.client_secret?.type === "vault")
 								? data.oauth_config.client_secret
 								: undefined,
 						authorize_url: data.oauth_config?.authorize_url || undefined,

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -33,13 +33,13 @@ const emptyStdioConfig: MCPStdioConfig = {
 	envs: [],
 };
 
-const emptySecretVar: SecretVar = { value: "", env_var: "", from_env: false };
+const emptySecretVar: SecretVar = { value: "", secret_ref: "", from_secret: false };
 
 /** Strips empty TLS config so we don't send `{}` to the server. */
 function buildTLSConfigPayload(tls: MCPTLSConfig | undefined): MCPTLSConfig | undefined {
 	if (!tls) return undefined;
 	const hasSkipVerify = tls.insecure_skip_verify === true;
-	const hasCACert = tls.ca_cert_pem?.value || tls.ca_cert_pem?.from_env;
+	const hasCACert = tls.ca_cert_pem?.value || tls.ca_cert_pem?.from_secret;
 	if (!hasSkipVerify && !hasCACert) return undefined;
 	return { insecure_skip_verify: tls.insecure_skip_verify, ca_cert_pem: hasCACert ? tls.ca_cert_pem : undefined };
 }
@@ -139,7 +139,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		headers
 	) {
 		for (const [key, secretVar] of Object.entries(headers)) {
-			if (!secretVar.value && !secretVar.env_var) {
+			if (!secretVar.value && !secretVar.secret_ref) {
 				headersValidationError = `Header "${key}" must have a value`;
 				break;
 			}
@@ -245,7 +245,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					? {
 						client_id: data.oauth_config?.client_id ?? emptySecretVar,
 						client_secret:
-							data.oauth_config?.client_secret?.value || data.oauth_config?.client_secret?.from_env
+							data.oauth_config?.client_secret?.value || data.oauth_config?.client_secret?.from_secret
 								? data.oauth_config.client_secret
 								: undefined,
 						authorize_url: data.oauth_config?.authorize_url || undefined,

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -506,8 +506,8 @@ export default function MCPClientSheet({
 												{mcpClient.config.connection_type === "stdio"
 													? `${mcpClient.config.stdio_config?.command ?? ""} ${(mcpClient.config.stdio_config?.args ?? []).join(" ")}`.trim() ||
 													"-"
-													: mcpClient.config.connection_string?.from_env
-														? `env.${mcpClient.config.connection_string.env_var}`
+													: mcpClient.config.connection_string?.from_secret
+														? mcpClient.config.connection_string.secret_ref
 														: mcpClient.config.connection_string?.value || "-"}
 											</span>
 										</div>

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -506,8 +506,8 @@ export default function MCPClientSheet({
 												{mcpClient.config.connection_type === "stdio"
 													? `${mcpClient.config.stdio_config?.command ?? ""} ${(mcpClient.config.stdio_config?.args ?? []).join(" ")}`.trim() ||
 													"-"
-													: mcpClient.config.connection_string?.from_secret
-														? mcpClient.config.connection_string.secret_ref
+													: (mcpClient.config.connection_string?.type === "env" || mcpClient.config.connection_string?.type === "vault")
+														? mcpClient.config.connection_string.ref
 														: mcpClient.config.connection_string?.value || "-"}
 											</span>
 										</div>

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -311,7 +311,7 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 	// without expanding every collapsed section.
 	const hasError = Boolean(form.formState.errors?.profiles?.[index]);
 
-	const collectorPreview = collectorUrl?.from_env ? collectorUrl.env_var : collectorUrl?.value;
+	const collectorPreview = typeof collectorUrl === "string" ? collectorUrl : collectorUrl?.from_secret ? collectorUrl.secret_ref : collectorUrl?.value;
 
 	return (
 		<Collapsible open={open} onOpenChange={onOpenChange} className="rounded-sm border" data-testid={`otel-profile-${index}`}>

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -311,7 +311,7 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 	// without expanding every collapsed section.
 	const hasError = Boolean(form.formState.errors?.profiles?.[index]);
 
-	const collectorPreview = typeof collectorUrl === "string" ? collectorUrl : collectorUrl?.from_secret ? collectorUrl.secret_ref : collectorUrl?.value;
+	const collectorPreview = typeof collectorUrl === "string" ? collectorUrl : (collectorUrl?.type === "env" || collectorUrl?.type === "vault") ? collectorUrl.ref : collectorUrl?.value;
 
 	return (
 		<Collapsible open={open} onOpenChange={onOpenChange} className="rounded-sm border" data-testid={`otel-profile-${index}`}>

--- a/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
@@ -37,7 +37,7 @@ interface PrometheusFormFragmentProps {
 }
 
 const hasAuth = (v?: string | SecretVar): boolean =>
-	typeof v === "string" ? !!v.trim() : !!(v?.value?.trim() || (v?.from_secret && !!v?.secret_ref?.trim()));
+	typeof v === "string" ? !!v.trim() : !!(v?.value?.trim() || ((v?.type === "env" || v?.type === "vault") && !!v?.ref?.trim()));
 
 const buildDefaults = (initialConfig?: PrometheusFormFragmentProps["currentConfig"]): PrometheusFormSchema => ({
 	metrics_enabled: initialConfig?.metrics_enabled ?? true,

--- a/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
@@ -37,7 +37,7 @@ interface PrometheusFormFragmentProps {
 }
 
 const hasAuth = (v?: string | SecretVar): boolean =>
-	typeof v === "string" ? !!v.trim() : !!(v?.value?.trim() || (v?.from_env && !!v?.env_var?.trim()) || (v?.from_vault && !!v?.vault_var?.trim()));
+	typeof v === "string" ? !!v.trim() : !!(v?.value?.trim() || (v?.from_secret && !!v?.secret_ref?.trim()));
 
 const buildDefaults = (initialConfig?: PrometheusFormFragmentProps["currentConfig"]): PrometheusFormSchema => ({
 	metrics_enabled: initialConfig?.metrics_enabled ?? true,

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -74,8 +74,8 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 			const tenantId = form.getValues("key.azure_key_config.tenant_id");
 			const apiKey = form.getValues("key.value");
 			const hasEntraField =
-				clientId?.value || clientId?.env_var || clientSecret?.value || clientSecret?.env_var || tenantId?.value || tenantId?.env_var;
-			const hasApiKey = apiKey?.value || apiKey?.env_var;
+				clientId?.value || clientId?.secret_ref || clientSecret?.value || clientSecret?.secret_ref || tenantId?.value || tenantId?.secret_ref;
+			const hasApiKey = apiKey?.value || apiKey?.secret_ref;
 			let detected: "api_key" | "entra_id" | "default_credential" = "api_key";
 			if (hasEntraField) {
 				detected = "entra_id";
@@ -91,9 +91,9 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 		if (form.formState.isDirty) return;
 		if (isVertex) {
 			const authCredentials = form.getValues("key.vertex_key_config.auth_credentials")?.value;
-			const authCredentialsEnv = form.getValues("key.vertex_key_config.auth_credentials")?.env_var;
+			const authCredentialsEnv = form.getValues("key.vertex_key_config.auth_credentials")?.secret_ref;
 			const apiKey = form.getValues("key.value")?.value;
-			const apiKeyEnv = form.getValues("key.value")?.env_var;
+			const apiKeyEnv = form.getValues("key.value")?.secret_ref;
 			let detected: "service_account" | "service_account_json" | "api_key" = "service_account";
 			if (authCredentials || authCredentialsEnv) {
 				detected = "service_account_json";
@@ -111,8 +111,8 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 			const accessKey = form.getValues("key.bedrock_key_config.access_key");
 			const secretKey = form.getValues("key.bedrock_key_config.secret_key");
 			const apiKey = form.getValues("key.value");
-			const hasExplicitCreds = accessKey?.value || accessKey?.env_var || secretKey?.value || secretKey?.env_var;
-			const hasApiKey = apiKey?.value || apiKey?.env_var;
+			const hasExplicitCreds = accessKey?.value || accessKey?.secret_ref || secretKey?.value || secretKey?.secret_ref;
+			const hasApiKey = apiKey?.value || apiKey?.secret_ref;
 			let detected: "iam_role" | "explicit" | "api_key" = "iam_role";
 			if (hasExplicitCreds) {
 				detected = "explicit";

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -74,8 +74,8 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 			const tenantId = form.getValues("key.azure_key_config.tenant_id");
 			const apiKey = form.getValues("key.value");
 			const hasEntraField =
-				clientId?.value || clientId?.secret_ref || clientSecret?.value || clientSecret?.secret_ref || tenantId?.value || tenantId?.secret_ref;
-			const hasApiKey = apiKey?.value || apiKey?.secret_ref;
+				clientId?.value || clientId?.ref || clientSecret?.value || clientSecret?.ref || tenantId?.value || tenantId?.ref;
+			const hasApiKey = apiKey?.value || apiKey?.ref;
 			let detected: "api_key" | "entra_id" | "default_credential" = "api_key";
 			if (hasEntraField) {
 				detected = "entra_id";
@@ -91,9 +91,9 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 		if (form.formState.isDirty) return;
 		if (isVertex) {
 			const authCredentials = form.getValues("key.vertex_key_config.auth_credentials")?.value;
-			const authCredentialsEnv = form.getValues("key.vertex_key_config.auth_credentials")?.secret_ref;
+			const authCredentialsEnv = form.getValues("key.vertex_key_config.auth_credentials")?.ref;
 			const apiKey = form.getValues("key.value")?.value;
-			const apiKeyEnv = form.getValues("key.value")?.secret_ref;
+			const apiKeyEnv = form.getValues("key.value")?.ref;
 			let detected: "service_account" | "service_account_json" | "api_key" = "service_account";
 			if (authCredentials || authCredentialsEnv) {
 				detected = "service_account_json";
@@ -111,8 +111,8 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 			const accessKey = form.getValues("key.bedrock_key_config.access_key");
 			const secretKey = form.getValues("key.bedrock_key_config.secret_key");
 			const apiKey = form.getValues("key.value");
-			const hasExplicitCreds = accessKey?.value || accessKey?.secret_ref || secretKey?.value || secretKey?.secret_ref;
-			const hasApiKey = apiKey?.value || apiKey?.secret_ref;
+			const hasExplicitCreds = accessKey?.value || accessKey?.ref || secretKey?.value || secretKey?.ref;
+			const hasApiKey = apiKey?.value || apiKey?.ref;
 			let detected: "iam_role" | "explicit" | "api_key" = "iam_role";
 			if (hasExplicitCreds) {
 				detected = "explicit";

--- a/ui/app/workspace/providers/fragments/deploymentsTable.tsx
+++ b/ui/app/workspace/providers/fragments/deploymentsTable.tsx
@@ -55,8 +55,8 @@ function normalize(value: DeploymentsValue): Record<string, AliasConfig> {
 	return out;
 }
 
-const emptySecretVar: SecretVar = { value: "", secret_ref: "", from_secret: false };
-const isEmptySecretVar = (v: SecretVar | undefined): boolean => !v || (!v.value && !v.secret_ref);
+const emptySecretVar: SecretVar = { value: "", ref: "" };
+const isEmptySecretVar = (v: SecretVar | undefined): boolean => !v || (!v.value && !v.ref);
 
 function FieldRow({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
 	return (

--- a/ui/app/workspace/providers/fragments/deploymentsTable.tsx
+++ b/ui/app/workspace/providers/fragments/deploymentsTable.tsx
@@ -55,8 +55,8 @@ function normalize(value: DeploymentsValue): Record<string, AliasConfig> {
 	return out;
 }
 
-const emptySecretVar: SecretVar = { value: "", env_var: "", from_env: false };
-const isEmptySecretVar = (v: SecretVar | undefined): boolean => !v || (!v.value && !v.env_var);
+const emptySecretVar: SecretVar = { value: "", secret_ref: "", from_secret: false };
+const isEmptySecretVar = (v: SecretVar | undefined): boolean => !v || (!v.value && !v.secret_ref);
 
 function FieldRow({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
 	return (

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -232,12 +232,12 @@ export default function ModelProviderKeysTableView({ provider, className, header
 													(() => {
 														// Check if the failure might be due to an env var that the server couldn't resolve
 														const hasSecretVarConfig =
-															key.azure_key_config?.endpoint?.from_env ||
-															key.vertex_key_config?.project_id?.from_env ||
-															key.vertex_key_config?.region?.from_env ||
-															key.bedrock_key_config?.region?.from_env ||
-															key.vllm_key_config?.url?.from_env ||
-															key.value?.from_env;
+															key.azure_key_config?.endpoint?.from_secret ||
+															key.vertex_key_config?.project_id?.from_secret ||
+															key.vertex_key_config?.region?.from_secret ||
+															key.bedrock_key_config?.region?.from_secret ||
+															key.vllm_key_config?.url?.from_secret ||
+															key.value?.from_secret;
 														const isEnvResolutionError =
 															hasSecretVarConfig && key.description && /not set|empty|missing/i.test(key.description);
 
@@ -246,7 +246,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 																<TooltipTrigger asChild>
 																	<button
 																		type="button"
-																		aria-label="Key status: env var may not be resolved"
+																		aria-label="Key status: secret reference may not be resolved"
 																		data-testid={`key-status-warning-${key.name}`}
 																		className="inline-flex"
 																	>
@@ -254,7 +254,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 																	</button>
 																</TooltipTrigger>
 																<TooltipContent className="max-w-xs break-words">
-																	{key.description} — verify the environment variable is set on the server
+																	{key.description} — verify the secret reference is configured on the server
 																</TooltipContent>
 															</Tooltip>
 														) : (

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -232,12 +232,12 @@ export default function ModelProviderKeysTableView({ provider, className, header
 													(() => {
 														// Check if the failure might be due to an env var that the server couldn't resolve
 														const hasSecretVarConfig =
-															key.azure_key_config?.endpoint?.from_secret ||
-															key.vertex_key_config?.project_id?.from_secret ||
-															key.vertex_key_config?.region?.from_secret ||
-															key.bedrock_key_config?.region?.from_secret ||
-															key.vllm_key_config?.url?.from_secret ||
-															key.value?.from_secret;
+															(key.azure_key_config?.endpoint?.type && key.azure_key_config.endpoint.type !== "plain_text") ||
+															(key.vertex_key_config?.project_id?.type && key.vertex_key_config.project_id.type !== "plain_text") ||
+															(key.vertex_key_config?.region?.type && key.vertex_key_config.region.type !== "plain_text") ||
+															(key.bedrock_key_config?.region?.type && key.bedrock_key_config.region.type !== "plain_text") ||
+															(key.vllm_key_config?.url?.type && key.vllm_key_config.url.type !== "plain_text") ||
+															(key.value?.type && key.value.type !== "plain_text");
 														const isEnvResolutionError =
 															hasSecretVarConfig && key.description && /not set|empty|missing/i.test(key.description);
 

--- a/ui/components/onboardingWidget.tsx
+++ b/ui/components/onboardingWidget.tsx
@@ -93,9 +93,9 @@ export default function OnboardingWidget() {
 
 	const authConfig = bifrostConfig?.auth_config;
 	const clientConfig = bifrostConfig?.client_config;
-	const authValueSet = (secretVar: { value?: string; env_var?: string; from_env?: boolean } | undefined) => {
+	const authValueSet = (secretVar: { value?: string; secret_ref?: string; from_secret?: boolean } | undefined) => {
 		if (!secretVar) return false;
-		return !!secretVar.value || !!secretVar.env_var;
+		return !!secretVar.value || !!secretVar.secret_ref;
 	};
 
 	const steps: Step[] = useMemo(() => {

--- a/ui/components/onboardingWidget.tsx
+++ b/ui/components/onboardingWidget.tsx
@@ -93,9 +93,9 @@ export default function OnboardingWidget() {
 
 	const authConfig = bifrostConfig?.auth_config;
 	const clientConfig = bifrostConfig?.client_config;
-	const authValueSet = (secretVar: { value?: string; secret_ref?: string; from_secret?: boolean } | undefined) => {
+	const authValueSet = (secretVar: { value?: string; ref?: string; type?: string } | undefined) => {
 		if (!secretVar) return false;
-		return !!secretVar.value || !!secretVar.secret_ref;
+		return !!secretVar.value || !!secretVar.ref;
 	};
 
 	const steps: Step[] = useMemo(() => {

--- a/ui/components/ui/headersTable.tsx
+++ b/ui/components/ui/headersTable.tsx
@@ -40,7 +40,7 @@ interface HeadersTableProps<T extends HeaderValue> {
 }
 
 // Empty SecretVar for new rows
-const emptySecretVar: SecretVar = { value: "", secret_ref: "", from_secret: false };
+const emptySecretVar: SecretVar = { value: "", ref: "" };
 
 // Helper to check if a value is an SecretVar object
 const isSecretVar = (val: HeaderValue): val is SecretVar => {
@@ -58,7 +58,7 @@ const getDisplayValue = (val: HeaderValue): string => {
 // Helper to check if a HeaderValue is empty
 const isValueEmpty = (val: HeaderValue): boolean => {
 	if (isSecretVar(val)) {
-		return !val.value && !val.secret_ref;
+		return !val.value && !val.ref;
 	}
 	return !val;
 };
@@ -152,7 +152,7 @@ export function HeadersTable<T extends HeaderValue>({
 				newHeaders[currentKey] = newValue as T;
 			} else {
 				// When user types, create a new SecretVar with the typed value
-				newHeaders[currentKey] = { value: newValue, secret_ref: "", from_secret: false} as T;
+				newHeaders[currentKey] = { value: newValue, ref: ""} as T;
 			}
 		} else {
 			newHeaders[currentKey] = (typeof newValue === "string" ? newValue : newValue.value) as T;

--- a/ui/components/ui/headersTable.tsx
+++ b/ui/components/ui/headersTable.tsx
@@ -40,7 +40,7 @@ interface HeadersTableProps<T extends HeaderValue> {
 }
 
 // Empty SecretVar for new rows
-const emptySecretVar: SecretVar = { value: "", env_var: "", from_env: false };
+const emptySecretVar: SecretVar = { value: "", secret_ref: "", from_secret: false };
 
 // Helper to check if a value is an SecretVar object
 const isSecretVar = (val: HeaderValue): val is SecretVar => {
@@ -58,7 +58,7 @@ const getDisplayValue = (val: HeaderValue): string => {
 // Helper to check if a HeaderValue is empty
 const isValueEmpty = (val: HeaderValue): boolean => {
 	if (isSecretVar(val)) {
-		return !val.value && !val.env_var;
+		return !val.value && !val.secret_ref;
 	}
 	return !val;
 };
@@ -152,7 +152,7 @@ export function HeadersTable<T extends HeaderValue>({
 				newHeaders[currentKey] = newValue as T;
 			} else {
 				// When user types, create a new SecretVar with the typed value
-				newHeaders[currentKey] = { value: newValue, env_var: "", from_env: false, vault_var: "", from_vault: false } as T;
+				newHeaders[currentKey] = { value: newValue, secret_ref: "", from_secret: false} as T;
 			}
 		} else {
 			newHeaders[currentKey] = (typeof newValue === "string" ? newValue : newValue.value) as T;

--- a/ui/components/ui/secretVarInput.tsx
+++ b/ui/components/ui/secretVarInput.tsx
@@ -71,10 +71,10 @@ export const SecretVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEl
 			isUserChange.current = false;
 		}, [value]);
 
-		// Show badge when value is from env (server-synced or user-typed)
-		const showEnvBadge = value?.from_env && value?.env_var;
-		const showVaultBadge = value?.from_vault && value?.vault_var;
-		const showBadge = showEnvBadge || showVaultBadge;
+		// Show badge when value is from a secret reference (env or vault)
+		const showEnvBadge = value?.from_secret && value?.secret_ref?.startsWith("env.");
+		const showVaultBadge = value?.from_secret && value?.secret_ref?.startsWith("vault.");
+		const showBadge = value?.from_secret && !!value?.secret_ref;
 		const rawValue = value?.value ?? "";
 		const displayValue =
 			showBadge && hideValueWhenEnv && !hasChanged.current
@@ -100,17 +100,15 @@ export const SecretVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEl
 			hasChanged.current = true;
 			isUserChange.current = true;
 			// Auto-detect env var / vault reference prefix
-			if (newValue.startsWith("env.")) {
-				onChange?.({ value: newValue, env_var: newValue, from_env: true, vault_var: "", from_vault: false });
-			} else if (newValue.startsWith("vault.")) {
-				onChange?.({ value: newValue, env_var: "", from_env: false, vault_var: newValue, from_vault: true });
+			if (newValue.startsWith("env.") || newValue.startsWith("vault.")) {
+				onChange?.({ value: "", secret_ref: newValue, from_secret: true });
 			} else {
-				onChange?.({ value: newValue, env_var: "", from_env: false, vault_var: "", from_vault: false });
+				onChange?.({ value: newValue, secret_ref: "", from_secret: false });
 			}
 		};
 
-		// Show hint when user is typing an env var / vault ref (reference set but no resolved value yet)
-		const showEnvHint = ((value?.from_env && value?.env_var) || (value?.from_vault && value?.vault_var)) && hasChanged.current;
+		// Show hint when user is typing a secret reference (reference set but no resolved value yet)
+		const showEnvHint = (value?.from_secret && value?.secret_ref) && hasChanged.current;
 
 		const isTextarea = variant === "textarea";
 
@@ -155,12 +153,12 @@ export const SecretVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEl
 					)}
 					{showEnvBadge && (
 						<Badge variant="success" className={cn("mr-2 whitespace-nowrap", isTextarea && "mb-2")}>
-							{value?.env_var}
+							{value?.secret_ref}
 						</Badge>
 					)}
 					{showVaultBadge && (
 						<Badge variant="warning" className={cn("mr-2 whitespace-nowrap", isTextarea && "mb-2")}>
-							{value?.vault_var}
+							{value?.secret_ref}
 						</Badge>
 					)}
 				</div>

--- a/ui/components/ui/secretVarInput.tsx
+++ b/ui/components/ui/secretVarInput.tsx
@@ -72,18 +72,20 @@ export const SecretVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEl
 		}, [value]);
 
 		// Show badge when value is from a secret reference (env or vault)
-		const showEnvBadge = value?.from_secret && value?.secret_ref?.startsWith("env.");
-		const showVaultBadge = value?.from_secret && value?.secret_ref?.startsWith("vault.");
-		const showBadge = value?.from_secret && !!value?.secret_ref;
+		const showEnvBadge = value?.type === "env";
+		const showVaultBadge = value?.type === "vault";
+		const showBadge = (value?.type === "env" || value?.type === "vault") && !!value?.ref;
 		const rawValue = value?.value ?? "";
 		const displayValue =
-			showBadge && hideValueWhenEnv && !hasChanged.current
-				? ""
-				: redactNonEnvValue && !showBadge && !hasChanged.current && rawValue
-					? "<REDACTED>"
-					: maskNonEnvValue && !showBadge && !hasChanged.current
-						? maskValue(rawValue, maskVisiblePrefix, maskVisibleSuffix)
-						: rawValue;
+			showBadge && hasChanged.current
+				? (value?.ref ?? "")
+				: showBadge && hideValueWhenEnv
+					? ""
+					: redactNonEnvValue && !showBadge && !hasChanged.current && rawValue
+						? "<REDACTED>"
+						: maskNonEnvValue && !showBadge && !hasChanged.current
+							? maskValue(rawValue, maskVisiblePrefix, maskVisibleSuffix)
+							: rawValue;
 
 		const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
 			const inputValue = e.target.value;
@@ -100,15 +102,17 @@ export const SecretVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEl
 			hasChanged.current = true;
 			isUserChange.current = true;
 			// Auto-detect env var / vault reference prefix
-			if (newValue.startsWith("env.") || newValue.startsWith("vault.")) {
-				onChange?.({ value: "", secret_ref: newValue, from_secret: true });
+			if (newValue.startsWith("vault.")) {
+				onChange?.({ value: "", ref: newValue, type: "vault" });
+			} else if (newValue.startsWith("env.")) {
+				onChange?.({ value: "", ref: newValue, type: "env" });
 			} else {
-				onChange?.({ value: newValue, secret_ref: "", from_secret: false });
+				onChange?.({ value: newValue, ref: "" });
 			}
 		};
 
 		// Show hint when user is typing a secret reference (reference set but no resolved value yet)
-		const showEnvHint = (value?.from_secret && value?.secret_ref) && hasChanged.current;
+		const showEnvHint = ((value?.type === "env" || value?.type === "vault") && value?.ref) && hasChanged.current;
 
 		const isTextarea = variant === "textarea";
 
@@ -153,12 +157,12 @@ export const SecretVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEl
 					)}
 					{showEnvBadge && (
 						<Badge variant="success" className={cn("mr-2 whitespace-nowrap", isTextarea && "mb-2")}>
-							{value?.secret_ref}
+							{value?.ref}
 						</Badge>
 					)}
 					{showVaultBadge && (
 						<Badge variant="warning" className={cn("mr-2 whitespace-nowrap", isTextarea && "mb-2")}>
-							{value?.secret_ref}
+							{value?.ref}
 						</Badge>
 					)}
 				</div>

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -88,7 +88,7 @@ export const DefaultNetworkConfig = {
 	retry_backoff_initial: 1000,
 	retry_backoff_max: 10000,
 	insecure_skip_verify: false,
-	ca_cert_pem: { value: "", secret_ref: "", from_secret: false },
+	ca_cert_pem: { value: "", ref: "" },
 	stream_idle_timeout_in_seconds: 120,
 	max_conns_per_host: 5000,
 	enforce_http2: false,

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -88,7 +88,7 @@ export const DefaultNetworkConfig = {
 	retry_backoff_initial: 1000,
 	retry_backoff_max: 10000,
 	insecure_skip_verify: false,
-	ca_cert_pem: { value: "", env_var: "", from_env: false },
+	ca_cert_pem: { value: "", secret_ref: "", from_secret: false },
 	stream_idle_timeout_in_seconds: 120,
 	max_conns_per_host: 5000,
 	enforce_http2: false,

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -81,10 +81,10 @@ export interface AzureKeyConfig {
 }
 
 export const DefaultAzureKeyConfig: AzureKeyConfig = {
-	endpoint: { value: "", env_var: "", from_env: false },
-	client_id: { value: "", env_var: "", from_env: false },
-	client_secret: { value: "", env_var: "", from_env: false },
-	tenant_id: { value: "", env_var: "", from_env: false },
+	endpoint: { value: "", secret_ref: "", from_secret: false },
+	client_id: { value: "", secret_ref: "", from_secret: false },
+	client_secret: { value: "", secret_ref: "", from_secret: false },
+	tenant_id: { value: "", secret_ref: "", from_secret: false },
 	scopes: [],
 } as const satisfies Required<AzureKeyConfig>;
 
@@ -97,10 +97,10 @@ export interface VertexKeyConfig {
 }
 
 export const DefaultVertexKeyConfig: VertexKeyConfig = {
-	project_id: { value: "", env_var: "", from_env: false },
-	project_number: { value: "", env_var: "", from_env: false },
-	region: { value: "", env_var: "", from_env: false },
-	auth_credentials: { value: "", env_var: "", from_env: false },
+	project_id: { value: "", secret_ref: "", from_secret: false },
+	project_number: { value: "", secret_ref: "", from_secret: false },
+	region: { value: "", secret_ref: "", from_secret: false },
+	auth_credentials: { value: "", secret_ref: "", from_secret: false },
 } as const satisfies Required<VertexKeyConfig>;
 
 export interface S3BucketConfig {
@@ -125,11 +125,11 @@ export interface BedrockKeyConfig {
 
 // Default BedrockKeyConfig
 export const DefaultBedrockKeyConfig: BedrockKeyConfig = {
-	access_key: { value: "", env_var: "", from_env: false },
-	secret_key: { value: "", env_var: "", from_env: false },
+	access_key: { value: "", secret_ref: "", from_secret: false },
+	secret_key: { value: "", secret_ref: "", from_secret: false },
 	session_token: undefined as unknown as SecretVar,
-	region: { value: "us-east-1", env_var: "", from_env: false },
-	arn: { value: "", env_var: "", from_env: false },
+	region: { value: "us-east-1", secret_ref: "", from_secret: false },
+	arn: { value: "", secret_ref: "", from_secret: false },
 	batch_s3_config: undefined as unknown as BatchS3Config,
 } as const satisfies Required<BedrockKeyConfig>;
 
@@ -141,7 +141,7 @@ export interface VLLMKeyConfig {
 
 // Default VLLMKeyConfig
 export const DefaultVLLMKeyConfig: VLLMKeyConfig = {
-	url: { value: "", env_var: "", from_env: false },
+	url: { value: "", secret_ref: "", from_secret: false },
 	model_name: "",
 } as const satisfies Required<VLLMKeyConfig>;
 
@@ -162,7 +162,7 @@ export interface OllamaKeyConfig {
 
 // Default OllamaKeyConfig
 export const DefaultOllamaKeyConfig: OllamaKeyConfig = {
-	url: { value: "", env_var: "", from_env: false },
+	url: { value: "", secret_ref: "", from_secret: false },
 } as const satisfies Required<OllamaKeyConfig>;
 
 // SGLKeyConfig matching Go's schemas.SGLKeyConfig
@@ -172,7 +172,7 @@ export interface SGLKeyConfig {
 
 // Default SGLKeyConfig
 export const DefaultSGLKeyConfig: SGLKeyConfig = {
-	url: { value: "", env_var: "", from_env: false },
+	url: { value: "", secret_ref: "", from_secret: false },
 } as const satisfies Required<SGLKeyConfig>;
 
 // Key structure matching Go's schemas.Key
@@ -204,8 +204,8 @@ export const DefaultModelProviderKey: ModelProviderKey = {
 	name: "",
 	value: {
 		value: "",
-		env_var: "",
-		from_env: false,
+		secret_ref: "",
+		from_secret: false,
 	},
 	models: [],
 	blacklisted_models: [],

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -81,10 +81,10 @@ export interface AzureKeyConfig {
 }
 
 export const DefaultAzureKeyConfig: AzureKeyConfig = {
-	endpoint: { value: "", secret_ref: "", from_secret: false },
-	client_id: { value: "", secret_ref: "", from_secret: false },
-	client_secret: { value: "", secret_ref: "", from_secret: false },
-	tenant_id: { value: "", secret_ref: "", from_secret: false },
+	endpoint: { value: "", ref: "" },
+	client_id: { value: "", ref: "" },
+	client_secret: { value: "", ref: "" },
+	tenant_id: { value: "", ref: "" },
 	scopes: [],
 } as const satisfies Required<AzureKeyConfig>;
 
@@ -97,10 +97,10 @@ export interface VertexKeyConfig {
 }
 
 export const DefaultVertexKeyConfig: VertexKeyConfig = {
-	project_id: { value: "", secret_ref: "", from_secret: false },
-	project_number: { value: "", secret_ref: "", from_secret: false },
-	region: { value: "", secret_ref: "", from_secret: false },
-	auth_credentials: { value: "", secret_ref: "", from_secret: false },
+	project_id: { value: "", ref: "" },
+	project_number: { value: "", ref: "" },
+	region: { value: "", ref: "" },
+	auth_credentials: { value: "", ref: "" },
 } as const satisfies Required<VertexKeyConfig>;
 
 export interface S3BucketConfig {
@@ -125,11 +125,11 @@ export interface BedrockKeyConfig {
 
 // Default BedrockKeyConfig
 export const DefaultBedrockKeyConfig: BedrockKeyConfig = {
-	access_key: { value: "", secret_ref: "", from_secret: false },
-	secret_key: { value: "", secret_ref: "", from_secret: false },
+	access_key: { value: "", ref: "" },
+	secret_key: { value: "", ref: "" },
 	session_token: undefined as unknown as SecretVar,
-	region: { value: "us-east-1", secret_ref: "", from_secret: false },
-	arn: { value: "", secret_ref: "", from_secret: false },
+	region: { value: "us-east-1", ref: "" },
+	arn: { value: "", ref: "" },
 	batch_s3_config: undefined as unknown as BatchS3Config,
 } as const satisfies Required<BedrockKeyConfig>;
 
@@ -141,7 +141,7 @@ export interface VLLMKeyConfig {
 
 // Default VLLMKeyConfig
 export const DefaultVLLMKeyConfig: VLLMKeyConfig = {
-	url: { value: "", secret_ref: "", from_secret: false },
+	url: { value: "", ref: "" },
 	model_name: "",
 } as const satisfies Required<VLLMKeyConfig>;
 
@@ -162,7 +162,7 @@ export interface OllamaKeyConfig {
 
 // Default OllamaKeyConfig
 export const DefaultOllamaKeyConfig: OllamaKeyConfig = {
-	url: { value: "", secret_ref: "", from_secret: false },
+	url: { value: "", ref: "" },
 } as const satisfies Required<OllamaKeyConfig>;
 
 // SGLKeyConfig matching Go's schemas.SGLKeyConfig
@@ -172,7 +172,7 @@ export interface SGLKeyConfig {
 
 // Default SGLKeyConfig
 export const DefaultSGLKeyConfig: SGLKeyConfig = {
-	url: { value: "", secret_ref: "", from_secret: false },
+	url: { value: "", ref: "" },
 } as const satisfies Required<SGLKeyConfig>;
 
 // Key structure matching Go's schemas.Key
@@ -204,8 +204,8 @@ export const DefaultModelProviderKey: ModelProviderKey = {
 	name: "",
 	value: {
 		value: "",
-		secret_ref: "",
-		from_secret: false,
+		ref: "",
+		
 	},
 	models: [],
 	blacklisted_models: [],

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -56,25 +56,23 @@ export const customProviderNameSchema = z.string().min(1, "Custom provider name 
 // Model provider name schema (union of known and custom providers)
 export const modelProviderNameSchema = z.union([knownProviderSchema, customProviderNameSchema]);
 
-// SecretVar schema - matches the Go SecretVar type from schemas/env.go
+// SecretVar schema - matches the Go SecretVar type from schemas/secretvar.go
 export const _secretVarBase = z.object({
 	value: z.string().optional(),
-	env_var: z.string().optional(),
-	from_env: z.boolean().optional(),
-	vault_var: z.string().optional(),
-	from_vault: z.boolean().optional(),
+	secret_ref: z.string().optional(),
+	from_secret: z.boolean().optional(),
 });
 
 // Extending the base schema
 export const secretVarSchema = Object.assign(_secretVarBase, {
 	required: (message: string) =>
-		_secretVarBase.refine((v) => !!v?.value?.trim() || !!v?.env_var?.trim() || !!v?.vault_var?.trim(), message),
+		_secretVarBase.refine((v) => !!v?.value?.trim() || !!v?.secret_ref?.trim(), message),
 });
 
-// Helper to check if an secretVar field has a value, env reference, or vault reference
-function isSecretVarSet(v: { value?: string; env_var?: string; vault_var?: string } | undefined): boolean {
+// Helper to check if a secretVar field has a value or secret reference
+function isSecretVarSet(v: { value?: string; secret_ref?: string } | undefined): boolean {
 	if (!v) return false;
-	return !!v.value?.trim() || !!v.env_var?.trim() || !!v.vault_var?.trim();
+	return !!v.value?.trim() || !!v.secret_ref?.trim();
 }
 
 // Azure key config schema
@@ -456,8 +454,7 @@ export const proxyConfigSchema = z
 	.refine(
 		(data) =>
 			!(data.type === "http" || data.type === "socks5") ||
-			data.url?.from_env === true ||
-			data.url?.from_vault === true ||
+			data.url?.from_secret === true ||
 			(data.url?.value && data.url.value.trim().length > 0),
 		{
 			message: "Proxy URL is required when using HTTP or SOCKS5 proxy",
@@ -502,7 +499,7 @@ export const proxyFormConfigSchema = z
 			// URL is required when proxy type is http or socks5
 			if (data.type === "http" || data.type === "socks5") {
 				// Env-backed URLs may have empty resolved value before env resolution.
-				if (data.url?.from_env || data.url?.env_var?.startsWith("env.") || data.url?.from_vault || data.url?.vault_var?.startsWith("vault.")) return true;
+				if (data.url?.from_secret || data.url?.secret_ref) return true;
 				// Literal URLs must be non-empty.
 				if (!data.url?.value || data.url.value.trim().length === 0) return false;
 			}
@@ -794,7 +791,7 @@ export const otelConfigSchema = z
 		// Per-profile enable toggle. A disabled profile exports nothing and is not validated.
 		enabled: z.boolean().default(true),
 		service_name: z.string().optional(),
-		collector_url: secretVarSchema.default({ value: "", env_var: "", from_env: false }),
+		collector_url: secretVarSchema.default({ value: "" }),
 		trace_type: z
 			.enum(["genai_extension", "vercel", "open_inference"], {
 				message: "Please select a trace type",
@@ -880,9 +877,9 @@ export const otelConfigSchema = z
 
 		// Validate collector_url format — skip format check for env var references
 		const collectorUrl = (data.collector_url?.value || "").trim();
-		if (collectorUrl && !data.collector_url?.from_env && !data.collector_url?.from_vault && protocol === "http") {
+		if (collectorUrl && !data.collector_url?.from_secret && protocol === "http") {
 			validateHttpUrl(collectorUrl, ["collector_url"]);
-		} else if (collectorUrl && !data.collector_url?.from_env && !data.collector_url?.from_vault && protocol === "grpc") {
+		} else if (collectorUrl && !data.collector_url?.from_secret && protocol === "grpc") {
 			validateHostPort(collectorUrl, ["collector_url"], "otel-collector:4317");
 		}
 
@@ -895,9 +892,9 @@ export const otelConfigSchema = z
 					path: ["metrics_endpoint"],
 					message: "Metrics endpoint is required when metrics push is enabled",
 				});
-			} else if (metricsEndpoint && !data.metrics_endpoint?.from_env && !data.metrics_endpoint?.from_vault && protocol === "http") {
+			} else if (metricsEndpoint && !data.metrics_endpoint?.from_secret && protocol === "http") {
 				validateHttpUrl(metricsEndpoint, ["metrics_endpoint"]);
-			} else if (metricsEndpoint && !data.metrics_endpoint?.from_env && !data.metrics_endpoint?.from_vault && protocol === "grpc") {
+			} else if (metricsEndpoint && !data.metrics_endpoint?.from_secret && protocol === "grpc") {
 				validateHostPort(metricsEndpoint, ["metrics_endpoint"], "otel-collector:4317");
 			}
 		}
@@ -955,7 +952,7 @@ export const prometheusConfigSchema = z
 	.superRefine((data, ctx) => {
 		// Validate push_gateway_url format — skip for env var references
 		const url = (data.push_gateway_url?.value || "").trim();
-		if (url && !data.push_gateway_url?.from_env && !data.push_gateway_url?.from_vault) {
+		if (url && !data.push_gateway_url?.from_secret) {
 			try {
 				const u = new URL(url);
 				if (!(u.protocol === "http:" || u.protocol === "https:")) {

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -59,20 +59,20 @@ export const modelProviderNameSchema = z.union([knownProviderSchema, customProvi
 // SecretVar schema - matches the Go SecretVar type from schemas/secretvar.go
 export const _secretVarBase = z.object({
 	value: z.string().optional(),
-	secret_ref: z.string().optional(),
-	from_secret: z.boolean().optional(),
+	ref: z.string().optional(),
+	type: z.enum(["plain_text", "env", "vault"]).optional(),
 });
 
 // Extending the base schema
 export const secretVarSchema = Object.assign(_secretVarBase, {
 	required: (message: string) =>
-		_secretVarBase.refine((v) => !!v?.value?.trim() || !!v?.secret_ref?.trim(), message),
+		_secretVarBase.refine((v) => !!v?.value?.trim() || !!v?.ref?.trim(), message),
 });
 
 // Helper to check if a secretVar field has a value or secret reference
-function isSecretVarSet(v: { value?: string; secret_ref?: string } | undefined): boolean {
+function isSecretVarSet(v: { value?: string; ref?: string } | undefined): boolean {
 	if (!v) return false;
-	return !!v.value?.trim() || !!v.secret_ref?.trim();
+	return !!v.value?.trim() || !!v.ref?.trim();
 }
 
 // Azure key config schema
@@ -454,7 +454,7 @@ export const proxyConfigSchema = z
 	.refine(
 		(data) =>
 			!(data.type === "http" || data.type === "socks5") ||
-			data.url?.from_secret === true ||
+			data.url?.type === "env" || data.url?.type === "vault" ||
 			(data.url?.value && data.url.value.trim().length > 0),
 		{
 			message: "Proxy URL is required when using HTTP or SOCKS5 proxy",
@@ -499,7 +499,7 @@ export const proxyFormConfigSchema = z
 			// URL is required when proxy type is http or socks5
 			if (data.type === "http" || data.type === "socks5") {
 				// Env-backed URLs may have empty resolved value before env resolution.
-				if (data.url?.from_secret || data.url?.secret_ref) return true;
+				if (!!(data.url?.type && data.url?.type !== "plain_text") || data.url?.ref) return true;
 				// Literal URLs must be non-empty.
 				if (!data.url?.value || data.url.value.trim().length === 0) return false;
 			}
@@ -877,9 +877,9 @@ export const otelConfigSchema = z
 
 		// Validate collector_url format — skip format check for env var references
 		const collectorUrl = (data.collector_url?.value || "").trim();
-		if (collectorUrl && !data.collector_url?.from_secret && protocol === "http") {
+		if (collectorUrl && (data.collector_url?.type === "plain_text" || !data.collector_url?.type) && protocol === "http") {
 			validateHttpUrl(collectorUrl, ["collector_url"]);
-		} else if (collectorUrl && !data.collector_url?.from_secret && protocol === "grpc") {
+		} else if (collectorUrl && (data.collector_url?.type === "plain_text" || !data.collector_url?.type) && protocol === "grpc") {
 			validateHostPort(collectorUrl, ["collector_url"], "otel-collector:4317");
 		}
 
@@ -892,9 +892,9 @@ export const otelConfigSchema = z
 					path: ["metrics_endpoint"],
 					message: "Metrics endpoint is required when metrics push is enabled",
 				});
-			} else if (metricsEndpoint && !data.metrics_endpoint?.from_secret && protocol === "http") {
+			} else if (metricsEndpoint && (data.metrics_endpoint?.type === "plain_text" || !data.metrics_endpoint?.type) && protocol === "http") {
 				validateHttpUrl(metricsEndpoint, ["metrics_endpoint"]);
-			} else if (metricsEndpoint && !data.metrics_endpoint?.from_secret && protocol === "grpc") {
+			} else if (metricsEndpoint && (data.metrics_endpoint?.type === "plain_text" || !data.metrics_endpoint?.type) && protocol === "grpc") {
 				validateHostPort(metricsEndpoint, ["metrics_endpoint"], "otel-collector:4317");
 			}
 		}
@@ -952,7 +952,7 @@ export const prometheusConfigSchema = z
 	.superRefine((data, ctx) => {
 		// Validate push_gateway_url format — skip for env var references
 		const url = (data.push_gateway_url?.value || "").trim();
-		if (url && !data.push_gateway_url?.from_secret) {
+		if (url && (data.push_gateway_url?.type === "plain_text" || !data.push_gateway_url?.type)) {
 			try {
 				const u = new URL(url);
 				if (!(u.protocol === "http:" || u.protocol === "https:")) {

--- a/ui/lib/utils/secretVarForm.ts
+++ b/ui/lib/utils/secretVarForm.ts
@@ -1,30 +1,23 @@
 import { type SecretVar } from "@/lib/types/schemas";
 
-export const emptySecretVar = (): SecretVar => ({ value: "", env_var: "", from_env: false, vault_var: "", from_vault: false });
+export const emptySecretVar = (): SecretVar => ({ value: "", secret_ref: "", from_secret: false });
 
 export const toSecretVarFormValue = (field?: SecretVar | string): SecretVar => {
 	if (!field) return emptySecretVar();
 	if (typeof field === "string") {
 		const value = field.trim();
 		if (!value) return emptySecretVar();
-		if (value.startsWith("vault.")) {
-			return { value: "", env_var: "", from_env: false, vault_var: value, from_vault: true };
-		}
-		const isEnvRef = value.startsWith("env.");
+		const isSecretRef = value.startsWith("env.") || value.startsWith("vault.");
 		return {
-			value: isEnvRef ? "" : value,
-			env_var: isEnvRef ? value : "",
-			from_env: isEnvRef,
-			vault_var: "",
-			from_vault: false,
+			value: isSecretRef ? "" : value,
+			secret_ref: isSecretRef ? value : "",
+			from_secret: isSecretRef,
 		};
 	}
 	return {
 		value: field.value || "",
-		env_var: field.env_var || "",
-		from_env: field.from_env ?? false,
-		vault_var: field.vault_var || "",
-		from_vault: field.from_vault ?? false,
+		secret_ref: field.secret_ref || "",
+		from_secret: field.from_secret ?? false,
 	};
 };
 
@@ -33,13 +26,11 @@ export const toSecretVarMapFormValue = (map?: Record<string, string | SecretVar>
 	return Object.fromEntries(Object.entries(map).map(([k, v]) => [k, toSecretVarFormValue(v)]));
 };
 
-// toEnvRefString flattens an SecretVar form value to its persisted string form:
-// the "vault.path" reference when vault-backed, the "env.VAR" reference when sourced
-// from the environment, otherwise the literal value.
+// toEnvRefString flattens a SecretVar form value to its persisted string form:
+// the "vault.path" or "env.VAR" reference when secret-backed, otherwise the literal value.
 export const toEnvRefString = (field?: SecretVar): string => {
 	if (!field) return "";
-	if (field.from_vault) return (field.vault_var || "").trim();
-	if (field.from_env) return (field.env_var || "").trim();
+	if (field.from_secret) return (field.secret_ref || "").trim();
 	return (field.value || "").trim();
 };
 
@@ -59,20 +50,15 @@ export const toHeaderStringMap = (headers?: Record<string, SecretVar>): Record<s
 
 export const toOptionalSecretVarPayload = (field?: {
 	value?: string;
-	env_var?: string;
-	from_env?: boolean;
-	vault_var?: string;
-	from_vault?: boolean;
+	secret_ref?: string;
+	from_secret?: boolean;
 }) => {
-	const secretVar = field?.env_var?.trim();
-	const vaultVar = field?.vault_var?.trim();
+	const secretRef = field?.secret_ref?.trim();
 	const value = field?.value?.trim();
-	if (!value && !(field?.from_env && secretVar) && !(field?.from_vault && vaultVar)) return undefined;
+	if (!value && !(field?.from_secret && secretRef)) return undefined;
 	return {
 		value: value || "",
-		env_var: secretVar || "",
-		from_env: field?.from_env ?? false,
-		vault_var: vaultVar || "",
-		from_vault: field?.from_vault ?? false,
+		secret_ref: secretRef || "",
+		from_secret: field?.from_secret ?? false,
 	};
 };

--- a/ui/lib/utils/secretVarForm.ts
+++ b/ui/lib/utils/secretVarForm.ts
@@ -1,6 +1,13 @@
 import { type SecretVar } from "@/lib/types/schemas";
 
-export const emptySecretVar = (): SecretVar => ({ value: "", secret_ref: "", from_secret: false });
+function inferType(ref: string | undefined): SecretVar["type"] | undefined {
+	if (!ref) return undefined;
+	if (ref.startsWith("vault.")) return "vault";
+	if (ref.startsWith("env.")) return "env";
+	return undefined;
+}
+
+export const emptySecretVar = (): SecretVar => ({ value: "", ref: "" });
 
 export const toSecretVarFormValue = (field?: SecretVar | string): SecretVar => {
 	if (!field) return emptySecretVar();
@@ -10,14 +17,14 @@ export const toSecretVarFormValue = (field?: SecretVar | string): SecretVar => {
 		const isSecretRef = value.startsWith("env.") || value.startsWith("vault.");
 		return {
 			value: isSecretRef ? "" : value,
-			secret_ref: isSecretRef ? value : "",
-			from_secret: isSecretRef,
+			ref: isSecretRef ? value : "",
+			type: isSecretRef ? (value.startsWith("vault.") ? "vault" : "env") : undefined,
 		};
 	}
 	return {
 		value: field.value || "",
-		secret_ref: field.secret_ref || "",
-		from_secret: field.from_secret ?? false,
+		ref: field.ref || "",
+		type: field.type ?? inferType(field.ref),
 	};
 };
 
@@ -30,7 +37,8 @@ export const toSecretVarMapFormValue = (map?: Record<string, string | SecretVar>
 // the "vault.path" or "env.VAR" reference when secret-backed, otherwise the literal value.
 export const toEnvRefString = (field?: SecretVar): string => {
 	if (!field) return "";
-	if (field.from_secret) return (field.secret_ref || "").trim();
+	const effectiveType = field.type ?? inferType(field.ref);
+	if (effectiveType && effectiveType !== "plain_text") return (field.ref || "").trim();
 	return (field.value || "").trim();
 };
 
@@ -50,15 +58,17 @@ export const toHeaderStringMap = (headers?: Record<string, SecretVar>): Record<s
 
 export const toOptionalSecretVarPayload = (field?: {
 	value?: string;
-	secret_ref?: string;
-	from_secret?: boolean;
+	ref?: string;
+	type?: string;
 }) => {
-	const secretRef = field?.secret_ref?.trim();
+	const secretRef = field?.ref?.trim();
 	const value = field?.value?.trim();
-	if (!value && !(field?.from_secret && secretRef)) return undefined;
+	const effectiveType = field?.type ?? inferType(field?.ref);
+	const isSecret = effectiveType && effectiveType !== "plain_text";
+	if (!value && !(isSecret && secretRef)) return undefined;
 	return {
 		value: value || "",
-		secret_ref: secretRef || "",
-		from_secret: field?.from_secret ?? false,
+		ref: secretRef || "",
+		type: effectiveType,
 	};
 };


### PR DESCRIPTION
## Summary

Consolidates the `SecretVar` type's dual-source tracking fields (`FromEnv`/`EnvVar` and `FromVault`/`VaultRef`) into a unified `SecretType` enum with a single `ref` string field. Both environment variable references (`env.VAR`) and vault references (`vault.path`) are now represented identically, with the reference string stored in `ref` and the source type in `SecretType`. Backward compatibility is preserved for the old `env_var`/`from_env` JSON format.

## Changes

- `SecretVar` struct fields `FromEnv`, `EnvVar`, `FromVault`, and `VaultRef` replaced with a `SecretType` enum (`plain_text`, `env`, `vault`) and a single unexported `ref` string.
- `IsFromEnv()` and `IsFromVault()` methods supplemented with a unified `IsFromSecret()` method; `GetRawSecretRef()`, `GetRef()`, `EnvKey()`, `VaultPath()`, and `Type()` accessors added.
- `MarshalJSON` added to emit `ref` and `type` fields; `UnmarshalJSON`, `Scan`, `Value`, `Redacted`, `FullyRedacted`, `Equals`, `IsSet`, and `ShouldPreserveStored` updated to use the unified fields.
- Old `env_var`/`from_env` JSON payloads are transparently migrated to `ref`/`type` on deserialization.
- `StoreVaultSecretVar` now sets `ref` to `"vault." + path` and `SecretType` to `SecretTypeVault` instead of populating the old `VaultRef` field.
- `removeOwnedVaultSecretVar` updated to use `GetRef()` instead of manually stripping the `vault.` prefix from `VaultRef`.
- All call sites across proxy configuration, auth config, encryption hooks, MCP table hooks, config store, plugins, and HTTP handlers updated to use `IsFromSecret()` and `GetRawSecretRef()`.
- UI TypeScript `SecretVar` type updated: `env_var`, `from_env`, `vault_var`, and `from_vault` fields replaced with `ref` and `from_secret`; Zod schemas, form utilities, default constants, and all component logic updated accordingly.
- Error and warning messages updated from "environment variable" to "external reference" to be source-agnostic.
- `config.schema.json` updated to include `ref` and `type` fields alongside the legacy `env_var`/`from_env` fields for backward compatibility.
- Tests updated to reflect the new field names and accessors; a dedicated backward-compatibility test added for the old `env_var`/`from_env` JSON format.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/...
go test ./core/providers/utils/...
go test ./framework/configstore/...
go test ./transports/bifrost-http/...
```

Verify that existing `env.VAR` and `vault.path` references in stored configs continue to resolve correctly after the migration, including configs written in the old `env_var`/`from_env` format.

## Breaking changes

- [x] Yes
- [ ] No

The `SecretVar` JSON representation changes from `env_var`/`from_env`/`vault_var`/`from_vault` to `ref`/`type`. Deserialization of the old format remains supported, but any client or config consuming API responses will receive the new format. The UI has been updated accordingly; external API consumers producing the old format will continue to work on ingest.

## Security considerations

Secret source metadata previously exposed separate env var names and vault paths in distinct fields. These are now unified under `ref`, which is preserved in redacted responses so references remain visible to operators without leaking resolved values. The `Scan` method no longer strips quotes before checking for `vault.` prefixes, preventing a quoted literal string such as `"vault.x"` from being misidentified as a vault reference.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable