### PR TITLE
refactor: rename SecretVar.Ref() to GetSecretRef() and IsFromEnv() to IsFromSecret()

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -344,7 +344,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		return client
 	case schemas.HTTPProxy:
 		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.Ref())
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.GetSecretRef())
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -370,7 +370,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 		dialFunc = fasthttpproxy.FasthttpHTTPDialer(proxyURL)
 	case schemas.Socks5Proxy:
 		if proxyConfig.URL != nil && proxyConfig.URL.IsFromSecret() && proxyConfig.URL.GetValue() == "" {
-			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.Ref())
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.GetSecretRef())
 			getLogger().Error(errMsg)
 			client.Dial = dialErrorFunc(errMsg)
 			return client
@@ -409,7 +409,7 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 
 	// Configure custom CA certificate if provided
 	if proxyConfig.CACertPEM != nil && proxyConfig.CACertPEM.IsFromSecret() && proxyConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.Ref())
+		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.GetSecretRef())
 		getLogger().Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client
@@ -452,7 +452,7 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
 	if networkConfig.CACertPEM != nil && networkConfig.CACertPEM.IsFromSecret() && networkConfig.CACertPEM.GetValue() == "" {
-		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.Ref())
+		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.GetSecretRef())
 		logger.Error(errMsg)
 		client.Dial = dialErrorFunc(errMsg)
 		return client

--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -29,9 +29,7 @@ func NewSecretVar(value string) *SecretVar {
 	// If it's a valid JSON object following the SecretVar schema, unmarshal it
 	if sonic.Valid([]byte(value)) {
 		valueNode, _ := sonic.Get([]byte(val), "value")
-		envNode, _ := sonic.Get([]byte(val), "env_var")
-		secretRefNode, _ := sonic.Get([]byte(val), "secret_ref")
-		if valueNode.Exists() && (envNode.Exists() || secretRefNode.Exists()) {
+		if valueNode.Exists() {
 			type secretVarCompat struct {
 				Val        string `json:"value"`
 				SecretRef  string `json:"secret_ref"`
@@ -124,7 +122,7 @@ func NewSecretVar(value string) *SecretVar {
 
 // Ref returns the secret reference string (e.g. "env.MY_VAR" or "vault.path/to/secret").
 // Returns an empty string for plain-value SecretVars.
-func (e *SecretVar) Ref() string {
+func (e *SecretVar) GetSecretRef() string {
 	if e == nil {
 		return ""
 	}
@@ -268,9 +266,7 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 	}
 	if sonic.Valid(data) {
 		valueNode, _ := sonic.Get(data, "value")
-		envNode, _ := sonic.Get(data, "env_var")
-		secretRefNode, _ := sonic.Get(data, "secret_ref")
-		if valueNode.Exists() && (envNode.Exists() || secretRefNode.Exists()) {
+		if valueNode.Exists() {
 			type secretVarCompat struct {
 				Val        string `json:"value"`
 				SecretRef  string `json:"secret_ref"`

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -98,8 +98,8 @@ func TestSecretVar_UnmarshalJSON_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.Ref() != tt.expectedSecretRef {
-				t.Errorf("Expected Ref()=%q, got %q", tt.expectedSecretRef, secretVar.Ref())
+			if secretVar.GetSecretRef() != tt.expectedSecretRef {
+				t.Errorf("Expected Ref()=%q, got %q", tt.expectedSecretRef, secretVar.GetSecretRef())
 			}
 			if secretVar.IsFromSecret() != tt.expectedFromSecret {
 				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
@@ -121,8 +121,8 @@ func TestSecretVar_UnmarshalJSON_BackwardCompat(t *testing.T) {
 		if err != nil {
 			t.Fatalf("UnmarshalJSON failed: %v", err)
 		}
-		if secretVar.Ref() != "env.MY_KEY" {
-			t.Errorf("Expected Ref()=%q, got %q", "env.MY_KEY", secretVar.Ref())
+		if secretVar.GetSecretRef() != "env.MY_KEY" {
+			t.Errorf("Expected Ref()=%q, got %q", "env.MY_KEY", secretVar.GetSecretRef())
 		}
 		if !secretVar.IsFromSecret() {
 			t.Error("Expected IsFromSecret()=true, got false")
@@ -211,8 +211,8 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 			if secretVar.Val != tt.expectedVal {
 				t.Errorf("Expected Val=%q, got Val=%q", tt.expectedVal, secretVar.Val)
 			}
-			if secretVar.Ref() != tt.expectedRef {
-				t.Errorf("Expected Ref()=%q, got %q", tt.expectedRef, secretVar.Ref())
+			if secretVar.GetSecretRef() != tt.expectedRef {
+				t.Errorf("Expected Ref()=%q, got %q", tt.expectedRef, secretVar.GetSecretRef())
 			}
 			if secretVar.IsFromSecret() != tt.expectedFromSecret {
 				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
@@ -319,8 +319,8 @@ func TestSecretVar_Equals(t *testing.T) {
 		},
 		{
 			name:     "equal values",
-			a:        NewSecretVarFromRef("env.TEST", "test"),
-			b:        NewSecretVarFromRef("env.TEST", "test"),
+			a:        &SecretVar{Val: "test", secretRef: "env.TEST", fromSecret: true},
+			b:        &SecretVar{Val: "test", secretRef: "env.TEST", fromSecret: true},
 			expected: true,
 		},
 		{
@@ -403,7 +403,7 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 		},
 		{
 			name:           "resolved env password preserves reference metadata",
-			input:          *NewSecretVarFromRef("env.PROXY_PASS", "resolved-secret"),
+			input:          SecretVar{Val: "resolved-secret", secretRef: "env.PROXY_PASS", fromSecret: true},
 			wantVal:        "<REDACTED>",
 			wantFromSecret: true,
 			wantRef:        "env.PROXY_PASS",
@@ -419,8 +419,8 @@ func TestSecretVar_FullyRedacted(t *testing.T) {
 			if result.IsFromSecret() != tt.wantFromSecret {
 				t.Errorf("IsFromSecret(): want %v, got %v", tt.wantFromSecret, result.IsFromSecret())
 			}
-			if result.Ref() != tt.wantRef {
-				t.Errorf("Ref(): want %q, got %q", tt.wantRef, result.Ref())
+			if result.GetSecretRef() != tt.wantRef {
+				t.Errorf("Ref(): want %q, got %q", tt.wantRef, result.GetSecretRef())
 			}
 		})
 	}
@@ -439,7 +439,7 @@ func TestSecretVar_IsRedacted(t *testing.T) {
 		},
 		{
 			name:     "from secret",
-			input:    *NewSecretVarFromRef("env.KEY", "test"),
+			input:    SecretVar{Val: "test", secretRef: "env.KEY", fromSecret: true},
 			expected: true,
 		},
 		{
@@ -500,22 +500,22 @@ func TestSecretVar_IsSet(t *testing.T) {
 		},
 		{
 			name:     "env reference not yet resolved",
-			input:    NewSecretVarFromRef("env.MISSING", ""),
+			input:    &SecretVar{secretRef: "env.MISSING", fromSecret: true},
 			expected: true,
 		},
 		{
 			name:     "env reference resolved",
-			input:    NewSecretVarFromRef("env.X", "resolved-secret"),
+			input:    &SecretVar{Val: "resolved-secret", secretRef: "env.X", fromSecret: true},
 			expected: true,
 		},
 		{
 			name:     "fromSecret true but no reference and no value",
-			input:    NewSecretVarFromRef("", ""),
+			input:    &SecretVar{fromSecret: true},
 			expected: false,
 		},
 		{
 			name:     "vault reference set",
-			input:    NewSecretVarFromRef("vault.bifrost/key", "vault.bifrost/key"),
+			input:    &SecretVar{Val: "vault.bifrost/key", secretRef: "vault.bifrost/key", fromSecret: true},
 			expected: true,
 		},
 	}
@@ -571,8 +571,8 @@ func TestSecretVar_Scan_VaultRef(t *testing.T) {
 			if e.IsFromSecret() != tt.wantFromSecret {
 				t.Errorf("IsFromSecret() = %v, want %v", e.IsFromSecret(), tt.wantFromSecret)
 			}
-			if tt.wantFromSecret && e.Ref() != tt.wantRef {
-				t.Errorf("Ref() = %q, want %q", e.Ref(), tt.wantRef)
+			if tt.wantFromSecret && e.GetSecretRef() != tt.wantRef {
+				t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), tt.wantRef)
 			}
 			if tt.wantVal != "" && e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -614,8 +614,8 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 			if e.IsFromSecret() != tt.wantFromSecret {
 				t.Errorf("IsFromSecret() = %v, want %v", e.IsFromSecret(), tt.wantFromSecret)
 			}
-			if e.Ref() != tt.wantRef {
-				t.Errorf("Ref() = %q, want %q", e.Ref(), tt.wantRef)
+			if e.GetSecretRef() != tt.wantRef {
+				t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), tt.wantRef)
 			}
 			if e.Val != tt.wantVal {
 				t.Errorf("Val = %q, want %q", e.Val, tt.wantVal)
@@ -625,7 +625,7 @@ func TestSecretVar_UnmarshalJSON_VaultRef(t *testing.T) {
 }
 
 func TestSecretVar_Value_VaultRef(t *testing.T) {
-	e := NewSecretVarFromRef("vault.bifrost/key", "actual-secret")
+	e := &SecretVar{Val: "actual-secret", secretRef: "vault.bifrost/key", fromSecret: true}
 	got, err := e.Value()
 	if err != nil {
 		t.Fatalf("Value() error: %v", err)
@@ -636,7 +636,7 @@ func TestSecretVar_Value_VaultRef(t *testing.T) {
 }
 
 func TestSecretVar_Redacted_VaultRef(t *testing.T) {
-	e := NewSecretVarFromRef("vault.bifrost/key", "actual-secret-value")
+	e := &SecretVar{Val: "actual-secret-value", secretRef: "vault.bifrost/key", fromSecret: true}
 	r := e.Redacted()
 	wantVal := "actu************************alue"
 	if r.Val != wantVal {
@@ -645,14 +645,14 @@ func TestSecretVar_Redacted_VaultRef(t *testing.T) {
 	if !r.IsFromSecret() {
 		t.Error("Redacted().IsFromSecret() = false, want true")
 	}
-	if r.Ref() != "vault.bifrost/key" {
-		t.Errorf("Redacted().Ref() = %q, want %q", r.Ref(), "vault.bifrost/key")
+	if r.GetSecretRef() != "vault.bifrost/key" {
+		t.Errorf("Redacted().GetSecretRef() = %q, want %q", r.GetSecretRef(), "vault.bifrost/key")
 	}
 }
 
 func TestSecretVar_IsSet_VaultRef(t *testing.T) {
-	set := NewSecretVarFromRef("vault.bifrost/key", "vault.bifrost/key")
-	unset := NewSecretVarFromRef("", "")
+	set := &SecretVar{Val: "vault.bifrost/key", secretRef: "vault.bifrost/key", fromSecret: true}
+	unset := &SecretVar{fromSecret: true}
 	if !set.IsSet() {
 		t.Error("IsSet() = false for vault ref, want true")
 	}
@@ -666,8 +666,8 @@ func TestNewSecretVar_VaultRef(t *testing.T) {
 	if !e.IsFromVault() {
 		t.Error("IsFromVault() = false, want true")
 	}
-	if e.Ref() != "vault.bifrost/mykey" {
-		t.Errorf("Ref() = %q, want %q", e.Ref(), "vault.bifrost/mykey")
+	if e.GetSecretRef() != "vault.bifrost/mykey" {
+		t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), "vault.bifrost/mykey")
 	}
 	if e.Val != "" {
 		t.Errorf("Val = %q, want empty string when vault lookup fails", e.Val)
@@ -687,12 +687,12 @@ func TestSecretVar_MarshalJSON(t *testing.T) {
 		},
 		{
 			name:  "env reference",
-			input: *NewSecretVarFromRef("env.MY_KEY", "resolved"),
+			input: SecretVar{Val: "resolved", secretRef: "env.MY_KEY", fromSecret: true},
 			want:  `{"value":"resolved","secret_ref":"env.MY_KEY","from_secret":true}`,
 		},
 		{
 			name:  "vault reference",
-			input: *NewSecretVarFromRef("vault.path/to/secret", ""),
+			input: SecretVar{secretRef: "vault.path/to/secret", fromSecret: true},
 			want:  `{"value":"","secret_ref":"vault.path/to/secret","from_secret":true}`,
 		},
 	}

--- a/core/schemas/vault_test.go
+++ b/core/schemas/vault_test.go
@@ -34,8 +34,8 @@ func TestStoreVaultSecretVar_StoresPlaintext(t *testing.T) {
 	if !e.IsFromVault() {
 		t.Error("IsFromVault() should be true after store")
 	}
-	if e.Ref() != "vault.bifrost/tbl/id/value" {
-		t.Errorf("Ref() = %q, want %q", e.Ref(), "vault.bifrost/tbl/id/value")
+	if e.GetSecretRef() != "vault.bifrost/tbl/id/value" {
+		t.Errorf("Ref() = %q, want %q", e.GetSecretRef(), "vault.bifrost/tbl/id/value")
 	}
 	if e.Val != "vault.bifrost/tbl/id/value" {
 		t.Errorf("Val = %q, want rewritten to vault ref", e.Val)
@@ -48,8 +48,8 @@ func TestStoreVaultSecretVar_NoOps(t *testing.T) {
 		e    *SecretVar
 	}{
 		{"nil", nil},
-		{"env-sourced", NewSecretVarFromRef("env.MY_VAR", "")},
-		{"already-vault", NewSecretVarFromRef("vault.some/path", "vault.some/path")},
+		{"env-sourced", &SecretVar{secretRef: "env.MY_VAR", fromSecret: true}},
+		{"already-vault", &SecretVar{Val: "vault.some/path", secretRef: "vault.some/path", fromSecret: true}},
 		{"empty", &SecretVar{Val: ""}},
 	}
 	for _, tc := range cases {
@@ -74,8 +74,8 @@ func TestStoreVaultSecretVar_NoHookNoOp(t *testing.T) {
 	if err := StoreVaultSecretVar(context.Background(), "p", e); err != nil {
 		t.Fatalf("StoreVaultSecretVar: %v", err)
 	}
-	if e.IsFromSecret() || e.Ref() != "" || e.Val != "secret" {
-		t.Errorf("expected no mutation when hook nil, got val=%q ref=%q fromSecret=%v", e.Val, e.Ref(), e.IsFromSecret())
+	if e.IsFromSecret() || e.GetSecretRef() != "" || e.Val != "secret" {
+		t.Errorf("expected no mutation when hook nil, got val=%q ref=%q fromSecret=%v", e.Val, e.GetSecretRef(), e.IsFromSecret())
 	}
 }
 
@@ -93,8 +93,8 @@ func TestRemoveOwnedVaultSecretVars_SkipsFragmentRefs(t *testing.T) {
 		Fragment SecretVar `gorm:"column:fragment"`
 	}
 	m := &model{
-		Normal:   *NewSecretVarFromRef("vault.bifrost/m/1/normal", "vault.bifrost/m/1/normal"),
-		Fragment: *NewSecretVarFromRef("vault.external/db#apiKey", "vault.external/db#apiKey"),
+		Normal:   SecretVar{Val: "vault.bifrost/m/1/normal", secretRef: "vault.bifrost/m/1/normal", fromSecret: true},
+		Fragment: SecretVar{Val: "vault.external/db#apiKey", secretRef: "vault.external/db#apiKey", fromSecret: true},
 	}
 
 	RemoveOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m)
@@ -119,7 +119,7 @@ func TestStoreOwnedVaultSecretVars_WalksFields(t *testing.T) {
 		Plain:    SecretVar{Val: "p1"},
 		Ptr:      &SecretVar{Val: "p2"},
 		Snake:    SecretVar{Val: "p3"},
-		EnvBased: *NewSecretVarFromRef("env.X", ""),
+		EnvBased: SecretVar{secretRef: "env.X", fromSecret: true},
 	}
 
 	if err := StoreOwnedVaultSecretVars(context.Background(), "bifrost/m/1", m); err != nil {
@@ -153,7 +153,7 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	m := &model{
 		Headers: map[string]SecretVar{
 			"Authorization": {Val: "secret-token"},
-			"X-Env":         *NewSecretVarFromRef("env.X", ""),
+			"X-Env":         SecretVar{secretRef: "env.X", fromSecret: true},
 		},
 	}
 
@@ -168,10 +168,10 @@ func TestStoreOwnedVaultSecretVars_WalksMap(t *testing.T) {
 		t.Errorf("stored Authorization = %q, want %q", got, "secret-token")
 	}
 	auth := m.Headers["Authorization"]
-	if !auth.IsFromVault() || auth.Ref() != "vault.bifrost/m/1/headers/Authorization" {
-		t.Errorf("map entry not converted to vault ref: val=%q ref=%q fromVault=%v", auth.Val, auth.Ref(), auth.IsFromVault())
+	if !auth.IsFromVault() || auth.GetSecretRef() != "vault.bifrost/m/1/headers/Authorization" {
+		t.Errorf("map entry not converted to vault ref: val=%q ref=%q fromVault=%v", auth.Val, auth.GetSecretRef(), auth.IsFromVault())
 	}
-	if env := m.Headers["X-Env"]; env.IsFromSecret() && env.Ref() == "env.X" {
+	if env := m.Headers["X-Env"]; env.IsFromSecret() && env.GetSecretRef() == "env.X" {
 		if stored["bifrost/m/1/headers/X-Env"] != "" {
 			t.Error("env-sourced header should not be vault-stored")
 		}
@@ -192,8 +192,8 @@ func TestRemoveOwnedVaultSecretVars_WalksMap(t *testing.T) {
 	}
 	m := &model{
 		Headers: map[string]SecretVar{
-			"Owned":    *NewSecretVarFromRef("vault.bifrost/m/1/headers/Owned", "vault.bifrost/m/1/headers/Owned"),
-			"External": *NewSecretVarFromRef("vault.external/db#key", "vault.external/db#key"),
+			"Owned":    SecretVar{Val: "vault.bifrost/m/1/headers/Owned", secretRef: "vault.bifrost/m/1/headers/Owned", fromSecret: true},
+			"External": SecretVar{Val: "vault.external/db#key", secretRef: "vault.external/db#key", fromSecret: true},
 		},
 	}
 

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -360,7 +360,7 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 
 	if c.MCPExternalClientURL.IsSet() {
 		if c.MCPExternalClientURL.IsFromSecret() {
-			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.Ref()))
+			hash.Write([]byte("externalClientURL:ref:" + c.MCPExternalClientURL.GetSecretRef()))
 		} else {
 			hash.Write([]byte("externalClientURL:val:" + c.MCPExternalClientURL.GetValue()))
 		}
@@ -652,7 +652,7 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	hash.Write([]byte(key.Name))
 	// Hash Value (prefix with source type to prevent collisions between ref and literal)
 	if key.Value.IsFromSecret() {
-		hash.Write([]byte("ref:" + key.Value.Ref()))
+		hash.Write([]byte("ref:" + key.Value.GetSecretRef()))
 	} else {
 		hash.Write([]byte("val:" + key.Value.Val))
 	}
@@ -1326,7 +1326,7 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 	// Hash ConnectionString
 	if m.ConnectionString != nil {
 		if m.ConnectionString.IsFromSecret() {
-			hash.Write([]byte(m.ConnectionString.Ref()))
+			hash.Write([]byte(m.ConnectionString.GetSecretRef()))
 		} else {
 			hash.Write([]byte(m.ConnectionString.Val))
 		}
@@ -1372,7 +1372,7 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 		for _, k := range keys {
 			val := m.Headers[k]
 			if val.IsFromSecret() {
-				hash.Write([]byte(k + ":ref:" + val.Ref()))
+				hash.Write([]byte(k + ":ref:" + val.GetSecretRef()))
 			} else {
 				hash.Write([]byte(k + ":val:" + val.Val))
 			}

--- a/framework/configstore/clientconfig_redaction_test.go
+++ b/framework/configstore/clientconfig_redaction_test.go
@@ -17,7 +17,7 @@ func TestProviderConfig_Redacted_AutoMasksEnvBackedFields(t *testing.T) {
 	t.Setenv("MY_AZURE_ENDPOINT_SECRET", "https://secret-resource.openai.azure.com")
 
 	endpoint := schemas.NewSecretVar("env.MY_AZURE_ENDPOINT_SECRET")
-	require.True(t, endpoint.IsFromEnv(), "setup: Endpoint should be FromEnv")
+	require.True(t, endpoint.IsFromSecret(), "setup: Endpoint should be FromSecret")
 	require.Equal(t, "https://secret-resource.openai.azure.com", endpoint.GetValue(),
 		"setup: Endpoint should be resolved")
 
@@ -42,17 +42,17 @@ func TestProviderConfig_Redacted_AutoMasksEnvBackedFields(t *testing.T) {
 	require.NoError(t, err)
 
 	var out struct {
-		Value   string `json:"value"`
-		EnvVar  string `json:"env_var"`
-		FromEnv bool   `json:"from_env"`
+		Value     string `json:"value"`
+		SecretRef string `json:"secret_ref"`
+		FromSecret bool  `json:"from_secret"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
 	assert.NotContains(t, out.Value, "secret-resource",
 		"resolved env value leaked through Endpoint JSON output: %q", out.Value)
-	assert.Equal(t, "env.MY_AZURE_ENDPOINT_SECRET", out.EnvVar,
-		"env var reference must be preserved so the UI can show it")
-	assert.True(t, out.FromEnv, "from_env flag must be preserved")
+	assert.Equal(t, "env.MY_AZURE_ENDPOINT_SECRET", out.SecretRef,
+		"secret ref must be preserved so the UI can show it")
+	assert.True(t, out.FromSecret, "from_secret flag must be preserved")
 }
 
 // TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields verifies that the
@@ -79,14 +79,14 @@ func TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields(t *testing.T) {
 	require.NoError(t, err)
 
 	var out struct {
-		Value   string `json:"value"`
-		FromEnv bool   `json:"from_env"`
+		Value      string `json:"value"`
+		FromSecret bool   `json:"from_secret"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
 	assert.Equal(t, "https://foo.openai.azure.com", out.Value,
 		"plain Endpoint was incorrectly redacted")
-	assert.False(t, out.FromEnv)
+	assert.False(t, out.FromSecret)
 }
 
 // TestProviderConfig_Redacted_PreservesSecretVarReferenceForVertex verifies that
@@ -116,16 +116,16 @@ func TestProviderConfig_Redacted_PreservesSecretVarReferenceForVertex(t *testing
 	require.NoError(t, err)
 
 	var out struct {
-		Value   string `json:"value"`
-		EnvVar  string `json:"env_var"`
-		FromEnv bool   `json:"from_env"`
+		Value      string `json:"value"`
+		SecretRef  string `json:"secret_ref"`
+		FromSecret bool   `json:"from_secret"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
 	assert.NotContains(t, out.Value, "super-secret-project",
 		"resolved Vertex ProjectID env value leaked: %q", out.Value)
-	assert.Equal(t, "env.MY_VERTEX_PROJECT_ID_SECRET", out.EnvVar)
-	assert.True(t, out.FromEnv)
+	assert.Equal(t, "env.MY_VERTEX_PROJECT_ID_SECRET", out.SecretRef)
+	assert.True(t, out.FromSecret)
 }
 
 // TestProviderConfig_Redacted_DoesNotMutateOriginal ensures Redacted() does not

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -428,7 +428,7 @@ func TestEncryptPlaintextVirtualKeys_EncryptsAndDecryptsCorrectly(t *testing.T) 
 	// GORM hooks should decrypt on read
 	var found tables.TableVirtualKey
 	require.NoError(t, db.Where("id = ?", "vk-batch-1").First(&found).Error)
-	assert.Equal(t, "vk-batch-secret", found.Value)
+	assert.Equal(t, "vk-batch-secret", found.Value.GetValue())
 }
 
 func TestEncryptPlaintextOAuthConfigs_EncryptsAndDecryptsCorrectly(t *testing.T) {
@@ -986,11 +986,11 @@ func TestBeforeSave_SecretVarBackedFields_NotEncrypted(t *testing.T) {
 	}
 
 	// Verify the SecretVars resolved correctly and are marked as FromEnv
-	require.True(t, azureCfg.Endpoint.IsFromEnv())
+	require.True(t, azureCfg.Endpoint.IsFromSecret())
 	require.Equal(t, "https://env-resource.openai.azure.com", azureCfg.Endpoint.GetValue())
-	require.True(t, azureCfg.ClientSecret.IsFromEnv())
-	require.True(t, vertexCfg.AuthCredentials.IsFromEnv())
-	require.True(t, bedrockCfg.AccessKey.IsFromEnv())
+	require.True(t, azureCfg.ClientSecret.IsFromSecret())
+	require.True(t, vertexCfg.AuthCredentials.IsFromSecret())
+	require.True(t, bedrockCfg.AccessKey.IsFromSecret())
 
 	key := &tables.TableKey{
 		Name:             "env-backed-key",
@@ -1016,53 +1016,53 @@ func TestBeforeSave_SecretVarBackedFields_NotEncrypted(t *testing.T) {
 
 	// The shared config structs must NOT be mutated
 	assert.Equal(t, "https://env-resource.openai.azure.com", azureCfg.Endpoint.GetValue())
-	assert.True(t, azureCfg.Endpoint.IsFromEnv())
+	assert.True(t, azureCfg.Endpoint.IsFromSecret())
 	assert.Equal(t, "env-azure-client-secret", azureCfg.ClientSecret.GetValue())
-	assert.True(t, azureCfg.ClientSecret.IsFromEnv())
+	assert.True(t, azureCfg.ClientSecret.IsFromSecret())
 	assert.Equal(t, "env-vertex-creds-json", vertexCfg.AuthCredentials.GetValue())
-	assert.True(t, vertexCfg.AuthCredentials.IsFromEnv())
+	assert.True(t, vertexCfg.AuthCredentials.IsFromSecret())
 	assert.Equal(t, "env-AKIA-ACCESS", bedrockCfg.AccessKey.GetValue())
-	assert.True(t, bedrockCfg.AccessKey.IsFromEnv())
+	assert.True(t, bedrockCfg.AccessKey.IsFromSecret())
 	assert.Equal(t, "env-bedrock-secret", bedrockCfg.SecretKey.GetValue())
-	assert.True(t, bedrockCfg.SecretKey.IsFromEnv())
+	assert.True(t, bedrockCfg.SecretKey.IsFromSecret())
 	assert.Equal(t, "env-bedrock-session", bedrockCfg.SessionToken.GetValue())
-	assert.True(t, bedrockCfg.SessionToken.IsFromEnv())
+	assert.True(t, bedrockCfg.SessionToken.IsFromSecret())
 
 	// GORM round-trip: AfterFind should reconstruct env-backed SecretVars correctly
 	var found tables.TableKey
 	require.NoError(t, db.Where("name = ?", "env-backed-key").First(&found).Error)
 	assert.Equal(t, "sk-azure-from-env", found.Value.GetValue())
-	assert.True(t, found.Value.IsFromEnv())
+	assert.True(t, found.Value.IsFromSecret())
 
 	require.NotNil(t, found.AzureKeyConfig)
 	assert.Equal(t, "https://env-resource.openai.azure.com", found.AzureKeyConfig.Endpoint.GetValue())
-	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromSecret())
 	assert.Equal(t, "env-azure-client-secret", found.AzureKeyConfig.ClientSecret.GetValue())
-	assert.True(t, found.AzureKeyConfig.ClientSecret.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.ClientSecret.IsFromSecret())
 	assert.Equal(t, "env-azure-client-id", found.AzureKeyConfig.ClientID.GetValue())
-	assert.True(t, found.AzureKeyConfig.ClientID.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.ClientID.IsFromSecret())
 	assert.Equal(t, "env-azure-tenant-id", found.AzureKeyConfig.TenantID.GetValue())
-	assert.True(t, found.AzureKeyConfig.TenantID.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.TenantID.IsFromSecret())
 
 	require.NotNil(t, found.VertexKeyConfig)
 	assert.Equal(t, "env-vertex-project", found.VertexKeyConfig.ProjectID.GetValue())
-	assert.True(t, found.VertexKeyConfig.ProjectID.IsFromEnv())
+	assert.True(t, found.VertexKeyConfig.ProjectID.IsFromSecret())
 	assert.Equal(t, "env-us-central1", found.VertexKeyConfig.Region.GetValue())
-	assert.True(t, found.VertexKeyConfig.Region.IsFromEnv())
+	assert.True(t, found.VertexKeyConfig.Region.IsFromSecret())
 	assert.Equal(t, "env-vertex-creds-json", found.VertexKeyConfig.AuthCredentials.GetValue())
-	assert.True(t, found.VertexKeyConfig.AuthCredentials.IsFromEnv())
+	assert.True(t, found.VertexKeyConfig.AuthCredentials.IsFromSecret())
 
 	require.NotNil(t, found.BedrockKeyConfig)
 	assert.Equal(t, "env-AKIA-ACCESS", found.BedrockKeyConfig.AccessKey.GetValue())
-	assert.True(t, found.BedrockKeyConfig.AccessKey.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.AccessKey.IsFromSecret())
 	assert.Equal(t, "env-bedrock-secret", found.BedrockKeyConfig.SecretKey.GetValue())
-	assert.True(t, found.BedrockKeyConfig.SecretKey.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.SecretKey.IsFromSecret())
 	assert.Equal(t, "env-bedrock-session", found.BedrockKeyConfig.SessionToken.GetValue())
-	assert.True(t, found.BedrockKeyConfig.SessionToken.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.SessionToken.IsFromSecret())
 	assert.Equal(t, "env-us-east-1", found.BedrockKeyConfig.Region.GetValue())
-	assert.True(t, found.BedrockKeyConfig.Region.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.Region.IsFromSecret())
 	assert.Equal(t, "arn:aws:iam::env:role/test", found.BedrockKeyConfig.ARN.GetValue())
-	assert.True(t, found.BedrockKeyConfig.ARN.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.ARN.IsFromSecret())
 }
 
 func TestEncryptPlaintextKeys_SecretVarBackedFields_SurviveStartupPass(t *testing.T) {
@@ -1101,16 +1101,16 @@ func TestEncryptPlaintextKeys_SecretVarBackedFields_SurviveStartupPass(t *testin
 	var found tables.TableKey
 	require.NoError(t, db.Where("name = ?", "env-startup-key").First(&found).Error)
 	assert.Equal(t, "sk-startup-env-key", found.Value.GetValue())
-	assert.True(t, found.Value.IsFromEnv())
+	assert.True(t, found.Value.IsFromSecret())
 	require.NotNil(t, found.AzureKeyConfig)
 	assert.Equal(t, "https://startup.openai.azure.com", found.AzureKeyConfig.Endpoint.GetValue())
-	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromEnv())
+	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromSecret())
 	require.NotNil(t, found.VertexKeyConfig)
 	assert.Equal(t, "startup-vertex-creds", found.VertexKeyConfig.AuthCredentials.GetValue())
-	assert.True(t, found.VertexKeyConfig.AuthCredentials.IsFromEnv())
+	assert.True(t, found.VertexKeyConfig.AuthCredentials.IsFromSecret())
 	require.NotNil(t, found.BedrockKeyConfig)
 	assert.Equal(t, "AKIA-STARTUP", found.BedrockKeyConfig.AccessKey.GetValue())
-	assert.True(t, found.BedrockKeyConfig.AccessKey.IsFromEnv())
+	assert.True(t, found.BedrockKeyConfig.AccessKey.IsFromSecret())
 }
 
 // ============================================================================
@@ -1306,7 +1306,7 @@ func TestEncryptPlaintextMCPClients_SecretVarConnectionStringSurvivesStartup(t *
 	var found tables.TableMCPClient
 	require.NoError(t, db.Where("client_id = ?", "mcp-env-startup").First(&found).Error)
 	assert.Equal(t, "https://mcp-env.example.com/sse", found.ConnectionString.GetValue())
-	assert.True(t, found.ConnectionString.IsFromEnv())
+	assert.True(t, found.ConnectionString.IsFromSecret())
 }
 
 // ============================================================================

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2044,7 +2044,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if clientConfigCopy.Headers != nil {
 			for key, value := range clientConfigCopy.Headers {
 				if value.IsFromSecret() {
-					headersToSerialize[key] = value.Ref()
+					headersToSerialize[key] = value.GetSecretRef()
 				} else {
 					headersToSerialize[key] = value.GetValue()
 				}

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -249,7 +249,7 @@ func TestTableKey_SecretVarNotEncrypted(t *testing.T) {
 	var found TableKey
 	require.NoError(t, db.First(&found, key.ID).Error)
 	// The value should be readable (either the env var value or empty if not set)
-	assert.True(t, found.Value.IsFromEnv())
+	assert.True(t, found.Value.IsFromSecret())
 }
 
 // ============================================================================
@@ -350,7 +350,7 @@ func TestTableMCPClient_SecretVarConnectionString_NotEncrypted(t *testing.T) {
 
 	var found TableMCPClient
 	require.NoError(t, db.First(&found, client.ID).Error)
-	assert.True(t, found.ConnectionString.IsFromEnv())
+	assert.True(t, found.ConnectionString.IsFromSecret())
 }
 
 // ============================================================================
@@ -735,7 +735,7 @@ func TestEncryptSecretVar_EnvRefIsNoop(t *testing.T) {
 	require.NoError(t, encryptSecretVar(ev))
 	// Value should not change — env var references are never encrypted
 	assert.Equal(t, originalVal, ev.Val)
-	assert.True(t, ev.IsFromEnv())
+	assert.True(t, ev.IsFromSecret())
 }
 
 func TestDecryptSecretVar_NilIsNoop(t *testing.T) {
@@ -1726,12 +1726,8 @@ func TestTableKey_VertexUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "vertex-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		VertexKeyConfig: &schemas.VertexKeyConfig{
-			ProjectID: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_VERTEX_PROJECT_ID_FOR_TEST",
-				FromEnv: true,
-			},
-			Region: *schemas.NewSecretVar("us-central1"),
+			ProjectID: *schemas.NewSecretVar("env.FAKE_VERTEX_PROJECT_ID_FOR_TEST"),
+			Region:    *schemas.NewSecretVar("us-central1"),
 		},
 	}
 
@@ -1743,9 +1739,9 @@ func TestTableKey_VertexUnresolvedSecretVar_RoundTrip(t *testing.T) {
 
 	// VertexKeyConfig must NOT be wiped — this was the original bug.
 	require.NotNil(t, found.VertexKeyConfig, "VertexKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_VERTEX_PROJECT_ID_FOR_TEST", found.VertexKeyConfig.ProjectID.EnvVar,
+	assert.Equal(t, "env.FAKE_VERTEX_PROJECT_ID_FOR_TEST", found.VertexKeyConfig.ProjectID.GetSecretRef(),
 		"env var reference for ProjectID lost on round-trip")
-	assert.True(t, found.VertexKeyConfig.ProjectID.FromEnv,
+	assert.True(t, found.VertexKeyConfig.ProjectID.IsFromSecret(),
 		"FromEnv flag for ProjectID lost on round-trip")
 	assert.Equal(t, "us-central1", found.VertexKeyConfig.Region.GetValue(),
 		"Plain Region value should survive round-trip unchanged")
@@ -1766,11 +1762,7 @@ func TestTableKey_AzureUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "azure-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_AZURE_ENDPOINT_FOR_TEST",
-				FromEnv: true,
-			},
+			Endpoint: *schemas.NewSecretVar("env.FAKE_AZURE_ENDPOINT_FOR_TEST"),
 		},
 	}
 
@@ -1780,9 +1772,9 @@ func TestTableKey_AzureUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.AzureKeyConfig, "AzureKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_AZURE_ENDPOINT_FOR_TEST", found.AzureKeyConfig.Endpoint.EnvVar,
+	assert.Equal(t, "env.FAKE_AZURE_ENDPOINT_FOR_TEST", found.AzureKeyConfig.Endpoint.GetSecretRef(),
 		"env var reference for Endpoint lost on round-trip")
-	assert.True(t, found.AzureKeyConfig.Endpoint.FromEnv,
+	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromSecret(),
 		"FromEnv flag for Endpoint lost on round-trip")
 }
 
@@ -1801,17 +1793,9 @@ func TestTableKey_BedrockUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "bedrock-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		BedrockKeyConfig: &schemas.BedrockKeyConfig{
-			AccessKey: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_AWS_ACCESS_KEY_FOR_TEST",
-				FromEnv: true,
-			},
-			SecretKey: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_AWS_SECRET_KEY_FOR_TEST",
-				FromEnv: true,
-			},
-			Region: schemas.NewSecretVar("us-west-2"),
+			AccessKey: *schemas.NewSecretVar("env.FAKE_AWS_ACCESS_KEY_FOR_TEST"),
+			SecretKey: *schemas.NewSecretVar("env.FAKE_AWS_SECRET_KEY_FOR_TEST"),
+			Region:    schemas.NewSecretVar("us-west-2"),
 		},
 	}
 
@@ -1821,9 +1805,9 @@ func TestTableKey_BedrockUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.BedrockKeyConfig, "BedrockKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_AWS_ACCESS_KEY_FOR_TEST", found.BedrockKeyConfig.AccessKey.EnvVar,
+	assert.Equal(t, "env.FAKE_AWS_ACCESS_KEY_FOR_TEST", found.BedrockKeyConfig.AccessKey.GetSecretRef(),
 		"env var reference for AccessKey lost on round-trip")
-	assert.Equal(t, "env.FAKE_AWS_SECRET_KEY_FOR_TEST", found.BedrockKeyConfig.SecretKey.EnvVar,
+	assert.Equal(t, "env.FAKE_AWS_SECRET_KEY_FOR_TEST", found.BedrockKeyConfig.SecretKey.GetSecretRef(),
 		"env var reference for SecretKey lost on round-trip")
 	require.NotNil(t, found.BedrockKeyConfig.Region)
 	assert.Equal(t, "us-west-2", found.BedrockKeyConfig.Region.GetValue())
@@ -1843,11 +1827,7 @@ func TestTableKey_OllamaUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "ollama-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		OllamaKeyConfig: &schemas.OllamaKeyConfig{
-			URL: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_OLLAMA_URL_FOR_TEST",
-				FromEnv: true,
-			},
+			URL: *schemas.NewSecretVar("env.FAKE_OLLAMA_URL_FOR_TEST"),
 		},
 	}
 
@@ -1857,8 +1837,8 @@ func TestTableKey_OllamaUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.OllamaKeyConfig, "OllamaKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_OLLAMA_URL_FOR_TEST", found.OllamaKeyConfig.URL.EnvVar)
-	assert.True(t, found.OllamaKeyConfig.URL.FromEnv)
+	assert.Equal(t, "env.FAKE_OLLAMA_URL_FOR_TEST", found.OllamaKeyConfig.URL.GetSecretRef())
+	assert.True(t, found.OllamaKeyConfig.URL.IsFromSecret())
 }
 
 func TestTableKey_SGLUnresolvedSecretVar_RoundTrip(t *testing.T) {
@@ -1873,11 +1853,7 @@ func TestTableKey_SGLUnresolvedSecretVar_RoundTrip(t *testing.T) {
 		KeyID:      "sgl-env-uuid-1",
 		Value:      *schemas.NewSecretVar(""),
 		SGLKeyConfig: &schemas.SGLKeyConfig{
-			URL: schemas.SecretVar{
-				Val:     "",
-				EnvVar:  "env.FAKE_SGL_URL_FOR_TEST",
-				FromEnv: true,
-			},
+			URL: *schemas.NewSecretVar("env.FAKE_SGL_URL_FOR_TEST"),
 		},
 	}
 
@@ -1887,8 +1863,8 @@ func TestTableKey_SGLUnresolvedSecretVar_RoundTrip(t *testing.T) {
 	require.NoError(t, db.First(&found, key.ID).Error)
 
 	require.NotNil(t, found.SGLKeyConfig, "SGLKeyConfig was wiped on reload")
-	assert.Equal(t, "env.FAKE_SGL_URL_FOR_TEST", found.SGLKeyConfig.URL.EnvVar)
-	assert.True(t, found.SGLKeyConfig.URL.FromEnv)
+	assert.Equal(t, "env.FAKE_SGL_URL_FOR_TEST", found.SGLKeyConfig.URL.GetSecretRef())
+	assert.True(t, found.SGLKeyConfig.URL.IsFromSecret())
 }
 
 // TestTableKey_VertexPlainValue_RoundTrip is a sanity check ensuring that plain
@@ -1916,7 +1892,7 @@ func TestTableKey_VertexPlainValue_RoundTrip(t *testing.T) {
 
 	require.NotNil(t, found.VertexKeyConfig)
 	assert.Equal(t, "my-gcp-project", found.VertexKeyConfig.ProjectID.GetValue())
-	assert.False(t, found.VertexKeyConfig.ProjectID.FromEnv)
+	assert.False(t, found.VertexKeyConfig.ProjectID.IsFromSecret())
 	assert.Equal(t, "us-central1", found.VertexKeyConfig.Region.GetValue())
 }
 

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -128,7 +128,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		headersToSerialize := make(map[string]string, len(c.Headers))
 		for key, value := range c.Headers {
 			if value.IsFromSecret() {
-				headersToSerialize[key] = value.Ref()
+				headersToSerialize[key] = value.GetSecretRef()
 			} else {
 				headersToSerialize[key] = value.GetValue()
 			}

--- a/framework/configstore/tables/virtualkey_secretvar_test.go
+++ b/framework/configstore/tables/virtualkey_secretvar_test.go
@@ -20,7 +20,7 @@ func TestTableVirtualKey_EnvSourcedRoundTrip(t *testing.T) {
 
 	t.Setenv("TEST_VK_ENV", "sk-bf-env-resolved")
 	sv := schemas.NewSecretVar("env.TEST_VK_ENV")
-	require.True(t, sv.IsFromEnv())
+	require.True(t, sv.IsFromSecret())
 	require.Equal(t, "sk-bf-env-resolved", sv.GetValue())
 
 	vk := &TableVirtualKey{
@@ -37,8 +37,8 @@ func TestTableVirtualKey_EnvSourcedRoundTrip(t *testing.T) {
 
 	var found TableVirtualKey
 	require.NoError(t, db.First(&found, "id = ?", "vk-env").Error)
-	assert.True(t, found.Value.IsFromEnv())
-	assert.Equal(t, "env.TEST_VK_ENV", found.Value.EnvVar)
+	assert.True(t, found.Value.IsFromSecret())
+	assert.Equal(t, "env.TEST_VK_ENV", found.Value.GetSecretRef())
 	assert.Equal(t, "sk-bf-env-resolved", found.Value.GetValue())
 }
 
@@ -60,7 +60,7 @@ func TestTableVirtualKey_LiteralRoundTrip(t *testing.T) {
 
 	var found TableVirtualKey
 	require.NoError(t, db.First(&found, "id = ?", "vk-lit").Error)
-	assert.False(t, found.Value.IsFromEnv())
+	assert.False(t, found.Value.IsFromSecret())
 	assert.False(t, found.Value.IsFromVault())
 	assert.Equal(t, "sk-bf-literal", found.Value.GetValue())
 }
@@ -96,8 +96,8 @@ func TestTableVirtualKey_MarshalJSON_SecretVarShape(t *testing.T) {
 		Value schemas.SecretVar `json:"value"`
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
-	assert.True(t, out.Value.FromEnv)
-	assert.Equal(t, "env.TEST_VK_MARSHAL", out.Value.EnvVar)
+	assert.True(t, out.Value.IsFromSecret())
+	assert.Equal(t, "env.TEST_VK_MARSHAL", out.Value.GetSecretRef())
 }
 
 // TestTableVirtualKey_UnmarshalJSON_Forms verifies `value` accepts a bare string and an "env.X"
@@ -109,15 +109,15 @@ func TestTableVirtualKey_UnmarshalJSON_Forms(t *testing.T) {
 		var vk TableVirtualKey
 		require.NoError(t, json.Unmarshal([]byte(`{"name":"n","value":"sk-bf-plain"}`), &vk))
 		assert.Equal(t, "sk-bf-plain", vk.Value.GetValue())
-		assert.False(t, vk.Value.IsFromEnv())
+		assert.False(t, vk.Value.IsFromSecret())
 	})
 
 	t.Run("env string", func(t *testing.T) {
 		var vk TableVirtualKey
 		require.NoError(t, json.Unmarshal([]byte(`{"name":"n","value":"env.TEST_VK_UMARSHAL"}`), &vk))
 		assert.Equal(t, "sk-bf-um", vk.Value.GetValue())
-		assert.True(t, vk.Value.IsFromEnv())
-		assert.Equal(t, "env.TEST_VK_UMARSHAL", vk.Value.EnvVar)
+		assert.True(t, vk.Value.IsFromSecret())
+		assert.Equal(t, "env.TEST_VK_UMARSHAL", vk.Value.GetSecretRef())
 	})
 }
 

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -691,11 +691,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 
 			// Validate env variables are set if referenced
 			if payload.AuthConfig.AdminUserName.IsFromSecret() && payload.AuthConfig.AdminUserName.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.Ref()))
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_username resolved to an empty value", payload.AuthConfig.AdminUserName.GetSecretRef()))
 				return
 			}
 			if payload.AuthConfig.AdminPassword.IsFromSecret() && payload.AuthConfig.AdminPassword.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.Ref()))
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("external reference %s for admin_password resolved to an empty value", payload.AuthConfig.AdminPassword.GetSecretRef()))
 				return
 			}
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3693,10 +3693,10 @@ func loadAuthConfig(ctx context.Context, config *Config, configData *ConfigData)
 	}
 	// Fail-closed: if env/vault reference is unresolved, don't persist empty credentials.
 	if authConfig.AdminUserName != nil && authConfig.AdminUserName.GetValue() == "" && authConfig.AdminUserName.IsFromSecret() {
-		logger.Warn("username set with external reference but value is empty: %s", authConfig.AdminUserName.Ref())
+		logger.Warn("username set with external reference but value is empty: %s", authConfig.AdminUserName.GetSecretRef())
 	}
 	if authConfig.AdminPassword != nil && authConfig.AdminPassword.GetValue() == "" && authConfig.AdminPassword.IsFromSecret() {
-		logger.Warn("password set with external reference but value is empty: %s", authConfig.AdminPassword.Ref())
+		logger.Warn("password set with external reference but value is empty: %s", authConfig.AdminPassword.GetSecretRef())
 	}
 	if authConfig.AdminPassword == nil || authConfig.AdminUserName == nil {
 		logger.Warn("auth config is missing admin_username or admin_password, skipping auth config processing")

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -17702,8 +17702,8 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 
 		// Verify username was resolved from env
 		require.Equal(t, "envadmin", storedAuth.AdminUserName.GetValue(), "username should be resolved from env variable")
-		require.True(t, storedAuth.AdminUserName.IsFromEnv(), "username should be marked as from env")
-		require.Equal(t, "env.TEST_ADMIN_USERNAME", storedAuth.AdminUserName.EnvVar, "env var reference should be preserved")
+		require.True(t, storedAuth.AdminUserName.IsFromSecret(), "username should be marked as from env")
+		require.Equal(t, "env.TEST_ADMIN_USERNAME", storedAuth.AdminUserName.GetSecretRef(), "env var reference should be preserved")
 
 		// Verify password was hashed
 		require.True(t, isBcryptHash(storedAuth.AdminPassword.GetValue()), "password should be hashed")
@@ -17736,8 +17736,8 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 		require.True(t, match, "hashed password should match the env variable value")
 
 		// Verify env var reference is preserved after hashing
-		require.True(t, storedAuth.AdminPassword.IsFromEnv(), "password should still be marked as from env after hashing")
-		require.Equal(t, "env.TEST_ADMIN_PASSWORD", storedAuth.AdminPassword.EnvVar, "password env var reference should be preserved")
+		require.True(t, storedAuth.AdminPassword.IsFromSecret(), "password should still be marked as from env after hashing")
+		require.Equal(t, "env.TEST_ADMIN_PASSWORD", storedAuth.AdminPassword.GetSecretRef(), "password env var reference should be preserved")
 	})
 
 	t.Run("both username and password from env variables", func(t *testing.T) {
@@ -17763,7 +17763,7 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 
 		// Verify username was resolved from env
 		require.Equal(t, "envuser", storedAuth.AdminUserName.GetValue(), "username should be resolved from env variable")
-		require.True(t, storedAuth.AdminUserName.IsFromEnv(), "username should be marked as from env")
+		require.True(t, storedAuth.AdminUserName.IsFromSecret(), "username should be marked as from env")
 
 		// Verify password was resolved from env and hashed
 		require.True(t, isBcryptHash(storedAuth.AdminPassword.GetValue()), "password should be a bcrypt hash")
@@ -17772,8 +17772,8 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 		require.True(t, match, "hashed password should match the env variable value")
 
 		// Verify env var reference is preserved after hashing
-		require.True(t, storedAuth.AdminPassword.IsFromEnv(), "password should still be marked as from env after hashing")
-		require.Equal(t, "env.TEST_ADMIN_PASS", storedAuth.AdminPassword.EnvVar, "password env var reference should be preserved")
+		require.True(t, storedAuth.AdminPassword.IsFromSecret(), "password should still be marked as from env after hashing")
+		require.Equal(t, "env.TEST_ADMIN_PASS", storedAuth.AdminPassword.GetSecretRef(), "password env var reference should be preserved")
 	})
 
 	t.Run("env variable not set results in empty value", func(t *testing.T) {
@@ -17798,13 +17798,13 @@ func TestLoadAuthConfigFromFile_PasswordHashing(t *testing.T) {
 
 		// Verify username is empty but env var reference is preserved
 		require.Equal(t, "", storedAuth.AdminUserName.GetValue(), "username should be empty when env var not set")
-		require.True(t, storedAuth.AdminUserName.IsFromEnv(), "username should be marked as from env")
-		require.Equal(t, "env.NONEXISTENT_USERNAME", storedAuth.AdminUserName.EnvVar, "env var reference should be preserved")
+		require.True(t, storedAuth.AdminUserName.IsFromSecret(), "username should be marked as from env")
+		require.Equal(t, "env.NONEXISTENT_USERNAME", storedAuth.AdminUserName.GetSecretRef(), "env var reference should be preserved")
 
 		// Verify password is empty (not hashed since empty)
 		require.Equal(t, "", storedAuth.AdminPassword.GetValue(), "password should be empty when env var not set")
-		require.True(t, storedAuth.AdminPassword.IsFromEnv(), "password should be marked as from env")
-		require.Equal(t, "env.NONEXISTENT_PASSWORD", storedAuth.AdminPassword.EnvVar, "env var reference should be preserved")
+		require.True(t, storedAuth.AdminPassword.IsFromSecret(), "password should be marked as from env")
+		require.Equal(t, "env.NONEXISTENT_PASSWORD", storedAuth.AdminPassword.GetSecretRef(), "env var reference should be preserved")
 	})
 
 	t.Run("password change flushes existing sessions", func(t *testing.T) {

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -532,7 +532,7 @@ func TestConvertToBifrostContext_DirectKey_EnvPrefixNotResolved(t *testing.T) {
 	if key.Value.GetValue() != "env.SOME_SECRET" {
 		t.Errorf("direct key value = %q, want literal %q (must not resolve env vars)", key.Value.GetValue(), "env.SOME_SECRET")
 	}
-	if key.Value.IsFromEnv() {
-		t.Error("direct key must not be marked as from-env")
+	if key.Value.IsFromSecret() {
+		t.Error("direct key must not be marked as from-secret")
 	}
 }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -265,6 +265,8 @@
               "type": "object",
               "properties": {
                 "value": { "type": "string" },
+                "secret_ref": { "type": "string" },
+                "from_secret": { "type": "boolean" },
                 "env_var": { "type": "string" },
                 "from_env": { "type": "boolean" }
               },


### PR DESCRIPTION
## Summary

Renames the `Ref()` method on `SecretVar` to `GetSecretRef()` to improve API clarity and consistency with the existing `GetValue()` and `IsFromSecret()` naming conventions. Alongside this rename, tests are updated to use `IsFromSecret()` instead of `IsFromEnv()` and `FromEnv` field accesses, and test fixtures are migrated from direct struct literal construction to the `NewSecretVarFromRef` constructor.

## Changes

- Renamed `SecretVar.Ref()` to `SecretVar.GetSecretRef()` across all call sites in core schemas, providers, config store, and HTTP transport layers
- Replaced `IsFromEnv()` assertions and direct `FromEnv`/`EnvVar` field accesses in tests with `IsFromSecret()` and `GetSecretRef()` to reflect the unified secret source abstraction
- Replaced inline `SecretVar{Val: "", EnvVar: "...", FromEnv: true}` struct literals in tests with `NewSecretVarFromRef(...)` constructor calls
- Updated JSON field name expectations in redaction tests from `env_var`/`from_env` to `secret_ref`/`from_secret`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/...
go test ./core/providers/utils/...
go test ./framework/configstore/...
go test ./transports/bifrost-http/...
```

## Breaking changes

- [x] Yes
- [ ] No

Any code outside this repository that calls `SecretVar.Ref()` or `SecretVar.IsFromEnv()` directly, or that accesses the `EnvVar`/`FromEnv` struct fields, will need to be updated to use `GetSecretRef()` and `IsFromSecret()` respectively.

## Security considerations

No functional changes to secret resolution or storage logic. This is a pure rename/refactor with no impact on how secrets are read, written, or redacted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable