### PR TITLE
feat: add `direction_selection_enabled`, `route_selection_enabled`, `reroute_failed_directions`, and `prune_failed_fallbacks` to config schema

### DIFF
--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1891,7 +1891,7 @@ func TestGetVirtualKeyQuota_EndToEndWithRealStore(t *testing.T) {
 func TestGetVirtualKeyQuota_WindowClampedToBudgetCreation(t *testing.T) {
 	SetLogger(&mockLogger{})
 	ctx := context.Background()
-	periodStart := time.Date(2026, time.June, 24, 0, 0, 0, 0, time.UTC) // backdated "1d" boundary (midnight)
+	periodStart := time.Date(2026, time.June, 24, 0, 0, 0, 0, time.UTC)  // backdated "1d" boundary (midnight)
 	createdAt := time.Date(2026, time.June, 24, 11, 56, 42, 0, time.UTC) // budget created mid-day
 
 	store, err := configstore.NewConfigStore(ctx, &configstore.Config{
@@ -1908,7 +1908,7 @@ func TestGetVirtualKeyQuota_WindowClampedToBudgetCreation(t *testing.T) {
 	vk := &configstoreTables.TableVirtualKey{
 		ID:       vkID,
 		Name:     "Clamp",
-		Value:    *schemas.NewSecretVar("sk-bf-clamp-secret"),
+		Value:    "sk-bf-clamp-secret",
 		IsActive: &active,
 	}
 	if err := store.CreateVirtualKey(ctx, vk); err != nil {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4825,6 +4825,22 @@
           "type": "boolean",
           "description": "Whether load balancing is enabled"
         },
+        "direction_selection_enabled": {
+          "type": "boolean",
+          "description": "Enable adaptive provider (direction) selection. Defaults to true; omit to leave on."
+        },
+        "route_selection_enabled": {
+          "type": "boolean",
+          "description": "Enable adaptive per-key (route) selection. Defaults to true; omit to leave on."
+        },
+        "reroute_failed_directions": {
+          "type": "boolean",
+          "description": "When a pinned provider's direction is unhealthy, re-route the request to a healthy provider. Defaults to false."
+        },
+        "prune_failed_fallbacks": {
+          "type": "boolean",
+          "description": "Drop unhealthy directions from a request's configured fallbacks. Defaults to false."
+        },
         "tracker_config": {
           "type": "object",
           "description": "Configuration for tracking route metrics and performance"


### PR DESCRIPTION
## Summary

Adds four new optional configuration fields to the transport config schema to give operators finer-grained control over adaptive routing behavior, including the ability to selectively disable direction/route selection and to handle unhealthy providers more gracefully.

## Changes

- Added `direction_selection_enabled` boolean field to enable or disable adaptive provider (direction) selection. Defaults to `true`.
- Added `route_selection_enabled` boolean field to enable or disable adaptive per-key (route) selection. Defaults to `true`.
- Added `reroute_failed_directions` boolean field to allow requests pinned to an unhealthy provider's direction to be automatically re-routed to a healthy provider. Defaults to `false`.
- Added `prune_failed_fallbacks` boolean field to drop unhealthy directions from a request's configured fallbacks. Defaults to `false`.

These fields provide explicit opt-in/opt-out controls for adaptive routing behaviors that were previously not configurable, allowing operators to tune routing resilience without changing application logic.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate the schema accepts and correctly describes the new fields by providing a config that includes each new boolean option and confirming it passes schema validation.

```sh
go test ./...
```

New config fields:

| Field | Type | Default | Description |
|---|---|---|---|
| `direction_selection_enabled` | boolean | `true` | Enables adaptive provider (direction) selection |
| `route_selection_enabled` | boolean | `true` | Enables adaptive per-key (route) selection |
| `reroute_failed_directions` | boolean | `false` | Re-routes requests when a pinned provider's direction is unhealthy |
| `prune_failed_fallbacks` | boolean | `false` | Drops unhealthy directions from a request's configured fallbacks |

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. These are opt-in routing configuration flags with no impact on auth, secrets, or PII.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable