### PR TITLE
feat: add server/client_id filter to MCP clients list

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1581,6 +1581,9 @@ func (s *RDBConfigStore) GetMCPClientsPaginated(ctx context.Context, params MCPC
 		search := "%" + strings.ToLower(params.Search) + "%"
 		baseQuery = baseQuery.Where("LOWER(name) LIKE ?", search)
 	}
+	if params.ClientID != "" {
+		baseQuery = baseQuery.Where("client_id = ?", params.ClientID)
+	}
 
 	var totalCount int64
 	if err := baseQuery.Count(&totalCount).Error; err != nil {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -64,9 +64,10 @@ type RoutingRulesQueryParams struct {
 
 // MCPClientsQueryParams holds pagination, filtering, and search parameters for MCP client queries.
 type MCPClientsQueryParams struct {
-	Limit  int
-	Offset int
-	Search string
+	Limit    int
+	Offset   int
+	Search   string
+	ClientID string
 }
 
 // MCPLibraryQueryParams holds pagination, filtering, search, and sort

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -114,8 +114,9 @@ func (h *MCPHandler) getMCPClients(ctx *fasthttp.RequestCtx) {
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
 	searchStr := string(ctx.QueryArgs().Peek("search"))
+	serverStr := string(ctx.QueryArgs().Peek("server"))
 
-	h.getMCPClientsPaginated(ctx, limitStr, offsetStr, searchStr)
+	h.getMCPClientsPaginated(ctx, limitStr, offsetStr, searchStr, serverStr)
 }
 
 // getMCPLibrary handles GET /api/mcp/library — paginated, searchable, filterable
@@ -245,10 +246,11 @@ func (h *MCPHandler) forceSyncMCPLibrary(ctx *fasthttp.RequestCtx) {
 }
 
 // getMCPClientsPaginated handles the paginated path for GET /api/mcp/clients
-func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, offsetStr, searchStr string) {
+func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, offsetStr, searchStr, serverStr string) {
 	params := configstore.MCPClientsQueryParams{
-		Search: searchStr,
-		Limit:  100,
+		Search:   searchStr,
+		ClientID: serverStr,
+		Limit:    100,
 	}
 	if limitStr != "" {
 		n, err := strconv.Atoi(limitStr)
@@ -469,10 +471,10 @@ func (h *MCPHandler) reconnectMCPClient(ctx *fasthttp.RequestCtx) {
 type OAuthConfigRequest struct {
 	ClientID        *schemas.SecretVar `json:"client_id"`
 	ClientSecret    *schemas.SecretVar `json:"client_secret"`
-	AuthorizeURL    string          `json:"authorize_url"`
-	TokenURL        string          `json:"token_url"`
-	RegistrationURL string          `json:"registration_url"`
-	Scopes          []string        `json:"scopes"`
+	AuthorizeURL    string             `json:"authorize_url"`
+	TokenURL        string             `json:"token_url"`
+	RegistrationURL string             `json:"registration_url"`
+	Scopes          []string           `json:"scopes"`
 }
 
 // MCPClientRequest represents the full MCP client creation request with OAuth support.
@@ -499,21 +501,21 @@ type MCPVKConfigRequest struct {
 // Immutable fields (connection_type, auth_type, connection_string, stdio_config) are not
 // accepted here; they cannot be changed after creation.
 type MCPClientUpdateRequest struct {
-	Name                  *string                   `json:"name,omitempty"`
-	Disabled              *bool                     `json:"disabled,omitempty"`
-	AllowOnAllVirtualKeys *bool                     `json:"allow_on_all_virtual_keys,omitempty"`
-	IsCodeModeClient      *bool                     `json:"is_code_mode_client,omitempty"`
-	IsPingAvailable       *bool                     `json:"is_ping_available,omitempty"`
-	ToolSyncInterval      *int                      `json:"tool_sync_interval,omitempty"`
+	Name                  *string                      `json:"name,omitempty"`
+	Disabled              *bool                        `json:"disabled,omitempty"`
+	AllowOnAllVirtualKeys *bool                        `json:"allow_on_all_virtual_keys,omitempty"`
+	IsCodeModeClient      *bool                        `json:"is_code_mode_client,omitempty"`
+	IsPingAvailable       *bool                        `json:"is_ping_available,omitempty"`
+	ToolSyncInterval      *int                         `json:"tool_sync_interval,omitempty"`
 	Headers               map[string]schemas.SecretVar `json:"headers,omitempty"`
-	AllowedExtraHeaders   *schemas.WhiteList        `json:"allowed_extra_headers,omitempty"`
-	ToolPricing           map[string]float64        `json:"tool_pricing,omitempty"`
-	ToolsToExecute        *schemas.WhiteList        `json:"tools_to_execute,omitempty"`
-	ToolsToAutoExecute    *schemas.WhiteList        `json:"tools_to_auto_execute,omitempty"`
-	PerUserHeaderKeys     *[]string                 `json:"per_user_header_keys,omitempty"`
-	TLSConfig             *schemas.MCPTLSConfig     `json:"tls_config,omitempty"`
-	VKConfigs             *[]MCPVKConfigRequest     `json:"vk_configs,omitempty"`
-	OauthConfig           *OAuthConfigRequest       `json:"oauth_config,omitempty"`
+	AllowedExtraHeaders   *schemas.WhiteList           `json:"allowed_extra_headers,omitempty"`
+	ToolPricing           map[string]float64           `json:"tool_pricing,omitempty"`
+	ToolsToExecute        *schemas.WhiteList           `json:"tools_to_execute,omitempty"`
+	ToolsToAutoExecute    *schemas.WhiteList           `json:"tools_to_auto_execute,omitempty"`
+	PerUserHeaderKeys     *[]string                    `json:"per_user_header_keys,omitempty"`
+	TLSConfig             *schemas.MCPTLSConfig        `json:"tls_config,omitempty"`
+	VKConfigs             *[]MCPVKConfigRequest        `json:"vk_configs,omitempty"`
+	OauthConfig           *OAuthConfigRequest          `json:"oauth_config,omitempty"`
 }
 
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client

--- a/ui/app/workspace/mcp-registry/page.tsx
+++ b/ui/app/workspace/mcp-registry/page.tsx
@@ -2,21 +2,23 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { useToast } from "@/hooks/use-toast";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetMCPClientsQuery } from "@/lib/store";
-import { useEffect, useState } from "react";
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { useEffect } from "react";
 import MCPClientsTable from "./views/mcpClientsTable";
 
 const POLLING_INTERVAL = 5000;
 const PAGE_SIZE = 25;
 
 export default function MCPServersPage() {
-	const [search, setSearch] = useState("");
-	const [offset, setOffset] = useState(0);
-	const debouncedSearch = useDebouncedValue(search, 300);
-
-	// Reset to first page when search changes
-	useEffect(() => {
-		setOffset(0);
-	}, [debouncedSearch]);
+	const [urlState, setUrlState] = useQueryStates(
+		{
+			search: parseAsString.withDefault(""),
+			server: parseAsString.withDefault(""),
+			offset: parseAsInteger.withDefault(0),
+		},
+		{ history: "replace" },
+	);
+	const debouncedSearch = useDebouncedValue(urlState.search, 300);
 
 	const {
 		data: mcpClientsData,
@@ -26,8 +28,9 @@ export default function MCPServersPage() {
 	} = useGetMCPClientsQuery(
 		{
 			limit: PAGE_SIZE,
-			offset,
+			offset: urlState.offset,
 			search: debouncedSearch || undefined,
+			server: urlState.server || undefined,
 		},
 		{
 			pollingInterval: POLLING_INTERVAL,
@@ -39,9 +42,9 @@ export default function MCPServersPage() {
 
 	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
 	useEffect(() => {
-		if (!mcpClientsData || offset < totalCount) return;
-		setOffset(totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE);
-	}, [totalCount, offset]);
+		if (!mcpClientsData || urlState.offset < totalCount) return;
+		void setUrlState({ offset: totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE });
+	}, [totalCount, urlState.offset, mcpClientsData, setUrlState]);
 
 	const { toast } = useToast();
 
@@ -61,18 +64,24 @@ export default function MCPServersPage() {
 		return <FullPageLoader />;
 	}
 
+	const handleSearchChange = (value: string) => void setUrlState({ search: value, offset: 0 });
+	const handleServerFilterClear = () => void setUrlState({ server: null, offset: 0 });
+	const handleOffsetChange = (offset: number) => void setUrlState({ offset }, { history: "push" });
+
 	return (
 		<div className="mx-auto flex h-[calc(100dvh-50px)] w-full max-w-7xl flex-col">
 			<MCPClientsTable
 				mcpClients={mcpClients}
 				totalCount={totalCount}
 				refetch={refetch}
-				search={search}
+				search={urlState.search}
 				debouncedSearch={debouncedSearch}
-				onSearchChange={setSearch}
-				offset={offset}
+				server={urlState.server}
+				onSearchChange={handleSearchChange}
+				onServerFilterClear={handleServerFilterClear}
+				offset={urlState.offset}
 				limit={PAGE_SIZE}
-				onOffsetChange={setOffset}
+				onOffsetChange={handleOffsetChange}
 			/>
 		</div>
 	);

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -22,7 +22,7 @@ import { getErrorMessage, useDeleteMCPClientMutation, useReconnectMCPClientMutat
 import { MCPClient } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
-import { Box, ChevronLeft, ChevronRight, Loader2, MoreHorizontal, PencilIcon, Plus, RefreshCcw, Search, Trash2 } from "lucide-react";
+import { Box, ChevronLeft, ChevronRight, Loader2, MoreHorizontal, PencilIcon, Plus, RefreshCcw, Search, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import MCPClientSheet from "./mcpClientSheet";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
@@ -125,7 +125,9 @@ interface MCPClientsTableProps {
 	refetch?: () => void;
 	search: string;
 	debouncedSearch: string;
+	server: string;
 	onSearchChange: (value: string) => void;
+	onServerFilterClear: () => void;
 	offset: number;
 	limit: number;
 	onOffsetChange: (offset: number) => void;
@@ -137,7 +139,9 @@ export default function MCPClientsTable({
 	refetch,
 	search,
 	debouncedSearch,
+	server,
 	onSearchChange,
+	onServerFilterClear,
 	offset,
 	limit,
 	onOffsetChange,
@@ -286,7 +290,7 @@ export default function MCPClientsTable({
 		}
 	};
 
-	const hasActiveFilters = debouncedSearch;
+	const hasActiveFilters = debouncedSearch || server;
 
 	// True empty state: no servers at all (not just filtered to zero)
 	if (totalCount === 0 && !hasActiveFilters) {
@@ -372,6 +376,18 @@ export default function MCPClientsTable({
 						data-testid="mcp-clients-search-input"
 					/>
 				</div>
+				{server && (
+					<Button
+						variant="outline"
+						size="sm"
+						className="h-8 gap-2"
+						onClick={onServerFilterClear}
+						data-testid="mcp-client-server-filter-clear-btn"
+					>
+						Server filter
+						<X className="size-3" />
+					</Button>
+				)}
 			</div>
 
 			<div className="flex grow flex-col overflow-auto">

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -26,6 +26,7 @@ export const mcpApi = baseApi.injectEndpoints({
 					...(params?.limit !== undefined && { limit: params.limit }),
 					...(params?.offset !== undefined && { offset: params.offset }),
 					...(params?.search && { search: params.search }),
+					...(params?.server && { server: params.server }),
 				},
 			}),
 			providesTags: ["MCPClients"],

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -160,6 +160,7 @@ export interface GetMCPClientsParams {
 	limit?: number;
 	offset?: number;
 	search?: string;
+	server?: string;
 }
 
 // Paginated response for MCP clients list


### PR DESCRIPTION
## Summary

Adds a `server` (client ID) filter to the MCP clients list endpoint and UI, allowing users to filter the MCP clients table to a specific server. The filter state is persisted in the URL via query parameters, enabling shareable and bookmarkable filtered views.

## Changes

- Added `ClientID` field to `MCPClientsQueryParams` and applied it as a `WHERE client_id = ?` clause in `GetMCPClientsPaginated`
- Exposed the filter via a new `server` query parameter on `GET /api/mcp/clients`
- Migrated the MCP registry page from local `useState` to `nuqs` `useQueryStates`, storing `search`, `server`, and `offset` in the URL
- Added `server` prop and `onServerFilterClear` callback to `MCPClientsTable`, rendering a dismissible "Server filter" badge/button when the filter is active
- Extended `GetMCPClientsParams` type and the RTK Query API call to pass the `server` parameter through to the backend
- `hasActiveFilters` now accounts for both `debouncedSearch` and `server`, preventing the empty state from showing while a server filter is active

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the MCP Registry page.
2. Confirm that `search`, `server`, and `offset` appear in the URL and survive a page refresh.
3. Set a `server` query param (e.g. `?server=<client_id>`) directly in the URL and verify the table filters to only that client.
4. Click the "Server filter" dismiss button and confirm the filter clears and the URL updates.
5. Verify that the empty state is not shown when a server filter is active but returns no results.

```sh
# Core/Transports
go test ./framework/configstore/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots showing the server filter badge and URL state._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

_Link related issues here._

## Security considerations

The `client_id` filter is applied as a parameterised query (`WHERE client_id = ?`), so there is no SQL injection risk. No secrets or PII are exposed through the new filter parameter.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable