### PR TITLE
fixes realtime messages logging

### DIFF
--- a/tests/cmd/e2eseed/go.mod
+++ b/tests/cmd/e2eseed/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
-	github.com/maximhq/bifrost/core v1.5.21 // indirect
+	github.com/maximhq/bifrost/core v1.5.22 // indirect
 	github.com/maximhq/bifrost/framework v1.3.16 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect

--- a/tests/cmd/seed/go.mod
+++ b/tests/cmd/seed/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/maximhq/bifrost/core v1.5.21
+	github.com/maximhq/bifrost/core v1.5.22
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0

--- a/tests/cmd/seedvks/go.mod
+++ b/tests/cmd/seedvks/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/maximhq/bifrost/core v1.5.21
+	github.com/maximhq/bifrost/core v1.5.22
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1

--- a/transports/bifrost-http/handlers/realtime_turn_pipeline.go
+++ b/transports/bifrost-http/handlers/realtime_turn_pipeline.go
@@ -28,9 +28,17 @@ func newRealtimeTurnContext(
 		// Realtime post-hook contexts must preserve plugin-private values written in
 		// pre-hooks (for example telemetry start timestamps), not just public keys.
 		for ctxKey, value := range baseCtx.GetUserValues() {
-			if value != nil {
-				ctx.SetValue(ctxKey, value)
+			if value == nil {
+				continue
 			}
+			// Never inherit a session/transport-level trace ID. Each realtime turn
+			// must mint its own trace in RunRealtimeTurnPreHooks so its log entry is
+			// delivered when the turn's trace is completed and flushed. Inheriting a
+			// trace whose lifecycle is owned elsewhere strands the entry forever.
+			if ctxKey == schemas.BifrostContextKeyTraceID {
+				continue
+			}
+			ctx.SetValue(ctxKey, value)
 		}
 	}
 

--- a/transports/bifrost-http/handlers/wsrealtime.go
+++ b/transports/bifrost-http/handlers/wsrealtime.go
@@ -830,7 +830,11 @@ var realtimeMiddlewareKeys = []any{
 	schemas.BifrostContextKeyAPIKeyName,
 	schemas.BifrostContextKeySelectedKeyID,
 	schemas.BifrostContextKeySelectedKeyName,
-	schemas.BifrostContextKeyTraceID,
+	// NOTE: BifrostContextKeyTraceID is intentionally NOT inherited here. The
+	// upgrade request's trace is already ended by the time realtime turns run, so
+	// inheriting it would route each turn's log entry into pendingLogsToInject
+	// under a dead trace ID whose Inject() never fires, dropping the row. Each
+	// realtime turn mints its own trace in RunRealtimeTurnPreHooks instead.
 	schemas.BifrostContextKeyTransportPluginLogs,
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where realtime turn log entries were silently dropped. Each WebSocket realtime turn was inheriting the session/transport-level trace ID from the upgrade request context. By the time individual turns execute, that parent trace is already completed, so any log entries associated with it are queued under a dead trace ID whose `Inject()` never fires — permanently stranding the rows. This PR ensures each realtime turn mints its own trace ID instead. Closes #4606

## Changes

- Removed `BifrostContextKeyTraceID` from `realtimeMiddlewareKeys` so the upgrade request's trace ID is no longer propagated into realtime turn contexts.
- Added an explicit guard in `newRealtimeTurnContext` to skip inheriting `BifrostContextKeyTraceID` when copying base context values into a new turn context, ensuring each turn's pre-hook generates a fresh trace.
- Bumped `github.com/maximhq/bifrost/core` from `v1.5.21` to `v1.5.22` across test modules.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Establish a WebSocket realtime session and send multiple turns. Verify that log entries for each individual turn are persisted correctly and not dropped.

```sh
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications. This change only affects internal trace ID scoping for realtime turn log delivery.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable