### PR TITLE
streaming memory improvements

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -641,9 +641,23 @@ func HandleAnthropicChatCompletionStreaming(
 
 	usedLargePayloadBody := setAnthropicRequestBody(ctx, req, jsonBody)
 
+	// Close the connection after this streaming response instead of returning it to
+	// the keep-alive pool. fasthttp can otherwise reuse a streaming connection whose
+	// reader is still in a torn state (body not fully drained, or the idle-timeout/
+	// consumer goroutine still attached), corrupting the next request's RoundTrip and
+	// panicking with "slice bounds out of range" in mustPeekBuffered. Mirrors the
+	// mitigation already used on Gemini/Azure/OpenAI streaming and anthropic.go:2716.
+	req.Header.Set("Connection", "close")
+
+	// Use a fresh streaming client per request so fasthttp's internal readerPool
+	// cannot be poisoned across concurrent Anthropic streams by a non-idempotent
+	// streaming-body close path. The cloned client preserves dialer/TLS/proxy
+	// config but starts with empty reader/writer pools.
+	requestClient := providerUtils.BuildStreamingClient(client)
+
 	// Use streaming-aware client when large payload optimization is active — ensures
 	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
+	activeClient := providerUtils.PrepareResponseStreaming(ctx, requestClient, resp)
 
 	startTime := time.Now()
 	// Make the request
@@ -1141,9 +1155,23 @@ func HandleAnthropicResponsesStream(
 	// Set body
 	usedLargePayloadBody := setAnthropicRequestBody(ctx, req, jsonBody)
 
+	// Close the connection after this streaming response instead of returning it to
+	// the keep-alive pool. fasthttp can otherwise reuse a streaming connection whose
+	// reader is still in a torn state (body not fully drained, or the idle-timeout/
+	// consumer goroutine still attached), corrupting the next request's RoundTrip and
+	// panicking with "slice bounds out of range" in mustPeekBuffered. Mirrors the
+	// mitigation already used on Gemini/Azure/OpenAI streaming and anthropic.go:2716.
+	req.Header.Set("Connection", "close")
+
+	// Use a fresh streaming client per request so fasthttp's internal readerPool
+	// cannot be poisoned across concurrent Anthropic streams by a non-idempotent
+	// streaming-body close path. The cloned client preserves dialer/TLS/proxy
+	// config but starts with empty reader/writer pools.
+	requestClient := providerUtils.BuildStreamingClient(client)
+
 	// Use streaming-aware client when large payload optimization is active — ensures
 	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
+	activeClient := providerUtils.PrepareResponseStreaming(ctx, requestClient, resp)
 
 	startTime := time.Now()
 	// Make the request

--- a/core/providers/utils/idle_timeout_reader_test.go
+++ b/core/providers/utils/idle_timeout_reader_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
 )
 
 // ---------------------------------------------------------------------------
@@ -564,7 +565,7 @@ func TestSetupStreamCancellation_NoPanicOnCancelledContext(t *testing.T) {
 	defer close(body.allowReturn)
 
 	type readResult struct {
-		err     error
+		err      error
 		panicked any
 	}
 	resultCh := make(chan readResult, 1)
@@ -596,5 +597,139 @@ func TestSetupStreamCancellation_NoPanicOnCancelledContext(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Error("Read goroutine did not unblock after context cancellation")
+	}
+}
+
+// countingStreamCloser models fasthttp's non-idempotent streaming body handle:
+// it implements streamCloserWithError (CloseWithError) and io.Reader, counting
+// closes and reads. The whole point of the atomic-claim fix is that the
+// underlying close runs at most once across the cancellation goroutine, the
+// idle-timeout timer, and ReleaseStreamingResponse — a second close would
+// re-run fasthttp's releaseRequestStream and double-Put the pooled struct.
+type countingStreamCloser struct {
+	closeCount atomic.Int32
+	readCount  atomic.Int32
+}
+
+func (c *countingStreamCloser) Read([]byte) (int, error) {
+	c.readCount.Add(1)
+	return 0, io.EOF
+}
+
+func (c *countingStreamCloser) CloseWithError(error) error {
+	c.closeCount.Add(1)
+	return nil
+}
+
+// TestStreamClose_ExactlyOnceAcrossOwners drives the idle-timeout timer and the
+// cancellation goroutine concurrently against one shared stream + context and
+// asserts the underlying CloseWithError fires exactly once. Before the fix the
+// two owners used a racy Value-then-SetValue guard and could both close, which
+// double-released the pooled fasthttp requestStream and poisoned another
+// request (the `slice bounds out of range [:-680]` crash). Run with -race.
+func TestStreamClose_ExactlyOnceAcrossOwners(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 100; i++ {
+		body := &countingStreamCloser{}
+		goCtx, cancel := context.WithCancel(context.Background())
+		ctx := schemas.NewBifrostContext(goCtx, time.Time{})
+
+		// Tiny idle timeout so the timer races the cancellation.
+		_, cleanup := NewIdleTimeoutReader(body, body, time.Millisecond, ctx)
+		stop := SetupStreamCancellation(ctx, body, getLogger())
+
+		go cancel() // fire cancellation concurrently with the idle timer
+
+		// Wait (bounded) until at least one owner has performed the close, rather
+		// than relying on a fixed sleep that can miss both close paths on slow CI.
+		deadline := time.Now().Add(2 * time.Second)
+		for body.closeCount.Load() == 0 && time.Now().Before(deadline) {
+			time.Sleep(50 * time.Microsecond)
+		}
+		stop()
+		cleanup()
+
+		if got := body.closeCount.Load(); got != 1 {
+			t.Fatalf("iteration %d: CloseWithError called %d times, want exactly 1", i, got)
+		}
+	}
+}
+
+// TestConnectionClosedClaim_SerializesOwners verifies the primitive the fix
+// relies on: GetAndSetValue on BifrostContextKeyConnectionClosed is an atomic
+// compare-and-claim, so exactly one of many concurrent owners observes the
+// prior `false` and is permitted to perform the underlying close.
+func TestConnectionClosedClaim_SerializesOwners(t *testing.T) {
+	t.Parallel()
+
+	const owners = 64
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+
+	var winners atomic.Int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < owners; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if prev, _ := ctx.GetAndSetValue(schemas.BifrostContextKeyConnectionClosed, true).(bool); !prev {
+				winners.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := winners.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 owner to win the close claim, got %d", got)
+	}
+}
+
+// TestReleaseStreamingResponse_SkipsWhenAlreadyClaimed asserts that once a
+// cancel/timeout owner has claimed the close, ReleaseStreamingResponse neither
+// drains nor releases the body stream — preventing fasthttp.ReleaseResponse
+// from triggering a second releaseRequestStream on an already-relinquished
+// pooled struct.
+func TestReleaseStreamingResponse_SkipsWhenAlreadyClaimed(t *testing.T) {
+	t.Parallel()
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	// A prior owner already claimed + closed the stream.
+	ctx.GetAndSetValue(schemas.BifrostContextKeyConnectionClosed, true)
+
+	body := &countingStreamCloser{}
+	resp := fasthttp.AcquireResponse()
+	resp.SetBodyStream(body, -1)
+
+	ReleaseStreamingResponse(ctx, resp)
+
+	if got := body.readCount.Load(); got != 0 {
+		t.Fatalf("ReleaseStreamingResponse drained the body despite a prior close claim (read %d times)", got)
+	}
+	if got := body.closeCount.Load(); got != 0 {
+		t.Fatalf("ReleaseStreamingResponse closed an already-claimed stream (%d times)", got)
+	}
+
+	// The claim was lost, so resp was intentionally not released (the
+	// production GC-leak trade-off). Release it here to keep the test clean.
+	fasthttp.ReleaseResponse(resp)
+}
+
+// TestReleaseStreamingResponse_NoBodyDoesNotClaimConnection covers the
+// pre-response error path: fasthttp.Do can fail before installing a body stream.
+// Releasing that empty response must not mark the request context as
+// connection-closed, because retries/fallbacks reuse the same BifrostContext.
+func TestReleaseStreamingResponse_NoBodyDoesNotClaimConnection(t *testing.T) {
+	t.Parallel()
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	resp := fasthttp.AcquireResponse()
+
+	ReleaseStreamingResponse(ctx, resp)
+
+	if closed, _ := ctx.Value(schemas.BifrostContextKeyConnectionClosed).(bool); closed {
+		t.Fatal("ReleaseStreamingResponse claimed connection ownership without a body stream")
 	}
 }

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2219,17 +2219,23 @@ func SetupStreamCancellation(ctx *schemas.BifrostContext, bodyStream io.Reader, 
 		defer close(closed)
 		select {
 		case <-ctx.Done():
-			if connClosed, ok := ctx.Value(schemas.BifrostContextKeyConnectionClosed).(bool); ok && connClosed {
+			// Atomically claim the close. Only one owner (this goroutine, the
+			// idle-timeout timer, or ReleaseStreamingResponse) may close the
+			// non-idempotent fasthttp body stream: a second CloseWithError
+			// re-runs releaseRequestStream, double-Putting the pooled
+			// requestStream so a later request aliases it concurrently and
+			// panics with a negative chunkLeft slice bound. GetAndSetValue is a
+			// single locked compare-and-swap, unlike the previous racy
+			// Value-then-SetValue check.
+			if prev, _ := ctx.GetAndSetValue(schemas.BifrostContextKeyConnectionClosed, true).(bool); prev {
 				return
 			}
 			// Context cancelled or deadline exceeded - close the body stream to unblock reads
 			if closer, ok := bodyStream.(io.Closer); ok {
-				ctx.SetValue(schemas.BifrostContextKeyConnectionClosed, true)
 				if err := closer.Close(); err != nil {
 					getLogger().Debug(fmt.Sprintf("Error closing body stream on context done: %v", err))
 				}
 			} else if wce, ok := bodyStream.(streamCloserWithError); ok {
-				ctx.SetValue(schemas.BifrostContextKeyConnectionClosed, true)
 				if err := wce.CloseWithError(ctx.Err()); err != nil {
 					getLogger().Debug(fmt.Sprintf("Error closing body stream on context done: %v", err))
 				}
@@ -2243,16 +2249,16 @@ func SetupStreamCancellation(ctx *schemas.BifrostContext, bodyStream io.Reader, 
 			// ctx.Done branch above) so ReleaseStreamingResponse skips a second CloseWithError.
 			// A second close against an already-pooled conn nil-derefs in fasthttp's connsCleaner.
 			if ctx.Err() != nil {
-				if connClosed, ok := ctx.Value(schemas.BifrostContextKeyConnectionClosed).(bool); ok && connClosed {
+				// Same atomic claim as the ctx.Done branch: skip if another
+				// owner already closed/released the stream.
+				if prev, _ := ctx.GetAndSetValue(schemas.BifrostContextKeyConnectionClosed, true).(bool); prev {
 					return
 				}
 				if closer, ok := bodyStream.(io.Closer); ok {
-					ctx.SetValue(schemas.BifrostContextKeyConnectionClosed, true)
 					if err := closer.Close(); err != nil {
 						getLogger().Debug(fmt.Sprintf("Error closing body stream on done with cancelled context: %v", err))
 					}
 				} else if wce, ok := bodyStream.(streamCloserWithError); ok {
-					ctx.SetValue(schemas.BifrostContextKeyConnectionClosed, true)
 					if err := wce.CloseWithError(ctx.Err()); err != nil {
 						getLogger().Debug(fmt.Sprintf("Error closing body stream on done with cancelled context: %v", err))
 					}
@@ -2357,10 +2363,18 @@ func NewIdleTimeoutReader(reader io.Reader, bodyStream io.Reader, timeout time.D
 	r.timer = time.AfterFunc(timeout, func() {
 		defer r.timerDoneOnce.Do(func() { close(r.timerDone) })
 		r.once.Do(func() {
-			r.fired.Store(true)
+			// Atomically claim the close before tearing anything down. If a
+			// cancellation/release owner already closed the stream, do nothing:
+			// a second closeBodyStream re-runs releaseRequestStream and
+			// double-Puts the pooled requestStream, poisoning another request.
+			// Setting r.fired only on the winning path keeps the Read recover's
+			// idle-timeout vs closed error classification accurate.
 			if ctx != nil {
-				ctx.SetValue(schemas.BifrostContextKeyConnectionClosed, true)
+				if prev, _ := ctx.GetAndSetValue(schemas.BifrostContextKeyConnectionClosed, true).(bool); prev {
+					return
+				}
 			}
+			r.fired.Store(true)
 			// closeBodyStream may panic: an orphaned timer can fire after the
 			// stream's connection has already been released to / reused from
 			// the fasthttp pool, so CloseWithError nil-derefs in
@@ -2416,7 +2430,6 @@ func (r *idleTimeoutReader) Read(p []byte) (n int, err error) {
 				err = r.closedReadError()
 				return
 			}
-			panic(recovered)
 		}
 	}()
 
@@ -2721,8 +2734,22 @@ func ProviderIsResponsesAPINative(providerName schemas.ModelProvider) bool {
 
 // ReleaseStreamingResponse releases a streaming response by draining the body stream and releasing the response.
 func ReleaseStreamingResponse(ctx *schemas.BifrostContext, resp *fasthttp.Response) {
-	// Skip drain + ReleaseResponse if the stream was already closed (e.g. by SetupStreamCancellation); fasthttp.ReleaseResponse would re-Close and nil-deref the TCP conn — leaking to GC is the intentional trade-off, so keep the defer below this check.
-	if closed, ok := ctx.Value(schemas.BifrostContextKeyConnectionClosed).(bool); ok && closed {
+	if resp == nil {
+		return
+	}
+	bodyStream := resp.BodyStream()
+	if bodyStream == nil {
+		fasthttp.ReleaseResponse(resp)
+		return
+	}
+	// Atomically claim the close. If a cancel/timeout owner already closed the
+	// stream, skip drain + ReleaseResponse: fasthttp.ReleaseResponse would
+	// re-Close and double-release the pooled requestStream/conn (poisoning
+	// another request, or nil-derefing the TCP conn). Leaking to GC is the
+	// intentional trade-off, so keep the defer below this check. GetAndSetValue
+	// is a single locked compare-and-swap, closing the race the previous
+	// Value-only check left open against a concurrent timer/cancellation close.
+	if prev, _ := ctx.GetAndSetValue(schemas.BifrostContextKeyConnectionClosed, true).(bool); prev {
 		return
 	}
 	defer func() {
@@ -2733,11 +2760,22 @@ func ReleaseStreamingResponse(ctx *schemas.BifrostContext, resp *fasthttp.Respon
 	// Drain any remaining data from the body stream before releasing.
 	// This prevents "whitespace in header" errors when the connection is reused
 	// (see: https://github.com/valyala/fasthttp/issues/1743).
-	if bodyStream := resp.BodyStream(); bodyStream != nil {
-		if _, err := io.Copy(io.Discard, bodyStream); err != nil {
-			getLogger().Warn("failed to drain streaming response body before release (may cause stale connection reuse): %v", err)
-		}
+	if _, err := io.Copy(io.Discard, bodyStream); err != nil {
+		getLogger().Warn("failed to drain streaming response body before release (may cause stale connection reuse): %v", err)
 	}
+	// Close the body-stream wrapper exactly once HERE and detach it from resp
+	// (CloseBodyStream sets resp.bodyStream = nil). fasthttp's streaming close
+	// callback releases the pooled *bufio.Reader and *requestStream with NO
+	// idempotency guard (client.go: hc.ReleaseReader(br) + releaseRequestStream
+	// are bare sync.Pool.Put). Without detaching, the fasthttp.ReleaseResponse
+	// below runs Reset -> closeBodyStream and fires that callback a SECOND time,
+	// double-Putting the reader; two later requests then acquire and Reset the
+	// same *bufio.Reader and race on it, producing the
+	// "slice bounds out of range [:N] with capacity 4096" panic in
+	// mustPeekBuffered. Detaching makes ReleaseResponse's Reset a no-op
+	// (closeBodyStream short-circuits on nil). The CAS above already serializes
+	// this against the cancellation / idle-timeout closers.
+	resp.CloseBodyStream()
 	fasthttp.ReleaseResponse(resp)
 }
 

--- a/framework/streaming/accumulator.go
+++ b/framework/streaming/accumulator.go
@@ -530,6 +530,29 @@ func (a *Accumulator) CleanupStreamAccumulator(requestID string) error {
 	return nil
 }
 
+// ForceCleanupStreamAccumulator reaps a stream accumulator regardless of its
+// reference counter. It is the guaranteed end-of-stream backstop: callers invoke
+// it from the stream's terminal lifecycle hook (the provider goroutine's
+// finalizer), at which point the stream has stopped delivering chunks and the
+// per-plugin refcount handshake may be incomplete (e.g. a client abort that
+// never produced a terminal chunk, or multiple plugins that each Create but not
+// all Cleanup). Force-reaping here mirrors the TTL sweep (cleanupOldAccumulators),
+// which already deletes with forceEndGate=true. Idempotent and safe to call after
+// CleanupStreamAccumulator has already freed the entry.
+func (a *Accumulator) ForceCleanupStreamAccumulator(requestID string) {
+	acc, exists := a.streamAccumulators.Load(requestID)
+	if !exists {
+		return
+	}
+	accumulator, ok := acc.(*StreamAccumulator)
+	if !ok {
+		return
+	}
+	accumulator.mu.Lock()
+	defer accumulator.mu.Unlock()
+	a.cleanupStreamAccumulator(requestID, true) // stream is over — force-end the gate and reap
+}
+
 // cleanupOldAccumulators removes old accumulators
 func (a *Accumulator) cleanupOldAccumulators() {
 	count := 0

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -505,7 +505,23 @@ func deepCopyResponsesMessageContentBlock(original schemas.ResponsesMessageConte
 	return copy
 }
 
-// buildCompleteMessageFromResponsesStreamChunks builds complete messages from accumulated responses stream chunks
+// respMsgAccum holds strings.Builders for one output message so streamed deltas
+// accumulate in O(n) instead of O(n²) repeated string concatenation. Keyed by the
+// message's index in the build's `messages` slice (append-only → stable identity).
+type respMsgAccum struct {
+	cbText      map[int]*strings.Builder // contentIndex -> text / reasoning-text builder (block.Text)
+	cbRefusal   map[int]*strings.Builder // contentIndex -> refusal builder
+	cbSignature map[int]*strings.Builder // contentIndex -> signature builder
+	args        *strings.Builder         // function-call arguments
+	summary     *strings.Builder         // reasoning summary text (Summary[0].Text)
+	encrypted   *strings.Builder         // reasoning encrypted content
+}
+
+// buildCompleteMessageFromResponsesStreamChunks builds complete messages from
+// accumulated responses stream chunks. Streamed string fields are gathered into
+// strings.Builder accumulators during the walk and materialized once at the end,
+// avoiding the O(n²) churn of repeated `*field += delta` on immutable strings
+// (mirrors buildCompleteMessageFromChatStreamChunks).
 func (a *Accumulator) buildCompleteMessageFromResponsesStreamChunks(chunks []*ResponsesStreamChunk) []schemas.ResponsesMessage {
 	var messages []schemas.ResponsesMessage
 
@@ -516,6 +532,62 @@ func (a *Accumulator) buildCompleteMessageFromResponsesStreamChunks(chunks []*Re
 		}
 		return chunks[i].ChunkIndex < chunks[j].ChunkIndex
 	})
+
+	// Builder accumulators keyed by message index. Materialized after the walk.
+	accums := map[int]*respMsgAccum{}
+	getAccum := func(idx int) *respMsgAccum {
+		acc := accums[idx]
+		if acc == nil {
+			acc = &respMsgAccum{
+				cbText:      map[int]*strings.Builder{},
+				cbRefusal:   map[int]*strings.Builder{},
+				cbSignature: map[int]*strings.Builder{},
+			}
+			accums[idx] = acc
+		}
+		return acc
+	}
+	// builderFor lazily creates a per-contentIndex builder, seeding it once with
+	// any value already present on the block (e.g. from content_part.added /
+	// output_item.added deep copies) so pre-existing content is preserved.
+	builderFor := func(m map[int]*strings.Builder, key int, seed *string) *strings.Builder {
+		b := m[key]
+		if b == nil {
+			b = &strings.Builder{}
+			if seed != nil {
+				b.WriteString(*seed)
+			}
+			m[key] = b
+		}
+		return b
+	}
+	// singleBuilder lazily creates a message-level builder, seeding once.
+	singleBuilder := func(b *strings.Builder, seed *string) *strings.Builder {
+		if b == nil {
+			b = &strings.Builder{}
+			if seed != nil {
+				b.WriteString(*seed)
+			}
+		}
+		return b
+	}
+	// ensureContentBlock grows the block slice to include contentIndex and sets
+	// its type if not yet initialized. The string mutation now flows through the
+	// builders above instead of in-place `+=`.
+	ensureContentBlock := func(message *schemas.ResponsesMessage, contentIndex int, typ schemas.ResponsesMessageContentBlockType) {
+		if message.Content == nil {
+			message.Content = &schemas.ResponsesMessageContent{}
+		}
+		if message.Content.ContentBlocks == nil {
+			message.Content.ContentBlocks = make([]schemas.ResponsesMessageContentBlock, contentIndex+1)
+		}
+		for len(message.Content.ContentBlocks) <= contentIndex {
+			message.Content.ContentBlocks = append(message.Content.ContentBlocks, schemas.ResponsesMessageContentBlock{})
+		}
+		if message.Content.ContentBlocks[contentIndex].Type == "" {
+			message.Content.ContentBlocks[contentIndex].Type = typ
+		}
+	}
 
 	for _, chunk := range chunks {
 		if chunk.StreamResponse == nil {
@@ -553,18 +625,31 @@ func (a *Accumulator) buildCompleteMessageFromResponsesStreamChunks(chunks []*Re
 			if len(messages) == 0 {
 				messages = append(messages, createNewMessage())
 			}
-			// Append text delta to the most recent message
+			// Accumulate text delta into the most recent message
 			if resp.Delta != nil && resp.ContentIndex != nil && len(messages) > 0 {
-				a.appendTextDeltaToResponsesMessage(&messages[len(messages)-1], *resp.Delta, *resp.ContentIndex)
+				idx := len(messages) - 1
+				ensureContentBlock(&messages[idx], *resp.ContentIndex, schemas.ResponsesOutputMessageContentTypeText)
+				block := &messages[idx].Content.ContentBlocks[*resp.ContentIndex]
+				if block.ResponsesOutputMessageContentText == nil {
+					block.ResponsesOutputMessageContentText = &schemas.ResponsesOutputMessageContentText{}
+				}
+				builderFor(getAccum(idx).cbText, *resp.ContentIndex, block.Text).WriteString(*resp.Delta)
 			}
 
 		case schemas.ResponsesStreamResponseTypeRefusalDelta:
 			if len(messages) == 0 {
 				messages = append(messages, createNewMessage())
 			}
-			// Append refusal delta to the most recent message
+			// Accumulate refusal delta into the most recent message
 			if resp.Refusal != nil && resp.ContentIndex != nil && len(messages) > 0 {
-				a.appendRefusalDeltaToResponsesMessage(&messages[len(messages)-1], *resp.Refusal, *resp.ContentIndex)
+				idx := len(messages) - 1
+				ensureContentBlock(&messages[idx], *resp.ContentIndex, schemas.ResponsesOutputMessageContentTypeRefusal)
+				block := &messages[idx].Content.ContentBlocks[*resp.ContentIndex]
+				var seed *string
+				if block.ResponsesOutputMessageContentRefusal != nil {
+					seed = &block.ResponsesOutputMessageContentRefusal.Refusal
+				}
+				builderFor(getAccum(idx).cbRefusal, *resp.ContentIndex, seed).WriteString(*resp.Refusal)
 			}
 
 		case schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta:
@@ -598,24 +683,30 @@ func (a *Accumulator) buildCompleteMessageFromResponsesStreamChunks(chunks []*Re
 						targetIdx = len(messages) - 1
 					}
 				}
-				a.appendFunctionArgumentsDeltaToResponsesMessage(&messages[targetIdx], *resp.Delta)
+				msg := &messages[targetIdx]
+				if msg.ResponsesToolMessage == nil {
+					msg.ResponsesToolMessage = &schemas.ResponsesToolMessage{}
+				}
+				acc := getAccum(targetIdx)
+				acc.args = singleBuilder(acc.args, msg.ResponsesToolMessage.Arguments)
+				acc.args.WriteString(*resp.Delta)
 			}
 
 		case schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta:
 			// Create new reasoning message if none exists, or find existing reasoning message to append delta to
 			if (resp.Delta != nil || resp.Signature != nil) && resp.ItemID != nil {
-				var targetMessage *schemas.ResponsesMessage
+				targetIdx := -1
 
 				// Find the reasoning message by ItemID
 				for i := len(messages) - 1; i >= 0; i-- {
 					if messages[i].ID != nil && *messages[i].ID == *resp.ItemID {
-						targetMessage = &messages[i]
+						targetIdx = i
 						break
 					}
 				}
 
 				// If no message found, create a new reasoning message
-				if targetMessage == nil {
+				if targetIdx == -1 {
 					// Deep copy ItemID to prevent shared pointer mutation
 					var copyID *string
 					if resp.ItemID != nil {
@@ -631,19 +722,94 @@ func (a *Accumulator) buildCompleteMessageFromResponsesStreamChunks(chunks []*Re
 						},
 					}
 					messages = append(messages, newMessage)
-					targetMessage = &messages[len(messages)-1]
+					targetIdx = len(messages) - 1
 				}
 
-				// Handle text delta
+				targetMessage := &messages[targetIdx]
+
+				// Handle text delta (content-block reasoning text or summary accumulation)
 				if resp.Delta != nil {
-					a.appendReasoningDeltaToResponsesMessage(targetMessage, *resp.Delta, resp.ContentIndex)
+					if resp.ContentIndex != nil {
+						ensureContentBlock(targetMessage, *resp.ContentIndex, schemas.ResponsesOutputMessageContentTypeReasoning)
+						block := &targetMessage.Content.ContentBlocks[*resp.ContentIndex]
+						builderFor(getAccum(targetIdx).cbText, *resp.ContentIndex, block.Text).WriteString(*resp.Delta)
+					} else {
+						if targetMessage.ResponsesReasoning == nil {
+							targetMessage.ResponsesReasoning = &schemas.ResponsesReasoning{Summary: []schemas.ResponsesReasoningSummary{}}
+						}
+						if len(targetMessage.ResponsesReasoning.Summary) == 0 {
+							targetMessage.ResponsesReasoning.Summary = append(targetMessage.ResponsesReasoning.Summary, schemas.ResponsesReasoningSummary{
+								Type: schemas.ResponsesReasoningContentBlockTypeSummaryText,
+							})
+						}
+						acc := getAccum(targetIdx)
+						acc.summary = singleBuilder(acc.summary, &targetMessage.ResponsesReasoning.Summary[0].Text)
+						acc.summary.WriteString(*resp.Delta)
+					}
 				}
 
-				// Handle signature delta
+				// Handle signature delta (content-block signature or encrypted content)
 				if resp.Signature != nil {
-					a.appendReasoningSignatureToResponsesMessage(targetMessage, *resp.Signature, resp.ContentIndex)
+					if resp.ContentIndex != nil {
+						ensureContentBlock(targetMessage, *resp.ContentIndex, schemas.ResponsesOutputMessageContentTypeReasoning)
+						block := &targetMessage.Content.ContentBlocks[*resp.ContentIndex]
+						builderFor(getAccum(targetIdx).cbSignature, *resp.ContentIndex, block.Signature).WriteString(*resp.Signature)
+					} else {
+						if targetMessage.ResponsesReasoning == nil {
+							targetMessage.ResponsesReasoning = &schemas.ResponsesReasoning{Summary: []schemas.ResponsesReasoningSummary{}}
+						}
+						acc := getAccum(targetIdx)
+						acc.encrypted = singleBuilder(acc.encrypted, targetMessage.ResponsesReasoning.EncryptedContent)
+						acc.encrypted.WriteString(*resp.Signature)
+					}
 				}
 			}
+		}
+	}
+
+	// Materialize all accumulated builders into the message fields once. Linear
+	// in total streamed bytes — this is what replaces the O(n²) in-place `+=`.
+	for idx, acc := range accums {
+		msg := &messages[idx]
+		for ci, b := range acc.cbText {
+			s := b.String()
+			msg.Content.ContentBlocks[ci].Text = &s
+		}
+		for ci, b := range acc.cbRefusal {
+			block := &msg.Content.ContentBlocks[ci]
+			if block.ResponsesOutputMessageContentRefusal == nil {
+				block.ResponsesOutputMessageContentRefusal = &schemas.ResponsesOutputMessageContentRefusal{}
+			}
+			block.ResponsesOutputMessageContentRefusal.Refusal = b.String()
+		}
+		for ci, b := range acc.cbSignature {
+			s := b.String()
+			msg.Content.ContentBlocks[ci].Signature = &s
+		}
+		if acc.args != nil {
+			s := acc.args.String()
+			if msg.ResponsesToolMessage == nil {
+				msg.ResponsesToolMessage = &schemas.ResponsesToolMessage{}
+			}
+			msg.ResponsesToolMessage.Arguments = &s
+		}
+		if acc.summary != nil {
+			if msg.ResponsesReasoning == nil {
+				msg.ResponsesReasoning = &schemas.ResponsesReasoning{}
+			}
+			if len(msg.ResponsesReasoning.Summary) == 0 {
+				msg.ResponsesReasoning.Summary = append(msg.ResponsesReasoning.Summary, schemas.ResponsesReasoningSummary{
+					Type: schemas.ResponsesReasoningContentBlockTypeSummaryText,
+				})
+			}
+			msg.ResponsesReasoning.Summary[0].Text = acc.summary.String()
+		}
+		if acc.encrypted != nil {
+			s := acc.encrypted.String()
+			if msg.ResponsesReasoning == nil {
+				msg.ResponsesReasoning = &schemas.ResponsesReasoning{}
+			}
+			msg.ResponsesReasoning.EncryptedContent = &s
 		}
 	}
 
@@ -657,184 +823,6 @@ func createNewMessage() schemas.ResponsesMessage {
 		Content: &schemas.ResponsesMessageContent{
 			ContentBlocks: make([]schemas.ResponsesMessageContentBlock, 0),
 		},
-	}
-}
-
-// appendTextDeltaToResponsesMessage appends text delta to a responses message
-func (a *Accumulator) appendTextDeltaToResponsesMessage(message *schemas.ResponsesMessage, delta string, contentIndex int) {
-	if message.Content == nil {
-		message.Content = &schemas.ResponsesMessageContent{}
-	}
-
-	// If we don't have content blocks yet, create them
-	if message.Content.ContentBlocks == nil {
-		message.Content.ContentBlocks = make([]schemas.ResponsesMessageContentBlock, contentIndex+1)
-	}
-
-	// Ensure we have enough content blocks
-	for len(message.Content.ContentBlocks) <= contentIndex {
-		message.Content.ContentBlocks = append(message.Content.ContentBlocks, schemas.ResponsesMessageContentBlock{})
-	}
-
-	// Initialize the content block if needed
-	if message.Content.ContentBlocks[contentIndex].Type == "" {
-		message.Content.ContentBlocks[contentIndex].Type = schemas.ResponsesOutputMessageContentTypeText
-		message.Content.ContentBlocks[contentIndex].ResponsesOutputMessageContentText = &schemas.ResponsesOutputMessageContentText{}
-	}
-
-	// Append to existing text or create new text
-	if message.Content.ContentBlocks[contentIndex].Text == nil {
-		message.Content.ContentBlocks[contentIndex].Text = &delta
-	} else {
-		*message.Content.ContentBlocks[contentIndex].Text += delta
-	}
-}
-
-// appendRefusalDeltaToResponsesMessage appends refusal delta to a responses message
-func (a *Accumulator) appendRefusalDeltaToResponsesMessage(message *schemas.ResponsesMessage, refusal string, contentIndex int) {
-	if message.Content == nil {
-		message.Content = &schemas.ResponsesMessageContent{}
-	}
-
-	// If we don't have content blocks yet, create them
-	if message.Content.ContentBlocks == nil {
-		message.Content.ContentBlocks = make([]schemas.ResponsesMessageContentBlock, contentIndex+1)
-	}
-
-	// Ensure we have enough content blocks
-	for len(message.Content.ContentBlocks) <= contentIndex {
-		message.Content.ContentBlocks = append(message.Content.ContentBlocks, schemas.ResponsesMessageContentBlock{})
-	}
-
-	// Initialize the content block if needed
-	if message.Content.ContentBlocks[contentIndex].Type == "" {
-		message.Content.ContentBlocks[contentIndex].Type = schemas.ResponsesOutputMessageContentTypeRefusal
-		message.Content.ContentBlocks[contentIndex].ResponsesOutputMessageContentRefusal = &schemas.ResponsesOutputMessageContentRefusal{}
-	}
-
-	// Append to existing refusal text
-	if message.Content.ContentBlocks[contentIndex].ResponsesOutputMessageContentRefusal == nil {
-		message.Content.ContentBlocks[contentIndex].ResponsesOutputMessageContentRefusal = &schemas.ResponsesOutputMessageContentRefusal{
-			Refusal: refusal,
-		}
-	} else {
-		message.Content.ContentBlocks[contentIndex].ResponsesOutputMessageContentRefusal.Refusal += refusal
-	}
-}
-
-// appendFunctionArgumentsDeltaToResponsesMessage appends function arguments delta to a responses message
-func (a *Accumulator) appendFunctionArgumentsDeltaToResponsesMessage(message *schemas.ResponsesMessage, arguments string) {
-	if message.ResponsesToolMessage == nil {
-		message.ResponsesToolMessage = &schemas.ResponsesToolMessage{}
-	}
-
-	if message.ResponsesToolMessage.Arguments == nil {
-		message.ResponsesToolMessage.Arguments = &arguments
-	} else {
-		*message.ResponsesToolMessage.Arguments += arguments
-	}
-}
-
-// appendReasoningDeltaToResponsesMessage appends reasoning delta to a responses message
-func (a *Accumulator) appendReasoningDeltaToResponsesMessage(message *schemas.ResponsesMessage, delta string, contentIndex *int) {
-	// Handle reasoning content in two ways:
-	// 1. Content blocks (for reasoning_text content blocks)
-	// 2. ResponsesReasoning.Summary (for reasoning summary accumulation)
-
-	// If we have a content index, this is reasoning content in content blocks
-	if contentIndex != nil {
-		if message.Content == nil {
-			message.Content = &schemas.ResponsesMessageContent{}
-		}
-
-		// If we don't have content blocks yet, create them
-		if message.Content.ContentBlocks == nil {
-			message.Content.ContentBlocks = make([]schemas.ResponsesMessageContentBlock, *contentIndex+1)
-		}
-
-		// Ensure we have enough content blocks
-		for len(message.Content.ContentBlocks) <= *contentIndex {
-			message.Content.ContentBlocks = append(message.Content.ContentBlocks, schemas.ResponsesMessageContentBlock{})
-		}
-
-		// Initialize the content block if needed
-		if message.Content.ContentBlocks[*contentIndex].Type == "" {
-			message.Content.ContentBlocks[*contentIndex].Type = schemas.ResponsesOutputMessageContentTypeReasoning
-		}
-
-		// Append to existing reasoning text or create new text
-		if message.Content.ContentBlocks[*contentIndex].Text == nil {
-			message.Content.ContentBlocks[*contentIndex].Text = &delta
-		} else {
-			*message.Content.ContentBlocks[*contentIndex].Text += delta
-		}
-	} else {
-		// No content index - this is reasoning summary accumulation
-		if message.ResponsesReasoning == nil {
-			message.ResponsesReasoning = &schemas.ResponsesReasoning{
-				Summary: []schemas.ResponsesReasoningSummary{},
-			}
-		}
-
-		// For now, accumulate into a single summary entry
-		// In the future, this could be enhanced to handle multiple summary entries
-		if len(message.ResponsesReasoning.Summary) == 0 {
-			message.ResponsesReasoning.Summary = append(message.ResponsesReasoning.Summary, schemas.ResponsesReasoningSummary{
-				Type: schemas.ResponsesReasoningContentBlockTypeSummaryText,
-				Text: delta,
-			})
-		} else {
-			// Append to the first (and typically only) summary entry
-			message.ResponsesReasoning.Summary[0].Text += delta
-		}
-	}
-}
-
-// appendReasoningSignatureToResponsesMessage appends reasoning signature to a responses message
-func (a *Accumulator) appendReasoningSignatureToResponsesMessage(message *schemas.ResponsesMessage, signature string, contentIndex *int) {
-	// Handle signature content in content blocks or ResponsesReasoning.EncryptedContent
-
-	// If we have a content index, this is signature content in content blocks
-	if contentIndex != nil {
-		if message.Content == nil {
-			message.Content = &schemas.ResponsesMessageContent{}
-		}
-
-		// If we don't have content blocks yet, create them
-		if message.Content.ContentBlocks == nil {
-			message.Content.ContentBlocks = make([]schemas.ResponsesMessageContentBlock, *contentIndex+1)
-		}
-
-		// Ensure we have enough content blocks
-		for len(message.Content.ContentBlocks) <= *contentIndex {
-			message.Content.ContentBlocks = append(message.Content.ContentBlocks, schemas.ResponsesMessageContentBlock{})
-		}
-
-		// Initialize the content block if needed
-		if message.Content.ContentBlocks[*contentIndex].Type == "" {
-			message.Content.ContentBlocks[*contentIndex].Type = schemas.ResponsesOutputMessageContentTypeReasoning
-		}
-
-		// Set or append signature to the content block
-		if message.Content.ContentBlocks[*contentIndex].Signature == nil {
-			message.Content.ContentBlocks[*contentIndex].Signature = &signature
-		} else {
-			*message.Content.ContentBlocks[*contentIndex].Signature += signature
-		}
-	} else {
-		// No content index - this is encrypted content at the reasoning level
-		if message.ResponsesReasoning == nil {
-			message.ResponsesReasoning = &schemas.ResponsesReasoning{
-				Summary: []schemas.ResponsesReasoningSummary{},
-			}
-		}
-
-		// Set or append to encrypted content
-		if message.ResponsesReasoning.EncryptedContent == nil {
-			message.ResponsesReasoning.EncryptedContent = &signature
-		} else {
-			*message.ResponsesReasoning.EncryptedContent += signature
-		}
 	}
 }
 

--- a/framework/streaming/responses_test.go
+++ b/framework/streaming/responses_test.go
@@ -1,10 +1,194 @@
 package streaming
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+func testResponsesAccumulator(tb testing.TB) *Accumulator {
+	tb.Helper()
+	acc := NewAccumulator(nil, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	tb.Cleanup(acc.Cleanup)
+	return acc
+}
+
+// TestBuildResponsesMessageConcatenatesTextDeltas verifies that many streamed
+// text deltas are joined in order. This is the path that previously accumulated
+// via O(n²) `*Text += delta`; the builder rewrite must produce identical bytes.
+func TestBuildResponsesMessageConcatenatesTextDeltas(t *testing.T) {
+	acc := testResponsesAccumulator(t)
+	ci := 0
+	var want strings.Builder
+	var chunks []*ResponsesStreamChunk
+	for i := 0; i < 500; i++ {
+		d := fmt.Sprintf("tok%d ", i)
+		want.WriteString(d)
+		chunks = append(chunks, &ResponsesStreamChunk{
+			ChunkIndex: i,
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:         schemas.ResponsesStreamResponseTypeOutputTextDelta,
+				Delta:        schemas.Ptr(d),
+				ContentIndex: &ci,
+			},
+		})
+	}
+
+	msgs := acc.buildCompleteMessageFromResponsesStreamChunks(chunks)
+	if len(msgs) != 1 {
+		t.Fatalf("want 1 message, got %d", len(msgs))
+	}
+	got := msgs[0].Content.ContentBlocks[0].Text
+	if got == nil {
+		t.Fatal("text block is nil")
+	}
+	if *got != want.String() {
+		t.Fatalf("text mismatch:\n got %q\nwant %q", *got, want.String())
+	}
+}
+
+// TestBuildResponsesMessageRoutesParallelToolArgs verifies that interleaved
+// function-call argument deltas are routed to the correct item by ItemID and
+// concatenated independently.
+func TestBuildResponsesMessageRoutesParallelToolArgs(t *testing.T) {
+	acc := testResponsesAccumulator(t)
+	item := func(id string) *ResponsesStreamChunk {
+		return &ResponsesStreamChunk{
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type: schemas.ResponsesStreamResponseTypeOutputItemAdded,
+				Item: &schemas.ResponsesMessage{ID: schemas.Ptr(id)},
+			},
+		}
+	}
+	argDelta := func(id, delta string) *ResponsesStreamChunk {
+		return &ResponsesStreamChunk{
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:   schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+				ItemID: schemas.Ptr(id),
+				Delta:  schemas.Ptr(delta),
+			},
+		}
+	}
+	chunks := []*ResponsesStreamChunk{
+		item("call_a"), item("call_b"),
+		argDelta("call_a", `{"x":`), argDelta("call_b", `{"y":`),
+		argDelta("call_a", `1}`), argDelta("call_b", `2}`),
+	}
+	for i, c := range chunks {
+		c.ChunkIndex = i
+	}
+
+	msgs := acc.buildCompleteMessageFromResponsesStreamChunks(chunks)
+	gotArgs := map[string]string{}
+	for _, m := range msgs {
+		if m.ID != nil && m.ResponsesToolMessage != nil && m.ResponsesToolMessage.Arguments != nil {
+			gotArgs[*m.ID] = *m.ResponsesToolMessage.Arguments
+		}
+	}
+	if gotArgs["call_a"] != `{"x":1}` {
+		t.Errorf("call_a args: got %q, want %q", gotArgs["call_a"], `{"x":1}`)
+	}
+	if gotArgs["call_b"] != `{"y":2}` {
+		t.Errorf("call_b args: got %q, want %q", gotArgs["call_b"], `{"y":2}`)
+	}
+}
+
+// TestBuildResponsesMessageAccumulatesReasoningSummary verifies reasoning
+// summary deltas (no content index) concatenate into a single summary entry.
+func TestBuildResponsesMessageAccumulatesReasoningSummary(t *testing.T) {
+	acc := testResponsesAccumulator(t)
+	parts := []string{"Let me ", "think ", "step by step."}
+	var chunks []*ResponsesStreamChunk
+	for i, p := range parts {
+		chunks = append(chunks, &ResponsesStreamChunk{
+			ChunkIndex: i,
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:   schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
+				ItemID: schemas.Ptr("reason_1"),
+				Delta:  schemas.Ptr(p),
+			},
+		})
+	}
+
+	msgs := acc.buildCompleteMessageFromResponsesStreamChunks(chunks)
+	if len(msgs) != 1 || msgs[0].ResponsesReasoning == nil || len(msgs[0].ResponsesReasoning.Summary) != 1 {
+		t.Fatalf("unexpected reasoning shape: %+v", msgs)
+	}
+	if got := msgs[0].ResponsesReasoning.Summary[0].Text; got != "Let me think step by step." {
+		t.Fatalf("summary mismatch: got %q", got)
+	}
+}
+
+// TestForceCleanupStreamAccumulatorReapsRegardlessOfRefcount is the Tier-1 leak
+// guard: it reproduces a stream that ended without its per-plugin refcount being
+// driven to zero (e.g. a client abort, or multiple plugins that each Create but
+// not all Cleanup) and asserts the finalizer's force-reap still frees it.
+func TestForceCleanupStreamAccumulatorReapsRegardlessOfRefcount(t *testing.T) {
+	acc := testResponsesAccumulator(t)
+
+	const requestID = "force-reap-test"
+	// Simulate two independent plugins each taking a hold (logging + maxim).
+	acc.CreateStreamAccumulator(requestID, time.Now())
+	acc.CreateStreamAccumulator(requestID, time.Now())
+
+	// Accumulate a chunk so the accumulator holds real data.
+	ci := 0
+	chunk := acc.getResponsesStreamChunk()
+	chunk.ChunkIndex = 0
+	chunk.StreamResponse = &schemas.BifrostResponsesStreamResponse{
+		Type:         schemas.ResponsesStreamResponseTypeOutputTextDelta,
+		Delta:        schemas.Ptr("hello"),
+		ContentIndex: &ci,
+	}
+	if err := acc.addResponsesStreamChunk(requestID, chunk, false); err != nil {
+		t.Fatalf("addResponsesStreamChunk: %v", err)
+	}
+
+	// A single refcount-based cleanup must NOT reap (refcount went 2 -> 1).
+	_ = acc.CleanupStreamAccumulator(requestID)
+	if _, ok := acc.streamAccumulators.Load(requestID); !ok {
+		t.Fatal("accumulator was reaped by a single refcount cleanup despite refcount > 0")
+	}
+
+	// The end-of-stream finalizer force-reaps regardless of the remaining hold.
+	acc.ForceCleanupStreamAccumulator(requestID)
+	if _, ok := acc.streamAccumulators.Load(requestID); ok {
+		t.Fatal("accumulator survived ForceCleanupStreamAccumulator")
+	}
+
+	// Idempotent: calling again after the entry is gone must not panic.
+	acc.ForceCleanupStreamAccumulator(requestID)
+}
+
+// BenchmarkBuildResponsesMessageTextDeltas guards against regressing back to
+// O(n²) accumulation. allocs/op and B/op should scale ~linearly with the chunk
+// count, not quadratically.
+func BenchmarkBuildResponsesMessageTextDeltas(b *testing.B) {
+	acc := testResponsesAccumulator(b)
+	ci := 0
+	const n = 2000
+	chunks := make([]*ResponsesStreamChunk, n)
+	for i := 0; i < n; i++ {
+		chunks[i] = &ResponsesStreamChunk{
+			ChunkIndex: i,
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:         schemas.ResponsesStreamResponseTypeOutputTextDelta,
+				Delta:        schemas.Ptr("hello world "),
+				ContentIndex: &ci,
+			},
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = acc.buildCompleteMessageFromResponsesStreamChunks(chunks)
+	}
+}
 
 // TestDeepCopyResponsesStreamResponsePreservesAllFields guards the deep-copy
 // helper against silently dropping fields that survive unmarshal/WithDefaults.

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -540,6 +540,18 @@ func (t *Tracer) CleanupStreamAccumulator(traceID string) {
 	}
 }
 
+// ForceCleanupStreamAccumulator reaps the stream accumulator for the given trace
+// ID regardless of its reference counter. It is the guaranteed end-of-stream
+// backstop, called from the transport's trace completer once the stream has fully
+// drained, so an aborted or otherwise non-cleanly-terminated stream (or a
+// multi-plugin refcount imbalance) cannot leak its accumulator.
+func (t *Tracer) ForceCleanupStreamAccumulator(traceID string) {
+	if traceID == "" || t.accumulator == nil {
+		return
+	}
+	t.accumulator.ForceCleanupStreamAccumulator(traceID)
+}
+
 // ProcessStreamingChunk processes a streaming chunk and accumulates it.
 // Returns the accumulated result when isFinalChunk is true and the stream is complete;
 // returns nil for non-final chunks.

--- a/tests/integrations/python/config.json
+++ b/tests/integrations/python/config.json
@@ -351,6 +351,9 @@
       }
     ]
   },
+  "server": {
+    "read_buffer_size": 65536
+  },
   "client": {
     "drop_excess_requests": false,
     "initial_pool_size": 300,

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -1246,6 +1246,14 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 					tracer.EndSpan(rootHandle, schemas.SpanStatusOk, "")
 				}
 				tracer.CompleteAndFlushTrace(traceID)
+				// Guaranteed end-of-stream backstop: force-reap the stream accumulator
+				// now that the stream has fully drained and the trace is flushed. This
+				// covers streams that ended without a clean terminal chunk (client abort,
+				// broken SSE write, or a multi-plugin refcount imbalance), which would
+				// otherwise leak their accumulated (deep-copied) chunks until the TTL
+				// sweep. Safe after CompleteAndFlushTrace: span completion reads the
+				// separately stored accumulated response, not the live accumulator.
+				tracer.ForceCleanupStreamAccumulator(traceID)
 			})
 			// Create root span for the HTTP request
 			spanCtx, rootSpan := tracer.StartSpan(ctx, string(ctx.RequestURI()), schemas.SpanKindHTTPRequest)

--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -7,17 +7,9 @@ import TrialExpiryBanner from "@/components/trialExpiryBanner";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useStoreSync } from "@/hooks/useStoreSync";
 import { WebSocketProvider } from "@/hooks/useWebSocket";
-import {
-  getErrorMessage,
-  ReduxProvider,
-  useGetCoreConfigQuery,
-  useIsAuthEnabledQuery,
-} from "@/lib/store";
+import { getErrorMessage, ReduxProvider, useGetCoreConfigQuery, useIsAuthEnabledQuery } from "@/lib/store";
 import { BifrostConfig } from "@/lib/types/config";
-import {
-  RbacProvider,
-  useRbacContext,
-} from "@enterprise/lib/contexts/rbacContext";
+import { RbacProvider, useRbacContext } from "@enterprise/lib/contexts/rbacContext";
 import { useLocation, useMatches } from "@tanstack/react-router";
 import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
 import { lazy, Suspense, useEffect, useState } from "react";
@@ -26,127 +18,108 @@ import { toast, Toaster } from "sonner";
 
 // Lazy import — only loaded in development, completely excluded from prod bundle
 const DevProfilerLazy = lazy(() =>
-  import("@/components/devProfiler").then((mod) => ({
-    default: mod.DevProfiler,
-  })),
+	import("@/components/devProfiler").then((mod) => ({
+		default: mod.DevProfiler,
+	})),
 );
 const DevProfiler = () => (
-  <Suspense fallback={null}>
-    <DevProfilerLazy />
-  </Suspense>
+	<Suspense fallback={null}>
+		<DevProfilerLazy />
+	</Suspense>
 );
 
 function StoreSyncInitializer() {
-  useStoreSync();
-  return null;
+	useStoreSync();
+	return null;
 }
 
 function AppContent({ children }: { children: React.ReactNode }) {
-  // Routes can declare `staticData: { tempTokenScoped: true }` to advertise that
-  // they're reachable via a server-emitted, temp-token-bearing URL by visitors
-  // without a dashboard session. The actual layout choice is made per-visitor:
-  // an authenticated admin still sees the full dashboard chrome, while an
-  // anonymous visitor arriving with `#t=<token>` gets a stripped MinimalShell.
-  // The auth-via-temp-token half lives in <TempTokenScope>.
-  const matches = useMatches();
-  const tempTokenScoped = matches.some(
-    (m) =>
-      (m.staticData as { tempTokenScoped?: boolean } | undefined)
-        ?.tempTokenScoped === true,
-  );
-  // publicShell: route declares it's a static, auth-free page that should
-  // always render MinimalShell — no chrome, no auth probe, no API calls.
-  // Used by the post-OAuth "authentication successful" landing, which has
-  // neither a fragment nor a cookie to drive the tempTokenScoped per-visitor
-  // logic.
-  const publicShell = matches.some(
-    (m) =>
-      (m.staticData as { publicShell?: boolean } | undefined)?.publicShell ===
-      true,
-  );
+	// Routes can declare `staticData: { tempTokenScoped: true }` to advertise that
+	// they're reachable via a server-emitted, temp-token-bearing URL by visitors
+	// without a dashboard session. The actual layout choice is made per-visitor:
+	// an authenticated admin still sees the full dashboard chrome, while an
+	// anonymous visitor arriving with `#t=<token>` gets a stripped MinimalShell.
+	// The auth-via-temp-token half lives in <TempTokenScope>.
+	const matches = useMatches();
+	const tempTokenScoped = matches.some((m) => (m.staticData as { tempTokenScoped?: boolean } | undefined)?.tempTokenScoped === true);
+	// publicShell: route declares it's a static, auth-free page that should
+	// always render MinimalShell — no chrome, no auth probe, no API calls.
+	// Used by the post-OAuth "authentication successful" landing, which has
+	// neither a fragment nor a cookie to drive the tempTokenScoped per-visitor
+	// logic.
+	const publicShell = matches.some((m) => (m.staticData as { publicShell?: boolean } | undefined)?.publicShell === true);
 
-  // Probe dashboard auth state on opted-in routes. is-auth-enabled is whitelisted
-  // (no 401 risk) and returns whether the current cookie is a valid session.
-  const { data: authState, isLoading: authLoading } = useIsAuthEnabledQuery(
-    undefined,
-    { skip: !tempTokenScoped },
-  );
+	// Probe dashboard auth state on opted-in routes. is-auth-enabled is whitelisted
+	// (no 401 risk) and returns whether the current cookie is a valid session.
+	const { data: authState, isLoading: authLoading } = useIsAuthEnabledQuery(undefined, { skip: !tempTokenScoped });
 
-  // Snapshot fragment presence at mount: TempTokenScope strips the fragment
-  // shortly after, so re-reading window.location.hash would flip false on
-  // re-render. Only fragment-bearing arrivals are MinimalShell candidates.
-  const [hadFragmentTempToken] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const fragment = window.location.hash;
-    if (!fragment || fragment.length < 2) return false;
-    return !!new URLSearchParams(fragment.slice(1)).get("t");
-  });
+	// Snapshot fragment presence at mount: TempTokenScope strips the fragment
+	// shortly after, so re-reading window.location.hash would flip false on
+	// re-render. Only fragment-bearing arrivals are MinimalShell candidates.
+	const [hadFragmentTempToken] = useState(() => {
+		if (typeof window === "undefined") return false;
+		const fragment = window.location.hash;
+		if (!fragment || fragment.length < 2) return false;
+		return !!new URLSearchParams(fragment.slice(1)).get("t");
+	});
 
-  const useMinimalShell =
-    tempTokenScoped &&
-    !!authState?.is_auth_enabled &&
-    !authState?.has_valid_token &&
-    hadFragmentTempToken;
+	const useMinimalShell = tempTokenScoped && !!authState?.is_auth_enabled && !authState?.has_valid_token && hadFragmentTempToken;
 
-  const {
-    data: bifrostConfig,
-    error,
-    isLoading,
-  } = useGetCoreConfigQuery(
-    {},
-    {
-      skip: publicShell || useMinimalShell || (tempTokenScoped && authLoading),
-    },
-  );
+	const {
+		data: bifrostConfig,
+		error,
+		isLoading,
+	} = useGetCoreConfigQuery(
+		{},
+		{
+			skip: publicShell || useMinimalShell || (tempTokenScoped && authLoading),
+		},
+	);
 
-  // Permissions are restored from sessionStorage (async) and refreshed from the
-  // API. Until that first resolve, useRbac() returns false for everything, which
-  // would briefly collapse the sidebar to a single tab and flash NoPermissionView
-  // on the active route. Gate the full dashboard chrome on it; the cached read is
-  // a single frame so this is imperceptible. Minimal/public shells don't use RBAC
-  // and are handled by the early returns below.
-  const { isLoading: rbacLoading } = useRbacContext();
+	// Permissions are restored from sessionStorage (async) and refreshed from the
+	// API. Until that first resolve, useRbac() returns false for everything, which
+	// would briefly collapse the sidebar to a single tab and flash NoPermissionView
+	// on the active route. Gate the full dashboard chrome on it; the cached read is
+	// a single frame so this is imperceptible. Minimal/public shells don't use RBAC
+	// and are handled by the early returns below.
+	const { isLoading: rbacLoading } = useRbacContext();
 
-  useEffect(() => {
-    if (error) {
-      toast.error(getErrorMessage(error));
-    }
-  }, [error]);
+	useEffect(() => {
+		if (error) {
+			toast.error(getErrorMessage(error));
+		}
+	}, [error]);
 
-  if (publicShell) {
-    return <MinimalShell>{children}</MinimalShell>;
-  }
-  if (tempTokenScoped && authLoading) {
-    return <FullPageLoader />;
-  }
-  if (useMinimalShell) {
-    return <MinimalShell>{children}</MinimalShell>;
-  }
+	if (publicShell) {
+		return <MinimalShell>{children}</MinimalShell>;
+	}
+	if (tempTokenScoped && authLoading) {
+		return <FullPageLoader />;
+	}
+	if (useMinimalShell) {
+		return <MinimalShell>{children}</MinimalShell>;
+	}
 
-  if (rbacLoading) {
-    return <FullPageLoader />;
-  }
+	if (rbacLoading) {
+		return <FullPageLoader />;
+	}
 
-  return (
-    <WebSocketProvider>
-      <CookiesProvider>
-        <StoreSyncInitializer />
-        <SidebarProvider>
-          <Sidebar />
-          <div className="dark:bg-card custom-scrollbar content-container my-[0.5rem] mr-[0.5rem] h-[calc(100dvh-1rem)] w-full min-w-xl overflow-auto rounded-md border border-gray-200 bg-white px-10 dark:border-zinc-800">
-            <TrialExpiryBanner />
-            <main className="custom-scrollbar content-container-inner relative mx-auto flex h-full min-h-0 flex-col overflow-y-hidden p-4">
-              {isLoading ? (
-                <FullPageLoader />
-              ) : (
-                <FullPage config={bifrostConfig}>{children}</FullPage>
-              )}
-            </main>
-          </div>
-        </SidebarProvider>
-      </CookiesProvider>
-    </WebSocketProvider>
-  );
+	return (
+		<WebSocketProvider>
+			<CookiesProvider>
+				<StoreSyncInitializer />
+				<SidebarProvider>
+					<Sidebar />
+					<div className="dark:bg-card custom-scrollbar content-container my-[0.5rem] mr-[0.5rem] h-[calc(100dvh-1rem)] w-full min-w-xl overflow-auto rounded-md border border-gray-200 bg-white px-10 dark:border-zinc-800">
+						<TrialExpiryBanner />
+						<main className="custom-scrollbar content-container-inner relative mx-auto flex h-full min-h-0 flex-col overflow-y-hidden p-4">
+							{isLoading ? <FullPageLoader /> : <FullPage config={bifrostConfig}>{children}</FullPage>}
+						</main>
+					</div>
+				</SidebarProvider>
+			</CookiesProvider>
+		</WebSocketProvider>
+	);
 }
 
 // MinimalShell renders a centered container without sidebar, websocket,
@@ -154,51 +127,40 @@ function AppContent({ children }: { children: React.ReactNode }) {
 // in via `staticData.tempTokenScoped` — typically public, scoped pages
 // like the MCP per-user OAuth auth page.
 function MinimalShell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="dark:bg-card custom-scrollbar content-container my-[0.5rem] h-[calc(100dvh-1rem)] w-full overflow-auto rounded-md border border-gray-200 bg-white px-10 dark:border-zinc-800">
-      <main className="custom-scrollbar content-container-inner relative mx-auto flex h-full min-h-0 flex-col overflow-y-hidden p-4">
-        {children}
-      </main>
-    </div>
-  );
+	return (
+		<div className="dark:bg-card custom-scrollbar content-container my-[0.5rem] h-[calc(100dvh-1rem)] w-full overflow-auto rounded-md border border-gray-200 bg-white px-10 dark:border-zinc-800">
+			<main className="custom-scrollbar content-container-inner relative mx-auto flex h-full min-h-0 flex-col overflow-y-hidden p-4">
+				{children}
+			</main>
+		</div>
+	);
 }
 
-function FullPage({
-  config,
-  children,
-}: {
-  config: BifrostConfig | undefined;
-  children: React.ReactNode;
-}) {
-  const pathname = useLocation({ select: (l) => l.pathname });
-  if (config && config.is_db_connected) {
-    return children;
-  }
-  if (
-    config &&
-    config.is_logs_connected &&
-    pathname.startsWith("/workspace/logs")
-  ) {
-    return children;
-  }
-  return <NotAvailableBanner />;
+function FullPage({ config, children }: { config: BifrostConfig | undefined; children: React.ReactNode }) {
+	const pathname = useLocation({ select: (l) => l.pathname });
+	if (config && config.is_db_connected) {
+		return children;
+	}
+	if (config && config.is_logs_connected && pathname.startsWith("/workspace/logs")) {
+		return children;
+	}
+	return <NotAvailableBanner />;
 }
 
 export function ClientLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <ProgressProvider>
-      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-        <Toaster closeButton />
-        <ReduxProvider>
-          <NuqsAdapter>
-            <RbacProvider>
-              <AppContent>{children}</AppContent>
-              {process.env.NODE_ENV === "development" &&
-                !process.env.BIFROST_DISABLE_PROFILER && <DevProfiler />}
-            </RbacProvider>
-          </NuqsAdapter>
-        </ReduxProvider>
-      </ThemeProvider>
-    </ProgressProvider>
-  );
+	return (
+		<ProgressProvider>
+			<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+				<Toaster closeButton />
+				<ReduxProvider>
+					<NuqsAdapter>
+						<RbacProvider>
+							<AppContent>{children}</AppContent>
+							{process.env.NODE_ENV === "development" && !process.env.BIFROST_DISABLE_PROFILER && <DevProfiler />}
+						</RbacProvider>
+					</NuqsAdapter>
+				</ReduxProvider>
+			</ThemeProvider>
+		</ProgressProvider>
+	);
 }


### PR DESCRIPTION
## Summary

This PR fixes two classes of bugs: a race condition that caused fasthttp's pooled `requestStream` to be double-released (producing `slice bounds out of range` panics on concurrent requests), and a stream accumulator memory leak where accumulators for aborted or non-cleanly-terminated streams were not freed until the TTL sweep. It also replaces O(n²) string concatenation in the Responses API stream builder with a `strings.Builder`-based accumulator pattern.

## Changes

- **Atomic stream close ownership (`utils.go`):** Replaced the racy `Value`-then-`SetValue` guard on `BifrostContextKeyConnectionClosed` with a single `GetAndSetValue` compare-and-swap in `SetupStreamCancellation`, `NewIdleTimeoutReader`, and `ReleaseStreamingResponse`. Previously, the cancellation goroutine, the idle-timeout timer, and `ReleaseStreamingResponse` could each observe `false` and all proceed to call `CloseWithError`, double-releasing the pooled fasthttp `requestStream` and corrupting a concurrent request's slice bounds. Now exactly one owner wins the claim and performs the close.

- **Removed re-panic in idle timeout reader (`utils.go`):** Dropped the unconditional `panic(recovered)` in `idleTimeoutReader.Read`'s recover block, which was re-panicking on legitimate post-close reads after the atomic-claim fix moved `r.fired.Store(true)` to the winning-owner path only.

- **Force-reap stream accumulator backstop (`accumulator.go`, `tracer.go`, `bifrost.go`):** Added `ForceCleanupStreamAccumulator` to the `Tracer` interface, `NoOpTracer`, `Accumulator`, and `Tracer` implementations. The stream's terminal lifecycle hook (the provider goroutine's `postHookSpanFinalizer`) now calls this after releasing the plugin pipeline, guaranteeing that accumulators for streams that end without a clean terminal chunk (client abort, broken SSE write, multi-plugin refcount imbalance) are freed immediately rather than waiting for the TTL sweep. The trace ID is captured as an immutable string before the pooled request object is recycled.

- **O(n²) → O(n) Responses stream builder (`responses.go`):** Replaced per-delta `*field += delta` string concatenation in `buildCompleteMessageFromResponsesStreamChunks` with `strings.Builder` accumulators keyed by message and content-block index. Builders are materialized into final strings once after the chunk walk. The five helper methods (`appendTextDeltaToResponsesMessage`, `appendRefusalDeltaToResponsesMessage`, `appendFunctionArgumentsDeltaToResponsesMessage`, `appendReasoningDeltaToResponsesMessage`, `appendReasoningSignatureToResponsesMessage`) are removed and their logic is inlined into the walk + materialization pass.

- **Tests (`idle_timeout_reader_test.go`, `responses_test.go`):** Added `TestStreamClose_ExactlyOnceAcrossOwners` (races the timer and cancellation goroutine 100 times, asserts `CloseWithError` fires exactly once), `TestConnectionClosedClaim_SerializesOwners` (64 concurrent goroutines, asserts exactly one wins), `TestReleaseStreamingResponse_SkipsWhenAlreadyClaimed`, `TestBuildResponsesMessageConcatenatesTextDeltas`, `TestBuildResponsesMessageRoutesParallelToolArgs`, `TestBuildResponsesMessageAccumulatesReasoningSummary`, `TestForceCleanupStreamAccumulatorReapsRegardlessOfRefcount`, and `BenchmarkBuildResponsesMessageTextDeltas`.

- **UI formatting (`clientLayout.tsx`):** Reformatted from 2-space to tab indentation and collapsed some multi-line imports; no behavioral changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Run with race detector to exercise the atomic-claim fix
go test -race ./core/providers/utils/... -run TestStreamClose_ExactlyOnceAcrossOwners -count=10
go test -race ./core/providers/utils/... -run TestConnectionClosedClaim_SerializesOwners
go test -race ./core/providers/utils/... -run TestReleaseStreamingResponse_SkipsWhenAlreadyClaimed

# Force-reap accumulator backstop
go test ./framework/streaming/... -run TestForceCleanupStreamAccumulatorReapsRegardlessOfRefcount -v

# Responses stream builder correctness and performance
go test ./framework/streaming/... -run TestBuildResponsesMessage
go test -bench=BenchmarkBuildResponsesMessageTextDeltas -benchmem ./framework/streaming/...

# Full suite
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

## Breaking changes

- [x] No

The `Tracer` interface gains `ForceCleanupStreamAccumulator`. Any external implementations of `Tracer` must add this method. The `NoOpTracer` implementation is provided as a reference.

## Related issues

Fixes the `slice bounds out of range [:-680]` crash caused by double-release of fasthttp's pooled `requestStream`. Fixes stream accumulator leaks on client-aborted or non-cleanly-terminated streams.

## Security considerations

No auth, secrets, or PII implications. The fix closes a memory-corruption vector (double-pool-release) that could cause one request to alias another's in-flight data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable