### PR TITLE
adds broader file extension support for bedrock closes #4622

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -493,7 +493,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 	case schemas.Runware:
 		return []schemas.Key{
 			{
-				Value:          *schemas.NewEnvVar("env.RUNWARE_API_KEY"),
+				Value:          *schemas.NewSecretVar("env.RUNWARE_API_KEY"),
 				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -4926,6 +4926,63 @@ func TestDocumentFormatResponseMapping(t *testing.T) {
 	}
 }
 
+// TestDocumentFormatResponsesPathRoundTrip verifies that the Bedrock Converse
+// responses path (Bedrock -> Bifrost -> Bedrock) preserves the document format
+// for every Bedrock-supported format. This guards against the regression where
+// xlsx/xls/doc/docx (and md/html/csv) collapsed to "pdf"/"txt" because the
+// responses-path converters lagged behind the chat path. See issue #4622.
+func TestDocumentFormatResponsesPathRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	formats := []string{"pdf", "txt", "md", "html", "csv", "doc", "docx", "xls", "xlsx"}
+
+	for _, format := range formats {
+		t.Run(format, func(t *testing.T) {
+			docBytes := "UEsDBA==" // arbitrary base64; only the format mapping is under test
+			bedrockMessages := []bedrock.BedrockMessage{
+				{
+					Role: bedrock.BedrockMessageRoleUser,
+					Content: []bedrock.BedrockContentBlock{
+						{
+							Document: &bedrock.BedrockDocumentSource{
+								Format: format,
+								Name:   "testdoc",
+								Source: &bedrock.BedrockDocumentSourceData{
+									Bytes: &docBytes,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+			// Inbound: Bedrock -> Bifrost responses messages
+			bifrostMessages := bedrock.ConvertBedrockMessagesToBifrostMessages(ctx, bedrockMessages, nil, false)
+			require.NotEmpty(t, bifrostMessages, "expected at least one Bifrost message")
+
+			// Outbound: Bifrost responses messages -> Bedrock
+			roundTripped, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(ctx, bifrostMessages)
+			require.NoError(t, err)
+			require.NotEmpty(t, roundTripped, "expected at least one Bedrock message after round-trip")
+
+			// Locate the document block in the round-tripped output.
+			var doc *bedrock.BedrockDocumentSource
+			for _, msg := range roundTripped {
+				for _, block := range msg.Content {
+					if block.Document != nil {
+						doc = block.Document
+					}
+				}
+			}
+			require.NotNil(t, doc, "document block should survive the round-trip")
+			assert.Equal(t, format, doc.Format,
+				"format %q should be preserved through the responses path, got %q", format, doc.Format)
+		})
+	}
+}
+
 // TestBedrockToolInputKeyOrderPreservation verifies that multiple parallel tool calls
 // preserve the client's original key ordering after conversion to Bedrock format.
 func TestBedrockToolInputKeyOrderPreservation(t *testing.T) {

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -4113,8 +4113,22 @@ func convertSingleBedrockMessageToBifrostMessages(ctx *schemas.BifrostContext, m
 				switch block.Document.Format {
 				case "pdf":
 					fileType = "application/pdf"
-				case "txt", "md", "html", "csv":
+				case "txt":
 					fileType = "text/plain"
+				case "md":
+					fileType = "text/markdown"
+				case "html":
+					fileType = "text/html"
+				case "csv":
+					fileType = "text/csv"
+				case "doc":
+					fileType = "application/msword"
+				case "docx":
+					fileType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+				case "xls":
+					fileType = "application/vnd.ms-excel"
+				case "xlsx":
+					fileType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 				default:
 					fileType = "application/pdf" // Default to PDF
 				}
@@ -4359,13 +4373,28 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 					if block.ResponsesInputMessageContentBlockFile.FileType != nil {
 						fileType := *block.ResponsesInputMessageContentBlockFile.FileType
 						// Check if it's a text type
-						if strings.HasPrefix(fileType, "text/") ||
-							fileType == "txt" || fileType == "md" ||
-							fileType == "html" {
+						if fileType == "text/markdown" || fileType == "md" {
+							doc.Format = "md"
+							isTextFile = true
+						} else if fileType == "text/html" || fileType == "html" {
+							doc.Format = "html"
+							isTextFile = true
+						} else if fileType == "text/csv" || fileType == "csv" {
+							doc.Format = "csv"
+							isTextFile = true
+						} else if strings.HasPrefix(fileType, "text/") || fileType == "txt" {
 							doc.Format = "txt"
 							isTextFile = true
 						} else if strings.Contains(fileType, "pdf") || fileType == "pdf" {
 							doc.Format = "pdf"
+						} else if strings.Contains(fileType, "spreadsheetml") || fileType == "xlsx" {
+							doc.Format = "xlsx"
+						} else if fileType == "application/vnd.ms-excel" || fileType == "xls" {
+							doc.Format = "xls"
+						} else if strings.Contains(fileType, "wordprocessingml") || fileType == "docx" {
+							doc.Format = "docx"
+						} else if fileType == "application/msword" || fileType == "doc" {
+							doc.Format = "doc"
 						}
 					}
 


### PR DESCRIPTION
## Summary

Fixes a regression where Bedrock document formats `xlsx`, `xls`, `doc`, `docx`, `md`, `html`, and `csv` were incorrectly collapsed to `"pdf"` or `"txt"` when passing through the responses path (Bedrock → Bifrost → Bedrock). The inbound and outbound converters on the responses path were not handling these MIME types with the same granularity as the chat path. closes #4622

## Changes

- Expanded the inbound responses-path converter (`convertSingleBedrockMessageToBifrostMessages`) to map each Bedrock document format to its correct MIME type instead of grouping `md`, `html`, and `csv` together under `text/plain`.
- Expanded the outbound responses-path converter (`convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks`) to reverse-map specific MIME types (`text/markdown`, `text/html`, `text/csv`, `application/msword`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`, `application/vnd.ms-excel`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`) back to their correct Bedrock format strings rather than falling through to `"txt"` or `"pdf"`.
- Added a round-trip test (`TestDocumentFormatResponsesPathRoundTrip`) that exercises all nine Bedrock-supported document formats and asserts the format string is preserved end-to-end.
- Fixed a `NewEnvVar` → `NewSecretVar` call in the LLM test account for the Runware provider key.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/bedrock/... -run TestDocumentFormatResponsesPathRoundTrip -v
go test ./core/providers/bedrock/... -v
go test ./...
```

Each sub-test is named after its format (`pdf`, `txt`, `md`, `html`, `csv`, `doc`, `docx`, `xls`, `xlsx`). All nine should pass and report the format string unchanged after the round-trip.

## Breaking changes

- [x] No

## Related issues

Closes #4622

## Security considerations

No auth, secrets, or PII implications. The `NewEnvVar` → `NewSecretVar` fix aligns the Runware key with the intended secret-variable handling used by other providers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable