### PR TITLE
feat: circuit breaker in config schema

### DIFF
--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -74,6 +74,7 @@ var ignoreSchemaProps = map[string]string{
 	"/properties/large_payload_optimization": "enterprise-only; defined in bifrost-enterprise/lib/config.go",
 	"/properties/load_balancer_config":       "enterprise-only; defined in bifrost-enterprise/lib/config.go",
 	"/properties/scim_config":                "enterprise-only; defined in bifrost-enterprise/lib/config.go",
+	"/properties/circuit_breaker_config":     "enterprise-only; defined in bifrost-enterprise/lib/config.go",
 	// Enterprise governance extensions not yet in OSS structs.
 	"/properties/governance/properties/business_units":                          "enterprise-only; business unit governance",
 	"/properties/governance/properties/teams/items/properties/business_unit_id": "enterprise-only; team→business unit association",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2404,6 +2404,9 @@
     },
     "feature_flags": {
       "$ref": "#/$defs/feature_flags_config"
+    },
+    "circuit_breaker_config": {
+      "$ref": "#/$defs/circuit_breaker_config"
     }
   },
   "additionalProperties": false,
@@ -5880,6 +5883,111 @@
         }
       },
       "required": ["base_provider_type"],
+      "additionalProperties": false
+    },
+    "circuit_breaker_config": {
+      "type": "object",
+      "description": "Circuit breaker configuration for automatic failover when a provider endpoint degrades",
+      "properties": {
+        "policies": {
+          "type": "array",
+          "description": "List of circuit breaker policies",
+          "items": {
+            "type": "object",
+            "description": "A single circuit breaker policy that monitors a primary provider+model and redirects to a fallback when the circuit opens",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Unique name for this policy"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this policy is active. Disabled policies are ignored by all hooks."
+              },
+              "primary_provider": {
+                "type": "string",
+                "description": "Provider to monitor (e.g. 'azure', 'openai')"
+              },
+              "primary_model": {
+                "type": "string",
+                "description": "Model to monitor as it appears in requests (e.g. 'gpt-4-ptu')"
+              },
+              "primary_key_ids": {
+                "type": "array",
+                "description": "Optional list of key UUIDs to monitor individually. Each key gets its own sub-circuit; the main circuit opens only when all listed keys are exhausted. Leave empty to use a single shared circuit for all keys serving this provider+model.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "fallback_provider": {
+                "type": "string",
+                "description": "Provider to route to when the circuit is open"
+              },
+              "fallback_model": {
+                "type": "string",
+                "description": "Model to request from the fallback provider when the circuit is open"
+              },
+              "condition": {
+                "type": "object",
+                "description": "Response signals that trigger the circuit to open",
+                "properties": {
+                  "operator": {
+                    "type": "string",
+                    "enum": ["OR", "AND"],
+                    "default": "OR",
+                    "description": "OR (default): circuit opens when any signal matches. AND: circuit opens only when all signals match simultaneously."
+                  },
+                  "signals": {
+                    "type": "array",
+                    "description": "List of response signals to evaluate",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "source": {
+                          "type": "string",
+                          "enum": ["response_header"],
+                          "description": "What part of the HTTP response to inspect"
+                        },
+                        "header_name": {
+                          "type": "string",
+                          "description": "HTTP response header name to inspect"
+                        },
+                        "header_value": {
+                          "type": "string",
+                          "description": "Trips when the header equals this value (case-insensitive). Mutually exclusive with header_contains."
+                        },
+                        "header_contains": {
+                          "type": "string",
+                          "description": "Trips when the header value contains this substring (case-insensitive). Mutually exclusive with header_value. If neither is set, trips when the header is present."
+                        }
+                      },
+                      "required": ["source", "header_name"],
+                      "not": {
+                        "required": ["header_value", "header_contains"]
+                      },
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": ["signals"],
+                "additionalProperties": false
+              },
+              "default_cooldown": {
+                "type": "string",
+                "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                "description": "How long to keep the circuit open when no header-based cooldown is available. Accepts a Go duration string (e.g. '30s', '5m'). Defaults to 30s."
+              },
+              "cooldown_header": {
+                "type": "string",
+                "description": "Response header whose value (in milliseconds) overrides default_cooldown (e.g. 'retry-after-ms'). Falls back to default_cooldown when absent or unparsable."
+              }
+            },
+            "required": ["name", "primary_provider", "primary_model", "fallback_provider", "fallback_model", "condition"],
+            "additionalProperties": false
+          }
+        }
+      },
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
## Summary

Adds a `circuit_breaker_config` top-level configuration block to the transports config schema, enabling automatic failover from a primary provider/model to a fallback when degraded response signals are detected.

## Changes

- Added `circuit_breaker_config` as a top-level property in the transport config schema, referencing a new `circuit_breaker_config` definition.
- Defined the `circuit_breaker_config` schema with a `policies` array, where each policy specifies:
  - A primary provider and model to monitor, with optional per-key sub-circuits via `primary_key_ids`.
  - A fallback provider and model to route traffic to when the circuit opens.
  - A `condition` block with configurable `signals` (currently `response_header`-based) and an `operator` (`OR`/`AND`) to control when the circuit trips.
  - `default_cooldown` (Go duration string) and `cooldown_header` (millisecond-valued response header) to control how long the circuit stays open before resetting.
- Per-key sub-circuits allow granular monitoring: the main circuit opens only when all listed keys are exhausted, rather than treating all keys as a single shared circuit.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate the schema accepts a valid circuit breaker config and rejects invalid ones:

```sh
# Transports
go test ./...
```

Example valid config snippet:

```json
{
  "circuit_breaker_config": {
    "policies": [
      {
        "name": "azure-ptu-failover",
        "primary_provider": "azure",
        "primary_model": "gpt-4-ptu",
        "fallback_provider": "openai",
        "fallback_model": "gpt-4",
        "condition": {
          "operator": "OR",
          "signals": [
            {
              "source": "response_header",
              "header_name": "x-ms-region",
              "header_value": "throttled"
            }
          ]
        },
        "default_cooldown": "30s",
        "cooldown_header": "retry-after-ms"
      }
    ]
  }
}
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No direct auth or secrets implications. Circuit breaker policies reference provider and model names only; no credentials are stored in this config block.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable