### PR TITLE
k8s deployment docs update with notice for namespace

### DIFF
--- a/docs/enterprise/clustering.mdx
+++ b/docs/enterprise/clustering.mdx
@@ -388,7 +388,7 @@ Kubernetes discovery uses the K8s API to automatically discover pods based on la
 
 | Parameter | Required | Description | Example |
 |-----------|----------|-------------|---------|
-| `k8s_namespace` | No | Kubernetes namespace to search | `"default"`, `"production"` |
+| `k8s_namespace` | No | Kubernetes namespace to search (if empty we pick the "default" as the namespace). If you are using a custom namespace, make sure to provide it here. | `"production"` |
 | `k8s_label_selector` | Yes | Label selector for pod discovery | `"app=bifrost"`, `"app=bifrost,env=prod"` |
 
 ### Kubernetes Deployment Example


### PR DESCRIPTION
## Summary

Improves the documentation for the `k8s_namespace` parameter in the Kubernetes clustering discovery section to clarify its default behavior and usage with custom namespaces.

## Changes

- Updated the `k8s_namespace` parameter description to explicitly state that when left empty, `"default"` is used as the namespace, and added guidance to provide a custom namespace when needed.
- Removed `"default"` from the example column since it is now explained in the description.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated Kubernetes discovery parameter table in `docs/enterprise/clustering.mdx` to confirm the description accurately reflects the default namespace behavior.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable