### PR TITLE
refactor: replace Select with ComboboxSelect for provider dropdowns in routing rules and CEL builder

### DIFF
--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -109,6 +109,11 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 			...rules.flatMap((r) => (r.fallbacks ?? []).map((f) => f.split("/")[0]?.trim()).filter(Boolean)),
 		]),
 	);
+	const providerOptions = availableProviders.map((prov) => ({
+		label: getProviderLabel(prov),
+		value: prov,
+		icon: <RenderProviderIcon provider={prov as ProviderIconType} size="sm" className="h-4 w-4" />,
+	}));
 
 	// Initialize form data when editing rule changes
 	useEffect(() => {
@@ -273,8 +278,8 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 					</SheetDescription>
 				</SheetHeader>
 
-				<form onSubmit={handleSubmit(onSubmit)} className="flex flex-col grow">
-					<div className="flex flex-col gap-6 px-8 pb-6 grow">
+				<form onSubmit={handleSubmit(onSubmit)} className="flex grow flex-col">
+					<div className="flex grow flex-col gap-6 px-8 pb-6">
 						{/* Rule Name */}
 						<div className="space-y-3">
 							<Label htmlFor="name">
@@ -464,7 +469,7 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 										key={index}
 										target={target}
 										index={index}
-										availableProviders={availableProviders}
+										providerOptions={providerOptions}
 										allKeys={allKeysData}
 										showRemove={targets.length > 1}
 										onUpdate={updateTarget}
@@ -536,21 +541,14 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 										return (
 											<div key={index} className="flex items-center gap-2">
 												<div className="flex-1">
-													<Select value={fbProvider} onValueChange={handleProviderChange}>
-														<SelectTrigger className="w-full">
-															<SelectValue placeholder="Select provider..." />
-														</SelectTrigger>
-														<SelectContent>
-															{availableProviders.map((prov) => (
-																<SelectItem key={prov} value={prov}>
-																	<div className="flex items-center gap-2">
-																		<RenderProviderIcon provider={prov as ProviderIconType} size="sm" className="h-4 w-4" />
-																		<span>{getProviderLabel(prov)}</span>
-																	</div>
-																</SelectItem>
-															))}
-														</SelectContent>
-													</Select>
+													<ComboboxSelect
+														options={providerOptions}
+														value={fbProvider || null}
+														onValueChange={(value) => handleProviderChange(value ?? "")}
+														placeholder="Select provider..."
+														className="h-9"
+														noPortal
+													/>
 												</div>
 												<div className="flex-1">
 													<ModelMultiselect
@@ -599,14 +597,14 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 interface TargetRowProps {
 	target: RoutingTargetFormData;
 	index: number;
-	availableProviders: string[];
+	providerOptions: Array<{ label: string; value: string; icon: React.ReactNode }>;
 	allKeys: Array<{ key_id: string; name: string; provider: string }>;
 	showRemove: boolean;
 	onUpdate: (index: number, field: keyof RoutingTargetFormData, value: string | number) => void;
 	onRemove: (index: number) => void;
 }
 
-function TargetRow({ target, index, availableProviders, allKeys, showRemove, onUpdate, onRemove }: TargetRowProps) {
+function TargetRow({ target, index, providerOptions, allKeys, showRemove, onUpdate, onRemove }: TargetRowProps) {
 	const availableKeys = target.provider
 		? allKeys.filter((k) => k.provider === target.provider).map((k) => ({ id: k.key_id, name: k.name }))
 		: [];
@@ -654,33 +652,19 @@ function TargetRow({ target, index, availableProviders, allKeys, showRemove, onU
 						Provider
 					</Label>
 					<div className="flex gap-1.5">
-						<Select
-							value={target.provider}
+						<ComboboxSelect
+							options={providerOptions}
+							value={target.provider || null}
 							onValueChange={(value) => {
-								onUpdate(index, "provider", value);
+								onUpdate(index, "provider", value ?? "");
 								onUpdate(index, "model", "");
 								onUpdate(index, "key_id", "");
 							}}
-						>
-							<SelectTrigger
-								id={`routing-target-${index}-provider-select`}
-								aria-labelledby={`routing-target-${index}-provider-label`}
-								className="h-9 flex-1 text-sm"
-								data-testid={`routing-target-${index}-provider-select`}
-							>
-								<SelectValue placeholder="Incoming (optional)" />
-							</SelectTrigger>
-							<SelectContent>
-								{availableProviders.map((prov) => (
-									<SelectItem key={prov} value={prov}>
-										<div className="flex items-center gap-2">
-											<RenderProviderIcon provider={prov as ProviderIconType} size="sm" className="h-4 w-4" />
-											<span>{getProviderLabel(prov)}</span>
-										</div>
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
+							placeholder="Incoming (optional)"
+							className="h-9 flex-1 text-sm"
+							data-testid={`routing-target-${index}-provider-select`}
+							noPortal
+						/>
 						{target.provider && (
 							<Button
 								type="button"

--- a/ui/components/ui/custom/celBuilder/valueEditor.tsx
+++ b/ui/components/ui/custom/celBuilder/valueEditor.tsx
@@ -3,11 +3,9 @@
  * Smart input component that adapts based on operator and field type
  */
 
-import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
+import { ComboboxSelect, ComboboxSelectOption } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
-import { Option } from "@/components/ui/multiselectUtils";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
@@ -163,6 +161,21 @@ export function ValueEditor({
 
 	// Handle select type (for provider dropdown)
 	if (isSelectType && fieldData?.values) {
+		const isProviderField = fieldData?.name === "provider";
+		const options: ComboboxSelectOption[] = (fieldData.values as any[])
+			.filter((option) => !("options" in option) && (option as any).name)
+			.map((option) => {
+				const optName = (option as any).name || "";
+				const optLabel = (option as any).label || optName;
+
+				return {
+					value: optName,
+					label: isProviderField ? getProviderLabel(optName) : optLabel,
+					disabled: (option as any).disabled || false,
+					icon: isProviderField ? <RenderProviderIcon provider={optName as ProviderIconType} size="sm" className="h-4 w-4" /> : undefined,
+				};
+			});
+
 		// For array operators with provider, use multi-select dropdown
 		if (isArrayOperator) {
 			// Parse comma-separated or JSON array value
@@ -183,77 +196,32 @@ export function ValueEditor({
 				}
 			}
 
-			const selectedOptions: Option<string>[] = selectedValues.map((val) => ({
-				value: val,
-				label: (fieldData.values as any[]).find((opt) => (opt as any).name === val)?.label || val,
-			}));
-
-			const allOptions: Option<string>[] = (fieldData.values as any[])
-				.filter((opt) => !("options" in opt) && (opt as any).name)
-				.map((opt) => ({
-					value: (opt as any).name,
-					label: (opt as any).label,
-				}));
-
-			const handleMultiselectChange = (selected: Option<string>[]) => {
-				const values = selected.map((opt) => opt.value);
+			const handleMultiselectChange = (values: string[]) => {
 				handleOnChange(values.length > 0 ? JSON.stringify(values) : "");
 			};
 
 			return (
-				<AsyncMultiSelect
-					value={selectedOptions}
-					onChange={handleMultiselectChange}
-					defaultOptions={allOptions}
-					isNonAsync={true}
-					isClearable={false}
+				<ComboboxSelect
+					multiple
+					value={selectedValues}
+					onValueChange={handleMultiselectChange}
+					options={options}
 					placeholder="Select providers..."
-					className="w-[360px]"
-					triggerClassName="!shadow-none !border-border h-10"
-					menuClassName="!z-[100] w-full cursor-pointer"
+					className="h-10 w-[360px]"
+					noPortal
 				/>
 			);
 		}
 
-		// Check if this is a provider field to render icons in trigger
-		const isProviderField = fieldData?.name === "provider";
-
 		return (
-			<Select value={value || ""} onValueChange={handleOnChange}>
-				<SelectTrigger className="w-[360px]">
-					{isProviderField && value ? (
-						<div className="flex items-center gap-2">
-							<RenderProviderIcon provider={value as ProviderIconType} size="sm" className="h-4 w-4" />
-							<span>{getProviderLabel(value)}</span>
-						</div>
-					) : (
-						<SelectValue placeholder={fieldData.placeholder || "Select..."} />
-					)}
-				</SelectTrigger>
-				<SelectContent>
-					{fieldData.values.map((option) => {
-						if ("options" in option) return null; // Skip option groups
-						const optName = (option as any).name || "";
-						if (!optName) return null; // Skip empty values — SelectItem requires non-empty value
-						const optLabel = (option as any).label || optName;
-						const optDisabled = (option as any).disabled || false;
-
-						let iconElement: React.ReactNode | undefined;
-						let displayLabel = optLabel;
-
-						if (isProviderField) {
-							iconElement = <RenderProviderIcon provider={optName as ProviderIconType} size="sm" className="h-4 w-4" />;
-							displayLabel = getProviderLabel(optName);
-						}
-
-						return (
-							<SelectItem key={optName} value={optName} disabled={optDisabled} icon={iconElement}>
-								{displayLabel}
-							</SelectItem>
-						);
-					})}
-				</SelectContent>
-			</Select>
+			<ComboboxSelect
+				value={value || null}
+				onValueChange={(newValue) => handleOnChange(newValue ?? "")}
+				options={options}
+				placeholder={fieldData.placeholder || "Select..."}
+				className="h-10 w-[360px]"
+				noPortal
+			/>
 		);
 	}
 

--- a/ui/components/ui/select.tsx
+++ b/ui/components/ui/select.tsx
@@ -29,7 +29,7 @@ function SelectTrigger({
 			data-slot="select-trigger"
 			data-size={size}
 			className={cn(
-				"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-sm border bg-transparent px-3 py-2 text-sm whitespace-nowrap outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:ring-offset-1 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-sm border bg-transparent px-3 py-2 text-sm whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}
@@ -50,7 +50,7 @@ function SelectContent({ className, children, position = "popper", ...props }: R
 				className={cn(
 					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 !pointer-events-auto fixed z-[9999] max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-sm border shadow-md",
 					position === "popper" &&
-						"w-(--radix-select-trigger-width) data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+					"w-(--radix-select-trigger-width) data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
 					className,
 				)}
 				position={position}
@@ -158,5 +158,5 @@ export {
 	SelectScrollUpButton,
 	SelectSeparator,
 	SelectTrigger,
-	SelectValue,
+	SelectValue
 };


### PR DESCRIPTION
## Summary

Replaces `Select` and `AsyncMultiSelect` components with `ComboboxSelect` in the routing rules sheet and CEL builder value editor. This standardizes provider dropdowns across these views, enabling searchable/filterable selection with consistent icon rendering.

## Changes

- Provider options (label, value, icon) are now computed once and passed down as `providerOptions` to `TargetRow` instead of passing raw `availableProviders` strings and reconstructing display logic inside each component.
- The fallback provider selector in the routing rule sheet now uses `ComboboxSelect` instead of `Select`.
- The `TargetRow` provider selector now uses `ComboboxSelect` instead of `Select`.
- The CEL builder `ValueEditor` now uses `ComboboxSelect` for both single and multi-select provider fields, replacing `Select` and `AsyncMultiSelect` respectively.
- `noPortal` is set on all new `ComboboxSelect` usages to avoid z-index/portal issues within sheets and overlays.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Navigate to the routing rules section and open the sheet to create or edit a rule.
2. Verify the provider dropdowns in target rows and fallback rows are searchable and display provider icons correctly.
3. Open the CEL builder and select a `provider` field — confirm the single-select and multi-select (array operator) dropdowns render with icons and are searchable.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable