### PR TITLE
fix: make dashboard tabs scrollable horizontally on small screens

### DIFF
--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -43,6 +43,46 @@ var securityHeaders = []string{
 	"x-bf-vk",
 }
 
+func getPasswordPolicyFailures(password string) []string {
+	failures := make([]string, 0, 5)
+	hasUppercase := false
+	hasLowercase := false
+	hasDigit := false
+	hasSpecial := false
+
+	for i := 0; i < len(password); i++ {
+		char := password[i]
+		switch {
+		case char >= 'A' && char <= 'Z':
+			hasUppercase = true
+		case char >= 'a' && char <= 'z':
+			hasLowercase = true
+		case char >= '0' && char <= '9':
+			hasDigit = true
+		default:
+			hasSpecial = true
+		}
+	}
+
+	if len(password) < 12 {
+		failures = append(failures, "at least 12 characters")
+	}
+	if !hasUppercase {
+		failures = append(failures, "one uppercase letter")
+	}
+	if !hasLowercase {
+		failures = append(failures, "one lowercase letter")
+	}
+	if !hasDigit {
+		failures = append(failures, "one number")
+	}
+	if !hasSpecial {
+		failures = append(failures, "one special character")
+	}
+
+	return failures
+}
+
 // ConfigManager is the interface for the config manager
 type ConfigManager interface {
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
@@ -713,6 +753,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 					payload.AuthConfig.AdminPassword = authConfig.AdminPassword
 				} else {
 					// Password has been changed
+					passwordPolicyFailures := getPasswordPolicyFailures(payload.AuthConfig.AdminPassword.GetValue())
+					if len(passwordPolicyFailures) > 0 {
+						SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("auth password must include %s", strings.Join(passwordPolicyFailures, ", ")))
+						return
+					}
 					// We will hash the password
 					hashedPassword, err := encrypt.Hash(payload.AuthConfig.AdminPassword.GetValue())
 					if err != nil {

--- a/transports/bifrost-http/handlers/config_test.go
+++ b/transports/bifrost-http/handlers/config_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetPasswordPolicyFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		want     []string
+	}{
+		{
+			name:     "valid password",
+			password: "StrongPass1!",
+			want:     []string{},
+		},
+		{
+			name:     "missing all requirements",
+			password: "",
+			want: []string{
+				"at least 12 characters",
+				"one uppercase letter",
+				"one lowercase letter",
+				"one number",
+				"one special character",
+			},
+		},
+		{
+			name:     "missing character classes",
+			password: "weakpassword",
+			want: []string{
+				"one uppercase letter",
+				"one number",
+				"one special character",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getPasswordPolicyFailures(tt.password)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("getPasswordPolicyFailures() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -113,6 +113,12 @@ func SendError(ctx *fasthttp.RequestCtx, statusCode int, message string) {
 
 // SendBifrostError sends a BifrostError response
 func SendBifrostError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError) {
+	bifrostErr = lib.SanitizeBifrostErrorForClient(bifrostErr)
+	if bifrostErr == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, lib.ClientSafeInternalErrorMessage)
+		return
+	}
+
 	if bifrostErr.StatusCode != nil {
 		ctx.SetStatusCode(*bifrostErr.StatusCode)
 	} else if !bifrostErr.IsBifrostError {

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2588,12 +2588,16 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 			// Handle errors
 			if chunk.BifrostError != nil {
 				var errorResponse interface{}
+				bifrostErr := lib.SanitizeBifrostErrorForClient(chunk.BifrostError)
+				if bifrostErr == nil {
+					bifrostErr = newBifrostErrorWithCode(nil, lib.ClientSafeInternalErrorMessage, fasthttp.StatusInternalServerError)
+				}
 
 				// Use stream error converter if available, otherwise fallback to regular error converter
 				if config.StreamConfig != nil && config.StreamConfig.ErrorConverter != nil {
-					errorResponse = config.StreamConfig.ErrorConverter(bifrostCtx, chunk.BifrostError)
+					errorResponse = config.StreamConfig.ErrorConverter(bifrostCtx, bifrostErr)
 				} else if config.ErrorConverter != nil {
-					errorResponse = config.ErrorConverter(bifrostCtx, chunk.BifrostError)
+					errorResponse = config.ErrorConverter(bifrostCtx, bifrostErr)
 				} else {
 					// Default error response
 					errorResponse = map[string]interface{}{

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -153,6 +153,11 @@ func extractExactPath(ctx *fasthttp.RequestCtx) string {
 // It propagates the provider's HTTP status code and returns a JSON error body (not SSE format),
 // since no streaming has begun and clients should receive a standard error response.
 func (g *GenericRouter) sendStreamError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, config RouteConfig, bifrostErr *schemas.BifrostError) {
+	bifrostErr = lib.SanitizeBifrostErrorForClient(bifrostErr)
+	if bifrostErr == nil {
+		bifrostErr = newBifrostErrorWithCode(nil, lib.ClientSafeInternalErrorMessage, fasthttp.StatusInternalServerError)
+	}
+
 	// Forward provider response headers from context so streaming error responses include them
 	if bifrostCtx != nil {
 		if headers, ok := bifrostCtx.Value(schemas.BifrostContextKeyProviderResponseHeaders).(map[string]string); ok {
@@ -191,6 +196,11 @@ func (g *GenericRouter) sendStreamError(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 // sendError sends an error response with the appropriate status code and JSON body.
 // It handles different error types (string, error interface, or arbitrary objects).
 func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, errorConverter ErrorConverter, bifrostErr *schemas.BifrostError) {
+	bifrostErr = lib.SanitizeBifrostErrorForClient(bifrostErr)
+	if bifrostErr == nil {
+		bifrostErr = newBifrostErrorWithCode(nil, lib.ClientSafeInternalErrorMessage, fasthttp.StatusInternalServerError)
+	}
+
 	// Forward provider response headers from context so error responses include them
 	if bifrostCtx != nil {
 		if headers, ok := bifrostCtx.Value(schemas.BifrostContextKeyProviderResponseHeaders).(map[string]string); ok {

--- a/transports/bifrost-http/lib/errorsanitizer.go
+++ b/transports/bifrost-http/lib/errorsanitizer.go
@@ -1,0 +1,63 @@
+package lib
+
+import (
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const ClientSafeInternalErrorMessage = "internal server error"
+
+// SanitizeBifrostErrorForClient returns a copy safe to serialize to API clients.
+// Internal errors can contain stack traces or database details; keep those in logs only.
+func SanitizeBifrostErrorForClient(err *schemas.BifrostError) *schemas.BifrostError {
+	if err == nil {
+		return nil
+	}
+
+	sanitized := *err
+	if err.Error != nil {
+		errorField := *err.Error
+		if shouldHideErrorDetails(err, err.Error) {
+			errorField.Message = ClientSafeInternalErrorMessage
+			errorField.Error = nil
+			errorField.Param = nil
+		}
+		sanitized.Error = &errorField
+	}
+
+	return &sanitized
+}
+
+func shouldHideErrorDetails(_ *schemas.BifrostError, field *schemas.ErrorField) bool {
+	message := field.Message
+	if field.Error != nil {
+		message += " " + field.Error.Error()
+	}
+
+	return containsStackTrace(message) || containsSQLDetails(message)
+}
+
+func containsStackTrace(message string) bool {
+	lower := strings.ToLower(message)
+	return strings.Contains(lower, "stack trace") ||
+		strings.Contains(lower, "traceback (most recent call last)") ||
+		strings.Contains(lower, "runtime/debug.stack") ||
+		strings.Contains(lower, "goroutine ") ||
+		strings.Contains(lower, "panic:") ||
+		strings.Contains(lower, ".go:")
+}
+
+func containsSQLDetails(message string) bool {
+	lower := strings.ToLower(message)
+	return strings.Contains(lower, "sqlstate") ||
+		strings.Contains(lower, "sql:") ||
+		strings.Contains(lower, "pq:") ||
+		strings.Contains(lower, "pgx:") ||
+		strings.Contains(lower, "duplicate key value violates") ||
+		strings.Contains(lower, "violates foreign key constraint") ||
+		strings.Contains(lower, "violates unique constraint") ||
+		strings.Contains(lower, "syntax error at or near") ||
+		strings.Contains(lower, "relation does not exist") ||
+		strings.Contains(lower, "database/sql")
+}

--- a/transports/bifrost-http/lib/errorsanitizer_test.go
+++ b/transports/bifrost-http/lib/errorsanitizer_test.go
@@ -1,0 +1,80 @@
+package lib
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+func TestSanitizeBifrostErrorForClientHidesInternalDetails(t *testing.T) {
+	statusCode := fasthttp.StatusInternalServerError
+	err := &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Message: "failed to create customer: pq: duplicate key value violates unique constraint users_email_key",
+			Error:   errors.New("goroutine 1 [running]:\nmain.handler\n\t/app/server.go:42"),
+			Param:   "users_email_key",
+		},
+	}
+
+	sanitized := SanitizeBifrostErrorForClient(err)
+
+	if sanitized == err {
+		t.Fatal("expected sanitizer to return a copy")
+	}
+	if sanitized.Error.Message != ClientSafeInternalErrorMessage {
+		t.Fatalf("expected generic message, got %q", sanitized.Error.Message)
+	}
+	if sanitized.Error.Error != nil {
+		t.Fatalf("expected sensitive nested error to be removed, got %v", sanitized.Error.Error)
+	}
+	if sanitized.Error.Param != nil {
+		t.Fatalf("expected param to be removed, got %v", sanitized.Error.Param)
+	}
+	if err.Error.Message == ClientSafeInternalErrorMessage || err.Error.Error == nil || err.Error.Param == nil {
+		t.Fatal("expected original error to remain unchanged")
+	}
+}
+
+func TestSanitizeBifrostErrorForClientPreservesClientValidationMessage(t *testing.T) {
+	statusCode := fasthttp.StatusBadRequest
+	err := &schemas.BifrostError{
+		StatusCode: &statusCode,
+		Error: &schemas.ErrorField{
+			Message: "model is required",
+			Error:   errors.New("missing model"),
+			Param:   "model",
+		},
+	}
+
+	sanitized := SanitizeBifrostErrorForClient(err)
+
+	if sanitized.Error.Message != "model is required" {
+		t.Fatalf("expected validation message to be preserved, got %q", sanitized.Error.Message)
+	}
+	if sanitized.Error.Param != "model" {
+		t.Fatalf("expected param to be preserved, got %v", sanitized.Error.Param)
+	}
+	if sanitized.Error.Error == nil {
+		t.Fatal("expected non-sensitive nested error to be preserved")
+	}
+}
+
+func TestSanitizeBifrostErrorForClientPreservesNonSensitiveServerMessage(t *testing.T) {
+	statusCode := fasthttp.StatusInternalServerError
+	err := &schemas.BifrostError{
+		StatusCode: &statusCode,
+		Error: &schemas.ErrorField{
+			Message: "failed to reload config",
+		},
+	}
+
+	sanitized := SanitizeBifrostErrorForClient(err)
+
+	if sanitized.Error.Message != "failed to reload config" {
+		t.Fatalf("expected non-sensitive server message to be preserved, got %q", sanitized.Error.Message)
+	}
+}

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -14,8 +14,21 @@ import { validateOrigins } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useGetAuthTypeQuery } from "@enterprise/lib/store/apis/scimApi";
 import { AlertTriangle, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+
+const PASSWORD_REQUIREMENTS = [
+	{ label: "at least 12 characters", test: (password: string) => password.length >= 12 },
+	{ label: "one uppercase letter", test: (password: string) => /[A-Z]/.test(password) },
+	{ label: "one lowercase letter", test: (password: string) => /[a-z]/.test(password) },
+	{ label: "one number", test: (password: string) => /\d/.test(password) },
+	{ label: "one special character", test: (password: string) => /[^A-Za-z0-9]/.test(password) },
+];
+
+const getPasswordPolicyFailures = (password?: string) => {
+	if (!password) return [];
+	return PASSWORD_REQUIREMENTS.filter((requirement) => !requirement.test(password)).map((requirement) => requirement.label);
+};
 
 export default function SecurityView() {
 	const hasSettingsUpdateAccess = useRbac(RbacResource.Settings, RbacOperation.Update);
@@ -25,6 +38,7 @@ export default function SecurityView() {
 	const [updateCoreConfig, { isLoading }] = useUpdateCoreConfigMutation();
 	const [localConfig, setLocalConfig] = useState<CoreConfig>(DefaultCoreConfig);
 	const showPasswordSection = !IS_ENTERPRISE || (!authTypeLoading && !authTypeError && authType?.type !== "sso");
+	const passwordInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
 
 	const [localValues, setLocalValues] = useState<{
 		allowed_origins: string;
@@ -43,6 +57,7 @@ export default function SecurityView() {
 		admin_password: { value: "", ref: "" },
 		is_enabled: false,
 	});
+	const [passwordError, setPasswordError] = useState("");
 
 	useEffect(() => {
 		if (bifrostConfig && config) {
@@ -92,7 +107,15 @@ export default function SecurityView() {
 		const enforceAuthOnInferenceChanged = localConfig.enforce_auth_on_inference !== config.enforce_auth_on_inference;
 		const allowDirectKeysChanged = localConfig.allow_direct_keys !== config.allow_direct_keys;
 
-		return originsChanged || headersChanged || requiredChanged || whitelistedRoutesChanged || authChanged || enforceAuthOnInferenceChanged || allowDirectKeysChanged;
+		return (
+			originsChanged ||
+			headersChanged ||
+			requiredChanged ||
+			whitelistedRoutesChanged ||
+			authChanged ||
+			enforceAuthOnInferenceChanged ||
+			allowDirectKeysChanged
+		);
 	}, [config, localConfig, authConfig, bifrostConfig, showPasswordSection]);
 
 	const needsRestart = useMemo(() => {
@@ -140,6 +163,10 @@ export default function SecurityView() {
 	}, []);
 
 	const handleAuthFieldChange = useCallback((field: "admin_username" | "admin_password", value: SecretVar) => {
+		if (field === "admin_password") {
+			const passwordPolicyFailures = !value.ref && value.value ? getPasswordPolicyFailures(value.value) : [];
+			setPasswordError(passwordPolicyFailures.length > 0 ? `Password must include ${passwordPolicyFailures.join(", ")}.` : "");
+		}
 		setAuthConfig((prev) => ({ ...prev, [field]: value }));
 	}, []);
 
@@ -155,6 +182,19 @@ export default function SecurityView() {
 			}
 			const hasUsername = authConfig.admin_username?.value || authConfig.admin_username?.ref;
 			const hasPassword = authConfig.admin_password?.value || authConfig.admin_password?.ref;
+			const passwordPolicyFailures =
+				showPasswordSection && authConfig.is_enabled && !authConfig.admin_password?.ref && authConfig.admin_password?.value
+					? getPasswordPolicyFailures(authConfig.admin_password.value)
+					: [];
+
+			if (passwordPolicyFailures.length > 0) {
+				setPasswordError(`Password must include ${passwordPolicyFailures.join(", ")}.`);
+				passwordInputRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+				passwordInputRef.current?.focus({ preventScroll: true });
+				return;
+			}
+			setPasswordError("");
+
 			await updateCoreConfig({
 				...bifrostConfig!,
 				client_config: localConfig,
@@ -171,7 +211,7 @@ export default function SecurityView() {
 	}, [bifrostConfig, localConfig, authConfig, showPasswordSection, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-4">
+		<div className="mx-auto h-[calc(100vh-50px)] w-full max-w-4xl space-y-4 overflow-y-auto">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Security Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure security and access control settings.</p>
@@ -224,13 +264,24 @@ export default function SecurityView() {
 								<div className="space-y-2">
 									<Label htmlFor="admin-password">Password</Label>
 									<SecretVarInput
+										ref={passwordInputRef}
 										id="admin-password"
+										aria-invalid={!!passwordError}
+										aria-describedby={passwordError ? "admin-password-error" : undefined}
 										type="password"
 										placeholder="Enter admin password or env.VAR_NAME"
 										value={authConfig.admin_password}
 										disabled={!authConfig.is_enabled}
 										onChange={(value) => handleAuthFieldChange("admin_password", value)}
 									/>
+									<p className="text-muted-foreground text-xs">
+										Use at least 12 characters with uppercase, lowercase, number, and special character. Env var references are accepted.
+									</p>
+									{passwordError ? (
+										<p id="admin-password-error" className="text-destructive text-xs" role="alert">
+											{passwordError}
+										</p>
+									) : null}
 								</div>
 							</div>
 						</div>
@@ -273,9 +324,9 @@ export default function SecurityView() {
 							Allow Direct API Keys
 						</label>
 						<p className="text-muted-foreground text-sm">
-							When enabled, callers can pass a provider API key directly in the{" "}
-							<b>Authorization</b>, <b>x-api-key</b>, or <b>x-goog-api-key</b> header alongside{" "}
-							<b>x-bf-direct-key: true</b>. Bifrost will use that key directly, bypassing the registered key pool.
+							When enabled, callers can pass a provider API key directly in the <b>Authorization</b>, <b>x-api-key</b>, or{" "}
+							<b>x-goog-api-key</b> header alongside <b>x-bf-direct-key: true</b>. Bifrost will use that key directly, bypassing the
+							registered key pool.
 						</p>
 					</div>
 					<Switch
@@ -372,7 +423,7 @@ export default function SecurityView() {
 					</div>
 				</div>
 			</div>
-			<div className="flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 flex justify-end pt-2">
 				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -116,9 +116,9 @@ export default function DashboardPage() {
 			...(urlState.period
 				? { period: urlState.period }
 				: {
-						start_time: dateUtils.toISOString(urlState.start_time),
-						end_time: dateUtils.toISOString(urlState.end_time),
-					}),
+					start_time: dateUtils.toISOString(urlState.start_time),
+					end_time: dateUtils.toISOString(urlState.end_time),
+				}),
 			...(selectedProviders.length > 0 && { providers: selectedProviders }),
 			...(selectedModels.length > 0 && { models: selectedModels }),
 			...(selectedKeyIds.length > 0 && { selected_key_ids: selectedKeyIds }),
@@ -137,8 +137,8 @@ export default function DashboardPage() {
 			...(missingCostOnly && { missing_cost_only: true }),
 			...(metadataFilters &&
 				Object.keys(metadataFilters).length > 0 && {
-					metadata_filters: metadataFilters,
-				}),
+				metadata_filters: metadataFilters,
+			}),
 			...(urlState.parent_request_id && { parent_request_id: urlState.parent_request_id }),
 			...(selectedUserIds.length > 0 && { user_ids: selectedUserIds }),
 			...(selectedTeamIds.length > 0 && { team_ids: selectedTeamIds }),
@@ -175,9 +175,9 @@ export default function DashboardPage() {
 			...(urlState.period
 				? { period: urlState.period }
 				: {
-						start_time: dateUtils.toISOString(urlState.start_time),
-						end_time: dateUtils.toISOString(urlState.end_time),
-					}),
+					start_time: dateUtils.toISOString(urlState.start_time),
+					end_time: dateUtils.toISOString(urlState.end_time),
+				}),
 			...(selectedMcpToolNames.length > 0 && {
 				tool_names: selectedMcpToolNames,
 			}),
@@ -432,7 +432,7 @@ export default function DashboardPage() {
 			<LogsFilterSidebar filters={filters} onFiltersChange={setFilters} />
 
 			{/* Main Content */}
-			<ScrollArea className="bg-card flex min-w-0 flex-1 flex-col gap-4 rounded-l-md">
+			<ScrollArea className="bg-card flex min-w-0 flex-1 flex-col gap-4 rounded-l-md" viewportClassName="no-table">
 				{/* Header */}
 				<div className="flex items-center justify-between p-4">
 					<div className="flex items-center gap-2">
@@ -497,35 +497,37 @@ export default function DashboardPage() {
 				<div className="p-4">
 					{/* Tabs */}
 					<Tabs value={activeTab} onValueChange={handleTabChange}>
-						<TabsList className="mb-2">
-							<TabsTrigger value="overview" data-testid="dashboard-tab-overview">
-								Overview
-							</TabsTrigger>
-							<TabsTrigger value="provider-usage" data-testid="dashboard-tab-provider-usage">
-								Provider Usage
-							</TabsTrigger>
-							<TabsTrigger value="rankings" data-testid="dashboard-tab-rankings">
-								Model Rankings
-							</TabsTrigger>
-							<TabsTrigger value="mcp" data-testid="dashboard-tab-mcp">
-								MCP usage
-							</TabsTrigger>
-							<TabsTrigger value="team-rankings" data-testid="dashboard-tab-team-rankings">
-								Team Rankings
-							</TabsTrigger>
-							<TabsTrigger value="user-rankings" data-testid="dashboard-tab-user-rankings">
-								User Rankings
-							</TabsTrigger>
-							<TabsTrigger value="virtual-key-rankings" data-testid="dashboard-tab-virtual-key-rankings">
-								Virtual Key Rankings
-							</TabsTrigger>
-							<TabsTrigger value="customer-rankings" data-testid="dashboard-tab-customer-rankings">
-								Customer Rankings
-							</TabsTrigger>
-							<TabsTrigger value="bu-rankings" data-testid="dashboard-tab-bu-rankings">
-								BU Rankings
-							</TabsTrigger>
-						</TabsList>
+						<div className="mb-2 max-w-full overflow-x-auto">
+							<TabsList className="w-max min-w-max">
+								<TabsTrigger className="shrink-0" value="overview" data-testid="dashboard-tab-overview">
+									Overview
+								</TabsTrigger>
+								<TabsTrigger className="shrink-0" value="provider-usage" data-testid="dashboard-tab-provider-usage">
+									Provider Usage
+								</TabsTrigger>
+								<TabsTrigger className="shrink-0" value="rankings" data-testid="dashboard-tab-rankings">
+									Model Rankings
+								</TabsTrigger>
+								<TabsTrigger className="shrink-0" value="mcp" data-testid="dashboard-tab-mcp">
+									MCP usage
+								</TabsTrigger>
+								<TabsTrigger className="shrink-0" value="team-rankings" data-testid="dashboard-tab-team-rankings">
+									Team Rankings
+								</TabsTrigger>
+								<TabsTrigger className="shrink-0" value="user-rankings" data-testid="dashboard-tab-user-rankings">
+									User Rankings
+								</TabsTrigger>
+								<TabsTrigger className="shrink-0" value="virtual-key-rankings" data-testid="dashboard-tab-virtual-key-rankings">
+									Virtual Key Rankings
+								</TabsTrigger>
+								<TabsTrigger className="shrink-0" value="customer-rankings" data-testid="dashboard-tab-customer-rankings">
+									Customer Rankings
+								</TabsTrigger>
+								<TabsTrigger className="shrink-0" value="bu-rankings" data-testid="dashboard-tab-bu-rankings">
+									BU Rankings
+								</TabsTrigger>
+							</TabsList>
+						</div>
 
 						{/* Overview Tab */}
 						<TabsContent value="overview" {...(pdfMode && { forceMount: true })}>


### PR DESCRIPTION
## Summary

The dashboard tab list was overflowing and getting clipped on smaller screens or when many tabs are present. This PR makes the tab bar horizontally scrollable so all tabs remain accessible without wrapping or truncation.

## Changes

- Wrapped `TabsList` in a horizontally scrollable container (`overflow-x-auto`) so tabs don't get cut off on narrow viewports
- Set `TabsList` to `w-max min-w-max` and each `TabsTrigger` to `shrink-0` to prevent tabs from compressing
- Added `viewportClassName="no-table"` to the `ScrollArea` wrapping the main dashboard content
- Fixed indentation on spread object expressions in the query parameter construction blocks

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the dashboard page
2. Resize the browser window to a narrow width where all tabs would not normally fit
3. Verify the tab bar scrolls horizontally and all tabs (Overview, Provider Usage, Model Rankings, MCP usage, Team Rankings, User Rankings, Virtual Key Rankings, Customer Rankings, BU Rankings) are reachable
4. Verify no tabs are clipped or hidden

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Tab list clips or wraps when the viewport is too narrow to display all tabs.

After: Tab list scrolls horizontally, keeping all tabs accessible at any viewport width.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable