### PR TITLE
feat: add `disable_vk_identity` to suppress virtual-key identity in OAuth consent flow

### DIFF
--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -560,6 +560,22 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// disable_vk_identity only makes sense in oauth mode: in both mode virtual
+	// keys can still authenticate via headers, so suppressing them in the consent
+	// flow alone would be misleading. Evaluate the merged config so a partial
+	// update that switches the mode away from oauth (without resending the config)
+	// cannot leave a previously stored disable_vk_identity active.
+	effectiveOAuth2Config := currentConfig.OAuth2ServerConfig
+	if payload.ClientConfig.OAuth2ServerConfig != nil {
+		effectiveOAuth2Config = payload.ClientConfig.OAuth2ServerConfig
+	}
+	if effectiveOAuth2Config != nil &&
+		effectiveOAuth2Config.DisableVKIdentity &&
+		effectiveAuthMode != configstoreTables.MCPServerAuthModeOAuth {
+		SendError(ctx, fasthttp.StatusBadRequest, "disable_vk_identity is only valid when mcp_server_auth_mode is oauth")
+		return
+	}
+
 	// Only update each field when explicitly provided so partial /api/config
 	// payloads do not clear stored values (matches the MCP field handling above).
 	if payload.ClientConfig.MCPServerAuthMode != "" {

--- a/transports/bifrost-http/handlers/mcpoauth2consent.go
+++ b/transports/bifrost-http/handlers/mcpoauth2consent.go
@@ -266,14 +266,29 @@ func (h *OAuth2ConsentHandler) loadPendingFlow(ctx *fasthttp.RequestCtx, flowID 
 
 // availableModes derives which identity modes to offer based on server config.
 func (h *OAuth2ConsentHandler) availableModes() []consentFlowMode {
-	modes := []consentFlowMode{consentFlowModeVK}
 	h.store.Mu.RLock()
 	enforceAuth := h.store.ClientConfig.EnforceAuthOnInference
 	h.store.Mu.RUnlock()
+	// oauth2ServerCfg is nil-safe: OAuth2ServerConfig is an unset pointer until the
+	// AS is configured, and a raw deref here panics the request worker. It takes its
+	// own read lock, so it's called outside the lock above.
+	disableVKIdentity := oauth2ServerCfg(h.store).DisableVKIdentity
+
+	userModeAvailable := h.identityResolver != nil && h.identityResolver.IsUserModeAvailable()
+
+	// Virtual-key identity may be suppressed, but only when user identity is
+	// available — so the flow always retains the identity-provider path and can
+	// never be left with no usable mode.
+	disableVK := userModeAvailable && disableVKIdentity
+
+	modes := []consentFlowMode{}
+	if !disableVK {
+		modes = append(modes, consentFlowModeVK)
+	}
 	if !enforceAuth {
 		modes = append(modes, consentFlowModeSession)
 	}
-	if h.identityResolver != nil && h.identityResolver.IsUserModeAvailable() {
+	if userModeAvailable {
 		modes = append(modes, consentFlowModeUser)
 	}
 	return modes

--- a/transports/bifrost-http/handlers/mcpoauth2consent_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2consent_test.go
@@ -125,15 +125,22 @@ func TestConsentAvailableModes(t *testing.T) {
 		name        string
 		resolver    OAuth2IdentityResolver
 		enforceAuth bool
+		disableVK   bool
 		want        []consentFlowMode
 	}{
-		{"vk and session when auth not enforced", nil, false, []consentFlowMode{consentFlowModeVK, consentFlowModeSession}},
-		{"vk only when auth enforced", nil, true, []consentFlowMode{consentFlowModeVK}},
-		{"adds user when resolver offers it", &fakeResolver{userModeAvailable: true}, false, []consentFlowMode{consentFlowModeVK, consentFlowModeSession, consentFlowModeUser}},
+		{"vk and session when auth not enforced", nil, false, false, []consentFlowMode{consentFlowModeVK, consentFlowModeSession}},
+		{"vk only when auth enforced", nil, true, false, []consentFlowMode{consentFlowModeVK}},
+		{"adds user when resolver offers it", &fakeResolver{userModeAvailable: true}, false, false, []consentFlowMode{consentFlowModeVK, consentFlowModeSession, consentFlowModeUser}},
+		// DisableVKIdentity drops vk, but only when user mode is available so the
+		// flow always keeps a usable identity path.
+		{"disable vk drops vk when user mode available", &fakeResolver{userModeAvailable: true}, false, true, []consentFlowMode{consentFlowModeSession, consentFlowModeUser}},
+		{"disable vk leaves user-only when auth enforced", &fakeResolver{userModeAvailable: true}, true, true, []consentFlowMode{consentFlowModeUser}},
+		{"disable vk ignored without user mode", nil, false, true, []consentFlowMode{consentFlowModeVK, consentFlowModeSession}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newConsentHandler(newConsentStore(), tc.resolver, tc.enforceAuth)
+			h.store.ClientConfig.OAuth2ServerConfig.DisableVKIdentity = tc.disableVK
 			assert.Equal(t, tc.want, h.availableModes())
 		})
 	}

--- a/transports/bifrost-http/handlers/mcpoauth2issuance.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance.go
@@ -35,11 +35,18 @@ import (
 type OAuth2IssuanceHandler struct {
 	store      *lib.Config
 	tempTokens *temptoken.Service // optional; nil = no consent temp-token minted
+	// identityResolver mirrors the consent handler's resolver. It is consulted
+	// only to decide whether DisableVKIdentity is in effect (it is honored only
+	// when user identity is available). May be nil — VK refresh is never blocked
+	// then, matching availableModes which keeps offering vk without a resolver.
+	identityResolver OAuth2IdentityResolver
 }
 
-// NewOAuth2IssuanceHandler creates a new issuance handler.
-func NewOAuth2IssuanceHandler(store *lib.Config, tempTokens *temptoken.Service) *OAuth2IssuanceHandler {
-	return &OAuth2IssuanceHandler{store: store, tempTokens: tempTokens}
+// NewOAuth2IssuanceHandler creates a new issuance handler. identityResolver may
+// be nil — the VK-refresh cutoff degrades to a no-op, consistent with the
+// consent handler offering vk when no resolver is present.
+func NewOAuth2IssuanceHandler(store *lib.Config, tempTokens *temptoken.Service, identityResolver OAuth2IdentityResolver) *OAuth2IssuanceHandler {
+	return &OAuth2IssuanceHandler{store: store, tempTokens: tempTokens, identityResolver: identityResolver}
 }
 
 // RegisterRoutes wires the three OAuth2 issuance routes.
@@ -419,6 +426,20 @@ func (h *OAuth2IssuanceHandler) handleTokenRefresh(ctx *fasthttp.RequestCtx) {
 	if rt.ClientID != clientID {
 		sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "client_id mismatch")
 		return
+	}
+
+	// VK identity cutoff (refresh side): when virtual-key identity has been
+	// disabled, vk-mode grants must not refresh. Live /mcp requests are already
+	// rejected at request time (see getMCPServerForRequest); denying refresh here
+	// closes the second path so a disabled grant can neither be used nor renewed.
+	// Gated on user identity being available, identical to the consent flow's
+	// availableModes — so this can never fire where vk is still the offered path.
+	if schemas.MCPAuthMode(rt.BfMode) == schemas.MCPAuthModeVK {
+		userModeAvailable := h.identityResolver != nil && h.identityResolver.IsUserModeAvailable()
+		if userModeAvailable && oauth2ServerCfg(h.store).DisableVKIdentity {
+			sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "virtual-key identity is no longer accepted; re-authenticate")
+			return
+		}
 	}
 
 	// bf_sub liveness check: for VK-mode tokens, verify the VK still exists

--- a/transports/bifrost-http/handlers/mcpoauth2issuance_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance_test.go
@@ -38,7 +38,7 @@ func newIssuanceHandler(t *testing.T) (*OAuth2IssuanceHandler, configstore.Confi
 	SetLogger(&mockLogger{})
 	store := newRealOAuth2Store(t)
 	cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-	return NewOAuth2IssuanceHandler(cfg, nil), store, cfg
+	return NewOAuth2IssuanceHandler(cfg, nil, nil), store, cfg
 }
 
 func pkceChallenge(verifier string) string {
@@ -512,5 +512,58 @@ func TestHandleToken_RefreshRotationAndReplay(t *testing.T) {
 		h.handleToken(ctx)
 		assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
 		assert.Contains(t, string(ctx.Response.Body()), "invalid_request")
+	})
+}
+
+func TestHandleToken_RefreshVKIdentityDisabled(t *testing.T) {
+	seedVKRefresh := func(t *testing.T, store configstore.ConfigStore, plain string) {
+		t.Helper()
+		seedConsentedRequest(t, store, "fam-vk", "client-1", "auth-code-vk", pkceChallenge("v"), "vk", "vk-1", time.Now().Add(time.Minute))
+		rt := &configtables.TableOAuth2RefreshToken{
+			ID: "rt-vk", TokenHash: hashSHA256Hex(plain), FamilyID: "fam-vk", ClientID: "client-1",
+			BfMode: "vk", BfSub: "vk-1", Scope: "mcp", Resource: testMCPResource, CreatedAt: time.Now(),
+		}
+		require.NoError(t, store.ConsumeOAuth2AuthorizeRequest(context.Background(), "fam-vk", rt))
+	}
+
+	refreshReq := func() *fasthttp.RequestCtx {
+		return formPostCtx(url.Values{
+			"grant_type": {"refresh_token"}, "refresh_token": {"refresh-vk-1"}, "client_id": {"client-1"},
+		}.Encode())
+	}
+
+	t.Run("vk refresh rejected when disabled and user mode available", func(t *testing.T) {
+		store := newRealOAuth2Store(t)
+		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false)
+		cfg.ClientConfig.OAuth2ServerConfig.DisableVKIdentity = true
+		h := NewOAuth2IssuanceHandler(cfg, nil, &fakeResolver{userModeAvailable: true})
+		seedClient(t, store, []string{"http://127.0.0.1/cb"})
+		seedVKRefresh(t, store, "refresh-vk-1")
+
+		ctx := refreshReq()
+		h.handleToken(ctx)
+		assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
+		body := string(ctx.Response.Body())
+		assert.Contains(t, body, "invalid_grant")
+		assert.Contains(t, body, "no longer accepted")
+	})
+
+	t.Run("vk refresh not blocked by flag when user mode unavailable", func(t *testing.T) {
+		store := newRealOAuth2Store(t)
+		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false)
+		cfg.ClientConfig.OAuth2ServerConfig.DisableVKIdentity = true
+		// nil resolver → user mode unavailable → the flag is ignored and the flow
+		// falls through to the VK liveness check, which rejects the (unseeded) VK
+		// with a different message. That proves the cutoff did not fire.
+		h := NewOAuth2IssuanceHandler(cfg, nil, nil)
+		seedClient(t, store, []string{"http://127.0.0.1/cb"})
+		seedVKRefresh(t, store, "refresh-vk-1")
+
+		ctx := refreshReq()
+		h.handleToken(ctx)
+		assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
+		body := string(ctx.Response.Body())
+		assert.NotContains(t, body, "no longer accepted")
+		assert.Contains(t, body, "no longer active")
 	})
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1407,12 +1407,16 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	promptsHandler := handlers.NewPromptsHandler(s.Config.ConfigStore, promptsReloader)
 	featureFlagsHandler := handlers.NewFeatureFlagsHandler(s.Config.FeatureFlags, s.Config.ConfigStore)
 	// Going ahead with API handlers
-	handlers.NewOAuth2DiscoveryHandler(s.Config).RegisterRoutes(s.Router, middlewares...)
-	handlers.NewOAuth2IssuanceHandler(s.Config, s.TempTokens).RegisterRoutes(s.Router)
+	oauth2DiscoveryHandler := handlers.NewOAuth2DiscoveryHandler(s.Config)
+	oauth2IssuanceHandler := handlers.NewOAuth2IssuanceHandler(s.Config, s.TempTokens, s.OAuth2IdentityResolver)
 	oauth2SessionsHandler := handlers.NewOAuth2SessionsHandler(s.Config)
 	oauth2ConsentHandler := handlers.NewOAuth2ConsentHandler(s.Config, s.TempTokens, s.OAuth2IdentityResolver)
-	oauth2ConsentHandler.RegisterRoutes(s.Router, middlewares...)
+
+	oauth2DiscoveryHandler.RegisterRoutes(s.Router, middlewares...)
+	// No middleware needed for mcp issuance routes, they should be open
+	oauth2IssuanceHandler.RegisterRoutes(s.Router)
 	oauth2SessionsHandler.RegisterRoutes(s.Router, middlewares...)
+	oauth2ConsentHandler.RegisterRoutes(s.Router, middlewares...)
 	healthHandler.RegisterRoutes(s.Router, middlewares...)
 	providerHandler.RegisterRoutes(s.Router, middlewares...)
 	mcpHandler.RegisterRoutes(s.Router, middlewares...)

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -314,6 +314,11 @@
               "minimum": 1,
               "default": 600,
               "description": "Lifetime of the issued JWT Bearer token in seconds (default: 600)."
+            },
+            "disable_vk_identity": {
+              "type": "boolean",
+              "default": false,
+              "description": "When true, the OAuth consent flow no longer offers or accepts virtual-key identity and existing virtual-key grants lose access immediately (rejected at request time and unable to refresh). Honored only when an identity provider is configured. Only valid when mcp_server_auth_mode is 'oauth'."
             }
           },
           "additionalProperties": false,

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -9,6 +9,8 @@ import { getErrorMessage, useGetCoreConfigQuery, useUpdateCoreConfigMutation } f
 import { CoreConfig, DefaultCoreConfig } from "@/lib/types/config";
 import { SecretVar } from "@/lib/types/schemas";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { useGetSCIMProvidersQuery } from "@enterprise/lib/store/apis/scimApi";
+import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { AlertTriangle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -20,6 +22,13 @@ export default function MCPView() {
 	const hasSettingsUpdateAccess = useRbac(RbacResource.Settings, RbacOperation.Update);
 	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
 	const config = bifrostConfig?.client_config;
+
+	// The "require identity-provider login" toggle is enterprise-only and only
+	// meaningful when an identity provider is configured — the backend ignores
+	// disable_vk_identity otherwise, so surfacing it would be a no-op. The SCIM
+	// query is skipped (and stubbed to []) in OSS builds.
+	const { data: scimProviders } = useGetSCIMProvidersQuery(undefined, { skip: !IS_ENTERPRISE });
+	const idpConfigured = !!scimProviders?.some((p) => (p as { enabled?: boolean }).enabled);
 	const [updateCoreConfig, { isLoading }] = useUpdateCoreConfigMutation();
 	const [localConfig, setLocalConfig] = useState<CoreConfig>(DefaultCoreConfig);
 
@@ -80,7 +89,9 @@ export default function MCPView() {
       (localConfig.oauth2_server_config?.auth_code_ttl ?? 600) !==
         (config.oauth2_server_config?.auth_code_ttl ?? 600) ||
       (localConfig.oauth2_server_config?.access_token_ttl ?? 600) !==
-        (config.oauth2_server_config?.access_token_ttl ?? 600)
+        (config.oauth2_server_config?.access_token_ttl ?? 600) ||
+      (localConfig.oauth2_server_config?.disable_vk_identity ?? false) !==
+        (config.oauth2_server_config?.disable_vk_identity ?? false)
 		);
 	}, [config, localConfig]);
 
@@ -182,6 +193,13 @@ export default function MCPView() {
         oauth2_server_config: { ...prev.oauth2_server_config, access_token_ttl: num },
       }));
     }
+  }, []);
+
+  const handleDisableVKIdentityChange = useCallback((checked: boolean) => {
+    setLocalConfig((prev) => ({
+      ...prev,
+      oauth2_server_config: { ...prev.oauth2_server_config, disable_vk_identity: checked },
+    }));
   }, []);
 
 	const handleSave = useCallback(async () => {
@@ -609,6 +627,57 @@ export default function MCPView() {
                       />
                     </div>
                   </div>
+
+                  {/* Require identity-provider login. Enterprise-only and only
+                      meaningful in oauth mode with an IdP configured. Stays visible
+                      when the setting is already enabled so it is never silently lost. */}
+                  {localConfig.mcp_server_auth_mode === "oauth" &&
+                    (idpConfigured ||
+                      localConfig.oauth2_server_config?.disable_vk_identity) && (
+                    <div className="mt-4 space-y-2 border-t pt-4">
+                      <div className="flex items-center justify-between space-x-2">
+                        <div className="space-y-0.5">
+                          <label
+                            htmlFor="oauth2-disable-vk-identity"
+                            className="text-sm font-medium"
+                          >
+                            Require identity-provider login
+                          </label>
+                          <p className="text-muted-foreground text-sm">
+                            When enabled, the OAuth consent flow only offers
+                            identity-provider login. Virtual keys can no longer be
+                            used to obtain an MCP token, and existing virtual-key
+                            OAuth sessions lose access immediately. Anonymous session
+                            access is unaffected (controlled by Enforce Authentication
+                            on Inference).
+                          </p>
+                        </div>
+                        <Switch
+                          id="oauth2-disable-vk-identity"
+                          data-testid="oauth2-disable-vk-identity-switch"
+                          size="md"
+                          checked={
+                            localConfig.oauth2_server_config?.disable_vk_identity ?? false
+                          }
+                          onCheckedChange={handleDisableVKIdentityChange}
+                          disabled={!hasSettingsUpdateAccess}
+                        />
+                      </div>
+                      {localConfig.oauth2_server_config?.disable_vk_identity && (
+                        <Alert variant="warning">
+                          <AlertTriangle className="size-4" />
+                          <AlertTitle>
+                            Virtual-key MCP access via OAuth will stop
+                          </AlertTitle>
+                          <AlertDescription>
+                            MCP clients that authenticated with a virtual key will
+                            lose access immediately and must sign in through your
+                            identity provider to reconnect.
+                          </AlertDescription>
+                        </Alert>
+                      )}
+                    </div>
+                  )}
                 </div>
               )}
 						</AccordionContent>

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -586,6 +586,7 @@ export interface CoreConfig {
 		issuer_url?: SecretVar;
 		auth_code_ttl?: number;
 		access_token_ttl?: number;
+		disable_vk_identity?: boolean;
 	};
 }
 


### PR DESCRIPTION
## Summary

Adds a `disable_vk_identity` configuration option that removes virtual-key identity from the OAuth consent flow. When enabled, virtual keys are no longer offered or accepted during OAuth consent, and existing virtual-key grants stop refreshing (they expire within one access-token TTL). The flag is only honored when an identity provider is configured, ensuring the consent flow always retains at least one usable identity path. Anonymous session access remains unaffected and is still governed by `EnforceAuthOnInference`.

## Changes

- Added `DisableVKIdentity bool` field to `OAuth2ServerConfig` with the constraint that it is only honored when an identity provider is configured and `mcp_server_auth_mode` is `oauth`.
- `availableModes()` in the consent handler now conditionally excludes `consentFlowModeVK` when `DisableVKIdentity` is set and user mode is available.
- Token refresh in the issuance handler rejects VK-mode grants with `invalid_grant` when `DisableVKIdentity` is active and user mode is available, causing existing VK sessions to expire within one access-token TTL.
- `OAuth2IssuanceHandler` now accepts an `OAuth2IdentityResolver` so it can apply the same user-mode availability gate as the consent handler.
- `OAuth2IssuanceHandler` is promoted to a named field on `BifrostHTTPServer` (matching the existing pattern for `OAuth2ConsentHandler`) so it can be injected with a resolver.
- Config update endpoint validates that `disable_vk_identity` is only set when `mcp_server_auth_mode` is `oauth`, returning a `400` otherwise.
- JSON schema updated with the new `disable_vk_identity` boolean field.
- UI exposes a "Require identity-provider login" toggle in the MCP settings view, visible only in `oauth` mode when an IdP is configured (enterprise-only, gated via SCIM provider check). A warning alert is shown when the toggle is enabled, explaining that existing VK OAuth sessions will lose access within one access-token lifetime.
- `disable_vk_identity` added to the `CoreConfig` TypeScript interface and to the dirty-state comparison in the MCP settings view.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/...
```

1. Configure an identity provider and set `mcp_server_auth_mode` to `oauth`.
2. Enable `disable_vk_identity` via the API or UI toggle.
3. Attempt to initiate an OAuth consent flow — verify the virtual-key option is absent from the consent page.
4. Attempt to refresh an existing VK-mode token — verify the response is `400 invalid_grant` with the message "virtual-key identity is no longer accepted; re-authenticate".
5. Verify that setting `disable_vk_identity` without an identity provider configured results in the flag being silently ignored (VK remains available).
6. Verify that setting `disable_vk_identity` when `mcp_server_auth_mode` is not `oauth` returns `400 disable_vk_identity is only valid when mcp_server_auth_mode is oauth`.

## Breaking changes

- [x] Yes
- [ ] No

Enabling `disable_vk_identity` causes existing MCP clients authenticated via virtual-key OAuth grants to lose access within one access-token TTL. They must re-authenticate through the configured identity provider. The flag is opt-in and off by default, so no existing deployments are affected unless explicitly enabled.

## Security considerations

This feature is intended to enforce identity-provider authentication for MCP OAuth flows, preventing virtual keys from being used as an OAuth identity mechanism. The guard that requires user mode to be available before the flag takes effect ensures the consent flow can never be left with zero usable identity options. The refresh cutoff uses the same availability gate as the consent handler, so the two surfaces remain consistent.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable