### PR TITLE
fix:preserve structured errors for streaming plugin blocks

### DIFF
--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -264,6 +264,19 @@ type HTTPTransportPlugin interface {
 	HTTPTransportStreamChunkHook(ctx *BifrostContext, req *HTTPRequest, chunk *BifrostStreamChunk) (*BifrostStreamChunk, error)
 }
 
+// StreamInterceptionError carries a structured client error when an HTTP stream plugin terminates a stream.
+type StreamInterceptionError struct {
+	BifrostError *BifrostError
+}
+
+// Error returns the best available client message for callers that only understand Go errors.
+func (e *StreamInterceptionError) Error() string {
+	if e != nil && e.BifrostError != nil && e.BifrostError.Error != nil && e.BifrostError.Error.Message != "" {
+		return e.BifrostError.Error.Message
+	}
+	return "stream interception failed"
+}
+
 type LLMPlugin interface {
 	BasePlugin
 

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -7,6 +7,7 @@ import (
 
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -1792,7 +1793,14 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 				chunk, err = interceptor.InterceptChunk(bifrostCtx, httpReq, chunk)
 				if err != nil {
 					if chunk == nil {
-						errorJSON, marshalErr := sonic.Marshal(map[string]string{"error": err.Error()})
+						var errorPayload interface{} = map[string]string{"error": err.Error()}
+						var structuredErr *schemas.StreamInterceptionError
+						if errors.As(err, &structuredErr) && structuredErr != nil {
+							if sanitized := lib.SanitizeBifrostErrorForClient(structuredErr.BifrostError); sanitized != nil {
+								errorPayload = sanitized
+							}
+						}
+						errorJSON, marshalErr := sonic.Marshal(errorPayload)
 						if marshalErr != nil {
 							cancel() // Payload invalid
 							for range stream {


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


