### PR TITLE
feat: add `sailpoint` and `generic` SSO providers, refactor SCIM attribute mapping schemas into shared `$defs`

### DIFF
--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -11,6 +11,8 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 ### Upcoming [2.1.25]
 
 - Added `evaluation_mode` to guardrail rules in `values.yaml`, `values.schema.json`, `config.schema.json`, and `_helpers.tpl`. The field renders into `guardrails_config.guardrail_rules[].evaluation_mode` and supports `bundled` (default) and `per_turn`.
+- Added `group_traces_by_session` boolean to the OTEL plugin (both single-profile and per-profile shapes) and the Datadog plugin. When `true`, all requests sharing the same `x-bf-session-id` header are grouped into a single trace using a deterministic trace ID derived from the session ID. An inbound W3C `traceparent` always takes precedence. When `false` (default), each request produces its own trace but `session.id` is still tagged on the root span.
+- Added `storage.configStore.vaultStore` to `values.yaml` (commented-out reference block). The schema (`values.schema.json`) and template (`_helpers.tpl`) already supported this field; the values file now documents all available options. Supports three backends — `aws-secrets-manager` (region, access key, role ARN, KMS key), `gcp-secret-manager` (project ID, credentials JSON), and `hashicorp-vault` (address, token, namespace, mount path, AppRole). Set `accessMode: read_and_write` to auto-store plaintext fields as vault secrets on save; `read_only` (default) only resolves existing `vault.<path>` references at load time.
 
 ### 2.1.24
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1278,6 +1278,9 @@ false
 {{- if hasKey $inputConfig "disable_content_logging" }}
 {{- $_ := set $otelConfig "disable_content_logging" $inputConfig.disable_content_logging }}
 {{- end }}
+{{- if hasKey $inputConfig "group_traces_by_session" }}
+{{- $_ := set $otelConfig "group_traces_by_session" $inputConfig.group_traces_by_session }}
+{{- end }}
 {{- if hasKey $inputConfig "disable_root_span_content" }}
 {{- $_ := set $otelConfig "disable_root_span_content" $inputConfig.disable_root_span_content }}
 {{- end }}
@@ -1336,6 +1339,9 @@ false
 {{- end }}
 {{- if hasKey $inputConfig "disable_content_logging" }}
 {{- $_ := set $datadogConfig "disable_content_logging" $inputConfig.disable_content_logging }}
+{{- end }}
+{{- if hasKey $inputConfig "group_traces_by_session" }}
+{{- $_ := set $datadogConfig "group_traces_by_session" $inputConfig.group_traces_by_session }}
 {{- end }}
 {{- if hasKey $inputConfig "agentless" }}
 {{- $_ := set $datadogConfig "agentless" $inputConfig.agentless }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2203,7 +2203,7 @@
             },
             "provider": {
               "type": "string",
-              "enum": ["", "okta", "entra", "keycloak", "zitadel", "google"],
+              "enum": ["", "okta", "entra", "keycloak", "zitadel", "google", "sailpoint", "generic"],
               "description": "SCIM/SSO provider type (empty when not configured)"
             },
             "config": {
@@ -2222,7 +2222,7 @@
               "then": {
                 "properties": {
                   "provider": {
-                    "enum": ["okta", "entra", "keycloak", "zitadel", "google"]
+                    "enum": ["okta", "entra", "keycloak", "zitadel", "google", "sailpoint", "generic"]
                   }
                 },
                 "required": ["provider"]
@@ -2287,93 +2287,10 @@
                         "description": "JWT claim field for roles (default: 'roles')",
                         "default": "roles"
                       },
-                      "attributeRoleMappings": {
-                        "type": "array",
-                        "description": "Ordered list of attribute -> role mappings (first match wins). Requires an Okta Custom Authorization Server; the free Org Authorization Server does not support claim expressions.",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": {
-                              "type": "string",
-                              "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')"
-                            },
-                            "value": {
-                              "type": "string",
-                              "description": "Claim value to match (case-insensitive)"
-                            },
-                            "role": {
-                              "type": "string",
-                              "description": "Bifrost role to assign on match"
-                            },
-                            "attributeType": {
-                              "type": "string",
-                              "enum": ["user", "group"],
-                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-                            },
-                            "attributeValue": {
-                              "type": "string",
-                              "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
-                            }
-                          },
-                          "required": ["attribute", "value", "role"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeTeamMappings": {
-                        "type": "array",
-                        "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through (every claim value becomes a team name). Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string", "description": "JWT claim name" },
-                            "value": {
-                              "type": "string",
-                              "description": "Claim value to match, or '*' for pass-through"
-                            },
-                            "team": {
-                              "type": "string",
-                              "description": "Bifrost team slug to assign"
-                            },
-                            "attributeType": {
-                              "type": "string",
-                              "enum": ["user", "group"],
-                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-                            },
-                            "attributeValue": {
-                              "type": "string",
-                              "description": "SCIM attribute value to match (for 'user': SCIM user attribute value; for 'group': SCIM group displayName, auto-set to 'displayName')"
-                            }
-                          },
-                          "required": ["attribute", "value", "team"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeBusinessUnitMappings": {
-                        "type": "array",
-                        "description": "Attribute -> business-unit mappings (all matches apply). Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string", "description": "JWT claim name" },
-                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
-                            "business_unit": {
-                              "type": "string",
-                              "description": "Bifrost business unit slug to assign"
-                            },
-                            "attributeType": {
-                              "type": "string",
-                              "enum": ["user", "group"],
-                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-                            },
-                            "attributeValue": {
-                              "type": "string",
-                              "description": "SCIM attribute value to match (for 'user': SCIM user attribute value; for 'group': SCIM group displayName, auto-set to 'displayName')"
-                            }
-                          },
-                          "required": ["attribute", "value"],
-                          "additionalProperties": false
-                        }
-                      }
+                      "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+                      "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
                     },
                     "required": ["issuerUrl", "clientId", "clientSecret", "apiToken"],
                     "additionalProperties": false
@@ -2441,84 +2358,10 @@
                         "description": "JWT claim field for roles (default: 'roles')",
                         "default": "roles"
                       },
-                      "attributeRoleMappings": {
-                        "type": "array",
-                        "description": "Ordered list of attribute -> role mappings (first match wins).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": {
-                              "type": "string",
-                              "description": "JWT claim name (supports dot paths)"
-                            },
-                            "value": {
-                              "type": "string",
-                              "description": "Claim value to match (case-insensitive)"
-                            },
-                            "role": {
-                              "type": "string",
-                              "description": "Bifrost role to assign on match"
-                            },
-                            "attributeType": {
-                              "type": "string",
-                              "enum": ["user", "group"],
-                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-                            },
-                            "attributeValue": {
-                              "type": "string",
-                              "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
-                            }
-                          },
-                          "required": ["attribute", "value", "role"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeTeamMappings": {
-                        "type": "array",
-                        "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through. Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string", "description": "JWT claim name" },
-                            "value": { "type": "string", "description": "Claim value to match, or '*' for pass-through" },
-                            "team": { "type": "string", "description": "Bifrost team slug to assign. In case of '*' value, leave this empty" },
-                            "attributeType": {
-                              "type": "string",
-                              "enum": ["user", "group"],
-                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-                            },
-                            "attributeValue": {
-                              "type": "string",
-                              "description": "SCIM attribute value to match (for 'user': SCIM user attribute value; for 'group': SCIM group displayName, auto-set to 'displayName')"
-                            }
-                          },
-                          "required": ["attribute", "value", "team"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeBusinessUnitMappings": {
-                        "type": "array",
-                        "description": "Attribute -> business-unit mappings (all matches apply). Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string", "description": "JWT claim name" },
-                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
-                            "business_unit": { "type": "string", "description": "Bifrost business unit slug to assign. In case of '*' value, leave this empty" },
-                            "attributeType": {
-                              "type": "string",
-                              "enum": ["user", "group"],
-                              "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-                            },
-                            "attributeValue": {
-                              "type": "string",
-                              "description": "SCIM attribute value to match (for 'user': SCIM user attribute value; for 'group': SCIM group displayName, auto-set to 'displayName')"
-                            }
-                          },
-                          "required": ["attribute", "value"],
-                          "additionalProperties": false
-                        }
-                      }
+                      "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+                      "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
                     },
                     "required": ["tenantId", "clientId"],
                     "additionalProperties": false
@@ -2580,57 +2423,10 @@
                         "description": "JWT claim field for roles (default: 'roles')",
                         "default": "roles"
                       },
-                      "attributeRoleMappings": {
-                        "type": "array",
-                        "description": "Ordered list of attribute -> role mappings (first match wins).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": {
-                              "type": "string",
-                              "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')"
-                            },
-                            "value": {
-                              "type": "string",
-                              "description": "Claim value to match (case-insensitive)"
-                            },
-                            "role": {
-                              "type": "string",
-                              "description": "Bifrost role to assign on match"
-                            }
-                          },
-                          "required": ["attribute", "value", "role"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeTeamMappings": {
-                        "type": "array",
-                        "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through (every claim value becomes a team name).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string" },
-                            "team": { "type": "string" }
-                          },
-                          "required": ["attribute", "value", "team"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeBusinessUnitMappings": {
-                        "type": "array",
-                        "description": "Attribute -> business-unit mappings (all matches apply).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
-                            "business_unit": { "type": "string" }
-                          },
-                          "required": ["attribute", "value"],
-                          "additionalProperties": false
-                        }
-                      }
+                      "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+                      "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
                     },
                     "required": ["serverUrl", "realm", "clientId", "clientSecret"],
                     "additionalProperties": false
@@ -2691,48 +2487,10 @@
                         "description": "JWT claim field for team/group IDs (default: 'groups')",
                         "default": "groups"
                       },
-                      "attributeRoleMappings": {
-                        "type": "array",
-                        "description": "Ordered list of attribute -> role mappings (first match wins).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string" },
-                            "role": { "type": "string" }
-                          },
-                          "required": ["attribute", "value", "role"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeTeamMappings": {
-                        "type": "array",
-                        "description": "Attribute -> team mappings (all matches apply).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string" },
-                            "team": { "type": "string" }
-                          },
-                          "required": ["attribute", "value", "team"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeBusinessUnitMappings": {
-                        "type": "array",
-                        "description": "Attribute -> business-unit mappings (all matches apply).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
-                            "business_unit": { "type": "string" }
-                          },
-                          "required": ["attribute", "value"],
-                          "additionalProperties": false
-                        }
-                      }
+                      "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+                      "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
                     },
                     "required": ["domain", "clientId"],
                     "additionalProperties": false
@@ -2803,48 +2561,10 @@
                         "description": "Claim field for team/group IDs (default: 'groups')",
                         "default": "groups"
                       },
-                      "attributeRoleMappings": {
-                        "type": "array",
-                        "description": "Ordered list of attribute -> role mappings (first match wins).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string" },
-                            "role": { "type": "string" }
-                          },
-                          "required": ["attribute", "value", "role"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeTeamMappings": {
-                        "type": "array",
-                        "description": "Attribute -> team mappings (all matches apply).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string" },
-                            "team": { "type": "string" }
-                          },
-                          "required": ["attribute", "value", "team"],
-                          "additionalProperties": false
-                        }
-                      },
-                      "attributeBusinessUnitMappings": {
-                        "type": "array",
-                        "description": "Attribute -> business-unit mappings (all matches apply).",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "attribute": { "type": "string" },
-                            "value": { "type": "string", "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign." },
-                            "business_unit": { "type": "string" }
-                          },
-                          "required": ["attribute", "value"],
-                          "additionalProperties": false
-                        }
-                      }
+                      "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+                      "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
                     },
                     "required": ["domain", "clientId"],
                     "additionalProperties": false,
@@ -2885,6 +2605,135 @@
                         }
                       }
                     ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "enabled": { "const": true },
+                  "provider": { "const": "sailpoint" }
+                },
+                "required": ["enabled", "provider"]
+              },
+              "then": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "description": "SailPoint identity security platform configuration",
+                    "properties": {
+                      "product": {
+                        "type": "string",
+                        "enum": ["isc", "iiq"],
+                        "description": "SailPoint product type: 'isc' for Identity Security Cloud, 'iiq' for IdentityIQ"
+                      },
+                      "tenant": {
+                        "type": "string",
+                        "description": "ISC tenant identifier (required for ISC product)"
+                      },
+                      "baseUrl": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "IdentityIQ base URL (required for IIQ product)"
+                      },
+                      "username": {
+                        "type": "string",
+                        "description": "Username for IdentityIQ authentication"
+                      },
+                      "password": {
+                        "type": "string",
+                        "description": "Password for IdentityIQ authentication"
+                      },
+                      "clientId": {
+                        "type": "string",
+                        "description": "OAuth2 client ID"
+                      },
+                      "clientSecret": {
+                        "type": "string",
+                        "description": "OAuth2 client secret"
+                      },
+                      "teamIdsField": {
+                        "type": "string",
+                        "description": "JWT claim field for team IDs"
+                      },
+                      "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+                      "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+                    },
+                    "required": ["product"],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "enabled": { "const": true },
+                  "provider": { "const": "generic" }
+                },
+                "required": ["enabled", "provider"]
+              },
+              "then": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "description": "Generic OIDC authentication configuration",
+                    "properties": {
+                      "issuerUrl": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "OIDC issuer URL"
+                      },
+                      "clientId": {
+                        "type": "string",
+                        "description": "OAuth2 client ID"
+                      },
+                      "clientSecret": {
+                        "type": "string",
+                        "description": "OAuth2 client secret"
+                      },
+                      "audience": {
+                        "type": "string",
+                        "description": "JWT audience for validation"
+                      },
+                      "authorizationEndpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Override for the authorization endpoint"
+                      },
+                      "tokenEndpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Override for the token endpoint"
+                      },
+                      "userinfoEndpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Override for the userinfo endpoint"
+                      },
+                      "teamIdsField": {
+                        "type": "string",
+                        "description": "JWT claim field for team IDs"
+                      },
+                      "rolesField": {
+                        "type": "string",
+                        "description": "JWT claim field for roles"
+                      },
+                      "scopes": {
+                        "type": "array",
+                        "description": "Additional OAuth2 scopes to request",
+                        "items": { "type": "string" }
+                      },
+                      "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+                      "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+                    },
+                    "required": ["issuerUrl", "clientId"],
+                    "additionalProperties": false
                   }
                 }
               }
@@ -5632,6 +5481,95 @@
       },
       "required": ["provider"],
       "additionalProperties": false
+    },
+    "scim_attribute_role_mappings": {
+      "type": "array",
+      "description": "Ordered list of attribute -> role mappings (first match wins).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "attribute": {
+            "type": "string",
+            "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')"
+          },
+          "value": {
+            "type": "string",
+            "description": "Claim value to match (case-insensitive)"
+          },
+          "role": {
+            "type": "string",
+            "description": "Bifrost role to assign on match"
+          }
+        },
+        "required": ["attribute", "value", "role"],
+        "additionalProperties": false
+      }
+    },
+    "scim_attribute_team_mappings": {
+      "type": "array",
+      "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "attribute": {
+            "type": "string",
+            "description": "JWT claim name"
+          },
+          "value": {
+            "type": "string",
+            "description": "Claim value to match, or '*' for pass-through"
+          },
+          "team": {
+            "type": "string",
+            "description": "Bifrost team slug to assign. In case of '*' value, leave this empty"
+          }
+        },
+        "required": ["attribute", "value"],
+        "additionalProperties": false
+      }
+    },
+    "scim_attribute_business_unit_mappings": {
+      "type": "array",
+      "description": "Attribute -> business-unit mappings (all matches apply).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "attribute": {
+            "type": "string",
+            "description": "JWT claim name"
+          },
+          "value": {
+            "type": "string",
+            "description": "Claim value to match. Wildcard '*' will use the claim as the name of the business unit to assign."
+          },
+          "business_unit": {
+            "type": "string",
+            "description": "Bifrost business unit slug to assign. In case of '*' value, leave this empty"
+          }
+        },
+        "required": ["attribute", "value"],
+        "additionalProperties": false
+      }
+    },
+    "scim_claim_attributes": {
+      "type": "object",
+      "description": "Per-claim SCIM interpretation. Maps each claim name to its SCIM source type and attribute key. Set by the UI when SCIM provisioning is configured.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "attributeType": {
+            "type": "string",
+            "enum": ["user", "group"],
+            "description": "'user' reads from SCIM User resource attributes; 'group' matches SCIM Group resource."
+          },
+          "attributeValue": {
+            "type": "string",
+            "description": "SCIM attribute key or group match field for this claim."
+          }
+        },
+        "required": ["attributeType", "attributeValue"],
+        "additionalProperties": false
+      }
     }
   }
 }

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1062,6 +1062,37 @@ storage:
     # maxIdleConns: 5
     # maxOpenConns: 50
 
+    # Vault store for external secret management (enterprise).
+    # Resolves "vault.<path>" references in config fields at load time.
+    # vaultStore:
+    #   enabled: true
+    #   type: aws-secrets-manager  # Options: aws-secrets-manager, gcp-secret-manager, hashicorp-vault
+    #   prefix: bifrost             # Path prefix applied to every secret (default: bifrost)
+    #   accessMode: read_only       # read_only or read_and_write
+    #
+    #   # AWS Secrets Manager
+    #   aws:
+    #     region: us-east-1
+    #     accessKeyId: ""           # Leave empty to use default AWS credential chain
+    #     secretAccessKey: ""
+    #     sessionToken: ""          # AWS STS session token (optional)
+    #     roleArn: ""               # IAM role ARN to assume via STS
+    #     kmsKeyId: ""              # Customer-managed KMS key for encryption
+    #
+    #   # GCP Secret Manager
+    #   gcp:
+    #     projectId: ""
+    #     credentialsJson: ""       # Service account JSON; omit for default credentials
+    #
+    #   # HashiCorp Vault (KV v2)
+    #   hashicorp:
+    #     address: https://vault.example.com
+    #     token: ""                 # Static token; omit to use AppRole auth
+    #     namespace: ""             # Vault namespace (HCP Vault / Enterprise)
+    #     mountPath: secret         # KV v2 mount path
+    #     roleId: ""                # AppRole role_id
+    #     secretId: ""              # AppRole secret_id
+
   # Logs store settings
   logsStore:
     enabled: true

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4710,102 +4710,9 @@
           "description": "JWT claim field for roles (default: 'roles')",
           "default": "roles"
         },
-        "attributeRoleMappings": {
-          "type": "array",
-          "description": "Ordered list of attribute -> role mappings (first match wins). Requires an Okta Custom Authorization Server.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string",
-                "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')"
-              },
-              "value": {
-                "type": "string",
-                "description": "Claim value to match (case-insensitive)"
-              },
-              "role": {
-                "type": "string",
-                "description": "Bifrost role to assign on match"
-              },
-              "attributeType": {
-                "type": "string",
-                "enum": ["user", "group"],
-                "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-              },
-              "attributeValue": {
-                "type": "string",
-                "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
-              }
-            },
-            "required": ["attribute", "value", "role"],
-            "additionalProperties": false
-          }
-        },
-        "attributeTeamMappings": {
-          "type": "array",
-          "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through. Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string",
-                "description": "JWT claim name"
-              },
-              "value": {
-                "type": "string",
-                "description": "Claim value to match, or '*' for pass-through"
-              },
-              "team": {
-                "type": "string",
-                "description": "Bifrost team slug to assign. In case of '*' value, leave this empty"
-              },
-              "attributeType": {
-                "type": "string",
-                "enum": ["user", "group"],
-                "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-              },
-              "attributeValue": {
-                "type": "string",
-                "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
-              }
-            },
-            "required": ["attribute", "value", "team"],
-            "additionalProperties": false
-          }
-        },
-        "attributeBusinessUnitMappings": {
-          "type": "array",
-          "description": "Attribute -> business-unit mappings (all matches apply). Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string",
-                "description": "JWT claim name"
-              },
-              "value": {
-                "type": "string",
-                "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign."
-              },
-              "business_unit": {
-                "type": "string",
-                "description": "Bifrost business unit slug to assign. In case of '*' value, leave this empty"
-              },
-              "attributeType": {
-                "type": "string",
-                "enum": ["user", "group"],
-                "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-              },
-              "attributeValue": {
-                "type": "string",
-                "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
-              }
-            },
-            "required": ["attribute", "value"],
-            "additionalProperties": false
-          }
-        }
+        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"}
       },
       "required": ["issuerUrl", "clientId", "clientSecret", "apiToken"],
       "additionalProperties": false
@@ -4856,102 +4763,9 @@
           "description": "JWT claim field for roles (default: 'roles')",
           "default": "roles"
         },
-        "attributeRoleMappings": {
-          "type": "array",
-          "description": "Ordered list of attribute -> role mappings (first match wins).",
-          "items": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string",
-                "description": "JWT claim name (supports dot paths)"
-              },
-              "value": {
-                "type": "string",
-                "description": "Claim value to match (case-insensitive)"
-              },
-              "role": {
-                "type": "string",
-                "description": "Bifrost role to assign on match"
-              },
-              "attributeType": {
-                "type": "string",
-                "enum": ["user", "group"],
-                "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-              },
-              "attributeValue": {
-                "type": "string",
-                "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
-              }
-            },
-            "required": ["attribute", "value", "role"],
-            "additionalProperties": false
-          }
-        },
-        "attributeTeamMappings": {
-          "type": "array",
-          "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through. Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string",
-                "description": "JWT claim name"
-              },
-              "value": {
-                "type": "string",
-                "description": "Claim value to match, or '*' for pass-through"
-              },
-              "team": {
-                "type": "string",
-                "description": "Bifrost team slug to assign. In case of '*' value, leave this empty"
-              },
-              "attributeType": {
-                "type": "string",
-                "enum": ["user", "group"],
-                "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-              },
-              "attributeValue": {
-                "type": "string",
-                "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
-              }
-            },
-            "required": ["attribute", "value"],
-            "additionalProperties": false
-          }
-        },
-        "attributeBusinessUnitMappings": {
-          "type": "array",
-          "description": "Attribute -> business-unit mappings (all matches apply). Add attributeType/attributeValue to enable SCIM provisioning for a mapping.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string",
-                "description": "JWT claim name"
-              },
-              "value": {
-                "type": "string",
-                "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign."
-              },
-              "business_unit": {
-                "type": "string",
-                "description": "Bifrost business unit slug to assign. In case of '*' value, leave this empty"
-              },
-              "attributeType": {
-                "type": "string",
-                "enum": ["user", "group"],
-                "description": "SCIM provisioning type: 'user' matches SCIM User attributes, 'group' matches SCIM Group displayName"
-              },
-              "attributeValue": {
-                "type": "string",
-                "description": "SCIM attribute value to match (for attributeType 'user': the SCIM user attribute value; for 'group': the SCIM group displayName, auto-set to 'displayName')"
-              }
-            },
-            "required": ["attribute", "value"],
-            "additionalProperties": false
-          }
-        }
+        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"}
       },
       "required": ["tenantId", "clientId"],
       "additionalProperties": false
@@ -4996,75 +4810,9 @@
           "description": "JWT claim field for roles (default: 'roles')",
           "default": "roles"
         },
-        "attributeRoleMappings": {
-          "type": "array",
-          "description": "Ordered list of attribute -> role mappings (first match wins).",
-          "items": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string",
-                "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')"
-              },
-              "value": {
-                "type": "string",
-                "description": "Claim value to match (case-insensitive)"
-              },
-              "role": {
-                "type": "string",
-                "description": "Bifrost role to assign on match"
-              }
-            },
-            "required": ["attribute", "value", "role"],
-            "additionalProperties": false
-          }
-        },
-        "attributeTeamMappings": {
-          "type": "array",
-          "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string",
-                "description": "JWT claim name"
-              },
-              "value": {
-                "type": "string",
-                "description": "Claim value to match, or '*' for pass-through"
-              },
-              "team": {
-                "type": "string",
-                "description": "Bifrost team slug to assign. In case of '*' value, leave this empty"
-              }
-            },
-            "required": ["attribute", "value"],
-            "additionalProperties": false
-          }
-        },
-        "attributeBusinessUnitMappings": {
-          "type": "array",
-          "description": "Attribute -> business-unit mappings (all matches apply).",
-          "items": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string",
-                "description": "JWT claim name"
-              },
-              "value": {
-                "type": "string",
-                "description": "Claim value to match. Wildcard '*' will use the claim as is the name of the business unit to assign."
-              },
-              "business_unit": {
-                "type": "string",
-                "description": "Bifrost business unit slug to assign. In case of '*' value, leave this empty"
-              }
-            },
-            "required": ["attribute", "value"],
-            "additionalProperties": false
-          }
-        }
+        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"}
       },
       "required": ["serverUrl", "realm", "clientId", "clientSecret"],
       "additionalProperties": false
@@ -5989,6 +5737,75 @@
         }
       },
       "additionalProperties": false
+    },
+    "scim_attribute_role_mappings": {
+      "type": "array",
+      "description": "Ordered list of attribute -> role mappings (first match wins).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "attribute": {
+            "type": "string",
+            "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')"
+          },
+          "value": {
+            "type": "string",
+            "description": "Claim value to match (case-insensitive)"
+          },
+          "role": {
+            "type": "string",
+            "description": "Bifrost role to assign on match"
+          }
+        },
+        "required": ["attribute", "value", "role"],
+        "additionalProperties": false
+      }
+    },
+    "scim_attribute_team_mappings": {
+      "type": "array",
+      "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "attribute": {
+            "type": "string",
+            "description": "JWT claim name"
+          },
+          "value": {
+            "type": "string",
+            "description": "Claim value to match, or '*' for pass-through"
+          },
+          "team": {
+            "type": "string",
+            "description": "Bifrost team slug to assign. In case of '*' value, leave this empty"
+          }
+        },
+        "required": ["attribute", "value"],
+        "additionalProperties": false
+      }
+    },
+    "scim_attribute_business_unit_mappings": {
+      "type": "array",
+      "description": "Attribute -> business-unit mappings (all matches apply).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "attribute": {
+            "type": "string",
+            "description": "JWT claim name"
+          },
+          "value": {
+            "type": "string",
+            "description": "Claim value to match. Wildcard '*' will use the claim as the name of the business unit to assign."
+          },
+          "business_unit": {
+            "type": "string",
+            "description": "Bifrost business unit slug to assign. In case of '*' value, leave this empty"
+          }
+        },
+        "required": ["attribute", "value"],
+        "additionalProperties": false
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds `sailpoint` and `generic` as supported SSO/SCIM provider types, and refactors the repeated inline attribute mapping schemas across all providers into shared `$defs` references to eliminate duplication. A new `claimScimAttributes` field is also introduced across all providers to support per-claim SCIM interpretation configuration.

## Changes

- Added `sailpoint` and `generic` to the `provider` enum in both `helm-charts/bifrost/values.schema.json` and `transports/config.schema.json`
- Added conditional `then` blocks for `sailpoint` (supporting both ISC and IIQ product types) and `generic` (supporting standard OIDC fields with optional endpoint overrides and custom scopes)
- Extracted `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` inline definitions into reusable `$defs` entries (`scim_attribute_role_mappings`, `scim_attribute_team_mappings`, `scim_attribute_business_unit_mappings`) shared across all providers
- Added a new `scim_claim_attributes` `$defs` entry (Helm schema only) that maps claim names to their SCIM source type and attribute key, referenced as `claimScimAttributes` on all provider configs
- Removed `attributeType` and `attributeValue` from individual mapping item schemas in favor of the top-level `claimScimAttributes` map

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate the updated schemas accept valid SailPoint and generic OIDC configurations and reject invalid ones:

```sh
# Validate Helm chart schema
helm lint helm-charts/bifrost

# Validate transport config schema against example configs
# Ensure a config with provider: "sailpoint" and product: "isc" or "iiq" passes validation
# Ensure a config with provider: "generic" and required issuerUrl/clientId passes validation
# Ensure existing provider configs (okta, entra, keycloak, zitadel, google) still validate correctly
```

New provider config fields:

- `sailpoint`: requires `product` (`isc` or `iiq`). ISC uses `tenant` + `clientId`/`clientSecret`; IIQ uses `baseUrl` + `username`/`password`.
- `generic`: requires `issuerUrl` and `clientId`. Supports optional `clientSecret`, `audience`, `authorizationEndpoint`, `tokenEndpoint`, `userinfoEndpoint`, `teamIdsField`, `rolesField`, and `scopes`.

## Breaking changes

- [x] Yes
- [ ] No

The `attributeType` and `attributeValue` fields have been removed from individual `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` items. SCIM provisioning metadata is now expressed via the top-level `claimScimAttributes` map. Any existing configurations using per-item `attributeType`/`attributeValue` will need to be migrated to the new `claimScimAttributes` structure.

## Related issues

## Security considerations

The new `sailpoint` provider config accepts `password` and `clientSecret` fields for IdentityIQ authentication. These should be handled as secrets and not stored in plaintext in Helm values.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable