### PR TITLE
feat: add `UseAnthropicMessagesAPI` toggle to route Claude on Bedrock through Mantle native-Anthropic Messages endpoint instead of Converse

### DIFF
--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -405,6 +405,12 @@ func BuildAnthropicChatRequestBody(ctx *schemas.BifrostContext, request *schemas
 
 	defaults := AnthropicProviderRequestDefaultsMap[cfg.Provider]
 
+	// capModel is the canonical (alias-resolved) model used for capability gating,
+	// matching BuildAnthropicResponsesRequestBody. Tool-version remapping and
+	// unsupported-field stripping must see the canonical id, not a routing-alias
+	// literal, so substring-based gates (e.g. SupportsFastMode) match correctly.
+	capModel := schemas.ResolveCanonicalModel(ctx, request.Model)
+
 	newErr := func(msg string, err error, reqBody []byte) *schemas.BifrostError {
 		return providerUtils.EnrichError(
 			ctx,
@@ -469,7 +475,7 @@ func BuildAnthropicChatRequestBody(ctx *schemas.BifrostContext, request *schemas
 		}
 
 		if defaults.RemapToolVersions {
-			jsonBody, err = RemapRawToolVersionsForProvider(jsonBody, cfg.Provider, request.Model)
+			jsonBody, err = RemapRawToolVersionsForProvider(jsonBody, cfg.Provider, capModel)
 			if err != nil {
 				return nil, newErr(err.Error(), nil, jsonBody)
 			}
@@ -482,7 +488,7 @@ func BuildAnthropicChatRequestBody(ctx *schemas.BifrostContext, request *schemas
 			}
 		}
 
-		jsonBody, err = StripUnsupportedFieldsFromRawBody(jsonBody, cfg.Provider, request.Model)
+		jsonBody, err = StripUnsupportedFieldsFromRawBody(jsonBody, cfg.Provider, capModel)
 		if err != nil {
 			return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
 		}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1142,15 +1142,16 @@ func (provider *BedrockProvider) TextCompletionStream(ctx *schemas.BifrostContex
 }
 
 // ChatCompletion performs a chat completion request to Bedrock's API.
-// For Anthropic models, uses the Anthropic Messages API format via the InvokeModel endpoint.
-// For all other models, uses the Bedrock Converse API.
+// Claude models use the Bedrock Converse API by default, or the Bedrock Mantle native-Anthropic
+// Messages endpoint when the per-key/per-alias UseAnthropicMessagesAPI toggle is enabled.
+// gpt-* / Gemma 4 models always use the Bedrock Mantle endpoint; all other models use Converse.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
 func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Bedrock, provider.customProviderConfig, schemas.ChatCompletionRequest); err != nil {
 		return nil, err
 	}
 
-	if isMantleModel(ctx, request.Model) {
+	if provider.shouldRouteToMantle(ctx, key, request.Model) {
 		return provider.mantleChatCompletions(ctx, key, request)
 	}
 
@@ -1229,15 +1230,16 @@ func normalizeCachedUsage(usage *schemas.BifrostLLMUsage) {
 }
 
 // ChatCompletionStream performs a streaming chat completion request to Bedrock's API.
-// For Anthropic models, uses the Anthropic Messages API format via InvokeModel streaming.
-// For all other models, uses the Bedrock Converse streaming API.
+// Claude models use the Bedrock Converse streaming API by default, or the Bedrock Mantle
+// native-Anthropic Messages endpoint when the per-key/per-alias UseAnthropicMessagesAPI toggle
+// is enabled. gpt-* / Gemma 4 models always use Mantle; all other models use Converse streaming.
 // Returns a channel for streaming BifrostStreamChunk objects or an error if the request fails.
 func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Bedrock, provider.customProviderConfig, schemas.ChatCompletionStreamRequest); err != nil {
 		return nil, err
 	}
 
-	if isMantleModel(ctx, request.Model) {
+	if provider.shouldRouteToMantle(ctx, key, request.Model) {
 		return provider.mantleChatCompletionsStream(ctx, postHookRunner, postHookSpanFinalizer, key, request)
 	}
 
@@ -1563,15 +1565,16 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 }
 
 // Responses performs a responses request to Bedrock's API.
-// For Anthropic models, uses the Anthropic Messages API format via the InvokeModel endpoint.
-// For all other models, uses the Bedrock Converse API.
+// Claude models use the Bedrock Converse API by default, or the Bedrock Mantle native-Anthropic
+// Messages endpoint when the per-key/per-alias UseAnthropicMessagesAPI toggle is enabled.
+// gpt-* / Gemma 4 models always use the Bedrock Mantle endpoint; all other models use Converse.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
 func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Bedrock, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
 		return nil, err
 	}
 
-	if isMantleModel(ctx, request.Model) {
+	if provider.shouldRouteToMantle(ctx, key, request.Model) {
 		return provider.mantleResponses(ctx, key, request)
 	}
 
@@ -1641,7 +1644,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 		return nil, err
 	}
 
-	if isMantleModel(ctx, request.Model) {
+	if provider.shouldRouteToMantle(ctx, key, request.Model) {
 		return provider.mantleResponsesStream(ctx, postHookRunner, postHookSpanFinalizer, key, request)
 	}
 

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -19,14 +19,38 @@ import (
 // version as an "anthropic_version" body field).
 const mantleAnthropicVersion = "2023-06-01"
 
-// isMantleModel reports whether a model should be routed via the Bedrock Mantle endpoint.
+// isMantleModel reports whether a model is servable by the Bedrock Mantle endpoint.
 // OpenAI-family (gpt-*) and Gemma 4 models use the OpenAI-compatible paths; Anthropic-family
 // (Claude) models use the native Anthropic Messages path. The per-family split is handled
 // inside each mantle* dispatcher. Gemma 3 is intentionally excluded: it only supports Chat
 // (not Responses) on mantle, and the non-mantle path serves both APIs via Converse, so
 // forcing it to mantle would break Responses.
+//
+// This reports mantle *capability* only. The actual routing decision for Claude is made by
+// shouldRouteToMantle, which gates Claude behind the per-key/per-alias toggle so the default
+// stays on the Converse API.
 func isMantleModel(ctx *schemas.BifrostContext, model string) bool {
 	return schemas.IsOpenAIModelFamily(ctx, model) || schemas.IsAnthropicModelFamily(ctx, model) || strings.Contains(model, "gemma-4")
+}
+
+// shouldRouteToMantle decides whether a request should be dispatched to the Bedrock Mantle
+// endpoint. OpenAI-family and Gemma 4 models always use Mantle (their only endpoint). Claude
+// (Anthropic-family) models use Mantle's native-Anthropic Messages path only when the
+// per-key/per-alias UseAnthropicMessagesAPI toggle is enabled; otherwise they stay on the
+// default Bedrock Converse API. Defaults to Converse so existing Claude-on-Bedrock integrations
+// keep their guardrails, IAM scope, and request shape unless explicitly opted in.
+//
+// The decision is made on the canonical (alias-resolved) model — matching the canonical id that
+// mantleOpenAIURL already uses for path gating — so the "gemma-4" substring gate in isMantleModel
+// matches the underlying model id rather than a routing-alias literal. (The family checks resolve
+// via the alias config regardless, but the substring gate needs the canonical id.) The wire
+// request still carries the original request.Model.
+func (provider *BedrockProvider) shouldRouteToMantle(ctx *schemas.BifrostContext, key schemas.Key, model string) bool {
+	capModel := schemas.ResolveCanonicalModel(ctx, model)
+	if schemas.IsAnthropicModelFamily(ctx, capModel) {
+		return resolveBedrockUseClaudeMessagesAPI(ctx, key)
+	}
+	return isMantleModel(ctx, capModel)
 }
 
 // mantleOpenAIURL builds the Bedrock Mantle OpenAI-compatible endpoint URL for the given
@@ -79,9 +103,11 @@ func (provider *BedrockProvider) mantleSigV4Headers(
 }
 
 // mantleAnthropicHeaders builds the auth and version headers for a native-Anthropic
-// mantle request. A Bedrock API key authenticates via the x-api-key header; otherwise
-// the request is SigV4-signed for the bedrock-mantle service. jsonData and accept must
-// match the bytes and Accept header actually sent, since SigV4 signs over them.
+// mantle request. A Bedrock API key authenticates via the Authorization: Bearer header —
+// the same scheme the co-located OpenAI-compatible mantle paths use on the bedrock-mantle
+// host, since the credential is an AWS Bedrock API key rather than an Anthropic x-api-key.
+// Otherwise the request is SigV4-signed for the bedrock-mantle service. jsonData and accept
+// must match the bytes and Accept header actually sent, since SigV4 signs over them.
 func (provider *BedrockProvider) mantleAnthropicHeaders(
 	ctx *schemas.BifrostContext,
 	jsonData []byte,
@@ -94,7 +120,7 @@ func (provider *BedrockProvider) mantleAnthropicHeaders(
 		"Accept":            accept,
 	}
 	if key.Value.GetValue() != "" {
-		headers["x-api-key"] = key.Value.GetValue()
+		maps.Copy(headers, openai.BearerAuthHeader(key))
 		return headers, nil
 	}
 	sigHeaders, bifrostErr := provider.mantleSigV4Headers(ctx, jsonData, requestURL, accept, key, region)

--- a/core/providers/bedrock/mantle_test.go
+++ b/core/providers/bedrock/mantle_test.go
@@ -2,6 +2,7 @@ package bedrock
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	schemas "github.com/maximhq/bifrost/core/schemas"
@@ -41,6 +42,127 @@ func TestIsMantleModel(t *testing.T) {
 			t.Errorf("isMantleModel(%q) = %v, want %v", tc.model, got, tc.want)
 		}
 	}
+}
+
+func TestResolveBedrockUseClaudeMessagesAPI(t *testing.T) {
+	famAnthropic := schemas.ModelFamilyAnthropic
+	cases := []struct {
+		name  string
+		key   schemas.Key
+		alias *schemas.AliasConfig
+		want  bool
+	}{
+		{"default: no config -> false", schemas.Key{}, nil, false},
+		{"key toggle on", schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{UseAnthropicMessagesAPI: schemas.Ptr(true)}}, nil, true},
+		{"key toggle off", schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{UseAnthropicMessagesAPI: schemas.Ptr(false)}}, nil, false},
+		{"alias on overrides key off",
+			schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{UseAnthropicMessagesAPI: schemas.Ptr(false)}},
+			&schemas.AliasConfig{ModelFamily: &famAnthropic, BedrockAliasCfg: &schemas.BedrockAliasCfg{UseAnthropicMessagesAPI: schemas.Ptr(true)}}, true},
+		{"alias off overrides key on",
+			schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{UseAnthropicMessagesAPI: schemas.Ptr(true)}},
+			&schemas.AliasConfig{ModelFamily: &famAnthropic, BedrockAliasCfg: &schemas.BedrockAliasCfg{UseAnthropicMessagesAPI: schemas.Ptr(false)}}, false},
+		{"alias present but unset -> falls through to key",
+			schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{UseAnthropicMessagesAPI: schemas.Ptr(true)}},
+			&schemas.AliasConfig{ModelFamily: &famAnthropic}, true},
+	}
+	for _, tc := range cases {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		if tc.alias != nil {
+			ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{Config: tc.alias})
+		}
+		if got := resolveBedrockUseClaudeMessagesAPI(ctx, tc.key); got != tc.want {
+			t.Errorf("%s: resolveBedrockUseClaudeMessagesAPI = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestShouldRouteToMantle(t *testing.T) {
+	provider := &BedrockProvider{}
+	claudeOn := schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{UseAnthropicMessagesAPI: schemas.Ptr(true)}}
+	noToggle := schemas.Key{}
+	cases := []struct {
+		name  string
+		key   schemas.Key
+		model string
+		alias *schemas.AliasConfig // resolved alias stashed in ctx, if any
+		want  bool
+	}{
+		// OpenAI-family and Gemma 4 always route to mantle, regardless of the toggle.
+		{"gpt-oss always mantle", noToggle, "openai.gpt-oss-120b", nil, true},
+		{"gemma-4 always mantle", noToggle, "google.gemma-4-31b", nil, true},
+		// Claude defaults to the Converse path (toggle off).
+		{"claude default -> converse", noToggle, "anthropic.claude-3-5-sonnet-20240620-v1:0", nil, false},
+		{"claude bare default -> converse", noToggle, "claude-opus-4-8", nil, false},
+		// Claude with the toggle on routes to the native-Anthropic mantle path.
+		{"claude toggle on -> mantle", claudeOn, "anthropic.claude-3-5-sonnet-20240620-v1:0", nil, true},
+		// Non-mantle families stay on Converse; the Claude toggle is irrelevant to them.
+		{"gemma-3 -> converse", claudeOn, "google.gemma-3-27b-it", nil, false},
+		{"titan -> converse", claudeOn, "amazon.titan-text-express-v1", nil, false},
+		// Alias whose literal name lacks the "gemma-4" substring still routes to mantle because the
+		// decision is made on the canonical (alias-resolved) model id. Guards the canonicalization fix.
+		{"aliased gemma-4 -> mantle", noToggle, "my-gemma",
+			&schemas.AliasConfig{ModelID: "google.gemma-4-31b"}, true},
+		// Aliased Claude is gated by the toggle just like a bare Claude id.
+		{"aliased claude default -> converse", noToggle, "my-claude",
+			&schemas.AliasConfig{ModelID: "anthropic.claude-3-5-sonnet-20240620-v1:0"}, false},
+		{"aliased claude toggle on -> mantle", claudeOn, "my-claude",
+			&schemas.AliasConfig{ModelID: "anthropic.claude-3-5-sonnet-20240620-v1:0"}, true},
+	}
+	for _, tc := range cases {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		if tc.alias != nil {
+			ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{Key: tc.model, Config: tc.alias})
+		}
+		if got := provider.shouldRouteToMantle(ctx, tc.key, tc.model); got != tc.want {
+			t.Errorf("%s: shouldRouteToMantle(%q) = %v, want %v", tc.name, tc.model, got, tc.want)
+		}
+	}
+}
+
+func TestMantleAnthropicHeadersAuth(t *testing.T) {
+	provider := &BedrockProvider{}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	url := "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages"
+
+	// A Bedrock API key authenticates via Authorization: Bearer, not the
+	// Anthropic x-api-key scheme.
+	t.Run("api key -> Bearer", func(t *testing.T) {
+		key := schemas.Key{Value: *schemas.NewSecretVar("test-api-key")}
+		headers, bErr := provider.mantleAnthropicHeaders(ctx, []byte("{}"), url, "application/json", key, "us-east-1")
+		if bErr != nil {
+			t.Fatalf("unexpected error: %v", bErr)
+		}
+		if got := headers["Authorization"]; got != "Bearer test-api-key" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer test-api-key")
+		}
+		if _, ok := headers["x-api-key"]; ok {
+			t.Errorf("x-api-key must not be sent on the mantle path, got %q", headers["x-api-key"])
+		}
+		if _, ok := headers["X-Amz-Date"]; ok {
+			t.Errorf("SigV4 headers must not be present when an API key is used")
+		}
+	})
+
+	// Without an API key, the request is SigV4-signed for the bedrock-mantle service.
+	t.Run("no api key -> SigV4", func(t *testing.T) {
+		key := schemas.Key{
+			BedrockKeyConfig: &schemas.BedrockKeyConfig{
+				AccessKey: *schemas.NewSecretVar("AKIAEXAMPLE"),
+				SecretKey: *schemas.NewSecretVar("secretexamplekey"),
+			},
+		}
+		headers, bErr := provider.mantleAnthropicHeaders(ctx, []byte("{}"), url, "application/json", key, "us-east-1")
+		if bErr != nil {
+			t.Fatalf("unexpected error: %v", bErr)
+		}
+		auth := headers["Authorization"]
+		if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256") {
+			t.Errorf("expected SigV4 Authorization, got %q", auth)
+		}
+		if _, ok := headers["X-Amz-Date"]; !ok {
+			t.Errorf("expected SigV4 X-Amz-Date header to be present")
+		}
+	})
 }
 
 func TestMantleOpenAIURL(t *testing.T) {

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -78,6 +78,23 @@ func resolveBedrockARN(ctx *schemas.BifrostContext, key schemas.Key) string {
 	return ""
 }
 
+// resolveBedrockUseClaudeMessagesAPI reports whether Claude (Anthropic-family)
+// models should be served via the Bedrock Mantle native-Anthropic Messages
+// endpoint instead of the default Converse API. Priority: alias-level override >
+// key-level override > false (default). Opting in trades the Converse-only
+// request features (Bedrock Guardrails, performanceConfig, promptVariables,
+// additionalModel*FieldPaths) for the native Anthropic Messages wire format and
+// the "bedrock-mantle" SigV4 signing service.
+func resolveBedrockUseClaudeMessagesAPI(ctx *schemas.BifrostContext, key schemas.Key) bool {
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.BedrockAliasCfg != nil && ra.Config.BedrockAliasCfg.UseAnthropicMessagesAPI != nil {
+		return *ra.Config.BedrockAliasCfg.UseAnthropicMessagesAPI
+	}
+	if key.BedrockKeyConfig != nil && key.BedrockKeyConfig.UseAnthropicMessagesAPI != nil {
+		return *key.BedrockKeyConfig.UseAnthropicMessagesAPI
+	}
+	return false
+}
+
 var (
 	invalidCharRegex = regexp.MustCompile(`[^a-zA-Z0-9\s\-\(\)\[\]]`)
 	multiSpaceRegex  = regexp.MustCompile(`\s{2,}`)

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -126,7 +126,7 @@ func (bl BlackList) Validate() error {
 type Key struct {
 	ID                 string              `json:"id"`                             // The unique identifier for the key (used by bifrost to identify the key)
 	Name               string              `json:"name"`                           // The name of the key (used by users to identify the key, not used by bifrost)
-	Value              SecretVar              `json:"value"`                          // The actual API key value
+	Value              SecretVar           `json:"value"`                          // The actual API key value
 	Models             WhiteList           `json:"models"`                         // List of models this key can access
 	BlacklistedModels  BlackList           `json:"blacklisted_models"`             // List of models this key cannot access
 	Weight             float64             `json:"weight"`                         // Weight for load balancing between multiple keys
@@ -182,8 +182,8 @@ func (mf *ModelFamily) IsValid() bool {
 // AzureAliasCfg holds Azure-specific overrides that apply to a single alias.
 // Each field, when non-nil, overrides the corresponding key-level default.
 type AzureAliasCfg struct {
-	APIVersion       *string `json:"api_version,omitempty"`       // overrides the Azure OpenAI api-version query param for this alias
-	AnthropicVersion *string `json:"anthropic_version,omitempty"` // overrides the anthropic-version header for Claude-on-Azure deployments
+	APIVersion       *string    `json:"api_version,omitempty"`       // overrides the Azure OpenAI api-version query param for this alias
+	AnthropicVersion *string    `json:"anthropic_version,omitempty"` // overrides the anthropic-version header for Claude-on-Azure deployments
 	Endpoint         *SecretVar `json:"endpoint,omitempty"`          // overrides AzureKeyConfig.Endpoint for this alias — lets one credential span deployments on multiple Azure resources
 }
 
@@ -196,6 +196,13 @@ type VertexAliasCfg struct {
 // BedrockAliasCfg holds Bedrock-specific overrides that apply to a single alias.
 type BedrockAliasCfg struct {
 	InferenceProfileARN *SecretVar `json:"inference_profile_arn,omitempty"`
+
+	// UseAnthropicMessagesAPI, when true, routes Claude (Anthropic-family) models
+	// for this alias through the Bedrock Mantle native-Anthropic Messages endpoint
+	// instead of the default Converse API. Nil/false keeps the Converse path.
+	// Overrides the key-level BedrockKeyConfig.UseAnthropicMessagesAPI. See that
+	// field for the behavioural trade-offs.
+	UseAnthropicMessagesAPI *bool `json:"use_anthropic_messages_api,omitempty"`
 }
 
 // ReplicateAliasCfg holds Replicate-specific overrides that apply to a single alias.
@@ -213,7 +220,7 @@ type AliasConfig struct {
 	ModelName   *string      `json:"model_name,omitempty"`   // canonical model name used for pricing, logging, and 2nd-tier family routing
 	ModelFamily *ModelFamily `json:"model_family,omitempty"` // 1st-tier family routing enum
 	Description string       `json:"description,omitempty"`  // description of the alias for users to understand its purpose (not used by bifrost)
-	Region      *SecretVar      `json:"region,omitempty"`
+	Region      *SecretVar   `json:"region,omitempty"`
 
 	*AzureAliasCfg
 	*VertexAliasCfg
@@ -614,10 +621,10 @@ const (
 type AzureKeyConfig struct {
 	Endpoint SecretVar `json:"endpoint"` // Azure service endpoint URL
 
-	ClientID     *SecretVar  `json:"client_id,omitempty"`     // Azure client ID for authentication
-	ClientSecret *SecretVar  `json:"client_secret,omitempty"` // Azure client secret for authentication
-	TenantID     *SecretVar  `json:"tenant_id,omitempty"`     // Azure tenant ID for authentication
-	Scopes       []string `json:"scopes,omitempty"`
+	ClientID     *SecretVar `json:"client_id,omitempty"`     // Azure client ID for authentication
+	ClientSecret *SecretVar `json:"client_secret,omitempty"` // Azure client secret for authentication
+	TenantID     *SecretVar `json:"tenant_id,omitempty"`     // Azure tenant ID for authentication
+	Scopes       []string   `json:"scopes,omitempty"`
 }
 
 // VertexKeyConfig represents the Vertex-specific configuration.
@@ -658,6 +665,21 @@ type BedrockKeyConfig struct {
 	RoleSessionName *SecretVar `json:"session_name,omitempty"`
 
 	BatchS3Config *BatchS3Config `json:"batch_s3_config,omitempty"` // S3 bucket configuration for batch operations
+
+	// UseAnthropicMessagesAPI, when true, routes Claude (Anthropic-family) models
+	// for this key through the Bedrock Mantle native-Anthropic Messages endpoint
+	// (https://bedrock-mantle.{region}.api.aws/anthropic/v1/messages) instead of
+	// the default Bedrock Converse API. Defaults to false (nil) — Claude stays on
+	// Converse unless explicitly opted in.
+	//
+	// Trade-off: the native-Anthropic path sends the unmodified Anthropic Messages
+	// wire format, but it does NOT apply Converse-only request features — Bedrock
+	// Guardrails (guardrailConfig), performanceConfig, promptVariables, and
+	// additionalModelRequest/ResponseFieldPaths are not forwarded, and it signs
+	// requests with the "bedrock-mantle" SigV4 service (IAM principals need access
+	// to it). CountTokens continues to use the Converse API regardless of this flag.
+	// A per-alias BedrockAliasCfg.UseAnthropicMessagesAPI overrides this key-level value.
+	UseAnthropicMessagesAPI *bool `json:"use_anthropic_messages_api,omitempty"`
 }
 
 // NOTE: To use Bedrock IAM role authentication, set both AccessKey and SecretKey to empty strings.
@@ -668,7 +690,7 @@ type BedrockKeyConfig struct {
 // enabling per-key routing and round-robin load balancing across multiple vLLM instances.
 type VLLMKeyConfig struct {
 	URL       SecretVar `json:"url"`        // VLLM server base URL (required, supports env. prefix)
-	ModelName string `json:"model_name"` // Exact model name served on this VLLM instance (used for key selection)
+	ModelName string    `json:"model_name"` // Exact model name served on this VLLM instance (used for key selection)
 }
 
 // ReplicateKeyConfig represents the Replicate-specific key configuration.

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3236,6 +3236,10 @@
                     "type": "string",
                     "description": "Per-alias Bedrock inference profile ARN (can use env. prefix)."
                   },
+                  "use_anthropic_messages_api": {
+                    "type": "boolean",
+                    "description": "Bedrock: route Claude models for this alias through the Bedrock Mantle native-Anthropic Messages endpoint instead of the default Converse API. Overrides the key-level setting. Defaults to false."
+                  },
                   "use_deployments_endpoint": {
                     "type": "boolean",
                     "description": "Replicate: use the deployments endpoint instead of the predictions endpoint for this alias."
@@ -3296,6 +3300,10 @@
                 "session_name": {
                   "type": "string",
                   "description": "Role session name for AssumeRole (can use env. prefix)"
+                },
+                "use_anthropic_messages_api": {
+                  "type": "boolean",
+                  "description": "Route Claude (Anthropic-family) models for this key through the Bedrock Mantle native-Anthropic Messages endpoint instead of the default Converse API. Defaults to false. Note: the native path does not apply Converse-only features such as Bedrock Guardrails, and signs with the bedrock-mantle SigV4 service. A per-alias setting overrides this."
                 },
                 "deployments": {
                   "type": "object",

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -914,6 +914,25 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							</FormItem>
 						)}
 					/>
+					<FormField
+						control={control}
+						name={`key.bedrock_key_config.use_anthropic_messages_api`}
+						render={({ field }) => (
+							<FormItem className="flex flex-row items-center justify-between rounded-sm border p-2">
+								<div className="space-y-1.5">
+									<FormLabel>Use Anthropic Messages API for Claude</FormLabel>
+									<FormDescription>
+										Route Claude models through the Bedrock Mantle native-Anthropic Messages endpoint instead of
+										the default Converse API. Off by default. The native path does not apply Converse-only
+										features such as Bedrock Guardrails. A per-deployment setting overrides this.
+									</FormDescription>
+								</div>
+								<FormControl>
+									<Switch checked={field.value ?? false} onCheckedChange={field.onChange} />
+								</FormControl>
+							</FormItem>
+						)}
+					/>
 					{supportsBatchAPI && <BatchAPIFormField control={control} form={form} />}
 				</div>
 			)}

--- a/ui/app/workspace/providers/fragments/deploymentsTable.tsx
+++ b/ui/app/workspace/providers/fragments/deploymentsTable.tsx
@@ -218,6 +218,29 @@ function BedrockSection({ config, onChange, disabled }: ProviderSectionProps) {
 					disabled={disabled}
 				/>
 			</FieldRow>
+			<FieldRow
+				label="Claude Messages API"
+				hint="Inherit uses the key-level setting. Messages API routes Claude through the Bedrock Mantle native-Anthropic Messages endpoint; Converse forces the default Converse API for this deployment."
+			>
+				<Select
+					value={
+						config.use_anthropic_messages_api === undefined ? "__inherit__" : config.use_anthropic_messages_api ? "on" : "off"
+					}
+					onValueChange={(v) =>
+						onChange({ use_anthropic_messages_api: v === "__inherit__" ? undefined : v === "on" })
+					}
+					disabled={disabled}
+				>
+					<SelectTrigger className="w-full">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="__inherit__">Inherit (use key setting)</SelectItem>
+						<SelectItem value="on">Messages API (Mantle)</SelectItem>
+						<SelectItem value="off">Converse</SelectItem>
+					</SelectContent>
+				</Select>
+			</FieldRow>
 		</div>
 	);
 }

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -113,6 +113,7 @@ const BedrockKeyConfigSchema = z
 		session_name: z.string().optional(),
 		arn: z.string().optional(),
 		batch_s3_config: BatchS3ConfigSchema.optional(),
+		use_anthropic_messages_api: z.boolean().optional(),
 	})
 	.refine(
 		(data) => {

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -67,6 +67,7 @@ export interface AliasConfig {
 	project_number?: SecretVar;
 	// Bedrock overrides
 	inference_profile_arn?: SecretVar;
+	use_anthropic_messages_api?: boolean;
 	// Replicate overrides
 	use_deployments_endpoint?: boolean;
 }
@@ -121,6 +122,9 @@ export interface BedrockKeyConfig {
 	region?: SecretVar;
 	arn?: SecretVar;
 	batch_s3_config?: BatchS3Config;
+	// Route Claude models through the Bedrock Mantle native-Anthropic Messages
+	// endpoint instead of the default Converse API. Defaults to false.
+	use_anthropic_messages_api?: boolean;
 }
 
 // Default BedrockKeyConfig
@@ -131,6 +135,7 @@ export const DefaultBedrockKeyConfig: BedrockKeyConfig = {
 	region: { value: "us-east-1", ref: "" },
 	arn: { value: "", ref: "" },
 	batch_s3_config: undefined as unknown as BatchS3Config,
+	use_anthropic_messages_api: undefined as unknown as boolean,
 } as const satisfies Required<BedrockKeyConfig>;
 
 // VLLMKeyConfig matching Go's schemas.VLLMKeyConfig

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -163,6 +163,7 @@ export const bedrockKeyConfigSchema = z
 		session_name: secretVarSchema.optional(),
 		arn: secretVarSchema.optional(),
 		batch_s3_config: batchS3ConfigSchema.optional(),
+		use_anthropic_messages_api: z.boolean().optional(),
 	})
 	.refine(
 		(data) => {
@@ -260,6 +261,7 @@ const aliasConfigObjectSchema = z.object({
 	project_number: secretVarSchema.optional(),
 	// Bedrock overrides
 	inference_profile_arn: secretVarSchema.optional(),
+	use_anthropic_messages_api: z.boolean().optional(),
 	// Replicate overrides
 	use_deployments_endpoint: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary

Claude (Anthropic-family) models on Bedrock previously routed to the Bedrock Mantle native-Anthropic Messages endpoint unconditionally whenever `isMantleModel` returned true. This PR gates Claude's Mantle routing behind an explicit opt-in toggle (`UseAnthropicMessagesAPI`) at both the key and alias level, defaulting to the Bedrock Converse API. It also fixes a bug where routing and capability decisions were made against a routing-alias literal rather than the canonical (alias-resolved) model ID, causing substring-based gates (e.g. `gemma-4`, `SupportsFastMode`) to miss when an alias name didn't contain the expected substring.

## Changes

- Introduced `resolveBedrockUseClaudeMessagesAPI` which reads the `UseAnthropicMessagesAPI` toggle from the resolved alias config (highest priority) or the key config, defaulting to `false`.
- Replaced direct `isMantleModel` calls in `ChatCompletion`, `ChatCompletionStream`, `Responses`, and `ResponsesStream` with a new `shouldRouteToMantle` method that gates Claude behind the toggle while keeping OpenAI-family and Gemma 4 models always on Mantle.
- `shouldRouteToMantle` resolves the canonical model ID via `schemas.ResolveCanonicalModel` before evaluating `isMantleModel`, so the `gemma-4` substring gate and family checks operate on the underlying model ID rather than an alias literal.
- Applied the same canonical model resolution in `BuildAnthropicChatRequestBody` so `RemapRawToolVersionsForProvider` and `StripUnsupportedFieldsFromRawBody` also see the canonical ID.
- Fixed the `mantleAnthropicHeaders` auth scheme: API-key-authenticated requests now use `Authorization: Bearer` (matching the co-located OpenAI-compatible Mantle paths) instead of `x-api-key`.
- Added `UseAnthropicMessagesAPI *bool` to `BedrockKeyConfig` and `BedrockAliasCfg` in Go schemas, the JSON config schema, and all UI types/schemas.
- Added UI toggle controls for the new flag at both the key level (`apiKeysFormFragment`) and the alias/deployment level (`deploymentsTable`).
- Added unit tests for `resolveBedrockUseClaudeMessagesAPI` and `shouldRouteToMantle` covering default, key-level, alias-level, and alias-override-key scenarios, including the canonical-model-resolution fix.

**Trade-offs:** Opting in to the native-Anthropic path sends the unmodified Anthropic Messages wire format but drops Converse-only features — Bedrock Guardrails (`guardrailConfig`), `performanceConfig`, `promptVariables`, and `additionalModelRequest/ResponseFieldPaths` are not forwarded, and IAM principals need access to the `bedrock-mantle` SigV4 signing service. `CountTokens` continues to use Converse regardless of the flag.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./core/providers/bedrock/... ./core/providers/anthropic/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

**New config fields:**

- `BedrockKeyConfig.use_anthropic_messages_api` (`bool`, optional, default `false`): opt Claude models on this key into the Bedrock Mantle native-Anthropic Messages endpoint.
- `BedrockAliasCfg.use_anthropic_messages_api` (`bool`, optional): per-alias override; takes precedence over the key-level value.

To validate end-to-end: configure a Bedrock key with `use_anthropic_messages_api: true`, send a Claude chat completion, and confirm the request is signed with the `bedrock-mantle` service and hits the `/anthropic/v1/messages` path. Without the flag, the same request should use the Converse API.

## Breaking changes

- [x] Yes
- [ ] No

Claude models that were previously routing to the Bedrock Mantle native-Anthropic Messages endpoint will now default to the Converse API. Set `use_anthropic_messages_api: true` on the key or alias to restore the previous behaviour.

## Related issues

## Security considerations

The `mantleAnthropicHeaders` auth fix changes Claude-on-Mantle API-key requests from `x-api-key` to `Authorization: Bearer`, aligning with the credential scheme expected by the `bedrock-mantle` host. Existing SigV4-signed (IAM) paths are unchanged. The new `UseAnthropicMessagesAPI` toggle is a routing flag with no direct secret exposure, but enabling it changes the SigV4 signing service to `bedrock-mantle`, so IAM policies must grant access to that service for opted-in keys.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable