### PR TITLE
fix: use `@enterprise` alias for `DiscoverCallbackView` import path

### DIFF
--- a/ui/app/workspace/scim/oauth-discover-callback/page.tsx
+++ b/ui/app/workspace/scim/oauth-discover-callback/page.tsx
@@ -1,4 +1,4 @@
-import DiscoverCallbackView from "@/app/enterprise/components/scim/wizard/discoverCallbackView";
+import DiscoverCallbackView from "@enterprise/components/scim/wizard/discoverCallbackView";
 
 export default function OAuthDiscoverCallbackPage() {
 	return <DiscoverCallbackView />;


### PR DESCRIPTION
## Summary

Updates the import path for `DiscoverCallbackView` in the SCIM OAuth discover callback page to use the `@enterprise` path alias instead of the relative `@/app/enterprise` path.

## Changes

- Replaced the relative-style `@/app/enterprise` import alias with the `@enterprise` alias for `DiscoverCallbackView`, aligning with the established path alias conventions used elsewhere in the project.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable