### PR TITLE
[fix]: core - recover from closeBodyStream panic in idle-timeout timer goroutine

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,2 @@
+- fix: recover from idle-timeout timer-goroutine panic that could crash the process
 - fix: deterministic MCP tool ordering for prompt cache stability (closes #2347)

--- a/core/providers/utils/idle_timeout_reader_test.go
+++ b/core/providers/utils/idle_timeout_reader_test.go
@@ -59,6 +59,16 @@ func (panicReader) Read([]byte) (int, error) {
 	panic(errPanicReader)
 }
 
+// timerPanicCloser mimics fasthttp's streaming body when the underlying
+// connection has already been released to / reused from the pool: CloseWithError
+// nil-derefs in (*HostClient).CloseConn and panics. It implements
+// streamCloserWithError (not io.Closer) so closeBodyStream takes the
+// CloseWithError branch — the path the idle timer hits.
+type timerPanicCloser struct{}
+
+func (timerPanicCloser) Read([]byte) (int, error)   { return 0, io.EOF }
+func (timerPanicCloser) CloseWithError(error) error { panic("simulated fasthttp CloseConn nil-deref") }
+
 type blockingCloserSpy struct {
 	started chan struct{}
 	release chan struct{}
@@ -389,6 +399,31 @@ func TestIdleTimeoutReader_RecoversReadPanicAfterTimeout(t *testing.T) {
 	if !errors.Is(err, ErrStreamIdleTimeout) {
 		t.Fatalf("expected ErrStreamIdleTimeout, got %v", err)
 	}
+}
+
+// TestIdleTimeoutReader_RecoversCloseStreamPanicOnTimerFire verifies that a
+// panic raised by closeBodyStream WHEN THE IDLE TIMER FIRES — e.g. fasthttp's
+// CloseWithError nil-dereffing in (*HostClient).CloseConn because the stream's
+// connection was already released to / reused from the pool (an orphaned timer
+// on a completed stream) — is recovered inside the timer goroutine and does not
+// crash the process.
+//
+// This is the timer-callback counterpart to RecoversReadPanicAfterTimeout
+// (#3677), which guarded the Read() path but not the AfterFunc's own
+// closeBodyStream call. Without the recover in the AfterFunc, the panic runs in
+// the timer goroutine, is unrecoverable by callers, and takes the whole process
+// down (observed crashing a router under sustained streaming load).
+func TestIdleTimeoutReader_RecoversCloseStreamPanicOnTimerFire(t *testing.T) {
+	t.Parallel()
+	_, cleanup := NewIdleTimeoutReader(&readCloserSpy{}, timerPanicCloser{}, 10*time.Millisecond, nil)
+
+	// Wait past the idle timeout so the timer fires and invokes closeBodyStream,
+	// which panics. cleanup() then blocks on timerDone, which is only closed
+	// once the (now-recovered) timer callback has returned — so reaching the end
+	// of the test proves the panic was swallowed in the timer goroutine. Without
+	// the recover, the process would have already crashed.
+	time.Sleep(50 * time.Millisecond)
+	cleanup()
 }
 
 func TestIdleTimeoutReader_CleanupWaitsForRunningTimerCallback(t *testing.T) {

--- a/core/providers/utils/idle_timeout_reader_test.go
+++ b/core/providers/utils/idle_timeout_reader_test.go
@@ -66,10 +66,26 @@ func (panicReader) Read([]byte) (int, error) {
 // nil-derefs in (*HostClient).CloseConn and panics. It implements
 // streamCloserWithError (not io.Closer) so closeBodyStream takes the
 // CloseWithError branch — the path the idle timer hits.
-type timerPanicCloser struct{}
+//
+// called is closed the instant CloseWithError is entered (just before the
+// panic), so a test can deterministically wait for the guarded path to be
+// exercised rather than rely on a fixed sleep — which a slow runner could
+// outrun, letting cleanup stop the timer before it ever fired and passing the
+// test without touching the recover.
+type timerPanicCloser struct {
+	called chan struct{}
+}
 
-func (timerPanicCloser) Read([]byte) (int, error)   { return 0, io.EOF }
-func (timerPanicCloser) CloseWithError(error) error { panic("simulated fasthttp CloseConn nil-deref") }
+func newTimerPanicCloser() *timerPanicCloser {
+	return &timerPanicCloser{called: make(chan struct{})}
+}
+
+func (*timerPanicCloser) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (c *timerPanicCloser) CloseWithError(error) error {
+	close(c.called)
+	panic("simulated fasthttp CloseConn nil-deref")
+}
 
 // captureLogger records Debug messages so a test can assert that a recovered
 // panic value is logged (not silently swallowed). It embeds noopLogger to
@@ -443,14 +459,22 @@ func TestIdleTimeoutReader_RecoversReadPanicAfterTimeout(t *testing.T) {
 // down (observed crashing a router under sustained streaming load).
 func TestIdleTimeoutReader_RecoversCloseStreamPanicOnTimerFire(t *testing.T) {
 	t.Parallel()
-	_, cleanup := NewIdleTimeoutReader(&readCloserSpy{}, timerPanicCloser{}, 10*time.Millisecond, nil)
+	body := newTimerPanicCloser()
+	_, cleanup := NewIdleTimeoutReader(&readCloserSpy{}, body, 10*time.Millisecond, nil)
 
-	// Wait past the idle timeout so the timer fires and invokes closeBodyStream,
-	// which panics. cleanup() then blocks on timerDone, which is only closed
-	// once the (now-recovered) timer callback has returned — so reaching the end
-	// of the test proves the panic was swallowed in the timer goroutine. Without
-	// the recover, the process would have already crashed.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the timer goroutine has actually entered CloseWithError (about to
+	// panic). This proves the guarded path was exercised; a fixed sleep could be
+	// outrun by a slow runner, letting cleanup stop the timer before it fired and
+	// passing the test without ever touching the recover.
+	select {
+	case <-body.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("idle timer never fired CloseWithError within 2s")
+	}
+
+	// cleanup() blocks on timerDone, closed only after the (now-recovered) timer
+	// callback returns — so reaching the end proves the panic was recovered in the
+	// timer goroutine. Without the recover, the process would already have crashed.
 	cleanup()
 }
 
@@ -465,8 +489,13 @@ func TestIdleTimeoutReader_LogsRecoveredTimerPanic(t *testing.T) {
 	SetLogger(capLog)
 	t.Cleanup(func() { SetLogger(prev) })
 
-	_, cleanup := NewIdleTimeoutReader(&readCloserSpy{}, timerPanicCloser{}, 10*time.Millisecond, nil)
-	time.Sleep(50 * time.Millisecond)
+	body := newTimerPanicCloser()
+	_, cleanup := NewIdleTimeoutReader(&readCloserSpy{}, body, 10*time.Millisecond, nil)
+	select {
+	case <-body.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("idle timer never fired CloseWithError within 2s")
+	}
 	cleanup() // blocks until the timer callback (recover + log) has returned
 
 	if !capLog.contains("idle-timeout timer") || !capLog.contains("nil-deref") {

--- a/core/providers/utils/idle_timeout_reader_test.go
+++ b/core/providers/utils/idle_timeout_reader_test.go
@@ -3,7 +3,9 @@ package utils
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -68,6 +70,32 @@ type timerPanicCloser struct{}
 
 func (timerPanicCloser) Read([]byte) (int, error)   { return 0, io.EOF }
 func (timerPanicCloser) CloseWithError(error) error { panic("simulated fasthttp CloseConn nil-deref") }
+
+// captureLogger records Debug messages so a test can assert that a recovered
+// panic value is logged (not silently swallowed). It embeds noopLogger to
+// satisfy the rest of the schemas.Logger interface.
+type captureLogger struct {
+	noopLogger
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (c *captureLogger) Debug(format string, args ...any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.msgs = append(c.msgs, fmt.Sprintf(format, args...))
+}
+
+func (c *captureLogger) contains(sub string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, m := range c.msgs {
+		if strings.Contains(m, sub) {
+			return true
+		}
+	}
+	return false
+}
 
 type blockingCloserSpy struct {
 	started chan struct{}
@@ -424,6 +452,26 @@ func TestIdleTimeoutReader_RecoversCloseStreamPanicOnTimerFire(t *testing.T) {
 	// the recover, the process would have already crashed.
 	time.Sleep(50 * time.Millisecond)
 	cleanup()
+}
+
+// TestIdleTimeoutReader_LogsRecoveredTimerPanic verifies that the recovered
+// panic value is logged (not silently swallowed), so an unexpected future
+// panic on this path leaves a forensic trace. Not parallel: it swaps the
+// package-global logger and restores it via t.Cleanup before parallel tests
+// resume.
+func TestIdleTimeoutReader_LogsRecoveredTimerPanic(t *testing.T) {
+	capLog := &captureLogger{}
+	prev := getLogger()
+	SetLogger(capLog)
+	t.Cleanup(func() { SetLogger(prev) })
+
+	_, cleanup := NewIdleTimeoutReader(&readCloserSpy{}, timerPanicCloser{}, 10*time.Millisecond, nil)
+	time.Sleep(50 * time.Millisecond)
+	cleanup() // blocks until the timer callback (recover + log) has returned
+
+	if !capLog.contains("idle-timeout timer") || !capLog.contains("nil-deref") {
+		t.Fatalf("expected recovered panic to be logged; got %v", capLog.msgs)
+	}
 }
 
 func TestIdleTimeoutReader_CleanupWaitsForRunningTimerCallback(t *testing.T) {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2308,6 +2308,14 @@ func NewIdleTimeoutReader(reader io.Reader, bodyStream io.Reader, timeout time.D
 			if ctx != nil {
 				ctx.SetValue(schemas.BifrostContextKeyConnectionClosed, true)
 			}
+			// closeBodyStream may panic: an orphaned timer can fire after the
+			// stream's connection has already been released to / reused from
+			// the fasthttp pool, so CloseWithError nil-derefs in
+			// (*HostClient).CloseConn. Because this runs in the timer goroutine,
+			// that panic is unrecoverable by callers and crashes the whole
+			// process. Recover here so a stale idle timer can never take the
+			// process down (companion to the Read() recover added in #3677).
+			defer func() { _ = recover() }()
 			closeBodyStream(r.bodyStream, ErrStreamIdleTimeout)
 		})
 	})

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2315,7 +2315,15 @@ func NewIdleTimeoutReader(reader io.Reader, bodyStream io.Reader, timeout time.D
 			// that panic is unrecoverable by callers and crashes the whole
 			// process. Recover here so a stale idle timer can never take the
 			// process down (companion to the Read() recover added in #3677).
-			defer func() { _ = recover() }()
+			// Unlike the Read() path we cannot re-panic an unexpected value
+			// (that would crash the process — the very thing we are guarding
+			// against), so log the recovered value to leave a forensic trace
+			// for any future, unrelated panic introduced into this path.
+			defer func() {
+				if rec := recover(); rec != nil {
+					getLogger().Debug("recovered panic in idle-timeout timer closeBodyStream: %v", rec)
+				}
+			}()
 			closeBodyStream(r.bodyStream, ErrStreamIdleTimeout)
 		})
 	})


### PR DESCRIPTION
## Summary

An orphaned idle-timeout timer can crash the whole process. When the
`time.AfterFunc` registered by `NewIdleTimeoutReader` fires *after* the
stream's connection has already been released to / reused from the fasthttp
pool, the `closeBodyStream(r.bodyStream, ...)` call invokes the body's
`CloseWithError`, which nil-dereferences in fasthttp's
`(*HostClient).CloseConn`. Because that runs in the timer goroutine, the panic
is unrecoverable by any caller and takes the entire process down.

We observed this crashing a gateway built on bifrost under sustained streaming
load — the crash fires minutes after the originating stream has completed, when
the stale idle timer finally elapses, so it is hard to correlate with any
single request.

PR #3677 ("fix idle timeout panic") added a `recover()` to the
`idleTimeoutReader.Read()` path, but the `AfterFunc`'s own `closeBodyStream`
call has no such guard. This PR adds the companion `recover()` inside the timer
callback so a stale idle timer can never crash the process.

## Changes

- `core/providers/utils/utils.go` — wrap the `closeBodyStream` call inside
  `NewIdleTimeoutReader`'s `time.AfterFunc` with `defer func() { _ = recover() }()`.
  This is the timer-goroutine counterpart to the `Read()`-path recover from
  #3677. The `BifrostContextKeyConnectionClosed` signal and `timerDone` close
  semantics are unchanged — the recover only prevents an unrecoverable
  cross-goroutine panic.
- `core/providers/utils/idle_timeout_reader_test.go` — add
  `TestIdleTimeoutReader_RecoversCloseStreamPanicOnTimerFire` plus a
  `timerPanicCloser` stub whose `CloseWithError` panics (mimicking the fasthttp
  `CloseConn` nil-deref) and which implements `streamCloserWithError` so
  `closeBodyStream` takes the `CloseWithError` branch the idle timer actually
  hits.
- `core/changelog.md` — changelog entry for the fix (per `docs/contributing/raising-a-pr.mdx`).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The new test fails (the test process **crashes** with
`panic: simulated fasthttp CloseConn nil-deref`) without the fix, and passes
with it.

```sh
cd core
go test ./providers/utils/ -run IdleTimeout -race -v
# => ok  github.com/maximhq/bifrost/core/providers/utils
```

To see it fail without the fix, temporarily remove the
`defer func() { _ = recover() }()` line and re-run — the timer goroutine panic
takes the test binary down:

```
panic: simulated fasthttp CloseConn nil-deref
goroutine NN [running]:
FAIL    github.com/maximhq/bifrost/core/providers/utils
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4617.

Follow-up to #3677 (which guarded only the `Read()` path). This closes the
remaining timer-goroutine crash path.

## Security considerations

None. The change only swallows a panic in a background timer goroutine; it does
not alter auth, secrets handling, or what data is read/written. The connection
is already being torn down on the timeout path, and `BifrostContextKeyConnectionClosed`
is still set before the recover.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go: `go vet` + `go test ./providers/utils/ -race`)
- [x] I followed the contribution guidelines (`docs/contributing/raising-a-pr.mdx`, `code-conventions.mdx`) and added a `core/changelog.md` entry
- [x] No documentation changes needed (behavioral bug fix in an internal teardown path)
- [ ] I verified the full CI pipeline (`make test-all` / `make lint`) passes locally — only the affected package (`core/providers/utils`) was run + vetted + gofmt'd
