### PR TITLE
fix: handle `SecretVar` JSON objects without `value` field in `UnmarshalJSON`

### DIFF
--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -1,6 +1,7 @@
 package schemas
 
 import (
+	"bytes"
 	"database/sql/driver"
 	"fmt"
 	"os"
@@ -47,8 +48,7 @@ func NewSecretVar(value string) *SecretVar {
 	}
 	// If it's a valid JSON object following the SecretVar schema, unmarshal it
 	if sonic.Valid([]byte(value)) {
-		valueNode, _ := sonic.Get([]byte(val), "value")
-		if valueNode.Exists() {
+		if trimmed := bytes.TrimSpace([]byte(val)); len(trimmed) > 0 && trimmed[0] == '{' {
 			type secretVarCompat struct {
 				Val        string     `json:"value"`
 				Ref        string     `json:"ref"`
@@ -299,8 +299,7 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 		val = unquoted
 	}
 	if sonic.Valid(data) {
-		valueNode, _ := sonic.Get(data, "value")
-		if valueNode.Exists() {
+		if trimmed := bytes.TrimSpace(data); len(trimmed) > 0 && trimmed[0] == '{' {
 			type secretVarCompat struct {
 				Val        string     `json:"value"`
 				Ref        string     `json:"ref"`

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -114,6 +114,23 @@ func TestSecretVar_UnmarshalJSON_BackwardCompat(t *testing.T) {
 	os.Setenv("MY_KEY", "resolved-value")
 	defer os.Unsetenv("MY_KEY")
 
+	t.Run("from_env without value field", func(t *testing.T) {
+		input := `{"env_var":"MY_KEY","from_env":true}`
+		var sv SecretVar
+		if err := sv.UnmarshalJSON([]byte(input)); err != nil {
+			t.Fatalf("UnmarshalJSON failed: %v", err)
+		}
+		if sv.GetRawRef() != "env.MY_KEY" {
+			t.Errorf("expected ref %q, got %q", "env.MY_KEY", sv.GetRawRef())
+		}
+		if !sv.IsFromSecret() {
+			t.Error("expected IsFromSecret=true")
+		}
+		if sv.Val != "resolved-value" {
+			t.Errorf("expected Val=%q, got %q", "resolved-value", sv.Val)
+		}
+	})
+
 	t.Run("old env_var/from_env format", func(t *testing.T) {
 		input := `{"value":"my-api-key","env_var":"env.MY_KEY","from_env":true}`
 		var secretVar SecretVar
@@ -218,6 +235,22 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
 			}
 		})
+	}
+}
+
+func TestNewSecretVar_FromEnvWithoutValueField(t *testing.T) {
+	os.Setenv("MY_KEY", "resolved-value")
+	defer os.Unsetenv("MY_KEY")
+
+	sv := NewSecretVar(`{"env_var":"MY_KEY","from_env":true}`)
+	if sv.GetRawRef() != "env.MY_KEY" {
+		t.Errorf("expected ref %q, got %q", "env.MY_KEY", sv.GetRawRef())
+	}
+	if !sv.IsFromSecret() {
+		t.Error("expected IsFromSecret=true")
+	}
+	if sv.Val != "resolved-value" {
+		t.Errorf("expected Val=%q, got %q", "resolved-value", sv.Val)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug in `SecretVar.UnmarshalJSON` where JSON objects that do not contain a `"value"` field (e.g., `{"env_var":"MY_KEY","from_env":true}`) were not being parsed correctly as the structured compat format. The previous logic used `sonic.Get` to check for a `"value"` key, which caused the object to fall through to plain-string handling instead of the struct deserialization path.

## Changes

- Replaced the `sonic.Get(data, "value")` existence check with a direct byte-level inspection (`bytes.TrimSpace`) to detect whether the input is a JSON object (`{`). This ensures any JSON object — with or without a `"value"` field — is routed through the `secretVarCompat` struct unmarshaling path.
- Added a test case covering the `from_env` format without a `"value"` field to prevent regression.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... -run TestSecretVar_UnmarshalJSON_BackwardCompat
```

Expected: all subtests pass, including the new `from_env without value field` case which verifies that `env_var`/`from_env` objects without a `"value"` key correctly resolve the environment variable and set the ref to `env.MY_KEY`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change affects how secret variable references are resolved from environment variables. The fix ensures env-backed secrets are correctly identified and resolved rather than silently falling back to treating the raw JSON as a plain string value, which could have led to secrets being mishandled or unresolved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable