### PR TITLE
feat: add password policy validation with inline error and sticky save button to security view

### DIFF
--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -43,6 +43,46 @@ var securityHeaders = []string{
 	"x-bf-vk",
 }
 
+func getPasswordPolicyFailures(password string) []string {
+	failures := make([]string, 0, 5)
+	hasUppercase := false
+	hasLowercase := false
+	hasDigit := false
+	hasSpecial := false
+
+	for i := 0; i < len(password); i++ {
+		char := password[i]
+		switch {
+		case char >= 'A' && char <= 'Z':
+			hasUppercase = true
+		case char >= 'a' && char <= 'z':
+			hasLowercase = true
+		case char >= '0' && char <= '9':
+			hasDigit = true
+		default:
+			hasSpecial = true
+		}
+	}
+
+	if len(password) < 12 {
+		failures = append(failures, "at least 12 characters")
+	}
+	if !hasUppercase {
+		failures = append(failures, "one uppercase letter")
+	}
+	if !hasLowercase {
+		failures = append(failures, "one lowercase letter")
+	}
+	if !hasDigit {
+		failures = append(failures, "one number")
+	}
+	if !hasSpecial {
+		failures = append(failures, "one special character")
+	}
+
+	return failures
+}
+
 // ConfigManager is the interface for the config manager
 type ConfigManager interface {
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
@@ -713,6 +753,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 					payload.AuthConfig.AdminPassword = authConfig.AdminPassword
 				} else {
 					// Password has been changed
+					passwordPolicyFailures := getPasswordPolicyFailures(payload.AuthConfig.AdminPassword.GetValue())
+					if len(passwordPolicyFailures) > 0 {
+						SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("auth password must include %s", strings.Join(passwordPolicyFailures, ", ")))
+						return
+					}
 					// We will hash the password
 					hashedPassword, err := encrypt.Hash(payload.AuthConfig.AdminPassword.GetValue())
 					if err != nil {

--- a/transports/bifrost-http/handlers/config_test.go
+++ b/transports/bifrost-http/handlers/config_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetPasswordPolicyFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		want     []string
+	}{
+		{
+			name:     "valid password",
+			password: "StrongPass1!",
+			want:     []string{},
+		},
+		{
+			name:     "missing all requirements",
+			password: "",
+			want: []string{
+				"at least 12 characters",
+				"one uppercase letter",
+				"one lowercase letter",
+				"one number",
+				"one special character",
+			},
+		},
+		{
+			name:     "missing character classes",
+			password: "weakpassword",
+			want: []string{
+				"one uppercase letter",
+				"one number",
+				"one special character",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getPasswordPolicyFailures(tt.password)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("getPasswordPolicyFailures() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -14,8 +14,21 @@ import { validateOrigins } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useGetAuthTypeQuery } from "@enterprise/lib/store/apis/scimApi";
 import { AlertTriangle, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+
+const PASSWORD_REQUIREMENTS = [
+	{ label: "at least 12 characters", test: (password: string) => password.length >= 12 },
+	{ label: "one uppercase letter", test: (password: string) => /[A-Z]/.test(password) },
+	{ label: "one lowercase letter", test: (password: string) => /[a-z]/.test(password) },
+	{ label: "one number", test: (password: string) => /\d/.test(password) },
+	{ label: "one special character", test: (password: string) => /[^A-Za-z0-9]/.test(password) },
+];
+
+const getPasswordPolicyFailures = (password?: string) => {
+	if (!password) return [];
+	return PASSWORD_REQUIREMENTS.filter((requirement) => !requirement.test(password)).map((requirement) => requirement.label);
+};
 
 export default function SecurityView() {
 	const hasSettingsUpdateAccess = useRbac(RbacResource.Settings, RbacOperation.Update);
@@ -25,6 +38,7 @@ export default function SecurityView() {
 	const [updateCoreConfig, { isLoading }] = useUpdateCoreConfigMutation();
 	const [localConfig, setLocalConfig] = useState<CoreConfig>(DefaultCoreConfig);
 	const showPasswordSection = !IS_ENTERPRISE || (!authTypeLoading && !authTypeError && authType?.type !== "sso");
+	const passwordInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
 
 	const [localValues, setLocalValues] = useState<{
 		allowed_origins: string;
@@ -43,6 +57,7 @@ export default function SecurityView() {
 		admin_password: { value: "", ref: "" },
 		is_enabled: false,
 	});
+	const [passwordError, setPasswordError] = useState("");
 
 	useEffect(() => {
 		if (bifrostConfig && config) {
@@ -92,7 +107,15 @@ export default function SecurityView() {
 		const enforceAuthOnInferenceChanged = localConfig.enforce_auth_on_inference !== config.enforce_auth_on_inference;
 		const allowDirectKeysChanged = localConfig.allow_direct_keys !== config.allow_direct_keys;
 
-		return originsChanged || headersChanged || requiredChanged || whitelistedRoutesChanged || authChanged || enforceAuthOnInferenceChanged || allowDirectKeysChanged;
+		return (
+			originsChanged ||
+			headersChanged ||
+			requiredChanged ||
+			whitelistedRoutesChanged ||
+			authChanged ||
+			enforceAuthOnInferenceChanged ||
+			allowDirectKeysChanged
+		);
 	}, [config, localConfig, authConfig, bifrostConfig, showPasswordSection]);
 
 	const needsRestart = useMemo(() => {
@@ -140,6 +163,10 @@ export default function SecurityView() {
 	}, []);
 
 	const handleAuthFieldChange = useCallback((field: "admin_username" | "admin_password", value: SecretVar) => {
+		if (field === "admin_password") {
+			const passwordPolicyFailures = !value.ref && value.value ? getPasswordPolicyFailures(value.value) : [];
+			setPasswordError(passwordPolicyFailures.length > 0 ? `Password must include ${passwordPolicyFailures.join(", ")}.` : "");
+		}
 		setAuthConfig((prev) => ({ ...prev, [field]: value }));
 	}, []);
 
@@ -155,6 +182,19 @@ export default function SecurityView() {
 			}
 			const hasUsername = authConfig.admin_username?.value || authConfig.admin_username?.ref;
 			const hasPassword = authConfig.admin_password?.value || authConfig.admin_password?.ref;
+			const passwordPolicyFailures =
+				showPasswordSection && authConfig.is_enabled && !authConfig.admin_password?.ref && authConfig.admin_password?.value
+					? getPasswordPolicyFailures(authConfig.admin_password.value)
+					: [];
+
+			if (passwordPolicyFailures.length > 0) {
+				setPasswordError(`Password must include ${passwordPolicyFailures.join(", ")}.`);
+				passwordInputRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+				passwordInputRef.current?.focus({ preventScroll: true });
+				return;
+			}
+			setPasswordError("");
+
 			await updateCoreConfig({
 				...bifrostConfig!,
 				client_config: localConfig,
@@ -171,7 +211,7 @@ export default function SecurityView() {
 	}, [bifrostConfig, localConfig, authConfig, showPasswordSection, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-4">
+		<div className="mx-auto h-[calc(100vh-50px)] w-full max-w-4xl space-y-4 overflow-y-auto">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Security Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure security and access control settings.</p>
@@ -224,13 +264,24 @@ export default function SecurityView() {
 								<div className="space-y-2">
 									<Label htmlFor="admin-password">Password</Label>
 									<SecretVarInput
+										ref={passwordInputRef}
 										id="admin-password"
+										aria-invalid={!!passwordError}
+										aria-describedby={passwordError ? "admin-password-error" : undefined}
 										type="password"
 										placeholder="Enter admin password or env.VAR_NAME"
 										value={authConfig.admin_password}
 										disabled={!authConfig.is_enabled}
 										onChange={(value) => handleAuthFieldChange("admin_password", value)}
 									/>
+									<p className="text-muted-foreground text-xs">
+										Use at least 12 characters with uppercase, lowercase, number, and special character. Env var references are accepted.
+									</p>
+									{passwordError ? (
+										<p id="admin-password-error" className="text-destructive text-xs" role="alert">
+											{passwordError}
+										</p>
+									) : null}
 								</div>
 							</div>
 						</div>
@@ -273,9 +324,9 @@ export default function SecurityView() {
 							Allow Direct API Keys
 						</label>
 						<p className="text-muted-foreground text-sm">
-							When enabled, callers can pass a provider API key directly in the{" "}
-							<b>Authorization</b>, <b>x-api-key</b>, or <b>x-goog-api-key</b> header alongside{" "}
-							<b>x-bf-direct-key: true</b>. Bifrost will use that key directly, bypassing the registered key pool.
+							When enabled, callers can pass a provider API key directly in the <b>Authorization</b>, <b>x-api-key</b>, or{" "}
+							<b>x-goog-api-key</b> header alongside <b>x-bf-direct-key: true</b>. Bifrost will use that key directly, bypassing the
+							registered key pool.
 						</p>
 					</div>
 					<Switch
@@ -372,7 +423,7 @@ export default function SecurityView() {
 					</div>
 				</div>
 			</div>
-			<div className="flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 flex justify-end pt-2">
 				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>


### PR DESCRIPTION
## Summary

Adds client-side password policy validation to the Security Settings page for the admin password field, ensuring passwords meet minimum complexity requirements before saving.

## Changes

- Introduced `PASSWORD_REQUIREMENTS` and `getPasswordPolicyFailures` to validate that passwords contain at least 12 characters, one uppercase letter, one lowercase letter, one number, and one special character.
- Password policy is checked both on input change and on save, with a descriptive inline error message displayed below the password field.
- On save, if the password fails validation, the page scrolls to and focuses the password input automatically.
- Added a `ref` to `EnvVarInput` for the password field to enable programmatic focus and scroll behavior.
- Added ARIA attributes (`aria-invalid`, `aria-describedby`, `role="alert"`) to the password field and error message for accessibility.
- Added a helper hint below the password field describing the requirements.
- Made the "Save Changes" button sticky at the bottom of the view so it remains visible while scrolling.
- Made the security settings container scrollable within the viewport.
- Password policy validation is skipped when the password value is sourced from an environment variable reference.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Security Settings page.
2. Enable admin authentication and enter a password that does not meet the requirements (e.g., fewer than 12 characters or missing a special character).
3. Verify that an inline error message appears below the password field describing which requirements are not met.
4. Attempt to save — confirm the save is blocked and the page scrolls to and focuses the password field.
5. Enter a compliant password and confirm the save succeeds.
6. Set the password field to an environment variable reference (e.g., `env.ADMIN_PASSWORD`) and confirm no policy error is shown.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Add before/after screenshots showing the inline password error and the sticky save button.

## Breaking changes

- [x] No

## Related issues

Link related issues and discussions.

## Security considerations

Password policy enforcement is client-side only and serves as a UX guardrail. Server-side validation should also enforce these requirements to prevent weak passwords from being submitted via API directly.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable