### PR TITLE
feat: add `env.VAR_NAME` support to `dns_names` in cluster discovery config and update 2.1.25 changelog

### DIFF
--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -10,9 +10,10 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ### Upcoming [2.1.25]
 
-- Added `evaluation_mode` to guardrail rules in `values.yaml`, `values.schema.json`, `config.schema.json`, and `_helpers.tpl`. The field renders into `guardrails_config.guardrail_rules[].evaluation_mode` and supports `bundled` (default) and `per_turn`.
-- Added `group_traces_by_session` boolean to the OTEL plugin (both single-profile and per-profile shapes) and the Datadog plugin. When `true`, all requests sharing the same `x-bf-session-id` header are grouped into a single trace using a deterministic trace ID derived from the session ID. An inbound W3C `traceparent` always takes precedence. When `false` (default), each request produces its own trace but `session.id` is still tagged on the root span.
-- Added `storage.configStore.vaultStore` to `values.yaml` (commented-out reference block). The schema (`values.schema.json`) and template (`_helpers.tpl`) already supported this field; the values file now documents all available options. Supports three backends — `aws-secrets-manager` (region, access key, role ARN, KMS key), `gcp-secret-manager` (project ID, credentials JSON), and `hashicorp-vault` (address, token, namespace, mount path, AppRole). Set `accessMode: read_and_write` to auto-store plaintext fields as vault secrets on save; `read_only` (default) only resolves existing `vault.<path>` references at load time.
+- Added `evaluation_mode` to guardrail rules. Accepts `bundled` (default, evaluate all turns together) or `per_turn` (evaluate each turn independently). Set under `bifrost.guardrails.rules[].evaluation_mode`.
+- Added `group_traces_by_session` to the OTEL and Datadog plugin configs. When `true`, requests sharing the same `x-bf-session-id` header are grouped into a single trace. An inbound W3C `traceparent` always takes priority. Defaults to `false`.
+- Added `storage.configStore.vaultStore` to `values.yaml` with full commented-out examples for all three backends: `aws-secrets-manager`, `gcp-secret-manager`, and `hashicorp-vault`. Set `accessMode: read_and_write` to automatically store plaintext config fields as vault secrets; `read_only` (default) only resolves existing `vault.<path>` references.
+- `dns_names` in cluster discovery config now accepts `env.VAR_NAME` references in addition to literal hostnames, consistent with how other secret-bearing fields work across the chart.
 
 ### 2.1.24
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2134,7 +2134,7 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "DNS names to resolve for node discovery"
+                  "description": "DNS names to resolve for node discovery. Supports env.VAR_NAME for environment variable substitution."
                 },
                 "udpBroadcastPort": {
                   "type": "integer",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4525,7 +4525,7 @@
               "items": {
                 "type": "string"
               },
-              "description": "DNS names to resolve for node discovery"
+              "description": "DNS names to resolve for node discovery. Supports env.VAR_NAME for environment variable substitution."
             },
             "udp_broadcast_port": {
               "type": "integer",


### PR DESCRIPTION
## Summary

Updates the Bifrost Helm chart changelog and schema descriptions to document new features and clarify existing behavior for the upcoming 2.1.25 release.

## Changes

- Rewrote the 2.1.25 changelog entries in `README.md` to be more concise and user-facing, clarifying `evaluationMode` placement, `group_traces_by_session` behavior, and `vaultStore` access modes.
- Added a new changelog entry noting that `dns_names` in cluster discovery config now accepts `env.VAR_NAME` references in addition to literal hostnames.
- Updated the `dns_names` field description in both `values.schema.json` and `config.schema.json` to explicitly document `env.VAR_NAME` environment variable substitution support, making it consistent with how other secret-bearing fields are documented across the chart.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the schema descriptions render correctly by inspecting the updated JSON schema files and confirming the changelog reads accurately against the intended behavior of each feature.

```sh
# Validate JSON schemas are well-formed
cat helm-charts/bifrost/values.schema.json | python3 -m json.tool > /dev/null
cat transports/config.schema.json | python3 -m json.tool > /dev/null
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Changes are documentation and schema description updates only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable