### PR TITLE
fix(responses): preserve author, recipient, encrypted_content in multi-agent collab_tool_call items

### DIFF
--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1,6 +1,7 @@
 package schemas
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -928,6 +929,11 @@ type ResponsesMessage struct {
 	Role    *ResponsesMessageRoleType `json:"role,omitempty"`
 	Content *ResponsesMessageContent  `json:"content,omitempty"`
 
+	// Author and Recipient are required on multi-agent collab_tool_call items.
+	// Preserved as raw JSON to survive bifrost round-trip without schema coupling.
+	Author    json.RawMessage `json:"author,omitempty"`
+	Recipient json.RawMessage `json:"recipient,omitempty"`
+
 	*ResponsesToolMessage // For Tool calls and outputs
 
 	CacheControl *CacheControl `json:"cache_control,omitempty"` // Carries cache_control for function_call and function_call_output message types
@@ -1018,6 +1024,9 @@ type ResponsesMessageContentBlock struct {
 	FileID    *string                          `json:"file_id,omitempty"` // Reference to uploaded file
 	Text      *string                          `json:"text,omitempty"`
 	Signature *string                          `json:"signature,omitempty"` // Signature of the content (for reasoning)
+	// EncryptedContent is required on reasoning content blocks during history replay.
+	// OpenAI returns it alongside summary_text blocks; it must be echoed back verbatim.
+	EncryptedContent *string `json:"encrypted_content,omitempty"`
 
 	*ResponsesInputMessageContentBlockImage
 	*ResponsesInputMessageContentBlockFile


### PR DESCRIPTION
Fixes #4608

## Problem

`ResponsesMessage` had no `Author` or `Recipient` struct fields, and `ResponsesMessageContentBlock` had no `EncryptedContent` field. Go's JSON decoder silently drops unknown fields on decode, so these values were stripped before bifrost re-serialized the request to the upstream provider.

This breaks Codex 0.141.0+ `multi_agent_v2` subagent spawning entirely. OpenAI requires all three fields on `collab_tool_call` input items and on reasoning content blocks during history replay.

## Changes

**`core/schemas/responses.go`**

```go
// ResponsesMessage — two new fields:
Author    json.RawMessage `json:"author,omitempty"`
Recipient json.RawMessage `json:"recipient,omitempty"`

// ResponsesMessageContentBlock — one new field:
EncryptedContent *string `json:"encrypted_content,omitempty"`
```

`json.RawMessage` is used for `author`/`recipient` so bifrost passes the objects through verbatim without assuming OpenAI's multi-agent schema shape, which may evolve.

## How to verify

```bash
# Requires Codex 0.141.0+ and bifrost proxying an OpenAI Responses API endpoint
codex exec \
  -c model_provider=bifrost \
  -c model=gpt-5.5 \
  --enable multi_agent_v2 \
  --dangerously-bypass-approvals-and-sandbox \
  "write hello to hello.txt then spawn a subagent to verify it exists"
```

**Before fix:** 400 `Missing required parameter: 'input[N].author'` on the second request.  
**After fix:** Session completes — subagent spawns, verifies file, reports back. All `/v1/responses` return 200.

## Test plan

- [ ] Existing unit/integration tests pass
- [ ] Manual end-to-end: Codex `multi_agent_v2` subagent spawn through bifrost returns 200 on all turns
- [ ] Verify `author`, `recipient`, `encrypted_content` are present in the request bifrost forwards upstream (can check with `send_back_raw_request: true` on a deliberate error)