### PR TITLE
feat: add `group_traces_by_session` to OTEL/Datadog plugins and `vaultStore` reference block to Bifrost Helm chart values

### DIFF
--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -11,6 +11,8 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 ### Upcoming [2.1.25]
 
 - Added `evaluation_mode` to guardrail rules in `values.yaml`, `values.schema.json`, `config.schema.json`, and `_helpers.tpl`. The field renders into `guardrails_config.guardrail_rules[].evaluation_mode` and supports `bundled` (default) and `per_turn`.
+- Added `group_traces_by_session` boolean to the OTEL plugin (both single-profile and per-profile shapes) and the Datadog plugin. When `true`, all requests sharing the same `x-bf-session-id` header are grouped into a single trace using a deterministic trace ID derived from the session ID. An inbound W3C `traceparent` always takes precedence. When `false` (default), each request produces its own trace but `session.id` is still tagged on the root span.
+- Added `storage.configStore.vaultStore` to `values.yaml` (commented-out reference block). The schema (`values.schema.json`) and template (`_helpers.tpl`) already supported this field; the values file now documents all available options. Supports three backends — `aws-secrets-manager` (region, access key, role ARN, KMS key), `gcp-secret-manager` (project ID, credentials JSON), and `hashicorp-vault` (address, token, namespace, mount path, AppRole). Set `accessMode: read_and_write` to auto-store plaintext fields as vault secrets on save; `read_only` (default) only resolves existing `vault.<path>` references at load time.
 
 ### 2.1.24
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1278,6 +1278,9 @@ false
 {{- if hasKey $inputConfig "disable_content_logging" }}
 {{- $_ := set $otelConfig "disable_content_logging" $inputConfig.disable_content_logging }}
 {{- end }}
+{{- if hasKey $inputConfig "group_traces_by_session" }}
+{{- $_ := set $otelConfig "group_traces_by_session" $inputConfig.group_traces_by_session }}
+{{- end }}
 {{- if hasKey $inputConfig "disable_root_span_content" }}
 {{- $_ := set $otelConfig "disable_root_span_content" $inputConfig.disable_root_span_content }}
 {{- end }}
@@ -1336,6 +1339,9 @@ false
 {{- end }}
 {{- if hasKey $inputConfig "disable_content_logging" }}
 {{- $_ := set $datadogConfig "disable_content_logging" $inputConfig.disable_content_logging }}
+{{- end }}
+{{- if hasKey $inputConfig "group_traces_by_session" }}
+{{- $_ := set $datadogConfig "group_traces_by_session" $inputConfig.group_traces_by_session }}
 {{- end }}
 {{- if hasKey $inputConfig "agentless" }}
 {{- $_ := set $datadogConfig "agentless" $inputConfig.agentless }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1062,6 +1062,37 @@ storage:
     # maxIdleConns: 5
     # maxOpenConns: 50
 
+    # Vault store for external secret management (enterprise).
+    # Resolves "vault.<path>" references in config fields at load time.
+    # vaultStore:
+    #   enabled: true
+    #   type: aws-secrets-manager  # Options: aws-secrets-manager, gcp-secret-manager, hashicorp-vault
+    #   prefix: bifrost             # Path prefix applied to every secret (default: bifrost)
+    #   accessMode: read_only       # read_only or read_and_write
+    #
+    #   # AWS Secrets Manager
+    #   aws:
+    #     region: us-east-1
+    #     accessKeyId: ""           # Leave empty to use default AWS credential chain
+    #     secretAccessKey: ""
+    #     sessionToken: ""          # AWS STS session token (optional)
+    #     roleArn: ""               # IAM role ARN to assume via STS
+    #     kmsKeyId: ""              # Customer-managed KMS key for encryption
+    #
+    #   # GCP Secret Manager
+    #   gcp:
+    #     projectId: ""
+    #     credentialsJson: ""       # Service account JSON; omit for default credentials
+    #
+    #   # HashiCorp Vault (KV v2)
+    #   hashicorp:
+    #     address: https://vault.example.com
+    #     token: ""                 # Static token; omit to use AppRole auth
+    #     namespace: ""             # Vault namespace (HCP Vault / Enterprise)
+    #     mountPath: secret         # KV v2 mount path
+    #     roleId: ""                # AppRole role_id
+    #     secretId: ""              # AppRole secret_id
+
   # Logs store settings
   logsStore:
     enabled: true


### PR DESCRIPTION
## Summary

This PR extends the Bifrost Helm chart with two new configuration capabilities: session-based trace grouping for the OTEL and Datadog plugins, and a documented vault store reference block for external secret management.

## Changes

- Added `group_traces_by_session` boolean field to both the OTEL and Datadog plugin configurations. When `true`, requests sharing the same `x-bf-session-id` header are grouped into a single trace using a deterministic trace ID derived from the session ID. An inbound W3C `traceparent` always takes precedence. When `false` (default), each request produces its own trace but `session.id` is still tagged on the root span. The `_helpers.tpl` template was updated to render this field for both plugin types.
- Added a commented-out `storage.configStore.vaultStore` reference block to `values.yaml` to document all available vault backend options. The schema and template already supported this field; the values file now surfaces the full configuration surface including AWS Secrets Manager, GCP Secret Manager, and HashiCorp Vault backends. Setting `accessMode: read_and_write` auto-stores plaintext fields as vault secrets on save; `read_only` (default) only resolves existing `vault.<path>` references at load time.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Render the Helm chart and verify group_traces_by_session appears in the OTEL and Datadog plugin configs
helm template bifrost ./helm-charts/bifrost \
  --set plugins.otel.enabled=true \
  --set plugins.otel.group_traces_by_session=true

helm template bifrost ./helm-charts/bifrost \
  --set plugins.datadog.enabled=true \
  --set plugins.datadog.group_traces_by_session=true

# Verify vaultStore block renders correctly when enabled
helm template bifrost ./helm-charts/bifrost \
  --set storage.configStore.vaultStore.enabled=true \
  --set storage.configStore.vaultStore.type=hashicorp-vault
```

**New config fields:**

| Field | Type | Default | Description |
|---|---|---|---|
| `plugins.otel.group_traces_by_session` | bool | `false` | Groups requests by `x-bf-session-id` into a single trace |
| `plugins.datadog.group_traces_by_session` | bool | `false` | Groups requests by `x-bf-session-id` into a single trace |
| `storage.configStore.vaultStore.accessMode` | string | `read_only` | `read_only` or `read_and_write` |

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

See changelog entry for `2.1.25`.

## Security considerations

The `vaultStore` configuration may contain sensitive credentials (access keys, tokens, AppRole secret IDs). These should be provided via Kubernetes secrets or a secrets injection mechanism rather than hardcoded in `values.yaml`. The `read_and_write` access mode will write plaintext config fields back to the configured vault backend, which should be reviewed carefully before enabling in production.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable