### PR TITLE
fix: fix the provider governance form UI to only show calendar aligned toggle when budget is alignable

### DIFF
--- a/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
@@ -5,6 +5,7 @@ import MultiBudgetLines, { BudgetLineEntry } from "@/components/ui/multibudgets"
 import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
+import { supportsCalendarAlignment } from "@/lib/constants/governance";
 import {
 	getErrorMessage,
 	useDeleteProviderGovernanceMutation,
@@ -87,6 +88,8 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 
 	const watchedBudgets = form.watch("budgets");
 	const watchedCalendarAligned = form.watch("calendarAligned");
+	const configuredBudgets = watchedBudgets.filter((b) => b.max_limit !== undefined && b.max_limit > 0);
+	const showCalendarAlignment = configuredBudgets.some((b) => supportsCalendarAlignment(b.reset_duration));
 
 	useEffect(() => {
 		if (providerGovernance && !form.formState.isDirty) {
@@ -100,9 +103,18 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 		form.reset(governanceToFormValues(newProvGov));
 	}, [provider.name, form]);
 
+	// Drop a stale calendarAligned when no configured budget supports alignment, so the
+	// toggle never reappears pre-enabled if an alignable budget is added back later.
+	useEffect(() => {
+		if (!showCalendarAlignment && watchedCalendarAligned) {
+			form.setValue("calendarAligned", false, { shouldDirty: true });
+		}
+	}, [showCalendarAlignment, watchedCalendarAligned, form]);
+
 	const onSubmit = async (data: FormData) => {
 		try {
 			const validBudgets = data.budgets.filter((b) => b.max_limit !== undefined && b.max_limit > 0);
+			const hasAlignableBudget = validBudgets.some((b) => supportsCalendarAlignment(b.reset_duration));
 			const hadBudgets = (providerGovernance?.budgets?.length ?? 0) > 0;
 			const hadRateLimit = !!providerGovernance?.rate_limit;
 			const hasRateLimit = data.tokenMaxLimit !== undefined || data.requestMaxLimit !== undefined;
@@ -141,7 +153,7 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 				provider: provider.name,
 				data: {
 					budgets: budgetsPayload,
-					...(budgetsPayload !== undefined ? { calendar_aligned: data.calendarAligned } : {}),
+					...(budgetsPayload !== undefined ? { calendar_aligned: hasAlignableBudget && data.calendarAligned } : {}),
 					rate_limit: rateLimitPayload,
 				},
 			}).unwrap();
@@ -177,8 +189,8 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 					onChange={(lines) => form.setValue("budgets", lines, { shouldDirty: true })}
 				/>
 
-				{/* Calendar Alignment — only shown when there are budgets */}
-				{watchedBudgets.length > 0 && (
+				{/* Calendar Alignment — only shown when a budget uses a calendar-alignable period (day/week/month/year) */}
+				{showCalendarAlignment && (
 					<div className="flex items-center justify-between gap-4">
 						<div className="space-y-1">
 							<Label className="text-sm" htmlFor="provider-calendar-aligned">


### PR DESCRIPTION
## Summary

The calendar alignment toggle in the provider governance form was previously shown whenever any budget existed. This PR restricts its visibility and submission to only when at least one budget uses a calendar-alignable reset period (day, week, month, or year).

## Changes

- Introduced a `showCalendarAlignment` derived boolean that checks whether any configured budget has a reset duration supported by `supportsCalendarAlignment`.
- Replaced the previous condition (`watchedBudgets.length > 0`) with `showCalendarAlignment` to control rendering of the calendar alignment toggle.
- Updated the form submission payload so that `calendar_aligned` is only set to `true` when at least one budget actually supports calendar alignment — preventing the flag from being submitted for incompatible budget configurations.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to a provider's governance settings in the UI.
2. Add a budget with a reset duration that does **not** support calendar alignment (e.g., hourly). Verify the calendar alignment toggle does **not** appear.
3. Add or change a budget to use a calendar-alignable period (e.g., daily, weekly, monthly, yearly). Verify the toggle **does** appear.
4. Enable the toggle and save. Confirm `calendar_aligned: true` is included in the submitted payload.
5. Remove all calendar-alignable budgets and save. Confirm `calendar_aligned` is not set to `true` in the payload.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Before:_ Calendar alignment toggle appears whenever any budget is present, regardless of reset period.

_After:_ Calendar alignment toggle only appears when at least one budget uses a day/week/month/year reset period.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable