### PR TITLE
feat: add `circuitBreakerConfig` (`policies[]`) to Bifrost Helm chart values, schema, and helpers

### DIFF
--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -10,6 +10,7 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ### Upcoming [2.1.25]
 
+- Added `bifrost.circuitBreakerConfig` (`policies[]`) to `values.yaml`, `_helpers.tpl`, and `values.schema.json`. Renders into `circuit_breaker_config` in the generated config JSON. 
 - Added `evaluation_mode` to guardrail rules. Accepts `bundled` (default, evaluate all turns together) or `per_turn` (evaluate each turn independently). Set under `bifrost.guardrails.rules[].evaluation_mode`.
 - Added `group_traces_by_session` to the OTEL and Datadog plugin configs. When `true`, requests sharing the same `x-bf-session-id` header are grouped into a single trace. An inbound W3C `traceparent` always takes priority. Defaults to `false`.
 - Added `storage.configStore.vaultStore` to `values.yaml` with full commented-out examples for all three backends: `aws-secrets-manager`, `gcp-secret-manager`, and `hashicorp-vault`. Set `accessMode: read_and_write` to automatically store plaintext config fields as vault secrets; `read_only` (default) only resolves existing `vault.<path>` references.

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1578,6 +1578,10 @@ false
 {{- $_ := set $config "feature_flags" (dict "flags" $flags) }}
 {{- end }}
 {{- end }}
+{{- /* Circuit Breaker Config */ -}}
+{{- if .Values.bifrost.circuitBreakerConfig }}
+{{- $_ := set $config "circuit_breaker_config" .Values.bifrost.circuitBreakerConfig }}
+{{- end }}
 {{- $config | toJson }}
 {{- end }}
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3270,6 +3270,101 @@
             }
           },
           "additionalProperties": false
+        },
+        "circuitBreakerConfig": {
+          "type": "object",
+          "description": "Circuit breaker configuration for automatic failover when a provider endpoint degrades",
+          "properties": {
+            "policies": {
+              "type": "array",
+              "description": "List of circuit breaker policies",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Unique name for this policy"
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "Whether this policy is active"
+                  },
+                  "primary_provider": {
+                    "type": "string",
+                    "description": "Provider to monitor (e.g. 'azure', 'openai')"
+                  },
+                  "primary_model": {
+                    "type": "string",
+                    "description": "Model to monitor as it appears in requests"
+                  },
+                  "primary_key_ids": {
+                    "type": "array",
+                    "description": "Optional key UUIDs to monitor individually; empty uses a single shared circuit",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "fallback_provider": {
+                    "type": "string",
+                    "description": "Provider to route to when the circuit is open"
+                  },
+                  "fallback_model": {
+                    "type": "string",
+                    "description": "Model to request from the fallback provider"
+                  },
+                  "condition": {
+                    "type": "object",
+                    "description": "Response signals that trigger the circuit to open",
+                    "properties": {
+                      "operator": {
+                        "type": "string",
+                        "enum": ["OR", "AND"],
+                        "default": "OR"
+                      },
+                      "signals": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string",
+                              "enum": ["response_header"]
+                            },
+                            "header_name": {
+                              "type": "string"
+                            },
+                            "header_value": {
+                              "type": "string"
+                            },
+                            "header_contains": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["source", "header_name"],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": ["signals"],
+                    "additionalProperties": false
+                  },
+                  "default_cooldown": {
+                    "type": "string",
+                    "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                    "description": "How long to keep the circuit open when no header-based cooldown is available (Go duration, e.g. '30s')"
+                  },
+                  "cooldown_header": {
+                    "type": "string",
+                    "description": "Response header whose value (in ms) overrides default_cooldown"
+                  }
+                },
+                "required": ["name", "primary_provider", "primary_model", "fallback_provider", "fallback_model", "condition"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1039,6 +1039,27 @@ bifrost:
   #     idleTimeoutSeconds: 600
   #     maxConnectionLifetimeSeconds: 7200
 
+  # Circuit breaker configuration: automatic failover when a provider endpoint degrades.
+  # Each policy monitors a primary provider+model and redirects traffic to a fallback
+  # when the circuit opens based on response header signals.
+  # circuitBreakerConfig:
+  #   policies:
+  #     - name: "azure-gpt4-ptu-failover"
+  #       enabled: true
+  #       primary_provider: "azure"
+  #       primary_model: "gpt-4-ptu"
+  #       primary_key_ids: []          # leave empty for a single shared circuit
+  #       fallback_provider: "openai"
+  #       fallback_model: "gpt-4o"
+  #       condition:
+  #         operator: "OR"             # OR (default) | AND
+  #         signals:
+  #           - source: "response_header"
+  #             header_name: "x-ms-throttle-reason"
+  #             header_value: "ModelCapacityExceeded"
+  #       default_cooldown: "30s"      # Go duration; used when no header-based cooldown
+  #       cooldown_header: "retry-after-ms"  # header whose value (ms) overrides default_cooldown
+
 # Storage configuration
 storage:
   # Default storage mode: sqlite or postgres


### PR DESCRIPTION
## Summary

Adds circuit breaker configuration support to the Bifrost Helm chart, enabling automatic failover from a primary provider/model to a fallback when response header signals indicate degradation (e.g., throttling or capacity exhaustion).

## Changes

- Added `bifrost.circuitBreakerConfig` to `values.yaml` with a commented-out example policy demonstrating Azure PTU → OpenAI failover triggered by `x-ms-throttle-reason: ModelCapacityExceeded`.
- Added schema validation for `circuitBreakerConfig` in `values.schema.json`, covering `policies[]` with fields for primary/fallback provider and model, `condition` signals (currently `response_header` source), `default_cooldown` (Go duration), and `cooldown_header`.
- Updated `_helpers.tpl` to render `circuitBreakerConfig` into `circuit_breaker_config` in the generated config JSON when the value is present.
- Updated `README.md` changelog to document the new field.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy the Helm chart with a `circuitBreakerConfig` block in your `values.yaml`:

```yaml
bifrost:
  circuitBreakerConfig:
    policies:
      - name: "azure-gpt4-ptu-failover"
        enabled: true
        primary_provider: "azure"
        primary_model: "gpt-4-ptu"
        fallback_provider: "openai"
        fallback_model: "gpt-4o"
        condition:
          operator: "OR"
          signals:
            - source: "response_header"
              header_name: "x-ms-throttle-reason"
              header_value: "ModelCapacityExceeded"
        default_cooldown: "30s"
        cooldown_header: "retry-after-ms"
```

Then render the chart and confirm `circuit_breaker_config` appears correctly in the generated config JSON:

```sh
helm template bifrost ./helm-charts/bifrost -f your-values.yaml | grep -A 20 circuit_breaker_config
```

Validate schema enforcement by providing an invalid policy (e.g., missing `condition`) and confirming Helm rejects it.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new secrets or auth surfaces introduced. Circuit breaker policies reference provider and model names only; no credentials are handled within this config block.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable