### PR TITLE
feat: drop reasoning when tools present but reasoning_with_tool_calls unsupported

### DIFF
--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -294,7 +294,7 @@ type customPricingData struct {
 }
 
 // modelParametersParseResult is the parsed result type used by
-// buildSupportedOutputsIndex (consumed by params.go's applyModelParameters).
+// extractSupportedParams (consumed by params.go's applyModelParameters).
 type modelParametersParseResult struct {
 	Mode               *string  `json:"mode,omitempty"`
 	SupportedEndpoints []string `json:"supported_endpoints,omitempty"`
@@ -307,6 +307,7 @@ type modelParametersParseResult struct {
 	SupportsToolChoice              *bool `json:"supports_tool_choice,omitempty"`
 	SupportsReasoning               *bool `json:"supports_reasoning,omitempty"`
 	SupportsResponseSchema          *bool `json:"supports_response_schema,omitempty"`
+	SupportsReasoningWithToolCalls  *bool `json:"supports_reasoning_with_tool_calls,omitempty"`
 	SupportsServiceTier             *bool `json:"supports_service_tier,omitempty"`
 	SupportsPromptCaching           *bool `json:"supports_prompt_caching,omitempty"`
 	SupportsWebSearch               *bool `json:"supports_web_search,omitempty"`
@@ -475,6 +476,9 @@ func extractSupportedParams(parsed *modelParametersParseResult) []string {
 	}
 	if parsed.SupportsReasoning != nil && *parsed.SupportsReasoning {
 		addParam("reasoning")
+	}
+	if parsed.SupportsReasoningWithToolCalls == nil || *parsed.SupportsReasoningWithToolCalls {
+		addParam("reasoning_with_tool_calls")
 	}
 	if parsed.SupportsResponseSchema != nil && *parsed.SupportsResponseSchema {
 		addParam("response_format")

--- a/plugins/compat/dropparams.go
+++ b/plugins/compat/dropparams.go
@@ -21,6 +21,7 @@ func dropUnsupportedParams(ctx *schemas.BifrostContext, req *schemas.BifrostRequ
 
 	if req.ChatRequest != nil && req.ChatRequest.Params != nil {
 		params := req.ChatRequest.Params
+		hasSupportedTools := len(params.Tools) > 0 && isSupported["tools"]
 
 		if params.Audio != nil && !isSupported["audio"] {
 			params.Audio = nil
@@ -68,9 +69,13 @@ func dropUnsupportedParams(ctx *schemas.BifrostContext, req *schemas.BifrostRequ
 			params.PromptCacheRetention = nil
 			dropped = append(dropped, "prompt_cache_retention")
 		}
-		if params.Reasoning != nil && !isSupported["reasoning"] {
-			params.Reasoning = nil
-			dropped = append(dropped, "reasoning")
+		if params.Reasoning != nil {
+			// for chat completions, some models do not support reasoning_effort
+			// with tools
+			if !isSupported["reasoning"] || (hasSupportedTools && !isSupported["reasoning_with_tool_calls"]) {
+				params.Reasoning = nil
+				dropped = append(dropped, "reasoning")
+			}
 		}
 		if params.ResponseFormat != nil && !isSupported["response_format"] {
 			params.ResponseFormat = nil

--- a/plugins/compat/dropparams_test.go
+++ b/plugins/compat/dropparams_test.go
@@ -170,3 +170,52 @@ func TestDropUnsupportedParams_ChatMaxCompletionTokensUnchanged(t *testing.T) {
 		t.Errorf("max_completion_tokens = preserved, want dropped (no token cap supported)")
 	}
 }
+
+func TestDropUnsupportedParams_ChatReasoningWithUnsupportedTools(t *testing.T) {
+	newChat := func() *schemas.BifrostRequest {
+		return &schemas.BifrostRequest{
+			RequestType: schemas.ChatCompletionRequest,
+			ChatRequest: &schemas.BifrostChatRequest{
+				Provider: schemas.OpenAI,
+				Model:    "reasoning-no-tools-model",
+				Params: &schemas.ChatParameters{
+					Reasoning: &schemas.ChatReasoning{},
+					Tools: []schemas.ChatTool{{
+						Type: schemas.ChatToolTypeFunction,
+						Function: &schemas.ChatToolFunction{
+							Name:        "get_weather",
+							Description: schemas.Ptr("Returns weather"),
+						},
+					}},
+				},
+			},
+		}
+	}
+
+	preserveReasoning := newChat()
+	dropped := dropUnsupportedParams(newTestContext(), preserveReasoning, []string{"reasoning"})
+	if preserveReasoning.ChatRequest.Params.Reasoning == nil {
+		t.Fatalf("reasoning = dropped, want preserved when tools are also dropped")
+	}
+	if preserveReasoning.ChatRequest.Params.Tools != nil {
+		t.Fatalf("tools = preserved, want dropped")
+	}
+	if slices.Contains(dropped, "reasoning") {
+		t.Errorf("reasoning reported in dropped=%v, want absent", dropped)
+	}
+	if !slices.Contains(dropped, "tools") {
+		t.Errorf("tools not reported in dropped=%v, want present", dropped)
+	}
+
+	dropReasoning := newChat()
+	dropped = dropUnsupportedParams(newTestContext(), dropReasoning, []string{"reasoning", "tools"})
+	if dropReasoning.ChatRequest.Params.Reasoning != nil {
+		t.Fatalf("reasoning = preserved, want dropped when tools survive without reasoning_with_tool_calls")
+	}
+	if dropReasoning.ChatRequest.Params.Tools == nil {
+		t.Fatalf("tools = dropped, want preserved")
+	}
+	if !slices.Contains(dropped, "reasoning") {
+		t.Errorf("reasoning not reported in dropped=%v, want present", dropped)
+	}
+}


### PR DESCRIPTION
## Summary

Some models that support reasoning do not support using reasoning alongside tool calls. This PR introduces a `reasoning_with_tool_calls` capability flag so that reasoning parameters can be selectively dropped when tools are present but the model doesn't support that combination.

## Changes

- Added `SupportsReasoningWithToolCalls` field to `modelParametersParseResult`, allowing datasheets to explicitly declare whether a model supports reasoning when tool calls are also present.
- In `extractSupportedParams`, `reasoning_with_tool_calls` is added as a supported param by default (when the field is `nil`), preserving backward compatibility. It is only excluded when explicitly set to `false`.
- Updated `dropUnsupportedParams` in the compat plugin to drop `reasoning` not only when the model doesn't support reasoning at all, but also when tools are present and the model doesn't support `reasoning_with_tool_calls`.
- Updated a stale comment referencing `buildSupportedOutputsIndex` to correctly reference `extractSupportedParams`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request with both `reasoning` and `tools` parameters to a model whose datasheet has `supports_reasoning_with_tool_calls` set to `false`. Verify that the `reasoning` parameter is dropped and the request proceeds without error.

Send the same request to a model without `supports_reasoning_with_tool_calls` set (i.e., `nil`) and verify that `reasoning` is preserved, confirming backward-compatible behavior.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable