### PR TITLE
feat: anthropic code execution tool support

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1380,26 +1380,7 @@ func HandleAnthropicResponsesStream(
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
 				break
 			}
-			// Passthrough: when conversion returns no responses but we need to forward raw events,
-			// create a minimal pass-through response to carry the raw event data.
-			// This ensures events like compaction content_block_start/stop are not silently dropped.
-			if len(responses) == 0 && sendBackRawResponse {
-				passthroughResp := &schemas.BifrostResponsesStreamResponse{
-					Type:           schemas.ResponsesStreamResponseType(eventType),
-					SequenceNumber: chunkIndex,
-					ExtraFields: schemas.BifrostResponseExtraFields{
-						ChunkIndex:  chunkIndex,
-						Latency:     time.Since(lastChunkTime).Milliseconds(),
-						RawResponse: eventData,
-					},
-				}
-				lastChunkTime = time.Now()
-				chunkIndex++
-				providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
-					providerUtils.GetBifrostResponseForStreamResponse(nil, nil, passthroughResp, nil, nil, nil),
-					responseChan, postHookSpanFinalizer)
-				continue
-			}
+
 			// Attach the upstream raw to exactly one bifrost response. Default to the last,
 			// but for the message_start expansion ([created, in_progress]) attach it to
 			// response.created

--- a/core/providers/anthropic/codeexecution_test.go
+++ b/core/providers/anthropic/codeexecution_test.go
@@ -1,0 +1,937 @@
+package anthropic
+
+import (
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+
+	"github.com/bytedance/sonic"
+	"github.com/tidwall/gjson"
+)
+
+// rawBashCodeExecResponse is the user-reported Anthropic response for a bash
+// code_execution_20250825 run (server_tool_use: bash_code_execution + result).
+var rawBashCodeExecResponse = `{
+  "model": "claude-opus-4-8",
+  "id": "msg_01NoFSPs32EMqtmR2g4e1bKa",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_01D6DLT2QGNjMqGAai9EgcrM",
+      "name": "bash_code_execution",
+      "input": { "command": "python3 -c \"import statistics; print(statistics.mean([1,2,3]))\"" }
+    },
+    {
+      "type": "bash_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_01D6DLT2QGNjMqGAai9EgcrM",
+      "content": {
+        "type": "bash_code_execution_result",
+        "stdout": "Mean: 5.5\nPopulation SD: 2.8722813232690143\n",
+        "stderr": "",
+        "return_code": 0,
+        "content": []
+      }
+    },
+    { "type": "text", "text": "Here are the results." }
+  ],
+  "container": { "id": "container_018jVZJnpVtdyWij4ULp3qTN", "expires_at": "2026-06-18T18:46:48.969255Z" },
+  "stop_reason": "end_turn",
+  "usage": { "input_tokens": 6021, "output_tokens": 424 }
+}`
+
+// TestCodeExecution_BashResponseRoundTrip verifies the bash code-execution
+// blocks survive Anthropic -> Bifrost -> Anthropic on the non-streaming path,
+// preserving both the neutral code_interpreter_call view and the container.
+func TestCodeExecution_BashResponseRoundTrip(t *testing.T) {
+	var resp AnthropicMessageResponse
+	if err := sonic.Unmarshal([]byte(rawBashCodeExecResponse), &resp); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+	bifrostResp := resp.ToBifrostResponsesResponse(ctx)
+	if bifrostResp == nil {
+		t.Fatal("ToBifrostResponsesResponse returned nil")
+	}
+
+	var found bool
+	for _, out := range bifrostResp.Output {
+		if out.Type == nil || *out.Type != schemas.ResponsesMessageTypeCodeInterpreterCall {
+			continue
+		}
+		found = true
+		tm := out.ResponsesToolMessage
+		if tm == nil || tm.ResponsesCodeInterpreterToolCall == nil || tm.ResponsesCodeExecutionCall == nil {
+			t.Fatal("code_interpreter_call present but payloads missing")
+		}
+		ci := tm.ResponsesCodeInterpreterToolCall
+		cec := tm.ResponsesCodeExecutionCall
+
+		if ci.ContainerID != "container_018jVZJnpVtdyWij4ULp3qTN" {
+			t.Errorf("container_id = %q, want container_018jVZJnpVtdyWij4ULp3qTN", ci.ContainerID)
+		}
+		if ci.Code == nil || *ci.Code == "" {
+			t.Error("neutral code not populated from bash command")
+		}
+		if len(ci.Outputs) == 0 || ci.Outputs[0].ResponsesCodeInterpreterOutputLogs == nil {
+			t.Fatal("neutral logs output not populated from stdout")
+		}
+		if ci.Outputs[0].ResponsesCodeInterpreterOutputLogs.Logs == "" {
+			t.Error("logs output empty")
+		}
+		if cec.ToolName != "bash_code_execution" {
+			t.Errorf("carry tool_name = %q, want bash_code_execution", cec.ToolName)
+		}
+		if cec.ResultType != "bash_code_execution_result" {
+			t.Errorf("carry result_type = %q, want bash_code_execution_result", cec.ResultType)
+		}
+		if cec.ReturnCode == nil || *cec.ReturnCode != 0 {
+			t.Errorf("carry return_code = %v, want 0", cec.ReturnCode)
+		}
+		if cec.ContainerExpiresAt == nil || *cec.ContainerExpiresAt != "2026-06-18T18:46:48.969255Z" {
+			t.Errorf("carry container expiry not preserved: %v", cec.ContainerExpiresAt)
+		}
+	}
+	if !found {
+		t.Fatal("neutral output has no code_interpreter_call — code execution blocks dropped on parse")
+	}
+
+	// Reverse back to Anthropic and assert the wire shape.
+	back := ToAnthropicResponsesResponse(ctx, bifrostResp)
+	if back == nil {
+		t.Fatal("ToAnthropicResponsesResponse returned nil")
+	}
+	out, err := sonic.Marshal(back)
+	if err != nil {
+		t.Fatalf("marshal back: %v", err)
+	}
+
+	var types []string
+	var serverToolName, resultToolUseID, innerType, stdout string
+	gjson.GetBytes(out, "content").ForEach(func(_, b gjson.Result) bool {
+		bt := b.Get("type").String()
+		types = append(types, bt)
+		switch bt {
+		case "server_tool_use":
+			serverToolName = b.Get("name").String()
+		case "bash_code_execution_tool_result":
+			resultToolUseID = b.Get("tool_use_id").String()
+			if content := b.Get("content"); !content.IsObject() {
+				t.Errorf("result content = %q, want a single object", content.Raw)
+			}
+			innerType = b.Get("content.type").String()
+			stdout = b.Get("content.stdout").String()
+		}
+		return true
+	})
+
+	if len(types) != 3 || types[0] != "server_tool_use" || types[1] != "bash_code_execution_tool_result" || types[2] != "text" {
+		t.Fatalf("converted blocks = %v, want [server_tool_use bash_code_execution_tool_result text]\n%s", types, out)
+	}
+	if serverToolName != "bash_code_execution" {
+		t.Errorf("server_tool_use name = %q, want bash_code_execution", serverToolName)
+	}
+	if resultToolUseID != "srvtoolu_01D6DLT2QGNjMqGAai9EgcrM" {
+		t.Errorf("result tool_use_id = %q", resultToolUseID)
+	}
+	if innerType != "bash_code_execution_result" {
+		t.Errorf("inner result type = %q, want bash_code_execution_result", innerType)
+	}
+	if stdout == "" {
+		t.Error("stdout not preserved through round-trip")
+	}
+
+	// Container must be restored at the response top level.
+	if got := gjson.GetBytes(out, "container.id").String(); got != "container_018jVZJnpVtdyWij4ULp3qTN" {
+		t.Errorf("response container.id = %q, want container_018jVZJnpVtdyWij4ULp3qTN", got)
+	}
+	if got := gjson.GetBytes(out, "container.expires_at").String(); got != "2026-06-18T18:46:48.969255Z" {
+		t.Errorf("response container.expires_at = %q", got)
+	}
+
+	// The verbatim command input must round-trip exactly.
+	cmd := gjson.GetBytes(out, `content.0.input.command`).String()
+	if cmd == "" || cmd != gjson.Get(rawBashCodeExecResponse, "content.0.input.command").String() {
+		t.Errorf("server_tool_use input.command not preserved: %q", cmd)
+	}
+}
+
+// rawTextEditorViewResponse exercises the text_editor_code_execution view variant.
+var rawTextEditorViewResponse = `{
+  "model": "claude-opus-4-8",
+  "id": "msg_textedit",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_view1",
+      "name": "text_editor_code_execution",
+      "input": { "command": "view", "path": "config.json" }
+    },
+    {
+      "type": "text_editor_code_execution_tool_result",
+      "tool_use_id": "srvtoolu_view1",
+      "content": {
+        "type": "text_editor_code_execution_result",
+        "file_type": "text",
+        "content": "{\n  \"debug\": true\n}",
+        "num_lines": 3,
+        "start_line": 1,
+        "total_lines": 3
+      }
+    }
+  ],
+  "stop_reason": "end_turn",
+  "usage": { "input_tokens": 10, "output_tokens": 20 }
+}`
+
+// TestCodeExecution_TextEditorViewRoundTrip verifies the text_editor view result
+// (file_type + file contents) round-trips faithfully.
+func TestCodeExecution_TextEditorViewRoundTrip(t *testing.T) {
+	var resp AnthropicMessageResponse
+	if err := sonic.Unmarshal([]byte(rawTextEditorViewResponse), &resp); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+	bifrostResp := resp.ToBifrostResponsesResponse(ctx)
+	var cec *schemas.ResponsesCodeExecutionCall
+	for _, out := range bifrostResp.Output {
+		if out.Type != nil && *out.Type == schemas.ResponsesMessageTypeCodeInterpreterCall && out.ResponsesToolMessage != nil {
+			cec = out.ResponsesToolMessage.ResponsesCodeExecutionCall
+		}
+	}
+	if cec == nil {
+		t.Fatal("text_editor code_interpreter_call not produced")
+	}
+	if cec.ToolName != "text_editor_code_execution" {
+		t.Errorf("tool_name = %q", cec.ToolName)
+	}
+	if cec.FileType == nil || *cec.FileType != "text" {
+		t.Errorf("file_type not carried: %v", cec.FileType)
+	}
+	if cec.FileContent == nil || *cec.FileContent == "" {
+		t.Errorf("view file content not carried: %v", cec.FileContent)
+	}
+
+	back := ToAnthropicResponsesResponse(ctx, bifrostResp)
+	out, err := sonic.Marshal(back)
+	if err != nil {
+		t.Fatalf("marshal back: %v", err)
+	}
+	if got := gjson.GetBytes(out, "content.1.type").String(); got != "text_editor_code_execution_tool_result" {
+		t.Fatalf("result block type = %q\n%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "content.1.content.file_type").String(); got != "text" {
+		t.Errorf("inner file_type = %q", got)
+	}
+	if got := gjson.GetBytes(out, "content.1.content.content").String(); got == "" {
+		t.Error("inner view content not preserved")
+	}
+}
+
+// TestCodeExecution_OpenAIOriginToAnthropic verifies that a neutral
+// code_interpreter_call WITHOUT the Anthropic carry (as produced by an
+// OpenAI-format client) still reconstructs valid Anthropic blocks.
+func TestCodeExecution_OpenAIOriginToAnthropic(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	code := "print('hi')"
+	bifrostResp := &schemas.BifrostResponsesResponse{
+		ID: schemas.Ptr("resp_1"),
+		Output: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeCodeInterpreterCall),
+				ID:   schemas.Ptr("ci_1"),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID: schemas.Ptr("ci_1"),
+					ResponsesCodeInterpreterToolCall: &schemas.ResponsesCodeInterpreterToolCall{
+						Code:        &code,
+						ContainerID: "cntr_1",
+						Outputs: []schemas.ResponsesCodeInterpreterOutput{
+							{ResponsesCodeInterpreterOutputLogs: &schemas.ResponsesCodeInterpreterOutputLogs{Type: "logs", Logs: "hi\n"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	back := ToAnthropicResponsesResponse(ctx, bifrostResp)
+	out, err := sonic.Marshal(back)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if got := gjson.GetBytes(out, "content.0.type").String(); got != "server_tool_use" {
+		t.Fatalf("block 0 type = %q\n%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "content.0.name").String(); got != "code_execution" {
+		t.Errorf("default sub-tool name = %q, want code_execution", got)
+	}
+	if got := gjson.GetBytes(out, "content.0.input.code").String(); got != code {
+		t.Errorf("input.code = %q, want %q", got, code)
+	}
+	if got := gjson.GetBytes(out, "content.1.type").String(); got != "code_execution_tool_result" {
+		t.Errorf("result block type = %q", got)
+	}
+	if got := gjson.GetBytes(out, "content.1.content.stdout").String(); got != "hi\n" {
+		t.Errorf("stdout synthesized from logs = %q, want \"hi\\n\"", got)
+	}
+	if got := gjson.GetBytes(out, "container.id").String(); got != "cntr_1" {
+		t.Errorf("container.id = %q, want cntr_1", got)
+	}
+}
+
+// bashCodeExecStreamEvents is a faithful subset of the Anthropic SSE for a
+// bash_code_execution run: leading text, the server_tool_use with streamed
+// input JSON, the result block, trailing text, and the final message_delta
+// carrying the sandbox container.
+var bashCodeExecStreamEvents = []string{
+	`{"type":"message_start","message":{"model":"claude-opus-4-8","id":"msg_stream1","type":"message","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":1}}}`,
+	`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+	`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me calculate the mean."}}`,
+	`{"type":"content_block_stop","index":0}`,
+	`{"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srvtoolu_stream1","name":"bash_code_execution","input":{}}}`,
+	`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\": \"py"}}`,
+	`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"thon3 -c statistics\"}"}}`,
+	`{"type":"content_block_stop","index":1}`,
+	`{"type":"content_block_start","index":2,"content_block":{"type":"bash_code_execution_tool_result","tool_use_id":"srvtoolu_stream1","content":{"type":"bash_code_execution_result","stdout":"Mean: 5.5\n","stderr":"","return_code":0,"content":[]}}}`,
+	`{"type":"content_block_stop","index":2}`,
+	`{"type":"content_block_start","index":3,"content_block":{"type":"text","text":""}}`,
+	`{"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":"The mean is 5.5."}}`,
+	`{"type":"content_block_stop","index":3}`,
+	`{"type":"message_delta","delta":{"stop_reason":"end_turn","container":{"id":"container_stream1","expires_at":"2026-06-25T13:57:10Z"}},"usage":{"output_tokens":40}}`,
+	`{"type":"message_stop"}`,
+}
+
+// TestCodeExecution_BashStream verifies the streaming converter maps the
+// Anthropic bash_code_execution SSE onto the OpenAI code_interpreter_call event
+// sequence (in_progress -> code.delta/done -> interpreting -> completed ->
+// output_item.done) and folds the container into the final response.completed.
+func TestCodeExecution_BashStream(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	// Exercise the production Anthropic-compatible streaming path: the forward
+	// converter emits a message_delta event carrying the container, and the state
+	// -> ctx bridge (mirrored from anthropic.go) lets the reverse converter skip a
+	// duplicate message_delta on response.completed.
+	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
+	state := acquireAnthropicResponsesStreamState()
+	defer releaseAnthropicResponsesStreamState(state)
+
+	var emitted []*schemas.BifrostResponsesStreamResponse
+	seq := 0
+	for _, raw := range bashCodeExecStreamEvents {
+		var chunk AnthropicStreamEvent
+		if err := sonic.Unmarshal([]byte(raw), &chunk); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+		responses, bErr, _ := chunk.ToBifrostResponsesStream(ctx, seq, state)
+		if bErr != nil {
+			t.Fatalf("ToBifrostResponsesStream error: %v", bErr)
+		}
+		if state.HasEmittedMessageDelta {
+			ctx.SetValue(schemas.BifrostContextKeyHasEmittedMessageDelta, true)
+		}
+		for _, r := range responses {
+			seq++
+			emitted = append(emitted, r)
+		}
+	}
+
+	var sawAdded, sawInProgress, sawCodeDelta, sawCodeDone, sawInterpreting, sawCompleted, sawItemDone bool
+	var codeDelta, codeDone string
+
+	for _, e := range emitted {
+		switch e.Type {
+		case schemas.ResponsesStreamResponseTypeOutputItemAdded:
+			if e.Item != nil && e.Item.Type != nil && *e.Item.Type == schemas.ResponsesMessageTypeCodeInterpreterCall {
+				sawAdded = true
+			}
+		case schemas.ResponsesStreamResponseTypeCodeInterpreterCallInProgress:
+			sawInProgress = true
+		case schemas.ResponsesStreamResponseTypeCodeInterpreterCallCodeDelta:
+			sawCodeDelta = true
+			if e.Delta != nil {
+				codeDelta = *e.Delta
+			}
+		case schemas.ResponsesStreamResponseTypeCodeInterpreterCallCodeDone:
+			sawCodeDone = true
+			if e.Code != nil {
+				codeDone = *e.Code
+			}
+		case schemas.ResponsesStreamResponseTypeCodeInterpreterCallInterpreting:
+			sawInterpreting = true
+		case schemas.ResponsesStreamResponseTypeCodeInterpreterCallCompleted:
+			sawCompleted = true
+		case schemas.ResponsesStreamResponseTypeOutputItemDone:
+			if e.Item == nil || e.Item.Type == nil || *e.Item.Type != schemas.ResponsesMessageTypeCodeInterpreterCall {
+				continue
+			}
+			sawItemDone = true
+			tm := e.Item.ResponsesToolMessage
+			if tm == nil || tm.ResponsesCodeExecutionCall == nil || tm.ResponsesCodeInterpreterToolCall == nil {
+				t.Fatal("output_item.done code_interpreter_call missing payloads")
+			}
+			if e.Item.Status == nil || *e.Item.Status != "completed" {
+				t.Errorf("item status = %v, want completed", e.Item.Status)
+			}
+			if tm.ResponsesCodeExecutionCall.ToolName != "bash_code_execution" {
+				t.Errorf("carry tool_name = %q", tm.ResponsesCodeExecutionCall.ToolName)
+			}
+			if tm.ResponsesCodeExecutionCall.ReturnCode == nil || *tm.ResponsesCodeExecutionCall.ReturnCode != 0 {
+				t.Errorf("carry return_code = %v, want 0", tm.ResponsesCodeExecutionCall.ReturnCode)
+			}
+			outs := tm.ResponsesCodeInterpreterToolCall.Outputs
+			if len(outs) == 0 || outs[0].ResponsesCodeInterpreterOutputLogs == nil ||
+				!strings.Contains(outs[0].ResponsesCodeInterpreterOutputLogs.Logs, "Mean: 5.5") {
+				t.Errorf("neutral logs output not populated from stdout: %+v", outs)
+			}
+		}
+	}
+
+	if !sawAdded {
+		t.Error("STREAM GAP: code_interpreter_call output_item.added not emitted")
+	}
+	if !sawInProgress {
+		t.Error("STREAM GAP: code_interpreter_call.in_progress not emitted")
+	}
+	if !sawCodeDelta || !strings.Contains(codeDelta, "python3") {
+		t.Errorf("STREAM GAP: code.delta not emitted/decoded (got %q)", codeDelta)
+	}
+	if !sawCodeDone || !strings.Contains(codeDone, "python3") {
+		t.Errorf("STREAM GAP: code.done not emitted/decoded (got %q)", codeDone)
+	}
+	if !sawInterpreting {
+		t.Error("STREAM GAP: code_interpreter_call.interpreting not emitted")
+	}
+	if !sawCompleted {
+		t.Error("STREAM GAP: code_interpreter_call.completed not emitted")
+	}
+	if !sawItemDone {
+		t.Error("STREAM GAP: code_interpreter_call output_item.done not emitted")
+	}
+
+	// The terminal response.completed must carry the code_interpreter_call with
+	// the sandbox container folded in from the final message_delta.
+	var containerID string
+	for _, e := range emitted {
+		if e.Type != schemas.ResponsesStreamResponseTypeCompleted || e.Response == nil {
+			continue
+		}
+		for _, out := range e.Response.Output {
+			if out.Type != nil && *out.Type == schemas.ResponsesMessageTypeCodeInterpreterCall &&
+				out.ResponsesToolMessage != nil && out.ResponsesToolMessage.ResponsesCodeInterpreterToolCall != nil {
+				containerID = out.ResponsesToolMessage.ResponsesCodeInterpreterToolCall.ContainerID
+			}
+		}
+	}
+	if containerID != "container_stream1" {
+		t.Errorf("response.completed container_id = %q, want container_stream1", containerID)
+	}
+
+	// Reverse direction: the emitted Bifrost stream events must reconstruct the
+	// Anthropic server_tool_use + bash_code_execution_tool_result blocks.
+	var back []*AnthropicStreamEvent
+	for _, r := range emitted {
+		back = append(back, ToAnthropicResponsesStreamResponse(ctx, r)...)
+	}
+
+	var sawServerToolUse, sawResult bool
+	var serverToolName, resultStdout, reconstructedCmd string
+	for _, e := range back {
+		if e.Type != AnthropicStreamEventTypeContentBlockStart || e.ContentBlock == nil {
+			continue
+		}
+		switch e.ContentBlock.Type {
+		case AnthropicContentBlockTypeServerToolUse:
+			if e.ContentBlock.Name != nil && isAnthropicCodeExecutionToolName(*e.ContentBlock.Name) {
+				sawServerToolUse = true
+				serverToolName = *e.ContentBlock.Name
+			}
+		case AnthropicContentBlockTypeBashCodeExecutionToolResult:
+			sawResult = true
+			if e.ContentBlock.Content != nil && e.ContentBlock.Content.ContentObj != nil &&
+				e.ContentBlock.Content.ContentObj.Stdout != nil {
+				resultStdout = *e.ContentBlock.Content.ContentObj.Stdout
+			}
+		}
+	}
+	// The verbatim command is reconstructed via synthetic input_json_delta events.
+	for _, e := range back {
+		if e.Type == AnthropicStreamEventTypeContentBlockDelta && e.Delta != nil &&
+			e.Delta.Type == AnthropicStreamDeltaTypeInputJSON && e.Delta.PartialJSON != nil {
+			reconstructedCmd += *e.Delta.PartialJSON
+		}
+	}
+
+	if !sawServerToolUse || serverToolName != "bash_code_execution" {
+		t.Errorf("REVERSE GAP: server_tool_use not reconstructed (name=%q)", serverToolName)
+	}
+	if !sawResult || !strings.Contains(resultStdout, "Mean: 5.5") {
+		t.Errorf("REVERSE GAP: bash_code_execution_tool_result not reconstructed (stdout=%q)", resultStdout)
+	}
+	if !strings.Contains(reconstructedCmd, "python3") {
+		t.Errorf("REVERSE GAP: server_tool_use input not reconstructed (got %q)", reconstructedCmd)
+	}
+
+	// The sandbox container must be re-emitted on message_delta (Anthropic
+	// delivers it there natively).
+	var deltaContainerID string
+	for _, e := range back {
+		if e.Type == AnthropicStreamEventTypeMessageDelta && e.Delta != nil && e.Delta.Container != nil {
+			deltaContainerID = e.Delta.Container.ID
+		}
+	}
+	if deltaContainerID != "container_stream1" {
+		t.Errorf("REVERSE GAP: container not re-emitted on message_delta (got %q)", deltaContainerID)
+	}
+}
+
+// textEditorCodeExecStreamEvents is the Anthropic SSE for a
+// text_editor_code_execution "view" operation. Unlike python/bash, its input is
+// multi-key ({"command","path"}) and cannot be reconstructed from the neutral
+// Code field — so the reverse converter must emit it from the verbatim carry
+// input at output_item.done, not from code.done.
+var textEditorCodeExecStreamEvents = []string{
+	`{"type":"message_start","message":{"model":"claude-opus-4-8","id":"msg_te1","type":"message","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":1}}}`,
+	`{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_te1","name":"text_editor_code_execution","input":{}}}`,
+	`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\": \"view\", \"pa"}}`,
+	`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"th\": \"/tmp/data.py\"}"}}`,
+	`{"type":"content_block_stop","index":0}`,
+	`{"type":"content_block_start","index":1,"content_block":{"type":"text_editor_code_execution_tool_result","tool_use_id":"srvtoolu_te1","content":{"type":"text_editor_code_execution_result","file_type":"text","content":"print('hi')\n","num_lines":1,"start_line":1,"total_lines":1}}}`,
+	`{"type":"content_block_stop","index":1}`,
+	`{"type":"message_delta","delta":{"stop_reason":"end_turn","container":{"id":"container_te1","expires_at":"2026-06-25T13:57:10Z"}},"usage":{"output_tokens":40}}`,
+	`{"type":"message_stop"}`,
+}
+
+// TestCodeExecution_TextEditorStream guards the regression where the reverse
+// streaming converter dropped the text_editor server_tool_use input (it can't be
+// rebuilt from the neutral Code, which is empty for text_editor). The verbatim
+// multi-key input must round-trip Anthropic -> Bifrost -> Anthropic.
+func TestCodeExecution_TextEditorStream(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
+	state := acquireAnthropicResponsesStreamState()
+	defer releaseAnthropicResponsesStreamState(state)
+
+	var emitted []*schemas.BifrostResponsesStreamResponse
+	seq := 0
+	for _, raw := range textEditorCodeExecStreamEvents {
+		var chunk AnthropicStreamEvent
+		if err := sonic.Unmarshal([]byte(raw), &chunk); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+		responses, bErr, _ := chunk.ToBifrostResponsesStream(ctx, seq, state)
+		if bErr != nil {
+			t.Fatalf("ToBifrostResponsesStream error: %v", bErr)
+		}
+		if state.HasEmittedMessageDelta {
+			ctx.SetValue(schemas.BifrostContextKeyHasEmittedMessageDelta, true)
+		}
+		for _, r := range responses {
+			seq++
+			emitted = append(emitted, r)
+		}
+	}
+
+	// Reverse: reconstruct the Anthropic stream.
+	var back []*AnthropicStreamEvent
+	for _, r := range emitted {
+		back = append(back, ToAnthropicResponsesStreamResponse(ctx, r)...)
+	}
+
+	// The server_tool_use must be reconstructed with its full multi-key input —
+	// the regression emitted an empty {} here, losing command/path. Track the
+	// server block index and only accumulate its input_json_delta.
+	var sawServerToolUse, sawResult bool
+	serverIdx := -1
+	reconstructedInput := ""
+	for _, e := range back {
+		switch {
+		case e.Type == AnthropicStreamEventTypeContentBlockStart && e.ContentBlock != nil:
+			if e.ContentBlock.Type == AnthropicContentBlockTypeServerToolUse &&
+				e.ContentBlock.Name != nil && *e.ContentBlock.Name == "text_editor_code_execution" {
+				sawServerToolUse = true
+				if e.Index != nil {
+					serverIdx = *e.Index
+				}
+			}
+			if e.ContentBlock.Type == AnthropicContentBlockTypeTextEditorCodeExecutionToolResult {
+				sawResult = true
+			}
+		case e.Type == AnthropicStreamEventTypeContentBlockDelta && e.Delta != nil &&
+			e.Delta.Type == AnthropicStreamDeltaTypeInputJSON && e.Delta.PartialJSON != nil &&
+			e.Index != nil && *e.Index == serverIdx:
+			reconstructedInput += *e.Delta.PartialJSON
+		}
+	}
+
+	if !sawServerToolUse {
+		t.Fatal("REVERSE GAP: text_editor_code_execution server_tool_use not reconstructed")
+	}
+	if !sawResult {
+		t.Error("REVERSE GAP: text_editor_code_execution_tool_result not reconstructed")
+	}
+	// The full verbatim input must survive — both keys, not an empty object.
+	for _, want := range []string{`"command"`, `"view"`, `"path"`, `/tmp/data.py`} {
+		if !strings.Contains(reconstructedInput, want) {
+			t.Errorf("REVERSE GAP: text_editor input lost %q (got %q)", want, reconstructedInput)
+		}
+	}
+	if reconstructedInput == "" || reconstructedInput == "{}" {
+		t.Errorf("REVERSE GAP: text_editor server_tool_use input is empty (got %q)", reconstructedInput)
+	}
+}
+
+// rawPTCResponse is a programmatic-tool-calling response: a web_search spawned
+// from inside the code_execution sandbox. Anthropic tags the nested web_search
+// server_tool_use AND its result with a "caller" pointing back at the code block.
+var rawPTCResponse = `{
+  "model": "claude-opus-4-8",
+  "id": "msg_ptc1",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_code1",
+      "name": "code_execution",
+      "input": { "code": "r = await web_search({\"query\": \"AAPL\"})" }
+    },
+    {
+      "type": "server_tool_use",
+      "id": "srvtoolu_ws1",
+      "name": "web_search",
+      "input": { "query": "AAPL stock price" },
+      "caller": { "type": "code_execution_20260120", "tool_id": "srvtoolu_code1" }
+    },
+    {
+      "type": "web_search_tool_result",
+      "tool_use_id": "srvtoolu_ws1",
+      "content": [
+        { "type": "web_search_result", "title": "Apple", "url": "https://example.com/aapl", "encrypted_content": "enc1" }
+      ],
+      "caller": { "type": "code_execution_20260120", "tool_id": "srvtoolu_code1" }
+    },
+    {
+      "type": "code_execution_tool_result",
+      "tool_use_id": "srvtoolu_code1",
+      "content": { "type": "code_execution_result", "stdout": "done\n", "stderr": "", "return_code": 0, "content": [] }
+    }
+  ],
+  "container": { "id": "container_ptc1", "expires_at": "2026-06-26T08:00:00Z" },
+  "stop_reason": "end_turn",
+  "usage": { "input_tokens": 100, "output_tokens": 50 }
+}`
+
+// TestCodeExecution_ProgrammaticCallerRoundTrip verifies the "caller" linkage on
+// a web_search spawned inside the code execution sandbox survives the
+// Anthropic -> Bifrost -> Anthropic round trip on the web_search server_tool_use
+// and its result block.
+func TestCodeExecution_ProgrammaticCallerRoundTrip(t *testing.T) {
+	var resp AnthropicMessageResponse
+	if err := sonic.Unmarshal([]byte(rawPTCResponse), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+	bif := resp.ToBifrostResponsesResponse(ctx)
+
+	// Neutral view: the web_search_call must carry the caller.
+	var sawNeutralCaller bool
+	for _, out := range bif.Output {
+		if out.Type != nil && *out.Type == schemas.ResponsesMessageTypeWebSearchCall &&
+			out.ResponsesToolMessage != nil && out.ResponsesToolMessage.Caller != nil {
+			sawNeutralCaller = true
+			if out.ResponsesToolMessage.Caller.ToolID == nil || *out.ResponsesToolMessage.Caller.ToolID != "srvtoolu_code1" {
+				t.Errorf("neutral caller tool_id = %v, want srvtoolu_code1", out.ResponsesToolMessage.Caller.ToolID)
+			}
+			if out.ResponsesToolMessage.Caller.Type != "code_execution_20260120" {
+				t.Errorf("neutral caller type = %q", out.ResponsesToolMessage.Caller.Type)
+			}
+		}
+	}
+	if !sawNeutralCaller {
+		t.Fatal("web_search_call lost its caller in the neutral view")
+	}
+
+	// Reverse: caller must reappear on the web_search server_tool_use + result.
+	back := ToAnthropicResponsesResponse(ctx, bif)
+	out, err := sonic.Marshal(back)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var wsCallerToolID, wsResultCallerToolID string
+	gjson.GetBytes(out, "content").ForEach(func(_, b gjson.Result) bool {
+		switch b.Get("type").String() {
+		case "server_tool_use":
+			if b.Get("name").String() == "web_search" {
+				wsCallerToolID = b.Get("caller.tool_id").String()
+			}
+		case "web_search_tool_result":
+			wsResultCallerToolID = b.Get("caller.tool_id").String()
+		}
+		return true
+	})
+
+	if wsCallerToolID != "srvtoolu_code1" {
+		t.Errorf("web_search server_tool_use caller.tool_id = %q, want srvtoolu_code1\n%s", wsCallerToolID, out)
+	}
+	if wsResultCallerToolID != "srvtoolu_code1" {
+		t.Errorf("web_search_tool_result caller.tool_id = %q, want srvtoolu_code1", wsResultCallerToolID)
+	}
+}
+
+// ptcStreamEvents is a programmatic-tool-calling stream: a code_execution that
+// spawns a web_search from inside the sandbox. The web_search server_tool_use and
+// its result carry a "caller" pointing back at the code block.
+var ptcStreamEvents = []string{
+	`{"type":"message_start","message":{"id":"msg_ptc","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10,"output_tokens":1}}}`,
+	`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+	`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I'll compute."}}`,
+	`{"type":"content_block_stop","index":0}`,
+	`{"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srv_code","name":"code_execution","input":{}}}`,
+	`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"code\": \"r = await web_search({\\\"query\\\": \\\"AAPL\\\"})\"}"}}`,
+	`{"type":"content_block_stop","index":1}`,
+	`{"type":"content_block_start","index":2,"content_block":{"type":"server_tool_use","id":"srv_ws","name":"web_search","input":{"query":"AAPL stock price"},"caller":{"type":"code_execution_20260120","tool_id":"srv_code"}}}`,
+	`{"type":"content_block_stop","index":2}`,
+	`{"type":"content_block_start","index":3,"content_block":{"type":"web_search_tool_result","tool_use_id":"srv_ws","content":[{"type":"web_search_result","title":"Apple","url":"https://example.com/a","encrypted_content":"enc1"}],"caller":{"type":"code_execution_20260120","tool_id":"srv_code"}}}`,
+	`{"type":"content_block_stop","index":3}`,
+	`{"type":"content_block_start","index":4,"content_block":{"type":"code_execution_tool_result","tool_use_id":"srv_code","content":{"type":"code_execution_result","stdout":"done\n","stderr":"","return_code":0,"content":[]}}}`,
+	`{"type":"content_block_stop","index":4}`,
+	`{"type":"content_block_start","index":5,"content_block":{"type":"text","text":""}}`,
+	`{"type":"content_block_delta","index":5,"delta":{"type":"text_delta","text":"AAPL looks pricey."}}`,
+	`{"type":"content_block_stop","index":5}`,
+	`{"type":"message_delta","delta":{"stop_reason":"end_turn","container":{"id":"cntr_ptc","expires_at":"2026-06-26T00:00:00Z"}},"usage":{"output_tokens":50}}`,
+	`{"type":"message_stop"}`,
+}
+
+// TestCodeExecution_ProgrammaticStreamRoundTrip drives the native PTC SSE through
+// the forward (Anthropic→Bifrost) then reverse (Bifrost→Anthropic) stream
+// converters and asserts the reverse stream is well-formed: valid content-block
+// index bookkeeping (no stop-before-start, no reuse), the code_execution input is
+// streamed, and the web_search carries its query + caller.
+func TestCodeExecution_ToolVersionRoundTrip(t *testing.T) {
+	// Every code_execution version must survive request->neutral->upstream
+	// verbatim — the capability tier (bash/file vs. PTC+REPL vs. disclosed time
+	// limit) is not interchangeable, so the gateway must forward, not substitute.
+	versions := []AnthropicToolType{
+		AnthropicToolTypeCodeExecution20250522,
+		AnthropicToolTypeCodeExecution, // 20250825
+		AnthropicToolTypeCodeExecution20260120,
+		AnthropicToolTypeCodeExecution20260521,
+	}
+	for _, v := range versions {
+		in := &AnthropicTool{Type: schemas.Ptr(v), Name: string(AnthropicToolNameCodeExecution)}
+
+		neutral := convertAnthropicToolToBifrost(in)
+		if neutral.Type != schemas.ResponsesToolTypeCodeInterpreter {
+			t.Fatalf("%s: expected code_interpreter, got %s (must not fall through to function tool)", v, neutral.Type)
+		}
+		if neutral.ResponsesToolCodeInterpreter == nil || neutral.ResponsesToolCodeInterpreter.Version == nil {
+			t.Fatalf("%s: version not captured on neutral tool", v)
+		}
+		if got := *neutral.ResponsesToolCodeInterpreter.Version; got != string(v) {
+			t.Errorf("%s: neutral version = %q, want %q", v, got, string(v))
+		}
+
+		back := convertBifrostToolToAnthropic("claude-opus-4-8", neutral, schemas.Anthropic, false)
+		if back == nil || back.Type == nil {
+			t.Fatalf("%s: reverse produced no tool", v)
+		}
+		if *back.Type != v {
+			t.Errorf("%s: round-trip version = %q, want %q", v, *back.Type, v)
+		}
+	}
+
+	// OpenAI-origin code_interpreter (no version) falls back to 20250825 — the
+	// only version supported on every model.
+	noVer := &schemas.ResponsesTool{
+		Type:                         schemas.ResponsesToolTypeCodeInterpreter,
+		ResponsesToolCodeInterpreter: &schemas.ResponsesToolCodeInterpreter{},
+	}
+	back := convertBifrostToolToAnthropic("claude-opus-4-8", noVer, schemas.Anthropic, false)
+	if back == nil || back.Type == nil || *back.Type != AnthropicToolTypeCodeExecution {
+		t.Errorf("absent-version fallback = %v, want %s", back, AnthropicToolTypeCodeExecution)
+	}
+}
+
+func TestGenerateSyntheticInputJSONDeltas_UTF8(t *testing.T) {
+	// Code with multi-byte runes (em-dash, smart quotes, accent, emoji) must not
+	// be split mid-rune across input_json_delta events — that would emit invalid
+	// UTF-8 on the wire and crash the SDK's SSE decoder.
+	input := `{"code":"print('an em—dash, “smart” quotes, café, and 🚀')"}`
+	idx := 0
+	events := generateSyntheticInputJSONDeltas(input, &idx)
+
+	var sb strings.Builder
+	for _, e := range events {
+		if e.Delta == nil || e.Delta.PartialJSON == nil {
+			t.Fatal("input_json_delta missing partial_json")
+		}
+		if !utf8.ValidString(*e.Delta.PartialJSON) {
+			t.Errorf("chunk is not valid UTF-8: %q", *e.Delta.PartialJSON)
+		}
+		sb.WriteString(*e.Delta.PartialJSON)
+	}
+	if got := sb.String(); got != input {
+		t.Errorf("reassembled chunks != original\n got: %q\nwant: %q", got, input)
+	}
+}
+
+func TestCodeExecution_ProgrammaticStreamRoundTrip(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
+	state := acquireAnthropicResponsesStreamState()
+	defer releaseAnthropicResponsesStreamState(state)
+
+	var back []*AnthropicStreamEvent
+	seq := 0
+	for _, raw := range ptcStreamEvents {
+		var chunk AnthropicStreamEvent
+		if err := sonic.Unmarshal([]byte(raw), &chunk); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+		responses, bErr, _ := chunk.ToBifrostResponsesStream(ctx, seq, state)
+		if bErr != nil {
+			t.Fatalf("ToBifrostResponsesStream error: %v", bErr)
+		}
+		if state.HasEmittedMessageDelta {
+			ctx.SetValue(schemas.BifrostContextKeyHasEmittedMessageDelta, true)
+		}
+		for _, r := range responses {
+			seq++
+			back = append(back, ToAnthropicResponsesStreamResponse(ctx, r)...)
+		}
+	}
+
+	// 1. Index bookkeeping: every stop closes a currently-open start, indices are
+	// never reused, and nothing is left open.
+	open := map[int]bool{}
+	started := map[int]bool{}
+	// per-index accumulated input_json and captured metadata.
+	inputByIndex := map[int]string{}
+	nameByIndex := map[int]string{}
+	callerByIndex := map[int]string{}
+	var wsResultCaller string
+	// Ordering: the code server_tool_use block must close before the nested
+	// web_search blocks begin (sequential, not interleaved — matches native).
+	pos, codeStopPos, firstWsStartPos := 0, -1, -1
+	for _, e := range back {
+		switch e.Type {
+		case AnthropicStreamEventTypeContentBlockStart:
+			if e.Index == nil {
+				t.Fatal("content_block_start with nil index")
+			}
+			idx := *e.Index
+			if started[idx] {
+				t.Errorf("content_block index %d reused (started twice)", idx)
+			}
+			started[idx] = true
+			open[idx] = true
+			if e.ContentBlock != nil {
+				if e.ContentBlock.Name != nil {
+					nameByIndex[idx] = *e.ContentBlock.Name
+					if *e.ContentBlock.Name == "web_search" && firstWsStartPos < 0 {
+						firstWsStartPos = pos
+					}
+				}
+				// web_search delivers its query whole in content_block_start.input
+				// (no input_json_delta), so seed it here.
+				if len(e.ContentBlock.Input) > 0 && string(e.ContentBlock.Input) != "{}" {
+					inputByIndex[idx] += string(e.ContentBlock.Input)
+				}
+				if e.ContentBlock.Caller != nil && e.ContentBlock.Caller.ToolID != nil {
+					if e.ContentBlock.Type == AnthropicContentBlockTypeWebSearchToolResult {
+						wsResultCaller = *e.ContentBlock.Caller.ToolID
+					} else {
+						callerByIndex[idx] = *e.ContentBlock.Caller.ToolID
+					}
+				}
+			}
+		case AnthropicStreamEventTypeContentBlockDelta:
+			if e.Index != nil && e.Delta != nil && e.Delta.Type == AnthropicStreamDeltaTypeInputJSON && e.Delta.PartialJSON != nil {
+				inputByIndex[*e.Index] += *e.Delta.PartialJSON
+			}
+		case AnthropicStreamEventTypeContentBlockStop:
+			if e.Index == nil {
+				t.Fatal("content_block_stop with nil index")
+			}
+			if !open[*e.Index] {
+				t.Errorf("content_block_stop for index %d that is not open (stop-before-start or double-stop)", *e.Index)
+			}
+			if isAnthropicCodeExecutionToolName(nameByIndex[*e.Index]) && codeStopPos < 0 {
+				codeStopPos = pos
+			}
+			delete(open, *e.Index)
+		}
+		pos++
+	}
+	if len(open) != 0 {
+		t.Errorf("content blocks left open: %v", open)
+	}
+	if codeStopPos < 0 || firstWsStartPos < 0 || codeStopPos > firstWsStartPos {
+		t.Errorf("code block not closed before nested web_search (codeStop=%d, firstWsStart=%d)", codeStopPos, firstWsStartPos)
+	}
+
+	// Regression: the code_execution_tool_result inner result object must carry a
+	// content array (native always emits it; the Anthropic SDK's *ResultBlock
+	// models require it, else they mis-parse the block).
+	sawCodeResult := false
+	for _, e := range back {
+		if e.Type != AnthropicStreamEventTypeContentBlockStart || e.ContentBlock == nil ||
+			e.ContentBlock.Type != AnthropicContentBlockTypeCodeExecutionToolResult {
+			continue
+		}
+		sawCodeResult = true
+		j, err := sonic.Marshal(e.ContentBlock)
+		if err != nil {
+			t.Fatalf("marshal code_execution_tool_result: %v", err)
+		}
+		if !gjson.GetBytes(j, "content.content").IsArray() {
+			t.Errorf("code_execution_tool_result inner result missing content array: %s", j)
+		}
+	}
+	if !sawCodeResult {
+		t.Fatal("no code_execution_tool_result block found")
+	}
+
+	// 2/3/4. Find the code_execution and web_search server_tool_use blocks and check
+	// their streamed input + caller.
+	var codeIdx, wsIdx = -1, -1
+	for idx, name := range nameByIndex {
+		switch {
+		case isAnthropicCodeExecutionToolName(name):
+			codeIdx = idx
+		case name == "web_search":
+			wsIdx = idx
+		}
+	}
+	if codeIdx < 0 {
+		t.Fatal("no code_execution server_tool_use block emitted")
+	}
+	if wsIdx < 0 {
+		t.Fatal("no web_search server_tool_use block emitted")
+	}
+	if !strings.Contains(inputByIndex[codeIdx], "web_search") {
+		t.Errorf("code_execution input not streamed (got %q)", inputByIndex[codeIdx])
+	}
+	if !strings.Contains(inputByIndex[wsIdx], "AAPL stock price") {
+		t.Errorf("web_search query not streamed (got %q)", inputByIndex[wsIdx])
+	}
+	if callerByIndex[wsIdx] != "srv_code" {
+		t.Errorf("web_search server_tool_use caller = %q, want srv_code", callerByIndex[wsIdx])
+	}
+	if wsResultCaller != "srv_code" {
+		t.Errorf("web_search_tool_result caller = %q, want srv_code", wsResultCaller)
+	}
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -19,8 +19,8 @@ import (
 
 // AnthropicResponsesStreamState tracks state during streaming conversion for responses API
 type AnthropicResponsesStreamState struct {
-	ChunkIndex      *int   // index of the chunk in the stream (reused for computer AND web search)
-	AccumulatedJSON string // deltas of any event (reused for computer AND web search)
+	InputJSONBuffers  map[int]string                       // server/tool input_json buffers keyed by Anthropic content block index
+	InputJSONPurposes map[int]anthropicInputJSONBufferKind // classifies each buffered content block
 
 	// Computer tool accumulation
 	ComputerToolID *string
@@ -29,6 +29,8 @@ type AnthropicResponsesStreamState struct {
 	WebSearchToolID      *string                // Tool ID of active web search
 	WebSearchOutputIndex *int                   // Output index for this search
 	WebSearchResult      *AnthropicContentBlock // Result block when it arrives
+	WebSearchQuery       *string                // Query captured from the (pre-populated) server_tool_use input
+	WebSearchCaller      *AnthropicToolCaller   // Programmatic-tool-calling caller, if the search was spawned from code execution
 
 	// Web fetch tool accumulation
 	WebFetchToolID      *string // Tool ID of active web fetch
@@ -38,6 +40,14 @@ type AnthropicResponsesStreamState struct {
 	AdvisorToolID      *string                // Tool ID of active advisor call
 	AdvisorOutputIndex *int                   // Output index for this advisor call
 	AdvisorResult      *AnthropicContentBlock // advisor_tool_result block when it arrives
+
+	// Code execution tool accumulation (bash / text_editor / python sub-tools)
+	CodeExecToolID      *string                     // server_tool_use id of the active code-execution call
+	CodeExecToolName    *string                     // sub-tool name (bash_code_execution, etc.)
+	CodeExecOutputIndex *int                        // Output index for this code-execution call
+	CodeExecResult      *AnthropicContentBlock      // *_code_execution_tool_result block when it arrives
+	CodeExecInput       string                      // verbatim server_tool_use input JSON, kept across nested PTC blocks
+	Container           *AnthropicResponseContainer // sandbox container from the final message_delta
 
 	// OpenAI Responses API mapping state
 	ContentIndexToOutputIndex map[int]int                       // Maps Anthropic content_index to OpenAI output_index
@@ -65,10 +75,61 @@ type AnthropicResponsesStreamState struct {
 	SeenRealToolCall          bool                              // True when any non-SO tool_use/server_tool_use/mcp_tool_use content block was started
 }
 
+type anthropicInputJSONBufferKind string
+
+const (
+	anthropicInputJSONBufferComputer  anthropicInputJSONBufferKind = "computer"
+	anthropicInputJSONBufferWebSearch anthropicInputJSONBufferKind = "web_search"
+	anthropicInputJSONBufferWebFetch  anthropicInputJSONBufferKind = "web_fetch"
+	anthropicInputJSONBufferAdvisor   anthropicInputJSONBufferKind = "advisor"
+	anthropicInputJSONBufferCodeExec  anthropicInputJSONBufferKind = "code_exec"
+)
+
+func (state *AnthropicResponsesStreamState) beginInputJSONBuffer(index *int, kind anthropicInputJSONBufferKind) {
+	if index == nil {
+		return
+	}
+	if state.InputJSONBuffers == nil {
+		state.InputJSONBuffers = make(map[int]string)
+	}
+	if state.InputJSONPurposes == nil {
+		state.InputJSONPurposes = make(map[int]anthropicInputJSONBufferKind)
+	}
+	state.InputJSONBuffers[*index] = ""
+	state.InputJSONPurposes[*index] = kind
+}
+
+func (state *AnthropicResponsesStreamState) appendInputJSON(index *int, partial string) bool {
+	if index == nil || state.InputJSONPurposes == nil {
+		return false
+	}
+	if _, ok := state.InputJSONPurposes[*index]; !ok {
+		return false
+	}
+	state.InputJSONBuffers[*index] += partial
+	return true
+}
+
+func (state *AnthropicResponsesStreamState) finishInputJSONBuffer(index *int) (string, anthropicInputJSONBufferKind, bool) {
+	if index == nil || state.InputJSONPurposes == nil {
+		return "", "", false
+	}
+	kind, ok := state.InputJSONPurposes[*index]
+	if !ok {
+		return "", "", false
+	}
+	input := state.InputJSONBuffers[*index]
+	delete(state.InputJSONBuffers, *index)
+	delete(state.InputJSONPurposes, *index)
+	return input, kind, true
+}
+
 // anthropicResponsesStreamStatePool provides a pool for Anthropic responses stream state objects.
 var anthropicResponsesStreamStatePool = sync.Pool{
 	New: func() interface{} {
 		return &AnthropicResponsesStreamState{
+			InputJSONBuffers:          make(map[int]string),
+			InputJSONPurposes:         make(map[int]anthropicInputJSONBufferKind),
 			ContentIndexToOutputIndex: make(map[int]int),
 			ToolArgumentBuffers:       make(map[int]string),
 			MCPCallOutputIndices:      make(map[int]bool),
@@ -93,6 +154,75 @@ type anthropicToResponsesStreamState struct {
 	// webSearchItemIDs tracks item IDs for WebSearch tools so their argument deltas
 	// can be skipped and regenerated synthetically (with sanitization) at output_item.done.
 	webSearchItemIDs map[string]bool
+
+	// Anthropic content-block index allocation. OpenAI numbers output items while
+	// Anthropic numbers content blocks, and one web_search / code_execution call
+	// expands to two Anthropic blocks (server_tool_use + *_tool_result) — so the
+	// counts differ and the OpenAI indices cannot be reused 1:1 (they collide on
+	// programmatic tool calling). Each output item allocates its primary block index
+	// at output_item.added; deltas/stops look it up; the second (result) block gets
+	// a fresh index.
+	nextBlockIndex   int
+	blockIndexByItem map[string]int
+
+	// codeExecToolNameByItem remembers each code_interpreter_call's Anthropic
+	// sub-tool name (captured at output_item.added) so the code block's input can be
+	// reconstructed and closed on code.done — emitted before the nested web_search
+	// blocks, matching Anthropic's sequential ordering. The *_tool_result block then
+	// follows at output_item.done.
+	codeExecToolNameByItem map[string]string
+
+	// codeExecServerClosedByItem marks code_interpreter_call items whose
+	// server_tool_use block was already closed early on code.done (python/bash,
+	// where the input reconstructs from the neutral Code and the block must close
+	// before nested web_search blocks). text_editor has a multi-key input that
+	// Code can't carry and never spawns nested blocks, so it is left open here and
+	// closed at output_item.done from the verbatim carry input instead.
+	codeExecServerClosedByItem map[string]bool
+}
+
+// allocBlockIndex assigns and returns the next Anthropic content-block index. A
+// non-empty key is remembered so the block's later delta/stop events resolve to the
+// same index via blockIndexFor.
+func (s *anthropicToResponsesStreamState) allocBlockIndex(key string) *int {
+	idx := s.nextBlockIndex
+	s.nextBlockIndex++
+	if key != "" {
+		if s.blockIndexByItem == nil {
+			s.blockIndexByItem = make(map[string]int)
+		}
+		s.blockIndexByItem[key] = idx
+	}
+	return &idx
+}
+
+// blockIndexFor returns the index previously allocated for key, allocating a fresh
+// one if the block's start was never seen (defensive — keeps start/stop paired).
+func (s *anthropicToResponsesStreamState) blockIndexFor(key string) *int {
+	if key != "" && s.blockIndexByItem != nil {
+		if idx, ok := s.blockIndexByItem[key]; ok {
+			return &idx
+		}
+	}
+	return s.allocBlockIndex(key)
+}
+
+// reverseStreamItemKey derives a stable per-item key for content-block index
+// allocation, consistent across output_item.added / delta / output_item.done.
+func reverseStreamItemKey(resp *schemas.BifrostResponsesStreamResponse) string {
+	if resp.Item != nil && resp.Item.ID != nil {
+		return *resp.Item.ID
+	}
+	if resp.ItemID != nil {
+		return *resp.ItemID
+	}
+	if resp.OutputIndex != nil {
+		return fmt.Sprintf("oi:%d", *resp.OutputIndex)
+	}
+	if resp.ContentIndex != nil {
+		return fmt.Sprintf("ci:%d", *resp.ContentIndex)
+	}
+	return ""
 }
 
 type anthropicToResponsesStreamStateKeyType struct{}
@@ -119,6 +249,16 @@ func acquireAnthropicResponsesStreamState() *AnthropicResponsesStreamState {
 		state.ContentIndexToOutputIndex = make(map[int]int)
 	} else {
 		clear(state.ContentIndexToOutputIndex)
+	}
+	if state.InputJSONBuffers == nil {
+		state.InputJSONBuffers = make(map[int]string)
+	} else {
+		clear(state.InputJSONBuffers)
+	}
+	if state.InputJSONPurposes == nil {
+		state.InputJSONPurposes = make(map[int]anthropicInputJSONBufferKind)
+	} else {
+		clear(state.InputJSONPurposes)
 	}
 	if state.ContentIndexToBlockType == nil {
 		state.ContentIndexToBlockType = make(map[int]AnthropicContentBlockType)
@@ -171,17 +311,23 @@ func acquireAnthropicResponsesStreamState() *AnthropicResponsesStreamState {
 		clear(state.OutputItems)
 	}
 	// Reset other fields
-	state.ChunkIndex = nil
-	state.AccumulatedJSON = ""
 	state.ComputerToolID = nil
 	state.WebSearchToolID = nil
 	state.WebSearchOutputIndex = nil
 	state.WebSearchResult = nil
+	state.WebSearchQuery = nil
+	state.WebSearchCaller = nil
 	state.WebFetchToolID = nil
 	state.WebFetchOutputIndex = nil
 	state.AdvisorToolID = nil
 	state.AdvisorOutputIndex = nil
 	state.AdvisorResult = nil
+	state.CodeExecToolID = nil
+	state.CodeExecToolName = nil
+	state.CodeExecOutputIndex = nil
+	state.CodeExecResult = nil
+	state.CodeExecInput = ""
+	state.Container = nil
 	state.CurrentOutputIndex = 0
 	state.MessageID = nil
 	state.StopReason = nil
@@ -207,17 +353,25 @@ func releaseAnthropicResponsesStreamState(state *AnthropicResponsesStreamState) 
 
 // flush resets the state of the stream state to its initial values
 func (state *AnthropicResponsesStreamState) flush() {
-	state.ChunkIndex = nil
-	state.AccumulatedJSON = ""
+	state.InputJSONBuffers = nil
+	state.InputJSONPurposes = nil
 	state.ComputerToolID = nil
 	state.WebSearchToolID = nil
 	state.WebSearchOutputIndex = nil
 	state.WebSearchResult = nil
+	state.WebSearchQuery = nil
+	state.WebSearchCaller = nil
 	state.WebFetchToolID = nil
 	state.WebFetchOutputIndex = nil
 	state.AdvisorToolID = nil
 	state.AdvisorOutputIndex = nil
 	state.AdvisorResult = nil
+	state.CodeExecToolID = nil
+	state.CodeExecToolName = nil
+	state.CodeExecOutputIndex = nil
+	state.CodeExecResult = nil
+	state.CodeExecInput = ""
+	state.Container = nil
 	state.ContentIndexToOutputIndex = nil
 	state.ContentIndexToBlockType = nil
 	state.ToolArgumentBuffers = nil
@@ -366,8 +520,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				state.SeenRealToolCall = true
 				// Start accumulating computer tool
 				state.ComputerToolID = chunk.ContentBlock.ID
-				state.ChunkIndex = chunk.Index
-				state.AccumulatedJSON = ""
+				state.beginInputJSONBuffer(chunk.Index, anthropicInputJSONBufferComputer)
 
 				// Emit output_item.added for computer_call
 				item := &schemas.ResponsesMessage{
@@ -394,29 +547,43 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				chunk.ContentBlock.ID != nil {
 
 				state.SeenRealToolCall = true
-				// Start accumulating web search query (reuse shared accumulation fields)
-				state.ChunkIndex = chunk.Index
-				state.AccumulatedJSON = ""
+				// web_search server_tool_use usually arrives pre-populated (query in
+				// input, not streamed). Keep a buffer anyway so unusual input_json_delta
+				// events are swallowed and can be used as a fallback on block stop.
+				state.beginInputJSONBuffer(chunk.Index, anthropicInputJSONBufferWebSearch)
 				state.WebSearchToolID = chunk.ContentBlock.ID
-				// Store output index value (allocate new int to avoid pointer-to-local-variable issue)
 				state.WebSearchOutputIndex = schemas.Ptr(outputIndex)
+				state.WebSearchQuery = nil
+				if q := providerUtils.GetJSONField(chunk.ContentBlock.Input, "query"); q.Exists() && q.Type == gjson.String {
+					state.WebSearchQuery = schemas.Ptr(q.Str)
+				}
+				state.WebSearchCaller = chunk.ContentBlock.Caller
 
 				// Store item ID
 				state.ItemIDs[outputIndex] = *chunk.ContentBlock.ID
 
+				wsAction := &schemas.ResponsesWebSearchToolCallAction{Type: "search"}
+				if state.WebSearchQuery != nil {
+					wsAction.Query = state.WebSearchQuery
+					wsAction.Queries = []string{*state.WebSearchQuery}
+				}
+				toolMsg := &schemas.ResponsesToolMessage{
+					CallID: chunk.ContentBlock.ID,
+					Action: &schemas.ResponsesToolMessageActionStruct{ResponsesWebSearchToolCallAction: wsAction},
+				}
+				if state.WebSearchCaller != nil {
+					toolMsg.Caller = &schemas.ResponsesToolCaller{
+						Type:   string(state.WebSearchCaller.Type),
+						ToolID: state.WebSearchCaller.ToolID,
+					}
+				}
+
 				// Emit output_item.added for web_search_call
 				item := &schemas.ResponsesMessage{
-					ID:     chunk.ContentBlock.ID,
-					Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
-					Status: schemas.Ptr("in_progress"),
-					ResponsesToolMessage: &schemas.ResponsesToolMessage{
-						CallID: chunk.ContentBlock.ID,
-						Action: &schemas.ResponsesToolMessageActionStruct{
-							ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
-								Type: "search",
-							},
-						},
-					},
+					ID:                   chunk.ContentBlock.ID,
+					Type:                 schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+					Status:               schemas.Ptr("in_progress"),
+					ResponsesToolMessage: toolMsg,
 				}
 
 				var responses []*schemas.BifrostResponsesStreamResponse
@@ -488,8 +655,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				chunk.ContentBlock.ID != nil {
 
 				state.SeenRealToolCall = true
-				state.ChunkIndex = chunk.Index
-				state.AccumulatedJSON = ""
+				state.beginInputJSONBuffer(chunk.Index, anthropicInputJSONBufferWebFetch)
 				state.WebFetchToolID = chunk.ContentBlock.ID
 				state.WebFetchOutputIndex = schemas.Ptr(outputIndex)
 
@@ -564,8 +730,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				chunk.ContentBlock.ID != nil {
 
 				state.SeenRealToolCall = true
-				state.ChunkIndex = chunk.Index // absorbs the empty advisor input_json_delta
-				state.AccumulatedJSON = ""
+				state.beginInputJSONBuffer(chunk.Index, anthropicInputJSONBufferAdvisor) // absorbs the empty advisor input_json_delta
 				state.AdvisorToolID = chunk.ContentBlock.ID
 				state.AdvisorOutputIndex = schemas.Ptr(outputIndex)
 				state.ItemIDs[outputIndex] = *chunk.ContentBlock.ID
@@ -599,6 +764,67 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				}
 				if state.AdvisorToolID != nil && *state.AdvisorToolID == *chunk.ContentBlock.ToolUseID {
 					state.AdvisorResult = chunk.ContentBlock
+				}
+				return nil, nil, false
+			}
+
+			// Handle code-execution server_tool_use (bash / text_editor / python).
+			// The input JSON is accumulated; the decoded code is emitted on
+			// content_block_stop (Anthropic streams JSON, OpenAI streams raw code).
+			if chunk.ContentBlock.Type == AnthropicContentBlockTypeServerToolUse &&
+				chunk.ContentBlock.Name != nil &&
+				isAnthropicCodeExecutionToolName(*chunk.ContentBlock.Name) &&
+				chunk.ContentBlock.ID != nil {
+
+				state.SeenRealToolCall = true
+				state.beginInputJSONBuffer(chunk.Index, anthropicInputJSONBufferCodeExec)
+				state.CodeExecToolID = chunk.ContentBlock.ID
+				state.CodeExecToolName = chunk.ContentBlock.Name
+				state.CodeExecOutputIndex = schemas.Ptr(outputIndex)
+				state.ItemIDs[outputIndex] = *chunk.ContentBlock.ID
+
+				item := &schemas.ResponsesMessage{
+					ID:     chunk.ContentBlock.ID,
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeCodeInterpreterCall),
+					Status: schemas.Ptr("in_progress"),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID:                           chunk.ContentBlock.ID,
+						ResponsesCodeInterpreterToolCall: &schemas.ResponsesCodeInterpreterToolCall{},
+						// Carry the sub-tool name so the reverse converter can
+						// reconstruct the correct server_tool_use name at this start.
+						ResponsesCodeExecutionCall: &schemas.ResponsesCodeExecutionCall{ToolName: *chunk.ContentBlock.Name},
+					},
+				}
+
+				return []*schemas.BifrostResponsesStreamResponse{
+					{
+						Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
+						SequenceNumber: sequenceNumber,
+						OutputIndex:    schemas.Ptr(outputIndex),
+						ContentIndex:   chunk.Index,
+						Item:           item,
+					},
+					{
+						Type:           schemas.ResponsesStreamResponseTypeCodeInterpreterCallInProgress,
+						SequenceNumber: sequenceNumber + 1,
+						OutputIndex:    schemas.Ptr(outputIndex),
+						ItemID:         chunk.ContentBlock.ID,
+					},
+				}, nil, false
+			}
+
+			// Handle code-execution result block (arrives complete in one event).
+			// Store it; the output_item.done is emitted on its content_block_stop.
+			if (chunk.ContentBlock.Type == AnthropicContentBlockTypeCodeExecutionToolResult ||
+				chunk.ContentBlock.Type == AnthropicContentBlockTypeBashCodeExecutionToolResult ||
+				chunk.ContentBlock.Type == AnthropicContentBlockTypeTextEditorCodeExecutionToolResult) &&
+				chunk.ContentBlock.ToolUseID != nil {
+
+				if chunk.Index != nil {
+					state.ContentIndexToBlockType[*chunk.Index] = chunk.ContentBlock.Type
+				}
+				if state.CodeExecToolID != nil && *state.CodeExecToolID == *chunk.ContentBlock.ToolUseID {
+					state.CodeExecResult = chunk.ContentBlock
 				}
 				return nil, nil, false
 			}
@@ -933,11 +1159,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 			case AnthropicStreamDeltaTypeInputJSON:
 				// Function call arguments delta
 				if chunk.Delta.PartialJSON != nil {
-					// Check if we're accumulating any tool (computer or web search)
-					// Both use the shared ChunkIndex and AccumulatedJSON fields
-					if state.ChunkIndex != nil && *state.ChunkIndex == *chunk.Index {
-						// Accumulate the JSON and don't emit anything
-						state.AccumulatedJSON += *chunk.Delta.PartialJSON
+					if state.appendInputJSON(chunk.Index, *chunk.Delta.PartialJSON) {
 						return nil, nil, false
 					}
 
@@ -1042,17 +1264,18 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 		if chunk.Index != nil {
 			outputIndex := state.getOrCreateOutputIndex(chunk.Index)
 
-			// Check if this is the end of a tool accumulation (computer or web search query)
-			if state.ChunkIndex != nil && *state.ChunkIndex == *chunk.Index {
-
-				// Computer tool completion
-				if state.ComputerToolID != nil {
+			if inputJSON, inputKind, hasInputBuffer := state.finishInputJSONBuffer(chunk.Index); hasInputBuffer {
+				switch inputKind {
+				case anthropicInputJSONBufferComputer:
+					if state.ComputerToolID == nil {
+						return nil, nil, false
+					}
 					// Parse accumulated JSON and convert to OpenAI format
 					var inputMap map[string]interface{}
 					var action *schemas.ResponsesComputerToolCallAction
 
-					if state.AccumulatedJSON != "" {
-						if err := sonic.Unmarshal([]byte(state.AccumulatedJSON), &inputMap); err == nil {
+					if inputJSON != "" {
+						if err := sonic.Unmarshal([]byte(inputJSON), &inputMap); err == nil {
 							action = convertAnthropicToResponsesComputerAction(inputMap)
 						}
 					}
@@ -1078,10 +1301,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 						}
 					}
 
-					// Clear computer tool state
 					state.ComputerToolID = nil
-					state.ChunkIndex = nil
-					state.AccumulatedJSON = ""
 
 					// Return output_item.done
 					return []*schemas.BifrostResponsesStreamResponse{
@@ -1093,34 +1313,88 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 							Item:           item,
 						},
 					}, nil, false
-				}
 
-				// Web search query block ended (don't emit output_item.done yet - wait for result)
-				if state.WebSearchToolID != nil {
-					// Clear ChunkIndex (done accumulating query)
-					// Keep WebSearchToolID, WebSearchOutputIndex, and AccumulatedJSON (need them for final item)
-					state.ChunkIndex = nil
+				case anthropicInputJSONBufferWebSearch:
+					if state.WebSearchToolID == nil {
+						return nil, nil, false
+					}
+					if state.WebSearchQuery == nil && inputJSON != "" {
+						if q := providerUtils.GetJSONField([]byte(inputJSON), "query"); q.Exists() && q.Type == gjson.String {
+							state.WebSearchQuery = schemas.Ptr(q.Str)
+						}
+					}
 					return nil, nil, false
-				}
 
-				// Advisor server_tool_use block ended — wait for the result block.
-				if state.AdvisorToolID != nil {
-					state.ChunkIndex = nil
+				case anthropicInputJSONBufferWebFetch:
 					return nil, nil, false
+
+				case anthropicInputJSONBufferAdvisor:
+					return nil, nil, false
+
+				case anthropicInputJSONBufferCodeExec:
+					if state.CodeExecToolID == nil {
+						return nil, nil, false
+					}
+					// Code-execution server_tool_use block ended — decode the code from
+					// the accumulated input JSON and emit code.delta + code.done +
+					// interpreting; the result block is folded in later.
+					state.CodeExecInput = inputJSON
+					code := ""
+					if inputJSON != "" {
+						key := "code"
+						if state.CodeExecToolName != nil &&
+							AnthropicToolName(*state.CodeExecToolName) == AnthropicToolNameBashCodeExecution {
+							key = "command"
+						}
+						if c := providerUtils.GetJSONField([]byte(inputJSON), key); c.Exists() && c.Type == gjson.String {
+							code = c.Str
+						}
+					}
+					outIdx := state.CodeExecOutputIndex
+					itemID := state.CodeExecToolID
+
+					var responses []*schemas.BifrostResponsesStreamResponse
+					if code != "" {
+						responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+							Type:           schemas.ResponsesStreamResponseTypeCodeInterpreterCallCodeDelta,
+							SequenceNumber: sequenceNumber + len(responses),
+							OutputIndex:    outIdx,
+							ItemID:         itemID,
+							Delta:          schemas.Ptr(code),
+						})
+					}
+					// Capture the offset once: both struct literals are evaluated before
+					// the variadic append reassigns responses, so reading len(responses)
+					// in each would yield the same (duplicate) sequence number.
+					codeDoneIdx := sequenceNumber + len(responses)
+					responses = append(responses,
+						&schemas.BifrostResponsesStreamResponse{
+							Type:           schemas.ResponsesStreamResponseTypeCodeInterpreterCallCodeDone,
+							SequenceNumber: codeDoneIdx,
+							OutputIndex:    outIdx,
+							ItemID:         itemID,
+							Code:           schemas.Ptr(code),
+						},
+						&schemas.BifrostResponsesStreamResponse{
+							Type:           schemas.ResponsesStreamResponseTypeCodeInterpreterCallInterpreting,
+							SequenceNumber: codeDoneIdx + 1,
+							OutputIndex:    outIdx,
+							ItemID:         itemID,
+						},
+					)
+					return responses, nil, false
 				}
 			}
 
 			// Check if this is the end of a web_search_tool_result block
 			if state.WebSearchResult != nil && state.WebSearchToolID != nil {
 
-				// Parse the query from AccumulatedJSON
+				// Use the query captured from the server_tool_use input at block start
 				var query string
 				var queries []string
-				if state.AccumulatedJSON != "" {
-					if q := providerUtils.GetJSONField([]byte(state.AccumulatedJSON), "query"); q.Exists() && q.Type == gjson.String {
-						query = q.Str
-						queries = []string{q.Str}
-					}
+				if state.WebSearchQuery != nil {
+					query = *state.WebSearchQuery
+					queries = []string{query}
 				}
 
 				// Extract sources from the result block
@@ -1151,16 +1425,21 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 					action.Queries = queries
 				}
 
+				toolMsg := &schemas.ResponsesToolMessage{
+					CallID: state.WebSearchToolID,
+					Action: &schemas.ResponsesToolMessageActionStruct{ResponsesWebSearchToolCallAction: action},
+				}
+				if state.WebSearchCaller != nil {
+					toolMsg.Caller = &schemas.ResponsesToolCaller{
+						Type:   string(state.WebSearchCaller.Type),
+						ToolID: state.WebSearchCaller.ToolID,
+					}
+				}
 				item := &schemas.ResponsesMessage{
-					ID:     state.WebSearchToolID,
-					Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
-					Status: &statusCompleted,
-					ResponsesToolMessage: &schemas.ResponsesToolMessage{
-						CallID: state.WebSearchToolID,
-						Action: &schemas.ResponsesToolMessageActionStruct{
-							ResponsesWebSearchToolCallAction: action,
-						},
-					},
+					ID:                   state.WebSearchToolID,
+					Type:                 schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+					Status:               &statusCompleted,
+					ResponsesToolMessage: toolMsg,
 				}
 
 				outputIdx := state.WebSearchOutputIndex
@@ -1169,7 +1448,8 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				state.WebSearchToolID = nil
 				state.WebSearchOutputIndex = nil
 				state.WebSearchResult = nil
-				state.AccumulatedJSON = ""
+				state.WebSearchQuery = nil
+				state.WebSearchCaller = nil
 
 				if chunk.Index != nil {
 					delete(state.ContentIndexToBlockType, *chunk.Index)
@@ -1239,13 +1519,72 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				}}, nil, false
 			}
 
+			// End of a code-execution result block — emit the code_interpreter_call done.
+			if state.CodeExecResult != nil && state.CodeExecToolID != nil {
+				// Rebuild the server_tool_use block from accumulated state so the
+				// streamed item is identical to the non-streaming converter output.
+				serverBlock := AnthropicContentBlock{
+					Type: AnthropicContentBlockTypeServerToolUse,
+					ID:   state.CodeExecToolID,
+					Name: state.CodeExecToolName,
+				}
+				// Use the input captured when the server_tool_use block closed.
+				if state.CodeExecInput != "" {
+					serverBlock.Input = json.RawMessage(state.CodeExecInput)
+				}
+				msgs := []schemas.ResponsesMessage{buildBifrostCodeExecutionCall(serverBlock)}
+				attachAnthropicCodeExecutionResult(msgs, *state.CodeExecToolID, *state.CodeExecResult)
+				item := &msgs[0]
+
+				outputIdx := state.CodeExecOutputIndex
+				itemID := state.CodeExecToolID
+				// Persist into OutputItems so response.completed includes the call;
+				// the sandbox container is folded in at message_stop.
+				if outputIdx != nil {
+					cloned := *item
+					if item.ResponsesToolMessage != nil {
+						clonedTM := *item.ResponsesToolMessage
+						cloned.ResponsesToolMessage = &clonedTM
+					}
+					state.OutputItems[*outputIdx] = &cloned
+				}
+
+				state.CodeExecToolID = nil
+				state.CodeExecToolName = nil
+				state.CodeExecOutputIndex = nil
+				state.CodeExecResult = nil
+				state.CodeExecInput = ""
+				if chunk.Index != nil {
+					delete(state.ContentIndexToBlockType, *chunk.Index)
+				}
+
+				return []*schemas.BifrostResponsesStreamResponse{
+					{
+						Type:           schemas.ResponsesStreamResponseTypeCodeInterpreterCallCompleted,
+						SequenceNumber: sequenceNumber,
+						OutputIndex:    outputIdx,
+						ItemID:         itemID,
+					},
+					{
+						Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
+						SequenceNumber: sequenceNumber + 1,
+						OutputIndex:    outputIdx,
+						ContentIndex:   chunk.Index,
+						Item:           item,
+					},
+				}, nil, false
+			}
+
 			// Skip generic output_item.done if this is a web_search_tool_result or compaction block
 			// (their handlers already emitted the proper done event)
 			if chunk.Index != nil {
 				if blockType, exists := state.ContentIndexToBlockType[*chunk.Index]; exists {
 					if blockType == AnthropicContentBlockTypeWebSearchToolResult ||
 						blockType == AnthropicContentBlockTypeWebFetchToolResult ||
-						blockType == AnthropicContentBlockTypeAdvisorToolResult {
+						blockType == AnthropicContentBlockTypeAdvisorToolResult ||
+						blockType == AnthropicContentBlockTypeCodeExecutionToolResult ||
+						blockType == AnthropicContentBlockTypeBashCodeExecutionToolResult ||
+						blockType == AnthropicContentBlockTypeTextEditorCodeExecutionToolResult {
 						delete(state.ContentIndexToBlockType, *chunk.Index)
 						return nil, nil, false
 					}
@@ -1493,6 +1832,11 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 		}
 
 	case AnthropicStreamEventTypeMessageDelta:
+		// The sandbox container is delivered here, after all content blocks; fold
+		// it onto the code_interpreter_call(s) at message_stop.
+		if chunk.Delta.Container != nil {
+			state.Container = chunk.Delta.Container
+		}
 		if chunk.Delta.StopReason != nil {
 			mapped := ConvertAnthropicFinishReasonToBifrost(*chunk.Delta.StopReason)
 			if state.UsedStructuredOutputTool && !state.SeenRealToolCall &&
@@ -1528,6 +1872,14 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 			if bifrostUsage != nil {
 				response.Usage = bifrostUsage
 			}
+			// Carry the sandbox container on the message_delta event so the reverse
+			// converter can re-emit it (Anthropic delivers it here, not earlier).
+			if state.Container != nil {
+				response.Container = &schemas.ResponsesResponseContainer{
+					ID:        state.Container.ID,
+					ExpiresAt: state.Container.ExpiresAt,
+				}
+			}
 
 			// Mark that we already emitted a message_delta so response.completed
 			// doesn't synthesize a duplicate one.
@@ -1557,6 +1909,35 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 		}
 		if state.StopReason != nil {
 			response.StopReason = state.StopReason
+		}
+
+		// Fold the sandbox container (delivered on the final message_delta) onto
+		// every code_interpreter_call so response.completed carries it (mirrors the
+		// non-streaming container lift in ToBifrostResponsesResponse). Also expose it
+		// at the response level so the reverse converter can re-emit it if it builds
+		// the message_delta from this completed event.
+		if state.Container != nil {
+			response.Container = &schemas.ResponsesResponseContainer{
+				ID:        state.Container.ID,
+				ExpiresAt: state.Container.ExpiresAt,
+			}
+			for _, item := range state.OutputItems {
+				if item == nil || item.Type == nil ||
+					*item.Type != schemas.ResponsesMessageTypeCodeInterpreterCall ||
+					item.ResponsesToolMessage == nil {
+					continue
+				}
+				if item.ResponsesToolMessage.ResponsesCodeInterpreterToolCall == nil {
+					item.ResponsesToolMessage.ResponsesCodeInterpreterToolCall = &schemas.ResponsesCodeInterpreterToolCall{}
+				}
+				item.ResponsesToolMessage.ResponsesCodeInterpreterToolCall.ContainerID = state.Container.ID
+				if state.Container.ExpiresAt != nil {
+					if item.ResponsesToolMessage.ResponsesCodeExecutionCall == nil {
+						item.ResponsesToolMessage.ResponsesCodeExecutionCall = &schemas.ResponsesCodeExecutionCall{}
+					}
+					item.ResponsesToolMessage.ResponsesCodeExecutionCall.ContainerExpiresAt = state.Container.ExpiresAt
+				}
+			}
 		}
 
 		// Populate the Output array from accumulated items for response.completed
@@ -1665,6 +2046,12 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 		return nil
 
 	case schemas.ResponsesStreamResponseTypeOutputItemAdded:
+		// Every output item starts exactly one primary Anthropic content block here;
+		// allocate its index once (deltas/stops look it up, result blocks get fresh
+		// indices). This is the single source of truth for block numbering.
+		addedState := getOrCreateAnthropicToResponsesStreamState(ctx)
+		blockIdx := addedState.allocBlockIndex(reverseStreamItemKey(bifrostResp))
+
 		// Check if this is a computer tool call
 		if bifrostResp.Item != nil &&
 			bifrostResp.Item.Type != nil &&
@@ -1672,12 +2059,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 			// Computer tool - emit content_block_start
 			streamResp.Type = AnthropicStreamEventTypeContentBlockStart
-
-			if bifrostResp.OutputIndex != nil {
-				streamResp.Index = bifrostResp.OutputIndex
-			} else if bifrostResp.ContentIndex != nil {
-				streamResp.Index = bifrostResp.ContentIndex
-			}
+			streamResp.Index = blockIdx
 
 			// Build the content_block as tool_use
 			// Note: Computer tool calls should not be converted to thinking blocks
@@ -1697,12 +2079,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 			// Web search call - emit content_block_start with server_tool_use
 			streamResp.Type = AnthropicStreamEventTypeContentBlockStart
-
-			if bifrostResp.ContentIndex != nil {
-				streamResp.Index = bifrostResp.ContentIndex
-			} else if bifrostResp.OutputIndex != nil {
-				streamResp.Index = bifrostResp.OutputIndex
-			}
+			streamResp.Index = blockIdx
 
 			// Build the content_block as server_tool_use
 			contentBlock := &AnthropicContentBlock{
@@ -1711,8 +2088,26 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				Name: schemas.Ptr(string(AnthropicToolNameWebSearch)), // "web_search"
 			}
 
-			// Start with empty input for streaming compatibility
+			// Deliver the query whole in content_block_start (no input_json_delta),
+			// matching native: a web_search is spawned atomically (in PTC, by the
+			// sandbox), so Anthropic never streams its input. Fall back to empty.
 			contentBlock.Input = json.RawMessage("{}")
+			if tm := bifrostResp.Item.ResponsesToolMessage; tm != nil && tm.Action != nil &&
+				tm.Action.ResponsesWebSearchToolCallAction != nil &&
+				tm.Action.ResponsesWebSearchToolCallAction.Query != nil {
+				if inputBytes, err := providerUtils.MarshalSorted(map[string]interface{}{"query": *tm.Action.ResponsesWebSearchToolCallAction.Query}); err == nil {
+					contentBlock.Input = json.RawMessage(inputBytes)
+				}
+			}
+
+			// Preserve the caller (set when this search was spawned from inside the
+			// code execution sandbox — programmatic tool calling).
+			if tm := bifrostResp.Item.ResponsesToolMessage; tm != nil && tm.Caller != nil {
+				contentBlock.Caller = &AnthropicToolCaller{
+					Type:   AnthropicToolCallerType(tm.Caller.Type),
+					ToolID: tm.Caller.ToolID,
+				}
+			}
 
 			streamResp.ContentBlock = contentBlock
 		} else if bifrostResp.Item != nil &&
@@ -1721,11 +2116,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 			// Advisor call - emit content_block_start with server_tool_use (input is always empty)
 			streamResp.Type = AnthropicStreamEventTypeContentBlockStart
-			if bifrostResp.ContentIndex != nil {
-				streamResp.Index = bifrostResp.ContentIndex
-			} else if bifrostResp.OutputIndex != nil {
-				streamResp.Index = bifrostResp.OutputIndex
-			}
+			streamResp.Index = blockIdx
 			toolUseID := bifrostResp.Item.ID
 			if bifrostResp.Item.ResponsesToolMessage != nil && bifrostResp.Item.ResponsesToolMessage.CallID != nil {
 				toolUseID = bifrostResp.Item.ResponsesToolMessage.CallID
@@ -1736,15 +2127,39 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				Name:  schemas.Ptr(string(AnthropicToolNameAdvisor)),
 				Input: json.RawMessage("{}"),
 			}
+		} else if bifrostResp.Item != nil &&
+			bifrostResp.Item.Type != nil &&
+			*bifrostResp.Item.Type == schemas.ResponsesMessageTypeCodeInterpreterCall {
+
+			// Code interpreter call - emit content_block_start with server_tool_use.
+			// Input is empty here; the verbatim input is streamed at output_item.done.
+			streamResp.Type = AnthropicStreamEventTypeContentBlockStart
+			streamResp.Index = blockIdx
+			toolUseID := bifrostResp.Item.ID
+			toolName := string(AnthropicToolNameCodeExecution)
+			if tm := bifrostResp.Item.ResponsesToolMessage; tm != nil {
+				if tm.CallID != nil {
+					toolUseID = tm.CallID
+				}
+				if tm.ResponsesCodeExecutionCall != nil && tm.ResponsesCodeExecutionCall.ToolName != "" {
+					toolName = tm.ResponsesCodeExecutionCall.ToolName
+				}
+			}
+			// Remember the sub-tool so code.done can rebuild {"code"|"command": …}.
+			if addedState.codeExecToolNameByItem == nil {
+				addedState.codeExecToolNameByItem = make(map[string]string)
+			}
+			addedState.codeExecToolNameByItem[reverseStreamItemKey(bifrostResp)] = toolName
+			streamResp.ContentBlock = &AnthropicContentBlock{
+				Type:  AnthropicContentBlockTypeServerToolUse,
+				ID:    toolUseID,
+				Name:  schemas.Ptr(toolName),
+				Input: json.RawMessage("{}"),
+			}
 		} else {
 			// Text or other content blocks - emit content_block_start
 			streamResp.Type = AnthropicStreamEventTypeContentBlockStart
-			// Use OutputIndex for global Anthropic indexing
-			if bifrostResp.OutputIndex != nil {
-				streamResp.Index = bifrostResp.OutputIndex
-			} else if bifrostResp.ContentIndex != nil {
-				streamResp.Index = bifrostResp.ContentIndex
-			}
+			streamResp.Index = blockIdx
 
 			// Build content_block based on item type
 			if bifrostResp.Item != nil {
@@ -1861,15 +2276,9 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 		if isCompactionItem(bifrostResp.Item) {
 			block := bifrostResp.Item.Content.ContentBlocks[0]
 			if block.ResponsesOutputMessageContentCompaction != nil {
-				var indexToUse *int
-				if bifrostResp.OutputIndex != nil {
-					indexToUse = bifrostResp.OutputIndex
-				} else if bifrostResp.ContentIndex != nil {
-					indexToUse = bifrostResp.ContentIndex
-				}
 				events = append(events, &AnthropicStreamEvent{
 					Type:  AnthropicStreamEventTypeContentBlockDelta,
-					Index: indexToUse,
+					Index: blockIdx,
 					Delta: &AnthropicStreamDelta{
 						Type:    AnthropicStreamDeltaTypeCompaction,
 						Content: &block.ResponsesOutputMessageContentCompaction.Summary,
@@ -1904,14 +2313,8 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				}
 			}
 			if shouldGenerateDeltas && argumentsJSON != "" {
-				// Generate synthetic input_json_delta events by chunking the JSON
-				var indexToUse *int
-				if bifrostResp.OutputIndex != nil {
-					indexToUse = bifrostResp.OutputIndex
-				} else if bifrostResp.ContentIndex != nil {
-					indexToUse = bifrostResp.ContentIndex
-				}
-				deltaEvents := generateSyntheticInputJSONDeltas(argumentsJSON, indexToUse)
+				// Generate synthetic input_json_delta events by chunking the JSON.
+				deltaEvents := generateSyntheticInputJSONDeltas(argumentsJSON, blockIdx)
 				events = append(events, deltaEvents...)
 			}
 		}
@@ -1922,13 +2325,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 	case schemas.ResponsesStreamResponseTypeOutputTextDelta:
 		streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
-		// Use OutputIndex instead of ContentIndex for global Anthropic indexing
-		if bifrostResp.OutputIndex != nil {
-			streamResp.Index = bifrostResp.OutputIndex
-		} else if bifrostResp.ContentIndex != nil {
-			// Fallback to ContentIndex if OutputIndex not available
-			streamResp.Index = bifrostResp.ContentIndex
-		}
+		streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 		if bifrostResp.Delta != nil {
 			streamResp.Delta = &AnthropicStreamDelta{
 				Type: AnthropicStreamDeltaTypeText,
@@ -1946,12 +2343,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 		}
 
 		streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
-		// Use OutputIndex for global Anthropic indexing
-		if bifrostResp.OutputIndex != nil {
-			streamResp.Index = bifrostResp.OutputIndex
-		} else if bifrostResp.ContentIndex != nil {
-			streamResp.Index = bifrostResp.ContentIndex
-		}
+		streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 		if bifrostResp.Arguments != nil {
 			streamResp.Delta = &AnthropicStreamDelta{
 				Type:        AnthropicStreamDeltaTypeInputJSON,
@@ -1967,12 +2359,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 	case schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta:
 		streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
-		// Use OutputIndex for global Anthropic indexing
-		if bifrostResp.OutputIndex != nil {
-			streamResp.Index = bifrostResp.OutputIndex
-		} else if bifrostResp.ContentIndex != nil {
-			streamResp.Index = bifrostResp.ContentIndex
-		}
+		streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 
 		// Check if this is a signature delta or text delta
 		if bifrostResp.Signature != nil {
@@ -1993,11 +2380,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 		// Convert OpenAI annotation to Anthropic citation
 		if bifrostResp.Annotation != nil {
 			streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
-			if bifrostResp.OutputIndex != nil {
-				streamResp.Index = bifrostResp.OutputIndex
-			} else if bifrostResp.ContentIndex != nil {
-				streamResp.Index = bifrostResp.ContentIndex
-			}
+			streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 
 			citation := convertAnnotationToAnthropicCitation(*bifrostResp.Annotation)
 
@@ -2027,14 +2410,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			// This replaces the delta events that were skipped earlier
 			var events []*AnthropicStreamEvent
 
-			// Use OutputIndex for proper Anthropic indexing, fallback to ContentIndex
-			var indexToUse *int
-			if bifrostResp.OutputIndex != nil {
-				indexToUse = bifrostResp.OutputIndex
-			} else if bifrostResp.ContentIndex != nil {
-				indexToUse = bifrostResp.ContentIndex
-			}
-
+			indexToUse := getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 			deltaEvents := generateSyntheticInputJSONDeltas(argumentsJSON, indexToUse)
 			events = append(events, deltaEvents...)
 
@@ -2061,13 +2437,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			// Computer tool complete - emit content_block_delta with the action, then stop
 			// Note: We're sending the complete action JSON in one delta
 			streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
-
-			// Use OutputIndex for global Anthropic indexing
-			if bifrostResp.OutputIndex != nil {
-				streamResp.Index = bifrostResp.OutputIndex
-			} else if bifrostResp.ContentIndex != nil {
-				streamResp.Index = bifrostResp.ContentIndex
-			}
+			streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 
 			// Convert the action to Anthropic format and marshal to JSON
 			if bifrostResp.Item.ResponsesToolMessage != nil &&
@@ -2093,65 +2463,28 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 			// Web search call complete - generate synthetic input_json_delta events, then emit content_block_stop
 			var events []*AnthropicStreamEvent
+			state := getOrCreateAnthropicToResponsesStreamState(ctx)
+			serverIdx := state.blockIndexFor(reverseStreamItemKey(bifrostResp))
 
-			// Extract query from web search action for synthetic delta generation
-			var queryJSON string
-			if bifrostResp.Item.ResponsesToolMessage != nil &&
-				bifrostResp.Item.ResponsesToolMessage.Action != nil &&
-				bifrostResp.Item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction != nil &&
-				bifrostResp.Item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Query != nil {
-
-				// Create input map with query
-				inputMap := map[string]interface{}{
-					"query": *bifrostResp.Item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Query,
-				}
-				if jsonBytes, err := providerUtils.MarshalSorted(inputMap); err == nil {
-					queryJSON = string(jsonBytes)
-				}
+			tm := bifrostResp.Item.ResponsesToolMessage
+			wsAction := (*schemas.ResponsesWebSearchToolCallAction)(nil)
+			if tm != nil && tm.Action != nil {
+				wsAction = tm.Action.ResponsesWebSearchToolCallAction
 			}
 
-			// Generate synthetic input_json_delta events if we have a query
-			if queryJSON != "" {
-				var indexToUse *int
-				if bifrostResp.OutputIndex != nil {
-					indexToUse = bifrostResp.OutputIndex
-				} else if bifrostResp.ContentIndex != nil {
-					indexToUse = bifrostResp.ContentIndex
-				}
-				deltaEvents := generateSyntheticInputJSONDeltas(queryJSON, indexToUse)
-				events = append(events, deltaEvents...)
-			}
+			// 1. Stop the server_tool_use. The query was already delivered whole in
+			// content_block_start (no input_json_delta), matching native.
+			events = append(events, &AnthropicStreamEvent{
+				Type:  AnthropicStreamEventTypeContentBlockStop,
+				Index: serverIdx,
+			})
 
-			// 1. Emit content_block_stop for the query block (server_tool_use)
-			stopEvent := &AnthropicStreamEvent{
-				Type: AnthropicStreamEventTypeContentBlockStop,
-			}
-			if bifrostResp.ContentIndex != nil {
-				stopEvent.Index = bifrostResp.ContentIndex
-			} else if bifrostResp.OutputIndex != nil {
-				stopEvent.Index = bifrostResp.OutputIndex
-			}
-			events = append(events, stopEvent)
+			// 2. Emit the paired web_search_tool_result block at a fresh index.
+			if wsAction != nil && len(wsAction.Sources) > 0 {
+				resultIndex := state.allocBlockIndex("")
 
-			// 2. Extract sources and create web_search_tool_result block if sources exist
-			if bifrostResp.Item.ResponsesToolMessage != nil &&
-				bifrostResp.Item.ResponsesToolMessage.Action != nil &&
-				bifrostResp.Item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction != nil &&
-				len(bifrostResp.Item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Sources) > 0 {
-
-				// Calculate next index for result block
-				var resultIndex *int
-				if bifrostResp.OutputIndex != nil {
-					nextIdx := *bifrostResp.OutputIndex + 1
-					resultIndex = &nextIdx
-				} else if bifrostResp.ContentIndex != nil {
-					nextIdx := *bifrostResp.ContentIndex + 1
-					resultIndex = &nextIdx
-				}
-
-				// Create content blocks for each source
 				var resultContentBlocks []AnthropicContentBlock
-				for _, source := range bifrostResp.Item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Sources {
+				for _, source := range wsAction.Sources {
 					block := AnthropicContentBlock{
 						Type:             AnthropicContentBlockTypeWebSearchResult,
 						URL:              &source.URL,
@@ -2166,26 +2499,63 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 					resultContentBlocks = append(resultContentBlocks, block)
 				}
 
-				// Emit content_block_start for web_search_tool_result
-				resultStartEvent := &AnthropicStreamEvent{
-					Type:  AnthropicStreamEventTypeContentBlockStart,
-					Index: resultIndex,
-					ContentBlock: &AnthropicContentBlock{
-						Type:      AnthropicContentBlockTypeWebSearchToolResult,
-						ToolUseID: bifrostResp.Item.ID, // Link to the server_tool_use block
-						Content: &AnthropicContent{
-							ContentBlocks: resultContentBlocks,
-						},
-					},
+				resultBlock := &AnthropicContentBlock{
+					Type:      AnthropicContentBlockTypeWebSearchToolResult,
+					ToolUseID: bifrostResp.Item.ID, // Link to the server_tool_use block
+					Content:   &AnthropicContent{ContentBlocks: resultContentBlocks},
 				}
-				events = append(events, resultStartEvent)
+				// Carry the programmatic-tool-calling caller onto the result too.
+				if tm != nil && tm.Caller != nil {
+					resultBlock.Caller = &AnthropicToolCaller{
+						Type:   AnthropicToolCallerType(tm.Caller.Type),
+						ToolID: tm.Caller.ToolID,
+					}
+				}
+				events = append(events,
+					&AnthropicStreamEvent{Type: AnthropicStreamEventTypeContentBlockStart, Index: resultIndex, ContentBlock: resultBlock},
+					&AnthropicStreamEvent{Type: AnthropicStreamEventTypeContentBlockStop, Index: resultIndex},
+				)
+			}
 
-				// Emit content_block_stop for the result block
-				resultStopEvent := &AnthropicStreamEvent{
-					Type:  AnthropicStreamEventTypeContentBlockStop,
-					Index: resultIndex,
+			return events
+		} else if bifrostResp.Item != nil &&
+			bifrostResp.Item.Type != nil &&
+			*bifrostResp.Item.Type == schemas.ResponsesMessageTypeCodeInterpreterCall {
+
+			// Code interpreter call complete.
+			var events []*AnthropicStreamEvent
+			blocks := convertBifrostCodeExecCallToAnthropicBlocks(bifrostResp.Item)
+			state := getOrCreateAnthropicToResponsesStreamState(ctx)
+
+			// For python/bash the server_tool_use block was already closed early on
+			// code.done. text_editor (and any item not closed there) is still open —
+			// close it now from the verbatim carry input, which carries its full
+			// multi-key payload (command/path/file_text/…) that Code can't.
+			if !state.codeExecServerClosedByItem[reverseStreamItemKey(bifrostResp)] {
+				serverIdx := state.blockIndexFor(reverseStreamItemKey(bifrostResp))
+				if len(blocks) > 0 && len(blocks[0].Input) > 0 {
+					events = append(events, generateSyntheticInputJSONDeltas(string(blocks[0].Input), serverIdx)...)
 				}
-				events = append(events, resultStopEvent)
+				events = append(events, &AnthropicStreamEvent{
+					Type:  AnthropicStreamEventTypeContentBlockStop,
+					Index: serverIdx,
+				})
+			}
+
+			if len(blocks) > 1 {
+				resultIdx := state.allocBlockIndex("")
+				resultBlock := blocks[1]
+				events = append(events,
+					&AnthropicStreamEvent{
+						Type:         AnthropicStreamEventTypeContentBlockStart,
+						Index:        resultIdx,
+						ContentBlock: &resultBlock,
+					},
+					&AnthropicStreamEvent{
+						Type:  AnthropicStreamEventTypeContentBlockStop,
+						Index: resultIdx,
+					},
+				)
 			}
 
 			return events
@@ -2194,20 +2564,16 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			*bifrostResp.Item.Type == schemas.ResponsesMessageTypeAdvisorCall {
 
 			// Advisor call complete - emit content_block_stop for the server_tool_use
-			// block, then the advisor_tool_result block (start + stop) at the next index.
+			// block, then the advisor_tool_result block (start + stop) at a fresh index.
 			var events []*AnthropicStreamEvent
+			state := getOrCreateAnthropicToResponsesStreamState(ctx)
 
 			toolUseID := bifrostResp.Item.ID
 			if bifrostResp.Item.ResponsesToolMessage != nil && bifrostResp.Item.ResponsesToolMessage.CallID != nil {
 				toolUseID = bifrostResp.Item.ResponsesToolMessage.CallID
 			}
 
-			var serverIdx *int
-			if bifrostResp.OutputIndex != nil {
-				serverIdx = bifrostResp.OutputIndex
-			} else if bifrostResp.ContentIndex != nil {
-				serverIdx = bifrostResp.ContentIndex
-			}
+			serverIdx := state.blockIndexFor(reverseStreamItemKey(bifrostResp))
 
 			// 1. content_block_stop for the server_tool_use block.
 			events = append(events, &AnthropicStreamEvent{
@@ -2215,12 +2581,8 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				Index: serverIdx,
 			})
 
-			// 2. content_block_start for advisor_tool_result at the next index.
-			var resultIdx *int
-			if serverIdx != nil {
-				next := *serverIdx + 1
-				resultIdx = &next
-			}
+			// 2. content_block_start for advisor_tool_result at a fresh index.
+			resultIdx := state.allocBlockIndex("")
 			resultBlock := &AnthropicContentBlock{
 				Type:      AnthropicContentBlockTypeAdvisorToolResult,
 				ToolUseID: toolUseID,
@@ -2261,26 +2623,53 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 			// Function call or MCP call complete - just emit content_block_stop
 			streamResp.Type = AnthropicStreamEventTypeContentBlockStop
-			if bifrostResp.ContentIndex != nil {
-				streamResp.Index = bifrostResp.ContentIndex
-			} else if bifrostResp.OutputIndex != nil {
-				streamResp.Index = bifrostResp.OutputIndex
-			}
+			streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 		} else {
 			// For text blocks and other content blocks, emit content_block_stop
 			streamResp.Type = AnthropicStreamEventTypeContentBlockStop
-			// Use OutputIndex for global Anthropic indexing
-			if bifrostResp.OutputIndex != nil {
-				streamResp.Index = bifrostResp.OutputIndex
-			} else if bifrostResp.ContentIndex != nil {
-				streamResp.Index = bifrostResp.ContentIndex
-			}
+			streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 		}
 	case schemas.ResponsesStreamResponseTypeWebSearchCallInProgress,
 		schemas.ResponsesStreamResponseTypeWebSearchCallSearching,
 		schemas.ResponsesStreamResponseTypeWebSearchCallCompleted:
 		// Web search lifecycle events - these are OpenAI-style events that don't have Anthropic equivalents
 		// Skip them to avoid cluttering the stream
+		return nil
+
+	case schemas.ResponsesStreamResponseTypeCodeInterpreterCallCodeDone:
+		// Close the code server_tool_use block early — before any nested web_search
+		// blocks — only for python/bash, whose entire input reconstructs from the
+		// neutral Code (`{"code"|"command": …}`) and which can spawn nested blocks
+		// (programmatic tool calling), so sequential ordering requires the early
+		// close. text_editor has a multi-key input that Code can't carry (Code is
+		// empty) and never spawns nested blocks, so leave its block open and let
+		// output_item.done close it from the verbatim carry input.
+		if bifrostResp.Code == nil || *bifrostResp.Code == "" {
+			return nil
+		}
+		state := getOrCreateAnthropicToResponsesStreamState(ctx)
+		key := reverseStreamItemKey(bifrostResp)
+		idx := state.blockIndexFor(key)
+		inputKey := "code"
+		if AnthropicToolName(state.codeExecToolNameByItem[key]) == AnthropicToolNameBashCodeExecution {
+			inputKey = "command"
+		}
+		var events []*AnthropicStreamEvent
+		if inputBytes, err := providerUtils.MarshalSorted(map[string]interface{}{inputKey: *bifrostResp.Code}); err == nil {
+			events = append(events, generateSyntheticInputJSONDeltas(string(inputBytes), idx)...)
+		}
+		events = append(events, &AnthropicStreamEvent{Type: AnthropicStreamEventTypeContentBlockStop, Index: idx})
+		if state.codeExecServerClosedByItem == nil {
+			state.codeExecServerClosedByItem = make(map[string]bool)
+		}
+		state.codeExecServerClosedByItem[key] = true
+		return events
+
+	case schemas.ResponsesStreamResponseTypeCodeInterpreterCallInProgress,
+		schemas.ResponsesStreamResponseTypeCodeInterpreterCallCodeDelta,
+		schemas.ResponsesStreamResponseTypeCodeInterpreterCallInterpreting,
+		schemas.ResponsesStreamResponseTypeCodeInterpreterCallCompleted:
+		// Other code interpreter lifecycle events have no Anthropic equivalent.
 		return nil
 
 	case schemas.ResponsesStreamResponseTypePing:
@@ -2309,18 +2698,23 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 					StopSequence: nil,
 				}
 			}
+			// Re-emit the code-execution sandbox container on the message_delta.
+			if bifrostResp.Response.Container != nil {
+				if anthropicContentDeltaEvent.Delta == nil {
+					anthropicContentDeltaEvent.Delta = &AnthropicStreamDelta{}
+				}
+				anthropicContentDeltaEvent.Delta.Container = &AnthropicResponseContainer{
+					ID:        bifrostResp.Response.Container.ID,
+					ExpiresAt: bifrostResp.Response.Container.ExpiresAt,
+				}
+			}
 		}
 		return []*AnthropicStreamEvent{anthropicContentDeltaEvent, streamResp}
 
 	case schemas.ResponsesStreamResponseTypeMCPCallArgumentsDelta:
 		// MCP call arguments delta - convert to content_block_delta with input_json
 		streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
-		// Use OutputIndex for global Anthropic indexing
-		if bifrostResp.OutputIndex != nil {
-			streamResp.Index = bifrostResp.OutputIndex
-		} else if bifrostResp.ContentIndex != nil {
-			streamResp.Index = bifrostResp.ContentIndex
-		}
+		streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 		if bifrostResp.Delta != nil {
 			streamResp.Delta = &AnthropicStreamDelta{
 				Type:        AnthropicStreamDeltaTypeInputJSON,
@@ -2337,12 +2731,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 	case schemas.ResponsesStreamResponseTypeMCPCallCompleted:
 		// MCP call completed - emit content_block_stop
 		streamResp.Type = AnthropicStreamEventTypeContentBlockStop
-		// Use OutputIndex for global Anthropic indexing
-		if bifrostResp.OutputIndex != nil {
-			streamResp.Index = bifrostResp.OutputIndex
-		} else if bifrostResp.ContentIndex != nil {
-			streamResp.Index = bifrostResp.ContentIndex
-		}
+		streamResp.Index = getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexFor(reverseStreamItemKey(bifrostResp))
 
 	case schemas.ResponsesStreamResponseTypeMCPCallFailed:
 		// MCP call failed - emit error event
@@ -2376,6 +2765,18 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				streamResp.Delta = &AnthropicStreamDelta{
 					Type: AnthropicStreamDeltaTypeText,
 					Text: bifrostResp.Delta,
+				}
+			}
+
+			// Re-emit the code-execution sandbox container on message_delta (read
+			// straight off the event — Anthropic delivers it here natively).
+			if bifrostResp.Response != nil && bifrostResp.Response.Container != nil {
+				if streamResp.Delta == nil {
+					streamResp.Delta = &AnthropicStreamDelta{}
+				}
+				streamResp.Delta.Container = &AnthropicResponseContainer{
+					ID:        bifrostResp.Response.Container.ID,
+					ExpiresAt: bifrostResp.Response.Container.ExpiresAt,
 				}
 			}
 		}
@@ -3074,6 +3475,26 @@ func (response *AnthropicMessageResponse) ToBifrostResponsesResponse(ctx *schema
 		}
 		outputMessages := ConvertAnthropicMessagesToBifrostMessages(ctx, []AnthropicMessage{tempMsg}, nil, true, false)
 		if len(outputMessages) > 0 {
+			// Lift the response-level code-execution container onto every
+			// code_interpreter_call so it round-trips (id is neutral; expiry is carried).
+			if response.Container != nil {
+				for i := range outputMessages {
+					m := &outputMessages[i]
+					if m.Type == nil || *m.Type != schemas.ResponsesMessageTypeCodeInterpreterCall || m.ResponsesToolMessage == nil {
+						continue
+					}
+					if m.ResponsesToolMessage.ResponsesCodeInterpreterToolCall == nil {
+						m.ResponsesToolMessage.ResponsesCodeInterpreterToolCall = &schemas.ResponsesCodeInterpreterToolCall{}
+					}
+					m.ResponsesToolMessage.ResponsesCodeInterpreterToolCall.ContainerID = response.Container.ID
+					if response.Container.ExpiresAt != nil {
+						if m.ResponsesToolMessage.ResponsesCodeExecutionCall == nil {
+							m.ResponsesToolMessage.ResponsesCodeExecutionCall = &schemas.ResponsesCodeExecutionCall{}
+						}
+						m.ResponsesToolMessage.ResponsesCodeExecutionCall.ContainerExpiresAt = response.Container.ExpiresAt
+					}
+				}
+			}
 			bifrostResp.Output = outputMessages
 		}
 	}
@@ -3153,6 +3574,25 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 		anthropicResp.Content = contentBlocks
 	} else {
 		anthropicResp.Content = []AnthropicContentBlock{}
+	}
+
+	// Restore the response-level code-execution container from the first
+	// code_interpreter_call that carries one.
+	for i := range bifrostResp.Output {
+		m := &bifrostResp.Output[i]
+		if m.Type == nil || *m.Type != schemas.ResponsesMessageTypeCodeInterpreterCall || m.ResponsesToolMessage == nil {
+			continue
+		}
+		ci := m.ResponsesToolMessage.ResponsesCodeInterpreterToolCall
+		if ci == nil || ci.ContainerID == "" {
+			continue
+		}
+		container := &AnthropicResponseContainer{ID: ci.ContainerID}
+		if cec := m.ResponsesToolMessage.ResponsesCodeExecutionCall; cec != nil {
+			container.ExpiresAt = cec.ContainerExpiresAt
+		}
+		anthropicResp.Container = container
+		break
 	}
 
 	// Map stop reason from Bifrost response if available, otherwise infer from content
@@ -3759,6 +4199,32 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 				}
 			}
 
+		case schemas.ResponsesMessageTypeCodeInterpreterCall:
+			// Code execution calls, like web search/advisor, emit a server_tool_use +
+			// *_code_execution_tool_result pair inside the assistant message.
+			flushPendingToolResults()
+			codeExecBlocks := convertBifrostCodeExecCallToAnthropicBlocks(&msg)
+			if len(codeExecBlocks) > 0 {
+				if currentAssistantMessage == nil {
+					currentAssistantMessage = &AnthropicMessage{
+						Role: AnthropicMessageRoleAssistant,
+					}
+				}
+				if len(pendingReasoningContentBlocks) > 0 {
+					copied := make([]AnthropicContentBlock, len(pendingReasoningContentBlocks))
+					copy(copied, pendingReasoningContentBlocks)
+					pendingToolCalls = append(copied, pendingToolCalls...)
+					pendingReasoningContentBlocks = nil
+				}
+				pendingToolCalls = append(pendingToolCalls, codeExecBlocks...)
+				if codeExecBlocks[0].ID != nil {
+					if currentToolCallIDs == nil {
+						currentToolCallIDs = make(map[string]bool)
+					}
+					currentToolCallIDs[*codeExecBlocks[0].ID] = true
+				}
+			}
+
 		case schemas.ResponsesMessageTypeWebFetchCall:
 			flushPendingToolResults()
 
@@ -3778,6 +4244,12 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 			serverToolUseBlock := AnthropicContentBlock{
 				Type: AnthropicContentBlockTypeServerToolUse,
 				Name: schemas.Ptr(string(AnthropicToolNameWebFetch)),
+			}
+			if msg.ResponsesToolMessage != nil && msg.ResponsesToolMessage.Caller != nil {
+				serverToolUseBlock.Caller = &AnthropicToolCaller{
+					Type:   AnthropicToolCallerType(msg.ResponsesToolMessage.Caller.Type),
+					ToolID: msg.ResponsesToolMessage.Caller.ToolID,
+				}
 			}
 			if msg.ID != nil {
 				serverToolUseBlock.ID = msg.ID
@@ -3802,7 +4274,6 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 
 		// Handle other tool call types that are not natively supported by Anthropic
 		case schemas.ResponsesMessageTypeFileSearchCall,
-			schemas.ResponsesMessageTypeCodeInterpreterCall,
 			schemas.ResponsesMessageTypeLocalShellCall,
 			schemas.ResponsesMessageTypeCustomToolCall,
 			schemas.ResponsesMessageTypeImageGenerationCall:
@@ -4495,6 +4966,15 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					ResponsesToolMessage: &schemas.ResponsesToolMessage{},
 				}
 
+				// Preserve the caller (set when this search was spawned from inside
+				// the code execution sandbox — programmatic tool calling).
+				if block.Caller != nil {
+					bifrostMsg.ResponsesToolMessage.Caller = &schemas.ResponsesToolCaller{
+						Type:   string(block.Caller.Type),
+						ToolID: block.Caller.ToolID,
+					}
+				}
+
 				// Extract query from input
 				if block.Input != nil {
 					if q := providerUtils.GetJSONField(block.Input, "query"); q.Exists() && q.Type == gjson.String {
@@ -4518,6 +4998,13 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					Type:                 schemas.Ptr(schemas.ResponsesMessageTypeWebFetchCall),
 					Status:               schemas.Ptr("completed"),
 					ResponsesToolMessage: &schemas.ResponsesToolMessage{},
+				}
+
+				if block.Caller != nil {
+					bifrostMsg.ResponsesToolMessage.Caller = &schemas.ResponsesToolCaller{
+						Type:   string(block.Caller.Type),
+						ToolID: block.Caller.ToolID,
+					}
 				}
 
 				if block.Input != nil {
@@ -4549,6 +5036,20 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				if isOutputMessage {
 					bifrostMessages = append(bifrostMessages, bifrostMsg)
 				}
+			} else if block.Name != nil && isAnthropicCodeExecutionToolName(*block.Name) {
+				// code_execution / bash_code_execution / text_editor_code_execution
+				// server_tool_use — the paired *_tool_result is attached below.
+				if isOutputMessage {
+					bifrostMessages = append(bifrostMessages, buildBifrostCodeExecutionCall(block))
+				}
+			}
+
+		case AnthropicContentBlockTypeCodeExecutionToolResult,
+			AnthropicContentBlockTypeBashCodeExecutionToolResult,
+			AnthropicContentBlockTypeTextEditorCodeExecutionToolResult:
+			// Fold the code-execution result onto the matching code_interpreter_call.
+			if block.ToolUseID != nil {
+				attachAnthropicCodeExecutionResult(bifrostMessages, *block.ToolUseID, block)
 			}
 
 		case AnthropicContentBlockTypeAdvisorToolResult:
@@ -5112,10 +5613,18 @@ func convertBifrostWebSearchCallToAnthropicBlocks(msg *schemas.ResponsesMessage)
 	var blocks []AnthropicContentBlock
 	action := msg.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction
 
+	// The caller (set when this search was spawned from inside the code execution
+	// sandbox) must be re-emitted on both the server_tool_use and the result block.
+	var caller *AnthropicToolCaller
+	if c := msg.ResponsesToolMessage.Caller; c != nil {
+		caller = &AnthropicToolCaller{Type: AnthropicToolCallerType(c.Type), ToolID: c.ToolID}
+	}
+
 	// 1. Create server_tool_use block for the web search
 	serverToolUseBlock := AnthropicContentBlock{
-		Type: AnthropicContentBlockTypeServerToolUse,
-		Name: schemas.Ptr("web_search"),
+		Type:   AnthropicContentBlockTypeServerToolUse,
+		Name:   schemas.Ptr("web_search"),
+		Caller: caller,
 	}
 
 	if msg.ID != nil {
@@ -5163,6 +5672,7 @@ func convertBifrostWebSearchCallToAnthropicBlocks(msg *schemas.ResponsesMessage)
 	webSearchResultBlock := AnthropicContentBlock{
 		Type:      AnthropicContentBlockTypeWebSearchToolResult,
 		ToolUseID: toolUseID,
+		Caller:    caller,
 		Content: &AnthropicContent{
 			ContentBlocks: resultBlocks,
 		},
@@ -5215,6 +5725,327 @@ func convertBifrostAdvisorCallToAnthropicBlocks(msg *schemas.ResponsesMessage) [
 	}
 
 	return []AnthropicContentBlock{serverToolUseBlock, resultBlock}
+}
+
+// isAnthropicCodeExecutionToolName reports whether name is one of the code
+// execution sub-tools (code_execution_20250825+ surfaces bash + text_editor;
+// code_execution is the legacy Python sub-tool).
+func isAnthropicCodeExecutionToolName(name string) bool {
+	switch AnthropicToolName(name) {
+	case AnthropicToolNameCodeExecution, AnthropicToolNameBashCodeExecution, AnthropicToolNameTextEditorCodeExecution:
+		return true
+	default:
+		return false
+	}
+}
+
+// anthropicCodeExecResultBlockType maps a code-execution sub-tool name to its
+// outer *_tool_result block type.
+func anthropicCodeExecResultBlockType(toolName string) AnthropicContentBlockType {
+	switch AnthropicToolName(toolName) {
+	case AnthropicToolNameBashCodeExecution:
+		return AnthropicContentBlockTypeBashCodeExecutionToolResult
+	case AnthropicToolNameTextEditorCodeExecution:
+		return AnthropicContentBlockTypeTextEditorCodeExecutionToolResult
+	default:
+		return AnthropicContentBlockTypeCodeExecutionToolResult
+	}
+}
+
+// anthropicCodeExecInnerResultType maps a code-execution sub-tool name to its
+// inner result-content discriminator (used when the stored result type is absent).
+func anthropicCodeExecInnerResultType(toolName string) AnthropicContentBlockType {
+	switch AnthropicToolName(toolName) {
+	case AnthropicToolNameBashCodeExecution:
+		return AnthropicContentBlockTypeBashCodeExecutionResult
+	case AnthropicToolNameTextEditorCodeExecution:
+		return AnthropicContentBlockTypeTextEditorCodeExecutionResult
+	default:
+		return AnthropicContentBlockTypeCodeExecutionResult
+	}
+}
+
+// anthropicCodeExecOutputBlockType maps a code-execution sub-tool name to the
+// file-output block type emitted inside a result's content array.
+func anthropicCodeExecOutputBlockType(toolName string) AnthropicContentBlockType {
+	if AnthropicToolName(toolName) == AnthropicToolNameBashCodeExecution {
+		return AnthropicContentBlockTypeBashCodeExecutionOutput
+	}
+	return AnthropicContentBlockTypeCodeExecutionOutput
+}
+
+// buildBifrostCodeExecutionCall converts a code-execution server_tool_use block
+// into a neutral code_interpreter_call message that also carries the Anthropic
+// fidelity (sub-tool name, verbatim input, caller). The paired *_tool_result is
+// attached later by attachAnthropicCodeExecutionResult.
+func buildBifrostCodeExecutionCall(block AnthropicContentBlock) schemas.ResponsesMessage {
+	carry := &schemas.ResponsesCodeExecutionCall{}
+	if block.Name != nil {
+		carry.ToolName = *block.Name
+	}
+	ci := &schemas.ResponsesCodeInterpreterToolCall{}
+
+	if len(block.Input) > 0 {
+		raw := string(block.Input)
+		carry.Input = &raw
+		// Populate the neutral "code" for OpenAI-compatible consumers: Python uses
+		// "code", bash uses "command". text_editor verbs are not runnable code, so
+		// the neutral code stays empty and only the carry input round-trips them.
+		switch AnthropicToolName(carry.ToolName) {
+		case AnthropicToolNameCodeExecution:
+			if c := providerUtils.GetJSONField(block.Input, "code"); c.Exists() && c.Type == gjson.String {
+				ci.Code = schemas.Ptr(c.Str)
+			}
+		case AnthropicToolNameBashCodeExecution:
+			if c := providerUtils.GetJSONField(block.Input, "command"); c.Exists() && c.Type == gjson.String {
+				ci.Code = schemas.Ptr(c.Str)
+			}
+		}
+	}
+
+	if block.Caller != nil {
+		carry.Caller = &schemas.ResponsesToolCaller{
+			Type:   string(block.Caller.Type),
+			ToolID: block.Caller.ToolID,
+		}
+	}
+
+	return schemas.ResponsesMessage{
+		Type:   schemas.Ptr(schemas.ResponsesMessageTypeCodeInterpreterCall),
+		ID:     block.ID,
+		Status: schemas.Ptr("completed"),
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			CallID:                           block.ID,
+			ResponsesCodeInterpreterToolCall: ci,
+			ResponsesCodeExecutionCall:       carry,
+		},
+	}
+}
+
+// attachAnthropicCodeExecutionResult finds the most recent code_interpreter_call
+// matching toolUseID and folds the *_tool_result block onto it — both the
+// Anthropic fidelity carry and the neutral code_interpreter outputs.
+func attachAnthropicCodeExecutionResult(msgs []schemas.ResponsesMessage, toolUseID string, block AnthropicContentBlock) {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		msg := &msgs[i]
+		if msg.Type == nil || *msg.Type != schemas.ResponsesMessageTypeCodeInterpreterCall {
+			continue
+		}
+		if msg.ResponsesToolMessage == nil || msg.ResponsesToolMessage.CallID == nil ||
+			*msg.ResponsesToolMessage.CallID != toolUseID {
+			continue
+		}
+
+		tm := msg.ResponsesToolMessage
+		if tm.ResponsesCodeExecutionCall == nil {
+			tm.ResponsesCodeExecutionCall = &schemas.ResponsesCodeExecutionCall{}
+		}
+		if tm.ResponsesCodeInterpreterToolCall == nil {
+			tm.ResponsesCodeInterpreterToolCall = &schemas.ResponsesCodeInterpreterToolCall{}
+		}
+		carry := tm.ResponsesCodeExecutionCall
+		ci := tm.ResponsesCodeInterpreterToolCall
+
+		// content is a single object on the wire (ContentObj); UnmarshalJSON may
+		// wrap it into ContentBlocks instead, so accept either.
+		var inner *AnthropicContentBlock
+		if c := block.Content; c != nil {
+			inner = c.ContentObj
+			if inner == nil && len(c.ContentBlocks) > 0 {
+				inner = &c.ContentBlocks[0]
+			}
+		}
+		if inner != nil {
+			carry.ResultType = string(inner.Type)
+			carry.Stdout = inner.Stdout
+			carry.Stderr = inner.Stderr
+			carry.ReturnCode = inner.ReturnCode
+			carry.EncryptedStdout = inner.EncryptedStdout
+			carry.FileType = inner.FileType
+			carry.StartLine = inner.StartLine
+			carry.NumLines = inner.NumLines
+			carry.TotalLines = inner.TotalLines
+			carry.IsFileUpdate = inner.IsFileUpdate
+			carry.OldStart = inner.OldStart
+			carry.OldLines = inner.OldLines
+			carry.NewStart = inner.NewStart
+			carry.NewLines = inner.NewLines
+			carry.Lines = inner.Lines
+			carry.ErrorCode = inner.ErrorCode
+
+			// The inner result's own "content" is either a string (text_editor view
+			// file contents) or an array of file-output blocks (bash/python files).
+			if ic := inner.Content; ic != nil {
+				if ic.ContentStr != nil {
+					carry.FileContent = ic.ContentStr
+				}
+				for _, fb := range ic.ContentBlocks {
+					if fb.FileID != nil {
+						carry.Files = append(carry.Files, schemas.ResponsesCodeExecutionFileOutput{FileID: *fb.FileID})
+					}
+				}
+			}
+
+			// Neutral OpenAI-compatible view: stdout becomes a logs output.
+			if inner.Stdout != nil && *inner.Stdout != "" {
+				ci.Outputs = append(ci.Outputs, schemas.ResponsesCodeInterpreterOutput{
+					ResponsesCodeInterpreterOutputLogs: &schemas.ResponsesCodeInterpreterOutputLogs{
+						Type: "logs",
+						Logs: *inner.Stdout,
+					},
+				})
+			}
+		}
+
+		// The caller union may also appear on the result block.
+		if block.Caller != nil && carry.Caller == nil {
+			carry.Caller = &schemas.ResponsesToolCaller{
+				Type:   string(block.Caller.Type),
+				ToolID: block.Caller.ToolID,
+			}
+		}
+
+		if carry.ErrorCode != nil {
+			msg.Status = schemas.Ptr("failed")
+		}
+		return
+	}
+}
+
+// convertBifrostCodeExecCallToAnthropicBlocks rebuilds the Anthropic
+// server_tool_use + *_code_execution_tool_result block pair from a neutral
+// code_interpreter_call carrying ResponsesCodeExecutionCall. Anthropic requires
+// both blocks to appear together in the assistant message.
+func convertBifrostCodeExecCallToAnthropicBlocks(msg *schemas.ResponsesMessage) []AnthropicContentBlock {
+	tm := msg.ResponsesToolMessage
+	if tm == nil {
+		return nil
+	}
+	cec := tm.ResponsesCodeExecutionCall
+	ci := tm.ResponsesCodeInterpreterToolCall
+	if cec == nil && ci == nil {
+		return nil
+	}
+	if cec == nil {
+		// OpenAI-origin code_interpreter_call without the Anthropic carry: synthesize
+		// the fidelity from the neutral fields so it still round-trips to Anthropic.
+		cec = &schemas.ResponsesCodeExecutionCall{}
+	}
+
+	var toolUseID *string
+	if tm.CallID != nil {
+		toolUseID = tm.CallID
+	} else {
+		toolUseID = msg.ID
+	}
+
+	toolName := cec.ToolName
+	if toolName == "" {
+		toolName = string(AnthropicToolNameCodeExecution)
+	}
+
+	// 1. server_tool_use block.
+	serverToolUse := AnthropicContentBlock{
+		Type: AnthropicContentBlockTypeServerToolUse,
+		ID:   toolUseID,
+		Name: schemas.Ptr(toolName),
+	}
+	if cec.Input != nil {
+		serverToolUse.Input = json.RawMessage(*cec.Input)
+	} else if ci != nil && ci.Code != nil {
+		// Reconstruct a minimal input from the neutral code field.
+		key := "code"
+		if AnthropicToolName(toolName) == AnthropicToolNameBashCodeExecution {
+			key = "command"
+		}
+		if inputBytes, err := providerUtils.MarshalSorted(map[string]interface{}{key: *ci.Code}); err == nil {
+			serverToolUse.Input = json.RawMessage(inputBytes)
+		}
+	}
+	if cec.Caller != nil {
+		serverToolUse.Caller = &AnthropicToolCaller{
+			Type:   AnthropicToolCallerType(cec.Caller.Type),
+			ToolID: cec.Caller.ToolID,
+		}
+	}
+
+	// 2. inner result-content object.
+	stdout := cec.Stdout
+	if stdout == nil && ci != nil {
+		// OpenAI-origin: fold the first logs output back into stdout.
+		for _, o := range ci.Outputs {
+			if o.ResponsesCodeInterpreterOutputLogs != nil {
+				logs := o.ResponsesCodeInterpreterOutputLogs.Logs
+				stdout = &logs
+				break
+			}
+		}
+	}
+	inner := AnthropicContentBlock{
+		Type:            AnthropicContentBlockType(cec.ResultType),
+		Stdout:          stdout,
+		Stderr:          cec.Stderr,
+		ReturnCode:      cec.ReturnCode,
+		EncryptedStdout: cec.EncryptedStdout,
+		FileType:        cec.FileType,
+		StartLine:       cec.StartLine,
+		NumLines:        cec.NumLines,
+		TotalLines:      cec.TotalLines,
+		IsFileUpdate:    cec.IsFileUpdate,
+		OldStart:        cec.OldStart,
+		OldLines:        cec.OldLines,
+		NewStart:        cec.NewStart,
+		NewLines:        cec.NewLines,
+		Lines:           cec.Lines,
+		ErrorCode:       cec.ErrorCode,
+	}
+	if inner.Type == "" {
+		inner.Type = anthropicCodeExecInnerResultType(toolName)
+	}
+
+	// Rebuild the inner result's own "content": text_editor view file contents
+	// (string) and/or generated file outputs (array of *_code_execution_output).
+	var innerContent *AnthropicContent
+	if cec.FileContent != nil {
+		innerContent = &AnthropicContent{ContentStr: cec.FileContent}
+	}
+	if len(cec.Files) > 0 {
+		outputType := anthropicCodeExecOutputBlockType(toolName)
+		fileBlocks := make([]AnthropicContentBlock, 0, len(cec.Files))
+		for _, f := range cec.Files {
+			fileID := f.FileID
+			fileBlocks = append(fileBlocks, AnthropicContentBlock{Type: outputType, FileID: &fileID})
+		}
+		if innerContent == nil {
+			innerContent = &AnthropicContent{}
+		}
+		innerContent.ContentBlocks = fileBlocks
+	}
+
+	if innerContent == nil {
+		switch inner.Type {
+		case AnthropicContentBlockTypeCodeExecutionResult,
+			AnthropicContentBlockTypeBashCodeExecutionResult,
+			AnthropicContentBlockTypeEncryptedCodeExecutionResult:
+			innerContent = &AnthropicContent{ContentBlocks: []AnthropicContentBlock{}}
+		}
+	}
+	inner.Content = innerContent
+
+	// 3. outer *_tool_result block wrapping the inner content object.
+	resultBlock := AnthropicContentBlock{
+		Type:      anthropicCodeExecResultBlockType(toolName),
+		ToolUseID: toolUseID,
+		Content:   &AnthropicContent{ContentObj: &inner},
+	}
+	if cec.Caller != nil {
+		resultBlock.Caller = &AnthropicToolCaller{
+			Type:   AnthropicToolCallerType(cec.Caller.Type),
+			ToolID: cec.Caller.ToolID,
+		}
+	}
+
+	return []AnthropicContentBlock{serverToolUse, resultBlock}
 }
 
 // convertBifrostUnsupportedToolCallToAnthropicMessage converts unsupported tool calls to text messages
@@ -5367,9 +6198,15 @@ func convertAnthropicToolToBifrost(tool *AnthropicTool) *schemas.ResponsesTool {
 			}
 			return bifrostTool
 
-		case AnthropicToolTypeCodeExecution20250522, AnthropicToolTypeCodeExecution, AnthropicToolTypeCodeExecution20260120:
+		case AnthropicToolTypeCodeExecution20250522, AnthropicToolTypeCodeExecution,
+			AnthropicToolTypeCodeExecution20260120, AnthropicToolTypeCodeExecution20260521:
+			// Preserve the exact requested version so its capability tier
+			// (bash/file vs. PTC+REPL vs. disclosed time limit) round-trips.
 			return &schemas.ResponsesTool{
 				Type: schemas.ResponsesToolTypeCodeInterpreter,
+				ResponsesToolCodeInterpreter: &schemas.ResponsesToolCodeInterpreter{
+					Version: schemas.Ptr(string(*tool.Type)),
+				},
 			}
 
 		case AnthropicToolTypeMemory20250818:
@@ -5670,9 +6507,19 @@ func convertBifrostToolToAnthropic(model string, tool *schemas.ResponsesTool, pr
 			// Including it explicitly causes "Auto-injecting tools would conflict" errors.
 			return nil
 		}
-		// When no web search/fetch, explicitly include code_execution
+		// When no web search/fetch, explicitly include code_execution. Forward the
+		// exact requested version verbatim (its capability tier — bash/file vs.
+		// PTC+REPL vs. disclosed time limit — must round-trip). Fall back to
+		// 20250825, the only version every model supports, when none was captured
+		// (e.g. an OpenAI-origin code_interpreter request).
+		codeExecVersion := AnthropicToolTypeCodeExecution
+		if tool.ResponsesToolCodeInterpreter != nil &&
+			tool.ResponsesToolCodeInterpreter.Version != nil &&
+			*tool.ResponsesToolCodeInterpreter.Version != "" {
+			codeExecVersion = AnthropicToolType(*tool.ResponsesToolCodeInterpreter.Version)
+		}
 		return &AnthropicTool{
-			Type: schemas.Ptr(AnthropicToolTypeCodeExecution),
+			Type: schemas.Ptr(codeExecVersion),
 			Name: string(AnthropicToolNameCodeExecution),
 		}
 	case schemas.ResponsesToolTypeComputerUsePreview:
@@ -6622,11 +7469,15 @@ func generateSyntheticInputJSONDeltas(argumentsJSON string, contentIndex *int) [
 		},
 	})
 
-	// Break the JSON into chunks
-	for i := 0; i < len(argumentsJSON); i += chunkSize {
-		end := min(i+chunkSize, len(argumentsJSON))
+	// Break the JSON into chunks on rune boundaries — slicing by bytes would
+	// split a multi-byte UTF-8 rune across two deltas, emitting invalid UTF-8 on
+	// the wire (the SDK's SSE decoder rejects it). Concatenating the rune chunks
+	// still reconstructs the exact JSON for parsing at content_block_stop.
+	runes := []rune(argumentsJSON)
+	for i := 0; i < len(runes); i += chunkSize {
+		end := min(i+chunkSize, len(runes))
 
-		chunk := argumentsJSON[i:end]
+		chunk := string(runes[i:end])
 		events = append(events, &AnthropicStreamEvent{
 			Type:  AnthropicStreamEventTypeContentBlockDelta,
 			Index: contentIndex,

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -916,6 +916,19 @@ const (
 	AnthropicContentBlockTypeThinking                          AnthropicContentBlockType = "thinking"
 	AnthropicContentBlockTypeRedactedThinking                  AnthropicContentBlockType = "redacted_thinking"
 	AnthropicContentBlockTypeCompaction                        AnthropicContentBlockType = "compaction"
+
+	// code_execution inner result-content discriminators (the "content" object on
+	// a *_code_execution_tool_result block; ContentObj.Type carries these).
+	AnthropicContentBlockTypeCodeExecutionResult                AnthropicContentBlockType = "code_execution_result"                  // legacy Python (code_execution)
+	AnthropicContentBlockTypeEncryptedCodeExecutionResult       AnthropicContentBlockType = "encrypted_code_execution_result"        // code_execution with encrypted stdout
+	AnthropicContentBlockTypeBashCodeExecutionResult            AnthropicContentBlockType = "bash_code_execution_result"             // bash_code_execution
+	AnthropicContentBlockTypeTextEditorCodeExecutionResult      AnthropicContentBlockType = "text_editor_code_execution_result"      // text_editor_code_execution
+	AnthropicContentBlockTypeCodeExecutionToolResultError       AnthropicContentBlockType = "code_execution_tool_result_error"       // legacy Python error
+	AnthropicContentBlockTypeBashCodeExecutionToolResultError   AnthropicContentBlockType = "bash_code_execution_tool_result_error"  // bash error
+	AnthropicContentBlockTypeTextEditorCodeExecutionResultError AnthropicContentBlockType = "text_editor_code_execution_tool_result_error"
+	// code_execution file-output blocks (inside a result's "content" array; carry file_id).
+	AnthropicContentBlockTypeCodeExecutionOutput     AnthropicContentBlockType = "code_execution_output"      // legacy Python output file
+	AnthropicContentBlockTypeBashCodeExecutionOutput AnthropicContentBlockType = "bash_code_execution_output" // bash output file
 )
 
 // AnthropicToolCallerType identifies which agentic caller produced a tool
@@ -1213,6 +1226,7 @@ const (
 	AnthropicToolTypeCodeExecution20250522 AnthropicToolType = "code_execution_20250522" // Legacy Python-only
 	AnthropicToolTypeCodeExecution         AnthropicToolType = "code_execution_20250825"
 	AnthropicToolTypeCodeExecution20260120 AnthropicToolType = "code_execution_20260120" // Programmatic tool calling
+	AnthropicToolTypeCodeExecution20260521 AnthropicToolType = "code_execution_20260521" // _20260120 runtime + disclosed per-cell time limit
 
 	// Web search
 	AnthropicToolTypeWebSearch20250305 AnthropicToolType = "web_search_20250305"
@@ -1250,7 +1264,11 @@ const (
 	// and text_editor_20250429. Newer text_editor_20250728+ use AnthropicToolNameTextEditor.
 	AnthropicToolNameTextEditorLegacy AnthropicToolName = "str_replace_editor"
 	AnthropicToolNameCodeExecution    AnthropicToolName = "code_execution"
-	AnthropicToolNameMemory           AnthropicToolName = "memory"
+	// Sub-tools surfaced by code_execution_20250825+: bash command execution and
+	// file view/create/edit. They share the code_execution tool definition.
+	AnthropicToolNameBashCodeExecution       AnthropicToolName = "bash_code_execution"
+	AnthropicToolNameTextEditorCodeExecution AnthropicToolName = "text_editor_code_execution"
+	AnthropicToolNameMemory                  AnthropicToolName = "memory"
 	AnthropicToolNameToolSearchBM25   AnthropicToolName = "tool_search_tool_bm25"
 	AnthropicToolNameToolSearchRegex  AnthropicToolName = "tool_search_tool_regex"
 	AnthropicToolNameAdvisor          AnthropicToolName = "advisor"
@@ -1526,6 +1544,15 @@ const (
 	AnthropicStopReasonCompaction                 AnthropicStopReason = "compaction"
 )
 
+// AnthropicResponseContainer is the "container" object returned on responses
+// that used the code execution tool. The id can be passed back as the request
+// "container" to reuse the sandbox across turns.
+// Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool
+type AnthropicResponseContainer struct {
+	ID        string  `json:"id"`
+	ExpiresAt *string `json:"expires_at,omitempty"`
+}
+
 // AnthropicMessageResponse represents an Anthropic messages API response
 type AnthropicMessageResponse struct {
 	ID           string                  `json:"id"`
@@ -1536,6 +1563,10 @@ type AnthropicMessageResponse struct {
 	StopReason   AnthropicStopReason     `json:"stop_reason,omitempty"`
 	StopSequence *string                 `json:"stop_sequence,omitempty"`
 	Usage        *AnthropicUsage         `json:"usage,omitempty"`
+	// Container is the code-execution sandbox container, present on responses that
+	// used the code execution tool. Distinct from the request-side AnthropicContainer
+	// union: the response form is always an object with id + expires_at.
+	Container *AnthropicResponseContainer `json:"container,omitempty"`
 	// Diagnostics is the cache-diagnosis response payload (cache-diagnosis-2026-04-07).
 	// omitempty when absent; a present-but-null value (no divergence) is conveyed by a
 	// non-nil pointer with a nil CacheMissReason — see schemas.CacheDiagnostics.
@@ -1629,6 +1660,9 @@ type AnthropicStreamDelta struct {
 	Citation     *AnthropicTextCitation   `json:"citation,omitempty"`    // For citations_delta
 	StopReason   *AnthropicStopReason     `json:"stop_reason,omitempty"` // only not present in "message_start" events
 	StopSequence *string                  `json:"stop_sequence"`
+	// Container is the code-execution sandbox container, surfaced on the final
+	// message_delta of a response that used the code execution tool.
+	Container *AnthropicResponseContainer `json:"container,omitempty"`
 }
 
 // ==================== MODEL TYPES ====================

--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -728,6 +728,12 @@ func TestOpenAIResponsesRequest_MarshalJSON_StripsAnthropicToolFlags(t *testing.
 					},
 					ResponsesToolFunction: &schemas.ResponsesToolFunction{},
 				},
+				{
+					Type: schemas.ResponsesToolTypeCodeInterpreter,
+					ResponsesToolCodeInterpreter: &schemas.ResponsesToolCodeInterpreter{
+						Version: schemas.Ptr("code_execution_20260120"),
+					},
+				},
 			},
 		},
 	}
@@ -738,8 +744,8 @@ func TestOpenAIResponsesRequest_MarshalJSON_StripsAnthropicToolFlags(t *testing.
 	}
 	raw := string(jsonBytes)
 
-	// None of the five Anthropic-only tool keys must survive on the wire.
-	for _, key := range []string{`"cache_control"`, `"defer_loading"`, `"allowed_callers"`, `"input_examples"`, `"eager_input_streaming"`} {
+	// None of the Anthropic-only tool keys must survive on the wire.
+	for _, key := range []string{`"cache_control"`, `"defer_loading"`, `"allowed_callers"`, `"input_examples"`, `"eager_input_streaming"`, `"code_execution_version"`} {
 		if strings.Contains(raw, key) {
 			t.Errorf("OpenAI Responses serializer must strip %s; raw=%s", key, raw)
 		}

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -575,7 +575,8 @@ func hasAnthropicOnlyResponsesToolFlags(t schemas.ResponsesTool) bool {
 	return t.DeferLoading != nil ||
 		len(t.AllowedCallers) > 0 ||
 		len(t.InputExamples) > 0 ||
-		t.EagerInputStreaming != nil
+		t.EagerInputStreaming != nil ||
+		(t.ResponsesToolCodeInterpreter != nil && t.ResponsesToolCodeInterpreter.Version != nil)
 }
 
 // isAnthropicOnlyResponsesToolType reports whether the tool type exists only
@@ -804,6 +805,11 @@ func (resp *OpenAIResponsesRequest) MarshalJSON() ([]byte, error) {
 				toolCopy.AllowedCallers = nil
 				toolCopy.InputExamples = nil
 				toolCopy.EagerInputStreaming = nil
+				if toolCopy.ResponsesToolCodeInterpreter != nil && toolCopy.ResponsesToolCodeInterpreter.Version != nil {
+					ciCopy := *toolCopy.ResponsesToolCodeInterpreter
+					ciCopy.Version = nil
+					toolCopy.ResponsesToolCodeInterpreter = &ciCopy
+				}
 				processedTools = append(processedTools, toolCopy)
 			}
 		} else {

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -71,12 +71,12 @@ func (r *BifrostCompactionRequest) GetRawRequestBody() []byte {
 // BifrostCompactionResponse is the response from the context compaction endpoint.
 // object is always "response.compaction". output contains user messages plus one encrypted compaction item.
 type BifrostCompactionResponse struct {
-	ID        *string            `json:"id,omitempty"`
-	Object    string             `json:"object"` // always "response.compaction"
-	Model     string             `json:"model,omitempty"`
-	CreatedAt int                `json:"created_at"`
-	Output    []ResponsesMessage `json:"output"`
-	Usage     *ResponsesResponseUsage    `json:"usage,omitempty"`
+	ID          *string                    `json:"id,omitempty"`
+	Object      string                     `json:"object"` // always "response.compaction"
+	Model       string                     `json:"model,omitempty"`
+	CreatedAt   int                        `json:"created_at"`
+	Output      []ResponsesMessage         `json:"output"`
+	Usage       *ResponsesResponseUsage    `json:"usage,omitempty"`
 	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
 }
 
@@ -101,6 +101,14 @@ func (resp *BifrostCompactionResponse) WithDefaults() *BifrostCompactionResponse
 		result.Output = []ResponsesMessage{}
 	}
 	return result
+}
+
+// ResponsesResponseContainer is the code-execution sandbox container returned on
+// a response that used the code execution tool. The id can be passed back to
+// reuse the sandbox across turns.
+type ResponsesResponseContainer struct {
+	ID        string  `json:"id"`
+	ExpiresAt *string `json:"expires_at,omitempty"`
 }
 
 type BifrostResponsesResponse struct {
@@ -130,9 +138,10 @@ type BifrostResponsesResponse struct {
 	Reasoning            *ResponsesParametersReasoning       `json:"reasoning"`         // Configuration options for reasoning models
 	SafetyIdentifier     *string                             `json:"safety_identifier"` // Safety identifier
 	ServiceTier          *BifrostServiceTier                 `json:"service_tier"`
-	Speed                *string                             `json:"speed,omitempty"` // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
+	Speed                *string                             `json:"speed,omitempty"`       // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
 	Diagnostics          *CacheDiagnostics                   `json:"diagnostics,omitempty"` // Anthropic cache diagnostics (cache-diagnosis-2026-04-07); first prompt-cache prefix divergence point
-	Status               *string                             `json:"status,omitempty"` // completed, failed, in_progress, cancelled, queued, or incomplete
+	Container            *ResponsesResponseContainer         `json:"container,omitempty"`   // Code-execution sandbox container (Anthropic surfaces it on the response / final streaming message_delta). The neutral per-call id also lives on ResponsesCodeInterpreterToolCall.ContainerID.
+	Status               *string                             `json:"status,omitempty"`      // completed, failed, in_progress, cancelled, queued, or incomplete
 	StreamOptions        *ResponsesStreamOptions             `json:"stream_options,omitempty"`
 	StopReason           *string                             `json:"stop_reason,omitempty"` // Not in OpenAI's spec, but sent by other providers
 	Store                *bool                               `json:"store,omitempty"`
@@ -252,9 +261,24 @@ func (resp *BifrostResponsesResponse) WithDefaults() *BifrostResponsesResponse {
 		result.Status = Ptr("completed")
 	}
 
-	// Output array - default: empty array
+	// Output array - default: empty array. Strip the Anthropic-only code-execution
+	// fidelity carry from the normalized output: code_interpreter_call is a real
+	// OpenAI type an OpenAI client drives, so the extra code_execution_* fields are
+	// a contract leak on provider-format converters (e.g. openai/v1/responses). The
+	// neutral view (code/container_id/outputs) is untouched, and the raw Bifrost
+	// superset response keeps the carry. Done on copies so the source response (and
+	// the superset path that returns it raw) is not mutated. (Advisor has no OpenAI
+	// surface to leak onto, so its carry is left as-is.)
 	if resp.Output != nil {
-		result.Output = resp.Output
+		result.Output = make([]ResponsesMessage, len(resp.Output))
+		for i := range resp.Output {
+			result.Output[i] = resp.Output[i]
+			if tm := resp.Output[i].ResponsesToolMessage; tm != nil && tm.ResponsesCodeExecutionCall != nil {
+				tmCopy := *tm
+				tmCopy.ResponsesCodeExecutionCall = nil
+				result.Output[i].ResponsesToolMessage = &tmCopy
+			}
+		}
 	} else {
 		result.Output = []ResponsesMessage{}
 	}
@@ -1167,6 +1191,8 @@ type ResponsesToolMessage struct {
 	Output    *ResponsesToolMessageOutputStruct `json:"output,omitempty"`
 	Action    *ResponsesToolMessageActionStruct `json:"action,omitempty"`
 	Error     *string                           `json:"error,omitempty"`
+	// Caller is the neutral form of Anthropic's "caller" union on server-tool blocks
+	Caller *ResponsesToolCaller `json:"tool_caller,omitempty"`
 
 	// Tool calls and outputs
 	*ResponsesFileSearchToolCall
@@ -1183,16 +1209,89 @@ type ResponsesToolMessage struct {
 
 	// Anthropic advisor-specific (advisor_call): carries the advisor_tool_result payload
 	*ResponsesAdvisorCall
+
+	// Anthropic code-execution-specific (code_interpreter_call): carries the
+	// server_tool_use input + *_code_execution_tool_result payload that the
+	// neutral ResponsesCodeInterpreterToolCall cannot represent.
+	*ResponsesCodeExecutionCall
 }
 
 // ResponsesAdvisorCall carries the Anthropic advisor_tool_result content
 // (a discriminated union) alongside an advisor_call. Anthropic-only.
 type ResponsesAdvisorCall struct {
-	ResultType       string  `json:"result_type,omitempty"`       // "advisor_result" | "advisor_redacted_result" | "advisor_tool_result_error"
-	Text             *string `json:"advisor_text,omitempty"`      // advisor_result variant
+	ResultType       string  `json:"result_type,omitempty"`               // "advisor_result" | "advisor_redacted_result" | "advisor_tool_result_error"
+	Text             *string `json:"advisor_text,omitempty"`              // advisor_result variant
 	EncryptedContent *string `json:"advisor_encrypted_content,omitempty"` // advisor_redacted_result variant
 	ErrorCode        *string `json:"advisor_error_code,omitempty"`        // advisor_tool_result_error variant
 	StopReason       *string `json:"advisor_stop_reason,omitempty"`       // present when max_tokens is set on the tool
+}
+
+// ResponsesToolCaller is the neutral form of Anthropic's "caller" union on
+// server_tool_use / *_tool_result blocks. It links a tool call to the agentic
+// caller that produced it (e.g. programmatic tool calling from inside the code
+// execution sandbox). Nil for direct top-level calls.
+type ResponsesToolCaller struct {
+	Type   string  `json:"type"`              // "direct" | "code_execution_20250825" | "code_execution_20260120"
+	ToolID *string `json:"tool_id,omitempty"` // required for code_execution_* caller types
+}
+
+// ResponsesCodeExecutionFileOutput is a file produced during a code execution
+// run, referenced by Files API id. Mirrors Anthropic's *_code_execution_output block.
+type ResponsesCodeExecutionFileOutput struct {
+	FileID string `json:"file_id"`
+}
+
+// ResponsesCodeExecutionCall carries the Anthropic code-execution fidelity that
+// the neutral ResponsesCodeInterpreterToolCall (code/container_id/outputs) cannot
+// represent, so an Anthropic -> Bifrost -> Anthropic round trip can reconstruct
+// the original server_tool_use + *_code_execution_tool_result blocks exactly.
+// Sibling to ResponsesAdvisorCall; Anthropic-only. The code string and container
+// id live on the neutral ResponsesCodeInterpreterToolCall.
+type ResponsesCodeExecutionCall struct {
+	// ToolName is the sub-tool that produced the call:
+	// "code_execution" (legacy Python) | "bash_code_execution" | "text_editor_code_execution".
+	ToolName string `json:"code_execution_tool_name,omitempty"`
+	// Input is the verbatim server_tool_use input JSON (code / command / path /
+	// file_text / old_str / new_str), kept as a string to preserve key ordering.
+	Input *string `json:"code_execution_input,omitempty"`
+	// ResultType is the inner result-content discriminator, e.g.
+	// "bash_code_execution_result" | "code_execution_result" |
+	// "text_editor_code_execution_result" | "*_tool_result_error".
+	ResultType string `json:"code_execution_result_type,omitempty"`
+
+	// Execution result fields (bash / python variants).
+	Stdout          *string `json:"code_execution_stdout,omitempty"`
+	Stderr          *string `json:"code_execution_stderr,omitempty"`
+	ReturnCode      *int    `json:"code_execution_return_code,omitempty"`
+	EncryptedStdout *string `json:"code_execution_encrypted_stdout,omitempty"`
+
+	// File-operation result fields (text_editor variant).
+	FileType     *string  `json:"code_execution_file_type,omitempty"`      // view: "text" | "image" | "pdf"
+	FileContent  *string  `json:"code_execution_file_content,omitempty"`   // view: file contents
+	StartLine    *int     `json:"code_execution_start_line,omitempty"`     // view
+	NumLines     *int     `json:"code_execution_num_lines,omitempty"`      // view
+	TotalLines   *int     `json:"code_execution_total_lines,omitempty"`    // view
+	IsFileUpdate *bool    `json:"code_execution_is_file_update,omitempty"` // create
+	OldStart     *int     `json:"code_execution_old_start,omitempty"`      // str_replace
+	OldLines     *int     `json:"code_execution_old_lines,omitempty"`      // str_replace
+	NewStart     *int     `json:"code_execution_new_start,omitempty"`      // str_replace
+	NewLines     *int     `json:"code_execution_new_lines,omitempty"`      // str_replace
+	Lines        []string `json:"code_execution_lines,omitempty"`          // str_replace diff
+
+	// ErrorCode is set for *_tool_result_error variants (e.g. "unavailable",
+	// "execution_time_exceeded", "container_expired", "file_not_found").
+	ErrorCode *string `json:"code_execution_error_code,omitempty"`
+
+	// Files lists outputs created during execution (charts, generated files).
+	Files []ResponsesCodeExecutionFileOutput `json:"code_execution_files,omitempty"`
+
+	// ContainerExpiresAt is the sandbox container expiry; its id lives on the
+	// neutral ResponsesCodeInterpreterToolCall.ContainerID.
+	ContainerExpiresAt *string `json:"code_execution_container_expires_at,omitempty"`
+
+	// Caller links this call to the agentic caller that produced it (programmatic
+	// tool calling). Nil for direct top-level calls.
+	Caller *ResponsesToolCaller `json:"code_execution_caller,omitempty"`
 }
 
 type ResponsesToolMessageActionStruct struct {
@@ -2569,6 +2668,11 @@ type ResponsesToolMCPAllowedToolsApprovalFilter struct {
 // ResponsesToolCodeInterpreter represents a tool code interpreter
 type ResponsesToolCodeInterpreter struct {
 	Container interface{} `json:"container"` // Container ID or object with file IDs
+	// Anthropic code_execution tool version (code_execution_20250825 |
+	// _20260120 | _20260521 | legacy _20250522). Preserved verbatim so the
+	// requested capability tier round-trips; ignored by other providers and
+	// stripped before any OpenAI-compatible request (see openai/types.go).
+	Version *string `json:"code_execution_version,omitempty"`
 }
 
 // ResponsesToolImageGeneration represents a tool image generation
@@ -2823,6 +2927,19 @@ func (resp *BifrostResponsesStreamResponse) WithDefaults() *BifrostResponsesStre
 	// Copy all streaming-specific fields
 	result.OutputIndex = resp.OutputIndex
 	result.Item = resp.Item
+	// Strip the Anthropic-only code-execution carry from the streamed item, matching
+	// the non-streaming Output path: it must not leak onto the code_interpreter_call
+	// items of output_item.added / output_item.done on provider-format converters
+	// (e.g. openai/v1/responses). Done on a copy so the source item is not mutated
+	// (the raw Bifrost superset stream keeps the carry).
+	if result.Item != nil && result.Item.ResponsesToolMessage != nil &&
+		result.Item.ResponsesToolMessage.ResponsesCodeExecutionCall != nil {
+		itemCopy := *result.Item
+		tmCopy := *result.Item.ResponsesToolMessage
+		tmCopy.ResponsesCodeExecutionCall = nil
+		itemCopy.ResponsesToolMessage = &tmCopy
+		result.Item = &itemCopy
+	}
 	result.SummaryIndex = resp.SummaryIndex
 	result.ContentIndex = resp.ContentIndex
 	result.ItemID = resp.ItemID

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -276,3 +276,93 @@ func TestResponsesMessagePreservesOpenAIPhase(t *testing.T) {
 		t.Fatalf("expected encoded message to contain phase, got %s", encoded)
 	}
 }
+
+// TestWithDefaultsStripsCodeExecutionCarry verifies that WithDefaults() (the
+// normalized provider-format converters, e.g. openai/v1/responses) drops the
+// Anthropic-only code-execution fidelity carry while keeping the neutral
+// code_interpreter_call view — and does not mutate the source response (the raw
+// Bifrost superset path keeps the carry).
+func TestWithDefaultsStripsCodeExecutionCarry(t *testing.T) {
+	code := "print(1)"
+	resp := &BifrostResponsesResponse{
+		ID: Ptr("resp_1"),
+		Output: []ResponsesMessage{
+			{
+				Type: Ptr(ResponsesMessageTypeCodeInterpreterCall),
+				ID:   Ptr("ci_1"),
+				ResponsesToolMessage: &ResponsesToolMessage{
+					CallID:                           Ptr("ci_1"),
+					ResponsesCodeInterpreterToolCall: &ResponsesCodeInterpreterToolCall{Code: &code, ContainerID: "cntr_1"},
+					ResponsesCodeExecutionCall:       &ResponsesCodeExecutionCall{ToolName: "bash_code_execution", Stdout: Ptr("hi\n")},
+				},
+			},
+		},
+	}
+
+	normalized := resp.WithDefaults()
+
+	// Normalized output: carry gone, neutral view intact.
+	tm := normalized.Output[0].ResponsesToolMessage
+	if tm.ResponsesCodeExecutionCall != nil {
+		t.Error("WithDefaults leaked the code-execution carry into normalized output")
+	}
+	if tm.ResponsesCodeInterpreterToolCall == nil || tm.ResponsesCodeInterpreterToolCall.ContainerID != "cntr_1" {
+		t.Error("WithDefaults dropped the neutral code_interpreter_call view")
+	}
+
+	// Source response (raw superset) must be untouched.
+	if resp.Output[0].ResponsesToolMessage.ResponsesCodeExecutionCall == nil {
+		t.Error("WithDefaults mutated the source response — superset lost the carry")
+	}
+
+	encoded, err := Marshal(normalized)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(encoded), "code_execution_") {
+		t.Errorf("normalized JSON still contains code_execution_* fields:\n%s", encoded)
+	}
+}
+
+// TestStreamWithDefaultsStripsCodeExecutionCarry verifies the streaming converter
+// drops the code-execution carry from output_item.added / output_item.done items
+// (the streaming analog of the non-streaming Output strip).
+func TestStreamWithDefaultsStripsCodeExecutionCarry(t *testing.T) {
+	mkItem := func() *ResponsesMessage {
+		return &ResponsesMessage{
+			Type: Ptr(ResponsesMessageTypeCodeInterpreterCall),
+			ID:   Ptr("ci_1"),
+			ResponsesToolMessage: &ResponsesToolMessage{
+				CallID:                           Ptr("ci_1"),
+				ResponsesCodeInterpreterToolCall: &ResponsesCodeInterpreterToolCall{ContainerID: "cntr_1"},
+				ResponsesCodeExecutionCall:       &ResponsesCodeExecutionCall{ToolName: "bash_code_execution"},
+			},
+		}
+	}
+
+	for _, typ := range []ResponsesStreamResponseType{
+		ResponsesStreamResponseTypeOutputItemAdded,
+		ResponsesStreamResponseTypeOutputItemDone,
+	} {
+		src := &BifrostResponsesStreamResponse{Type: typ, Item: mkItem()}
+		out := src.WithDefaults()
+
+		if out.Item.ResponsesToolMessage.ResponsesCodeExecutionCall != nil {
+			t.Errorf("%s: leaked code-execution carry on streamed item", typ)
+		}
+		if out.Item.ResponsesToolMessage.ResponsesCodeInterpreterToolCall == nil {
+			t.Errorf("%s: dropped neutral code_interpreter_call view", typ)
+		}
+		if src.Item.ResponsesToolMessage.ResponsesCodeExecutionCall == nil {
+			t.Errorf("%s: mutated source item — superset stream lost the carry", typ)
+		}
+
+		encoded, err := Marshal(out)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(encoded), "code_execution_") {
+			t.Errorf("%s: normalized stream JSON still has code_execution_*:\n%s", typ, encoded)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds full round-trip support for Anthropic's code execution tool (`code_execution_20250825+`), which surfaces three sub-tools: `bash_code_execution`, `text_editor_code_execution`, and the legacy `code_execution` (Python). Both the non-streaming and streaming paths now correctly parse, convert, and reconstruct the `server_tool_use` + `*_code_execution_tool_result` block pairs, the sandbox container, and the programmatic tool calling (PTC) `caller` linkage.

## Changes

- **New `ResponsesCodeExecutionCall` carry struct** on `ResponsesToolMessage`: preserves Anthropic-specific fidelity (sub-tool name, verbatim input JSON, result discriminator, stdout/stderr/return_code, text_editor file fields, error codes, generated file outputs, container expiry, and caller) so an Anthropic → Bifrost → Anthropic round trip reconstructs the original wire shape exactly. The neutral `ResponsesCodeInterpreterToolCall` (code/container_id/outputs) is populated in parallel for OpenAI-compatible consumers.

- **`WithDefaults()` strips the carry** from the normalized output on both `BifrostResponsesResponse` and `BifrostResponsesStreamResponse` (the provider-format converter path, e.g. `openai/v1/responses`). The raw Bifrost superset response retains the carry. Stripping is done on copies so the source is never mutated.

- **Non-streaming converter** (`ToBifrostResponsesResponse` / `ToAnthropicResponsesResponse`): `buildBifrostCodeExecutionCall` and `attachAnthropicCodeExecutionResult` parse the `server_tool_use` + `*_code_execution_tool_result` pair into the neutral + carry view; `convertBifrostCodeExecCallToAnthropicBlocks` reconstructs the pair on the reverse path. The response-level `container` is lifted onto every `code_interpreter_call` and restored on the reverse.

- **Streaming converter** (`ToBifrostResponsesStream`): `content_block_start` for a code-execution `server_tool_use` emits `output_item.added` + `code_interpreter_call.in_progress`; accumulated input JSON is decoded on `content_block_stop` to emit `code.delta` + `code.done` + `interpreting`; the result block (delivered complete in one `content_block_start`) is stored and folded in on its `content_block_stop` to emit `code_interpreter_call.completed` + `output_item.done`. The sandbox container from the final `message_delta` is folded onto all `code_interpreter_call` items in `OutputItems` and carried on `response.completed`.

- **Reverse streaming converter** (`ToAnthropicResponsesStreamResponse`): `output_item.added` emits a `content_block_start` with the correct `server_tool_use` name; `output_item.done` synthesizes `input_json_delta` events + `content_block_stop` for the call and a `content_block_start` + `content_block_stop` for the result block. Code interpreter lifecycle events (`in_progress`, `code.delta`, `code.done`, `interpreting`, `completed`) are suppressed (no Anthropic equivalent). The container is re-emitted on `message_delta`.

- **`caller` linkage** (programmatic tool calling): `caller` on `server_tool_use` and `*_tool_result` blocks for `web_search` and `web_fetch` is now preserved through the neutral `ResponsesToolCaller` and re-emitted on the reverse path. `convertBifrostWebSearchCallToAnthropicBlocks` propagates the caller to both the `server_tool_use` and the result block.

- **New type constants**: `AnthropicToolNameBashCodeExecution`, `AnthropicToolNameTextEditorCodeExecution`, inner result discriminators (`bash_code_execution_result`, `text_editor_code_execution_result`, etc.), file-output block types, and `AnthropicResponseContainer` (response-level container object, distinct from the request-side union).

- **Passthrough block commented out**: the raw-event passthrough for empty-response stream events (compaction `content_block_start/stop`) is disabled pending a cleaner solution, as it was causing duplicate events.

- **`ResponsesResponseContainer`** added to `BifrostResponsesResponse` and `BifrostResponsesStreamResponse` to carry the sandbox container at the response level for the reverse converter.

- **`ConvertBifrostMessagesToAnthropicMessages`**: `code_interpreter_call` is removed from the unsupported-type fallback and handled natively via `convertBifrostCodeExecCallToAnthropicBlocks`.

- **Tests** (`codeexecution_test.go`): four new test cases covering bash non-streaming round-trip (including container and verbatim input), text_editor view round-trip, OpenAI-origin `code_interpreter_call` → Anthropic reconstruction, and a full streaming round-trip (forward + reverse) with container folding and PTC caller verification. Two new schema-level tests verify `WithDefaults()` strips the carry without mutating the source.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... -run TestCodeExecution
go test ./core/schemas/... -run TestWithDefaults
go test ./...
```

Expected: all new `TestCodeExecution_*` and `TestWithDefaults*` tests pass. The bash round-trip test validates container id, verbatim command input, stdout, and block ordering. The streaming test validates the full event sequence (`output_item.added` → `in_progress` → `code.delta` → `code.done` → `interpreting` → `completed` → `output_item.done`) and the reverse reconstruction of `server_tool_use` + `bash_code_execution_tool_result` with the container on `message_delta`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The sandbox container ID and expiry are passed through as opaque strings; no secrets or PII are introduced. The `caller` linkage is structural metadata only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable