### PR TITLE
key pool filter

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -89,6 +89,7 @@ type Bifrost struct {
 	mcpInitOnce         sync.Once                           // Ensures MCP manager is initialized only once
 	dropExcessRequests  atomic.Bool                         // If true, in cases where the queue is full, requests will not wait for the queue to be empty and will be dropped instead.
 	keySelector         schemas.KeySelector                 // Custom key selector function
+	keyPoolFilter       schemas.KeyPoolFilter               // optional hook to veto keys before selection (nil = all eligible)
 	kvStore             schemas.KVStore                     // optional KV store for session stickiness (nil = disabled)
 }
 
@@ -236,6 +237,7 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 		requestQueues: sync.Map{},
 		waitGroups:    sync.Map{},
 		keySelector:   config.KeySelector,
+		keyPoolFilter: config.KeyPoolFilter,
 		mcpCredStore:  credstore.NewCredStore(config.OAuth2Provider, config.MCPHeadersProvider, config.Logger),
 		logger:        config.Logger,
 		kvStore:       config.KVStore,
@@ -5475,6 +5477,11 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 // keyProvider (custom selector failure, etc.) is propagated unchanged.
 var errAllKeysDead = errors.New("all configured keys returned permanent per-key errors (401/402/403)")
 
+// errAllKeysFiltered is returned by a keyProvider closure when healthy (non-dead) keys exist but
+// the KeyPoolFilter hook suppressed all of them. Unlike errAllKeysDead this is a transient
+// condition (the filter/circuit breaker self-heals), so it surfaces as a 503 rather than a 502.
+var errAllKeysFiltered = errors.New("all eligible keys are temporarily suppressed by the key pool filter")
+
 // executeRequestWithRetries is a generic function that handles common request processing logic.
 // It consolidates retry logic, backoff calculation, error handling, and key rotation.
 // It is not a bifrost method because interface methods in go cannot be generic.
@@ -5603,6 +5610,19 @@ func executeRequestWithRetries[T any](
 				// Any other error (custom selector failure, etc.) propagates unchanged so
 				// that a stray selector error doesn't get misreported as exhausted just
 				// because *some* keys happened to be dead.
+				if errors.Is(err, errAllKeysFiltered) {
+					statusCode := 503
+					errType := "no_eligible_keys"
+					return zero, &schemas.BifrostError{
+						IsBifrostError: false,
+						StatusCode:     &statusCode,
+						Type:           &errType,
+						Error: &schemas.ErrorField{
+							Type:    &errType,
+							Message: err.Error(),
+						},
+					}
+				}
 				if errors.Is(err, errAllKeysDead) {
 					statusCode := 502
 					errType := "upstream_credentials_exhausted"
@@ -6274,6 +6294,13 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 								}
 								available = append(available, k)
 							}
+							if bifrost.keyPoolFilter != nil {
+								if filtered, err := bifrost.keyPoolFilter(req.Context, provKey, mdl, available); err != nil {
+									bifrost.logger.Warn("key pool filter failed for provider %s, using unfiltered keys: %v", provKey, err)
+								} else {
+									available = filtered
+								}
+							}
 							if len(available) == 0 {
 								// No non-dead keys remain in this cycle. If every key has been
 								// marked permanently dead, give up — retrying won't help.
@@ -6285,7 +6312,18 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 										available = append(available, k)
 									}
 								}
+								liveCount := len(available) // non-dead keys before the filter runs
+								if bifrost.keyPoolFilter != nil {
+									if filtered, err := bifrost.keyPoolFilter(req.Context, provKey, mdl, available); err != nil {
+										bifrost.logger.Warn("key pool filter failed for provider %s, using unfiltered keys: %v", provKey, err)
+									} else {
+										available = filtered
+									}
+								}
 								if len(available) == 0 {
+									if liveCount > 0 {
+										return schemas.Key{}, fmt.Errorf("%w: provider %s", errAllKeysFiltered, provKey)
+									}
 									return schemas.Key{}, fmt.Errorf("%w: provider %s", errAllKeysDead, provKey)
 								}
 								for id := range usedKeyIDs {

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -14,6 +14,10 @@ const (
 
 type KeySelector func(ctx *BifrostContext, keys []Key, providerKey ModelProvider, model string) (Key, error)
 
+// KeyPoolFilter is an optional hook called before key selection to veto keys
+// from the available pool.
+type KeyPoolFilter func(ctx *BifrostContext, provider ModelProvider, model string, keys []Key) ([]Key, error)
+
 // BifrostConfig represents the configuration for initializing a Bifrost instance.
 // It contains the necessary components for setting up the system including account details,
 // plugins, logging, and initial pool size.
@@ -24,12 +28,13 @@ type BifrostConfig struct {
 	OAuth2Provider     OAuth2Provider
 	MCPHeadersProvider MCPHeadersProvider // Backend for MCPAuthTypePerUserHeaders credential storage; nil disables per-user-headers auth (resolver errors at use)
 	Logger             Logger
-	Tracer             Tracer      // Tracer for distributed tracing (nil = NoOpTracer)
-	InitialPoolSize    int         // Initial pool size for sync pools in Bifrost. Higher values will reduce memory allocations but will increase memory usage.
-	DropExcessRequests bool        // If true, in cases where the queue is full, requests will not wait for the queue to be empty and will be dropped instead.
-	MCPConfig          *MCPConfig  // MCP (Model Context Protocol) configuration for tool integration
-	KeySelector        KeySelector // Custom key selector function
-	KVStore            KVStore     // shared KV store for clustering/session stickiness; nil = disabled
+	Tracer             Tracer        // Tracer for distributed tracing (nil = NoOpTracer)
+	InitialPoolSize    int           // Initial pool size for sync pools in Bifrost. Higher values will reduce memory allocations but will increase memory usage.
+	DropExcessRequests bool          // If true, in cases where the queue is full, requests will not wait for the queue to be empty and will be dropped instead.
+	MCPConfig          *MCPConfig    // MCP (Model Context Protocol) configuration for tool integration
+	KeySelector        KeySelector   // Custom key selector function
+	KeyPoolFilter      KeyPoolFilter // Optional hook to filter available keys before selection; nil = all keys eligible
+	KVStore            KVStore       // shared KV store for clustering/session stickiness; nil = disabled
 }
 
 // ModelProvider represents the different AI model providers supported by Bifrost.
@@ -364,10 +369,11 @@ const (
 
 // RoutingEngine constants
 const (
-	RoutingEngineGovernance    = "governance"
-	RoutingEngineRoutingRule   = "routing-rule"
-	RoutingEngineLoadbalancing = "loadbalancing"
-	RoutingEngineModelCatalog  = "model-catalog"
+	RoutingEngineGovernance      = "governance"
+	RoutingEngineRoutingRule     = "routing-rule"
+	RoutingEngineLoadbalancing   = "loadbalancing"
+	RoutingEngineModelCatalog    = "model-catalog"
+	RoutingEngineCircuitBreaker  = "circuit-breaker"
 	// RoutingEngineCore represents the Bifrost core orchestrator's own
 	// routing decisions — primarily fallback transitions. Emitted when the
 	// primary attempt fails and core advances through the fallback chain so


### PR DESCRIPTION
## Summary

Introduces a `KeyPoolFilter` hook that allows callers to veto keys from the available pool before key selection occurs. This enables use cases such as circuit-breaking, tenant isolation, or any custom logic that needs to exclude specific keys without replacing the full `KeySelector`.

## Changes

- Added the `KeyPoolFilter` type (`func(ctx *BifrostContext, provider ModelProvider, model string, keys []Key) ([]Key, error)`) to `core/schemas/bifrost.go`
- Added `KeyPoolFilter` as an optional field on `BifrostConfig`; when `nil`, all keys remain eligible (no behavioral change)
- Wired `KeyPoolFilter` into `Bifrost` and applied it in `requestWorker` at both the initial key pool filtering stage and the dead-key recovery stage
- Added `RoutingEngineCircuitBreaker` constant to support tagging routing decisions made by circuit-breaker logic

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Provide a `KeyPoolFilter` in `BifrostConfig` that filters out specific keys based on custom criteria (e.g., a circuit-breaker state map) and verify that those keys are excluded from selection during request routing.

```sh
go version
go test ./...
```

**Configuration:**

| Field | Type | Default | Description |
|---|---|---|---|
| `BifrostConfig.KeyPoolFilter` | `KeyPoolFilter` | `nil` | Optional hook to filter available keys before selection. Return a subset of the provided keys. Returning an error leaves the pool unchanged. |

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The `KeyPoolFilter` callback receives the full list of candidate keys for a given provider and model. Implementors should ensure that any filtering logic does not inadvertently log or leak key material, and that the callback itself is safe for concurrent invocation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable