### PR TITLE
refactor: unify SecretVar env/vault fields into single SecretRef/FromSecret

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -343,12 +343,8 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 	case schemas.NoProxy:
 		return client
 	case schemas.HTTPProxy:
-		if proxyConfig.URL != nil && (proxyConfig.URL.IsFromEnv() || proxyConfig.URL.IsFromVault()) && proxyConfig.URL.GetValue() == "" {
-			ref := proxyConfig.URL.EnvVar
-			if proxyConfig.URL.IsFromVault() {
-				ref = proxyConfig.URL.VaultRef
-			}
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", ref)
+		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.SecretRef)
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -373,12 +369,8 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		}
 		dialFunc = fasthttpproxy.FasthttpHTTPDialer(proxyURL)
 	case schemas.Socks5Proxy:
-		if proxyConfig.URL != nil && (proxyConfig.URL.IsFromEnv() || proxyConfig.URL.IsFromVault()) && proxyConfig.URL.GetValue() == "" {
-			ref := proxyConfig.URL.EnvVar
-			if proxyConfig.URL.IsFromVault() {
-				ref = proxyConfig.URL.VaultRef
-			}
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", ref)
+		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.SecretRef)
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -416,12 +408,8 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 	}
 
 	// Configure custom CA certificate if provided
-	if proxyConfig.CACertPEM != nil && (proxyConfig.CACertPEM.IsFromEnv() || proxyConfig.CACertPEM.IsFromVault()) && proxyConfig.CACertPEM.GetValue() == "" {
-		ref := proxyConfig.CACertPEM.EnvVar
-		if proxyConfig.CACertPEM.IsFromVault() {
-			ref = proxyConfig.CACertPEM.VaultRef
-		}
-		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", ref)
+	if proxyConfig.CACertPEM != nil && proxyConfig.CACertPEM.IsFromSecret() && proxyConfig.CACertPEM.GetValue() == "" {
+		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.SecretRef)
 		getLogger().Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client
@@ -463,12 +451,8 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 // ConfigureTLS applies TLS settings from NetworkConfig to the fasthttp client.
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
-	if networkConfig.CACertPEM != nil && (networkConfig.CACertPEM.IsFromEnv() || networkConfig.CACertPEM.IsFromVault()) && networkConfig.CACertPEM.GetValue() == "" {
-		ref := networkConfig.CACertPEM.EnvVar
-		if networkConfig.CACertPEM.IsFromVault() {
-			ref = networkConfig.CACertPEM.VaultRef
-		}
-		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", ref)
+	if networkConfig.CACertPEM != nil && networkConfig.CACertPEM.IsFromSecret() && networkConfig.CACertPEM.GetValue() == "" {
+		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.SecretRef)
 		logger.Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client

--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -14,65 +14,79 @@ import (
 // or an external vault (e.g. AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault).
 // Three reference forms are accepted: plain text, "env.VAR_NAME", and "vault.path/to/secret".
 type SecretVar struct {
-	Val       string `json:"value"`
-	EnvVar    string `json:"env_var"`
-	FromEnv   bool   `json:"from_env"`
-	VaultRef  string `json:"vault_var,omitempty"`
-	FromVault bool   `json:"from_vault,omitempty"`
+	Val        string `json:"value"`
+	SecretRef  string `json:"secret_ref,omitempty"`
+	FromSecret bool   `json:"from_secret,omitempty"`
 }
 
-// NewSecretVar creates a new EnvValue from a string.
+// NewSecretVar creates a new SecretVar from a string.
 func NewSecretVar(value string) *SecretVar {
-	// Cleanup string if required
 	// Use strconv.Unquote to properly handle JSON string escape sequences
-	// This converts "\"{\\\"key\\\":\\\"value\\\"}\"" to "{\"key\":\"value\"}"
 	val := value
 	if unquoted, err := strconv.Unquote(value); err == nil {
 		val = unquoted
 	}
-	// Here we will need to check if the incoming data is a valid JSON object
-	// If it's a valid JSON object and follows the SecretVar schema, then we will unmarshal it into an SecretVar object
+	// If it's a valid JSON object following the SecretVar schema, unmarshal it
 	if sonic.Valid([]byte(value)) {
 		valueNode, _ := sonic.Get([]byte(val), "value")
 		envNode, _ := sonic.Get([]byte(val), "env_var")
-		if valueNode.Exists() && envNode.Exists() {
-			// Use a type alias to avoid infinite recursion (alias doesn't inherit methods)
-			type secretVarAlias SecretVar
-			var secretVar secretVarAlias
-			if err := sonic.Unmarshal([]byte(value), &secretVar); err == nil {
-				e := &SecretVar{
-					Val:       secretVar.Val,
-					FromEnv:   secretVar.FromEnv,
-					EnvVar: secretVar.EnvVar,
-					FromVault: secretVar.FromVault,
-					VaultRef:  secretVar.VaultRef,
-				}
-				// Explicit vault reference: {from_vault: true, vault_var: "vault.path"}
-				if e.FromVault && e.VaultRef != "" {
-					if !strings.HasPrefix(e.VaultRef, "vault.") {
-						e.VaultRef = "vault." + e.VaultRef
+		secretRefNode, _ := sonic.Get([]byte(val), "secret_ref")
+		if valueNode.Exists() && (envNode.Exists() || secretRefNode.Exists()) {
+			type secretVarCompat struct {
+				Val        string `json:"value"`
+				SecretRef  string `json:"secret_ref"`
+				FromSecret bool   `json:"from_secret"`
+				// backward compat: env_var/from_env (shipped)
+				EnvVar  string `json:"env_var"`
+				FromEnv bool   `json:"from_env"`
+			}
+			var raw secretVarCompat
+			if err := sonic.Unmarshal([]byte(value), &raw); err == nil {
+				e := &SecretVar{Val: raw.Val}
+				// New format
+				if raw.SecretRef != "" || raw.FromSecret {
+					e.SecretRef = raw.SecretRef
+					e.FromSecret = raw.FromSecret
+				} else {
+					// Backward compat: env (shipped — must keep working)
+					if raw.FromEnv && raw.EnvVar != "" {
+						ref := raw.EnvVar
+						if !strings.HasPrefix(ref, "env.") {
+							ref = "env." + ref
+						}
+						e.SecretRef = ref
+						e.FromSecret = true
+						if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
+							e.Val = envValue
+						} else {
+							e.Val = ""
+						}
+						return e
 					}
-					e.Val = e.VaultRef
-					if vaultValue, ok := LookupVault(e.VaultRef); ok {
+					// Legacy format: value == env_var == "env.XXX"
+					if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
+						e.SecretRef = raw.EnvVar
+						e.FromSecret = true
+						e.Val = ""
+						if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
+							e.Val = envValue
+						}
+						return e
+					}
+				}
+				// Resolve vault reference
+				if e.FromSecret && strings.HasPrefix(e.SecretRef, "vault.") {
+					e.Val = e.SecretRef
+					if vaultValue, ok := LookupVault(e.SecretRef); ok {
 						e.Val = vaultValue
 					}
-					return e
 				}
-				// Old format: value == env_var == "env.XXX"
-				if strings.HasPrefix(e.Val, "env.") && e.Val == e.EnvVar {
-					e.Val = ""
-					// Load the environment variable value
-					envValue, ok := os.LookupEnv(strings.TrimPrefix(e.EnvVar, "env."))
-					if ok {
+				// Resolve env reference
+				if e.FromSecret && strings.HasPrefix(e.SecretRef, "env.") {
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.SecretRef, "env.")); ok {
 						e.Val = envValue
-					}
-					e.FromEnv = true
-				}
-				// New format: value is empty, from_env=true, env_var holds the reference
-				if e.Val == "" && e.FromEnv && strings.HasPrefix(e.EnvVar, "env.") {
-					e.FromEnv = true
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.EnvVar, "env.")); ok {
-						e.Val = envValue
+					} else {
+						e.Val = ""
 					}
 				}
 				return e
@@ -81,11 +95,11 @@ func NewSecretVar(value string) *SecretVar {
 	}
 	if strings.HasPrefix(val, "vault.") {
 		e := &SecretVar{
-			Val:       val,
-			VaultRef:  val,
-			FromVault: true,
+			Val:        val,
+			SecretRef:  val,
+			FromSecret: true,
 		}
-		if vaultValue, ok := LookupVault(e.VaultRef); ok {
+		if vaultValue, ok := LookupVault(val); ok {
 			e.Val = vaultValue
 		}
 		return e
@@ -93,30 +107,28 @@ func NewSecretVar(value string) *SecretVar {
 	if envKey, ok := strings.CutPrefix(val, "env."); ok {
 		if envValue, ok := os.LookupEnv(envKey); ok {
 			return &SecretVar{
-				Val:       envValue,
-				FromEnv:   true,
-				EnvVar: val,
+				Val:        envValue,
+				SecretRef:  val,
+				FromSecret: true,
 			}
 		}
 		return &SecretVar{
-			Val:       "",
-			FromEnv:   true,
-			EnvVar: val,
+			Val:        "",
+			SecretRef:  val,
+			FromSecret: true,
 		}
 	}
 	return &SecretVar{
-		Val:       val,
-		FromEnv:   false,
-		EnvVar: "",
+		Val: val,
 	}
 }
 
-// IsFromVault returns true if the value is sourced from an external vault.
-func (e *SecretVar) IsFromVault() bool {
+// IsFromSecret returns true if the value is sourced from an external secret (env var or vault).
+func (e *SecretVar) IsFromSecret() bool {
 	if e == nil {
 		return false
 	}
-	return e.FromVault
+	return e.FromSecret
 }
 
 // IsRedacted returns true if the value is redacted.
@@ -124,11 +136,11 @@ func (e *SecretVar) IsRedacted() bool {
 	if e == nil {
 		return false
 	}
-	if e.Val == "" && !e.FromEnv && !e.FromVault {
+	if e.Val == "" && !e.FromSecret {
 		return false
 	}
-	// Vault and env references are treated as redacted (the real value is external)
-	if e.FromEnv || e.FromVault {
+	// Secret references (env/vault) are treated as redacted — the real value is external
+	if e.FromSecret {
 		return true
 	}
 	if len(e.Val) <= 8 {
@@ -152,7 +164,7 @@ func (e *SecretVar) IsRedacted() bool {
 	return false
 }
 
-// Equals checks if two SecretKeys are equal.
+// Equals checks if two SecretVars are equal.
 func (e *SecretVar) Equals(other *SecretVar) bool {
 	if e == nil && other == nil {
 		return true
@@ -161,34 +173,28 @@ func (e *SecretVar) Equals(other *SecretVar) bool {
 		return false
 	}
 	return e.Val == other.Val &&
-		e.EnvVar == other.EnvVar &&
-		e.FromEnv == other.FromEnv &&
-		e.VaultRef == other.VaultRef &&
-		e.FromVault == other.FromVault
+		e.SecretRef == other.SecretRef &&
+		e.FromSecret == other.FromSecret
 }
 
-// Redacted returns a new SecretKey with the value redacted.
+// Redacted returns a new SecretVar with the value redacted.
 func (e *SecretVar) Redacted() *SecretVar {
 	if e == nil {
 		return nil
 	}
 	if e.Val == "" {
 		return &SecretVar{
-			Val:       "",
-			FromEnv:   e.FromEnv,
-			EnvVar: e.EnvVar,
-			FromVault: e.FromVault,
-			VaultRef:  e.VaultRef,
+			Val:        "",
+			SecretRef:  e.SecretRef,
+			FromSecret: e.FromSecret,
 		}
 	}
 	// If key is 8 characters or less, just return all asterisks
 	if len(e.Val) <= 8 {
 		return &SecretVar{
-			Val:       strings.Repeat("*", len(e.Val)),
-			FromEnv:   e.FromEnv,
-			EnvVar: e.EnvVar,
-			FromVault: e.FromVault,
-			VaultRef:  e.VaultRef,
+			Val:        strings.Repeat("*", len(e.Val)),
+			SecretRef:  e.SecretRef,
+			FromSecret: e.FromSecret,
 		}
 	}
 	// Show first 4 and last 4 characters, replace middle with asterisks
@@ -197,126 +203,127 @@ func (e *SecretVar) Redacted() *SecretVar {
 	middle := strings.Repeat("*", 24)
 
 	return &SecretVar{
-		Val:       prefix + middle + suffix,
-		FromEnv:   e.FromEnv,
-		EnvVar: e.EnvVar,
-		FromVault: e.FromVault,
-		VaultRef:  e.VaultRef,
+		Val:        prefix + middle + suffix,
+		SecretRef:  e.SecretRef,
+		FromSecret: e.FromSecret,
 	}
 }
 
 // FullyRedacted returns a copy of the SecretVar with Val replaced by a fixed placeholder
 // so no substring of the original value is exposed. Use for API responses where
-// Redacted is unsafe (e.g. literal proxy passwords). FromEnv/SecretVar and
-// FromVault/VaultRef are preserved so references remain visible.
+// Redacted is unsafe (e.g. literal proxy passwords). SecretRef and FromSecret are
+// preserved so references remain visible.
 func (e *SecretVar) FullyRedacted() *SecretVar {
 	if e == nil {
 		return nil
 	}
 	if e.Val == "" {
 		return &SecretVar{
-			Val:       "",
-			FromEnv:   e.FromEnv,
-			EnvVar: e.EnvVar,
-			FromVault: e.FromVault,
-			VaultRef:  e.VaultRef,
+			Val:        "",
+			SecretRef:  e.SecretRef,
+			FromSecret: e.FromSecret,
 		}
 	}
 	return &SecretVar{
-		Val:       "<REDACTED>",
-		FromEnv:   e.FromEnv,
-		EnvVar: e.EnvVar,
-		FromVault: e.FromVault,
-		VaultRef:  e.VaultRef,
+		Val:        "<REDACTED>",
+		SecretRef:  e.SecretRef,
+		FromSecret: e.FromSecret,
 	}
 }
 
 // UnmarshalJSON unmarshals the value from JSON.
 func (e *SecretVar) UnmarshalJSON(data []byte) error {
 	val := string(data)
-	// Cleanup string if required
-	// Use strconv.Unquote to properly handle JSON string escape sequences
-	// This converts "\"{\\\"key\\\":\\\"value\\\"}\"" to "{\"key\":\"value\"}"
 	if unquoted, err := strconv.Unquote(val); err == nil {
 		val = unquoted
 	}
-	// Check if the incoming data is a valid JSON object matching the SecretVar schema.
 	if sonic.Valid(data) {
 		valueNode, _ := sonic.Get(data, "value")
 		envNode, _ := sonic.Get(data, "env_var")
-		if valueNode.Exists() && envNode.Exists() {
-			// Use a type alias to avoid infinite recursion (alias doesn't inherit methods)
-			type secretVarAlias SecretVar
-			var secretVar secretVarAlias
-			if err := sonic.Unmarshal(data, &secretVar); err == nil {
-				e.Val = secretVar.Val
-				e.FromEnv = secretVar.FromEnv
-				e.EnvVar = secretVar.EnvVar
-				e.FromVault = secretVar.FromVault
-				e.VaultRef = secretVar.VaultRef
+		secretRefNode, _ := sonic.Get(data, "secret_ref")
+		if valueNode.Exists() && (envNode.Exists() || secretRefNode.Exists()) {
+			type secretVarCompat struct {
+				Val        string `json:"value"`
+				SecretRef  string `json:"secret_ref"`
+				FromSecret bool   `json:"from_secret"`
+				// backward compat: env_var/from_env (shipped)
+				EnvVar  string `json:"env_var"`
+				FromEnv bool   `json:"from_env"`
+			}
+			var raw secretVarCompat
+			if err := sonic.Unmarshal(data, &raw); err == nil {
+				e.Val = raw.Val
 
-				// Explicit vault reference: {from_vault: true, vault_var: "vault.path"}
-				if e.FromVault && e.VaultRef != "" {
-					if !strings.HasPrefix(e.VaultRef, "vault.") {
-						e.VaultRef = "vault." + e.VaultRef
+				// New format
+				if raw.SecretRef != "" || raw.FromSecret {
+					e.SecretRef = raw.SecretRef
+					e.FromSecret = raw.FromSecret
+				} else if raw.FromEnv && raw.EnvVar != "" {
+					// Backward compat: env
+					ref := raw.EnvVar
+					if !strings.HasPrefix(ref, "env.") {
+						ref = "env." + ref
 					}
-					e.Val = e.VaultRef
-					if vaultValue, ok := LookupVault(e.VaultRef); ok {
-						e.Val = vaultValue
+					e.SecretRef = ref
+					e.FromSecret = true
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
+						e.Val = envValue
+					} else {
+						e.Val = ""
+					}
+					return nil
+				} else if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
+					// Old format: value == env_var == "env.XXX"
+					e.SecretRef = raw.EnvVar
+					e.FromSecret = true
+					e.Val = ""
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
+						e.Val = envValue
 					}
 					return nil
 				}
-				// Old format: value == env_var == "env.XXX"
-				if strings.HasPrefix(e.Val, "env.") && e.Val == e.EnvVar {
-					e.Val = ""
-					envValue, ok := os.LookupEnv(strings.TrimPrefix(e.EnvVar, "env."))
-					if ok {
-						e.Val = envValue
+
+				// Resolve references
+				if e.FromSecret && strings.HasPrefix(e.SecretRef, "vault.") {
+					e.Val = e.SecretRef
+					if vaultValue, ok := LookupVault(e.SecretRef); ok {
+						e.Val = vaultValue
 					}
-					e.FromEnv = true
 				}
-				// New format: value is empty, from_env=true, env_var holds the reference
-				if e.Val == "" && e.FromEnv && strings.HasPrefix(e.EnvVar, "env.") {
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.EnvVar, "env.")); ok {
+				if e.FromSecret && strings.HasPrefix(e.SecretRef, "env.") {
+					if envValue, ok := os.LookupEnv(strings.TrimPrefix(e.SecretRef, "env.")); ok {
 						e.Val = envValue
+					} else {
+						e.Val = ""
 					}
 				}
 				return nil
 			}
-			// Else the value is JSON, so we will treat this as a normal value
 		}
 	}
-	// Plain string forms: "vault.path/to/secret", "env.VAR", or literal value
+	// Plain string forms
 	if strings.HasPrefix(val, "vault.") {
-		e.VaultRef = val
-		e.FromVault = true
+		e.SecretRef = val
+		e.FromSecret = true
 		e.Val = val
-		e.FromEnv = false
-		e.EnvVar = ""
 		if vaultValue, ok := LookupVault(val); ok {
 			e.Val = vaultValue
 		}
 		return nil
 	}
 	if envKey, ok := strings.CutPrefix(val, "env."); ok {
+		e.SecretRef = val
+		e.FromSecret = true
 		if envValue, ok := os.LookupEnv(envKey); ok {
 			e.Val = envValue
-			e.FromEnv = true
-			e.EnvVar = val
-			return nil
+		} else {
+			e.Val = ""
 		}
-		e.Val = ""
-		e.FromEnv = true
-		e.EnvVar = val
-		e.FromVault = false
-		e.VaultRef = ""
 		return nil
 	}
 	e.Val = val
-	e.FromEnv = false
-	e.EnvVar = ""
-	e.FromVault = false
-	e.VaultRef = ""
+	e.SecretRef = ""
+	e.FromSecret = false
 	return nil
 }
 
@@ -332,108 +339,75 @@ func (e *SecretVar) String() string {
 func (e *SecretVar) Scan(value any) error {
 	if value == nil {
 		e.Val = ""
-		e.FromEnv = false
-		e.EnvVar = ""
-		e.FromVault = false
-		e.VaultRef = ""
+		e.SecretRef = ""
+		e.FromSecret = false
 		return nil
 	}
 	switch v := value.(type) {
 	case []byte:
 		return e.Scan(string(v))
 	case string:
-		// Cleanup string if required
-		// The string may have "\"env.TEST\"", "env.TEST" or "env.TEST\"", we need to clean it up to "env.TEST"
 		val := strings.Trim(v, "\"")
-		// Vault reference: keep the reference in Val so the AfterFind GORM hook
-		// (resolveVaultSecretVar) can resolve it via ResolveString(&e.Val). VaultRef
-		// preserves the original path so it survives resolution and can be surfaced
-		// in API responses and re-stored correctly on writes.
 		if strings.HasPrefix(val, "vault.") {
 			e.Val = val
-			e.VaultRef = val
-			e.FromVault = true
-			e.FromEnv = false
-			e.EnvVar = ""
+			e.SecretRef = val
+			e.FromSecret = true
 			if vaultValue, ok := LookupVault(val); ok {
 				e.Val = vaultValue
 			}
 			return nil
 		}
 		if envKey, ok := strings.CutPrefix(val, "env."); ok {
+			e.SecretRef = val
+			e.FromSecret = true
 			if envValue, ok := os.LookupEnv(envKey); ok {
 				e.Val = envValue
-				e.FromEnv = true
-				e.EnvVar = val
-				e.FromVault = false
-				e.VaultRef = ""
-				return nil
+			} else {
+				e.Val = ""
 			}
-			e.Val = ""
-			e.FromEnv = true
-			e.EnvVar = val
-			e.FromVault = false
-			e.VaultRef = ""
 			return nil
 		}
 		e.Val = val
-		e.FromEnv = false
-		e.EnvVar = ""
-		e.FromVault = false
-		e.VaultRef = ""
+		e.SecretRef = ""
+		e.FromSecret = false
 		return nil
 	}
 	return fmt.Errorf("failed to scan value: %v", value)
 }
 
 // Value implements driver.Valuer for database storage.
-// It stores the vault reference (e.g., "vault.path/to/secret") if FromVault is true,
-// the env reference (e.g., "env.API_KEY") if FromEnv is true, otherwise the raw value.
+// It stores the secret reference (e.g., "env.API_KEY" or "vault.path/to/secret") if
+// FromSecret is true, otherwise the raw value.
 func (e SecretVar) Value() (driver.Value, error) {
-	if e.FromVault {
-		return e.VaultRef, nil
-	}
-	if e.FromEnv {
-		return e.EnvVar, nil
+	if e.FromSecret {
+		return e.SecretRef, nil
 	}
 	return e.Val, nil
 }
 
-// IsFromEnv returns true if the value is sourced from an environment variable.
-func (e *SecretVar) IsFromEnv() bool {
-	if e == nil {
-		return false
-	}
-	return e.FromEnv
-}
-
 // ShouldPreserveStored returns true when the SecretVar is a client-side placeholder
 // that should not overwrite the stored credential. Returns true for a nil receiver,
-// an empty non-env/non-vault value, or a redacted non-env/non-vault value. Returns
-// false for env/vault references (always intentional) and plain non-empty values.
+// an empty non-secret value, or a redacted non-secret value. Returns false for secret
+// references (always intentional) and plain non-empty values.
 func (e *SecretVar) ShouldPreserveStored() bool {
 	if e == nil {
 		return true
 	}
-	if e.IsFromEnv() || e.IsFromVault() {
+	if e.FromSecret {
 		return false
 	}
 	return e.GetValue() == "" || e.IsRedacted()
 }
 
-// IsSet returns true if the SecretVar has a resolved value or an environment variable
-// or vault reference. This should be used instead of GetValue() != "" when checking
-// whether a field was configured, because references may have an empty Val before
-// resolution (e.g., when the env var is not set in the current environment).
+// IsSet returns true if the SecretVar has a resolved value or a secret reference.
+// Use instead of GetValue() != "" when checking whether a field was configured,
+// because references may have an empty Val before resolution.
 func (e *SecretVar) IsSet() bool {
 	if e == nil {
 		return false
 	}
-	if e.IsFromVault() {
-		return e.VaultRef != ""
-	}
-	if e.IsFromEnv() {
-		return e.EnvVar != ""
+	if e.FromSecret {
+		return e.SecretRef != ""
 	}
 	return e.Val != ""
 }

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -54,38 +54,37 @@ func TestSecretVar_UnmarshalJSON_DoubleEscapedJSON(t *testing.T) {
 			if secretVar.Val != tt.expected {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expected, secretVar.Val)
 			}
-			if secretVar.FromEnv {
-				t.Errorf("Expected FromEnv=false, got FromEnv=true")
+			if secretVar.FromSecret {
+				t.Errorf("Expected FromSecret=false, got FromSecret=true")
 			}
 		})
 	}
 }
 
 func TestSecretVar_UnmarshalJSON_SecretVarReference(t *testing.T) {
-	// Set up test environment variable
 	os.Setenv("TEST_API_KEY", "actual-api-key-value")
 	defer os.Unsetenv("TEST_API_KEY")
 
 	tests := []struct {
-		name            string
-		input           string
-		expectedVal     string
-		expectedEnvVar  string
-		expectedFromEnv bool
+		name               string
+		input              string
+		expectedVal        string
+		expectedSecretRef  string
+		expectedFromSecret bool
 	}{
 		{
-			name:            "env var reference with value present",
-			input:           `"env.TEST_API_KEY"`,
-			expectedVal:     "actual-api-key-value",
-			expectedEnvVar:  "env.TEST_API_KEY",
-			expectedFromEnv: true,
+			name:               "env var reference with value present",
+			input:              `"env.TEST_API_KEY"`,
+			expectedVal:        "actual-api-key-value",
+			expectedSecretRef:  "env.TEST_API_KEY",
+			expectedFromSecret: true,
 		},
 		{
-			name:            "env var reference with missing value",
-			input:           `"env.NONEXISTENT_VAR"`,
-			expectedVal:     "",
-			expectedEnvVar:  "env.NONEXISTENT_VAR",
-			expectedFromEnv: true,
+			name:               "env var reference with missing value",
+			input:              `"env.NONEXISTENT_VAR"`,
+			expectedVal:        "",
+			expectedSecretRef:  "env.NONEXISTENT_VAR",
+			expectedFromSecret: true,
 		},
 	}
 
@@ -99,34 +98,40 @@ func TestSecretVar_UnmarshalJSON_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.EnvVar != tt.expectedEnvVar {
-				t.Errorf("Expected SecretVar=%q, got SecretVar=%q", tt.expectedEnvVar, secretVar.EnvVar)
+			if secretVar.SecretRef != tt.expectedSecretRef {
+				t.Errorf("Expected SecretRef=%q, got SecretRef=%q", tt.expectedSecretRef, secretVar.SecretRef)
 			}
-			if secretVar.FromEnv != tt.expectedFromEnv {
-				t.Errorf("Expected FromEnv=%v, got FromEnv=%v", tt.expectedFromEnv, secretVar.FromEnv)
+			if secretVar.FromSecret != tt.expectedFromSecret {
+				t.Errorf("Expected FromSecret=%v, got FromSecret=%v", tt.expectedFromSecret, secretVar.FromSecret)
 			}
 		})
 	}
 }
 
-func TestSecretVar_UnmarshalJSON_FullStructure(t *testing.T) {
-	// Test when the input is already an SecretVar JSON object
-	input := `{"value":"my-api-key","env_var":"env.MY_KEY","from_env":true}`
+// TestSecretVar_UnmarshalJSON_BackwardCompat verifies that the old env_var/from_env JSON
+// format (shipped in previous versions) still deserializes correctly to the new fields.
+func TestSecretVar_UnmarshalJSON_BackwardCompat(t *testing.T) {
+	os.Setenv("MY_KEY", "resolved-value")
+	defer os.Unsetenv("MY_KEY")
 
-	var secretVar SecretVar
-	err := secretVar.UnmarshalJSON([]byte(input))
-	if err != nil {
-		t.Fatalf("UnmarshalJSON failed: %v", err)
-	}
-	if secretVar.Val != "my-api-key" {
-		t.Errorf("Expected Val=%q, got Val=%q", "my-api-key", secretVar.Val)
-	}
-	if secretVar.EnvVar != "env.MY_KEY" {
-		t.Errorf("Expected SecretVar=%q, got SecretVar=%q", "env.MY_KEY", secretVar.EnvVar)
-	}
-	if !secretVar.FromEnv {
-		t.Errorf("Expected FromEnv=true, got FromEnv=false")
-	}
+	t.Run("old env_var/from_env format", func(t *testing.T) {
+		input := `{"value":"my-api-key","env_var":"env.MY_KEY","from_env":true}`
+		var secretVar SecretVar
+		err := secretVar.UnmarshalJSON([]byte(input))
+		if err != nil {
+			t.Fatalf("UnmarshalJSON failed: %v", err)
+		}
+		if secretVar.SecretRef != "env.MY_KEY" {
+			t.Errorf("Expected SecretRef=%q, got %q", "env.MY_KEY", secretVar.SecretRef)
+		}
+		if !secretVar.FromSecret {
+			t.Error("Expected FromSecret=true, got false")
+		}
+		if secretVar.Val != "resolved-value" {
+			t.Errorf("Expected Val=%q, got %q", "resolved-value", secretVar.Val)
+		}
+	})
+
 }
 
 func TestNewSecretVar_DoubleEscapedJSON(t *testing.T) {
@@ -168,37 +173,36 @@ func TestNewSecretVar_DoubleEscapedJSON(t *testing.T) {
 }
 
 func TestNewSecretVar_SecretVarReference(t *testing.T) {
-	// Set up test environment variable
 	os.Setenv("TEST_NEW_ENVVAR_KEY", "resolved-value")
 	defer os.Unsetenv("TEST_NEW_ENVVAR_KEY")
 
 	tests := []struct {
-		name            string
-		input           string
-		expectedVal     string
-		expectedEnvVar  string
-		expectedFromEnv bool
+		name               string
+		input              string
+		expectedVal        string
+		expectedSecretRef  string
+		expectedFromSecret bool
 	}{
 		{
-			name:            "env var reference with value present",
-			input:           "env.TEST_NEW_ENVVAR_KEY",
-			expectedVal:     "resolved-value",
-			expectedEnvVar:  "env.TEST_NEW_ENVVAR_KEY",
-			expectedFromEnv: true,
+			name:               "env var reference with value present",
+			input:              "env.TEST_NEW_ENVVAR_KEY",
+			expectedVal:        "resolved-value",
+			expectedSecretRef:  "env.TEST_NEW_ENVVAR_KEY",
+			expectedFromSecret: true,
 		},
 		{
-			name:            "env var reference with quotes",
-			input:           `"env.TEST_NEW_ENVVAR_KEY"`,
-			expectedVal:     "resolved-value",
-			expectedEnvVar:  "env.TEST_NEW_ENVVAR_KEY",
-			expectedFromEnv: true,
+			name:               "env var reference with quotes",
+			input:              `"env.TEST_NEW_ENVVAR_KEY"`,
+			expectedVal:        "resolved-value",
+			expectedSecretRef:  "env.TEST_NEW_ENVVAR_KEY",
+			expectedFromSecret: true,
 		},
 		{
-			name:            "env var reference missing",
-			input:           "env.MISSING_VAR",
-			expectedVal:     "",
-			expectedEnvVar:  "env.MISSING_VAR",
-			expectedFromEnv: true,
+			name:               "env var reference missing",
+			input:              "env.MISSING_VAR",
+			expectedVal:        "",
+			expectedSecretRef:  "env.MISSING_VAR",
+			expectedFromSecret: true,
 		},
 	}
 
@@ -208,11 +212,11 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.EnvVar != tt.expectedEnvVar {
-				t.Errorf("Expected SecretVar=%q, got SecretVar=%q", tt.expectedEnvVar, secretVar.EnvVar)
+			if secretVar.SecretRef != tt.expectedSecretRef {
+				t.Errorf("Expected SecretRef=%q, got SecretRef=%q", tt.expectedSecretRef, secretVar.SecretRef)
 			}
-			if secretVar.FromEnv != tt.expectedFromEnv {
-				t.Errorf("Expected FromEnv=%v, got FromEnv=%v", tt.expectedFromEnv, secretVar.FromEnv)
+			if secretVar.FromSecret != tt.expectedFromSecret {
+				t.Errorf("Expected FromSecret=%v, got FromSecret=%v", tt.expectedFromSecret, secretVar.FromSecret)
 			}
 		})
 	}
@@ -221,7 +225,6 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 // TestSecretVar_RealWorldVertexCredentials tests the actual use case that triggered
 // the double-escaping bug: Vertex AI service account credentials
 func TestSecretVar_RealWorldVertexCredentials(t *testing.T) {
-	// This simulates what happens when parsing config.json with embedded service account JSON
 	type VertexKeyConfig struct {
 		ProjectID       SecretVar `json:"project_id"`
 		Region          SecretVar `json:"region"`
@@ -240,13 +243,10 @@ func TestSecretVar_RealWorldVertexCredentials(t *testing.T) {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
 
-	// Verify auth_credentials is properly unescaped
 	expectedAuthCreds := `{"type":"service_account","project_id":"my-project","private_key_id":"abc123","private_key":"-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----\n","client_email":"test@my-project.iam.gserviceaccount.com"}`
 	if config.AuthCredentials.Val != expectedAuthCreds {
 		t.Errorf("AuthCredentials not properly unescaped.\nExpected: %s\nGot: %s", expectedAuthCreds, config.AuthCredentials.Val)
 	}
-
-	// Verify simple string fields work correctly
 	if config.ProjectID.Val != "my-project" {
 		t.Errorf("Expected ProjectID=%q, got %q", "my-project", config.ProjectID.Val)
 	}
@@ -277,21 +277,19 @@ func TestSecretVar_MixedConfigParsing(t *testing.T) {
 		t.Fatalf("Failed to unmarshal: %v", err)
 	}
 
-	// Verify env var reference is resolved
 	if config.ProjectID.Val != "env-project-id" {
 		t.Errorf("Expected ProjectID=%q, got %q", "env-project-id", config.ProjectID.Val)
 	}
-	if !config.ProjectID.FromEnv {
-		t.Errorf("Expected ProjectID.FromEnv=true")
+	if !config.ProjectID.FromSecret {
+		t.Errorf("Expected ProjectID.FromSecret=true")
 	}
 
-	// Verify JSON credentials are properly unescaped
 	expectedCreds := `{"type":"service_account","key":"value"}`
 	if config.Credentials.Val != expectedCreds {
 		t.Errorf("Expected Credentials=%q, got %q", expectedCreds, config.Credentials.Val)
 	}
-	if config.Credentials.FromEnv {
-		t.Errorf("Expected Credentials.FromEnv=false")
+	if config.Credentials.FromSecret {
+		t.Errorf("Expected Credentials.FromSecret=false")
 	}
 }
 
@@ -322,8 +320,8 @@ func TestSecretVar_Equals(t *testing.T) {
 		},
 		{
 			name:     "equal values",
-			a:        &SecretVar{Val: "test", EnvVar: "env.TEST", FromEnv: true},
-			b:        &SecretVar{Val: "test", EnvVar: "env.TEST", FromEnv: true},
+			a:        &SecretVar{Val: "test", SecretRef: "env.TEST", FromSecret: true},
+			b:        &SecretVar{Val: "test", SecretRef: "env.TEST", FromSecret: true},
 			expected: true,
 		},
 		{
@@ -386,30 +384,30 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 	})
 
 	tests := []struct {
-		name        string
-		input       SecretVar
-		wantVal     string
-		wantFromEnv bool
-		wantEnvVar  string
+		name               string
+		input              SecretVar
+		wantVal            string
+		wantFromSecret     bool
+		wantSecretRef      string
 	}{
 		{
-			name:        "empty value",
-			input:       SecretVar{Val: ""},
-			wantVal:     "",
-			wantFromEnv: false,
+			name:           "empty value",
+			input:          SecretVar{Val: ""},
+			wantVal:        "",
+			wantFromSecret: false,
 		},
 		{
-			name:        "long literal never leaks prefix or suffix",
-			input:       SecretVar{Val: "mysecretpassword", FromEnv: false},
-			wantVal:     "<REDACTED>",
-			wantFromEnv: false,
+			name:           "long literal never leaks prefix or suffix",
+			input:          SecretVar{Val: "mysecretpassword"},
+			wantVal:        "<REDACTED>",
+			wantFromSecret: false,
 		},
 		{
-			name:        "resolved env password preserves reference metadata",
-			input:       SecretVar{Val: "resolved-secret", FromEnv: true, EnvVar: "env.PROXY_PASS"},
-			wantVal:     "<REDACTED>",
-			wantFromEnv: true,
-			wantEnvVar:  "env.PROXY_PASS",
+			name:           "resolved env password preserves reference metadata",
+			input:          SecretVar{Val: "resolved-secret", FromSecret: true, SecretRef: "env.PROXY_PASS"},
+			wantVal:        "<REDACTED>",
+			wantFromSecret: true,
+			wantSecretRef:  "env.PROXY_PASS",
 		},
 	}
 
@@ -419,11 +417,11 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 			if result.Val != tt.wantVal {
 				t.Errorf("Val: want %q, got %q", tt.wantVal, result.Val)
 			}
-			if result.FromEnv != tt.wantFromEnv {
-				t.Errorf("FromEnv: want %v, got %v", tt.wantFromEnv, result.FromEnv)
+			if result.FromSecret != tt.wantFromSecret {
+				t.Errorf("FromSecret: want %v, got %v", tt.wantFromSecret, result.FromSecret)
 			}
-			if result.EnvVar != tt.wantEnvVar {
-				t.Errorf("EnvVar: want %q, got %q", tt.wantEnvVar, result.EnvVar)
+			if result.SecretRef != tt.wantSecretRef {
+				t.Errorf("SecretRef: want %q, got %q", tt.wantSecretRef, result.SecretRef)
 			}
 		})
 	}
@@ -436,13 +434,13 @@ func TestSecretVar_IsRedacted(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "empty not from env",
-			input:    SecretVar{Val: "", FromEnv: false},
+			name:     "empty not from secret",
+			input:    SecretVar{Val: ""},
 			expected: false,
 		},
 		{
-			name:     "from env",
-			input:    SecretVar{Val: "test", FromEnv: true},
+			name:     "from secret",
+			input:    SecretVar{Val: "test", FromSecret: true, SecretRef: "env.KEY"},
 			expected: true,
 		},
 		{
@@ -478,9 +476,8 @@ func TestSecretVar_IsRedacted(t *testing.T) {
 }
 
 // TestSecretVar_IsSet verifies the semantic difference between GetValue() != "" and IsSet().
-// IsSet() must return true when the SecretVar references an env var (regardless of whether
-// that env var has been resolved to a non-empty Val). This is the property that the
-// BeforeSave hooks rely on so env var references survive persistence.
+// IsSet() must return true when the SecretVar references an env var or vault secret
+// (regardless of whether the reference has been resolved to a non-empty Val).
 func TestSecretVar_IsSet(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -488,7 +485,7 @@ func TestSecretVar_IsSet(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "nil envvar",
+			name:     "nil",
 			input:    nil,
 			expected: false,
 		},
@@ -503,28 +500,28 @@ func TestSecretVar_IsSet(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "only SecretVar reference set (env not resolved on this server)",
-			input:    &SecretVar{EnvVar: "env.MISSING", FromEnv: true},
+			name:     "env reference not yet resolved",
+			input:    &SecretVar{SecretRef: "env.MISSING", FromSecret: true},
 			expected: true,
 		},
 		{
-			name:     "Val and SecretVar both set (env was resolved)",
-			input:    &SecretVar{Val: "resolved-secret", EnvVar: "env.X", FromEnv: true},
+			name:     "env reference resolved",
+			input:    &SecretVar{Val: "resolved-secret", SecretRef: "env.X", FromSecret: true},
 			expected: true,
 		},
 		{
-			name:     "FromEnv true but no reference and no value",
-			input:    &SecretVar{FromEnv: true},
+			name:     "FromSecret true but no reference and no value",
+			input:    &SecretVar{FromSecret: true},
 			expected: false,
 		},
 		{
 			name:     "vault reference set",
-			input:    &SecretVar{VaultRef: "vault.bifrost/key", FromVault: true, Val: "vault.bifrost/key"},
+			input:    &SecretVar{SecretRef: "vault.bifrost/key", FromSecret: true, Val: "vault.bifrost/key"},
 			expected: true,
 		},
 		{
-			name:     "FromVault true but no reference",
-			input:    &SecretVar{FromVault: true},
+			name:     "FromSecret true but empty SecretRef",
+			input:    &SecretVar{FromSecret: true, SecretRef: ""},
 			expected: false,
 		},
 	}
@@ -540,31 +537,31 @@ func TestSecretVar_IsSet(t *testing.T) {
 
 func TestSecretVar_Scan_VaultRef(t *testing.T) {
 	tests := []struct {
-		name              string
-		input             string
-		wantVal           string
-		wantVaultRef      string
-		wantFromVault     bool
-		wantFromEnv       bool
+		name               string
+		input              string
+		wantVal            string
+		wantSecretRef      string
+		wantFromSecret     bool
 	}{
 		{
-			name:          "plain vault reference",
-			input:         "vault.bifrost/providers/openai/key",
-			wantVal:       "vault.bifrost/providers/openai/key",
-			wantVaultRef:  "vault.bifrost/providers/openai/key",
-			wantFromVault: true,
+			name:           "plain vault reference",
+			input:          "vault.bifrost/providers/openai/key",
+			wantVal:        "vault.bifrost/providers/openai/key",
+			wantSecretRef:  "vault.bifrost/providers/openai/key",
+			wantFromSecret: true,
 		},
 		{
-			name:          "vault reference with quoted wrapping",
-			input:         `"vault.myproject/secret"`,
-			wantVal:       "vault.myproject/secret",
-			wantVaultRef:  "vault.myproject/secret",
-			wantFromVault: true,
+			name:           "vault reference with quoted wrapping",
+			input:          `"vault.myproject/secret"`,
+			wantVal:        "vault.myproject/secret",
+			wantSecretRef:  "vault.myproject/secret",
+			wantFromSecret: true,
 		},
 		{
-			name:        "env reference still works",
-			input:       "env.MY_VAR",
-			wantFromEnv: true,
+			name:           "env reference",
+			input:          "env.MY_VAR",
+			wantSecretRef:  "env.MY_VAR",
+			wantFromSecret: true,
 		},
 		{
 			name:    "plain string unaffected",
@@ -579,21 +576,15 @@ func TestSecretVar_Scan_VaultRef(t *testing.T) {
 			if err := e.Scan(tt.input); err != nil {
 				t.Fatalf("Scan() error: %v", err)
 			}
-			if tt.wantFromVault {
-				if !e.FromVault {
-					t.Errorf("FromVault = false, want true")
+			if tt.wantFromSecret {
+				if !e.FromSecret {
+					t.Errorf("FromSecret = false, want true")
 				}
-				if e.VaultRef != tt.wantVaultRef {
-					t.Errorf("VaultRef = %q, want %q", e.VaultRef, tt.wantVaultRef)
-				}
-				if e.Val != tt.wantVal {
-					t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
+				if e.SecretRef != tt.wantSecretRef {
+					t.Errorf("SecretRef = %q, want %q", e.SecretRef, tt.wantSecretRef)
 				}
 			}
-			if tt.wantFromEnv && !e.FromEnv {
-				t.Errorf("FromEnv = false, want true")
-			}
-			if !tt.wantFromVault && !tt.wantFromEnv && e.Val != tt.wantVal {
+			if tt.wantVal != "" && e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
 			}
 		})
@@ -602,32 +593,25 @@ func TestSecretVar_Scan_VaultRef(t *testing.T) {
 
 func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         string
-		wantVal       string
-		wantVaultRef  string
-		wantFromVault bool
+		name           string
+		input          string
+		wantVal        string
+		wantSecretRef  string
+		wantFromSecret bool
 	}{
 		{
-			name:          "struct form with from_vault",
-			input:         `{"value":"","env_var":"","from_env":false,"vault_var":"vault.bifrost/key","from_vault":true}`,
-			wantVal:       "vault.bifrost/key",
-			wantVaultRef:  "vault.bifrost/key",
-			wantFromVault: true,
+			name:           "new format: secret_ref/from_secret",
+			input:          `{"value":"vault.bifrost/key","secret_ref":"vault.bifrost/key","from_secret":true}`,
+			wantVal:        "vault.bifrost/key",
+			wantSecretRef:  "vault.bifrost/key",
+			wantFromSecret: true,
 		},
 		{
-			name:          "struct form vault_var without vault. prefix — prefix auto-added",
-			input:         `{"value":"","env_var":"","from_env":false,"vault_var":"bifrost/key","from_vault":true}`,
-			wantVal:       "vault.bifrost/key",
-			wantVaultRef:  "vault.bifrost/key",
-			wantFromVault: true,
-		},
-		{
-			name:          "plain string vault reference",
-			input:         `"vault.myproject/secret"`,
-			wantVal:       "vault.myproject/secret",
-			wantVaultRef:  "vault.myproject/secret",
-			wantFromVault: true,
+			name:           "plain string vault reference",
+			input:          `"vault.myproject/secret"`,
+			wantVal:        "vault.myproject/secret",
+			wantSecretRef:  "vault.myproject/secret",
+			wantFromSecret: true,
 		},
 	}
 
@@ -637,11 +621,11 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 			if err := json.Unmarshal([]byte(tt.input), &e); err != nil {
 				t.Fatalf("UnmarshalJSON() error: %v", err)
 			}
-			if e.FromVault != tt.wantFromVault {
-				t.Errorf("FromVault = %v, want %v", e.FromVault, tt.wantFromVault)
+			if e.FromSecret != tt.wantFromSecret {
+				t.Errorf("FromSecret = %v, want %v", e.FromSecret, tt.wantFromSecret)
 			}
-			if e.VaultRef != tt.wantVaultRef {
-				t.Errorf("VaultRef = %q, want %q", e.VaultRef, tt.wantVaultRef)
+			if e.SecretRef != tt.wantSecretRef {
+				t.Errorf("SecretRef = %q, want %q", e.SecretRef, tt.wantSecretRef)
 			}
 			if e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -652,9 +636,9 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 
 func TestSecretVar_Value_VaultRef(t *testing.T) {
 	e := &SecretVar{
-		Val:       "actual-secret",
-		VaultRef:  "vault.bifrost/key",
-		FromVault: true,
+		Val:        "actual-secret",
+		SecretRef:  "vault.bifrost/key",
+		FromSecret: true,
 	}
 	got, err := e.Value()
 	if err != nil {
@@ -667,26 +651,26 @@ func TestSecretVar_Value_VaultRef(t *testing.T) {
 
 func TestSecretVar_Redacted_VaultRef(t *testing.T) {
 	e := &SecretVar{
-		Val:       "actual-secret-value",
-		VaultRef:  "vault.bifrost/key",
-		FromVault: true,
+		Val:        "actual-secret-value",
+		SecretRef:  "vault.bifrost/key",
+		FromSecret: true,
 	}
 	r := e.Redacted()
 	wantVal := "actu************************alue"
 	if r.Val != wantVal {
 		t.Errorf("Redacted().Val = %q, want %q", r.Val, wantVal)
 	}
-	if !r.FromVault {
-		t.Errorf("Redacted().FromVault = false, want true")
+	if !r.FromSecret {
+		t.Errorf("Redacted().FromSecret = false, want true")
 	}
-	if r.VaultRef != "vault.bifrost/key" {
-		t.Errorf("Redacted().VaultRef = %q, want %q", r.VaultRef, "vault.bifrost/key")
+	if r.SecretRef != "vault.bifrost/key" {
+		t.Errorf("Redacted().SecretRef = %q, want %q", r.SecretRef, "vault.bifrost/key")
 	}
 }
 
 func TestSecretVar_IsSet_VaultRef(t *testing.T) {
-	set := &SecretVar{VaultRef: "vault.bifrost/key", FromVault: true, Val: "vault.bifrost/key"}
-	unset := &SecretVar{FromVault: true}
+	set := &SecretVar{SecretRef: "vault.bifrost/key", FromSecret: true, Val: "vault.bifrost/key"}
+	unset := &SecretVar{FromSecret: true}
 	if !set.IsSet() {
 		t.Error("IsSet() = false for vault ref, want true")
 	}
@@ -697,14 +681,13 @@ func TestSecretVar_IsSet_VaultRef(t *testing.T) {
 
 func TestNewSecretVar_VaultRef(t *testing.T) {
 	e := NewSecretVar("vault.bifrost/mykey")
-	if !e.FromVault {
-		t.Error("FromVault = false, want true")
+	if !e.FromSecret {
+		t.Error("FromSecret = false, want true")
 	}
-	if e.VaultRef != "vault.bifrost/mykey" {
-		t.Errorf("VaultRef = %q, want %q", e.VaultRef, "vault.bifrost/mykey")
+	if e.SecretRef != "vault.bifrost/mykey" {
+		t.Errorf("SecretRef = %q, want %q", e.SecretRef, "vault.bifrost/mykey")
 	}
 	if e.Val != "vault.bifrost/mykey" {
 		t.Errorf("Val = %q, want %q", e.Val, "vault.bifrost/mykey")
 	}
 }
-

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -37,11 +37,8 @@ func SecretVarAsString(e *SecretVar) string {
 	if e == nil {
 		return ""
 	}
-	if e.IsFromEnv() {
-		return e.EnvVar
-	}
-	if e.IsFromVault() {
-		return e.VaultRef
+	if e.IsFromSecret() {
+		return e.SecretRef
 	}
 	return e.GetValue()
 }

--- a/core/schemas/vault.go
+++ b/core/schemas/vault.go
@@ -119,10 +119,10 @@ func RemoveOwnedVaultSecretVars(ctx context.Context, ownedPrefix string, model i
 // vault-backed, non-fragment reference under ownedPrefix. Fragment refs (#key)
 // point at shared, externally-managed secrets and are never auto-deleted.
 func removeOwnedVaultSecretVar(ctx context.Context, ownedPrefix string, field *SecretVar) {
-	if field == nil || !field.IsFromVault() || field.VaultRef == "" {
+	if field == nil || !strings.HasPrefix(field.SecretRef, "vault.") || field.SecretRef == "" {
 		return
 	}
-	path := strings.TrimPrefix(field.VaultRef, "vault.")
+	path := strings.TrimPrefix(field.SecretRef, "vault.")
 	if strings.IndexByte(path, '#') >= 0 {
 		return
 	}
@@ -139,14 +139,14 @@ func StoreVaultSecretVar(ctx context.Context, path string, e *SecretVar) error {
 	if VaultStoreHook == nil || e == nil {
 		return nil
 	}
-	if e.IsFromEnv() || e.IsFromVault() || e.Val == "" || e.IsRedacted() {
+	if e.IsFromSecret() || e.Val == "" || e.IsRedacted() {
 		return nil
 	}
 	if err := VaultStoreHook(ctx, path, &e.Val); err != nil {
 		return err
 	}
-	e.VaultRef = e.Val
-	e.FromVault = true
+	e.SecretRef = "vault." + path
+	e.FromSecret = true
 	return nil
 }
 

--- a/core/schemas/vault_test.go
+++ b/core/schemas/vault_test.go
@@ -31,11 +31,11 @@ func TestStoreVaultSecretVar_StoresPlaintext(t *testing.T) {
 	if got := stored["bifrost/tbl/id/value"]; got != "secret-key" {
 		t.Errorf("stored plaintext = %q, want %q", got, "secret-key")
 	}
-	if !e.FromVault {
-		t.Error("FromVault should be true after store")
+	if !e.FromSecret {
+		t.Error("FromSecret should be true after store")
 	}
-	if e.VaultRef != "vault.bifrost/tbl/id/value" {
-		t.Errorf("VaultRef = %q, want %q", e.VaultRef, "vault.bifrost/tbl/id/value")
+	if e.SecretRef != "vault.bifrost/tbl/id/value" {
+		t.Errorf("SecretRef = %q, want %q", e.SecretRef, "vault.bifrost/tbl/id/value")
 	}
 	if e.Val != "vault.bifrost/tbl/id/value" {
 		t.Errorf("Val = %q, want rewritten to vault ref", e.Val)
@@ -48,8 +48,8 @@ func TestStoreVaultSecretVar_NoOps(t *testing.T) {
 		e    *SecretVar
 	}{
 		{"nil", nil},
-		{"env-sourced", &SecretVar{FromEnv: true, EnvVar: "MY_VAR"}},
-		{"already-vault", &SecretVar{FromVault: true, VaultRef: "vault.some/path", Val: "vault.some/path"}},
+		{"env-sourced", &SecretVar{FromSecret: true, SecretRef: "env.MY_VAR"}},
+		{"already-vault", &SecretVar{FromSecret: true, SecretRef: "vault.some/path", Val: "vault.some/path"}},
 		{"empty", &SecretVar{Val: ""}},
 	}
 	for _, tc := range cases {
@@ -74,7 +74,7 @@ func TestStoreVaultSecretVar_NoHookNoOp(t *testing.T) {
 	if err := StoreVaultSecretVar(context.Background(), "p", e); err != nil {
 		t.Fatalf("StoreVaultSecretVar: %v", err)
 	}
-	if e.FromVault || e.VaultRef != "" || e.Val != "secret" {
+	if e.FromSecret || e.SecretRef != "" || e.Val != "secret" {
 		t.Errorf("expected no mutation when hook nil, got %+v", e)
 	}
 }
@@ -93,8 +93,8 @@ func TestRemoveOwnedVaultSecretVars_SkipsFragmentRefs(t *testing.T) {
 		Fragment SecretVar `gorm:"column:fragment"`
 	}
 	m := &model{
-		Normal:   SecretVar{FromVault: true, VaultRef: "vault.bifrost/m/1/normal", Val: "vault.bifrost/m/1/normal"},
-		Fragment: SecretVar{FromVault: true, VaultRef: "vault.external/db#apiKey", Val: "vault.external/db#apiKey"},
+		Normal:   SecretVar{FromSecret: true, SecretRef: "vault.bifrost/m/1/normal", Val: "vault.bifrost/m/1/normal"},
+		Fragment: SecretVar{FromSecret: true, SecretRef: "vault.external/db#apiKey", Val: "vault.external/db#apiKey"},
 	}
 
 	RemoveOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m)
@@ -119,7 +119,7 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 		Plain:    SecretVar{Val: "p1"},
 		Ptr:      &SecretVar{Val: "p2"},
 		Snake:    SecretVar{Val: "p3"},
-		EnvBased: SecretVar{FromEnv: true, EnvVar: "X"},
+		EnvBased: SecretVar{FromSecret: true, SecretRef: "env.X"},
 	}
 
 	if err := StoreOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m); err != nil {
@@ -139,8 +139,8 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 			t.Errorf("stored[%q] = %q, want %q", path, stored[path], val)
 		}
 	}
-	if !m.Plain.FromVault || !m.Ptr.FromVault || !m.Snake.FromVault {
-		t.Error("SecretVar fields should be marked FromVault after store")
+	if !m.Plain.FromSecret || !m.Ptr.FromSecret || !m.Snake.FromSecret {
+		t.Error("SecretVar fields should be marked FromSecret after store")
 	}
 }
 
@@ -153,7 +153,7 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	m := &model{
 		Headers: map[string]SecretVar{
 			"Authorization": {Val: "secret-token"},
-			"X-Env":         {FromEnv: true, EnvVar: "X"},
+			"X-Env":         {FromSecret: true, SecretRef: "env.X"},
 		},
 	}
 
@@ -168,11 +168,14 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 		t.Errorf("stored Authorization = %q, want %q", got, "secret-token")
 	}
 	auth := m.Headers["Authorization"]
-	if !auth.FromVault || auth.VaultRef != "vault.bifrost/m/1/headers/Authorization" {
+	if !auth.FromSecret || auth.SecretRef != "vault.bifrost/m/1/headers/Authorization" {
 		t.Errorf("map entry not converted to ref: %+v", auth)
 	}
-	if env := m.Headers["X-Env"]; env.FromVault {
-		t.Error("env-sourced header should not be vault-stored")
+	if env := m.Headers["X-Env"]; env.FromSecret && env.SecretRef == "env.X" {
+		// still FromSecret=true (it was env-sourced), but it should NOT have been vault-stored
+		if stored["bifrost/m/1/headers/X-Env"] != "" {
+			t.Error("env-sourced header should not be vault-stored")
+		}
 	}
 }
 
@@ -190,8 +193,8 @@ func TestRemoveOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	}
 	m := &model{
 		Headers: map[string]SecretVar{
-			"Owned":    {FromVault: true, VaultRef: "vault.bifrost/m/1/headers/Owned", Val: "vault.bifrost/m/1/headers/Owned"},
-			"External": {FromVault: true, VaultRef: "vault.external/db#key", Val: "vault.external/db#key"},
+			"Owned":    {FromSecret: true, SecretRef: "vault.bifrost/m/1/headers/Owned", Val: "vault.bifrost/m/1/headers/Owned"},
+			"External": {FromSecret: true, SecretRef: "vault.external/db#key", Val: "vault.external/db#key"},
 		},
 	}
 

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -359,10 +359,8 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 	}
 
 	if c.MCPExternalClientURL.IsSet() {
-		if c.MCPExternalClientURL.IsFromEnv() {
-			hash.Write([]byte("externalClientURL:env:" + c.MCPExternalClientURL.EnvVar))
-		} else if c.MCPExternalClientURL.IsFromVault() {
-			hash.Write([]byte("externalClientURL:vault:" + c.MCPExternalClientURL.VaultRef))
+		if c.MCPExternalClientURL.IsFromSecret() {
+			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.SecretRef))
 		} else {
 			hash.Write([]byte("externalClientURL:val:" + c.MCPExternalClientURL.GetValue()))
 		}
@@ -395,7 +393,7 @@ func (c *ClientConfig) GenerateClientConfigHashWithToolManager(tm *schemas.MCPTo
 // Redacted returns a copy of ClientConfig with any env-backed SecretVar fields masked.
 func (c *ClientConfig) Redacted() ClientConfig {
 	out := *c
-	if c.MCPExternalClientURL != nil && (c.MCPExternalClientURL.IsFromEnv() || c.MCPExternalClientURL.IsFromVault()) {
+	if c.MCPExternalClientURL != nil && c.MCPExternalClientURL.IsFromSecret() {
 		out.MCPExternalClientURL = c.MCPExternalClientURL.Redacted()
 	}
 	return out
@@ -483,7 +481,7 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		// Redact Azure key config if present
 		if key.AzureKeyConfig != nil {
 			azureConfig := &schemas.AzureKeyConfig{}
-			if key.AzureKeyConfig.Endpoint.IsFromEnv() || key.AzureKeyConfig.Endpoint.IsFromVault() {
+			if key.AzureKeyConfig.Endpoint.IsFromSecret() {
 				azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.Redacted()
 			} else {
 				azureConfig.Endpoint = key.AzureKeyConfig.Endpoint
@@ -652,11 +650,9 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	hash := sha256.New()
 	// Hash Name
 	hash.Write([]byte(key.Name))
-	// Hash Value (prefix with source type to prevent collisions between env and literal)
-	if key.Value.IsFromEnv() {
-		hash.Write([]byte("env:" + key.Value.EnvVar))
-	} else if key.Value.IsFromVault() {
-		hash.Write([]byte("vault:" + key.Value.VaultRef))
+	// Hash Value (prefix with source type to prevent collisions between ref and literal)
+	if key.Value.IsFromSecret() {
+		hash.Write([]byte("ref:" + key.Value.SecretRef))
 	} else {
 		hash.Write([]byte("val:" + key.Value.Val))
 	}
@@ -1329,10 +1325,8 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 
 	// Hash ConnectionString
 	if m.ConnectionString != nil {
-		if m.ConnectionString.IsFromEnv() {
-			hash.Write([]byte(m.ConnectionString.EnvVar))
-		} else if m.ConnectionString.IsFromVault() {
-			hash.Write([]byte(m.ConnectionString.VaultRef))
+		if m.ConnectionString.IsFromSecret() {
+			hash.Write([]byte(m.ConnectionString.SecretRef))
 		} else {
 			hash.Write([]byte(m.ConnectionString.Val))
 		}
@@ -1377,8 +1371,8 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 		sort.Strings(keys)
 		for _, k := range keys {
 			val := m.Headers[k]
-			if val.FromEnv {
-				hash.Write([]byte(k + ":env:" + val.EnvVar))
+			if val.IsFromSecret() {
+				hash.Write([]byte(k + ":ref:" + val.SecretRef))
 			} else {
 				hash.Write([]byte(k + ":val:" + val.Val))
 			}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2043,10 +2043,8 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		headersToSerialize := make(map[string]string)
 		if clientConfigCopy.Headers != nil {
 			for key, value := range clientConfigCopy.Headers {
-				if value.IsFromEnv() {
-					headersToSerialize[key] = value.EnvVar
-				} else if value.IsFromVault() {
-					headersToSerialize[key] = value.VaultRef
+				if value.IsFromSecret() {
+					headersToSerialize[key] = value.SecretRef
 				} else {
 					headersToSerialize[key] = value.GetValue()
 				}
@@ -2165,7 +2163,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if clientConfigCopy.ConfigHash != "" {
 			connectionStringToPersist := clientConfigCopy.ConnectionString
 			if encrypt.IsEnabled() && connectionStringToPersist != nil &&
-				!connectionStringToPersist.IsFromEnv() && !connectionStringToPersist.IsFromVault() && connectionStringToPersist.GetValue() != "" {
+				!connectionStringToPersist.IsFromSecret() && connectionStringToPersist.GetValue() != "" {
 				// Mirror TableMCPClient.BeforeSave behavior for map-based Updates.
 				cs := *connectionStringToPersist
 				encryptedConnString, encErr := encrypt.Encrypt(cs.Val)

--- a/framework/configstore/tables/encryption.go
+++ b/framework/configstore/tables/encryption.go
@@ -15,7 +15,7 @@ const (
 // encryptSecretVar encrypts the Val field of an SecretVar in place using AES-256-GCM.
 // It is a no-op if the field is nil, references an environment variable or vault, or has an empty value.
 func encryptSecretVar(field *schemas.SecretVar) error {
-	if field == nil || field.IsFromEnv() || field.IsFromVault() || field.GetValue() == "" {
+	if field == nil || field.IsFromSecret() || field.GetValue() == "" {
 		return nil
 	}
 	encrypted, err := encrypt.Encrypt(field.Val)
@@ -29,7 +29,7 @@ func encryptSecretVar(field *schemas.SecretVar) error {
 // decryptSecretVar decrypts the Val field of an SecretVar in place using AES-256-GCM.
 // It is a no-op if the field is nil, references an environment variable or vault, or has an empty value.
 func decryptSecretVar(field *schemas.SecretVar) error {
-	if field == nil || field.IsFromEnv() || field.IsFromVault() || field.GetValue() == "" {
+	if field == nil || field.IsFromSecret() || field.GetValue() == "" {
 		return nil
 	}
 	decrypted, err := encrypt.Decrypt(field.Val)

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -127,10 +127,8 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 	if c.Headers != nil {
 		headersToSerialize := make(map[string]string, len(c.Headers))
 		for key, value := range c.Headers {
-			if value.IsFromEnv() {
-				headersToSerialize[key] = value.EnvVar
-			} else if value.IsFromVault() {
-				headersToSerialize[key] = value.VaultRef
+			if value.IsFromSecret() {
+				headersToSerialize[key] = value.SecretRef
 			} else {
 				headersToSerialize[key] = value.GetValue()
 			}
@@ -197,7 +195,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 	// Always set EncryptionStatus when encryption is enabled so the startup
 	// batch pass does not re-process this row indefinitely.
 	if encrypt.IsEnabled() {
-		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && !c.ConnectionString.IsFromVault() && c.ConnectionString.GetValue() != "" {
+		if c.ConnectionString != nil && !c.ConnectionString.IsFromSecret() && c.ConnectionString.GetValue() != "" {
 			// Copy to avoid encrypting the shared ConnectionString through the pointer
 			cs := *c.ConnectionString
 			enc, err := encrypt.Encrypt(cs.Val)
@@ -231,7 +229,7 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 			}
 			c.HeadersJSON = decrypted
 		}
-		if c.ConnectionString != nil && !c.ConnectionString.IsFromEnv() && !c.ConnectionString.IsFromVault() && c.ConnectionString.GetValue() != "" {
+		if c.ConnectionString != nil && !c.ConnectionString.IsFromSecret() && c.ConnectionString.GetValue() != "" {
 			decrypted, err := encrypt.Decrypt(c.ConnectionString.Val)
 			if err != nil {
 				return fmt.Errorf("failed to decrypt mcp connection string: %w", err)

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -48,7 +48,7 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 
 	if encrypt.IsEnabled() {
 		encrypted := false
-		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && !c.ClientSecret.IsFromVault() && c.ClientSecret.Val != "" {
+		if c.ClientSecret != nil && !c.ClientSecret.IsFromSecret() && c.ClientSecret.Val != "" {
 			if err := encryptString(&c.ClientSecret.Val); err != nil {
 				return fmt.Errorf("failed to encrypt oauth client secret: %w", err)
 			}
@@ -71,7 +71,7 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 func (c *TableOauthConfig) AfterFind(tx *gorm.DB) error {
 	switch c.EncryptionStatus {
 	case EncryptionStatusEncrypted:
-		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && !c.ClientSecret.IsFromVault() && c.ClientSecret.Val != "" {
+		if c.ClientSecret != nil && !c.ClientSecret.IsFromSecret() && c.ClientSecret.Val != "" {
 			if err := decryptString(&c.ClientSecret.Val); err != nil {
 				return fmt.Errorf("failed to decrypt oauth client secret: %w", err)
 			}

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -295,7 +295,7 @@ func redactHeaderValue(v string) string {
 // consumers can tell the value exists without leaking env content. Unresolved env
 // references keep an empty Val, while preserving env_var for round-trip edits.
 func hideResolvedEnvValue(v *schemas.SecretVar) *schemas.SecretVar {
-	if v == nil || (!v.IsFromEnv() && !v.IsFromVault()) {
+	if v == nil || !v.IsFromSecret() {
 		return v
 	}
 	return v.Redacted()

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -128,7 +128,7 @@ func (c *Config) Redacted() *Config {
 // For env var references it zeroes out the resolved Val so the actual env content is
 // not leaked in API responses, while keeping the env_var name for round-trip edits.
 func hideResolvedEnvValue(v *schemas.SecretVar) *schemas.SecretVar {
-	if v == nil || (!v.IsFromEnv() && !v.IsFromVault()) {
+	if v == nil || !v.IsFromSecret() {
 		return v
 	}
 	return v.Redacted()

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -136,23 +136,15 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 			// If from env, preserve env_var reference but clear value
 			// If not from env, show <redacted> as the value
 			var passwordSecretVar *schemas.SecretVar
-			if authConfig.AdminPassword != nil && authConfig.AdminPassword.IsFromEnv() {
+			if authConfig.AdminPassword != nil && authConfig.AdminPassword.IsFromSecret() {
 				passwordSecretVar = &schemas.SecretVar{
-					Val:     "",
-					EnvVar:  authConfig.AdminPassword.EnvVar,
-					FromEnv: true,
-				}
-			} else if authConfig.AdminPassword != nil && authConfig.AdminPassword.IsFromVault() {
-				passwordSecretVar = &schemas.SecretVar{
-					Val:       "",
-					FromVault: true,
-					VaultRef:  authConfig.AdminPassword.VaultRef,
+					Val:        "",
+					SecretRef:  authConfig.AdminPassword.SecretRef,
+					FromSecret: true,
 				}
 			} else {
 				passwordSecretVar = &schemas.SecretVar{
-					Val:     "<redacted>",
-					EnvVar:  "",
-					FromEnv: false,
+					Val: "<redacted>",
 				}
 			}
 			mapConfig["auth_config"] = map[string]any{
@@ -163,15 +155,15 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 		} else {
 			// No auth config exists yet, return default empty SecretVar values
 			mapConfig["auth_config"] = map[string]any{
-				"admin_username": &schemas.SecretVar{Val: "", EnvVar: "", FromEnv: false},
-				"admin_password": &schemas.SecretVar{Val: "", EnvVar: "", FromEnv: false},
+				"admin_username": &schemas.SecretVar{},
+				"admin_password": &schemas.SecretVar{},
 				"is_enabled":     false,
 			}
 		}
 	} else {
 		mapConfig["auth_config"] = map[string]any{
-			"admin_username": &schemas.SecretVar{Val: "", EnvVar: "", FromEnv: false},
-			"admin_password": &schemas.SecretVar{Val: "", EnvVar: "", FromEnv: false},
+			"admin_username": &schemas.SecretVar{},
+			"admin_password": &schemas.SecretVar{},
 			"is_enabled":     false,
 		}
 	}
@@ -702,20 +694,12 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			}
 
 			// Validate env variables are set if referenced
-			if (payload.AuthConfig.AdminUserName.IsFromEnv() || payload.AuthConfig.AdminUserName.IsFromVault()) && payload.AuthConfig.AdminUserName.GetValue() == "" {
-				ref := payload.AuthConfig.AdminUserName.EnvVar
-				if payload.AuthConfig.AdminUserName.IsFromVault() {
-					ref = payload.AuthConfig.AdminUserName.VaultRef
-				}
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", ref))
+			if payload.AuthConfig.AdminUserName.IsFromSecret() && payload.AuthConfig.AdminUserName.GetValue() == "" {
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.SecretRef))
 				return
 			}
-			if (payload.AuthConfig.AdminPassword.IsFromEnv() || payload.AuthConfig.AdminPassword.IsFromVault()) && payload.AuthConfig.AdminPassword.GetValue() == "" {
-				ref := payload.AuthConfig.AdminPassword.EnvVar
-				if payload.AuthConfig.AdminPassword.IsFromVault() {
-					ref = payload.AuthConfig.AdminPassword.VaultRef
-				}
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", ref))
+			if payload.AuthConfig.AdminPassword.IsFromSecret() && payload.AuthConfig.AdminPassword.GetValue() == "" {
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.SecretRef))
 				return
 			}
 
@@ -743,11 +727,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 					}
 					// Preserve env/vault reference metadata when storing hashed password
 					payload.AuthConfig.AdminPassword = &schemas.SecretVar{
-						Val:       hashedPassword,
-						FromEnv:   payload.AuthConfig.AdminPassword.IsFromEnv(),
-						EnvVar:    payload.AuthConfig.AdminPassword.EnvVar,
-						FromVault: payload.AuthConfig.AdminPassword.IsFromVault(),
-						VaultRef:  payload.AuthConfig.AdminPassword.VaultRef,
+						Val:        hashedPassword,
+						SecretRef:  payload.AuthConfig.AdminPassword.SecretRef,
+						FromSecret: payload.AuthConfig.AdminPassword.IsFromSecret(),
 					}
 				}
 			}

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -618,7 +618,7 @@ func restoreRedactedValue(incoming, existing any) any {
 		// left as-is so clearing a value works.
 		if existingStr, ok := existing.(string); ok {
 			secretVal := schemas.NewSecretVar(val)
-			if !secretVal.IsFromEnv() && !secretVal.IsFromVault() && secretVal.IsRedacted() {
+			if !secretVal.IsFromSecret() && secretVal.IsRedacted() {
 				return existingStr
 			}
 		}
@@ -632,15 +632,27 @@ func restoreRedactedValue(incoming, existing any) any {
 // keys "value", "env_var", and "from_env".
 func isSecretVarObject(m map[string]any) bool {
 	_, hasValue := m["value"]
-	_, hasSecretVar := m["env_var"]
+	_, hasSecretRef := m["secret_ref"]
+	_, hasFromSecret := m["from_secret"]
+	// also accept legacy env_var/from_env keys for backward compat
+	_, hasEnvVar := m["env_var"]
 	_, hasFromEnv := m["from_env"]
-	return hasValue && hasSecretVar && hasFromEnv
+	return hasValue && ((hasSecretRef && hasFromSecret) || (hasEnvVar && hasFromEnv))
 }
 
-// marshalSecretVarObject serialises an SecretVar-shaped map back to the JSON string that
+// marshalSecretVarObject serialises a SecretVar-shaped map back to the JSON string that
 // schemas.NewSecretVar expects so we can call ShouldPreserveStored on it.
 func marshalSecretVarObject(m map[string]any) string {
 	value, _ := m["value"].(string)
+	// new format
+	if secretRef, ok := m["secret_ref"].(string); ok {
+		fromSecret, _ := m["from_secret"].(bool)
+		if fromSecret {
+			return fmt.Sprintf(`{"value":%q,"secret_ref":%q,"from_secret":true}`, value, secretRef)
+		}
+		return fmt.Sprintf(`{"value":%q}`, value)
+	}
+	// backward compat: old env_var/from_env format
 	secretVar, _ := m["env_var"].(string)
 	fromEnv, _ := m["from_env"].(bool)
 	if fromEnv {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2257,7 +2257,7 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 					// If the value is an env/vault reference that is currently unresolved, leave the
 					// existing DB entry untouched rather than silently generating a new literal key.
 					vkVal := &configData.Governance.VirtualKeys[i].Value
-					if (vkVal.IsFromEnv() || vkVal.IsFromVault()) && vkVal.GetValue() == "" {
+					if vkVal.IsFromSecret() && vkVal.GetValue() == "" {
 						logger.Warn("virtual key %s has an unresolved env/vault reference, skipping update to preserve existing credential", newVirtualKey.ID)
 						break
 					}
@@ -2287,7 +2287,7 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 			// If the value is an env/vault reference that is currently unresolved, skip creating
 			// the entry. It will be created on the next sync once the reference resolves.
 			newVKVal := &configData.Governance.VirtualKeys[i].Value
-			if (newVKVal.IsFromEnv() || newVKVal.IsFromVault()) && newVKVal.GetValue() == "" {
+			if newVKVal.IsFromSecret() && newVKVal.GetValue() == "" {
 				logger.Warn("virtual key %s has an unresolved env/vault reference, skipping creation until reference resolves", newVirtualKey.ID)
 				continue
 			}
@@ -3644,9 +3644,9 @@ func preserveSecretVar(source *schemas.SecretVar, value string) *schemas.SecretV
 		return schemas.NewSecretVar(value)
 	}
 	return &schemas.SecretVar{
-		Val:     value,
-		EnvVar:  source.EnvVar,
-		FromEnv: source.FromEnv,
+		Val:        value,
+		SecretRef:  source.SecretRef,
+		FromSecret: source.IsFromSecret(),
 	}
 }
 
@@ -3691,19 +3691,11 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 		return
 	}
 	// File config present: warn about empty env/vault references but continue processing
-	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && (authConfig.AdminUserName.IsFromEnv() || authConfig.AdminUserName.IsFromVault()) {
-		ref := authConfig.AdminUserName.EnvVar
-		if authConfig.AdminUserName.IsFromVault() {
-			ref = authConfig.AdminUserName.VaultRef
-		}
-		logger.Warn("username set with external reference but value is empty: %s", ref)
+	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && authConfig.AdminUserName.IsFromSecret() {
+		logger.Warn("username set with external reference but value is empty: %s", authConfig.AdminUserName.SecretRef)
 	}
-	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && (authConfig.AdminPassword.IsFromEnv() || authConfig.AdminPassword.IsFromVault()) {
-		ref := authConfig.AdminPassword.EnvVar
-		if authConfig.AdminPassword.IsFromVault() {
-			ref = authConfig.AdminPassword.VaultRef
-		}
-		logger.Warn("password set with external reference but value is empty: %s", ref)
+	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && authConfig.AdminPassword.IsFromSecret() {
+		logger.Warn("password set with external reference but value is empty: %s", authConfig.AdminPassword.SecretRef)
 	}
 	if authConfig.AdminPassword == nil || authConfig.AdminUserName == nil {
 		logger.Warn("auth config is missing admin_username or admin_password, skipping auth config processing")


### PR DESCRIPTION
## Summary

Unifies the `SecretVar` struct's dual-track secret sourcing (`FromEnv`/`EnvVar` + `FromVault`/`VaultRef`) into a single, source-agnostic pair of fields: `FromSecret bool` and `SecretRef string`. This eliminates branching throughout the codebase wherever env and vault references were handled separately, and establishes a cleaner abstraction for any future secret backend.

## Changes

- Replaced `FromEnv`/`EnvVar`/`FromVault`/`VaultRef` fields on `SecretVar` with `FromSecret bool` and `SecretRef string`
- `SecretRef` now holds the full prefixed reference (e.g. `env.MY_VAR` or `vault.path/to/secret`) regardless of backend
- `IsFromEnv()` and `IsFromVault()` methods removed; replaced by a single `IsFromSecret()` method
- Backward-compatible deserialization added in `UnmarshalJSON`, `NewSecretVar`, and `Scan` so existing stored records using the old `env_var`/`from_env` JSON format continue to deserialize correctly
- `StoreVaultSecretVar` now sets `SecretRef` to `"vault." + path` (previously it stored the raw path in `VaultRef`)
- All call sites updated: proxy/TLS configuration, config store hashing, encryption hooks, GORM `BeforeSave`/`AfterFind` hooks, HTTP config handlers, and plugins
- `isSecretVarObject` and `marshalSecretVarObject` in the HTTP plugin handler updated to recognize both the new `secret_ref`/`from_secret` keys and the legacy `env_var`/`from_env` keys
- Tests updated throughout to use the new field names; `TestSecretVar_UnmarshalJSON_FullStructure` replaced with `TestSecretVar_UnmarshalJSON_BackwardCompat` to explicitly cover the old format

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./core/providers/... ./framework/configstore/... ./transports/... ./plugins/...
```

Verify that existing configurations using `env.VAR` and `vault.path/to/secret` references continue to resolve correctly after the schema change. Confirm that records persisted with the old `env_var`/`from_env` JSON format deserialize into the new fields without data loss.

## Breaking changes

- [x] Yes
- [ ] No

The `SecretVar` struct's exported fields have changed. Any code outside this repository that directly reads or writes `EnvVar`, `FromEnv`, `VaultRef`, or `FromVault` will need to migrate to `SecretRef` and `FromSecret`. The JSON serialization format changes from `env_var`/`from_env`/`vault_var`/`from_vault` to `secret_ref`/`from_secret`; backward-compatible deserialization is provided for reading old records, but newly written records will use the new format.

## Related issues

N/A

## Security considerations

Secret reference metadata (`SecretRef`) is preserved through redaction and serialization paths so that env/vault references remain identifiable in API responses without exposing resolved values. The `FullyRedacted` and `Redacted` methods carry `SecretRef`/`FromSecret` through unchanged, maintaining the same security properties as before.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable