### PR TITLE
fix: fireworks list models from config

### DIFF
--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -74,6 +74,7 @@ var ignoreSchemaProps = map[string]string{
 	"/properties/large_payload_optimization": "enterprise-only; defined in bifrost-enterprise/lib/config.go",
 	"/properties/load_balancer_config":       "enterprise-only; defined in bifrost-enterprise/lib/config.go",
 	"/properties/scim_config":                "enterprise-only; defined in bifrost-enterprise/lib/config.go",
+	"/properties/circuit_breaker_config":     "enterprise-only; defined in bifrost-enterprise/lib/config.go",
 	// Enterprise governance extensions not yet in OSS structs.
 	"/properties/governance/properties/business_units":                          "enterprise-only; business unit governance",
 	"/properties/governance/properties/teams/items/properties/business_unit_id": "enterprise-only; team→business unit association",

--- a/core/providers/fireworks/fireworks.go
+++ b/core/providers/fireworks/fireworks.go
@@ -65,19 +65,28 @@ func (provider *FireworksProvider) GetProviderKey() schemas.ModelProvider {
 	return schemas.Fireworks
 }
 
-// ListModels performs a list models request to Fireworks AI's API.
+// ListModels lists models for Fireworks AI from each key's configured models and aliases.
+// Fireworks serverless has no usable OpenAI-style /v1/models endpoint (it returns
+// "Error listing deployed models"), so models are sourced from config rather than a live
+// API call, mirroring the Replicate non-deployment path.
 func (provider *FireworksProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	return openai.HandleOpenAIListModelsRequest(
-		ctx,
-		provider.client,
-		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
-		keys,
-		provider.networkConfig.ExtraHeaders,
+	return providerUtils.HandleMultipleListModelsRequests(ctx, keys, request, provider.listModelsByKey)
+}
+
+// listModelsByKey builds the model list for a single key from its configured models and
+// aliases, without calling the upstream API. The configured set is the full catalog we
+// can produce (Fireworks has no enumerable live endpoint), so the filtered pipeline path
+// is forced regardless of request.Unfiltered — the pipeline skips config backfill when
+// unfiltered (it assumes a live response supplies the catalog), which would otherwise
+// yield an empty list and drop configured models/aliases from the unfiltered catalog view.
+func (provider *FireworksProvider) listModelsByKey(_ *schemas.BifrostContext, key schemas.Key, _ *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	return (&openai.OpenAIListModelsResponse{}).ToBifrostListModelsResponse(
 		schemas.Fireworks,
-		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
-		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
-	)
+		key.Models,
+		key.BlacklistedModels,
+		key.Aliases,
+		false,
+	), nil
 }
 
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2404,6 +2404,9 @@
     },
     "feature_flags": {
       "$ref": "#/$defs/feature_flags_config"
+    },
+    "circuit_breaker_config": {
+      "$ref": "#/$defs/circuit_breaker_config"
     }
   },
   "additionalProperties": false,
@@ -5880,6 +5883,111 @@
         }
       },
       "required": ["base_provider_type"],
+      "additionalProperties": false
+    },
+    "circuit_breaker_config": {
+      "type": "object",
+      "description": "Circuit breaker configuration for automatic failover when a provider endpoint degrades",
+      "properties": {
+        "policies": {
+          "type": "array",
+          "description": "List of circuit breaker policies",
+          "items": {
+            "type": "object",
+            "description": "A single circuit breaker policy that monitors a primary provider+model and redirects to a fallback when the circuit opens",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Unique name for this policy"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this policy is active. Disabled policies are ignored by all hooks."
+              },
+              "primary_provider": {
+                "type": "string",
+                "description": "Provider to monitor (e.g. 'azure', 'openai')"
+              },
+              "primary_model": {
+                "type": "string",
+                "description": "Model to monitor as it appears in requests (e.g. 'gpt-4-ptu')"
+              },
+              "primary_key_ids": {
+                "type": "array",
+                "description": "Optional list of key UUIDs to monitor individually. Each key gets its own sub-circuit; the main circuit opens only when all listed keys are exhausted. Leave empty to use a single shared circuit for all keys serving this provider+model.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "fallback_provider": {
+                "type": "string",
+                "description": "Provider to route to when the circuit is open"
+              },
+              "fallback_model": {
+                "type": "string",
+                "description": "Model to request from the fallback provider when the circuit is open"
+              },
+              "condition": {
+                "type": "object",
+                "description": "Response signals that trigger the circuit to open",
+                "properties": {
+                  "operator": {
+                    "type": "string",
+                    "enum": ["OR", "AND"],
+                    "default": "OR",
+                    "description": "OR (default): circuit opens when any signal matches. AND: circuit opens only when all signals match simultaneously."
+                  },
+                  "signals": {
+                    "type": "array",
+                    "description": "List of response signals to evaluate",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "source": {
+                          "type": "string",
+                          "enum": ["response_header"],
+                          "description": "What part of the HTTP response to inspect"
+                        },
+                        "header_name": {
+                          "type": "string",
+                          "description": "HTTP response header name to inspect"
+                        },
+                        "header_value": {
+                          "type": "string",
+                          "description": "Trips when the header equals this value (case-insensitive). Mutually exclusive with header_contains."
+                        },
+                        "header_contains": {
+                          "type": "string",
+                          "description": "Trips when the header value contains this substring (case-insensitive). Mutually exclusive with header_value. If neither is set, trips when the header is present."
+                        }
+                      },
+                      "required": ["source", "header_name"],
+                      "not": {
+                        "required": ["header_value", "header_contains"]
+                      },
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": ["signals"],
+                "additionalProperties": false
+              },
+              "default_cooldown": {
+                "type": "string",
+                "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                "description": "How long to keep the circuit open when no header-based cooldown is available. Accepts a Go duration string (e.g. '30s', '5m'). Defaults to 30s."
+              },
+              "cooldown_header": {
+                "type": "string",
+                "description": "Response header whose value (in milliseconds) overrides default_cooldown (e.g. 'retry-after-ms'). Falls back to default_cooldown when absent or unparsable."
+              }
+            },
+            "required": ["name", "primary_provider", "primary_model", "fallback_provider", "fallback_model", "condition"],
+            "additionalProperties": false
+          }
+        }
+      },
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
## Summary

The Fireworks AI `/v1/models` endpoint returns an error ("Error listing deployed models") rather than a usable model list, making live API calls for model listing non-functional. This PR fixes `ListModels` for the Fireworks provider by sourcing models from each key's configured models and aliases instead of calling the upstream API, mirroring the approach already used by the Replicate non-deployment path.

## Changes

- Replaced the OpenAI-style `/v1/models` HTTP call in `FireworksProvider.ListModels` with a config-driven approach via `providerUtils.HandleMultipleListModelsRequests`.
- Added `listModelsByKey`, which builds the model list for a single key using its configured `Models`, `BlacklistedModels`, and `Aliases` fields without any upstream API call.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Call the `ListModels` endpoint configured with a Fireworks key that has models and aliases defined. Verify the response returns the configured models rather than an upstream API error.

```sh
go test ./...
```

Ensure your Fireworks key config includes `models`, `blacklisted_models`, and/or `aliases` fields to validate they are correctly reflected in the response.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth, secrets, or PII handling introduced. Model listing is now entirely config-driven for Fireworks, so no API key is transmitted to the Fireworks `/v1/models` endpoint during this operation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable