### PR TITLE
feat: enrich list models response with `ContextLength`, `MaxInputTokens`, `MaxOutputTokens`, `Architecture`, and `WebSearch` pricing from pricing entries

### DIFF
--- a/core/providers/openai/models.go
+++ b/core/providers/openai/models.go
@@ -72,6 +72,11 @@ func ToOpenAIListModelsResponse(response *schemas.BifrostListModelsResponse) *Op
 		if model.OwnedBy != nil {
 			openaiModel.OwnedBy = *model.OwnedBy
 		}
+		if model.ContextLength != nil {
+			openaiModel.ContextWindow = model.ContextLength
+		} else if model.MaxInputTokens != nil {
+			openaiModel.ContextWindow = model.MaxInputTokens // Fallback to MaxInputTokens if ContextLength is not set
+		}
 
 		openaiResponse.Data = append(openaiResponse.Data, openaiModel)
 

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -878,6 +878,21 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 				if len(pricingEntry.AdditionalAttributes) > 0 && resp.Data[i].AdditionalAttributes == nil {
 					resp.Data[i].AdditionalAttributes = pricingEntry.AdditionalAttributes
 				}
+				if pricingEntry.ContextLength != nil && resp.Data[i].ContextLength == nil {
+					resp.Data[i].ContextLength = pricingEntry.ContextLength
+				} else if pricingEntry.MaxInputTokens != nil && resp.Data[i].ContextLength == nil {
+					resp.Data[i].ContextLength = pricingEntry.MaxInputTokens // fallback to MaxInputTokens if ContextLength is not set
+				}
+
+				if pricingEntry.MaxInputTokens != nil && resp.Data[i].MaxInputTokens == nil {
+					resp.Data[i].MaxInputTokens = pricingEntry.MaxInputTokens
+				}
+				if pricingEntry.MaxOutputTokens != nil && resp.Data[i].MaxOutputTokens == nil {
+					resp.Data[i].MaxOutputTokens = pricingEntry.MaxOutputTokens
+				}
+				if pricingEntry.Architecture != nil && resp.Data[i].Architecture == nil {
+					resp.Data[i].Architecture = pricingEntry.Architecture
+				}
 				if modelEntry.Pricing == nil {
 					pricing := &schemas.Pricing{}
 					if pricingEntry.InputCostPerToken != nil {
@@ -894,6 +909,9 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 					}
 					if pricingEntry.CacheCreationInputTokenCost != nil {
 						pricing.InputCacheWrite = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.CacheCreationInputTokenCost))
+					}
+					if pricingEntry.SearchContextCostPerQuery != nil {
+						pricing.WebSearch = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.SearchContextCostPerQuery))
 					}
 					resp.Data[i].Pricing = pricing
 				}


### PR DESCRIPTION
## Summary

Propagates `ContextLength`, `MaxInputTokens`, `MaxOutputTokens`, `Architecture`, and `WebSearch` pricing fields from pricing catalog entries into list models responses, and maps `ContextLength` through to the OpenAI-compatible `context_window` field.

## Changes

- When enriching model list responses with pricing data, `ContextLength`, `MaxInputTokens`, `MaxOutputTokens`, and `Architecture` are now copied from the pricing entry onto the model entry if those fields are not already set by the provider.
- `ContextLength` falls back to `MaxInputTokens` from the pricing entry if `ContextLength` is not set.
- Web search pricing (`SearchContextCostPerQuery`) is now mapped to the `WebSearch` field in the pricing response.
- In the OpenAI provider model conversion, `ContextLength` is now mapped to `ContextWindow` in the OpenAI list models response, with a fallback to `MaxInputTokens` if `ContextLength` is not set.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Call the list models endpoint and verify that models returned include populated `context_length`, `max_input_tokens`, `max_output_tokens`, and `architecture` fields sourced from the pricing catalog when the provider does not return them directly. For OpenAI-compatible responses, confirm the `context_window` field is populated. Verify that models with web search pricing include a populated `web_search` field in the pricing object.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable