### PR TITLE
fix(transports): reject `keys` in PUT /api/providers/{provider} body

### DIFF
--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -389,6 +389,21 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Reject `keys` in the request body. This endpoint manages provider-level
+	// configuration only; keys are managed via the dedicated /keys endpoints
+	// (POST/PUT/DELETE /api/providers/{provider}/keys[/{key_id}]). Accepting
+	// the field silently would discard the caller's intent — the construction
+	// below ignores `payload.Keys` and reuses `oldConfigRaw.Keys`. Failing
+	// fast keeps the API contract honest.
+	if len(payload.Keys) > 0 {
+		SendError(
+			ctx,
+			fasthttp.StatusBadRequest,
+			"keys are not accepted on this endpoint; use POST/PUT /api/providers/{provider}/keys[/{key_id}] to manage keys",
+		)
+		return
+	}
+
 	// Get the raw config to access actual values for merging with redacted request values
 	oldConfigRaw, err := h.inMemoryStore.GetProviderConfigRaw(provider)
 	if err != nil {

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -175,6 +175,87 @@ func TestAddProvider_ReturnsErrorWhenRuntimeReloadFails(t *testing.T) {
 	}
 }
 
+// TestUpdateProvider_RejectsKeysInBody guards against a silent-discard regression
+// where `keys` is decoded into `payload.Keys` but never written to the persisted
+// `ProviderConfig`. The endpoint manages provider-level config only; key edits
+// must go through PUT /api/providers/{provider}/keys/{key_id}. Without this
+// guard, callers (third-party API users, older dashboard bundles, integration
+// tests) get HTTP 200 with their `blacklisted_models`/`weight`/etc. silently
+// dropped — and the in-memory cache is rewritten with the stale `oldConfigRaw`
+// keys, causing list/per-key endpoints to diverge from the DB.
+func TestUpdateProvider_RejectsKeysInBody(t *testing.T) {
+	SetLogger(&mockLogger{})
+	lib.SetLogger(&mockLogger{})
+
+	existingKey := schemas.Key{
+		ID:                "key-existing",
+		Models:            []string{"*"},
+		BlacklistedModels: []string{"gpt-3.5-turbo"},
+		Weight:            0.8,
+	}
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				schemas.OpenAI: {Keys: []schemas.Key{existingKey}},
+			},
+		},
+		modelsManager: &mockModelsManager{},
+	}
+
+	body, err := sonic.Marshal(struct {
+		Keys                     []schemas.Key                    `json:"keys"`
+		NetworkConfig            schemas.NetworkConfig            `json:"network_config"`
+		ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"`
+	}{
+		Keys: []schemas.Key{{
+			ID:                "key-existing",
+			Models:            []string{"*"},
+			BlacklistedModels: []string{"gpt-4o", "o1-preview"},
+			Weight:            0.42,
+		}},
+		ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+			Concurrency: 1000,
+			BufferSize:  5000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPut)
+	ctx.Request.SetRequestURI("/api/providers/openai")
+	ctx.Request.SetBody(body)
+	ctx.SetUserValue("provider", string(schemas.OpenAI))
+
+	h.updateProvider(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var bifrostErr schemas.BifrostError
+	if err := json.Unmarshal(ctx.Response.Body(), &bifrostErr); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+	if bifrostErr.Error == nil || bifrostErr.Error.Message == "" {
+		t.Fatalf("expected error message in response, got %#v", bifrostErr)
+	}
+	if !strings.Contains(bifrostErr.Error.Message, "/keys") {
+		t.Fatalf("expected error message to mention the /keys endpoint, got %q", bifrostErr.Error.Message)
+	}
+
+	// In-memory cache must NOT have been mutated by the rejected request.
+	stored, ok := h.inMemoryStore.Providers[schemas.OpenAI]
+	if !ok || len(stored.Keys) != 1 {
+		t.Fatalf("expected provider to retain its single existing key, got %#v", stored)
+	}
+	if stored.Keys[0].Weight != 0.8 || len(stored.Keys[0].BlacklistedModels) != 1 || stored.Keys[0].BlacklistedModels[0] != "gpt-3.5-turbo" {
+		t.Fatalf("expected key to be untouched (weight=0.8, blacklisted=[gpt-3.5-turbo]); got weight=%v blacklisted=%v",
+			stored.Keys[0].Weight, stored.Keys[0].BlacklistedModels)
+	}
+}
+
 // boolPtr keeps pointer-valued key fixtures inline without pulling in pointer helpers.
 func boolPtr(v bool) *bool {
 	return &v

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -256,6 +256,94 @@ func TestUpdateProvider_RejectsKeysInBody(t *testing.T) {
 	}
 }
 
+// TestUpdateProvider_PassesThroughForEmptyOrAbsentKeys locks in the explicit
+// promise that the keys-guard only rejects NON-empty `keys` arrays. A future
+// refactor that accidentally tightens the guard to `payload.Keys != nil` (or
+// silently strips the field with `json:",omitempty"`) would silently break
+// provider-level config saves that legitimately include an empty/null `keys`
+// field, so we assert the guard does NOT fire for those cases.
+//
+// We can't easily run the handler all the way through to a 200 here because
+// `inMemoryStore.UpdateProviderConfig` requires a real *bifrost.Bifrost client
+// that's out of scope for a unit test. Instead, we deliberately send
+// `concurrency: 0` so the handler short-circuits with a deterministic 400
+// from the concurrency validator that lives AFTER the keys-guard. The
+// invariant under test is: the error we get is the concurrency error, not the
+// keys-not-accepted error.
+func TestUpdateProvider_PassesThroughForEmptyOrAbsentKeys(t *testing.T) {
+	SetLogger(&mockLogger{})
+	lib.SetLogger(&mockLogger{})
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "keys field omitted entirely",
+			body: `{
+				"network_config": {},
+				"concurrency_and_buffer_size": {"concurrency": 0, "buffer_size": 0}
+			}`,
+		},
+		{
+			name: "keys explicitly null",
+			body: `{
+				"keys": null,
+				"network_config": {},
+				"concurrency_and_buffer_size": {"concurrency": 0, "buffer_size": 0}
+			}`,
+		},
+		{
+			name: "keys explicitly empty array",
+			body: `{
+				"keys": [],
+				"network_config": {},
+				"concurrency_and_buffer_size": {"concurrency": 0, "buffer_size": 0}
+			}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &ProviderHandler{
+				inMemoryStore: &lib.Config{
+					Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+						schemas.OpenAI: {Keys: []schemas.Key{{ID: "key-existing"}}},
+					},
+				},
+				modelsManager: &mockModelsManager{},
+			}
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.Header.SetMethod(fasthttp.MethodPut)
+			ctx.Request.SetRequestURI("/api/providers/openai")
+			ctx.Request.SetBody([]byte(tc.body))
+			ctx.SetUserValue("provider", string(schemas.OpenAI))
+
+			h.updateProvider(ctx)
+
+			if ctx.Response.StatusCode() != fasthttp.StatusBadRequest {
+				t.Fatalf("expected 400 (from concurrency validator, NOT keys-guard), got %d: %s",
+					ctx.Response.StatusCode(), string(ctx.Response.Body()))
+			}
+
+			var bifrostErr schemas.BifrostError
+			if err := json.Unmarshal(ctx.Response.Body(), &bifrostErr); err != nil {
+				t.Fatalf("failed to unmarshal error response: %v", err)
+			}
+			if bifrostErr.Error == nil {
+				t.Fatalf("expected error in response, got %#v", bifrostErr)
+			}
+			if strings.Contains(bifrostErr.Error.Message, "keys are not accepted on this endpoint") {
+				t.Fatalf("keys-guard should NOT fire for empty/absent keys, got: %s", bifrostErr.Error.Message)
+			}
+			if !strings.Contains(bifrostErr.Error.Message, "Concurrency") {
+				t.Fatalf("expected concurrency error (proves we passed the keys-guard), got: %s", bifrostErr.Error.Message)
+			}
+		})
+	}
+}
+
 // boolPtr keeps pointer-valued key fixtures inline without pulling in pointer helpers.
 func boolPtr(v bool) *bool {
 	return &v


### PR DESCRIPTION
## Summary

Fixes #4648.

`updateProvider` (`PUT /api/providers/{provider}`) accepts a `keys` array in its request body — decoded into `payload.Keys` — but never assigns it to the persisted `ProviderConfig`. The struct construction at `providers.go:421` (pre-fix) was:

```go
// Construct ProviderConfig from individual fields (keys are managed separately via /keys endpoints)
config := configstore.ProviderConfig{
    Keys:                     oldConfigRaw.Keys,   // <-- payload.Keys silently dropped
    NetworkConfig:            oldConfigRaw.NetworkConfig,
    ...
}
```

Any client sending key-level fields (`blacklisted_models`, `weight`, `enabled`, `name`, `models`) via this endpoint gets HTTP 200 with their changes silently discarded.

Worse: the subsequent `inMemoryStore.UpdateProviderConfig(ctx, provider, config)` overwrites the in-memory cache with the stale `oldConfigRaw.Keys` — which can be older than the DB if a prior `PUT /keys/{key_id}` updated the DB without invalidating the provider-level cache. List endpoints then serve stale data that diverges from the DB.

Reproduced live against `transports/v1.5.15` — see #4648 for the full curl reproduction.

## Approach

The existing comment in the code already documents the intent: *"keys are managed separately via /keys endpoints"*. This PR honors that intent at the API boundary instead of relying on it implicitly:

```go
if len(payload.Keys) > 0 {
    SendError(
        ctx,
        fasthttp.StatusBadRequest,
        "keys are not accepted on this endpoint; use POST/PUT /api/providers/{provider}/keys[/{key_id}] to manage keys",
    )
    return
}
```

Effects:
- Third-party API users get an immediate, actionable error instead of silent data loss.
- Older dashboard bundles or integration tests that still send `keys` in a provider update body surface the misuse loudly.
- The in-memory cache is no longer corrupted by the stale `oldConfigRaw.Keys` write path.

## What does NOT change

- **Empty `keys: []` arrays still flow through.** The guard checks `len(payload.Keys) > 0`. Existing provider-level saves that include an empty `keys` field for any reason are not broken.
- **The `dev`-branch dashboard is unaffected.** `ui/app/workspace/providers/views/providerKeyForm.tsx` already routes key edits through `useUpdateProviderKeyMutation` → `PUT /api/providers/{provider}/keys/{key_id}`. All `useUpdateProviderMutation` consumers (`betaHeadersFormFragment`, `performanceFormFragment`, `networkFormFragment`, `apiStructureFormFragment`, `debuggingFormFragment`, `proxyFormFragment`, `openaiConfigFormFragment`) are provider-level config tabs that have no `keys` in their payloads.
- **No data migrations.** The DB schema is untouched.
- **No frontend changes.** The dashboard is already correct on `dev`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd transports/bifrost-http && go test ./handlers/ -run TestUpdateProvider_RejectsKeysInBody -v
```

The new test (`TestUpdateProvider_RejectsKeysInBody`) asserts:
- The handler returns HTTP 400 when `payload.Keys` is non-empty.
- The error message points the caller at the `/keys` endpoint.
- The in-memory cache is unchanged after the rejected request (proves the bug doesn't even briefly mutate state on the rejected path).

Manual repro (post-fix expectation):
```bash
curl -sS -u 'admin:pwd' -X PUT \
  -H 'Content-Type: application/json' \
  -d '{
    "concurrency_and_buffer_size": {"concurrency": 1000, "buffer_size": 5000},
    "network_config": {...},
    "keys": [{"id": "<uuid>", "blacklisted_models": ["gpt-4o"], ...}]
  }' \
  https://your-host/api/providers/openai
# Expected: HTTP 400, body: {"error": {"message": "keys are not accepted on this endpoint; ..."}}
```

## Breaking changes

- [x] Yes
- [ ] No

**Wire-level break:** any client currently sending `keys` in a `PUT /api/providers/{provider}` body — and silently losing their changes — will now get HTTP 400. This is intentional: the previous behavior was silent data loss, which is strictly worse than a loud error.

The migration is trivial: callers should split key edits out into `PUT /api/providers/{provider}/keys/{key_id}` per key.

I did not find any current dashboard caller that sends `keys` in a provider update body (verified by grepping `useUpdateProviderMutation` consumers in `ui/app/workspace/providers/`). If reviewers know of any in-tree caller that does, please flag.

## Related issues

- Closes #4648
- Similar in nature to #4640 / #4641 — both manifest as `blacklisted_models` failing to persist, but the code paths differ: #4640 is `reconcileVirtualKeyAssociations` for virtual keys (config.json reconcile), this is `updateProvider` for provider keys (HTTP handler). Worth a broader sweep on `blacklisted_models` end-to-end coverage when convenient.

## Security considerations

None. The change only adds an explicit `400` error path; it does not weaken any auth or validation.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (no doc references found; happy to add if reviewers want)
- [x] I verified builds succeed (Go)
- [x] I verified the CI pipeline passes locally if applicable (`go test ./handlers/ -run TestUpdateProvider` passes; pre-existing `TestGetVirtualKeys_FromMemory*` failures in `governance_test.go` are unrelated to this change — confirmed by stashing the diff and re-running)
