### PR TITLE
fix: use parseAsSafeArrayOf for logs page array query params to handle special characters in URLs

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -26,8 +26,8 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import NumberFlow from "@number-flow/react";
 import { useLocation } from "@tanstack/react-router";
 import { AlertCircle, BarChart, CheckCircle, Clock, DollarSign, Hash, Info } from "lucide-react";
-import { parseAsSafeString } from "@/lib/queryParamsParser";
-import { parseAsArrayOf, parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { parseAsSafeArrayOf, parseAsSafeString } from "@/lib/queryParamsParser";
+import { parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export default function LogsPage() {
@@ -72,20 +72,20 @@ export default function LogsPage() {
 	const [urlState, setUrlState] = useQueryStates(
 		{
 			parent_request_id: parseAsString.withDefault(""),
-			providers: parseAsArrayOf(parseAsString).withDefault([]),
-			models: parseAsArrayOf(parseAsString).withDefault([]),
-			aliases: parseAsArrayOf(parseAsString).withDefault([]),
-			status: parseAsArrayOf(parseAsString).withDefault([]),
-			stop_reasons: parseAsArrayOf(parseAsString).withDefault([]),
-			objects: parseAsArrayOf(parseAsString).withDefault([]),
-			selected_key_ids: parseAsArrayOf(parseAsString).withDefault([]),
-			virtual_key_ids: parseAsArrayOf(parseAsString).withDefault([]),
-			routing_rule_ids: parseAsArrayOf(parseAsString).withDefault([]),
-			routing_engine_used: parseAsArrayOf(parseAsString).withDefault([]),
-			user_ids: parseAsArrayOf(parseAsString).withDefault([]),
-			team_ids: parseAsArrayOf(parseAsString).withDefault([]),
-			customer_ids: parseAsArrayOf(parseAsString).withDefault([]),
-			business_unit_ids: parseAsArrayOf(parseAsString).withDefault([]),
+			providers: parseAsSafeArrayOf.withDefault([]),
+			models: parseAsSafeArrayOf.withDefault([]),
+			aliases: parseAsSafeArrayOf.withDefault([]),
+			status: parseAsSafeArrayOf.withDefault([]),
+			stop_reasons: parseAsSafeArrayOf.withDefault([]),
+			objects: parseAsSafeArrayOf.withDefault([]),
+			selected_key_ids: parseAsSafeArrayOf.withDefault([]),
+			virtual_key_ids: parseAsSafeArrayOf.withDefault([]),
+			routing_rule_ids: parseAsSafeArrayOf.withDefault([]),
+			routing_engine_used: parseAsSafeArrayOf.withDefault([]),
+			user_ids: parseAsSafeArrayOf.withDefault([]),
+			team_ids: parseAsSafeArrayOf.withDefault([]),
+			customer_ids: parseAsSafeArrayOf.withDefault([]),
+			business_unit_ids: parseAsSafeArrayOf.withDefault([]),
 			content_search: parseAsSafeString.withDefault(""),
 			start_time: parseAsInteger.withDefault(defaultTimeRange.startTime),
 			end_time: parseAsInteger.withDefault(defaultTimeRange.endTime),
@@ -96,7 +96,7 @@ export default function LogsPage() {
 			polling: parseAsBoolean.withDefault(true).withOptions({ clearOnDefault: false }),
 			period: parseAsString.withDefault(hasExplicitTimeRange ? "" : "1h").withOptions({ clearOnDefault: false }),
 			missing_cost_only: parseAsBoolean.withDefault(false),
-			cache_hit_types: parseAsArrayOf(parseAsString).withDefault([]),
+			cache_hit_types: parseAsSafeArrayOf.withDefault([]),
 			metadata_filters: parseAsString.withDefault(""),
 			selected_log: parseAsString.withDefault(""),
 		},

--- a/ui/lib/queryParamsParser.test.ts
+++ b/ui/lib/queryParamsParser.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+import { parseAsSafeArrayOf, parseAsSafeString } from "./queryParamsParser";
+
+describe("parseAsSafeString", () => {
+	test("roundtrips model names with double slashes", () => {
+		const model = "gpt://b1g9n2rqsrnikgh0uofm/gpt-oss-120b";
+		const serialized = parseAsSafeString.serialize(model);
+		expect(serialized).not.toContain("://");
+		expect(parseAsSafeString.parse(serialized)).toBe(model);
+	});
+});
+
+describe("parseAsSafeArrayOf", () => {
+	test("roundtrips multiple models with special characters", () => {
+		const models = ["gpt://b1g9n2rqsrnikgh0uofm/gpt-oss-20b", "gpt://b1g9n2rqsrnikgh0uofm/gpt-oss-120b"];
+		const serialized = parseAsSafeArrayOf.serialize(models);
+		expect(serialized).not.toContain("://");
+		expect(parseAsSafeArrayOf.parse(serialized)).toEqual(models);
+	});
+});

--- a/ui/lib/queryParamsParser.ts
+++ b/ui/lib/queryParamsParser.ts
@@ -1,4 +1,4 @@
-import { createParser } from "nuqs";
+import { createParser, parseAsArrayOf } from "nuqs";
 
 // nuqs's encodeQueryValue skips characters like "/" that TanStack Router's
 // navigate({ to }) interprets as path/query delimiters. Full URI-encoding
@@ -19,3 +19,7 @@ export const parseAsSafeString = createParser({
 		}
 	},
 });
+
+// Comma-separated filter values (models, providers, etc.) with the same
+// encoding guarantees as parseAsSafeString.
+export const parseAsSafeArrayOf = parseAsArrayOf(parseAsSafeString);


### PR DESCRIPTION
Cherry-picked from dev: 99ae84702983d939a042067aec7e0e22e4e8d97a