### PR TITLE
feat: adds group_traces_by_session support to OTEL plugin

### DIFF
--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -40,6 +40,7 @@ The plugin supports multiple trace formats to match your observability platform:
 | `protocol` | `string` | ✅ Yes | Transport protocol: `http` or `grpc` |
 | `headers` | `object` | ❌ No | Custom headers for authentication — values support `env.VAR_NAME` |
 | `tls_ca_cert` | `string` | ❌ No | File path to client CA certificate for TLS. Optional. Works with both gRPC and HTTP protocol |
+| `group_traces_by_session` | `boolean` | ❌ No | Group requests sharing the same `x-bf-session-id` into one trace (default: `false`). See [Grouping Traces by Session](#grouping-traces-by-session) |
 
 ### Environment Variable Substitution
 
@@ -83,6 +84,30 @@ This is useful for:
 - **Service versioning** - Track which version of your service generated the trace
 - **Team attribution** - Tag traces with team ownership for filtering and alerting
 - **Custom metadata** - Add any key-value pairs relevant to your observability needs
+
+### Session Tracking
+
+Whenever a request carries the [`x-bf-session-id`](/providers/request-options) header, Bifrost tags the trace's root span with the OTEL-conventional `session.id` attribute. This happens **regardless** of the `group_traces_by_session` setting, so you can always filter and correlate traces by session in your backend even when each request remains its own trace.
+
+### Grouping Traces by Session
+
+By default, each request Bifrost handles becomes its own OTEL trace (still tagged with `session.id` as described above). Enable `group_traces_by_session` to instead group every request that carries the same `x-bf-session-id` header into a **single trace**, with each request's root span appearing as a top-level sibling under that trace. This is useful for viewing a multi-turn conversation or agent run as one trace in your backend.
+
+```json
+{
+  "group_traces_by_session": true
+}
+```
+
+When enabled, requests sharing a session ID adopt a deterministic trace ID derived from that session ID, so they land in the same trace regardless of which Bifrost node handled them.
+
+<Note>
+An inbound [W3C `traceparent`](https://www.w3.org/TR/trace-context/) always takes precedence: a request that arrives on a distributed trace stays on that trace and is **not** regrouped by session. Session grouping only applies to requests that have a session ID but no incoming trace context.
+
+Because all requests in a session share one trace, very long-lived sessions produce large traces. Use a session scope that matches how you want to view activity in your backend.
+</Note>
+
+To send a session ID, pass the [`x-bf-session-id`](/providers/request-options) header on each request you want grouped together.
 
 ---
 
@@ -704,6 +729,7 @@ Each trace includes comprehensive LLM operation metadata following OpenTelemetry
 - **Span Name**: Based on request type (`gen_ai.chat`, `gen_ai.text`, `gen_ai.embedding`, etc.)
 - **Service Info**: `service.name=bifrost`, `service.version`
 - **Provider & Model**: `gen_ai.provider.name`, `gen_ai.request.model`
+- **Session**: `session.id` on the root span when the request carries an `x-bf-session-id` header (see [Session Tracking](#session-tracking))
 
 ### Request Parameters
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -4213,6 +4213,11 @@
           "description": "When true, message content (input/output messages, embeddings, tool definitions, and tool call arguments/results) is dropped from exported spans. Only metadata such as model, tokens, and latency is sent to the collector.",
           "default": false
         },
+        "group_traces_by_session": {
+          "type": "boolean",
+          "description": "When true, requests sharing the same x-bf-session-id header are grouped into a single OTEL trace, each request's root span appearing as a top-level sibling. An inbound W3C traceparent takes precedence, leaving that request on its own distributed trace.",
+          "default": false
+        },
         "plugin_span_filter": {
           "$ref": "#/$defs/pluginSpanFilter"
         }
@@ -4318,6 +4323,10 @@
         "disable_content_logging": {
           "type": "boolean",
           "description": "Deprecated in the profiles wrapper; configure disable_content_logging per profile instead."
+        },
+        "group_traces_by_session": {
+          "type": "boolean",
+          "description": "Deprecated in the profiles wrapper; configure group_traces_by_session per profile instead."
         }
       },
       "required": ["profiles"],

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -539,6 +539,7 @@ bifrost:
         #     tls_ca_cert: ""         # Path to TLS CA certificate file
         #     insecure: true          # Skip TLS verification (ignored if tls_ca_cert is set)
         #     disable_content_logging: false
+        #     group_traces_by_session: false # Group requests sharing x-bf-session-id into one trace (traceparent takes precedence)
         #
         # Single-profile shape:
         service_name: "bifrost"
@@ -556,6 +557,8 @@ bifrost:
         insecure: false # Skip TLS verification (ignored if tls_ca_cert is set)
         # Drop message content (input/output messages, embeddings, tool defs/args/results) from exported spans
         disable_content_logging: false
+        # Group requests sharing the same x-bf-session-id header into one trace (an inbound W3C traceparent takes precedence)
+        group_traces_by_session: false
     datadog:
       enabled: false
       version: 1

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -1,6 +1,7 @@
 package otel
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -10,6 +11,29 @@ import (
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
+
+// sessionIDHash returns the SHA-256 digest of sessionID. Callers extract
+// non-overlapping slices for the trace ID (bytes 0-15) and synthetic parent
+// span ID (bytes 16-23) so both are derived from a single hash invocation.
+func sessionIDHash(sessionID string) [32]byte {
+	return sha256.Sum256([]byte(sessionID))
+}
+
+// sessionTraceID derives a deterministic 128-bit (32 lowercase hex char) trace ID
+// from an x-bf-session-id value. Used to pin every request sharing a session into one
+// OTEL trace when group_traces_by_session is enabled.
+func sessionTraceID(sessionID string) string {
+	sum := sessionIDHash(sessionID)
+	return hex.EncodeToString(sum[:16])
+}
+
+// sessionParentSpanID derives a deterministic 64-bit (16 lowercase hex char) span ID
+// from an x-bf-session-id value. It serves as the synthetic (never-emitted) parent of
+// each request's root span so requests render as top-level siblings under one trace.
+func sessionParentSpanID(sessionID string) string {
+	sum := sessionIDHash(sessionID)
+	return hex.EncodeToString(sum[16:24])
+}
 
 // kvStr creates a key-value pair with a string value
 func kvStr(k, v string) *KeyValue {
@@ -72,15 +96,34 @@ func hexToBytes(hexStr string, length int) []byte {
 // convertTraceToResourceSpan converts a Bifrost trace to OTEL ResourceSpan for the given
 // profile service name. Span filtering and instance attributes are shared across profiles;
 // only the resource service name differs per profile.
-func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace, requestHeaders []string, disableContentLogging bool) *ResourceSpan {
+func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace, requestHeaders []string, disableContentLogging bool, groupTracesBySession bool) *ResourceSpan {
 	reparent := p.pluginSpanFilter.BuildReparentMap(trace.Spans)
 	filteredHeaders := schemas.FilterHeaders(trace.RequestHeaders, requestHeaders)
+
+	// The x-bf-session-id header is a trace-level attribute, so it is not emitted as a span
+	// attribute by default. Surface it on the root span as the OTEL-conventional session.id
+	// whenever present, so traces can always be filtered/correlated by session — independent
+	// of grouping.
+	sessionID := getStringAttr(trace.Attributes, schemas.TraceAttrSessionID)
+
+	// Session grouping: when enabled and this request carries an x-bf-session-id but no
+	// inbound W3C traceparent (root span has no parent), pin every span to a trace ID
+	// derived from the session ID so all requests in the session share one OTEL trace. The
+	// root span is parented to a synthetic, never-emitted session span, making each request
+	// a top-level sibling under one trace. An inbound traceparent sets RootSpan.ParentID, so
+	// it takes precedence and the request stays on its distributed trace.
+	traceID := trace.TraceID
+	groupBySession := groupTracesBySession && sessionID != "" && trace.RootSpan != nil && trace.RootSpan.ParentID == ""
+	if groupBySession {
+		traceID = sessionTraceID(sessionID)
+	}
+
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
 		if !p.pluginSpanFilter.ShouldExportSpan(span) {
 			continue
 		}
-		otelSpan := convertSpanToOTELSpan(trace.TraceID, span, disableContentLogging)
+		otelSpan := convertSpanToOTELSpan(traceID, span, disableContentLogging)
 		// If the span's direct parent was filtered, rewrite its parent ID to the
 		// nearest exported ancestor so the hierarchy stays connected.
 		if effectiveParent, ok := reparent[span.ParentID]; ok {
@@ -91,6 +134,13 @@ func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schem
 			}
 		}
 		if span == trace.RootSpan {
+			if sessionID != "" {
+				otelSpan.Attributes = append(otelSpan.Attributes, kvStr("session.id", sessionID))
+			}
+			if groupBySession {
+				// Parent the root to the synthetic session span so requests are siblings.
+				otelSpan.ParentSpanId = hexToBytes(sessionParentSpanID(sessionID), 8)
+			}
 			if requestID := trace.GetRequestID(); requestID != "" {
 				otelSpan.Attributes = append(otelSpan.Attributes,
 					kvStr(schemas.AttrRequestID, requestID), // legacy: gen_ai.* placement of bifrost-internal attr; replaced by bifrost.request.id

--- a/plugins/otel/converter_test.go
+++ b/plugins/otel/converter_test.go
@@ -42,7 +42,7 @@ func TestConvertTraceToResourceSpan_PluginSpanFilter(t *testing.T) {
 		},
 	}
 
-	rs := p.convertTraceToResourceSpan("svc", trace, nil, false)
+	rs := p.convertTraceToResourceSpan("svc", trace, nil, false, false)
 	spans := rs.ScopeSpans[0].Spans
 
 	// The filtered logging span is dropped; root + governance remain.
@@ -64,5 +64,171 @@ func TestConvertTraceToResourceSpan_PluginSpanFilter(t *testing.T) {
 	// the nearest exported ancestor (root), not left dangling at the dropped logging span.
 	if !bytes.Equal(gov.ParentSpanId, hexToBytes("aaaa", 8)) {
 		t.Errorf("governance ParentSpanId = %x, want %x (reparented to root)", gov.ParentSpanId, hexToBytes("aaaa", 8))
+	}
+}
+
+// TestSessionDerivedIDsAreDeterministicAndValid asserts the session-derived trace and parent
+// span IDs are stable across calls and have the byte widths OTEL requires (16-byte trace,
+// 8-byte span).
+func TestSessionDerivedIDsAreDeterministicAndValid(t *testing.T) {
+	const sess = "session-abc-123"
+	if got := sessionTraceID(sess); got != sessionTraceID(sess) {
+		t.Fatal("sessionTraceID is not deterministic")
+	}
+	if got := sessionParentSpanID(sess); got != sessionParentSpanID(sess) {
+		t.Fatal("sessionParentSpanID is not deterministic")
+	}
+	if sessionTraceID(sess) == sessionTraceID("other-session") {
+		t.Error("distinct sessions produced the same trace ID")
+	}
+	if n := len(sessionTraceID(sess)); n != 32 { // 16 bytes in hex
+		t.Errorf("session trace ID hex length = %d, want 32", n)
+	}
+	if n := len(sessionParentSpanID(sess)); n != 16 { // 8 bytes in hex
+		t.Errorf("session parent span ID hex length = %d, want 16", n)
+	}
+}
+
+// attrString returns the string value of the named attribute on a span, or "" if absent.
+func attrString(s *Span, key string) string {
+	for _, kv := range s.Attributes {
+		if kv.Key == key {
+			return kv.Value.GetStringValue()
+		}
+	}
+	return ""
+}
+
+// findRoot returns the exported root span (SpanID "aaaa") from a converted span slice.
+func findRoot(spans []*Span) *Span {
+	for _, s := range spans {
+		if bytes.Equal(s.SpanId, hexToBytes("aaaa", 8)) {
+			return s
+		}
+	}
+	return nil
+}
+
+// makeSessionTrace builds a single-request trace (root + one LLM child) optionally carrying an
+// x-bf-session-id attribute and an inbound traceparent parent on the root span.
+func makeSessionTrace(traceID, sessionID, rootParentID string) *schemas.Trace {
+	root := makeSpan("aaaa", rootParentID, "request", schemas.SpanKindInternal)
+	child := makeSpan("bbbb", "aaaa", "chat", schemas.SpanKindLLMCall)
+	tr := &schemas.Trace{
+		TraceID:  traceID,
+		RootSpan: root,
+		Spans:    []*schemas.Span{root, child},
+	}
+	if sessionID != "" {
+		tr.Attributes = map[string]any{"x-bf-session-id": sessionID}
+	}
+	return tr
+}
+
+// TestSessionGroupingOverridesTraceID asserts that, with grouping enabled and a session ID
+// present (and no inbound traceparent), every span adopts the session-derived trace ID, two
+// requests in the same session share that trace ID, and each root span is parented to the
+// synthetic session span so they render as siblings.
+func TestSessionGroupingOverridesTraceID(t *testing.T) {
+	p := &OtelPlugin{}
+	const sess = "user-42"
+	wantTrace := hexToBytes(sessionTraceID(sess), 16)
+	wantParent := hexToBytes(sessionParentSpanID(sess), 8)
+
+	for _, original := range []string{"00000000000000000000000000000001", "00000000000000000000000000000002"} {
+		rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, sess, ""), nil, false, true)
+		spans := rs.ScopeSpans[0].Spans
+		if len(spans) != 2 {
+			t.Fatalf("expected 2 spans, got %d", len(spans))
+		}
+		for _, s := range spans {
+			if !bytes.Equal(s.TraceId, wantTrace) {
+				t.Errorf("span %q TraceId = %x, want session trace %x", s.Name, s.TraceId, wantTrace)
+			}
+		}
+		root := findRoot(spans)
+		if root == nil {
+			t.Fatal("root span not found")
+		}
+		if !bytes.Equal(root.ParentSpanId, wantParent) {
+			t.Errorf("root ParentSpanId = %x, want session parent %x", root.ParentSpanId, wantParent)
+		}
+		if got := attrString(root, "session.id"); got != sess {
+			t.Errorf("root session.id = %q, want %q", got, sess)
+		}
+	}
+}
+
+// TestSessionGroupingTraceparentWins asserts that an inbound W3C traceparent (root span has a
+// ParentID) takes precedence: the request keeps its original trace ID and root parent even when
+// grouping is enabled and a session ID is present.
+func TestSessionGroupingTraceparentWins(t *testing.T) {
+	p := &OtelPlugin{}
+	const original = "0123456789abcdef0123456789abcdef"
+	const inboundParent = "fedcba9876543210"
+	rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, "user-42", inboundParent), nil, false, true)
+	spans := rs.ScopeSpans[0].Spans
+
+	wantTrace := hexToBytes(original, 16)
+	for _, s := range spans {
+		if !bytes.Equal(s.TraceId, wantTrace) {
+			t.Errorf("span %q TraceId = %x, want original %x (traceparent wins)", s.Name, s.TraceId, wantTrace)
+		}
+	}
+	root := findRoot(spans)
+	if root == nil {
+		t.Fatal("root span not found")
+	}
+	if !bytes.Equal(root.ParentSpanId, hexToBytes(inboundParent, 8)) {
+		t.Errorf("root ParentSpanId = %x, want inbound traceparent %x", root.ParentSpanId, hexToBytes(inboundParent, 8))
+	}
+	// session.id is still tagged even though grouping was skipped (traceparent wins).
+	if got := attrString(root, "session.id"); got != "user-42" {
+		t.Errorf("root session.id = %q, want %q", got, "user-42")
+	}
+}
+
+// TestSessionGroupingDisabled asserts that with grouping off the original trace ID is kept and
+// the root span has no parent, but the session ID is still tagged on the root as session.id.
+func TestSessionGroupingDisabled(t *testing.T) {
+	p := &OtelPlugin{}
+	const original = "00000000000000000000000000000009"
+	rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, "user-42", ""), nil, false, false)
+	spans := rs.ScopeSpans[0].Spans
+
+	wantTrace := hexToBytes(original, 16)
+	for _, s := range spans {
+		if !bytes.Equal(s.TraceId, wantTrace) {
+			t.Errorf("span %q TraceId = %x, want original %x", s.Name, s.TraceId, wantTrace)
+		}
+	}
+	root := findRoot(spans)
+	if root == nil {
+		t.Fatal("root span not found")
+	}
+	if root.ParentSpanId != nil {
+		t.Errorf("root ParentSpanId = %x, want nil (grouping disabled)", root.ParentSpanId)
+	}
+	if got := attrString(root, "session.id"); got != "user-42" {
+		t.Errorf("root session.id = %q, want %q (always tagged)", got, "user-42")
+	}
+}
+
+// TestNoSessionIDNoTag asserts that when no x-bf-session-id is present the root span carries no
+// session.id attribute.
+func TestNoSessionIDNoTag(t *testing.T) {
+	p := &OtelPlugin{}
+	const original = "0000000000000000000000000000000a"
+	rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, "", ""), nil, false, true)
+	root := findRoot(rs.ScopeSpans[0].Spans)
+	if root == nil {
+		t.Fatal("root span not found")
+	}
+	if got := attrString(root, "session.id"); got != "" {
+		t.Errorf("root session.id = %q, want empty (no session header)", got)
+	}
+	// With no session ID, grouping cannot apply: trace ID stays original.
+	if !bytes.Equal(root.TraceId, hexToBytes(original, 16)) {
+		t.Errorf("root TraceId = %x, want original %x", root.TraceId, hexToBytes(original, 16))
 	}
 }

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -86,6 +86,13 @@ type Profile struct {
 	// When true, only metadata (model, tokens, latency, etc.) is exported; input/output message
 	// content, tool definitions, and tool call arguments/results are dropped from span attributes.
 	DisableContentLogging bool `json:"disable_content_logging,omitempty"`
+
+	// GroupTracesBySession, when true, groups all requests sharing the same x-bf-session-id
+	// header into a single OTEL trace: every span adopts a session-derived trace ID and each
+	// request's root span becomes a top-level sibling under one synthetic session parent
+	// (default: false). An inbound W3C traceparent always takes precedence, leaving that
+	// request on its own distributed trace.
+	GroupTracesBySession bool `json:"group_traces_by_session,omitempty"`
 }
 
 // UnmarshalJSON applies field defaults that the zero-value wouldn't capture.
@@ -207,6 +214,7 @@ type profileForStorage struct {
 	MetricsPushInterval   int               `json:"metrics_push_interval,omitempty"`
 	RequestHeaders        []string          `json:"request_headers,omitempty"`
 	DisableContentLogging bool              `json:"disable_content_logging,omitempty"`
+	GroupTracesBySession  bool              `json:"group_traces_by_session,omitempty"`
 }
 
 // configForStorage is the persisted wrapper shape.
@@ -242,6 +250,7 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			MetricsPushInterval:   p.MetricsPushInterval,
 			RequestHeaders:        p.RequestHeaders,
 			DisableContentLogging: p.DisableContentLogging,
+			GroupTracesBySession:  p.GroupTracesBySession,
 		})
 	}
 	return sonic.Marshal(out)
@@ -312,6 +321,7 @@ type otelTarget struct {
 	metricsExporter       *MetricsExporter
 	requestHeaders        []string
 	disableContentLogging bool
+	groupTracesBySession  bool
 }
 
 // OtelPlugin is the plugin for OpenTelemetry.
@@ -434,6 +444,7 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		traceType:             profile.TraceType,
 		requestHeaders:        slices.Clone(profile.RequestHeaders),
 		disableContentLogging: profile.DisableContentLogging,
+		groupTracesBySession:  profile.GroupTracesBySession,
 	}
 
 	var err error
@@ -645,7 +656,7 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 		go func(t *otelTarget) {
 			defer wg.Done()
 			if t.client != nil {
-				resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders, t.disableContentLogging)
+				resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders, t.disableContentLogging, t.groupTracesBySession)
 				if err := t.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
 					logger.Error("failed to emit trace %s to %s: %v", trace.TraceID, t.url, err)
 				}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2426,6 +2426,11 @@
           "description": "When true, message content (input/output messages, embeddings, tool definitions, and tool call arguments/results) is dropped from exported spans. Only metadata such as model, tokens, and latency is sent to the collector.",
           "default": false
         },
+        "group_traces_by_session": {
+          "type": "boolean",
+          "description": "When true, requests sharing the same x-bf-session-id header are grouped into a single OTEL trace, each request's root span appearing as a top-level sibling. An inbound W3C traceparent takes precedence, leaving that request on its own distributed trace.",
+          "default": false
+        },
         "headers": {
           "type": "object",
           "additionalProperties": {

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -36,6 +36,7 @@ interface StoredOtelProfile {
 	metrics_push_interval?: number;
 	request_headers?: string[];
 	disable_content_logging?: boolean;
+	group_traces_by_session?: boolean;
 }
 
 // StoredOtelConfig is either the canonical { profiles: [...] } wrapper or a legacy single
@@ -98,6 +99,7 @@ const emptyProfile = (): ProfileForm => ({
 	metrics_push_interval: 15,
 	request_headers: [],
 	disable_content_logging: false,
+	group_traces_by_session: false,
 });
 
 // toProfileForm normalizes a stored profile into the EnvVar-based form representation.
@@ -115,6 +117,7 @@ const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
 	metrics_push_interval: p?.metrics_push_interval ?? 15,
 	request_headers: p?.request_headers ?? [],
 	disable_content_logging: p?.disable_content_logging ?? false,
+	group_traces_by_session: p?.group_traces_by_session ?? false,
 });
 
 // buildDefaults handles both stored shapes: the { profiles: [...] } wrapper and the legacy
@@ -455,6 +458,25 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 								</div>
 								<FormControl>
 									<Switch checked={field.value} onCheckedChange={field.onChange} disabled={!hasOtelAccess} data-testid={`otel-profile-${index}-disable-content-logging-toggle`} />
+								</FormControl>
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={control}
+						name={`${base}.group_traces_by_session`}
+						render={({ field }) => (
+							<FormItem className="flex flex-row items-center justify-between">
+								<div className="space-y-0.5">
+									<FormLabel className="text-base">Group Traces by Session</FormLabel>
+									<FormDescription>
+										When enabled, requests sharing the same x-bf-session-id header are grouped into a single trace, each request
+										appearing as a top-level sibling span. A request carrying an inbound W3C traceparent stays on its own
+										distributed trace and is unaffected.
+									</FormDescription>
+								</div>
+								<FormControl>
+									<Switch checked={field.value} onCheckedChange={field.onChange} disabled={!hasOtelAccess} data-testid={`otel-profile-${index}-group-traces-by-session-toggle`} />
 								</FormControl>
 							</FormItem>
 						)}

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -811,6 +811,7 @@ export const otelConfigSchema = z
 		metrics_push_interval: z.number().int().min(1).max(300).default(15),
 		request_headers: z.array(z.string()).default([]),
 		disable_content_logging: z.boolean().default(false),
+		group_traces_by_session: z.boolean().default(false),
 	})
 	.superRefine((data, ctx) => {
 		// A disabled profile is not sent anywhere, so skip all validation for it.


### PR DESCRIPTION
## Summary

Adds a `group_traces_by_session` option to the OTEL plugin that groups all requests sharing the same `x-bf-session-id` header into a single OTEL trace. Without this, each request produces its own trace (though `session.id` is always tagged on the root span). When enabled, requests sharing a session ID adopt a deterministic trace ID derived from that session ID, and each request's root span is parented to a synthetic, never-emitted session span so they render as top-level siblings under one trace. An inbound W3C `traceparent` always takes precedence, leaving that request on its own distributed trace.

## Changes

- Added `sessionTraceID` and `sessionParentSpanID` helpers in `converter.go` that derive deterministic 128-bit trace IDs and 64-bit parent span IDs from a session ID via SHA-256.
- `convertTraceToResourceSpan` now accepts a `groupTracesBySession bool` parameter. When enabled and a session ID is present with no inbound traceparent, all spans in the request adopt the session-derived trace ID and the root span is reparented to the synthetic session span.
- The `session.id` attribute is always set on the root span when `x-bf-session-id` is present, regardless of whether grouping is enabled.
- Added `GroupTracesBySession` field to `Profile`, `profileForStorage`, and `otelTarget` structs, wired through config marshaling and target construction.
- Updated the config JSON schema (`transports/config.schema.json`) and Helm chart schema (`values.schema.json`) with the new boolean field and its deprecation entry in the profiles wrapper.
- Added the toggle to the OTEL profile form in the UI with appropriate label and description.
- Added `group_traces_by_session` to the Zod schema in `schemas.ts`.
- Added four new test cases covering: deterministic ID generation, grouping overriding the trace ID, inbound traceparent taking precedence, grouping disabled, and no session ID present.
- Documented the feature in `docs/features/observability/otel.mdx` under new "Session Tracking" and "Grouping Traces by Session" sections, and added `session.id` to the span attributes reference table.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/otel/...

# UI
cd ui
pnpm i
pnpm build
```

To validate end-to-end:
1. Configure the OTEL plugin with `group_traces_by_session: true`.
2. Send two or more requests to Bifrost with the same `x-bf-session-id` header value.
3. Confirm in your OTEL backend that both requests appear under a single trace, each as a top-level sibling span.
4. Send a request with both `x-bf-session-id` and a valid W3C `traceparent` header; confirm it stays on its own distributed trace and is not regrouped.
5. Send a request with `x-bf-session-id` but `group_traces_by_session: false`; confirm each request is its own trace but the root span carries a `session.id` attribute.

**New config field:**

| Field | Type | Default | Description |
|---|---|---|---|
| `group_traces_by_session` | `boolean` | `false` | Group requests sharing the same `x-bf-session-id` into one OTEL trace. An inbound W3C `traceparent` takes precedence. |

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Session IDs passed via `x-bf-session-id` are hashed with SHA-256 before being used to derive trace and span IDs, so the raw session ID value is never embedded in the trace or span ID bytes. The session ID itself is emitted as the `session.id` span attribute on the root span, consistent with existing header forwarding behavior — operators should ensure session IDs do not contain PII if their OTEL backend is not trusted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable