### PR TITLE
feat: runware provider support

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -41,6 +41,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/perplexity"
 	"github.com/maximhq/bifrost/core/providers/replicate"
 	"github.com/maximhq/bifrost/core/providers/runway"
+	"github.com/maximhq/bifrost/core/providers/runware"
 	"github.com/maximhq/bifrost/core/providers/sgl"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/providers/vertex"
@@ -4049,6 +4050,8 @@ func (bifrost *Bifrost) createBaseProvider(providerKey schemas.ModelProvider, co
 		return vllm.NewVLLMProvider(config, bifrost.logger)
 	case schemas.Runway:
 		return runway.NewRunwayProvider(config, bifrost.logger)
+	case schemas.Runware:
+		return runware.NewRunwareProvider(config, bifrost.logger)
 	case schemas.Fireworks:
 		return fireworks.NewFireworksProvider(config, bifrost.logger)
 	default:

--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -181,6 +181,7 @@ func (account *ComprehensiveTestAccount) GetConfiguredProviders() ([]schemas.Mod
 		schemas.Replicate,
 		schemas.VLLM,
 		schemas.Runway,
+		schemas.Runware,
 		schemas.Fireworks,
 		ProviderOpenAICustom,
 	}, nil
@@ -484,6 +485,15 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewSecretVar("env.RUNWAY_API_KEY"),
+				Models:         []string{"*"},
+				Weight:         1.0,
+				UseForBatchAPI: bifrost.Ptr(true),
+			},
+		}, nil
+	case schemas.Runware:
+		return []schemas.Key{
+			{
+				Value:          *schemas.NewEnvVar("env.RUNWARE_API_KEY"),
 				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
@@ -832,6 +842,19 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 			},
 		}, nil
 	case schemas.Runway:
+		return &schemas.ProviderConfig{
+			NetworkConfig: schemas.NetworkConfig{
+				DefaultRequestTimeoutInSeconds: 300,
+				MaxRetries:                     10,
+				RetryBackoffInitial:            1 * time.Second,
+				RetryBackoffMax:                12 * time.Second,
+			},
+			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+				Concurrency: Concurrency,
+				BufferSize:  10,
+			},
+		}, nil
+	case schemas.Runware:
 		return &schemas.ProviderConfig{
 			NetworkConfig: schemas.NetworkConfig{
 				DefaultRequestTimeoutInSeconds: 300,

--- a/core/internal/llmtests/validation_presets.go
+++ b/core/internal/llmtests/validation_presets.go
@@ -534,6 +534,12 @@ func ModifyExpectationsForProvider(expectations ResponseExpectations, provider s
 		expectations.ShouldHaveTimestamps = false
 		expectations.ShouldHaveLatency = true
 
+	case schemas.Runware:
+		// Runware is image generation only
+		expectations.ShouldHaveUsageStats = false
+		expectations.ShouldHaveTimestamps = false
+		expectations.ShouldHaveLatency = true
+
 	default:
 		// Keep default expectations — all true from BasicChatExpectations
 	}

--- a/core/providers/runware/cachedcontents.go
+++ b/core/providers/runware/cachedcontents.go
@@ -1,0 +1,32 @@
+package runware
+
+import (
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// CachedContentCreate is unsupported on RunwareProvider. Only Gemini and Vertex AI
+// support the named cache lifecycle.
+func (provider *RunwareProvider) CachedContentCreate(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCachedContentCreateRequest) (*schemas.BifrostCachedContentCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentCreateRequest, provider.GetProviderKey())
+}
+
+// CachedContentList is unsupported on RunwareProvider (see CachedContentCreate).
+func (provider *RunwareProvider) CachedContentList(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentListRequest) (*schemas.BifrostCachedContentListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentListRequest, provider.GetProviderKey())
+}
+
+// CachedContentRetrieve is unsupported on RunwareProvider (see CachedContentCreate).
+func (provider *RunwareProvider) CachedContentRetrieve(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentRetrieveRequest) (*schemas.BifrostCachedContentRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentRetrieveRequest, provider.GetProviderKey())
+}
+
+// CachedContentUpdate is unsupported on RunwareProvider (see CachedContentCreate).
+func (provider *RunwareProvider) CachedContentUpdate(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentUpdateRequest) (*schemas.BifrostCachedContentUpdateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentUpdateRequest, provider.GetProviderKey())
+}
+
+// CachedContentDelete is unsupported on RunwareProvider (see CachedContentCreate).
+func (provider *RunwareProvider) CachedContentDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentDeleteRequest) (*schemas.BifrostCachedContentDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/runware/errors.go
+++ b/core/providers/runware/errors.go
@@ -1,0 +1,47 @@
+package runware
+
+import (
+	"strings"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// parseRunwareError parses a Runware error HTTP response into a BifrostError.
+// Runware reports failures in a top-level "errors" array.
+func parseRunwareError(resp *fasthttp.Response) *schemas.BifrostError {
+	var errorResp RunwareResponse
+	bifrostErr := providerUtils.HandleProviderAPIError(resp, &errorResp)
+
+	if msg := firstRunwareErrorMessage(errorResp.Errors); msg != "" {
+		if bifrostErr.Error == nil {
+			bifrostErr.Error = &schemas.ErrorField{}
+		}
+		bifrostErr.Error.Message = msg
+	} else if bifrostErr.Error == nil || bifrostErr.Error.Message == "" {
+		if bifrostErr.Error == nil {
+			bifrostErr.Error = &schemas.ErrorField{}
+		}
+		bifrostErr.Error.Message = "Runware API request failed"
+	}
+
+	if bifrostErr.Error != nil {
+		bifrostErr.Error.Message = strings.TrimRight(bifrostErr.Error.Message, "\n")
+	}
+
+	return bifrostErr
+}
+
+// firstRunwareErrorMessage returns a human-readable message from the first error, if any.
+func firstRunwareErrorMessage(errs []RunwareError) string {
+	for _, e := range errs {
+		if e.Message != "" {
+			if e.Parameter != "" {
+				return e.Message + " (parameter: " + e.Parameter + ")"
+			}
+			return e.Message
+		}
+	}
+	return ""
+}

--- a/core/providers/runware/images.go
+++ b/core/providers/runware/images.go
@@ -1,0 +1,144 @@
+package runware
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToRunwareImageGenerationRequest converts a Bifrost image generation request to a Runware
+// imageInference task. A "seedImage" supplied via extra params (a Runware image UUID, a public
+// URL, or a base64/data-URI string) turns the request into an image-to-image generation.
+func ToRunwareImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRequest) (*RunwareImageInferenceRequest, error) {
+	if bifrostReq.Input == nil {
+		return nil, fmt.Errorf("input is required")
+	}
+
+	request := &RunwareImageInferenceRequest{
+		TaskType:       taskTypeImageInference,
+		TaskUUID:       uuid.New().String(),
+		Model:          bifrostReq.Model,
+		PositivePrompt: bifrostReq.Input.Prompt,
+		Width:          defaultRunwareWidth,
+		Height:         defaultRunwareHeight,
+	}
+
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		if params.Size != nil && *params.Size != "" {
+			request.Width, request.Height = parseRunwareSize(*params.Size)
+		}
+		request.NegativePrompt = params.NegativePrompt
+		request.Steps = params.NumInferenceSteps
+		request.Seed = params.Seed
+		request.NumberResults = params.N
+		request.OutputType = runwareOutputType(params.ResponseFormat)
+		request.OutputFormat = runwareOutputFormat(params.OutputFormat)
+
+		request.ExtraParams = params.ExtraParams
+
+		if v := request.ExtraParams["seedImage"]; v != nil {
+			delete(request.ExtraParams, "seedImage")
+			if s, ok := v.(string); ok && s != "" {
+				request.SeedImage = &s
+			}
+		}
+	}
+
+	return request, nil
+}
+
+// ToRunwareImageEditRequest converts a Bifrost image edit request to a Runware imageInference task.
+// The first input image is the seed image; an optional mask enables inpainting. Outpainting,
+// strength, maskMargin and other operation-specific fields flow through via extra params.
+func ToRunwareImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) (*RunwareImageInferenceRequest, error) {
+	if bifrostReq.Input == nil {
+		return nil, fmt.Errorf("input is required")
+	}
+	if len(bifrostReq.Input.Images) == 0 || len(bifrostReq.Input.Images[0].Image) == 0 {
+		return nil, fmt.Errorf("at least one input image is required")
+	}
+
+	request := &RunwareImageInferenceRequest{
+		TaskType:       taskTypeImageInference,
+		TaskUUID:       uuid.New().String(),
+		Model:          bifrostReq.Model,
+		PositivePrompt: bifrostReq.Input.Prompt,
+		Width:          defaultRunwareWidth,
+		Height:         defaultRunwareHeight,
+	}
+
+	// Seed image: the base image being edited (raw bytes -> base64 data URI).
+	seedImage := providerUtils.FileBytesToBase64DataURL(bifrostReq.Input.Images[0].Image)
+	request.SeedImage = &seedImage
+
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		if params.Size != nil && *params.Size != "" {
+			request.Width, request.Height = parseRunwareSize(*params.Size)
+		}
+		request.NegativePrompt = params.NegativePrompt
+		request.Steps = params.NumInferenceSteps
+		request.Seed = params.Seed
+		request.NumberResults = params.N
+		request.OutputType = runwareOutputType(params.ResponseFormat)
+		request.OutputFormat = runwareOutputFormat(params.OutputFormat)
+
+		// Mask image enables inpainting (raw bytes -> base64 data URI).
+		if len(params.Mask) > 0 {
+			maskImage := providerUtils.FileBytesToBase64DataURL(params.Mask)
+			request.MaskImage = &maskImage
+		}
+
+		request.ExtraParams = params.ExtraParams
+	}
+
+	return request, nil
+}
+
+// ToBifrostImageGenerationResponse converts a Runware response envelope to a Bifrost image response.
+func ToBifrostImageGenerationResponse(resp *RunwareResponse) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	if resp == nil {
+		return nil, providerUtils.NewBifrostOperationError("runware response is nil", nil)
+	}
+
+	// Surface task-level failures returned alongside (or instead of) data.
+	if len(resp.Data) == 0 {
+		if msg := firstRunwareErrorMessage(resp.Errors); msg != "" {
+			return nil, providerUtils.NewBifrostOperationError(msg, nil)
+		}
+		return nil, providerUtils.NewBifrostOperationError("runware returned no images", nil)
+	}
+
+	bifrostResp := &schemas.BifrostImageGenerationResponse{
+		ID:   resp.Data[0].TaskUUID,
+		Data: []schemas.ImageData{},
+	}
+
+	var seeds []int
+	for i, img := range resp.Data {
+		data := schemas.ImageData{Index: i}
+		switch {
+		case img.ImageURL != "":
+			data.URL = img.ImageURL
+		case img.ImageBase64Data != "":
+			data.B64JSON = img.ImageBase64Data
+		case img.ImageDataURI != "":
+			data.URL = img.ImageDataURI
+		}
+		bifrostResp.Data = append(bifrostResp.Data, data)
+		if img.Seed != nil {
+			seeds = append(seeds, *img.Seed)
+		}
+	}
+
+	if len(seeds) > 0 {
+		bifrostResp.ImageGenerationResponseParameters = &schemas.ImageGenerationResponseParameters{Seeds: seeds}
+	}
+
+	return bifrostResp, nil
+}

--- a/core/providers/runware/runware.go
+++ b/core/providers/runware/runware.go
@@ -1,0 +1,402 @@
+// Package runware implements the Runware provider for Bifrost.
+// Runware exposes a single synchronous endpoint that accepts an array of tasks; this
+// provider supports its image operations (text-to-image, image-to-image, inpainting, outpainting),
+// all of which use the "imageInference" task type.
+package runware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// RunwareProvider implements the Provider interface for Runware's API.
+type RunwareProvider struct {
+	logger              schemas.Logger        // Logger for provider operations
+	client              *fasthttp.Client      // HTTP client for API requests
+	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
+	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
+}
+
+// NewRunwareProvider creates a new Runware provider instance.
+func NewRunwareProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*RunwareProvider, error) {
+	config.CheckAndSetDefaults()
+
+	requestTimeout := time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds)
+	client := &fasthttp.Client{
+		ReadTimeout:         requestTimeout,
+		WriteTimeout:        requestTimeout,
+		MaxConnsPerHost:     config.NetworkConfig.MaxConnsPerHost,
+		MaxIdleConnDuration: 60 * time.Second, // Image generation can be slow; keep connections warm longer.
+		MaxConnWaitTimeout:  requestTimeout,
+		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
+		ConnPoolStrategy:    fasthttp.FIFO,
+	}
+
+	// Configure proxy if provided
+	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
+	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
+
+	// Set default BaseURL if not provided. Runware's single endpoint already includes /v1.
+	if config.NetworkConfig.BaseURL == "" {
+		config.NetworkConfig.BaseURL = "https://api.runware.ai/v1"
+	}
+	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+
+	return &RunwareProvider{
+		logger:              logger,
+		client:              client,
+		networkConfig:       config.NetworkConfig,
+		sendBackRawRequest:  config.SendBackRawRequest,
+		sendBackRawResponse: config.SendBackRawResponse,
+	}, nil
+}
+
+// GetProviderKey returns the provider identifier for Runware.
+func (provider *RunwareProvider) GetProviderKey() schemas.ModelProvider {
+	return schemas.Runware
+}
+
+// ListModels is not supported by the Runware provider.
+func (provider *RunwareProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ListModelsRequest, provider.GetProviderKey())
+}
+
+// TextCompletion is not supported by the Runware provider.
+func (provider *RunwareProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TextCompletionRequest, provider.GetProviderKey())
+}
+
+// TextCompletionStream is not supported by the Runware provider.
+func (provider *RunwareProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
+}
+
+// ChatCompletion is not supported by the Runware provider.
+func (provider *RunwareProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ChatCompletionRequest, provider.GetProviderKey())
+}
+
+// ChatCompletionStream is not supported by the Runware provider.
+func (provider *RunwareProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ChatCompletionStreamRequest, provider.GetProviderKey())
+}
+
+// Responses is not supported by the Runware provider.
+func (provider *RunwareProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ResponsesRequest, provider.GetProviderKey())
+}
+
+// ResponsesStream is not supported by the Runware provider.
+func (provider *RunwareProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ResponsesStreamRequest, provider.GetProviderKey())
+}
+
+// Embedding is not supported by the Runware provider.
+func (provider *RunwareProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
+}
+
+// Speech is not supported by the Runware provider.
+func (provider *RunwareProvider) Speech(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
+}
+
+// SpeechStream is not supported by the Runware provider.
+func (provider *RunwareProvider) SpeechStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
+}
+
+// Transcription is not supported by the Runware provider.
+func (provider *RunwareProvider) Transcription(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
+}
+
+// TranscriptionStream is not supported by the Runware provider.
+func (provider *RunwareProvider) TranscriptionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
+}
+
+// ImageGeneration performs a text-to-image (or image-to-image) request to Runware's API.
+func (provider *RunwareProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key, bifrostReq *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		bifrostReq,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToRunwareImageGenerationRequest(bifrostReq)
+		})
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	return provider.handleImageInference(ctx, key, bifrostReq.Model, jsonData)
+}
+
+// ImageEdit performs an image edit (image-to-image, inpainting, or outpainting) request to Runware's API.
+func (provider *RunwareProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, bifrostReq *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		bifrostReq,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToRunwareImageEditRequest(bifrostReq)
+		})
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	return provider.handleImageInference(ctx, key, bifrostReq.Model, jsonData)
+}
+
+// handleImageInference wraps a single imageInference task in the array Runware expects, posts it
+// to the unified endpoint, and converts the synchronous response into a Bifrost image response.
+func (provider *RunwareProvider) handleImageInference(ctx *schemas.BifrostContext, key schemas.Key, model string, jsonData []byte) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+
+	// Runware expects an array of tasks; wrap the single marshalled task object.
+	body := make([]byte, 0, len(jsonData)+2)
+	body = append(body, '[')
+	body = append(body, jsonData...)
+	body = append(body, ']')
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, ""))
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	req.SetBody(body)
+
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		return nil, providerUtils.EnrichError(ctx, parseRunwareError(resp), body, nil, sendBackRawRequest, sendBackRawResponse)
+	}
+
+	// Decode response body
+	respBody, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		rawErrBody := append([]byte(nil), resp.Body()...)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), body, rawErrBody, sendBackRawRequest, sendBackRawResponse)
+	}
+
+	// Parse response envelope
+	var runwareResp RunwareResponse
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(respBody, &runwareResp, body, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Convert to Bifrost response
+	bifrostResp, bifrostErr := ToBifrostImageGenerationResponse(&runwareResp)
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, body, respBody, sendBackRawRequest, sendBackRawResponse)
+	}
+
+	bifrostResp.Model = model
+	bifrostResp.ExtraFields.Latency = latency.Milliseconds()
+
+	if sendBackRawRequest {
+		bifrostResp.ExtraFields.RawRequest = rawRequest
+	}
+	if sendBackRawResponse {
+		bifrostResp.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResp, nil
+}
+
+// Rerank is not supported by the Runware provider.
+func (provider *RunwareProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, provider.GetProviderKey())
+}
+
+// OCR is not supported by the Runware provider.
+func (provider *RunwareProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostOCRRequest) (*schemas.BifrostOCRResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.OCRRequest, provider.GetProviderKey())
+}
+
+// ImageGenerationStream is not supported by the Runware provider.
+func (provider *RunwareProvider) ImageGenerationStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostImageGenerationRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationStreamRequest, provider.GetProviderKey())
+}
+
+// ImageEditStream is not supported by the Runware provider.
+func (provider *RunwareProvider) ImageEditStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostImageEditRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageEditStreamRequest, provider.GetProviderKey())
+}
+
+// ImageVariation is not supported by the Runware provider.
+func (provider *RunwareProvider) ImageVariation(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageVariationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageVariationRequest, provider.GetProviderKey())
+}
+
+// VideoGeneration is not supported by the Runware provider.
+func (provider *RunwareProvider) VideoGeneration(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoGenerationRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoGenerationRequest, provider.GetProviderKey())
+}
+
+// VideoRetrieve is not supported by the Runware provider.
+func (provider *RunwareProvider) VideoRetrieve(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoRetrieveRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoRetrieveRequest, provider.GetProviderKey())
+}
+
+// VideoDownload is not supported by the Runware provider.
+func (provider *RunwareProvider) VideoDownload(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoDownloadRequest) (*schemas.BifrostVideoDownloadResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoDownloadRequest, provider.GetProviderKey())
+}
+
+// VideoDelete is not supported by the Runware provider.
+func (provider *RunwareProvider) VideoDelete(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoDeleteRequest) (*schemas.BifrostVideoDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoDeleteRequest, provider.GetProviderKey())
+}
+
+// VideoList is not supported by the Runware provider.
+func (provider *RunwareProvider) VideoList(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoListRequest) (*schemas.BifrostVideoListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoListRequest, provider.GetProviderKey())
+}
+
+// VideoRemix is not supported by the Runware provider.
+func (provider *RunwareProvider) VideoRemix(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoRemixRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoRemixRequest, provider.GetProviderKey())
+}
+
+// FileUpload is not supported by Runware provider.
+func (provider *RunwareProvider) FileUpload(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostFileUploadRequest) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileUploadRequest, provider.GetProviderKey())
+}
+
+// FileList is not supported by Runware provider.
+func (provider *RunwareProvider) FileList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileListRequest) (*schemas.BifrostFileListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileListRequest, provider.GetProviderKey())
+}
+
+// FileRetrieve is not supported by Runware provider.
+func (provider *RunwareProvider) FileRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileRetrieveRequest) (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileRetrieveRequest, provider.GetProviderKey())
+}
+
+// FileDelete is not supported by Runware provider.
+func (provider *RunwareProvider) FileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileDeleteRequest) (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileDeleteRequest, provider.GetProviderKey())
+}
+
+// FileContent is not supported by Runware provider.
+func (provider *RunwareProvider) FileContent(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
+}
+
+// BatchCreate is not supported by Runware provider.
+func (provider *RunwareProvider) BatchCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostBatchCreateRequest) (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCreateRequest, provider.GetProviderKey())
+}
+
+// BatchList is not supported by Runware provider.
+func (provider *RunwareProvider) BatchList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchListRequest) (*schemas.BifrostBatchListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchListRequest, provider.GetProviderKey())
+}
+
+// BatchRetrieve is not supported by Runware provider.
+func (provider *RunwareProvider) BatchRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchRetrieveRequest) (*schemas.BifrostBatchRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchRetrieveRequest, provider.GetProviderKey())
+}
+
+// BatchCancel is not supported by Runware provider.
+func (provider *RunwareProvider) BatchCancel(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchCancelRequest) (*schemas.BifrostBatchCancelResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
+}
+
+// BatchDelete is not supported by Runware provider.
+func (provider *RunwareProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
+// BatchResults is not supported by Runware provider.
+func (provider *RunwareProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
+}
+
+// CountTokens is not supported by the Runware provider.
+func (provider *RunwareProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}
+
+// Compaction is not supported by the Runware provider.
+func (provider *RunwareProvider) Compaction(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCompactionRequest) (*schemas.BifrostCompactionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CompactionRequest, provider.GetProviderKey())
+}
+
+// ContainerCreate is not supported by the Runware provider.
+func (provider *RunwareProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Runware provider.
+func (provider *RunwareProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Runware provider.
+func (provider *RunwareProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Runware provider.
+func (provider *RunwareProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}
+
+// ContainerFileCreate is not supported by the Runware provider.
+func (provider *RunwareProvider) ContainerFileCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerFileCreateRequest) (*schemas.BifrostContainerFileCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerFileList is not supported by the Runware provider.
+func (provider *RunwareProvider) ContainerFileList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileListRequest) (*schemas.BifrostContainerFileListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileListRequest, provider.GetProviderKey())
+}
+
+// ContainerFileRetrieve is not supported by the Runware provider.
+func (provider *RunwareProvider) ContainerFileRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileRetrieveRequest) (*schemas.BifrostContainerFileRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerFileContent is not supported by the Runware provider.
+func (provider *RunwareProvider) ContainerFileContent(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileContentRequest) (*schemas.BifrostContainerFileContentResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileContentRequest, provider.GetProviderKey())
+}
+
+// ContainerFileDelete is not supported by the Runware provider.
+func (provider *RunwareProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Runware provider.
+func (provider *RunwareProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+// PassthroughStream is not supported by the Runware provider.
+func (provider *RunwareProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ func(context.Context), _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
+}

--- a/core/providers/runware/runware_test.go
+++ b/core/providers/runware/runware_test.go
@@ -1,0 +1,38 @@
+package runware_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/llmtests"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestRunware(t *testing.T) {
+	t.Parallel()
+	if strings.TrimSpace(os.Getenv("RUNWARE_API_KEY")) == "" {
+		t.Skip("Skipping Runware tests because RUNWARE_API_KEY is not set")
+	}
+
+	client, ctx, cancel, err := llmtests.SetupTest()
+	if err != nil {
+		t.Fatalf("Error initializing test setup: %v", err)
+	}
+	defer cancel()
+	defer client.Shutdown()
+
+	testConfig := llmtests.ComprehensiveTestConfig{
+		Provider:             schemas.Runware,
+		ImageGenerationModel: "runware:101@1",
+		ImageEditModel:       "runware:400@1",
+		Scenarios: llmtests.TestScenarios{
+			ImageGeneration: true,
+			ImageEdit:       true,
+		},
+	}
+
+	t.Run("RunwareTests", func(t *testing.T) {
+		llmtests.RunAllComprehensiveTests(t, client, ctx, testConfig)
+	})
+}

--- a/core/providers/runware/types.go
+++ b/core/providers/runware/types.go
@@ -1,0 +1,62 @@
+package runware
+
+// taskTypeImageInference is the Runware task type used for all image operations
+// (text-to-image, image-to-image, inpainting, outpainting).
+const taskTypeImageInference = "imageInference"
+
+// RunwareImageInferenceRequest is a single Runware image inference task. Runware accepts an
+// array of these objects per request; the provider wraps a single task in an array before sending.
+type RunwareImageInferenceRequest struct {
+	TaskType       string  `json:"taskType"`
+	TaskUUID       string  `json:"taskUUID"`
+	Model          string  `json:"model"`
+	PositivePrompt string  `json:"positivePrompt"`
+	NegativePrompt *string `json:"negativePrompt,omitempty"`
+	Width          int     `json:"width"`
+	Height         int     `json:"height"`
+	Steps          *int    `json:"steps,omitempty"`
+	Seed           *int    `json:"seed,omitempty"`
+	NumberResults  *int    `json:"numberResults,omitempty"`
+	OutputType     *string `json:"outputType,omitempty"` // "URL", "base64Data", "dataURI"
+	OutputFormat   *string `json:"outputFormat,omitempty"` // "PNG", "JPG", "WEBP"
+	SeedImage      *string `json:"seedImage,omitempty"`    // image-to-image / inpainting / outpainting base image
+	MaskImage      *string `json:"maskImage,omitempty"`    // inpainting mask
+
+	// ExtraParams carries provider-native fields with no Bifrost equivalent
+	// (CFGScale, scheduler, strength, maskMargin, outpaint, lora, ...). Merged into
+	// the request body by the transport layer when passthrough is enabled.
+	ExtraParams map[string]interface{} `json:"-"`
+}
+
+func (r *RunwareImageInferenceRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
+}
+
+// RunwareResponse is the envelope returned by the Runware API. Successful task outputs
+// land in Data; per-task failures land in Errors (which can be present on a 200 response).
+type RunwareResponse struct {
+	Data   []RunwareImageResult `json:"data,omitempty"`
+	Errors []RunwareError       `json:"errors,omitempty"`
+}
+
+// RunwareImageResult is a single generated image returned for an imageInference task.
+type RunwareImageResult struct {
+	TaskType         string  `json:"taskType"`
+	TaskUUID         string  `json:"taskUUID"`
+	ImageUUID        string  `json:"imageUUID"`
+	ImageURL         string  `json:"imageURL,omitempty"`
+	ImageBase64Data  string  `json:"imageBase64Data,omitempty"`
+	ImageDataURI     string  `json:"imageDataURI,omitempty"`
+	Seed             *int    `json:"seed,omitempty"`
+	Cost             float64 `json:"cost,omitempty"`
+	NSFWContent      *bool   `json:"NSFWContent,omitempty"`
+}
+
+// RunwareError describes a single task failure returned by the Runware API.
+type RunwareError struct {
+	Code      string `json:"code,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Parameter string `json:"parameter,omitempty"`
+	TaskType  string `json:"taskType,omitempty"`
+	TaskUUID  string `json:"taskUUID,omitempty"`
+}

--- a/core/providers/runware/utils.go
+++ b/core/providers/runware/utils.go
@@ -1,0 +1,67 @@
+package runware
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Runware requires explicit pixel dimensions; default to a square when the caller omits a size.
+const (
+	defaultRunwareWidth  = 1024
+	defaultRunwareHeight = 1024
+)
+
+// parseRunwareSize converts a Bifrost size string ("1024x1024") to width/height pixels.
+// Falls back to the defaults when the value is empty or malformed.
+func parseRunwareSize(size string) (width int, height int) {
+	width, height = defaultRunwareWidth, defaultRunwareHeight
+	parts := strings.SplitN(strings.ToLower(strings.TrimSpace(size)), "x", 2)
+	if len(parts) != 2 {
+		return width, height
+	}
+	if w, err := strconv.Atoi(strings.TrimSpace(parts[0])); err == nil && w > 0 {
+		width = w
+	}
+	if h, err := strconv.Atoi(strings.TrimSpace(parts[1])); err == nil && h > 0 {
+		height = h
+	}
+	return width, height
+}
+
+// runwareOutputType maps a Bifrost response_format to Runware's outputType.
+// Returns nil to let Runware use its default (URL).
+func runwareOutputType(responseFormat *string) *string {
+	if responseFormat == nil {
+		return nil
+	}
+	var out string
+	switch strings.ToLower(*responseFormat) {
+	case "b64_json", "base64", "base64data":
+		out = "base64Data"
+	case "url":
+		out = "URL"
+	default:
+		return nil
+	}
+	return &out
+}
+
+// runwareOutputFormat maps a Bifrost output_format to Runware's outputFormat enum.
+// Returns nil to let Runware use its default.
+func runwareOutputFormat(outputFormat *string) *string {
+	if outputFormat == nil {
+		return nil
+	}
+	var out string
+	switch strings.ToLower(*outputFormat) {
+	case "png":
+		out = "PNG"
+	case "jpeg", "jpg":
+		out = "JPG"
+	case "webp":
+		out = "WEBP"
+	default:
+		return nil
+	}
+	return &out
+}

--- a/core/providers/runway/images.go
+++ b/core/providers/runway/images.go
@@ -1,0 +1,210 @@
+package runway
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToRunwayImageGenerationRequest converts a Bifrost image generation request to Runway's text_to_image format.
+func ToRunwayImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRequest) (*RunwayImageGenerationRequest, error) {
+	if bifrostReq.Input == nil {
+		return nil, fmt.Errorf("input is required")
+	}
+
+	// Field support varies by model; only attach what the target model accepts.
+	caps := runwayImageModelCapabilities(bifrostReq.Model)
+
+	request := &RunwayImageGenerationRequest{
+		Model:      bifrostReq.Model,
+		PromptText: bifrostReq.Input.Prompt,
+		Ratio:      defaultRunwayImageRatio(bifrostReq.Model),
+	}
+
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		if params.AspectRatio != nil && *params.AspectRatio != "" {
+			request.Ratio = *params.AspectRatio
+		} else if params.Size != nil && *params.Size != "" {
+			// convert 1920x1080 to 1920:1080
+			request.Ratio = strings.Replace(*params.Size, "x", ":", 1)
+		}
+
+		if caps.seed && params.Seed != nil {
+			request.Seed = params.Seed
+		}
+		if caps.outputCount && params.N != nil {
+			request.OutputCount = params.N
+		}
+		if caps.quality && params.Quality != nil {
+			request.Quality = params.Quality
+		}
+		if caps.background && params.Background != nil {
+			request.Background = params.Background
+		}
+		if caps.contentModeration && params.Moderation != nil && *params.Moderation != "" {
+			request.ContentModeration = &ContentModeration{PublicFigureThreshold: params.Moderation}
+		}
+
+		// Map input images to reference images (no tag unless provided via extra params)
+		for _, img := range params.InputImages {
+			sanitizedURL, err := schemas.SanitizeImageURL(img)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input image: %w", err)
+			}
+			request.ReferenceImages = append(request.ReferenceImages, ReferenceImage{URI: sanitizedURL})
+		}
+
+		if params.ExtraParams != nil {
+			request.ExtraParams = params.ExtraParams
+
+			// Explicit reference images (with tags for at-mention syntax) override input images
+			if refImagesVal := params.ExtraParams["reference_images"]; refImagesVal != nil {
+				if refImages, ok := refImagesVal.([]ReferenceImage); ok && refImages != nil {
+					delete(request.ExtraParams, "reference_images")
+					request.ReferenceImages = refImages
+				} else if refImages, err := schemas.ConvertViaJSON[[]ReferenceImage](refImagesVal); err == nil {
+					delete(request.ExtraParams, "reference_images")
+					request.ReferenceImages = refImages
+				}
+			}
+
+			// Content moderation: always remove from extra params (avoid leaking the
+			// snake_case key into the body), but only attach for models that support it.
+			if cmVal := params.ExtraParams["content_moderation"]; cmVal != nil {
+				delete(request.ExtraParams, "content_moderation")
+				if caps.contentModeration {
+					if cm, ok := cmVal.(*ContentModeration); ok && cm != nil {
+						request.ContentModeration = cm
+					} else if cm, err := schemas.ConvertViaJSON[ContentModeration](cmVal); err == nil {
+						request.ContentModeration = &cm
+					}
+				}
+			}
+		}
+	}
+
+	// Drop the per-reference subject for models that don't support character/object consistency.
+	if !caps.referenceSubject {
+		for i := range request.ReferenceImages {
+			request.ReferenceImages[i].Subject = ""
+		}
+	}
+
+	return request, nil
+}
+
+// ToRunwayImageEditRequest converts a Bifrost image edit request to Runway's text_to_image format.
+// Runway has no dedicated edit endpoint, so the input images are sent as reference images.
+func ToRunwayImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) (*RunwayImageGenerationRequest, error) {
+	if bifrostReq.Input == nil {
+		return nil, fmt.Errorf("input is required")
+	}
+
+	// Field support varies by model; only attach what the target model accepts.
+	caps := runwayImageModelCapabilities(bifrostReq.Model)
+
+	request := &RunwayImageGenerationRequest{
+		Model:      bifrostReq.Model,
+		PromptText: bifrostReq.Input.Prompt,
+		Ratio:      defaultRunwayImageRatio(bifrostReq.Model),
+	}
+
+	// Map edit input images (raw bytes) to reference images as data URIs.
+	for _, img := range bifrostReq.Input.Images {
+		if len(img.Image) == 0 {
+			continue
+		}
+		request.ReferenceImages = append(request.ReferenceImages, ReferenceImage{URI: providerUtils.FileBytesToBase64DataURL(img.Image)})
+	}
+
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		if params.Size != nil && *params.Size != "" {
+			// convert 1920x1080 to 1920:1080
+			request.Ratio = strings.Replace(*params.Size, "x", ":", 1)
+		}
+
+		if caps.seed && params.Seed != nil {
+			request.Seed = params.Seed
+		}
+		if caps.outputCount && params.N != nil {
+			request.OutputCount = params.N
+		}
+		if caps.quality && params.Quality != nil {
+			request.Quality = params.Quality
+		}
+		if caps.background && params.Background != nil {
+			request.Background = params.Background
+		}
+
+		if params.ExtraParams != nil {
+			request.ExtraParams = params.ExtraParams
+
+			// Explicit reference images (with tags/subject) are appended after the edit images.
+			if refImagesVal := params.ExtraParams["reference_images"]; refImagesVal != nil {
+				if refImages, ok := refImagesVal.([]ReferenceImage); ok && refImages != nil {
+					delete(request.ExtraParams, "reference_images")
+					request.ReferenceImages = append(request.ReferenceImages, refImages...)
+				} else if refImages, err := schemas.ConvertViaJSON[[]ReferenceImage](refImagesVal); err == nil {
+					delete(request.ExtraParams, "reference_images")
+					request.ReferenceImages = append(request.ReferenceImages, refImages...)
+				}
+			}
+
+			// Content moderation: always remove from extra params (avoid leaking the
+			// snake_case key into the body), but only attach for models that support it.
+			if cmVal := params.ExtraParams["content_moderation"]; cmVal != nil {
+				delete(request.ExtraParams, "content_moderation")
+				if caps.contentModeration {
+					if cm, ok := cmVal.(*ContentModeration); ok && cm != nil {
+						request.ContentModeration = cm
+					} else if cm, err := schemas.ConvertViaJSON[ContentModeration](cmVal); err == nil {
+						request.ContentModeration = &cm
+					}
+				}
+			}
+		}
+	}
+
+	// Drop the per-reference subject for models that don't support character/object consistency.
+	if !caps.referenceSubject {
+		for i := range request.ReferenceImages {
+			request.ReferenceImages[i].Subject = ""
+		}
+	}
+
+	return request, nil
+}
+
+// ToBifrostImageGenerationResponse converts Runway task details to Bifrost image generation response format.
+func ToBifrostImageGenerationResponse(taskDetails *RunwayTaskDetailsResponse) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	if taskDetails == nil {
+		return nil, providerUtils.NewBifrostOperationError("task details is nil", nil)
+	}
+
+	response := &schemas.BifrostImageGenerationResponse{
+		ID:   taskDetails.ID,
+		Data: []schemas.ImageData{},
+	}
+
+	if taskDetails.CreatedAt != "" {
+		if t, err := time.Parse(time.RFC3339, taskDetails.CreatedAt); err == nil {
+			response.Created = t.Unix()
+		}
+	}
+
+	for i, url := range taskDetails.Output {
+		response.Data = append(response.Data, schemas.ImageData{
+			URL:   url,
+			Index: i,
+		})
+	}
+
+	return response, nil
+}

--- a/core/providers/runway/images_test.go
+++ b/core/providers/runway/images_test.go
@@ -1,0 +1,261 @@
+package runway
+
+import (
+	"strings"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeImageReq(model, prompt string, params *schemas.ImageGenerationParameters) *schemas.BifrostImageGenerationRequest {
+	return &schemas.BifrostImageGenerationRequest{
+		Model:  model,
+		Input:  &schemas.ImageGenerationInput{Prompt: prompt},
+		Params: params,
+	}
+}
+
+func TestToRunwayImageGenerationRequest(t *testing.T) {
+	t.Run("defaults_ratio_when_unset", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", nil))
+		require.NoError(t, err)
+		assert.Equal(t, "gen4_image", result.Model)
+		assert.Equal(t, "a cat", result.PromptText)
+		assert.Equal(t, "1024:1024", result.Ratio)
+	})
+
+	t.Run("defaults_ratio_auto_for_gpt_image_2", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gpt_image_2", "a cat", nil))
+		require.NoError(t, err)
+		assert.Equal(t, "auto", result.Ratio)
+	})
+
+	t.Run("nil_input_errors", func(t *testing.T) {
+		_, err := ToRunwayImageGenerationRequest(&schemas.BifrostImageGenerationRequest{Model: "gen4_image"})
+		require.Error(t, err)
+	})
+
+	t.Run("aspect_ratio_takes_precedence_over_size", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			AspectRatio: schemas.Ptr("1080:1920"),
+			Size:        schemas.Ptr("1280x720"),
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1080:1920", result.Ratio)
+	})
+
+	t.Run("size_converted_to_ratio", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			Size: schemas.Ptr("1280x720"),
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1280:720", result.Ratio)
+	})
+
+	t.Run("seed_mapped", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			Seed: schemas.Ptr(42),
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, result.Seed)
+		assert.Equal(t, 42, *result.Seed)
+	})
+
+	t.Run("input_images_mapped_to_reference_images", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "@ref a cat", &schemas.ImageGenerationParameters{
+			InputImages: []string{"https://example.com/ref.jpg"},
+		}))
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 1)
+		assert.Equal(t, "https://example.com/ref.jpg", result.ReferenceImages[0].URI)
+		assert.Empty(t, result.ReferenceImages[0].Tag)
+	})
+
+	t.Run("explicit_reference_images_override_input_images", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "@logo a cat", &schemas.ImageGenerationParameters{
+			InputImages: []string{"https://example.com/input.jpg"},
+			ExtraParams: map[string]interface{}{
+				"reference_images": []ReferenceImage{{URI: "https://example.com/ref.jpg", Tag: "logo"}},
+			},
+		}))
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 1)
+		assert.Equal(t, "https://example.com/ref.jpg", result.ReferenceImages[0].URI)
+		assert.Equal(t, "logo", result.ReferenceImages[0].Tag)
+		assert.NotContains(t, result.ExtraParams, "reference_images")
+	})
+
+	t.Run("map_fallback_content_moderation", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			ExtraParams: map[string]interface{}{
+				"content_moderation": map[string]interface{}{"public_figure_threshold": "low"},
+			},
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, result.ContentModeration)
+		require.NotNil(t, result.ContentModeration.PublicFigureThreshold)
+		assert.Equal(t, "low", *result.ContentModeration.PublicFigureThreshold)
+		assert.NotContains(t, result.ExtraParams, "content_moderation")
+	})
+
+	t.Run("gpt_image_2_fields_attached", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gpt_image_2", "a cat", &schemas.ImageGenerationParameters{
+			N:          schemas.Ptr(3),
+			Quality:    schemas.Ptr("high"),
+			Background: schemas.Ptr("opaque"),
+			Seed:       schemas.Ptr(7),
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, result.OutputCount)
+		assert.Equal(t, 3, *result.OutputCount)
+		require.NotNil(t, result.Quality)
+		assert.Equal(t, "high", *result.Quality)
+		require.NotNil(t, result.Background)
+		assert.Equal(t, "opaque", *result.Background)
+		assert.Nil(t, result.Seed, "gpt_image_2 does not support seed")
+	})
+
+	t.Run("gen4_drops_unsupported_fields", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "a cat", &schemas.ImageGenerationParameters{
+			N:          schemas.Ptr(3),
+			Quality:    schemas.Ptr("high"),
+			Background: schemas.Ptr("opaque"),
+			Seed:       schemas.Ptr(7),
+		}))
+		require.NoError(t, err)
+		assert.Nil(t, result.OutputCount, "gen4_image does not support outputCount")
+		assert.Nil(t, result.Quality, "gen4_image does not support quality")
+		assert.Nil(t, result.Background, "gen4_image does not support background")
+		require.NotNil(t, result.Seed)
+		assert.Equal(t, 7, *result.Seed)
+	})
+
+	t.Run("content_moderation_dropped_for_unsupported_model", func(t *testing.T) {
+		result, err := ToRunwayImageGenerationRequest(makeImageReq("gpt_image_2", "a cat", &schemas.ImageGenerationParameters{
+			ExtraParams: map[string]interface{}{
+				"content_moderation": map[string]interface{}{"public_figure_threshold": "low"},
+			},
+		}))
+		require.NoError(t, err)
+		assert.Nil(t, result.ContentModeration, "gpt_image_2 does not support content moderation")
+		assert.NotContains(t, result.ExtraParams, "content_moderation", "key must not leak into body")
+	})
+
+	t.Run("reference_subject_kept_for_gemini_stripped_otherwise", func(t *testing.T) {
+		refImages := []ReferenceImage{{URI: "https://example.com/ref.jpg", Tag: "hero", Subject: "human"}}
+
+		gemini, err := ToRunwayImageGenerationRequest(makeImageReq("gemini_image3_pro", "@hero a cat", &schemas.ImageGenerationParameters{
+			ExtraParams: map[string]interface{}{"reference_images": refImages},
+		}))
+		require.NoError(t, err)
+		require.Len(t, gemini.ReferenceImages, 1)
+		assert.Equal(t, "human", gemini.ReferenceImages[0].Subject)
+
+		gen4, err := ToRunwayImageGenerationRequest(makeImageReq("gen4_image", "@hero a cat", &schemas.ImageGenerationParameters{
+			ExtraParams: map[string]interface{}{"reference_images": []ReferenceImage{{URI: "https://example.com/ref.jpg", Tag: "hero", Subject: "human"}}},
+		}))
+		require.NoError(t, err)
+		require.Len(t, gen4.ReferenceImages, 1)
+		assert.Empty(t, gen4.ReferenceImages[0].Subject, "non-gemini models must not send subject")
+	})
+}
+
+func makeImageEditReq(model, prompt string, images [][]byte, params *schemas.ImageEditParameters) *schemas.BifrostImageEditRequest {
+	imgs := make([]schemas.ImageInput, len(images))
+	for i, b := range images {
+		imgs[i] = schemas.ImageInput{Image: b}
+	}
+	return &schemas.BifrostImageEditRequest{
+		Model:  model,
+		Input:  &schemas.ImageEditInput{Images: imgs, Prompt: prompt},
+		Params: params,
+	}
+}
+
+func TestToRunwayImageEditRequest(t *testing.T) {
+	t.Run("nil_input_errors", func(t *testing.T) {
+		_, err := ToRunwayImageEditRequest(&schemas.BifrostImageEditRequest{Model: "gen4_image"})
+		require.Error(t, err)
+	})
+
+	t.Run("maps_image_bytes_to_data_uri_reference_images", func(t *testing.T) {
+		// minimal PNG header bytes so DetectContentType yields image/png
+		png := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "make it blue", [][]byte{png}, nil))
+		require.NoError(t, err)
+		assert.Equal(t, "make it blue", result.PromptText)
+		assert.Equal(t, "1024:1024", result.Ratio)
+		require.Len(t, result.ReferenceImages, 1)
+		assert.True(t, strings.HasPrefix(result.ReferenceImages[0].URI, "data:image/png;base64,"), "got %s", result.ReferenceImages[0].URI)
+	})
+
+	t.Run("skips_empty_images", func(t *testing.T) {
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "x", [][]byte{{}, {0x89, 0x50, 0x4E, 0x47}}, nil))
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 1)
+	})
+
+	t.Run("size_converted_to_ratio", func(t *testing.T) {
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "x", [][]byte{{0x89, 0x50}}, &schemas.ImageEditParameters{
+			Size: schemas.Ptr("1280x720"),
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1280:720", result.Ratio)
+	})
+
+	t.Run("explicit_reference_images_appended_after_edit_images", func(t *testing.T) {
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "@logo x", [][]byte{{0x89, 0x50}}, &schemas.ImageEditParameters{
+			ExtraParams: map[string]interface{}{
+				"reference_images": []ReferenceImage{{URI: "https://example.com/logo.png", Tag: "logo"}},
+			},
+		}))
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 2)
+		assert.True(t, strings.HasPrefix(result.ReferenceImages[0].URI, "data:"))
+		assert.Equal(t, "https://example.com/logo.png", result.ReferenceImages[1].URI)
+		assert.Equal(t, "logo", result.ReferenceImages[1].Tag)
+		assert.NotContains(t, result.ExtraParams, "reference_images")
+	})
+
+	t.Run("gen4_drops_unsupported_fields", func(t *testing.T) {
+		result, err := ToRunwayImageEditRequest(makeImageEditReq("gen4_image", "x", [][]byte{{0x89, 0x50}}, &schemas.ImageEditParameters{
+			N:          schemas.Ptr(3),
+			Quality:    schemas.Ptr("high"),
+			Background: schemas.Ptr("opaque"),
+			Seed:       schemas.Ptr(7),
+		}))
+		require.NoError(t, err)
+		assert.Nil(t, result.OutputCount)
+		assert.Nil(t, result.Quality)
+		assert.Nil(t, result.Background)
+		require.NotNil(t, result.Seed)
+		assert.Equal(t, 7, *result.Seed)
+	})
+}
+
+func TestToBifrostImageGenerationResponse(t *testing.T) {
+	t.Run("nil_task_details_errors", func(t *testing.T) {
+		_, err := ToBifrostImageGenerationResponse(nil)
+		require.NotNil(t, err)
+	})
+
+	t.Run("maps_output_urls", func(t *testing.T) {
+		taskDetails := &RunwayTaskDetailsResponse{
+			ID:        "task-123",
+			Status:    RunwayTaskStatusSucceeded,
+			CreatedAt: "2024-11-06T12:00:00Z",
+			Output:    []string{"https://example.com/0.png", "https://example.com/1.png"},
+		}
+		resp, err := ToBifrostImageGenerationResponse(taskDetails)
+		require.Nil(t, err)
+		assert.Equal(t, "task-123", resp.ID)
+		require.Len(t, resp.Data, 2)
+		assert.Equal(t, "https://example.com/0.png", resp.Data[0].URL)
+		assert.Equal(t, 0, resp.Data[0].Index)
+		assert.Equal(t, "https://example.com/1.png", resp.Data[1].URL)
+		assert.Equal(t, 1, resp.Data[1].Index)
+		assert.NotZero(t, resp.Created)
+	})
+}

--- a/core/providers/runway/runway.go
+++ b/core/providers/runway/runway.go
@@ -135,9 +135,169 @@ func (provider *RunwayProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.OCRRequest, provider.GetProviderKey())
 }
 
-// ImageGeneration is not supported by the Runway provider.
-func (provider *RunwayProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationRequest, provider.GetProviderKey())
+// ImageGeneration performs a text-to-image generation request to Runway's API.
+// Runway image generation is task-based: a task is created and then polled until it
+// reaches a terminal state, after which the generated image URLs are returned.
+func (provider *RunwayProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key, bifrostReq *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	// Convert Bifrost request to Runway format
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		bifrostReq,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToRunwayImageGenerationRequest(bifrostReq)
+		})
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	return provider.HandleRunwayImageTask(ctx, key, bifrostReq.Model, jsonData)
+}
+
+// HandleRunwayImageTask posts a prebuilt text_to_image body, polls the task to completion,
+// and builds the Bifrost image response. Shared by ImageGeneration and ImageEdit since both
+// use the same /v1/text_to_image endpoint and response shape.
+func (provider *RunwayProvider) HandleRunwayImageTask(ctx *schemas.BifrostContext, key schemas.Key, model string, jsonData []byte) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+
+	// Create HTTP request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/text_to_image"))
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	req.Header.Set("X-Runway-Version", "2024-11-06")
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	req.SetBody(jsonData)
+
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		return nil, providerUtils.EnrichError(ctx, parseRunwayError(resp), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
+	}
+
+	// Decode response body
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		rawErrBody := append([]byte(nil), resp.Body()...)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), jsonData, rawErrBody, sendBackRawRequest, sendBackRawResponse)
+	}
+
+	// Parse task creation response
+	var taskResp RunwayTaskCreationResponse
+	rawRequest, _, bifrostErr := providerUtils.HandleProviderResponse(body, &taskResp, jsonData, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Poll the task until it reaches a terminal state
+	taskDetails, rawResponse, bifrostErr := provider.pollRunwayTask(ctx, key, taskResp.ID, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse)
+	}
+
+	// Convert to Bifrost response
+	bifrostResp, bifrostErr := ToBifrostImageGenerationResponse(taskDetails)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	bifrostResp.Model = model
+	bifrostResp.ExtraFields.Latency = latency.Milliseconds()
+
+	if sendBackRawRequest {
+		bifrostResp.ExtraFields.RawRequest = rawRequest
+	}
+	if sendBackRawResponse {
+		bifrostResp.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResp, nil
+}
+
+// runwayImagePollingInterval is the interval between Runway task status polls for image generation.
+const runwayImagePollingInterval = 2 * time.Second
+
+// pollRunwayTask polls a Runway task until it reaches a terminal state or the context times out.
+func (provider *RunwayProvider) pollRunwayTask(ctx *schemas.BifrostContext, key schemas.Key, taskID string, sendBackRawResponse bool) (*RunwayTaskDetailsResponse, interface{}, *schemas.BifrostError) {
+	pollCtx, cancel := schemas.NewBifrostContextWithTimeout(ctx, time.Duration(provider.networkConfig.DefaultRequestTimeoutInSeconds)*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(runwayImagePollingInterval)
+	defer ticker.Stop()
+
+	for {
+		taskDetails, rawResponse, bifrostErr := provider.retrieveRunwayTask(pollCtx, key, taskID, sendBackRawResponse)
+		if bifrostErr != nil {
+			return nil, nil, bifrostErr
+		}
+
+		switch taskDetails.Status {
+		case RunwayTaskStatusSucceeded:
+			return taskDetails, rawResponse, nil
+		case RunwayTaskStatusFailed, RunwayTaskStatusCancelled:
+			return nil, nil, providerUtils.NewBifrostOperationError(fmt.Sprintf("runway task %s", taskDetails.Status), nil)
+		}
+
+		select {
+		case <-pollCtx.Done():
+			return nil, nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, fmt.Errorf("runway task polling timed out"))
+		case <-ticker.C:
+		}
+	}
+}
+
+// retrieveRunwayTask fetches the current state of a Runway task.
+func (provider *RunwayProvider) retrieveRunwayTask(ctx *schemas.BifrostContext, key schemas.Key, taskID string, sendBackRawResponse bool) (*RunwayTaskDetailsResponse, interface{}, *schemas.BifrostError) {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/tasks/"+taskID))
+	req.Header.SetMethod(http.MethodGet)
+	req.Header.Set("X-Runway-Version", "2024-11-06")
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, nil, bifrostErr
+	}
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		return nil, nil, parseRunwayError(resp)
+	}
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
+	}
+
+	var taskDetails RunwayTaskDetailsResponse
+	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &taskDetails, nil, false, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, nil, bifrostErr
+	}
+
+	return &taskDetails, rawResponse, nil
 }
 
 // ImageGenerationStream is not supported by the Runway provider.
@@ -145,9 +305,21 @@ func (provider *RunwayProvider) ImageGenerationStream(ctx *schemas.BifrostContex
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationStreamRequest, provider.GetProviderKey())
 }
 
-// ImageEdit is not supported by the Runway provider.
-func (provider *RunwayProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageEditRequest, provider.GetProviderKey())
+// ImageEdit performs an image edit request to Runway's API. Runway has no dedicated edit
+// endpoint, so the input images are passed as reference images to /v1/text_to_image.
+func (provider *RunwayProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, bifrostReq *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	// Convert Bifrost request to Runway format
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		bifrostReq,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToRunwayImageEditRequest(bifrostReq)
+		})
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	return provider.HandleRunwayImageTask(ctx, key, bifrostReq.Model, jsonData)
 }
 
 // ImageEditStream is not supported by the Runway provider.

--- a/core/providers/runway/runway_test.go
+++ b/core/providers/runway/runway_test.go
@@ -25,7 +25,11 @@ func TestRunway(t *testing.T) {
 	testConfig := llmtests.ComprehensiveTestConfig{
 		Provider:             schemas.Runway,
 		VideoGenerationModel: "gen4.5",
+		ImageGenerationModel: "gen4_image",
+		ImageEditModel:       "gen4_image",
 		Scenarios: llmtests.TestScenarios{
+			ImageGeneration: true,
+			ImageEdit:       true,
 			VideoGeneration: false, // disabled for now because of long running operations
 			VideoRetrieve:   false,
 			VideoRemix:      false,

--- a/core/providers/runway/types.go
+++ b/core/providers/runway/types.go
@@ -13,8 +13,9 @@ type Reference struct {
 }
 
 type ReferenceImage struct {
-	URI string `json:"uri"`
-	Tag string `json:"tag"`
+	URI     string `json:"uri"`
+	Tag     string `json:"tag,omitempty"`
+	Subject string `json:"subject,omitempty"` // "object" or "human" (gemini image models)
 }
 
 type PromptImageObject struct {
@@ -90,6 +91,23 @@ func (r *RunwayVideoGenerationRequest) GetExtraParams() map[string]interface{} {
 
 type ContentModeration struct {
 	PublicFigureThreshold *string `json:"public_figure_threshold,omitempty"`
+}
+
+type RunwayImageGenerationRequest struct {
+	Model             string                 `json:"model"`
+	PromptText        string                 `json:"promptText"`
+	Ratio             string                 `json:"ratio"`
+	Seed              *int                   `json:"seed,omitempty"`
+	ReferenceImages   []ReferenceImage       `json:"referenceImages,omitempty"`
+	Quality           *string                `json:"quality,omitempty"`     // gpt_image_2: "low", "medium", "high", "auto"
+	Background        *string                `json:"background,omitempty"`  // gpt_image_2: "opaque", "auto"
+	OutputCount       *int                   `json:"outputCount,omitempty"` // gpt_image_2 (1-10), gemini (1 or 4)
+	ContentModeration *ContentModeration     `json:"contentModeration,omitempty"`
+	ExtraParams       map[string]interface{} `json:"-"`
+}
+
+func (r *RunwayImageGenerationRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 type RunwayTaskCreationResponse struct {

--- a/core/providers/runway/utils.go
+++ b/core/providers/runway/utils.go
@@ -21,6 +21,44 @@ func getRunwayEndpoint(req *schemas.BifrostVideoGenerationRequest) string {
 	return "/v1/text_to_video"
 }
 
+// runwayImageModelCaps describes which optional fields a Runway image model accepts.
+type runwayImageModelCaps struct {
+	seed              bool
+	contentModeration bool
+	quality           bool
+	background        bool
+	outputCount       bool
+	referenceSubject  bool
+}
+
+// runwayImageModelCapabilities returns the supported optional fields for a Runway image model.
+// Unknown/custom models are treated permissively so new models work without code changes;
+// Runway validates the final combination.
+func runwayImageModelCapabilities(model string) runwayImageModelCaps {
+	switch model {
+	case "gen4_image", "gen4_image_turbo":
+		return runwayImageModelCaps{seed: true, contentModeration: true}
+	case "gpt_image_2":
+		return runwayImageModelCaps{quality: true, background: true, outputCount: true}
+	case "gemini_image3_pro", "gemini_image3.1_flash":
+		return runwayImageModelCaps{outputCount: true, referenceSubject: true}
+	case "gemini_2.5_flash":
+		return runwayImageModelCaps{}
+	default:
+		return runwayImageModelCaps{seed: true, contentModeration: true, quality: true, background: true, outputCount: true, referenceSubject: true}
+	}
+}
+
+// defaultRunwayImageRatio returns a sensible default ratio when the caller omits one.
+// Valid ratios differ per model, so the default is model-aware.
+func defaultRunwayImageRatio(model string) string {
+	if model == "gpt_image_2" {
+		return "auto"
+	}
+	// Valid for the gen4 family and every gemini image model.
+	return "1024:1024"
+}
+
 func isRunwayGenModel(model string) bool {
 	return strings.Contains(model, "gen")
 }

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -60,6 +60,7 @@ const (
 	Replicate   ModelProvider = "replicate"
 	VLLM        ModelProvider = "vllm"
 	Runway      ModelProvider = "runway"
+	Runware     ModelProvider = "runware"
 	Fireworks   ModelProvider = "fireworks"
 )
 
@@ -100,6 +101,7 @@ var StandardProviders = []ModelProvider{
 	Replicate,
 	VLLM,
 	Runway,
+	Runware,
 	Fireworks,
 }
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -365,6 +365,9 @@
         },
         "runway": {
           "$ref": "#/$defs/provider"
+        },
+        "runware": {
+          "$ref": "#/$defs/provider"
         }
       },
       "additionalProperties": true
@@ -5678,6 +5681,7 @@
             "replicate",
             "vllm",
             "runway",
+            "runware",
             "fireworks"
           ],
           "description": "Base provider type to extend"


### PR DESCRIPTION
## Summary

Adds [Runware](https://runware.ai) as a new image generation provider in Bifrost. Runware exposes a single synchronous endpoint that accepts an array of tasks; this integration supports text-to-image, image-to-image, inpainting, and outpainting via the `imageInference` task type.

## Changes

- Registered `runware` as a `ModelProvider` constant and added it to `StandardProviders`
- Implemented `RunwareProvider` with `ImageGeneration` and `ImageEdit` as the only supported operations; all other provider interface methods return an unsupported operation error
- Runware's API wraps tasks in a JSON array — `handleImageInference` handles this wrapping transparently before sending and unwraps the response envelope back into a `BifrostImageGenerationResponse`
- Error parsing handles Runware's top-level `errors` array (which can appear even on HTTP 200 responses), surfacing the first error message and optional parameter context
- Size strings (`"1024x1024"`) are parsed into explicit `width`/`height` pixel values since Runware requires dimensions rather than named sizes; defaults to 1024×1024
- `response_format` and `output_format` are mapped to Runware's `outputType` and `outputFormat` enums respectively
- Seed images for image-to-image are accepted as URLs or base64 data URIs; mask images for inpainting are converted from raw bytes to base64 data URIs
- Added Runware to the comprehensive test account with `RUNWARE_API_KEY` env var, provider config, and validation preset adjustments (no usage stats or timestamps, latency only)
- Added `runware` to the transport config JSON schema as a valid provider key and model provider enum value

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Set the `RUNWARE_API_KEY` environment variable to a valid Runware API key, then run the integration tests:

```sh
export RUNWARE_API_KEY=your_runware_api_key

go test ./core/... -run TestRunware
go test ./core/internal/llmtests/...
```

To test image generation directly, configure the provider with `runware` as the provider key and submit an `ImageGeneration` request with a supported model (e.g. `runware:100@1`). Verify that the response contains either a `url` or `b64_json` field in the returned image data.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The Runware API key is read from the `RUNWARE_API_KEY` environment variable via `schemas.NewEnvVar` and passed as a `Bearer` token in the `Authorization` header. No keys are logged or included in raw request/response output unless `SendBackRawRequest`/`SendBackRawResponse` is explicitly enabled.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable