### PR TITLE
feat: add login attempt rate limiting with per-key and global lockout

### DIFF
--- a/transports/bifrost-http/handlers/loginattempts.go
+++ b/transports/bifrost-http/handlers/loginattempts.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	maxLoginAttemptsPerKey    = 10
+	maxLoginAttemptsGlobal    = 1000
+	maxStoredLoginAttemptKeys = 1024
+	loginAttemptWindow        = 2 * time.Minute
+	loginAttemptLockout       = 2 * time.Minute
+)
+
+type loginAttemptLimiter struct {
+	mu        sync.Mutex
+	attempts  map[string]loginAttemptEntry
+	global    loginAttemptEntry
+	now       func() time.Time
+	max       int
+	globalMax int
+	window    time.Duration
+	lockout   time.Duration
+}
+
+type loginAttemptEntry struct {
+	count        int
+	firstAttempt time.Time
+	lockedUntil  time.Time
+}
+
+func newLoginAttemptLimiter() *loginAttemptLimiter {
+	return &loginAttemptLimiter{
+		attempts:  make(map[string]loginAttemptEntry),
+		now:       time.Now,
+		max:       maxLoginAttemptsPerKey,
+		globalMax: maxLoginAttemptsGlobal,
+		window:    loginAttemptWindow,
+		lockout:   loginAttemptLockout,
+	}
+}
+
+func (l *loginAttemptLimiter) isAllowed(key string) (time.Duration, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	l.pruneExpiredLocked(now)
+
+	if retryAfter, locked := lockoutRemaining(l.global, now); locked {
+		return retryAfter, false
+	}
+	entry, ok := l.attempts[key]
+	if !ok {
+		return 0, true
+	}
+	if retryAfter, locked := lockoutRemaining(entry, now); locked {
+		return retryAfter, false
+	}
+	return 0, true
+}
+
+func (l *loginAttemptLimiter) recordFailure(key string) (time.Duration, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	l.pruneExpiredLocked(now)
+
+	entry, hasEntry := l.attempts[key]
+	if hasEntry || len(l.attempts) < maxStoredLoginAttemptKeys {
+		entry = l.recordFailureLocked(entry, l.max, now)
+		l.attempts[key] = entry
+	}
+
+	l.global = l.recordFailureLocked(l.global, l.globalMax, now)
+
+	usernameRetryAfter, usernameLocked := lockoutRemaining(entry, now)
+	globalRetryAfter, globalLocked := lockoutRemaining(l.global, now)
+	if globalLocked && globalRetryAfter > usernameRetryAfter {
+		return globalRetryAfter, true
+	}
+	if usernameLocked {
+		return usernameRetryAfter, true
+	}
+	return 0, false
+}
+
+func (l *loginAttemptLimiter) recordSuccess(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.attempts, key)
+	l.global = loginAttemptEntry{}
+}
+
+func (l *loginAttemptLimiter) recordFailureLocked(entry loginAttemptEntry, maxAttempts int, now time.Time) loginAttemptEntry {
+	if entry.firstAttempt.IsZero() || now.Sub(entry.firstAttempt) > l.window {
+		entry = loginAttemptEntry{firstAttempt: now}
+	}
+	entry.count++
+	if entry.count >= maxAttempts {
+		entry.lockedUntil = now.Add(l.lockout)
+	}
+	return entry
+}
+
+func (l *loginAttemptLimiter) pruneExpiredLocked(now time.Time) {
+	for key, entry := range l.attempts {
+		if entry.lockedUntil.After(now) {
+			continue
+		}
+		if !entry.firstAttempt.IsZero() && now.Sub(entry.firstAttempt) <= l.window {
+			continue
+		}
+		delete(l.attempts, key)
+	}
+	if !l.global.lockedUntil.After(now) && !l.global.firstAttempt.IsZero() && now.Sub(l.global.firstAttempt) > l.window {
+		l.global = loginAttemptEntry{}
+	}
+}
+
+func loginAttemptKey(ctx *fasthttp.RequestCtx, username string) string {
+	if forwardedIP := clientForwardedIP(ctx); forwardedIP != "" {
+		return "ip:" + strings.ToLower(strings.TrimSpace(forwardedIP))
+	}
+
+	key := strings.ToLower(strings.TrimSpace(username))
+	if key == "" {
+		return "username:<empty>"
+	}
+	return "username:" + key
+}
+
+func lockoutRemaining(entry loginAttemptEntry, now time.Time) (time.Duration, bool) {
+	if entry.lockedUntil.After(now) {
+		return entry.lockedUntil.Sub(now), true
+	}
+	return 0, false
+}

--- a/transports/bifrost-http/handlers/session.go
+++ b/transports/bifrost-http/handlers/session.go
@@ -19,15 +19,17 @@ import (
 
 // SessionHandler manages HTTP requests for session operations
 type SessionHandler struct {
-	configStore   configstore.ConfigStore
-	wsTicketStore *WSTicketStore
+	configStore         configstore.ConfigStore
+	wsTicketStore       *WSTicketStore
+	loginAttemptLimiter *loginAttemptLimiter
 }
 
 // NewSessionHandler creates a new session handler instance
 func NewSessionHandler(configStore configstore.ConfigStore, wsTicketStore *WSTicketStore) *SessionHandler {
 	return &SessionHandler{
-		configStore:   configStore,
-		wsTicketStore: wsTicketStore,
+		configStore:         configStore,
+		wsTicketStore:       wsTicketStore,
+		loginAttemptLimiter: newLoginAttemptLimiter(),
 	}
 }
 
@@ -120,20 +122,30 @@ func (h *SessionHandler) login(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	if h.loginAttemptLimiter == nil {
+		h.loginAttemptLimiter = newLoginAttemptLimiter()
+	}
+	limiterKey := loginAttemptKey(ctx, payload.Username)
+	if retryAfter, allowed := h.loginAttemptLimiter.isAllowed(limiterKey); !allowed {
+		sendLoginRateLimited(ctx, retryAfter)
+		return
+	}
+
 	// Verify credentials
 	if payload.Username != authConfig.AdminUserName.GetValue() {
-		SendError(ctx, fasthttp.StatusUnauthorized, "Invalid username or password")
+		h.recordFailedLogin(ctx, limiterKey)
 		return
 	}
 	compare, err := encrypt.CompareHash(authConfig.AdminPassword.GetValue(), payload.Password)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
+		h.recordFailedLogin(ctx, limiterKey)
 		return
 	}
 	if !compare {
-		SendError(ctx, fasthttp.StatusUnauthorized, "Invalid username or password")
+		h.recordFailedLogin(ctx, limiterKey)
 		return
 	}
+	h.loginAttemptLimiter.recordSuccess(limiterKey)
 
 	// Creating a new session
 	token := uuid.New().String()
@@ -167,6 +179,21 @@ func (h *SessionHandler) login(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]any{
 		"message": "Login successful",
 	})
+}
+
+func (h *SessionHandler) recordFailedLogin(ctx *fasthttp.RequestCtx, loginAttemptKey string) {
+	retryAfter, locked := h.loginAttemptLimiter.recordFailure(loginAttemptKey)
+	if locked {
+		sendLoginRateLimited(ctx, retryAfter)
+		return
+	}
+	SendError(ctx, fasthttp.StatusUnauthorized, "Invalid username or password")
+}
+
+func sendLoginRateLimited(ctx *fasthttp.RequestCtx, retryAfter time.Duration) {
+	seconds := max(int(retryAfter.Seconds()), 1)
+	ctx.Response.Header.Set("Retry-After", fmt.Sprintf("%d", seconds))
+	SendError(ctx, fasthttp.StatusTooManyRequests, "Too many login attempts. Please try again later.")
 }
 
 // logout handles POST /api/session/logout - Logout a user

--- a/transports/bifrost-http/handlers/session_test.go
+++ b/transports/bifrost-http/handlers/session_test.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/encrypt"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+func setupSessionHandler(t *testing.T) *SessionHandler {
+	t.Helper()
+
+	store, err := configstore.NewConfigStore(context.Background(), &configstore.Config{
+		Enabled: true,
+		Type:    configstore.ConfigStoreTypeSQLite,
+		Config: &configstore.SQLiteConfig{
+			Path: t.TempDir() + "/config.db",
+		},
+	}, &mockLogger{})
+	require.NoError(t, err)
+
+	hashedPassword, err := encrypt.Hash("correct-password")
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateAuthConfig(context.Background(), &configstore.AuthConfig{
+		AdminUserName: schemas.NewEnvVar("admin"),
+		AdminPassword: schemas.NewEnvVar(hashedPassword),
+		IsEnabled:     true,
+	}))
+
+	return NewSessionHandler(store, nil)
+}
+
+func loginRequestCtx(username string, password string) *fasthttp.RequestCtx {
+	return newTestRequestCtx(fmt.Sprintf(`{"username":%q,"password":%q}`, username, password))
+}
+
+func loginRequestCtxWithForwardedIP(username string, password string, forwardedIP string) *fasthttp.RequestCtx {
+	ctx := loginRequestCtx(username, password)
+	ctx.Request.Header.Set("X-Forwarded-For", forwardedIP)
+	return ctx
+}
+
+func TestSessionLogin_RateLimitsFailedPasswordAttempts(t *testing.T) {
+	handler := setupSessionHandler(t)
+
+	for i := 0; i < maxLoginAttemptsPerKey-1; i++ {
+		ctx := loginRequestCtx("admin", "wrong-password")
+		handler.login(ctx)
+		require.Equal(t, fasthttp.StatusUnauthorized, ctx.Response.StatusCode())
+	}
+
+	ctx := loginRequestCtx("admin", "wrong-password")
+	handler.login(ctx)
+	require.Equal(t, fasthttp.StatusTooManyRequests, ctx.Response.StatusCode())
+	require.NotEmpty(t, ctx.Response.Header.Peek("Retry-After"))
+
+	ctx = loginRequestCtx("admin", "correct-password")
+	handler.login(ctx)
+	require.Equal(t, fasthttp.StatusTooManyRequests, ctx.Response.StatusCode())
+}
+
+func TestSessionLogin_SuccessClearsFailedAttempts(t *testing.T) {
+	handler := setupSessionHandler(t)
+
+	for i := 0; i < maxLoginAttemptsPerKey-1; i++ {
+		ctx := loginRequestCtx("admin", "wrong-password")
+		handler.login(ctx)
+		require.Equal(t, fasthttp.StatusUnauthorized, ctx.Response.StatusCode())
+	}
+
+	ctx := loginRequestCtx("admin", "correct-password")
+	handler.login(ctx)
+	require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+
+	for i := 0; i < maxLoginAttemptsPerKey-1; i++ {
+		ctx = loginRequestCtx("admin", "wrong-password")
+		handler.login(ctx)
+		require.Equal(t, fasthttp.StatusUnauthorized, ctx.Response.StatusCode())
+	}
+}
+
+func TestSessionLogin_UsesForwardedIPWhenPresent(t *testing.T) {
+	handler := setupSessionHandler(t)
+
+	for i := 0; i < maxLoginAttemptsPerKey-1; i++ {
+		ctx := loginRequestCtxWithForwardedIP(fmt.Sprintf("unknown-user-%d", i), "wrong-password", "203.0.113.10, 10.0.0.1")
+		handler.login(ctx)
+		require.Equal(t, fasthttp.StatusUnauthorized, ctx.Response.StatusCode())
+	}
+
+	ctx := loginRequestCtxWithForwardedIP("admin", "wrong-password", "203.0.113.10, 10.0.0.1")
+	handler.login(ctx)
+	require.Equal(t, fasthttp.StatusTooManyRequests, ctx.Response.StatusCode())
+
+	ctx = loginRequestCtxWithForwardedIP("admin", "correct-password", "198.51.100.7")
+	handler.login(ctx)
+	require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+}


### PR DESCRIPTION
## Summary

Adds brute-force protection to the admin login endpoint by rate limiting failed login attempts per IP address (or username when no forwarded IP is present) and globally across all requests.

## Changes

- Introduced `loginAttemptLimiter`, a thread-safe in-memory rate limiter that tracks failed login attempts within a sliding 2-minute window, locking out a key for 2 minutes after 10 consecutive failures and globally after 1000 failures across all keys.
- Integrated the limiter into `SessionHandler.login`: requests are checked before credential verification, failures are recorded and may trigger a `429 Too Many Requests` response with a `Retry-After` header, and a successful login clears the failure state for that key.
- Rate limiting keys are derived from the `X-Forwarded-For` header when present, falling back to the normalized username, so IP-based lockouts apply consistently across different usernames from the same client.
- Added tests covering: lockout after repeated failures, successful login clearing the failure counter, and IP-based keying when a forwarded IP header is present.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

Expected: all tests pass, including the three new login rate limiting scenarios.

To validate manually, send more than 5 failed login requests to `POST /api/session/login` within 2 minutes and confirm the response transitions from `401 Unauthorized` to `429 Too Many Requests` with a `Retry-After` header set.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change directly addresses a brute-force attack vector on the admin login endpoint. The limiter is in-memory and does not persist across restarts, so a process restart would reset lockout state. The global cap of 1000 attempts and the per-key cap of 5 attempts are enforced independently, meaning a distributed attack from many IPs can still trigger the global lockout. The stored key map is bounded to 1024 entries to prevent unbounded memory growth.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable