### PR TITLE
fix: drops assistant reasoning for cerebras

### DIFF
--- a/core/providers/cerebras/cerebras_test.go
+++ b/core/providers/cerebras/cerebras_test.go
@@ -28,7 +28,7 @@ func TestCerebras(t *testing.T) {
 		ChatModel: "gpt-oss-120b",
 		Fallbacks: []schemas.Fallback{
 			{Provider: schemas.Cerebras, Model: "gpt-oss-120b"},
-			{Provider: schemas.Cerebras, Model: "gpt-oss-120b"},
+			{Provider: schemas.Cerebras, Model: "zai-glm-4.7"},
 		},
 		TextModel:      "gpt-oss-120b",
 		EmbeddingModel: "", // Cerebras doesn't support embedding

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -58,9 +58,14 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 			openaiReq.ChatParameters.Tools = normalizedTools
 		}
 	}
+
 	switch bifrostReq.Provider {
 	case schemas.OpenAI, schemas.Azure:
 		openaiReq.normalizeReasoningEffort(capModel)
+		return openaiReq
+	case schemas.Cerebras:
+		openaiReq.filterOpenAISpecificParameters(capModel)
+		openaiReq.applyCerebrasCompatibility()
 		return openaiReq
 	case schemas.XAI:
 		openaiReq.filterOpenAISpecificParameters(capModel)
@@ -182,6 +187,17 @@ func (req *OpenAIChatRequest) applyMistralCompatibility() {
 		if *req.Reasoning.Effort != "none" && *req.Reasoning.Effort != "high" {
 			req.Reasoning.Effort = schemas.Ptr("high")
 		}
+	}
+}
+
+// applyCerebrasCompatibility applies Cerebras-specific transformations to the request.
+func (req *OpenAIChatRequest) applyCerebrasCompatibility() {
+	for i := range req.Messages {
+		assistantMessage := req.Messages[i].OpenAIChatAssistantMessage
+		if assistantMessage == nil {
+			continue
+		}
+		assistantMessage.Reasoning = nil
 	}
 }
 

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -650,6 +650,73 @@ func TestToOpenAIChatRequest_FireworksPreservesReasoningAndCacheIsolation(t *tes
 	}
 }
 
+func TestToOpenAIChatRequest_CerebrasStripsAssistantReasoningContent(t *testing.T) {
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+
+	reasoning := "step by step"
+	assistantContent := "The weather in Paris is mild today."
+	userContent := "What is the weather in Paris?"
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Cerebras,
+		Model:    "gpt-oss-120b",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentStr: &userContent},
+			},
+			{
+				Role: schemas.ChatMessageRoleAssistant,
+				Content: &schemas.ChatMessageContent{ContentStr: &assistantContent},
+				ChatAssistantMessage: &schemas.ChatAssistantMessage{
+					Reasoning: &reasoning,
+				},
+			},
+		},
+	}
+
+	result := ToOpenAIChatRequest(ctx, bifrostReq)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Messages) != 2 || result.Messages[1].OpenAIChatAssistantMessage == nil {
+		t.Fatalf("expected assistant message with OpenAI assistant payload, got %#v", result.Messages)
+	}
+	if result.Messages[1].OpenAIChatAssistantMessage.Reasoning != nil {
+		t.Fatalf("expected assistant reasoning_content to be stripped for cerebras, got %#v", result.Messages[1].OpenAIChatAssistantMessage.Reasoning)
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+	wireBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		bifrostReq,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIChatRequest(ctx, bifrostReq), nil
+		},
+	)
+	if bifrostErr != nil {
+		t.Fatalf("failed to build request body: %v", bifrostErr.Error.Message)
+	}
+
+	var jsonMap map[string]interface{}
+	if err := sonic.Unmarshal(wireBody, &jsonMap); err != nil {
+		t.Fatalf("failed to parse marshaled request body: %v", err)
+	}
+
+	messages, ok := jsonMap["messages"].([]interface{})
+	if !ok || len(messages) != 2 {
+		t.Fatalf("expected 2 messages in wire payload, got %#v", jsonMap["messages"])
+	}
+	assistantMessage, ok := messages[1].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected assistant message object, got %#v", messages[1])
+	}
+	if _, ok := assistantMessage["reasoning_content"]; ok {
+		t.Fatalf("expected reasoning_content to be absent from cerebras assistant payload, got %#v", assistantMessage["reasoning_content"])
+	}
+}
+
 // TestToOpenAIChatRequest_AnnotationsNotInWirePayload verifies that MCPToolAnnotations
 // (stored on ChatTool with json:"-") are never included in the JSON body sent to OpenAI.
 func TestToOpenAIChatRequest_AnnotationsNotInWirePayload(t *testing.T) {


### PR DESCRIPTION
## Summary

Cerebras does not support the `reasoning_content` field on assistant messages. When multi-turn conversations include assistant messages with reasoning content (e.g. from a prior reasoning model response), sending that field to Cerebras causes request failures. This PR strips the`reasoning` field from assistant messages before forwarding requests to the Cerebras provider. Closes #4544

## Changes

- Added a `applyCerebrasCompatibility()` method that nullifies the `Reasoning` field on all assistant messages in the request.
- Wired `applyCerebrasCompatibility()` into the `ToOpenAIChatRequest` provider switch alongside the existing `filterOpenAISpecificParameters` call for the Cerebras case.
- Updated the Cerebras test fallback model to use a distinct model (`zai-glm-4.7`) so the two fallback entries are no longer duplicates.
- Added `TestToOpenAIChatRequest_CerebrasStripsAssistantReasoningContent` to verify that `reasoning_content` is absent from both the in-memory struct and the serialized wire payload when targeting Cerebras.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestToOpenAIChatRequest_CerebrasStripsAssistantReasoningContent -v
go test ./core/providers/cerebras/... -v
go test ./...
```

The new test constructs a multi-turn request with an assistant message containing `reasoning_content`, sends it through `ToOpenAIChatRequest` targeting Cerebras, and asserts that:

1. The in-memory `Reasoning` field is `nil` on the resulting assistant message.
2. The serialized JSON wire body does not contain a `reasoning_content` key.

## Breaking changes

- [x] No

## Security considerations

None. This change only removes a field from outbound requests to Cerebras; no auth, secrets, or PII handling is affected.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable