### PR TITLE
removes leaking body in console logs

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -98,11 +98,6 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 					if traceID, ok := ctx.UserValue(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
 						logBuilder = logBuilder.Str("trace_id", traceID)
 					}
-					if statusCode >= 400 && !ctx.Response.IsBodyStream() {
-						if body := ctx.Response.Body(); len(body) > 0 {
-							logBuilder = logBuilder.Str("http.error", string(body))
-						}
-					}
 					logBuilder.Send()
 				}()
 			}


### PR DESCRIPTION
## Summary

Removes the logging of HTTP response bodies for error status codes (4xx+) in the CORS middleware request logger.

## Changes

- Removed the block that appended the response body as `http.error` to the log entry when the status code was 400 or above and the body was not a stream. This eliminates potentially sensitive or verbose response body content from being written to logs.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify that HTTP error responses no longer include a `http.error` field in the request logs when a 4xx or 5xx response is returned.

```sh
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change reduces the risk of logging sensitive response body content (e.g., error messages that may contain PII or internal details) for HTTP error responses.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable