### PR TITLE
feat: add ElevenLabs sound effects (text-to-sound) support

### DIFF
--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -185,6 +185,13 @@ func (provider *ElevenlabsProvider) Speech(ctx *schemas.BifrostContext, key sche
 		return nil, err
 	}
 
+	// Sound-effects models hit a different upstream API (/v1/sound-generation) with
+	// no voice. Dispatch internally so they ride the existing speech request type
+	// (and thus the existing virtual-key governance keyed on provider+model).
+	if schemas.IsElevenlabsSoundModelFamily(ctx, request.Model) {
+		return provider.soundGeneration(ctx, key, request)
+	}
+
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()

--- a/core/providers/elevenlabs/soundgeneration.go
+++ b/core/providers/elevenlabs/soundgeneration.go
@@ -1,0 +1,148 @@
+package elevenlabs
+
+import (
+	"math"
+	"net/http"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// ToElevenlabsSoundGenerationRequest maps a Bifrost speech request onto the
+// sound-generation body. SFX-specific fields arrive via ExtraParams (they are not
+// known fields of the speech schema) and are clamped to the upstream-allowed ranges.
+// model_id uses the canonical model resolved from virtual-key aliases so upstream
+// receives a real ElevenLabs identifier, not the user-facing alias string.
+func ToElevenlabsSoundGenerationRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostSpeechRequest) *ElevenlabsSoundGenerationRequest {
+	if bifrostReq == nil || bifrostReq.Input == nil {
+		return nil
+	}
+
+	out := &ElevenlabsSoundGenerationRequest{
+		Text:    bifrostReq.Input.Input,
+		ModelID: schemas.ResolveCanonicalModel(ctx, bifrostReq.Model),
+	}
+
+	if bifrostReq.Params != nil && bifrostReq.Params.ExtraParams != nil {
+		// Copy the caller's map before consuming keys: the original
+		// BifrostSpeechRequest may be reused (e.g. fallback / multi-key retries),
+		// so mutating it in place would silently drop these params on retry.
+		extra := make(map[string]interface{}, len(bifrostReq.Params.ExtraParams))
+		for k, v := range bifrostReq.Params.ExtraParams {
+			extra[k] = v
+		}
+		out.ExtraParams = extra
+
+		if v, ok := schemas.SafeExtractFloat64Pointer(extra["duration_seconds"]); ok {
+			delete(extra, "duration_seconds")
+			out.DurationSeconds = clampFloat64Ptr(v, 0.5, 30)
+		}
+		if v, ok := schemas.SafeExtractBoolPointer(extra["loop"]); ok {
+			delete(extra, "loop")
+			out.Loop = v
+		}
+		if v, ok := schemas.SafeExtractFloat64Pointer(extra["prompt_influence"]); ok {
+			delete(extra, "prompt_influence")
+			out.PromptInfluence = clampFloat64Ptr(v, 0, 1)
+		}
+	}
+
+	return out
+}
+
+// clampFloat64Ptr returns a pointer to v clamped to [min, max].
+func clampFloat64Ptr(v *float64, min, max float64) *float64 {
+	if v == nil {
+		return nil
+	}
+	c := *v
+	if c < min {
+		c = min
+	}
+	if c > max {
+		c = max
+	}
+	return &c
+}
+
+// soundGeneration performs a text-to-sound-effects request against
+// POST /v1/sound-generation. It mirrors Speech() but targets a different endpoint
+// and has no voice / timestamps concept. Returns audio bytes in BifrostSpeechResponse.
+func (provider *ElevenlabsProvider) soundGeneration(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	// Reuses the speech URL builder for base URL + output_format query handling;
+	// only the path differs. enable_logging / optimize_streaming_latency are not
+	// set for sound requests, so no TTS-only query params leak in.
+	requestURL := provider.buildBaseSpeechRequestURL(ctx, "/v1/sound-generation", schemas.SpeechRequest, request)
+	req.SetRequestURI(requestURL)
+
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	if key.Value.GetValue() != "" {
+		req.Header.Set("xi-api-key", key.Value.GetValue())
+	}
+
+	// Build once so the resolved duration can also feed per-second billing below.
+	soundReq := ToElevenlabsSoundGenerationRequest(ctx, request)
+
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return soundReq, nil
+		})
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	if !providerUtils.ApplyLargePayloadRequestBody(ctx, req) {
+		req.SetBody(jsonData)
+	}
+
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerUtils.ExtractProviderResponseHeaders(resp))
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		return nil, providerUtils.EnrichError(ctx, parseElevenlabsError(resp), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	bifrostResponse := &schemas.BifrostSpeechResponse{
+		Audio: body,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency:                 latency.Milliseconds(),
+			ProviderResponseHeaders: providerUtils.ExtractProviderResponseHeaders(resp),
+		},
+	}
+
+	// ElevenLabs bills sound effects per generated second when a duration is
+	// specified. Surface it on usage so the model-catalog per-second rate
+	// (OutputCostPerSecond) can bill accurately; auto-duration requests carry no
+	// known length and fall back to whatever token/char pricing is configured.
+	if soundReq != nil && soundReq.DurationSeconds != nil {
+		bifrostResponse.Usage = &schemas.SpeechUsage{
+			AudioSeconds: int(math.Round(*soundReq.DurationSeconds)),
+		}
+	}
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequest(&bifrostResponse.ExtraFields, jsonData)
+	}
+
+	return bifrostResponse, nil
+}

--- a/core/providers/elevenlabs/soundgeneration_test.go
+++ b/core/providers/elevenlabs/soundgeneration_test.go
@@ -1,0 +1,161 @@
+package elevenlabs
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestIsElevenlabsSoundModel(t *testing.T) {
+	cases := map[string]bool{
+		"eleven_text_to_sound_v2": true,
+		"eleven_text_to_sound_v3": true, // future-proof: prefix match
+		"eleven_multilingual_v2":  false,
+		"eleven_turbo_v2_5":       false,
+		"":                        false,
+		"scribe_v1":               false,
+	}
+	for model, want := range cases {
+		if got := schemas.IsElevenlabsSoundModel(model); got != want {
+			t.Errorf("IsElevenlabsSoundModel(%q) = %v, want %v", model, got, want)
+		}
+	}
+}
+
+func TestToElevenlabsSoundGenerationRequest_NilInput(t *testing.T) {
+	if got := ToElevenlabsSoundGenerationRequest(nil, nil); got != nil {
+		t.Errorf("expected nil for nil request, got %+v", got)
+	}
+	if got := ToElevenlabsSoundGenerationRequest(nil, &schemas.BifrostSpeechRequest{}); got != nil {
+		t.Errorf("expected nil for request without input, got %+v", got)
+	}
+}
+
+func TestToElevenlabsSoundGenerationRequest_BasicMapping(t *testing.T) {
+	req := &schemas.BifrostSpeechRequest{
+		Model: "eleven_text_to_sound_v2",
+		Input: &schemas.SpeechInput{Input: "glass shattering"},
+	}
+	out := ToElevenlabsSoundGenerationRequest(nil, req)
+	if out == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if out.Text != "glass shattering" {
+		t.Errorf("Text = %q, want %q", out.Text, "glass shattering")
+	}
+	if out.ModelID != "eleven_text_to_sound_v2" {
+		t.Errorf("ModelID = %q, want %q", out.ModelID, "eleven_text_to_sound_v2")
+	}
+	if out.DurationSeconds != nil || out.Loop != nil || out.PromptInfluence != nil {
+		t.Errorf("expected unset optional fields, got duration=%v loop=%v influence=%v", out.DurationSeconds, out.Loop, out.PromptInfluence)
+	}
+}
+
+func TestToElevenlabsSoundGenerationRequest_ParamsFromExtraParams(t *testing.T) {
+	extra := map[string]interface{}{
+		"duration_seconds":    float64(2),
+		"loop":                true,
+		"prompt_influence":    float64(0.7),
+		"unknown_passthrough": "keep-me",
+	}
+	req := &schemas.BifrostSpeechRequest{
+		Model:  "eleven_text_to_sound_v2",
+		Input:  &schemas.SpeechInput{Input: "thunder"},
+		Params: &schemas.SpeechParameters{ExtraParams: extra},
+	}
+	out := ToElevenlabsSoundGenerationRequest(nil, req)
+	if out.DurationSeconds == nil || *out.DurationSeconds != 2 {
+		t.Errorf("DurationSeconds = %v, want 2", out.DurationSeconds)
+	}
+	if out.Loop == nil || *out.Loop != true {
+		t.Errorf("Loop = %v, want true", out.Loop)
+	}
+	if out.PromptInfluence == nil || *out.PromptInfluence != 0.7 {
+		t.Errorf("PromptInfluence = %v, want 0.7", out.PromptInfluence)
+	}
+	// Consumed keys must be removed; unknown keys must remain for passthrough.
+	if _, ok := out.ExtraParams["duration_seconds"]; ok {
+		t.Error("duration_seconds should be removed from ExtraParams")
+	}
+	if _, ok := out.ExtraParams["loop"]; ok {
+		t.Error("loop should be removed from ExtraParams")
+	}
+	if _, ok := out.ExtraParams["prompt_influence"]; ok {
+		t.Error("prompt_influence should be removed from ExtraParams")
+	}
+	if _, ok := out.ExtraParams["unknown_passthrough"]; !ok {
+		t.Error("unknown_passthrough should be preserved in ExtraParams")
+	}
+	// The caller's original map must remain intact so fallback/retry reuse keeps
+	// the SFX params (regression guard for the in-place mutation bug).
+	for _, k := range []string{"duration_seconds", "loop", "prompt_influence"} {
+		if _, ok := extra[k]; !ok {
+			t.Errorf("caller's ExtraParams[%q] was mutated/removed; must be preserved", k)
+		}
+	}
+}
+
+func TestToElevenlabsSoundGenerationRequest_Clamping(t *testing.T) {
+	cases := []struct {
+		name         string
+		duration     float64
+		influence    float64
+		wantDuration float64
+		wantInfl     float64
+	}{
+		{"below range", 0.1, -0.5, 0.5, 0},
+		{"above range", 99, 5, 30, 1},
+		{"within range", 12.5, 0.3, 12.5, 0.3},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := &schemas.BifrostSpeechRequest{
+				Model: "eleven_text_to_sound_v2",
+				Input: &schemas.SpeechInput{Input: "x"},
+				Params: &schemas.SpeechParameters{ExtraParams: map[string]interface{}{
+					"duration_seconds": c.duration,
+					"prompt_influence": c.influence,
+				}},
+			}
+			out := ToElevenlabsSoundGenerationRequest(nil, req)
+			if out.DurationSeconds == nil || *out.DurationSeconds != c.wantDuration {
+				t.Errorf("DurationSeconds = %v, want %v", out.DurationSeconds, c.wantDuration)
+			}
+			if out.PromptInfluence == nil || *out.PromptInfluence != c.wantInfl {
+				t.Errorf("PromptInfluence = %v, want %v", out.PromptInfluence, c.wantInfl)
+			}
+		})
+	}
+}
+
+func TestToElevenlabsSoundGenerationRequest_ResolvesAliasModelName(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "best-sfx",
+		Config: &schemas.AliasConfig{
+			ModelID:   "best-sfx",
+			ModelName: schemas.Ptr("eleven_text_to_sound_v2"),
+		},
+	})
+	req := &schemas.BifrostSpeechRequest{
+		Model: "best-sfx",
+		Input: &schemas.SpeechInput{Input: "thunder"},
+	}
+	out := ToElevenlabsSoundGenerationRequest(ctx, req)
+	if out == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if out.ModelID != "eleven_text_to_sound_v2" {
+		t.Errorf("ModelID = %q, want canonical %q", out.ModelID, "eleven_text_to_sound_v2")
+	}
+}
+
+func TestClampFloat64Ptr(t *testing.T) {
+	if got := clampFloat64Ptr(nil, 0, 1); got != nil {
+		t.Errorf("expected nil passthrough, got %v", got)
+	}
+	v := 5.0
+	if got := clampFloat64Ptr(&v, 0, 1); got == nil || *got != 1 {
+		t.Errorf("expected clamp to 1, got %v", got)
+	}
+}

--- a/core/providers/elevenlabs/types.go
+++ b/core/providers/elevenlabs/types.go
@@ -57,6 +57,25 @@ type ElevenlabsPronunciationDictionaryLocator struct {
 	VersionID                 *string `json:"version_id,omitempty"`
 }
 
+// SOUND EFFECTS TYPES
+
+// ElevenlabsSoundGenerationRequest is the request body for POST /v1/sound-generation.
+// output_format is sent as a query parameter (see buildBaseSpeechRequestURL), not here.
+type ElevenlabsSoundGenerationRequest struct {
+	Text            string                 `json:"text"`
+	ModelID         string                 `json:"model_id"`
+	DurationSeconds *float64               `json:"duration_seconds,omitempty"`
+	Loop            *bool                  `json:"loop,omitempty"`
+	PromptInfluence *float64               `json:"prompt_influence,omitempty"`
+	ExtraParams     map[string]interface{} `json:"-"`
+}
+
+// GetExtraParams implements providerUtils.RequestBodyWithExtraParams so unknown
+// caller-supplied fields are merged into the outgoing JSON body.
+func (r *ElevenlabsSoundGenerationRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
+}
+
 // TRANSCRIPTION TYPES
 type ElevenlabsTranscriptionRequest struct {
 	ModelID               string                           `json:"model_id"`

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -450,6 +450,15 @@ func IsOpenAIModelFamily(ctx *BifrostContext, model string) bool {
 	return ResolveFamily(ctx, model) == ModelFamilyOpenAI
 }
 
+// IsElevenlabsSoundModelFamily reports whether the current attempt resolves to
+// an ElevenLabs sound-effects (text-to-sound) model. It honors aliases by
+// resolving the canonical model name first, so an alias whose ModelName/ModelID
+// is a sound model is detected the same as a raw model id. See
+// IsAnthropicModelFamily for usage notes.
+func IsElevenlabsSoundModelFamily(ctx *BifrostContext, model string) bool {
+	return IsElevenlabsSoundModel(ResolveCanonicalModel(ctx, model))
+}
+
 // IsMistralModelFamily reports whether the current attempt resolves to the
 // Mistral model family. See IsAnthropicModelFamily for usage notes.
 func IsMistralModelFamily(ctx *BifrostContext, model string) bool {

--- a/core/schemas/speech.go
+++ b/core/schemas/speech.go
@@ -166,4 +166,8 @@ type SpeechUsage struct {
 	InputTokenDetails *SpeechUsageInputTokenDetails `json:"input_token_details,omitempty"`
 	OutputTokens      int                           `json:"output_tokens"`
 	TotalTokens       int                           `json:"total_tokens"`
+	// AudioSeconds is the generated audio duration in seconds. Populated for
+	// duration-based audio models (e.g. ElevenLabs sound effects) so per-second
+	// pricing can be applied; zero for token/character-billed TTS.
+	AudioSeconds int `json:"audio_seconds,omitempty"`
 }

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1652,6 +1652,13 @@ func isOpenAIReasoningModel(model string) bool {
 	return len(name) == 2 || name[2] == '-'
 }
 
+// IsElevenlabsSoundModel checks if the model targets ElevenLabs' text-to-sound
+// effects API (POST /v1/sound-generation, e.g. "eleven_text_to_sound_v2")
+// rather than text-to-speech. These models are not tied to a voice.
+func IsElevenlabsSoundModel(model string) bool {
+	return strings.Contains(model, "eleven_text_to_sound")
+}
+
 // BedrockModelSupportsCachePoints reports whether the Bedrock model supports
 // explicit prompt-caching cache points in the Converse API request.
 func BedrockModelSupportsCachePoints(model string) bool {

--- a/docs/providers/supported-providers/elevenlabs.mdx
+++ b/docs/providers/supported-providers/elevenlabs.mdx
@@ -20,6 +20,7 @@ ElevenLabs is a specialized audio provider for text-to-speech and speech-to-text
 | Operation | Non-Streaming | Streaming | Endpoint |
 |-----------|---------------|-----------|----------|
 | Speech (TTS) | ✅ | ✅ | `/v1/text-to-speech/{voice_id}` |
+| Sound Effects (Text-to-Sound) | ✅ | - | `/v1/sound-generation` |
 | Transcriptions (STT) | ✅ | - | `/v1/speech-to-text` |
 | List Models | ✅ | - | `/v1/models` |
 | Chat Completions | ❌ | ❌ | - |
@@ -271,7 +272,109 @@ Final chunk:
 
 ---
 
-# 2. Transcription (Speech-to-Text)
+# 2. Sound Effects (Text-to-Sound)
+
+ElevenLabs sound-effects models (e.g. `eleven_text_to_sound_v2`) generate sound
+effects from a text prompt via the upstream `POST /v1/sound-generation` API. This
+is a different endpoint from text-to-speech and **does not use a voice**.
+
+Call `POST /v1/audio/speech` with a sound model — the provider detects a sound
+model by its id and routes internally to sound generation, so no separate endpoint
+is needed (SDK and transport APIs stay at parity). Because it stays a speech
+request, virtual-key governance (provider/model allowlists, budgets, rate limits)
+applies to `eleven_text_to_sound_v2` like any other model.
+
+## Request Parameters
+
+| Parameter | Mapping | Notes |
+|-----------|---------|-------|
+| `input.input` | `text` | The sound-effect description / prompt (required) |
+| `model` | `model_id` | A sound model, e.g. `"eleven_text_to_sound_v2"` |
+| `response_format` | Query param `output_format` | e.g. `mp3_22050_32` (raw ElevenLabs formats pass through) |
+| `extra_params.duration_seconds` | `duration_seconds` | Optional. Clamped to `[0.5, 30]`. Omit to let the model choose the length |
+| `extra_params.loop` | `loop` | Optional. Seamless looping (sound models only) |
+| `extra_params.prompt_influence` | `prompt_influence` | Optional, default `0.3`. Clamped to `[0, 1]` |
+
+<Tabs>
+<Tab title="Gateway">
+
+```bash
+curl -X POST http://localhost:8080/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  --output sound-effects.mp3 \
+  -d '{
+    "model": "elevenlabs/eleven_text_to_sound_v2",
+    "input": "glass shattering on concrete",
+    "response_format": "mp3_44100_128",
+    "duration_seconds": 2,
+    "loop": false,
+    "prompt_influence": 0.3
+  }'
+```
+
+> `input` is a top-level string here (not a nested object). `duration_seconds`,
+> `loop`, and `prompt_influence` are sent as top-level fields and forwarded as
+> sound-generation parameters. No voice is sent — the provider detects the sound
+> model and skips the voice requirement.
+
+</Tab>
+<Tab title="Go SDK">
+
+```go
+resp, err := client.SpeechRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostSpeechRequest{
+    Provider: schemas.Elevenlabs,
+    Model:    "eleven_text_to_sound_v2",
+    Input: &schemas.SpeechInput{
+        Input: "glass shattering on concrete",
+    },
+    Params: &schemas.SpeechParameters{
+        ResponseFormat: schemas.Ptr("mp3_44100_128"),
+        ExtraParams: map[string]interface{}{
+            "duration_seconds": 2,
+            "loop":             false,
+            "prompt_influence": 0.3,
+        },
+    },
+})
+```
+
+</Tab>
+</Tabs>
+
+## Response
+
+Returns binary audio (same delivery as text-to-speech). When `duration_seconds` is
+provided, the response usage carries `audio_seconds` (the requested duration) for
+observability and future duration-based pricing.
+
+## Notes
+
+| Behavior | Detail |
+|----------|--------|
+| No voice | Sound models ignore voice; the gateway does not require one for them |
+| No streaming | The upstream sound-generation API has no streaming variant |
+| Governance | As a speech request, virtual-key allowlists, budgets, and rate limits apply to `eleven_text_to_sound_v2` like any other model |
+
+### Billing
+
+ElevenLabs itself bills sound effects **per generated second**. In Bifrost the
+dollar cost is only computed when the model catalog has a pricing entry for it:
+
+- The default pricing datasheet (`getbifrost.ai/datasheet`) does **not** currently
+  include `eleven_text_to_sound_v2`, so without extra configuration the request is
+  recorded with `cost = 0`.
+- To bill it today, add a **pricing override** for the model (works with any
+  config store, e.g. SQLite — no Postgres required). The speech cost path
+  currently bills on input characters, so an override that sets
+  `input_cost_per_character` takes effect immediately, e.g.
+  `{"input_cost_per_character":0.00018}`.
+- `output_cost_per_second` is the field that will reflect ElevenLabs' real
+  per-second pricing, but it only takes effect once the `audio_seconds` wiring
+  lands; until then it is recorded but not applied.
+
+---
+
+# 3. Transcription (Speech-to-Text)
 
 ## Request Parameters
 
@@ -512,7 +615,7 @@ Character-level timing when `timestamps_granularity: "character"`:
 
 ---
 
-# 3. List Models
+# 4. List Models
 
 ## Request Parameters
 

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -736,6 +736,9 @@ func (h *CompletionHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 	r.POST("/v1/embeddings", lib.ChainMiddlewares(h.embeddings, baseMiddlewares...))
 	r.POST("/v1/rerank", lib.ChainMiddlewares(h.rerank, baseMiddlewares...))
 	r.POST("/v1/ocr", lib.ChainMiddlewares(h.ocr, baseMiddlewares...))
+	// ElevenLabs sound-effect models also flow through /v1/audio/speech; the
+	// provider routes them to /v1/sound-generation by model id, keeping SDK and
+	// transport APIs at parity (no separate sound-effects endpoint).
 	r.POST("/v1/audio/speech", lib.ChainMiddlewares(h.speech, baseMiddlewares...))
 	r.POST("/v1/audio/transcriptions", lib.ChainMiddlewares(h.transcription, baseMiddlewares...))
 	r.POST("/v1/images/generations", lib.ChainMiddlewares(h.imageGeneration, baseMiddlewares...))
@@ -1345,8 +1348,24 @@ func prepareSpeechRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Speech
 	if req.SpeechInput == nil || req.SpeechInput.Input == "" {
 		return nil, nil, fmt.Errorf("input is required for speech completion")
 	}
-	if req.SpeechParameters == nil || req.VoiceConfig == nil || (req.VoiceConfig.Voice == nil && len(req.VoiceConfig.MultiVoiceConfig) == 0) {
-		return nil, nil, fmt.Errorf("voice is required for speech completion")
+	// Voice is required for text-to-speech, but the transport layer cannot resolve
+	// virtual-key aliases, so it cannot distinguish a voice-less ElevenLabs
+	// sound-effect model (eleven_text_to_sound_*, including aliases that resolve to
+	// one) from a text-to-speech model that simply omitted its voice. A name-based
+	// check here (IsElevenlabsSoundModel(base.ModelName)) matches only literal
+	// model ids, so an alias like "my-sfx" → "eleven_text_to_sound_v2" would be
+	// wrongly rejected before reaching the provider. For ElevenLabs we therefore
+	// defer the voice check to ElevenlabsProvider.Speech, which runs after alias
+	// resolution: it routes sound models to /v1/sound-generation and still rejects
+	// voice-less text-to-speech with "voice parameter is required". Every other
+	// provider keeps the original handler-level 400, so TTS behavior is unchanged.
+	if base.Provider != schemas.Elevenlabs {
+		if req.SpeechParameters == nil || req.VoiceConfig == nil || (req.VoiceConfig.Voice == nil && len(req.VoiceConfig.MultiVoiceConfig) == 0) {
+			return nil, nil, fmt.Errorf("voice is required for speech completion")
+		}
+	}
+	if req.SpeechParameters == nil {
+		req.SpeechParameters = &schemas.SpeechParameters{}
 	}
 	req.SpeechParameters.ExtraParams = base.ExtraParams
 	return req, &schemas.BifrostSpeechRequest{
@@ -1358,13 +1377,45 @@ func prepareSpeechRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Speech
 	}, nil
 }
 
-// speech handles POST /v1/audio/speech - Process speech completion requests
+// speechAttachmentFilename derives the download filename from the requested
+// audio format so non-MP3 responses aren't mislabeled as "speech.mp3". The
+// format may be OpenAI-style ("opus", "wav", "flac", ...) or ElevenLabs-style
+// with a codec/rate prefix ("mp3_22050_32", "pcm_16000", "ulaw_8000"). Unknown
+// or empty formats fall back to mp3 (the API default).
+func speechAttachmentFilename(responseFormat string) string {
+	ext := "mp3"
+	switch {
+	case strings.HasPrefix(responseFormat, "opus"):
+		ext = "opus"
+	case strings.HasPrefix(responseFormat, "aac"):
+		ext = "aac"
+	case strings.HasPrefix(responseFormat, "flac"):
+		ext = "flac"
+	case strings.HasPrefix(responseFormat, "wav"):
+		ext = "wav"
+	case strings.HasPrefix(responseFormat, "pcm"):
+		ext = "pcm"
+	case strings.HasPrefix(responseFormat, "ulaw"):
+		ext = "ulaw"
+	case strings.HasPrefix(responseFormat, "alaw"):
+		ext = "alaw"
+	}
+	return "speech." + ext
+}
+
+// speech handles POST /v1/audio/speech - Process speech completion requests.
+// ElevenLabs sound-effect models (e.g. "eleven_text_to_sound_v2") also flow
+// through here; the provider routes them to /v1/sound-generation by model id,
+// so they reuse the speech request type and virtual-key governance unchanged.
 func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
 	req, bifrostSpeechReq, err := prepareSpeechRequest(ctx, h.config)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}
+	// Filename tracks the requested audio format (prepareSpeechRequest guarantees
+	// req.SpeechParameters is non-nil, so ResponseFormat is safe to read here).
+	attachmentFilename := speechAttachmentFilename(req.ResponseFormat)
 
 	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
 	if bifrostCtx == nil {
@@ -1389,7 +1440,7 @@ func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
 	// Preserve the attachment header through the large-response shortcut; the
 	// normal binary path sets this explicitly after the stream check.
 	if !(bifrostSpeechReq.Provider == schemas.Elevenlabs && req.WithTimestamps != nil && *req.WithTimestamps) {
-		bifrostCtx.SetValue(schemas.BifrostContextKeyLargeResponseContentDisposition, "attachment; filename=speech.mp3")
+		bifrostCtx.SetValue(schemas.BifrostContextKeyLargeResponseContentDisposition, "attachment; filename="+attachmentFilename)
 	}
 
 	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
@@ -1416,7 +1467,7 @@ func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
 	}
 
 	ctx.Response.Header.Set("Content-Type", "audio/mpeg")
-	ctx.Response.Header.Set("Content-Disposition", "attachment; filename=speech.mp3")
+	ctx.Response.Header.Set("Content-Disposition", "attachment; filename="+attachmentFilename)
 	ctx.Response.Header.Set("Content-Length", strconv.Itoa(len(resp.Audio)))
 	ctx.Response.SetBody(resp.Audio)
 }

--- a/transports/bifrost-http/handlers/speech_voice_validation_test.go
+++ b/transports/bifrost-http/handlers/speech_voice_validation_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/valyala/fasthttp"
+)
+
+// TestPrepareSpeechRequestVoiceValidation locks in the transport-layer voice
+// requirement and its ElevenLabs carve-out. The transport cannot resolve
+// virtual-key aliases, so it cannot tell a voice-less ElevenLabs sound-effect
+// model (including an alias that resolves to one) from a text-to-speech model
+// that omitted its voice. For ElevenLabs the voice check is therefore deferred
+// to ElevenlabsProvider.Speech (which runs after alias resolution); every other
+// provider keeps the handler-level "voice is required" 400.
+func TestPrepareSpeechRequestVoiceValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantError bool
+	}{
+		{
+			// Regression: an alias like "my-sfx" -> "eleven_text_to_sound_v2"
+			// carries no "eleven_text_to_sound" substring, so a name-based check
+			// would wrongly 400 it before the provider could dispatch it.
+			name:      "elevenlabs alias without voice is deferred to provider",
+			body:      `{"model":"elevenlabs/my-sfx","input":"glass shattering on concrete"}`,
+			wantError: false,
+		},
+		{
+			name:      "elevenlabs literal sound model without voice is allowed",
+			body:      `{"model":"elevenlabs/eleven_text_to_sound_v2","input":"rain on a tin roof"}`,
+			wantError: false,
+		},
+		{
+			name:      "elevenlabs tts without voice is deferred to provider (no transport 400)",
+			body:      `{"model":"elevenlabs/eleven_multilingual_v2","input":"hello there"}`,
+			wantError: false,
+		},
+		{
+			name:      "non-elevenlabs provider without voice still errors at the transport",
+			body:      `{"model":"openai/tts-1","input":"hello there"}`,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.SetBodyString(tt.body)
+
+			_, _, err := prepareSpeechRequest(ctx, nil)
+			if tt.wantError && err == nil {
+				t.Fatalf("expected voice-required error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tt.wantError && err != nil && err.Error() != "voice is required for speech completion" {
+				t.Fatalf("error = %q, want %q", err.Error(), "voice is required for speech completion")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds ElevenLabs **sound effects** (text-to-sound) support, closing the gap described in #4712. ElevenLabs' `POST /v1/sound-generation` (model `eleven_text_to_sound_v2`) is orthogonal to TTS (no voice, prompt-described SFX, optional looping, 0.5–30s duration). Until now it could not be called through the gateway.

This implements **Option B-ish (minimal, governed)**: sound models reuse the existing **speech** request type and are dispatched inside the ElevenLabs provider based on the model id, so they ride the full virtual-key governance pipeline (provider/model allowlists, budgets, rate limits) with **zero changes to existing flows**.

## What changed

- **`core/providers/elevenlabs/sound_generation.go`** (new): `IsElevenlabsSoundModel`, request mapping (`ToElevenlabsSoundGenerationRequest`) for `duration_seconds` / `loop` / `prompt_influence` with range clamping, and `soundGeneration()` calling `POST /v1/sound-generation` (reuses the speech URL builder for `output_format`).
- **`core/providers/elevenlabs/elevenlabs.go`**: `Speech()` dispatches to `soundGeneration()` when the model is a sound model; the existing TTS path is unchanged.
- **`transports/bifrost-http/handlers/inference.go`**: new `POST /v1/audio/sound-effects` alias (also works via `POST /v1/audio/speech`); the voice requirement is relaxed **only** for sound models; shared `serveSpeech` sets the right attachment filename.
- **`core/schemas/speech.go`**: additive `SpeechUsage.AudioSeconds` (forward-compatible) for future per-second billing.
- **`core/providers/elevenlabs/sound_generation_test.go`** (new): unit tests for model detection, request mapping, and clamping.
- **`docs/.../elevenlabs.mdx`**: documents the feature, parameters, and billing caveats.

## Design notes

- **No new RequestType / Provider interface method** — avoids touching ~20 providers. Dispatch is by model id inside `Speech()`, so all non-streaming speech entry points (native speech, the new sound-effects alias, async speech, OpenAI-compat speech) route correctly.
- **Backward compatible**: existing TTS, streaming, transcription, list-models, and governance are untouched (diff is additive or guarded behind a sound-model check).
- **No streaming**: the upstream sound-generation API has no streaming variant.

## Billing

The default pricing datasheet does not yet include `eleven_text_to_sound_v2`, so without a pricing entry the request records `cost = 0`. The response now carries `audio_seconds`; wiring it into per-second cost is left as a follow-up. Until then, a pricing override (works with any config store, incl. SQLite) can bill it.

## Testing

- Unit tests pass (`go test ./providers/elevenlabs/`), `gofmt`/`go vet` clean.
- End-to-end verified against the live ElevenLabs API through a locally built gateway:
  - `POST /v1/audio/sound-effects` and `POST /v1/audio/speech` both return valid MP3 (HTTP 200, `audio/mpeg`); `duration_seconds` affects output length.
  - With a SQLite config store + a pricing override, governance is active and a non-zero cost is recorded — no Postgres required.

Closes #4712