### PR TITLE
[fix]: accept object-valued tool_search_call arguments on Responses streaming path

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
+- fix: accept object-valued tool-call arguments (e.g. tool_search_call) on the Responses API streaming path
 - fix: recover from idle-timeout timer-goroutine panic that could crash the process
 - fix: deterministic MCP tool ordering for prompt cache stability (closes #2347)

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -943,6 +943,53 @@ type ResponsesMessage struct {
 	*ResponsesReasoning
 }
 
+// UnmarshalJSON normalizes function/tool-call arguments before decoding the rest
+// of the item. OpenAI's Responses API serializes `function_call` `arguments` as
+// a JSON string, but `tool_search_call` items (emitted when the request enables
+// the `tool_search` deferred-tool-discovery tool, as Codex does) serialize
+// `arguments` as a JSON object — e.g. {} while in_progress and
+// {"query":"...","limit":10} when completed. The embedded
+// ResponsesToolMessage.Arguments field is a *string, so an object value makes a
+// plain decode fail with "Mismatch type string with value object", which
+// silently drops the item mid-stream and hangs streaming clients. We shadow
+// `arguments` as raw JSON, decode everything else as usual, then store the
+// canonical stringified form.
+func (m *ResponsesMessage) UnmarshalJSON(data []byte) error {
+	type Alias ResponsesMessage
+	aux := &struct {
+		Arguments json.RawMessage `json:"arguments,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(m),
+	}
+
+	if err := Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	if len(aux.Arguments) > 0 && string(aux.Arguments) != "null" {
+		args := responsesToolArgumentsToString(aux.Arguments)
+		if m.ResponsesToolMessage == nil {
+			m.ResponsesToolMessage = &ResponsesToolMessage{}
+		}
+		m.Arguments = &args
+	}
+
+	return nil
+}
+
+// responsesToolArgumentsToString normalizes a function/tool-call `arguments`
+// value into the stringified-JSON form expected downstream. function_call items
+// send a JSON string; tool_search_call items send a JSON object. Both are
+// accepted, with the object preserved as its raw JSON text.
+func responsesToolArgumentsToString(raw json.RawMessage) string {
+	var str string
+	if err := Unmarshal(raw, &str); err == nil {
+		return str
+	}
+	return string(raw)
+}
+
 type ResponsesMessageRoleType string
 
 const (

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -146,6 +146,116 @@ func TestResponsesMessageContentEmptyMarshalsToEmptyString(t *testing.T) {
 	}
 }
 
+// TestResponsesMessageToolCallArguments verifies that function/tool-call
+// `arguments` parse whether the provider serializes them as a JSON string
+// (`function_call` items) or as a JSON object (`tool_search_call` items, emitted
+// when the request enables OpenAI's `tool_search` tool — captured live from
+// api.openai.com). The object form previously failed with "Mismatch type string
+// with value object", silently dropping the item mid-stream and hanging the
+// client.
+func TestResponsesMessageToolCallArguments(t *testing.T) {
+	t.Run("string arguments are preserved", func(t *testing.T) {
+		raw := []byte(`{"id":"fc_1","type":"function_call","status":"completed","name":"grafana","call_id":"call_123","arguments":"{\"query\":\"observability\"}"}`)
+
+		var msg ResponsesMessage
+		if err := Unmarshal(raw, &msg); err != nil {
+			t.Fatalf("unmarshal function_call item: %v", err)
+		}
+		if msg.ResponsesToolMessage == nil || msg.Arguments == nil {
+			t.Fatalf("expected arguments to be set, got %#v", msg.ResponsesToolMessage)
+		}
+		if *msg.Arguments != `{"query":"observability"}` {
+			t.Fatalf("expected stringified arguments, got %q", *msg.Arguments)
+		}
+		if msg.CallID == nil || *msg.CallID != "call_123" {
+			t.Fatalf("expected call_id to survive, got %#v", msg.CallID)
+		}
+		if msg.Name == nil || *msg.Name != "grafana" {
+			t.Fatalf("expected name to survive, got %#v", msg.Name)
+		}
+	})
+
+	t.Run("object arguments are normalized to stringified json", func(t *testing.T) {
+		raw := []byte(`{"id":"fc_1","type":"function_call","status":"completed","name":"grafana","call_id":"call_123","arguments":{"query":"observability"}}`)
+
+		var msg ResponsesMessage
+		if err := Unmarshal(raw, &msg); err != nil {
+			t.Fatalf("unmarshal function_call item with object arguments: %v", err)
+		}
+		if msg.ResponsesToolMessage == nil || msg.Arguments == nil {
+			t.Fatalf("expected arguments to be set, got %#v", msg.ResponsesToolMessage)
+		}
+		if *msg.Arguments != `{"query":"observability"}` {
+			t.Fatalf("expected object arguments to normalize to stringified json, got %q", *msg.Arguments)
+		}
+		if msg.CallID == nil || *msg.CallID != "call_123" {
+			t.Fatalf("expected call_id to survive object-argument decode, got %#v", msg.CallID)
+		}
+
+		encoded, err := MarshalSorted(msg)
+		if err != nil {
+			t.Fatalf("marshal normalized message: %v", err)
+		}
+		if !strings.Contains(string(encoded), `"arguments":"{\"query\":\"observability\"}"`) {
+			t.Fatalf("expected arguments to round-trip as a string, got %s", encoded)
+		}
+	})
+
+	t.Run("empty object arguments", func(t *testing.T) {
+		raw := []byte(`{"id":"fc_1","type":"function_call","name":"grafana","call_id":"call_123","arguments":{}}`)
+
+		var msg ResponsesMessage
+		if err := Unmarshal(raw, &msg); err != nil {
+			t.Fatalf("unmarshal function_call item with empty object arguments: %v", err)
+		}
+		if msg.Arguments == nil || *msg.Arguments != `{}` {
+			t.Fatalf("expected empty object arguments to normalize to %q, got %#v", `{}`, msg.Arguments)
+		}
+	})
+
+	t.Run("object arguments inside a streamed output_item.done event", func(t *testing.T) {
+		raw := []byte(`{"type":"response.output_item.done","sequence_number":7,"output_index":0,"item":{"id":"fc_1","type":"function_call","status":"completed","name":"grafana","call_id":"call_123","arguments":{"query":"observability"}}}`)
+
+		var resp BifrostResponsesStreamResponse
+		if err := Unmarshal(raw, &resp); err != nil {
+			t.Fatalf("unmarshal output_item.done with object arguments: %v", err)
+		}
+		if resp.Item == nil || resp.Item.ResponsesToolMessage == nil || resp.Item.Arguments == nil {
+			t.Fatalf("expected streamed item arguments to be set, got %#v", resp.Item)
+		}
+		if *resp.Item.Arguments != `{"query":"observability"}` {
+			t.Fatalf("expected streamed object arguments to normalize, got %q", *resp.Item.Arguments)
+		}
+	})
+
+	// Real tool_search_call frames captured from api.openai.com by replaying
+	// Codex's request (which enables the `tool_search` tool). These are the exact
+	// frames that triggered the production "Mismatch type string with value
+	// object" failure.
+	t.Run("real tool_search_call frames from openai", func(t *testing.T) {
+		frames := map[string]string{
+			"in_progress (empty object)":   `{"type":"response.output_item.added","output_index":1,"sequence_number":4,"item":{"id":"tsc_01429bcd111d3db1016a3abc8e12948191a9efb0edcbd7f68a","type":"tool_search_call","status":"in_progress","arguments":{},"call_id":"call_OYgDGFxcFL8POxRYssDHUsaM","execution":"client"}}`,
+			"completed (populated object)": `{"type":"response.output_item.done","output_index":1,"sequence_number":5,"item":{"id":"tsc_01429bcd111d3db1016a3abc8e12948191a9efb0edcbd7f68a","type":"tool_search_call","status":"completed","arguments":{"query":"observability_repro sentry grafana websocket responses","limit":10},"call_id":"call_OYgDGFxcFL8POxRYssDHUsaM","execution":"client"}}`,
+		}
+		want := map[string]string{
+			"in_progress (empty object)":   `{}`,
+			"completed (populated object)": `{"query":"observability_repro sentry grafana websocket responses","limit":10}`,
+		}
+		for name, raw := range frames {
+			var resp BifrostResponsesStreamResponse
+			if err := Unmarshal([]byte(raw), &resp); err != nil {
+				t.Fatalf("[%s] unmarshal tool_search_call frame: %v", name, err)
+			}
+			if resp.Item == nil || resp.Item.ResponsesToolMessage == nil || resp.Item.Arguments == nil {
+				t.Fatalf("[%s] expected tool_search_call arguments to be set, got %#v", name, resp.Item)
+			}
+			if *resp.Item.Arguments != want[name] {
+				t.Fatalf("[%s] expected arguments %q, got %q", name, want[name], *resp.Item.Arguments)
+			}
+		}
+	})
+}
+
 func TestResponsesMessagePreservesOpenAIPhase(t *testing.T) {
 	raw := []byte(`{"id":"msg_123","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"}`)
 


### PR DESCRIPTION
## Description

When a model streams tool calls over the OpenAI **Responses API**, `tool_search_call` items serialize their `arguments` as a **JSON object** instead of the JSON **string** that `function_call` items use.

`tool_search_call` items are emitted whenever the request enables OpenAI's `tool_search` tool (deferred tool discovery) — which **Codex (`codex_cli_rs`) enables by default**. The streamed item (`response.output_item.added` / `.done`) decodes into `ResponsesMessage`, whose embedded `ResponsesToolMessage.Arguments` is a `*string`. An object value therefore fails to decode:

```
Failed to parse stream response: Mismatch type string with value object
  ... "status":"in_progress","arguments":{},"call_id":"ca...
  ... "status":"completed","arguments":{"query":"..."} ...
```

`HandleOpenAIResponsesStreaming` logs this at `warn` and `continue`s, so the item is **silently dropped mid-stream**. Strict streaming clients never receive it and hang on a half-open stream until their own idle watchdog fires — no error is surfaced.

This reproduces on the latest release (`maximhq/bifrost:v1.5.16`).

## Root cause

- Regular `function_call` items serialize `arguments` as a **string** — these decode fine.
- `tool_search_call` items serialize `arguments` as an **object**: `{}` while `in_progress`, and e.g. `{"query":"...","limit":10}` when `completed`.
- The object form appears when the request includes OpenAI's `tool_search` tool. Codex enables this by default for deferred tool discovery.

## Runnable reproduction

From a local `maximhq/bifrost` checkout, run this command. It imports the local checkout and feeds three Responses stream frames through the same parser path Bifrost uses (`schemas.Unmarshal` into `BifrostResponsesStreamResponse`).

```bash
REPO="$PWD"
TMP="$(mktemp -d)"
cd "$TMP"

go mod init bifrost-tool-search-repro >/dev/null
go mod edit -require github.com/maximhq/bifrost/core@v0.0.0
go mod edit -replace github.com/maximhq/bifrost/core="$REPO/core"

cat > main.go <<'GO'
package main

import (
  "fmt"
  "os"

  "github.com/maximhq/bifrost/core/schemas"
)

var frames = []struct {
  label string
  raw   string
}{
  {
    "function_call args as string",
    `{"type":"response.output_item.done","output_index":1,"sequence_number":1,"item":{"id":"fc_1","type":"function_call","status":"completed","name":"grafana_query","call_id":"call_function","arguments":"{\"query\":\"rate(http_requests_total[5m])\"}"}}`,
  },
  {
    "tool_search_call args as empty object",
    `{"type":"response.output_item.added","output_index":1,"sequence_number":4,"item":{"id":"tsc_1","type":"tool_search_call","status":"in_progress","arguments":{},"call_id":"call_tool_search","execution":"client"}}`,
  },
  {
    "tool_search_call args as object",
    `{"type":"response.output_item.done","output_index":1,"sequence_number":5,"item":{"id":"tsc_1","type":"tool_search_call","status":"completed","arguments":{"query":"observability logs","limit":10},"call_id":"call_tool_search","execution":"client"}}`,
  },
}

func main() {
  failed := false
  for _, frame := range frames {
    var resp schemas.BifrostResponsesStreamResponse
    if err := schemas.Unmarshal([]byte(frame.raw), &resp); err != nil {
      fmt.Printf("FAIL: %s: %v\n", frame.label, err)
      failed = true
      continue
    }
    fmt.Printf("OK:   %s -> %s\n", frame.label, *resp.Item.Arguments)
  }
  if failed {
    os.Exit(1)
  }
}
GO

go mod tidy >/dev/null
go run .
```

### Before this fix

Run the repro against `dev` / `v1.5.16` and the `tool_search_call` frames fail with the same parse error seen in production:

```text
OK:   function_call args as string -> {"query":"rate(http_requests_total[5m])"}
FAIL: tool_search_call args as empty object: Mismatch type string with value object ... "arguments":{},"call_id":"ca...
FAIL: tool_search_call args as object: Mismatch type string with value object ... "arguments":{"query":"observability logs"...
exit status 1
```

### After this fix

Run the same repro on this PR branch and all frames parse. Object-valued `arguments` are preserved as stringified JSON:

```text
OK:   function_call args as string -> {"query":"rate(http_requests_total[5m])"}
OK:   tool_search_call args as empty object -> {}
OK:   tool_search_call args as object -> {"query":"observability logs","limit":10}
```

## Optional live OpenAI shape check

The deterministic repro above does not require credentials. To verify the upstream shape directly, send a Responses request that includes a `tool_search` tool. OpenAI streams `tool_search_call` frames like this:

```text
event: response.output_item.added
data: {"item":{"type":"tool_search_call","status":"in_progress","arguments":{}, ...}}

event: response.output_item.done
data: {"item":{"type":"tool_search_call","status":"completed","arguments":{"query":"...","limit":10}, ...}}
```

That object-valued `arguments` field is what the old parser rejected.

## Type of Change

- [x] Bug fix

## Affected Packages

- `core/schemas/responses.go`
- `core/schemas/responses_test.go`
- `core/changelog.md`

## Changes Made

- Added `ResponsesMessage.UnmarshalJSON` that shadows `arguments` as raw JSON, decodes the rest of the item normally, then normalizes `arguments` to the canonical stringified-JSON form (a JSON object is preserved as its raw JSON text; a JSON string is kept as-is). Every downstream consumer that reads `*Arguments` as stringified JSON keeps working unchanged.
- Added `responsesToolArgumentsToString` helper.
- Added regression tests covering: string arguments (unchanged), object arguments (normalized), empty object `{}`, an object inside a streamed `response.output_item.done` event, and real `tool_search_call` frames captured from `api.openai.com`.

## Testing

- [x] Unit tests added/updated
- [x] Tests passing locally

```bash
go test ./schemas/ -run TestResponsesMessageToolCallArguments -v
```

## Checklist

- [x] Code follows the project's code style
- [x] Tests are passing locally
- [x] Commit message follows the format: `[type]: description`
- [x] Changelog updated (`core/changelog.md`)

## Related Issues

Relates to the broader streaming tool-call serialization issues (e.g. #3443, #3475); this one is the OpenAI Responses path receiving `tool_search_call.arguments` as an object rather than a string.

Made with [Cursor](https://cursor.com)