### PR TITLE
fix: rebuild token_usage from denormalized columns in hybrid log list

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+[fix]: rebuild token usage from denormalized columns in hybrid log list [@G-XD](https://github.com/G-XD)

--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -721,6 +721,54 @@ func TestHybrid_ResponsesInputHistoryPreservesLastUserMessage(t *testing.T) {
 	require.Len(t, found.ResponsesInputHistoryParsed, 2, "full responses history should be hydrated from S3")
 }
 
+func TestHybrid_TokenUsageSummaryForListPreview(t *testing.T) {
+	// token_usage is offloaded to object storage and cleared from the DB row. The
+	// denormalized prompt/completion/total columns must remain so list queries can
+	// rebuild token_usage for the UI without hydrating from S3 (same pattern as
+	// content_summary for message previews).
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	entry := &Log{
+		ID:        "chat-tokens-1",
+		Timestamp: time.Now().UTC(),
+		Provider:  "openai",
+		Model:     "gpt-4",
+		Status:    "success",
+		Object:    "chat.completion",
+		TokenUsageParsed: &schemas.BifrostLLMUsage{
+			PromptTokens:     120,
+			CompletionTokens: 45,
+			TotalTokens:      165,
+		},
+	}
+	require.NoError(t, entry.SerializeFields())
+	require.NoError(t, hybrid.CreateIfNotExists(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	dbLog, err := inner.FindByID(ctx, "chat-tokens-1")
+	require.NoError(t, err)
+	assert.Empty(t, dbLog.TokenUsage, "token_usage should be offloaded to object storage")
+	assert.Equal(t, 120, dbLog.PromptTokens)
+	assert.Equal(t, 45, dbLog.CompletionTokens)
+	assert.Equal(t, 165, dbLog.TotalTokens)
+
+	result, err := hybrid.SearchLogs(ctx, SearchFilters{}, PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, result.Logs, 1)
+	listLog := result.Logs[0]
+	require.NotNil(t, listLog.TokenUsageParsed, "list query should rebuild token_usage from denormalized columns")
+	assert.Equal(t, 120, listLog.TokenUsageParsed.PromptTokens)
+	assert.Equal(t, 45, listLog.TokenUsageParsed.CompletionTokens)
+	assert.Equal(t, 165, listLog.TokenUsageParsed.TotalTokens)
+
+	found, err := hybrid.FindByID(ctx, "chat-tokens-1")
+	require.NoError(t, err)
+	require.NotNil(t, found.TokenUsageParsed, "detail view should hydrate full token_usage from S3")
+	assert.Equal(t, 165, found.TokenUsageParsed.TotalTokens)
+}
+
 func TestHybrid_SpeechInputSummaryForListPreview(t *testing.T) {
 	// /audio/speech (TTS) requests carry their text in speech_input, which is
 	// offloaded to object storage and cleared from the DB row. The DB must still

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -914,7 +914,31 @@ func (l *Log) DeserializeFields() error {
 		l.RoutingEnginesUsed = []string{}
 	}
 
+	// Hybrid log store offloads token_usage to object storage but keeps denormalized
+	// prompt/completion/total columns in the DB for analytics. Rebuild the virtual
+	// field so list APIs and the UI can render tokens without hydrating from S3 —
+	// same role content_summary plays for message previews.
+	l.reconstructTokenUsageFromDenormalizedFields()
+
 	return nil
+}
+
+// reconstructTokenUsageFromDenormalizedFields populates TokenUsageParsed from the
+// denormalized token columns when the serialized token_usage payload is absent
+// (e.g. hybrid storage offloaded it to object storage).
+func (l *Log) reconstructTokenUsageFromDenormalizedFields() {
+	if l.TokenUsageParsed != nil {
+		return
+	}
+	if l.PromptTokens == 0 && l.CompletionTokens == 0 && l.TotalTokens == 0 {
+		return
+	}
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     l.PromptTokens,
+		CompletionTokens: l.CompletionTokens,
+		TotalTokens:      l.TotalTokens,
+	}
+	l.TokenUsageParsed = usage
 }
 
 // MCPToolLog represents a log entry for MCP tool executions

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -918,27 +918,15 @@ func (l *Log) DeserializeFields() error {
 	// prompt/completion/total columns in the DB for analytics. Rebuild the virtual
 	// field so list APIs and the UI can render tokens without hydrating from S3 —
 	// same role content_summary plays for message previews.
-	l.reconstructTokenUsageFromDenormalizedFields()
+	if l.TokenUsageParsed == nil && (l.PromptTokens != 0 || l.CompletionTokens != 0 || l.TotalTokens != 0) {
+		l.TokenUsageParsed = &schemas.BifrostLLMUsage{
+			PromptTokens:     l.PromptTokens,
+			CompletionTokens: l.CompletionTokens,
+			TotalTokens:      l.TotalTokens,
+		}
+	}
 
 	return nil
-}
-
-// reconstructTokenUsageFromDenormalizedFields populates TokenUsageParsed from the
-// denormalized token columns when the serialized token_usage payload is absent
-// (e.g. hybrid storage offloaded it to object storage).
-func (l *Log) reconstructTokenUsageFromDenormalizedFields() {
-	if l.TokenUsageParsed != nil {
-		return
-	}
-	if l.PromptTokens == 0 && l.CompletionTokens == 0 && l.TotalTokens == 0 {
-		return
-	}
-	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     l.PromptTokens,
-		CompletionTokens: l.CompletionTokens,
-		TotalTokens:      l.TotalTokens,
-	}
-	l.TokenUsageParsed = usage
 }
 
 // MCPToolLog represents a log entry for MCP tool executions

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -918,7 +918,7 @@ func (l *Log) DeserializeFields() error {
 	// prompt/completion/total columns in the DB for analytics. Rebuild the virtual
 	// field so list APIs and the UI can render tokens without hydrating from S3 —
 	// same role content_summary plays for message previews.
-	if l.TokenUsageParsed == nil && (l.PromptTokens != 0 || l.CompletionTokens != 0 || l.TotalTokens != 0) {
+	if l.TokenUsage == "" && l.TokenUsageParsed == nil && (l.PromptTokens != 0 || l.CompletionTokens != 0 || l.TotalTokens != 0) {
 		l.TokenUsageParsed = &schemas.BifrostLLMUsage{
 			PromptTokens:     l.PromptTokens,
 			CompletionTokens: l.CompletionTokens,

--- a/framework/logstore/tables_test.go
+++ b/framework/logstore/tables_test.go
@@ -1,0 +1,42 @@
+package logstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeserializeFieldsReconstructsTokenUsageFromDenormalizedColumns(t *testing.T) {
+	log := &Log{
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      15,
+	}
+	require.NoError(t, log.DeserializeFields())
+	require.NotNil(t, log.TokenUsageParsed)
+	assert.Equal(t, 10, log.TokenUsageParsed.PromptTokens)
+	assert.Equal(t, 5, log.TokenUsageParsed.CompletionTokens)
+	assert.Equal(t, 15, log.TokenUsageParsed.TotalTokens)
+	assert.Nil(t, log.TokenUsageParsed.PromptTokensDetails)
+}
+
+func TestDeserializeFieldsPrefersSerializedTokenUsage(t *testing.T) {
+	log := &Log{
+		TokenUsage:       `{"prompt_tokens":99,"completion_tokens":1,"total_tokens":100}`,
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      15,
+	}
+	require.NoError(t, log.DeserializeFields())
+	require.NotNil(t, log.TokenUsageParsed)
+	assert.Equal(t, 99, log.TokenUsageParsed.PromptTokens)
+	assert.Equal(t, 1, log.TokenUsageParsed.CompletionTokens)
+	assert.Equal(t, 100, log.TokenUsageParsed.TotalTokens)
+}
+
+func TestDeserializeFieldsSkipsTokenUsageReconstructionWhenAllZero(t *testing.T) {
+	log := &Log{}
+	require.NoError(t, log.DeserializeFields())
+	assert.Nil(t, log.TokenUsageParsed)
+}

--- a/framework/logstore/tables_test.go
+++ b/framework/logstore/tables_test.go
@@ -35,6 +35,17 @@ func TestDeserializeFieldsPrefersSerializedTokenUsage(t *testing.T) {
 	assert.Equal(t, 100, log.TokenUsageParsed.TotalTokens)
 }
 
+func TestDeserializeFieldsDoesNotReconstructTokenUsageWhenSerializedValueIsMalformed(t *testing.T) {
+	log := &Log{
+		TokenUsage:       `{"prompt_tokens":`,
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      15,
+	}
+	require.NoError(t, log.DeserializeFields())
+	assert.Nil(t, log.TokenUsageParsed)
+}
+
 func TestDeserializeFieldsSkipsTokenUsageReconstructionWhenAllZero(t *testing.T) {
 	log := &Log{}
 	require.NoError(t, log.DeserializeFields())


### PR DESCRIPTION
## Summary

Fixes the logs table Tokens column when hybrid/S3 log storage is enabled.

## Changes

- Rebuild minimal `token_usage` from denormalized DB columns during log deserialization when serialized
  `token_usage` is absent.
- Preserve serialized `token_usage` as the source of truth when it exists.
- Add unit coverage for the reconstruction behavior.
- Add hybrid log store coverage to ensure list queries can render token counts without hydrating payloads
from object storage.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs
- [x] Framework / Logstore

## How to test

```sh
go test ./framework/logstore
```

## Screenshots/Recordings

No.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4721

## Security considerations

No new auth, secret, or PII surfaces. This only reconstructs token count summary fields already stored in
  DB columns.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
