### PR TITLE
[fix]: route mantle-only Bedrock models via catalog instead of name heuristic

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -43,6 +43,7 @@ type BedrockProvider struct {
 	customProviderConfig  *schemas.CustomProviderConfig // Custom provider config
 	sendBackRawRequest    bool                          // Whether to include raw request in BifrostResponse
 	sendBackRawResponse   bool                          // Whether to include raw response in BifrostResponse
+	mantleRegistry        *mantleRegistry               // Per-AWS-region cache of mantle-only models, populated by ListModels and consulted for routing
 }
 
 // assumeRoleCredsCache caches *aws.CredentialsCache instances keyed by the
@@ -155,6 +156,7 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 		customProviderConfig:  config.CustomProviderConfig,
 		sendBackRawRequest:    config.SendBackRawRequest,
 		sendBackRawResponse:   config.SendBackRawResponse,
+		mantleRegistry:        newMantleRegistry(),
 	}, nil
 }
 
@@ -864,18 +866,24 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 
 	// Merge in the mantle catalog: ListFoundationModels omits the mantle-only models
 	// (gpt-5.x, gemma-4, ...) served on the OpenAI-compatible endpoint. Same gating, dedup by id.
+	// Record each appended model in mantleRegistry so request routing can recognize it without
+	// the name-substring heuristic. Models present in both catalogs (e.g. Gemma 3, which has a
+	// Converse fallback) never get appended here, so they stay on the Converse path.
 	if mantleResponse := provider.listMantleModels(ctx, key, region, request.Unfiltered); mantleResponse != nil {
 		seen := make(map[string]struct{}, len(response.Data))
 		for _, m := range response.Data {
 			seen[m.ID] = struct{}{}
 		}
+		mantleOnly := make([]string, 0, len(mantleResponse.Data))
 		for _, m := range mantleResponse.Data {
 			if _, ok := seen[m.ID]; ok {
 				continue
 			}
 			seen[m.ID] = struct{}{}
 			response.Data = append(response.Data, m)
+			mantleOnly = append(mantleOnly, m.ID)
 		}
+		provider.mantleRegistry.addRegion(region, mantleOnly)
 	}
 
 	response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
@@ -1139,7 +1147,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 		return nil, err
 	}
 
-	if isMantleModel(schemas.ResolveCanonicalModel(ctx, request.Model)) {
+	if provider.shouldRouteToMantle(ctx, key, request.Model) {
 		return provider.chatCompletionViaMantle(ctx, key, request)
 	}
 
@@ -1231,7 +1239,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 		return nil, err
 	}
 
-	if isMantleModel(schemas.ResolveCanonicalModel(ctx, request.Model)) {
+	if provider.shouldRouteToMantle(ctx, key, request.Model) {
 		return provider.chatCompletionStreamViaMantle(ctx, postHookRunner, postHookSpanFinalizer, key, request)
 	}
 
@@ -1559,7 +1567,7 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 		return nil, err
 	}
 
-	if isMantleModel(schemas.ResolveCanonicalModel(ctx, request.Model)) {
+	if provider.shouldRouteToMantle(ctx, key, request.Model) {
 		return provider.responsesViaMantle(ctx, key, request)
 	}
 
@@ -1631,7 +1639,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 		return nil, err
 	}
 
-	if isMantleModel(schemas.ResolveCanonicalModel(ctx, request.Model)) {
+	if provider.shouldRouteToMantle(ctx, key, request.Model) {
 		return provider.responsesStreamViaMantle(ctx, postHookRunner, postHookSpanFinalizer, key, request)
 	}
 

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -13,12 +13,30 @@ import (
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
-// isMantleModel reports whether a model should be routed via the Bedrock Mantle endpoint.
-// Accepts "gpt-*"/"gemma-4-*", "openai.gpt-*"/"google.gemma-4-*", or region-prefixed variants.
-// Gemma 3 is intentionally excluded: it only supports Chat (not Responses) on mantle, and the
-// non-mantle path serves both APIs via Converse, so forcing it to mantle would break Responses.
-func isMantleModel(model string) bool {
+// matchesMantleModelNameHeuristic guesses, from the model name alone, whether a model
+// is mantle-served. It is a fallback for when the authoritative mantle-only registry
+// has not been populated yet (see shouldRouteToMantle) — not a definitive check.
+// Matches "gpt-*"/"gemma-4-*", "openai.gpt-*"/"google.gemma-4-*", or region-prefixed
+// variants. Gemma 3 is intentionally excluded: it only supports Chat (not Responses)
+// on mantle, and the non-mantle path serves both APIs via Converse, so forcing it to
+// mantle would break Responses.
+func matchesMantleModelNameHeuristic(model string) bool {
 	return strings.Contains(model, "gpt-") || strings.Contains(model, "gemma-4")
+}
+
+// shouldRouteToMantle decides whether a request should go to the Bedrock Mantle
+// endpoint. It prefers the authoritative signal — membership in the mantle-only
+// registry populated by ListModels — and falls back to the name heuristic
+// (matchesMantleModelNameHeuristic) before the registry is populated (cold start)
+// or when the model was never observed. This unblocks mantle-only models whose names
+// don't contain "gpt-"/"gemma-4" without regressing models the heuristic handled.
+func (provider *BedrockProvider) shouldRouteToMantle(ctx *schemas.BifrostContext, key schemas.Key, model string) bool {
+	canonical := schemas.ResolveCanonicalModel(ctx, model)
+	if matchesMantleModelNameHeuristic(canonical) {
+		return true
+	}
+	awsRegion := resolveBedrockRegion(ctx, key, model)
+	return provider.mantleRegistry.isMantleOnly(awsRegion, canonical)
 }
 
 // mantleURL builds the Bedrock Mantle endpoint URL for the given region, model, and API path.

--- a/core/providers/bedrock/mantle_registry.go
+++ b/core/providers/bedrock/mantle_registry.go
@@ -58,13 +58,14 @@ func (r *mantleRegistry) addRegion(awsRegion string, ids []string) {
 // pre-registry behavior).
 func (r *mantleRegistry) isMantleOnly(awsRegion, model string) bool {
 	r.mu.RLock()
+	defer r.mu.RUnlock()
 	set := r.byRegion[awsRegion]
-	r.mu.RUnlock()
 	if set == nil {
 		return false
 	}
 	_, ok := set[bareMantleID(model)]
 	return ok
+}
 }
 
 // mantlePrefixRegex matches the leading prefixes of a Bedrock model ID that carry

--- a/core/providers/bedrock/mantle_registry.go
+++ b/core/providers/bedrock/mantle_registry.go
@@ -66,7 +66,6 @@ func (r *mantleRegistry) isMantleOnly(awsRegion, model string) bool {
 	_, ok := set[bareMantleID(model)]
 	return ok
 }
-}
 
 // mantlePrefixRegex matches the leading prefixes of a Bedrock model ID that carry
 // no identity of their own and must be stripped before comparison:

--- a/core/providers/bedrock/mantle_registry.go
+++ b/core/providers/bedrock/mantle_registry.go
@@ -1,0 +1,96 @@
+package bedrock
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// mantleRegistry caches, per AWS region, the set of models that are served ONLY
+// by the Bedrock Mantle endpoint (i.e. present in the mantle /v1/models catalog
+// but absent from ListFoundationModels). Membership is the authoritative signal
+// for routing a request to mantle, replacing the name-substring heuristic for any
+// model that has been observed via ListModels.
+//
+// Keyed by AWS region because mantle availability is region-specific: a model can
+// be mantle-only in one region and absent (or Converse-served) in another, so the
+// routing decision must match the region the request will actually hit.
+//
+// Why "mantle-only" and not merely "in the mantle catalog": some models (e.g.
+// Gemma 3) appear on mantle for Chat but also have a Converse fallback that
+// serves both Chat and Responses. Routing those to mantle would break Responses.
+// A model that is mantle-only has no Converse fallback, so it must go to mantle.
+// See shouldRouteToMantle for how this composes with the name heuristic.
+type mantleRegistry struct {
+	mu       sync.RWMutex
+	byRegion map[string]map[string]struct{} // region -> set of bare mantle-only model names
+}
+
+func newMantleRegistry() *mantleRegistry {
+	return &mantleRegistry{byRegion: make(map[string]map[string]struct{})}
+}
+
+// addRegion records the given catalog IDs as mantle-only for a region. IDs are
+// normalized to bare form so lookups are insensitive to region/vendor prefixes.
+// The set only grows (union, not replace): ListModels populates per key
+// concurrently and different keys may surface different filtered subsets for the
+// same region, so unioning avoids one key's write clobbering another's. Stale
+// entries aren't worth evicting — the mantle-only catalog is small and stable,
+// and a routing miss harmlessly falls back to the Converse path.
+func (r *mantleRegistry) addRegion(awsRegion string, ids []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	set := r.byRegion[awsRegion]
+	if set == nil {
+		set = make(map[string]struct{}, len(ids))
+		r.byRegion[awsRegion] = set
+	}
+	for _, id := range ids {
+		if bare := bareMantleID(id); bare != "" {
+			set[bare] = struct{}{}
+		}
+	}
+}
+
+// isMantleOnly reports whether model is known to be mantle-only in the given
+// region. Returns false before ListModels has populated the region, in which case
+// routing falls back to the legacy name heuristic (never worse than the
+// pre-registry behavior).
+func (r *mantleRegistry) isMantleOnly(awsRegion, model string) bool {
+	r.mu.RLock()
+	set := r.byRegion[awsRegion]
+	r.mu.RUnlock()
+	if set == nil {
+		return false
+	}
+	_, ok := set[bareMantleID(model)]
+	return ok
+}
+
+// mantlePrefixRegex matches the leading prefixes of a Bedrock model ID that carry
+// no identity of their own and must be stripped before comparison:
+//   - an optional "region/" path prefix (e.g. "us-east-1/"), reusing the shared
+//     awsRegionPattern so the definition of a region lives in exactly one place;
+//   - the namespace segments — runs of pure ASCII letters each followed by '.' —
+//     which cover both the vendor prefix ("openai.", "deepseek.", "zai.", ...) and
+//     any cross-region inference-profile prefix ("us.", "eu.", "global.").
+//
+// The namespace rule is structural rather than a hardcoded vendor list: real model
+// tokens always carry a digit or dash ("gpt-5.5", "v3.1", "glm-4.6"), so a version
+// dot is never matched and new vendors need no code change.
+var mantlePrefixRegex = regexp.MustCompile(`^(?:` + awsRegionPattern + `/)?(?:[a-z]+\.)*`)
+
+// bareMantleID normalizes a model identifier to a prefix-insensitive form so that
+// the registry (populated from catalog IDs) and routing lookups (using the
+// requested model) agree regardless of region-path, geo, or vendor prefixes.
+//
+// Examples:
+//
+//	"us-east-1/openai.gpt-oss-120b" -> "gpt-oss-120b"
+//	"us.openai.gpt-oss-120b"        -> "gpt-oss-120b"
+//	"deepseek.v3.1"                 -> "v3.1"
+//	"gpt-5.5"                       -> "gpt-5.5"  (version dot preserved)
+func bareMantleID(model string) string {
+	s := strings.ToLower(strings.TrimSpace(model))
+	return mantlePrefixRegex.ReplaceAllString(s, "")
+}

--- a/core/providers/bedrock/mantle_registry_test.go
+++ b/core/providers/bedrock/mantle_registry_test.go
@@ -1,0 +1,82 @@
+package bedrock
+
+import "testing"
+
+func TestBareMantleID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// region path prefix
+		{"us-east-1/openai.gpt-oss-120b", "gpt-oss-120b"},
+		// geo inference-profile prefix
+		{"us.openai.gpt-oss-120b", "gpt-oss-120b"},
+		{"eu.google.gemma-4-31b", "gemma-4-31b"},
+		// vendor prefix only
+		{"google.gemma-4-31b", "gemma-4-31b"},
+		{"openai.gpt-5.5", "gpt-5.5"},
+		// other mantle vendors (regression: all known prefixes must strip)
+		{"deepseek.v3.1", "v3.1"},
+		{"zai.glm-4.6", "glm-4.6"},
+		{"qwen.qwen3-235b-a22b-2507", "qwen3-235b-a22b-2507"},
+		{"qwen.qwen3-coder-480b-a35b-instruct", "qwen3-coder-480b-a35b-instruct"},
+		{"us.qwen.qwen3-32b", "qwen3-32b"},
+		// bare names unchanged; version dot preserved
+		{"gpt-5.5", "gpt-5.5"},
+		{"gpt-oss-120b", "gpt-oss-120b"},
+		// case + whitespace normalization
+		{"  OpenAI.GPT-OSS-120B  ", "gpt-oss-120b"},
+		// empty
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := bareMantleID(tc.in); got != tc.want {
+			t.Errorf("bareMantleID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMantleRegistry(t *testing.T) {
+	r := newMantleRegistry()
+
+	// Cold start: nothing observed yet → not mantle-only for any region.
+	if r.isMantleOnly("us-east-1", "some-new-mantle-model") {
+		t.Fatal("expected cold-start registry to report false")
+	}
+
+	// Populate us-east-1 with a mantle-only catalog (as ListModels would).
+	r.addRegion("us-east-1", []string{
+		"openai.gpt-oss-120b",
+		"some-new-mantle-model", // a model the name heuristic would miss
+	})
+
+	// Looked up via various prefix forms → all resolve to the bare id.
+	for _, m := range []string{
+		"some-new-mantle-model",
+		"us.some-new-mantle-model",
+		"us-east-1/some-new-mantle-model",
+	} {
+		if !r.isMantleOnly("us-east-1", m) {
+			t.Errorf("expected %q to be mantle-only in us-east-1", m)
+		}
+	}
+
+	// Region isolation: the same model in an unpopulated region is unknown.
+	if r.isMantleOnly("eu-west-1", "some-new-mantle-model") {
+		t.Error("expected model to be unknown in a region with no catalog")
+	}
+
+	// A model not in the catalog is not mantle-only.
+	if r.isMantleOnly("us-east-1", "claude-opus-4-8") {
+		t.Error("expected non-catalog model to report false")
+	}
+
+	// addRegion accumulates (union) rather than replacing the region's set.
+	r.addRegion("us-east-1", []string{"google.gemma-4-31b"})
+	if !r.isMantleOnly("us-east-1", "some-new-mantle-model") {
+		t.Error("expected earlier entry to survive a later addRegion()")
+	}
+	if !r.isMantleOnly("us-east-1", "gemma-4-31b") {
+		t.Error("expected newly added entry to be present")
+	}
+}

--- a/core/providers/bedrock/mantle_test.go
+++ b/core/providers/bedrock/mantle_test.go
@@ -2,7 +2,7 @@ package bedrock
 
 import "testing"
 
-func TestIsMantleModel(t *testing.T) {
+func TestMatchesMantleModelNameHeuristic(t *testing.T) {
 	cases := []struct {
 		model string
 		want  bool
@@ -30,8 +30,8 @@ func TestIsMantleModel(t *testing.T) {
 		{"amazon.titan-text-express-v1", false},
 	}
 	for _, tc := range cases {
-		if got := isMantleModel(tc.model); got != tc.want {
-			t.Errorf("isMantleModel(%q) = %v, want %v", tc.model, got, tc.want)
+		if got := matchesMantleModelNameHeuristic(tc.model); got != tc.want {
+			t.Errorf("matchesMantleModelNameHeuristic(%q) = %v, want %v", tc.model, got, tc.want)
 		}
 	}
 }

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -19,10 +19,14 @@ import (
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
-// awsRegionRegex matches valid AWS region identifiers (e.g. "us-east-1", "eu-north-1", "us-gov-east-1").
-// (?:-[a-z]+)+ allows multi-segment directional parts so GovCloud regions (us-gov-east-1) are
-// recognised alongside standard single-segment ones (eu-north-1, ap-southeast-2).
-var awsRegionRegex = regexp.MustCompile(`^[a-z]{2,3}(?:-[a-z]+)+-\d+$`)
+// awsRegionPattern matches a valid AWS region identifier (e.g. "us-east-1", "eu-north-1",
+// "us-gov-east-1"). (?:-[a-z]+)+ allows multi-segment directional parts so GovCloud regions
+// (us-gov-east-1) are recognised alongside standard single-segment ones (eu-north-1,
+// ap-southeast-2). Unanchored so it can be composed into larger patterns (see bareMantleID).
+const awsRegionPattern = `[a-z]{2,3}(?:-[a-z]+)+-\d+`
+
+// awsRegionRegex matches a string that is exactly an AWS region identifier.
+var awsRegionRegex = regexp.MustCompile(`^` + awsRegionPattern + `$`)
 var bedrockUnsafeToolNameCharRegex = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
 
 // bedrockToolNameAliasKey stores Bedrock wire-name aliases on the request context.


### PR DESCRIPTION
Mantle-only Bedrock models whose IDs don't contain `gpt-` or `gemma-4` (10+ models) are currently un-callable through Bifrost: they miss the `isMantleModel` name heuristic, get routed to the traditional Converse endpoint, and fail because Converse doesn't serve them. These are directly callable against the mantle endpoint but unreachable through Bifrost today:

```
deepseek.v3.1
zai.glm-4.6
qwen.qwen3-235b-a22b-2507
qwen.qwen3-32b
qwen.qwen3-coder-30b-a3b-instruct
qwen.qwen3-coder-480b-a35b-instruct
qwen.qwen3-next-80b-a3b-instruct
qwen.qwen3-vl-235b-a22b-instruct
```

This makes routing consult the authoritative mantle catalog (already fetched by `ListModels` since #4677) instead of relying solely on the name substring. A model is routed to mantle if it is **mantle-only** — present in the mantle `/v1/models` catalog but absent from `ListFoundationModels` — which is exactly the set the existing merge loop computes. The legacy name heuristic is retained as a cold-start fallback, so behavior is never worse than today.

Models present in both catalogs (e.g. Gemma 3, which has a Converse fallback for Responses) are intentionally **not** treated as mantle-only, preserving current behavior asserted by `mantle_test.go`.

## Type of Change

- [x] Bug fix

## Affected Packages

- `core/providers/bedrock/` — mantle routing + per-region mantle-only registry

## Changes Made

- Add `mantleRegistry` (`core/providers/bedrock/mantle_registry.go`): per-region cache of mantle-only model IDs with prefix-insensitive normalization (`bareMantleID` strips region/geo/vendor prefixes; preserves version dots).
- Populate the registry as a side effect of `listModelsByKey`'s existing mantle merge loop (the appended models are exactly the mantle-only set).
- Add `BedrockProvider.shouldRouteToMantle`: legacy heuristic OR registry membership for the request's region. Wire it into all four routing sites (`ChatCompletion`, `ChatCompletionStream`, `Responses`, `ResponsesStream`).
- `isMantleModel` / `mantleURL` are unchanged (base-path selection untouched).

## Testing

- [x] Unit tests added (`mantle_registry_test.go`): `bareMantleID` normalization, registry set/lookup, region isolation, cold-start fallback, replace-on-set.
- [x] Existing `TestIsMantleModel` / `TestMantleURL` still pass (no regression).
- [x] `go build ./...`, `go vet`, and `go test ./providers/bedrock/` pass.

```sh
cd core
go test ./providers/bedrock/ -v -run 'Mantle|BareMantle'
```

## Open question (flagged for maintainers)

Base-path selection (`v1` vs `openai/v1`) is left heuristic. If the `/v1/models` response exposes which surface a model uses, a follow-up can make that catalog-driven too. See the linked issue.

## Checklist

- [x] Code follows the project's code style
- [x] Tests pass locally
- [ ] Documentation updated if needed (n/a — internal routing behavior)
- [x] No breaking changes
- [x] Commit messages follow `[type]: description`
- [x] Affected packages listed
- [x] Changelog entry — added to `core/changelog.md`

## Related Issues

Addresses #4673
Relates to #4676, #4677
