### PR TITLE
fix: fix the start time for vk quota model usage

### DIFF
--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -4663,6 +4663,9 @@ func (h *GovernanceHandler) buildVKBudgetsWithUsage(ctx context.Context, vk *con
 		entry := quotaBudget{TableBudget: *b, Models: []quotaModelSpend{}}
 		if h.logManager != nil {
 			start := b.LastReset
+			if b.CreatedAt.After(start) {
+				start = b.CreatedAt
+			}
 			ranking, err := h.logManager.GetModelRankings(ctx, &logstore.SearchFilters{
 				VirtualKeyIDs: []string{vk.ID},
 				StartTime:     &start,

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1760,7 +1760,9 @@ func TestGetVirtualKeyQuota_EndToEndWithRealStore(t *testing.T) {
 		Scope:     configstoreTables.ModelConfigScopeVirtualKey,
 		ScopeID:   &scopeID,
 		Budgets: []configstoreTables.TableBudget{
-			{ID: "b-vk-e2e", MaxLimit: 100, CurrentUsage: 30, ResetDuration: "1d", LastReset: cycleStart},
+			// CreatedAt precedes LastReset (the steady-state: budget has existed for
+			// several cycles), so the window clamp keeps LastReset as the query start.
+			{ID: "b-vk-e2e", MaxLimit: 100, CurrentUsage: 30, ResetDuration: "1d", LastReset: cycleStart, CreatedAt: cycleStart.Add(-24 * time.Hour)},
 		},
 	}
 	if err := store.CreateModelConfig(ctx, vkMC); err != nil {
@@ -1863,7 +1865,8 @@ func TestGetVirtualKeyQuota_EndToEndWithRealStore(t *testing.T) {
 	if s := resp.Budgets[0].Models[0]; s.Model != "gpt-4o" || s.Provider != "openai" || s.TotalRequests != 3 || s.TotalTokens != 900 || s.TotalCost != 0.42 {
 		t.Fatalf("unexpected per_model_usage spend: %#v", s)
 	}
-	// The usage query must be scoped to this VK and windowed at the budget's last reset.
+	// The usage query must be scoped to this VK and windowed at the budget's last
+	// reset (the budget predates LastReset, so the creation-time clamp is a no-op here).
 	if len(logMgr.calls) != 1 {
 		t.Fatalf("expected GetModelRankings called once, got %d", len(logMgr.calls))
 	}
@@ -1876,6 +1879,74 @@ func TestGetVirtualKeyQuota_EndToEndWithRealStore(t *testing.T) {
 	}
 	if call.EndTime == nil || call.EndTime.Before(cycleStart) {
 		t.Fatalf("expected EndTime >= StartTime, got %v", call.EndTime)
+	}
+}
+
+// TestGetVirtualKeyQuota_WindowClampedToBudgetCreation verifies that when a budget's
+// LastReset is backdated to a calendar period start that predates the budget's
+// creation (e.g. a "1d" budget created mid-day with LastReset at midnight), the
+// per_model_usage query window starts at CreatedAt rather than LastReset — so the
+// breakdown does not report spend that occurred before the budget existed and stays
+// consistent with current_usage (which only accrues from creation).
+func TestGetVirtualKeyQuota_WindowClampedToBudgetCreation(t *testing.T) {
+	SetLogger(&mockLogger{})
+	ctx := context.Background()
+	periodStart := time.Date(2026, time.June, 24, 0, 0, 0, 0, time.UTC) // backdated "1d" boundary (midnight)
+	createdAt := time.Date(2026, time.June, 24, 11, 56, 42, 0, time.UTC) // budget created mid-day
+
+	store, err := configstore.NewConfigStore(ctx, &configstore.Config{
+		Enabled: true,
+		Type:    configstore.ConfigStoreTypeSQLite,
+		Config:  &configstore.SQLiteConfig{Path: filepath.Join(t.TempDir(), "quota_clamp.db")},
+	}, &mockLogger{})
+	if err != nil {
+		t.Fatalf("failed to create config store: %v", err)
+	}
+
+	const vkID = "vk-clamp"
+	active := true
+	vk := &configstoreTables.TableVirtualKey{
+		ID:       vkID,
+		Name:     "Clamp",
+		Value:    *schemas.NewSecretVar("sk-bf-clamp-secret"),
+		IsActive: &active,
+	}
+	if err := store.CreateVirtualKey(ctx, vk); err != nil {
+		t.Fatalf("failed to create VK: %v", err)
+	}
+
+	scopeID := vkID
+	vkMC := &configstoreTables.TableModelConfig{
+		ID:        "mc-clamp",
+		ModelName: configstoreTables.ModelConfigAllModels,
+		Scope:     configstoreTables.ModelConfigScopeVirtualKey,
+		ScopeID:   &scopeID,
+		Budgets: []configstoreTables.TableBudget{
+			{ID: "b-clamp", MaxLimit: 6, CurrentUsage: 0, ResetDuration: "1d", LastReset: periodStart, CreatedAt: createdAt},
+		},
+	}
+	if err := store.CreateModelConfig(ctx, vkMC); err != nil {
+		t.Fatalf("failed to create model config: %v", err)
+	}
+
+	logMgr := &mockQuotaLogManager{rankings: &logstore.ModelRankingResult{}}
+	h := &GovernanceHandler{configStore: store, logManager: logMgr}
+
+	var req fasthttp.Request
+	req.Header.Set("x-bf-vk", "sk-bf-clamp-secret")
+	reqCtx := &fasthttp.RequestCtx{}
+	reqCtx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+	h.getVirtualKeyQuota(reqCtx)
+
+	if reqCtx.Response.StatusCode() != 200 {
+		t.Fatalf("expected status 200, got %d: %s", reqCtx.Response.StatusCode(), string(reqCtx.Response.Body()))
+	}
+	if len(logMgr.calls) != 1 {
+		t.Fatalf("expected GetModelRankings called once, got %d", len(logMgr.calls))
+	}
+	call := logMgr.calls[0]
+	if call.StartTime == nil || !call.StartTime.Equal(createdAt) {
+		t.Fatalf("expected StartTime=%v (budget creation, clamped above backdated last reset), got %v", createdAt, call.StartTime)
 	}
 }
 


### PR DESCRIPTION
## Summary

When a budget's `LastReset` is backdated to a calendar period boundary (e.g. midnight for a `1d` budget) that precedes the budget's actual creation time, the per-model usage query was incorrectly starting at `LastReset`. This caused the breakdown to include spend that occurred before the budget existed, making it inconsistent with `current_usage`, which only accrues from the moment the budget was created.

## Changes

- In `buildVKBudgetsWithUsage`, the log query's `StartTime` is now clamped to `max(LastReset, CreatedAt)`, ensuring the usage window never starts before the budget existed.
- Added `TestGetVirtualKeyQuota_WindowClampedToBudgetCreation` to explicitly verify that when `CreatedAt` is later than `LastReset`, the query window starts at `CreatedAt`.
- Updated the existing `TestGetVirtualKeyQuota_EndToEndWithRealStore` to set `CreatedAt` before `LastReset`, confirming the clamp is a no-op in the steady-state case (budget has existed across multiple reset cycles).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/... -run TestGetVirtualKeyQuota
```

The new test `TestGetVirtualKeyQuota_WindowClampedToBudgetCreation` asserts that `GetModelRankings` is called with `StartTime` equal to `CreatedAt` (not the backdated `LastReset`) when a budget is created mid-period. The existing end-to-end test confirms the clamp does not affect budgets where `CreatedAt` predates `LastReset`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. The change narrows the time window used for log queries, reducing the risk of surfacing usage data that predates a budget's existence.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable