### PR TITLE
feat: add __type return for Bedrock error in streaming paths

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -29,6 +29,12 @@ import (
 // calling addColumnIfNotExists(tx, ...) directly.
 var addColumnIfNotExists = migrator.AddColumnIfNotExists
 
+// dropColumnIfExists is the drop counterpart to addColumnIfNotExists: a
+// package-local alias for migrator.DropColumnIfExists, the idempotent
+// column-drop helper shared with logstore. Declared at package scope for the
+// same reason as above so call sites can use dropColumnIfExists(tx, ...).
+var dropColumnIfExists = migrator.DropColumnIfExists
+
 const (
 	// migrationAdvisoryLockKey is used for PostgreSQL advisory locks
 	// to serialize migrations across cluster nodes
@@ -575,7 +581,7 @@ func dropLegacyBudgetColumn(tx *gorm.DB, tableName string) error {
 		if err != nil {
 			return err
 		}
-		if err := mg.DropColumn(model, "budget_id"); err != nil {
+		if err := dropColumnIfExists(tx, nil, model, "budget_id"); err != nil {
 			return fmt.Errorf("failed to drop legacy %s.budget_id column: %w", tableName, err)
 		}
 	}
@@ -659,9 +665,7 @@ func migrationAddClientConfigMetadataColumn(ctx context.Context, db *gorm.DB, lo
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column metadata_json from TableClientConfig", migrationName)
-			if err := migrator.DropColumn(&tables.TableClientConfig{}, "metadata_json"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "metadata_json"); err != nil {
 				return err
 			}
 			return nil
@@ -760,9 +764,7 @@ func migrationAddStoreRawRequestResponseColumn(ctx context.Context, db *gorm.DB,
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column store_raw_request_response from TableProvider", migrationName)
-			if err := migrator.DropColumn(&tables.TableProvider{}, "store_raw_request_response"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableProvider{}, "store_raw_request_response"); err != nil {
 				return err
 			}
 			return nil
@@ -1249,12 +1251,8 @@ func migrationDropAllowDirectKeysColumnDDL(ctx context.Context, db *gorm.DB, log
 		ID: migrationName,
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&tables.TableClientConfig{}, "allow_direct_keys") {
-				logger.Info("[configstore] %s: dropping column allow_direct_keys from TableClientConfig", migrationName)
-				if err := mig.DropColumn(&tables.TableClientConfig{}, "allow_direct_keys"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "allow_direct_keys"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1392,11 +1390,8 @@ func migrationAddTeamSourceIDColumn(ctx context.Context, db *gorm.DB, logger sch
 					return fmt.Errorf("drop unique index on governance_teams.source_id: %w", err)
 				}
 			}
-			if mg.HasColumn(&tables.TableTeam{}, "source_id") {
-				logger.Info("[configstore] %s: dropping column source_id from TableTeam", migrationName)
-				if err := mg.DropColumn(&tables.TableTeam{}, "source_id"); err != nil {
-					return fmt.Errorf("drop source_id column from governance_teams: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableTeam{}, "source_id"); err != nil {
+				return fmt.Errorf("drop source_id column from governance_teams: %w", err)
 			}
 			return nil
 		},
@@ -1451,13 +1446,11 @@ func migrationAddKeyNameColumn(ctx context.Context, db *gorm.DB, logger schemas.
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 			// Drop the unique index first to avoid orphaned index artifacts
 			if err := tx.Exec("DROP INDEX IF EXISTS idx_key_name").Error; err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column name from TableKey", migrationName)
-			if err := migrator.DropColumn(&tables.TableKey{}, "name"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "name"); err != nil {
 				return err
 			}
 			return nil
@@ -1479,22 +1472,15 @@ func migrationCleanupMCPClientToolsConfig(ctx context.Context, db *gorm.DB, logg
 		ID: migrationName,
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
 			// Step 1: Remove ToolsToSkipJSON column if it exists (cleanup from old versions)
-			if migrator.HasColumn(&tables.TableMCPClient{}, "tools_to_skip_json") {
-				logger.Info("[configstore] %s: dropping column tools_to_skip_json from TableMCPClient", migrationName)
-				if err := migrator.DropColumn(&tables.TableMCPClient{}, "tools_to_skip_json"); err != nil {
-					return fmt.Errorf("failed to drop tools_to_skip_json column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "tools_to_skip_json"); err != nil {
+				return fmt.Errorf("failed to drop tools_to_skip_json column: %w", err)
 			}
 
 			// Alternative column name variations that might exist
-			if migrator.HasColumn(&tables.TableMCPClient{}, "ToolsToSkipJSON") {
-				logger.Info("[configstore] %s: dropping column ToolsToSkipJSON from TableMCPClient", migrationName)
-				if err := migrator.DropColumn(&tables.TableMCPClient{}, "ToolsToSkipJSON"); err != nil {
-					return fmt.Errorf("failed to drop ToolsToSkipJSON column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "ToolsToSkipJSON"); err != nil {
+				return fmt.Errorf("failed to drop ToolsToSkipJSON column: %w", err)
 			}
 
 			// Step 2: Update empty ToolsToExecuteJSON arrays to wildcard ["*"]
@@ -1632,11 +1618,8 @@ func migrationAddProviderConfigBudgetRateLimit(ctx context.Context, db *gorm.DB,
 
 			// Drop columns via raw SQL (budget_id no longer on struct)
 			_ = tx.Exec("ALTER TABLE governance_virtual_key_provider_configs DROP COLUMN IF EXISTS budget_id")
-			if migrator.HasColumn(&tables.TableVirtualKeyProviderConfig{}, "rate_limit_id") {
-				logger.Info("[configstore] %s: dropping column rate_limit_id from TableVirtualKeyProviderConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableVirtualKeyProviderConfig{}, "rate_limit_id"); err != nil {
-					return fmt.Errorf("failed to drop rate_limit_id column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableVirtualKeyProviderConfig{}, "rate_limit_id"); err != nil {
+				return fmt.Errorf("failed to drop rate_limit_id column: %w", err)
 			}
 
 			return nil
@@ -1668,13 +1651,10 @@ func migrationAddPluginPathColumn(ctx context.Context, db *gorm.DB, logger schem
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column path from TablePlugin", migrationName)
-			if err := migrator.DropColumn(&tables.TablePlugin{}, "path"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TablePlugin{}, "path"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column is_custom from TablePlugin", migrationName)
-			if err := migrator.DropColumn(&tables.TablePlugin{}, "is_custom"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TablePlugin{}, "is_custom"); err != nil {
 				return err
 			}
 			return nil
@@ -1738,9 +1718,7 @@ func migrationAddHeadersJSONColumnIntoMCPClient(ctx context.Context, db *gorm.DB
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column headers_json from TableMCPClient", migrationName)
-			if err := migrator.DropColumn(&tables.TableMCPClient{}, "headers_json"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "headers_json"); err != nil {
 				return err
 			}
 			return nil
@@ -1769,9 +1747,7 @@ func migrationAddDisableContentLoggingColumn(ctx context.Context, db *gorm.DB, l
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column disable_content_logging from TableClientConfig", migrationName)
-			if err := migrator.DropColumn(&tables.TableClientConfig{}, "disable_content_logging"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "disable_content_logging"); err != nil {
 				return err
 			}
 			return nil
@@ -1834,15 +1810,13 @@ func migrationAddMCPClientIDColumn(ctx context.Context, db *gorm.DB, logger sche
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
 			// Drop the unique index first to avoid orphaned index artifacts
 			if err := tx.Exec("DROP INDEX IF EXISTS idx_mcp_client_id").Error; err != nil {
 				return fmt.Errorf("failed to drop client_id index: %w", err)
 			}
 
-			logger.Info("[configstore] %s: dropping column client_id from TableMCPClient", migrationName)
-			if err := migrator.DropColumn(&tables.TableMCPClient{}, "client_id"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "client_id"); err != nil {
 				return fmt.Errorf("failed to drop client_id column: %w", err)
 			}
 
@@ -1873,9 +1847,7 @@ func migrationAddVertexProjectNumberColumn(ctx context.Context, db *gorm.DB, log
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column vertex_project_number from TableKey", migrationName)
-			if err := migrator.DropColumn(&tables.TableKey{}, "vertex_project_number"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "vertex_project_number"); err != nil {
 				return err
 			}
 			return nil
@@ -1974,9 +1946,7 @@ func migrationMissingProviderColumnInKeyTable(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column provider from TableKey", migrationName)
-			if err := migrator.DropColumn(&tables.TableKey{}, "provider"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "provider"); err != nil {
 				return err
 			}
 			return nil
@@ -2012,9 +1982,7 @@ func migrationAddToolsToAutoExecuteJSONColumn(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column tools_to_auto_execute_json from TableMCPClient", migrationName)
-			if err := migrator.DropColumn(&tables.TableMCPClient{}, "tools_to_auto_execute_json"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "tools_to_auto_execute_json"); err != nil {
 				return err
 			}
 			return nil
@@ -2050,9 +2018,7 @@ func migrationAddIsCodeModeClientColumn(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column is_code_mode_client from TableMCPClient", migrationName)
-			if err := migrator.DropColumn(&tables.TableMCPClient{}, "is_code_mode_client"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "is_code_mode_client"); err != nil {
 				return err
 			}
 			return nil
@@ -2081,9 +2047,7 @@ func migrationAddLogRetentionDaysColumn(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column log_retention_days from TableClientConfig", migrationName)
-			if err := migrator.DropColumn(&tables.TableClientConfig{}, "log_retention_days"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "log_retention_days"); err != nil {
 				return err
 			}
 			return nil
@@ -2118,13 +2082,9 @@ func migrationAddEnabledColumnToKeyTable(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 
-			if mg.HasColumn(&tables.TableKey{}, "enabled") {
-				logger.Info("[configstore] %s: dropping column enabled from TableKey", migrationName)
-				if err := mg.DropColumn(&tables.TableKey{}, "enabled"); err != nil {
-					return fmt.Errorf("failed to drop enabled column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "enabled"); err != nil {
+				return fmt.Errorf("failed to drop enabled column: %w", err)
 			}
 
 			return nil
@@ -2162,21 +2122,16 @@ func migrationAddBatchAndCachePricingColumns(ctx context.Context, db *gorm.DB, l
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column cache_read_input_token_cost from TableModelPricing", migrationName)
-			if err := migrator.DropColumn(&tables.TableModelPricing{}, "cache_read_input_token_cost"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "cache_read_input_token_cost"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column cache_creation_input_token_cost from TableModelPricing", migrationName)
-			if err := migrator.DropColumn(&tables.TableModelPricing{}, "cache_creation_input_token_cost"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "cache_creation_input_token_cost"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column input_cost_per_token_batches from TableModelPricing", migrationName)
-			if err := migrator.DropColumn(&tables.TableModelPricing{}, "input_cost_per_token_batches"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "input_cost_per_token_batches"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column output_cost_per_token_batches from TableModelPricing", migrationName)
-			if err := migrator.DropColumn(&tables.TableModelPricing{}, "output_cost_per_token_batches"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "output_cost_per_token_batches"); err != nil {
 				return err
 			}
 			return nil
@@ -2203,13 +2158,10 @@ func migrationAddMCPAgentDepthAndMCPToolExecutionTimeoutColumns(ctx context.Cont
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column mcp_agent_depth from TableClientConfig", migrationName)
-			if err := migrator.DropColumn(&tables.TableClientConfig{}, "mcp_agent_depth"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "mcp_agent_depth"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column mcp_tool_execution_timeout from TableClientConfig", migrationName)
-			if err := migrator.DropColumn(&tables.TableClientConfig{}, "mcp_tool_execution_timeout"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "mcp_tool_execution_timeout"); err != nil {
 				return err
 			}
 			return nil
@@ -2239,9 +2191,7 @@ func migrationAddMCPCodeModeBindingLevelColumn(ctx context.Context, db *gorm.DB,
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migratorInstance := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column mcp_code_mode_binding_level from TableClientConfig", migrationName)
-			if err := migratorInstance.DropColumn(&tables.TableClientConfig{}, "mcp_code_mode_binding_level"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "mcp_code_mode_binding_level"); err != nil {
 				return err
 			}
 			return nil
@@ -2544,9 +2494,7 @@ func migrationAddPluginVersionColumn(ctx context.Context, db *gorm.DB, logger sc
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column version from TablePlugin", migrationName)
-			if err := migrator.DropColumn(&tables.TablePlugin{}, "version"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TablePlugin{}, "version"); err != nil {
 				return err
 			}
 			return nil
@@ -2574,9 +2522,7 @@ func migrationAddSendBackRawRequestColumns(ctx context.Context, db *gorm.DB, log
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column send_back_raw_request from TableProvider", migrationName)
-			if err := migrator.DropColumn(&tables.TableProvider{}, "send_back_raw_request"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableProvider{}, "send_back_raw_request"); err != nil {
 				return err
 			}
 			return nil
@@ -2669,13 +2615,10 @@ func migrationAddConfigHashColumn(ctx context.Context, db *gorm.DB, logger schem
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column config_hash from TableProvider", migrationName)
-			if err := migrator.DropColumn(&tables.TableProvider{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableProvider{}, "config_hash"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column config_hash from TableKey", migrationName)
-			if err := migrator.DropColumn(&tables.TableKey{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "config_hash"); err != nil {
 				return err
 			}
 			return nil
@@ -2725,9 +2668,7 @@ func migrationAddVirtualKeyConfigHashColumn(ctx context.Context, db *gorm.DB, lo
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column config_hash from TableVirtualKey", migrationName)
-			if err := migrator.DropColumn(&tables.TableVirtualKey{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableVirtualKey{}, "config_hash"); err != nil {
 				return err
 			}
 			return nil
@@ -2935,33 +2876,25 @@ func migrationAddAdditionalConfigHashColumns(ctx context.Context, db *gorm.DB, l
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column config_hash from TableClientConfig", migrationName)
-			if err := migrator.DropColumn(&tables.TableClientConfig{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "config_hash"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column config_hash from TableBudget", migrationName)
-			if err := migrator.DropColumn(&tables.TableBudget{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableBudget{}, "config_hash"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column config_hash from TableRateLimit", migrationName)
-			if err := migrator.DropColumn(&tables.TableRateLimit{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableRateLimit{}, "config_hash"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column config_hash from TableCustomer", migrationName)
-			if err := migrator.DropColumn(&tables.TableCustomer{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableCustomer{}, "config_hash"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column config_hash from TableTeam", migrationName)
-			if err := migrator.DropColumn(&tables.TableTeam{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableTeam{}, "config_hash"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column config_hash from TableMCPClient", migrationName)
-			if err := migrator.DropColumn(&tables.TableMCPClient{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "config_hash"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column config_hash from TablePlugin", migrationName)
-			if err := migrator.DropColumn(&tables.TablePlugin{}, "config_hash"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TablePlugin{}, "config_hash"); err != nil {
 				return err
 			}
 			return nil
@@ -3000,7 +2933,6 @@ func migrationAdd200kTokenPricingColumns(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
 			columns := []string{
 				"input_cost_per_token_above_200k_tokens",
@@ -3010,11 +2942,8 @@ func migrationAdd200kTokenPricingColumns(ctx context.Context, db *gorm.DB, logge
 			}
 
 			for _, field := range columns {
-				if migrator.HasColumn(&tables.TableModelPricing{}, field) {
-					logger.Info("[configstore] %s: dropping column %s from TableModelPricing", migrationName, field)
-					if err := migrator.DropColumn(&tables.TableModelPricing{}, field); err != nil {
-						return fmt.Errorf("failed to drop column %s: %w", field, err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
 				}
 			}
 			return nil
@@ -3050,7 +2979,6 @@ func migrationAddImagePricingColumns(ctx context.Context, db *gorm.DB, logger sc
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
 			columns := []string{
 				"input_cost_per_image_token",
@@ -3061,11 +2989,8 @@ func migrationAddImagePricingColumns(ctx context.Context, db *gorm.DB, logger sc
 			}
 
 			for _, field := range columns {
-				if migrator.HasColumn(&tables.TableModelPricing{}, field) {
-					logger.Info("[configstore] %s: dropping column %s from TableModelPricing", migrationName, field)
-					if err := migrator.DropColumn(&tables.TableModelPricing{}, field); err != nil {
-						return fmt.Errorf("failed to drop column %s: %w", field, err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
 				}
 			}
 			return nil
@@ -3098,20 +3023,13 @@ func migrationAddUseForBatchAPIColumnAndS3BucketsConfig(ctx context.Context, db 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 
-			if mg.HasColumn(&tables.TableKey{}, "use_for_batch_api") {
-				logger.Info("[configstore] %s: dropping column use_for_batch_api from TableKey", migrationName)
-				if err := mg.DropColumn(&tables.TableKey{}, "use_for_batch_api"); err != nil {
-					return fmt.Errorf("failed to drop use_for_batch_api column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "use_for_batch_api"); err != nil {
+				return fmt.Errorf("failed to drop use_for_batch_api column: %w", err)
 			}
 
-			if mg.HasColumn(&tables.TableKey{}, "bedrock_batch_s3_config_json") {
-				logger.Info("[configstore] %s: dropping column bedrock_batch_s3_config_json from TableKey", migrationName)
-				if err := mg.DropColumn(&tables.TableKey{}, "bedrock_batch_s3_config_json"); err != nil {
-					return fmt.Errorf("failed to drop bedrock_batch_s3_config_json column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "bedrock_batch_s3_config_json"); err != nil {
+				return fmt.Errorf("failed to drop bedrock_batch_s3_config_json column: %w", err)
 			}
 
 			return nil
@@ -3141,13 +3059,9 @@ func migrationAddHeaderFilterConfigJSONColumn(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 
-			if mg.HasColumn(&tables.TableClientConfig{}, "header_filter_config_json") {
-				logger.Info("[configstore] %s: dropping column header_filter_config_json from TableClientConfig", migrationName)
-				if err := mg.DropColumn(&tables.TableClientConfig{}, "header_filter_config_json"); err != nil {
-					return fmt.Errorf("failed to drop header_filter_config_json column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "header_filter_config_json"); err != nil {
+				return fmt.Errorf("failed to drop header_filter_config_json column: %w", err)
 			}
 			return nil
 		},
@@ -3181,17 +3095,13 @@ func migrationAddAzureClientIDAndClientSecretAndTenantIDColumns(ctx context.Cont
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column azure_client_id from TableKey", migrationName)
-			if err := migrator.DropColumn(&tables.TableKey{}, "azure_client_id"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "azure_client_id"); err != nil {
 				return fmt.Errorf("failed to drop azure_client_id column: %w", err)
 			}
-			logger.Info("[configstore] %s: dropping column azure_client_secret from TableKey", migrationName)
-			if err := migrator.DropColumn(&tables.TableKey{}, "azure_client_secret"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "azure_client_secret"); err != nil {
 				return fmt.Errorf("failed to drop azure_client_secret column: %w", err)
 			}
-			logger.Info("[configstore] %s: dropping column azure_tenant_id from TableKey", migrationName)
-			if err := migrator.DropColumn(&tables.TableKey{}, "azure_tenant_id"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "azure_tenant_id"); err != nil {
 				return fmt.Errorf("failed to drop azure_tenant_id column: %w", err)
 			}
 			return nil
@@ -3218,9 +3128,7 @@ func migrationAddToolPricingJSONColumn(ctx context.Context, db *gorm.DB, logger 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column tool_pricing_json from TableMCPClient", migrationName)
-			if err := migrator.DropColumn(&tables.TableMCPClient{}, "tool_pricing_json"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "tool_pricing_json"); err != nil {
 				return fmt.Errorf("failed to drop tool_pricing_json column: %w", err)
 			}
 			return nil
@@ -3799,19 +3707,13 @@ func migrationAddProviderGovernanceColumns(ctx context.Context, db *gorm.DB, log
 			}
 
 			// Drop rate_limit_id column if it exists
-			if migrator.HasColumn(provider, "rate_limit_id") {
-				logger.Info("[configstore] %s: dropping column rate_limit_id from TableProvider", migrationName)
-				if err := migrator.DropColumn(provider, "rate_limit_id"); err != nil {
-					return fmt.Errorf("failed to drop rate_limit_id column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, provider, "rate_limit_id"); err != nil {
+				return fmt.Errorf("failed to drop rate_limit_id column: %w", err)
 			}
 
 			// Drop budget_id column if it exists
-			if migrator.HasColumn(provider, "budget_id") {
-				logger.Info("[configstore] %s: dropping column budget_id from TableProvider", migrationName)
-				if err := migrator.DropColumn(provider, "budget_id"); err != nil {
-					return fmt.Errorf("failed to drop budget_id column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, provider, "budget_id"); err != nil {
+				return fmt.Errorf("failed to drop budget_id column: %w", err)
 			}
 
 			return nil
@@ -4305,12 +4207,8 @@ func migrationAddModelConfigCalendarAlignedColumn(ctx context.Context, db *gorm.
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&tables.TableModelConfig{}, "calendar_aligned") {
-				logger.Info("[configstore] %s: dropping column calendar_aligned from TableModelConfig", migrationName)
-				if err := mig.DropColumn(&tables.TableModelConfig{}, "calendar_aligned"); err != nil {
-					return fmt.Errorf("failed to drop calendar_aligned column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelConfig{}, "calendar_aligned"); err != nil {
+				return fmt.Errorf("failed to drop calendar_aligned column: %w", err)
 			}
 			return nil
 		},
@@ -4337,12 +4235,8 @@ func migrationAddAllowedHeadersJSONColumn(ctx context.Context, db *gorm.DB, logg
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableClientConfig{}, "allowed_headers_json") {
-				logger.Info("[configstore] %s: dropping column allowed_headers_json from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "allowed_headers_json"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "allowed_headers_json"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -4370,12 +4264,8 @@ func migrationAddDisableDBPingsInHealthColumn(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableClientConfig{}, "disable_db_pings_in_health") {
-				logger.Info("[configstore] %s: dropping column disable_db_pings_in_health from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "disable_db_pings_in_health"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "disable_db_pings_in_health"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -4410,12 +4300,8 @@ func migrationAddIsPingAvailableColumnToMCPClientTable(ctx context.Context, db *
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableMCPClient{}, "is_ping_available") {
-				logger.Info("[configstore] %s: dropping column is_ping_available from TableMCPClient", migrationName)
-				if err := migrator.DropColumn(&tables.TableMCPClient{}, "is_ping_available"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "is_ping_available"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -4561,14 +4447,11 @@ func migrationAddToolSyncIntervalColumns(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			logger.Info("[configstore] %s: dropping column mcp_tool_sync_interval from TableClientConfig", migrationName)
-			if err := migrator.DropColumn(&tables.TableClientConfig{}, "mcp_tool_sync_interval"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "mcp_tool_sync_interval"); err != nil {
 				return err
 			}
-			logger.Info("[configstore] %s: dropping column tool_sync_interval from TableMCPClient", migrationName)
-			if err := migrator.DropColumn(&tables.TableMCPClient{}, "tool_sync_interval"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "tool_sync_interval"); err != nil {
 				return err
 			}
 
@@ -4636,12 +4519,8 @@ func migrationAddMCPClientConfigToOAuthConfig(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableOauthConfig{}, "mcp_client_config_json") {
-				logger.Info("[configstore] %s: dropping column mcp_client_config_json from TableOauthConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableOauthConfig{}, "mcp_client_config_json"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableOauthConfig{}, "mcp_client_config_json"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -4669,12 +4548,8 @@ func migrationAddBaseModelPricingColumn(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableModelPricing{}, "base_model") {
-				logger.Info("[configstore] %s: dropping column base_model from TableModelPricing", migrationName)
-				if err := migrator.DropColumn(&tables.TableModelPricing{}, "base_model"); err != nil {
-					return fmt.Errorf("failed to drop column base_model: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "base_model"); err != nil {
+				return fmt.Errorf("failed to drop column base_model: %w", err)
 			}
 			return nil
 		},
@@ -4698,12 +4573,8 @@ func migrationAddAzureScopesColumn(ctx context.Context, db *gorm.DB, logger sche
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableKey{}, "azure_scopes") {
-				logger.Info("[configstore] %s: dropping column azure_scopes from TableKey", migrationName)
-				if err := migrator.DropColumn(&tables.TableKey{}, "azure_scopes"); err != nil {
-					return fmt.Errorf("failed to drop azure_scopes column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "azure_scopes"); err != nil {
+				return fmt.Errorf("failed to drop azure_scopes column: %w", err)
 			}
 			return nil
 		},
@@ -4897,12 +4768,8 @@ func migrationDropDeploymentColumnsAndAddAliases(ctx context.Context, db *gorm.D
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			m := tx.Migrator()
-			if m.HasColumn(&tables.TableKey{}, "aliases_json") {
-				logger.Info("[configstore] %s: dropping column aliases_json from TableKey", migrationName)
-				if err := m.DropColumn(&tables.TableKey{}, "aliases_json"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "aliases_json"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -4938,22 +4805,15 @@ func migrationAddKeyStatusColumns(ctx context.Context, db *gorm.DB, logger schem
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
 			// Drop description column
-			if migrator.HasColumn(&tables.TableKey{}, "description") {
-				logger.Info("[configstore] %s: dropping column description from TableKey", migrationName)
-				if err := migrator.DropColumn(&tables.TableKey{}, "description"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "description"); err != nil {
+				return err
 			}
 
 			// Drop status column
-			if migrator.HasColumn(&tables.TableKey{}, "status") {
-				logger.Info("[configstore] %s: dropping column status from TableKey", migrationName)
-				if err := migrator.DropColumn(&tables.TableKey{}, "status"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "status"); err != nil {
+				return err
 			}
 
 			return nil
@@ -4991,22 +4851,15 @@ func migrationAddProviderStatusColumns(ctx context.Context, db *gorm.DB, logger 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
 			// Drop description column
-			if migrator.HasColumn(&tables.TableProvider{}, "description") {
-				logger.Info("[configstore] %s: dropping column description from TableProvider", migrationName)
-				if err := migrator.DropColumn(&tables.TableProvider{}, "description"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableProvider{}, "description"); err != nil {
+				return err
 			}
 
 			// Drop status column
-			if migrator.HasColumn(&tables.TableProvider{}, "status") {
-				logger.Info("[configstore] %s: dropping column status from TableProvider", migrationName)
-				if err := migrator.DropColumn(&tables.TableProvider{}, "status"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableProvider{}, "status"); err != nil {
+				return err
 			}
 
 			return nil
@@ -5037,13 +4890,9 @@ func migrationAddAsyncJobResultTTLColumn(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TableClientConfig{}, "async_job_result_ttl") {
-				logger.Info("[configstore] %s: dropping column async_job_result_ttl from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "async_job_result_ttl"); err != nil {
-					return fmt.Errorf("failed to drop async_job_result_ttl column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "async_job_result_ttl"); err != nil {
+				return fmt.Errorf("failed to drop async_job_result_ttl column: %w", err)
 			}
 
 			return nil
@@ -5079,20 +4928,13 @@ func migrationAddRateLimitToTeamsAndCustomers(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TableTeam{}, "rate_limit_id") {
-				logger.Info("[configstore] %s: dropping column rate_limit_id from TableTeam", migrationName)
-				if err := migrator.DropColumn(&tables.TableTeam{}, "rate_limit_id"); err != nil {
-					return fmt.Errorf("failed to drop rate_limit_id column from teams: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableTeam{}, "rate_limit_id"); err != nil {
+				return fmt.Errorf("failed to drop rate_limit_id column from teams: %w", err)
 			}
 
-			if migrator.HasColumn(&tables.TableCustomer{}, "rate_limit_id") {
-				logger.Info("[configstore] %s: dropping column rate_limit_id from TableCustomer", migrationName)
-				if err := migrator.DropColumn(&tables.TableCustomer{}, "rate_limit_id"); err != nil {
-					return fmt.Errorf("failed to drop rate_limit_id column from customers: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableCustomer{}, "rate_limit_id"); err != nil {
+				return fmt.Errorf("failed to drop rate_limit_id column from customers: %w", err)
 			}
 
 			return nil
@@ -5250,13 +5092,9 @@ func migrationAddRequiredHeadersJSONColumn(ctx context.Context, db *gorm.DB, log
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TableClientConfig{}, "required_headers_json") {
-				logger.Info("[configstore] %s: dropping column required_headers_json from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "required_headers_json"); err != nil {
-					return fmt.Errorf("failed to drop required_headers_json column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "required_headers_json"); err != nil {
+				return fmt.Errorf("failed to drop required_headers_json column: %w", err)
 			}
 
 			return nil
@@ -5289,20 +5127,13 @@ func migrationAddOutputCostPerVideoPerSecond(ctx context.Context, db *gorm.DB, l
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TableModelPricing{}, "output_cost_per_video_per_second") {
-				logger.Info("[configstore] %s: dropping column output_cost_per_video_per_second from TableModelPricing", migrationName)
-				if err := migrator.DropColumn(&tables.TableModelPricing{}, "output_cost_per_video_per_second"); err != nil {
-					return fmt.Errorf("failed to drop output_cost_per_video_per_second column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "output_cost_per_video_per_second"); err != nil {
+				return fmt.Errorf("failed to drop output_cost_per_video_per_second column: %w", err)
 			}
 
-			if migrator.HasColumn(&tables.TableModelPricing{}, "output_cost_per_second") {
-				logger.Info("[configstore] %s: dropping column output_cost_per_second from TableModelPricing", migrationName)
-				if err := migrator.DropColumn(&tables.TableModelPricing{}, "output_cost_per_second"); err != nil {
-					return fmt.Errorf("failed to drop output_cost_per_second column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "output_cost_per_second"); err != nil {
+				return fmt.Errorf("failed to drop output_cost_per_second column: %w", err)
 			}
 
 			return nil
@@ -5332,13 +5163,9 @@ func migrationAddLoggingHeadersJSONColumn(ctx context.Context, db *gorm.DB, logg
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TableClientConfig{}, "logging_headers_json") {
-				logger.Info("[configstore] %s: dropping column logging_headers_json from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "logging_headers_json"); err != nil {
-					return fmt.Errorf("failed to drop logging_headers_json column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "logging_headers_json"); err != nil {
+				return fmt.Errorf("failed to drop logging_headers_json column: %w", err)
 			}
 
 			return nil
@@ -5368,13 +5195,9 @@ func migrationAddHideDeletedVirtualKeysInFiltersColumn(ctx context.Context, db *
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TableClientConfig{}, "hide_deleted_virtual_keys_in_filters") {
-				logger.Info("[configstore] %s: dropping column hide_deleted_virtual_keys_in_filters from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "hide_deleted_virtual_keys_in_filters"); err != nil {
-					return fmt.Errorf("failed to drop hide_deleted_virtual_keys_in_filters column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "hide_deleted_virtual_keys_in_filters"); err != nil {
+				return fmt.Errorf("failed to drop hide_deleted_virtual_keys_in_filters column: %w", err)
 			}
 
 			return nil
@@ -5402,12 +5225,8 @@ func migrationAddEnforceSCIMAuthColumn(ctx context.Context, db *gorm.DB, logger 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableClientConfig{}, "enforce_scim_auth") {
-				logger.Info("[configstore] %s: dropping column enforce_scim_auth from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "enforce_scim_auth"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "enforce_scim_auth"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -5438,12 +5257,8 @@ func migrationAddEnforceAuthOnInferenceColumn(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableClientConfig{}, "enforce_auth_on_inference") {
-				logger.Info("[configstore] %s: dropping column enforce_auth_on_inference from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "enforce_auth_on_inference"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "enforce_auth_on_inference"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -5586,7 +5401,6 @@ func migrationAddEncryptionColumns(ctx context.Context, db *gorm.DB, logger sche
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mgr := tx.Migrator()
 
 			type dropInfo struct {
 				table   interface{}
@@ -5607,11 +5421,8 @@ func migrationAddEncryptionColumns(ctx context.Context, db *gorm.DB, logger sche
 
 			for _, d := range drops {
 				for _, col := range d.columns {
-					if mgr.HasColumn(d.table, col) {
-						logger.Info("[configstore] %s: dropping column %s from %T", migrationName, col, d.table)
-						if err := mgr.DropColumn(d.table, col); err != nil {
-							return err
-						}
+					if err := dropColumnIfExists(tx, logger, d.table, col); err != nil {
+						return err
 					}
 				}
 			}
@@ -5633,12 +5444,8 @@ func migrationDropEnableGovernanceColumn(ctx context.Context, db *gorm.DB, logge
 		ID: migrationName,
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableClientConfig{}, "enable_governance") {
-				logger.Info("[configstore] %s: dropping column enable_governance from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "enable_governance"); err != nil {
-					return fmt.Errorf("failed to drop enable_governance column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "enable_governance"); err != nil {
+				return fmt.Errorf("failed to drop enable_governance column: %w", err)
 			}
 			return nil
 		},
@@ -5668,18 +5475,11 @@ func migrationAddVLLMKeyConfigColumns(ctx context.Context, db *gorm.DB, logger s
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableKey{}, "vllm_url") {
-				logger.Info("[configstore] %s: dropping column vllm_url from TableKey", migrationName)
-				if err := migrator.DropColumn(&tables.TableKey{}, "vllm_url"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "vllm_url"); err != nil {
+				return err
 			}
-			if migrator.HasColumn(&tables.TableKey{}, "vllm_model_name") {
-				logger.Info("[configstore] %s: dropping column vllm_model_name from TableKey", migrationName)
-				if err := migrator.DropColumn(&tables.TableKey{}, "vllm_model_name"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "vllm_model_name"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -5767,24 +5567,14 @@ func migrationAddBedrockAssumeRoleColumns(ctx context.Context, db *gorm.DB, logg
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableKey{}, "bedrock_role_arn") {
-				logger.Info("[configstore] %s: dropping column bedrock_role_arn from TableKey", migrationName)
-				if err := mg.DropColumn(&tables.TableKey{}, "bedrock_role_arn"); err != nil {
-					return fmt.Errorf("failed to drop bedrock_role_arn column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "bedrock_role_arn"); err != nil {
+				return fmt.Errorf("failed to drop bedrock_role_arn column: %w", err)
 			}
-			if mg.HasColumn(&tables.TableKey{}, "bedrock_external_id") {
-				logger.Info("[configstore] %s: dropping column bedrock_external_id from TableKey", migrationName)
-				if err := mg.DropColumn(&tables.TableKey{}, "bedrock_external_id"); err != nil {
-					return fmt.Errorf("failed to drop bedrock_external_id column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "bedrock_external_id"); err != nil {
+				return fmt.Errorf("failed to drop bedrock_external_id column: %w", err)
 			}
-			if mg.HasColumn(&tables.TableKey{}, "bedrock_role_session_name") {
-				logger.Info("[configstore] %s: dropping column bedrock_role_session_name from TableKey", migrationName)
-				if err := mg.DropColumn(&tables.TableKey{}, "bedrock_role_session_name"); err != nil {
-					return fmt.Errorf("failed to drop bedrock_role_session_name column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "bedrock_role_session_name"); err != nil {
+				return fmt.Errorf("failed to drop bedrock_role_session_name column: %w", err)
 			}
 			return nil
 		},
@@ -5874,12 +5664,8 @@ func migrationAddAllowAllKeysToProviderConfig(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migratorInstance := tx.Migrator()
-			if migratorInstance.HasColumn(&tables.TableVirtualKeyProviderConfig{}, "allow_all_keys") {
-				logger.Info("[configstore] %s: dropping column allow_all_keys from TableVirtualKeyProviderConfig", migrationName)
-				if err := migratorInstance.DropColumn(&tables.TableVirtualKeyProviderConfig{}, "allow_all_keys"); err != nil {
-					return fmt.Errorf("failed to drop allow_all_keys column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableVirtualKeyProviderConfig{}, "allow_all_keys"); err != nil {
+				return fmt.Errorf("failed to drop allow_all_keys column: %w", err)
 			}
 			return nil
 		},
@@ -5907,9 +5693,7 @@ func migrationAddMCPDisableAutoToolInjectColumn(ctx context.Context, db *gorm.DB
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migratorInstance := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column mcp_disable_auto_tool_inject from TableClientConfig", migrationName)
-			if err := migratorInstance.DropColumn(&tables.TableClientConfig{}, "mcp_disable_auto_tool_inject"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "mcp_disable_auto_tool_inject"); err != nil {
 				return err
 			}
 			return nil
@@ -5937,9 +5721,7 @@ func migrationAddMCPEnableTempTokenAuthColumn(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migratorInstance := tx.Migrator()
-			logger.Info("[configstore] %s: dropping column mcp_enable_temp_token_auth from TableClientConfig", migrationName)
-			if err := migratorInstance.DropColumn(&tables.TableClientConfig{}, "mcp_enable_temp_token_auth"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "mcp_enable_temp_token_auth"); err != nil {
 				return err
 			}
 			return nil
@@ -5999,7 +5781,6 @@ func migrationAddPricingRefactorColumns(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 
 			columns := []string{
 				"input_cost_per_token_priority",
@@ -6031,11 +5812,8 @@ func migrationAddPricingRefactorColumns(ctx context.Context, db *gorm.DB, logger
 			}
 
 			for _, field := range columns {
-				if mg.HasColumn(&tables.TableModelPricing{}, field) {
-					logger.Info("[configstore] %s: dropping column %s from TableModelPricing", migrationName, field)
-					if err := mg.DropColumn(&tables.TableModelPricing{}, field); err != nil {
-						return fmt.Errorf("failed to drop column %s: %w", field, err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
 				}
 			}
 			return nil
@@ -6118,7 +5896,6 @@ func migrationAddImageQualityPricingColumns(ctx context.Context, db *gorm.DB, lo
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 			columns := []string{
 				"output_cost_per_image_above_2048_and_2048_pixels",
 				"output_cost_per_image_above_4096_and_4096_pixels",
@@ -6128,11 +5905,8 @@ func migrationAddImageQualityPricingColumns(ctx context.Context, db *gorm.DB, lo
 				"output_cost_per_image_auto_quality",
 			}
 			for _, field := range columns {
-				if mg.HasColumn(&tables.TableModelPricing{}, field) {
-					logger.Info("[configstore] %s: dropping column %s from TableModelPricing", migrationName, field)
-					if err := mg.DropColumn(&tables.TableModelPricing{}, field); err != nil {
-						return fmt.Errorf("failed to drop column %s: %w", field, err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
 				}
 			}
 			return nil
@@ -6203,11 +5977,8 @@ func migrationAddRoutingTargetsTable(ctx context.Context, db *gorm.DB, logger sc
 			// routing_targets table (nothing to delete yet).
 			legacyModel := &legacyRoutingRuleColumns{}
 			for _, col := range []string{"provider", "model"} {
-				if mg.HasColumn("routing_rules", col) {
-					logger.Info("[configstore] %s: dropping column %s from %T", migrationName, col, legacyModel)
-					if err := mg.DropColumn(legacyModel, col); err != nil {
-						return fmt.Errorf("failed to drop column %s from routing_rules: %w", col, err)
-					}
+				if err := dropColumnIfExists(tx, logger, legacyModel, col); err != nil {
+					return fmt.Errorf("failed to drop column %s from routing_rules: %w", col, err)
 				}
 			}
 
@@ -6432,19 +6203,12 @@ func migrationAddPromptRepoTables(ctx context.Context, db *gorm.DB, logger schem
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TablePromptVersionMessage{}, "prompt_id") {
-				logger.Info("[configstore] %s: dropping column prompt_id from TablePromptVersionMessage", migrationName)
-				if err := migrator.DropColumn(&tables.TablePromptVersionMessage{}, "prompt_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TablePromptVersionMessage{}, "prompt_id"); err != nil {
+				return err
 			}
-			if migrator.HasColumn(&tables.TablePromptSessionMessage{}, "prompt_id") {
-				logger.Info("[configstore] %s: dropping column prompt_id from TablePromptSessionMessage", migrationName)
-				if err := migrator.DropColumn(&tables.TablePromptSessionMessage{}, "prompt_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TablePromptSessionMessage{}, "prompt_id"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -6611,12 +6375,8 @@ func migrationAddMCPClientAllowedExtraHeadersJSONColumn(ctx context.Context, db 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableMCPClient{}, "allowed_extra_headers_json") {
-				logger.Info("[configstore] %s: dropping column allowed_extra_headers_json from TableMCPClient", migrationName)
-				if err := migrator.DropColumn(&tables.TableMCPClient{}, "allowed_extra_headers_json"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "allowed_extra_headers_json"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -6712,19 +6472,12 @@ func migrationAddPluginOrderColumns(ctx context.Context, db *gorm.DB, logger sch
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TablePlugin{}, "placement") {
-				logger.Info("[configstore] %s: dropping column placement from TablePlugin", migrationName)
-				if err := migrator.DropColumn(&tables.TablePlugin{}, "placement"); err != nil {
-					return fmt.Errorf("failed to drop placement column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TablePlugin{}, "placement"); err != nil {
+				return fmt.Errorf("failed to drop placement column: %w", err)
 			}
-			if migrator.HasColumn(&tables.TablePlugin{}, "exec_order") {
-				logger.Info("[configstore] %s: dropping column exec_order from TablePlugin", migrationName)
-				if err := migrator.DropColumn(&tables.TablePlugin{}, "exec_order"); err != nil {
-					return fmt.Errorf("failed to drop exec_order column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TablePlugin{}, "exec_order"); err != nil {
+				return fmt.Errorf("failed to drop exec_order column: %w", err)
 			}
 			return nil
 		},
@@ -6782,12 +6535,8 @@ func migrationAddAllowOnAllVirtualKeysColumn(ctx context.Context, db *gorm.DB, l
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableMCPClient{}, "allow_on_all_virtual_keys") {
-				logger.Info("[configstore] %s: dropping column allow_on_all_virtual_keys from TableMCPClient", migrationName)
-				if err := migrator.DropColumn(&tables.TableMCPClient{}, "allow_on_all_virtual_keys"); err != nil {
-					return fmt.Errorf("failed to drop allow_on_all_virtual_keys column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "allow_on_all_virtual_keys"); err != nil {
+				return fmt.Errorf("failed to drop allow_on_all_virtual_keys column: %w", err)
 			}
 			return nil
 		},
@@ -6814,12 +6563,8 @@ func migrationAddOpenAIConfigJSONColumn(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableProvider{}, "open_ai_config_json") {
-				logger.Info("[configstore] %s: dropping column open_ai_config_json from TableProvider", migrationName)
-				if err := migrator.DropColumn(&tables.TableProvider{}, "open_ai_config_json"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableProvider{}, "open_ai_config_json"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -6852,18 +6597,11 @@ func migrationAddPromptVariablesColumns(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TablePromptSession{}, "variables_json") {
-				logger.Info("[configstore] %s: dropping column variables_json from TablePromptSession", migrationName)
-				if err := migrator.DropColumn(&tables.TablePromptSession{}, "variables_json"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TablePromptSession{}, "variables_json"); err != nil {
+				return err
 			}
-			if migrator.HasColumn(&tables.TablePromptVersion{}, "variables_json") {
-				logger.Info("[configstore] %s: dropping column variables_json from TablePromptVersion", migrationName)
-				if err := migrator.DropColumn(&tables.TablePromptVersion{}, "variables_json"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TablePromptVersion{}, "variables_json"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -6894,12 +6632,8 @@ func migrationAddKeyBlacklistedModelsJSONColumn(ctx context.Context, db *gorm.DB
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableKey{}, "blacklisted_models_json") {
-				logger.Info("[configstore] %s: dropping column blacklisted_models_json from TableKey", migrationName)
-				if err := mg.DropColumn(&tables.TableKey{}, "blacklisted_models_json"); err != nil {
-					return fmt.Errorf("failed to drop blacklisted_models_json column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "blacklisted_models_json"); err != nil {
+				return fmt.Errorf("failed to drop blacklisted_models_json column: %w", err)
 			}
 			return nil
 		},
@@ -6947,12 +6681,8 @@ func migrationAddChainRuleColumnToRoutingRules(ctx context.Context, db *gorm.DB,
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableRoutingRule{}, "chain_rule") {
-				logger.Info("[configstore] %s: dropping column chain_rule from TableRoutingRule", migrationName)
-				if err := mg.DropColumn(&tables.TableRoutingRule{}, "chain_rule"); err != nil {
-					return fmt.Errorf("failed to drop chain_rule column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableRoutingRule{}, "chain_rule"); err != nil {
+				return fmt.Errorf("failed to drop chain_rule column: %w", err)
 			}
 			return nil
 		},
@@ -7028,12 +6758,8 @@ func migrationAddReplicateKeyConfigColumn(ctx context.Context, db *gorm.DB, logg
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableKey{}, "replicate_use_deployments_endpoint") {
-				logger.Info("[configstore] %s: dropping column replicate_use_deployments_endpoint from TableKey", migrationName)
-				if err := mg.DropColumn(&tables.TableKey{}, "replicate_use_deployments_endpoint"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "replicate_use_deployments_endpoint"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -7132,12 +6858,8 @@ func migrationAddRoutingChainMaxDepthColumn(ctx context.Context, db *gorm.DB, lo
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableClientConfig{}, "routing_chain_max_depth") {
-				logger.Info("[configstore] %s: dropping column routing_chain_max_depth from TableClientConfig", migrationName)
-				if err := mg.DropColumn(&tables.TableClientConfig{}, "routing_chain_max_depth"); err != nil {
-					return fmt.Errorf("failed to drop routing_chain_max_depth column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "routing_chain_max_depth"); err != nil {
+				return fmt.Errorf("failed to drop routing_chain_max_depth column: %w", err)
 			}
 			return nil
 		},
@@ -7172,7 +6894,6 @@ func migrationAddModelCapabilityColumns(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 			columns := []string{
 				"context_length",
 				"max_input_tokens",
@@ -7180,11 +6901,8 @@ func migrationAddModelCapabilityColumns(ctx context.Context, db *gorm.DB, logger
 				"architecture",
 			}
 			for _, column := range columns {
-				if mg.HasColumn(&tables.TableModelPricing{}, column) {
-					logger.Info("[configstore] %s: dropping column %s from TableModelPricing", migrationName, column)
-					if err := mg.DropColumn(&tables.TableModelPricing{}, column); err != nil {
-						return fmt.Errorf("failed to drop %s column: %w", column, err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, column); err != nil {
+					return fmt.Errorf("failed to drop %s column: %w", column, err)
 				}
 			}
 			return nil
@@ -7269,18 +6987,11 @@ func migrationAddOllamaSGLConfigColumns(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableKey{}, "ollama_url") {
-				logger.Info("[configstore] %s: dropping column ollama_url from TableKey", migrationName)
-				if err := migrator.DropColumn(&tables.TableKey{}, "ollama_url"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "ollama_url"); err != nil {
+				return err
 			}
-			if migrator.HasColumn(&tables.TableKey{}, "sgl_url") {
-				logger.Info("[configstore] %s: dropping column sgl_url from TableKey", migrationName)
-				if err := migrator.DropColumn(&tables.TableKey{}, "sgl_url"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "sgl_url"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -7407,18 +7118,11 @@ func migrationAddMultiBudgetTables(ctx context.Context, db *gorm.DB, logger sche
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableBudget{}, "virtual_key_id") {
-				logger.Info("[configstore] %s: dropping column virtual_key_id from TableBudget", migrationName)
-				if err := mg.DropColumn(&tables.TableBudget{}, "virtual_key_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableBudget{}, "VirtualKeyID"); err != nil {
+				return fmt.Errorf("failed to drop virtual_key_id column from governance_budgets: %w", err)
 			}
-			if mg.HasColumn(&tables.TableBudget{}, "provider_config_id") {
-				logger.Info("[configstore] %s: dropping column provider_config_id from TableBudget", migrationName)
-				if err := mg.DropColumn(&tables.TableBudget{}, "provider_config_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableBudget{}, "ProviderConfigID"); err != nil {
+				return fmt.Errorf("failed to drop provider_config_id column from governance_budgets: %w", err)
 			}
 			return nil
 		},
@@ -7558,12 +7262,8 @@ func migrationAddTeamBudgetsToBudgetsTable(ctx context.Context, db *gorm.DB, log
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableBudget{}, "team_id") {
-				logger.Info("[configstore] %s: dropping column team_id from TableBudget", migrationName)
-				if err := mg.DropColumn(&tables.TableBudget{}, "team_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableBudget{}, "TeamID"); err != nil {
+				return fmt.Errorf("failed to drop team_id column from governance_budgets: %w", err)
 			}
 			return nil
 		},
@@ -7789,13 +7489,9 @@ func migrationAddAllowPerRequestContentStorageOverrideColumn(ctx context.Context
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TableClientConfig{}, "allow_per_request_content_storage_override") {
-				logger.Info("[configstore] %s: dropping column allow_per_request_content_storage_override from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "allow_per_request_content_storage_override"); err != nil {
-					return fmt.Errorf("failed to drop allow_per_request_content_storage_override column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "allow_per_request_content_storage_override"); err != nil {
+				return fmt.Errorf("failed to drop allow_per_request_content_storage_override column: %w", err)
 			}
 
 			return nil
@@ -7825,13 +7521,9 @@ func migrationAddAllowPerRequestRawOverrideColumn(ctx context.Context, db *gorm.
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TableClientConfig{}, "allow_per_request_raw_override") {
-				logger.Info("[configstore] %s: dropping column allow_per_request_raw_override from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "allow_per_request_raw_override"); err != nil {
-					return fmt.Errorf("failed to drop allow_per_request_raw_override column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "allow_per_request_raw_override"); err != nil {
+				return fmt.Errorf("failed to drop allow_per_request_raw_override column: %w", err)
 			}
 
 			return nil
@@ -7862,18 +7554,11 @@ func migrationAddMCPClientDiscoveredToolsColumns(ctx context.Context, db *gorm.D
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&tables.TableMCPClient{}, "discovered_tools_json") {
-				logger.Info("[configstore] %s: dropping column discovered_tools_json from TableMCPClient", migrationName)
-				if err := migrator.DropColumn(&tables.TableMCPClient{}, "discovered_tools_json"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "discovered_tools_json"); err != nil {
+				return err
 			}
-			if migrator.HasColumn(&tables.TableMCPClient{}, "tool_name_mapping_json") {
-				logger.Info("[configstore] %s: dropping column tool_name_mapping_json from TableMCPClient", migrationName)
-				if err := migrator.DropColumn(&tables.TableMCPClient{}, "tool_name_mapping_json"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "tool_name_mapping_json"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -7916,7 +7601,6 @@ func migrationAddPriorityTierPricingColumns(ctx context.Context, db *gorm.DB, lo
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 			columns := []string{
 				"input_cost_per_token_above_272k_tokens",
 				"input_cost_per_token_above_272k_tokens_priority",
@@ -7930,11 +7614,8 @@ func migrationAddPriorityTierPricingColumns(ctx context.Context, db *gorm.DB, lo
 			}
 
 			for _, field := range columns {
-				if mg.HasColumn(&tables.TableModelPricing{}, field) {
-					logger.Info("[configstore] %s: dropping column %s from TableModelPricing", migrationName, field)
-					if err := mg.DropColumn(&tables.TableModelPricing{}, field); err != nil {
-						return fmt.Errorf("failed to drop column %s: %w", field, err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
 				}
 			}
 			return nil
@@ -7971,7 +7652,6 @@ func migrationAddFlexTierPricingColumns(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 
 			columns := []string{
 				"input_cost_per_token_flex",
@@ -7980,11 +7660,8 @@ func migrationAddFlexTierPricingColumns(ctx context.Context, db *gorm.DB, logger
 			}
 
 			for _, field := range columns {
-				if mg.HasColumn(&tables.TableModelPricing{}, field) {
-					logger.Info("[configstore] %s: dropping column %s from TableModelPricing", migrationName, field)
-					if err := mg.DropColumn(&tables.TableModelPricing{}, field); err != nil {
-						return fmt.Errorf("failed to drop column %s: %w", field, err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
 				}
 			}
 			return nil
@@ -8022,7 +7699,6 @@ func migrationAddFastModePricingColumns(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 
 			columns := []string{
 				"input_cost_per_token_fast",
@@ -8030,11 +7706,8 @@ func migrationAddFastModePricingColumns(ctx context.Context, db *gorm.DB, logger
 			}
 
 			for _, field := range columns {
-				if mg.HasColumn(&tables.TableModelPricing{}, field) {
-					logger.Info("[configstore] %s: dropping column %s from TableModelPricing", migrationName, field)
-					if err := mg.DropColumn(&tables.TableModelPricing{}, field); err != nil {
-						return fmt.Errorf("failed to drop column %s: %w", field, err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
 				}
 			}
 			return nil
@@ -8064,13 +7737,9 @@ func migrationAddWhitelistedRoutesJSONColumn(ctx context.Context, db *gorm.DB, l
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
-			if migrator.HasColumn(&tables.TableClientConfig{}, "whitelisted_routes_json") {
-				logger.Info("[configstore] %s: dropping column whitelisted_routes_json from TableClientConfig", migrationName)
-				if err := migrator.DropColumn(&tables.TableClientConfig{}, "whitelisted_routes_json"); err != nil {
-					return fmt.Errorf("failed to drop whitelisted_routes_json column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "whitelisted_routes_json"); err != nil {
+				return fmt.Errorf("failed to drop whitelisted_routes_json column: %w", err)
 			}
 
 			return nil
@@ -8118,8 +7787,7 @@ func migrationReplaceEnableLiteLLMWithCompatColumns(ctx context.Context, db *gor
 				if err := tx.Exec("UPDATE config_client SET compat_convert_text_to_chat = enable_litellm_fallbacks").Error; err != nil {
 					return err
 				}
-				logger.Info("[configstore] %s: dropping column enable_litellm_fallbacks from TableClientConfig", migrationName)
-				if err := mig.DropColumn(&tables.TableClientConfig{}, "enable_litellm_fallbacks"); err != nil {
+				if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "enable_litellm_fallbacks"); err != nil {
 					return err
 				}
 			}
@@ -8145,11 +7813,8 @@ func migrationReplaceEnableLiteLLMWithCompatColumns(ctx context.Context, db *gor
 				"compat_should_drop_params",
 				"compat_should_convert_params",
 			} {
-				if mig.HasColumn(&tables.TableClientConfig{}, col) {
-					logger.Info("[configstore] %s: dropping column %s from TableClientConfig", migrationName, col)
-					if err := mig.DropColumn(&tables.TableClientConfig{}, col); err != nil {
-						return err
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, col); err != nil {
+					return err
 				}
 			}
 			return nil
@@ -8403,17 +8068,13 @@ func migrationAddOCRPricingColumns(ctx context.Context, db *gorm.DB, logger sche
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 			columns := []string{
 				"ocr_cost_per_page",
 				"annotation_cost_per_page",
 			}
 			for _, field := range columns {
-				if mg.HasColumn(&tables.TableModelPricing{}, field) {
-					logger.Info("[configstore] %s: dropping column %s from TableModelPricing", migrationName, field)
-					if err := mg.DropColumn(&tables.TableModelPricing{}, field); err != nil {
-						return fmt.Errorf("failed to drop column %s: %w", field, err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
 				}
 			}
 			return nil
@@ -8512,16 +8173,12 @@ func migrationSplitMCPExternalBaseURL(ctx context.Context, db *gorm.DB, logger s
 				).Error; err != nil {
 					return fmt.Errorf("failed to backfill mcp_external_base_url from mcp_external_server_url: %w", err)
 				}
-				logger.Info("[configstore] %s: dropping column mcp_external_server_url from TableClientConfig", migrationName)
-				if err := mg.DropColumn(&tables.TableClientConfig{}, "mcp_external_server_url"); err != nil {
+				if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "mcp_external_server_url"); err != nil {
 					return fmt.Errorf("failed to drop mcp_external_server_url column: %w", err)
 				}
 			}
-			if mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_client_url") {
-				logger.Info("[configstore] %s: dropping column mcp_external_client_url from TableClientConfig", migrationName)
-				if err := mg.DropColumn(&tables.TableClientConfig{}, "mcp_external_client_url"); err != nil {
-					return fmt.Errorf("failed to drop mcp_external_client_url column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "mcp_external_client_url"); err != nil {
+				return fmt.Errorf("failed to drop mcp_external_client_url column: %w", err)
 			}
 			return nil
 		},
@@ -8555,12 +8212,8 @@ func migrationAddMCPClientDisabledColumn(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableMCPClient{}, "disabled") {
-				logger.Info("[configstore] %s: dropping column disabled from TableMCPClient", migrationName)
-				if err := mg.DropColumn(&tables.TableMCPClient{}, "disabled"); err != nil {
-					return fmt.Errorf("failed to drop disabled column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "disabled"); err != nil {
+				return fmt.Errorf("failed to drop disabled column: %w", err)
 			}
 			return nil
 		},
@@ -8888,18 +8541,17 @@ func migrationAddOAuthAuthModeColumns(ctx context.Context, db *gorm.DB, logger s
 				if err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_user_mcp ON oauth_user_tokens (user_id, mcp_client_id)`).Error; err != nil {
 					return fmt.Errorf("restore idx_user_mcp: %w", err)
 				}
-				if mg.HasColumn(&tables.TableOauthUserToken{}, "status") {
-					logger.Info("[configstore] %s: dropping column Status from TableOauthUserToken", migrationName)
-					_ = mg.DropColumn(&tables.TableOauthUserToken{}, "Status")
+				if err := dropColumnIfExists(tx, logger, &tables.TableOauthUserToken{}, "Status"); err != nil {
+					return fmt.Errorf("drop status from oauth_user_tokens: %w", err)
 				}
-				if mg.HasColumn(&tables.TableOauthUserToken{}, "auth_mode") {
-					logger.Info("[configstore] %s: dropping column AuthMode from TableOauthUserToken", migrationName)
-					_ = mg.DropColumn(&tables.TableOauthUserToken{}, "AuthMode")
+				if err := dropColumnIfExists(tx, logger, &tables.TableOauthUserToken{}, "AuthMode"); err != nil {
+					return fmt.Errorf("drop auth_mode from oauth_user_tokens: %w", err)
 				}
 			}
 			if mg.HasTable(&tables.TableOauthUserSession{}) && mg.HasColumn(&tables.TableOauthUserSession{}, "flow_mode") {
-				logger.Info("[configstore] %s: dropping column FlowMode from TableOauthUserSession", migrationName)
-				_ = mg.DropColumn(&tables.TableOauthUserSession{}, "FlowMode")
+				if err := dropColumnIfExists(tx, logger, &tables.TableOauthUserSession{}, "FlowMode"); err != nil {
+					return fmt.Errorf("drop flow_mode from oauth_user_sessions: %w", err)
+				}
 			}
 
 			return nil
@@ -8946,17 +8598,11 @@ func migrationReplaceOauthSessionTokenWithSessionID(ctx context.Context, db *gor
 				if err := tx.Exec("DROP INDEX IF EXISTS idx_oauth_user_sessions_session_token_hash").Error; err != nil {
 					return fmt.Errorf("drop legacy session_token_hash index on oauth_user_sessions: %w", err)
 				}
-				if mg.HasColumn(&tables.TableOauthUserSession{}, "session_token_hash") {
-					logger.Info("[configstore] %s: dropping column session_token_hash from TableOauthUserSession", migrationName)
-					if err := mg.DropColumn(&tables.TableOauthUserSession{}, "session_token_hash"); err != nil {
-						return fmt.Errorf("drop session_token_hash from oauth_user_sessions: %w", err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableOauthUserSession{}, "session_token_hash"); err != nil {
+					return fmt.Errorf("drop session_token_hash from oauth_user_sessions: %w", err)
 				}
-				if mg.HasColumn(&tables.TableOauthUserSession{}, "session_token") {
-					logger.Info("[configstore] %s: dropping column session_token from TableOauthUserSession", migrationName)
-					if err := mg.DropColumn(&tables.TableOauthUserSession{}, "session_token"); err != nil {
-						return fmt.Errorf("drop session_token from oauth_user_sessions: %w", err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableOauthUserSession{}, "session_token"); err != nil {
+					return fmt.Errorf("drop session_token from oauth_user_sessions: %w", err)
 				}
 			}
 
@@ -8973,17 +8619,11 @@ func migrationReplaceOauthSessionTokenWithSessionID(ctx context.Context, db *gor
 				if err := tx.Exec("DROP INDEX IF EXISTS idx_oauth_user_tokens_session_token_hash").Error; err != nil {
 					return fmt.Errorf("drop legacy session_token_hash index on oauth_user_tokens: %w", err)
 				}
-				if mg.HasColumn(&tables.TableOauthUserToken{}, "session_token_hash") {
-					logger.Info("[configstore] %s: dropping column session_token_hash from TableOauthUserToken", migrationName)
-					if err := mg.DropColumn(&tables.TableOauthUserToken{}, "session_token_hash"); err != nil {
-						return fmt.Errorf("drop session_token_hash from oauth_user_tokens: %w", err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableOauthUserToken{}, "session_token_hash"); err != nil {
+					return fmt.Errorf("drop session_token_hash from oauth_user_tokens: %w", err)
 				}
-				if mg.HasColumn(&tables.TableOauthUserToken{}, "session_token") {
-					logger.Info("[configstore] %s: dropping column session_token from TableOauthUserToken", migrationName)
-					if err := mg.DropColumn(&tables.TableOauthUserToken{}, "session_token"); err != nil {
-						return fmt.Errorf("drop session_token from oauth_user_tokens: %w", err)
-					}
+				if err := dropColumnIfExists(tx, logger, &tables.TableOauthUserToken{}, "session_token"); err != nil {
+					return fmt.Errorf("drop session_token from oauth_user_tokens: %w", err)
 				}
 
 				// Replace the partial unique index with one keyed on the new
@@ -9027,8 +8667,9 @@ func migrationReplaceOauthSessionTokenWithSessionID(ctx context.Context, db *gor
 			}
 			for _, model := range []interface{}{&tables.TableOauthUserSession{}, &tables.TableOauthUserToken{}} {
 				if mg.HasTable(model) && mg.HasColumn(model, "session_id") {
-					logger.Info("[configstore] %s: dropping column SessionID from %T", migrationName, model)
-					_ = mg.DropColumn(model, "SessionID")
+					if err := dropColumnIfExists(tx, logger, model, "SessionID"); err != nil {
+						return fmt.Errorf("drop session_id from %T: %w", model, err)
+					}
 				}
 			}
 
@@ -9371,12 +9012,7 @@ func migrationAddTeamCalendarAlignedColumn(ctx context.Context, db *gorm.DB, log
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&tables.TableTeam{}, "calendar_aligned") {
-				logger.Info("[configstore] %s: dropping column calendar_aligned from TableTeam", migrationName)
-				return mig.DropColumn(&tables.TableTeam{}, "calendar_aligned")
-			}
-			return nil
+			return dropColumnIfExists(tx, logger, &tables.TableTeam{}, "calendar_aligned")
 		},
 	}})
 	if err := m.Migrate(); err != nil {
@@ -9401,12 +9037,7 @@ func migrationAddModelParametersURLColumn(ctx context.Context, db *gorm.DB, logg
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&tables.TableFrameworkConfig{}, "model_parameters_url") {
-				logger.Info("[configstore] %s: dropping column model_parameters_url from TableFrameworkConfig", migrationName)
-				return mig.DropColumn(&tables.TableFrameworkConfig{}, "model_parameters_url")
-			}
-			return nil
+			return dropColumnIfExists(tx, logger, &tables.TableFrameworkConfig{}, "model_parameters_url")
 		},
 	}})
 	if err := m.Migrate(); err != nil {
@@ -9432,12 +9063,7 @@ func migrationAddFrameworkConfigHashColumn(ctx context.Context, db *gorm.DB, log
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&tables.TableFrameworkConfig{}, "config_hash") {
-				logger.Info("[configstore] %s: dropping column config_hash from TableFrameworkConfig", migrationName)
-				return mig.DropColumn(&tables.TableFrameworkConfig{}, "config_hash")
-			}
-			return nil
+			return dropColumnIfExists(tx, logger, &tables.TableFrameworkConfig{}, "config_hash")
 		},
 	}})
 	if err := m.Migrate(); err != nil {
@@ -9612,12 +9238,8 @@ func migrationDropVKAccessProfileIDColumn(ctx context.Context, db *gorm.DB, logg
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models") {
-				logger.Info("[configstore] %s: dropping column blacklisted_models from TableVirtualKeyProviderConfig", migrationName)
-				if err := mg.DropColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models"); err != nil {
-					return fmt.Errorf("failed to drop blacklisted_models column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableVirtualKeyProviderConfig{}, "blacklisted_models"); err != nil {
+				return fmt.Errorf("failed to drop blacklisted_models column: %w", err)
 			}
 			return nil
 		},
@@ -9718,11 +9340,8 @@ func migrationAddPerUserHeadersTables(ctx context.Context, db *gorm.DB, logger s
 					return fmt.Errorf("drop mcp_per_user_header_credentials: %w", err)
 				}
 			}
-			if mg.HasColumn(&tables.TableMCPClient{}, "per_user_header_keys_json") {
-				logger.Info("[configstore] %s: dropping column PerUserHeaderKeysJSON from TableMCPClient", migrationName)
-				if err := mg.DropColumn(&tables.TableMCPClient{}, "PerUserHeaderKeysJSON"); err != nil {
-					return fmt.Errorf("drop per_user_header_keys_json column from config_mcp_clients: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "PerUserHeaderKeysJSON"); err != nil {
+				return fmt.Errorf("drop per_user_header_keys_json column from config_mcp_clients: %w", err)
 			}
 			return nil
 		},
@@ -9860,11 +9479,8 @@ func migrationReAddAllowDirectKeysColumn(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			if tx.Migrator().HasColumn(&tables.TableClientConfig{}, "allow_direct_keys") {
-				logger.Info("[configstore] %s: dropping column allow_direct_keys from TableClientConfig", migrationName)
-				if err := tx.Migrator().DropColumn(&tables.TableClientConfig{}, "allow_direct_keys"); err != nil {
-					return fmt.Errorf("failed to drop allow_direct_keys column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableClientConfig{}, "allow_direct_keys"); err != nil {
+				return fmt.Errorf("failed to drop allow_direct_keys column: %w", err)
 			}
 			return nil
 		},
@@ -9927,11 +9543,8 @@ func migrationAddAdditionalAttributesToPricing(ctx context.Context, db *gorm.DB,
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			if tx.Migrator().HasColumn(&tables.TableModelPricing{}, "additional_attributes") {
-				logger.Info("[configstore] %s: dropping column AdditionalAttributesJSON from TableModelPricing", migrationName)
-				if err := tx.Migrator().DropColumn(&tables.TableModelPricing{}, "AdditionalAttributesJSON"); err != nil {
-					return fmt.Errorf("failed to drop additional_attributes column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "AdditionalAttributesJSON"); err != nil {
+				return fmt.Errorf("failed to drop additional_attributes column: %w", err)
 			}
 			return nil
 		},
@@ -9962,12 +9575,7 @@ func migrationAddCustomerCalendarAlignedColumn(ctx context.Context, db *gorm.DB,
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&tables.TableCustomer{}, "calendar_aligned") {
-				logger.Info("[configstore] %s: dropping column calendar_aligned from TableCustomer", migrationName)
-				return mig.DropColumn(&tables.TableCustomer{}, "calendar_aligned")
-			}
-			return nil
+			return dropColumnIfExists(tx, logger, &tables.TableCustomer{}, "calendar_aligned")
 		},
 	}})
 	if err := m.Migrate(); err != nil {
@@ -10070,12 +9678,8 @@ func migrationAddCustomerBudgetsToBudgetsTable(ctx context.Context, db *gorm.DB,
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableBudget{}, "customer_id") {
-				logger.Info("[configstore] %s: dropping column customer_id from TableBudget", migrationName)
-				if err := mg.DropColumn(&tables.TableBudget{}, "customer_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableBudget{}, "CustomerID"); err != nil {
+				return fmt.Errorf("failed to drop customer_id column from governance_budgets: %w", err)
 			}
 			return nil
 		},
@@ -10281,18 +9885,11 @@ func migrationAddMCPLibraryConfigColumns(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if mg.HasColumn(&tables.TableFrameworkConfig{}, "mcp_library_url") {
-				logger.Info("[configstore] %s: dropping column MCPLibraryURL from TableFrameworkConfig", migrationName)
-				if err := mg.DropColumn(&tables.TableFrameworkConfig{}, "MCPLibraryURL"); err != nil {
-					return fmt.Errorf("drop mcp_library_url column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableFrameworkConfig{}, "MCPLibraryURL"); err != nil {
+				return fmt.Errorf("drop mcp_library_url column: %w", err)
 			}
-			if mg.HasColumn(&tables.TableFrameworkConfig{}, "mcp_library_sync_interval") {
-				logger.Info("[configstore] %s: dropping column MCPLibrarySyncInterval from TableFrameworkConfig", migrationName)
-				if err := mg.DropColumn(&tables.TableFrameworkConfig{}, "MCPLibrarySyncInterval"); err != nil {
-					return fmt.Errorf("drop mcp_library_sync_interval column: %w", err)
-				}
+			if err := dropColumnIfExists(tx, logger, &tables.TableFrameworkConfig{}, "MCPLibrarySyncInterval"); err != nil {
+				return fmt.Errorf("drop mcp_library_sync_interval column: %w", err)
 			}
 			return nil
 		},

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -25,6 +25,12 @@ func isValidJSON(s string) bool {
 // calling addColumnIfNotExists(tx, ...) directly.
 var addColumnIfNotExists = migrator.AddColumnIfNotExists
 
+// dropColumnIfExists is the drop counterpart to addColumnIfNotExists: a
+// package-local alias for migrator.DropColumnIfExists, the idempotent
+// column-drop helper shared with configstore. Declared at package scope for the
+// same reason as above so call sites can use dropColumnIfExists(tx, ...).
+var dropColumnIfExists = migrator.DropColumnIfExists
+
 const (
 	// migrationAdvisoryLockKey is used for PostgreSQL advisory locks
 	// to serialize migrations across cluster nodes.
@@ -478,9 +484,7 @@ func migrationAddParentRequestIDColumn(ctx context.Context, db *gorm.DB, logger 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[logstore] %s: dropping column parent_request_id from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "parent_request_id"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "parent_request_id"); err != nil {
 				return err
 			}
 			return nil
@@ -524,25 +528,19 @@ func migrationAddResponsesOutputColumn(ctx context.Context, db *gorm.DB, logger 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[logstore] %s: dropping column responses_output from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "responses_output"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "responses_output"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column input_history from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "input_history"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "input_history"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column output_message from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "output_message"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "output_message"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column embedding_output from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "embedding_output"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "embedding_output"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column raw_response from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "raw_response"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "raw_response"); err != nil {
 				return err
 			}
 			return nil
@@ -576,13 +574,10 @@ func migrationAddCostAndCacheDebugColumn(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[logstore] %s: dropping column cost from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "cost"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "cost"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column cache_debug from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "cache_debug"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "cache_debug"); err != nil {
 				return err
 			}
 			return nil
@@ -613,9 +608,7 @@ func migrationAddResponsesInputHistoryColumn(ctx context.Context, db *gorm.DB, l
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[logstore] %s: dropping column responses_input_history from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "responses_input_history"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "responses_input_history"); err != nil {
 				return err
 			}
 			return nil
@@ -662,29 +655,22 @@ func migrationAddNumberOfRetriesAndFallbackIndexAndSelectedKeyAndVirtualKeyColum
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			logger.Info("[logstore] %s: dropping column number_of_retries from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "number_of_retries"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "number_of_retries"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column fallback_index from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "fallback_index"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "fallback_index"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column selected_key_id from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "selected_key_id"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "selected_key_id"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column selected_key_name from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "selected_key_name"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "selected_key_name"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column virtual_key_id from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "virtual_key_id"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "virtual_key_id"); err != nil {
 				return err
 			}
-			logger.Info("[logstore] %s: dropping column virtual_key_name from Log", migrationName)
-			if err := migrator.DropColumn(&Log{}, "virtual_key_name"); err != nil {
+			if err := dropColumnIfExists(tx, logger, &Log{}, "virtual_key_name"); err != nil {
 				return err
 			}
 			return nil
@@ -989,12 +975,8 @@ func migrationAddRawRequestColumn(ctx context.Context, db *gorm.DB, logger schem
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "raw_request") {
-				logger.Info("[logstore] %s: dropping column raw_request from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "raw_request"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "raw_request"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1123,11 +1105,8 @@ func migrationAddCostColumnToMCPToolLogs(ctx context.Context, db *gorm.DB, logge
 			}
 
 			// Drop column
-			if migrator.HasColumn(&MCPToolLog{}, "cost") {
-				logger.Info("[logstore] %s: dropping column cost from MCPToolLog", migrationName)
-				if err := migrator.DropColumn(&MCPToolLog{}, "cost"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &MCPToolLog{}, "cost"); err != nil {
+				return err
 			}
 
 			return nil
@@ -1158,12 +1137,8 @@ func migrationAddImageGenerationOutputColumn(ctx context.Context, db *gorm.DB, l
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "image_generation_output") {
-				logger.Info("[logstore] %s: dropping column image_generation_output from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "image_generation_output"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "image_generation_output"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1193,12 +1168,8 @@ func migrationAddImageGenerationInputColumn(ctx context.Context, db *gorm.DB, lo
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "image_generation_input") {
-				logger.Info("[logstore] %s: dropping column image_generation_input from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "image_generation_input"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "image_generation_input"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1231,18 +1202,11 @@ func migrationAddRoutingRuleIDAndRoutingRuleNameColumns(ctx context.Context, db 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "routing_rule_id") {
-				logger.Info("[logstore] %s: dropping column routing_rule_id from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "routing_rule_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "routing_rule_id"); err != nil {
+				return err
 			}
-			if migrator.HasColumn(&Log{}, "routing_rule_name") {
-				logger.Info("[logstore] %s: dropping column routing_rule_name from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "routing_rule_name"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "routing_rule_name"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1300,19 +1264,13 @@ func migrationAddVirtualKeyColumnsToMCPToolLogs(ctx context.Context, db *gorm.DB
 			}
 
 			// Drop virtual_key_name column
-			if migrator.HasColumn(&MCPToolLog{}, "virtual_key_name") {
-				logger.Info("[logstore] %s: dropping column virtual_key_name from MCPToolLog", migrationName)
-				if err := migrator.DropColumn(&MCPToolLog{}, "virtual_key_name"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &MCPToolLog{}, "virtual_key_name"); err != nil {
+				return err
 			}
 
 			// Drop virtual_key_id column
-			if migrator.HasColumn(&MCPToolLog{}, "virtual_key_id") {
-				logger.Info("[logstore] %s: dropping column virtual_key_id from MCPToolLog", migrationName)
-				if err := migrator.DropColumn(&MCPToolLog{}, "virtual_key_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &MCPToolLog{}, "virtual_key_id"); err != nil {
+				return err
 			}
 
 			return nil
@@ -1348,12 +1306,8 @@ func migrationAddRoutingEngineUsedColumn(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "routing_engine_used") {
-				logger.Info("[logstore] %s: dropping column routing_engine_used from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "routing_engine_used"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "routing_engine_used"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1388,8 +1342,7 @@ func migrationAddRoutingEnginesUsedColumn(ctx context.Context, db *gorm.DB, logg
 				}
 			} else if hasOldColumn && hasNewColumn {
 				// Both columns exist - drop the old one (new column is already in use)
-				logger.Info("[logstore] %s: dropping column routing_engine_used from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "routing_engine_used"); err != nil {
+				if err := dropColumnIfExists(tx, logger, &Log{}, "routing_engine_used"); err != nil {
 					return fmt.Errorf("failed to drop old routing_engine_used column: %w", err)
 				}
 			}
@@ -1437,12 +1390,8 @@ func migrationAddListModelsOutputColumn(ctx context.Context, db *gorm.DB, logger
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "list_models_output") {
-				logger.Info("[logstore] %s: dropping column list_models_output from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "list_models_output"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "list_models_output"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1472,12 +1421,8 @@ func migrationAddRerankOutputColumn(ctx context.Context, db *gorm.DB, logger sch
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "rerank_output") {
-				logger.Info("[logstore] %s: dropping column rerank_output from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "rerank_output"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "rerank_output"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1507,12 +1452,8 @@ func migrationAddRoutingEngineLogsColumn(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "routing_engine_logs") {
-				logger.Info("[logstore] %s: dropping column routing_engine_logs from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "routing_engine_logs"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "routing_engine_logs"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1545,18 +1486,11 @@ func migrationAddLargePayloadColumns(ctx context.Context, db *gorm.DB, logger sc
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "is_large_payload_request") {
-				logger.Info("[logstore] %s: dropping column is_large_payload_request from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "is_large_payload_request"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "is_large_payload_request"); err != nil {
+				return err
 			}
-			if migrator.HasColumn(&Log{}, "is_large_payload_response") {
-				logger.Info("[logstore] %s: dropping column is_large_payload_response from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "is_large_payload_response"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "is_large_payload_response"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1640,12 +1574,8 @@ func migrationAddMetadataColumn(ctx context.Context, db *gorm.DB, logger schemas
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "metadata") {
-				logger.Info("[logstore] %s: dropping column metadata from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "metadata"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "metadata"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1675,12 +1605,8 @@ func migrationAddMetadataColumnToMCPToolLogs(ctx context.Context, db *gorm.DB, l
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&MCPToolLog{}, "metadata") {
-				logger.Info("[logstore] %s: dropping column metadata from MCPToolLog", migrationName)
-				if err := migrator.DropColumn(&MCPToolLog{}, "metadata"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &MCPToolLog{}, "metadata"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1749,11 +1675,8 @@ func migrationAddRequestIDColumnToMCPToolLogs(ctx context.Context, db *gorm.DB, 
 					return err
 				}
 			}
-			if migrator.HasColumn(&MCPToolLog{}, "request_id") {
-				logger.Info("[logstore] %s: dropping column request_id from MCPToolLog", migrationName)
-				if err := migrator.DropColumn(&MCPToolLog{}, "request_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &MCPToolLog{}, "request_id"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1877,7 +1800,6 @@ func migrationAddVideoColumns(ctx context.Context, db *gorm.DB, logger schemas.L
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
 
 			videoColumns := []string{
 				"video_generation_input",
@@ -1889,11 +1811,8 @@ func migrationAddVideoColumns(ctx context.Context, db *gorm.DB, logger schemas.L
 			}
 
 			for _, column := range videoColumns {
-				if migrator.HasColumn(&Log{}, column) {
-					logger.Info("[logstore] %s: dropping column %s from Log", migrationName, column)
-					if err := migrator.DropColumn(&Log{}, column); err != nil {
-						return err
-					}
+				if err := dropColumnIfExists(tx, logger, &Log{}, column); err != nil {
+					return err
 				}
 			}
 
@@ -1958,12 +1877,8 @@ func migrationAddPassthroughRequestBodyColumn(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "passthrough_request_body") {
-				logger.Info("[logstore] %s: dropping column passthrough_request_body from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "passthrough_request_body"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "passthrough_request_body"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -1993,12 +1908,8 @@ func migrationAddPassthroughResponseBodyColumn(ctx context.Context, db *gorm.DB,
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "passthrough_response_body") {
-				logger.Info("[logstore] %s: dropping column passthrough_response_body from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "passthrough_response_body"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "passthrough_response_body"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -2240,11 +2151,9 @@ func migrationAddDashboardEnhancements(ctx context.Context, db *gorm.DB, logger 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			dbMigrator := tx.Migrator()
 
-			if dbMigrator.HasColumn(&Log{}, "cached_read_tokens") {
-				logger.Info("[logstore] %s: dropping column cached_read_tokens from Log", migrationName)
-				_ = dbMigrator.DropColumn(&Log{}, "cached_read_tokens")
+			if err := dropColumnIfExists(tx, logger, &Log{}, "cached_read_tokens"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -2713,12 +2622,8 @@ func migrationAddImageEditInputColumn(ctx context.Context, db *gorm.DB, logger s
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "image_edit_input") {
-				logger.Info("[logstore] %s: dropping column image_edit_input from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "image_edit_input"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "image_edit_input"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -2748,12 +2653,8 @@ func migrationAddPluginLogsColumn(ctx context.Context, db *gorm.DB, logger schem
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "plugin_logs") {
-				logger.Info("[logstore] %s: dropping column plugin_logs from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "plugin_logs"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "plugin_logs"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -2787,12 +2688,8 @@ func migrationAddAliasColumn(ctx context.Context, db *gorm.DB, logger schemas.Lo
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&Log{}, "alias") {
-				logger.Info("[logstore] %s: dropping column alias from Log", migrationName)
-				if err := mig.DropColumn(&Log{}, "alias"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "alias"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -2828,12 +2725,9 @@ func migrationAddCanonicalModelColumns(ctx context.Context, db *gorm.DB, logger 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
 			for _, column := range []string{"canonical_model_name", "alias_model_family"} {
-				if mig.HasColumn(&Log{}, column) {
-					if err := mig.DropColumn(&Log{}, column); err != nil {
-						return err
-					}
+				if err := dropColumnIfExists(tx, logger, &Log{}, column); err != nil {
+					return err
 				}
 			}
 			return nil
@@ -2864,12 +2758,8 @@ func migrationAddHasObjectColumn(ctx context.Context, db *gorm.DB, logger schema
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mgr := tx.Migrator()
-			if mgr.HasColumn(&Log{}, "has_object") {
-				logger.Info("[logstore] %s: dropping column has_object from Log", migrationName)
-				if err := mgr.DropColumn(&Log{}, "has_object"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "has_object"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -2900,12 +2790,8 @@ func migrationAddHasObjectColumnToMCPToolLogs(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mgr := tx.Migrator()
-			if mgr.HasColumn(&MCPToolLog{}, "has_object") {
-				logger.Info("[logstore] %s: dropping column has_object from MCPToolLog", migrationName)
-				if err := mgr.DropColumn(&MCPToolLog{}, "has_object"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &MCPToolLog{}, "has_object"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -2935,12 +2821,8 @@ func migrationAddImageVariationInputColumn(ctx context.Context, db *gorm.DB, log
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "image_variation_input") {
-				logger.Info("[logstore] %s: dropping column image_variation_input from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "image_variation_input"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "image_variation_input"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -2971,12 +2853,8 @@ func migrationAddUserNameColumn(ctx context.Context, db *gorm.DB, logger schemas
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&Log{}, "user_name") {
-				logger.Info("[logstore] %s: dropping column user_name from Log", migrationName)
-				if err := mig.DropColumn(&Log{}, "user_name"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "user_name"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -3011,13 +2889,9 @@ func migrationAddGovernanceContextColumns(ctx context.Context, db *gorm.DB, logg
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
 			for _, col := range columns {
-				if mig.HasColumn(&Log{}, col) {
-					logger.Info("[logstore] %s: dropping column %s from Log", migrationName, col)
-					if err := mig.DropColumn(&Log{}, col); err != nil {
-						return err
-					}
+				if err := dropColumnIfExists(tx, logger, &Log{}, col); err != nil {
+					return err
 				}
 			}
 			return nil
@@ -3056,13 +2930,9 @@ func migrationAddMultiTeamBusinessUnitColumns(ctx context.Context, db *gorm.DB, 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
 			for _, col := range columns {
-				if mig.HasColumn(&Log{}, col) {
-					logger.Info("[logstore] %s: dropping column %s from Log", migrationName, col)
-					if err := mig.DropColumn(&Log{}, col); err != nil {
-						return err
-					}
+				if err := dropColumnIfExists(tx, logger, &Log{}, col); err != nil {
+					return err
 				}
 			}
 			return nil
@@ -3166,12 +3036,8 @@ func migrationAddOCROutputColumn(ctx context.Context, db *gorm.DB, logger schema
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "ocr_output") {
-				logger.Info("[logstore] %s: dropping column ocr_output from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "ocr_output"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "ocr_output"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -3203,12 +3069,8 @@ func migrationAddAttemptTrailColumn(ctx context.Context, db *gorm.DB, logger sch
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "attempt_trail") {
-				logger.Info("[logstore] %s: dropping column attempt_trail from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "attempt_trail"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "attempt_trail"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -3243,13 +3105,9 @@ func migrationAddSelectedPromptColumns(ctx context.Context, db *gorm.DB, logger 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
 			for _, col := range columns {
-				if mig.HasColumn(&Log{}, col) {
-					logger.Info("[logstore] %s: dropping column %s from Log", migrationName, col)
-					if err := mig.DropColumn(&Log{}, col); err != nil {
-						return err
-					}
+				if err := dropColumnIfExists(tx, logger, &Log{}, col); err != nil {
+					return err
 				}
 			}
 			return nil
@@ -3280,12 +3138,8 @@ func migrationAddOCRInputColumn(ctx context.Context, db *gorm.DB, logger schemas
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&Log{}, "ocr_input") {
-				logger.Info("[logstore] %s: dropping column ocr_input from Log", migrationName)
-				if err := mig.DropColumn(&Log{}, "ocr_input"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "ocr_input"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -3315,12 +3169,8 @@ func migrationAddStopReasonColumn(ctx context.Context, db *gorm.DB, logger schem
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
-			if mig.HasColumn(&Log{}, "stop_reason") {
-				logger.Info("[logstore] %s: dropping column stop_reason from Log", migrationName)
-				if err := mig.DropColumn(&Log{}, "stop_reason"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "stop_reason"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -3424,13 +3274,9 @@ func migrationAddDACColumnsToMCPToolLogs(ctx context.Context, db *gorm.DB, logge
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
 			for _, col := range []string{"business_unit_id", "customer_id", "team_id", "user_id"} {
-				if mg.HasColumn(&MCPToolLog{}, col) {
-					logger.Info("[logstore] %s: dropping column %s from MCPToolLog", migrationName, col)
-					if err := mg.DropColumn(&MCPToolLog{}, col); err != nil {
-						return err
-					}
+				if err := dropColumnIfExists(tx, logger, &MCPToolLog{}, col); err != nil {
+					return err
 				}
 			}
 			return nil
@@ -3467,24 +3313,14 @@ func migrationAddClusterGovernanceColumns(ctx context.Context, db *gorm.DB, logg
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "cluster_node_id") {
-				logger.Info("[logstore] %s: dropping column cluster_node_id from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "cluster_node_id"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "cluster_node_id"); err != nil {
+				return err
 			}
-			if migrator.HasColumn(&Log{}, "budget_ids") {
-				logger.Info("[logstore] %s: dropping column budget_ids from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "budget_ids"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "budget_ids"); err != nil {
+				return err
 			}
-			if migrator.HasColumn(&Log{}, "rate_limit_ids") {
-				logger.Info("[logstore] %s: dropping column rate_limit_ids from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "rate_limit_ids"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "rate_limit_ids"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -3538,12 +3374,8 @@ func migrationAddLogIncNumberColumn(ctx context.Context, db *gorm.DB, logger sch
 					return fmt.Errorf("failed to drop logs_inc_number_seq: %w", err)
 				}
 			}
-			migrator := tx.Migrator()
-			if migrator.HasColumn(&Log{}, "inc_number") {
-				logger.Info("[logstore] %s: dropping column IncNumber from Log", migrationName)
-				if err := migrator.DropColumn(&Log{}, "IncNumber"); err != nil {
-					return err
-				}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "IncNumber"); err != nil {
+				return err
 			}
 			return nil
 		},
@@ -3651,13 +3483,9 @@ func migrationAddCustomerArrayColumns(ctx context.Context, db *gorm.DB, logger s
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
 			for _, col := range columns {
-				if mig.HasColumn(&Log{}, col) {
-					logger.Info("[logstore] %s: dropping column %s from Log", migrationName, col)
-					if err := mig.DropColumn(&Log{}, col); err != nil {
-						return err
-					}
+				if err := dropColumnIfExists(tx, logger, &Log{}, col); err != nil {
+					return err
 				}
 			}
 			return nil

--- a/framework/migrator/dropcolumn.go
+++ b/framework/migrator/dropcolumn.go
@@ -1,0 +1,64 @@
+package migrator
+
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// DropColumnIfExists drops the column backing struct field `field` of `model`
+// in a way that is idempotent at the database statement level, so concurrent
+// migration runners (rolling deploys, version skew, or a duplicate side path)
+// and re-runs cannot fail with an "undefined column" error (PostgreSQL SQLSTATE
+// 42703).
+//
+// GORM's Migrator.DropColumn emits a bare `ALTER TABLE ... DROP COLUMN`, and the
+// usual `if HasColumn { DropColumn }` guard is a non-atomic check-then-act: two
+// sessions can both observe the column as present and then both issue the DROP,
+// and the loser fails when its DDL finally executes. On PostgreSQL we instead
+// emit `ALTER TABLE ... DROP COLUMN IF EXISTS`, which is a true no-op when the
+// column is already gone and therefore never aborts the surrounding migration
+// transaction.
+//
+// Other dialects (e.g. SQLite) do not support `DROP COLUMN IF EXISTS`, so we
+// keep the HasColumn guard and fall back to GORM's DropColumn there.
+//
+// The function owns the existence check, so call sites should NOT wrap it in
+// their own `if HasColumn { ... }` guard — that just adds a second, redundant
+// round-trip. The single HasColumn here also lets us emit the "dropping column"
+// log line only when a column is actually dropped: pass a non-nil logger to get
+// that line, or nil to stay silent.
+func DropColumnIfExists(tx *gorm.DB, logger schemas.Logger, model interface{}, field string) error {
+	mig := tx.Migrator()
+	if !mig.HasColumn(model, field) {
+		return nil
+	}
+
+	// Resolve the field to its DB column name so the DDL and log line match
+	// what GORM's Migrator.DropColumn would target. Migrations routinely drop
+	// *legacy* columns whose Go struct field has already been removed from the
+	// model, so a missing field is expected: fall back to treating `field` as
+	// the raw column name, exactly as GORM's DropColumn does.
+	stmt := &gorm.Statement{DB: tx}
+	if err := stmt.Parse(model); err != nil {
+		return fmt.Errorf("failed to parse schema for %T: %w", model, err)
+	}
+	columnName := field
+	if f := stmt.Schema.LookUpField(field); f != nil {
+		columnName = f.DBName
+	}
+
+	if logger != nil {
+		logger.Info("[migrator] dropping column %s from table %s", columnName, stmt.Table)
+	}
+
+	if tx.Dialector.Name() != "postgres" {
+		return mig.DropColumn(model, field)
+	}
+	return tx.Exec(
+		"ALTER TABLE ? DROP COLUMN IF EXISTS ?",
+		clause.Table{Name: stmt.Table}, clause.Column{Name: columnName},
+	).Error
+}

--- a/framework/migrator/dropcolumn_test.go
+++ b/framework/migrator/dropcolumn_test.go
@@ -1,0 +1,88 @@
+package migrator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// dropColTestModel maps to a table that starts WITH the `extra` column, giving
+// DropColumnIfExists something to drop.
+type dropColTestModel struct {
+	ID    uint   `gorm:"primaryKey"`
+	Extra string `gorm:"column:extra"`
+}
+
+func (dropColTestModel) TableName() string { return "dropcol_test" }
+
+// dropColTestBare maps to the same table but does NOT declare the `extra`
+// field, mimicking a migration that drops a legacy column already removed from
+// the current struct.
+type dropColTestBare struct {
+	ID uint `gorm:"primaryKey"`
+}
+
+func (dropColTestBare) TableName() string { return "dropcol_test" }
+
+func openDropColumnTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&dropColTestModel{}))
+	return db
+}
+
+// TestDropColumnIfExistsDropsExistingColumn covers the non-Postgres (SQLite)
+// fallback path: the column is present, so it is dropped and logged once.
+func TestDropColumnIfExistsDropsExistingColumn(t *testing.T) {
+	db := openDropColumnTestDB(t)
+	require.True(t, db.Migrator().HasColumn(&dropColTestModel{}, "extra"))
+
+	log := &captureLogger{}
+	require.NoError(t, DropColumnIfExists(db, log, &dropColTestModel{}, "Extra"))
+
+	require.False(t, db.Migrator().HasColumn(&dropColTestModel{}, "extra"))
+	require.Len(t, log.infos, 1, "should log exactly once when the column is dropped")
+}
+
+// TestDropColumnIfExistsIsIdempotent verifies a second call is a silent no-op,
+// which is the property that makes dropping the per-call-site HasColumn guard safe.
+func TestDropColumnIfExistsIsIdempotent(t *testing.T) {
+	db := openDropColumnTestDB(t)
+	require.NoError(t, DropColumnIfExists(db, nil, &dropColTestModel{}, "Extra"))
+
+	log := &captureLogger{}
+	require.NoError(t, DropColumnIfExists(db, log, &dropColTestModel{}, "Extra"))
+
+	require.False(t, db.Migrator().HasColumn(&dropColTestModel{}, "extra"))
+	require.Empty(t, log.infos, "should not log when the column is already gone")
+}
+
+// TestDropColumnIfExistsUnknownFieldIsNoOp verifies that passing a name that
+// does not correspond to any DB column is a silent no-op: HasColumn returns
+// false, so DropColumnIfExists returns early without touching the table (and
+// without erroring).
+func TestDropColumnIfExistsUnknownFieldIsNoOp(t *testing.T) {
+	db := openDropColumnTestDB(t)
+
+	// "extra" exists as a column, but "DoesNotExist" is neither a field nor a
+	// column; HasColumn is false for it, so the call is a no-op rather than an
+	// error. Assert the safe no-op contract for an unknown field.
+	require.NoError(t, DropColumnIfExists(db, nil, &dropColTestModel{}, "DoesNotExist"))
+	require.True(t, db.Migrator().HasColumn(&dropColTestModel{}, "extra"))
+}
+
+// TestDropColumnIfExistsDropsLegacyColumnNotOnStruct covers the common migration
+// case: the column still exists in the table but its Go field has already been
+// removed from the current struct. The helper must fall back to the raw column
+// name and drop it rather than erroring on the missing field.
+func TestDropColumnIfExistsDropsLegacyColumnNotOnStruct(t *testing.T) {
+	db := openDropColumnTestDB(t)
+	require.True(t, db.Migrator().HasColumn(&dropColTestBare{}, "extra"))
+
+	require.NoError(t, DropColumnIfExists(db, nil, &dropColTestBare{}, "extra"))
+	require.False(t, db.Migrator().HasColumn(&dropColTestBare{}, "extra"))
+}

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -250,7 +250,7 @@ func Test_bedrockStreamErrorConverterEncodesEventStreamException(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "exception", eventStreamHeaderString(t, msg.Headers, ":message-type"))
 	assert.Equal(t, "PluginDenied", eventStreamHeaderString(t, msg.Headers, ":exception-type"))
-	assert.JSONEq(t, `{"message":"blocked by policy"}`, string(msg.Payload))
+	assert.JSONEq(t, `{"__type":"PluginDenied","message":"blocked by policy"}`, string(msg.Payload))
 	assert.False(t, strings.Contains(string(body), "data:"), "AWS EventStream bytes must not contain SSE framing")
 }
 
@@ -273,7 +273,7 @@ func Test_toBedrockEventStreamExceptionAcceptsBedrockError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "exception", eventStreamHeaderString(t, msg.Headers, ":message-type"))
 	assert.Equal(t, "ValidationException", eventStreamHeaderString(t, msg.Headers, ":exception-type"))
-	assert.JSONEq(t, `{"message":"invalid request"}`, string(msg.Payload))
+	assert.JSONEq(t, `{"__type":"ValidationException","message":"invalid request"}`, string(msg.Payload))
 }
 
 func Test_handleStreamingBedrockUnknownErrorResponseFallsBackToEventStreamException(t *testing.T) {
@@ -314,7 +314,7 @@ func Test_handleStreamingBedrockUnknownErrorResponseFallsBackToEventStreamExcept
 	require.NoError(t, err)
 	assert.Equal(t, "exception", eventStreamHeaderString(t, msg.Headers, ":message-type"))
 	assert.Equal(t, "InternalServerException", eventStreamHeaderString(t, msg.Headers, ":exception-type"))
-	assert.JSONEq(t, `{"message":"An error occurred while processing your request"}`, string(msg.Payload))
+	assert.JSONEq(t, `{"__type":"InternalServerException","message":"An error occurred while processing your request"}`, string(msg.Payload))
 	assert.False(t, cancelCalled, "fallback write should not cancel unless the client disconnects")
 }
 

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2809,9 +2809,12 @@ func newBedrockEventStreamException(exceptionType, message string) *bedrockEvent
 		exceptionType = "InternalServerException"
 	}
 
-	payloadJSON, err := sonic.Marshal(map[string]string{"message": message})
+	payloadJSON, err := sonic.Marshal(map[string]string{
+		"__type":  exceptionType,
+		"message": message,
+	})
 	if err != nil {
-		payloadJSON = []byte(`{"message":"An error occurred while processing your request"}`)
+		payloadJSON = []byte(fmt.Sprintf(`{"__type":%q,"message":"An error occurred while processing your request"}`, exceptionType))
 	}
 
 	return &bedrockEventStreamException{


### PR DESCRIPTION
## Summary

Bedrock EventStream exception payloads were missing the `__type` field, which AWS clients use to identify the exception type when deserializing error responses. This caused clients to be unable to properly distinguish exception types from the payload body alone.

## Changes

- Added `__type` field to the JSON payload of Bedrock EventStream exceptions, set to the exception type string (e.g., `"PluginDenied"`, `"ValidationException"`, `"InternalServerException"`)
- Updated the hardcoded fallback error payload to also include `"__type":"InternalServerException"`
- Updated tests to assert the presence of `__type` in exception payloads

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/integrations/...
```

Verify that Bedrock streaming error responses include `__type` in the event stream exception payload, matching the `:exception-type` header value.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects the structure of error response payloads returned to clients.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable