### PR TITLE
fix: responses.go build fix

### DIFF
--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -967,7 +967,15 @@ func isToolSearchItem(t string) bool {
 }
 
 // UnmarshalJSON preserves codex tool_search items verbatim (see rawToolSearch)
-// and defers every other item type to the default struct decoding.
+// and otherwise normalizes function/tool-call arguments before decoding the rest
+// of the item. OpenAI's Responses API serializes `function_call` `arguments` as
+// a JSON string, but `tool_search_call` items serialize `arguments` as a JSON
+// object — e.g. {} while in_progress and {"query":"...","limit":10} when
+// completed. The embedded ResponsesToolMessage.Arguments field is a *string, so
+// an object value makes a plain decode fail with "Mismatch type string with
+// value object", which silently drops the item mid-stream and hangs streaming
+// clients. We shadow `arguments` as raw JSON, decode everything else as usual,
+// then store the canonical stringified form.
 func (m *ResponsesMessage) UnmarshalJSON(data []byte) error {
 	// Clear the receiver first so a reused instance never retains a stale
 	// rawToolSearch (or other fields) from a prior decode — unmarshalling a
@@ -980,32 +988,7 @@ func (m *ResponsesMessage) UnmarshalJSON(data []byte) error {
 		m.rawToolSearch = append([]byte(nil), data...)
 		return nil
 	}
-	type alias ResponsesMessage
-	return sonic.Unmarshal(data, (*alias)(m))
-}
 
-// MarshalJSON re-emits preserved tool_search items verbatim and defers every
-// other item type to the default (sorted-key) struct encoding.
-func (m ResponsesMessage) MarshalJSON() ([]byte, error) {
-	if m.rawToolSearch != nil {
-		return m.rawToolSearch, nil
-	}
-	type alias ResponsesMessage
-	return MarshalSorted(alias(m))
-}
-
-// UnmarshalJSON normalizes function/tool-call arguments before decoding the rest
-// of the item. OpenAI's Responses API serializes `function_call` `arguments` as
-// a JSON string, but `tool_search_call` items (emitted when the request enables
-// the `tool_search` deferred-tool-discovery tool, as Codex does) serialize
-// `arguments` as a JSON object — e.g. {} while in_progress and
-// {"query":"...","limit":10} when completed. The embedded
-// ResponsesToolMessage.Arguments field is a *string, so an object value makes a
-// plain decode fail with "Mismatch type string with value object", which
-// silently drops the item mid-stream and hangs streaming clients. We shadow
-// `arguments` as raw JSON, decode everything else as usual, then store the
-// canonical stringified form.
-func (m *ResponsesMessage) UnmarshalJSON(data []byte) error {
 	type Alias ResponsesMessage
 	aux := &struct {
 		Arguments json.RawMessage `json:"arguments,omitempty"`
@@ -1027,6 +1010,16 @@ func (m *ResponsesMessage) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// MarshalJSON re-emits preserved tool_search items verbatim and defers every
+// other item type to the default (sorted-key) struct encoding.
+func (m ResponsesMessage) MarshalJSON() ([]byte, error) {
+	if m.rawToolSearch != nil {
+		return m.rawToolSearch, nil
+	}
+	type alias ResponsesMessage
+	return MarshalSorted(alias(m))
 }
 
 // responsesToolArgumentsToString normalizes a function/tool-call `arguments`


### PR DESCRIPTION
## Summary

Consolidates the two separate `UnmarshalJSON` implementations on `ResponsesMessage` into a single method that handles both the verbatim `tool_search` preservation and the `arguments` normalization logic. Previously, the file contained a duplicate `UnmarshalJSON` definition — the first handled `tool_search` items and fell back to a plain `sonic.Unmarshal`, while the second (the correct one) handled argument normalization. The duplicate caused the normalization path to be unreachable for non-`tool_search` items, meaning `tool_search_call` items with object-typed `arguments` would silently fail mid-stream and hang streaming clients.

## Changes

- Removed the redundant first `UnmarshalJSON` that short-circuited to `sonic.Unmarshal` without normalizing `arguments`, leaving only the correct implementation that handles both the `rawToolSearch` early-return and the `arguments` object-to-string normalization.
- Relocated `MarshalJSON` to follow `UnmarshalJSON` for logical grouping.
- The fix ensures `tool_search_call` items whose `arguments` field is a JSON object (e.g. `{}` while in-progress, `{"query":"...","limit":10}` when completed) are correctly stringified into the `*string` field expected by `ResponsesToolMessage`, preventing decode failures that previously dropped items silently.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/...
```

Validate by sending a request that triggers `tool_search_call` streaming events and confirming that items with both `{}` (in-progress) and `{"query":"...","limit":10}` (completed) `arguments` values are decoded without error and do not hang the streaming client.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable