### PR TITLE
fix: bedrock usage calculation

### DIFF
--- a/core/providers/bedrock/cache_points_test.go
+++ b/core/providers/bedrock/cache_points_test.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -228,5 +229,88 @@ func TestBedrockModelSupportsExtendedCacheTTL(t *testing.T) {
 		if got := schemas.BedrockModelSupportsExtendedCacheTTL(model); got != want {
 			t.Errorf("BedrockModelSupportsExtendedCacheTTL(%q) = %v, want %v", model, got, want)
 		}
+	}
+}
+
+// TestToBedrockConverseStreamResponse_CopiesCacheTokens guards the streaming Converse
+// path against dropping prompt-cache token counts (issue #4746). Cached tokens are folded
+// into InputTokens upstream, so the converter must copy them into the cache fields AND
+// subtract them back out of InputTokens.
+func TestToBedrockConverseStreamResponse_CopiesCacheTokens(t *testing.T) {
+	resp := &schemas.BifrostResponsesStreamResponse{
+		Type: schemas.ResponsesStreamResponseTypeCompleted,
+		Response: &schemas.BifrostResponsesResponse{
+			Usage: &schemas.ResponsesResponseUsage{
+				InputTokens:  2660, // cached tokens folded in (as FinalizeBedrockStream does)
+				OutputTokens: 4,
+				TotalTokens:  2664,
+				InputTokensDetails: &schemas.ResponsesResponseInputTokens{
+					CachedReadTokens: 2647,
+				},
+			},
+		},
+	}
+
+	event, err := ToBedrockConverseStreamResponse(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil || event.Usage == nil {
+		t.Fatal("expected usage on completed event")
+	}
+	if event.Usage.CacheReadInputTokens != 2647 {
+		t.Errorf("CacheReadInputTokens: want 2647, got %d", event.Usage.CacheReadInputTokens)
+	}
+	// Cached tokens must be subtracted so inputTokens is not double-counted.
+	if event.Usage.InputTokens != 13 {
+		t.Errorf("InputTokens: want 13 (cached subtracted), got %d", event.Usage.InputTokens)
+	}
+}
+
+// TestBuildBedrockTokenUsage_StreamMatchesNonStream asserts the streaming and non-streaming
+// Converse converters report identical usage from the same Responses usage — the drift that
+// caused issue #4746. Exercises cache write + 5m/1h breakdown in addition to cache read.
+func TestBuildBedrockTokenUsage_StreamMatchesNonStream(t *testing.T) {
+	usage := &schemas.ResponsesResponseUsage{
+		InputTokens:  2660, // cached read + write folded in
+		OutputTokens: 4,
+		TotalTokens:  2664,
+		InputTokensDetails: &schemas.ResponsesResponseInputTokens{
+			CachedReadTokens:  2000,
+			CachedWriteTokens: 647,
+			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens5m: 600,
+				CachedWriteTokens1h: 47,
+			},
+		},
+	}
+
+	streamResp := &schemas.BifrostResponsesStreamResponse{
+		Type:     schemas.ResponsesStreamResponseTypeCompleted,
+		Response: &schemas.BifrostResponsesResponse{Usage: usage},
+	}
+	streamEvent, err := ToBedrockConverseStreamResponse(streamResp)
+	if err != nil {
+		t.Fatalf("stream conversion error: %v", err)
+	}
+
+	nonStreamResp, err := ToBedrockConverseResponse(&schemas.BifrostResponsesResponse{Usage: usage})
+	if err != nil {
+		t.Fatalf("non-stream conversion error: %v", err)
+	}
+
+	if streamEvent.Usage == nil || nonStreamResp.Usage == nil {
+		t.Fatal("expected usage on both converters")
+	}
+	if !reflect.DeepEqual(streamEvent.Usage, nonStreamResp.Usage) {
+		t.Errorf("usage mismatch:\n  stream:     %+v\n  non-stream: %+v", *streamEvent.Usage, *nonStreamResp.Usage)
+	}
+	// Spot-check the expected values: 2660 - 2000 - 647 = 13.
+	if streamEvent.Usage.InputTokens != 13 {
+		t.Errorf("InputTokens: want 13, got %d", streamEvent.Usage.InputTokens)
+	}
+	if streamEvent.Usage.CacheReadInputTokens != 2000 || streamEvent.Usage.CacheWriteInputTokens != 647 {
+		t.Errorf("cache tokens: want read=2000 write=647, got read=%d write=%d",
+			streamEvent.Usage.CacheReadInputTokens, streamEvent.Usage.CacheWriteInputTokens)
 	}
 }

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1519,6 +1519,41 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 	return responses
 }
 
+// buildBedrockTokenUsage maps Responses usage to Bedrock usage. Cached tokens are folded
+// into InputTokens upstream, so they are copied into the cache fields and subtracted back
+// out of InputTokens. Shared by the streaming and non-streaming converters to keep them in sync.
+func buildBedrockTokenUsage(usage *schemas.ResponsesResponseUsage) *BedrockTokenUsage {
+	if usage == nil {
+		return nil
+	}
+	out := &BedrockTokenUsage{
+		InputTokens:  usage.InputTokens,
+		OutputTokens: usage.OutputTokens,
+		TotalTokens:  usage.TotalTokens,
+	}
+	if usage.InputTokensDetails != nil {
+		if usage.InputTokensDetails.CachedReadTokens > 0 {
+			out.CacheReadInputTokens = usage.InputTokensDetails.CachedReadTokens
+			out.InputTokens -= usage.InputTokensDetails.CachedReadTokens
+		}
+		if usage.InputTokensDetails.CachedWriteTokens > 0 {
+			out.CacheWriteInputTokens = usage.InputTokensDetails.CachedWriteTokens
+			if d := usage.InputTokensDetails.CachedWriteTokenDetails; d != nil {
+				var cacheDetails []BedrockCacheWriteDetails
+				if d.CachedWriteTokens5m > 0 {
+					cacheDetails = append(cacheDetails, BedrockCacheWriteDetails{InputTokens: d.CachedWriteTokens5m, TTL: BedrockCacheWriteTTL5m})
+				}
+				if d.CachedWriteTokens1h > 0 {
+					cacheDetails = append(cacheDetails, BedrockCacheWriteDetails{InputTokens: d.CachedWriteTokens1h, TTL: BedrockCacheWriteTTL1h})
+				}
+				out.CacheDetails = &cacheDetails
+			}
+			out.InputTokens -= usage.InputTokensDetails.CachedWriteTokens
+		}
+	}
+	return out
+}
+
 // ToBedrockConverseStreamResponse converts a Bifrost Responses stream response to Bedrock streaming format
 // Returns a BedrockStreamEvent that represents the streaming event in Bedrock's format
 func ToBedrockConverseStreamResponse(bifrostResp *schemas.BifrostResponsesStreamResponse) (*BedrockStreamEvent, error) {
@@ -1735,12 +1770,8 @@ func ToBedrockConverseStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 		event.StopReason = &stopReason
 
 		// Add usage if available
-		if bifrostResp.Response != nil && bifrostResp.Response.Usage != nil {
-			event.Usage = &BedrockTokenUsage{
-				InputTokens:  bifrostResp.Response.Usage.InputTokens,
-				OutputTokens: bifrostResp.Response.Usage.OutputTokens,
-				TotalTokens:  bifrostResp.Response.Usage.TotalTokens,
-			}
+		if bifrostResp.Response != nil {
+			event.Usage = buildBedrockTokenUsage(bifrostResp.Response.Usage)
 		}
 
 		// Restore guardrail trace from provider extra fields
@@ -2731,37 +2762,8 @@ func ToBedrockConverseResponse(bifrostResp *schemas.BifrostResponsesResponse) (*
 	bedrockResp.StopReason = stopReason
 
 	// Convert usage stats
-	if bifrostResp.Usage != nil {
-		bedrockResp.Usage.InputTokens = bifrostResp.Usage.InputTokens
-		bedrockResp.Usage.OutputTokens = bifrostResp.Usage.OutputTokens
-		bedrockResp.Usage.TotalTokens = bifrostResp.Usage.TotalTokens
-
-		if bifrostResp.Usage.InputTokensDetails != nil {
-			if bifrostResp.Usage.InputTokensDetails.CachedReadTokens > 0 {
-				bedrockResp.Usage.CacheReadInputTokens = bifrostResp.Usage.InputTokensDetails.CachedReadTokens
-				bedrockResp.Usage.InputTokens = bedrockResp.Usage.InputTokens - bifrostResp.Usage.InputTokensDetails.CachedReadTokens
-			}
-			if bifrostResp.Usage.InputTokensDetails.CachedWriteTokens > 0 {
-				bedrockResp.Usage.CacheWriteInputTokens = bifrostResp.Usage.InputTokensDetails.CachedWriteTokens
-				if bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails != nil {
-					var cacheDetails []BedrockCacheWriteDetails
-					if bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m > 0 {
-						cacheDetails = append(cacheDetails, BedrockCacheWriteDetails{
-							InputTokens: bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m,
-							TTL:         BedrockCacheWriteTTL5m,
-						})
-					}
-					if bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h > 0 {
-						cacheDetails = append(cacheDetails, BedrockCacheWriteDetails{
-							InputTokens: bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h,
-							TTL:         BedrockCacheWriteTTL1h,
-						})
-					}
-					bedrockResp.Usage.CacheDetails = &cacheDetails
-				}
-				bedrockResp.Usage.InputTokens = bedrockResp.Usage.InputTokens - bifrostResp.Usage.InputTokensDetails.CachedWriteTokens
-			}
-		}
+	if bedrockUsage := buildBedrockTokenUsage(bifrostResp.Usage); bedrockUsage != nil {
+		bedrockResp.Usage = bedrockUsage
 	}
 
 	// Set metrics


### PR DESCRIPTION
## Summary

Fixes a bug where prompt-cache token counts were silently dropped on the Bedrock streaming Converse path (issue #4746). Because cached tokens are folded into `InputTokens` upstream, the converter must copy them into the dedicated cache fields and subtract them back out of `InputTokens` to avoid double-counting. Previously, the streaming converter omitted this logic entirely while the non-streaming converter handled it correctly, causing the two paths to diverge.

## Changes

- Extracted the cache-aware token usage mapping into a shared `buildBedrockTokenUsage` helper that correctly copies `CachedReadTokens` and `CachedWriteTokens` into `CacheReadInputTokens`/`CacheWriteInputTokens` and subtracts them from `InputTokens`.
- Replaced the inline usage-mapping blocks in both `ToBedrockConverseStreamResponse` and `ToBedrockConverseResponse` with calls to `buildBedrockTokenUsage`, ensuring the two paths are always in sync.
- Added `TestToBedrockConverseStreamResponse_CopiesCacheTokens` to verify the streaming path correctly propagates cache read tokens and subtracts them from `InputTokens`.
- Added `TestBuildBedrockTokenUsage_StreamMatchesNonStream` to assert that the streaming and non-streaming converters produce identical `BedrockTokenUsage` from the same input, covering cache read, cache write, and the 5m/1h write breakdown.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... -run "TestToBedrockConverseStreamResponse_CopiesCacheTokens|TestBuildBedrockTokenUsage_StreamMatchesNonStream|TestBedrockModelSupportsExtendedCacheTTL"
```

Expected: all three tests pass. The streaming event should report `InputTokens: 13`, `CacheReadInputTokens: 2647` for the single-read case, and `InputTokens: 13`, `CacheReadInputTokens: 2000`, `CacheWriteInputTokens: 647` for the combined read+write case, with the stream and non-stream results being `reflect.DeepEqual`.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

Closes #4746

## Security considerations

None. This change only affects token count bookkeeping in response conversion.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable