### PR TITLE
fix: bedrock glm-5 stop sequences and remove web search error

### DIFF
--- a/core/providers/bedrock/convert_tool_config_test.go
+++ b/core/providers/bedrock/convert_tool_config_test.go
@@ -556,3 +556,88 @@ func TestConvertChatParameters_ResponseFormatWithPinnedServerTool_NoConflictingC
 		t.Errorf("expected NO additionalModelRequestFields.tool_choice when response_format pins bf_so_* (conflict hazard)")
 	}
 }
+
+// TestConvertInferenceConfig_GLMSkipsStopSequences locks in the fix for the
+// user-reported 400 ("This model doesn't support the stopSequences field"):
+// GLM models on Bedrock reject inferenceConfig.stopSequences, so we omit it
+// for them while keeping it for every other model family.
+func TestConvertInferenceConfig_GLMSkipsStopSequences(t *testing.T) {
+	params := &schemas.ChatParameters{
+		MaxCompletionTokens: schemas.Ptr(12000),
+		Stop:                []string{"hi"},
+	}
+
+	glm := convertInferenceConfig(params, "zai.glm-5")
+	if glm.StopSequences != nil {
+		t.Fatalf("expected StopSequences to be omitted for GLM, got %v", glm.StopSequences)
+	}
+	// Other inference params must still pass through.
+	if glm.MaxTokens == nil || *glm.MaxTokens != 12000 {
+		t.Fatalf("expected MaxTokens to be preserved, got %v", glm.MaxTokens)
+	}
+
+	other := convertInferenceConfig(params, "anthropic.claude-sonnet-4")
+	if len(other.StopSequences) != 1 || other.StopSequences[0] != "hi" {
+		t.Fatalf("expected StopSequences to be preserved for non-GLM, got %v", other.StopSequences)
+	}
+}
+
+// TestToBedrockResponsesRequest_GLMSkipsStopSequences verifies the Responses
+// path (where `stop` arrives via ExtraParams) also drops stopSequences for GLM.
+func TestToBedrockResponsesRequest_GLMSkipsStopSequences(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostResponsesRequest{
+		Model: "zai.glm-5",
+		Input: []schemas.ResponsesMessage{glmUserMessage("hello")},
+		Params: &schemas.ResponsesParameters{
+			MaxOutputTokens: schemas.Ptr(32000),
+			ExtraParams:     map[string]interface{}{"stop": []string{"hi"}},
+		},
+	}
+
+	bedrockReq, err := ToBedrockResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("ToBedrockResponsesRequest failed: %v", err)
+	}
+	if bedrockReq.InferenceConfig != nil && bedrockReq.InferenceConfig.StopSequences != nil {
+		t.Fatalf("expected StopSequences to be omitted for GLM, got %v", bedrockReq.InferenceConfig.StopSequences)
+	}
+}
+
+// TestToBedrockResponsesRequest_OmitsToolChoiceWhenNoTools reproduces the 400
+// ("The provided request is not valid"): a web_search tool with tool_choice:auto
+// on GLM. Web search is skipped for GLM, so no tools survive — the request must
+// not carry a toolConfig that holds a toolChoice with an empty tools list.
+func TestToBedrockResponsesRequest_OmitsToolChoiceWhenNoTools(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	autoStr := string(schemas.ResponsesToolChoiceTypeAuto)
+	req := &schemas.BifrostResponsesRequest{
+		Model: "zai.glm-5",
+		Input: []schemas.ResponsesMessage{glmUserMessage("Perform a web search")},
+		Params: &schemas.ResponsesParameters{
+			MaxOutputTokens: schemas.Ptr(32000),
+			Tools:           []schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeWebSearch}},
+			ToolChoice: &schemas.ResponsesToolChoice{
+				ResponsesToolChoiceStr: &autoStr,
+			},
+		},
+	}
+
+	bedrockReq, err := ToBedrockResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("ToBedrockResponsesRequest failed: %v", err)
+	}
+	if bedrockReq.ToolConfig != nil {
+		t.Fatalf("expected no ToolConfig when all tools are skipped, got %+v", bedrockReq.ToolConfig)
+	}
+}
+
+func glmUserMessage(text string) schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+		Content: &schemas.ResponsesMessageContent{
+			ContentStr: schemas.Ptr(text),
+		},
+	}
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2399,7 +2399,10 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 			bedrockReq.ExtraParams = bifrostReq.Params.ExtraParams
 			if stop, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["stop"]); ok {
 				delete(bedrockReq.ExtraParams, "stop")
-				inferenceConfig.StopSequences = stop
+				// GLM models on Bedrock reject the stopSequences field.
+				if !schemas.IsGLMModel(capModel) {
+					inferenceConfig.StopSequences = stop
+				}
 			}
 			applyBedrockExtraParams(bedrockReq.ExtraParams, bedrockReq)
 			if len(bedrockReq.ExtraParams) == 0 {
@@ -2419,11 +2422,12 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 	// Convert tools (using the provider-filtered keepTools set computed above).
 	if len(keepTools) > 0 {
 		var bedrockTools []BedrockTool
-		isNova2 := schemas.IsNova2Model(bifrostReq.Model)
+		isNova2 := schemas.IsNova2Model(capModel)
 		for _, tool := range keepTools {
 			if tool.Type == schemas.ResponsesToolTypeWebSearch || tool.Type == schemas.ResponsesToolTypeCodeInterpreter {
 				if !isNova2 {
-					return nil, fmt.Errorf("tool type %q is only supported on Nova 2 models in Bedrock; got model %q", tool.Type, bifrostReq.Model)
+					// skip adding this tool
+					continue
 				}
 				var systemToolName BedrockSystemToolType
 				switch tool.Type {
@@ -2528,10 +2532,11 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 		if bedrockToolChoice != nil && bedrockToolChoice.Tool != nil && schemas.IsLlamaModelFamily(ctx, bifrostReq.Model) {
 			bedrockToolChoice = nil
 		}
-		if bedrockToolChoice != nil {
-			if bedrockReq.ToolConfig == nil {
-				bedrockReq.ToolConfig = &BedrockToolConfig{}
-			}
+		// Only attach tool_choice when tools are actually present. Bedrock
+		// Converse rejects a toolConfig that carries a toolChoice with an empty
+		// tools list (e.g. the requested tools were all filtered/skipped, like
+		// web_search on GLM) with "The provided request is not valid".
+		if bedrockToolChoice != nil && bedrockReq.ToolConfig != nil && len(bedrockReq.ToolConfig.Tools) > 0 {
 			bedrockReq.ToolConfig.ToolChoice = bedrockToolChoice
 		}
 	}

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -227,7 +227,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 	// capModel is the canonical model used only for Anthropic capability gating
 	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
 	// Convert inference config
-	if inferenceConfig := convertInferenceConfig(bifrostReq.Params); inferenceConfig != nil {
+	if inferenceConfig := convertInferenceConfig(bifrostReq.Params, capModel); inferenceConfig != nil {
 		bedrockReq.InferenceConfig = inferenceConfig
 	}
 
@@ -1508,7 +1508,7 @@ func convertTextFormatToTool(ctx *schemas.BifrostContext, model string, textConf
 }
 
 // convertInferenceConfig converts Bifrost parameters to Bedrock inference config
-func convertInferenceConfig(params *schemas.ChatParameters) *BedrockInferenceConfig {
+func convertInferenceConfig(params *schemas.ChatParameters, model string) *BedrockInferenceConfig {
 	var config BedrockInferenceConfig
 	if params.MaxCompletionTokens != nil {
 		config.MaxTokens = params.MaxCompletionTokens
@@ -1522,7 +1522,8 @@ func convertInferenceConfig(params *schemas.ChatParameters) *BedrockInferenceCon
 		config.TopP = params.TopP
 	}
 
-	if params.Stop != nil {
+	// GLM models on Bedrock reject the stopSequences field.
+	if params.Stop != nil && !schemas.IsGLMModel(model) {
 		config.StopSequences = params.Stop
 	}
 

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1555,6 +1555,11 @@ func IsNova2Model(model string) bool {
 	return strings.Contains(model, "nova-2") && (strings.Contains(model, "lite") || strings.Contains(model, "sonic"))
 }
 
+// IsGLMModel checks if the model is a Z.AI GLM model.
+func IsGLMModel(model string) bool {
+	return strings.Contains(model, "glm")
+}
+
 // IsAnthropicModel checks if the model is an Anthropic model.
 func IsAnthropicModel(model string) bool {
 	return strings.Contains(model, "anthropic.") || strings.Contains(model, "claude")


### PR DESCRIPTION
## Summary

Fixes two user-reported 400 errors when using Z.AI GLM models on Bedrock:
1. `"This model doesn't support the stopSequences field"` — GLM models reject `inferenceConfig.stopSequences`, so it is now omitted for them.
2. `"The provided request is not valid"` — when all requested tools (e.g. `web_search`) are filtered/skipped for GLM, the resulting empty tools list with a `toolChoice` attached caused Bedrock Converse to reject the request. Tool choice is now only attached when tools are actually present.

## Changes

- Added `IsGLMModel` helper to `core/schemas/utils.go` to identify Z.AI GLM models by name.
- `convertInferenceConfig` now accepts the resolved canonical model name and skips setting `StopSequences` for GLM models. This applies to both the Chat and Responses paths.
- In `ToBedrockResponsesRequest`, unsupported tool types (e.g. `web_search`, `code_interpreter`) on non-Nova-2 models are now silently skipped rather than returning an error, preventing hard failures when a mix of tool types is passed.
- `toolChoice` is only attached to `toolConfig` when the resulting tools list is non-empty, avoiding the invalid-request error from Bedrock when all tools were filtered out.
- Fixed `IsNova2Model` being called with the raw model string instead of the resolved canonical model in the Responses path.
- Added unit tests covering GLM `stopSequences` omission for both the Chat and Responses paths, and the empty-tools/tool-choice guard.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/bedrock/... -run TestConvertInferenceConfig_GLMSkipsStopSequences
go test ./core/providers/bedrock/... -run TestToBedrockResponsesRequest_GLMSkipsStopSequences
go test ./core/providers/bedrock/... -run TestToBedrockResponsesRequest_OmitsToolChoiceWhenNoTools
go test ./...
```

Send a request to a `zai.glm-*` model on Bedrock with `stop` sequences and/or `web_search` tool with `tool_choice: auto`. Expect a successful response rather than a 400 error.

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable