### PR TITLE
feat: add `bedrock_mantle` as a first-class provider with native-Anthropic and OpenAI-compatible routing

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -24,6 +24,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/azure"
 	"github.com/maximhq/bifrost/core/providers/bedrock"
+	"github.com/maximhq/bifrost/core/providers/bedrockmantle"
 	"github.com/maximhq/bifrost/core/providers/cerebras"
 	"github.com/maximhq/bifrost/core/providers/cohere"
 	"github.com/maximhq/bifrost/core/providers/elevenlabs"
@@ -40,8 +41,8 @@ import (
 	"github.com/maximhq/bifrost/core/providers/parasail"
 	"github.com/maximhq/bifrost/core/providers/perplexity"
 	"github.com/maximhq/bifrost/core/providers/replicate"
-	"github.com/maximhq/bifrost/core/providers/runway"
 	"github.com/maximhq/bifrost/core/providers/runware"
+	"github.com/maximhq/bifrost/core/providers/runway"
 	"github.com/maximhq/bifrost/core/providers/sgl"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/providers/vertex"
@@ -4010,6 +4011,8 @@ func (bifrost *Bifrost) createBaseProvider(providerKey schemas.ModelProvider, co
 		return anthropic.NewAnthropicProvider(config, bifrost.logger), nil
 	case schemas.Bedrock:
 		return bedrock.NewBedrockProvider(config, bifrost.logger)
+	case schemas.BedrockMantle:
+		return bedrockmantle.NewBedrockMantleProvider(config, bifrost.logger)
 	case schemas.Cohere:
 		return cohere.NewCohereProvider(config, bifrost.logger)
 	case schemas.Azure:

--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -162,6 +162,7 @@ func (account *ComprehensiveTestAccount) GetConfiguredProviders() ([]schemas.Mod
 		schemas.OpenAI,
 		schemas.Anthropic,
 		schemas.Bedrock,
+		schemas.BedrockMantle,
 		schemas.Cohere,
 		schemas.Azure,
 		schemas.Vertex,
@@ -288,6 +289,28 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 					SessionToken: schemas.NewSecretVar("env.AWS_SESSION_TOKEN"),
 					Region:       schemas.NewSecretVar(getEnvWithDefault("AWS_REGION", "us-east-1")),
 				},
+			},
+		}, nil
+	case schemas.BedrockMantle:
+		// A single Bedrock Mantle endpoint serves the whole catalog (see /v1/models), so one key
+		// serves all models ("*"). The native-Anthropic surface uses "anthropic.{model}" ids (no
+		// cross-region prefix or version suffix); the OpenAI-compatible surface uses
+		// "openai.{model}" / "google.{model}".
+		return []schemas.Key{
+			{
+				Models: []string{"*"},
+				Weight: 1.0,
+				BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{
+					AccessKey:    *schemas.NewSecretVar("env.AWS_ACCESS_KEY_ID"),
+					SecretKey:    *schemas.NewSecretVar("env.AWS_SECRET_ACCESS_KEY"),
+					SessionToken: schemas.NewSecretVar("env.AWS_SESSION_TOKEN"),
+					Region:       schemas.NewSecretVar(getEnvWithDefault("AWS_REGION", "us-east-1")),
+				},
+				// Mantle does not support batch/file ops, but the key must pass the batch-key
+				// filter so those requests reach the provider's unsupported-operation stub
+				// (the BatchUnsupported/FileUnsupported harness checks), as other non-batch
+				// providers (e.g. Cohere) do.
+				UseForBatchAPI: bifrost.Ptr(true),
 			},
 		}, nil
 	case schemas.Cohere:
@@ -592,6 +615,19 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 			},
 		}, nil
 	case schemas.Bedrock:
+		return &schemas.ProviderConfig{
+			NetworkConfig: schemas.NetworkConfig{
+				DefaultRequestTimeoutInSeconds: 120,
+				MaxRetries:                     10, // AWS services can have occasional issues
+				RetryBackoffInitial:            5 * time.Second,
+				RetryBackoffMax:                40 * time.Second,
+			},
+			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+				Concurrency: Concurrency,
+				BufferSize:  10,
+			},
+		}, nil
+	case schemas.BedrockMantle:
 		return &schemas.ProviderConfig{
 			NetworkConfig: schemas.NetworkConfig{
 				DefaultRequestTimeoutInSeconds: 120,

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -410,8 +410,9 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 			anthropicReq.MCPServers = servers
 		}
 		if bifrostReq.Params.ResponseFormat != nil {
-			// Vertex doesn't support native structured outputs, so convert to tool
-			if bifrostReq.Provider == schemas.Vertex {
+			// Vertex and Bedrock Mantle don't accept native structured outputs
+			// (output_config.format), so convert to a tool instead.
+			if bifrostReq.Provider == schemas.Vertex || bifrostReq.Provider == schemas.BedrockMantle {
 				responseFormatTool := convertChatResponseFormatToTool(ctx, bifrostReq.Params)
 				if responseFormatTool != nil {
 					anthropicReq.Tools = append(anthropicReq.Tools, *responseFormatTool)

--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -105,6 +105,13 @@ var AnthropicProviderRequestDefaultsMap = map[schemas.ModelProvider]AnthropicPro
 	schemas.Bedrock: {
 		RemapToolVersions: true,
 	},
+	// Bedrock Mantle shares the Bedrock native-Anthropic request shape (model in
+	// body, anthropic-version HTTP header, tool versions remapped). It has its own
+	// entry so its feature surface in ProviderFeatures can diverge from Bedrock's
+	// Converse path without coupling the two.
+	schemas.BedrockMantle: {
+		RemapToolVersions: true,
+	},
 	// Vertex publisher endpoint: model + region in URL, anthropic_version
 	// required, beta headers in body (not HTTP), cache_control.scope stripped
 	// at marshal time, tool versions remapped.

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2637,8 +2637,9 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 			}
 		}
 		if bifrostReq.Params.Text != nil {
-			// Vertex doesn't support native structured outputs, so convert to tool
-			if bifrostReq.Provider == schemas.Vertex {
+			// Vertex and Bedrock Mantle don't accept native structured outputs
+			// (output_config.format), so convert to a tool instead.
+			if bifrostReq.Provider == schemas.Vertex || bifrostReq.Provider == schemas.BedrockMantle {
 				if bifrostReq.Params.Text.Format != nil {
 					responseFormatTool := convertResponsesTextFormatToTool(ctx, bifrostReq.Params.Text)
 					if responseFormatTool != nil {

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -214,6 +214,32 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		// narrow tool-examples-2025-10-29 header is, gated via InputExamples above.
 		ServiceTier: true, // Bedrock handles service_tier via its own typed conversion
 	},
+	// Bedrock Mantle — same AWS-hosted Claude models as Bedrock, reached through
+	// the native Anthropic Messages surface (/anthropic/v1/messages) instead of
+	// Converse. Feature support is a property of the model+cloud, so this mirrors
+	// schemas.Bedrock — with one deliberate exception: the *Nova flags below.
+	//
+	// WebSearchNova / CodeExecNova are intentionally OFF here. They exist only to
+	// keep web_search / code_interpreter tools so the Bedrock Converse/Responses
+	// converter can rewrite them into nova_grounding / nova_code_interpreter.
+	// Mantle uses the native Anthropic body builder, which never runs that
+	// conversion, so leaving them on would forward an un-rewritten web_search /
+	// code_interpreter tool that the endpoint rejects. Mantle's native surface
+	// does not support the Anthropic web_search / code_execution server tools
+	// either, so both stay false (no WebSearch / CodeExecution).
+	schemas.BedrockMantle: {
+		ComputerUse: true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
+		ContainerBasic:         true,
+		StructuredOutputs:      true,
+		Compaction:             true,
+		ContextEditing:         true,
+		ContextManagementField: true,
+		InterleavedThinking:    true,
+		Context1M:              true,
+		EagerInputStreaming:    true,
+		InputExamples:          true,
+		ServiceTier:            true,
+	},
 	// Microsoft Azure AI Foundry — cite: A (most features azureAiBeta) +
 	// Az-platform ("supports most of Claude's features"). Excluded per
 	// Az-platform: Admin API, Models API, Message Batch API (not in scope).

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -237,7 +237,7 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
 	} else {
 		// Sign the request using either explicit credentials or IAM role authentication
-		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, bedrockSigningService); err != nil {
+		if err := signAWSRequest(ctx, req, config, region, bedrockSigningService); err != nil {
 			return nil, 0, nil, err
 		}
 	}
@@ -371,7 +371,7 @@ func (provider *BedrockProvider) completeAgentRuntimeRequest(ctx *schemas.Bifros
 	if key.Value.GetValue() != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
 	} else {
-		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, bedrockSigningService); err != nil {
+		if err := signAWSRequest(ctx, req, config, region, bedrockSigningService); err != nil {
 			return nil, 0, nil, err
 		}
 	}
@@ -472,7 +472,7 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
 	} else {
 		// Sign the request using either explicit credentials or IAM role authentication
-		if err := signAWSRequest(ctx, req, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService); err != nil {
+		if err := signAWSRequest(ctx, req, key.BedrockKeyConfig, region, bedrockSigningService); err != nil {
 			return nil, err
 		}
 	}
@@ -532,45 +532,25 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 	return resp, nil
 }
 
-// signAWSRequest signs an HTTP request using AWS Signature Version 4.
-// It is used in providers like Bedrock.
-// It sets required headers, calculates the request body hash, and signs the request
-// using the provided AWS credentials.
-// signAWSRequestFromKey is a convenience wrapper around signAWSRequest that reads
-// credentials from a BedrockKeyConfig. When cfg is nil (no explicit key configured),
-// all credential fields are zero-valued, causing signAWSRequest to fall back to the
-// default AWS credential chain (IAM role, env vars, instance profile, etc.).
-func signAWSRequestFromKey(
-	ctx *schemas.BifrostContext,
-	req *http.Request,
-	cfg *schemas.BedrockKeyConfig,
-	region, service string,
-) *schemas.BifrostError {
-	if cfg != nil {
-		return signAWSRequest(ctx, req,
-			cfg.AccessKey, cfg.SecretKey,
-			cfg.SessionToken, cfg.RoleARN,
-			cfg.ExternalID, cfg.RoleSessionName,
-			region, service)
-	}
-	// No config: pass zero SecretVar values so signAWSRequest uses the default chain.
-	return signAWSRequest(ctx, req,
-		schemas.SecretVar{}, schemas.SecretVar{},
-		nil, nil, nil, nil,
-		region, service)
-}
-
 // Returns a BifrostError if signing fails.
 func signAWSRequest(
 	ctx *schemas.BifrostContext,
 	req *http.Request,
-	accessKey, secretKey schemas.SecretVar,
-	sessionToken *schemas.SecretVar,
-	roleARN *schemas.SecretVar,
-	externalID *schemas.SecretVar,
-	sessionName *schemas.SecretVar,
+	keyCfg *schemas.BedrockKeyConfig,
 	region, service string,
 ) *schemas.BifrostError {
+	var accessKey, secretKey schemas.SecretVar
+	var sessionToken, roleARN, externalID, sessionName *schemas.SecretVar
+
+	if keyCfg != nil {
+		accessKey = keyCfg.AccessKey
+		secretKey = keyCfg.SecretKey
+		sessionToken = keyCfg.SessionToken
+		roleARN = keyCfg.RoleARN
+		externalID = keyCfg.ExternalID
+		sessionName = keyCfg.RoleSessionName
+	}
+
 	// Set required headers before signing (only if not already set)
 	if req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
@@ -714,7 +694,7 @@ func (provider *BedrockProvider) listMantleModels(ctx *schemas.BifrostContext, k
 	providerUtils.SetExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	if key.Value.GetValue() != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
-	} else if bifrostErr := signAWSRequestFromKey(ctx, req, key.BedrockKeyConfig, region, bedrockMantleSigningService); bifrostErr != nil {
+	} else if bifrostErr := signAWSRequest(ctx, req, key.BedrockKeyConfig, region, bedrockMantleSigningService); bifrostErr != nil {
 		provider.logger.Warn("failed to sign mantle list-models request: %v", bifrostErr.Error.Message)
 		return nil
 	}
@@ -792,7 +772,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	} else {
 		// Sign the request using either explicit credentials or IAM role authentication
 
-		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, bedrockSigningService); err != nil {
+		if err := signAWSRequest(ctx, req, config, region, bedrockSigningService); err != nil {
 			return nil, err
 		}
 	}
@@ -2452,7 +2432,7 @@ func (provider *BedrockProvider) FileUpload(ctx *schemas.BifrostContext, key sch
 	httpReq.ContentLength = int64(len(request.File))
 
 	// Sign request for S3
-	if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "s3"); err != nil {
+	if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, "s3"); err != nil {
 		provider.logger.Error("error signing request: %s", err.Error.Message)
 		return nil, err
 	}
@@ -2582,7 +2562,7 @@ func (provider *BedrockProvider) FileList(ctx *schemas.BifrostContext, keys []sc
 	}
 
 	// Sign request for S3
-	if bifrostErr := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "s3"); bifrostErr != nil {
+	if bifrostErr := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, "s3"); bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
@@ -2693,7 +2673,7 @@ func (provider *BedrockProvider) FileRetrieve(ctx *schemas.BifrostContext, keys 
 		}
 
 		// Sign request for S3
-		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "s3"); err != nil {
+		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, "s3"); err != nil {
 			lastErr = err
 			continue
 		}
@@ -2791,7 +2771,7 @@ func (provider *BedrockProvider) FileDelete(ctx *schemas.BifrostContext, keys []
 		}
 
 		// Sign request for S3
-		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "s3"); err != nil {
+		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, "s3"); err != nil {
 			lastErr = err
 			continue
 		}
@@ -2872,7 +2852,7 @@ func (provider *BedrockProvider) FileContent(ctx *schemas.BifrostContext, keys [
 		}
 
 		// Sign request for S3
-		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "s3"); err != nil {
+		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, "s3"); err != nil {
 			lastErr = err
 			continue
 		}
@@ -3078,7 +3058,7 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 	}
 
 	// Sign request
-	if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService); err != nil {
+	if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, bedrockSigningService); err != nil {
 		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
 
@@ -3203,7 +3183,7 @@ func (provider *BedrockProvider) BatchList(ctx *schemas.BifrostContext, keys []s
 	}
 
 	// Sign request
-	if bifrostErr := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService); bifrostErr != nil {
+	if bifrostErr := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, bedrockSigningService); bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
@@ -3322,7 +3302,7 @@ func (provider *BedrockProvider) fetchBatchManifest(ctx *schemas.BifrostContext,
 	}
 
 	// Sign request for S3
-	if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "s3"); err != nil {
+	if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, "s3"); err != nil {
 		provider.logger.Error("failed to sign manifest request: %v", err)
 		return nil
 	}
@@ -3382,7 +3362,7 @@ func (provider *BedrockProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys
 		}
 
 		// Sign request
-		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService); err != nil {
+		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, bedrockSigningService); err != nil {
 			lastErr = err
 			continue
 		}
@@ -3526,7 +3506,7 @@ func (provider *BedrockProvider) BatchCancel(ctx *schemas.BifrostContext, keys [
 		}
 
 		// Sign request
-		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService); err != nil {
+		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig, region, bedrockSigningService); err != nil {
 			lastErr = err
 			continue
 		}

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -17,6 +18,10 @@ import (
 // (they have no Converse equivalent). Gemma 3 is intentionally excluded: it only supports
 // Chat (not Responses) on mantle, and the Converse path serves both APIs, so forcing it to
 // mantle would break Responses.
+//
+// Deprecated: in-provider Bedrock Mantle routing is retained for backwards compatibility.
+// New configurations should use the "bedrock_mantle" provider, which owns the Bedrock Mantle
+// surface (Claude native-Anthropic, OpenAI-compatible, and Gemma).
 func isMantleModel(ctx *schemas.BifrostContext, model string) bool {
 	return schemas.IsOpenAIModelFamily(ctx, model) || strings.Contains(model, "gemma-4")
 }
@@ -34,13 +39,13 @@ func mantleOpenAIURL(region, model, path string) string {
 	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/%s/%s", region, base, path)
 }
 
-// mantleSigV4Headers computes SigV4 auth headers for a mantle request by signing a dummy
+// SignMantleV4Headers computes SigV4 auth headers for a mantle request by signing a dummy
 // net/http.Request. jsonData must be the exact bytes that will be sent. accept must match
 // the Accept header the actual request will send, since SigV4 signs all request headers.
 // extraHeaders are the static headers the actual request will carry; any x-amz-* among them
 // are added to the canonical request before signing so the signature covers them (AWS requires
 // every x-amz-* header on the wire to be signed, otherwise verification fails).
-func (provider *BedrockProvider) mantleSigV4Headers(
+func SignMantleV4Headers(
 	ctx *schemas.BifrostContext,
 	jsonData []byte,
 	requestURL, accept string,
@@ -48,7 +53,16 @@ func (provider *BedrockProvider) mantleSigV4Headers(
 	region string,
 	extraHeaders map[string]string,
 ) (map[string]string, *schemas.BifrostError) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(jsonData))
+	method := http.MethodPost
+	if jsonData == nil {
+		method = http.MethodGet
+	}
+	var body io.Reader
+	if jsonData != nil {
+		body = bytes.NewReader(jsonData)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to create signing request", err)
 	}
@@ -58,14 +72,33 @@ func (provider *BedrockProvider) mantleSigV4Headers(
 			req.Header.Set(k, v)
 		}
 	}
-	if bifrostErr := signAWSRequestFromKey(ctx, req, key.BedrockKeyConfig, region, bedrockMantleSigningService); bifrostErr != nil {
+
+	keyCfg := key.BedrockKeyConfig
+	// Create a synthetic BedrockKeyConfig in case of bedrock_mantle: its
+	// BedrockMantleKeyConfig carries the same credential fields, so map them across
+	// (Region is passed separately; ARN/batch config are not used for signing).
+	if key.BedrockMantleKeyConfig != nil && key.BedrockKeyConfig == nil {
+		keyCfg = &schemas.BedrockKeyConfig{
+			AccessKey:       key.BedrockMantleKeyConfig.AccessKey,
+			SecretKey:       key.BedrockMantleKeyConfig.SecretKey,
+			SessionToken:    key.BedrockMantleKeyConfig.SessionToken,
+			RoleARN:         key.BedrockMantleKeyConfig.RoleARN,
+			ExternalID:      key.BedrockMantleKeyConfig.ExternalID,
+			RoleSessionName: key.BedrockMantleKeyConfig.RoleSessionName,
+		}
+	}
+	if bifrostErr := signAWSRequest(ctx, req, keyCfg, region, bedrockMantleSigningService); bifrostErr != nil {
 		return nil, bifrostErr
 	}
+	// Return the headers exactly as signed: signAWSRequest defaults an empty Accept/Content-Type
+	// to "application/json" and includes them in SignedHeaders, so the caller must send those same
+	// values (not the original, possibly-empty, accept) or the signature won't match.
 	headers := map[string]string{
 		"Authorization":        req.Header.Get("Authorization"),
 		"X-Amz-Date":           req.Header.Get("X-Amz-Date"),
 		"x-amz-content-sha256": req.Header.Get("x-amz-content-sha256"),
-		"Accept":               accept,
+		"Accept":               req.Header.Get("Accept"),
+		"Content-Type":         req.Header.Get("Content-Type"),
 	}
 	if token := req.Header.Get("X-Amz-Security-Token"); token != "" {
 		headers["X-Amz-Security-Token"] = token
@@ -88,7 +121,7 @@ func (provider *BedrockProvider) mantleChatCompletions(
 	var signer providerUtils.BodySigner
 	if key.Value.GetValue() == "" {
 		signer = func(body []byte) (map[string]string, *schemas.BifrostError) {
-			return provider.mantleSigV4Headers(ctx, body, url, "application/json", key, region, provider.networkConfig.ExtraHeaders)
+			return SignMantleV4Headers(ctx, body, url, "application/json", key, region, provider.networkConfig.ExtraHeaders)
 		}
 	}
 
@@ -126,7 +159,7 @@ func (provider *BedrockProvider) mantleChatCompletionsStream(
 	var signer providerUtils.BodySigner
 	if key.Value.GetValue() == "" {
 		signer = func(body []byte) (map[string]string, *schemas.BifrostError) {
-			return provider.mantleSigV4Headers(ctx, body, url, "text/event-stream", key, region, provider.networkConfig.ExtraHeaders)
+			return SignMantleV4Headers(ctx, body, url, "text/event-stream", key, region, provider.networkConfig.ExtraHeaders)
 		}
 	}
 
@@ -163,7 +196,7 @@ func (provider *BedrockProvider) mantleResponses(
 	var signer providerUtils.BodySigner
 	if key.Value.GetValue() == "" {
 		signer = func(body []byte) (map[string]string, *schemas.BifrostError) {
-			return provider.mantleSigV4Headers(ctx, body, url, "application/json", key, region, provider.networkConfig.ExtraHeaders)
+			return SignMantleV4Headers(ctx, body, url, "application/json", key, region, provider.networkConfig.ExtraHeaders)
 		}
 	}
 
@@ -201,7 +234,7 @@ func (provider *BedrockProvider) mantleResponsesStream(
 	var signer providerUtils.BodySigner
 	if key.Value.GetValue() == "" {
 		signer = func(body []byte) (map[string]string, *schemas.BifrostError) {
-			return provider.mantleSigV4Headers(ctx, body, url, "text/event-stream", key, region, provider.networkConfig.ExtraHeaders)
+			return SignMantleV4Headers(ctx, body, url, "text/event-stream", key, region, provider.networkConfig.ExtraHeaders)
 		}
 	}
 

--- a/core/providers/bedrockmantle/bedrockmantle.go
+++ b/core/providers/bedrockmantle/bedrockmantle.go
@@ -1,0 +1,617 @@
+// Package bedrockmantle implements the Bedrock Mantle LLM provider. It owns the Bedrock Mantle
+// surface served on the bedrock-mantle.{region}.api.aws host: Claude models via the native
+// Anthropic Messages API (/anthropic/v1/messages), and OpenAI-family (gpt-*) and Gemma models
+// via the OpenAI-compatible API (/v1 or /openai/v1). The model id is sent verbatim, save for an
+// optional leading "region/" addressing prefix. Authentication is either a Bedrock Mantle API key
+// (Authorization: Bearer) or AWS SigV4 for the bedrock-mantle service.
+package bedrockmantle
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/providers/bedrock"
+	openai "github.com/maximhq/bifrost/core/providers/openai"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// BedrockMantleProvider implements the Provider interface for the Bedrock Mantle endpoint.
+type BedrockMantleProvider struct {
+	logger                schemas.Logger        // Logger for provider operations
+	mantleClient          *fasthttp.Client      // fasthttp client for unary requests (OpenAI-compatible and native-Anthropic paths)
+	mantleStreamingClient *fasthttp.Client      // fasthttp streaming client for streaming requests
+	networkConfig         schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest    bool                  // Whether to include raw request in BifrostResponse
+	sendBackRawResponse   bool                  // Whether to include raw response in BifrostResponse
+}
+
+// NewBedrockMantleProvider creates a new Bedrock Mantle provider instance.
+// It initializes the fasthttp unary and streaming clients with the provided configuration.
+// There is no default BaseURL: mantle requests target computed bedrock-mantle.{region}.api.aws hosts.
+func NewBedrockMantleProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*BedrockMantleProvider, error) {
+	config.CheckAndSetDefaults()
+
+	requestTimeout := time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds)
+
+	// fasthttp clients for Bedrock Mantle (shared by OpenAI-compatible and native-Anthropic paths).
+	// ReadTimeout is the shared provider request timeout; oversized Anthropic responses are handled
+	// by PrepareResponseStreaming, not by these static settings.
+	mantleFasthttpClient := &fasthttp.Client{
+		ReadTimeout:         requestTimeout,
+		WriteTimeout:        requestTimeout,
+		MaxConnsPerHost:     config.NetworkConfig.MaxConnsPerHost,
+		MaxIdleConnDuration: 30 * time.Second,
+		MaxConnWaitTimeout:  requestTimeout,
+		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
+		ConnPoolStrategy:    fasthttp.FIFO,
+	}
+	mantleFasthttpClient = providerUtils.ConfigureProxy(mantleFasthttpClient, config.ProxyConfig, logger)
+	mantleFasthttpClient = providerUtils.ConfigureDialer(mantleFasthttpClient, config.NetworkConfig.AllowPrivateNetwork)
+	mantleFasthttpClient = providerUtils.ConfigureTLS(mantleFasthttpClient, config.NetworkConfig, logger)
+	mantleStreamingFasthttpClient := providerUtils.BuildStreamingClient(mantleFasthttpClient)
+
+	return &BedrockMantleProvider{
+		logger:                logger,
+		mantleClient:          mantleFasthttpClient,
+		mantleStreamingClient: mantleStreamingFasthttpClient,
+		networkConfig:         config.NetworkConfig,
+		sendBackRawRequest:    config.SendBackRawRequest,
+		sendBackRawResponse:   config.SendBackRawResponse,
+	}, nil
+}
+
+// mantleAnthropicVersion is the Anthropic API version sent as an HTTP header on the
+// Bedrock Mantle native-Anthropic endpoint (unlike bedrock-runtime, which carries the
+// version as an "anthropic_version" body field).
+const mantleAnthropicVersion = "2023-06-01"
+
+// defaultMantleRegion is the fallback AWS region used to build the bedrock-mantle host when
+// no region is supplied by the model prefix, the resolved alias, or the key config.
+const defaultMantleRegion = "us-east-1"
+
+// mantleOpenAIURL builds the Bedrock Mantle OpenAI-compatible endpoint URL for the given
+// region, model, and API path (e.g. "chat/completions", "responses"). The native-Anthropic
+// path is built separately by mantleAnthropicURL. Pass the canonical (capability-resolved)
+// model for correct path gating; the request body still carries the wire request.Model.
+// Frontier families (closed gpt-5.x, Gemma 4) live under the "openai/v1" base path; gpt-oss
+// uses the bare "v1" path.
+func mantleOpenAIURL(region, model, path string) string {
+	base := "v1"
+	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gemma-4") {
+		base = "openai/v1"
+	}
+	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/%s/%s", region, base, path)
+}
+
+// mantleAnthropicURL builds the Bedrock Mantle native-Anthropic Messages endpoint URL.
+func mantleAnthropicURL(region string) string {
+	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/anthropic/v1/messages", region)
+}
+
+// mantleSigner returns a BodySigner that SigV4-signs the request body for the bedrock-mantle
+// service, or nil when a Bedrock Mantle API key is present (auth then flows through the
+// Authorization: Bearer header instead). The handler invokes the signer on the exact body it
+// builds, so the signature always covers what is actually sent.
+func (provider *BedrockMantleProvider) mantleSigner(ctx *schemas.BifrostContext, key schemas.Key, url, accept, region string) providerUtils.BodySigner {
+	if key.Value.GetValue() != "" {
+		return nil
+	}
+	return func(body []byte) (map[string]string, *schemas.BifrostError) {
+		return bedrock.SignMantleV4Headers(ctx, body, url, accept, key, region, provider.networkConfig.ExtraHeaders)
+	}
+}
+
+// GetProviderKey returns the provider identifier for Bedrock Mantle.
+func (provider *BedrockMantleProvider) GetProviderKey() schemas.ModelProvider {
+	return schemas.BedrockMantle
+}
+
+// listModelsByKey lists models from the Bedrock Mantle (OpenAI-compatible) /v1/models
+// endpoint for a single key, converted to a Bifrost response with the key's allow/blacklist/
+// alias gating. The request is signed as it is sent (the GET cannot reuse the POST signer);
+// a Bedrock Mantle API key authenticates via Authorization: Bearer, otherwise the request is
+// SigV4-signed for the bedrock-mantle service and the signed headers are merged into the
+// per-request extra headers consumed by the shared OpenAI list-models path.
+func (provider *BedrockMantleProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	region := provider.resolveRegion(ctx, key, "")
+	mURL := mantleOpenAIURL(region, "", "models")
+
+	extraHeaders := provider.networkConfig.ExtraHeaders
+	if key.Value.GetValue() == "" {
+		// SigV4: sign the GET and overlay the signed headers; OpenAI's ListModelsByKey only sets
+		// a Bearer header when the key carries a value, so the SigV4 Authorization wins here.
+		sigHeaders, bifrostErr := bedrock.SignMantleV4Headers(ctx, nil, mURL, "", key, region, provider.networkConfig.ExtraHeaders)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		merged := make(map[string]string, len(provider.networkConfig.ExtraHeaders)+len(sigHeaders))
+		maps.Copy(merged, provider.networkConfig.ExtraHeaders)
+		maps.Copy(merged, sigHeaders)
+		extraHeaders = merged
+	}
+
+	return openai.ListModelsByKey(
+		ctx,
+		provider.mantleClient,
+		mURL,
+		key,
+		request.Unfiltered,
+		extraHeaders,
+		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+	)
+}
+
+// ListModels lists models from the Bedrock Mantle OpenAI-compatible /v1/models endpoint,
+// aggregating across the supplied keys.
+func (provider *BedrockMantleProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	return providerUtils.HandleMultipleListModelsRequests(
+		ctx,
+		keys,
+		request,
+		provider.listModelsByKey,
+	)
+}
+
+// ChatCompletion performs a chat completion request to the Bedrock Mantle endpoint, dispatching
+// by model family: Anthropic-family (Claude) models use the native Anthropic Messages surface;
+// all other (OpenAI-family / Gemma) models use the OpenAI-compatible surface.
+func (provider *BedrockMantleProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	region := provider.resolveRegion(ctx, key, request.Model)
+
+	// Anthropic-family models (Claude) use the native Anthropic Messages surface; all other
+	// (OpenAI-family / Gemma) models use the OpenAI-compatible surface.
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+		url := mantleAnthropicURL(region)
+		_, bareModel := parseBedrockRegionAndModel(request.Model)
+		return anthropic.HandleAnthropicChatCompletionRequest(
+			ctx,
+			provider.mantleClient,
+			url,
+			request,
+			anthropic.AnthropicRequestBuildConfig{
+				Provider:                  schemas.BedrockMantle,
+				Model:                     bareModel,
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+				ShouldSendBackRawResponse: provider.sendBackRawResponse,
+			},
+			openai.BearerAuthHeader(key),
+			addAnthropicHeaders(provider.networkConfig.ExtraHeaders),
+			provider.mantleSigner(ctx, key, url, "application/json", region),
+			provider.logger,
+		)
+	}
+
+	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	return openai.HandleOpenAIChatCompletionRequest(
+		ctx,
+		provider.mantleClient,
+		url,
+		request,
+		openai.BearerAuthHeader(key),
+		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		nil,
+		nil,
+		provider.mantleSigner(ctx, key, url, "application/json", region),
+		provider.logger,
+	)
+}
+
+// ChatCompletionStream performs a streaming chat completion request to the Bedrock Mantle
+// endpoint, dispatching by model family (native Anthropic vs OpenAI-compatible).
+func (provider *BedrockMantleProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	region := provider.resolveRegion(ctx, key, request.Model)
+
+	// Anthropic-family models (Claude) use the native Anthropic Messages surface; all other
+	// (OpenAI-family / Gemma) models use the OpenAI-compatible surface.
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+		url := mantleAnthropicURL(region)
+
+		_, bareModel := parseBedrockRegionAndModel(request.Model)
+		jsonData, bifrostErr := anthropic.BuildAnthropicChatRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
+			Provider:                  schemas.BedrockMantle,
+			Model:                     bareModel,
+			IsStreaming:               true,
+			BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+			ShouldSendBackRawResponse: provider.sendBackRawResponse,
+		})
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+
+		return anthropic.HandleAnthropicChatCompletionStreaming(
+			ctx,
+			provider.mantleStreamingClient,
+			url,
+			jsonData,
+			openai.BearerAuthHeader(key),
+			addAnthropicHeaders(provider.networkConfig.ExtraHeaders),
+			provider.networkConfig.StreamIdleTimeoutInSeconds,
+			provider.networkConfig.BetaHeaderOverrides,
+			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+			provider.GetProviderKey(),
+			postHookRunner,
+			nil,
+			provider.mantleSigner(ctx, key, url, "text/event-stream", region),
+			provider.logger,
+			postHookSpanFinalizer,
+		)
+	}
+
+	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	return openai.HandleOpenAIChatCompletionStreaming(
+		ctx, provider.mantleStreamingClient, url, request,
+		openai.BearerAuthHeader(key), provider.networkConfig.ExtraHeaders,
+		provider.networkConfig.StreamIdleTimeoutInSeconds,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(), postHookRunner,
+		nil, nil, nil, nil, nil,
+		provider.mantleSigner(ctx, key, url, "text/event-stream", region),
+		provider.logger, postHookSpanFinalizer,
+	)
+}
+
+// Responses performs a Responses API request to the Bedrock Mantle endpoint, dispatching by
+// model family (native Anthropic vs OpenAI-compatible).
+func (provider *BedrockMantleProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	region := provider.resolveRegion(ctx, key, request.Model)
+
+	// Anthropic-family models (Claude) use the native Anthropic Messages surface; all other
+	// (OpenAI-family / Gemma) models use the OpenAI-compatible surface.
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+		url := mantleAnthropicURL(region)
+
+		_, bareModel := parseBedrockRegionAndModel(request.Model)
+		return anthropic.HandleAnthropicResponsesRequest(
+			ctx,
+			provider.mantleClient,
+			url,
+			request,
+			anthropic.AnthropicRequestBuildConfig{
+				Provider:                  schemas.BedrockMantle,
+				Model:                     bareModel,
+				ValidateTools:             true,
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+				ShouldSendBackRawResponse: provider.sendBackRawResponse,
+			},
+			openai.BearerAuthHeader(key),
+			addAnthropicHeaders(provider.networkConfig.ExtraHeaders),
+			provider.mantleSigner(ctx, key, url, "application/json", region),
+			provider.logger,
+		)
+	}
+
+	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
+	return openai.HandleOpenAIResponsesRequest(
+		ctx,
+		provider.mantleClient,
+		url,
+		request,
+		openai.BearerAuthHeader(key),
+		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		nil, nil,
+		provider.mantleSigner(ctx, key, url, "application/json", region),
+		provider.logger,
+	)
+}
+
+// ResponsesStream performs a streaming Responses API request to the Bedrock Mantle endpoint,
+// dispatching by model family (native Anthropic vs OpenAI-compatible).
+func (provider *BedrockMantleProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	region := provider.resolveRegion(ctx, key, request.Model)
+
+	// Anthropic-family models (Claude) use the native Anthropic Messages surface; all other
+	// (OpenAI-family / Gemma) models use the OpenAI-compatible surface.
+	if schemas.IsAnthropicModelFamily(ctx, request.Model) {
+		url := mantleAnthropicURL(region)
+
+		_, bareModel := parseBedrockRegionAndModel(request.Model)
+		jsonData, bifrostErr := anthropic.BuildAnthropicResponsesRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
+			Provider:                  schemas.BedrockMantle,
+			Model:                     bareModel,
+			IsStreaming:               true,
+			ValidateTools:             true,
+			BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+			ShouldSendBackRawResponse: provider.sendBackRawResponse,
+		})
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+
+		return anthropic.HandleAnthropicResponsesStream(
+			ctx,
+			provider.mantleStreamingClient,
+			url,
+			jsonData,
+			openai.BearerAuthHeader(key),
+			addAnthropicHeaders(provider.networkConfig.ExtraHeaders),
+			provider.networkConfig.StreamIdleTimeoutInSeconds,
+			provider.networkConfig.BetaHeaderOverrides,
+			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+			provider.GetProviderKey(),
+			postHookRunner,
+			nil,
+			provider.mantleSigner(ctx, key, url, "text/event-stream", region),
+			provider.logger,
+			postHookSpanFinalizer,
+		)
+	}
+
+	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
+	return openai.HandleOpenAIResponsesStreaming(
+		ctx, provider.mantleStreamingClient, url, request,
+		openai.BearerAuthHeader(key), provider.networkConfig.ExtraHeaders,
+		provider.networkConfig.StreamIdleTimeoutInSeconds,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(), postHookRunner,
+		nil, nil, nil, nil,
+		provider.mantleSigner(ctx, key, url, "text/event-stream", region),
+		provider.logger, postHookSpanFinalizer,
+	)
+}
+
+// TextCompletion is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TextCompletionRequest, provider.GetProviderKey())
+}
+
+// TextCompletionStream is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
+}
+
+// Embedding is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
+}
+
+// Speech is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) Speech(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
+}
+
+// Rerank is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, provider.GetProviderKey())
+}
+
+// OCR is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostOCRRequest) (*schemas.BifrostOCRResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.OCRRequest, provider.GetProviderKey())
+}
+
+// SpeechStream is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) SpeechStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
+}
+
+// Transcription is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) Transcription(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
+}
+
+// TranscriptionStream is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) TranscriptionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
+}
+
+// ImageGeneration is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationRequest, provider.GetProviderKey())
+}
+
+// ImageGenerationStream is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ImageGenerationStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostImageGenerationRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationStreamRequest, provider.GetProviderKey())
+}
+
+// ImageEdit is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageEditRequest, provider.GetProviderKey())
+}
+
+// ImageEditStream is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ImageEditStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostImageEditRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageEditStreamRequest, provider.GetProviderKey())
+}
+
+// ImageVariation is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ImageVariation(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageVariationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageVariationRequest, provider.GetProviderKey())
+}
+
+// VideoGeneration is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) VideoGeneration(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoGenerationRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoGenerationRequest, provider.GetProviderKey())
+}
+
+// VideoRetrieve is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) VideoRetrieve(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoRetrieveRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoRetrieveRequest, provider.GetProviderKey())
+}
+
+// VideoDownload is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) VideoDownload(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoDownloadRequest) (*schemas.BifrostVideoDownloadResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoDownloadRequest, provider.GetProviderKey())
+}
+
+// VideoDelete is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) VideoDelete(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoDeleteRequest) (*schemas.BifrostVideoDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoDeleteRequest, provider.GetProviderKey())
+}
+
+// VideoList is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) VideoList(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoListRequest) (*schemas.BifrostVideoListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoListRequest, provider.GetProviderKey())
+}
+
+// VideoRemix is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) VideoRemix(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostVideoRemixRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.VideoRemixRequest, provider.GetProviderKey())
+}
+
+// FileUpload is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) FileUpload(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostFileUploadRequest) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileUploadRequest, provider.GetProviderKey())
+}
+
+// FileList is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) FileList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileListRequest) (*schemas.BifrostFileListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileListRequest, provider.GetProviderKey())
+}
+
+// FileRetrieve is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) FileRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileRetrieveRequest) (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileRetrieveRequest, provider.GetProviderKey())
+}
+
+// FileDelete is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) FileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileDeleteRequest) (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileDeleteRequest, provider.GetProviderKey())
+}
+
+// FileContent is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) FileContent(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
+}
+
+// BatchCreate is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) BatchCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostBatchCreateRequest) (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCreateRequest, provider.GetProviderKey())
+}
+
+// BatchList is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) BatchList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchListRequest) (*schemas.BifrostBatchListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchListRequest, provider.GetProviderKey())
+}
+
+// BatchRetrieve is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) BatchRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchRetrieveRequest) (*schemas.BifrostBatchRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchRetrieveRequest, provider.GetProviderKey())
+}
+
+// BatchCancel is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) BatchCancel(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchCancelRequest) (*schemas.BifrostBatchCancelResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
+}
+
+// BatchDelete is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
+// BatchResults is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
+}
+
+// CountTokens is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}
+
+// Compaction is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) Compaction(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCompactionRequest) (*schemas.BifrostCompactionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CompactionRequest, provider.GetProviderKey())
+}
+
+// CachedContentCreate is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) CachedContentCreate(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostCachedContentCreateRequest) (*schemas.BifrostCachedContentCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentCreateRequest, provider.GetProviderKey())
+}
+
+// CachedContentList is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) CachedContentList(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentListRequest) (*schemas.BifrostCachedContentListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentListRequest, provider.GetProviderKey())
+}
+
+// CachedContentRetrieve is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) CachedContentRetrieve(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentRetrieveRequest) (*schemas.BifrostCachedContentRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentRetrieveRequest, provider.GetProviderKey())
+}
+
+// CachedContentUpdate is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) CachedContentUpdate(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentUpdateRequest) (*schemas.BifrostCachedContentUpdateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentUpdateRequest, provider.GetProviderKey())
+}
+
+// CachedContentDelete is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) CachedContentDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostCachedContentDeleteRequest) (*schemas.BifrostCachedContentDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CachedContentDeleteRequest, provider.GetProviderKey())
+}
+
+// ContainerCreate is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}
+
+// ContainerFileCreate is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ContainerFileCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerFileCreateRequest) (*schemas.BifrostContainerFileCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerFileList is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ContainerFileList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileListRequest) (*schemas.BifrostContainerFileListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileListRequest, provider.GetProviderKey())
+}
+
+// ContainerFileRetrieve is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ContainerFileRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileRetrieveRequest) (*schemas.BifrostContainerFileRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerFileContent is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ContainerFileContent(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileContentRequest) (*schemas.BifrostContainerFileContentResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileContentRequest, provider.GetProviderKey())
+}
+
+// ContainerFileDelete is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+// PassthroughStream is not supported by the Bedrock Mantle provider.
+func (provider *BedrockMantleProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ func(context.Context), _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
+}

--- a/core/providers/bedrockmantle/bedrockmantle_test.go
+++ b/core/providers/bedrockmantle/bedrockmantle_test.go
@@ -1,0 +1,93 @@
+package bedrockmantle_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/llmtests"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestBedrockMantle runs the comprehensive harness against the bedrock_mantle provider.
+//
+// It is gated on AWS credentials (the SigV4 path needs them). The Claude scenarios exercise the
+// native-Anthropic Messages surface; gpt-oss exercises the OpenAI-compatible surface. Only the
+// operations the provider actually implements are enabled — everything else (embeddings, rerank,
+// batch, files, image edit/variation, count tokens, text completion) is an unsupported stub.
+//
+// The model ids live in the harness account (GetKeysForProvider, case BedrockMantle); if a model
+// is reported as not found, tune the aliases there to whatever the mantle endpoints accept.
+func TestBedrockMantle(t *testing.T) {
+	t.Parallel()
+
+	if strings.TrimSpace(os.Getenv("AWS_ACCESS_KEY_ID")) == "" || strings.TrimSpace(os.Getenv("AWS_SECRET_ACCESS_KEY")) == "" {
+		t.Skip("Skipping Bedrock Mantle tests because AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY is not set")
+	}
+
+	client, ctx, cancel, err := llmtests.SetupTest()
+	if err != nil {
+		t.Fatalf("Error initializing test setup: %v", err)
+	}
+	defer cancel()
+	defer client.Shutdown()
+
+	testConfig := llmtests.ComprehensiveTestConfig{
+		Provider:           schemas.BedrockMantle,
+		ChatModel:          "anthropic.claude-haiku-4-5",
+		PromptCachingModel: "anthropic.claude-opus-4-8",
+		VisionModel:        "anthropic.claude-haiku-4-5",
+		Fallbacks: []schemas.Fallback{
+			{Provider: schemas.BedrockMantle, Model: "anthropic.claude-opus-4-8"},
+		},
+		ReasoningModel:           "anthropic.claude-opus-4-8",
+		InterleavedThinkingModel: "anthropic.claude-opus-4-8",
+		Scenarios: llmtests.TestScenarios{
+			// Supported: chat + responses surfaces (native-Anthropic and OpenAI-compatible).
+			SimpleChat:                 true,
+			CompletionStream:           true,
+			MultiTurnConversation:      true,
+			ToolCalls:                  true,
+			ToolCallsStreaming:         true,
+			MultipleToolCalls:          true,
+			MultipleToolCallsStreaming: true,
+			End2EndToolCalling:         true,
+			AutomaticFunctionCall:      true,
+			ImageBase64:                true, // Claude vision (native-Anthropic)
+			CompleteEnd2End:            true,
+			ListModels:                 true,
+			Reasoning:                  true,
+			InterleavedThinking:        true,
+			EagerInputStreaming:        true,
+			StructuredOutputs:          true,
+			PromptCaching:              true,
+
+			// Unsupported by the mantle provider (unsupported-operation stubs).
+			TextCompletion: false,
+			ImageURL:       false, // native-Anthropic does not accept image URLs
+			MultipleImages: false,
+			FileBase64:     false,
+			FileURL:        false,
+			Embedding:      false,
+			Rerank:         false,
+			BatchCreate:    false,
+			BatchList:      false,
+			BatchRetrieve:  false,
+			BatchCancel:    false,
+			BatchResults:   false,
+			FileUpload:     false,
+			FileList:       false,
+			FileRetrieve:   false,
+			FileDelete:     false,
+			FileContent:    false,
+			FileBatchInput: false,
+			CountTokens:    false,
+			ImageEdit:      false,
+			ImageVariation: false,
+		},
+	}
+
+	t.Run("BedrockMantleTests", func(t *testing.T) {
+		llmtests.RunAllComprehensiveTests(t, client, ctx, testConfig)
+	})
+}

--- a/core/providers/bedrockmantle/utils.go
+++ b/core/providers/bedrockmantle/utils.go
@@ -1,0 +1,60 @@
+package bedrockmantle
+
+import (
+	"maps"
+	"regexp"
+	"strings"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// awsRegionRegex matches valid AWS region identifiers (e.g. "us-east-1", "eu-north-1", "us-gov-east-1").
+// (?:-[a-z]+)+ allows multi-segment directional parts so GovCloud regions (us-gov-east-1) are
+// recognised alongside standard single-segment ones (eu-north-1, ap-southeast-2).
+var awsRegionRegex = regexp.MustCompile(`^[a-z]{2,3}(?:-[a-z]+)+-\d+$`)
+
+// addAnthropicHeaders returns a copy of the given extra headers with the native-Anthropic
+// mantle anthropic-version header added. It clones the input first so it never mutates the
+// shared networkConfig.ExtraHeaders map (which would leak anthropic-version onto the
+// OpenAI-compatible requests and race across concurrent requests).
+func addAnthropicHeaders(headers map[string]string) map[string]string {
+	out := maps.Clone(headers)
+	if out == nil {
+		out = make(map[string]string, 1)
+	}
+	out["anthropic-version"] = mantleAnthropicVersion
+	return out
+}
+
+// parseBedrockRegionAndModel splits a model string that optionally carries an AWS region prefix
+// into its region and bare model ID components.
+// If no region prefix is present the returned region is empty and bareModel equals model.
+func parseBedrockRegionAndModel(model string) (region, bareModel string) {
+	if idx := strings.IndexByte(model, '/'); idx > 0 {
+		prefix := model[:idx]
+		if awsRegionRegex.MatchString(prefix) {
+			return prefix, model[idx+1:]
+		}
+	}
+	return "", model
+}
+
+// resolveRegion returns the AWS region to use for a request.
+// Priority: model-string region prefix > alias-level Region > key-level
+// BedrockMantleKeyConfig.Region > defaultMantleRegion. The model-string prefix
+// stays highest since it's the most explicit signal — when an admin types a
+// region into their model ID they expect that to win.
+func (provider *BedrockMantleProvider) resolveRegion(ctx *schemas.BifrostContext, key schemas.Key, model string) string {
+	if region, _ := parseBedrockRegionAndModel(model); region != "" {
+		return region
+	}
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.Region != nil {
+		if v := ra.Config.Region.GetValue(); v != "" {
+			return v
+		}
+	}
+	if key.BedrockMantleKeyConfig != nil && key.BedrockMantleKeyConfig.Region != nil && key.BedrockMantleKeyConfig.Region.GetValue() != "" {
+		return key.BedrockMantleKeyConfig.Region.GetValue()
+	}
+	return defaultMantleRegion
+}

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -124,25 +124,26 @@ func (bl BlackList) Validate() error {
 // Key represents an API key and its associated configuration for a provider.
 // It contains the key value, supported models, and a weight for load balancing.
 type Key struct {
-	ID                 string              `json:"id"`                             // The unique identifier for the key (used by bifrost to identify the key)
-	Name               string              `json:"name"`                           // The name of the key (used by users to identify the key, not used by bifrost)
-	Value              SecretVar              `json:"value"`                          // The actual API key value
-	Models             WhiteList           `json:"models"`                         // List of models this key can access
-	BlacklistedModels  BlackList           `json:"blacklisted_models"`             // List of models this key cannot access
-	Weight             float64             `json:"weight"`                         // Weight for load balancing between multiple keys
-	Aliases            KeyAliases          `json:"aliases,omitempty"`              // Mapping of model identifiers to inference profiles
-	AzureKeyConfig     *AzureKeyConfig     `json:"azure_key_config,omitempty"`     // Azure-specific key configuration
-	VertexKeyConfig    *VertexKeyConfig    `json:"vertex_key_config,omitempty"`    // Vertex-specific key configuration
-	BedrockKeyConfig   *BedrockKeyConfig   `json:"bedrock_key_config,omitempty"`   // AWS Bedrock-specific key configuration
-	VLLMKeyConfig      *VLLMKeyConfig      `json:"vllm_key_config,omitempty"`      // vLLM-specific key configuration
-	ReplicateKeyConfig *ReplicateKeyConfig `json:"replicate_key_config,omitempty"` // Replicate-specific key configuration
-	OllamaKeyConfig    *OllamaKeyConfig    `json:"ollama_key_config,omitempty"`    // Ollama-specific key configuration
-	SGLKeyConfig       *SGLKeyConfig       `json:"sgl_key_config,omitempty"`       // SGLang-specific key configuration
-	Enabled            *bool               `json:"enabled,omitempty"`              // Whether the key is active (default:true)
-	UseForBatchAPI     *bool               `json:"use_for_batch_api,omitempty"`    // Whether this key can be used for batch API operations (default:false for new keys, migrated keys default to true)
-	ConfigHash         string              `json:"config_hash,omitempty"`          // Hash of config.json version, used for change detection
-	Status             KeyStatusType       `json:"status,omitempty"`               // Status of key
-	Description        string              `json:"description,omitempty"`          // Description of key
+	ID                     string                  `json:"id"`                                  // The unique identifier for the key (used by bifrost to identify the key)
+	Name                   string                  `json:"name"`                                // The name of the key (used by users to identify the key, not used by bifrost)
+	Value                  SecretVar               `json:"value"`                               // The actual API key value
+	Models                 WhiteList               `json:"models"`                              // List of models this key can access
+	BlacklistedModels      BlackList               `json:"blacklisted_models"`                  // List of models this key cannot access
+	Weight                 float64                 `json:"weight"`                              // Weight for load balancing between multiple keys
+	Aliases                KeyAliases              `json:"aliases,omitempty"`                   // Mapping of model identifiers to inference profiles
+	AzureKeyConfig         *AzureKeyConfig         `json:"azure_key_config,omitempty"`          // Azure-specific key configuration
+	VertexKeyConfig        *VertexKeyConfig        `json:"vertex_key_config,omitempty"`         // Vertex-specific key configuration
+	BedrockKeyConfig       *BedrockKeyConfig       `json:"bedrock_key_config,omitempty"`        // AWS Bedrock-specific key configuration
+	BedrockMantleKeyConfig *BedrockMantleKeyConfig `json:"bedrock_mantle_key_config,omitempty"` // Bedrock Mantle-specific key configuration
+	VLLMKeyConfig          *VLLMKeyConfig          `json:"vllm_key_config,omitempty"`           // vLLM-specific key configuration
+	ReplicateKeyConfig     *ReplicateKeyConfig     `json:"replicate_key_config,omitempty"`      // Replicate-specific key configuration
+	OllamaKeyConfig        *OllamaKeyConfig        `json:"ollama_key_config,omitempty"`         // Ollama-specific key configuration
+	SGLKeyConfig           *SGLKeyConfig           `json:"sgl_key_config,omitempty"`            // SGLang-specific key configuration
+	Enabled                *bool                   `json:"enabled,omitempty"`                   // Whether the key is active (default:true)
+	UseForBatchAPI         *bool                   `json:"use_for_batch_api,omitempty"`         // Whether this key can be used for batch API operations (default:false for new keys, migrated keys default to true)
+	ConfigHash             string                  `json:"config_hash,omitempty"`               // Hash of config.json version, used for change detection
+	Status                 KeyStatusType           `json:"status,omitempty"`                    // Status of key
+	Description            string                  `json:"description,omitempty"`               // Description of key
 }
 
 // ModelFamily is a typed enum identifying the underlying model family of an alias target.
@@ -182,8 +183,8 @@ func (mf *ModelFamily) IsValid() bool {
 // AzureAliasCfg holds Azure-specific overrides that apply to a single alias.
 // Each field, when non-nil, overrides the corresponding key-level default.
 type AzureAliasCfg struct {
-	APIVersion       *string `json:"api_version,omitempty"`       // overrides the Azure OpenAI api-version query param for this alias
-	AnthropicVersion *string `json:"anthropic_version,omitempty"` // overrides the anthropic-version header for Claude-on-Azure deployments
+	APIVersion       *string    `json:"api_version,omitempty"`       // overrides the Azure OpenAI api-version query param for this alias
+	AnthropicVersion *string    `json:"anthropic_version,omitempty"` // overrides the anthropic-version header for Claude-on-Azure deployments
 	Endpoint         *SecretVar `json:"endpoint,omitempty"`          // overrides AzureKeyConfig.Endpoint for this alias — lets one credential span deployments on multiple Azure resources
 }
 
@@ -213,7 +214,7 @@ type AliasConfig struct {
 	ModelName   *string      `json:"model_name,omitempty"`   // canonical model name used for pricing, logging, and 2nd-tier family routing
 	ModelFamily *ModelFamily `json:"model_family,omitempty"` // 1st-tier family routing enum
 	Description string       `json:"description,omitempty"`  // description of the alias for users to understand its purpose (not used by bifrost)
-	Region      *SecretVar      `json:"region,omitempty"`
+	Region      *SecretVar   `json:"region,omitempty"`
 
 	*AzureAliasCfg
 	*VertexAliasCfg
@@ -614,10 +615,10 @@ const (
 type AzureKeyConfig struct {
 	Endpoint SecretVar `json:"endpoint"` // Azure service endpoint URL
 
-	ClientID     *SecretVar  `json:"client_id,omitempty"`     // Azure client ID for authentication
-	ClientSecret *SecretVar  `json:"client_secret,omitempty"` // Azure client secret for authentication
-	TenantID     *SecretVar  `json:"tenant_id,omitempty"`     // Azure tenant ID for authentication
-	Scopes       []string `json:"scopes,omitempty"`
+	ClientID     *SecretVar `json:"client_id,omitempty"`     // Azure client ID for authentication
+	ClientSecret *SecretVar `json:"client_secret,omitempty"` // Azure client secret for authentication
+	TenantID     *SecretVar `json:"tenant_id,omitempty"`     // Azure tenant ID for authentication
+	Scopes       []string   `json:"scopes,omitempty"`
 }
 
 // VertexKeyConfig represents the Vertex-specific configuration.
@@ -663,12 +664,31 @@ type BedrockKeyConfig struct {
 // NOTE: To use Bedrock IAM role authentication, set both AccessKey and SecretKey to empty strings.
 // To use Bedrock API Key authentication, set Value in Key struct instead.
 
+// BedrockMantleKeyConfig represents the Bedrock Mantle-specific configuration. Mantle serves
+// Claude (native-Anthropic Messages), OpenAI-compatible, and Gemma models on the
+// bedrock-mantle.{region}.api.aws host. It carries only the credentials and region the mantle
+// endpoints use; it intentionally omits the inference-profile ARN and batch S3 config, which
+// apply only to the Converse/bedrock-runtime surface.
+type BedrockMantleKeyConfig struct {
+	AccessKey    SecretVar  `json:"access_key,omitempty"`    // AWS access key for SigV4 authentication
+	SecretKey    SecretVar  `json:"secret_key,omitempty"`    // AWS secret access key for SigV4 authentication
+	SessionToken *SecretVar `json:"session_token,omitempty"` // AWS session token for temporary credentials
+	Region       *SecretVar `json:"region,omitempty"`        // AWS region used to build the bedrock-mantle endpoint host
+	// IAM role for STS AssumeRole
+	RoleARN         *SecretVar `json:"role_arn,omitempty"`
+	ExternalID      *SecretVar `json:"external_id,omitempty"`
+	RoleSessionName *SecretVar `json:"session_name,omitempty"`
+}
+
+// NOTE: To use Bedrock Mantle IAM role authentication, set both AccessKey and SecretKey to empty
+// strings. To use Bedrock Mantle API Key authentication, set Value in the Key struct instead.
+
 // VLLMKeyConfig represents the vLLM-specific key configuration.
 // It allows each key to target a different vLLM server URL and model name,
 // enabling per-key routing and round-robin load balancing across multiple vLLM instances.
 type VLLMKeyConfig struct {
 	URL       SecretVar `json:"url"`        // VLLM server base URL (required, supports env. prefix)
-	ModelName string `json:"model_name"` // Exact model name served on this VLLM instance (used for key selection)
+	ModelName string    `json:"model_name"` // Exact model name served on this VLLM instance (used for key selection)
 }
 
 // ReplicateKeyConfig represents the Replicate-specific key configuration.

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -41,32 +41,33 @@ type BifrostConfig struct {
 type ModelProvider string
 
 const (
-	OpenAI      ModelProvider = "openai"
-	Azure       ModelProvider = "azure"
-	Anthropic   ModelProvider = "anthropic"
-	Bedrock     ModelProvider = "bedrock"
-	Cohere      ModelProvider = "cohere"
-	Vertex      ModelProvider = "vertex"
-	Mistral     ModelProvider = "mistral"
-	Ollama      ModelProvider = "ollama"
-	OpencodeGo  ModelProvider = "opencode-go"
-	OpencodeZen ModelProvider = "opencode-zen"
-	Groq        ModelProvider = "groq"
-	SGL         ModelProvider = "sgl"
-	Parasail    ModelProvider = "parasail"
-	Perplexity  ModelProvider = "perplexity"
-	Cerebras    ModelProvider = "cerebras"
-	Gemini      ModelProvider = "gemini"
-	OpenRouter  ModelProvider = "openrouter"
-	Elevenlabs  ModelProvider = "elevenlabs"
-	HuggingFace ModelProvider = "huggingface"
-	Nebius      ModelProvider = "nebius"
-	XAI         ModelProvider = "xai"
-	Replicate   ModelProvider = "replicate"
-	VLLM        ModelProvider = "vllm"
-	Runway      ModelProvider = "runway"
-	Runware     ModelProvider = "runware"
-	Fireworks   ModelProvider = "fireworks"
+	OpenAI        ModelProvider = "openai"
+	Azure         ModelProvider = "azure"
+	Anthropic     ModelProvider = "anthropic"
+	Bedrock       ModelProvider = "bedrock"
+	BedrockMantle ModelProvider = "bedrock_mantle"
+	Cohere        ModelProvider = "cohere"
+	Vertex        ModelProvider = "vertex"
+	Mistral       ModelProvider = "mistral"
+	Ollama        ModelProvider = "ollama"
+	OpencodeGo    ModelProvider = "opencode-go"
+	OpencodeZen   ModelProvider = "opencode-zen"
+	Groq          ModelProvider = "groq"
+	SGL           ModelProvider = "sgl"
+	Parasail      ModelProvider = "parasail"
+	Perplexity    ModelProvider = "perplexity"
+	Cerebras      ModelProvider = "cerebras"
+	Gemini        ModelProvider = "gemini"
+	OpenRouter    ModelProvider = "openrouter"
+	Elevenlabs    ModelProvider = "elevenlabs"
+	HuggingFace   ModelProvider = "huggingface"
+	Nebius        ModelProvider = "nebius"
+	XAI           ModelProvider = "xai"
+	Replicate     ModelProvider = "replicate"
+	VLLM          ModelProvider = "vllm"
+	Runway        ModelProvider = "runway"
+	Runware       ModelProvider = "runware"
+	Fireworks     ModelProvider = "fireworks"
 )
 
 // SupportedBaseProviders is the list of base providers allowed for custom providers.
@@ -85,6 +86,7 @@ var StandardProviders = []ModelProvider{
 	Anthropic,
 	Azure,
 	Bedrock,
+	BedrockMantle,
 	Cerebras,
 	Cohere,
 	Gemini,
@@ -243,7 +245,7 @@ const (
 	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"                 // int (to store the fallback index (set by bifrost - DO NOT SET THIS MANUALLY)) 0 for primary, 1 for first fallback, etc.
 	BifrostContextKeyResolvedAlias                       BifrostContextKey = "bifrost-resolved-alias"                 // *ResolvedAlias (set by bifrost after key-level alias resolution — providers read this for model_family routing and provider-specific overrides; nil/absent when no alias matched)
 	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator"           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyStreamGated                         BifrostContextKey = "bifrost-stream-gated"                  // bool (set by ctx.PauseStream/ResumeStream/EndStream when a plugin first engages the pause/resume gate; provider helpers use this as a fast-path check to skip Tracer.GateSend on streams that never engage the gate)
+	BifrostContextKeyStreamGated                         BifrostContextKey = "bifrost-stream-gated"                   // bool (set by ctx.PauseStream/ResumeStream/EndStream when a plugin first engages the pause/resume gate; provider helpers use this as a fast-path check to skip Tracer.GateSend on streams that never engage the gate)
 	BifrostContextKeyStreamIdleTimeout                   BifrostContextKey = "bifrost-stream-idle-timeout"            // time.Duration (per-chunk idle timeout for streaming)
 	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"             // bool (will pass an empty key to the provider)
 	BifrostContextKeyExtraHeaders                        BifrostContextKey = "bifrost-extra-headers"                  // map[string][]string
@@ -369,11 +371,11 @@ const (
 
 // RoutingEngine constants
 const (
-	RoutingEngineGovernance      = "governance"
-	RoutingEngineRoutingRule     = "routing-rule"
-	RoutingEngineLoadbalancing   = "loadbalancing"
-	RoutingEngineModelCatalog    = "model-catalog"
-	RoutingEngineCircuitBreaker  = "circuit-breaker"
+	RoutingEngineGovernance     = "governance"
+	RoutingEngineRoutingRule    = "routing-rule"
+	RoutingEngineLoadbalancing  = "loadbalancing"
+	RoutingEngineModelCatalog   = "model-catalog"
+	RoutingEngineCircuitBreaker = "circuit-breaker"
 	// RoutingEngineCore represents the Bifrost core orchestrator's own
 	// routing decisions — primarily fallback transitions. Emitted when the
 	// primary attempt fails and core advances through the fallback chain so

--- a/core/utils.go
+++ b/core/utils.go
@@ -83,6 +83,7 @@ var dynamicallyConfigurableProviders = []schemas.ModelProvider{
 	schemas.Anthropic,
 	schemas.Azure,
 	schemas.Bedrock,
+	schemas.BedrockMantle,
 	schemas.Cerebras,
 	schemas.Cohere,
 	schemas.Elevenlabs,
@@ -122,11 +123,11 @@ func providerRequiresKey(customConfig *schemas.CustomProviderConfig) bool {
 // Some providers like Vertex and Bedrock have their credentials in additional key configs.
 // Ollama and SGL are keyless (API Key is optional) but use per-key server URLs.
 func CanProviderKeyValueBeEmpty(providerKey schemas.ModelProvider) bool {
-	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock || providerKey == schemas.VLLM || providerKey == schemas.Azure || providerKey == schemas.Ollama || providerKey == schemas.SGL
+	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock || providerKey == schemas.BedrockMantle || providerKey == schemas.VLLM || providerKey == schemas.Azure || providerKey == schemas.Ollama || providerKey == schemas.SGL
 }
 
 func isKeySkippingAllowed(providerKey schemas.ModelProvider) bool {
-	return providerKey != schemas.Azure && providerKey != schemas.Bedrock && providerKey != schemas.Vertex
+	return providerKey != schemas.Azure && providerKey != schemas.Bedrock && providerKey != schemas.BedrockMantle && providerKey != schemas.Vertex
 }
 
 // calculateBackoff implements exponential backoff with jitter for retry attempts.
@@ -170,6 +171,11 @@ func validateKey(providerKey schemas.ModelProvider, key *schemas.Key) error {
 		// BedrockKeyConfig is optional — an empty config is valid for IRSA / ambient credential auth.
 		if key.BedrockKeyConfig == nil {
 			key.BedrockKeyConfig = &schemas.BedrockKeyConfig{}
+		}
+	case schemas.BedrockMantle:
+		// BedrockMantleKeyConfig is optional — an empty config is valid for IRSA / ambient credential auth.
+		if key.BedrockMantleKeyConfig == nil {
+			key.BedrockMantleKeyConfig = &schemas.BedrockMantleKeyConfig{}
 		}
 	case schemas.Vertex:
 		if key.VertexKeyConfig == nil {


### PR DESCRIPTION
## Summary

Introduces `bedrock_mantle` as a first-class, standalone provider that owns the Bedrock Mantle surface (`bedrock-mantle.{region}.api.aws`). Previously, Mantle routing was handled as an internal routing decision inside the existing `bedrock` provider. The new provider gives operators a dedicated configuration surface for Claude (native Anthropic Messages API), OpenAI-compatible models (gpt-*), and Gemma models served through Mantle, without requiring a full Bedrock setup.

## Changes

- Added `schemas.BedrockMantle` (`"bedrock_mantle"`) as a new `ModelProvider` constant and registered it in `StandardProviders`, `dynamicallyConfigurableProviders`, `CanProviderKeyValueBeEmpty`, and `isKeySkippingAllowed`.
- Added `BedrockMantleKeyConfig` to the `Key` struct, carrying AWS credentials and region for SigV4 auth against the `bedrock-mantle` service. The existing `BedrockKeyConfig` is unchanged.
- Introduced the `core/providers/bedrockmantle` package implementing the full `Provider` interface. Chat, streaming chat, Responses, and streaming Responses dispatch by model family: Anthropic-family models use the native Anthropic Messages surface (`/anthropic/v1/messages`); all others use the OpenAI-compatible surface (`/v1` or `/openai/v1`). All other operations return unsupported-operation errors.
- Refactored `signAWSRequest` in the `bedrock` package to accept a `*BedrockKeyConfig` instead of individual credential fields, eliminating the now-redundant `signAWSRequestFromKey` wrapper. All call sites updated accordingly.
- Exported `SignMantleV4Headers` (previously `mantleSigV4Headers`, a method on `BedrockProvider`) so the new `bedrockmantle` package can sign requests without depending on the internal Bedrock provider struct. The function now supports both `BedrockKeyConfig` and `BedrockMantleKeyConfig` by mapping the latter into a synthetic `BedrockKeyConfig` for signing, and correctly handles GET requests (nil body) for the list-models path.
- Extended the Anthropic chat and Responses request builders to convert native structured outputs to tool calls for `BedrockMantle`, matching the existing `Vertex` workaround.
- Added `BedrockMantle` to the comprehensive LLM test harness (`ComprehensiveTestAccount`) with key config, provider config, and a full test file covering the supported scenarios (chat, streaming, tool calls, vision, structured outputs, prompt caching, reasoning, list models) and explicitly disabling unsupported ones.
- Marked `isMantleModel` in `bedrock/mantle.go` as deprecated in favour of the new provider.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Set AWS credentials and run the new provider test:

```sh
export AWS_ACCESS_KEY_ID=...
export AWS_SECRET_ACCESS_KEY=...
export AWS_SESSION_TOKEN=...   # optional, for temporary credentials
export AWS_REGION=us-east-1

go test ./core/providers/bedrockmantle/... -v -run TestBedrockMantle
```

To run the full suite (skips Bedrock Mantle automatically when credentials are absent):

```sh
go test ./...
```

Configure a `bedrock_mantle` provider by supplying a `BedrockMantleKeyConfig` (or a Bearer API key in `Value`) with the desired region. The region can also be embedded as a prefix in the model ID (e.g. `us-west-2/anthropic.claude-haiku-4-5`) or set at the alias level via `AliasConfig.Region`.

## Breaking changes

- [ ] Yes
- [x] No

The `signAWSRequest` signature change is internal to the `bedrock` package and does not affect any public API. The `isMantleModel` function is deprecated but not removed.

## Security considerations

AWS credentials for `BedrockMantleKeyConfig` follow the same `SecretVar` resolution pattern used by `BedrockKeyConfig` (env-var references, never inlined literals). SigV4 signing is performed per-request on the exact body bytes that are sent, so the signature always covers what is transmitted. When a Bearer API key is present it takes precedence and no AWS credentials are required.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable