### PR TITLE
fix: base url protocol fix with custom header

### DIFF
--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -378,11 +378,11 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 				return true, fmt.Errorf("failed to store upload session: %w", err)
 			}
 
-			scheme := "http"
-			if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
-				scheme = "https"
+			baseURL := lib.BuildBaseURL(ctx, "")
+			if baseURL == "" {
+				return true, errors.New("cannot determine base URL for upload (empty Host)")
 			}
-			uploadURL := scheme + "://" + string(ctx.Host()) + pathPrefix + "/upload/v1beta/files?upload_id=" + uploadID
+			uploadURL := baseURL + pathPrefix + "/upload/v1beta/files?upload_id=" + uploadID
 
 			ctx.SetStatusCode(fasthttp.StatusOK)
 			ctx.Response.Header.Set("X-Goog-Upload-URL", uploadURL)

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -736,7 +736,13 @@ func BuildBaseURL(ctx *fasthttp.RequestCtx, externalBaseURL string) string {
 	if comma := strings.IndexByte(xfProto, ','); comma >= 0 {
 		xfProto = strings.TrimSpace(xfProto[:comma])
 	}
-	if ctx.IsTLS() || xfProto == "https" {
+	// x-bf-forwarded-proto is honored for setups where a managed LB overwrites the
+	// standard X-Forwarded-Proto (e.g. AWS L4 NLB -> ALB hops); the edge injects it.
+	xbfProto := strings.ToLower(strings.TrimSpace(string(ctx.Request.Header.Peek("x-bf-forwarded-proto"))))
+	if comma := strings.IndexByte(xbfProto, ','); comma >= 0 {
+		xbfProto = strings.TrimSpace(xbfProto[:comma])
+	}
+	if ctx.IsTLS() || xfProto == "https" || xbfProto == "https" {
 		scheme = "https"
 	}
 	host := string(ctx.Host())

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -536,3 +536,44 @@ func TestConvertToBifrostContext_DirectKey_EnvPrefixNotResolved(t *testing.T) {
 		t.Error("direct key must not be marked as from-secret")
 	}
 }
+
+func TestBuildBaseURL(t *testing.T) {
+	const host = "bifrost.example.com"
+	tests := []struct {
+		name     string
+		external string
+		host     string
+		xfProto  string
+		xbfProto string
+		want     string
+	}{
+		{name: "defaults to http", host: host, want: "http://" + host},
+		{name: "x-forwarded-proto https", host: host, xfProto: "https", want: "https://" + host},
+		{name: "x-forwarded-proto comma list", host: host, xfProto: "https, http", want: "https://" + host},
+		{name: "x-forwarded-proto uppercase", host: host, xfProto: "HTTPS", want: "https://" + host},
+		{name: "x-bf-forwarded-proto https", host: host, xbfProto: "https", want: "https://" + host},
+		{name: "x-bf-forwarded-proto uppercase trimmed", host: host, xbfProto: " HTTPS ", want: "https://" + host},
+		{name: "x-bf-forwarded-proto comma list", host: host, xbfProto: "https, http", want: "https://" + host},
+		{name: "x-bf-forwarded-proto http stays http", host: host, xbfProto: "http", want: "http://" + host},
+		{name: "external override wins", external: "https://proxy.example.com", host: host, xfProto: "http", want: "https://proxy.example.com"},
+		{name: "external override trailing slash trimmed", external: "https://proxy.example.com/", host: host, want: "https://proxy.example.com"},
+		{name: "invalid external falls back to inference", external: "not-a-url", host: host, xbfProto: "https", want: "https://" + host},
+		{name: "empty host yields empty", host: "", xbfProto: "https", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.SetHost(tt.host)
+			if tt.xfProto != "" {
+				ctx.Request.Header.Set("X-Forwarded-Proto", tt.xfProto)
+			}
+			if tt.xbfProto != "" {
+				ctx.Request.Header.Set("x-bf-forwarded-proto", tt.xbfProto)
+			}
+			if got := BuildBaseURL(ctx, tt.external); got != tt.want {
+				t.Fatalf("BuildBaseURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for a custom `x-bf-forwarded-proto` header in `BuildBaseURL` to correctly infer the request scheme in environments where a managed load balancer (e.g., an AWS L4 NLB sitting in front of an ALB) overwrites the standard `X-Forwarded-Proto` header before it reaches Bifrost. The edge layer can inject `x-bf-forwarded-proto` to preserve the original scheme.

## Changes

- `BuildBaseURL` now checks `x-bf-forwarded-proto` in addition to `X-Forwarded-Proto` and TLS state when determining whether to use `https`. The new header is normalized (lowercased, trimmed) before comparison.
- The inline scheme-detection logic in the GenAI file upload route handler was replaced with a call to `BuildBaseURL`, removing the duplication.
- A table-driven test suite for `BuildBaseURL` was added covering default HTTP, `X-Forwarded-Proto`, `x-bf-forwarded-proto` (including casing and whitespace variants), external base URL override, invalid external URL fallback, and empty host behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

To validate end-to-end, deploy behind an AWS NLB → ALB topology and confirm that upload URLs returned in `X-Goog-Upload-URL` use `https://` when the `x-bf-forwarded-proto: https` header is injected by the edge, even if `X-Forwarded-Proto` has been overwritten.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`x-bf-forwarded-proto` is intended to be injected only by a trusted edge component. Operators should ensure this header is stripped from untrusted inbound requests at the perimeter to prevent clients from spoofing the scheme.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable