### PR TITLE
fix: exclude terminal-status oauth configs from expiring token refresh query

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -5745,8 +5745,18 @@ func (s *RDBConfigStore) DeleteOauthToken(ctx context.Context, id string) error 
 // GetExpiringOauthTokens retrieves tokens that are expiring before the given time
 func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableOauthToken, error) {
 	var tokens []*tables.TableOauthToken
+	// Exclude tokens whose owning oauth_config has already reached a terminal
+	// state — "expired" (set when a refresh is permanently rejected, e.g.
+	// invalid_grant / Grant not found) or "revoked". Without this, the refresh
+	// worker re-selects a permanently-dead token on every tick (its expires_at
+	// stays in the past) and logs the same failure indefinitely; a dead grant
+	// needs re-authorization, not perpetual retries.
 	result := s.DB().WithContext(ctx).
 		Where("expires_at IS NOT NULL AND expires_at < ?", before).
+		Where("NOT EXISTS (?)",
+			s.DB().Model(&tables.TableOauthConfig{}).
+				Select("1").
+				Where("oauth_configs.token_id = oauth_tokens.id AND oauth_configs.status IN ?", []string{"expired", "revoked"})).
 		Find(&tokens)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get expiring tokens: %w", result.Error)

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -59,6 +59,50 @@ func makeRefreshToken(id, familyID, clientID, hash string) *tables.TableOAuth2Re
 	}
 }
 
+// TestGetExpiringOauthTokens_ExcludesTerminalConfigs verifies the refresh worker
+// query skips tokens whose oauth_config is already terminal (expired/revoked), so
+// a permanently-dead grant is not retried — and re-logged — on every tick.
+func TestGetExpiringOauthTokens_ExcludesTerminalConfigs(t *testing.T) {
+	s := setupRDBTestStore(t)
+	require.NoError(t, s.DB().AutoMigrate(&tables.TableOauthConfig{}, &tables.TableOauthToken{}))
+	ctx := context.Background()
+	past := time.Now().Add(-time.Hour)
+
+	mkToken := func(id string) {
+		require.NoError(t, s.DB().Create(&tables.TableOauthToken{
+			ID: id, AccessToken: "at-" + id, TokenType: "Bearer",
+			ExpiresAt: &past, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}).Error)
+	}
+	mkConfig := func(id, tokenID, status, state string) {
+		require.NoError(t, s.DB().Create(&tables.TableOauthConfig{
+			ID: id, RedirectURI: "http://127.0.0.1/cb", State: state, Status: status,
+			TokenID: &tokenID, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+			ExpiresAt: time.Now().Add(time.Hour),
+		}).Error)
+	}
+
+	mkToken("tok-live")
+	mkConfig("cfg-live", "tok-live", "authorized", "state-live")
+	mkToken("tok-expired")
+	mkConfig("cfg-expired", "tok-expired", "expired", "state-expired")
+	mkToken("tok-revoked")
+	mkConfig("cfg-revoked", "tok-revoked", "revoked", "state-revoked")
+	mkToken("tok-orphan") // no owning config at all
+
+	got, err := s.GetExpiringOauthTokens(ctx, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+
+	ids := make(map[string]bool, len(got))
+	for _, tk := range got {
+		ids[tk.ID] = true
+	}
+	assert.True(t, ids["tok-live"], "token with an authorized config should be refreshed")
+	assert.True(t, ids["tok-orphan"], "token with no config should still be returned")
+	assert.False(t, ids["tok-expired"], "token with an expired config must be excluded")
+	assert.False(t, ids["tok-revoked"], "token with a revoked config must be excluded")
+}
+
 func TestGetOAuth2SigningKey_AutoGeneratesAndIsStable(t *testing.T) {
 	s := setupOAuth2TestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

The OAuth token refresh worker was repeatedly selecting permanently-dead tokens on every tick because their `expires_at` timestamp remains in the past after a terminal failure (e.g., `invalid_grant` / "Grant not found"). This caused the same error to be logged indefinitely. Tokens whose owning `oauth_config` has reached a terminal state (`expired` or `revoked`) no longer need to be refreshed — they require re-authorization instead.

## Changes

- `GetExpiringOauthTokens` now excludes tokens whose associated `oauth_config` has a status of `expired` or `revoked`, using a `NOT EXISTS` subquery. This prevents the refresh worker from endlessly retrying permanently-dead grants.
- A new test, `TestGetExpiringOauthTokens_ExcludesTerminalConfigs`, validates that tokens linked to terminal configs are excluded from the result, while tokens with an active (`authorized`) config or no config at all are still returned.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... -run TestGetExpiringOauthTokens_ExcludesTerminalConfigs -v
```

Expected: the test passes, confirming that tokens with `expired` or `revoked` configs are excluded, while tokens with `authorized` configs or no config are included.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This change reduces unnecessary outbound refresh requests for revoked or expired OAuth grants, which could otherwise leak information about token state to external authorization servers on every refresh tick.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable