### PR TITLE
fix: mantle models and openai endpoint

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1076,7 +1076,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 		return nil, err
 	}
 
-	if isMantleModel(request.Model) {
+	if isMantleModel(schemas.ResolveCanonicalModel(ctx, request.Model)) {
 		return provider.chatCompletionViaMantle(ctx, key, request)
 	}
 
@@ -1168,7 +1168,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 		return nil, err
 	}
 
-	if isMantleModel(request.Model) {
+	if isMantleModel(schemas.ResolveCanonicalModel(ctx, request.Model)) {
 		return provider.chatCompletionStreamViaMantle(ctx, postHookRunner, postHookSpanFinalizer, key, request)
 	}
 
@@ -1496,7 +1496,7 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 		return nil, err
 	}
 
-	if isMantleModel(request.Model) {
+	if isMantleModel(schemas.ResolveCanonicalModel(ctx, request.Model)) {
 		return provider.responsesViaMantle(ctx, key, request)
 	}
 
@@ -1568,7 +1568,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 		return nil, err
 	}
 
-	if isMantleModel(request.Model) {
+	if isMantleModel(schemas.ResolveCanonicalModel(ctx, request.Model)) {
 		return provider.responsesStreamViaMantle(ctx, postHookRunner, postHookSpanFinalizer, key, request)
 	}
 

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -4963,7 +4963,7 @@ func TestDocumentFormatResponsesPathRoundTrip(t *testing.T) {
 			require.NotEmpty(t, bifrostMessages, "expected at least one Bifrost message")
 
 			// Outbound: Bifrost responses messages -> Bedrock
-			roundTripped, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(ctx, bifrostMessages)
+			roundTripped, _, err := bedrock.ConvertBifrostMessagesToBedrockMessages(ctx, bifrostMessages, false)
 			require.NoError(t, err)
 			require.NotEmpty(t, roundTripped, "expected at least one Bedrock message after round-trip")
 

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -14,14 +14,23 @@ import (
 )
 
 // isMantleModel reports whether a model should be routed via the Bedrock Mantle endpoint.
-// Accepts "gpt-*", "openai.gpt-*", or region-prefixed variants.
+// Accepts "gpt-*"/"gemma-4-*", "openai.gpt-*"/"google.gemma-4-*", or region-prefixed variants.
+// Gemma 3 is intentionally excluded: it only supports Chat (not Responses) on mantle, and the
+// non-mantle path serves both APIs via Converse, so forcing it to mantle would break Responses.
 func isMantleModel(model string) bool {
-	return strings.Contains(model, "gpt-")
+	return strings.Contains(model, "gpt-") || strings.Contains(model, "gemma-4")
 }
 
-// mantleURL builds the Bedrock Mantle endpoint URL for the given region and API path.
-func mantleURL(region, path string) string {
-	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/v1/%s", region, path)
+// mantleURL builds the Bedrock Mantle endpoint URL for the given region, model, and API path.
+// Pass the canonical (capability-resolved) model for correct path gating; the request body
+// still carries the wire request.Model. Frontier families (closed gpt-5.x, Gemma 4) live under
+// the "openai/v1" base path; gpt-oss uses the bare "v1" path.
+func mantleURL(region, model, path string) string {
+	base := "v1"
+	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gemma-4") {
+		base = "openai/v1"
+	}
+	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/%s/%s", region, base, path)
 }
 
 // mantleSigV4Headers computes SigV4 auth headers for a mantle request by signing a dummy
@@ -61,7 +70,7 @@ func (provider *BedrockProvider) chatCompletionViaMantle(
 	request *schemas.BifrostChatRequest,
 ) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleURL(region, "chat/completions")
+	url := mantleURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
 
 	// Build extraHeaders: always start with network-config headers, then overlay SigV4 if needed.
 	// Allocate explicitly so maps.Copy never writes into a nil map.
@@ -107,7 +116,7 @@ func (provider *BedrockProvider) chatCompletionStreamViaMantle(
 	request *schemas.BifrostChatRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleURL(region, "chat/completions")
+	url := mantleURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
 
 	// Bearer: identical to Groq / any OpenAI-compatible provider.
 	if key.Value.GetValue() != "" {
@@ -163,7 +172,7 @@ func (provider *BedrockProvider) responsesViaMantle(
 	request *schemas.BifrostResponsesRequest,
 ) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleURL(region, "responses")
+	url := mantleURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
 
 	extraHeaders := make(map[string]string, len(provider.networkConfig.ExtraHeaders))
 	maps.Copy(extraHeaders, provider.networkConfig.ExtraHeaders)
@@ -205,7 +214,7 @@ func (provider *BedrockProvider) responsesStreamViaMantle(
 	request *schemas.BifrostResponsesRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
-	url := mantleURL(region, "responses")
+	url := mantleURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
 
 	// Bearer: identical to Groq / any OpenAI-compatible provider.
 	if key.Value.GetValue() != "" {

--- a/core/providers/bedrock/mantle_test.go
+++ b/core/providers/bedrock/mantle_test.go
@@ -1,0 +1,65 @@
+package bedrock
+
+import "testing"
+
+func TestIsMantleModel(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		// gpt-oss family → mantle
+		{"gpt-oss-120b", true},
+		{"openai.gpt-oss-20b", true},
+		{"gpt-oss-safeguard-120b", true},
+		{"us.openai.gpt-oss-120b", true},
+		// closed gpt-5.x → mantle
+		{"gpt-5.5", true},
+		{"openai.gpt-5.4", true},
+		// Gemma 4 → mantle (mantle-only, no Converse endpoint)
+		{"gemma-4-31b", true},
+		{"google.gemma-4-e2b", true},
+		{"gemma-4-26b-a4b", true},
+		// Gemma 3 → NOT mantle: it has a Converse fallback that serves both APIs,
+		// while mantle only supports Chat (so Responses would break there).
+		{"gemma-3-12b-it", false},
+		{"google.gemma-3-27b-it", false},
+		{"gemma-3-4b-it", false},
+		// other families stay on the Converse path
+		{"claude-opus-4-8", false},
+		{"anthropic.claude-3-5-sonnet-20240620-v1:0", false},
+		{"amazon.titan-text-express-v1", false},
+	}
+	for _, tc := range cases {
+		if got := isMantleModel(tc.model); got != tc.want {
+			t.Errorf("isMantleModel(%q) = %v, want %v", tc.model, got, tc.want)
+		}
+	}
+}
+
+func TestMantleURL(t *testing.T) {
+	cases := []struct {
+		name   string
+		region string
+		model  string
+		path   string
+		want   string
+	}{
+		{"gpt-oss uses bare v1", "us-east-1", "openai.gpt-oss-120b", "chat/completions",
+			"https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions"},
+		{"gpt-oss-safeguard uses bare v1", "us-west-2", "openai.gpt-oss-safeguard-120b", "chat/completions",
+			"https://bedrock-mantle.us-west-2.api.aws/v1/chat/completions"},
+		{"gpt-5.x uses openai/v1", "us-east-2", "openai.gpt-5.5", "responses",
+			"https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"},
+		{"gemma-4 uses openai/v1", "us-east-1", "google.gemma-4-31b", "responses",
+			"https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses"},
+		{"gemma-3 uses bare v1", "us-east-1", "google.gemma-3-12b-it", "chat/completions",
+			"https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mantleURL(tc.region, tc.model, tc.path); got != tc.want {
+				t.Errorf("mantleURL(%q, %q, %q) = %q, want %q", tc.region, tc.model, tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds Gemma 4 support to the Bedrock Mantle routing path and fixes the Mantle URL base path selection so that frontier models (`gpt-5.x`, `gemma-4-*`) use the `openai/v1` base path while `gpt-oss` models continue to use the bare `v1` path. Also ensures Mantle routing decisions and URL construction use the canonical (capability-resolved) model name rather than the raw request model string.

## Changes

- `isMantleModel` now matches `gemma-4` in addition to `gpt-` prefixes. Gemma 3 is intentionally excluded because it has a Converse fallback that serves both Chat and Responses APIs, whereas the Mantle endpoint only supports Chat — routing Gemma 3 to Mantle would break Responses.
- `mantleURL` now accepts a `model` argument and selects `openai/v1` as the base path for `gpt-5.x` and `gemma-4` models, and `v1` for `gpt-oss` and other families.
- All four Mantle dispatch sites (`ChatCompletion`, `ChatCompletionStream`, `Responses`, `ResponsesStream`) now call `schemas.ResolveCanonicalModel` before passing the model to `isMantleModel` and `mantleURL`, ensuring alias/capability-resolved names are used for routing.
- Added `mantle_test.go` with table-driven tests covering `isMantleModel` and `mantleURL` for all relevant model families.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/...
```

Expected: all existing tests pass, and the new `TestIsMantleModel` and `TestMantleURL` cases in `mantle_test.go` pass, confirming correct routing for `gpt-oss`, `gpt-5.x`, `gemma-4`, and `gemma-3` model families.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth mechanisms introduced. SigV4 signing and Bearer token handling are unchanged; only the URL base path and routing predicate are affected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable