### PR TITLE
fix: keep token_usage DB-resident in hybrid mode instead of offloading to object storage

### DIFF
--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -643,6 +643,44 @@ func TestHybrid_MetadataIsRetainedInDBAndWrittenToObjectPayload(t *testing.T) {
 	assert.Equal(t, "payments", found.MetadataParsed["team"])
 }
 
+func TestHybrid_TokenUsageStaysInDB(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	inputText := "hello"
+	entry := &Log{
+		ID:        "tokens-1",
+		Timestamp: time.Now().UTC(),
+		Provider:  "anthropic",
+		Model:     "claude-sonnet",
+		Status:    "success",
+		Object:    "chat.completion",
+		InputHistoryParsed: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: &inputText}},
+		},
+		TokenUsageParsed: &schemas.BifrostLLMUsage{
+			PromptTokens:     8,
+			CompletionTokens: 24,
+			TotalTokens:      32,
+		},
+	}
+	require.NoError(t, entry.SerializeFields())
+	require.NoError(t, hybrid.CreateIfNotExists(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	dbLog, err := inner.FindByID(ctx, "tokens-1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, dbLog.TokenUsage, "token_usage JSON must remain in the DB row")
+	assert.Equal(t, 32, dbLog.TotalTokens)
+
+	result, err := hybrid.SearchLogs(ctx, SearchFilters{}, PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, result.Logs, 1)
+	require.NotNil(t, result.Logs[0].TokenUsageParsed)
+	assert.Equal(t, 32, result.Logs[0].TokenUsageParsed.TotalTokens)
+}
+
 func TestHybrid_ContentSummaryIsInputOnly(t *testing.T) {
 	hybrid, inner, _ := newTestHybrid(t)
 	defer hybrid.Close(context.Background())

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -12,9 +12,11 @@ import (
 const maxMCPToolInputPreviewRunes = 200
 
 // payloadFields lists the DB column names of large TEXT fields that are
-// offloaded to object storage in hybrid mode. These fields are never needed
-// for analytics queries (histograms, search, rankings) — only for individual
-// log detail views (FindByID).
+// offloaded to object storage in hybrid mode and cleared from the DB row on
+// write. Small index-friendly fields such as token_usage and metadata are
+// deliberately omitted: they stay DB-resident for list views, sorting, and
+// analytics while still being copied into the object-store snapshot via
+// ExtractPayload when present.
 var payloadFields = []string{
 	"input_history",
 	"responses_input_history",
@@ -43,7 +45,6 @@ var payloadFields = []string{
 	"video_list_output",
 	"video_delete_output",
 	"cache_debug",
-	"token_usage",
 	"error_details",
 	"raw_request",
 	"raw_response",
@@ -83,6 +84,9 @@ func ExtractPayload(l *Log) map[string]string {
 	m["video_list_output"] = l.VideoListOutput
 	m["video_delete_output"] = l.VideoDeleteOutput
 	m["cache_debug"] = l.CacheDebug
+	// token_usage is written to the snapshot for object consumers but is not
+	// part of payloadFields: it must stay DB-resident for log-list display and
+	// token sorting without hydrating every row from object storage.
 	m["token_usage"] = l.TokenUsage
 	m["error_details"] = l.ErrorDetails
 	m["raw_request"] = l.RawRequest
@@ -136,7 +140,6 @@ func ClearPayload(l *Log) {
 	l.VideoListOutput = ""
 	l.VideoDeleteOutput = ""
 	l.CacheDebug = ""
-	l.TokenUsage = ""
 	l.ErrorDetails = ""
 	l.RawRequest = ""
 	l.RawResponse = ""
@@ -172,7 +175,6 @@ func ClearPayload(l *Log) {
 	l.VideoListOutputParsed = nil
 	l.VideoDeleteOutputParsed = nil
 	l.CacheDebugParsed = nil
-	l.TokenUsageParsed = nil
 	l.ErrorDetailsParsed = nil
 }
 

--- a/framework/logstore/payload_test.go
+++ b/framework/logstore/payload_test.go
@@ -50,7 +50,7 @@ func TestExtractPayload_RoundTrip(t *testing.T) {
 	}
 
 	payload := ExtractPayload(log)
-	assert.Equal(t, len(payloadFields)+1, len(payload), "payload map should have all payload fields plus metadata")
+	assert.Equal(t, len(payloadFields)+2, len(payload), "payload map should have all payload fields plus token_usage and metadata")
 	assert.Equal(t, `[{"role":"user","content":"hello"}]`, payload["input_history"])
 	assert.Equal(t, `{"role":"assistant","content":"world"}`, payload["output_message"])
 	assert.Equal(t, `routing log`, payload["routing_engine_logs"])
@@ -64,6 +64,7 @@ func TestExtractPayload_RoundTrip(t *testing.T) {
 	assert.Empty(t, log.RoutingEngineLogs)
 	require.NotNil(t, log.Metadata)
 	assert.Equal(t, metadata, *log.Metadata)
+	assert.Equal(t, `{"total_tokens":100}`, log.TokenUsage, "token_usage must stay DB-resident like metadata")
 
 	// Marshal and merge back.
 	data, err := MarshalPayload(payload)
@@ -281,6 +282,19 @@ func TestPayloadFieldNames(t *testing.T) {
 	// Verify it's a copy.
 	fields[0] = "modified"
 	assert.NotEqual(t, "modified", payloadFields[0])
+}
+
+func TestDeserializeFields_TokenUsageFromDenormalizedColumns(t *testing.T) {
+	log := &Log{
+		PromptTokens:     8,
+		CompletionTokens: 24,
+		TotalTokens:      32,
+	}
+	require.NoError(t, log.DeserializeFields())
+	require.NotNil(t, log.TokenUsageParsed)
+	assert.Equal(t, 8, log.TokenUsageParsed.PromptTokens)
+	assert.Equal(t, 24, log.TokenUsageParsed.CompletionTokens)
+	assert.Equal(t, 32, log.TokenUsageParsed.TotalTokens)
 }
 
 func strPtr(s string) *string {

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -727,6 +727,16 @@ func (l *Log) DeserializeFields() error {
 			l.TokenUsageParsed = nil
 		}
 	}
+	// Hybrid object storage clears token_usage from older rows but keeps the
+	// denormalized prompt/completion/total columns. Rebuild token_usage for list
+	// responses when the JSON column is empty.
+	if l.TokenUsageParsed == nil && (l.PromptTokens > 0 || l.CompletionTokens > 0 || l.TotalTokens > 0) {
+		l.TokenUsageParsed = &schemas.BifrostLLMUsage{
+			PromptTokens:     l.PromptTokens,
+			CompletionTokens: l.CompletionTokens,
+			TotalTokens:      l.TotalTokens,
+		}
+	}
 
 	if l.ErrorDetails != "" {
 		if err := sonic.Unmarshal([]byte(l.ErrorDetails), &l.ErrorDetailsParsed); err != nil {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1472,7 +1472,7 @@
         },
         "object_storage_exclude_fields": {
           "type": "array",
-          "description": "LLM log payload field DB column names that should NOT be offloaded to object storage and must remain in the database (e.g. output_message, input_history, raw_request, raw_response). Unknown names are ignored. MCP logs always offload the full log and keep dashboard/table fields plus a 200-character input preview in the database.",
+          "description": "LLM log payload field DB column names that should NOT be offloaded to object storage and must remain in the database (e.g. output_message, input_history, raw_request, raw_response). token_usage is always kept in the database and does not need to be listed. Unknown names are ignored. MCP logs always offload the full log and keep dashboard/table fields plus a 200-character input preview in the database.",
           "items": {
             "type": "string"
           }


### PR DESCRIPTION
## Summary

In hybrid mode, `token_usage` was being offloaded to object storage and cleared from the database row, causing token counts to be unavailable in log list views and breaking token-based sorting without fetching every object from storage. This PR keeps `token_usage` DB-resident (like `metadata`) while still including it in the object-store snapshot for downstream consumers.

## Changes

- Removed `token_usage` from `payloadFields` so it is no longer cleared from the DB row during hybrid offload.
- Removed `token_usage` and `TokenUsageParsed` from `ClearPayload` so the JSON column and parsed struct are preserved after upload.
- `ExtractPayload` continues to write `token_usage` into the object-store snapshot so object consumers still receive the full payload.
- Added a fallback in `DeserializeFields` to reconstruct `TokenUsageParsed` from the denormalized `prompt_tokens`, `completion_tokens`, and `total_tokens` columns for older rows where the JSON column was previously cleared.
- Updated the `object_storage_exclude_fields` schema description to note that `token_usage` is always kept in the database and does not need to be listed explicitly.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/logstore/...
```

The new `TestHybrid_TokenUsageStaysInDB` test verifies that after a log is written and uploaded in hybrid mode, the `token_usage` JSON column and `TotalTokens` remain in the DB row and are returned correctly by `SearchLogs`. `TestDeserializeFields_TokenUsageFromDenormalizedColumns` verifies the fallback reconstruction path for older rows.

## Breaking changes

- [x] No

## Security considerations

No security implications. This change only affects which columns are retained in the database versus offloaded to object storage.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable