### PR TITLE
fix: runware in ui and test workflows

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -141,6 +141,7 @@ jobs:
           REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
           REPLICATE_OWNER : ${{ secrets.REPLICATE_OWNER }}
           RUNWAY_API_KEY : ${{ secrets.RUNWAY_API_KEY }}
+          RUNWARE_API_KEY : ${{ secrets.RUNWARE_API_KEY }}
         run: |
           echo "Running tests for PR #${{ github.event.pull_request.number || 'manual run' }}"
           ./.github/workflows/scripts/run-tests.sh

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1264,6 +1264,7 @@ jobs:
           REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
           REPLICATE_OWNER: ${{ secrets.REPLICATE_OWNER }}
           RUNWAY_API_KEY: ${{ secrets.RUNWAY_API_KEY }}
+          RUNWARE_API_KEY: ${{ secrets.RUNWARE_API_KEY }}
         run: ./.github/workflows/scripts/release-core.sh "${{ needs.detect-changes.outputs.core-version }}"
 
   framework-release:
@@ -1374,6 +1375,7 @@ jobs:
           REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
           REPLICATE_OWNER: ${{ secrets.REPLICATE_OWNER }}
           RUNWAY_API_KEY: ${{ secrets.RUNWAY_API_KEY }}
+          RUNWARE_API_KEY: ${{ secrets.RUNWARE_API_KEY }}
         run: ./.github/workflows/scripts/release-framework.sh "${{ needs.detect-changes.outputs.framework-version }}"
 
   plugins-release:
@@ -1502,6 +1504,7 @@ jobs:
           REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
           REPLICATE_OWNER: ${{ secrets.REPLICATE_OWNER }}
           RUNWAY_API_KEY: ${{ secrets.RUNWAY_API_KEY }}
+          RUNWARE_API_KEY: ${{ secrets.RUNWARE_API_KEY }}
         run: ./.github/workflows/scripts/release-all-plugins.sh '${{ needs.detect-changes.outputs.changed-plugins }}'
 
   # Prep: update dependencies, validate build, commit/push

--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -493,7 +493,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 	case schemas.Runware:
 		return []schemas.Key{
 			{
-				Value:          *schemas.NewEnvVar("env.RUNWARE_API_KEY"),
+				Value:          *schemas.NewSecretVar("env.RUNWARE_API_KEY"),
 				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -50,6 +50,7 @@ export const ModelPlaceholders = {
 	replicate: "e.g. meta/llama3-1-8b-instruct, black-forest-labs/flux-dev",
 	vllm: "e.g. Qwen/Qwen3-0.6B, Qwen/Qwen3-1.5B",
 	runway: "e.g. gen4_turbo_image_to_video, gen3a_turbo_image_to_video",
+	runware: "e.g. runware:100@1, runware:101@1",
 	fireworks: "e.g. accounts/fireworks/models/deepseek-v3p2",
 };
 
@@ -77,6 +78,7 @@ export const isKeyRequiredByProvider: Record<ProviderName, boolean> = {
 	xai: true,
 	replicate: true,
 	runway: true,
+	runware: true,
 	vllm: false,
 	fireworks: true,
 };

--- a/ui/lib/constants/icons.tsx
+++ b/ui/lib/constants/icons.tsx
@@ -679,6 +679,25 @@ export const ProviderIcons = {
 			</svg>
 		);
 	},
+	runware: ({ size = "md", className = "" }: IconProps) => {
+		const resolvedSize = resolveSize(size);
+
+		return (
+			<svg
+				fill="currentColor"
+				fillRule="evenodd"
+				height={resolvedSize}
+				style={{ flex: "none", lineHeight: "1" }}
+				viewBox="0 0 24 24"
+				width={resolvedSize}
+				xmlns="http://www.w3.org/2000/svg"
+				className={className}
+			>
+				<title>Runware</title>
+				<path d="M5.22 1 L19.61 1.09 L22.73 7.42 L8.24 7.33 Z M1.28 8.88 L7.78 8.88 L11.08 15.12 L4.3 15.03 Z M16.12 8.88 L22.73 8.88 L19.52 15.21 L12.92 15.21 Z M13.01 16.68 L19.61 16.77 L22.73 23 L16.12 23 Z"></path>
+			</svg>
+		);
+	},
 	fireworks: ({ size = "md", className = "" }: IconProps) => {
 		const resolvedSize = resolveSize(size);
 

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -24,6 +24,7 @@ export const KnownProvidersNames = [
 	"replicate",
 	"vllm",
 	"runway",
+	"runware",
 	"fireworks",
 ] as const;
 
@@ -126,6 +127,7 @@ export const ProviderLabels: Record<ProviderName, string> = {
 	replicate: "Replicate",
 	vllm: "vLLM",
 	runway: "Runway",
+	runware: "Runware",
 	fireworks: "Fireworks AI",
 } as const;
 


### PR DESCRIPTION
## Summary

Adds Runware as a supported provider across the CI pipelines and UI, and fixes a key type mismatch in the Runware test account configuration.

## Changes

- Added `RUNWARE_API_KEY` secret to PR tests, core release, framework release, and plugin release CI workflows so Runware integration tests run with proper credentials.
- Fixed the Runware provider key in `account.go` to use `NewSecretVar` instead of `NewEnvVar`, aligning it with how other providers handle secret keys.
- Added Runware to the UI's known providers list, including its display label, model placeholder text, key-required flag, and SVG icon.

## Type of change

- [x] Feature
- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] UI (React)
- [x] Chore/CI

## How to test

Set the `RUNWARE_API_KEY` environment variable and run the Runware-specific integration tests:

```sh
export RUNWARE_API_KEY=your_key_here
go test ./core/internal/llmtests/... -run Runware
```

For the UI, verify the Runware provider appears correctly in the provider list with its icon and placeholder:

```sh
cd ui
pnpm i
pnpm build
```

**New environment variable:**

| Variable | Description |
|---|---|
| `RUNWARE_API_KEY` | API key for authenticating with the Runware provider |

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The Runware API key is now handled as a `SecretVar` (correcting the previous `EnvVar` usage), ensuring it is treated as a secret and not exposed in logs or plaintext configurations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable