### PR TITLE
fix: signal Bedrock max_output_tokens truncation on Responses API

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -3,3 +3,4 @@
 - fix: recover from idle-timeout timer-goroutine panic that could crash the process
 - fix: deterministic MCP tool ordering for prompt cache stability (closes #2347)
 - fix: pass through `gs://` image URLs on Vertex Gemini (closes #4402)
+- fix: signal Bedrock max_output_tokens truncation on Responses API [@jeremym-tanium](https://github.com/jeremym-tanium)

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -4594,17 +4594,19 @@ func TestBedrockStopReasonMappingResponsesPath(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		bedrockReason   string
-		expectedBifrost string
+		name                      string
+		bedrockReason             string
+		expectedBifrost           string
+		expectedStatus            string // "" means Status should be nil
+		expectedIncompleteDetails string // "" means IncompleteDetails should be nil
 	}{
-		{"EndTurn", "end_turn", "stop"},
-		{"MaxTokens", "max_tokens", "length"},
-		{"StopSequence", "stop_sequence", "stop"},
-		{"ToolUse", "tool_use", "tool_calls"},
-		{"ContentFiltered", "content_filtered", "content_filter"},
-		{"GuardrailIntervened", "guardrail_intervened", "guardrail_intervened"}, // no clean mapping — passes through
-		{"UnknownReason", "some_unknown_reason", "some_unknown_reason"},         // no clean mapping — passes through
+		{"EndTurn", "end_turn", "stop", "completed", ""},
+		{"MaxTokens", "max_tokens", "length", "incomplete", "max_output_tokens"},
+		{"StopSequence", "stop_sequence", "stop", "completed", ""},
+		{"ToolUse", "tool_use", "tool_calls", "completed", ""},
+		{"ContentFiltered", "content_filtered", "content_filter", "", ""},               // no clean mapping — passes through, no Status
+		{"GuardrailIntervened", "guardrail_intervened", "guardrail_intervened", "", ""}, // no clean mapping — passes through, no Status
+		{"UnknownReason", "some_unknown_reason", "some_unknown_reason", "", ""},         // no clean mapping — passes through, no Status
 	}
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -4629,8 +4631,86 @@ func TestBedrockStopReasonMappingResponsesPath(t *testing.T) {
 			require.NotNil(t, bifrostResp.StopReason, "StopReason should be set")
 			assert.Equal(t, tt.expectedBifrost, *bifrostResp.StopReason,
 				"Bedrock stop reason %q should map to %q in responses path", tt.bedrockReason, tt.expectedBifrost)
+
+			// Status + IncompleteDetails mirror the OpenAI Responses-API spec.
+			// Truncation must surface as Status="incomplete" with the canonical
+			// IncompleteDetails.Reason; clean completions get Status="completed";
+			// unmapped reasons leave both unset (preserves prior behavior).
+			if tt.expectedStatus == "" {
+				assert.Nil(t, bifrostResp.Status, "Status must be nil for unmapped stop reasons")
+				assert.Nil(t, bifrostResp.IncompleteDetails, "IncompleteDetails must be nil for unmapped stop reasons")
+			} else {
+				require.NotNil(t, bifrostResp.Status, "Status must be set for mapped stop reason %q", tt.bedrockReason)
+				assert.Equal(t, tt.expectedStatus, *bifrostResp.Status)
+			}
+			if tt.expectedIncompleteDetails == "" {
+				assert.Nil(t, bifrostResp.IncompleteDetails)
+			} else {
+				require.NotNil(t, bifrostResp.IncompleteDetails)
+				assert.Equal(t, tt.expectedIncompleteDetails, bifrostResp.IncompleteDetails.Reason)
+			}
 		})
 	}
+}
+
+// TestFinalizeBedrockStream_MaxTokensTruncation guards the streaming counterpart:
+// when Bedrock's stopReason is "max_tokens", the terminal SSE event must be
+// response.incomplete (not response.completed) and the embedded response must
+// carry Status="incomplete" + IncompleteDetails.Reason="max_output_tokens" so
+// streaming consumers can detect truncation.
+func TestFinalizeBedrockStream_MaxTokensTruncation(t *testing.T) {
+	state := bedrock.NewBedrockResponsesStreamState()
+	state.StopReason = schemas.Ptr("length") // mapped from bedrock's "max_tokens"
+	usage := &schemas.ResponsesResponseUsage{InputTokens: 30, OutputTokens: 15, TotalTokens: 45}
+
+	finalResponses := bedrock.FinalizeBedrockStream(state, 0, usage, nil)
+	require.NotEmpty(t, finalResponses)
+
+	terminal := finalResponses[len(finalResponses)-1]
+	assert.Equal(t, schemas.ResponsesStreamResponseTypeIncomplete, terminal.Type,
+		"terminal event must be response.incomplete on max_output_tokens truncation")
+	require.NotNil(t, terminal.Response)
+	require.NotNil(t, terminal.Response.Status)
+	assert.Equal(t, "incomplete", *terminal.Response.Status)
+	require.NotNil(t, terminal.Response.IncompleteDetails)
+	assert.Equal(t, "max_output_tokens", terminal.Response.IncompleteDetails.Reason)
+}
+
+// TestFinalizeBedrockStream_CleanCompletionUnaffected verifies non-truncation
+// stop reasons still produce response.completed with Status="completed".
+func TestFinalizeBedrockStream_CleanCompletionUnaffected(t *testing.T) {
+	state := bedrock.NewBedrockResponsesStreamState()
+	state.StopReason = schemas.Ptr("stop")
+	usage := &schemas.ResponsesResponseUsage{InputTokens: 5, OutputTokens: 10, TotalTokens: 15}
+
+	finalResponses := bedrock.FinalizeBedrockStream(state, 0, usage, nil)
+	require.NotEmpty(t, finalResponses)
+
+	terminal := finalResponses[len(finalResponses)-1]
+	assert.Equal(t, schemas.ResponsesStreamResponseTypeCompleted, terminal.Type)
+	require.NotNil(t, terminal.Response)
+	require.NotNil(t, terminal.Response.Status)
+	assert.Equal(t, "completed", *terminal.Response.Status)
+	assert.Nil(t, terminal.Response.IncompleteDetails)
+}
+
+// TestFinalizeBedrockStream_UnmappedReasonLeavesStatusUnset keeps the streaming
+// path aligned with the non-streaming mapping: an unmapped stop reason (e.g.
+// content_filter) ends the stream as response.completed but must leave Status
+// unset rather than asserting "completed".
+func TestFinalizeBedrockStream_UnmappedReasonLeavesStatusUnset(t *testing.T) {
+	state := bedrock.NewBedrockResponsesStreamState()
+	state.StopReason = schemas.Ptr("content_filter")
+	usage := &schemas.ResponsesResponseUsage{InputTokens: 5, OutputTokens: 10, TotalTokens: 15}
+
+	finalResponses := bedrock.FinalizeBedrockStream(state, 0, usage, nil)
+	require.NotEmpty(t, finalResponses)
+
+	terminal := finalResponses[len(finalResponses)-1]
+	assert.Equal(t, schemas.ResponsesStreamResponseTypeCompleted, terminal.Type)
+	require.NotNil(t, terminal.Response)
+	assert.Nil(t, terminal.Response.Status, "unmapped stop reasons must leave Status unset, matching the non-streaming path")
+	assert.Nil(t, terminal.Response.IncompleteDetails)
 }
 
 // TestBifrostToBedrockStopReasonReverseMapping tests the reverse conversion

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1510,8 +1510,27 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 		}
 	}
 
+	// Set Status/IncompleteDetails and the terminal event type per OpenAI's
+	// Responses-API contract, matching the non-streaming switch above so
+	// unmapped reasons leave Status unset on both paths.
+	terminalEventType := schemas.ResponsesStreamResponseTypeCompleted
+	if response.StopReason != nil {
+		switch *response.StopReason {
+		case string(schemas.BifrostFinishReasonLength):
+			terminalEventType = schemas.ResponsesStreamResponseTypeIncomplete
+			response.Status = schemas.Ptr(schemas.ResponsesResponseStatusIncomplete)
+			response.IncompleteDetails = &schemas.ResponsesResponseIncompleteDetails{
+				Reason: schemas.ResponsesResponseIncompleteReasonMaxOutputTokens,
+			}
+		case string(schemas.BifrostFinishReasonStop), string(schemas.BifrostFinishReasonToolCalls):
+			if response.Status == nil {
+				response.Status = schemas.Ptr(schemas.ResponsesResponseStatusCompleted)
+			}
+		}
+	}
+
 	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-		Type:           schemas.ResponsesStreamResponseTypeCompleted,
+		Type:           terminalEventType,
 		SequenceNumber: sequenceNumber + len(responses),
 		Response:       response,
 	})
@@ -2696,6 +2715,19 @@ func (response *BedrockConverseResponse) ToBifrostResponsesResponse(ctx *schemas
 			}
 		}
 		bifrostResp.StopReason = &stopReason
+		// Surface truncation via Status + IncompleteDetails per OpenAI's
+		// Responses-API contract; without these, truncations are silent.
+		switch stopReason {
+		case string(schemas.BifrostFinishReasonLength):
+			bifrostResp.Status = schemas.Ptr(schemas.ResponsesResponseStatusIncomplete)
+			bifrostResp.IncompleteDetails = &schemas.ResponsesResponseIncompleteDetails{
+				Reason: schemas.ResponsesResponseIncompleteReasonMaxOutputTokens,
+			}
+		case string(schemas.BifrostFinishReasonStop), string(schemas.BifrostFinishReasonToolCalls):
+			if bifrostResp.Status == nil {
+				bifrostResp.Status = schemas.Ptr(schemas.ResponsesResponseStatusCompleted)
+			}
+		}
 	}
 
 	if response.Trace != nil {

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -802,6 +802,22 @@ type ResponsesResponseIncompleteDetails struct {
 	Reason string `json:"reason"` // The reason why the response is incomplete
 }
 
+// ResponsesResponse.Status values (OpenAI Responses API).
+const (
+	ResponsesResponseStatusInProgress = "in_progress"
+	ResponsesResponseStatusCompleted  = "completed"
+	ResponsesResponseStatusIncomplete = "incomplete"
+	ResponsesResponseStatusFailed     = "failed"
+	ResponsesResponseStatusCancelled  = "cancelled"
+	ResponsesResponseStatusQueued     = "queued"
+)
+
+// ResponsesResponseIncompleteDetails.Reason values.
+const (
+	ResponsesResponseIncompleteReasonMaxOutputTokens = "max_output_tokens"
+	ResponsesResponseIncompleteReasonContentFilter   = "content_filter"
+)
+
 type ResponsesResponseUsage struct {
 	Type                *string                        `json:"type,omitempty"`        // type field is sent by anthropic
 	InputTokens         int                            `json:"input_tokens"`          // Number of input tokens (prompt tokens + cached tokens)
@@ -943,7 +959,7 @@ const (
 	// `tools` array). See ResponsesMessage's (Un)MarshalJSON.
 	ResponsesMessageTypeToolSearchCall   ResponsesMessageType = "tool_search_call"
 	ResponsesMessageTypeToolSearchOutput ResponsesMessageType = "tool_search_output"
-	ResponsesMessageTypeAdvisorCall          ResponsesMessageType = "advisor_call" // Anthropic advisor server tool (server_tool_use + advisor_tool_result)
+	ResponsesMessageTypeAdvisorCall      ResponsesMessageType = "advisor_call" // Anthropic advisor server tool (server_tool_use + advisor_tool_result)
 )
 
 // ResponsesMessage is a union type that can contain different types of input items


### PR DESCRIPTION
## Summary

When a `/v1/responses` request to a Bedrock model is truncated by `max_output_tokens`, Bifrost drops the OpenAI-canonical truncation signals on the wire response:

- `response.status` is left unset (OpenAI sets `"incomplete"`)
- `response.incomplete_details` is left unset (OpenAI sets `{"reason": "max_output_tokens"}`)
- On the streaming path, the terminal SSE event is `response.completed` (OpenAI emits `response.incomplete`)

Consumers on the OpenAI Responses-API contract therefore cannot detect Bedrock-side truncation. This is especially damaging for streaming tool calls, where the truncated bytes parse as valid-but-incomplete JSON (required fields silently missing or `{}`), so a downstream parser cannot fall back on a parse error.

## Changes

Two narrow edits in `core/providers/bedrock/responses.go`:

- **Non-streaming path** (`BedrockConverseResponse.ToBifrostResponsesResponse`): after the existing `bifrostResp.StopReason = &stopReason`, set `Status`/`IncompleteDetails` from the mapped stop reason (`"length"` → `incomplete` + `max_output_tokens`; clean reasons → `completed`). Mirrors `core/schemas/mux.go::responsesStatusFromChatFinishReason`.
- **Streaming path** (`FinalizeBedrockStream`): the terminal chunk's hard-coded `ResponsesStreamResponseTypeCompleted` becomes conditional — when the mapped stop reason is `"length"`, emit `ResponsesStreamResponseTypeIncomplete` and set the same fields on the embedded `Response`.

Value flow: Bedrock `stopReason "max_tokens"` → Bifrost finish reason `"length"` → OpenAI `status "incomplete"` + `incomplete_details.reason "max_output_tokens"`. No new code paths or API surface; `status`/`incomplete_details` are existing optional fields.

Changelog entry added to `core/changelog.md`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/bedrock/ \
  -run 'TestBedrockStopReasonMappingResponsesPath|TestFinalizeBedrockStream' -count=1 -v
```

Covered by `TestBedrockStopReasonMappingResponsesPath` (extended with `Status`/`IncompleteDetails` per stop reason), `TestFinalizeBedrockStream_MaxTokensTruncation`, and `TestFinalizeBedrockStream_CleanCompletionUnaffected`. AWS reports `stopReason: "max_tokens"` for the same input (`aws bedrock-runtime converse-stream`); this brings the Bifrost translation in line with that signal.

## Breaking changes

- [ ] Yes
- [x] No

`status` and `incomplete_details` are existing optional fields. The streaming terminal event type changes from `response.completed` to `response.incomplete` only when Bedrock reports `max_tokens` — which is the bug fix (consumers now see the OpenAI-canonical type).

## Related issues

Closes #4679

## Security considerations

None — no auth, secret, or PII surface changed.

## Checklist

- [x] I read the contributing guidelines and followed them
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (no behavior outside the existing OpenAI contract)
- [x] I verified Go builds and tests succeed (UI not touched)
- [ ] I verified the full CI pipeline locally (provider suite needs live credentials; ran gofmt, go vet, go build, and the bedrock tests above)
