### PR TITLE
docs: update ent-v1.5.0 changelog to reflect Secret Manager integration and Generic OIDC Provider instead of `SecretVar`/`EnvVar`

### DIFF
--- a/docs/changelogs/ent-v1.5.0.mdx
+++ b/docs/changelogs/ent-v1.5.0.mdx
@@ -22,7 +22,8 @@ Release on `transports/v1.6.0`. Adds Runware and Runway providers (image and vid
 - **Cluster Discovery Env Refs** - Added `env.VAR_NAME` support to `dns_names` in cluster discovery config, so peer addresses can be supplied from the environment instead of being hard-coded.
 - **Server Logs Config** - Added configurable server logging so log verbosity and output can be tuned per deployment.
 - **Bedrock Streaming Errors** - Bedrock errors on streaming paths now carry the `__type` field, so clients receive a typed error instead of an opaque stream failure.
-- **Secret References** - Added typed `SecretVar` references across config and UI, replacing the old `EnvVar`. References currently resolve from environment variables (`env.VAR_NAME`); the typed form lets config declare where each secret comes from rather than inlining values.
+- **Secret Provider Support** - Connect AWS Secrets Manager, GCP Secret Manager, or HashiCorp Vault so Bifrost can store and read from secrets manager. [Docs](https://docs.getbifrost.ai/enterprise/secret-management)
+- **Generic OIDC Provider and SCIM Support** - Added a standards-compliant OIDC provider (`provider: "generic"`) for SSO and user provisioning with any OIDC-compliant IdP. [Docs](https://docs.getbifrost.ai/enterprise/user-provisioning)
 
 ## 🐞 Fixed
 


### PR DESCRIPTION
## Summary

Updates the Enterprise v1.5.0 changelog to accurately reflect the features shipped in this release, replacing the outdated description of `SecretVar`/`EnvVar` changes with the correct entries for Secret Manager integration and Generic OIDC Provider support.

## Changes

- Updated the release summary line to reference Secret Manager integration (AWS, GCP, HashiCorp Vault) and Generic OIDC Provider instead of the typed `SecretVar` env references.
- Replaced the **Secret References** feature entry with **Secret Manager**, describing runtime resolution of `vault.<path>` references via AWS Secrets Manager, GCP Secret Manager, or HashiCorp Vault, with a link to the relevant docs.
- Added **Generic OIDC Provider and SCIM Support** as a new feature entry, documenting the `provider: "generic"` option for SSO and user provisioning with any OIDC-compliant IdP, with a link to the relevant docs.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the rendered changelog at `docs/changelogs/ent-v1.5.0.mdx` displays the correct feature descriptions and that the embedded documentation links for Secret Manager and Generic OIDC Provider resolve correctly.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None. This is a documentation-only change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable